### PR TITLE
BUG: prevent ufunc output to an already-broadcasted array

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -72,6 +72,13 @@ details.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``out`` argument to these functions is now always tested for memory overlap
 to avoid corrupted results when memory overlap occurs.
+Ufuncs will not write to "broadcasted arrays"
+---------------------------------------------
+Code that uses `numpy.broadcast_arrays` can create an array with a 0-stride
+which effectively duplicates the underlying data along an axis. Using such
+an array for output of a ufunc such as `u += v` (where `u` has repeated data)
+will give an incorrect answer. This situation is now detected and an error
+raised.
 
 
 Changes

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1605,15 +1605,6 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
                     }
                     else {
                         strides[iop] = PyArray_STRIDE(op_cur, ondim-idim-1);
-                        if ((strides[iop] == 0) && (bshape > 0) &&
-                                (!(flags & NPY_ITER_REDUCE_OK)) &&
-                                (op_itflags[iop] & NPY_OP_ITFLAG_WRITE)) {
-                            PyErr_SetString(PyExc_ValueError,
-                                     "non-broadcastable output operand "
-                                     "with stride == 0 provided "
-                                     "but broadcasting required");
-                            return 0;
-                        }
                     }
                 }
             }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1605,6 +1605,15 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
                     }
                     else {
                         strides[iop] = PyArray_STRIDE(op_cur, ondim-idim-1);
+                        if ((strides[iop] == 0) && (bshape > 0) &&
+                                (!(flags & NPY_ITER_REDUCE_OK)) &&
+                                (op_itflags[iop] & NPY_OP_ITFLAG_WRITE)) {
+                            PyErr_SetString(PyExc_ValueError,
+                                     "non-broadcastable output operand "
+                                     "with stride == 0 provided "
+                                     "but broadcasting required");
+                            return 0;
+                        }
                     }
                 }
             }

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -545,6 +545,12 @@ class TestUfunc(object):
         a = np.arange(2).reshape((2, 1, 1))
         b = np.arange(3).reshape((3, 1, 1))
         assert_raises(ValueError, umt.inner1d, a, b)
+        # Writing to a broadcasted array should fail, gh-2705
+        a = np.arange(2)
+        b = np.arange(4).reshape((2, 2))
+        u, v = np.broadcast_arrays(a, b)
+        assert_equal(u.strides[0], 0)
+        assert_raises(ValueError, u.__iadd__, v)
 
     def test_type_cast(self):
         msg = "type cast"


### PR DESCRIPTION
Fixes #2705. 

I tried to find a balance between fixing all possible edge cases and keeping the code simple. The documentation for [broadcast_arrays](http://www.numpy.org/devdocs/reference/generated/numpy.broadcast_arrays.html) already warns against writing to these, this PR attempts to detect a pending, perhaps unintentional write in a func operation and raises a `ValueError`