### PR TITLE
ENH: support for empty matrices in linalg.lstsq

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -40,6 +40,12 @@ New Features
 Improvements
 ============
 
+``linalg.lstsq`` now works with empty matrices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, a ``LinAlgError`` would be raised when an empty matrix/empty
+matrices (with zero rows and/or columns) is passed in. Now outputs of
+appropriate shapes are returned.
+
 ``randint`` and ``choice`` now work on empty distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Even when no elements needed to be drawn, ``np.random.randint`` and

--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -40,12 +40,6 @@ New Features
 Improvements
 ============
 
-``linalg.lstsq`` now works with empty matrices
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Previously, a ``LinAlgError`` would be raised when an empty matrix/empty
-matrices (with zero rows and/or columns) is passed in. Now outputs of
-appropriate shapes are returned.
-
 ``randint`` and ``choice`` now work on empty distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Even when no elements needed to be drawn, ``np.random.randint`` and
@@ -53,11 +47,11 @@ Even when no elements needed to be drawn, ``np.random.randint`` and
 distribution. This has been fixed so that e.g.
 ``np.random.choice([], 0) == np.array([], dtype=float64)``.
 
-``linalg.qr`` now works with empty matrices
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Previously, a ``LinAlgError`` would be raised when empty matrix
-(with zero rows and/or columns) is passed in. This has been fixed
-so that outputs of appropriate shapes are returned for the various modes.
+``linalg.lstsq`` and ``linalg.qr`` now work with empty matrices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, a ``LinAlgError`` would be raised when an empty matrix/empty
+matrices (with zero rows and/or columns) is/are passed in. Now outputs of
+appropriate shapes are returned.
 
 ARM support updated
 -------------------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2110,7 +2110,6 @@ def lstsq(a, b, rcond="warn"):
     if is_1d:
         b = b[:, newaxis]
     _assertRank2(a, b)
-    _assertNoEmpty2d(a, b)  # TODO: relax this constraint
     m, n = a.shape[-2:]
     m2, n_rhs = b.shape[-2:]
     if m != m2:
@@ -2141,7 +2140,16 @@ def lstsq(a, b, rcond="warn"):
 
     signature = 'DDd->Ddid' if isComplexType(t) else 'ddd->ddid'
     extobj = get_linalg_error_extobj(_raise_linalgerror_lstsq)
+    if n_rhs == 0:
+        # lapack can't handle n_rhs = 0 - so allocate the array one larger in that axis
+        b = zeros(b.shape[:-2] + (m, n_rhs + 1), dtype=b.dtype)
     x, resids, rank, s = gufunc(a, b, rcond, signature=signature, extobj=extobj)
+    if m == 0:
+        x[...] = 0
+    if n_rhs == 0:
+        # remove the item we added
+        x = x[..., :n_rhs]
+        resids = resids[..., :n_rhs]
 
     # remove the axis we added
     if is_1d:


### PR DESCRIPTION
Added support for empty matrices in linalg.lstsq with tests

Relates to #8654 