### PR TITLE
BUG: Fix memory leak in pyfragments.swg

### DIFF
--- a/tools/swig/pyfragments.swg
+++ b/tools/swig/pyfragments.swg
@@ -73,8 +73,8 @@
           fragment="NumPy_Backward_Compatibility")
 {
   SWIGINTERN int
+  SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
   {
-    PyArray_Descr * ulongDescr = PyArray_DescrNewFromType(NPY_ULONG);
     %#if PY_VERSION_HEX < 0x03000000
     if (PyInt_Check(obj)) 
     {
@@ -120,7 +120,7 @@
     }
 %#endif
     if (!PyArray_IsScalar(obj,Integer)) return SWIG_TypeError;
-    SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
+    PyArray_Descr * ulongDescr = PyArray_DescrNewFromType(NPY_ULONG);
     PyArray_CastScalarToCtype(obj, (void*)val, ulongDescr);
     Py_DECREF(ulongDescr);
     return SWIG_OK;

--- a/tools/swig/pyfragments.swg
+++ b/tools/swig/pyfragments.swg
@@ -22,7 +22,6 @@
   SWIGINTERN int
   SWIG_AsVal_dec(long)(PyObject * obj, long * val)
   {
-    PyArray_Descr * longDescr = PyArray_DescrNewFromType(NPY_LONG);
     if (PyInt_Check(obj)) {
       if (val) *val = PyInt_AsLong(obj);
       return SWIG_OK;
@@ -56,7 +55,9 @@
     }
 %#endif
     if (!PyArray_IsScalar(obj,Integer)) return SWIG_TypeError;
+    PyArray_Descr * longDescr = PyArray_DescrNewFromType(NPY_LONG);
     PyArray_CastScalarToCtype(obj, (void*)val, longDescr);
+    Py_DECREF(longDescr);
     return SWIG_OK;
   }
 }
@@ -72,7 +73,6 @@
           fragment="NumPy_Backward_Compatibility")
 {
   SWIGINTERN int
-  SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
   {
     PyArray_Descr * ulongDescr = PyArray_DescrNewFromType(NPY_ULONG);
     %#if PY_VERSION_HEX < 0x03000000
@@ -120,7 +120,9 @@
     }
 %#endif
     if (!PyArray_IsScalar(obj,Integer)) return SWIG_TypeError;
+    SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
     PyArray_CastScalarToCtype(obj, (void*)val, ulongDescr);
+    Py_DECREF(ulongDescr);
     return SWIG_OK;
   }
 }


### PR DESCRIPTION
Make sure to Py_DECREF the Py_ArrayDesc created in the definition of
SWIG_CanCastAsInteger for long and unsigned long.

Fixes #11876

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
