### PR TITLE
DOC: Update testing section of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ It provides:
 - tools for integrating C/C++ and Fortran code
 - useful linear algebra, Fourier transform, and random number capabilities
 
-If ``nose`` is installed, tests can be run after installation with:
+Testing:
+
+- NumPy versions >= 1.15 require ``pytest``
+- NumPy versions < 1.15 require ``nose``
+
+Tests can then be run after installation with:
 
     python -c 'import numpy; numpy.test()'
 


### PR DESCRIPTION
Note that `pytest` is required for NumPy >= 1.15

[ci skip]