### PR TITLE
NEP: Add roadmap section and subdocuments to NEPs

### DIFF
--- a/doc/neps/grant_bids.rst
+++ b/doc/neps/grant_bids.rst
@@ -1,7 +1,0 @@
-===================
-NumPy Grant at BIDS
-===================
-
-Priorities / roadmap at BIDS.
-Description of how we structure our activities (cleanups,
-infrastructure, etc.)

--- a/doc/neps/grant_bids.rst
+++ b/doc/neps/grant_bids.rst
@@ -1,0 +1,7 @@
+===================
+NumPy Grant at BIDS
+===================
+
+Priorities / roadmap at BIDS.
+Description of how we structure our activities (cleanups,
+infrastructure, etc.)

--- a/doc/neps/index.rst.tmpl
+++ b/doc/neps/index.rst.tmpl
@@ -16,7 +16,6 @@ Roadmap
    The Scope of NumPy <scope>
    Current roadmap <roadmap>
    Wish list <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
-   Grant at UC Berkeley <grant_bids>
 
 Meta-NEPs (NEPs about NEPs or Processes)
 ----------------------------------------

--- a/doc/neps/index.rst.tmpl
+++ b/doc/neps/index.rst.tmpl
@@ -1,12 +1,22 @@
-===========================
-NumPy Enhancement Proposals
-===========================
+=====================================
+Roadmap & NumPy Enhancement Proposals
+=====================================
 
-NumPy Enhancement Proposals (NEPs) describe proposed changes to NumPy.
-NEPs are modeled on Python Enhancement Proposals (PEPs), and are typically
-written up when large changes to NumPy are proposed.
+This page provides an overview of development priorities for NumPy.
+Specifically, it contains a roadmap with a higher-level overview, as
+well as NumPy Enhancement Proposals (NEPs)—suggested changes
+to the library—in various stages of discussion or completion (see `NEP
+0 <nep-0000>`__).
 
-This page provides an overview of all NEPs.
+Roadmap
+-------
+.. toctree::
+   :maxdepth: 1
+
+   The Scope of NumPy <scope>
+   Current roadmap <roadmap>
+   Wish list <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
+   Grant at UC Berkeley <grant_bids>
 
 Meta-NEPs (NEPs about NEPs or Processes)
 ----------------------------------------

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -1,5 +1,114 @@
 =============
-NumPy roadmap
+NumPy Roadmap
 =============
 
-Current version of roadmap goes here.
+This is a live snapshot of tasks and features we will be investing resources
+in. It may be used to encourage and inspire developers and to search for
+funding.
+
+Interoperability protocols & duck typing
+========================================
+
+`__array_function__`
+--------------------
+See `NEP 18`_ and a sample implementation_
+
+Array Duck-Typing
+-----------------
+`NEP 22`_    `np.asduckarray()`
+
+
+Mixins like `NDArrayOperatorsMixin`:
+
+- for mutable arrays
+- for reduction methods implemented as ufuncs
+
+Better dtypes
+-------------
+
+- Easier custom dtypes
+  - Simplify and/or wrap the current C-API
+  - More consistent support for dtype metadata
+  - Support for writing a dtype in Python
+- New string dtype(s):
+  - Fixed width encoded strings (utf8, latin1, ...)
+  - Variable length strings (could share implementation with dtype=object, but are explicitly type-checked)
+  - One of these should probably be the default for text data. The current behavior on Python 3 is neither efficient nor user friendly.
+- `np.int` should not be platform dependent
+- better coercion for string + number
+
+Random number generation policy & rewrite
+-----------------------------------------
+
+`NEP 19`_ and a `reference implementation`_
+
+Indexing
+--------
+
+vindex/oindex `NEP 21`_
+
+Infrastructure
+--------------
+
+NumPy is much more than just the code base itself, we also maintain
+docs, CI, benchmarks, etc.
+
+- Rewrite numpy.org
+- Benchmarking: improve the extent of the existing suite, and run & render
+  the results as part of the docs or website.
+
+  - Hardware: find a machine that can reliably run serial benchmarks
+  - ASV produces graphs, could we set up a site? Currently at
+    https://pv.github.io/numpy-bench/, should that become a community resource?
+
+Functionality outside core
+--------------------------
+
+Some things inside NumPy do not actually match the `Scope of NumPy`.
+
+- A backend system for `numpy.fft` (so that e.g. `fft-mkl` doesn't need to monkeypatch numpy)
+
+- Rewrite masked arrays to not be a ndarray subclass -- maybe in a separate project?
+- MaskedArray as a duck-array type, and/or
+- dtypes that support missing values
+
+- Write a strategy on how to deal with overlap between numpy and scipy for `linalg` and `fft` (and implement it).
+
+- Deprecate `np.matrix`
+
+Continuous Integration
+----------------------
+
+We depend on CI to discover problems as we continue to develop NumPy before the
+code reaches downstream users.
+
+- CI for more exotic platforms (e.g. ARM is now available from
+  http://www.shippable.com/, but it is not free).
+- Multi-package testing
+- Add an official channel for numpy dev builds for CI usage by other projects so
+  they may confirm new builds do not break their package.
+
+Typing
+------
+
+Python type annotation syntax should support ndarrays and dtypes.
+
+- Type annotations for NumPy: github.com/numpy/numpy-stubs
+- Support for typing shape and dtype in multi-dimensional arrays in Python more generally
+
+NumPy scalars
+-------------
+
+Numpy has both scalars and zero-dimensional arrays.
+
+- The current implementation adds a large maintenance burden -- can we remove
+  scalars and/or simplify it internally?
+- Zero dimensional arrays get converted into scalars by most NumPy functions.
+  Can this be fixed?
+
+.. _`NEP 19`: https://www.numpy.org/neps/nep-0019-rng-policy.html
+.. _`NEP 22`: http://www.numpy.org/neps/nep-0022-ndarray-duck-typing-overview.html
+.. _`NEP 18`: https://www.numpy.org/neps/nep-0018-array-function-protocol.html
+.. _implementation: https://gist.github.com/shoyer/1f0a308a06cd96df20879a1ddb8f0006
+.. _`reference implementation`: https://github.com/bashtage/randomgen
+.. _`NEP 21`: https://www.numpy.org/neps/nep-0021-advanced-indexing.html

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -31,7 +31,7 @@ Better dtypes
   - More consistent support for dtype metadata
   - Support for writing a dtype in Python
 - New string dtype(s):
-  - Fixed width encoded strings (utf8, latin1, ...)
+  - Encoded strings with fixed-width storage (utf8, latin1, ...)
   - Variable length strings (could share implementation with dtype=object, but are explicitly type-checked)
   - One of these should probably be the default for text data. The current behavior on Python 3 is neither efficient nor user friendly.
 - `np.int` should not be platform dependent

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -103,8 +103,10 @@ Numpy has both scalars and zero-dimensional arrays.
 
 - The current implementation adds a large maintenance burden -- can we remove
   scalars and/or simplify it internally?
-- Zero dimensional arrays get converted into scalars by most NumPy functions.
-  Can this be fixed?
+- Zero dimensional arrays get converted into scalars by most NumPy
+  functions (i.e., output of `np.sin(x)` depends on whether `x` is
+  zero-dimensional or not).  This inconsistency should be addressed,
+  so that one could, e.g., write sane type annotations.
 
 .. _`NEP 19`: https://www.numpy.org/neps/nep-0019-rng-policy.html
 .. _`NEP 22`: http://www.numpy.org/neps/nep-0022-ndarray-duck-typing-overview.html

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -31,7 +31,7 @@ Better dtypes
   - More consistent support for dtype metadata
   - Support for writing a dtype in Python
 - New string dtype(s):
-  - Encoded strings with fixed-width storage (utf8, latin1, ...)
+  - Encoded strings with fixed-width storage (utf8, latin1, ...) and/or
   - Variable length strings (could share implementation with dtype=object, but are explicitly type-checked)
   - One of these should probably be the default for text data. The current behavior on Python 3 is neither efficient nor user friendly.
 - `np.int` should not be platform dependent

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -7,21 +7,20 @@ in. It may be used to encourage and inspire developers and to search for
 funding.
 
 Interoperability protocols & duck typing
-========================================
+----------------------------------------
 
-`__array_function__`
---------------------
-See `NEP 18`_ and a sample implementation_
+- `__array_function__`
 
-Array Duck-Typing
------------------
-`NEP 22`_    `np.asduckarray()`
+  See `NEP 18`_ and a sample implementation_
 
+- Array Duck-Typing
 
-Mixins like `NDArrayOperatorsMixin`:
+  `NEP 22`_    `np.asduckarray()`
 
-- for mutable arrays
-- for reduction methods implemented as ufuncs
+- Mixins like `NDArrayOperatorsMixin`:
+
+  - for mutable arrays
+  - for reduction methods implemented as ufuncs
 
 Better dtypes
 -------------

--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -1,0 +1,5 @@
+=============
+NumPy roadmap
+=============
+
+Current version of roadmap goes here.

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -39,4 +39,8 @@ Here, we describe aspects of N-d array computation that are within scope for Num
   - f2py (generating bindings for Fortran code)
   - testing utilities
 
-- **Speed**: while we take performance concerns seriously, where conflict arises maintenance and portability take precedence over performance. We aim to prevent regressions where possible (e.g., through asv).
+- **Speed**: we take performance concerns seriously and aim to execute
+  operations on large arrays with similar performance as native C
+  code. That said, where conflict arises, maintenance and portability take
+  precedence over performance. We aim to prevent regressions where
+  possible (e.g., through asv).

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -22,6 +22,7 @@ Here, we describe aspects of N-d array computation that are within scope for Num
 
   - Masked arrays
   - Structured arrays
+  - Memory mapped arrays
 
 - Historically, NumPy has included the following **basic functionality
   in support of scientific computation**. We intend to keep supporting

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -18,10 +18,10 @@ Here, we describe aspects of N-d array computation that are within scope for Num
 
 - **Python API and a C API** to the ndarray's methods and attributes.
 
-- Other **specialized types of N-dimensional arrays**:
+- Other **specialized types or uses of N-dimensional arrays**:
 
   - Masked arrays
-  - Structured arrays
+  - Structured arrays (informally known as record arrays)
   - Memory mapped arrays
 
 - Historically, NumPy has included the following **basic functionality

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -4,25 +4,38 @@ Scope of NumPy
 
 Here, we describe aspects of N-d array computation that are within scope for NumPy development. This is *not* an aspirational definition of where NumPy should aim, but instead captures the status quo—areas which we have decided to continue supporting, at least for the time being.
 
-- In-memory, N-dimensional, homogeneously typed (single pointer + strided) arrays on CPUs
-    - Support for a wide range of data types
-    - Not specialized hardware such as GPUs
-    - But, do support wide range of CPUs (e.g. ARM, PowerX)
-- Higher level APIs for N-dimensional arrays
-    - NumPy is a *de facto* standard for array APIs in Python
-    - Indexing and fast iteration over elements (ufunc)
-    - Interoperability protocols with other data container implementations (like `__array_ufunc__`).
-- Python API and a C API to the ndarray's methods and attributes.
-- More specialized types of N-dimensional arrays:
-    - Masked arrays
-    - Structured arrays
-- Historically, NumPy has included the following basic functionality in support of scientific computation. We intend to keep supporting (but not to expand) what is currently included:
-    - Linear algebra
-    - Fast Fourier transforms and windowing
-    - Pseudo-random number generators
-    - Polynomial fitting
-- NumPy provides some infrastructure for other packages in the scientific Python ecosystem:
-    - numpy.distutils (build support for C++, Fortran, BLAS/LAPACK, and other relevant libraries for scientific computing
-    - f2py (generating bindings for Fortran code)
-    - testing utilities
-- Speed: while we take performance concerns seriously, where conflict arises maintenance and portability take precedence over performance. We aim to prevent regressions where possible (e.g., through asv).
+- **In-memory, N-dimensional, homogeneously typed (single pointer + strided) arrays on CPUs**
+
+  - Support for a wide range of data types
+  - Not specialized hardware such as GPUs
+  - But, do support wide range of CPUs (e.g. ARM, PowerX)
+
+- **Higher level APIs for N-dimensional arrays**
+
+  - NumPy is a *de facto* standard for array APIs in Python
+  - Indexing and fast iteration over elements (ufunc)
+  - Interoperability protocols with other data container implementations (like `__array_ufunc__`).
+
+- **Python API and a C API** to the ndarray's methods and attributes.
+
+- Other **specialized types of N-dimensional arrays**:
+
+  - Masked arrays
+  - Structured arrays
+
+- Historically, NumPy has included the following **basic functionality
+  in support of scientific computation**. We intend to keep supporting
+  (but not to expand) what is currently included:
+
+  - Linear algebra
+  - Fast Fourier transforms and windowing
+  - Pseudo-random number generators
+  - Polynomial fitting
+
+- NumPy provides some **infrastructure for other packages in the scientific Python ecosystem**:
+
+  - numpy.distutils (build support for C++, Fortran, BLAS/LAPACK, and other relevant libraries for scientific computing
+  - f2py (generating bindings for Fortran code)
+  - testing utilities
+
+- **Speed**: while we take performance concerns seriously, where conflict arises maintenance and portability take precedence over performance. We aim to prevent regressions where possible (e.g., through asv).

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -1,0 +1,28 @@
+==============
+Scope of NumPy
+==============
+
+Here, we describe aspects of N-d array computation that are within scope for NumPy development. This is *not* an aspirational definition of where NumPy should aim, but instead captures the status quo—areas which we have decided to continue supporting, at least for the time being.
+
+- In-memory, N-dimensional, homogeneously typed (single pointer + strided) arrays on CPUs
+    - Support for a wide range of data types
+    - Not specialized hardware such as GPUs
+    - But, do support wide range of CPUs (e.g. ARM, PowerX)
+- Higher level APIs for N-dimensional arrays
+    - NumPy is a *de facto* standard for array APIs in Python
+    - Indexing and fast iteration over elements (ufunc)
+    - Interoperability protocols with other data container implementations (like `__array_ufunc__`).
+- Python API and a C API to the ndarray's methods and attributes.
+- More specialized types of N-dimensional arrays:
+    - Masked arrays
+    - Structured arrays
+- Historically, NumPy has included the following basic functionality in support of scientific computation. We intend to keep supporting (but not to expand) what is currently included:
+    - Linear algebra
+    - Fast Fourier transforms and windowing
+    - Pseudo-random number generators
+    - Polynomial fitting
+- NumPy provides some infrastructure for other packages in the scientific Python ecosystem:
+    - numpy.distutils (build support for C++, Fortran, BLAS/LAPACK, and other relevant libraries for scientific computing
+    - f2py (generating bindings for Fortran code)
+    - testing utilities
+- Speed: while we take performance concerns seriously, where conflict arises maintenance and portability take precedence over performance. We aim to prevent regressions where possible (e.g., through asv).


### PR DESCRIPTION
Together with @rgommers we refined the last roadmap version that he and @shoyer worked on further.  We think this is now pretty close to ready, so please go ahead and review (comments to the mailing list, please).

https://mail.python.org/pipermail/numpy-discussion/2018-July/078458.html

I've also added a section to the NEP website to host it.