### PR TITLE
NEP: accept nep 0019

### DIFF
--- a/doc/neps/nep-0019-rng-policy.rst
+++ b/doc/neps/nep-0019-rng-policy.rst
@@ -3,10 +3,10 @@ NEP 19 — Random Number Generator Policy
 =======================================
 
 :Author: Robert Kern <robert.kern@gmail.com>
-:Status: Draft
+:Status: Accepted
 :Type: Standards Track
 :Created: 2018-05-24
-
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2018-June/078126.html
 
 Abstract
 --------


### PR DESCRIPTION
The original mail proposing to accept this NEP to set a random number generator policy was sent July 1. According to the NEP acceptance policy, more than a week has passed, and there was no opposition on the mailing list.
