### PR TITLE
 BUG: Make np.array([[1], 2]) and np.array([1, [2]]) behave in the same way

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -846,11 +846,10 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         return 0;
     }
     else {
-        npy_intp dtmp[NPY_MAXDIMS];
-        int j, maxndim_m1 = *maxndim - 1;
-        e = PySequence_Fast_GET_ITEM(seq, 0);
+        int maxndim_m1 = *maxndim - 1;
+        PyObject *first = PySequence_Fast_GET_ITEM(seq, 0);
 
-        r = discover_dimensions(e, &maxndim_m1, d + 1, check_it,
+        r = discover_dimensions(first, &maxndim_m1, d + 1, check_it,
                                         stop_at_string, stop_at_tuple,
                                         out_is_object);
         if (r < 0) {
@@ -861,9 +860,12 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         /* For the dimension truncation check below */
         *maxndim = maxndim_m1 + 1;
         for (i = 1; i < n; ++i) {
-            e = PySequence_Fast_GET_ITEM(seq, i);
+            int j;
+            npy_intp dtmp[NPY_MAXDIMS];
+            PyObject *elem = PySequence_Fast_GET_ITEM(seq, i);
+
             /* Get the dimensions of the first item */
-            r = discover_dimensions(e, &maxndim_m1, dtmp, check_it,
+            r = discover_dimensions(elem, &maxndim_m1, dtmp, check_it,
                                             stop_at_string, stop_at_tuple,
                                             out_is_object);
             if (r < 0) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -688,6 +688,9 @@ class TestScalarIndexing(object):
 
 
 class TestCreation(object):
+    """
+    Test the np.array constructor
+    """
     def test_from_attribute(self):
         class x(object):
             def __array__(self, dtype=None):
@@ -916,6 +919,21 @@ class TestCreation(object):
         a = np.array([1, 2, [3]])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
+
+    def test_jagged_shape_object(self):
+        # The jagged dimension of a list is turned into an object array
+        a = np.array([[1, 1], [2], [3]])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
+
+        a = np.array([[1], [2, 2], [3]])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
+
+        a = np.array([[1], [2], [3, 3]])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
+
 
 class TestStructured(object):
     def test_subarray_field_access(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -903,6 +903,19 @@ class TestCreation(object):
             assert_raises(ValueError, np.ndarray, buffer=buf, strides=(0,),
                           shape=(max_bytes//itemsize + 1,), dtype=dtype)
 
+    def test_jagged_ndim_object(self):
+        # Lists of mismatching depths are treated as object arrays
+        a = np.array([[1], 2, 3])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
+
+        a = np.array([1, [2], 3])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
+
+        a = np.array([1, 2, [3]])
+        assert_equal(a.shape, (3,))
+        assert_equal(a.dtype, object)
 
 class TestStructured(object):
     def test_subarray_field_access(self):


### PR DESCRIPTION
Related to #6584 

Previously the former would succeed, but the latter would fail with a cryptic error message.