### PR TITLE
BUG: Add missing PyErr_NoMemory after failing malloc

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -468,6 +468,7 @@ _buffer_info_new(PyObject *obj)
 
     info = malloc(sizeof(_buffer_info_t));
     if (info == NULL) {
+        PyErr_NoMemory();
         goto fail;
     }
 
@@ -493,6 +494,7 @@ _buffer_info_new(PyObject *obj)
         else {
             info->shape = malloc(sizeof(Py_ssize_t) * PyArray_NDIM(arr) * 2 + 1);
             if (info->shape == NULL) {
+                PyErr_NoMemory();
                 goto fail;
             }
             info->strides = info->shape + PyArray_NDIM(arr);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -92,6 +92,7 @@ swab_separator(const char *sep)
 
     s = start = malloc(strlen(sep)+3);
     if (s == NULL) {
+        PyErr_NoMemory();
         return NULL;
     }
     /* add space to front if there isn't one */


### PR DESCRIPTION
Backport of #11695.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
