### PR TITLE
MAINT: remove exec_command() from f2py init

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -7,6 +7,10 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['run_main', 'compile', 'f2py_testing']
 
 import sys
+import subprocess
+import os
+
+import numpy as np
 
 from . import f2py2e
 from . import f2py_testing
@@ -32,8 +36,12 @@ def compile(source,
         Fortran source of module / subroutine to compile
     modulename : str, optional
         The name of the compiled python module
-    extra_args : str, optional
+    extra_args : str or list, optional
         Additional parameters passed to f2py
+
+        .. versionchanged:: 1.16.0
+            A list of args may also be provided.
+
     verbose : bool, optional
         Print f2py output to screen
     source_fn : str, optional
@@ -48,25 +56,48 @@ def compile(source,
         .. versionadded:: 1.11.0
 
     """
-    from numpy.distutils.exec_command import exec_command
     import tempfile
+    import shlex
+
     if source_fn is None:
-        f = tempfile.NamedTemporaryFile(suffix=extension)
+        f, fname = tempfile.mkstemp(suffix=extension)
+        # f is a file descriptor so need to close it
+        # carefully -- not with .close() directly
+        os.close(f)
     else:
-        f = open(source_fn, 'w')
+        fname = source_fn
 
     try:
-        f.write(source)
-        f.flush()
+        with open(fname, 'w') as f:
+            f.write(str(source))
 
-        args = ' -c -m {} {} {}'.format(modulename, f.name, extra_args)
-        c = '{} -c "import numpy.f2py as f2py2e;f2py2e.main()" {}'
-        c = c.format(sys.executable, args)
-        status, output = exec_command(c)
+        args = ['-c', '-m', modulename, f.name]
+
+        if isinstance(extra_args, np.compat.basestring):
+            is_posix = (os.name == 'posix')
+            extra_args = shlex.split(extra_args, posix=is_posix)
+
+        args.extend(extra_args)
+
+        c = [sys.executable,
+             '-c',
+             'import numpy.f2py as f2py2e;f2py2e.main()'] + args
+        try:
+            output = subprocess.check_output(c)
+        except subprocess.CalledProcessError as exc:
+            status = exc.returncode
+            output = ''
+        except OSError:
+            # preserve historic status code used by exec_command()
+            status = 127
+            output = ''
+        else:
+            status = 0
         if verbose:
             print(output)
     finally:
-        f.close()
+        if source_fn is None:
+            os.remove(fname)
     return status
 
 from numpy._pytesttester import PytestTester

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -1,7 +1,12 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import os
+import uuid
+from importlib import import_module
 import pytest
+
+import numpy.f2py
 
 from numpy.testing import assert_equal
 from . import util
@@ -28,3 +33,108 @@ Cf2py intent(out) OUT1, OUT2, OUT3, OUT4, OUT5, OUT6
                         reason='Fails with MinGW64 Gfortran (Issue #9673)')
     def test_quoted_character(self):
         assert_equal(self.module.foo(), (b"'", b'"', b';', b'!', b'(', b')'))
+
+@pytest.mark.xfail(sys.version_info[0] < 3 and os.name == 'nt',
+                   reason="our Appveyor CI configuration does not"
+                          " have Fortran compilers available for"
+                          " Python 2.x")
+@pytest.mark.parametrize("extra_args", [
+    # extra_args can be a list as of gh-11937
+    ['--noopt', '--debug'],
+    # test for string as well, using the same
+    # fcompiler options
+    '--noopt --debug',
+    # also test absence of extra_args
+    '',
+    ])
+def test_f2py_init_compile(extra_args):
+    # flush through the f2py __init__
+    # compile() function code path
+    # as a crude test for input handling
+    # following migration from exec_command()
+    # to subprocess.check_output() in gh-11937
+
+    # the Fortran 77 syntax requires 6 spaces
+    # before any commands, but more space may
+    # be added; gfortran can also compile
+    # with --ffree-form to remove the indentation
+    # requirement; here, the Fortran source is
+    # formatted to roughly match an example from
+    # the F2PY User Guide
+    fsource =  '''
+             integer function foo()
+             foo = 10 + 5
+             return
+             end
+             '''
+    # use various helper functions in util.py to
+    # enable robust build / compile and
+    # reimport cycle in test suite
+    d = util.get_module_dir()
+    modulename = util.get_temp_module_name()
+
+    cwd = os.getcwd()
+    target = os.path.join(d, str(uuid.uuid4()) + '.f')
+    # try running compile() with and without a
+    # source_fn provided so that the code path 
+    # where a temporary file for writing Fortran
+    # source is created is also explored
+    for source_fn in [target, None]:
+
+        # mimic the path changing behavior used
+        # by build_module() in util.py, but don't
+        # actually use build_module() because it
+        # has its own invocation of subprocess
+        # that circumvents the f2py.compile code
+        # block under test
+        try:
+            os.chdir(d)
+            ret_val = numpy.f2py.compile(fsource,
+                                         modulename=modulename,
+                                         extra_args=extra_args,
+                                         source_fn=source_fn)
+        finally:
+            os.chdir(cwd)
+
+        # check for compile success return value
+        assert_equal(ret_val, 0)
+
+        # we are not currently able to import the
+        # Python-Fortran interface module on Windows /
+        # Appveyor, even though we do get successful
+        # compilation on that platform with Python 3.x
+        if os.name != 'nt':
+            # check for sensible result of Fortran function;
+            # that means we can import the module name in Python
+            # and retrieve the result of the sum operation
+            return_check = import_module(modulename)
+            calc_result = return_check.foo()
+            assert_equal(calc_result, 15)
+
+def test_f2py_init_compile_failure():
+    # verify an appropriate integer status
+    # value returned by f2py.compile() when
+    # invalid Fortran is provided
+    ret_val = numpy.f2py.compile(b"invalid")
+    assert_equal(ret_val, 1)
+
+def test_f2py_init_compile_bad_cmd():
+    # verify that usage of invalid command in
+    # f2py.compile() returns status value of 127
+    # for historic consistency with exec_command()
+    # error handling
+
+    # patch the sys Python exe path temporarily to
+    # induce an OSError downstream
+    # NOTE: how bad of an idea is this patching?
+    try:
+        temp = sys.executable
+        sys.executable = 'does not exist'
+
+        # the OSError should take precedence over the invalid
+        # Fortran
+        ret_val = numpy.f2py.compile(b"invalid")
+
+        assert_equal(ret_val, 127)
+    finally:
+        sys.executable = temp


### PR DESCRIPTION
Related to #11824 and in the spirit of changes in #11900 

I almost didn't notice that a `string` object was being fed into `check_output`, and the tests were impervious so a bit *scary*. I've added a detailed comment to hopefully assist review.
