### PR TITLE
WIP, TST: include missing source files in gcov report

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -130,6 +130,10 @@ run_test()
     # the code paths
     cd ..
 
+    # update timestamps on *.gcda files to satisfy gcov
+    # see gh-11790
+    find . -type f -name "*.gcda" -exec touch {} +
+
     # execute gcov on source files
     find . -name '*.gcno' -type f -exec gcov -pb {} +
 


### PR DESCRIPTION
Fixes #11790 

See the linked issue for details -- this initial attempt is probably a bit optimistic, but I'm having a hard time reproducing the problem locally on my mac.
