### PR TITLE
DOC: Clarify difference between PySequence_GETITEM, PyArray_GETITEM 

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -122,10 +122,13 @@ sub-types).
 
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 
-    Get a Python object from the ndarray, *arr*, at the location
-    pointed to by itemptr. Return ``NULL`` on failure and return standard
-    Python types on success.
-
+    Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
+    at the location pointed to by itemptr. Return ``NULL`` on failure.
+    
+    `numpy.ndarray.item is identical to PyArray_GETITEM.
+    
+    .. _numpy.ndarray.item: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html
+    
 .. c:function:: int PyArray_SETITEM( \
         PyArrayObject* arr, void* itemptr, PyObject* obj)
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -125,9 +125,7 @@ sub-types).
     Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
-    numpy.ndarray.item_ is identical to PyArray_GETITEM.
-    
-    .. _numpy.ndarray.item: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html
+    :c:data:`numpy.ndarray.item<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html>_ is identical to PyArray_GETITEM.
     
 .. c:function:: int PyArray_SETITEM( \
         PyArrayObject* arr, void* itemptr, PyObject* obj)

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -123,7 +123,8 @@ sub-types).
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 
     Get a Python object from the ndarray, *arr*, at the location
-    pointed to by itemptr. Return ``NULL`` on failure.
+    pointed to by itemptr. Return ``NULL`` on failure and return standard
+    Python types on success.
 
 .. c:function:: int PyArray_SETITEM( \
         PyArrayObject* arr, void* itemptr, PyObject* obj)

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -125,7 +125,7 @@ sub-types).
     Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
-    `numpy.ndarray.item <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html>`_ is identical to PyArray_GETITEM.
+    `numpy.ndarray.item` is identical to PyArray_GETITEM.
     
 .. c:function:: int PyArray_SETITEM( \
         PyArrayObject* arr, void* itemptr, PyObject* obj)

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -122,7 +122,7 @@ sub-types).
 
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 
-    Get a Python object of builtin type from the ndarray, *arr*, 
+    Get a Python object of a builtin type from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
     `numpy.ndarray.item` is identical to PyArray_GETITEM.

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -125,7 +125,7 @@ sub-types).
     Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
-    `numpy.ndarray.item is identical to PyArray_GETITEM.
+    numpy.ndarray.item_ is identical to PyArray_GETITEM.
     
     .. _numpy.ndarray.item: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html
     

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -122,7 +122,7 @@ sub-types).
 
 .. c:function:: PyObject *PyArray_GETITEM(PyArrayObject* arr, void* itemptr)
 
-    Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
+    Get a Python object of builtin type from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
     `numpy.ndarray.item` is identical to PyArray_GETITEM.

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -125,7 +125,7 @@ sub-types).
     Return (builtin) Python types and get a Python object from the ndarray, *arr*, 
     at the location pointed to by itemptr. Return ``NULL`` on failure.
     
-    :c:data:`numpy.ndarray.item<https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html>_ is identical to PyArray_GETITEM.
+    `numpy.ndarray.item <https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.item.html>`_ is identical to PyArray_GETITEM.
     
 .. c:function:: int PyArray_SETITEM( \
         PyArrayObject* arr, void* itemptr, PyObject* obj)


### PR DESCRIPTION
~Closes <!-- --> #10966.~

Added documentation for return of standard python types on success to avoid confusion between PySequence_GETITEM and PyArray_GETITEM

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
