### PR TITLE
BUG: (closes #4352) any and all applied to object arrays should return bool

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2088,9 +2088,9 @@ def clip(a, a_min, a_max, out=None, **kwargs):
 
     Notes
     -----
-    When `a_min` is greater than `a_max`, `clip` returns an 
-    array in which all values are equal to `a_max`, 
-    as shown in the second example.  
+    When `a_min` is greater than `a_max`, `clip` returns an
+    array in which all values are equal to `a_max`,
+    as shown in the second example.
 
     Examples
     --------
@@ -2355,8 +2355,14 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (191614240, 191614240)
 
     """
-    return _wrapreduction(a, np.logical_or, 'any', axis, None, out,
-                          keepdims=keepdims, where=where)
+    result = _wrapreduction(a, np.logical_or, 'any', axis, None, out,
+                            keepdims=keepdims, where=where)
+    if result is None:
+        return None
+    try:
+        return result.astype('bool')
+    except:
+        return bool(result)
 
 
 def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
@@ -2447,8 +2453,14 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (28293632, 28293632, array(True)) # may vary
 
     """
-    return _wrapreduction(a, np.logical_and, 'all', axis, None, out,
-                          keepdims=keepdims, where=where)
+    result = _wrapreduction(a, np.logical_and, 'all', axis, None, out,
+                            keepdims=keepdims, where=where)
+    if result is None:
+        return None
+    try:
+        return result.astype('bool')
+    except:
+        return bool(result)
 
 
 def _cumsum_dispatcher(a, axis=None, dtype=None, out=None):

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2394,8 +2394,14 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (191614240, 191614240)
 
     """
-    return _wrapreduction(a, np.logical_or, 'any', axis, None, out,
-                          keepdims=keepdims, where=where)
+    result = _wrapreduction(a, np.logical_or, 'any', axis, None, out,
+                            keepdims=keepdims, where=where)
+    if result is None:
+        return None
+    try:
+        return result.astype('bool')
+    except:
+        return bool(result)
 
 
 def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
@@ -2486,8 +2492,14 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     (28293632, 28293632, array(True)) # may vary
 
     """
-    return _wrapreduction(a, np.logical_and, 'all', axis, None, out,
-                          keepdims=keepdims, where=where)
+    result = _wrapreduction(a, np.logical_and, 'all', axis, None, out,
+                            keepdims=keepdims, where=where)
+    if result is None:
+        return None
+    try:
+        return result.astype('bool')
+    except:
+        return bool(result)
 
 
 def _cumsum_dispatcher(a, axis=None, dtype=None, out=None):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3479,7 +3479,6 @@ def test_complex_nan_comparisons():
                 assert_equal(x >= y, False, err_msg="%r >= %r" % (x, y))
                 assert_equal(x == y, False, err_msg="%r == %r" % (x, y))
 
-
 def test_rint_big_int():
     # np.rint bug for large integer values on Windows 32-bit and MKL
     # https://github.com/numpy/numpy/issues/6685
@@ -3549,3 +3548,40 @@ def test_outer_exceeds_maxdims():
     with assert_raises(ValueError):
         np.add.outer(deep, deep)
 
+def test_any_as_bool():
+    """Regression test for gh-4352: any must return bool for object arrays"""
+    a = np.zeros(2, dtype='O')
+    b = np.ones(2, dtype='O')
+    c = np.array([1,0], dtype='O')
+    d = [a, b, c]
+    e = np.array([1.5, 2.4], dtype=object)
+    f = np.array([0.0, 2.4], dtype=object)
+    g = np.array([object(), 2.4], dtype=object)
+    h = np.array([np.array([3]), 0], dtype=object)
+    assert_equal(np.any(a), False)
+    assert_equal(np.any(b), True)
+    assert_equal(np.any(c), True)
+    assert_equal(np.any(d, axis=1), np.array([False, True, True]))
+    assert_equal(np.any(e), True)
+    assert_equal(np.any(f), True)
+    assert_equal(np.any(g), True)
+    assert_equal(np.any(h), True)
+
+def test_all_as_bool():
+    """Regression test for gh-4352: all must return bool for object arrays"""
+    a = np.zeros(2, dtype='O')
+    b = np.ones(2, dtype='O')
+    c = np.array([1,0], dtype='O')
+    d = [a, b, c]
+    e = np.array([1.5, 2.4], dtype=object)
+    f = np.array([0.0, 2.4], dtype=object)
+    g = np.array([object(), 2.4], dtype=object)
+    h = np.array([np.array([3]), 0], dtype=object)
+    assert_equal(np.all(a), False)
+    assert_equal(np.all(b), True)
+    assert_equal(np.all(c), False)
+    assert_equal(np.all(d, axis=1), np.array([False, True, False]))
+    assert_equal(np.all(e), True)
+    assert_equal(np.all(f), False)
+    assert_equal(np.all(g), True)
+    assert_equal(np.all(h), False)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3910,7 +3910,6 @@ def test_complex_nan_comparisons():
                 assert_equal(x >= y, False, err_msg="%r >= %r" % (x, y))
                 assert_equal(x == y, False, err_msg="%r == %r" % (x, y))
 
-
 def test_rint_big_int():
     # np.rint bug for large integer values on Windows 32-bit and MKL
     # https://github.com/numpy/numpy/issues/6685
@@ -4009,10 +4008,47 @@ def test_bad_legacy_ufunc_silent_errors():
     with pytest.raises(RuntimeError, match=r"How unexpected :\)!"):
         ncu_tests.always_error.at(arr, [0, 1, 2], arr)
 
-
 @pytest.mark.parametrize('x1', [np.arange(3.0), [0.0, 1.0, 2.0]])
 def test_bad_legacy_gufunc_silent_errors(x1):
     # Verify that an exception raised in a gufunc loop propagates correctly.
     # The signature of always_error_gufunc is '(i),()->()'.
     with pytest.raises(RuntimeError, match=r"How unexpected :\)!"):
         ncu_tests.always_error_gufunc(x1, 0.0)
+
+def test_any_as_bool():
+    """Regression test for gh-4352: any must return bool for object arrays"""
+    a = np.zeros(2, dtype='O')
+    b = np.ones(2, dtype='O')
+    c = np.array([1,0], dtype='O')
+    d = [a, b, c]
+    e = np.array([1.5, 2.4], dtype=object)
+    f = np.array([0.0, 2.4], dtype=object)
+    g = np.array([object(), 2.4], dtype=object)
+    h = np.array([np.array([3]), 0], dtype=object)
+    assert_equal(np.any(a), False)
+    assert_equal(np.any(b), True)
+    assert_equal(np.any(c), True)
+    assert_equal(np.any(d, axis=1), np.array([False, True, True]))
+    assert_equal(np.any(e), True)
+    assert_equal(np.any(f), True)
+    assert_equal(np.any(g), True)
+    assert_equal(np.any(h), True)
+
+def test_all_as_bool():
+    """Regression test for gh-4352: all must return bool for object arrays"""
+    a = np.zeros(2, dtype='O')
+    b = np.ones(2, dtype='O')
+    c = np.array([1,0], dtype='O')
+    d = [a, b, c]
+    e = np.array([1.5, 2.4], dtype=object)
+    f = np.array([0.0, 2.4], dtype=object)
+    g = np.array([object(), 2.4], dtype=object)
+    h = np.array([np.array([3]), 0], dtype=object)
+    assert_equal(np.all(a), False)
+    assert_equal(np.all(b), True)
+    assert_equal(np.all(c), False)
+    assert_equal(np.all(d, axis=1), np.array([False, True, False]))
+    assert_equal(np.all(e), True)
+    assert_equal(np.all(f), False)
+    assert_equal(np.all(g), True)
+    assert_equal(np.all(h), False)


### PR DESCRIPTION
BUG: (closes #4352) numpy any and all applied to object arrays should return bool

Fix problem of np.any and np.all not always return bool. 

(from EuroSciPy 2018 sprints)