### PR TITLE
WIP,ENH: Allow `copy=np.never_copy` for array creation and reshape

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -440,6 +440,11 @@ From other objects
         Make sure a copy is made of *op*. If this flag is not
         present, data is not copied if it can be avoided.
 
+    .. c:var:: NPY_ARRAY_ENSURENOCOPY
+
+        Make sure no copy is made of *op*. An error will be given if
+        a copy cannot be avoided.
+
     .. c:var:: NPY_ARRAY_ENSUREARRAY
 
         Make sure the result is a base-class ndarray. By

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -110,7 +110,7 @@ import sys
 import warnings
 
 from ._globals import ModuleDeprecationWarning, VisibleDeprecationWarning
-from ._globals import _NoValue
+from ._globals import _NoValue, never_copy
 
 # We first need to detect if we're being called as part of the numpy setup
 # procedure itself in a reliable manner.

--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -67,7 +67,7 @@ class _NoValueType(object):
     __instance = None
     def __new__(cls):
         # ensure that only one instance exists
-        if not cls.__instance:
+        if cls.__instance is None:
             cls.__instance = super(_NoValueType, cls).__new__(cls)
         return cls.__instance
 
@@ -94,13 +94,9 @@ class _NeverCopyType(object):
     __instance = None
     def __new__(cls):
         # ensure that only one instance exists
-        if not cls.__instance:
+        if cls.__instance is None:
             cls.__instance = super(_NeverCopyType, cls).__new__(cls)
         return cls.__instance
-
-    # needed for python 2 to preserve identity through a pickle
-    def __reduce__(self):
-        return (self.__class__, ())
 
     def __repr__(self):
         return "<never copy>"

--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -18,7 +18,8 @@ motivated this module.
 from __future__ import division, absolute_import, print_function
 
 __ALL__ = [
-    'ModuleDeprecationWarning', 'VisibleDeprecationWarning', '_NoValue'
+    'ModuleDeprecationWarning', 'VisibleDeprecationWarning', '_NoValue',
+    'never_copy'
     ]
 
 
@@ -79,3 +80,35 @@ class _NoValueType(object):
 
 
 _NoValue = _NoValueType()
+
+
+class _NeverCopyType(object):
+    """Special `copy` keyword value.
+
+    The instance of this class may be used for many `copy` arguments to
+    functions to indicate that a copy must not be made and an error will
+    be raised when this cannot be guaranteed.
+
+    In the future the string "never" may replace this variable.
+    """
+    __instance = None
+    def __new__(cls):
+        # ensure that only one instance exists
+        if not cls.__instance:
+            cls.__instance = super(_NeverCopyType, cls).__new__(cls)
+        return cls.__instance
+
+    # needed for python 2 to preserve identity through a pickle
+    def __reduce__(self):
+        return (self.__class__, ())
+
+    def __repr__(self):
+        return "<never copy>"
+
+    def __bool__(self):
+        raise ValueError("`np.never_copy` cannot be converted to True/False "
+                         "to avoid the unintended meaning to a function "
+                         "interpreting it as a boolean.")
+
+
+never_copy = _NeverCopyType()

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3524,7 +3524,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('reshape',
     Refer to `numpy.reshape` for full documentation.
 
     ..versionadded:: 1.17.0
-    
+
     The ``copy`` argument was added in version 1.17.0.
 
     See Also

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2323,6 +2323,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     the array and the remaining dimensions. Reshaping an array in-place will
     fail if a copy is required.
 
+    Assigning to the shape is discouraged. This is because it modifies the
+    properties of the array as opposed to only the data. `ndarray.reshape`
+    should be preferred.
+
     Examples
     --------
     >>> x = np.array([1, 2, 3, 4])
@@ -2331,7 +2335,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
     >>> y = np.zeros((2, 3, 4))
     >>> y.shape
     (2, 3, 4)
-    >>> y.shape = (3, 8)
+    >>> y.shape = (3, 8)  # discouarged, reshape should be preferred.
     >>> y
     array([[ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
            [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
@@ -3513,11 +3517,15 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('repeat',
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('reshape',
     """
-    a.reshape(shape, order='C')
+    a.reshape(shape, order='C', copy=False)
 
     Returns an array containing the same data with a new shape.
 
     Refer to `numpy.reshape` for full documentation.
+
+    ..versionadded:: 1.17.0
+    
+    The ``copy`` argument was added in version 1.17.0.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -198,7 +198,7 @@ def take(a, indices, axis=None, out=None, mode='raise'):
 
 
 
-def _reshape_dispatcher(a, newshape, order=None, copy=False):
+def _reshape_dispatcher(a, newshape, order=None, copy=None):
     return (a,)
 
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -189,13 +189,14 @@ def take(a, indices, axis=None, out=None, mode='raise'):
     return _wrapfunc(a, 'take', indices, axis=axis, out=out, mode=mode)
 
 
+
 def _reshape_dispatcher(a, newshape, order=None):
     return (a,)
 
 
 # not deprecated --- copy if necessary, view otherwise
 @array_function_dispatch(_reshape_dispatcher)
-def reshape(a, newshape, order='C'):
+def reshape(a, newshape, order='C', copy=False):
     """
     Gives a new shape to an array without changing its data.
 
@@ -221,6 +222,12 @@ def reshape(a, newshape, order='C'):
         'A' means to read / write the elements in Fortran-like index
         order if `a` is Fortran *contiguous* in memory, C-like order
         otherwise.
+    copy : {True, False, np.never_copy}, optional
+        Whether or not a copy is forced. If ``False`` is given, a copy
+        will be made when necessary. ``np.never_copy`` will cause an
+        error to be raised if `a` cannot be reshaped without a copy.
+
+        .. versionadded:: 1.16.0
 
     Returns
     -------
@@ -228,6 +235,8 @@ def reshape(a, newshape, order='C'):
         This will be a new view object if possible; otherwise, it will
         be a copy.  Note there is no guarantee of the *memory layout* (C- or
         Fortran- contiguous) of the returned array.
+        The `copy` argument can be used to enforce a copy or raise an error
+        when a `copy` would be made but is not desired.
 
     See Also
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -198,13 +198,13 @@ def take(a, indices, axis=None, out=None, mode='raise'):
 
 
 
-def _reshape_dispatcher(a, newshape, order=None):
+def _reshape_dispatcher(a, newshape, order=None, copy=False):
     return (a,)
 
 
 # not deprecated --- copy if necessary, view otherwise
 @array_function_dispatch(_reshape_dispatcher)
-def reshape(a, newshape, order='C', copy=False):
+def reshape(a, newshape, order='C', copy=np._NoValue):
     """
     Gives a new shape to an array without changing its data.
 
@@ -314,9 +314,14 @@ def reshape(a, newshape, order='C', copy=False):
     """
     # Since it is hard to tell if `np.array` had to copy, the copy is only
     # forced during reshape (but no-copy forced also for `np.array`).
-    return _wrapfunc_copy(
-            a, 'reshape', copy if copy is np.never_copy else False,
-            newshape, order=order, copy=copy)
+    if copy is np._NoValue:
+        return _wrapfunc_copy(
+                    a, 'reshape', copy if copy is np.never_copy else False,
+                    newshape, order=order)
+    else:
+        return _wrapfunc_copy(
+                    a, 'reshape', copy if copy is np.never_copy else False,
+                    newshape, order=order, copy=copy)
 
 
 def _choose_dispatcher(a, choices, out=None, mode=None):

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -38,12 +38,12 @@ array_function_dispatch = functools.partial(
 
 
 # functions that are now methods
-def _wrapit(obj, method, copy, *args, **kwds):
+def _wrapit(obj, method, _internal_copy, *args, **kwds):
     try:
         wrap = obj.__array_wrap__
     except AttributeError:
         wrap = None
-    result = getattr(array(obj, copy=copy), method)(*args, **kwds)
+    result = getattr(array(obj, copy=_internal_copy), method)(*args, **kwds)
     if wrap:
         if not isinstance(result, mu.ndarray):
             result = asarray(result)
@@ -66,12 +66,12 @@ def _wrapfunc(obj, method, *args, **kwds):
         return _wrapit(obj, method, False, *args, **kwds)
 
 
-def _wrapfunc_copy(obj, method, copy, *args, **kwds):
+def _wrapfunc_copy(obj, method, _internal_copy, *args, **kwds):
     # Same as _wrapfunc, but allows to pass copy argument to `np.array`.
     try:
         return getattr(obj, method)(*args, **kwds)
     except (AttributeError, TypeError):
-        return _wrapit(obj, method, copy, *args, **kwds)
+        return _wrapit(obj, method, _internal_copy, *args, **kwds)
 
 
 def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
@@ -237,7 +237,7 @@ def reshape(a, newshape, order='C', copy=False):
         If the input is not an array and copy is not ``np.never_copy``
         an additional copy may be made to convert to an array.
 
-        .. versionadded:: 1.16.0
+        .. versionadded:: 1.17.0
 
     Returns
     -------
@@ -1408,7 +1408,7 @@ def squeeze(a, axis=None):
     try:
         squeeze = a.squeeze
     except AttributeError:
-        return _wrapit(a, 'squeeze')
+        return _wrapit(a, 'squeeze', False)
     if axis is None:
         return squeeze()
     else:

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -874,9 +874,6 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
  */
 #define NPY_ARRAY_WRITEABLE       0x0400
 
-/*      NPY_ARRAY_ENSURENOCOPY    0x0800 */
-
-
 /*
  * If this flag is set, then base contains a pointer to an array of
  * the same size that should be updated with the current contents of
@@ -887,6 +884,8 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
  */
 #define NPY_ARRAY_UPDATEIFCOPY    0x1000 /* Deprecated in 1.14 */
 #define NPY_ARRAY_WRITEBACKIFCOPY 0x2000
+
+/*      NPY_ARRAY_ENSURENOCOPY    0x4000  defined above so next is 0x10000 */
 
 /*
  * NOTE: there are also internal flags defined in multiarray/arrayobject.h,

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -828,6 +828,12 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_ENSURECOPY      0x0020
 
 /*
+ * Make sure that no copy will be made. May be requested in constructor
+ * functions.
+ */
+#define NPY_ARRAY_ENSURENOCOPY    0x0800
+
+/*
  * Make sure the returned array is a base-class ndarray
  *
  * This flag may be requested in constructor functions.
@@ -867,6 +873,9 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
  * This flag may be tested for in PyArray_FLAGS(arr).
  */
 #define NPY_ARRAY_WRITEABLE       0x0400
+
+/*      NPY_ARRAY_ENSURENOCOPY    0x0800 */
+
 
 /*
  * If this flag is set, then base contains a pointer to an array of

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -278,8 +278,9 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      * Get either an array object we can copy from, or its parameters
      * if there isn't a convenient array available.
      */
-    if (PyArray_GetArrayParamsFromObject(src_object, PyArray_DESCR(dest),
-                0, &dtype, &ndim, dims, &src, NULL) < 0) {
+    if (PyArray_GetArrayParamsFromObject_int(
+                src_object, PyArray_DESCR(dest),
+                0, 0, &dtype, &ndim, dims, &src, NULL) < 0) {
         Py_DECREF(src_object);
         return -1;
     }
@@ -1216,25 +1217,6 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
     }
 }
 
-/*
- * Silence the current error and emit a deprecation warning instead.
- *
- * If warnings are raised as errors, this sets the warning __cause__ to the
- * silenced error.
- */
-NPY_NO_EXPORT int
-DEPRECATE_silence_error(const char *msg) {
-    PyObject *exc, *val, *tb;
-    PyErr_Fetch(&exc, &val, &tb);
-    if (DEPRECATE(msg) < 0) {
-        npy_PyErr_ChainExceptionsCause(exc, val, tb);
-        return -1;
-    }
-    Py_XDECREF(exc);
-    Py_XDECREF(val);
-    Py_XDECREF(tb);
-    return 0;
-}
 
 /*
  * Comparisons can fail, but we do not always want to pass on the exception

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -558,6 +558,27 @@ _array_typedescr_fromstr(char *c_str)
 }
 
 
+/*
+ * Silence the current error and emit a deprecation warning instead.
+ *
+ * If warnings are raised as errors, this sets the warning __cause__ to the
+ * silenced error.
+ */
+NPY_NO_EXPORT int
+DEPRECATE_silence_error(const char *msg) {
+    PyObject *exc, *val, *tb;
+    PyErr_Fetch(&exc, &val, &tb);
+    if (DEPRECATE(msg) < 0) {
+        npy_PyErr_ChainExceptionsCause(exc, val, tb);
+        return -1;
+    }
+    Py_XDECREF(exc);
+    Py_XDECREF(val);
+    Py_XDECREF(tb);
+    return 0;
+}
+
+
 NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i)
 {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -51,6 +51,8 @@ _array_find_python_scalar_type(PyObject *op);
 NPY_NO_EXPORT PyArray_Descr *
 _array_typedescr_fromstr(char *str);
 
+NPY_NO_EXPORT int DEPRECATE_silence_error(const char *msg);
+
 NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i);
 

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -817,7 +817,7 @@ PyArray_CastingConverter(PyObject *obj, NPY_CASTING *casting)
 NPY_NO_EXPORT int
 PyArray_CopyConverter(PyObject *object, int *copyflag)
 {
-    npy_bool obj_as_bool;
+    int obj_as_bool;
     Py_ssize_t obj_as_int;
     static PyObject *never_copy_singleton = NULL;
 

--- a/numpy/core/src/multiarray/conversion_utils.h
+++ b/numpy/core/src/multiarray/conversion_utils.h
@@ -13,6 +13,9 @@ NPY_NO_EXPORT int
 PyArray_BoolConverter(PyObject *object, npy_bool *val);
 
 NPY_NO_EXPORT int
+PyArray_CopyConverter(PyObject *obj, int *copyflag);
+
+NPY_NO_EXPORT int
 PyArray_ByteorderConverter(PyObject *obj, char *endian);
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1861,8 +1861,7 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
 
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {
-        assert((flags & NPY_ARRAY_ENSURENOCOPY == 0,
-                "ENSURENOCOPY in no-array path must not happen."));
+        assert(flags & NPY_ARRAY_ENSURENOCOPY) == 0);
 
         if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) ||
             (flags & NPY_ARRAY_UPDATEIFCOPY)) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1861,7 +1861,7 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
 
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {
-        assert(flags & NPY_ARRAY_ENSURENOCOPY) == 0);
+        assert((flags & NPY_ARRAY_ENSURENOCOPY) == 0);
 
         if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) ||
             (flags & NPY_ARRAY_UPDATEIFCOPY)) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1586,8 +1586,8 @@ PyArray_GetArrayParamsFromObject_int(
         }
         if (no_copy_allowed) {
             PyErr_SetString(PyExc_ValueError,
-                    "no copy was allowed during array creation, but it "
-                    "cannot be guaranteed.");
+                "never-copy was requested during array creation, but "
+                "scalar cannot be viewed as arrays.");
             return -1;
         }
 
@@ -1610,9 +1610,10 @@ PyArray_GetArrayParamsFromObject_int(
             return -1;
         }
         if (no_copy_allowed) {
+            Py_DECREF(*out_dtype);
             PyErr_SetString(PyExc_ValueError,
-                    "no copy was allowed during array creation, but it "
-                    "cannot be guaranteed.");
+                    "never-copy was requested during array creation, but "
+                    "scalar cannot be viewed as arrays.");
             return -1;
         }
         *out_ndim = 0;
@@ -1666,9 +1667,10 @@ PyArray_GetArrayParamsFromObject_int(
     }
 
     if (no_copy_allowed) {
+        /* None of the following possibilities can provide no-copy sementics  */
         PyErr_SetString(PyExc_ValueError,
-                "no copy was allowed during array creation, but it "
-                "cannot be guaranteed.");
+                "never-copy was requested during array creation, but object "
+                "cannot be directly interpreted as array.");
         return -1;
     }
 
@@ -1860,7 +1862,7 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {
         assert((flags & NPY_ARRAY_ENSURENOCOPY == 0,
-                "GetArrayParamsFromObject should not allow this to happen"));
+                "ENSURENOCOPY in no-array path must not happen."));
 
         if ((flags & NPY_ARRAY_WRITEBACKIFCOPY) ||
             (flags & NPY_ARRAY_UPDATEIFCOPY)) {
@@ -2037,7 +2039,7 @@ PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
         PyObject *ret;
         if (requires & NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError,
-                "array creation was requested with no-copy, but other "
+                "array creation was requested with never-copy, but other "
                 "requirements cannot be fullfilled without a copy.");
             return NULL;
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1580,6 +1580,14 @@ PyArray_GetArrayParamsFromObject_int(
                                 "cannot write to scalar");
             return -1;
         }
+
+        if (no_copy_allowed) {
+            PyErr_SetString(PyExc_ValueError,
+                    "no copy was allowed during array creation, but it "
+                    "cannot be guaranteed.");
+            return -1;
+        }
+
         *out_dtype = PyArray_DescrFromScalar(op);
         if (*out_dtype == NULL) {
             return -1;
@@ -1652,7 +1660,7 @@ PyArray_GetArrayParamsFromObject_int(
         PyErr_SetString(PyExc_ValueError,
                 "no copy was allowed during array creation, but it "
                 "cannot be guaranteed.");
-        return 0;
+        return -1;
     }
 
     /*

--- a/numpy/core/src/multiarray/ctors.h
+++ b/numpy/core/src/multiarray/ctors.h
@@ -21,6 +21,16 @@ PyArray_NewFromDescr_int(PyTypeObject *subtype, PyArray_Descr *descr, int nd,
 NPY_NO_EXPORT PyObject *PyArray_New(PyTypeObject *, int nd, npy_intp *,
                              int, npy_intp *, void *, int, int, PyObject *);
 
+NPY_NO_EXPORT int
+PyArray_GetArrayParamsFromObject_int(
+                        PyObject *op,
+                        PyArray_Descr *requested_dtype,
+                        npy_bool writeable,
+                        npy_bool no_copy_allowed,
+                        PyArray_Descr **out_dtype,
+                        int *out_ndim, npy_intp *out_dims,
+                        PyArrayObject **out_arr, PyObject *context);
+
 NPY_NO_EXPORT PyObject *
 PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
                 int max_depth, int flags, PyObject *context);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -178,13 +178,13 @@ array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
     static char *keywords[] = {"order", "copy", NULL};
     PyArray_Dims newshape;
     PyObject *ret;
-    PyObject *copyflag_obj = NULL;
     int copyflag;
     NPY_ORDER order = NPY_CORDER;
     Py_ssize_t n = PyTuple_Size(args);
 
-    if (!NpyArg_ParseKeywords(kwds, "|O&O", keywords,
-                PyArray_OrderConverter, &order, &copyflag_obj)) {
+    if (!NpyArg_ParseKeywords(kwds, "|O&O&", keywords,
+                PyArray_OrderConverter, &order,
+                PyArray_CopyConverter, &copyflag)) {
         return NULL;
     }
 
@@ -203,15 +203,6 @@ array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
                 PyErr_SetString(PyExc_TypeError,
                                 "invalid shape");
             }
-            goto fail;
-        }
-    }
-    if (copyflag_obj == NULL || copyflag_obj == Py_None) {
-        copyflag = -1;
-    }
-    else {
-        copyflag = PyObject_IsTrue(copyflag_obj);
-        if (copyflag < 0) {
             goto fail;
         }
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -178,7 +178,7 @@ array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
     static char *keywords[] = {"order", "copy", NULL};
     PyArray_Dims newshape;
     PyObject *ret;
-    int copyflag;
+    int copyflag = 0;
     NPY_ORDER order = NPY_CORDER;
     Py_ssize_t n = PyTuple_Size(args);
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -790,7 +790,8 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
      */
     NPY_CASTING casting = NPY_UNSAFE_CASTING;
     NPY_ORDER order = NPY_KEEPORDER;
-    int forcecopy = NPY_ARRAY_ENSURECOPY, subok = 1;
+    int forcecopy = NPY_ARRAY_ENSURECOPY;
+    int subok = 1;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&iO&:astype", kwlist,
                             PyArray_DescrConverter, &dtype,
@@ -829,7 +830,7 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
         if (forcecopy & NPY_ARRAY_ENSURENOCOPY) {
                 PyErr_SetString(PyExc_ValueError,
                     "cannot cast array without creating a copy, but "
-                    "never copy was requested.");
+                    "never-copy was requested.");
                 return NULL;
         }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1572,6 +1572,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
     PyObject *op;
     PyArrayObject *oparr = NULL, *ret = NULL;
     npy_bool subok = NPY_FALSE;
+    int copyflag = NPY_ARRAY_ENSURECOPY;
     npy_bool copy = NPY_TRUE;
     int ndmin = 0, nd;
     PyArray_Descr *type = NULL;
@@ -1657,12 +1658,13 @@ full_path:
     if (!PyArg_ParseTupleAndKeywords(args, kws, "O|O&O&O&O&i:array", kwd,
                 &op,
                 PyArray_DescrConverter2, &type,
-                PyArray_BoolConverter, &copy,
+                PyArray_CopyConverter, &copyflag,
                 PyArray_OrderConverter, &order,
                 PyArray_BoolConverter, &subok,
                 &ndmin)) {
         goto clean_type;
     }
+    copy = copyflag & NPY_ARRAY_ENSURECOPY;
 
     if (ndmin > NPY_MAXDIMS) {
         PyErr_Format(PyExc_ValueError,
@@ -1706,9 +1708,8 @@ full_path:
         }
     }
 
-    if (copy) {
-        flags = NPY_ARRAY_ENSURECOPY;
-    }
+    flags = copyflag;
+
     if (order == NPY_CORDER) {
         flags |= NPY_ARRAY_C_CONTIGUOUS;
     }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -231,13 +231,13 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
      * in order to get the right orientation and
      * because we can't just re-use the buffer with the
      * data in the order it is in.
-     * NPY_RELAXED_STRIDES_CHECKING: size check is unnecessary when set.
      */
     if (copyflag == NPY_ARRAY_ENSURECOPY) {
         /* force the copy no matter what */
         do_nocopy_reshape = 0;
     }
     else if ((PyArray_SIZE(self) <= 1) ||
+             /* NPY_RELAXED_STRIDES_CHECKING makes size check unnecessary */
              ((order == NPY_CORDER && PyArray_IS_C_CONTIGUOUS(self)) ||
               (order == NPY_FORTRANORDER && PyArray_IS_F_CONTIGUOUS(self)))) {
         /* the array can be trivially reshaped */

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -233,7 +233,7 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
      * data in the order it is in.
      * NPY_RELAXED_STRIDES_CHECKING: size check is unnecessary when set.
      */
-    if (copyflag == 1) {
+    if (copyflag == NPY_ARRAY_ENSURECOPY) {
         /* force the copy no matter what */
         do_nocopy_reshape = 0;
     }
@@ -254,7 +254,7 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
     Py_INCREF(self);
     if (!do_nocopy_reshape) {
         PyObject *newcopy;
-        if (copyflag == 0) {
+        if (copyflag == NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError,
                             "a no-copy reshape was requested but is not "
                             "possible for the given array and new shape.");

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -237,7 +237,7 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
         /* force the copy no matter what */
         do_nocopy_reshape = 0;
     }
-    else if ((PyArray_SIZE(self) == 1) ||
+    else if ((PyArray_SIZE(self) <= 1) ||
              ((order == NPY_CORDER && PyArray_IS_C_CONTIGUOUS(self)) ||
               (order == NPY_FORTRANORDER && PyArray_IS_F_CONTIGUOUS(self)))) {
         /* the array can be trivially reshaped */
@@ -256,7 +256,7 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
         PyObject *newcopy;
         if (copyflag == NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError,
-                            "a never copy reshape was requested but is not "
+                            "a never-copy reshape was requested but is not "
                             "possible for the given array and new shape.");
             Py_DECREF(self);
             return NULL;
@@ -311,7 +311,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_Newshape(PyArrayObject *self, PyArray_Dims *newdims,
                  NPY_ORDER order)
 {
-    return PyArray_Newshape_int(self, newdims, order, -1);
+    return PyArray_Newshape_int(self, newdims, order, 0);
 }
 
 

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -240,8 +240,8 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
     else if ((PyArray_SIZE(self) == 1) ||
              ((order == NPY_CORDER && PyArray_IS_C_CONTIGUOUS(self)) ||
               (order == NPY_FORTRANORDER && PyArray_IS_F_CONTIGUOUS(self)))) {
-            /* the array can be trivially reshaped */
-            do_nocopy_reshape = 1;
+        /* the array can be trivially reshaped */
+        do_nocopy_reshape = 1;
     }
     else {
         do_nocopy_reshape = _attempt_nocopy_reshape(self, ndim, dimensions,
@@ -256,7 +256,7 @@ PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
         PyObject *newcopy;
         if (copyflag == NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError,
-                            "a no-copy reshape was requested but is not "
+                            "a never copy reshape was requested but is not "
                             "possible for the given array and new shape.");
             Py_DECREF(self);
             return NULL;

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -28,4 +28,10 @@ PyArray_CreateMultiSortedStridePerm(int narrays, PyArrayObject **arrays,
 NPY_NO_EXPORT PyObject *
 PyArray_SqueezeSelected(PyArrayObject *self, npy_bool *axis_flags);
 
+/* Used internally to allow passing copy information */
+PyObject *
+PyArray_Newshape_int(PyArrayObject *self, PyArray_Dims *newdims,
+                     NPY_ORDER order, int copyflag);
+
+
 #endif

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -61,9 +61,9 @@ class TestReshape(object):
             # Test the most basic variants:
             res = arr.reshape(3, 5, 3, **order)
             assert_(res.base is arr)
-            res = arr.reshape(3, 5, 3, copy=None, **order)
-            assert_(res.base is arr)
             res = arr.reshape(3, 5, 3, copy=False, **order)
+            assert_(res.base is arr)
+            res = arr.reshape(3, 5, 3, copy=np.never_copy, **order)
             assert_(res.base is arr)
             res = arr.reshape(3, 5, 3, copy=True, **order)
             assert_(not np.may_share_memory(res.base, arr))
@@ -82,7 +82,7 @@ class TestReshape(object):
             res = arr.reshape(3, 5, 3, copy=True, order=order)
             assert_(not np.may_share_memory(res.base, arr))
             assert_raises(ValueError,
-                          arr.reshape, 3, 5, 3, copy=False, order=order)
+                          arr.reshape, 3, 5, 3, copy=np.never_copy, order=order)
             res = arr.reshape(3, 5, 3, copy=True)
             assert_(not np.may_share_memory(res.base, arr))
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -88,8 +88,13 @@ class TestReshape(object):
 
     def test_copyflag_error(self):
         # Test the error parse when parsing the copy kwarg:
+        # This used to error, but is currently deprecated to simplify C-code
+        # and behave the same as `np.array`.
         arr = np.zeros(5)
-        assert_raises(ValueError, arr.reshape, 5, copy=np.arange(10))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert_raises(DeprecationWarning,
+                          arr.reshape, 5, copy=np.arange(10))
 
 
 class TestNonarrayArgs(object):


### PR DESCRIPTION
This morphed into the more general addition of `np.never_copy` (`"never"` or similar are problematic, because currently `np.array(..., copy="never")` would use `bool("never")` doing the exact opposite.

Things to do:
 - [x] Check if buffer/memoryview paths are allowed to make a copy, if they are, do not allow them here. (They do not.)
 - Add tests for:
     - [x] `np.array`
     - [ ] `arr.astype`
     - [ ] Deprecation/argument parsing errors
     - [ ] `np.reshape` function (and a few for attribute)
---

The current version includes a deprection for some bool conversions, to only allow integers at least, that can be split off probably.