### PR TITLE
MAINT: C code no longer calls Python _newnames()

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "tip" (for mercurial).
-    "branches": ["master"],
+    "branches": ["newnames"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
@@ -28,14 +28,14 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "virtualenv",
+    "environment_type": "conda",
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/numpy/numpy/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7"],
+    "pythons": ["3.6"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/benchmarks/benchmarks/bench_methods.py
+++ b/benchmarks/benchmarks/bench_methods.py
@@ -6,22 +6,38 @@ import numpy as np
 
 class FieldHandling(Benchmark):
 
-    repeat = 1
+    # there's some kind of reference counting
+    # issue in C version of _newnames()
+    # so restrict to a single iteration
+    # with many repeats (and NO warmup)
+    # so that self.r may be defined in setup
+    # only and its reference isn't messed with
+    repeat = 40
     number = 1
+    warmup_time = 0.0
 
-    def setup(self):
-        self.x1 = np.array([21, 32, 14])
-        self.x2 = np.array(['my', 'first', 'name'])
-        self.x3 = np.array([3.1, 4.5, 6.2])
-        self.names = 'id,word,number'
-        self.r = np.rec.fromarrays([self.x1, 
-                                    self.x2,
-                                    self.x3],
-                                    names=self.names)
+    params = [(1, 3, 5, 10, 20, 200)]
+    param_names = 'num_fields'
 
-    def time_sort_array_fields(self):
+    def setup(self, num_fields):
+        num_fields = int(num_fields)
+        self.x = np.array([21, 32, 14])
+        self.arrays = []
+
+        for field_num in range(num_fields):
+            self.arrays.append(self.x)
+
+        self.names = ','.join(np.array(['field' + str(val) for
+                                val in range(num_fields)]))
+
+        self.order = self.names.split(',')[::-1]
+
+        self.r = np.rec.fromarrays(self.arrays,
+                                   names=self.names)
+
+    def time_sort_array_fields(self, num_fields):
         # time sorting recarray by field
         # why do I get "unknown field name" ValueError
         # from C code version when self.r is defined
         # above vs. here?? Ref counting issue again??
-        self.r.sort(order=['word'])
+        self.r.sort(order=self.order)

--- a/benchmarks/benchmarks/bench_methods.py
+++ b/benchmarks/benchmarks/bench_methods.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, division, print_function
+
+from .common import Benchmark
+
+import numpy as np 
+
+class FieldHandling(Benchmark):
+
+    repeat = 1
+    number = 1
+
+    def setup(self):
+        self.x1 = np.array([21, 32, 14])
+        self.x2 = np.array(['my', 'first', 'name'])
+        self.x3 = np.array([3.1, 4.5, 6.2])
+        self.names = 'id,word,number'
+        self.r = np.rec.fromarrays([self.x1, 
+                                    self.x2,
+                                    self.x3],
+                                    names=self.names)
+
+    def time_sort_array_fields(self):
+        # time sorting recarray by field
+        # why do I get "unknown field name" ValueError
+        # from C code version when self.r is defined
+        # above vs. here?? Ref counting issue again??
+        self.r.sort(order=['word'])

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -287,29 +287,6 @@ class _ctypes(object):
     _as_parameter_ = property(get_as_parameter, None, doc="_as parameter_")
 
 
-def _newnames(datatype, order):
-    """
-    Given a datatype and an order object, return a new names tuple, with the
-    order indicated
-    """
-    oldnames = datatype.names
-    nameslist = list(oldnames)
-    if isinstance(order, str):
-        order = [order]
-    seen = set()
-    if isinstance(order, (list, tuple)):
-        for name in order:
-            try:
-                nameslist.remove(name)
-            except ValueError:
-                if name in seen:
-                    raise ValueError("duplicate field name: %s" % (name,))
-                else:
-                    raise ValueError("unknown field name: %s" % (name,))
-            seen.add(name)
-        return tuple(list(order) + nameslist)
-    raise ValueError("unsupported order value: %s" % (order,))
-
 def _copy_fields(ary):
     """Return copy of structured array with padding between fields removed.
 


### PR DESCRIPTION
### Background

While looking through the source for some of the `dtype` internals (`numpy/core/src/multiarray/descriptor.c`) I noticed that C code calling Python code in `_convert_from_commastring()` is described in the comments as:

> path critical C code calling Python code

that should be cleaned up and re-written in C. While that particular effort looks very challenging (either re-implement the regex in C or use platform-specific regex options in C), there are other locations in the source code where `PyImport_ImportModule` is used to call Python code from C code, perhaps to some detriment (as the above comment implies).

### The target here

One of the awkward C-calling-Python scenarios surrounds the `_newnames()` function, which seems to be used a lot with i.e., `recarray` for handling fields. There are several C functions in `numpy/core/src/multiarray/methods.c` that call the Python version of this function, presumably to perform similar tasks.

### The changes here

I've reimplemented `_newnames()` using C / Python C-API; it was pretty painful to get working despite the apparent simplicity of the Python version. The Python equivalent has been removed and the C code now calls a C function proper that appears to now do the same thing as the previous Python version.

Not sure if this kind of transformation / maintenance is really called for, but it does seem less ugly to avoid the Python-C-Python thing. What do people think?