### PR TITLE
ENH: Allow moveaxis() to take strings as axis order

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1526,7 +1526,9 @@ def moveaxis(a, source, destination):
     """
     Move axes of an array to new positions.
 
-    Other axes remain in their original order.
+    Other axes remain in their original order. If `source` and `destination`
+    are strings, the axes will be moved according to the permutation of
+    the characters in `source` and `destination`.
 
     .. versionadded:: 1.11.0
 
@@ -1534,9 +1536,9 @@ def moveaxis(a, source, destination):
     ----------
     a : np.ndarray
         The array whose axes should be reordered.
-    source : int or sequence of int
+    source : int, str or sequence of int
         Original positions of the axes to move. These must be unique.
-    destination : int or sequence of int
+    destination : int, str or sequence of int
         Destination positions for each of the original axes. These must also be
         unique.
 
@@ -1569,6 +1571,8 @@ def moveaxis(a, source, destination):
     (5, 4, 3)
     >>> np.moveaxis(x, [0, 1, 2], [-1, -2, -3]).shape
     (5, 4, 3)
+    >>> np.moveaxis(x, 'xyz', 'zyx').shape
+    (5, 4, 3)
 
     """
     try:
@@ -1578,8 +1582,23 @@ def moveaxis(a, source, destination):
         a = asarray(a)
         transpose = a.transpose
 
+    if type(source) is str or type(destination) is str:
+        if type(source) is not str or type(destination) is not str:
+            raise ValueError('`source` and `destination` must be of type str')
+        if not (len(source) == len(destination) == a.ndim):
+            raise ValueError('`source` and `destination` arguments must have '
+                             'the same number of elements as the shape of `a`')
+
+        try:
+            destination = [destination.index(c) for c in source]
+        except ValueError:
+            raise ValueError('`source` and `destination` arguments must contain '
+                             'the same elements')
+        source = [i for i, _ in enumerate(source)]
+
     source = normalize_axis_tuple(source, a.ndim, 'source')
     destination = normalize_axis_tuple(destination, a.ndim, 'destination')
+
     if len(source) != len(destination):
         raise ValueError('`source` and `destination` arguments must have '
                          'the same number of elements')

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2486,6 +2486,16 @@ class TestMoveaxis(object):
             actual = np.moveaxis(x, source, destination).shape
             assert_(actual, expected)
 
+    def test_strings(self):
+        x = np.zeros((0, 1, 2, 3))
+        for source, destination, expected in [
+                ('ijkl', 'klij', (2, 3, 0, 1)),
+                ('ijkl', 'ljki', (3, 1, 2, 0)),
+                ('ijkl', 'iljk', (0, 3, 1, 2)),
+                ]:
+            actual = np.moveaxis(x, source, destination).shape
+            assert_(actual, expected)
+
     def test_errors(self):
         x = np.random.randn(1, 2, 3)
         assert_raises_regex(np.AxisError, 'source.*out of bounds',
@@ -2500,8 +2510,33 @@ class TestMoveaxis(object):
                             np.moveaxis, x, [0, 1], [1, 1])
         assert_raises_regex(ValueError, 'must have the same number',
                             np.moveaxis, x, 0, [0, 1])
+
+        assert_raises_regex(ValueError, 'must have the same number',
+                            np.moveaxis, x, 'x', 'xy')
         assert_raises_regex(ValueError, 'must have the same number',
                             np.moveaxis, x, [0, 1], [0])
+        assert_raises_regex(ValueError, 'must have the same number',
+                            np.moveaxis, x, 'xy', 'x')
+        assert_raises_regex(ValueError, 'must be of type str',
+                            np.moveaxis, x, 'xy', [0, 1])
+        assert_raises_regex(ValueError, 'must have the same number '
+                            'of elements as the shape of `a`',
+                            np.moveaxis, x, 'xyz', 'xy')
+        assert_raises_regex(ValueError, 'must contain the same elements',
+                            np.moveaxis, x, 'xyz', 'xyx')
+        assert_raises_regex(ValueError, 'repeated axis',
+                            np.moveaxis, x, 'xyx', 'xyz')
+        assert_raises_regex(ValueError, 'must have the same number '
+                            'of elements as the shape of `a`',
+                            np.moveaxis, x, 'xy', 'xyz')
+        assert_raises_regex(ValueError, 'must contain the same elements',
+                            np.moveaxis, x, 'ijk', 'xyz')
+        assert_raises_regex(ValueError, 'must have the same number '
+                            'of elements as the shape of `a`',
+                            np.moveaxis, x, 'ij', 'xyz')
+        assert_raises_regex(ValueError, 'must have the same number '
+                            'of elements as the shape of `a`',
+                            np.moveaxis, x, 'ijk', 'xy')
 
     def test_array_likes(self):
         x = np.ma.zeros((1, 2, 3))


### PR DESCRIPTION
Adds a feature to simplify moving axes around:

    x = np.zeros((0, 1, 2))
    np.moveaxis(x, 'xyz', 'zyx')
    np.moveaxis(x, 'ijk', 'kji') # has the same effect as above