### PR TITLE
BUG: random: Avoid bad behavior of hypergeometric with very large arguments.

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4259,8 +4259,12 @@ cdef class RandomState:
 
             if lngood < 0:
                 raise ValueError("ngood < 0")
+            if lngood >= 2**30:
+                raise ValueError("ngood must be less than 2**30")
             if lnbad < 0:
                 raise ValueError("nbad < 0")
+            if lnbad >= 2**30:
+                raise ValueError("nbad must be less than 2**30")
             if lnsample < 1:
                 raise ValueError("nsample < 1")
             if lngood + lnbad < lnsample:
@@ -4270,8 +4274,12 @@ cdef class RandomState:
 
         if np.any(np.less(ongood, 0)):
             raise ValueError("ngood < 0")
+        if np.any(np.greater_equal(ongood, 2**30)):
+            raise ValueError("ngood must be less than 2**30")
         if np.any(np.less(onbad, 0)):
             raise ValueError("nbad < 0")
+        if np.any(np.greater_equal(onbad, 2**30)):
+            raise ValueError("nbad must be less than 2**30")
         if np.any(np.less(onsample, 1)):
             raise ValueError("nsample < 1")
         if np.any(np.less(np.add(ongood, onbad),onsample)):

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -25,11 +25,9 @@ class TestRegression(object):
 
         # Test for ticket #5623
         args = [
-            (2**20 - 2, 2**20 - 2, 2**20 - 2),  # Check for 32-bit systems
+            (2**20 - 2, 2**20 - 2, 2**20 - 2),
+            (2**30 - 1, 2**30 - 1, 2**30 - 1),
         ]
-        is_64bits = sys.maxsize > 2**32
-        if is_64bits and sys.platform != 'win32':
-            args.append((2**40 - 2, 2**40 - 2, 2**40 - 2)) # Check for 64-bit systems
         for arg in args:
             assert_(np.random.hypergeometric(*arg) > 0)
 


### PR DESCRIPTION
The changes in this pull request restrict the arguments ngood and nbad
of numpy.random.hypergeometric to be less than 2**30.  This "fix" (in the
sense of the old joke "Doctor, it hurts when I do *this*") makes the
following problems impossible to encounter:

* Python hangs with these calls (see gh-11443):

      np.random.hypergeometric(2**62-1, 2**62-1, 26, size=2)
      np.random.hypergeometric(2**62-1, 2**62-1, 11, size=12)

* Also reported in gh-11443: the distribution of the variates of

      np.random.hypergeometric(ngood, nbad, nsample)

  is not correct when nsample >= 10 and ngood + nbad is sufficiently large.
  I don't have a rigorous bound, but a histogram of the p-values of 1500
  runs of a G-test with size=5000000 in each run starts to look suspicious
  when ngood + nbad is approximately `2**37`.  When the sum is greater than
  `2**38`, the distribution is clearly wrong, and, as reported in the pull
  request gh-9834, the following call returns all zeros:

      np.random.hypergeometric(2**55, 2**55, 10, size=20)

* The code does not check for integer overflow of ngood + nbad, so the
  following call

      np.random.hypergeometric(2**62, 2**62, 1)

  on a system where the default integer is 64 bit results in
  `ValueError: ngood + nbad < nsample`.

By restricting the two arguments to be less than `2**30`, the values are
well within the space of inputs for which I have no evidence of the
function generating an incorrect distribution, and the overflow problem
is avoided for both 32-bit and 64-bit systems.

I replaced the test for `hypergeometric(2**40 - 2, 2**40 - 2, 2**40 - 2) > 0`
with `hypergeometric(2**30 - 1, 2**30 - 1, 2**30 - 1) > 0`.  The test was a
regression test for a bug in which the function would enter an infinite
loop when the arguments were sufficiently large.  The regression test for
the fix included the call `hypergeometric(2**40 - 2, 2**40 - 2, 2**40 - 2)`
on systems with 64 bit integers.  This call is now disallowed, so I add a
call with the maximum allowed values of ngood and nbad.