### PR TITLE
DOC: Document average return type

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -310,10 +310,10 @@ def average(a, axis=None, weights=None, returned=False):
         of the weights as the second element. `sum_of_weights` is of the
         same type as `average`. The result dtype follows a genereal pattern.
         If `weights` is None, the result dtype will be that of `a` , or `float64`
-        if `a` is integral. Otherwise, if `weights` is not None and `a` is non
+        if `a` is integral. Otherwise, if `weights` is not None and `a` is non-
         integral, the result type will be the type of lowest precision capable of
-        representing values of both `a` and `weights` but if `a` happens to be
-        integral, the previous rules still applies but the result dtype would
+        representing values of both `a` and `weights`. If `a` happens to be
+        integral, the previous rules still applies but the result dtype will
         at least be `float64`.
 
     Raises
@@ -332,7 +332,8 @@ def average(a, axis=None, weights=None, returned=False):
     ma.average : average for masked arrays -- useful if your data contains
                  "missing" values
     numpy.result_type : Returns the type that results from applying the
-                        NumPy type promotion rules to the arguments.
+                        numpy type promotion rules to the arguments.
+
     Examples
     --------
     >>> data = range(1,5)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -308,11 +308,14 @@ def average(a, axis=None, weights=None, returned=False):
         Return the average along the specified axis. When `returned` is `True`,
         return a tuple with the average as the first element and the sum
         of the weights as the second element. `sum_of_weights` is of the
-        same type as `average`. The result type is the type of lowest precision
-        capable of representing values of both `a` and `weights` or 'float64'
-        if that type would be integral. Otherwise, if `a` is non integral,
-        result will be a `dtype` which is capable of representing both
-        `a.dtype` and `wgt.dtype`
+        same type as `average`. The result dtype follows a genereal pattern.
+        If `weights` is None, the result dtype will be that of `a` , or `float64`
+        if `a` is integral. Otherwise, if `weights` is not None and `a` is non
+        integral, the result type will be the type of lowest precision capable of
+        representing values of both `a` and `weights` but if `a` happens to be
+        integral, the previous rules still applies but the result dtype would
+        at least be `float64`.
+
     Raises
     ------
     ZeroDivisionError
@@ -348,9 +351,11 @@ def average(a, axis=None, weights=None, returned=False):
     >>> np.average(data, axis=1, weights=[1./4, 3./4])
     array([ 0.75,  2.75,  4.75])
     >>> np.average(data, weights=[1./4, 3./4])
+    
     Traceback (most recent call last):
     ...
     TypeError: Axis must be specified when shapes of a and weights differ.
+    
     >>> a = np.ones(5, dtype=np.float128)
     >>> w = np.ones(5, dtype=np.complex64)
     >>> avg = np.average(a, weights=w)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -305,9 +305,9 @@ def average(a, axis=None, weights=None, returned=False):
     Returns
     -------
     average, [sum_of_weights] : array_type or double
-        Return the average along the specified axis. When returned is `True`,
+        Return the average along the specified axis. When `returned` is `True`,
         return a tuple with the average as the first element and the sum
-        of the weights as the second element.`sum_of_weights` is of the
+        of the weights as the second element. `sum_of_weights` is of the
         same type as `average`. The result type is the type of lowest precision
         capable of representing values of both `a` and `weights` or 'float64'
         if that type would be integral. Otherwise, if `a` is non integral,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -307,10 +307,12 @@ def average(a, axis=None, weights=None, returned=False):
     average, [sum_of_weights] : array_type or double
         Return the average along the specified axis. When returned is `True`,
         return a tuple with the average as the first element and the sum
-        of the weights as the second element. The return type is `Float`
-        if `a` is of integer type, otherwise it is of the same type as `a`.
-        `sum_of_weights` is of the same type as `average`.
-
+        of the weights as the second element.`sum_of_weights` is of the
+        same type as `average`. The result type is the type of lowest precision
+        capable of representing values of both `a` and `weights` or 'float64'
+        if that type would be integral. Otherwise, if `a` is non integral,
+        result will be a `dtype` which is capable of representing both
+        `a.dtype` and `wgt.dtype`
     Raises
     ------
     ZeroDivisionError
@@ -326,7 +328,8 @@ def average(a, axis=None, weights=None, returned=False):
 
     ma.average : average for masked arrays -- useful if your data contains
                  "missing" values
-
+    numpy.result_type : Returns the type that results from applying the
+                        NumPy type promotion rules to the arguments.
     Examples
     --------
     >>> data = range(1,5)
@@ -348,7 +351,11 @@ def average(a, axis=None, weights=None, returned=False):
     Traceback (most recent call last):
     ...
     TypeError: Axis must be specified when shapes of a and weights differ.
-
+    >>> a = np.ones(5, dtype=np.float128)
+    >>> w = np.ones(5, dtype=np.complex64)
+    >>> avg = np.average(a, weights=w)
+    >>> print(avg.dtype)
+    complex256
     """
     a = np.asanyarray(a)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -304,17 +304,17 @@ def average(a, axis=None, weights=None, returned=False):
 
     Returns
     -------
-    average, [sum_of_weights] : array_type or double
+    retval, [sum_of_weights] : array_type or double
         Return the average along the specified axis. When `returned` is `True`,
         return a tuple with the average as the first element and the sum
         of the weights as the second element. `sum_of_weights` is of the
-        same type as `average`. The result dtype follows a genereal pattern.
-        If `weights` is None, the result dtype will be that of `a` , or `float64`
+        same type as `retval`. The result dtype follows a genereal pattern.
+        If `weights` is None, the result dtype will be that of `a` , or ``float64``
         if `a` is integral. Otherwise, if `weights` is not None and `a` is non-
         integral, the result type will be the type of lowest precision capable of
         representing values of both `a` and `weights`. If `a` happens to be
         integral, the previous rules still applies but the result dtype will
-        at least be `float64`.
+        at least be ``float64``.
 
     Raises
     ------


### PR DESCRIPTION
Updating average Docs as per Issue :Return dtype of numpy.average(a, ...) is not always that of its first argument #11290