### PR TITLE
MAINT: BUG: review need for NpyIter_Close, add missing test for out

### DIFF
--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1034,9 +1034,11 @@ test_nditer_too_large(PyObject *NPY_UNUSED(self), PyObject *args) {
             break;
     }
 
+    NpyIter_Close(iter);
     NpyIter_Deallocate(iter);
     Py_RETURN_NONE;
   fail:
+    NpyIter_Close(iter);
     NpyIter_Deallocate(iter);
     return NULL;
 }

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1112,6 +1112,7 @@ fail:
         Py_XDECREF(op[i]);
     }
     npy_free_cache_dim_obj(dimensions);
+    /* no NpyIter_Close required since output is always allocated */
     NpyIter_Deallocate(iter);
     return NULL;
 }
@@ -1373,6 +1374,7 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
     Py_DECREF(ret_arr);
     Py_XDECREF(indices);
     npy_free_cache_dim_obj(dimensions);
+    /* no NpyIter_Close since iter is NPY_ITER_READONLY */
     NpyIter_Deallocate(iter);
 
     return ret_tuple;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2794,6 +2794,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
                                 NPY_NO_CASTING,
                                 NULL);
     if (src_iter == NULL) {
+        /* no NpyIter_Close since iter is created with NPY_NO_CASTING */
         NpyIter_Deallocate(dst_iter);
         return -1;
     }
@@ -2813,7 +2814,9 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
     src_itemsize = PyArray_DESCR(src)->elsize;
 
     if (dst_iternext == NULL || src_iternext == NULL) {
+        /* no NpyIter_Close since iter is created with NPY_NO_CASTING */
         NpyIter_Deallocate(dst_iter);
+        /* no NpyIter_Close since src_iter is NPY_ITER_READONLY */
         NpyIter_Deallocate(src_iter);
         return -1;
     }
@@ -2834,7 +2837,9 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
                     0,
                     &stransfer, &transferdata,
                     &needs_api) != NPY_SUCCEED) {
+        /* no NpyIter_Close since iter is created with NPY_NO_CASTING */
         NpyIter_Deallocate(dst_iter);
+        /* no NpyIter_Close since src_iter is NPY_ITER_READONLY */
         NpyIter_Deallocate(src_iter);
         return -1;
     }
@@ -2884,7 +2889,9 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
     NPY_END_THREADS;
 
     NPY_AUXDATA_FREE(transferdata);
+    /* no NpyIter_Close since iter is created with NPY_NO_CASTING */
     NpyIter_Deallocate(dst_iter);
+    /* no NpyIter_Close since src_iter is NPY_ITER_READONLY */
     NpyIter_Deallocate(src_iter);
 
     return PyErr_Occurred() ? -1 : 0;

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3519,6 +3519,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
 
     iternext = NpyIter_GetIterNext(iter, NULL);
     if (iternext == NULL) {
+        /* no NpyIter_Close since iter is NPY_ITER_READONLY */
         NpyIter_Deallocate(iter);
         return -1;
     }
@@ -3533,6 +3534,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
     tmp_buffer = PyArray_malloc(maxlen+1);
     if (tmp_buffer == NULL) {
         PyErr_NoMemory();
+        /* no NpyIter_Close since iter is NPY_ITER_READONLY */
         NpyIter_Deallocate(iter);
         return -1;
     }
@@ -3585,6 +3587,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
     } while(iternext(iter));
 
     PyArray_free(tmp_buffer);
+    /* no NpyIter_Close since iter is NPY_ITER_READONLY */
     NpyIter_Deallocate(iter);
 
     return 0;

--- a/numpy/core/src/multiarray/datetime_busday.c
+++ b/numpy/core/src/multiarray/datetime_busday.c
@@ -562,6 +562,8 @@ finish:
     Py_XDECREF(dtypes[1]);
     Py_XDECREF(dtypes[2]);
     if (iter != NULL) {
+        /* not needed since iter is created with NPY_SAFE_CASTING */
+        /* NpyIter_Close(iter); */
         if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
             Py_XDECREF(ret);
             ret = NULL;
@@ -697,6 +699,8 @@ finish:
     Py_XDECREF(dtypes[1]);
     Py_XDECREF(dtypes[2]);
     if (iter != NULL) {
+        /* not needed since iter is created with NPY_SAFE_CASTING */
+        /* NpyIter_Close(iter); */
         if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
             Py_XDECREF(ret);
             ret = NULL;
@@ -822,6 +826,7 @@ finish:
     Py_XDECREF(dtypes[0]);
     Py_XDECREF(dtypes[1]);
     if (iter != NULL) {
+        NpyIter_Close(iter);
         if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
             Py_XDECREF(ret);
             ret = NULL;

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1575,6 +1575,7 @@ array_datetime_as_string(PyObject *NPY_UNUSED(self), PyObject *args,
     Py_XDECREF(op_dtypes[0]);
     Py_XDECREF(op_dtypes[1]);
     if (iter != NULL) {
+        /* no NpyIter_Close needed since writeable output is freshly created */
         NpyIter_Deallocate(iter);
     }
 

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2133,6 +2133,7 @@ PyArray_CountNonzero(PyArrayObject *self)
     /* Get the pointers for inner loop iteration */
     iternext = NpyIter_GetIterNext(iter, NULL);
     if (iternext == NULL) {
+        /* no NpyIter_Close since iter has NPY_ITER_READONLY */
         NpyIter_Deallocate(iter);
         return -1;
     }
@@ -2165,6 +2166,7 @@ PyArray_CountNonzero(PyArrayObject *self)
 finish:
     NPY_END_THREADS;
 
+    /* no NpyIter_Close since iter has NPY_ITER_READONLY */
     NpyIter_Deallocate(iter);
 
     return nonzero_count;
@@ -2291,12 +2293,14 @@ PyArray_Nonzero(PyArrayObject *self)
         /* Get the pointers for inner loop iteration */
         iternext = NpyIter_GetIterNext(iter, NULL);
         if (iternext == NULL) {
+            /* no NpyIter_Close since iter has NPY_ITER_READONLY */
             NpyIter_Deallocate(iter);
             Py_DECREF(ret);
             return NULL;
         }
         get_multi_index = NpyIter_GetGetMultiIndex(iter, NULL);
         if (get_multi_index == NULL) {
+            /* no NpyIter_Close since iter has NPY_ITER_READONLY */
             NpyIter_Deallocate(iter);
             Py_DECREF(ret);
             return NULL;
@@ -2330,6 +2334,7 @@ PyArray_Nonzero(PyArrayObject *self)
         NPY_END_THREADS;
     }
 
+    /* no NpyIter_Close since iter has NPY_ITER_READONLY */
     NpyIter_Deallocate(iter);
 
 finish:

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1698,6 +1698,12 @@ class TestDateTime(object):
         assert_equal(np.busday_offset(np.datetime64('NaT'), 1, roll='preceding'),
                      np.datetime64('NaT'))
 
+        # Use out
+        out = np.array(['2006-02-01'], dtype='datetime64[ms]')
+        a = np.array(['2006-02-01'], dtype='datetime64[D]')
+        res = np.busday_offset(a, 25.0, out=out)
+        assert_equal(res, out)
+        assert_equal(res[0], np.datetime64('2006-03-08'))
 
     def test_datetime_busdaycalendar(self):
         # Check that it removes NaT, duplicates, and weekends


### PR DESCRIPTION
After reviewing all the places `NpyIter_Dealloc` is called without `NpyIter_Close`, it seems the only case that can trigger the need to call `NpyIter_Close` (reminder: that is needed when an operand has been created with the `WRITEBACK_IF_COPY` flag) is in one of the compiled test modules.

I left comments next to the calls to `NpyIter_Dealloc` as reminders and for reviewers.

I also added a passing test for the `out` argument in `np.busday_offset`, see issue #11369 about test coverage