### PR TITLE
TST: add broadcast_arrays() kwarg unit test for TypeError

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -242,7 +242,7 @@ def broadcast_arrays(*args, **kwargs):
     subok = kwargs.pop('subok', False)
     if kwargs:
         raise TypeError('broadcast_arrays() got an unexpected keyword '
-                        'argument {!r}'.format(kwargs.keys()[0]))
+                        'argument {!r}'.format(list(kwargs.keys())[0]))
     args = [np.array(_m, copy=False, subok=subok) for _m in args]
 
     shape = _broadcast_shape(*args)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -66,7 +66,7 @@ def test_broadcast_kwargs():
     y = np.arange(10)
 
     with assert_raises_regex(TypeError,
-                             'broadcast_arrays\\(\\) got an unexpected keyword*'):
+                             r'broadcast_arrays\(\) got an unexpected keyword*'):
         broadcast_arrays(x, y, dtype='float64')
 
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -3,7 +3,8 @@ from __future__ import division, absolute_import, print_function
 import numpy as np
 from numpy.core._rational_tests import rational
 from numpy.testing import (
-    assert_equal, assert_array_equal, assert_raises, assert_
+    assert_equal, assert_array_equal, assert_raises, assert_,
+    assert_raises_regex
     )
 from numpy.lib.stride_tricks import (
     as_strided, broadcast_arrays, _broadcast_shape, broadcast_to
@@ -56,6 +57,17 @@ def test_same():
     bx, by = broadcast_arrays(x, y)
     assert_array_equal(x, bx)
     assert_array_equal(y, by)
+
+def test_broadcast_kwargs():
+    # ensure that a TypeError is appropriately raised when
+    # np.broadcast_arrays() is called with any keyword
+    # argument other than 'subok'
+    x = np.arange(10)
+    y = np.arange(10)
+
+    with assert_raises_regex(TypeError,
+                             'broadcast_arrays\\(\\) got an unexpected keyword*'):
+        broadcast_arrays(x, y, dtype='float64')
 
 
 def test_one_off():


### PR DESCRIPTION
In short, local coverage tests (hopefully reported online soon from: #11567) indicated that we weren't unit testing for the proper handling of invalid kwargs for `np.broadcast_arrays()`.

In adding the unit test for this kwarg handling in this PR, I also noticed that the appropriate error **message** is not raised in Python 3 because `dict.keys()` is not a list anymore, so the test was also adjusted to verify the correct error message & the associated source code modified to ensure an indexable object in Python 3.