### PR TITLE
DOC: add docstrings for numeric types

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -115,9 +115,9 @@ to avoid corrupted results when memory overlap occurs.
 
 Detailed docstrings for scalar numeric types
 --------------------------------------------
-The docstrings and ``help`` function of numeric types, such as `np.intc`,
-`np.int_`, `np.longlong`, etc. now list the different aliased types, both the
-hardcoded ones as well as the ones that depend on the platform.
+The ``help`` function, when applied to numeric types such as `np.intc`,
+`np.int_`, and `np.longlong`, now lists all of the aliased names for that type,
+distinguishing between platform -dependent and -independent aliases.
 
 
 Changes

--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -113,6 +113,12 @@ details.
 The ``out`` argument to these functions is now always tested for memory overlap
 to avoid corrupted results when memory overlap occurs.
 
+Detailed docstrings for scalar numeric types
+--------------------------------------------
+The docstrings and ``help`` function of numeric types, such as `np.intc`,
+`np.int_`, `np.longlong`, etc. now list the different aliased types, both the
+hardcoded ones as well as the ones that depend on the platform.
+
 
 Changes
 =======

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7970,6 +7970,51 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 #
 ##############################################################################
 
+def get_type(place, obj):
+    try:
+        return getattr(__import__(place, globals(), {}, [obj]), obj)
+    except Exception:
+        return None
+
+def type_aliases(place, aliases):
+    return [(alias_type, doc) for (alias, doc) in aliases
+                for alias_type in (get_type(place, alias),)
+                if alias_type is not None]
+
+integer_aliases = type_aliases('numpy.core.numerictypes', [
+    ('int8', '8-bit singed integer (-128 to 127)'),
+    ('int16', '16-bit singed integer (-32768 to 32767)'),
+    ('int32', '32-bit singed integer (-2147483648 to 2147483647)'),
+    ('int64', '64-bit singed integer (-9223372036854775808 to 9223372036854775807)'),
+    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``ssize_t``'),
+    ])
+
+unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
+    ('uint8', '8-bit unsinged integer (0 to 255)'),
+    ('uint16', '16-bit unsinged integer (0 to 65535)'),
+    ('uint32', '32-bit unsinged integer (0 to 4294967295)'),
+    ('uint64', '64-bit unsinged integer (0 to 18446744073709551615)'),
+    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``size_t``'),
+    ])
+
+float_aliases = type_aliases('numpy.core.numerictypes', [
+    ('float16', '16-bit-precision floating-point number type: sign bit, 5 bits exponent, 10 bits mantissa'),
+    ('float32', '32-bit-precision floating-point number type: sign bit, 8 bits exponent, 23 bits mantissa'),
+    ('float64', '64-bit precision floating-point number type: sign bit, 11 bits exponent, 52 bits mantissa'),
+    ('float128', '128-bit extended-precision floating-point number type'),
+    ])
+
+complex_aliases = type_aliases('numpy.core.numerictypes', [
+    ('complex64', 'Complex number type composed of 2 32-bit-precision floating-point numbers'),
+    ('complex128', 'Complex number type composed of 2 64-bit-precision floating-point numbers'),
+    ('complex256', 'Complex number type composed of 2 128-bit extended-precision floating-point numbers'),
+    ])
+
+def extra_alias_doc(place, obj, possible_aliases):
+    o = get_type(place, obj)
+    return ''.join("Alias *on this platform*: {}.\n".format(doc) for (alias, doc) in possible_aliases if alias is o)
+
+
 add_newdoc('numpy.core.numerictypes', 'bool_',
     """
     Boolean type (True or False), stored as a byte.
@@ -7982,101 +8027,101 @@ add_newdoc('numpy.core.numerictypes', 'byte',
     """
     Signed integer type, compatible with C ``char``.
     Character code: ``'b'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'byte', integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'short',
     """
     Signed integer type, compatible with C ``short``.
     Character code: ``'h'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'short', integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'intc',
     """
     Signed integer type, compatible with C ``int``.
     Character code: ``'i'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'intc', integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'int_',
     """
     Signed integer type, compatible with Python `int` anc C ``long``.
     Character code: ``'l'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'int_', integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'longlong',
     """
     Signed integer type, compatible with C ``long long``. 
     Character code: ``'q'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'longlong', integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'ubyte',
     """
     Unsigned integer type, compatible with C ``unsigned char``.
     Character code: ``'B'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'ubyte', unsigned_integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'ushort',
     """
     Unsigned integer type, compatible with C ``unsigned short``.
     Character code: ``'H'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'ushort', unsigned_integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'uintc',
     """
     Unsigned integer type, compatible with C ``unsigned int``.
     Character code: ``'I'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'uintc', unsigned_integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'uint',
     """
     Unsigned integer type, compatible with C ``unsigned long``.
     Character code: ``'L'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'uint', unsigned_integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'ulonglong',
     """
     Signed integer type, compatible with C ``unsigned long long``.
     Character code: ``'Q'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'ulonglong', unsigned_integer_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'half',
     """
     Half-precision floating-point number type.
     Character code ``'e'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'half', float_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'single',
     """
     Single-precision floating-point number type, compatible with C ``float``.
     Character code ``'f'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'single', float_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'float_',
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     Character code ``'d'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'float_', float_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'longfloat',
     """
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision. 
     Character code: ``'g'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'longfloat', float_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'float96',
     """
@@ -8090,22 +8135,28 @@ add_newdoc('numpy.core.numerictypes', 'csingle',
     Complex number type composed of two single-precision floating-point
     numbers.
     Character code: `'F'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'csingle', complex_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'complex_',
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     Character code: ``'D'``.
-
-    """)
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'complex_', complex_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'clongfloat',
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     Character code: ``'G'``.
+    {}
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'clongfloat', complex_aliases)))
+
+add_newdoc('numpy.core.numerictypes', 'complex192',
+    """
+    Complex number type composed of two 96-bit extended-precision numbers.
 
     """)
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7984,31 +7984,22 @@ def numeric_type_aliases(aliases):
     return list(type_aliases_gen())
 
 
-integer_aliases = numeric_type_aliases([
+possible_aliases = numeric_type_aliases([
     ('int8', '8-bit signed integer (-128 to 127)'),
     ('int16', '16-bit signed integer (-32768 to 32767)'),
     ('int32', '32-bit signed integer (-2147483648 to 2147483647)'),
     ('int64', '64-bit signed integer (-9223372036854775808 to 9223372036854775807)'),
     ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``'),
-    ])
-
-unsigned_integer_aliases = numeric_type_aliases([
     ('uint8', '8-bit unsigned integer (0 to 255)'),
     ('uint16', '16-bit unsigned integer (0 to 65535)'),
     ('uint32', '32-bit unsigned integer (0 to 4294967295)'),
     ('uint64', '64-bit unsigned integer (0 to 18446744073709551615)'),
     ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``'),
-    ])
-
-float_aliases = numeric_type_aliases([
     ('float16', '16-bit-precision floating-point number type: sign bit, 5 bits exponent, 10 bits mantissa'),
     ('float32', '32-bit-precision floating-point number type: sign bit, 8 bits exponent, 23 bits mantissa'),
     ('float64', '64-bit precision floating-point number type: sign bit, 11 bits exponent, 52 bits mantissa'),
     ('float96', '96-bit extended-precision floating-point number type'),
     ('float128', '128-bit extended-precision floating-point number type'),
-    ])
-
-complex_aliases = numeric_type_aliases([
     ('complex64', 'Complex number type composed of 2 32-bit-precision floating-point numbers'),
     ('complex128', 'Complex number type composed of 2 64-bit-precision floating-point numbers'),
     ('complex192', 'Complex number type composed of 2 96-bit extended-precision floating-point numbers'),
@@ -8016,12 +8007,12 @@ complex_aliases = numeric_type_aliases([
     ])
 
 
-def add_newdoc_for_scalar_type(obj, fixed_aliases, possible_aliases, doc):
+def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     o = getattr(_numerictypes, obj)
 
     character_code = dtype(o).char
     canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``np.{}``.\n    ".format(obj)
-    alias_doc = ''.join("Alias: ``{}``.\n    ".format(alias) for alias in fixed_aliases)
+    alias_doc = ''.join("Alias: ``np.{}``.\n    ".format(alias) for alias in fixed_aliases)
     alias_doc += ''.join("Alias *on this platform*: ``np.{}``: {}.\n    ".format(alias, doc)
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
@@ -8035,102 +8026,102 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, possible_aliases, doc):
     add_newdoc('numpy.core.numerictypes', obj, docstring)
 
 
-add_newdoc_for_scalar_type('bool_', ['bool8'], [],
+add_newdoc_for_scalar_type('bool_', ['bool8'],
     """
     Boolean type (True or False), stored as a byte.
     """)
 
-add_newdoc_for_scalar_type('byte', [], integer_aliases,
+add_newdoc_for_scalar_type('byte', [],
     """
     Signed integer type, compatible with C ``char``.
     """)
 
-add_newdoc_for_scalar_type('short', [], integer_aliases,
+add_newdoc_for_scalar_type('short', [],
     """
     Signed integer type, compatible with C ``short``.
     """)
 
-add_newdoc_for_scalar_type('intc', [], integer_aliases,
+add_newdoc_for_scalar_type('intc', [],
     """
     Signed integer type, compatible with C ``int``.
     """)
 
-add_newdoc_for_scalar_type('int_', [], integer_aliases,
+add_newdoc_for_scalar_type('int_', [],
     """
     Signed integer type, compatible with Python `int` anc C ``long``.
     """)
 
-add_newdoc_for_scalar_type('longlong', [], integer_aliases,
+add_newdoc_for_scalar_type('longlong', [],
     """
     Signed integer type, compatible with C ``long long``.
     """)
 
-add_newdoc_for_scalar_type('ubyte', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ubyte', [],
     """
     Unsigned integer type, compatible with C ``unsigned char``.
     """)
 
-add_newdoc_for_scalar_type('ushort', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ushort', [],
     """
     Unsigned integer type, compatible with C ``unsigned short``.
     """)
 
-add_newdoc_for_scalar_type('uintc', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('uintc', [],
     """
     Unsigned integer type, compatible with C ``unsigned int``.
     """)
 
-add_newdoc_for_scalar_type('uint', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('uint', [],
     """
     Unsigned integer type, compatible with C ``unsigned long``.
     """)
 
-add_newdoc_for_scalar_type('ulonglong', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ulonglong', [],
     """
     Signed integer type, compatible with C ``unsigned long long``.
     """)
 
-add_newdoc_for_scalar_type('half', [], float_aliases,
+add_newdoc_for_scalar_type('half', [],
     """
     Half-precision floating-point number type.
     """)
 
-add_newdoc_for_scalar_type('single', [], float_aliases,
+add_newdoc_for_scalar_type('single', [],
     """
     Single-precision floating-point number type, compatible with C ``float``.
     """)
 
-add_newdoc_for_scalar_type('double', ['float_'], float_aliases,
+add_newdoc_for_scalar_type('double', ['float_'],
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     """)
 
-add_newdoc_for_scalar_type('longdouble', ['longfloat'], float_aliases,
+add_newdoc_for_scalar_type('longdouble', ['longfloat'],
     """
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision.
     """)
 
-add_newdoc_for_scalar_type('csingle', ['singlecomplex'], complex_aliases,
+add_newdoc_for_scalar_type('csingle', ['singlecomplex'],
     """
     Complex number type composed of two single-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_scalar_type('cdouble', ['cfloat', 'complex_'], complex_aliases,
+add_newdoc_for_scalar_type('cdouble', ['cfloat', 'complex_'],
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     """)
 
-add_newdoc_for_scalar_type('clongdouble', ['clongfloat', 'longcomplex'], complex_aliases,
+add_newdoc_for_scalar_type('clongdouble', ['clongfloat', 'longcomplex'],
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_scalar_type('object_', [], [],
+add_newdoc_for_scalar_type('object_', [],
     """
     Any Python object.
     """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7989,7 +7989,7 @@ integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('int16', '16-bit signed integer (-32768 to 32767)'),
     ('int32', '32-bit signed integer (-2147483648 to 2147483647)'),
     ('int64', '64-bit signed integer (-9223372036854775808 to 9223372036854775807)'),
-    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``. Alias: int0'),
+    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``'),
     ])
 
 unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
@@ -7997,7 +7997,7 @@ unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('uint16', '16-bit unsigned integer (0 to 65535)'),
     ('uint32', '32-bit unsigned integer (0 to 4294967295)'),
     ('uint64', '64-bit unsigned integer (0 to 18446744073709551615)'),
-    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``. Alias: uint0'),
+    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``'),
     ])
 
 float_aliases = type_aliases('numpy.core.numerictypes', [
@@ -8015,153 +8015,124 @@ complex_aliases = type_aliases('numpy.core.numerictypes', [
     ('complex256', 'Complex number type composed of 2 128-bit extended-precision floating-point numbers'),
     ])
 
-def extra_alias_doc(place, obj, possible_aliases):
-    o = get_type(place, obj)
-    return ''.join("Alias *on this platform*: {}: {}.\n    ".format(alias, doc)
-                   for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
-add_newdoc('numpy.core.numerictypes', 'bool_',
+def add_newdoc_for_numeric_type(obj, character_code, fixed_aliases, possible_aliases, doc):
+    place = 'numpy.core.numerictypes'
+    o = get_type(place, obj)
+    if o is None:
+        return
+
+    canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``{}``.\n".format(obj)
+    alias_doc = ''.join("Alias: ``{}``.\n    ".format(alias) for alias in fixed_aliases)
+    alias_doc += ''.join("Alias *on this platform*: ``{}``: {}.\n    ".format(alias, doc)
+                         for (alias_type, alias, doc) in possible_aliases if alias_type is o)
+
+    docstring = """
+    {doc}
+    Character code: ``'{character_code}'``.
+    {canonical_name_doc}{alias_doc}
+    """.format(doc=doc.strip(), character_code=character_code,
+               canonical_name_doc=canonical_name_doc, alias_doc=alias_doc)
+
+    add_newdoc(place, obj, docstring)
+
+
+add_newdoc_for_numeric_type('bool_', '?', ['bool8'], [],
     """
     Boolean type (True or False), stored as a byte.
-    Character code: ``'?'``.
-    Alias: ``bool8``.
-
     """)
 
-add_newdoc('numpy.core.numerictypes', 'byte',
+add_newdoc_for_numeric_type('byte', 'b', [], integer_aliases,
     """
     Signed integer type, compatible with C ``char``.
-    Character code: ``'b'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'byte', integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'short',
+add_newdoc_for_numeric_type('short', 'h', [], integer_aliases,
     """
     Signed integer type, compatible with C ``short``.
-    Character code: ``'h'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'short', integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'intc',
+add_newdoc_for_numeric_type('intc', 'i', [], integer_aliases,
     """
     Signed integer type, compatible with C ``int``.
-    Character code: ``'i'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'intc', integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'int_',
+add_newdoc_for_numeric_type('int_', 'l', [], integer_aliases,
     """
     Signed integer type, compatible with Python `int` anc C ``long``.
-    Character code: ``'l'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'int_', integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'longlong',
+add_newdoc_for_numeric_type('longlong', 'q', [], integer_aliases,
     """
-    Signed integer type, compatible with C ``long long``. 
-    Character code: ``'q'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'longlong', integer_aliases)))
+    Signed integer type, compatible with C ``long long``.
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'ubyte',
+add_newdoc_for_numeric_type('ubyte', 'B', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned char``.
-    Character code: ``'B'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'ubyte', unsigned_integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'ushort',
+add_newdoc_for_numeric_type('ushort', 'H', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned short``.
-    Character code: ``'H'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'ushort', unsigned_integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'uintc',
+add_newdoc_for_numeric_type('uintc', 'I', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned int``.
-    Character code: ``'I'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'uintc', unsigned_integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'uint',
+add_newdoc_for_numeric_type('uint', 'L', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned long``.
-    Character code: ``'L'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'uint', unsigned_integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'ulonglong',
+add_newdoc_for_numeric_type('ulonglong', 'Q', [], unsigned_integer_aliases,
     """
     Signed integer type, compatible with C ``unsigned long long``.
-    Character code: ``'Q'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'ulonglong', unsigned_integer_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'half',
+add_newdoc_for_numeric_type('half', 'e', [], float_aliases,
     """
     Half-precision floating-point number type.
-    Character code ``'e'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'half', float_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'single',
+add_newdoc_for_numeric_type('single', 'f', [], float_aliases,
     """
     Single-precision floating-point number type, compatible with C ``float``.
-    Character code ``'f'``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'single', float_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'double',
+add_newdoc_for_numeric_type('double', 'd', ['float_'], float_aliases,
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
-    Character code ``'d'``.
-    Alias: ``float_``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'double', float_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'longdouble',
+add_newdoc_for_numeric_type('longdouble', 'g', ['longfloat'], float_aliases,
     """
     Extended-precision floating-point number type, compatible with C
-    ``long double`` but not necessarily with IEEE 754 quadruple-precision. 
-    Character code: ``'g'``.
-    Alias: ``longfloat``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'longdouble', float_aliases)))
+    ``long double`` but not necessarily with IEEE 754 quadruple-precision.
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'csingle',
+add_newdoc_for_numeric_type('csingle', 'F', ['singlecomplex'], float_aliases,
     """
     Complex number type composed of two single-precision floating-point
     numbers.
-    Character code: `'F'``.
-    Alias: ``singlecomplex``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'csingle', complex_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'cdouble',
+add_newdoc_for_numeric_type('cdouble', 'D', ['cfloat', 'complex_'], float_aliases,
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
-    Character code: ``'D'``.
-    Alias: ``cfloat``.
-    Alias: ``complex_``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'cdouble', complex_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'clongdouble',
+add_newdoc_for_numeric_type('clongdouble', 'G', ['clongfloat', 'longcomplex'], float_aliases,
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
-    Character code: ``'G'``.
-    Alias: ``clongfloat``.
-    Alias: ``longcomplex``.
-    {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'clongdouble', complex_aliases)))
+    """)
 
-add_newdoc('numpy.core.numerictypes', 'object_',
+add_newdoc_for_numeric_type('object_', 'O', [], [],
     """
     Any Python object.
-    Character code: ``'O'``.
-
     """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7972,116 +7972,146 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 
 add_newdoc('numpy.core.numerictypes', 'bool_',
     """
-    Boolean type (True or False), stored as a byte. Character code: ``'?'``.
+    Boolean type (True or False), stored as a byte.
+    Character code: ``'?'``.
     Alias: bool8.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'complex64',
+add_newdoc('numpy.core.numerictypes', 'byte',
     """
-    Complex number type composed of two 32 bit floats. Character code:
-    ``'F'``.
+    Signed integer type, compatible with C ``char``.
+    Character code: ``'b'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'complex128',
+add_newdoc('numpy.core.numerictypes', 'short',
     """
-    Complex number type composed of two 64 bit floats. Character code:
-    ``'D'``. Python complex compatible.
+    Signed integer type, compatible with C ``short``.
+    Character code: ``'h'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'complex256',
+add_newdoc('numpy.core.numerictypes', 'intc',
     """
-    Complex number type composed of two 128-bit floats. Character code:
-    ``'G'``.
+    Signed integer type, compatible with C ``int``.
+    Character code: ``'i'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'float16',
+add_newdoc('numpy.core.numerictypes', 'int_',
     """
-    16-bit floating-point number. Character code ``'e'``.
+    Signed integer type, compatible with Python `int` anc C ``long``.
+    Character code: ``'l'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'float32',
+add_newdoc('numpy.core.numerictypes', 'longlong',
     """
-    32-bit floating-point number. Character code ``'f'``. C float compatible.
+    Signed integer type, compatible with C ``long long``. 
+    Character code: ``'q'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'float64',
+add_newdoc('numpy.core.numerictypes', 'ubyte',
     """
-    64-bit floating-point number. Character code ``'d'``. Python float
-    compatible.
+    Unsigned integer type, compatible with C ``unsigned char``.
+    Character code: ``'B'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'ushort',
+    """
+    Unsigned integer type, compatible with C ``unsigned short``.
+    Character code: ``'H'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'uintc',
+    """
+    Unsigned integer type, compatible with C ``unsigned int``.
+    Character code: ``'I'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'uint',
+    """
+    Unsigned integer type, compatible with C ``unsigned long``.
+    Character code: ``'L'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'ulonglong',
+    """
+    Signed integer type, compatible with C ``unsigned long long``.
+    Character code: ``'Q'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'half',
+    """
+    Half-precision floating-point number type.
+    Character code ``'e'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'single',
+    """
+    Single-precision floating-point number type, compatible with C ``float``.
+    Character code ``'f'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'float_',
+    """
+    Double-precision floating-point number type, compatible with Python `float`
+    and C ``double``.
+    Character code ``'d'``.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'longfloat',
+    """
+    Extended-precision floating-point number type, compatible with C
+    ``long double`` but not necessarily with IEEE 754 quadruple-precision. 
+    Character code: ``'g'``.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'float96',
     """
+    96-bit extended-precision floating-point number type.
+    
     """)
 
-add_newdoc('numpy.core.numerictypes', 'float128',
+
+add_newdoc('numpy.core.numerictypes', 'csingle',
     """
-    128-bit floating-point number. Character code: ``'g'``. C long float
-    compatible.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'int8',
-    """
-    8-bit integer. Character code ``'b'``. C char compatible.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'int16',
-    """
-    16-bit integer. Character code ``'h'``. C short compatible.
+    Complex number type composed of two single-precision floating-point
+    numbers.
+    Character code: `'F'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'int32',
+add_newdoc('numpy.core.numerictypes', 'complex_',
     """
-    32-bit integer. Character code ``'i'``. C int compatible.
+    Complex number type composed of two double-precision floating-point
+    numbers, compatible with Python `complex`.
+    Character code: ``'D'``.
 
     """)
 
-add_newdoc('numpy.core.numerictypes', 'int64',
+add_newdoc('numpy.core.numerictypes', 'clongfloat',
     """
-    64-bit integer. Character code ``'l'``. Python int compatible.
+    Complex number type composed of two extended-precision floating-point
+    numbers.
+    Character code: ``'G'``.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'object_',
     """
-    Any Python object.  Character code: ``'O'``.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'uint8',
-    """
-    8-bit unsigned integer. Character code ``'B'``. C unsigned char
-    compatible.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'uint16',
-    """
-    16-bit unsigned integer. Character code ``'H'``. C unsigned short
-    compatible.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'uint32',
-    """
-    32-bit unsigned integer. Character code ``'I'``. C unsigned int
-    compatible.
-
-    """)
-
-add_newdoc('numpy.core.numerictypes', 'uint64',
-    """
-    64-bit unsigned integer. Character code ``'L'``. C unsigned long long
-    compatible.
+    Any Python object.
+    Character code: ``'O'``.
 
     """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -10,6 +10,8 @@ NOTE: Many of the methods of ndarray have corresponding functions.
 """
 from __future__ import division, absolute_import, print_function
 
+from numpy.core import numerictypes as _numerictypes
+from numpy.core import dtype
 from numpy.core.function_base import add_newdoc
 
 ###############################################################################
@@ -7970,21 +7972,16 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 #
 ##############################################################################
 
-def get_type(place, obj):
-    try:
-        return getattr(__import__(place, globals(), {}, [obj]), obj)
-    except AttributeError:
-        return None
-
-def type_aliases(place, aliases):
+def numeric_type_aliases(aliases):
     def type_aliases_gen():
         for (alias, doc) in aliases:
-            alias_type = get_type(place, alias)
+            alias_type = getattr(_numerictypes, alias, None)
             if alias_type is not None:
                 yield (alias_type, alias, doc)
     return list(type_aliases_gen())
 
-integer_aliases = type_aliases('numpy.core.numerictypes', [
+
+integer_aliases = numeric_type_aliases([
     ('int8', '8-bit signed integer (-128 to 127)'),
     ('int16', '16-bit signed integer (-32768 to 32767)'),
     ('int32', '32-bit signed integer (-2147483648 to 2147483647)'),
@@ -7992,7 +7989,7 @@ integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``'),
     ])
 
-unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
+unsigned_integer_aliases = numeric_type_aliases([
     ('uint8', '8-bit unsigned integer (0 to 255)'),
     ('uint16', '16-bit unsigned integer (0 to 65535)'),
     ('uint32', '32-bit unsigned integer (0 to 4294967295)'),
@@ -8000,7 +7997,7 @@ unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``'),
     ])
 
-float_aliases = type_aliases('numpy.core.numerictypes', [
+float_aliases = numeric_type_aliases([
     ('float16', '16-bit-precision floating-point number type: sign bit, 5 bits exponent, 10 bits mantissa'),
     ('float32', '32-bit-precision floating-point number type: sign bit, 8 bits exponent, 23 bits mantissa'),
     ('float64', '64-bit precision floating-point number type: sign bit, 11 bits exponent, 52 bits mantissa'),
@@ -8008,7 +8005,7 @@ float_aliases = type_aliases('numpy.core.numerictypes', [
     ('float128', '128-bit extended-precision floating-point number type'),
     ])
 
-complex_aliases = type_aliases('numpy.core.numerictypes', [
+complex_aliases = numeric_type_aliases([
     ('complex64', 'Complex number type composed of 2 32-bit-precision floating-point numbers'),
     ('complex128', 'Complex number type composed of 2 64-bit-precision floating-point numbers'),
     ('complex192', 'Complex number type composed of 2 96-bit extended-precision floating-point numbers'),
@@ -8016,13 +8013,13 @@ complex_aliases = type_aliases('numpy.core.numerictypes', [
     ])
 
 
-def add_newdoc_for_numeric_type(obj, character_code, fixed_aliases, possible_aliases, doc):
-    place = 'numpy.core.numerictypes'
-    o = get_type(place, obj)
+def add_newdoc_for_numeric_type(obj, fixed_aliases, possible_aliases, doc):
+    o = getattr(_numerictypes, obj, None)
     if o is None:
         return
 
-    canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``{}``.\n".format(obj)
+    character_code = dtype(o).char
+    canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``{}``.\n    ".format(obj)
     alias_doc = ''.join("Alias: ``{}``.\n    ".format(alias) for alias in fixed_aliases)
     alias_doc += ''.join("Alias *on this platform*: ``{}``: {}.\n    ".format(alias, doc)
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
@@ -8034,105 +8031,105 @@ def add_newdoc_for_numeric_type(obj, character_code, fixed_aliases, possible_ali
     """.format(doc=doc.strip(), character_code=character_code,
                canonical_name_doc=canonical_name_doc, alias_doc=alias_doc)
 
-    add_newdoc(place, obj, docstring)
+    add_newdoc('numpy.core.numerictypes', obj, docstring)
 
 
-add_newdoc_for_numeric_type('bool_', '?', ['bool8'], [],
+add_newdoc_for_numeric_type('bool_', ['bool8'], [],
     """
     Boolean type (True or False), stored as a byte.
     """)
 
-add_newdoc_for_numeric_type('byte', 'b', [], integer_aliases,
+add_newdoc_for_numeric_type('byte', [], integer_aliases,
     """
     Signed integer type, compatible with C ``char``.
     """)
 
-add_newdoc_for_numeric_type('short', 'h', [], integer_aliases,
+add_newdoc_for_numeric_type('short', [], integer_aliases,
     """
     Signed integer type, compatible with C ``short``.
     """)
 
-add_newdoc_for_numeric_type('intc', 'i', [], integer_aliases,
+add_newdoc_for_numeric_type('intc', [], integer_aliases,
     """
     Signed integer type, compatible with C ``int``.
     """)
 
-add_newdoc_for_numeric_type('int_', 'l', [], integer_aliases,
+add_newdoc_for_numeric_type('int_', [], integer_aliases,
     """
     Signed integer type, compatible with Python `int` anc C ``long``.
     """)
 
-add_newdoc_for_numeric_type('longlong', 'q', [], integer_aliases,
+add_newdoc_for_numeric_type('longlong', [], integer_aliases,
     """
     Signed integer type, compatible with C ``long long``.
     """)
 
-add_newdoc_for_numeric_type('ubyte', 'B', [], unsigned_integer_aliases,
+add_newdoc_for_numeric_type('ubyte', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned char``.
     """)
 
-add_newdoc_for_numeric_type('ushort', 'H', [], unsigned_integer_aliases,
+add_newdoc_for_numeric_type('ushort', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned short``.
     """)
 
-add_newdoc_for_numeric_type('uintc', 'I', [], unsigned_integer_aliases,
+add_newdoc_for_numeric_type('uintc', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned int``.
     """)
 
-add_newdoc_for_numeric_type('uint', 'L', [], unsigned_integer_aliases,
+add_newdoc_for_numeric_type('uint', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned long``.
     """)
 
-add_newdoc_for_numeric_type('ulonglong', 'Q', [], unsigned_integer_aliases,
+add_newdoc_for_numeric_type('ulonglong', [], unsigned_integer_aliases,
     """
     Signed integer type, compatible with C ``unsigned long long``.
     """)
 
-add_newdoc_for_numeric_type('half', 'e', [], float_aliases,
+add_newdoc_for_numeric_type('half', [], float_aliases,
     """
     Half-precision floating-point number type.
     """)
 
-add_newdoc_for_numeric_type('single', 'f', [], float_aliases,
+add_newdoc_for_numeric_type('single', [], float_aliases,
     """
     Single-precision floating-point number type, compatible with C ``float``.
     """)
 
-add_newdoc_for_numeric_type('double', 'd', ['float_'], float_aliases,
+add_newdoc_for_numeric_type('double', ['float_'], float_aliases,
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     """)
 
-add_newdoc_for_numeric_type('longdouble', 'g', ['longfloat'], float_aliases,
+add_newdoc_for_numeric_type('longdouble', ['longfloat'], float_aliases,
     """
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision.
     """)
 
-add_newdoc_for_numeric_type('csingle', 'F', ['singlecomplex'], float_aliases,
+add_newdoc_for_numeric_type('csingle', ['singlecomplex'], float_aliases,
     """
     Complex number type composed of two single-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_numeric_type('cdouble', 'D', ['cfloat', 'complex_'], float_aliases,
+add_newdoc_for_numeric_type('cdouble', ['cfloat', 'complex_'], float_aliases,
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     """)
 
-add_newdoc_for_numeric_type('clongdouble', 'G', ['clongfloat', 'longcomplex'], float_aliases,
+add_newdoc_for_numeric_type('clongdouble', ['clongfloat', 'longcomplex'], float_aliases,
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_numeric_type('object_', 'O', [], [],
+add_newdoc_for_numeric_type('object_', [], [],
     """
     Any Python object.
     """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7974,7 +7974,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 
 def numeric_type_aliases(aliases):
     def type_aliases_gen():
-        for (alias, doc) in aliases:
+        for alias, doc in aliases:
             alias_type = getattr(_numerictypes, alias, None)
             if alias_type is not None:
                 yield (alias_type, alias, doc)
@@ -8013,10 +8013,8 @@ complex_aliases = numeric_type_aliases([
     ])
 
 
-def add_newdoc_for_numeric_type(obj, fixed_aliases, possible_aliases, doc):
-    o = getattr(_numerictypes, obj, None)
-    if o is None:
-        return
+def add_newdoc_for_scalar_type(obj, fixed_aliases, possible_aliases, doc):
+    o = getattr(_numerictypes, obj)
 
     character_code = dtype(o).char
     canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``np.{}``.\n    ".format(obj)
@@ -8034,102 +8032,102 @@ def add_newdoc_for_numeric_type(obj, fixed_aliases, possible_aliases, doc):
     add_newdoc('numpy.core.numerictypes', obj, docstring)
 
 
-add_newdoc_for_numeric_type('bool_', ['bool8'], [],
+add_newdoc_for_scalar_type('bool_', ['bool8'], [],
     """
     Boolean type (True or False), stored as a byte.
     """)
 
-add_newdoc_for_numeric_type('byte', [], integer_aliases,
+add_newdoc_for_scalar_type('byte', [], integer_aliases,
     """
     Signed integer type, compatible with C ``char``.
     """)
 
-add_newdoc_for_numeric_type('short', [], integer_aliases,
+add_newdoc_for_scalar_type('short', [], integer_aliases,
     """
     Signed integer type, compatible with C ``short``.
     """)
 
-add_newdoc_for_numeric_type('intc', [], integer_aliases,
+add_newdoc_for_scalar_type('intc', [], integer_aliases,
     """
     Signed integer type, compatible with C ``int``.
     """)
 
-add_newdoc_for_numeric_type('int_', [], integer_aliases,
+add_newdoc_for_scalar_type('int_', [], integer_aliases,
     """
     Signed integer type, compatible with Python `int` anc C ``long``.
     """)
 
-add_newdoc_for_numeric_type('longlong', [], integer_aliases,
+add_newdoc_for_scalar_type('longlong', [], integer_aliases,
     """
     Signed integer type, compatible with C ``long long``.
     """)
 
-add_newdoc_for_numeric_type('ubyte', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ubyte', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned char``.
     """)
 
-add_newdoc_for_numeric_type('ushort', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ushort', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned short``.
     """)
 
-add_newdoc_for_numeric_type('uintc', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('uintc', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned int``.
     """)
 
-add_newdoc_for_numeric_type('uint', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('uint', [], unsigned_integer_aliases,
     """
     Unsigned integer type, compatible with C ``unsigned long``.
     """)
 
-add_newdoc_for_numeric_type('ulonglong', [], unsigned_integer_aliases,
+add_newdoc_for_scalar_type('ulonglong', [], unsigned_integer_aliases,
     """
     Signed integer type, compatible with C ``unsigned long long``.
     """)
 
-add_newdoc_for_numeric_type('half', [], float_aliases,
+add_newdoc_for_scalar_type('half', [], float_aliases,
     """
     Half-precision floating-point number type.
     """)
 
-add_newdoc_for_numeric_type('single', [], float_aliases,
+add_newdoc_for_scalar_type('single', [], float_aliases,
     """
     Single-precision floating-point number type, compatible with C ``float``.
     """)
 
-add_newdoc_for_numeric_type('double', ['float_'], float_aliases,
+add_newdoc_for_scalar_type('double', ['float_'], float_aliases,
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     """)
 
-add_newdoc_for_numeric_type('longdouble', ['longfloat'], float_aliases,
+add_newdoc_for_scalar_type('longdouble', ['longfloat'], float_aliases,
     """
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision.
     """)
 
-add_newdoc_for_numeric_type('csingle', ['singlecomplex'], float_aliases,
+add_newdoc_for_scalar_type('csingle', ['singlecomplex'], float_aliases,
     """
     Complex number type composed of two single-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_numeric_type('cdouble', ['cfloat', 'complex_'], float_aliases,
+add_newdoc_for_scalar_type('cdouble', ['cfloat', 'complex_'], float_aliases,
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     """)
 
-add_newdoc_for_numeric_type('clongdouble', ['clongfloat', 'longcomplex'], float_aliases,
+add_newdoc_for_scalar_type('clongdouble', ['clongfloat', 'longcomplex'], float_aliases,
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_numeric_type('object_', [], [],
+add_newdoc_for_scalar_type('object_', [], [],
     """
     Any Python object.
     """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7978,6 +7978,7 @@ def numeric_type_aliases(aliases):
             try:
                 alias_type = getattr(_numerictypes, alias)
             except AttributeError:
+                # The set of aliases that actually exist varies between platforms
                 pass
             else:
                 yield (alias_type, alias, doc)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7975,8 +7975,11 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 def numeric_type_aliases(aliases):
     def type_aliases_gen():
         for alias, doc in aliases:
-            alias_type = getattr(_numerictypes, alias, None)
-            if alias_type is not None:
+            try:
+                alias_type = getattr(_numerictypes, alias)
+            except AttributeError:
+                pass
+            else:
                 yield (alias_type, alias, doc)
     return list(type_aliases_gen())
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -8029,3 +8029,31 @@ add_newdoc('numpy.core.numerictypes', 'int64',
 
 add_newdoc('numpy.core.numerictypes', 'object_',
     """Any Python object.  Character code: 'O'.""")
+
+add_newdoc('numpy.core.numerictypes', 'uint8',
+    """
+    8-bit unsigned integer. Character code ``'B'``. C unsigned char
+    compatible.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'uint16',
+    """
+    16-bit unsigned integer. Character code ``'H'``. C unsigned short
+    compatible.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'uint32',
+    """
+    32-bit unsigned integer. Character code ``'I'``. C unsigned int
+    compatible.
+
+    """)
+
+add_newdoc('numpy.core.numerictypes', 'uint64',
+    """
+    64-bit unsigned integer. Character code ``'L'``. C unsigned long long
+    compatible.
+
+    """)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7971,36 +7971,43 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 ##############################################################################
 
 add_newdoc('numpy.core.numerictypes', 'bool_',
-    """NumPy's Boolean type.  Character code: ``?``.  Alias: bool8""")
+    """
+    Boolean type (True or False), stored as a byte. Character code: ``'?'``.
+    Alias: bool8.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'complex64',
     """
-    Complex number type composed of two 32 bit floats. Character code: 'F'.
+    Complex number type composed of two 32 bit floats. Character code:
+    ``'F'``.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'complex128',
     """
-    Complex number type composed of two 64 bit floats. Character code: 'D'.
-    Python complex compatible.
+    Complex number type composed of two 64 bit floats. Character code:
+    ``'D'``. Python complex compatible.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'complex256',
     """
-    Complex number type composed of two 128-bit floats. Character code: 'G'.
+    Complex number type composed of two 128-bit floats. Character code:
+    ``'G'``.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'float32',
     """
-    32-bit floating-point number. Character code 'f'. C float compatible.
+    32-bit floating-point number. Character code ``'f'``. C float compatible.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'float64',
     """
-    64-bit floating-point number. Character code 'd'. Python float compatible.
+    64-bit floating-point number. Character code ``'d'``. Python float
+    compatible.
 
     """)
 
@@ -8010,25 +8017,40 @@ add_newdoc('numpy.core.numerictypes', 'float96',
 
 add_newdoc('numpy.core.numerictypes', 'float128',
     """
-    128-bit floating-point number. Character code: 'g'. C long float
+    128-bit floating-point number. Character code: ``'g'``. C long float
     compatible.
 
     """)
 
 add_newdoc('numpy.core.numerictypes', 'int8',
-    """8-bit integer. Character code ``b``. C char compatible.""")
+    """
+    8-bit integer. Character code ``'b'``. C char compatible.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'int16',
-    """16-bit integer. Character code ``h``. C short compatible.""")
+    """
+    16-bit integer. Character code ``'h'``. C short compatible.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'int32',
-    """32-bit integer. Character code 'i'. C int compatible.""")
+    """
+    32-bit integer. Character code ``'i'``. C int compatible.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'int64',
-    """64-bit integer. Character code 'l'. Python int compatible.""")
+    """
+    64-bit integer. Character code ``'l'``. Python int compatible.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'object_',
-    """Any Python object.  Character code: 'O'.""")
+    """
+    Any Python object.  Character code: ``'O'``.
+
+    """)
 
 add_newdoc('numpy.core.numerictypes', 'uint8',
     """

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7973,7 +7973,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
 def get_type(place, obj):
     try:
         return getattr(__import__(place, globals(), {}, [obj]), obj)
-    except Exception:
+    except AttributeError:
         return None
 
 def type_aliases(place, aliases):
@@ -8018,7 +8018,7 @@ complex_aliases = type_aliases('numpy.core.numerictypes', [
 def extra_alias_doc(place, obj, possible_aliases):
     o = get_type(place, obj)
     return ''.join("Alias *on this platform*: {}: {}.\n".format(alias, doc)
-                   for (alias_type, alias, doc) in possible_aliases if alias is o)
+                   for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
 add_newdoc('numpy.core.numerictypes', 'bool_',
     """

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7977,36 +7977,41 @@ def get_type(place, obj):
         return None
 
 def type_aliases(place, aliases):
-    return [(alias_type, doc) for (alias, doc) in aliases
-                for alias_type in (get_type(place, alias),)
-                if alias_type is not None]
+    def type_aliases_gen():
+        for (alias, doc) in aliases:
+            alias_type = get_type(place, alias)
+            if alias_type is not None:
+                yield (alias_type, doc)
+    return list(type_aliases_gen())
 
 integer_aliases = type_aliases('numpy.core.numerictypes', [
-    ('int8', '8-bit singed integer (-128 to 127)'),
-    ('int16', '16-bit singed integer (-32768 to 32767)'),
-    ('int32', '32-bit singed integer (-2147483648 to 2147483647)'),
-    ('int64', '64-bit singed integer (-9223372036854775808 to 9223372036854775807)'),
-    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``ssize_t``'),
+    ('int8', '8-bit signed integer (-128 to 127)'),
+    ('int16', '16-bit signed integer (-32768 to 32767)'),
+    ('int32', '32-bit signed integer (-2147483648 to 2147483647)'),
+    ('int64', '64-bit signed integer (-9223372036854775808 to 9223372036854775807)'),
+    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``'),
     ])
 
 unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
-    ('uint8', '8-bit unsinged integer (0 to 255)'),
-    ('uint16', '16-bit unsinged integer (0 to 65535)'),
-    ('uint32', '32-bit unsinged integer (0 to 4294967295)'),
-    ('uint64', '64-bit unsinged integer (0 to 18446744073709551615)'),
-    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``size_t``'),
+    ('uint8', '8-bit unsigned integer (0 to 255)'),
+    ('uint16', '16-bit unsigned integer (0 to 65535)'),
+    ('uint32', '32-bit unsigned integer (0 to 4294967295)'),
+    ('uint64', '64-bit unsigned integer (0 to 18446744073709551615)'),
+    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``'),
     ])
 
 float_aliases = type_aliases('numpy.core.numerictypes', [
     ('float16', '16-bit-precision floating-point number type: sign bit, 5 bits exponent, 10 bits mantissa'),
     ('float32', '32-bit-precision floating-point number type: sign bit, 8 bits exponent, 23 bits mantissa'),
     ('float64', '64-bit precision floating-point number type: sign bit, 11 bits exponent, 52 bits mantissa'),
+    ('float96', '96-bit extended-precision floating-point number type'),
     ('float128', '128-bit extended-precision floating-point number type'),
     ])
 
 complex_aliases = type_aliases('numpy.core.numerictypes', [
     ('complex64', 'Complex number type composed of 2 32-bit-precision floating-point numbers'),
     ('complex128', 'Complex number type composed of 2 64-bit-precision floating-point numbers'),
+    ('complex192', 'Complex number type composed of 2 96-bit extended-precision floating-point numbers'),
     ('complex256', 'Complex number type composed of 2 128-bit extended-precision floating-point numbers'),
     ])
 
@@ -8107,27 +8112,21 @@ add_newdoc('numpy.core.numerictypes', 'single',
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'single', float_aliases)))
 
-add_newdoc('numpy.core.numerictypes', 'float_',
+add_newdoc('numpy.core.numerictypes', 'double',
     """
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     Character code ``'d'``.
     {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'float_', float_aliases)))
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'double', float_aliases)))
 
-add_newdoc('numpy.core.numerictypes', 'longfloat',
+add_newdoc('numpy.core.numerictypes', 'longdouble',
     """
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision. 
     Character code: ``'g'``.
     {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'longfloat', float_aliases)))
-
-add_newdoc('numpy.core.numerictypes', 'float96',
-    """
-    96-bit extended-precision floating-point number type.
-    
-    """)
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'longdouble', float_aliases)))
 
 
 add_newdoc('numpy.core.numerictypes', 'csingle',
@@ -8146,19 +8145,13 @@ add_newdoc('numpy.core.numerictypes', 'complex_',
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'complex_', complex_aliases)))
 
-add_newdoc('numpy.core.numerictypes', 'clongfloat',
+add_newdoc('numpy.core.numerictypes', 'clongdouble',
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     Character code: ``'G'``.
     {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'clongfloat', complex_aliases)))
-
-add_newdoc('numpy.core.numerictypes', 'complex192',
-    """
-    Complex number type composed of two 96-bit extended-precision numbers.
-
-    """)
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'clongdouble', complex_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'object_',
     """

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -8019,9 +8019,9 @@ def add_newdoc_for_numeric_type(obj, fixed_aliases, possible_aliases, doc):
         return
 
     character_code = dtype(o).char
-    canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``{}``.\n    ".format(obj)
+    canonical_name_doc = "" if obj == o.__name__ else "Canonical name: ``np.{}``.\n    ".format(obj)
     alias_doc = ''.join("Alias: ``{}``.\n    ".format(alias) for alias in fixed_aliases)
-    alias_doc += ''.join("Alias *on this platform*: ``{}``: {}.\n    ".format(alias, doc)
+    alias_doc += ''.join("Alias *on this platform*: ``np.{}``: {}.\n    ".format(alias, doc)
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
     docstring = """

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -8017,7 +8017,7 @@ complex_aliases = type_aliases('numpy.core.numerictypes', [
 
 def extra_alias_doc(place, obj, possible_aliases):
     o = get_type(place, obj)
-    return ''.join("Alias *on this platform*: {}: {}.\n".format(alias, doc)
+    return ''.join("Alias *on this platform*: {}: {}.\n    ".format(alias, doc)
                    for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
 add_newdoc('numpy.core.numerictypes', 'bool_',

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -8112,19 +8112,19 @@ add_newdoc_for_scalar_type('longdouble', ['longfloat'], float_aliases,
     ``long double`` but not necessarily with IEEE 754 quadruple-precision.
     """)
 
-add_newdoc_for_scalar_type('csingle', ['singlecomplex'], float_aliases,
+add_newdoc_for_scalar_type('csingle', ['singlecomplex'], complex_aliases,
     """
     Complex number type composed of two single-precision floating-point
     numbers.
     """)
 
-add_newdoc_for_scalar_type('cdouble', ['cfloat', 'complex_'], float_aliases,
+add_newdoc_for_scalar_type('cdouble', ['cfloat', 'complex_'], complex_aliases,
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     """)
 
-add_newdoc_for_scalar_type('clongdouble', ['clongfloat', 'longcomplex'], float_aliases,
+add_newdoc_for_scalar_type('clongdouble', ['clongfloat', 'longcomplex'], complex_aliases,
     """
     Complex number type composed of two extended-precision floating-point
     numbers.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7981,7 +7981,7 @@ def type_aliases(place, aliases):
         for (alias, doc) in aliases:
             alias_type = get_type(place, alias)
             if alias_type is not None:
-                yield (alias_type, doc)
+                yield (alias_type, alias, doc)
     return list(type_aliases_gen())
 
 integer_aliases = type_aliases('numpy.core.numerictypes', [
@@ -7989,7 +7989,7 @@ integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('int16', '16-bit signed integer (-32768 to 32767)'),
     ('int32', '32-bit signed integer (-2147483648 to 2147483647)'),
     ('int64', '64-bit signed integer (-9223372036854775808 to 9223372036854775807)'),
-    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``'),
+    ('intp', 'Signed integer large enough to fit pointer, compatible with C ``intptr_t``. Alias: int0'),
     ])
 
 unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
@@ -7997,7 +7997,7 @@ unsigned_integer_aliases = type_aliases('numpy.core.numerictypes', [
     ('uint16', '16-bit unsigned integer (0 to 65535)'),
     ('uint32', '32-bit unsigned integer (0 to 4294967295)'),
     ('uint64', '64-bit unsigned integer (0 to 18446744073709551615)'),
-    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``'),
+    ('uintp', 'Unsigned integer large enough to fit pointer, compatible with C ``uintptr_t``. Alias: uint0'),
     ])
 
 float_aliases = type_aliases('numpy.core.numerictypes', [
@@ -8017,14 +8017,14 @@ complex_aliases = type_aliases('numpy.core.numerictypes', [
 
 def extra_alias_doc(place, obj, possible_aliases):
     o = get_type(place, obj)
-    return ''.join("Alias *on this platform*: {}.\n".format(doc) for (alias, doc) in possible_aliases if alias is o)
-
+    return ''.join("Alias *on this platform*: {}: {}.\n".format(alias, doc)
+                   for (alias_type, alias, doc) in possible_aliases if alias is o)
 
 add_newdoc('numpy.core.numerictypes', 'bool_',
     """
     Boolean type (True or False), stored as a byte.
     Character code: ``'?'``.
-    Alias: bool8.
+    Alias: ``bool8``.
 
     """)
 
@@ -8117,6 +8117,7 @@ add_newdoc('numpy.core.numerictypes', 'double',
     Double-precision floating-point number type, compatible with Python `float`
     and C ``double``.
     Character code ``'d'``.
+    Alias: ``float_``.
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'double', float_aliases)))
 
@@ -8125,31 +8126,36 @@ add_newdoc('numpy.core.numerictypes', 'longdouble',
     Extended-precision floating-point number type, compatible with C
     ``long double`` but not necessarily with IEEE 754 quadruple-precision. 
     Character code: ``'g'``.
+    Alias: ``longfloat``.
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'longdouble', float_aliases)))
-
 
 add_newdoc('numpy.core.numerictypes', 'csingle',
     """
     Complex number type composed of two single-precision floating-point
     numbers.
     Character code: `'F'``.
+    Alias: ``singlecomplex``.
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'csingle', complex_aliases)))
 
-add_newdoc('numpy.core.numerictypes', 'complex_',
+add_newdoc('numpy.core.numerictypes', 'cdouble',
     """
     Complex number type composed of two double-precision floating-point
     numbers, compatible with Python `complex`.
     Character code: ``'D'``.
+    Alias: ``cfloat``.
+    Alias: ``complex_``.
     {}
-    """.format(extra_alias_doc('numpy.core.numerictypes', 'complex_', complex_aliases)))
+    """.format(extra_alias_doc('numpy.core.numerictypes', 'cdouble', complex_aliases)))
 
 add_newdoc('numpy.core.numerictypes', 'clongdouble',
     """
     Complex number type composed of two extended-precision floating-point
     numbers.
     Character code: ``'G'``.
+    Alias: ``clongfloat``.
+    Alias: ``longcomplex``.
     {}
     """.format(extra_alias_doc('numpy.core.numerictypes', 'clongdouble', complex_aliases)))
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -7998,6 +7998,12 @@ add_newdoc('numpy.core.numerictypes', 'complex256',
 
     """)
 
+add_newdoc('numpy.core.numerictypes', 'float16',
+    """
+    16-bit floating-point number. Character code ``'e'``.
+
+    """)
+
 add_newdoc('numpy.core.numerictypes', 'float32',
     """
     32-bit floating-point number. Character code ``'f'``. C float compatible.

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3748,29 +3748,20 @@ static PyMappingMethods gentype_as_mapping = {
  * #CNAME = FLOAT, DOUBLE, LONGDOUBLE#
  */
 #if NPY_BITSOF_@CNAME@ == 16
-#define _THIS_SIZE2 "16"
-#define _THIS_SIZE1 "32"
+#define _THIS_SIZE "32"
 #elif NPY_BITSOF_@CNAME@ == 32
-#define _THIS_SIZE2 "32"
-#define _THIS_SIZE1 "64"
+#define _THIS_SIZE "64"
 #elif NPY_BITSOF_@CNAME@ == 64
-#define _THIS_SIZE2 "64"
-#define _THIS_SIZE1 "128"
+#define _THIS_SIZE "128"
 #elif NPY_BITSOF_@CNAME@ == 80
-#define _THIS_SIZE2 "80"
-#define _THIS_SIZE1 "160"
+#define _THIS_SIZE "160"
 #elif NPY_BITSOF_@CNAME@ == 96
-#define _THIS_SIZE2 "96"
-#define _THIS_SIZE1 "192"
+#define _THIS_SIZE "192"
 #elif NPY_BITSOF_@CNAME@ == 128
-#define _THIS_SIZE2 "128"
-#define _THIS_SIZE1 "256"
+#define _THIS_SIZE "256"
 #elif NPY_BITSOF_@CNAME@ == 256
-#define _THIS_SIZE2 "256"
-#define _THIS_SIZE1 "512"
+#define _THIS_SIZE "512"
 #endif
-
-#define _THIS_DOC "Composed of two " _THIS_SIZE2 " bit floats"
 
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
 #if defined(NPY_PY3K)
@@ -3779,7 +3770,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     PyObject_HEAD_INIT(0)
     0,                                          /* ob_size */
 #endif
-    "numpy.@name@" _THIS_SIZE1,                 /* tp_name*/
+    "numpy.@name@" _THIS_SIZE,                  /* tp_name*/
     sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
     0,                                          /* tp_itemsize*/
     0,                                          /* tp_dealloc*/
@@ -3802,7 +3793,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_setattro*/
     0,                                          /* tp_as_buffer*/
     Py_TPFLAGS_DEFAULT,                         /* tp_flags*/
-    _THIS_DOC,                                  /* tp_doc */
+    0,                                          /* tp_doc */
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -3830,9 +3821,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_del */
     0,                                          /* tp_version_tag */
 };
-#undef _THIS_SIZE1
-#undef _THIS_SIZE2
-#undef _THIS_DOC
+#undef _THIS_SIZE
 
 /**end repeat**/
 

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -448,6 +448,9 @@ class TestMaximumSctype(object):
 
 class TestDocStrings(object):
     def test_platform_dependent_aliases(self):
+        if sys.flags.optimize > 1:
+            # Docstrings do not get added if PYTHONOPTIMIZE/Py_OptimizeFlag > 1
+            return
         if np.int64 is np.int_:
             assert_('int64' in np.int_.__doc__)
         elif np.int64 is np.longlong:

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -446,11 +446,10 @@ class TestMaximumSctype(object):
         assert_equal(np.maximum_sctype(t), t)
 
 
+@pytest.mark.skipif(sys.flags.optimize > 1,
+                    reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")
 class TestDocStrings(object):
     def test_platform_dependent_aliases(self):
-        if sys.flags.optimize > 1:
-            # Docstrings do not get added if PYTHONOPTIMIZE/Py_OptimizeFlag > 1
-            return
         if np.int64 is np.int_:
             assert_('int64' in np.int_.__doc__)
         elif np.int64 is np.longlong:

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -444,3 +444,11 @@ class TestMaximumSctype(object):
     @pytest.mark.parametrize('t', [np.bool_, np.object_, np.unicode_, np.bytes_, np.void])
     def test_other(self, t):
         assert_equal(np.maximum_sctype(t), t)
+
+
+class TestDocStrings(object):
+    def test_platform_dependent_aliases(self):
+        if np.int64 is np.int_:
+            assert_('int64' in np.int_.__doc__)
+        elif np.int64 is np.longlong:
+            assert_('int64' in np.longlong.__doc__)


### PR DESCRIPTION
This PR adds docstrings for `np.float16`, `np.uint8`, `np.uint16`, `np.uint32`, `np.uint64`. Furthermore, the formatting of the char codes in the existing docstrings is unified to the same format.

Where to generate the autosummary in sphinx, adding it to the reference documentation is not completely clear, though: the current documentation on dtypes is spread out over 2 or 3 different places:
- https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html
- https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
- https://docs.scipy.org/doc/numpy/user/basics.types.html

See #10106.

(Part of EuroSciPy 2018 sprints)