### PR TITLE
BUG: Fix regression in np.loadtxt for bz2 text files in Python 2.

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -37,6 +37,7 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import sys
+import warnings
 import shutil
 import io
 
@@ -85,9 +86,10 @@ def _python2_bz2open(fn, mode, encoding, newline):
 
     if "t" in mode:
         # BZ2File is missing necessary functions for TextIOWrapper
-        raise ValueError("bz2 text files not supported in python2")
-    else:
-        return bz2.BZ2File(fn, mode)
+        warnings.warn("Assuming latin1 encoding for bz2 text file in Python2",
+                      RuntimeWarning, stacklevel=5)
+        mode = mode.replace("t", "")
+    return bz2.BZ2File(fn, mode)
 
 def _python2_gzipopen(fn, mode, encoding, newline):
     """ Wrapper to open gzip in text mode.


### PR DESCRIPTION
Text bz2 files are not well supported in Python2, and, following the
NumPy upgrade in text handling, loadtxt was raising an error when they
were detected. This led to problems for those few who were using such
files. This patch is a quick fix that issues a RuntimeWarning, then
opens those files under the assumption that they are latin1 encoded.
Caveat emptor.

Closes #11633.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
