### PR TITLE
DOC: document use when f2py is not in the PATH

### DIFF
--- a/doc/source/f2py/compile_session.dat
+++ b/doc/source/f2py/compile_session.dat
@@ -1,10 +1,10 @@
->>> import f2py2e
+>>> import numpy.f2py
 >>> fsource = '''
 ...       subroutine foo
 ...       print*, "Hello world!"
 ...       end 
 ... '''
->>> f2py2e.compile(fsource,modulename='hello',verbose=0)
+>>> numpy.f2py.compile(fsource, modulename='hello', verbose=0)
 0
 >>> import hello
 >>> hello.foo()

--- a/doc/source/f2py/getting-started.rst
+++ b/doc/source/f2py/getting-started.rst
@@ -45,9 +45,9 @@ to run
 
 ::
 
-  f2py -c fib1.f -m fib1
+  python -mnumpy.f2py -c fib1.f -m fib1
 
-This command builds (see ``-c`` flag, execute ``f2py`` without
+This command builds (see ``-c`` flag, execute ``python -mnumpy.f2py`` without
 arguments to see the explanation of command line options) an extension
 module ``fib1.so`` (see ``-m`` flag) to the current directory. Now, in
 Python the Fortran subroutine ``FIB`` is accessible via ``fib1.fib``::
@@ -162,7 +162,7 @@ one.
 
   ::
 
-    f2py fib1.f -m fib2 -h fib1.pyf
+    python -mnumpy.f2py fib1.f -m fib2 -h fib1.pyf
 
   The signature file is saved to ``fib1.pyf`` (see ``-h`` flag) and
   its contents is shown below.
@@ -188,7 +188,7 @@ one.
 
   ::
 
-    f2py -c fib2.pyf fib1.f
+    python -mnumpy.f2py -c fib2.pyf fib1.f
 
 In Python::
 
@@ -243,7 +243,7 @@ __ fib3.f
 
 Building the extension module can be now carried out in one command::
 
-  f2py -c -m fib3 fib3.f
+  python -mnumpy.f2py -c -m fib3 fib3.f
 
 Notice that the resulting wrapper to ``FIB`` is as "smart" as in
 previous case::

--- a/doc/source/f2py/getting-started.rst
+++ b/doc/source/f2py/getting-started.rst
@@ -45,9 +45,9 @@ to run
 
 ::
 
-  python -mnumpy.f2py -c fib1.f -m fib1
+  python -m numpy.f2py -c fib1.f -m fib1
 
-This command builds (see ``-c`` flag, execute ``python -mnumpy.f2py`` without
+This command builds (see ``-c`` flag, execute ``python -m numpy.f2py`` without
 arguments to see the explanation of command line options) an extension
 module ``fib1.so`` (see ``-m`` flag) to the current directory. Now, in
 Python the Fortran subroutine ``FIB`` is accessible via ``fib1.fib``::
@@ -162,7 +162,7 @@ one.
 
   ::
 
-    python -mnumpy.f2py fib1.f -m fib2 -h fib1.pyf
+    python -m numpy.f2py fib1.f -m fib2 -h fib1.pyf
 
   The signature file is saved to ``fib1.pyf`` (see ``-h`` flag) and
   its contents is shown below.
@@ -188,7 +188,7 @@ one.
 
   ::
 
-    python -mnumpy.f2py -c fib2.pyf fib1.f
+    python -m numpy.f2py -c fib2.pyf fib1.f
 
 In Python::
 
@@ -243,7 +243,7 @@ __ fib3.f
 
 Building the extension module can be now carried out in one command::
 
-  python -mnumpy.f2py -c -m fib3 fib3.f
+  python -m numpy.f2py -c -m fib3 fib3.f
 
 Notice that the resulting wrapper to ``FIB`` is as "smart" as in
 previous case::

--- a/doc/source/f2py/run_main_session.dat
+++ b/doc/source/f2py/run_main_session.dat
@@ -1,14 +1,14 @@
->>> import f2py2e
->>> r=f2py2e.run_main(['-m','scalar','docs/usersguide/scalar.f'])
+>>> import numpy.f2py
+>>> r = numpy.f2py.run_main(['-m','scalar','doc/source/f2py/scalar.f'])
 Reading fortran codes...
-        Reading file 'docs/usersguide/scalar.f'
+        Reading file 'doc/source/f2py/scalar.f' (format:fix,strict)
 Post-processing...
         Block: scalar
                         Block: FOO
 Building modules...
         Building module "scalar"...
         Wrote C/API module "scalar" to file "./scalarmodule.c"
->>> print r
-{'scalar': {'h': ['/home/users/pearu/src_cvs/f2py2e/src/fortranobject.h'],
+>>> printr(r)
+{'scalar': {'h': ['/home/users/pearu/src_cvs/f2py/src/fortranobject.h'],
 	 'csrc': ['./scalarmodule.c', 
-                  '/home/users/pearu/src_cvs/f2py2e/src/fortranobject.c']}}
+                  '/home/users/pearu/src_cvs/f2py/src/fortranobject.c']}}

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -206,15 +206,15 @@ Other options:
 Execute ``f2py`` without any options to get an up-to-date list of
 available options.
 
-Python module ``f2py2e``
-========================
+Python module ``numpy.f2py``
+============================
 
 .. warning::
 
-  The current Python interface to ``f2py2e`` module is not mature and
-  may change in future depending on users needs.
+  The current Python interface to the ``f2py`` module is not mature and
+  may change in the future.
 
-The following functions are provided by the ``f2py2e`` module:
+The following functions are provided by the ``numpy.f2py`` module:
 
 ``run_main(<list>)``
   Equivalent to running::

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -3,17 +3,17 @@ Using F2PY
 ===========
 
 F2PY can be used either as a command line tool ``f2py`` or as a Python
-module ``f2py2e``. While we try to install the command line tool as part
+module ``numpy.f2py``. While we try to install the command line tool as part
 of the numpy setup, some platforms like Windows make it difficult to
 reliably put the executable on the ``PATH``. We will refer to ``f2py``
-in this document but you may have to run it as
+in this document but you may have to run it as a module
 
 ```
-python -mnumpy.f2py
+python -m numpy.f2py
 ```
 
 If you run ``f2py`` with no arguments, and the line ``numpy Version`` at the
-end matches the NumPy version printed from ``python -mnumpy.f2py``, then you
+end matches the NumPy version printed from ``python -m numpy.f2py``, then you
 can use the shorter version. If not, or if you cannot run ``f2py``, you should
 replace all calls to ``f2py`` here with the longer version.
 
@@ -207,7 +207,7 @@ Execute ``f2py`` without any options to get an up-to-date list of
 available options.
 
 Python module ``f2py2e``
-=========================
+========================
 
 .. warning::
 

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -3,7 +3,19 @@ Using F2PY
 ===========
 
 F2PY can be used either as a command line tool ``f2py`` or as a Python
-module ``f2py2e``.
+module ``f2py2e``. While we try to install the command line tool as part
+of the numpy setup, some platforms like Windows make it difficult to
+reliably put the executable on the ``PATH``. We will refer to ``f2py``
+in this document but you may have to run it as
+
+```
+python -mnumpy.f2py
+```
+
+If you run ``f2py`` with no arguments, and the line ``numpy Version`` at the
+end matches the NumPy version printed from ``python -mnumpy.f2py``, then you
+can use the shorter version. If not, or if you cannot run ``f2py``, you should
+replace all calls to ``f2py`` here with the longer version.
 
 Command ``f2py``
 =================


### PR DESCRIPTION
As issue #7532 shows, sometimes we fail to install `f2py` into the PATH. Since it seems we cannot be completely certain we have installed it properly, we should at least document how users can call `python -mnumpy.f2py` directly, without using the executable.
