### PR TITLE
MAINT: remove surviving, unused, list comprehension

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -317,13 +317,6 @@ class ABCPolyBase(object):
             )
             needs_parens = True
 
-        # filter out uninteresting coefficients
-        filtered_coeffs = [
-            (i, c)
-            for i, c in enumerate(self.coef)
-            # if not (c == 0)  # handle NaN
-        ]
-
         mute = r"\color{{LightGray}}{{{}}}".format
 
         parts = []


### PR DESCRIPTION
Issue #11842 

This variable is never used, and shows signs of being leftover from a previous implementation.