### PR TITLE
ENH: Added sum normalization to histogram()

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -605,13 +605,13 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         (instead of 1). If `density` is True, the weights are
         normalized, so that the integral of the density over the range
         remains 1.
-    density : bool, optional
+    density : bool or int, optional
         If ``False``, the result will contain the number of samples in
         each bin. If ``True``, the result is the value of the
         probability *density* function at the bin, normalized such that
-        the *integral* over the range is 1. Note that the sum of the
-        histogram values will not be equal to 1 unless bins of unity
-        width are chosen; it is not a probability *mass* function.
+        the *integral* over the range is 1. 
+        If ``2``, the result will be normalized such that the sum of the 
+        histogram values will be equal to 1.
 
         Overrides the ``normed`` keyword if given.
 
@@ -785,6 +785,10 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     elif density==2:
         # normalize for fractionals
         return n/n.sum(), bin_edges
+    elif normed:
+        # deprecated, buggy behavior. Remove for NumPy 2.0.0
+        db = np.array(np.diff(bin_edges), float)
+        return n/(n*db).sum(), bin_edges
     else:
         return n, bin_edges
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -779,13 +779,12 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     if density is not None:
         normed = False
 
-    if density:
+    if density==1:
         db = np.array(np.diff(bin_edges), float)
         return n/db/n.sum(), bin_edges
-    elif normed:
-        # deprecated, buggy behavior. Remove for NumPy 2.0.0
-        db = np.array(np.diff(bin_edges), float)
-        return n/(n*db).sum(), bin_edges
+    elif density==2:
+        # normalize for fractionals
+        return n/n.sum(), bin_edges
     else:
         return n, bin_edges
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -611,7 +611,8 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         probability *density* function at the bin, normalized such that
         the *integral* over the range is 1. 
         If ``sum``, the result will be normalized such that the sum of 
-        the histogram values will be equal to 1.
+        the histogram values will be equal to 1. This *is* a probability 
+        mass function. 
 
         Overrides the ``normed`` keyword if given.
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -605,13 +605,13 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
         (instead of 1). If `density` is True, the weights are
         normalized, so that the integral of the density over the range
         remains 1.
-    density : bool or int, optional
+    density : bool or str, optional
         If ``False``, the result will contain the number of samples in
         each bin. If ``True``, the result is the value of the
         probability *density* function at the bin, normalized such that
         the *integral* over the range is 1. 
-        If ``2``, the result will be normalized such that the sum of the 
-        histogram values will be equal to 1.
+        If ``sum``, the result will be normalized such that the sum of 
+        the histogram values will be equal to 1.
 
         Overrides the ``normed`` keyword if given.
 
@@ -779,12 +779,11 @@ def histogram(a, bins=10, range=None, normed=False, weights=None,
     if density is not None:
         normed = False
 
-    if density==1:
+    if density=='sum':
+        return n/n.sum(), bin_edges
+    elif density:
         db = np.array(np.diff(bin_edges), float)
         return n/db/n.sum(), bin_edges
-    elif density==2:
-        # normalize for fractionals
-        return n/n.sum(), bin_edges
     elif normed:
         # deprecated, buggy behavior. Remove for NumPy 2.0.0
         db = np.array(np.diff(bin_edges), float)


### PR DESCRIPTION
With matplotlib and pandas using histogram() for charting, this allows for fractional histograms by adding sum=1. It also removes that passive aggressive note about it not doing sum normalization by adding a one liner so people stop having to read that comment when looking for the functionality. 
Since strings default validate as True, nothing changes for existing codes and typos. 