### PR TITLE
DOC: Fix documentation for fromfunction

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1897,7 +1897,7 @@ def fromfunction(function, shape, **kwargs):
         The result of the call to `function` is passed back directly.
         Therefore the shape of `fromfunction` is completely determined by
         `function`.  If `function` returns a scalar value, the shape of
-        `fromfunction` would match the `shape` parameter.
+        `fromfunction` would not match the `shape` parameter.
 
     See Also
     --------


### PR DESCRIPTION
```np.fromfunction(lambda i, j: 1, (3, 3), dtype=int)``` returns ```1```.