### PR TITLE
NEP: accept nep 0015

### DIFF
--- a/doc/neps/nep-0015-merge-multiarray-umath.rst
+++ b/doc/neps/nep-0015-merge-multiarray-umath.rst
@@ -3,10 +3,10 @@ NEP 15 — Merging multiarray and umath
 =====================================
 
 :Author: Nathaniel J. Smith <njs@pobox.com>
-:Status: Draft
+:Status: Accepted
 :Type: Standards Track
 :Created: 2018-02-22
-
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2018-June/078345.html
 
 Abstract
 --------


### PR DESCRIPTION
The original mail proposing to accept this NEP to merge multiarray and umath modules was sent June 29. According to the NEP acceptance policy, more than a week has passed, and there was no opposition on the mailing list.

See also PR #10915 which implements the NEP.