### PR TITLE
DOC: fix hierarchy of numericaltype

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -41,9 +41,9 @@ Exported symbols include:
 
    generic
      +-> bool_                                  (kind=b)
-     +-> number                                 (kind=i)
+     +-> number
      |     integer
-     |     signedinteger   (intxx)
+     |     signedinteger   (intxx)              (kind=i)
      |     byte
      |     short
      |     intc

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -42,42 +42,41 @@ Exported symbols include:
    generic
      +-> bool_                                  (kind=b)
      +-> number
-     |     integer
-     |     signedinteger   (intxx)              (kind=i)
-     |     byte
-     |     short
-     |     intc
-     |     intp           int0
-     |     int_
-     |     longlong
-     +-> unsignedinteger  (uintxx)              (kind=u)
-     |     ubyte
-     |     ushort
-     |     uintc
-     |     uintp          uint0
-     |     uint_
-     |     ulonglong
-     +-> inexact
-     |   +-> floating           (floatxx)       (kind=f)
-     |   |     half
-     |   |     single
-     |   |     float_  (double)
-     |   |     longfloat
-     |   \\-> complexfloating    (complexxx)     (kind=c)
-     |         csingle  (singlecomplex)
-     |         complex_ (cfloat, cdouble)
-     |         clongfloat (longcomplex)
+     |   +-> integer
+     |   |   +-> signedinteger     (intxx)      (kind=i)
+     |   |   |     byte
+     |   |   |     short
+     |   |   |     intc
+     |   |   |     intp            int0
+     |   |   |     int_
+     |   |   |     longlong
+     |   |   \\-> unsignedinteger  (uintxx)     (kind=u)
+     |   |         ubyte
+     |   |         ushort
+     |   |         uintc
+     |   |         uintp           uint0
+     |   |         uint_
+     |   |         ulonglong
+     |   +-> inexact
+     |       +-> floating          (floatxx)    (kind=f)
+     |       |     half
+     |       |     single
+     |       |     float_          (double)
+     |       |     longfloat
+     |       \\-> complexfloating  (complexxx)  (kind=c)
+     |             csingle         (singlecomplex)
+     |             complex_        (cfloat, cdouble)
+     |             clongfloat      (longcomplex)
      +-> flexible
-     |     character
-     |     void                                 (kind=V)
-     |
-     |     str_     (string_, bytes_)           (kind=S)    [Python 2]
-     |     unicode_                             (kind=U)    [Python 2]
-     |
-     |     bytes_   (string_)                   (kind=S)    [Python 3]
-     |     str_     (unicode_)                  (kind=U)    [Python 3]
-     |
-     \\-> object_ (not used much)                (kind=O)
+     |   +-> character
+     |   |     str_     (string_, bytes_)       (kind=S)    [Python 2]
+     |   |     unicode_                         (kind=U)    [Python 2]
+     |   |
+     |   |     bytes_   (string_)               (kind=S)    [Python 3]
+     |   |     str_     (unicode_)              (kind=U)    [Python 3]
+     |   |
+     |   \\-> void                              (kind=V)
+     \\-> object_ (not used much)               (kind=O)
 
 """
 from __future__ import division, absolute_import, print_function


### PR DESCRIPTION
The `numericaltypes` module contains code documentation outlining the hierarchy of scalar dtypes. This hierarchy was however unclear or incorrect, e.g., seemingly indicating that floats and unsigned integers were not subtypes of `numpy.number`.

This PR is a trivial edit to align the hierarchy in the code documentation with the `subdtype` relation, cf. https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.scalars.html. The type indicated for the kind shorthand 'i' was also updated.