### PR TITLE
BUG: Decref of field title caused segfault

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1546,7 +1546,6 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view,
                     Py_DECREF(names);
                     return 0;
                 }
-                Py_DECREF(title);
             }
             /* disallow duplicate field indices */
             if (PyDict_Contains(fields, name)) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1540,7 +1540,6 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view,
                                 "cannot use field titles in multi-field index");
                 }
                 if (titlecmp != 0 || PyDict_SetItem(fields, title, tup) < 0) {
-                    Py_DECREF(title);
                     Py_DECREF(name);
                     Py_DECREF(fields);
                     Py_DECREF(names);

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2391,3 +2391,15 @@ class TestRegression(object):
                 squeezed = scvalue.squeeze(axis=axis)
                 assert_equal(squeezed, scvalue)
                 assert_equal(type(squeezed), type(scvalue))
+
+    def test_field_access_by_title(self):
+        # gh-11507
+        s = 'Some long field name'
+        if HAS_REFCOUNT:
+            base = sys.getrefcount(s)
+        t = np.dtype([((s, 'f1'), np.float64)])
+        data = np.zeros(10, t)
+        for i in range(10):
+            v = str(data[['f1']])
+            if HAS_REFCOUNT:
+                assert_(base <= sys.getrefcount(s))


### PR DESCRIPTION
Backport of  #11515.

Fixes #11507. Test added that fails before, passes after the fix.