### PR TITLE
DOC: Note that method is the polar form of Box-Muller.

### DIFF
--- a/numpy/random/mtrand/randomkit.c
+++ b/numpy/random/mtrand/randomkit.c
@@ -616,7 +616,7 @@ rk_gauss(rk_state *state)
         }
         while (r2 >= 1.0 || r2 == 0.0);
 
-        /* Box-Muller transform */
+        /* Polar method, a more efficient version of the Box-Muller approach. */
         f = sqrt(-2.0*log(r2)/r2);
         /* Keep for next call */
         state->gauss = f*x1;


### PR DESCRIPTION
The transform in line 620 onwards was the polar method, not Box-Muller. See section 11.3.1 of "Introduction to probability models" by Sheldon Ross (https://fac.ksu.edu.sa/sites/default/files/introduction-to-probability-model-s.ross-math-cs.blog_.ir_.pdf). Since this change only affects a comment, my environment is not relevant.