### PR TITLE
TST: Add Python 3.7 to CI testing (#11598)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,11 @@ environment:
       PYTHON_ARCH: 32
       TEST_MODE: fast
 
+    - PYTHON: C:\Python37
+      PYTHON_VERSION: 3.7
+      PYTHON_ARCH: 32
+      TEST_MODE: fast
+
     - PYTHON: C:\Python27-x64
       PYTHON_VERSION: 2.7
       PYTHON_ARCH: 64
@@ -37,6 +42,11 @@ environment:
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      TEST_MODE: full
+
+    - PYTHON: C:\Python37-x64
+      PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       TEST_MODE: full
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.6
 
     working_directory: ~/repo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
 matrix:
   include:
+    - python: 3.7
+      dist: xenial  # Required for Python 3.7
+      sudo: true    # travis-ci/travis-ci#9069
     - python: 3.6
       env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=3.6
       sudo: true


### PR DESCRIPTION
Backport of #11598.

Add testing with Python 3.7 to both appveyor and travis.