### PR TITLE
WIP: Allow lstsq on empty arrays

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2110,7 +2110,6 @@ def lstsq(a, b, rcond="warn"):
     if is_1d:
         b = b[:, newaxis]
     _assertRank2(a, b)
-    _assertNoEmpty2d(a, b)  # TODO: relax this constraint
     m, n = a.shape[-2:]
     m2, n_rhs = b.shape[-2:]
     if m != m2:

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -3197,7 +3197,13 @@ static void
             params.RCOND = args[2];
             not_ok = call_@lapack_func@(&params);
             if (!not_ok) {
-                delinearize_@TYPE@_matrix(args[3], params.B, &x_out);
+                if (m == 0) {
+                    /* Lapack has betrayed us and left this uninitialized */
+                    zero_@TYPE@_matrix(args[3], &x_out);
+                }
+                else {
+                    delinearize_@TYPE@_matrix(args[3], params.B, &x_out);
+                }
                 *(npy_int*) args[5] = params.RANK;
                 delinearize_@REALTYPE@_matrix(args[6], params.S, &s_out);
 


### PR DESCRIPTION
This fails on my lapack, so sending to CI to try and bisect a working lapack version. For me, it fails with:

    ValueError: On entry to DLALSD parameter number 4 had an illegal value

We don't even call that routine directly, so this is definitely a LAPACK bug.

Alternative to gh-11594