### PR TITLE
BUG: Fix pickle and memoryview for datetime64, timedelta64 scalars

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -809,8 +809,10 @@ gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
     /* Fill in information */
     info = _buffer_get_info(self);
     if (info == NULL) {
-        PyErr_SetString(PyExc_BufferError,
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_BufferError,
                         "could not get scalar buffer information");
+        }
         goto fail;
     }
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -404,8 +404,8 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
         case NPY_CFLOAT:       if (_append_str(str, "Zf")) return -1; break;
         case NPY_CDOUBLE:      if (_append_str(str, "Zd")) return -1; break;
         case NPY_CLONGDOUBLE:  if (_append_str(str, "Zg")) return -1; break;
-        /* XXX: datetime */
-        /* XXX: timedelta */
+        /* XXX NPY_DATETIME */
+        /* XXX NPY_TIMEDELTA */
         case NPY_OBJECT:       if (_append_char(str, 'O')) return -1; break;
         case NPY_STRING: {
             char buf[128];
@@ -483,7 +483,29 @@ _buffer_info_new(PyObject *obj)
         goto fail;
     }
 
-    if (PyArray_IsScalar(obj, Generic)) {
+    if (PyArray_IsScalar(obj, Datetime) || PyArray_IsScalar(obj, Timedelta)) {
+        /*
+         * Special case datetime64 scalars to remain backward compatible.
+         * This will change in a future version.
+         * Note arrays of datetime64 and strutured arrays with datetime64
+         * fields will not hit this code path and are currently unsupported
+         * in _buffer_format_string.
+         */
+        _append_char(&fmt, 'B');
+        _append_char(&fmt, '\0');
+        info->ndim = 1;
+        info->shape = malloc(sizeof(Py_ssize_t) * 2);
+        if (info->shape == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+        info->strides = info->shape + info->ndim;
+        info->shape[0] = 8;
+        info->strides[0] = 1;
+        info->format = fmt.s;
+        return info;
+    }
+    else if (PyArray_IsScalar(obj, Generic)) {
         descr = PyArray_DescrFromScalar(obj);
         if (descr == NULL) {
             goto fail;
@@ -809,10 +831,6 @@ gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
     /* Fill in information */
     info = _buffer_get_info(self);
     if (info == NULL) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_BufferError,
-                        "could not get scalar buffer information");
-        }
         goto fail;
     }
 
@@ -835,6 +853,9 @@ gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
     }
 #endif
     view->len = elsize;
+    if (PyArray_IsScalar(self, Datetime) || PyArray_IsScalar(self, Timedelta)) {
+        elsize = 1; /* descr->elsize,char is 8,'M', but we return 1,'B' */
+    }
     view->itemsize = elsize;
 
     Py_DECREF(descr);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1391,10 +1391,12 @@ _array_from_buffer_3118(PyObject *memoryview)
 
         if (!is_ctypes) {
             /* This object has no excuse for a broken PEP3118 buffer */
-            PyErr_SetString(
+            PyErr_Format(
                     PyExc_RuntimeError,
-                    "Item size computed from the PEP 3118 buffer format "
-                    "string does not match the actual item size.");
+                   "Item size %zd for PEP 3118 buffer format "
+                    "string %s does not match the dtype %c item size %d.",
+                    view->itemsize, view->format, descr->type,
+                    descr->elsize);
             Py_DECREF(descr);
             return NULL;
         }

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -620,6 +620,10 @@ class TestDateTime(object):
         assert_equal(pickle.loads(pickle.dumps(dt)), dt)
         dt = np.dtype('M8[W]')
         assert_equal(pickle.loads(pickle.dumps(dt)), dt)
+        scalar = np.datetime64('2016-01-01T00:00:00.000000000')
+        assert_equal(pickle.loads(pickle.dumps(scalar)), scalar)
+        delta = scalar - np.datetime64('2015-01-01T00:00:00.000000000')
+        assert_equal(pickle.loads(pickle.dumps(delta)), delta)
 
         # Check that loading pickles from 1.6 works
         pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n" + \

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6487,6 +6487,15 @@ class TestNewBufferProtocol(object):
         # Issue #4015.
         self._check_roundtrip(0)
 
+    def test_invalid_buffer_format(self):
+        # datetime64 cannot be used fully in a buffer yet
+        # Should be fixed in the next Numpy major release
+        dt = np.dtype([('a', 'uint16'), ('b', 'M8[s]')])
+        a = np.empty(3, dt)
+        assert_raises((ValueError, BufferError), memoryview, a)
+        assert_raises((ValueError, BufferError), memoryview, np.array((3), 'M8[D]'))
+
+
     def test_export_simple_1d(self):
         x = np.array([1, 2, 3, 4, 5], dtype='i')
         y = memoryview(x)


### PR DESCRIPTION
Fixes #11656, which is a regression after #10564.

Adds tests for pickling datetime64 and timedelta64 scalars. Pickling arrays of these `dtype`s works but pickling scalars fails. 

The problem seems to be in the new code for `gentype_getbuffer`, which creates a PEP 3118 compliant buffer. The old code was:
```C
int gentype_getbuffer(PyObject *self, Py_buffer *view, int flags)
{
    Py_ssize_t len;
    void *buf;
    /* FIXME: XXX: the format is not implemented! -- this needs more work */
    len = gentype_getreadbuf(self, 0, &buf);
    return PyBuffer_FillInfo(view, self, buf, len, 1, flags);
}
```
so now I need to find what is happening in that code that is not happening in the new code.

So far I only found where we override an original exception with a new one. ~Now `memoryview(np.datetime64('2016-01-01'))` raises an exception with the same message as `memoryview(np.array(100, 'M8[D]').~

Edit: python2 - python3 confusion