### PR TITLE
BUG: Ensure einsum(optimize=True) dispatches tensordot deterministically 

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1373,7 +1373,7 @@ def einsum(*operands, **kwargs):
 
             # Find indices to contract over
             left_pos, right_pos = [], []
-            for s in idx_rm:
+            for s in sorted(idx_rm):
                 left_pos.append(input_left.find(s))
                 right_pos.append(input_right.find(s))
 


### PR DESCRIPTION
Presently, `einsum` with `optimize=True` iterates over a `set` of operand-indices when populating the axes of `tensordot`. Changing the ordering in which the axes are supplied to `tensordot` can lead to [major fluctuations](https://github.com/numpy/numpy/issues/11940) in performance, thus it is important to ensure that `einsum` dispatches `tensordot` in a deterministic way.  
