### PR TITLE
BUG: Fix matrix PendingDeprecationWarning suppression for pytest 3.8+.

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -160,6 +160,24 @@ class PytestTester(object):
             "-W ignore::UserWarning:cpuinfo",
             ]
 
+        # When testing matrices, ignore their PendingDeprecationWarnings
+        pytest_args += [
+            "-W ignore:the matrix subclass is not",
+            ]
+
+        # Ignore python2.7 -3 warnings
+        pytest_args += [
+            r"-W ignore:sys\.exc_clear\(\) not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:in 3\.x, __setslice__:DeprecationWarning",
+            r"-W ignore:in 3\.x, __getslice__:DeprecationWarning",
+            r"-W ignore:buffer\(\) not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:CObject type is not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:comparing unequal types not supported in 3\.x:DeprecationWarning",
+            r"-W ignore:the commands module has been removed in Python 3\.0:DeprecationWarning",
+            r"-W ignore:The 'new' module has been removed in Python 3\.0:DeprecationWarning",
+            ]
+
+
         if doctests:
             raise ValueError("Doctests not supported")
 

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,12 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 try:
     # Accessing collections abstract classes from collections

--- a/numpy/matrixlib/tests/test_interaction.py
+++ b/numpy/matrixlib/tests/test_interaction.py
@@ -4,13 +4,7 @@ Note that tests with MaskedArray and linalg are done in separate files.
 """
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 import textwrap
 import warnings

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -1,14 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
-
 import pickle
+import pytest
 
 import numpy as np
 from numpy.ma.testutils import (assert_, assert_equal, assert_raises,

--- a/numpy/matrixlib/tests/test_matrix_linalg.py
+++ b/numpy/matrixlib/tests/test_matrix_linalg.py
@@ -1,13 +1,7 @@
 """ Test functions for linalg module using the matrix class."""
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 import numpy as np
 

--- a/numpy/matrixlib/tests/test_multiarray.py
+++ b/numpy/matrixlib/tests/test_multiarray.py
@@ -1,12 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_array_equal

--- a/numpy/matrixlib/tests/test_numeric.py
+++ b/numpy/matrixlib/tests/test_numeric.py
@@ -1,12 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 import numpy as np
 from numpy.testing import assert_equal

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -1,12 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
+import pytest
 
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,9 @@ filterwarnings =
     ignore:Not importing directory
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
+    ignore::UserWarning:cpuinfo,
+# Matrix PendingDeprecationWarning.
+    ignore:the matrix subclass is not
 # Ignore python2.7 -3 warnings
     ignore:sys\.exc_clear\(\) not supported in 3\.x:DeprecationWarning
     ignore:in 3\.x, __setslice__:DeprecationWarning
@@ -17,5 +20,7 @@ filterwarnings =
     ignore:CObject type is not supported in 3\.x:DeprecationWarning
     ignore:comparing unequal types not supported in 3\.x:DeprecationWarning
     ignore:the commands module has been removed in Python 3\.0:DeprecationWarning
+    ignore:The 'new' module has been removed in Python 3\.0:DeprecationWarning
+
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
Pytest < 3.8 ignored warnings issued during test collection, but that
changed in pytest 3.8 and the method NumPy used to suppress the
PendingDeprecationWarning for matrices no longer worked, or rather, was
exposed as not working. The fix here is to suppress the warning in
pytest.ini and pytesttester.py , which should work as long as the tests
are the only places left where NumPy uses matrices.

An alternate fix is to delay the construction of matrices in the tests
until they are actually run, which has the virtue of test localization
but is a bit more complicated.

See https://github.com/pytest-dev/pytest/issues/3945 for discussion.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
