### PR TITLE
BUG: Check for compiler used in env['CC'], then config_vars['CC']

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -328,9 +328,10 @@ def build_project(args):
     # Always use ccache, if installed
     env['PATH'] = os.pathsep.join(EXTRA_PATH + env.get('PATH', '').split(os.pathsep))
     cvars = distutils.sysconfig.get_config_vars()
-    if 'gcc' in cvars.get('CC', ''):
+    compiler = env.get('CC') or cvars.get('CC', '')
+    if 'gcc' in compiler:
         # Check that this isn't clang masquerading as gcc.
-        if sys.platform != 'darwin' or 'gnu-gcc' in cvars.get('CC', ''):
+        if sys.platform != 'darwin' or 'gnu-gcc' in compiler:
             # add flags used as werrors
             warnings_as_errors = ' '.join([
                 # from tools/travis-test.sh


### PR DESCRIPTION
PR #11139 attempts to turn some compiler warnings into errors, in an attempt to make `runtests.py` fail before pushing commits to CI, where the logic to check for errors is a bit different (uses [grep to look for warnings](https://github.com/numpy/numpy/blob/master/tools/travis-test.sh#L51). Unfortunately that PR did not test clang, which has different warning flags.  Subsequently we tried to fix the logic, see #11566 (sometimes `clang` masquerades as `gcc`). Here is one more fix. 

The logic distutils uses to find `CC` is 

- look in os.environ for `CC`
- if not found, look in `distutils.sysconfig`

This PR mimics that logic to determine use of `gcc` and the ability to turn warnings into errors. No effort is made to find the equivalent set of `clang` flags, since the motivation is to detect CI failures before pushing a branch. Once we add clang to our CI matrix, we should revisit this area of the code.

I tested this by `export CC=clang; export CXX=clang` and running `runtests.py`