### PR TITLE
BUG: Fix regression in void_getitem

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -733,7 +733,7 @@ VOID_getitem(void *input, void *vap)
         return (PyObject *)ret;
     }
 
-    return PyBytes_FromStringAndSize(PyArray_DATA(ap), descr->elsize);
+    return PyBytes_FromStringAndSize(ip, descr->elsize);
 }
 
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2366,6 +2366,13 @@ class TestRegression(object):
         del va
         assert_equal(x, b'\x00\x00\x00\x00')
 
+    def test_void_getitem(self):
+        # Test fix for gh-11668.
+        assert_(np.array([b'a'], 'V1').astype('O') == b'a')
+        assert_(np.array([b'ab'], 'V2').astype('O') == b'ab')
+        assert_(np.array([b'abc'], 'V3').astype('O') == b'abc')
+        assert_(np.array([b'abcd'], 'V4').astype('O') == b'abcd')
+
     def test_structarray_title(self):
         # The following used to segfault on pypy, due to NPY_TITLE_KEY
         # not working properly and resulting to double-decref of the


### PR DESCRIPTION
Backport of #11669.

The return value for a void array was not correct when fetching objects.

Closes #11668.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
