### PR TITLE
WIP / experiment: enable native unicode arr concatenation

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -918,7 +918,24 @@ class FloatingFormat(object):
         if data.size != finite_vals.size:
             neginf = self.sign != '-' or any(data[isinf(data)] < 0)
             nanlen = len(_format_options['nanstr'])
-            inflen = len(_format_options['infstr']) + neginf
+
+            # it is not appropriate to use the NumPy ndarray
+            # nb_add slot array_add() function for a simple
+            # sum of int and bool to determine repr padding;
+            # since neginf is of type np.bool_, coerce to
+            # a standard type for the purpose of simple padding
+            # integer value calculation;
+
+            # this will reduce our burden for handling strange and
+            # unnecessary inputs to array_add() at the C level,
+            # and potentially assist with the issues regarding
+            # repr crashes noted by njs in comments in
+            # PyArray_GenericBinaryFunction() in number.c
+
+            # NOTE: without this fix, my current unicode_
+            # array cat implementation would segfault certain
+            # reprs
+            inflen = len(_format_options['infstr']) + np.bool(neginf)
             offset = self.pad_right + 1  # +1 for decimal pt
             self.pad_left = max(self.pad_left, nanlen - offset, inflen - offset)
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -337,10 +337,10 @@ unicodetype_concat(PyObject *self, PyObject *other)
      * cast back to NPY_UNICODE before returning
      */
 
-    ret = PyArray_NewLikeArray(self,
+    ret = PyArray_NewLikeArray((PyArrayObject *)self,
                                NPY_ANYORDER,
                                PyArray_DescrFromType(NPY_OBJECT),
-                               NULL);
+                               0);
 
     self_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)self);
     other_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)other);
@@ -348,18 +348,20 @@ unicodetype_concat(PyObject *self, PyObject *other)
 
     while (other_iter->index < other_iter->size) {
         /* retrieve item from self */
-        item = PyArray_GETITEM(self, PyArray_ITER_DATA(self_iter));
+        item = PyArray_GETITEM((PyArrayObject *)self,
+                               PyArray_ITER_DATA(self_iter));
         /* retrieve item from other array in concat op */
-        other_item = PyArray_GETITEM(other, PyArray_ITER_DATA(other_iter));
+        other_item = PyArray_GETITEM((PyArrayObject *)other,
+                                     PyArray_ITER_DATA(other_iter));
 
         /*
          * concat the two Unicode PyObject elements and
          * place them at appropriate index in ret
          */
         combined = PyUnicode_Concat(item, other_item);
-        PyArray_SETITEM(ret,
-                        PyArray_ITER_DATA(ret_iter),
-                        combined);
+        PyArray_SETITEM((PyArrayObject *)ret,
+                         PyArray_ITER_DATA(ret_iter),
+                         combined);
         /* probably need XDECREFs */
         PyArray_ITER_NEXT(self_iter);
         PyArray_ITER_NEXT(other_iter);
@@ -397,7 +399,7 @@ array_add(PyArrayObject *m1, PyObject *m2)
          */
         if (PyArray_DESCR(m1)->type_num == NPY_UNICODE &&
             PyArray_DESCR((PyArrayObject *)m2)->type_num == NPY_UNICODE) {
-            return unicodetype_concat(m1, m2);
+            return unicodetype_concat((PyObject *)m1, m2);
         }
     }
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -387,9 +387,18 @@ array_add(PyArrayObject *m1, PyObject *m2)
      * for specifying these slots instead of intercepting
      * inside the general __add__ function pointer as I've done here
      */
-    if (PyArray_DESCR(m1)->type_num == NPY_UNICODE &&
-        PyArray_DESCR((PyArrayObject *)m2)->type_num == NPY_UNICODE) {
-        return unicodetype_concat(m1, m2);
+    if (PyArray_Check(m1)) {
+        /*
+         * specialized dispatch for nb_add for different array
+         * types is now guarded above against the case where
+         * PyArrayObject m1 is not a PyArrayObject, which seems
+         * like a sensible requirement for __add__ for np.ndarray
+         * type struct, but so far we haven't been checking this
+         */
+        if (PyArray_DESCR(m1)->type_num == NPY_UNICODE &&
+            PyArray_DESCR((PyArrayObject *)m2)->type_num == NPY_UNICODE) {
+            return unicodetype_concat(m1, m2);
+        }
     }
 
     BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_add, array_add);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -355,10 +355,8 @@ unicodetype_concat(PyObject *self, PyObject *other)
                                      PyArray_ITER_DATA(other_iter));
     }
     else if (other_iter->size != self_iter->size) {
-        /* TODO: handle shape mismatches and so on */
-        /* this is just a placeholder */
-        other_item = PyArray_GETITEM((PyArrayObject *)other,
-                                     PyArray_ITER_DATA(other_iter));
+        /* handle shape mismatches */
+        return NULL;
     }
     else {
         /* placeholder catch-all for initialization of other_item */
@@ -408,6 +406,7 @@ array_add(PyArrayObject *m1, PyObject *m2)
 {
     PyObject *res;
     PyObject *m2_converted;
+    PyObject *ret_val;
     /*
      * this function is pointed to by the nb_add
      * slot used by np.ndarray, and apparently also
@@ -444,7 +443,14 @@ array_add(PyArrayObject *m1, PyObject *m2)
         else if (PyArray_DESCR(m1)->type_num == NPY_UNICODE && (
                  PyArray_DESCR((PyArrayObject *)m2)->type_num == NPY_UNICODE)) {
             /* both m1 and m2 are unicode_ arrays */
-            return unicodetype_concat((PyObject *)m1, (PyObject *)m2);
+            ret_val = unicodetype_concat((PyObject *)m1, (PyObject *)m2);
+            if (ret_val == NULL) {
+                PyErr_SetString(PyExc_ValueError, "Array shape mismatch");
+                return NULL;
+            }
+            else {
+                return ret_val;
+            }
         }
     }
 

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -347,11 +347,21 @@ unicodetype_concat(PyObject *self, PyObject *other)
     other_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)other);
     ret_iter = (PyArrayIterObject *)PyArray_IterNew((PyObject *)ret);
 
-    /* TODO: handle shape mismatches and so on */
 
     /* handle case where other has only a single element */
     if (other_iter->size == 1) {
         /* we'll iterate over self & add other each time */
+        other_item = PyArray_GETITEM((PyArrayObject *)other,
+                                     PyArray_ITER_DATA(other_iter));
+    }
+    else if (other_iter->size != self_iter->size) {
+        /* TODO: handle shape mismatches and so on */
+        /* this is just a placeholder */
+        other_item = PyArray_GETITEM((PyArrayObject *)other,
+                                     PyArray_ITER_DATA(other_iter));
+    }
+    else {
+        /* placeholder catch-all for initialization of other_item */
         other_item = PyArray_GETITEM((PyArrayObject *)other,
                                      PyArray_ITER_DATA(other_iter));
     }
@@ -361,7 +371,7 @@ unicodetype_concat(PyObject *self, PyObject *other)
         item = PyArray_GETITEM((PyArrayObject *)self,
                                PyArray_ITER_DATA(self_iter));
         /* retrieve item from other array in concat op */
-        if (other_iter->size > 1) {
+        if (other_iter->size > 1 && self_iter->index > 0) {
             /* if other has a single item we can skip this */
             other_item = PyArray_GETITEM((PyArrayObject *)other,
                                          PyArray_ITER_DATA(other_iter));

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4244,12 +4244,23 @@ initialize_numeric_types(void)
     PyStringArrType_Type.tp_alloc = NULL;
     PyStringArrType_Type.tp_free = NULL;
 
+    /*
+     * NOTE: these slots aren't actually being used for
+     * string and unicode NumPy arrays -- the repr handling
+     * appears to funnel through np.ndarray Type struct and indeed
+     * none of the functions pointed to here even exist; trying
+     * to create them has no effect on behavior -- they
+     * are currently circumvented
+     */
     PyStringArrType_Type.tp_repr = stringtype_repr;
     PyStringArrType_Type.tp_str = stringtype_str;
 
     PyUnicodeArrType_Type.tp_repr = unicodetype_repr;
     PyUnicodeArrType_Type.tp_str = unicodetype_str;
 
+    /*
+     * we do actually use the void type slots
+     */
     PyVoidArrType_Type.tp_methods = voidtype_methods;
     PyVoidArrType_Type.tp_getset = voidtype_getsets;
     PyVoidArrType_Type.tp_as_mapping = &voidtype_as_mapping;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4245,12 +4245,9 @@ initialize_numeric_types(void)
     PyStringArrType_Type.tp_free = NULL;
 
     /*
-     * NOTE: these slots aren't actually being used for
-     * string and unicode NumPy arrays -- the repr handling
-     * appears to funnel through np.ndarray Type struct and indeed
-     * none of the functions pointed to here even exist; trying
-     * to create them has no effect on behavior -- they
-     * are currently circumvented
+     * NOTE: the string and unicode str and repr
+     * slots point to functions generated above
+     * using our type template language
      */
     PyStringArrType_Type.tp_repr = stringtype_repr;
     PyStringArrType_Type.tp_str = stringtype_str;

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -75,6 +75,11 @@ def test_string_cast():
     (np.array(['x', 'y'], dtype='U1'),
      u'abc',
      np.array(['xabc', 'yabc'], dtype='U4')),
+    # check for commutative Python unicode object
+    # handling (somewhat similar to  __radd__)
+    (u'abc',
+     np.array(['x', 'y'], dtype='U1'),
+     np.array(['abcx', 'abcy'], dtype='U4')),
     ])
 def test_native_unicode_add(arr1, arr2, expected):
     # element-wise array concat for unicode_ arrays

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -6,6 +6,8 @@ import numpy as np
 from numpy.compat import unicode
 from numpy.testing import assert_, assert_equal, assert_array_equal
 
+import pytest
+
 # Guess the UCS length for this python interpreter
 if sys.version_info[:2] >= (3, 3):
     # Python 3.3 uses a flexible string representation
@@ -62,16 +64,24 @@ def test_string_cast():
         assert_(str_arr != uni_arr2)
     assert_array_equal(uni_arr1, uni_arr2)
 
-def test_native_unicode_add():
+@pytest.mark.parametrize("arr1, arr2, expected", [
+    # concat two 1D unicode_ arrays of same size
+    (np.array(['a', 'b'], dtype='U1'),
+     np.array(['c', 'd'], dtype='U1'),
+     np.array(['ac', 'bd'], dtype='U2')),
+    # concat 1D unicode array with Python unicode
+    # object
+    (np.array(['x', 'y'], dtype='U1'),
+     u'abc',
+     np.array(['xabc', 'yabc'], dtype='U4')),
+    ])
+def test_native_unicode_add(arr1, arr2, expected):
     # element-wise array concat for unicode_ arrays
     # experimental, and probably belongs in a different
     # testing module
     # provides more natural interface than requiring
     # numpy.core.defchararray.add(a, b)
-    test = np.array(['a', 'b'], dtype='U1')
-    test2 = np.array(['c', 'd'], dtype='U1')
-    actual = test + test2
-    expected = np.array(['ac', 'bd'], dtype='U2')
+    actual = arr1 + arr2
     assert_equal(actual, expected)
 
 

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -4,7 +4,8 @@ import sys
 
 import numpy as np
 from numpy.compat import unicode
-from numpy.testing import assert_, assert_equal, assert_array_equal
+from numpy.testing import (assert_, assert_equal, assert_array_equal,
+                           assert_raises_regex)
 
 import pytest
 
@@ -83,6 +84,15 @@ def test_native_unicode_add(arr1, arr2, expected):
     # numpy.core.defchararray.add(a, b)
     actual = arr1 + arr2
     assert_equal(actual, expected)
+
+def test_native_unicode_add_shape_mismatch():
+    # a ValueError should be raised for unicode_
+    # array __add__ with shape mismatch if one
+    # of the inputs is not a "scalar"
+    arr = np.array(['a', 'b'], dtype='U1')
+    arr2 = np.array(['a', 'b', 'c', 'd'], dtype='U1')
+    with assert_raises_regex(ValueError, 'Array shape mismatch'):
+        arr + arr2
 
 
 ############################################################

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -62,6 +62,18 @@ def test_string_cast():
         assert_(str_arr != uni_arr2)
     assert_array_equal(uni_arr1, uni_arr2)
 
+def test_native_unicode_add():
+    # element-wise array concat for unicode_ arrays
+    # experimental, and probably belongs in a different
+    # testing module
+    # provides more natural interface than requiring
+    # numpy.core.defchararray.add(a, b)
+    test = np.array(['a', 'b'], dtype='U1')
+    test2 = np.array(['c', 'd'], dtype='U1')
+    actual = test + test2
+    expected = np.array(['ac', 'bd'], dtype='U2')
+    assert_equal(actual, expected)
+
 
 ############################################################
 #    Creation tests

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -80,6 +80,15 @@ def test_string_cast():
     (u'abc',
      np.array(['x', 'y'], dtype='U1'),
      np.array(['abcx', 'abcy'], dtype='U4')),
+    # concat 2D unicode_ arrays with same shape
+    (np.array([['a', 'b'], ['c', 'd']], dtype='U1'),
+     np.array([['e', 'f'], ['g', 'h']], dtype='U1'),
+     np.array([['ae', 'bf'], ['cg', 'dh']], dtype='U2')),
+    # verify broadcasted concat between 2D and 1D
+    # unicode_ arrays
+    (np.array(['x', 'y'], dtype='U1'),
+     np.array([['aa', 'bb'], ['gg', 'hh']], dtype='U2'),
+     np.array([['xaa', 'ybb'], ['xgg', 'yhh']], dtype='U3')),
     ])
 def test_native_unicode_add(arr1, arr2, expected):
     # element-wise array concat for unicode_ arrays


### PR DESCRIPTION
This is just an experiment that allows adding two unicode type arrays and getting an element-wise concatenated result without going through `numpy.core.defchararray.add()`.

So, `np.array(['a', 'b']) + np.array(['c', 'd']) -> np.array(['ac', 'bd'])`

The new unit test added does pass, but some other tests fail pretty badly for now.

I added some detailed comments to see if others think I'm misunderstanding here. Not suggesting we should do this, but more looking for feedback on what ideas I might have wrong re: making "string-type" handling better (which is on our roadmap). 