### PR TITLE
MAINT: update runtests.py node id example for pytest usage

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -34,7 +34,7 @@ from __future__ import division, print_function
 
 PROJECT_MODULE = "numpy"
 PROJECT_ROOT_FILES = ['numpy', 'LICENSE.txt', 'setup.py']
-SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py:test_byteorder_check"
+SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py::test_byteorder_check"
 SAMPLE_SUBMODULE = "linalg"
 
 EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',


### PR DESCRIPTION
The example of specific test selection in `runtests.py` is a little out of date since it uses the old `nose` syntax. I've added the extra colon used [in pytest test specification](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests) (they call these node ids for tests) so that users don't get confused if they copy / paste from that example.

In general, the `path/to/test_mod.py::TestClass::test_method` syntax can be hard to remember if you don't use it often.