### PR TITLE
TST: Fix unit tests that used to call unittest.TestCase.fail

### DIFF
--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.core.multiarray import _vec_string
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises,
-    suppress_warnings,
+    assert_raises_regex, suppress_warnings,
     )
 
 kw_unicode_true = {'unicode': True}  # make 2to3 work properly
@@ -626,13 +626,9 @@ class TestOperations(object):
             assert_array_equal(Ar, (self.A * r))
 
         for ob in [object(), 'qrs']:
-            try:
-                A * ob
-            except ValueError:
-                pass
-            else:
-                raise ValueError(
-                        "chararray can only be multiplied by integers")
+            with assert_raises_regex(ValueError,
+                                     'Can only multiply by integers'):
+                A*ob
 
     def test_rmul(self):
         A = self.A
@@ -642,13 +638,9 @@ class TestOperations(object):
             assert_array_equal(Ar, (r * self.A))
 
         for ob in [object(), 'qrs']:
-            try:
+            with assert_raises_regex(ValueError,
+                                     'Can only multiply by integers'):
                 ob * A
-            except ValueError:
-                pass
-            else:
-                raise ValueError(
-                        "chararray can only be multiplied by integers")
 
     def test_mod(self):
         """Ticket #856"""
@@ -670,13 +662,9 @@ class TestOperations(object):
         assert_(("%r" % self.A) == repr(self.A))
 
         for ob in [42, object()]:
-            try:
+            with assert_raises_regex(
+                    TypeError, "unsupported operand type.* and 'chararray'"):
                 ob % self.A
-            except TypeError:
-                pass
-            else:
-                raise ValueError("chararray __rmod__ should fail with "
-                                 "non-string objects")
 
     def test_slice(self):
         """Regression test for https://github.com/numpy/numpy/issues/5982"""

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -631,7 +631,8 @@ class TestOperations(object):
             except ValueError:
                 pass
             else:
-                self.fail("chararray can only be multiplied by integers")
+                raise ValueError(
+                        "chararray can only be multiplied by integers")
 
     def test_rmul(self):
         A = self.A
@@ -646,7 +647,8 @@ class TestOperations(object):
             except ValueError:
                 pass
             else:
-                self.fail("chararray can only be multiplied by integers")
+                raise ValueError(
+                        "chararray can only be multiplied by integers")
 
     def test_mod(self):
         """Ticket #856"""
@@ -673,8 +675,8 @@ class TestOperations(object):
             except TypeError:
                 pass
             else:
-                self.fail("chararray __rmod__ should fail with "
-                          "non-string objects")
+                raise ValueError("chararray __rmod__ should fail with "
+                                 "non-string objects")
 
     def test_slice(self):
         """Regression test for https://github.com/numpy/numpy/issues/5982"""

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -4,7 +4,7 @@ import platform
 import pytest
 
 import numpy as np
-from numpy.testing import assert_
+from numpy.testing import assert_, assert_raises
 
 
 class TestErrstate(object):
@@ -16,12 +16,8 @@ class TestErrstate(object):
             with np.errstate(invalid='ignore'):
                 np.sqrt(a)
             # While this should fail!
-            try:
+            with assert_raises(FloatingPointError):
                 np.sqrt(a)
-            except FloatingPointError:
-                pass
-            else:
-                raise ValueError("Did not raise an invalid error")
 
     def test_divide(self):
         with np.errstate(all='raise', under='ignore'):
@@ -30,12 +26,8 @@ class TestErrstate(object):
             with np.errstate(divide='ignore'):
                 a // 0
             # While this should fail!
-            try:
+            with assert_raises(FloatingPointError):
                 a // 0
-            except FloatingPointError:
-                pass
-            else:
-                raise ValueError("Did not raise divide by zero error")
 
     def test_errcall(self):
         def foo(*args):

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -21,7 +21,7 @@ class TestErrstate(object):
             except FloatingPointError:
                 pass
             else:
-                self.fail("Did not raise an invalid error")
+                raise ValueError("Did not raise an invalid error")
 
     def test_divide(self):
         with np.errstate(all='raise', under='ignore'):
@@ -35,7 +35,7 @@ class TestErrstate(object):
             except FloatingPointError:
                 pass
             else:
-                self.fail("Did not raise divide by zero error")
+                raise ValueError("Did not raise divide by zero error")
 
     def test_errcall(self):
         def foo(*args):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -476,7 +476,7 @@ class TestSeterr(object):
             except FloatingPointError:
                 pass
             else:
-                self.fail()
+                raise
             np.seterr(divide='ignore')
             np.array([1.]) / np.array([0.])
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -13,7 +13,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    suppress_warnings, HAS_REFCOUNT
+    assert_raises, suppress_warnings, HAS_REFCOUNT
     )
 
 
@@ -471,12 +471,9 @@ class TestSeterr(object):
     @pytest.mark.skipif(platform.machine() == "armv5tel", reason="See gh-413.")
     def test_divide_err(self):
         with np.errstate(divide='raise'):
-            try:
+            with assert_raises(FloatingPointError):
                 np.array([1.]) / np.array([0.])
-            except FloatingPointError:
-                pass
-            else:
-                raise
+
             np.seterr(divide='ignore')
             np.array([1.]) / np.array([0.])
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -16,7 +16,8 @@ import numpy as np
 from numpy.testing import (
         assert_, assert_equal, IS_PYPY, assert_almost_equal,
         assert_array_equal, assert_array_almost_equal, assert_raises,
-        assert_warns, suppress_warnings, _assert_valid_refcount, HAS_REFCOUNT,
+        assert_raises_regex, assert_warns, suppress_warnings,
+        _assert_valid_refcount, HAS_REFCOUNT,
         )
 from numpy.compat import asbytes, asunicode, long
 
@@ -1309,30 +1310,18 @@ class TestRegression(object):
         # Regression test for #1061.
         # Set a size which cannot fit into a 64 bits signed integer
         sz = 2 ** 64
-        good = 'Maximum allowed dimension exceeded'
-        try:
+        with assert_raises_regex(ValueError,
+                                 'Maximum allowed dimension exceeded'):
             np.empty(sz)
-        except ValueError as e:
-            if not str(e) == good:
-                raise AssertionError("Got msg '%s', expected '%s'" % (e, good))
-        except Exception as e:
-            raise AssertionError("Got exception of type %s instead "
-                                 "of ValueError" % type(e))
 
     def test_huge_arange(self):
         # Regression test for #1062.
         # Set a size which cannot fit into a 64 bits signed integer
         sz = 2 ** 64
-        good = 'Maximum allowed size exceeded'
-        try:
+        with assert_raises_regex(ValueError,
+                                 'Maximum allowed size exceeded'):
             np.arange(sz)
             assert_(np.size == sz)
-        except ValueError as e:
-            if not str(e) == good:
-                raise AssertionError("Got msg '%s', expected '%s'" % (e, good))
-        except Exception as e:
-            raise AssertionError("Got exception of type %s instead "
-                                 "of ValueError" % type(e))
 
     def test_fromiter_bytes(self):
         # Ticket #1058

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1314,9 +1314,10 @@ class TestRegression(object):
             np.empty(sz)
         except ValueError as e:
             if not str(e) == good:
-                self.fail("Got msg '%s', expected '%s'" % (e, good))
+                raise ValueError("Got msg '%s', expected '%s'" % (e, good))
         except Exception as e:
-            self.fail("Got exception of type %s instead of ValueError" % type(e))
+            raise TypeError("Got exception of type %s instead of ValueError"
+                            % type(e))
 
     def test_huge_arange(self):
         # Regression test for #1062.
@@ -1328,9 +1329,10 @@ class TestRegression(object):
             assert_(np.size == sz)
         except ValueError as e:
             if not str(e) == good:
-                self.fail("Got msg '%s', expected '%s'" % (e, good))
+                raise ValueError("Got msg '%s', expected '%s'" % (e, good))
         except Exception as e:
-            self.fail("Got exception of type %s instead of ValueError" % type(e))
+            raise TypeError("Got exception of type %s instead of ValueError"
+                            % type(e))
 
     def test_fromiter_bytes(self):
         # Ticket #1058

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1314,10 +1314,10 @@ class TestRegression(object):
             np.empty(sz)
         except ValueError as e:
             if not str(e) == good:
-                raise ValueError("Got msg '%s', expected '%s'" % (e, good))
+                raise AssertionError("Got msg '%s', expected '%s'" % (e, good))
         except Exception as e:
-            raise TypeError("Got exception of type %s instead of ValueError"
-                            % type(e))
+            raise AssertionError("Got exception of type %s instead "
+                                 "of ValueError" % type(e))
 
     def test_huge_arange(self):
         # Regression test for #1062.
@@ -1329,10 +1329,10 @@ class TestRegression(object):
             assert_(np.size == sz)
         except ValueError as e:
             if not str(e) == good:
-                raise ValueError("Got msg '%s', expected '%s'" % (e, good))
+                raise AssertionError("Got msg '%s', expected '%s'" % (e, good))
         except Exception as e:
-            raise TypeError("Got exception of type %s instead of ValueError"
-                            % type(e))
+            raise AssertionError("Got exception of type %s instead "
+                                 "of ValueError" % type(e))
 
     def test_fromiter_bytes(self):
         # Ticket #1058

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -286,7 +286,8 @@ from io import BytesIO
 
 import numpy as np
 from numpy.testing import (
-    assert_, assert_array_equal, assert_raises, raises, SkipTest
+    assert_, assert_array_equal, assert_raises, assert_raises_regex,
+    raises, SkipTest
     )
 from numpy.lib import format
 
@@ -678,12 +679,9 @@ def test_write_version():
         (255, 255),
     ]
     for version in bad_versions:
-        try:
+        with assert_raises_regex(ValueError,
+                                 'we only support format version.*'):
             format.write_array(f, arr, version=version)
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("we should have raised a ValueError for the bad version %r" % (version,))
 
 
 bad_version_magic = [

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1454,14 +1454,10 @@ M   33  21.99
         assert_equal(test, control)
 
         ndtype = [('nest', [('idx', int), ('code', object)])]
-        try:
+        with assert_raises_regex(NotImplementedError,
+                                 'Nested fields.* not supported.*'):
             test = np.genfromtxt(TextIO(data), delimiter=";",
                                  dtype=ndtype, converters=converters)
-        except NotImplementedError:
-            pass
-        else:
-            errmsg = "Nested dtype involving objects should be supported."
-            raise AssertionError(errmsg)
 
     def test_userconverters_with_explicit_dtype(self):
         # Test user_converters w/ explicit (standard) dtype

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -541,12 +541,8 @@ class TestStackArrays(object):
         test = stack_arrays((a, b), autoconvert=True)
         assert_equal(test, control)
         assert_equal(test.mask, control.mask)
-        try:
-            test = stack_arrays((a, b), autoconvert=False)
-        except TypeError:
-            pass
-        else:
-            raise AssertionError
+        with assert_raises(TypeError):
+            stack_arrays((a, b), autoconvert=False)
 
     def test_checktitles(self):
         # Test using titles in the field names

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3806,12 +3806,8 @@ class TestMaskedArrayFunctions(object):
 
     def test_masked_where_shape_constraint(self):
         a = arange(10)
-        try:
-            test = masked_equal(1, a)
-        except IndexError:
-            pass
-        else:
-            raise AssertionError("Should have failed...")
+        with assert_raises(IndexError):
+            masked_equal(1, a)
         test = masked_equal(a, 1)
         assert_equal(test.mask, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0])
 

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -268,21 +268,12 @@ class TestAlgebra(object):
                     [3., 4.]])
 
         # __rpow__
-        try:
+        with assert_raises(TypeError):
             1.0**A
-        except TypeError:
-            pass
-        else:
-            raise ValueError("matrix.__rpow__ doesn't raise a TypeError")
 
         # __mul__ with something not a list, ndarray, tuple, or scalar
-        try:
+        with assert_raises(TypeError):
             A*object()
-        except TypeError:
-            pass
-        else:
-            raise ValueError("matrix.__mul__ with non-numeric object doesn't "
-                             "raise a TypeError")
 
 
 class TestMatrixReturn(object):

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -273,7 +273,7 @@ class TestAlgebra(object):
         except TypeError:
             pass
         else:
-            self.fail("matrix.__rpow__ doesn't raise a TypeError")
+            raise ValueError("matrix.__rpow__ doesn't raise a TypeError")
 
         # __mul__ with something not a list, ndarray, tuple, or scalar
         try:
@@ -281,8 +281,9 @@ class TestAlgebra(object):
         except TypeError:
             pass
         else:
-            self.fail("matrix.__mul__ with non-numeric object doesn't raise"
-                      "a TypeError")
+            raise ValueError("matrix.__mul__ with non-numeric object doesn't "
+                             "raise a TypeError")
+
 
 class TestMatrixReturn(object):
     def test_instance_methods(self):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -25,12 +25,8 @@ class _GenericTest(object):
         self._assert_func(a, b)
 
     def _test_not_equal(self, a, b):
-        try:
+        with assert_raises(AssertionError):
             self._assert_func(a, b)
-        except AssertionError:
-            pass
-        else:
-            raise AssertionError("a and b are found equal but are not")
 
     def test_array_rank1_eq(self):
         """Test two equal array of rank 1 are found equal."""


### PR DESCRIPTION
Following pytest migration https://github.com/numpy/numpy/issues/10856 there are unit tests that used to call `unittest.TestCase.fail` and now will produce a misleading error message on failure because the `fail` method no longer exists (test classes just inherit from `object`).

This fixes this issue, by raising an exception on failure explicitly. 