### PR TITLE
WIP, TST: bump up CPU usage on shippable nodes

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -46,7 +46,7 @@ build:
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # run the test suite
-    - python runtests.py -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
+    - python runtests.py -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 96 --durations=10
 
     cache: true
     cache_dir_list:


### PR DESCRIPTION
The shippable team noted that although the pool of nodes is shared, once allocated for a job the node is exclusively assigned so we can use all the cores--trying to bump up usage here--will remove WIP tag if it helps.

I ran "lscpu" a week or two ago in one of the jobs and the number was quite large -- can't remember how much of that is physical vs. logical, but worth trying to bump up. I think previous small number testing suggested that it can help for testing more than building, but let's see.