### PR TITLE
WIP, TST: prevent patch-driven codecov CI failures

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,4 +7,6 @@ coverage:
       default:
         # Require 1% coverage, i.e., always succeed
         target: 1
+    patch: false
+    changes: false
 comment: off


### PR DESCRIPTION
It seems that codecov is causing CI failures when PR patch coverage diffs are lower than the total coverage for the project ([example PR](https://github.com/numpy/numpy/pull/10915) from @mattip that is otherwise passing tests).

The settings that affect this are not well-documented but this PR tries to mimic some additional settings from [SciPy yml](https://github.com/scipy/scipy/blob/master/codecov.yml) that appear to be related (in particular: `patch: false`).

I don't *think* we want CI to fail in this scenario, but if we do I can close this. Note that as usual the changes to behavior would only happen once devs rebase their branches to pull in the new yml file; we could require codecov to use the yml file on master branch only, but then PRs that adjust .codecov.yml might be harder to evaluate until merged.