### PR TITLE
TST: Integrate codecov testing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  ci:
+    - !appveyor
+coverage:
+  status:
+    project:
+      default:
+        # Require 1% coverage, i.e., always succeed
+        target: 1
+comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
             - python3-dev
             - python3-setuptools
     - python: 3.6
-      env: USE_WHEEL=1 RUN_FULL_TESTS=1
+      env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1
     - python: 2.7
       env: USE_WHEEL=1 RUN_FULL_TESTS=1 PYTHON_OPTS="-3 -OO"
     - python: 3.6

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis](https://img.shields.io/travis/numpy/numpy/master.svg?label=Travis%20CI)](https://travis-ci.org/numpy/numpy)
 [![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/charris/numpy)
+[![codecov](https://codecov.io/gh/numpy/numpy/branch/master/graph/badge.svg)](https://codecov.io/gh/numpy/numpy)
 
 NumPy is the fundamental package needed for scientific computing with Python.
 

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -46,6 +46,10 @@ elif numpy.ones((10, 1), order='C').flags.f_contiguous:
     print('NPY_RELAXED_STRIDES_CHECKING not set, but active.')
     sys.exit(1)
 
+if options.coverage:
+    # Produce code coverage XML report for codecov.io
+    args += ["--cov-report=xml"]
+
 result = numpy.test(options.mode,
                     verbose=options.verbose,
                     extra_argv=args,


### PR DESCRIPTION
Added `RUN_COVERAGE` flag to specify whether to run code coverage and passed `--cov-report=xml` to pytest to output the code coverage report in XML. Report is uploaded to the [codecov](https://codecov.io) service.

I had to ignore depreciation warnings from virtualenv as it was erroring the tests in python3.6. Its still an open issue: https://github.com/pypa/virtualenv/issues/1120 

Part of scipy2018 code sprint  🐍