### PR TITLE
BUG: better detect memory overlap when calling gufuncs

### DIFF
--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2769,8 +2769,11 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
 
     /* Initialize the output to all zeros and reset the iterator */
     ret = NpyIter_GetOperandArray(iter)[nop];
-    Py_INCREF(ret);
     PyArray_AssignZero(ret, NULL);
+    if (out) {
+        ret = out;
+    }
+    Py_INCREF(ret);
 
 
     /***************************/

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2609,8 +2609,11 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     for (i = 0; i < nin; ++i) {
         op_flags[i] = NPY_ITER_READONLY |
                       NPY_ITER_COPY |
-                      NPY_ITER_ALIGNED |
-                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+                      NPY_ITER_ALIGNED;
+        if (op[i] && PyArray_NDIM(op[i]) < 2) {
+            op_flags[i] |= NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+        }
+
         /*
          * If READWRITE flag has been set for this operand,
          * then clear default READONLY flag
@@ -2625,8 +2628,10 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                       NPY_ITER_UPDATEIFCOPY|
                       NPY_ITER_ALIGNED|
                       NPY_ITER_ALLOCATE|
-                      NPY_ITER_NO_BROADCAST|
-                      NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+                      NPY_ITER_NO_BROADCAST;
+        if (op[i] && PyArray_NDIM(op[i]) < 2) {
+            op_flags[i] |= NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+        }
     }
 
     iter_flags = ufunc->iter_flags |

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -948,3 +948,8 @@ class TestUFunc(object):
 
         x += x.T
         assert_array_equal(x - x.T, 0)
+
+def test_matrix_multiply_overlap():
+    a = np.arange(9, dtype=int).reshape(3,3)
+    b = a.copy()
+    assert_copy_equivalent(_umath_tests.matrix_multiply, [a, b], out=b)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7387,6 +7387,13 @@ class TestWritebackIfCopy(object):
         # if HAVE_CBLAS, will use WRITEBACKIFCOPY
         a = np.arange(9, dtype=float).reshape(3,3)
         b = np.dot(a, a, out=a)
+        assert b is a
+        assert_equal(b, np.array([[15, 18, 21], [42, 54, 66], [69, 90, 111]]))
+
+    def test_matmul_out(self):
+        a = np.arange(9, dtype=float).reshape(3,3)
+        b = np.matmul(a, a, out=a)
+        assert b is a
         assert_equal(b, np.array([[15, 18, 21], [42, 54, 66], [69, 90, 111]]))
 
     def test_view_assign(self):


### PR DESCRIPTION
Ufuncs need to check output args for memory overlap. In `PyUFunc_GeneralizedFunction`, the check assumed the gufunc was operating elementwise.

Found when I started implementing matmul as a gufunc. We seem to have avoided this issue by not having an `out` `kwarg` in our current gufuncs (i.e. `linalg`, see issue #11380).

This may impact downstream users of gufuncs who already try to detect this condition, but brings gufuncs into alignment with ufuncs and the comment in the code "For generalized ufuncs, we can't do buffering, so must COPY or UPDATEIFCOPY".

Test added that failed before, now passes. An additional passing test added for `matmul`, which currently uses `einsum` for implementation, but that will change in the future.