### PR TITLE
BUG: NaT now casts to NaN float64

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1086,6 +1086,95 @@ TIMEDELTA_setitem(PyObject *op, void *ov, void *vap)
 
 /* Assumes contiguous, and aligned, from and to */
 
+/* special case TIMEDELTA NPY_DATETIME_NAT handling */
+
+/**begin repeat
+ *
+ * #TYPE = TIMEDELTA#
+ * #type = npy_timedelta#
+ */
+
+static void
+@TYPE@_to_HALF(void *input, void *output, npy_intp n,
+        void *NPY_UNUSED(aip), void *NPY_UNUSED(aop))
+{
+    const @type@ *ip = input;
+    npy_half *op = output;
+
+    while (n--) {
+        if (*ip == NPY_DATETIME_NAT) {
+            *op = NPY_HALF_NAN;
+        }
+        else {
+            *op = npy_float_to_half((float)(*ip));
+        }
+        ip++;
+        op++;
+    }
+}
+
+static void
+HALF_to_@TYPE@(void *input, void *output, npy_intp n,
+        void *NPY_UNUSED(aip), void *NPY_UNUSED(aop))
+{
+    const npy_half *ip = input;
+    @type@ *op = output;
+
+    while (n--) {
+        *op++ = (@type@)npy_half_to_float(*ip++);
+    }
+}
+
+/**end repeat**/
+#if NPY_SIZEOF_SHORT == 2
+#define HALF_to_HALF SHORT_to_SHORT
+#elif NPY_SIZEOF_INT == 2
+#define HALF_to_HALF INT_to_INT
+#endif
+
+/**begin repeat
+ *
+ * #TOTYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
+ *           LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE, DATETIME,
+ *           TIMEDELTA#
+ * #totype = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
+ *           npy_long, npy_ulong, npy_longlong, npy_ulonglong,
+ *           npy_float, npy_double, npy_longdouble,
+ *           npy_datetime, npy_timedelta#
+ */
+
+/**begin repeat1
+ *
+ * #FROMTYPE = TIMEDELTA#
+ * #fromtype = npy_timedelta#
+ */
+static void
+@FROMTYPE@_to_@TOTYPE@(void *input, void *output, npy_intp n,
+        void *NPY_UNUSED(aip), void *NPY_UNUSED(aop))
+{
+    const @fromtype@ *ip = input;
+    @totype@ *op = output;
+
+    while (n--) {
+        if (*ip == NPY_DATETIME_NAT) {
+            if (*op == (npy_double)(*op)) {
+                *op = (double)NPY_NAN;
+            }
+            else if (*op == (npy_float)(*op)) {
+                *op = (float)NPY_NAN;
+            }
+        }
+        else {
+            *op = (@totype@)*ip;
+        }
+        ip++;
+        op++;
+    }
+}
+/**end repeat1**/
+
+/**end repeat**/
+
 
 /**begin repeat
  *
@@ -1101,12 +1190,11 @@ TIMEDELTA_setitem(PyObject *op, void *ov, void *vap)
 /**begin repeat1
  *
  * #FROMTYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
- *             LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE, DATETIME,
- *             TIMEDELTA#
+ *             LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE, DATETIME#
  * #fromtype = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *             npy_long, npy_ulong, npy_longlong, npy_ulonglong,
  *             npy_float, npy_double, npy_longdouble,
- *             npy_datetime, npy_timedelta#
+ *             npy_datetime#
  */
 static void
 @FROMTYPE@_to_@TOTYPE@(void *input, void *output, npy_intp n,
@@ -1120,6 +1208,7 @@ static void
     }
 }
 /**end repeat1**/
+
 
 /**begin repeat1
  *
@@ -1146,12 +1235,11 @@ static void
 /**begin repeat
  *
  * #TYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
- *         LONGLONG, ULONGLONG, LONGDOUBLE, DATETIME,
- *         TIMEDELTA#
+ *         LONGLONG, ULONGLONG, LONGDOUBLE, DATETIME#
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
  *         npy_longdouble,
- *         npy_datetime, npy_timedelta#
+ *         npy_datetime#
  */
 
 static void

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1126,20 +1126,16 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
 }
 
 /**end repeat**/
-#if NPY_SIZEOF_SHORT == 2
-#define HALF_to_HALF SHORT_to_SHORT
-#elif NPY_SIZEOF_INT == 2
-#define HALF_to_HALF INT_to_INT
-#endif
+
+/* TIMEDELTA to non-float types */
 
 /**begin repeat
  *
  * #TOTYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT, LONG, ULONG,
- *           LONGLONG, ULONGLONG, FLOAT, DOUBLE, LONGDOUBLE, DATETIME,
+ *           LONGLONG, ULONGLONG, DATETIME,
  *           TIMEDELTA#
  * #totype = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *           npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *           npy_float, npy_double, npy_longdouble,
  *           npy_datetime, npy_timedelta#
  */
 
@@ -1156,13 +1152,36 @@ static void
     @totype@ *op = output;
 
     while (n--) {
+        *op++ = (@totype@)*ip++;
+    }
+}
+/**end repeat1**/
+
+/**end repeat**/
+
+/* TIMEDELTA to float types; HALF is dealt with above */
+
+/**begin repeat
+ *
+ * #TOTYPE = FLOAT, DOUBLE, LONGDOUBLE#
+ * #totype = npy_float, npy_double, npy_longdouble#
+ */
+
+/**begin repeat1
+ *
+ * #FROMTYPE = TIMEDELTA#
+ * #fromtype = npy_timedelta#
+ */
+static void
+@FROMTYPE@_to_@TOTYPE@(void *input, void *output, npy_intp n,
+        void *NPY_UNUSED(aip), void *NPY_UNUSED(aop))
+{
+    const @fromtype@ *ip = input;
+    @totype@ *op = output;
+
+    while (n--) {
         if (*ip == NPY_DATETIME_NAT) {
-            if (*op == (npy_double)(*op)) {
-                *op = (double)NPY_NAN;
-            }
-            else if (*op == (npy_float)(*op)) {
-                *op = (float)NPY_NAN;
-            }
+                *op = (@totype@)NPY_NAN;
         }
         else {
             *op = (@totype@)*ip;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -7,6 +7,8 @@
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
+#include "numpy/npy_math.h"
+#include "numpy/npy_common.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"
@@ -841,6 +843,47 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
 
+        /*
+         * after casting from NPY_DATETIME_NAT to float64, we go back
+         * and replace the spurious floating point values with NPY_NAN
+         * at the appropriate indices; this may also be possible to
+         * achieve upstream, but the PyArray_CopyInto() operation above
+         * uses very low level general array iteration loops where it
+         * may not be desirable to perform a check for NAT on each
+         * iteration
+         */
+
+        /* confine the NaT to NaN substitution checks by type cast */
+        if ((PyArray_DESCR(self)->type_num == NPY_TIMEDELTA) &&
+            ((PyArray_DESCR(ret)->type_num == NPY_HALF)   ||
+            (PyArray_DESCR(ret)->type_num == NPY_FLOAT)   ||
+            (PyArray_DESCR(ret)->type_num == NPY_DOUBLE)  ||
+            (PyArray_DESCR(ret)->type_num == NPY_LONGDOUBLE))) {
+
+            PyObject *item;
+            PyArrayIterObject *self_iter;
+            PyObject *ret_iter;
+
+            /* array iterator objects */
+            self_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)self);
+            ret_iter = PyArray_IterNew((PyObject *)ret);
+
+            while (self_iter->index < self_iter->size) {
+               /* GETITEM will retrieve Py_None for NaT */
+               item = PyArray_GETITEM(self, PyArray_ITER_DATA(self_iter));
+
+               /* Check if the item in original array looks like NaT */
+               if (item == Py_None) {
+                   /* replace with NPY_NAN in returned array if it does */
+                   PyArray_SETITEM(ret,
+                                   PyArray_ITER_DATA(ret_iter),
+                                   PyFloat_FromDouble(NPY_NAN));
+               }
+               Py_XDECREF(item);
+               PyArray_ITER_NEXT(self_iter);
+               PyArray_ITER_NEXT(ret_iter);
+            }
+        }
         return (PyObject *)ret;
     }
     else {

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -154,6 +154,23 @@ class TestDateTime(object):
         for dtype in ['float16', 'float32', 'float64']:
             assert_equal(arr.astype(dtype),
                          expected_cast.astype(dtype))
+            # test the float->timedelta cast as well
+            assert_equal(expected_cast.astype(dtype).astype(arr.dtype),
+                         arr)
+
+    @pytest.mark.parametrize("float_type, cast_type", [
+    (np.float64, 'm8'),
+    (np.float32, 'm8'),
+    (np.float16, 'm8'),
+    (np.float64, 'm8[D]'),
+    (np.float32, 'm8[s]'),
+    (np.float16, 'm8[h]'),
+    ])
+    def test_float_cast_limits(self, float_type, cast_type):
+        arr = np.array([[np.iinfo(np.int64).max + 1],
+                        [np.iinfo(np.int64).min - 1]], dtype=float_type)
+        expected = np.array([['NaT'], ['NaT']], dtype=cast_type)
+        assert_equal(arr.astype(cast_type), expected)
 
     def test_compare_generic_nat(self):
         # regression tests for gh-6452

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -128,6 +128,33 @@ class TestDateTime(object):
         assert_(not np.can_cast('M8[h]', 'M8', casting='same_kind'))
         assert_(not np.can_cast('M8[h]', 'M8', casting='safe'))
 
+    @pytest.mark.parametrize("arr, expected_cast", [
+    # the example used in the issue itself
+    (np.array([3, None], 'm8[D]'),
+     np.array([3., np.nan], dtype=np.float64)),
+    # should be equivalent
+    (np.array([3, 'NaT'], 'm8[D]'),
+     np.array([3., np.nan], dtype=np.float64)),
+    # similar with generic units
+    (np.array([3, 'NaT'], 'm8'),
+     np.array([3., np.nan], dtype=np.float64)),
+    # multidimensional with specific units
+    (np.array([[9, 'NaT'],
+               ['NaT', 5]], 'm8[s]'),
+     np.array([[9., np.nan],
+               [np.nan, 5.]], dtype=np.float64)),
+    # multidimensional with generic units
+    (np.array([[9, 'NaT'],
+               ['NaT', 5]], 'm8'),
+     np.array([[9., np.nan],
+               [np.nan, 5.]], dtype=np.float64)),
+    ])
+    def test_cast_NaT_NaN_float(self, arr, expected_cast):
+        # regression test for gh-8449
+        for dtype in ['float16', 'float32', 'float64']:
+            assert_equal(arr.astype(dtype),
+                         expected_cast.astype(dtype))
+
     def test_compare_generic_nat(self):
         # regression tests for gh-6452
         assert_(np.datetime64('NaT') !=


### PR DESCRIPTION
Fixes #8449.

I think I used the "older" array iteration API if I'm reading the docs correctly; seems like this is still used in source though.
