### PR TITLE
ENH: add augmented assignments to `ABCPolybase`.

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -512,8 +512,47 @@ class ABCPolyBase(object):
         rem = self.__class__(rem, self.domain, self.window)
         return quo, rem
 
-    # Enhance me
-    # some augmented arithmetic operations could be added here
+    def __iadd__(self, other):
+        try:
+            self.coef = self._add(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __isub__(self, other):
+        try:
+            self.coef = self._sub(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __imul__(self, other):
+        try:
+            self.coef = self._mul(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __idiv__(self, other):
+        try:
+            self.coef = self.__rdivmod__(other)[0]
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __imod__(self, other):
+        try:
+            self.coef = self.__rdivmod__(other)[1]
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __ipow__(self, other):
+        try:
+            self.coef = self._pow(self.coef, other, maxpower=self.maxpower)
+        except Exception:
+            return NotImplemented
+        return self
 
     def __eq__(self, other):
         res = (isinstance(other, self.__class__) and

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -535,14 +535,18 @@ class ABCPolyBase(object):
 
     def __idiv__(self, other):
         try:
-            self.coef = self.__rdivmod__(other)[0]
+            self.coef, _ = self._div(self.coef, other)
+        except ZeroDivisionError as e:
+            raise e
         except Exception:
             return NotImplemented
         return self
 
     def __imod__(self, other):
         try:
-            self.coef = self.__rdivmod__(other)[1]
+            _, self.coef = self._div(self.coef, other)
+        except ZeroDivisionError as e:
+            raise e
         except Exception:
             return NotImplemented
         return self


### PR DESCRIPTION
As per the comment deleted from line 515-516, augmented assignment was not implemented for `ABCPolybase`. Since there was already `add`, `sub`, `mul`, `div`, `mod`, and `pow`, I went ahead and added in the augmented assignments for them.

If this has the potential to be useful to some users, I am happy to have added it, if it is problematic for reasons I am not aware of, I would appreciate being enlightened.