### PR TITLE
TST: Drop Python 3.4 testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,11 +20,6 @@ environment:
       NPY_NUM_BUILD_JOBS: 4
 
   matrix:
-    - PYTHON: C:\Python34-x64
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 64
-      TEST_MODE: fast
-
     - PYTHON: C:\Python36
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
 
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 matrix:
@@ -49,7 +48,9 @@ matrix:
           packages:
             - dpkg
             - debootstrap
-    - python: 3.4
+    - python: 3.5
+      dist: xenial  # Required for python3.5-dbg
+      sudo: true    # travis-ci/travis-ci#9069
       env: USE_DEBUG=1
       addons:
         apt:

--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -2,6 +2,15 @@
 NumPy 1.16.0 Release Notes
 ==========================
 
+This NumPy release is the last one to support Python 2.7. It will be maintained
+as a long term release with bug fixes only through 2020. To that end, the
+planned code reorganization detailed in NEP-0015 has been made in order to
+facilitate backporting fixes from future releases, which will now have the
+same code organization.
+
+Support for Python 3.4 been dropped in this release, the supported Python
+versions are 2.7 and 3.5-3.7. The wheels are linked with OpenBLAS v0.3.0 .
+
 
 Highlights
 ==========
@@ -27,8 +36,11 @@ and not documented. They will be removed in the 1.18 release. Use
 These were deprecated in 1.10, had no tests, and seem to no longer work in
 1.15 anyway.
 
+
 Future Changes
 ==============
+
+* NumPy 1.17 will drop support for Python 2.7.
 
 
 Compatibility notes

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -46,6 +46,8 @@ setup_base()
   if [ -z "$USE_DEBUG" ]; then
     $PIP install -v . 2>&1 | tee log
   else
+    # Python3.5-dbg on travis seems to need this
+    export CFLAGS=$CFLAGS" -Wno-maybe-uninitialized"
     $PYTHON setup.py build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \


### PR DESCRIPTION
TST: Drop Python 3.4 testing

* Drop Python 3.4 testing on travis and appveyor.
* Move the DEBUG build to 3.5.
* Document dropping 3.4 support in the release notes.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
