### PR TITLE
BUG: Fix incorrect deprecation logic for histogram(normed=...) (1.15.x)

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -782,7 +782,7 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
                     "The normed argument is ignored when density is provided. "
                     "In future passing both will result in an error.",
                     DeprecationWarning, stacklevel=2)
-        normed = False
+        normed = None
 
     if density:
         db = np.array(np.diff(bin_edges), float)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -78,6 +78,10 @@ class TestHistogram(object):
         assert_array_equal(a, .1)
         assert_equal(np.sum(a * np.diff(b)), 1)
 
+        # Test that passing False works too
+        a, b = histogram(v, bins, density=False)
+        assert_array_equal(a, [1, 2, 3, 4])
+
         # Variale bin widths are especially useful to deal with
         # infinities.
         v = np.arange(10)


### PR DESCRIPTION
Fixes #11426, which was introduced in #11323 and #11352 

Forward-ported at #11428