### PR TITLE
MAINT: Fix hierarchy of numericaltype in code documentation 

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -68,15 +68,14 @@ Exported symbols include:
      |             complex_ (cfloat, cdouble)
      |             clongfloat (longcomplex)
      +-> flexible
-     |     void                                 (kind=V)
-     |     character
-     |
-     |     str_     (string_, bytes_)           (kind=S)    [Python 2]
-     |     unicode_                             (kind=U)    [Python 2]
-     |
-     |     bytes_   (string_)                   (kind=S)    [Python 3]
-     |     str_     (unicode_)                  (kind=U)    [Python 3]
-     |
+     |   +-> character
+     |   |     str_     (string_, bytes_)           (kind=S)    [Python 2]
+     |   |     unicode_                             (kind=U)    [Python 2]
+     |   |
+     |   |     bytes_   (string_)                   (kind=S)    [Python 3]
+     |   |     str_     (unicode_)                  (kind=U)    [Python 3]
+     |   |
+     |   \\-> void                                 (kind=V)
      \\-> object_ (not used much)                (kind=O)
 
 """

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -41,9 +41,9 @@ Exported symbols include:
 
    generic
      +-> bool_                                  (kind=b)
-     +-> number                                 (kind=i)
+     +-> number
      |     integer
-     |     signedinteger   (intxx)
+     |     signedinteger   (intxx)              (kind=i)
      |     byte
      |     short
      |     intc

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -68,8 +68,8 @@ Exported symbols include:
      |             complex_ (cfloat, cdouble)
      |             clongfloat (longcomplex)
      +-> flexible
-     |     character
      |     void                                 (kind=V)
+     |     character
      |
      |     str_     (string_, bytes_)           (kind=S)    [Python 2]
      |     unicode_                             (kind=U)    [Python 2]

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -43,40 +43,40 @@ Exported symbols include:
      +-> bool_                                  (kind=b)
      +-> number
      |   +-> integer
-     |   |   +-> signedinteger   (intxx)              (kind=i)
+     |   |   +-> signedinteger     (intxx)      (kind=i)
      |   |   |     byte
      |   |   |     short
      |   |   |     intc
-     |   |   |     intp           int0
+     |   |   |     intp            int0
      |   |   |     int_
      |   |   |     longlong
-     |   |   \\-> unsignedinteger  (uintxx)              (kind=u)
+     |   |   \\-> unsignedinteger  (uintxx)     (kind=u)
      |   |         ubyte
      |   |         ushort
      |   |         uintc
-     |   |         uintp          uint0
+     |   |         uintp           uint0
      |   |         uint_
      |   |         ulonglong
      |   +-> inexact
-     |       +-> floating           (floatxx)       (kind=f)
+     |       +-> floating          (floatxx)    (kind=f)
      |       |     half
      |       |     single
-     |       |     float_  (double)
+     |       |     float_          (double)
      |       |     longfloat
-     |       \\-> complexfloating    (complexxx)     (kind=c)
+     |       \\-> complexfloating  (complexxx)  (kind=c)
      |             csingle  (singlecomplex)
      |             complex_ (cfloat, cdouble)
      |             clongfloat (longcomplex)
      +-> flexible
      |   +-> character
-     |   |     str_     (string_, bytes_)           (kind=S)    [Python 2]
-     |   |     unicode_                             (kind=U)    [Python 2]
+     |   |     str_     (string_, bytes_)       (kind=S)    [Python 2]
+     |   |     unicode_                         (kind=U)    [Python 2]
      |   |
-     |   |     bytes_   (string_)                   (kind=S)    [Python 3]
-     |   |     str_     (unicode_)                  (kind=U)    [Python 3]
+     |   |     bytes_   (string_)               (kind=S)    [Python 3]
+     |   |     str_     (unicode_)              (kind=U)    [Python 3]
      |   |
-     |   \\-> void                                 (kind=V)
-     \\-> object_ (not used much)                (kind=O)
+     |   \\-> void                              (kind=V)
+     \\-> object_ (not used much)               (kind=O)
 
 """
 from __future__ import division, absolute_import, print_function

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -42,31 +42,31 @@ Exported symbols include:
    generic
      +-> bool_                                  (kind=b)
      +-> number
-     |     integer
-     |     signedinteger   (intxx)              (kind=i)
-     |       byte
-     |       short
-     |       intc
-     |       intp           int0
-     |       int_
-     |       longlong
-     +-> unsignedinteger  (uintxx)              (kind=u)
-     |     ubyte
-     |     ushort
-     |     uintc
-     |     uintp          uint0
-     |     uint_
-     |     ulonglong
-     +-> inexact
-     |   +-> floating           (floatxx)       (kind=f)
-     |   |     half
-     |   |     single
-     |   |     float_  (double)
-     |   |     longfloat
-     |   \\-> complexfloating    (complexxx)     (kind=c)
-     |         csingle  (singlecomplex)
-     |         complex_ (cfloat, cdouble)
-     |         clongfloat (longcomplex)
+     |   +-> integer
+     |   |     signedinteger   (intxx)              (kind=i)
+     |   |       byte
+     |   |       short
+     |   |       intc
+     |   |       intp           int0
+     |   |       int_
+     |   |       longlong
+     |   +-> unsignedinteger  (uintxx)              (kind=u)
+     |   |     ubyte
+     |   |     ushort
+     |   |     uintc
+     |   |     uintp          uint0
+     |   |     uint_
+     |   |     ulonglong
+     |   +-> inexact
+     |       +-> floating           (floatxx)       (kind=f)
+     |       |     half
+     |       |     single
+     |       |     float_  (double)
+     |       |     longfloat
+     |       \\-> complexfloating    (complexxx)     (kind=c)
+     |             csingle  (singlecomplex)
+     |             complex_ (cfloat, cdouble)
+     |             clongfloat (longcomplex)
      +-> flexible
      |     character
      |     void                                 (kind=V)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -44,12 +44,12 @@ Exported symbols include:
      +-> number
      |     integer
      |     signedinteger   (intxx)              (kind=i)
-     |     byte
-     |     short
-     |     intc
-     |     intp           int0
-     |     int_
-     |     longlong
+     |       byte
+     |       short
+     |       intc
+     |       intp           int0
+     |       int_
+     |       longlong
      +-> unsignedinteger  (uintxx)              (kind=u)
      |     ubyte
      |     ushort

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -64,9 +64,9 @@ Exported symbols include:
      |       |     float_          (double)
      |       |     longfloat
      |       \\-> complexfloating  (complexxx)  (kind=c)
-     |             csingle  (singlecomplex)
-     |             complex_ (cfloat, cdouble)
-     |             clongfloat (longcomplex)
+     |             csingle         (singlecomplex)
+     |             complex_        (cfloat, cdouble)
+     |             clongfloat      (longcomplex)
      +-> flexible
      |   +-> character
      |   |     str_     (string_, bytes_)       (kind=S)    [Python 2]

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -43,20 +43,20 @@ Exported symbols include:
      +-> bool_                                  (kind=b)
      +-> number
      |   +-> integer
-     |   |     signedinteger   (intxx)              (kind=i)
-     |   |       byte
-     |   |       short
-     |   |       intc
-     |   |       intp           int0
-     |   |       int_
-     |   |       longlong
-     |   +-> unsignedinteger  (uintxx)              (kind=u)
-     |   |     ubyte
-     |   |     ushort
-     |   |     uintc
-     |   |     uintp          uint0
-     |   |     uint_
-     |   |     ulonglong
+     |   |   +-> signedinteger   (intxx)              (kind=i)
+     |   |   |     byte
+     |   |   |     short
+     |   |   |     intc
+     |   |   |     intp           int0
+     |   |   |     int_
+     |   |   |     longlong
+     |   |   \\-> unsignedinteger  (uintxx)              (kind=u)
+     |   |         ubyte
+     |   |         ushort
+     |   |         uintc
+     |   |         uintp          uint0
+     |   |         uint_
+     |   |         ulonglong
      |   +-> inexact
      |       +-> floating           (floatxx)       (kind=f)
      |       |     half


### PR DESCRIPTION
Reopening with updated commit messages - feel free to delete this PR.

The hierarchy of scalar dtypes in the code documentation was unclear and e.g. made it seem like floats and unsigned integers where not subtypes of `numpy.number`. This is a trivial edit to align the code comments with subdtype.