### PR TITLE
BUG: Remove extra trailing parentheses.

### DIFF
--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -584,7 +584,7 @@ int npy_get_floatstatus() {
     defined(__NetBSD__)
 #include <ieeefp.h>
 
-int npy_get_floatstatus_barrier(char * param))
+int npy_get_floatstatus_barrier(char * param)
 {
     int fpstatus = fpgetsticky();
     /*


### PR DESCRIPTION
Backport of  #11291.

The `npy_get_floatstatus_barrier` had an extra parentheses in the
argument list of the function definition that was exposed when compiling
on NetBSD.

Closes #11288.