### PR TITLE
BUG: add missing NpyIter_Close in einsum

### DIFF
--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2857,6 +2857,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
 
         iternext = NpyIter_GetIterNext(iter, NULL);
         if (iternext == NULL) {
+            NpyIter_Close(iter);
             NpyIter_Deallocate(iter);
             Py_DECREF(ret);
             goto fail;
@@ -2880,6 +2881,7 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
     }
 
 finish:
+    NpyIter_Close(iter);
     NpyIter_Deallocate(iter);
     for (iop = 0; iop < nop; ++iop) {
         Py_DECREF(op[iop]);


### PR DESCRIPTION
Backport of #11365.

Fixes #11363

`NpyIter_Close` must be used before `NpyIter_Deallocate` to prevent warnings. 

Looking through the code, I see there are other places with potentially this problem:

- `test_nditer_too_large` (test only)
- 'business_day_offset`, `,business_day_count`, `is_business_day` in `datetime_busday.c` with an `out` arg
- `array_datetime_as_string` in `datetime_strings` with an `out` arg

There are other places where `NpyIter_Dealloc` is called without `NpIter_Close` but they seem to preclude allocating an array with `WRITEBACK_IF_COPY` semantics. Either the output argument is allocated locally or the flags are all `NPY_ITER_READONLY` (famous last words).