### PR TITLE
TST, MAINT: add lgtm.yml to tweak LGTM.com analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,9 @@
+path_classifiers:
+  library:
+    - tools
+  generated:
+    # The exports defined in __init__.py are defined in the Cython module
+    # np.random.mtrand. By excluding this file we suppress a number of
+    # "undefined export" alerts
+    - __init__.py
+

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,5 +5,5 @@ path_classifiers:
     # The exports defined in __init__.py are defined in the Cython module
     # np.random.mtrand. By excluding this file we suppress a number of
     # "undefined export" alerts
-    - __init__.py
+    - numpy/random/__init__.py
 


### PR DESCRIPTION
As discussed with @eric-wieser and @markshannon in https://github.com/numpy/numpy/pull/11722, LGTM raises a number of "Undefined export" alerts in `__init__.py`: these functions are indeed undefined at analysis time, but are actually provided by the Cython module `np.random.mtrand`.

This PR sits on top of #11722 and introduces an `lgtm.yml` file to tweak the Python analysis on LGTM.com: it will still analyse `__init__.py`, but it will classify the file as `generated`. This means that the results will not be shown by default in the LGTM interface, nor will they weigh towards the code quality score.

An alternative would be to completely disable the "Undefined export" query (`py/undefined-export`) on LGTM, but I think that's not needed in this case. [Here's some more information](https://lgtm.com/help/lgtm/lgtm.yml-configuration-file) on tweaking LGTM's analysis using a `lgtm.yml` file.