### PR TITLE
TST: Fix urlopen stubbing.

### DIFF
--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -30,14 +30,14 @@ def urlopen_stub(url, data=None):
 old_urlopen = None
 
 
-def setup():
+def setup_module():
     global old_urlopen
 
     old_urlopen = urllib_request.urlopen
     urllib_request.urlopen = urlopen_stub
 
 
-def teardown():
+def teardown_module():
     urllib_request.urlopen = old_urlopen
 
 # A valid website for more robust testing


### PR DESCRIPTION
For whatever reason, this stubbing does not do anything. I think it is because the
class setup overrides the module setup, but I did not look into it too deeply.  Renaming
 `setup` to `setup_module` and `teardown` to `teardown_module` fixes that.