### PR TITLE
BUG: Fix memmap regression when shape=None

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -236,6 +236,7 @@ class memmap(ndarray):
                 raise ValueError("Size of available data is not a "
                         "multiple of the data-type size.")
             size = bytes // _dbytes
+            shape = (size,)
         else:
             if not isinstance(shape, tuple):
                 shape = (shape,)

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -196,3 +196,8 @@ class TestMemmap(object):
         offset = mmap.ALLOCATIONGRANULARITY + 1
         fp = memmap(self.tmpfp, shape=size, mode='w+', offset=offset)
         assert_(fp.offset == offset)
+
+    def test_no_shape(self):
+        self.tmpfp.write(b'a'*16)
+        mm = memmap(self.tmpfp, dtype='float64')
+        assert_equal(mm.shape, (2,))


### PR DESCRIPTION
See issue #11223 and #11305.

Later this week I'll have more time and will look into adding coverage for this into the test suite (if nobody else gets to it first).