### PR TITLE
MAINT: test, refactor design of recursive closures

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -1,5 +1,5 @@
 """
-A place for code to be called from core C-code.
+A place for internal code
 
 Some things are more easily handled Python.
 
@@ -808,3 +808,11 @@ def _is_from_ctypes(obj):
         return 'ctypes' in ctype_base.__module__
     except Exception:
         return False
+
+
+class recursive(object):
+    def __init__(self, func):
+        self.func = func
+    def __call__(self, *args, **kwargs):
+        return self.func(self, *args, **kwargs)
+

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -811,6 +811,30 @@ def _is_from_ctypes(obj):
 
 
 class recursive(object):
+    '''
+    A decorator class for recursive nested functions.
+    Naive recursive nested functions hold a reference to themselves:
+
+    def outer(*args):
+        def stringify_leaky(arg0, *arg1):
+            if len(arg1) > 0:
+                return stringify_leaky(*arg1)  # <- HERE
+            return str(arg0)
+        stringify_leaky(*args)
+
+    This design pattern creates a reference cycle that is difficult for a
+    garbage collector to resolve. The decorator class prevents the
+    cycle by passing the nested function in as an argument `self`:
+
+    def outer(*args):
+        @recursive
+        def stringify(self, arg0, *arg1):
+            if len(arg1) > 0:
+                return self(*arg1)
+            return str(arg0)
+        stringify(*args)
+
+    '''
     def __init__(self, func):
         self.func = func
     def __call__(self, *args, **kwargs):

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -7,6 +7,7 @@ __all__ = ['atleast_1d', 'atleast_2d', 'atleast_3d', 'block', 'hstack',
 from . import numeric as _nx
 from .numeric import array, asanyarray, newaxis
 from .multiarray import normalize_axis_index
+from ._internal import recursive
 
 def atleast_1d(*arys):
     """
@@ -435,19 +436,19 @@ def _block(arrays, max_depth, result_ndim):
         # ones to `a.shape` as necessary
         return array(a, ndmin=ndim, copy=False, subok=True)
 
-    def block_recursion(block_recursion, arrays, depth=0):
-        """ Prevent reference cycles by passing in the function"""
+    @recursive
+    def block_recursion(self, arrays, depth=0):
         if depth < max_depth:
             if len(arrays) == 0:
                 raise ValueError('Lists cannot be empty')
-            arrs = [block_recursion(block_recursion, arr, depth+1) for arr in arrays]
+            arrs = [self(arr, depth+1) for arr in arrays]
             return _nx.concatenate(arrs, axis=-(max_depth-depth))
         else:
             # We've 'bottomed out' - arrays is either a scalar or an array
             # type(arrays) is not list
             return atleast_nd(arrays, result_ndim)
 
-    return block_recursion(block_recursion, arrays)
+    return block_recursion(arrays)
 
 
 def block(arrays):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -944,8 +944,9 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         fencoding = locale.getpreferredencoding()
 
     # not to be confused with the flatten_dtype we import...
-    def flatten_dtype_internal(dt):
-        """Unpack a structured data-type, and produce re-packing info."""
+    def flatten_dtype_internal(flatten_dtype_internal, dt):
+        """Unpack a structured data-type, and produce re-packing info.
+           Prevent reference cycles by passing in the function"""
         if dt.names is None:
             # If the dtype is flattened, return.
             # If the dtype has a shape, the dtype occurs
@@ -964,7 +965,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             packing = []
             for field in dt.names:
                 tp, bytes = dt.fields[field]
-                flat_dt, flat_packing = flatten_dtype_internal(tp)
+                flat_dt, flat_packing = flatten_dtype_internal(flatten_dtype_internal, tp)
                 types.extend(flat_dt)
                 # Avoid extra nesting for subarrays
                 if tp.ndim > 0:
@@ -973,8 +974,9 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                     packing.append((len(flat_dt), flat_packing))
             return (types, packing)
 
-    def pack_items(items, packing):
-        """Pack items into nested lists based on re-packing info."""
+    def pack_items(pack_items, items, packing):
+        """Pack items into nested lists based on re-packing info.
+           Prevent reference cycles by passing in the function"""
         if packing is None:
             return items[0]
         elif packing is tuple:
@@ -985,7 +987,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             start = 0
             ret = []
             for length, subpacking in packing:
-                ret.append(pack_items(items[start:start+length], subpacking))
+                ret.append(pack_items(pack_items, items[start:start+length], subpacking))
                 start += length
             return tuple(ret)
 
@@ -1029,7 +1031,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             items = [conv(val) for (conv, val) in zip(converters, vals)]
 
             # Then pack it according to the dtype's nesting
-            items = pack_items(items, packing)
+            items = pack_items(pack_items, items, packing)
             X.append(items)
             if len(X) > chunk_size:
                 yield X
@@ -1060,7 +1062,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             warnings.warn('loadtxt: Empty input file: "%s"' % fname, stacklevel=2)
         N = len(usecols or first_vals)
 
-        dtype_types, packing = flatten_dtype_internal(dtype)
+        dtype_types, packing = flatten_dtype_internal(flatten_dtype_internal, dtype)
         if len(dtype_types) > 1:
             # We're dealing with a structured array, each field of
             # the dtype matches a column
@@ -1111,9 +1113,6 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     finally:
         if fown:
             fh.close()
-        # recursive closures have a cyclic reference to themselves, which
-        # requires gc to collect (gh-10620). To avoid this problem, for
-        # performance and PyPy friendliness, we break the cycle:
         flatten_dtype_internal = None
         pack_items = None
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2416,3 +2416,9 @@ def test_load_refcount():
 
     with assert_no_gc_cycles():
         np.load(f)
+
+    f.seek(0)
+    dt = [("a", 'u1', 2), ("b", 'u1', 2)]
+    with assert_no_gc_cycles():
+        x = np.loadtxt(TextIO("0 1 2 3"), dtype=dt)
+        assert_equal(x, np.array([((0, 1), (2, 3))], dtype=dt))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1729,12 +1729,13 @@ def mask_or(m1, m2, copy=False, shrink=True):
 
     """
 
-    def _recursive_mask_or(m1, m2, newmask):
+    def _recursive_mask_or(_recursive_mask_or, m1, m2, newmask):
+        """ Prevent reference cycles by passing in the function"""
         names = m1.dtype.names
         for name in names:
             current1 = m1[name]
             if current1.dtype.names is not None:
-                _recursive_mask_or(current1, m2[name], newmask[name])
+                _recursive_mask_or(_recursive_mask_or, current1, m2[name], newmask[name])
             else:
                 umath.logical_or(current1, m2[name], newmask[name])
         return
@@ -1753,7 +1754,7 @@ def mask_or(m1, m2, copy=False, shrink=True):
     if dtype1.names is not None:
         # Allocate an output mask array with the properly broadcast shape.
         newmask = np.empty(np.broadcast(m1, m2).shape, dtype1)
-        _recursive_mask_or(m1, m2, newmask)
+        _recursive_mask_or(_recursive_mask_or, m1, m2, newmask)
         return newmask
     return make_mask(umath.logical_or(m1, m2), copy=copy, shrink=shrink)
 


### PR DESCRIPTION
In looking at `flake8 --select F811` local variable reuse, I stumbled across the solution in PR #10621 to the problem of recursive closures (#10620). It seems we can avoid assigning the closure to None by using the design pattern in the [last comment](https://github.com/numpy/numpy/pull/10621#issuecomment-366617500) to that PR. 

I also added a test for the use of recursive closures in `loadtxt`, which exposed another place where we still had cyclical references.