### PR TITLE
BUG: Add home directory to path for global .numpy-site.cfg file.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -540,7 +540,7 @@ class system_info(object):
                     'extra_compile_args': '', 'extra_link_args': ''}
         self.cp = ConfigParser(defaults)
         self.files = []
-        self.files.extend(get_standard_file('.numpy-site.cfg'))
+        self.files.extend(get_standard_file('~/.numpy-site.cfg'))
         self.files.extend(get_standard_file('site.cfg'))
         self.parse_config_files()
 


### PR DESCRIPTION
Bug fix for issue #11581 