### PR TITLE
[WIP] BLD / BENCH: draft changes for quick asv run in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
       -  run:
           name: asv verification
           command: |
+              . venv/bin/activate
               # quick asv run to verify that there are no
               # errors when running the suite
               cd benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install cython sphinx matplotlib
+            pip install cython sphinx matplotlib asv
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
@@ -105,3 +105,15 @@ jobs:
             else
               echo "Not on the master branch; skipping deployment"
             fi
+
+      -  run:
+          name: asv verification
+          command: |
+              # quick asv run to verify that there are no
+              # errors when running the suite
+              cd benchmarks
+              # TODO: can we override the asv.conf.json
+              # for things like environment type, Python
+              # version(s), and pull in the branch identification
+              # from the PR?
+              asv run -e --quick


### PR DESCRIPTION
I discussed this a bit with @mattip, but I'm curious what others think about the idea of using CircleCI to make sure that any given PR doesn't break (cause an error during) the running of the `asv` suite.

There's no suggestion that the results of this would be reliable from a performance regression standpoint (nor stored as an artifact) -- it is just intended as a "prevent errors in the asv suite" check. Looks like ~5 minutes or so for the full NumPy suite, if not less, when done in "quick" mode where a given benchmark just runs once.

As noted in the comments, I'm not entirely sure how to do this for a given PR elegantly w.r.t overriding some of the settings in `asv.conf.json`; I suppose an ugly solution would be to pull out PR branch name and so on from CircleCI & then programmatically alter the contents of asv.conf.json before the test, but perhaps it is indeed possible to use the command line to override most / all of the directives in the file (I've not had success with altering things like the branch name / env type from command line though).

The best attempt I've seen so far for this kind of thing [is an open SciPy PR](https://github.com/scipy/scipy/pull/8779/files) that appears to merge the PR branch into master & write a custom JSON config file as needed. There doesn't seem to be too much resistance to the idea there--just have to think carefully about doing it cleanly it seems.

