### PR TITLE
ENH: Faster generation of random numbers in range by using a different rejection sampling algorithm.

### DIFF
--- a/numpy/random/mtrand/randomkit.c
+++ b/numpy/random/mtrand/randomkit.c
@@ -67,7 +67,7 @@
 
 
 //Rejection algorithm by Daniel Lemire https://arxiv.org/abs/1805.10941
-//Has a good chance of not requiring a division.
+//  Has a good chance of not requiring a division.
 #define USE_LEMIRE 1
 
 

--- a/numpy/random/mtrand/randomkit.c
+++ b/numpy/random/mtrand/randomkit.c
@@ -65,8 +65,10 @@
 /* static char const rcsid[] =
   "@(#) $Jeannot: randomkit.c,v 1.28 2005/07/21 22:14:09 js Exp $"; */
 
+//Lehmer is a very fast alternative RNG useful for performance testing.
 //#define USE_LEHMER 1
-//#define USE_LEMIRE 1
+
+#define USE_LEMIRE 1
 
 #ifdef _WIN32
 /*

--- a/numpy/random/mtrand/randomkit.c
+++ b/numpy/random/mtrand/randomkit.c
@@ -150,6 +150,8 @@ char *rk_strerror[RK_ERR_MAX] =
 #ifdef USE_LEHMER
 static __uint64_t splitmix64_stateless(const __uint64_t index);
 #endif
+
+/* static functions */
 static unsigned long rk_hash(unsigned long key);
 
 void

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -67,7 +67,7 @@
 //  Should be good enough for many use cases, but I still want to do my own statistical tests on it.
 //  Replaces rk_random, rk_uint64 and rk_double functions with version that are 4 - 9 times faster!
 
-#define USE_LEHMER 1
+// #define USE_LEHMER 1
 #endif //__SIZEOF_INT128__
 
 #define RK_STATE_LEN 624

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -62,13 +62,13 @@
 #include <stddef.h>
 #include <numpy/npy_common.h>
 
-#ifdef NPY_UINT128
+#if defined(__SIZEOF_INT128__)
 //Lehmer is a very fast alternative RNG useful for performance testing. Appearantly passes tests like BigCrush.
 //  Should be good enough for many use cases, but I still want to do my own statistical tests on it.
 //  Replaces rk_random, rk_uint64 and rk_double functions with version that are 4 - 9 times faster!
 
-//#define USE_LEHMER 1
-#endif //NPY_UINT128
+#define USE_LEHMER 1
+#endif //__SIZEOF_INT128__
 
 #define RK_STATE_LEN 624
 
@@ -76,7 +76,7 @@ typedef struct rk_state_
 {
 #ifdef USE_LEHMER
     //Simply maintain the Lehmer state within the rk_state_ so that MT still available if required.
-    union{npy_uint128 s128_; npy_uint64 s64_[2];} lehmer;
+    union{__uint128_t s128_; __uint64_t s64_[2];} lehmer;
 #endif //USE_LEHMER
 
     unsigned long key[RK_STATE_LEN];

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -67,6 +67,8 @@
 
 typedef struct rk_state_
 {
+    union{__uint128_t s128_; uint64_t s64_[2];} lehmer;
+
     unsigned long key[RK_STATE_LEN];
     int pos;
     int has_gauss; /* !=0: gauss contains a gaussian deviate */

--- a/numpy/random/mtrand/randomkit.h
+++ b/numpy/random/mtrand/randomkit.h
@@ -62,12 +62,22 @@
 #include <stddef.h>
 #include <numpy/npy_common.h>
 
+#ifdef NPY_UINT128
+//Lehmer is a very fast alternative RNG useful for performance testing. Appearantly passes tests like BigCrush.
+//  Should be good enough for many use cases, but I still want to do my own statistical tests on it.
+//  Replaces rk_random, rk_uint64 and rk_double functions with version that are 4 - 9 times faster!
+
+//#define USE_LEHMER 1
+#endif //NPY_UINT128
 
 #define RK_STATE_LEN 624
 
 typedef struct rk_state_
 {
-    union{__uint128_t s128_; uint64_t s64_[2];} lehmer;
+#ifdef USE_LEHMER
+    //Simply maintain the Lehmer state within the rk_state_ so that MT still available if required.
+    union{npy_uint128 s128_; npy_uint64 s64_[2];} lehmer;
+#endif //USE_LEHMER
 
     unsigned long key[RK_STATE_LEN];
     int pos;


### PR DESCRIPTION
ENH: Faster generation of random numbers in range by using a different rejection sampling algorithm.

Pull request:
Rejection algorithm by Daniel Lemire https://arxiv.org/abs/1805.10941 within `#ifdef USE_LEMIRE` blocks. Increases performance by an average of 2x (min=1x, max=4x). I'll attach a performance graph to the email to numpy-svn@python.org 

Other changes:
The code within `#ifdef USE LEHMER` is a 4x faster random number generator which I've used myself and for some performance testing of Numpy. (Note: Lehmer shouldn't be confused with Lemire mentioned in previous paragraph.) I don't know what the best way would be to allow and alternative random number generator so comments are welcome, but it need not be considered as part of this pull request.
/** Lehmer Reference:
* D. H. Lehmer, Mathematical methods in large-scale computing units. 
* Proceedings of a Second Symposium on Large Scale Digital Calculating Machinery;
* Annals of the Computation Laboratory, Harvard Univ. 26 (1951), pp. 141-146.
*
* P L'Ecuyer,  Tables of linear congruential generators of different sizes and
* good lattice structure. Mathematics of Computation of the American Mathematical 
* Society 68.225 (1999): 249-260.
*/