### PR TITLE
DOC: Polybase augmented assignment notes

### DIFF
--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -188,8 +188,9 @@ the original polynomial. However, all the multiplications and divisions
 will be done using Chebyshev series, hence the type of the result.
 
 It is intended that all polynomial instances are immutable, therefore
-augmented operations and any other fuctionality that would violate the
-immutablity of a polynomial instance are intentionally unimplemented.
+augmented operations (``+=``, ``-=``, etc.) and any other functionality that
+would violate the immutablity of a polynomial instance are intentionally
+unimplemented.
 
 Calculus
 --------

--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -35,11 +35,11 @@ degree :math:`n`, but could just as easily be the basis functions of
 any of the other classes. The convention for all the classes is that
 the coefficient :math:`c[i]` goes with the basis function of degree i.
 
-All of the classes have the same methods, and especially they implement the
-Python numeric operators +, -, \*, //, %, divmod, \*\*, ==,
-and !=. The last two can be a bit problematic due to floating point
-roundoff errors. We now give a quick demonstration of the various
-operations using NumPy version 1.7.0.
+All of the classes are immutable and have the same methods, and
+especially they implement the Python numeric operators +, -, \*, //, %,
+divmod, \*\*, ==, and !=. The last two can be a bit problematic due to
+floating point roundoff errors. We now give a quick demonstration of the
+various operations using NumPy version 1.7.0.
 
 Basics
 ------
@@ -186,6 +186,10 @@ Which gives the polynomial `p` in Chebyshev form. This works because
 :math:`T_1(x) = x` and substituting :math:`x` for :math:`x` doesn't change
 the original polynomial. However, all the multiplications and divisions
 will be done using Chebyshev series, hence the type of the result.
+
+It is intended that all polynomial instances are immutable, therefore
+augmented operations and any other fuctionality that would violate the
+immutablity of a polynomial instance are intentionally unimplemented.
 
 Calculus
 --------

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -58,6 +58,11 @@ class ABCPolyBase(object):
     window : (2,) ndarray
         Default window of the class.
 
+    Notes
+    -----
+    ABCPolyBase instances should be immutable. Pleae ensure that any
+    modifications to this baseclass conform with this intention.
+
     """
     __metaclass__ = ABCMeta
 
@@ -511,52 +516,6 @@ class ABCPolyBase(object):
         quo = self.__class__(quo, self.domain, self.window)
         rem = self.__class__(rem, self.domain, self.window)
         return quo, rem
-
-    def __iadd__(self, other):
-        try:
-            self.coef = self._add(self.coef, other)
-        except Exception:
-            return NotImplemented
-        return self
-
-    def __isub__(self, other):
-        try:
-            self.coef = self._sub(self.coef, other)
-        except Exception:
-            return NotImplemented
-        return self
-
-    def __imul__(self, other):
-        try:
-            self.coef = self._mul(self.coef, other)
-        except Exception:
-            return NotImplemented
-        return self
-
-    def __idiv__(self, other):
-        try:
-            self.coef, _ = self._div(self.coef, other)
-        except ZeroDivisionError as e:
-            raise e
-        except Exception:
-            return NotImplemented
-        return self
-
-    def __imod__(self, other):
-        try:
-            _, self.coef = self._div(self.coef, other)
-        except ZeroDivisionError as e:
-            raise e
-        except Exception:
-            return NotImplemented
-        return self
-
-    def __ipow__(self, other):
-        try:
-            self.coef = self._pow(self.coef, other, maxpower=self.maxpower)
-        except Exception:
-            return NotImplemented
-        return self
 
     def __eq__(self, other):
         res = (isinstance(other, self.__class__) and

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -17,7 +17,7 @@ from . import polyutils as pu
 __all__ = ['ABCPolyBase']
 
 class ABCPolyBase(object):
-    """An abstract base class for series classes.
+    """An abstract base class for immutable series classes.
 
     ABCPolyBase provides the standard Python numerical methods
     '+', '-', '*', '//', '%', 'divmod', '**', and '()' along with the
@@ -57,11 +57,6 @@ class ABCPolyBase(object):
         Default domain of the class.
     window : (2,) ndarray
         Default window of the class.
-
-    Notes
-    -----
-    ABCPolyBase instances should be immutable. Pleae ensure that any
-    modifications to this baseclass conform with this intention.
 
     """
     __metaclass__ = ABCMeta

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -512,8 +512,47 @@ class ABCPolyBase(object):
         rem = self.__class__(rem, self.domain, self.window)
         return quo, rem
 
-    # Enhance me
-    # some augmented arithmetic operations could be added here
+    def __iadd__(self, other):
+        try:
+            self.coef = self._add(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __isub__(self, other):
+        try:
+            self.coef = self._sub(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __imul__(self, other):
+        try:
+            self.coef = self._mul(self.coef, other)
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __idiv__(self, other):
+        try:
+            self.coef = self.__rdivmod__(other)[0]
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __imod__(self, other):
+        try:
+            self.coef = self.__rdivmod__(other)[1]
+        except Exception:
+            return NotImplemented
+        return self
+
+    def __ipow__(self, other):
+        try:
+            self.coef = self._pow(self.coef, other, maxpower=self.maxpower)
+        except Exception:
+            return NotImplemented
+        return self
 
     def __eq__(self, other):
         res = (isinstance(other, self.__class__) and

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -535,14 +535,18 @@ class ABCPolyBase(object):
 
     def __idiv__(self, other):
         try:
-            self.coef = self.__rdivmod__(other)[0]
+            self.coef, _ = self._div(self.coef, other)
+        except ZeroDivisionError as e:
+            raise e
         except Exception:
             return NotImplemented
         return self
 
     def __imod__(self, other):
         try:
-            self.coef = self.__rdivmod__(other)[1]
+            _, self.coef = self._div(self.coef, other)
+        except ZeroDivisionError as e:
+            raise e
         except Exception:
             return NotImplemented
         return self


### PR DESCRIPTION
Add notes to ABCPolyBase and Polynomial documentation to explicitly state that polynomial instances are intended to be strictly immutable by default implementation.