### PR TITLE
BUG: Fix #define for ppc64 and ppc64le

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -39,17 +39,19 @@
      * _M_AMD64 defined by MS compiler
      */
     #define NPY_CPU_AMD64
+#elif defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
+    #define NPY_CPU_PPC64LE
+#elif defined(__powerpc64__) && defined(__BIG_ENDIAN__)
+    #define NPY_CPU_PPC64
 #elif defined(__ppc__) || defined(__powerpc__) || defined(_ARCH_PPC)
     /*
      * __ppc__ is defined by gcc, I remember having seen __powerpc__ once,
      * but can't find it ATM
      * _ARCH_PPC is used by at least gcc on AIX
+     * As __powerpc__ and _ARCH_PPC are also defined by PPC64 check
+     * for those specifically first before defaulting to ppc
      */
     #define NPY_CPU_PPC
-#elif defined(__ppc64le__)
-    #define NPY_CPU_PPC64LE
-#elif defined(__ppc64__)
-    #define NPY_CPU_PPC64
 #elif defined(__sparc__) || defined(__sparc)
     /* __sparc__ is defined by gcc and Forte (e.g. Sun) compilers */
     #define NPY_CPU_SPARC


### PR DESCRIPTION
Backport of #11479.

The current logic for defining NPY_CPU_PPC64LE and NPY_CPU_PPC64 is
incorrect for two reasons:
1) The elif defined for `__powerpc__` is proceesed first so any
ppc64le or ppc64 system is defined as NPY_CPU_PPC.
2) `__ppc64le__` is not defined on a ppc64le system. `__PPC64__` is
defined and so is `__powerpc64__` but the check for little or
big endian needs to be done seperately.

This pull request fixes the defines for ppc64le and ppc64.
Note: This really isn't a issue in the numpy code base at this time
because the only place this variable is referenced is in npy_endian.h
as a fallback in case endian.h is not on the system.
It would be good to fix in case future code does reference
these defines.