### PR TITLE
DOC: include NEP number on each NEP page

### DIFF
--- a/doc/neps/index.rst.tmpl
+++ b/doc/neps/index.rst.tmpl
@@ -15,7 +15,7 @@ Meta-NEPs (NEPs about NEPs or Processes)
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Type'] == 'Process' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
    nep-template
@@ -27,7 +27,7 @@ Accepted NEPs, implementation in progress
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Status'] == 'Accepted' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
 
@@ -38,7 +38,7 @@ Open NEPs (under consideration)
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Status'] == 'Draft' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
 
@@ -50,7 +50,7 @@ Implemented NEPs
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Status'] == 'Final' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
 Deferred NEPs
@@ -60,7 +60,7 @@ Deferred NEPs
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Status'] == 'Deferred' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 
 Rejected NEPs
@@ -70,5 +70,5 @@ Rejected NEPs
    :maxdepth: 1
 
 {% for nep, tags in neps.items() if tags['Status'] == 'Rejected' %}
-   NEP {{ nep }} — {{ tags['Title'] }} <{{ tags['Filename'] }}>
+   {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}

--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -1,6 +1,6 @@
-===================
-Purpose and Process
-===================
+===========================
+NEP 0 — Purpose and Process
+===========================
 
 :Author: Jarrod Millman <millman@berkeley.edu>
 :Status: Active

--- a/doc/neps/nep-0001-npy-format.rst
+++ b/doc/neps/nep-0001-npy-format.rst
@@ -1,6 +1,6 @@
-=====================================
-A Simple File Format for NumPy Arrays
-=====================================
+=============================================
+NEP 1 — A Simple File Format for NumPy Arrays
+=============================================
 
 :Author: Robert Kern <robert.kern@gmail.com>
 :Status: Final

--- a/doc/neps/nep-0002-warnfix.rst
+++ b/doc/neps/nep-0002-warnfix.rst
@@ -1,6 +1,6 @@
-=========================================================================
-A proposal to build numpy without warning with a big set of warning flags
-=========================================================================
+=================================================================================
+NEP 2 — A proposal to build numpy without warning with a big set of warning flags
+=================================================================================
 
 :Author: David Cournapeau
 :Contact: david@ar.media.kyoto-u.ac.jp

--- a/doc/neps/nep-0003-math_config_clean.rst
+++ b/doc/neps/nep-0003-math_config_clean.rst
@@ -1,6 +1,6 @@
-===========================================================
-Cleaning the math configuration of numpy.core
-===========================================================
+=====================================================
+NEP 3 — Cleaning the math configuration of numpy.core
+=====================================================
 
 :Author: David Cournapeau
 :Contact: david@ar.media.kyoto-u.ac.jp

--- a/doc/neps/nep-0004-datetime-proposal3.rst
+++ b/doc/neps/nep-0004-datetime-proposal3.rst
@@ -1,6 +1,6 @@
-====================================================================
- A (third) proposal for implementing some date/time types in NumPy
-====================================================================
+=========================================================================
+NEP 4 — A (third) proposal for implementing some date/time types in NumPy
+=========================================================================
 
 :Author: Francesc Alted i Abad
 :Contact: faltet@pytables.com

--- a/doc/neps/nep-0005-generalized-ufuncs.rst
+++ b/doc/neps/nep-0005-generalized-ufuncs.rst
@@ -1,6 +1,6 @@
-===============================
-Generalized Universal Functions
-===============================
+=======================================
+NEP 5 — Generalized Universal Functions
+=======================================
 
 :Status: Final
 

--- a/doc/neps/nep-0006-newbugtracker.rst
+++ b/doc/neps/nep-0006-newbugtracker.rst
@@ -1,6 +1,6 @@
-===========================================
-Replacing Trac with a different bug tracker
-===========================================
+===================================================
+NEP 6 — Replacing Trac with a different bug tracker
+===================================================
 
 :Author: David Cournapeau, Stefan van der Walt
 :Status: Deferred

--- a/doc/neps/nep-0007-datetime-proposal.rst
+++ b/doc/neps/nep-0007-datetime-proposal.rst
@@ -1,6 +1,6 @@
-====================================================================
- A proposal for implementing some date/time types in NumPy
-====================================================================
+==================================================================
+NEP 7 — A proposal for implementing some date/time types in NumPy
+==================================================================
 
 :Author: Travis Oliphant
 :Contact: oliphant@enthought.com

--- a/doc/neps/nep-0008-groupby_additions.rst
+++ b/doc/neps/nep-0008-groupby_additions.rst
@@ -1,6 +1,6 @@
-====================================================================
- A proposal for adding groupby functionality to NumPy
-====================================================================
+=============================================================
+NEP 8 —  A proposal for adding groupby functionality to NumPy
+=============================================================
 
 :Author: Travis Oliphant
 :Contact: oliphant@enthought.com

--- a/doc/neps/nep-0009-structured_array_extensions.rst
+++ b/doc/neps/nep-0009-structured_array_extensions.rst
@@ -1,6 +1,6 @@
-===========================
-Structured array extensions
-===========================
+===================================
+NEP 9 — Structured array extensions
+===================================
 
 :Status: Deferred
 

--- a/doc/neps/nep-0010-new-iterator-ufunc.rst
+++ b/doc/neps/nep-0010-new-iterator-ufunc.rst
@@ -1,6 +1,6 @@
-=====================================
-Optimizing Iterator/UFunc Performance
-=====================================
+==============================================
+NEP 10 — Optimizing Iterator/UFunc Performance
+==============================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
 :Content-Type: text/x-rst

--- a/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
+++ b/doc/neps/nep-0011-deferred-ufunc-evaluation.rst
@@ -1,6 +1,6 @@
-=========================
-Deferred UFunc Evaluation
-=========================
+==================================
+NEP 11 — Deferred UFunc Evaluation
+==================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
 :Content-Type: text/x-rst

--- a/doc/neps/nep-0012-missing-data.rst
+++ b/doc/neps/nep-0012-missing-data.rst
@@ -1,6 +1,6 @@
-===================================
-Missing Data Functionality in NumPy
-===================================
+============================================
+NEP 12 — Missing Data Functionality in NumPy
+============================================
 
 :Author: Mark Wiebe <mwwiebe@gmail.com>
 :Copyright: Copyright 2011 by Enthought, Inc

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -1,6 +1,6 @@
-=================================
-A Mechanism for Overriding Ufuncs
-=================================
+==========================================
+NEP 13 — A Mechanism for Overriding Ufuncs
+==========================================
 
 .. currentmodule:: numpy
 

--- a/doc/neps/nep-0014-dropping-python2.7-proposal.rst
+++ b/doc/neps/nep-0014-dropping-python2.7-proposal.rst
@@ -1,6 +1,6 @@
-====================================
-Plan for dropping Python 2.7 support
-====================================
+=============================================
+NEP 14 — Plan for dropping Python 2.7 support
+=============================================
 
 :Status: Accepted
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2017-November/077419.html

--- a/doc/neps/nep-0015-merge-multiarray-umath.rst
+++ b/doc/neps/nep-0015-merge-multiarray-umath.rst
@@ -1,6 +1,6 @@
-============================
-Merging multiarray and umath
-============================
+=====================================
+NEP 15 — Merging multiarray and umath
+=====================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>
 :Status: Draft

--- a/doc/neps/nep-0017-split-out-maskedarray.rst
+++ b/doc/neps/nep-0017-split-out-maskedarray.rst
@@ -1,6 +1,6 @@
-=======================
-Split Out Masked Arrays
-=======================
+================================
+NEP 17 — Split Out Masked Arrays
+================================
 
 :Author: Stéfan van der Walt <stefanv@berkeley.edu>
 :Status: Rejected

--- a/doc/neps/nep-0018-array-function-protocol.rst
+++ b/doc/neps/nep-0018-array-function-protocol.rst
@@ -1,6 +1,6 @@
-===========================================================
-A dispatch mechanism for NumPy's high level array functions
-===========================================================
+====================================================================
+NEP 18 — A dispatch mechanism for NumPy's high level array functions
+====================================================================
 
 :Author: Stephan Hoyer <shoyer@google.com>
 :Author: Matthew Rocklin <mrocklin@gmail.com>

--- a/doc/neps/nep-0019-rng-policy.rst
+++ b/doc/neps/nep-0019-rng-policy.rst
@@ -1,6 +1,6 @@
-==============================
-Random Number Generator Policy
-==============================
+=======================================
+NEP 19 — Random Number Generator Policy
+=======================================
 
 :Author: Robert Kern <robert.kern@gmail.com>
 :Status: Draft

--- a/doc/neps/nep-0020-gufunc-signature-enhancement.rst
+++ b/doc/neps/nep-0020-gufunc-signature-enhancement.rst
@@ -1,6 +1,6 @@
-======================================================
-Expansion of Generalized Universal Function Signatures
-======================================================
+===============================================================
+NEP 20 — Expansion of Generalized Universal Function Signatures
+===============================================================
 
 :Author: Marten van Kerkwijk <mhvk@astro.utoronto.ca>
 :Status: Draft

--- a/doc/neps/nep-0021-advanced-indexing.rst
+++ b/doc/neps/nep-0021-advanced-indexing.rst
@@ -1,6 +1,6 @@
-=========================================
-Simplified and explicit advanced indexing
-=========================================
+==================================================
+NEP 21 — Simplified and explicit advanced indexing
+==================================================
 
 :Author: Sebastian Berg
 :Author: Stephan Hoyer <shoyer@google.com>

--- a/doc/neps/tools/build_index.py
+++ b/doc/neps/tools/build_index.py
@@ -40,6 +40,10 @@ def nep_metadata():
             tags['Title'] = lines[1].strip()
             tags['Filename'] = source
 
+        if not tags['Title'].startswith(f'NEP {nr} — '):
+            raise RuntimeError(
+                f'Title for NEP {nr} does not start with "NEP {nr} — " '
+                '(note that — here is a special, enlongated dash)')
 
         if tags['Status'] in ('Accepted', 'Rejected', 'Withdrawn'):
             if not 'Resolution' in tags:


### PR DESCRIPTION
Currently, if you include a NEP number in the title of a NEP, it gets rendered twice in the index.

This is just a minor annoyance I noticed while writing a few NEPs recently.