### PR TITLE
WIP, MAINT: simplify generic type memory handling

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -117,23 +117,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
 static PyObject *
 gentype_alloc(PyTypeObject *type, Py_ssize_t nitems)
 {
-    PyObject *obj;
-    const size_t size = _PyObject_VAR_SIZE(type, nitems + 1);
-
-    obj = (PyObject *)PyObject_Malloc(size);
-    /*
-     * Fixme. Need to check for no memory.
-     * If we don't need to zero memory, we could use
-     * PyObject_{New, NewVar} for this whole function.
-     */
-    memset(obj, 0, size);
-    if (type->tp_itemsize == 0) {
-        PyObject_Init(obj, type);
-    }
-    else {
-        (void) PyObject_InitVar((PyVarObject *)obj, type, nitems);
-    }
-    return obj;
+    return (PyTypeObject *) PyObject_NewVar(PyTypeObject *, type, nitems);
 }
 
 static void


### PR DESCRIPTION
I was experimenting with various permutations of the memory handling used by the `generic` type arrays. There's a comment in the source suggesting that we may not necessarily need to zero allocated memory before initializing the type data into it.

I figured this might be a bad idea since "residual" data in that memory block might cause all kinds of mysterious behaviors with things that are "supposed to be 0" actually being something else because of whatever was there before, etc.

However, I only see one unit test failure in the `--mode=full` test suite after making the change, `test_pickle_empty_string`, which produces a bizarre failure where `b' '` != `b' '`; perhaps related to  https://github.com/numpy/numpy/pull/5475. The test failure report is not informative at all -- it shows two identical-looking objects as being unequal, but maybe there's a subtle null-termination or related issue because of the non-zeroing.

I can also get the full suite to pass if I switch to `PyObject_Calloc` to auto-zero the memory block and then we can just use `(void) PyObject_InitVar((PyVarObject *)obj, type, nitems);` and not worry about fixed-width vs. variable width types because the tp_itemsize is used in a memory-related product downstream and should be 0 for fixed case. Although the full suite passes, I think the Python C API for that is 3.5 +.

Edit: see Python 3.6 --full test suite job for single failure; Python 2.7 is another matter