### PR TITLE
DOC: fix scipy-sphinx-theme license path

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -42,7 +42,7 @@ License: 2-clause BSD
 Name: scipy-sphinx-theme
 Files: doc/scipy-sphinx-theme/*
 License: 3-clause BSD, PSF and Apache 2.0
-  For details, see doc/sphinxext/LICENSE.txt
+  For details, see doc/scipy-sphinx-theme/LICENSE.txt
 
 Name: lapack-lite
 Files: numpy/linalg/lapack_lite/*


### PR DESCRIPTION
In base LICENSE.txt under scipy-sphinx-theme, LICENSE.txt path is wrong.

Point to right path:
doc/scipy-sphinx-theme/LICENSE.txt
instead of:
doc/sphinxext/LICENSE.txt

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
