### PR TITLE
TST: Parametrize f2py tests.

### DIFF
--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -1,9 +1,10 @@
 from __future__ import division, absolute_import, print_function
 
-import unittest
 import os
 import sys
 import copy
+
+import pytest
 
 from numpy import (
     array, alltrue, ndarray, zeros, dtype, intp, clongdouble
@@ -304,9 +305,15 @@ class TestIntent(object):
         assert_(not intent.in_.is_intent('c'))
 
 
-class _test_shared_memory(object):
+class TestSharedMemory(object):
     num2seq = [1, 2]
     num23seq = [[1, 2, 3], [4, 5, 6]]
+
+    @pytest.fixture(autouse=True, scope='class', params=_type_names)
+    def setup_type(self, request):
+        request.cls.type = Type(request.param)
+        request.cls.array = lambda self, dims, intent, obj: \
+            Array(Type(request.param), dims, intent, obj)
 
     def test_in_from_2seq(self):
         a = self.array([2], intent.in_, self.num2seq)
@@ -573,12 +580,3 @@ class _test_shared_memory(object):
             assert_(obj.flags['FORTRAN'])  # obj attributes changed inplace!
             assert_(not obj.flags['CONTIGUOUS'])
             assert_(obj.dtype.type is self.type.dtype)  # obj changed inplace!
-
-
-for t in _type_names:
-    exec('''\
-class TestGen_%s(_test_shared_memory):
-    def setup(self):
-        self.type = Type(%r)
-    array = lambda self,dims,intent,obj: Array(Type(%r),dims,intent,obj)
-''' % (t, t, t))

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -62,9 +62,9 @@ cf2py  intent(out) a
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t,t2".split(","):
-            self.check_function(name)
+    @pytest.mark.parametrize('name', 't,t2'.split(','))
+    def test_all(self, name):
+        self.check_function(name)
 
     @pytest.mark.slow
     def test_docstring(self):

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -82,9 +82,9 @@ cf2py    intent(out) ts
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t5,s0,s1,s5,ss".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't0,t1,t5,s0,s1,s5,ss'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnCharacter(TestReturnCharacter):
@@ -141,6 +141,6 @@ end module f90_return_char
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t5,ts,s0,s1,s5,ss".split(","):
-            self.check_function(getattr(self.module.f90_return_char, name))
+    @pytest.mark.parametrize('name', 't0,t1,t5,ts,s0,s1,s5,ss'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_char, name))

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -105,9 +105,9 @@ cf2py    intent(out) td
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t8,t16,td,s0,s8,s16,sd".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't0,t8,t16,td,s0,s8,s16,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnComplex(TestReturnComplex):
@@ -164,6 +164,6 @@ end module f90_return_complex
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t8,t16,td,s0,s8,s16,sd".split(","):
-            self.check_function(getattr(self.module.f90_return_complex, name))
+    @pytest.mark.parametrize('name', 't0,t8,t16,td,s0,s8,s16,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_complex, name))

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -104,9 +104,10 @@ cf2py    intent(out) t8
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name',
+                             't0,t1,t2,t4,t8,s0,s1,s2,s4,s8'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnInteger(TestReturnInteger):
@@ -174,6 +175,7 @@ end module f90_return_integer
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","):
-            self.check_function(getattr(self.module.f90_return_integer, name))
+    @pytest.mark.parametrize('name',
+                             't0,t1,t2,t4,t8,s0,s1,s2,s4,s8'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_integer, name))

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -113,9 +113,9 @@ c       end
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t2,t4,s0,s1,s2,s4".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't0,t1,t2,t4,s0,s1,s2,s4'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnLogical(TestReturnLogical):
@@ -183,6 +183,7 @@ end module f90_return_logical
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t1,t2,t4,t8,s0,s1,s2,s4,s8".split(","):
-            self.check_function(getattr(self.module.f90_return_logical, name))
+    @pytest.mark.parametrize('name',
+                             't0,t1,t2,t4,t8,s0,s1,s2,s4,s8'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_logical, name))

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -85,9 +85,9 @@ end python module c_ext_return_real
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t4,t8,s4,s8".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't4,t8,s4,s8'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF77ReturnReal(TestReturnReal):
@@ -140,9 +140,9 @@ cf2py    intent(out) td
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t4,t8,td,s0,s4,s8,sd".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnReal(TestReturnReal):
@@ -199,6 +199,6 @@ end module f90_return_real
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t4,t8,td,s0,s4,s8,sd".split(","):
-            self.check_function(getattr(self.module.f90_return_real, name))
+    @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_real, name))


### PR DESCRIPTION
A straight swap of:
```python
def test(...):
    for name in ...:
        ...
```
with
```python
@pytest.mark.parametrize('name', ...)
def test(..., name):
    ...
```

By my count, the test count should go up by 79, which it appears to do.

I would also like to do something about `numpy/f2py/tests/test_array_from_pyobj.py` so that it doesn't have to use `eval`, but that seems a bit more involved.