### PR TITLE
MAINT: reformat line spacing before test methods

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1702,7 +1702,6 @@ class TestDateTime(object):
         assert_equal(np.busday_offset(np.datetime64('NaT'), 1, roll='preceding'),
                      np.datetime64('NaT'))
 
-
     def test_datetime_busdaycalendar(self):
         # Check that it removes NaT, duplicates, and weekends
         # and sorts the result.

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -965,7 +965,6 @@ class TestEinsumPath(object):
         path, path_str = np.einsum_path(*edge_test4, optimize='optimal')
         self.assert_path_equal(path, ['einsum_path', (0, 1), (0, 1, 2, 3, 4, 5)])
 
-
     def test_path_type_input(self):
         # Test explicit path handeling
         path_test = self.build_operands('dcc,fce,ea,dbf->ab')

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -194,7 +194,6 @@ class TestIndexing(object):
 
         assert_raises(IndexError, arr.__getitem__, (slice(None), index))
 
-
     def test_boolean_indexing_onedim(self):
         # Indexing a 2-dimensional array with
         # boolean array of length one

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -108,7 +108,6 @@ class TestFlags(object):
         assert_equal(self.a.flags['X'], False)
         assert_equal(self.a.flags['WRITEBACKIFCOPY'], False)
 
-
     def test_string_align(self):
         a = np.zeros(4, dtype=np.dtype('|S4'))
         assert_(a.flags.aligned)
@@ -2729,7 +2728,6 @@ class TestMethods(object):
         # Order of axis argument doesn't matter:
         assert_equal(b.diagonal(0, 2, 1), [[0, 3], [4, 7]])
 
-
     def test_diagonal_view_notwriteable(self):
         # this test is only for 1.9, the diagonal view will be
         # writeable in 1.10.
@@ -4386,7 +4384,6 @@ class TestIO(object):
             d.tofile(f)
         assert_equal(os.path.getsize(self.filename), d.nbytes * 2)
 
-
     def test_io_open_buffered_fromfile(self):
         # gh-6632
         self.x.tofile(self.filename)
@@ -4925,7 +4922,6 @@ class TestRecord(object):
         c = np.zeros(3, dtype='i8,i8,i8')
         assert_equal(collect_warnings(c[['f0', 'f2']].view, 'i8,i8'),
                      [FutureWarning])
-
 
     def test_record_hash(self):
         a = np.array([(1, 2), (1, 2)], dtype='i1,i2')
@@ -6494,7 +6490,6 @@ class TestNewBufferProtocol(object):
         a = np.empty(3, dt)
         assert_raises((ValueError, BufferError), memoryview, a)
         assert_raises((ValueError, BufferError), memoryview, np.array((3), 'M8[D]'))
-
 
     def test_export_simple_1d(self):
         x = np.array([1, 2, 3, 4, 5], dtype='i')

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2358,7 +2358,6 @@ class TestIterNested(object):
         j.close()
         assert_equal(a, [[1, 2, 3], [4, 5, 6]])
 
-
     def test_dtype_buffered(self):
         # Test nested iteration with buffering to change dtype
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1275,7 +1275,6 @@ class TestArrayComparisons(object):
         assert_equal(a == None, [False, False, False])
         assert_equal(a != None, [True, True, True])
 
-
     def test_array_equiv(self):
         res = np.array_equiv(np.array([1, 2]), np.array([1, 2]))
         assert_(res)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1828,7 +1828,6 @@ class TestRegression(object):
             assert_equal(oct(a), oct(0))
             assert_equal(hex(a), hex(0))
 
-
     def test_object_array_self_copy(self):
         # An object array being copied into itself DECREF'ed before INCREF'ing
         # causing segmentation faults (gh-3787)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1173,7 +1173,6 @@ class TestBitwiseUFuncs(object):
             assert_(np.bitwise_xor(zeros, zeros).dtype == dt, msg)
             assert_(np.bitwise_and(zeros, zeros).dtype == dt, msg)
 
-
     def test_identity(self):
         assert_(np.bitwise_or.identity == 0, 'bitwise_or')
         assert_(np.bitwise_xor.identity == 0, 'bitwise_xor')

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -113,7 +113,6 @@ class TestRavelUnravelIndex(object):
         assert_(x.flags.writeable)
         assert_(y.flags.writeable)
 
-
     def test_0d(self):
         # gh-580
         x = np.unravel_index(0, ())

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -348,7 +348,6 @@ class TestSaveTxt(object):
         assert_raises(ValueError, np.savetxt, c, np.array(1))
         assert_raises(ValueError, np.savetxt, c, np.array([[[1], [2]]]))
 
-
     def test_record(self):
         a = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
         c = BytesIO()
@@ -2024,7 +2023,6 @@ M   33  21.99
                                  delimiter=',', encoding="UTF-8")
             assert_equal(test['f0'], 0)
             assert_equal(test['f1'], "testNonethe" + utf8.decode("UTF-8"))
-
 
     def test_utf8_file_nodtype_unicode(self):
         # bytes encoding with non-latin1 -> unicode upcast

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -959,7 +959,6 @@ class TestMatrixPower(object):
     #FIXME the 'e' dtype might work in future
     dtnoinv = [object, np.dtype('e'), np.dtype('g'), np.dtype('G')]
 
-
     def test_large_power(self, dt):
         power = matrix_power
         rshft = self.rshft_1.astype(dt)
@@ -1021,7 +1020,6 @@ class TestMatrixPower(object):
         mat = self.rshft_0.astype(dt)
         assert_raises(TypeError, matrix_power, mat, 1.5)
         assert_raises(TypeError, matrix_power, mat, [1])
-
 
     def test_exceptions_non_square(self, dt):
         assert_raises(LinAlgError, matrix_power, np.array([1], dt), 1)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -514,8 +514,6 @@ class TestMaskedArray(object):
               fill_value=999999)''')
         )
 
-
-
     def test_str_repr_legacy(self):
         oldopts = np.get_printoptions()
         np.set_printoptions(legacy='1.13')
@@ -787,7 +785,6 @@ class TestMaskedArray(object):
                              dtype = "int, (2,3)float, float")
         control = "(0, [[--, 0.0, --], [0.0, 0.0, --]], 0.0)"
         assert_equal(str(t_2d0), control)
-
 
     def test_flatten_structured_array(self):
         # Test flatten_structured_array on arrays

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -1454,7 +1454,6 @@ class TestBroadcast(object):
             assert_raises(ValueError, zipf, np.nan)
             assert_raises(ValueError, zipf, [0, 0, np.nan])
 
-
     def test_geometric(self):
         p = [0.5]
         bad_p_one = [-1]

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -53,7 +53,6 @@ class TestNoseDecorators(object):
         assert_(f_istest.__test__)
         assert_(not f_isnottest.__test__)
 
-
     def test_skip_functions_hardcoded(self):
         @dec.skipif(True)
         def f1(x):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1391,7 +1391,6 @@ class TestAssertNoGcCycles(object):
 
         assert_no_gc_cycles(no_cycle)
 
-
     def test_asserts(self):
         def make_cycle():
             a = []
@@ -1405,7 +1404,6 @@ class TestAssertNoGcCycles(object):
 
         with assert_raises(AssertionError):
             assert_no_gc_cycles(make_cycle)
-
 
     def test_fails(self):
         """


### PR DESCRIPTION
Some test methods had two empty lines before them instead of one, make them more PEP8 conformant.