### PR TITLE
TST: Add Python 3.7 to CI testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
       TEST_MODE: fast
 
     - PYTHON: C:\Python36
-      PYTHON_VERSION: 3.6
+      PYTHON_VERSION: 3.7
       PYTHON_ARCH: 32
       TEST_MODE: fast
 
@@ -36,7 +36,7 @@ environment:
       TEST_MODE: fast
 
     - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: 3.6
+      PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       TEST_MODE: full
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ environment:
       PYTHON_ARCH: 64
       TEST_MODE: fast
 
-    - PYTHON: C:\Python36
+    - PYTHON: C:\Python37
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 32
       TEST_MODE: fast
@@ -35,7 +35,7 @@ environment:
       PYTHON_ARCH: 64
       TEST_MODE: fast
 
-    - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       TEST_MODE: full

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,11 @@ environment:
       PYTHON_ARCH: 64
       TEST_MODE: fast
 
+    - PYTHON: C:\Python36
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 32
+      TEST_MODE: fast
+
     - PYTHON: C:\Python37
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 32
@@ -34,6 +39,11 @@ environment:
       PYTHON_VERSION: 2.7
       PYTHON_ARCH: 64
       TEST_MODE: fast
+
+    - PYTHON: C:\Python36-x64
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      TEST_MODE: full
 
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.7
+      - image: circleci/python:3.6.6
 
     working_directory: ~/repo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
 matrix:
   include:
+    - python: 3.7
+      dist: xenial  # Required for Python 3.7
+      sudo: true    # travis-ci/travis-ci#9069
     - python: 3.6
       env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=3.6
       sudo: true
@@ -76,9 +78,6 @@ matrix:
        - BLAS=None
        - LAPACK=None
        - ATLAS=None
-    - python: 3.7
-      dist: xenial  # Required for Python 3.7
-      sudo: true    # travis-ci/travis-ci#9069
 
 before_install:
   - ./tools/travis-before-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ matrix:
        - BLAS=None
        - LAPACK=None
        - ATLAS=None
+    - python: 3.7
+      dist: xenial  # Required for Python 3.7
+      sudo: true  # Required for Python 3.7
 
 before_install:
   - ./tools/travis-before-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
        - ATLAS=None
     - python: 3.7
       dist: xenial  # Required for Python 3.7
-      sudo: true  # Required for Python 3.7
+      sudo: true    # travis-ci/travis-ci#9069
 
 before_install:
   - ./tools/travis-before-install.sh

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER = 3.6
+PYVER = 3.7
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER = 3.7
+PYVER = 3.6
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.


### PR DESCRIPTION
Add Python 3.7 to CI testing.  Note that on travis-ci it must run with sudo on xenial, see travis-ci/travis-ci#9069.