### PR TITLE
MAINT: Filter Cython warnings in `__init__.py`

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -179,6 +179,11 @@ else:
     __all__.extend(lib.__all__)
     __all__.extend(['linalg', 'fft', 'random', 'ctypeslib', 'ma'])
 
+    # Filter out Cython harmless warnings
+    warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+    warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+    warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
+
     # oldnumeric and numarray were removed in 1.9. In case some packages import
     # but do not use them, we define them here for backward compatibility.
     oldnumeric = 'removed'


### PR DESCRIPTION
This pull requests adds back filters for the Cython-related RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88