### PR TITLE
BUG: fix repr for generic datetime

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -424,18 +424,14 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
     out->month = 1;
     out->day = 1;
 
-    /* NaT is signaled in the year */
-    if (dt == NPY_DATETIME_NAT) {
+    /* NaT is signaled in the year
+     * and we will also default to
+     * NaT when only generic units
+     * are retrieved
+     */
+    if (dt == NPY_DATETIME_NAT || meta->base == NPY_FR_GENERIC) {
         out->year = NPY_DATETIME_NAT;
         return 0;
-    }
-
-    /* Datetimes can't be in generic units */
-    if (meta->base == NPY_FR_GENERIC) {
-        PyErr_SetString(PyExc_ValueError,
-                    "Cannot convert a NumPy datetime value other than NaT "
-                    "with generic units");
-        return -1;
     }
 
     /* TODO: Change to a mechanism that avoids the potential overflow */

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -138,6 +138,16 @@ class TestDateTime(object):
             assert_(np.datetime64('NaT') == np.datetime64('NaT', 'us'))
             assert_(np.datetime64('NaT', 'us') == np.datetime64('NaT'))
 
+    @pytest.mark.parametrize("arr, expected_repr", [
+    (np.zeros(1, np.dtype([('b', np.datetime64)])),
+     "array([('NaT',)], dtype=[('b', '<M8')])"),
+    (np.zeros(2, np.datetime64),
+     "array(['NaT', 'NaT'], dtype=datetime64)"),
+    ])
+    def test_repr_generic_datetime(self, arr, expected_repr):
+        # regression test for gh-11752
+        assert_equal(repr(arr), expected_repr)
+
     def test_datetime_scalar_construction(self):
         # Construct with different units
         assert_equal(np.datetime64('1950-03-12', 'D'),


### PR DESCRIPTION
Fixes #11752.

Some discussion may be needed since `git bisect` didn't reveal a commit where one of Eric's cases didn't raise an `Exception` of some sort.

For example, with the changes here, instead of `repr` crashing we get `NaT` as filler:
```Python
repr(np.zeros(2, np.datetime64))
# "array(['NaT', 'NaT'], dtype=datetime64)"
```

As a reference:
```Python
repr(np.zeros(2, 'datetime64[M]'))
# "array(['1970-01', '1970-01'], dtype='datetime64[M]')"
```
