### PR TITLE
BUG: disallow setting flag to writeable after fromstring, frombuffer

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -387,6 +387,8 @@ Previously `np.core.umath` and `np.core.multiarray` were the c-extension
 modules, they are now python wrappers to the single `np.core/_multiarray_math`
 c-extension module.
 
+.. _`NEP 15` : http://www.numpy.org/neps/nep-0015-merge-multiarray-umath.html
+
 ``getfield`` validity checks extended
 ----------------------------------------
 `numpy.ndarray.getfield` now checks the dtype and offset arguments to prevent
@@ -403,3 +405,7 @@ the future.
 
 .. _`NEP 15` : http://www.numpy.org/neps/nep-0015-merge-multiarray-umath.html
 .. _`NEP 18` : http://www.numpy.org/neps/nep-0018-array-function-protocol.html
+Arrays based off readonly buffers cannot be set ``writeable``
+-------------------------------------------------------------
+We now disallow setting the ``writeable`` flag True on arrays created
+from ``fromstring(readonly-buffer)``.

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -609,12 +609,6 @@ _IsWriteable(PyArrayObject *ap)
      * If it is a writeable array, then return TRUE
      * If we can find an array object
      * or a writeable buffer object as the final base object
-     * or a string object (for pickling support memory savings).
-     * - this last could be removed if a proper pickleable
-     * buffer was added to Python.
-     *
-     * MW: I think it would better to disallow switching from READONLY
-     *     to WRITEABLE like this...
      */
 
     while(PyArray_Check(base)) {
@@ -622,15 +616,6 @@ _IsWriteable(PyArrayObject *ap)
             return (npy_bool) (PyArray_ISWRITEABLE((PyArrayObject *)base));
         }
         base = PyArray_BASE((PyArrayObject *)base);
-    }
-
-    /*
-     * here so pickle support works seamlessly
-     * and unpickled array can be set and reset writeable
-     * -- could be abused --
-     */
-    if (PyString_Check(base)) {
-        return NPY_TRUE;
     }
 #if defined(NPY_PY3K)
     if (PyObject_GetBuffer(base, &view, PyBUF_WRITABLE|PyBUF_SIMPLE) < 0) {


### PR DESCRIPTION
Fixes #9440. The comment in the code was incorrect, `array_setstate` used in unpickling does not call `_IsWriteable`. `_IsWriteable` is only used in setting flags.

Note that new pickling tests use a large buffer to ensure it goes through `PyArray_SetBaseObject` in `array_setstate`, but that the flag is still set to `writeable`.