### PR TITLE
MAINT: test NPY_INTERNAL_BUILD only if defined

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -14,7 +14,7 @@
  * using static inline modifiers when defining npy_math functions
  * allows the compiler to make optimizations when possible
  */
-#if NPY_INTERNAL_BUILD
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
 #ifndef NPY_INLINE_MATH
 #define NPY_INLINE_MATH 1
 #endif


### PR DESCRIPTION
When using GCC 4.4.7 on RHEL 6 to compile a C program that embeds Python and includes `numpy/core/include/numpy/npy_common.h`, and the compiler is configured to warn about all questionable constructions (`-Wall`) and warn about undefined identifiers (`-Wundef`), it emits a warning like

```
/tmp/python-2.7.15/lib/python2.7/site-packages/numpy/core/include/numpy/npy_common.h:17:5: warning: "NPY_INTERNAL_BUILD" is not defined
```

A minimal C program and compiler invocation to reproduce the warning is

```
$ cat main.c
#include <Python.h>
#include <numpy/npy_common.h>

int main(void) {
  return 0;
}
$ cc -o -Wall -Wundef \
    -I/tmp/python-2.7.15/include/python2.7 \
    -I/tmp/python-2.7.15/lib/python2.7/site-packages/numpy/core/include \
    main.c
```

The warning in `npy_common.h` comes from

```
#if NPY_INTERNAL_BUILD
#ifndef NPY_INLINE_MATH
#define NPY_INLINE_MATH 1
#endif
#endif
```

Eliminate this warning by changing the `#if` expression to test `NPY_INTERNAL_BUILD` only if it is defined.  (This preserves the original behavior because in the original, when `NPY_INTERNAL_BUILD` is undefined, the preprocessor treats it as `0` (false).)