### PR TITLE
MAINT: improve error message for isposinf and isneginf on complex values

### DIFF
--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -11,26 +11,28 @@ from numpy.testing import (
 class TestUfunclike(object):
 
     def test_isposinf(self):
-        a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])
-        out = nx.zeros(a.shape, bool)
-        tgt = nx.array([True, False, False, False, False, False])
+        for dtype in [np.float, np.complex]:
+            a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0], dtype=dtype)
+            out = nx.zeros(a.shape, bool)
+            tgt = nx.array([True, False, False, False, False, False])
 
-        res = ufl.isposinf(a)
-        assert_equal(res, tgt)
-        res = ufl.isposinf(a, out)
-        assert_equal(res, tgt)
-        assert_equal(out, tgt)
+            res = ufl.isposinf(a)
+            assert_equal(res, tgt)
+            res = ufl.isposinf(a, out)
+            assert_equal(res, tgt)
+            assert_equal(out, tgt)
 
     def test_isneginf(self):
-        a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])
-        out = nx.zeros(a.shape, bool)
-        tgt = nx.array([False, True, False, False, False, False])
+        for dtype in [np.float, np.complex]:
+            a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0], dtype=dtype)
+            out = nx.zeros(a.shape, bool)
+            tgt = nx.array([False, True, False, False, False, False])
 
-        res = ufl.isneginf(a)
-        assert_equal(res, tgt)
-        res = ufl.isneginf(a, out)
-        assert_equal(res, tgt)
-        assert_equal(out, tgt)
+            res = ufl.isneginf(a)
+            assert_equal(res, tgt)
+            res = ufl.isneginf(a, out)
+            assert_equal(res, tgt)
+            assert_equal(out, tgt)
 
     def test_fix(self):
         a = nx.array([[1.0, 1.1, 1.5, 1.8], [-1.0, -1.1, -1.5, -1.8]])

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -4,8 +4,8 @@ import numpy as np
 import numpy.core as nx
 import numpy.lib.ufunclike as ufl
 from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, assert_warns
-    )
+    assert_, assert_equal, assert_array_equal, assert_warns, assert_raises
+)
 
 
 class TestUfunclike(object):
@@ -21,6 +21,10 @@ class TestUfunclike(object):
         assert_equal(res, tgt)
         assert_equal(out, tgt)
 
+        a = a.astype(np.complex)
+        with assert_raises(ValueError):
+            ufl.isposinf(a)
+
     def test_isneginf(self):
         a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])
         out = nx.zeros(a.shape, bool)
@@ -31,6 +35,10 @@ class TestUfunclike(object):
         res = ufl.isneginf(a, out)
         assert_equal(res, tgt)
         assert_equal(out, tgt)
+
+        a = a.astype(np.complex)
+        with assert_raises(ValueError):
+            ufl.isneginf(a)
 
     def test_fix(self):
         a = nx.array([[1.0, 1.1, 1.5, 1.8], [-1.0, -1.1, -1.5, -1.8]])

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -11,28 +11,26 @@ from numpy.testing import (
 class TestUfunclike(object):
 
     def test_isposinf(self):
-        for dtype in [np.float, np.complex]:
-            a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0], dtype=dtype)
-            out = nx.zeros(a.shape, bool)
-            tgt = nx.array([True, False, False, False, False, False])
+        a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])
+        out = nx.zeros(a.shape, bool)
+        tgt = nx.array([True, False, False, False, False, False])
 
-            res = ufl.isposinf(a)
-            assert_equal(res, tgt)
-            res = ufl.isposinf(a, out)
-            assert_equal(res, tgt)
-            assert_equal(out, tgt)
+        res = ufl.isposinf(a)
+        assert_equal(res, tgt)
+        res = ufl.isposinf(a, out)
+        assert_equal(res, tgt)
+        assert_equal(out, tgt)
 
     def test_isneginf(self):
-        for dtype in [np.float, np.complex]:
-            a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0], dtype=dtype)
-            out = nx.zeros(a.shape, bool)
-            tgt = nx.array([False, True, False, False, False, False])
+        a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])
+        out = nx.zeros(a.shape, bool)
+        tgt = nx.array([False, True, False, False, False, False])
 
-            res = ufl.isneginf(a)
-            assert_equal(res, tgt)
-            res = ufl.isneginf(a, out)
-            assert_equal(res, tgt)
-            assert_equal(out, tgt)
+        res = ufl.isneginf(a)
+        assert_equal(res, tgt)
+        res = ufl.isneginf(a, out)
+        assert_equal(res, tgt)
+        assert_equal(out, tgt)
 
     def test_fix(self):
         a = nx.array([[1.0, 1.1, 1.5, 1.8], [-1.0, -1.1, -1.5, -1.8]])

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -22,7 +22,7 @@ class TestUfunclike(object):
         assert_equal(out, tgt)
 
         a = a.astype(np.complex)
-        with assert_raises(ValueError):
+        with assert_raises(TypeError):
             ufl.isposinf(a)
 
     def test_isneginf(self):
@@ -37,7 +37,7 @@ class TestUfunclike(object):
         assert_equal(out, tgt)
 
         a = a.astype(np.complex)
-        with assert_raises(ValueError):
+        with assert_raises(TypeError):
             ufl.isneginf(a)
 
     def test_fix(self):

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -141,8 +141,8 @@ def isposinf(x, out=None):
     """
     x = nx.asanyarray(x)
     if nx.issubdtype(x.dtype, nx.complexfloating):
-        raise ValueError('This operation is not supported for complex values'
-                         'because it would be ambiguous.')
+        raise TypeError('This operation is not supported for complex values '
+                        'because it would be ambiguous.')
     return nx.logical_and(nx.isinf(x), ~nx.signbit(x), out)
 
 
@@ -207,6 +207,6 @@ def isneginf(x, out=None):
     """
     x = nx.asanyarray(x)
     if nx.issubdtype(x.dtype, nx.complexfloating):
-        raise ValueError('This operation is not supported for complex values'
-                         'because it would be ambiguous.')
+        raise TypeError('This operation is not supported for complex values '
+                        'because it would be ambiguous.')
     return nx.logical_and(nx.isinf(x), nx.signbit(x), out)

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -118,7 +118,7 @@ def isposinf(x, out=None):
 
     Errors result if the second argument is also supplied when x is a scalar
     input, if first and second arguments have different shapes, or if the
-    first argument as complex values
+    first argument has complex values
 
     Examples
     --------
@@ -184,7 +184,7 @@ def isneginf(x, out=None):
 
     Errors result if the second argument is also supplied when x is a scalar
     input, if first and second arguments have different shapes, or if the
-    first argument as complex values.
+    first argument has complex values.
 
     Examples
     --------

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -81,21 +81,6 @@ def fix(x, out=None):
         res = res[()]
     return res
 
-
-def _isinf(x, sign, out=None):
-    if nx.isscalar(x):
-        if out is not None:
-            raise ValueError('out has to be None if x is scalar.')
-        return nx.isinf(x) and nx.sign(x) == sign
-    else:
-        x = nx.asanyarray(x)
-        out = nx.isinf(x, out)
-        if x.ndim == 0:
-            out = nx.asanyarray(out)
-        out_b = out.astype(bool, copy=False)
-        out[out_b] = nx.sign(x[out_b]) == sign
-        return out
-
 @_deprecate_out_named_y
 def isposinf(x, out=None):
     """
@@ -153,7 +138,7 @@ def isposinf(x, out=None):
     array([0, 0, 1])
 
     """
-    return _isinf(x, 1, out=out)
+    return nx.logical_and(nx.isinf(x), ~nx.signbit(x), out)
 
 
 @_deprecate_out_named_y
@@ -214,4 +199,4 @@ def isneginf(x, out=None):
     array([1, 0, 0])
 
     """
-    return _isinf(x, -1, out=out)
+    return nx.logical_and(nx.isinf(x), nx.signbit(x), out)

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -116,8 +116,9 @@ def isposinf(x, out=None):
     NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
     (IEEE 754).
 
-    Errors result if the second argument is also supplied when `x` is a
-    scalar input, or if first and second arguments have different shapes.
+    Errors result if the second argument is also supplied when x is a scalar
+    input, if first and second arguments have different shapes, or if the
+    first argument as complex values
 
     Examples
     --------
@@ -138,6 +139,10 @@ def isposinf(x, out=None):
     array([0, 0, 1])
 
     """
+    x = nx.asanyarray(x)
+    if nx.issubdtype(x.dtype, nx.complexfloating):
+        raise ValueError('This operation is not supported for complex values'
+                         'because it would be ambiguous.')
     return nx.logical_and(nx.isinf(x), ~nx.signbit(x), out)
 
 
@@ -178,7 +183,8 @@ def isneginf(x, out=None):
     (IEEE 754).
 
     Errors result if the second argument is also supplied when x is a scalar
-    input, or if first and second arguments have different shapes.
+    input, if first and second arguments have different shapes, or if the
+    first argument as complex values.
 
     Examples
     --------
@@ -199,4 +205,8 @@ def isneginf(x, out=None):
     array([1, 0, 0])
 
     """
+    x = nx.asanyarray(x)
+    if nx.issubdtype(x.dtype, nx.complexfloating):
+        raise ValueError('This operation is not supported for complex values'
+                         'because it would be ambiguous.')
     return nx.logical_and(nx.isinf(x), nx.signbit(x), out)

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -11,6 +11,7 @@ import numpy.core.numeric as nx
 import warnings
 import functools
 
+
 def _deprecate_out_named_y(f):
     """
     Allow the out argument to be passed as the name `y` (deprecated)
@@ -81,6 +82,7 @@ def fix(x, out=None):
         res = res[()]
     return res
 
+
 @_deprecate_out_named_y
 def isposinf(x, out=None):
     """
@@ -139,11 +141,14 @@ def isposinf(x, out=None):
     array([0, 0, 1])
 
     """
-    x = nx.asanyarray(x)
-    if nx.issubdtype(x.dtype, nx.complexfloating):
+    is_inf = nx.isinf(x)
+    try:
+        signbit = ~nx.signbit(x)
+    except TypeError:
         raise TypeError('This operation is not supported for complex values '
                         'because it would be ambiguous.')
-    return nx.logical_and(nx.isinf(x), ~nx.signbit(x), out)
+    else:
+        return nx.logical_and(is_inf, signbit, out)
 
 
 @_deprecate_out_named_y
@@ -205,8 +210,11 @@ def isneginf(x, out=None):
     array([1, 0, 0])
 
     """
-    x = nx.asanyarray(x)
-    if nx.issubdtype(x.dtype, nx.complexfloating):
+    is_inf = nx.isinf(x)
+    try:
+        signbit = nx.signbit(x)
+    except TypeError:
         raise TypeError('This operation is not supported for complex values '
                         'because it would be ambiguous.')
-    return nx.logical_and(nx.isinf(x), nx.signbit(x), out)
+    else:
+        return nx.logical_and(is_inf, signbit, out)

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -81,6 +81,21 @@ def fix(x, out=None):
         res = res[()]
     return res
 
+
+def _isinf(x, sign, out=None):
+    if nx.isscalar(x):
+        if out is not None:
+            raise ValueError('out has to be None if x is scalar.')
+        return nx.isinf(x) and nx.sign(x) == sign
+    else:
+        x = nx.asanyarray(x)
+        out = nx.isinf(x, out)
+        if x.ndim == 0:
+            out = nx.asanyarray(out)
+        out_b = out.astype(bool, copy=False)
+        out[out_b] = nx.sign(x[out_b]) == sign
+        return out
+
 @_deprecate_out_named_y
 def isposinf(x, out=None):
     """
@@ -138,7 +153,7 @@ def isposinf(x, out=None):
     array([0, 0, 1])
 
     """
-    return nx.logical_and(nx.isinf(x), ~nx.signbit(x), out)
+    return _isinf(x, 1, out=out)
 
 
 @_deprecate_out_named_y
@@ -199,4 +214,4 @@ def isneginf(x, out=None):
     array([1, 0, 0])
 
     """
-    return nx.logical_and(nx.isinf(x), nx.signbit(x), out)
+    return _isinf(x, -1, out=out)


### PR DESCRIPTION
Fixes a bug in `isposinf` and `isneginf` for complex values (#11438) and adds additional tests for these functions with complex values.