### PR TITLE
MAINT: reduce void type repr code duplication

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -538,19 +538,22 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
 }
 
 static PyObject *
+_void_scalar_repr(PyObject *obj) {
+    static PyObject *reprfunc = NULL;
+    npy_cache_import("numpy.core.arrayprint",
+                     "_void_scalar_repr", &reprfunc);
+    if (reprfunc == NULL) {
+        return NULL;
+    }
+    return PyObject_CallFunction(reprfunc, "O", obj);
+}
+
+static PyObject *
 voidtype_repr(PyObject *self)
 {
     PyVoidScalarObject *s = (PyVoidScalarObject*) self;
     if (PyDataType_HASFIELDS(s->descr)) {
-        static PyObject *reprfunc = NULL;
-
-        npy_cache_import("numpy.core.arrayprint",
-                         "_void_scalar_repr", &reprfunc);
-        if (reprfunc == NULL) {
-            return NULL;
-        }
-
-        return PyObject_CallFunction(reprfunc, "O", self);
+        return _void_scalar_repr(self);
     }
     return _void_to_hex(s->obval, s->descr->elsize, "void(b'", "\\x", "')");
 }
@@ -560,15 +563,7 @@ voidtype_str(PyObject *self)
 {
     PyVoidScalarObject *s = (PyVoidScalarObject*) self;
     if (PyDataType_HASFIELDS(s->descr)) {
-        static PyObject *reprfunc = NULL;
-
-        npy_cache_import("numpy.core.arrayprint",
-                         "_void_scalar_repr", &reprfunc);
-        if (reprfunc == NULL) {
-            return NULL;
-        }
-
-        return PyObject_CallFunction(reprfunc, "O", self);
+        return _void_scalar_repr(self);
     }
     return _void_to_hex(s->obval, s->descr->elsize, "b'", "\\x", "'");
 }


### PR DESCRIPTION
The void type `__str__` and `__repr__` handling code at the C level was almost completely identical in their respective C functions. Both already called common `__repr__` handling code at the Python level, and this PR aims to similarly reduce code duplication / maintenance burden at the C level.

Note that it is, of course, not uncommon for `__str__` implementations to simply call `__repr__`, and the quaternion dtype implementation uses [exact duplicate code for both](https://github.com/moble/quaternion/blob/master/numpy_quaternion.c#L760) instead of one calling the other.

Here, both functions weren't quite identical, so the common handler function accepts arguments to allow the formatting differences between `__repr__` and `__str__` to be specified while abstracting the common logic.

void type discussion / work in PR from @ahaldane : https://github.com/numpy/numpy/pull/8981