### PR TITLE
MAINT: remove unused "npy_import"

### DIFF
--- a/numpy/core/src/private/npy_import.h
+++ b/numpy/core/src/private/npy_import.h
@@ -29,18 +29,4 @@ npy_cache_import(const char *module, const char *attr, PyObject **cache)
     }
 }
 
-NPY_INLINE static PyObject *
-npy_import(const char *module, const char *attr)
-{
-    PyObject *mod = PyImport_ImportModule(module);
-    PyObject *ret = NULL;
-
-    if (mod != NULL) {
-        ret = PyObject_GetAttrString(mod, attr);
-    }
-    Py_XDECREF(mod);
-
-    return ret;
-}
-
 #endif


### PR DESCRIPTION
This removes an unnecessary function I accidentally added in #10411.

The original purpose was to add a way to import a global python variable which could be toggled by the user, so it shouldn't be cached. But I removed that variable, so we don't need this function.