### PR TITLE
WIP: BUG: Prevent running initialize_numeric_types more than once

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4216,6 +4216,10 @@ static void init_basetypes(void);
 NPY_NO_EXPORT void
 initialize_numeric_types(void)
 {
+    if (PyUnicodeArrType_Type.tp_flags & Py_TPFLAGS_READY) {
+        /* already called */
+        return;
+    }
     init_basetypes();
     PyGenericArrType_Type.tp_dealloc = (destructor)gentype_dealloc;
     PyGenericArrType_Type.tp_as_number = &gentype_as_number;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7582,3 +7582,8 @@ def test_npymath_real():
                 got = fun(z)
                 expected = npfun(z)
                 assert_allclose(got, expected)
+
+def test_double_import():
+    sys.modules['np'] = sys.modules['numpy']
+    # ensure no segfault on python3
+    __import__('np.core.multiarray')


### PR DESCRIPTION
This code
```
import sys, numpy
sys.modules['np'] = sys.modules['numpy']
__import__('np.core.multiarray')
```
will segfault on CPython3. The code calls `PyInit_multiarray` a second time, which gets to `initialize_numeric_types`, which tries to reinitialize all the `Py*ArrType_Type`s. Normally `PyType_Ready` will check the `tp_flags` for initialized type objects, but `initialize_numeric_types` resets the flags and many more pointers. The easiest fix is to check if one of the types has already been initialized.