### PR TITLE
MAINT: Make einsum optimize default to False.

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1220,8 +1220,8 @@ def einsum(*operands, **kwargs):
 
     """
 
-    # Grab non-einsum kwargs; never optimize 2-argument case.
-    optimize_arg = kwargs.pop('optimize', len(operands) > 3)
+    # Grab non-einsum kwargs; do not optimize by default.
+    optimize_arg = kwargs.pop('optimize', False)
 
     # If no optimization, run pure einsum
     if optimize_arg is False:


### PR DESCRIPTION
False is the documented value and the value used in 1.14, but 1.15.0 was
turning optimization on when there were more than two arguments,
resulting in slowdowns for small matrices. This choice can be revisited
as the einsum optimization code matures.

Closes #11714.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
