### PR TITLE
TST: reorder duplicate mem_overlap.c compile

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -710,6 +710,17 @@ def configuration(parent_package='',top_path=None):
                        include_dirs=[])
 
     #######################################################################
+    #                     multiarray_tests module                         #
+    #######################################################################
+
+    config.add_extension('_multiarray_tests',
+                    sources=[join('src', 'multiarray', '_multiarray_tests.c.src'),
+                             join('src', 'common', 'mem_overlap.c')],
+                    depends=[join('src', 'common', 'mem_overlap.h'),
+                             join('src', 'common', 'npy_extint128.h')],
+                    libraries=['npymath'])
+
+    #######################################################################
     #             _multiarray_umath module - common part                  #
     #######################################################################
 
@@ -933,16 +944,6 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_struct_ufunc_tests',
                     sources=[join('src', 'umath', '_struct_ufunc_tests.c.src')])
 
-    #######################################################################
-    #                     multiarray_tests module                         #
-    #######################################################################
-
-    config.add_extension('_multiarray_tests',
-                    sources=[join('src', 'multiarray', '_multiarray_tests.c.src'),
-                             join('src', 'common', 'mem_overlap.c')],
-                    depends=[join('src', 'common', 'mem_overlap.h'),
-                             join('src', 'common', 'npy_extint128.h')],
-                    libraries=['npymath'])
 
     #######################################################################
     #                        operand_flag_tests module                    #


### PR DESCRIPTION
Fixes #11790

`mem_overlap.c` was being recompiled to build a C test extension after `mem_overlap.c` was already compiled by the C extension it is testing. This PR switches the order of compilation--build the test extension first, and then the library, so that `gcov` runs on source files that match the building of the library files, not the files that are testing them.

A better design might eventually avoid requiring the diophantine code from `mem_overlap` to be used in the test file itself--i.e., find a way to probe the code paths in the library without reusing that dependency.