### PR TITLE
BUG: test and fix np.dtype('i,L') #5645

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -146,7 +146,7 @@ def _reconstruct(subtype, shape, dtype):
 # format_re was originally from numarray by J. Todd Miller
 
 format_re = re.compile(br'(?P<order1>[<>|=]?)'
-                       br'(?P<repeats> *[(]?[ ,0-9L]*[)]? *)'
+                       br'(?P<repeats> *[(]?[ ,0-9]*[)]? *)'
                        br'(?P<order2>[<>|=]?)'
                        br'(?P<dtype>[A-Za-z0-9.?]*(?:\[[a-zA-Z0-9,.]+\])?)')
 sep_re = re.compile(br'\s*,\s*')

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -11,6 +11,7 @@ from numpy.core._rational_tests import rational
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT)
 from numpy.compat import pickle
+from itertools import permutations
 
 def assert_dtype_equal(a, b):
     assert_equal(a, b)
@@ -1124,3 +1125,18 @@ class TestFromCTypes(object):
         self.check(ctypes.c_uint16.__ctype_be__, np.dtype('>u2'))
         self.check(ctypes.c_uint8.__ctype_le__, np.dtype('u1'))
         self.check(ctypes.c_uint8.__ctype_be__, np.dtype('u1'))
+
+    all_types = set(np.typecodes['All'])
+    all_pairs = permutations(all_types, 2)
+
+    @pytest.mark.parametrize("pair", all_pairs)
+    def test_pairs(self, pair):
+        """
+        Check that np.dtype('x,y') matches [np.dtype('x'), np.dtype('y')]
+        Example: np.dtype('d,I') -> dtype([('f0', '<f8'), ('f1', '<u4')])
+        """
+        # gh-5645: check that np.dtype('i,L') can be used
+        pair_type = np.dtype('{},{}'.format(*pair))
+        expected = np.dtype([('f0', pair[0]), ('f1', pair[1])])
+        assert_equal(pair_type, expected)
+


### PR DESCRIPTION
This commit fixes #5645 in `python3`, since we don't need to use `123L` syntax for integers anymore. It affects _only_ cases with `L` types and _only_ when there's a comma inside the `dtype` string.

At the same time, this will break backward compatibility with `python2`, since at least in theory one may want to use something like `np.dtype('d, (2,3L)L')` in `python2`. So we need to decide whether we need this right now, or we will wait until the support of `python2` is dropped.

The solution is shipped with parametrized tests for all types' pairs.