### PR TITLE
MAINT: cancel multifield copy->view and copy-by-position plans (alternate proposal)

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -654,27 +654,7 @@ PyArray_CompareString(char *s1, char *s2, size_t len)
 NPY_NO_EXPORT int
 array_might_be_written(PyArrayObject *obj)
 {
-    const char *msg =
-        "Numpy has detected that you (may be) writing to an array returned\n"
-        "by numpy.diagonal or by selecting multiple fields in a structured\n"
-        "array. This code will likely break in a future numpy release --\n"
-        "see numpy.diagonal or arrays.indexing reference docs for details.\n"
-        "The quick fix is to make an explicit copy (e.g., do\n"
-        "arr.diagonal().copy() or arr[['f0','f1']].copy()).";
-    if (PyArray_FLAGS(obj) & NPY_ARRAY_WARN_ON_WRITE) {
-        /* 2012-07-17, 1.7 */
-        if (DEPRECATE_FUTUREWARNING(msg) < 0) {
-            return -1;
-        }
-        /* Only warn once per array */
-        while (1) {
-            PyArray_CLEARFLAGS(obj, NPY_ARRAY_WARN_ON_WRITE);
-            if (!PyArray_BASE(obj) || !PyArray_Check(PyArray_BASE(obj))) {
-                break;
-            }
-            obj = (PyArrayObject *)PyArray_BASE(obj);
-        }
-    }
+    /* XXX finish removing this warning functionality */
     return 0;
 }
 
@@ -695,9 +675,6 @@ PyArray_FailUnlessWriteable(PyArrayObject *obj, const char *name)
 {
     if (!PyArray_ISWRITEABLE(obj)) {
         PyErr_Format(PyExc_ValueError, "%s is read-only", name);
-        return -1;
-    }
-    if (array_might_be_written(obj) < 0) {
         return -1;
     }
     return 0;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1389,8 +1389,7 @@ array_subscript_asarray(PyArrayObject *self, PyObject *op)
 
 /*
  * Helper function for _get_field_view which turns a multifield
- * view into a "packed" copy, as done in numpy 1.15 and before.
- * In numpy 1.16 this function should be removed.
+ * view into a "packed" copy.
  */
 NPY_NO_EXPORT int
 _multifield_view_to_copy(PyArrayObject **view) {
@@ -1403,7 +1402,6 @@ _multifield_view_to_copy(PyArrayObject **view) {
         goto view_fail;
     }
 
-    PyArray_CLEARFLAGS(*view, NPY_ARRAY_WARN_ON_WRITE);
     viewcopy = PyObject_CallFunction(copyfunc, "O", *view);
     if (viewcopy == NULL) {
         goto view_fail;
@@ -1411,8 +1409,6 @@ _multifield_view_to_copy(PyArrayObject **view) {
     Py_DECREF(*view);
     *view = (PyArrayObject*)viewcopy;
 
-    /* warn when writing to the copy */
-    PyArray_ENABLEFLAGS(*view, NPY_ARRAY_WARN_ON_WRITE);
     return 0;
 
 view_fail:
@@ -1427,11 +1423,6 @@ view_fail:
  * If an error occurred, return 0 and set view to NULL. If the subscript is not
  * a string or list of strings, return -1 and set view to NULL. Otherwise
  * return 0 and set view to point to a new view into arr for the given fields.
- *
- * In numpy 1.15 and before, in the case of a list of field names the returned
- * view will actually be a copy by default, with fields packed together.
- * The `force_view` argument causes a view to be returned. This argument can be
- * removed in 1.16 when we plan to return a view always.
  */
 NPY_NO_EXPORT int
 _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view,
@@ -1598,7 +1589,6 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view,
             return 0;
         }
 
-        /* the code below can be replaced by "return 0" in 1.16 */
         if (force_view) {
             return 0;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1389,7 +1389,7 @@ _equivalent_fields(PyArray_Descr *type1, PyArray_Descr *type2) {
 
     int val;
 
-    if (type1->fields == type2->fields && type1->names == type2->names) {
+    if (type1->fields == type2->fields) {
         return 1;
     }
     if (type1->fields == NULL || type2->fields == NULL) {
@@ -1397,12 +1397,6 @@ _equivalent_fields(PyArray_Descr *type1, PyArray_Descr *type2) {
     }
 
     val = PyObject_RichCompareBool(type1->fields, type2->fields, Py_EQ);
-    if (val != 1 || PyErr_Occurred()) {
-        PyErr_Clear();
-        return 0;
-    }
-
-    val = PyObject_RichCompareBool(type1->names, type2->names, Py_EQ);
     if (val != 1 || PyErr_Occurred()) {
         PyErr_Clear();
         return 0;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -103,15 +103,6 @@ class TestBuiltin(object):
                          'formats':['i1', 'f4'],
                          'offsets':[0, 2]}, align=True)
 
-    def test_field_order_equality(self):
-        x = np.dtype({'names': ['A', 'B'], 
-                      'formats': ['i4', 'f4'], 
-                      'offsets': [0, 4]})
-        y = np.dtype({'names': ['B', 'A'], 
-                      'formats': ['f4', 'i4'], 
-                      'offsets': [4, 0]})
-        assert_equal(x == y, False)
-
 class TestRecord(object):
     def test_equivalent_record(self):
         """Test whether equivalent record dtypes hash the same."""
@@ -227,12 +218,11 @@ class TestRecord(object):
         dt = np.dtype({'names':['f0', 'f1', 'f2'], 'formats':['<u4', '<u2', '<u2'],
                         'offsets':[4, 0, 2]}, align=True)
         assert_equal(dt.itemsize, 8)
-        # field name should not matter: assignment is by position
         dt2 = np.dtype({'names':['f2', 'f0', 'f1'],
-                        'formats':['<u4', '<u2', '<u2'],
-                        'offsets':[4, 0, 2]}, align=True)
+                        'formats':['<u2', '<u4', '<u2'],
+                        'offsets':[2, 4, 0]}, align=True)
         vals = [(0, 1, 2), (3, -1, 4)]
-        vals2 = [(0, 1, 2), (3, -1, 4)]
+        vals2 = [(2, 0, 1), (4, 3, -1)]
         a = np.array(vals, dt)
         b = np.array(vals2, dt2)
         assert_equal(a.astype(dt2), b)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1879,20 +1879,74 @@ def test_iter_buffered_cast_structured_type():
                     op_dtypes=sdt2)
     assert_equal(i[0].dtype, np.dtype(sdt2))
     assert_equal([np.array(x_) for x_ in i],
-                 [np.array((1, 2, 3), dtype=sdt2),
-                  np.array((4, 5, 6), dtype=sdt2)])
+                 [np.array((3, 1, 2), dtype=sdt2),
+                  np.array((6, 4, 5), dtype=sdt2)])
 
-    # make sure struct type -> struct type with different
-    # number of fields fails
+    # struct type -> struct type (field gets discarded)
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', 'O')]
     sdt2 = [('b', 'O'), ('a', 'f8')]
     a = np.array([(1, 2, 3), (4, 5, 6)], dtype=sdt1)
 
-    assert_raises(ValueError, lambda : (
-        nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
-               casting='unsafe',
-               op_dtypes=sdt2)))
+    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                    casting='unsafe',
+                    op_dtypes=sdt2)
+    assert_equal(i[0].dtype, np.dtype(sdt2))
+    vals = []
+    for x in i:
+        vals.append(np.array(x))
+        x['a'] = x['b']+3
+    assert_equal(vals, [np.array((2, 1), dtype=sdt2),
+                     np.array((5, 4), dtype=sdt2)])
+    assert_equal(a, np.array([(5, 2, None), (8, 5, None)], dtype=sdt1))
 
+    # struct type -> struct type (structured field gets discarded)
+    sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'i4')])]
+    sdt2 = [('b', 'O'), ('a', 'f8')]
+    a = np.array([(1, 2, (0, 9)), (4, 5, (20, 21))], dtype=sdt1)
+    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                    casting='unsafe',
+                    op_dtypes=sdt2)
+    assert_equal(i[0].dtype, np.dtype(sdt2))
+    vals = []
+    for x in i:
+        vals.append(np.array(x))
+        x['a'] = x['b']+3
+    assert_equal(vals, [np.array((2, 1), dtype=sdt2),
+                     np.array((5, 4), dtype=sdt2)])
+    assert_equal(a, np.array([(5, 2, (0, 0)), (8, 5, (0, 0))], dtype=sdt1))
+
+    # struct type -> struct type (structured field w/ ref gets discarded)
+    sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'O')])]
+    sdt2 = [('b', 'O'), ('a', 'f8')]
+    a = np.array([(1, 2, (0, 9)), (4, 5, (20, 21))], dtype=sdt1)
+    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                    casting='unsafe',
+                    op_dtypes=sdt2)
+    assert_equal(i[0].dtype, np.dtype(sdt2))
+    vals = []
+    for x in i:
+        vals.append(np.array(x))
+        x['a'] = x['b']+3
+    assert_equal(vals, [np.array((2, 1), dtype=sdt2),
+                     np.array((5, 4), dtype=sdt2)])
+    assert_equal(a, np.array([(5, 2, (0, None)), (8, 5, (0, None))], dtype=sdt1))
+
+    # struct type -> struct type back (structured field w/ ref gets discarded)
+    sdt1 = [('b', 'O'), ('a', 'f8')]
+    sdt2 = [('a', 'f4'), ('b', 'i8'), ('d', [('a', 'i2'), ('b', 'O')])]
+    a = np.array([(1, 2), (4, 5)], dtype=sdt1)
+    i = nditer(a, ['buffered', 'refs_ok'], ['readwrite'],
+                    casting='unsafe',
+                    op_dtypes=sdt2)
+    assert_equal(i[0].dtype, np.dtype(sdt2))
+    vals = []
+    for x in i:
+        vals.append(np.array(x))
+        assert_equal(x['d'], np.array((0, None), dtype=[('a', 'i2'), ('b', 'O')]))
+        x['a'] = x['b']+3
+    assert_equal(vals, [np.array((2, 1, (0, None)), dtype=sdt2),
+                     np.array((5, 4, (0, None)), dtype=sdt2)])
+    assert_equal(a, np.array([(1, 4), (4, 7)], dtype=sdt1))
 
 def test_iter_buffered_cast_subarray():
     # Tests buffering of subarrays

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1784,11 +1784,12 @@ class TestFillingValues(object):
         assert_(isinstance(fval, ndarray))
         assert_equal(fval.item(), [-999, -12345678.9, b"???"])
 
-        #.....Using a flexible type w/ a different type shouldn't matter
-        # BEHAVIOR in 1.5 and earlier, and 1.13 and later: match structured
-        # types by position
-        fill_val = np.array((-999, -12345678.9, "???"),
-                            dtype=[("A", int), ("B", float), ("C", "|S3")])
+        # BEHAVIOR in 1.5 and earlier: match structured types by position
+        #fill_val = np.array((-999, -12345678.9, "???"),
+        #                    dtype=[("A", int), ("B", float), ("C", "|S3")])
+        # BEHAVIOR in 1.6 and later: match structured types by name
+        fill_val = np.array(("???", -999, -12345678.9),
+                            dtype=[("c", "|S3"), ("a", int), ("b", float), ])
         fval = _check_fill_value(fill_val, ndtype)
         assert_(isinstance(fval, ndarray))
         assert_equal(fval.item(), [-999, -12345678.9, b"???"])


### PR DESCRIPTION
This is a branch where I essentially reverted the major changes of #6053, since it causes some back-compat problems. Putting it here so we can compare, before deciding which way to go.  See discussion in #11526. This revers the "multifield indexing returns a view" change, and the "multifield assignment occurs by-position instead of by-name" change.

#6053 wouldn't all be a loss though. This PR still keeps all the little fixes from that PR, and I also make multifield assignment consistent: Before #6053 you would get different behavior depending on whether you did array vs scalar assignment. In #6053 I chose to make all of numpy use "copy-by-position" for multifield assignment, in this PR everything is "copy-by-name". That means there is still a back-compat break in this PR for structured scalar assignment, but probably it has much less effect than #6053.

So if we go this route, at least numpy will be more self-consistent, while still being fairly back-compatible.

Also, at least in #6053 I have worked out how I think multifield indexing behavior should work, without all the quirks of current numpy. The day we implement the new standalone structured dtypes I suggest we use the behavior I worked out in #6053, if we decide to remove it here.

A lot of the code change here is just pasting back in things I removed in #6053.