### PR TITLE
BUG: Swap erroneously transposed tuple elements in `_pointer_type_cache` key

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -296,7 +296,7 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
         elif isinstance(flags, flagsobj):
             num = flags.num
             flags = _flags_fromnum(num)
-        if flags is None:
+        if num is None:
             try:
                 flags = [str(x).strip().upper() for x in iter(flags)]
             except Exception:

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -292,19 +292,19 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
             flags = flags.split(',')
         elif isinstance(flags, (int, integer)):
             num = flags
-            flags = _flags_fromnum(num)
         elif isinstance(flags, flagsobj):
             num = flags.num
-            flags = _flags_fromnum(num)
         if num is None:
             try:
                 flags = [str(x).strip().upper() for x in iter(flags)]
             except Exception:
                 raise TypeError("invalid flags specification")
     
-    # Fetch the integer flag value, if needed:
+    # Fetch the integer or string flag values, if needed:
     if num is None:
         num = _num_fromflags(flags)
+    elif flags is None:
+        flags = _flags_fromnum(num)
     
     # Choose a name string based on the dtype:
     if dtype is None:

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -316,7 +316,7 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
                   "_shape_" : shape,
                   "_ndim_" : ndim,
                   "_flags_" : num})
-    _pointer_type_cache[(dtype, shape, ndim, num)] = klass
+    _pointer_type_cache[(dtype, ndim, shape, num)] = klass
     return klass
 
 

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -296,10 +296,11 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
         elif isinstance(flags, flagsobj):
             num = flags.num
             flags = _flags_fromnum(num)
-        try:
-            flags = [str(x).strip().upper() for x in iter(flags)]
-        except Exception:
-            raise TypeError("invalid flags specification")
+        if flags is None:
+            try:
+                flags = [str(x).strip().upper() for x in iter(flags)]
+            except Exception:
+                raise TypeError("invalid flags specification")
     
     # Fetch the integer flag value, if needed:
     if num is None:

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -51,10 +51,11 @@ Then, we're ready to call ``foo_func``:
 """
 from __future__ import division, absolute_import, print_function
 
-__all__ = ['load_library', 'ndpointer', 'test', 'ctypes_load_library',
-           'c_intp', 'as_ctypes', 'as_array']
+__all__ = ['load_library', 'ctypes_load_library',
+           'c_intp', 'ndpointer',
+           'as_ctypes', 'as_array']
 
-import sys, os
+import os
 from numpy import integer, ndarray, dtype as _dtype, deprecate, array
 from numpy.core.multiarray import _flagdict, flagsobj
 

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -286,25 +286,21 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
         dtype = _dtype(dtype)
     
     # Transform flag strings to their integer equivaluent:
-    num = None
     if flags is not None:
         if isinstance(flags, str):
             flags = flags.split(',')
         elif isinstance(flags, (int, integer)):
             num = flags
+            flags = _flags_fromnum(num)
         elif isinstance(flags, flagsobj):
             num = flags.num
+            flags = _flags_fromnum(num)
         if num is None:
             try:
-                flags = [str(x).strip().upper() for x in iter(flags)]
+                flags = [x.strip().upper() for x in flags]
             except Exception:
                 raise TypeError("invalid flags specification")
-    
-    # Fetch the integer or string flag values, if needed:
-    if flags is None:
-        flags = _flags_fromnum(num)
-    elif num is None:
-        num = _num_fromflags(flags)
+            num = _num_fromflags(flags)
     
     # Choose a name string based on the dtype:
     if dtype is None:

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -301,10 +301,10 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
                 raise TypeError("invalid flags specification")
     
     # Fetch the integer or string flag values, if needed:
-    if num is None:
-        num = _num_fromflags(flags)
-    elif flags is None:
+    if flags is None:
         flags = _flags_fromnum(num)
+    elif num is None:
+        num = _num_fromflags(flags)
     
     # Choose a name string based on the dtype:
     if dtype is None:


### PR DESCRIPTION
The `numpy.ctypeslib.ndpointer(…)` function creates bespoke new Python classes using calls to `type(…)`. These new classes inherit from `_ndptr` (a `ctypes` primitive representing a `PyArrayObject*`) and are created in such a way that they are particular to a set of givens: a `numpy.dtype`, a shape tuple, the array rank (`ndim`), and a tuple of string flags. Internal to the `numpy.ctypeslib` module is a dict, `_pointer_type_cache`, used by `ndpointer(…)` to cache the new classes it creates, composing a tuple to use as a dict key of the form `(dtype, ndim, shape, num)`.

The cache is accessed twice in `ndpointer(…)` – once in an attempt to read an existing entry, and should that fail, it is accessed again right before its final `return` statement to write an entry with the new class. The problem was that the second access had the second and third tuple elements erroneously transposed – it was `(dtype, shape, ndim, num)` rather instead of `(dtype, ndim, shape, num)`, resulting in a cache-miss rate of 100%.

This PR swaps the tuple elements to be consistent at both points of access to the cache.