### PR TITLE
MAINT: Add new `_test.c` files and `benchmarks/html` to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ Icon?
 .gdb_history
 ehthumbs.db
 Thumbs.db
+.directory
 
 # pytest generated files #
 ##########################

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ numpy/core/include/numpy/config.h
 numpy/core/include/numpy/multiarray_api.txt
 numpy/core/include/numpy/ufunc_api.txt
 numpy/core/lib/
+numpy/core/src/multiarray/_multiarray_tests.c
 numpy/core/src/multiarray/arraytypes.c
 numpy/core/src/multiarray/einsum.c
 numpy/core/src/multiarray/lowlevel_strided_loops.c
@@ -141,6 +142,10 @@ numpy/core/src/npysort/sort.c
 numpy/core/src/private/npy_binsearch.h
 numpy/core/src/private/npy_partition.h
 numpy/core/src/private/templ_common.h
+numpy/core/src/umath/_operand_flag_tests.c
+numpy/core/src/umath/_rational_tests.c
+numpy/core/src/umath/_struct_ufunc_tests.c
+numpy/core/src/umath/_umath_tests.c
 numpy/core/src/umath/scalarmath.c
 numpy/core/src/umath/funcs.inc
 numpy/core/src/umath/loops.[ch]
@@ -153,6 +158,7 @@ numpy/distutils/__config__.py
 numpy/linalg/umath_linalg.c
 doc/source/reference/generated
 benchmarks/results
+benchmarks/html
 benchmarks/env
 benchmarks/numpy
 # cythonized files


### PR DESCRIPTION
I apologize if the maintenance of the gitignore is usually handled by maintainers or subject to an extensive discussion. But I noticed that some generated files and a generated directory in `benchmarks` seem to be missing and I figured it couldn't hurt to raise this PR.
 
The changes should be self-explanatory. 

Furthermore: Would it be okay to add `.directory` as created by the file manager Dolphin (from KDE) to the gitiginore or is this to specific and would clutter the file? It may fit under the section `OS generated files`.