### PR TITLE
BUG: Revert use of `console_scripts`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -368,13 +368,6 @@ def setup_package():
         cmdclass={"sdist": sdist_checked},
         python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
         zip_safe=False,
-        entry_points={
-            'console_scripts': [
-                'f2py = numpy.f2py.__main__:main',
-                'conv-template = numpy.distutils.conv_template:main',
-                'from-template = numpy.distutils.from_template:main',
-            ]
-        },
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
The changes introduced in #10463 caused f2py to hang in somde
circumstances. There is may a better fix than this, but
until it is implemented it is better to undo the change.

Closes #11649.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
