### PR TITLE
BUG: decref in failure path; replace `PyObject_Type` by `Py_TYPE`

### DIFF
--- a/numpy/core/src/private/ufunc_override.c
+++ b/numpy/core/src/private/ufunc_override.c
@@ -140,6 +140,9 @@ PyUFunc_WithOverride(PyObject *args, PyObject *kwds,
             if (methods != NULL) {
                 methods[num_override_args] = method;
             }
+            else {
+                Py_DECREF(method);
+            }
             ++num_override_args;
         }
     }
@@ -148,7 +151,12 @@ PyUFunc_WithOverride(PyObject *args, PyObject *kwds,
 fail:
     if (methods != NULL) {
         for (i = 0; i < num_override_args; i++) {
-            Py_XDECREF(methods[i]);
+            Py_DECREF(methods[i]);
+        }
+    }
+    if (with_override != NULL) {
+        for (i = 0; i < num_override_args; i++) {
+            Py_DECREF(with_override[i]);
         }
     }
     return -1;

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -347,8 +347,6 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     PyObject *with_override[NPY_MAXARGS];
     PyObject *array_ufunc_methods[NPY_MAXARGS];
 
-    PyObject *obj;
-    PyObject *other_obj;
     PyObject *out;
 
     PyObject *method_name = NULL;
@@ -511,21 +509,18 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
 
         /* Choose an overriding argument */
         for (i = 0; i < num_override_args; i++) {
-            obj = with_override[i];
-            if (obj == NULL) {
+            override_obj = with_override[i];
+            if (override_obj == NULL) {
                 continue;
             }
 
-            /* Get the first instance of an overriding arg.*/
-            override_obj = obj;
-
             /* Check for sub-types to the right of obj. */
             for (j = i + 1; j < num_override_args; j++) {
-                other_obj = with_override[j];
+                PyObject *other_obj = with_override[j];
                 if (other_obj != NULL &&
-                    PyObject_Type(other_obj) != PyObject_Type(obj) &&
+                    Py_TYPE(other_obj) != Py_TYPE(override_obj) &&
                     PyObject_IsInstance(other_obj,
-                                        PyObject_Type(override_obj))) {
+                                        (PyObject *)Py_TYPE(override_obj))) {
                     override_obj = NULL;
                     break;
                 }


### PR DESCRIPTION
`PyObject_Type` increases the reference count, which was not taken into account.

Split off from #11320, since that one was getting too complex (don't understand the failure in USE_DEBUG...), and this part should probably be back-ported.
