### PR TITLE
DOC: Change array lengths/entries in `broadcast_arrays` example to reduce confusion.

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -219,23 +219,19 @@ def broadcast_arrays(*args, **kwargs):
     Examples
     --------
     >>> x = np.array([[1,2,3]])
-    >>> y = np.array([[1],[2],[3]])
+    >>> y = np.array([[4],[5]])
     >>> np.broadcast_arrays(x, y)
     [array([[1, 2, 3],
-           [1, 2, 3],
-           [1, 2, 3]]), array([[1, 1, 1],
-           [2, 2, 2],
-           [3, 3, 3]])]
+           [1, 2, 3]]), array([[4, 4, 4],
+           [5, 5, 5]])]
 
     Here is a useful idiom for getting contiguous copies instead of
     non-contiguous views.
 
     >>> [np.array(a) for a in np.broadcast_arrays(x, y)]
     [array([[1, 2, 3],
-           [1, 2, 3],
-           [1, 2, 3]]), array([[1, 1, 1],
-           [2, 2, 2],
-           [3, 3, 3]])]
+           [1, 2, 3]]), array([[4, 4, 4],
+           [5, 5, 5]])]
 
     """
     # nditer is not used here to avoid the limit of 32 arrays.


### PR DESCRIPTION
The current example for `broadcast_arrays(x, y)` uses two copies of the same array `[1, 2, 3]`. This change instead uses two arrays of different lengths and values (`[1, 2, 3]` and `[4, 5]`) to make clearer the shapes of the outputs and where each output entry is coming from (which input array and which entry).
Original example:
```
np.broadcast_arrays([[1, 2, 3]], [[1], [2], [3]]) 
->
[array([[1, 2, 3], [1, 2, 3], [1, 2, 3]]), 
 array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])]
```
New example:
```
np.broadcast_arrays([[1, 2, 3]], [[4], [5]]) 
->
[array([[1, 2, 3], [1, 2, 3]]), 
 array([[4, 4, 4], [5, 5, 5]])]
```