### PR TITLE
DOC: Update broadcasting doc with current exception details

### DIFF
--- a/numpy/doc/broadcasting.py
+++ b/numpy/doc/broadcasting.py
@@ -53,9 +53,10 @@ dimensions are compatible when
 2) one of them is 1
 
 If these conditions are not met, a
-``ValueError: frames are not aligned`` exception is thrown, indicating that
-the arrays have incompatible shapes. The size of the resulting array
-is the maximum size along each dimension of the input arrays.
+``ValueError: operands could not be broadcast together`` exception is 
+thrown, indicating that the arrays have incompatible shapes. The size of 
+the resulting array is the maximum size along each dimension of the input 
+arrays.
 
 Arrays do not need to have the same *number* of dimensions.  For example,
 if you have a ``256x256x3`` array of RGB values, and you want to scale
@@ -124,7 +125,7 @@ An example of broadcasting in practice::
  (5,)
 
  >>> x + y
- <type 'exceptions.ValueError'>: shape mismatch: objects cannot be broadcast to a single shape
+ <type 'exceptions.ValueError'>: operands could not be broadcast together with shapes (4,) (5,)
 
  >>> xx.shape
  (4, 1)

--- a/numpy/doc/broadcasting.py
+++ b/numpy/doc/broadcasting.py
@@ -125,7 +125,7 @@ An example of broadcasting in practice::
  (5,)
 
  >>> x + y
- <type 'exceptions.ValueError'>: operands could not be broadcast together with shapes (4,) (5,)
+ ValueError: operands could not be broadcast together with shapes (4,) (5,)
 
  >>> xx.shape
  (4, 1)


### PR DESCRIPTION
The exception details in the broadcast documentation were old and have since been updated. This commit changes the documentation to reflect the current exception details when a shape mismatch is raised.

Old:

> If these conditions are not met, a `ValueError: frames are not aligned` exception is thrown

New:

> If these conditions are not met, a `ValueError: operands could not be broadcast together` exception is thrown

There was a similar issue in an example in the documentation:

Old:

```python
 >>> x + y
 <type 'exceptions.ValueError'>: shape mismatch: objects cannot be broadcast to a single shape
```

New:

```python
 >>> x + y
 <type 'exceptions.ValueError'>: operands could not be broadcast together with shapes (4,) (5,)
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->