### PR TITLE
BUG: cython sometimes emits invalid gcc attribute

### DIFF
--- a/doc/release/1.15.1-notes.rst
+++ b/doc/release/1.15.1-notes.rst
@@ -1,0 +1,23 @@
+==========================
+NumPy 1.15.1 Release Notes
+==========================
+
+This is a bugfix release for some problems reported following the 1.15.0
+release. The major problems fixed are the following.
+
+* The update to cython 0.28.3 exposed a problematic use of a gcc attribute used
+  to prefer code size rather than speed in module intialization.
+
+The Python versions supported by this release are 2.7, 3.4-3.7. The wheels are
+linked with OpenBLAS v0.3.0, which should fix some of the linalg problems
+reported for NumPy 1.14.
+
+Contributors
+============
+
+
+Pull requests merged
+====================
+
+
+

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -39,6 +39,9 @@ def configuration(parent_package='',top_path=None):
                 ('_LARGEFILE64_SOURCE', '1')]
     if needs_mingw_ftime_workaround():
         defs.append(("NPY_NEEDS_MINGW_TIME_WORKAROUND", None))
+    # fix for 0.26 < cython < 0.29 and perhaps 0.28.5
+    # see https://github.com/cython/cython/issues/2494
+    defs.append(('CYTHON_SMALL_CODE', ''))
 
     libs = []
     # Configure mtrand


### PR DESCRIPTION
Adds a `CYTHON_SMALL_CODE` macro to building our only cython module, `mtrand`

Relates to #11664, fixes it for 1.15 branch. Assumes cython will fix it and we will update cython accordingly for 1.16.

Also starts the release note for 1.15.1
