### PR TITLE
DOC, MAINT: Fixes for errstate() and README.md documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-
+group: travis_latest
 # Run jobs on container-based infrastructure, can be overridden per job
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img alt="NumPy" src="https://cdn.rawgit.com/numpy/numpy/master/branding/icons/numpylogo.svg" height="60">
 
 [![Travis](https://img.shields.io/travis/numpy/numpy/master.svg?label=Travis%20CI)](https://travis-ci.org/numpy/numpy)
-[![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/charris/numpy)
+[![AppVeyor](https://img.shields.io/appveyor/ci/numpy/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/numpy/numpy)
 [![codecov](https://codecov.io/gh/numpy/numpy/branch/master/graph/badge.svg)](https://codecov.io/gh/numpy/numpy)
 
 NumPy is the fundamental package needed for scientific computing with Python.
@@ -20,8 +20,8 @@ It provides:
 
 Testing:
 
-- NumPy versions >= 1.15 require ``pytest``
-- NumPy versions < 1.15 require ``nose``
+- NumPy versions &ge; 1.15 require `pytest`
+- NumPy versions &lt; 1.15 require `nose`
 
 Tests can then be run after installation with:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img alt="NumPy" src="https://cdn.rawgit.com/numpy/numpy/master/branding/icons/numpylogo.svg" height="60">
 
 [![Travis](https://img.shields.io/travis/numpy/numpy/master.svg?label=Travis%20CI)](https://travis-ci.org/numpy/numpy)
-[![AppVeyor](https://img.shields.io/appveyor/ci/numpy/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/numpy/numpy)
+[![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](https://ci.appveyor.com/project/charris/numpy)
 [![codecov](https://codecov.io/gh/numpy/numpy/branch/master/graph/badge.svg)](https://codecov.io/gh/numpy/numpy)
 
 NumPy is the fundamental package needed for scientific computing with Python.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2850,16 +2850,11 @@ class errstate(object):
 
     Notes
     -----
-    The ``with`` statement was introduced in Python 2.5, and can only be used
-    there by importing it: ``from __future__ import with_statement``. In
-    earlier Python versions the ``with`` statement is not available.
-
     For complete documentation of the types of floating-point exceptions and
     treatment options, see `seterr`.
 
     Examples
     --------
-    >>> from __future__ import with_statement  # use 'with' in Python 2.5
     >>> olderr = np.seterr(all='ignore')  # Set error handling to known state.
 
     >>> np.arange(3) / 0.


### PR DESCRIPTION
Removes outdated references to Python 2.5 in numpy.errstate() docs, which hasn't been
supported for several releases.

