### PR TITLE
TST: ignore setup.py files for codecov reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,6 @@ coverage:
         # Require 1% coverage, i.e., always succeed
         target: 1
 comment: off
+
+ignore:
+  - "**/setup.py"


### PR DESCRIPTION
We currently have a [PR that is failing CI](https://github.com/numpy/numpy/pull/10915#issuecomment-410828129) because codecov is failing. The codecov patch/ diff failure is due in part to added `setup.py` file lines when `setup.py` itself is obviously not flushed through by test code paths at all, so the patch or diff of the PR relative to master adds ten lines to `setup.py`, none of which are covered, so there's effectively a penalty for that.

The suggestion here is to use the [codecov.yml path ignore feature](https://docs.codecov.io/docs/ignoring-paths) to ignore all `setup.py` files in all paths of our source. This is an alternative suggested by @eric-wieser in [my initial PR to completely deactivate the patch / diff failure in CI](https://github.com/numpy/numpy/pull/11662). Perhaps this will help probe reviewers to look at coverage changes but prevent wasting their time on `setup.py` lines.

See also: 
-  [related issue in Scipy](https://github.com/scipy/scipy/issues/9074)
- [related PR to ignore `setup.py` in SciPy](https://github.com/scipy/scipy/pull/9114/files) [they currently propose to ignore some other things as well]

There are some differences between the projects of course--we may have an even stronger incentive to include test files themselves since we test a testsuite (and there's a compelling argument linked above that ignoring test files means that you don't catch the accidental addition of a test with the same name).