### PR TITLE
MAINT, ENH: simplify and standardize polynomial pow fns using reduce.

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -856,10 +856,8 @@ def chebpow(c, pow, maxpower=16):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(chebmul, [c]*power)
+        return reduce(chebmul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def chebder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -92,6 +92,8 @@ import numbers
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -856,16 +858,8 @@ def chebpow(c, pow, maxpower=16):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        zs = _cseries_to_zseries(c)
-        prd = zs
-        for i in range(2, power + 1):
-            prd = np.convolve(prd, zs)
-        return _zseries_to_cseries(prd)
+        return reduce(chebmul, [c]*power)
 
 
 def chebder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -62,6 +62,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -624,15 +626,8 @@ def hermpow(c, pow, maxpower=16):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        prd = c
-        for i in range(2, power + 1):
-            prd = hermmul(prd, c)
-        return prd
+        return reduce(hermmul, [c]*power)
 
 
 def hermder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -624,10 +624,8 @@ def hermpow(c, pow, maxpower=16):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(hermmul, [c]*power)
+        return reduce(hermmul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def hermder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -62,6 +62,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -623,15 +625,8 @@ def hermepow(c, pow, maxpower=16):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        prd = c
-        for i in range(2, power + 1):
-            prd = hermemul(prd, c)
-        return prd
+        return reduce(hermemul, [c]*power)
 
 
 def hermeder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -623,10 +623,8 @@ def hermepow(c, pow, maxpower=16):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(hermemul, [c]*power)
+        return reduce(hermemul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def hermeder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -62,6 +62,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -621,15 +623,8 @@ def lagpow(c, pow, maxpower=16):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        prd = c
-        for i in range(2, power + 1):
-            prd = lagmul(prd, c)
-        return prd
+        return reduce(lagmul, [c]*power)
 
 
 def lagder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -621,10 +621,8 @@ def lagpow(c, pow, maxpower=16):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(lagmul, [c]*power)
+        return reduce(lagmul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def lagder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -655,10 +655,8 @@ def legpow(c, pow, maxpower=16):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(legmul, [c]*power)
+        return reduce(legmul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def legder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -86,6 +86,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -655,15 +657,8 @@ def legpow(c, pow, maxpower=16):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        prd = c
-        for i in range(2, power + 1):
-            prd = legmul(prd, c)
-        return prd
+        return reduce(legmul, [c]*power)
 
 
 def legder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -465,10 +465,8 @@ def polypow(c, pow, maxpower=None):
         raise ValueError("Power must be a non-negative integer.")
     elif maxpower is not None and power > maxpower:
         raise ValueError("Power is too large")
-    elif power == 0:
-        return np.array([1], dtype=c.dtype)
     else:
-        return reduce(polymul, [c]*power)
+        return reduce(polymul, [c]*power, np.array([1], dtype=c.dtype))
 
 
 def polyder(c, m=1, scl=1, axis=0):

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -66,6 +66,8 @@ __all__ = [
 import warnings
 import numpy as np
 import numpy.linalg as la
+
+from functools import reduce
 from numpy.core.multiarray import normalize_axis_index
 
 from . import polyutils as pu
@@ -465,15 +467,8 @@ def polypow(c, pow, maxpower=None):
         raise ValueError("Power is too large")
     elif power == 0:
         return np.array([1], dtype=c.dtype)
-    elif power == 1:
-        return c
     else:
-        # This can be made more efficient by using powers of two
-        # in the usual way.
-        prd = c
-        for i in range(2, power + 1):
-            prd = np.convolve(prd, c)
-        return prd
+        return reduce(polymul, [c]*power)
 
 
 def polyder(c, m=1, scl=1, axis=0):


### PR DESCRIPTION
While working on #11811 I found that the `pow` functions for the various polynomial subclasses could be simplified and standardized by using the `reduce` function. In my testing the `reduce` approach performed marginally better than the current implementation, though the difference was small enough that it flipped occasionally. This changes

```
    elif power == 1:
        return c
    else:
        # This can be made more efficient by using powers of two
        # in the usual way.
        zs = _cseries_to_zseries(c)
        prd = zs
        for i in range(2, power + 1):
            prd = np.convolve(prd, zs)
        return _zseries_to_cseries(prd)
```
and 
```
    elif power == 1:
        return c
    else:
        # This can be made more efficient by using powers of two
        # in the usual way.
        prd = c
        for i in range(2, power + 1):
            prd = hermmul(prd, c)
        return prd
```
to 
```
    else:
        return reduce(chebmul, [c]*power)
```

Also, all of these functions have the note "This can be made more efficient by using powers of two in the usual way." If there are any recommendations on either trying to implement this, or removing the comment, please share.

@charris and @eric-wieser, if this is not a desirable change or we are not wanting to use functools, please let me know and I can close the PR. 

