### PR TITLE
ENH np.asscalar passes through scalars

### DIFF
--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -429,6 +429,27 @@ class TestRealIfClose(object):
         assert_all(isrealobj(b))
 
 
+class TestAsScalar(object):
+
+    def test_basic(self):
+        s = np.asscalar(np.array([1.0]))
+        assert_equal(s, 1.0)
+        s = np.asscalar(1)
+        assert_equal(s, 1)
+        s = np.asscalar(2j)
+        assert_equal(s, 2j)
+
+    def test_badvalues(self):
+        assert_raises(ValueError,
+                      np.asscalar, np.array([1.0, 2.0]))
+        assert_raises(AttributeError,
+                      np.asscalar, [])
+        assert_raises(AttributeError,
+                      np.asscalar, [1])
+        assert_raises(AttributeError,
+                      np.asscalar, min)
+
+
 class TestArrayConversion(object):
 
     def test_asfarray(self):

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -9,7 +9,7 @@ __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'common_type']
 
 import numpy.core.numeric as _nx
-from numpy.core.numeric import asarray, asanyarray, array, isnan, zeros
+from numpy.core.numeric import asarray, asanyarray, array, isnan, zeros, isscalar
 from .ufunclike import isneginf, isposinf
 
 _typecodes_by_elsize = 'GDFgdfQqLlIiHhBb?'
@@ -472,7 +472,7 @@ def asscalar(a):
     Parameters
     ----------
     a : ndarray
-        Input array of size 1.
+        Input array of size 1 or a scalar.
 
     Returns
     -------
@@ -486,7 +486,13 @@ def asscalar(a):
     24
 
     """
-    return a.item()
+    try:
+        return a.item()
+    except AttributeError as e:
+        if isscalar(a):
+            return a
+        else:
+            raise e
 
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Passing a scalar value to np.asscalar now returns the scalar instead of
raising an AttributeError. See #4701.

(Part of EuroScipPy 2018 Sprints)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
