### PR TITLE
TST: Update travis testing to use latest virtualenv.

### DIFF
--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -9,12 +9,7 @@ pushd builds
 
 # Build into own virtualenv
 # We therefore control our own environment, avoid travis' numpy
-#
-# Some change in virtualenv 14.0.5 caused `test_f2py` to fail. So, we have
-# pinned `virtualenv` to the last known working version to avoid this failure.
-# Appears we had some issues with certificates on Travis. It looks like
-# bumping to 14.0.6 will help.
-pip install -U 'virtualenv==14.0.6'
+pip install -U virtualenv
 
 if [ -n "$USE_DEBUG" ]
 then


### PR DESCRIPTION
The virtualenv version was pinned to 14.0.6, which seems to have started
causing test failures on Python 2.7 for some unknown reason. The lastest
version is 16.0.0 and that seems to fix the problem.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
