### PR TITLE
BUG: Fix segfault on failing `__array_wrap__`

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4593,11 +4593,11 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
                 res = PyObject_CallFunctionObjArgs(wrap, mps[j], NULL);
             }
             Py_DECREF(wrap);
+            Py_DECREF(mps[j]);
+            mps[j] = NULL;  /* Prevent fail double-freeing this */
             if (res == NULL) {
                 goto fail;
             }
-
-            Py_DECREF(mps[j]);
             retobj[i] = res;
         }
     }

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1576,6 +1576,25 @@ class TestSpecialMethods(object):
         a = A()
         assert_raises(RuntimeError, ncu.maximum, a, a)
 
+    def test_failing_out_wrap(self):
+
+        singleton = np.array([1.0])
+
+        class Ok(np.ndarray):
+            def __array_wrap__(self, obj):
+                return singleton
+
+        class Bad(np.ndarray):
+            def __array_wrap__(self, obj):
+                raise RuntimeError
+
+        ok = np.empty(1).view(Ok)
+        bad = np.empty(1).view(Bad)
+
+        # double-free (segfault) of "ok" if "bad" raises an exception
+        for i in range(10):
+            assert_raises(RuntimeError, ncu.frexp, 1, ok, bad)
+
     def test_none_wrap(self):
         # Tests that issue #8507 is resolved. Previously, this would segfault
 


### PR DESCRIPTION
Milestoning for 1.15, since we changed the behavior of `__array_wrap__`  in #10919, so if user code breaks as a result, it needs to not segfault!