### PR TITLE
ENH: Use entry_points to install the f2py scripts.

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -18,7 +18,7 @@ Deprecations
 --------------------------------------------
 
 The type dictionaries `numpy.core.typeNA` and `numpy.core.sctypeNA` were buggy
-and not documented. They will be removed in the 1.18 release. Use 
+and not documented. They will be removed in the 1.18 release. Use
 `numpy.sctypeDict` instead.
 
 
@@ -33,6 +33,14 @@ Future Changes
 
 Compatibility notes
 ===================
+
+f2py script on Windows
+----------------------
+On Windows, the installed script for running f2py is now an ``.exe`` file
+rather than a ``*.py`` file and should be run from the command line as ``f2py``
+whenever the ``Scripts`` directory is in the path. Folks needing compatibility
+with earler versions of Numpy should run ``f2py`` as a module: ``python -m
+numpy.f2py [...]``.
 
 
 C API changes

--- a/numpy/f2py/__main__.py
+++ b/numpy/f2py/__main__.py
@@ -1,27 +1,6 @@
 # See http://cens.ioc.ee/projects/f2py2e/
 from __future__ import division, print_function
 
-import os
-import sys
-for mode in ["g3-numpy", "2e-numeric", "2e-numarray", "2e-numpy"]:
-    try:
-        i = sys.argv.index("--" + mode)
-        del sys.argv[i]
-        break
-    except ValueError:
-        pass
-os.environ["NO_SCIPY_IMPORT"] = "f2py"
-if mode == "g3-numpy":
-    sys.stderr.write("G3 f2py support is not implemented, yet.\\n")
-    sys.exit(1)
-elif mode == "2e-numeric":
-    from f2py2e import main
-elif mode == "2e-numarray":
-    sys.argv.append("-DNUMARRAY")
-    from f2py2e import main
-elif mode == "2e-numpy":
-    from numpy.f2py import main
-else:
-    sys.stderr.write("Unknown mode: " + repr(mode) + "\\n")
-    sys.exit(1)
+from f2py2e import main
+
 main()

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -644,13 +644,25 @@ def main():
         from numpy.distutils.system_info import show_all
         show_all()
         return
+
+    # Probably outdated options that were not working before 1.16
+    if '--g3-numpy' in sys.argv[1:]:
+        sys.stderr.write("G3 f2py support is not implemented, yet.\\n")
+        sys.exit(1)
+    elif '--2e-numeric' in sys.argv[1:]:
+        sys.argv.remove('--2e-numeric')
+    elif '--2e-numarray' in sys.argv[1:]:
+        # Note that this errors becaust the -DNUMARRAY argument is
+        # not recognized. Just here for back compatibility and the
+        # error message.
+        sys.argv.append("-DNUMARRAY")
+        sys.argv.remove('--2e-numarray')
+    elif '--2e-numpy' in sys.argv[1:]:
+        sys.argv.remove('--2e-numpy')
+    else:
+        pass
+
     if '-c' in sys.argv[1:]:
         run_compile()
     else:
         run_main(sys.argv[1:])
-
-# if __name__ == "__main__":
-#    main()
-
-
-# EOF

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -18,8 +18,6 @@ Pearu Peterson
 """
 from __future__ import division, print_function
 
-__version__ = "$Id: setup.py,v 1.32 2005/01/30 17:22:14 pearu Exp $"
-
 import os
 import sys
 from distutils.dep_util import newer
@@ -27,60 +25,22 @@ from numpy.distutils import log
 from numpy.distutils.core import setup
 from numpy.distutils.misc_util import Configuration
 
+
 from __version__ import version
-
-
-def _get_f2py_shebang():
-    """ Return shebang line for f2py script
-
-    If we are building a binary distribution format, then the shebang line
-    should be ``#!python`` rather than ``#!`` followed by the contents of
-    ``sys.executable``.
-    """
-    if set(('bdist_wheel', 'bdist_egg', 'bdist_wininst',
-            'bdist_rpm')).intersection(sys.argv):
-        return '#!python'
-    return '#!' + sys.executable
 
 
 def configuration(parent_package='', top_path=None):
     config = Configuration('f2py', parent_package, top_path)
-
     config.add_data_dir('tests')
-
-    config.add_data_files('src/fortranobject.c',
-                          'src/fortranobject.h',
-                          )
-
-    config.make_svn_version_py()
-
-    def generate_f2py_py(build_dir):
-        f2py_exe = 'f2py' + os.path.basename(sys.executable)[6:]
-        if f2py_exe[-4:] == '.exe':
-            f2py_exe = f2py_exe[:-4] + '.py'
-        if 'bdist_wininst' in sys.argv and f2py_exe[-3:] != '.py':
-            f2py_exe = f2py_exe + '.py'
-        target = os.path.join(build_dir, f2py_exe)
-        if newer(__file__, target):
-            log.info('Creating %s', target)
-            f = open(target, 'w')
-            f.write(_get_f2py_shebang() + '\n')
-            mainloc = os.path.join(os.path.dirname(__file__), "__main__.py")
-            with open(mainloc) as mf:
-                f.write(mf.read())
-            f.close()
-        return target
-
-    config.add_scripts(generate_f2py_py)
-
-    log.info('F2PY Version %s', config.get_version())
-
+    config.add_data_files(
+        'src/fortranobject.c',
+        'src/fortranobject.h')
     return config
+
 
 if __name__ == "__main__":
 
     config = configuration(top_path='')
-    print('F2PY Version', version)
     config = config.todict()
 
     config['download_url'] = "http://cens.ioc.ee/projects/f2py2e/2.x"\

--- a/setup.py
+++ b/setup.py
@@ -352,6 +352,18 @@ def setup_package():
     # Rewrite the version file everytime
     write_version_py()
 
+    # The f2py scripts that will be installed
+    if sys.platform == 'win32':
+        f2py_cmds = [
+            'f2py = numpy.f2py.f2py2e:main',
+            ]
+    else:
+        f2py_cmds = [
+            'f2py = numpy.f2py.f2py2e:main',
+            'f2py%s = numpy.f2py.f2py2e:main' % sys.version_info[:1],
+            'f2py%s.%s = numpy.f2py.f2py2e:main' % sys.version_info[:2],
+            ]
+
     metadata = dict(
         name = 'numpy',
         maintainer = "NumPy Developers",
@@ -368,6 +380,9 @@ def setup_package():
         cmdclass={"sdist": sdist_checked},
         python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
         zip_safe=False,
+        entry_points={
+            'console_scripts': f2py_cmds
+        },
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
This adds entry_points for the f2py scripts. The installed scripts
differ between Windows and other environments.

* On Windows, the only script installed is 'f2py'. This works well in
  that environment because each Python version is installed in its own
  directory, making it easy to keep the differing script versions
  separate.

* Otherwise, three scripts are installed, 'f2py', 'f2py' + 'minor', and
  'f2py' + 'major.minor'. For instance, if Numpy is installed by
  Python 2.7, then the installed scripts will be named 'f2py', 'f2py2',
  and 'f2py2.7'. That naming scheme is used for back compatibility, and
  also so that more than one Python version can be dealt with in a way
  common to many Linux distros. Note that 'f2py' will always point to
  the latest install and 'f2py(2|3)' to the latest Python (2|3) install

The script tests have been modified to check for the new environment
and the code previously used to install the scripts has been removed.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
