### PR TITLE
BUG: Clip uses wrong memory order in output 

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -62,6 +62,12 @@ behavior will be appending.  This applied to: `LDFLAGS`, `F77FLAGS`,
 `F90FLAGS`, `FREEFLAGS`, `FOPT`, `FDEBUG`, and `FFLAGS`.  See gh-11525 for more
 details.
 
+``np.clip`` and the ``clip`` method check for memory overlap
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``out`` argument to these functions is now always tested for memory overlap
+to avoid corrupted results when memory overlap occurs.
+
+
 Changes
 =======
 

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1103,6 +1103,8 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
         outgood = 1;
     }
     if (!outgood && PyArray_ISONESEGMENT(out) &&
+                        /* Both are contiguous, but must be identically so */
+                        PyArray_ISFORTRAN(out) == PyArray_ISFORTRAN(self) &&
                         PyArray_CHKFLAGS(out, NPY_ARRAY_ALIGNED) &&
                         PyArray_ISNOTSWAPPED(out) &&
                         PyArray_EquivTypes(PyArray_DESCR(out), indescr)) {
@@ -1115,7 +1117,7 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
      */
     if (!outgood) {
         int oflags;
-        if (PyArray_ISFORTRAN(out))
+        if (PyArray_ISFORTRAN(self))
             oflags = NPY_ARRAY_FARRAY;
         else
             oflags = NPY_ARRAY_CARRAY;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1530,7 +1530,7 @@ class TestClip(object):
         m = -0.5
         M = 0.6
         self.fastclip(a, m, M, a)
-        self.clip(a, m, M, ac)
+        self.clip(ac, m, M, ac)
         assert_array_strict_equal(a, ac)
 
     def test_noncontig_inplace(self):
@@ -1543,7 +1543,7 @@ class TestClip(object):
         m = -0.5
         M = 0.6
         self.fastclip(a, m, M, a)
-        self.clip(a, m, M, ac)
+        self.clip(ac, m, M, ac)
         assert_array_equal(a, ac)
 
     def test_type_cast_01(self):
@@ -1721,6 +1721,14 @@ class TestClip(object):
         self.fastclip(a, m, M, ac)
         self.clip(a, m, M, act)
         assert_array_strict_equal(ac, act)
+
+    def test_clip_with_out_transposed(self):
+        # Test that the out argument works when tranposed
+        a = np.arange(16).reshape(4, 4)
+        out = np.empty_like(a).T
+        a.clip(4, 10, out=out)
+        expected = self.clip(a, 4, 10)
+        assert_array_equal(out, expected)
 
     def test_clip_inplace_array(self):
         # Test native double input with array min/max

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1730,6 +1730,14 @@ class TestClip(object):
         expected = self.clip(a, 4, 10)
         assert_array_equal(out, expected)
 
+    def test_clip_with_out_memory_overlap(self):
+        # Test that the out argument works when it has memory overlap
+        a = np.arange(16).reshape(4, 4)
+        ac = a.copy()
+        a[:-1].clip(4, 10, out=a[1:])
+        expected = self.clip(ac[:-1], 4, 10)
+        assert_array_equal(a[1:], expected)
+
     def test_clip_inplace_array(self):
         # Test native double input with array min/max
         a = self._generate_data(self.nr, self.nc)


### PR DESCRIPTION
First commit just fixes the transpose bug, second commit makes it so that it checks for overlap on the argument.