### PR TITLE
BUG: The multiarray/ufunc merge broke old wheels.

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -3,30 +3,33 @@ Create the numpy.core.multiarray namespace for backward compatibility. In v1.16
 the multiarray and umath c-extension modules were merged into a single
 _multiarray_umath extension module. So we replicate the old namespace
 by importing from the extension module.
+
 """
 
 from . import _multiarray_umath
 from numpy.core._multiarray_umath import *
-from numpy.core._multiarray_umath import (_fastCopyAndTranspose, _flagdict, _insert,
-     _reconstruct, _vec_string, _ARRAY_API, _monotonicity)
+from numpy.core._multiarray_umath import (
+    _fastCopyAndTranspose, _flagdict, _insert, _reconstruct, _vec_string,
+    _ARRAY_API, _monotonicity
+    )
 
-__all__ = ['_ARRAY_API', 'ALLOW_THREADS', 'BUFSIZE', 'CLIP', 'DATETIMEUNITS',
+__all__ = [
+    '_ARRAY_API', 'ALLOW_THREADS', 'BUFSIZE', 'CLIP', 'DATETIMEUNITS',
     'ITEM_HASOBJECT', 'ITEM_IS_POINTER', 'LIST_PICKLE', 'MAXDIMS',
     'MAY_SHARE_BOUNDS', 'MAY_SHARE_EXACT', 'NEEDS_INIT', 'NEEDS_PYAPI',
-    'RAISE', 'USE_GETITEM', 'USE_SETITEM', 'WRAP',
-    '_fastCopyAndTranspose', '_flagdict', '_insert', '_reconstruct',
-    '_vec_string', '_monotonicity',
-    'add_docstring', 'arange', 'array', 'bincount', 'broadcast', 'busday_count',
-    'busday_offset', 'busdaycalendar', 'can_cast', 'compare_chararrays',
-    'concatenate', 'copyto', 'correlate', 'correlate2', 'count_nonzero',
-    'c_einsum', 'datetime_as_string', 'datetime_data', 'digitize', 'dot',
-    'dragon4_positional', 'dragon4_scientific', 'dtype', 'empty', 'empty_like',
-    'error', 'flagsobj', 'flatiter', 'format_longfloat', 'frombuffer',
-    'fromfile', 'fromiter', 'fromstring', 'getbuffer', 'inner', 'int_asbuffer',
-    'interp', 'interp_complex', 'is_busday', 'lexsort', 'matmul',
-    'may_share_memory', 'min_scalar_type', 'ndarray', 'nditer', 'nested_iters',
-    'newbuffer', 'normalize_axis_index', 'packbits', 'promote_types',
-    'putmask', 'ravel_multi_index', 'result_type', 'scalar',
+    'RAISE', 'USE_GETITEM', 'USE_SETITEM', 'WRAP', '_fastCopyAndTranspose',
+    '_flagdict', '_insert', '_reconstruct', '_vec_string', '_monotonicity',
+    'add_docstring', 'arange', 'array', 'bincount', 'broadcast',
+    'busday_count', 'busday_offset', 'busdaycalendar', 'can_cast',
+    'compare_chararrays', 'concatenate', 'copyto', 'correlate', 'correlate2',
+    'count_nonzero', 'c_einsum', 'datetime_as_string', 'datetime_data',
+    'digitize', 'dot', 'dragon4_positional', 'dragon4_scientific', 'dtype',
+    'empty', 'empty_like', 'error', 'flagsobj', 'flatiter', 'format_longfloat',
+    'frombuffer', 'fromfile', 'fromiter', 'fromstring', 'getbuffer', 'inner',
+    'int_asbuffer', 'interp', 'interp_complex', 'is_busday', 'lexsort',
+    'matmul', 'may_share_memory', 'min_scalar_type', 'ndarray', 'nditer',
+    'nested_iters', 'newbuffer', 'normalize_axis_index', 'packbits',
+    'promote_types', 'putmask', 'ravel_multi_index', 'result_type', 'scalar',
     'set_datetimeparse_function', 'set_legacy_print_mode', 'set_numeric_ops',
     'set_string_function', 'set_typeDict', 'shares_memory', 'test_interrupt',
     'tracemalloc_domain', 'typeinfo', 'unpackbits', 'unravel_index', 'vdot',

--- a/numpy/core/umath.py
+++ b/numpy/core/umath.py
@@ -3,29 +3,33 @@ Create the numpy.core.umath namespace for backward compatibility. In v1.16
 the multiarray and umath c-extension modules were merged into a single
 _multiarray_umath extension module. So we replicate the old namespace
 by importing from the extension module.
+
 """
 
 from . import _multiarray_umath
 from numpy.core._multiarray_umath import *
-from numpy.core._multiarray_umath import _add_newdoc_ufunc, _arg, _ones_like
+from numpy.core._multiarray_umath import (
+    _UFUNC_API, _add_newdoc_ufunc, _arg, _ones_like
+    )
 
-__all__ = ['ERR_CALL', 'ERR_DEFAULT', 'ERR_IGNORE', 'ERR_LOG', 'ERR_PRINT',
-    'ERR_RAISE', 'ERR_WARN', 'FLOATING_POINT_SUPPORT', 'FPE_DIVIDEBYZERO',
-    'FPE_INVALID', 'FPE_OVERFLOW', 'FPE_UNDERFLOW', 'NAN', 'NINF', 'NZERO',
-    'PINF', 'PZERO', 'SHIFT_DIVIDEBYZERO', 'SHIFT_INVALID', 'SHIFT_OVERFLOW',
-    'SHIFT_UNDERFLOW', 'UFUNC_BUFSIZE_DEFAULT', 'UFUNC_PYVALS_NAME',
-    '_add_newdoc_ufunc', '_arg',
-    'absolute', 'add', 'arccos', 'arccosh', 'arcsin', 'arcsinh', 'arctan',
-    'arctan2', 'arctanh', 'bitwise_and', 'bitwise_or', 'bitwise_xor', 'cbrt',
-    'ceil', 'conj', 'conjugate', 'copysign', 'cos', 'cosh', 'deg2rad',
-    'degrees', 'divide', 'divmod', 'e', 'equal', 'euler_gamma', 'exp', 'exp2',
-    'expm1', 'fabs', 'floor', 'floor_divide', 'float_power', 'fmax', 'fmin',
-    'fmod', 'frexp', 'frompyfunc', 'gcd', 'geterrobj', 'greater',
-    'greater_equal', 'heaviside', 'hypot', 'invert', 'isfinite', 'isinf',
-    'isnan', 'isnat', 'lcm', 'ldexp', 'left_shift', 'less', 'less_equal',
-    'log', 'log10', 'log1p', 'log2', 'logaddexp', 'logaddexp2', 'logical_and',
-    'logical_not', 'logical_or', 'logical_xor', 'maximum', 'minimum', 'mod',
-    'modf', 'multiply', 'negative', 'nextafter', 'not_equal', 'pi', 'positive',
-    'power', 'rad2deg', 'radians', 'reciprocal', 'remainder', 'right_shift',
-    'rint', 'seterrobj', 'sign', 'signbit', 'sin', 'sinh', 'spacing', 'sqrt',
-    'square', 'subtract', 'tan', 'tanh', 'true_divide', 'trunc']
+__all__ = [
+    '_UFUNC_API', 'ERR_CALL', 'ERR_DEFAULT', 'ERR_IGNORE', 'ERR_LOG',
+    'ERR_PRINT', 'ERR_RAISE', 'ERR_WARN', 'FLOATING_POINT_SUPPORT',
+    'FPE_DIVIDEBYZERO', 'FPE_INVALID', 'FPE_OVERFLOW', 'FPE_UNDERFLOW', 'NAN',
+    'NINF', 'NZERO', 'PINF', 'PZERO', 'SHIFT_DIVIDEBYZERO', 'SHIFT_INVALID',
+    'SHIFT_OVERFLOW', 'SHIFT_UNDERFLOW', 'UFUNC_BUFSIZE_DEFAULT',
+    'UFUNC_PYVALS_NAME', '_add_newdoc_ufunc', '_arg', 'absolute', 'add',
+    'arccos', 'arccosh', 'arcsin', 'arcsinh', 'arctan', 'arctan2', 'arctanh',
+    'bitwise_and', 'bitwise_or', 'bitwise_xor', 'cbrt', 'ceil', 'conj',
+    'conjugate', 'copysign', 'cos', 'cosh', 'deg2rad', 'degrees', 'divide',
+    'divmod', 'e', 'equal', 'euler_gamma', 'exp', 'exp2', 'expm1', 'fabs',
+    'floor', 'floor_divide', 'float_power', 'fmax', 'fmin', 'fmod', 'frexp',
+    'frompyfunc', 'gcd', 'geterrobj', 'greater', 'greater_equal', 'heaviside',
+    'hypot', 'invert', 'isfinite', 'isinf', 'isnan', 'isnat', 'lcm', 'ldexp',
+    'left_shift', 'less', 'less_equal', 'log', 'log10', 'log1p', 'log2',
+    'logaddexp', 'logaddexp2', 'logical_and', 'logical_not', 'logical_or',
+    'logical_xor', 'maximum', 'minimum', 'mod', 'modf', 'multiply', 'negative',
+    'nextafter', 'not_equal', 'pi', 'positive', 'power', 'rad2deg', 'radians',
+    'reciprocal', 'remainder', 'right_shift', 'rint', 'seterrobj', 'sign',
+    'signbit', 'sin', 'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan',
+    'tanh', 'true_divide', 'trunc']


### PR DESCRIPTION
BUG: The multiarray/ufunc merge broke old wheels.

The numpy/core/umath.py compatibility module was missing the
`_UFUNC_API` attribute that needed to be imported from
`_multiarray_umath`.

* Add the `_UFUNC_API` attribute
* Make some style fixups.

See https://github.com/scipy/scipy/issues/9220 for discussion.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
