### PR TITLE
MAINT: add PyPI classifier for Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering


### PR DESCRIPTION
``[ci skip]``

Noticed this was missing. should also be backported to 1.15.x I think, we need 3.7 wheels for that release.