### PR TITLE
MAINT: Speed up normalize_axis_tuple by about 30%

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1509,8 +1509,8 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     --------
     normalize_axis_index : normalizing a single scalar axis
     """
-    # Speed-up most common cases.
-    if not isinstance(axis, (list, tuple)):
+    # Optimization to speed-up the most common cases.
+    if type(axis) not in (tuple, list):
         try:
             axis = [operator.index(axis)]
         except TypeError:

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1509,11 +1509,14 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     --------
     normalize_axis_index : normalizing a single scalar axis
     """
-    try:
-        axis = [operator.index(axis)]
-    except TypeError:
-        axis = tuple(axis)
-    axis = tuple(normalize_axis_index(ax, ndim, argname) for ax in axis)
+    # Speed-up most common cases.
+    if not isinstance(axis, (list, tuple)):
+        try:
+            axis = [operator.index(axis)]
+        except TypeError:
+            pass
+    # Going via an iterator directly is slower than via list comprehension.
+    axis = tuple([normalize_axis_index(ax, ndim, argname) for ax in axis])
     if not allow_duplicate and len(set(axis)) != len(axis):
         if argname:
             raise ValueError('repeated axis in `{}` argument'.format(argname))


### PR DESCRIPTION
This is used in `np.moveaxis`, which is relatively slow. Timings change as follows:
```
import numpy as np
from numpy.core.numeric import normalize_axis_tuple
%timeit normalize_axis_tuple([0, 1, 2], 4, 'parrot')
a = np.zeros((10,20,30))
%timeit np.moveaxis(a, [0,1,2], [2,1,0])
100000 loops, best of 3: 5.56 µs per loop -> 4.17 µs
```

Should add that I'm not really all that happy with the present solution, but I cannot think of a better one that wouldn't either impact the iterable or  the scalar case.