### PR TITLE
DOC: document new functions

### DIFF
--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -63,6 +63,7 @@ Text formatting options
    set_printoptions
    get_printoptions
    set_string_function
+   printoptions
 
 Base-n representations
 ----------------------

--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -126,6 +126,7 @@ Changing the number of dimensions
 
    ma.MaskedArray.squeeze
 
+   ma.stack
    ma.column_stack
    ma.concatenate
    ma.dstack
@@ -141,6 +142,7 @@ Joining arrays
 .. autosummary::
    :toctree: generated/
 
+   ma.stack
    ma.column_stack
    ma.concatenate
    ma.append

--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -56,4 +56,5 @@ Histograms
    histogram2d
    histogramdd
    bincount
+   histogram_bin_edges
    digitize


### PR DESCRIPTION
a few of the functions new to 1.15 were not in any `toctree`, so documentation for them was not generated.

Consider backporting to 1.15, or sneaking the change in to make the release notice a little nicer?