### PR TITLE
BUG: Raise when unravel_index, ravel_multi_index are given empty input

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -868,6 +868,7 @@ astype_anyint(PyObject *obj) {
     if (!(PyArray_ISINTEGER(ret) || PyArray_ISBOOL(ret))) {
         /* ensure dtype is int-based */
         PyErr_SetString(PyExc_TypeError, NON_INTEGRAL_ERROR_MSG);
+        Py_DECREF(ret);
         return NULL;
     }
 
@@ -899,7 +900,6 @@ static int int_sequence_to_arrays(PyObject *seq,
     }
 
     for (i = 0; i < count; ++i) {
-        PyArray_Descr *dtype = NULL;
         PyObject *item = PySequence_GetItem(seq, i);
         if (item == NULL) {
             goto fail;

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -77,6 +77,26 @@ class TestRavelUnravelIndex(object):
             [[3, 6, 6], [4, 5, 1]])
         assert_equal(np.unravel_index(1621, (6, 7, 8, 9)), [3, 1, 4, 1])
 
+    def test_empty_indices(self):
+        msg1 = 'indices must be integral: the provided empty sequence was'
+        msg2 = 'only int indices permitted'
+        assert_raises_regex(TypeError, msg1, np.unravel_index, [], (10, 3, 5))
+        assert_raises_regex(TypeError, msg1, np.unravel_index, (), (10, 3, 5))
+        assert_raises_regex(TypeError, msg2, np.unravel_index, np.array([]),
+                            (10, 3, 5))
+        assert_equal(np.unravel_index(np.array([],dtype=int), (10, 3, 5)),
+                     [[], [], []])
+        assert_raises_regex(TypeError, msg1, np.ravel_multi_index, ([], []),
+                            (10, 3))
+        assert_raises_regex(TypeError, msg1, np.ravel_multi_index, ([], ['abc']),
+                            (10, 3))
+        assert_raises_regex(TypeError, msg2, np.ravel_multi_index,
+                    (np.array([]), np.array([])), (5, 3))
+        assert_equal(np.ravel_multi_index(
+                (np.array([], dtype=int), np.array([], dtype=int)), (5, 3)), [])
+        assert_equal(np.ravel_multi_index(np.array([[], []], dtype=int),
+                     (5, 3)), [])
+
     def test_big_indices(self):
         # ravel_multi_index for big indices (issue #7546)
         if np.intp == np.int64:


### PR DESCRIPTION
Fixes #7165. Replaces #7170.

Adds tests and fixes for `unravel_index`, `ravel_multi_index` when the input is an empty list. The strategy in #7170 relied on internal use of `PyArray_DTypeFromObject`. But we can proactively use it with a minimal `int` type (I used `NPY_BOOL` as the most basic type) to determine the dtype of the object while restricting the possibilities to `int` dtypes before calling `PyArray_FromAny`.

Also added a small refactor of privately used sequence_to_arrays to put output values at the end of the paramter list and use a goto to reduce duplicate code.