### PR TITLE
BUG: prevent datetime64 span chokes

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -155,6 +155,8 @@ get_datetimestruct_seconds(const npy_datetimestruct *dts)
 {
     npy_int64 seconds = get_datetimestruct_minutes(dts) * 60;
     seconds += dts->sec;
+    seconds += (dts->us / pow(10, 6));
+    seconds += (dts->ps / pow(10, 12));
 
     return seconds;
 }
@@ -344,7 +346,7 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
             case NPY_FR_ps:
                 /* only +- 106 days around epoch tolerated */
                 if (abs(get_datetimestruct_seconds(dts)) > 
-                        106 * 24 * 60 * 60) {
+                        NPY_MAX_INT64 * pow(10, -12)) {
                     /* reject with seconds resolution */
                     PyErr_SetString(PyExc_ValueError,
                             "Time span around POSIX epoch is "
@@ -380,7 +382,8 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                 break;
             case NPY_FR_as:
                 /* only 9.2 secs */
-                if (abs(get_datetimestruct_seconds(dts)) > 9.2) {
+                if (abs(get_datetimestruct_seconds(dts)) >
+                        NPY_MAX_INT64 / pow(10, 18)) {
                     /* NOTE: may want to increase resolution here */
                     PyErr_SetString(PyExc_ValueError,
                             "Time span around POSIX epoch is "


### PR DESCRIPTION
Fixes #5452.

I've added time span (relative to the epoch) checks / guards for sub-ns datetime64 units to fix the above issue. We may want to use higher-resolution rejection checks (currently seconds units are used to reject time spans) & expand the guards to include all units of datetime64. 

For now / initially, I've focused on the sub-ns range discussed in that linked issue. It may also be more robust to use the C89 / portable `limits.h` header file for max int values instead of the hard-coded time-span limits I've taken from the [docs](https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html#datetime-units).

I've also had to make minor adjustments to unit tests -- we had silent wrapping (garbage) for one test that worked for that test but didn't make sense, and for another test we now intercept unreasonable datetime spans before an overflow can occur, so we sometimes expect a different exception type.