### PR TITLE
MAINT: Package `tools/allocation_tracking`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ include doc/Makefile doc/postprocess.py
 recursive-include doc/release *
 recursive-include doc/source *
 recursive-include doc/sphinxext *
+recursive-include tools/allocation_tracking *
 recursive-include tools/swig *
 recursive-include doc/scipy-sphinx-theme *
 


### PR DESCRIPTION
Ensure `tools/allocation_tracking` is included in `sdist`s.