### PR TITLE
DEP: Deprecate the normed argument to histogramdd to match histogram

### DIFF
--- a/doc/release/1.15.0-notes.rst
+++ b/doc/release/1.15.0-notes.rst
@@ -281,8 +281,8 @@ data. Previously, this could not be specified on a per-axis basis.
 The normed arguments of ``histogramdd`` and ``histogram2d`` have been renamed
 -----------------------------------------------------------------------------
 These arguments are now called ``density``, which is consistent with
-``histogram``. The old argument continues to work, but the new name should be
-preferred.
+``histogram``. The old argument continues to work, but in a future release will
+be deprecated.
 
 ``np.r_`` works with 0d arrays, and ``np.ma.mr_`` works with ``np.ma.masked``
 ----------------------------------------------------------------------------

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -4,6 +4,7 @@ Histogram-related functions
 from __future__ import division, absolute_import, print_function
 
 import operator
+import warnings
 
 import numpy as np
 from numpy.compat.py3k import basestring
@@ -944,12 +945,16 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
     core = D*(slice(1, -1),)
     hist = hist[core]
 
-    # handle the aliasing normed argument
+    # handle the deprecated normed argument
     if normed is None:
         if density is None:
             density = False
     elif density is None:
-        # an explicit normed argument was passed, alias it to the new name
+        # 2018-06-20, NumPy 1.15.0
+        warnings.warn(
+            "The 'normed' argument to histogramdd is being renamed to "
+            "'density', to match np.histogram",
+            PendingDeprecationWarning, stacklevel=2)
         density = normed
     else:
         raise TypeError("Cannot specify both 'normed' and 'density'")

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -731,3 +731,14 @@ class TestHistogramdd(object):
         hist_dd, edges_dd = histogramdd((v,), (bins,), density=True)
         assert_equal(hist, hist_dd)
         assert_equal(edges, edges_dd[0])
+
+    def test_normed_argument(self):
+        v = np.arange(10)
+        bins = np.array([0, 1, 3, 6, 10])
+        # 2018-06-20, NumPy 1.15.0
+        assert_warns(
+            PendingDeprecationWarning,
+            lambda: histogramdd((v,), (bins,), normed=True))
+        assert_raises(
+            TypeError,
+            lambda: histogramdd((v,), (bins,), normed=True, density=False))


### PR DESCRIPTION
Only emit pending deprecation warnings, to give people a few releases to switch over, rather than making them have to pick a numpy version to squash warnings.

~Fixes gh-4371~

Leaving this as PendingDeprecationWarning since we're late in the release cycle - the important thing is to get the new argument name in, not to make noise about the old one.