### PR TITLE
DOC: Insert up to date link to Spyder website in Dev Env doc where Spyder is mentioned

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -59,7 +59,7 @@ For development, you can set up an in-place build so that changes made to
 This allows you to import the in-place built NumPy *from the repo base
 directory only*.  If you want the in-place build to be visible outside that
 base dir, you need to point your ``PYTHONPATH`` environment variable to this
-directory.  Some IDEs (Spyder for example) have utilities to manage
+directory.  Some IDEs (`Spyder`_ for example) have utilities to manage
 ``PYTHONPATH``.  On Linux and OSX, you can run the command::
 
     $ export PYTHONPATH=$PWD
@@ -77,6 +77,8 @@ is with ``python setup.py develop``.  Instead of adjusting ``PYTHONPATH``, this
 installs a ``.egg-link`` file into your site-packages as well as adjusts the
 ``easy-install.pth`` there, so its a more permanent (and magical) operation.
 
+
+.. _Spyder: https://www.spyder-ide.org/
 
 Other build options
 -------------------

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -216,13 +216,13 @@ Understanding the code & getting started
 ----------------------------------------
 
 The best strategy to better understand the code base is to pick something you
-want to change and start reading the code to figure out how it works. When in 
+want to change and start reading the code to figure out how it works. When in
 doubt, you can ask questions on the mailing list. It is perfectly okay if your
-pull requests aren't perfect, the community is always happy to help. As a 
-volunteer project, things do sometimes get dropped and it's totally fine to 
+pull requests aren't perfect, the community is always happy to help. As a
+volunteer project, things do sometimes get dropped and it's totally fine to
 ping us if something has sat without a response for about two to four weeks.
 
-So go ahead and pick something that annoys or confuses you about numpy, 
-experiment with the code, hang around for discussions or go through the 
-reference documents to try to fix it. Things will fall in place and soon 
+So go ahead and pick something that annoys or confuses you about numpy,
+experiment with the code, hang around for discussions or go through the
+reference documents to try to fix it. Things will fall in place and soon
 you'll have a pretty good understanding of the project as a whole. Good Luck!


### PR DESCRIPTION
A rather trivial PR, this simply inserts the up to date link to the Spyder IDE's new website in the Development Environment documentation, where Spyder is mentioned. It also cleans up a few trailing spaces present in the file while its at it, although I made it a separate commit so I can easily drop/revert it if not desired. Thanks!

Part of the broader effort described in spyder-ide/spyder-docs#39 to update out of date links to Spyder across the web.