### PR TITLE
MAINT: Don't rely on `__name__` in bitname - use the information directly from the typeinfo.

### DIFF
--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -415,6 +415,11 @@ def TestSctypeDict(object):
         assert_(np.sctypeDict['c16'] is not np.clongdouble)
 
 
+class TestBitName(object):
+    def test_abstract(self):
+        assert_raises(ValueError, np.core.numerictypes.bitname, np.floating)
+
+
 class TestMaximumSctype(object):
 
     # note that parametrizing with sctype['int'] and similar would skip types


### PR DESCRIPTION
The following code produces the same output (on 64-bit windows, python 3) before and after this change:

```python
In [4]: {
   ...:     name: np.core.numerictypes.bitname(info.type)
   ...:     for name, info in sorted(np.core.numerictypes._concrete_typeinfo.items())
   ...: }
Out[4]:
{'bool': ('bool', 8, 'b1'),
 'byte': ('int', 8, 'i1'),
 'cdouble': ('complex', 128, 'c16'),
 'cfloat': ('complex', 64, 'c8'),
 'clongdouble': ('complex', 128, 'c16'),
 'datetime': ('datetime', 64, 'M8'),
 'double': ('float', 64, 'f8'),
 'float': ('float', 32, 'f4'),
 'half': ('float', 16, 'f2'),
 'int': ('int', 32, 'i4'),
 'intp': ('int', 64, 'i8'),
 'long': ('int', 32, 'i4'),
 'longdouble': ('float', 64, 'f8'),
 'longlong': ('int', 64, 'i8'),
 'object': ('object', 0, 'O'),
 'short': ('int', 16, 'i2'),
 'string': ('bytes', 0, 'S'),
 'timedelta': ('timedelta', 64, 'm8'),
 'ubyte': ('uint', 8, 'u1'),
 'uint': ('uint', 32, 'u4'),
 'uintp': ('uint', 64, 'u8'),
 'ulong': ('uint', 32, 'u4'),
 'ulonglong': ('uint', 64, 'u8'),
 'unicode': ('str', 0, 'U'),
 'ushort': ('uint', 16, 'u2'),
 'void': ('void', 0, 'V')}
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->

This blocks changing the name of `np.longdouble` in #10151 