### PR TITLE
BLD: Do not use gcc warnings flags when 'gcc' is actually clang.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -329,18 +329,20 @@ def build_project(args):
     env['PATH'] = os.pathsep.join(EXTRA_PATH + env.get('PATH', '').split(os.pathsep))
     cvars = distutils.sysconfig.get_config_vars()
     if 'gcc' in cvars.get('CC', ''):
-        # add flags used as werrors
-        warnings_as_errors = ' '.join([
-            # from tools/travis-test.sh
-            '-Werror=declaration-after-statement',
-            '-Werror=vla',
-            '-Werror=nonnull',
-            '-Werror=pointer-arith',
-            '-Wlogical-op',
-            # from sysconfig
-            '-Werror=unused-function',
-        ])
-        env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
+        # Check that this isn't clang masquerading as gcc.
+        if sys.platform != 'darwin' or 'gnu-gcc' in cvars.get('CC', ''):
+            # add flags used as werrors
+            warnings_as_errors = ' '.join([
+                # from tools/travis-test.sh
+                '-Werror=declaration-after-statement',
+                '-Werror=vla',
+                '-Werror=nonnull',
+                '-Werror=pointer-arith',
+                '-Wlogical-op',
+                # from sysconfig
+                '-Werror=unused-function',
+            ])
+            env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
     if args.debug or args.gcov:
         # assume everyone uses gcc/gfortran
         env['OPT'] = '-O0 -ggdb'


### PR DESCRIPTION
On OSX, `python runtests.py` fails because `runtests.py` adds some gcc-specific warnings flags. There is a check in `runtests.py` that attempts detect whether the C compiler is `gcc`, but it is fooled by Xcode developer tools. This change successfully differentiates between GNU gcc and gcc-that-is-actually-clang. I wish there were a more explicit way to switch on this, but this seems like the best available option. See [this gist](https://gist.github.com/danielballan/4a684ea4458a49fdd5d032c821e1daff) for the content of `distutils.sysconfig.get_config_vars()` on OSX and then, in a comment, the same output from Linux gnu-gcc compiler.

Thanks to @mattip for help, here at the SciPy Sprints! :tada: