### PR TITLE
BUG/ENH: Ensure einsum(optimize=True) dispatches tensordot using ordered axes

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1373,7 +1373,7 @@ def einsum(*operands, **kwargs):
 
             # Find indices to contract over
             left_pos, right_pos = [], []
-            for s in idx_rm:
+            for s in sorted(idx_rm):
                 left_pos.append(input_left.find(s))
                 right_pos.append(input_right.find(s))
 


### PR DESCRIPTION
## The issue
I encountered the following (catastrophic) slowdown when using `einsum` with `optimize=True` in the following common circumstance: `np.einsum('ijk,ijk', x, x, optimize=True)` 

```python
>>> import numpy as np
>>> x = np.random.rand(100, 100, 100)
>>> %%timeit
... np.einsum('ijk,ijk', x, x, optimize=False)
521 µs ± 3.14 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
>>> %%timeit
... np.einsum('ijk,ijk', x, x, optimize=True)
7.61 ms ± 183 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
A 14x slowdown. Brutal.

## Finding the culprit
Stepping through [this patch of the code in einsumfunc.py](https://github.com/numpy/numpy/blob/ebcbd4f4d8c761ac758e7ae9da4bc0d202f80fff/numpy/core/einsumfunc.py#L1376) with a debugger revealed that the axes being passed to `tensordot` are formed by iterating over a set... sets are unordered! 

```python
# Find indices to contract over
left_pos, right_pos = [], []
for s in idx_rm:   # idx_rm={'i', 'j', 'k'}
    left_pos.append(input_left.find(s))       # left_pos=[1, 2, 0]
    right_pos.append(input_right.find(s))     # right_pos=[1, 2, 0]

# Contract!
new_view = tensordot(*tmp_operands, axes=(tuple(left_pos), tuple(right_pos)))
```

That `idx_rm` is set a containing the operand-indices means that the axes being passed to `tensordot` are not consistent. Invoking `tensordot(x, x, axes=((1, 2, 0), (1, 2, 0))`, which is the ordering that manifests on a 64-bit Windows machine running Python 3.6, leads to a whole world of unnecessary transposing/copying  of `x`:

```python
>>> import numpy as np
>>> x = np.random.rand(100, 100, 100)
>>> %%timeit
... np.tensordot(x, x, axes=((1, 2, 0), (1, 2, 0)))   # equiv to optimize=True
7.9 ms ± 143 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
>>> %%timeit
... np.tensordot(x, x, axes=((0, 1, 2), (0, 1, 2)))   # what optimize=True *should* do
151 µs ± 6.9 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
52x slowdown... 🌌brutal🌌. This explains the slowdown that we see with einsum (with the additional factor of ~3.5 accounting for the improvement over `einsum(optimize=False)` when blas is dispatched).


## The solution
Simply iterate over `sorted(idx_rm)` 🎃 

