### PR TITLE
MAINT: Move _do_append and _do_prepend out of the functions to generate padding values

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -103,7 +103,7 @@ def _do_append(arr, pad_chunk, axis):
         (arr, pad_chunk.astype(arr.dtype, copy=False)), axis=axis)
 
 
-def _prepend_const(arr, pad_amt, val, axis=-1):
+def _leading_const(arr, pad_amt, val, axis=-1):
     """
     Prepend constant `val` along `axis` of `arr`.
 
@@ -132,7 +132,7 @@ def _prepend_const(arr, pad_amt, val, axis=-1):
     return np.full(padshape, val, dtype=arr.dtype)
 
 
-def _append_const(arr, pad_amt, val, axis=-1):
+def _trailing_const(arr, pad_amt, val, axis=-1):
     """
     Append constant `val` along `axis` of `arr`.
 
@@ -162,7 +162,7 @@ def _append_const(arr, pad_amt, val, axis=-1):
 
 
 
-def _prepend_edge(arr, pad_amt, axis=-1):
+def _leading_edge(arr, pad_amt, axis=-1):
     """
     Prepend `pad_amt` to `arr` along `axis` by extending edge values.
 
@@ -189,7 +189,7 @@ def _prepend_edge(arr, pad_amt, axis=-1):
     return edge_arr.repeat(pad_amt, axis=axis)
 
 
-def _append_edge(arr, pad_amt, axis=-1):
+def _trailing_edge(arr, pad_amt, axis=-1):
     """
     Append `pad_amt` to `arr` along `axis` by extending edge values.
 
@@ -217,7 +217,7 @@ def _append_edge(arr, pad_amt, axis=-1):
     return edge_arr.repeat(pad_amt, axis=axis)
 
 
-def _prepend_ramp(arr, pad_amt, end, axis=-1):
+def _leading_ramp(arr, pad_amt, end, axis=-1):
     """
     Prepend linear ramp along `axis`.
 
@@ -267,7 +267,7 @@ def _prepend_ramp(arr, pad_amt, end, axis=-1):
     return ramp_arr
 
 
-def _append_ramp(arr, pad_amt, end, axis=-1):
+def _trailing_ramp(arr, pad_amt, end, axis=-1):
     """
     Append linear ramp along `axis`.
 
@@ -317,7 +317,7 @@ def _append_ramp(arr, pad_amt, end, axis=-1):
     return ramp_arr
 
 
-def _prepend_max(arr, pad_amt, num, axis=-1):
+def _leading_max(arr, pad_amt, num, axis=-1):
     """
     Prepend `pad_amt` maximum values along `axis`.
 
@@ -346,7 +346,7 @@ def _prepend_max(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _prepend_edge(arr, pad_amt, axis)
+        return _leading_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -363,7 +363,7 @@ def _prepend_max(arr, pad_amt, num, axis=-1):
     return max_chunk.repeat(pad_amt, axis=axis)
 
 
-def _append_max(arr, pad_amt, num, axis=-1):
+def _trailing_max(arr, pad_amt, num, axis=-1):
     """
     Pad one `axis` of `arr` with the maximum of the last `num` elements.
 
@@ -391,7 +391,7 @@ def _append_max(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _append_edge(arr, pad_amt, axis)
+        return _trailing_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -411,7 +411,7 @@ def _append_max(arr, pad_amt, num, axis=-1):
     return max_chunk.repeat(pad_amt, axis=axis)
 
 
-def _prepend_mean(arr, pad_amt, num, axis=-1):
+def _leading_mean(arr, pad_amt, num, axis=-1):
     """
     Prepend `pad_amt` mean values along `axis`.
 
@@ -439,7 +439,7 @@ def _prepend_mean(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _prepend_edge(arr, pad_amt, axis)
+        return _leading_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -457,7 +457,7 @@ def _prepend_mean(arr, pad_amt, num, axis=-1):
     return mean_chunk.repeat(pad_amt, axis)
 
 
-def _append_mean(arr, pad_amt, num, axis=-1):
+def _trailing_mean(arr, pad_amt, num, axis=-1):
     """
     Append `pad_amt` mean values along `axis`.
 
@@ -485,7 +485,7 @@ def _append_mean(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _append_edge(arr, pad_amt, axis)
+        return _trailing_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -506,7 +506,7 @@ def _append_mean(arr, pad_amt, num, axis=-1):
     return mean_chunk.repeat(pad_amt, axis)
 
 
-def _prepend_med(arr, pad_amt, num, axis=-1):
+def _leading_med(arr, pad_amt, num, axis=-1):
     """
     Prepend `pad_amt` median values along `axis`.
 
@@ -534,7 +534,7 @@ def _prepend_med(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _prepend_edge(arr, pad_amt, axis)
+        return _leading_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -552,7 +552,7 @@ def _prepend_med(arr, pad_amt, num, axis=-1):
     return med_chunk.repeat(pad_amt, axis)
 
 
-def _append_med(arr, pad_amt, num, axis=-1):
+def _trailing_med(arr, pad_amt, num, axis=-1):
     """
     Append `pad_amt` median values along `axis`.
 
@@ -580,7 +580,7 @@ def _append_med(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _append_edge(arr, pad_amt, axis)
+        return _trailing_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -601,7 +601,7 @@ def _append_med(arr, pad_amt, num, axis=-1):
     return med_chunk.repeat(pad_amt, axis)
 
 
-def _prepend_min(arr, pad_amt, num, axis=-1):
+def _leading_min(arr, pad_amt, num, axis=-1):
     """
     Prepend `pad_amt` minimum values along `axis`.
 
@@ -630,7 +630,7 @@ def _prepend_min(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _prepend_edge(arr, pad_amt, axis)
+        return _leading_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -647,7 +647,7 @@ def _prepend_min(arr, pad_amt, num, axis=-1):
     return min_chunk.repeat(pad_amt, axis)
 
 
-def _append_min(arr, pad_amt, num, axis=-1):
+def _trailing_min(arr, pad_amt, num, axis=-1):
     """
     Append `pad_amt` median values along `axis`.
 
@@ -675,7 +675,7 @@ def _append_min(arr, pad_amt, num, axis=-1):
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
-        return _append_edge(arr, pad_amt, axis)
+        return _trailing_edge(arr, pad_amt, axis)
 
     # Use entire array if `num` is too large
     if num is not None:
@@ -1272,37 +1272,37 @@ def pad(array, pad_width, mode, **kwargs):
     if mode == 'constant':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['constant_values'])):
-            newmat = _do_prepend(newmat, _prepend_const(newmat, pad_before, before_val, axis), axis)
-            newmat = _do_append(newmat, _append_const(newmat, pad_after, after_val, axis), axis)
+            newmat = _do_prepend(newmat, _leading_const(newmat, pad_before, before_val, axis), axis)
+            newmat = _do_append(newmat, _trailing_const(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'edge':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
-            newmat = _do_prepend(newmat, _prepend_edge(newmat, pad_before, axis), axis)
-            newmat = _do_append(newmat, _append_edge(newmat, pad_after, axis), axis)
+            newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
+            newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
 
     elif mode == 'linear_ramp':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['end_values'])):
-            newmat = _do_prepend(newmat, _prepend_ramp(newmat, pad_before, before_val, axis), axis)
-            newmat = _do_append(newmat, _append_ramp(newmat, pad_after, after_val, axis), axis)
+            newmat = _do_prepend(newmat, _leading_ramp(newmat, pad_before, before_val, axis), axis)
+            newmat = _do_append(newmat, _trailing_ramp(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'maximum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _prepend_max(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _append_max(newmat, pad_after, chunk_after, axis), axis)
+            newmat = _do_prepend(newmat, _leading_max(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _trailing_max(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'mean':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _prepend_mean(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _append_mean(newmat, pad_after, chunk_after, axis), axis)
+            newmat = _do_prepend(newmat, _leading_mean(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _trailing_mean(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'median':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _prepend_med(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _append_med(newmat, pad_after, chunk_after, axis), axis)
+            newmat = _do_prepend(newmat, _leading_med(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _trailing_med(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'minimum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
@@ -1327,8 +1327,8 @@ def pad(array, pad_width, mode, **kwargs):
                     (pad_after > 0)) and newmat.shape[axis] == 1:
                 # Extending singleton dimension for 'reflect' is legacy
                 # behavior; it really should raise an error.
-                newmat = _do_prepend(newmat, _prepend_edge(newmat, pad_before, axis), axis)
-                newmat = _do_append(newmat, _append_edge(newmat, pad_after, axis), axis)
+                newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
+                newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
                 continue
 
             method = kwargs['reflect_type']

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -125,8 +125,6 @@ def _leading_const(arr, pad_amt, val, axis=-1):
         Output array, with `pad_amt` constant `val` along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
     return np.full(padshape, val, dtype=arr.dtype)
@@ -154,8 +152,6 @@ def _trailing_const(arr, pad_amt, val, axis=-1):
         Output array, with `pad_amt` constant `val` along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
     return np.full(padshape, val, dtype=arr.dtype)
@@ -181,9 +177,6 @@ def _leading_edge(arr, pad_amt, axis=-1):
         Output array, with `pad_amt` edge values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
-
     edge_slice = _slice_first(arr.shape, 1, axis=axis)
     edge_arr = arr[edge_slice]
     return edge_arr.repeat(pad_amt, axis=axis)
@@ -208,9 +201,6 @@ def _trailing_edge(arr, pad_amt, axis=-1):
         Output array, with `pad_amt` edge values  along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
-
     edge_slice = _slice_last(arr.shape, 1, axis=axis)
     edge_arr = arr[edge_slice]
     return edge_arr.repeat(pad_amt, axis=axis)
@@ -239,9 +229,6 @@ def _leading_ramp(arr, pad_amt, end, axis=-1):
         This ramps linearly from the edge value to `end`.
 
     """
-    if pad_amt == 0:
-        return arr
-
     # Generate shape for final concatenated array
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
@@ -289,9 +276,6 @@ def _trailing_ramp(arr, pad_amt, end, axis=-1):
         This ramps linearly from the edge value to `end`.
 
     """
-    if pad_amt == 0:
-        return arr
-
     # Generate shape for final concatenated array
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
@@ -339,8 +323,6 @@ def _leading_max(arr, pad_amt, num, axis=-1):
         This is the maximum of the first `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -384,9 +366,6 @@ def _trailing_max(arr, pad_amt, num, axis=-1):
         This is the maximum of the final `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
-
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
         return _trailing_edge(arr, pad_amt, axis)
@@ -432,8 +411,6 @@ def _leading_mean(arr, pad_amt, num, axis=-1):
         This is the mean of the first `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -478,8 +455,6 @@ def _trailing_mean(arr, pad_amt, num, axis=-1):
         This is the maximum of the final `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -527,8 +502,6 @@ def _leading_med(arr, pad_amt, num, axis=-1):
         This is the median of the first `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -573,8 +546,6 @@ def _trailing_med(arr, pad_amt, num, axis=-1):
         This is the median of the final `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -622,8 +593,6 @@ def _leading_min(arr, pad_amt, num, axis=-1):
         This is the minimum of the first `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -667,8 +636,6 @@ def _trailing_min(arr, pad_amt, num, axis=-1):
         This is the minimum of the final `num` values along `axis`.
 
     """
-    if pad_amt == 0:
-        return arr
 
     # Equivalent to edge padding for single value, so do that instead
     if num == 1:
@@ -1269,43 +1236,57 @@ def pad(array, pad_width, mode, **kwargs):
     if mode == 'constant':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['constant_values'])):
-            newmat = _do_prepend(newmat, _leading_const(newmat, pad_before, before_val, axis), axis)
-            newmat = _do_append(newmat, _trailing_const(newmat, pad_after, after_val, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_const(newmat, pad_before, before_val, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_const(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'edge':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
-            newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
-            newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
 
     elif mode == 'linear_ramp':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['end_values'])):
-            newmat = _do_prepend(newmat, _leading_ramp(newmat, pad_before, before_val, axis), axis)
-            newmat = _do_append(newmat, _trailing_ramp(newmat, pad_after, after_val, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_ramp(newmat, pad_before, before_val, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_ramp(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'maximum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _leading_max(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _trailing_max(newmat, pad_after, chunk_after, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_max(newmat, pad_before, chunk_before, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_max(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'mean':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _leading_mean(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _trailing_mean(newmat, pad_after, chunk_after, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_mean(newmat, pad_before, chunk_before, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_mean(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'median':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _leading_med(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _trailing_med(newmat, pad_after, chunk_after, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_med(newmat, pad_before, chunk_before, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_med(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'minimum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _do_prepend(newmat, _leading_min(newmat, pad_before, chunk_before, axis), axis)
-            newmat = _do_append(newmat, _trailing_min(newmat, pad_after, chunk_after, axis), axis)
+            if pad_before:
+                newmat = _do_prepend(newmat, _leading_min(newmat, pad_before, chunk_before, axis), axis)
+            if pad_after:
+                newmat = _do_append(newmat, _trailing_min(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'reflect':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
@@ -1324,8 +1305,10 @@ def pad(array, pad_width, mode, **kwargs):
                     (pad_after > 0)) and newmat.shape[axis] == 1:
                 # Extending singleton dimension for 'reflect' is legacy
                 # behavior; it really should raise an error.
-                newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
-                newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
+                if pad_before:
+                    newmat = _do_prepend(newmat, _leading_edge(newmat, pad_before, axis), axis)
+                if pad_after:
+                    newmat = _do_append(newmat, _trailing_edge(newmat, pad_after, axis), axis)
                 continue
 
             method = kwargs['reflect_type']

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -105,7 +105,7 @@ def _do_append(arr, pad_chunk, axis):
 
 def _leading_const(arr, pad_amt, val, axis=-1):
     """
-    Prepend constant `val` along `axis` of `arr`.
+    Get a constant array of `val` to prepend along `axis` of `arr`.
 
     Parameters
     ----------
@@ -122,7 +122,7 @@ def _leading_const(arr, pad_amt, val, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` constant `val` prepended along `axis`.
+        Output array, with `pad_amt` constant `val` along `axis`.
 
     """
     if pad_amt == 0:
@@ -134,7 +134,7 @@ def _leading_const(arr, pad_amt, val, axis=-1):
 
 def _trailing_const(arr, pad_amt, val, axis=-1):
     """
-    Append constant `val` along `axis` of `arr`.
+    Get a constant array of `val` to append along `axis` of `arr`.
 
     Parameters
     ----------
@@ -151,7 +151,7 @@ def _trailing_const(arr, pad_amt, val, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` constant `val` appended along `axis`.
+        Output array, with `pad_amt` constant `val` along `axis`.
 
     """
     if pad_amt == 0:
@@ -164,7 +164,7 @@ def _trailing_const(arr, pad_amt, val, axis=-1):
 
 def _leading_edge(arr, pad_amt, axis=-1):
     """
-    Prepend `pad_amt` to `arr` along `axis` by extending edge values.
+    Get an array of `pad_amt` extended edge values to prepend to `arr` along `axis`
 
     Parameters
     ----------
@@ -178,7 +178,7 @@ def _leading_edge(arr, pad_amt, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, extended by `pad_amt` edge values appended along `axis`.
+        Output array, with `pad_amt` edge values along `axis`.
 
     """
     if pad_amt == 0:
@@ -191,7 +191,7 @@ def _leading_edge(arr, pad_amt, axis=-1):
 
 def _trailing_edge(arr, pad_amt, axis=-1):
     """
-    Append `pad_amt` to `arr` along `axis` by extending edge values.
+    Get an array of `pad_amt` extended edge values to append to `arr` along `axis`
 
     Parameters
     ----------
@@ -205,8 +205,7 @@ def _trailing_edge(arr, pad_amt, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, extended by `pad_amt` edge values prepended along
-        `axis`.
+        Output array, with `pad_amt` edge values  along `axis`.
 
     """
     if pad_amt == 0:
@@ -219,7 +218,7 @@ def _trailing_edge(arr, pad_amt, axis=-1):
 
 def _leading_ramp(arr, pad_amt, end, axis=-1):
     """
-    Prepend linear ramp along `axis`.
+    Get a linear ramp to prepend along `axis`.
 
     Parameters
     ----------
@@ -236,8 +235,8 @@ def _leading_ramp(arr, pad_amt, end, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values prepended along `axis`. The
-        prepended region ramps linearly from the edge value to `end`.
+        Output array, with `pad_amt` values along `axis`.
+        This ramps linearly from the edge value to `end`.
 
     """
     if pad_amt == 0:
@@ -269,7 +268,7 @@ def _leading_ramp(arr, pad_amt, end, axis=-1):
 
 def _trailing_ramp(arr, pad_amt, end, axis=-1):
     """
-    Append linear ramp along `axis`.
+    Get a linear ramp to append along `axis`.
 
     Parameters
     ----------
@@ -286,8 +285,8 @@ def _trailing_ramp(arr, pad_amt, end, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        appended region ramps linearly from the edge value to `end`.
+        Output array, with `pad_amt` values along `axis`.
+        This ramps linearly from the edge value to `end`.
 
     """
     if pad_amt == 0:
@@ -319,7 +318,7 @@ def _trailing_ramp(arr, pad_amt, end, axis=-1):
 
 def _leading_max(arr, pad_amt, num, axis=-1):
     """
-    Prepend `pad_amt` maximum values along `axis`.
+    Get `pad_amt` maximum values to prepend along `axis`.
 
     Parameters
     ----------
@@ -336,9 +335,8 @@ def _leading_max(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        prepended region is the maximum of the first `num` values along
-        `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the maximum of the first `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -365,7 +363,7 @@ def _leading_max(arr, pad_amt, num, axis=-1):
 
 def _trailing_max(arr, pad_amt, num, axis=-1):
     """
-    Pad one `axis` of `arr` with the maximum of the last `num` elements.
+    Get `pad_amt` maximum values to append along `axis`.
 
     Parameters
     ----------
@@ -382,8 +380,8 @@ def _trailing_max(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        appended region is the maximum of the final `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the maximum of the final `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -413,7 +411,7 @@ def _trailing_max(arr, pad_amt, num, axis=-1):
 
 def _leading_mean(arr, pad_amt, num, axis=-1):
     """
-    Prepend `pad_amt` mean values along `axis`.
+    Get `pad_amt` mean values to prepend along `axis`.
 
     Parameters
     ----------
@@ -430,8 +428,8 @@ def _leading_mean(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values prepended along `axis`. The
-        prepended region is the mean of the first `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the mean of the first `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -459,7 +457,7 @@ def _leading_mean(arr, pad_amt, num, axis=-1):
 
 def _trailing_mean(arr, pad_amt, num, axis=-1):
     """
-    Append `pad_amt` mean values along `axis`.
+    Get `pad_amt` mean values to append along `axis`.
 
     Parameters
     ----------
@@ -476,8 +474,8 @@ def _trailing_mean(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        appended region is the maximum of the final `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the maximum of the final `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -508,7 +506,7 @@ def _trailing_mean(arr, pad_amt, num, axis=-1):
 
 def _leading_med(arr, pad_amt, num, axis=-1):
     """
-    Prepend `pad_amt` median values along `axis`.
+    Get `pad_amt` median values to prepend along `axis`.
 
     Parameters
     ----------
@@ -525,8 +523,8 @@ def _leading_med(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values prepended along `axis`. The
-        prepended region is the median of the first `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the median of the first `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -554,7 +552,7 @@ def _leading_med(arr, pad_amt, num, axis=-1):
 
 def _trailing_med(arr, pad_amt, num, axis=-1):
     """
-    Append `pad_amt` median values along `axis`.
+    Get `pad_amt` median values to append along `axis`.
 
     Parameters
     ----------
@@ -571,8 +569,8 @@ def _trailing_med(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        appended region is the median of the final `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the median of the final `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -603,7 +601,7 @@ def _trailing_med(arr, pad_amt, num, axis=-1):
 
 def _leading_min(arr, pad_amt, num, axis=-1):
     """
-    Prepend `pad_amt` minimum values along `axis`.
+    Get `pad_amt` minimum values to prepend along `axis`.
 
     Parameters
     ----------
@@ -620,9 +618,8 @@ def _leading_min(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values prepended along `axis`. The
-        prepended region is the minimum of the first `num` values along
-        `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the minimum of the first `num` values along `axis`.
 
     """
     if pad_amt == 0:
@@ -649,7 +646,7 @@ def _leading_min(arr, pad_amt, num, axis=-1):
 
 def _trailing_min(arr, pad_amt, num, axis=-1):
     """
-    Append `pad_amt` median values along `axis`.
+    Get `pad_amt` median values to append along `axis`.
 
     Parameters
     ----------
@@ -666,8 +663,8 @@ def _trailing_min(arr, pad_amt, num, axis=-1):
     Returns
     -------
     padarr : ndarray
-        Output array, with `pad_amt` values appended along `axis`. The
-        appended region is the minimum of the final `num` values along `axis`.
+        Output array, with `pad_amt` values along `axis`.
+        This is the minimum of the final `num` values along `axis`.
 
     """
     if pad_amt == 0:

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -129,7 +129,7 @@ def _prepend_const(arr, pad_amt, val, axis=-1):
         return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
-    return _do_prepend(arr, np.full(padshape, val, dtype=arr.dtype), axis)
+    return np.full(padshape, val, dtype=arr.dtype)
 
 
 def _append_const(arr, pad_amt, val, axis=-1):
@@ -158,7 +158,7 @@ def _append_const(arr, pad_amt, val, axis=-1):
         return arr
     padshape = tuple(x if i != axis else pad_amt
                      for (i, x) in enumerate(arr.shape))
-    return _do_append(arr, np.full(padshape, val, dtype=arr.dtype), axis)
+    return np.full(padshape, val, dtype=arr.dtype)
 
 
 
@@ -186,7 +186,7 @@ def _prepend_edge(arr, pad_amt, axis=-1):
 
     edge_slice = _slice_first(arr.shape, 1, axis=axis)
     edge_arr = arr[edge_slice]
-    return _do_prepend(arr, edge_arr.repeat(pad_amt, axis=axis), axis)
+    return edge_arr.repeat(pad_amt, axis=axis)
 
 
 def _append_edge(arr, pad_amt, axis=-1):
@@ -214,7 +214,7 @@ def _append_edge(arr, pad_amt, axis=-1):
 
     edge_slice = _slice_last(arr.shape, 1, axis=axis)
     edge_arr = arr[edge_slice]
-    return _do_append(arr, edge_arr.repeat(pad_amt, axis=axis), axis)
+    return edge_arr.repeat(pad_amt, axis=axis)
 
 
 def _prepend_ramp(arr, pad_amt, end, axis=-1):
@@ -264,7 +264,7 @@ def _prepend_ramp(arr, pad_amt, end, axis=-1):
     _round_ifneeded(ramp_arr, arr.dtype)
 
     # Ramp values will most likely be float, cast them to the same type as arr
-    return _do_prepend(arr, ramp_arr, axis)
+    return ramp_arr
 
 
 def _append_ramp(arr, pad_amt, end, axis=-1):
@@ -314,7 +314,7 @@ def _append_ramp(arr, pad_amt, end, axis=-1):
     _round_ifneeded(ramp_arr, arr.dtype)
 
     # Ramp values will most likely be float, cast them to the same type as arr
-    return _do_append(arr, ramp_arr, axis)
+    return ramp_arr
 
 
 def _prepend_max(arr, pad_amt, num, axis=-1):
@@ -359,8 +359,8 @@ def _prepend_max(arr, pad_amt, num, axis=-1):
     # Extract slice, calculate max
     max_chunk = arr[max_slice].max(axis=axis, keepdims=True)
 
-    # Concatenate `arr` with `max_chunk`, extended along `axis` by `pad_amt`
-    return _do_prepend(arr, max_chunk.repeat(pad_amt, axis=axis), axis)
+    # Extend along `axis` by `pad_amt`
+    return max_chunk.repeat(pad_amt, axis=axis)
 
 
 def _append_max(arr, pad_amt, num, axis=-1):
@@ -407,8 +407,8 @@ def _append_max(arr, pad_amt, num, axis=-1):
     # Extract slice, calculate max
     max_chunk = arr[max_slice].max(axis=axis, keepdims=True)
 
-    # Concatenate `arr` with `max_chunk`, extended along `axis` by `pad_amt`
-    return _do_append(arr, max_chunk.repeat(pad_amt, axis=axis), axis)
+    # Extend along `axis` by `pad_amt`
+    return max_chunk.repeat(pad_amt, axis=axis)
 
 
 def _prepend_mean(arr, pad_amt, num, axis=-1):
@@ -453,8 +453,8 @@ def _prepend_mean(arr, pad_amt, num, axis=-1):
     mean_chunk = arr[mean_slice].mean(axis, keepdims=True)
     _round_ifneeded(mean_chunk, arr.dtype)
 
-    # Concatenate `arr` with `mean_chunk`, extended along `axis` by `pad_amt`
-    return _do_prepend(arr, mean_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return mean_chunk.repeat(pad_amt, axis)
 
 
 def _append_mean(arr, pad_amt, num, axis=-1):
@@ -502,8 +502,8 @@ def _append_mean(arr, pad_amt, num, axis=-1):
     mean_chunk = arr[mean_slice].mean(axis=axis, keepdims=True)
     _round_ifneeded(mean_chunk, arr.dtype)
 
-    # Concatenate `arr` with `mean_chunk`, extended along `axis` by `pad_amt`
-    return _do_append(arr, mean_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return mean_chunk.repeat(pad_amt, axis)
 
 
 def _prepend_med(arr, pad_amt, num, axis=-1):
@@ -548,8 +548,8 @@ def _prepend_med(arr, pad_amt, num, axis=-1):
     med_chunk = np.median(arr[med_slice], axis=axis, keepdims=True)
     _round_ifneeded(med_chunk, arr.dtype)
 
-    # Concatenate `arr` with `med_chunk`, extended along `axis` by `pad_amt`
-    return _do_prepend(arr, med_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return med_chunk.repeat(pad_amt, axis)
 
 
 def _append_med(arr, pad_amt, num, axis=-1):
@@ -597,8 +597,8 @@ def _append_med(arr, pad_amt, num, axis=-1):
     med_chunk = np.median(arr[med_slice], axis=axis, keepdims=True)
     _round_ifneeded(med_chunk, arr.dtype)
 
-    # Concatenate `arr` with `med_chunk`, extended along `axis` by `pad_amt`
-    return _do_append(arr, med_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return med_chunk.repeat(pad_amt, axis)
 
 
 def _prepend_min(arr, pad_amt, num, axis=-1):
@@ -643,8 +643,8 @@ def _prepend_min(arr, pad_amt, num, axis=-1):
     # Extract slice, calculate min
     min_chunk = arr[min_slice].min(axis=axis, keepdims=True)
 
-    # Concatenate `arr` with `min_chunk`, extended along `axis` by `pad_amt`
-    return _do_prepend(arr, min_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return min_chunk.repeat(pad_amt, axis)
 
 
 def _append_min(arr, pad_amt, num, axis=-1):
@@ -691,8 +691,8 @@ def _append_min(arr, pad_amt, num, axis=-1):
     # Extract slice, calculate min
     min_chunk = arr[min_slice].min(axis=axis, keepdims=True)
 
-    # Concatenate `arr` with `min_chunk`, extended along `axis` by `pad_amt`
-    return _do_append(arr, min_chunk.repeat(pad_amt, axis), axis=axis)
+    # Extend along `axis` by `pad_amt`
+    return min_chunk.repeat(pad_amt, axis)
 
 
 def _pad_ref(arr, pad_amt, method, axis=-1):
@@ -1272,43 +1272,43 @@ def pad(array, pad_width, mode, **kwargs):
     if mode == 'constant':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['constant_values'])):
-            newmat = _prepend_const(newmat, pad_before, before_val, axis)
-            newmat = _append_const(newmat, pad_after, after_val, axis)
+            newmat = _do_prepend(newmat, _prepend_const(newmat, pad_before, before_val, axis), axis)
+            newmat = _do_append(newmat, _append_const(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'edge':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
-            newmat = _prepend_edge(newmat, pad_before, axis)
-            newmat = _append_edge(newmat, pad_after, axis)
+            newmat = _do_prepend(newmat, _prepend_edge(newmat, pad_before, axis), axis)
+            newmat = _do_append(newmat, _append_edge(newmat, pad_after, axis), axis)
 
     elif mode == 'linear_ramp':
         for axis, ((pad_before, pad_after), (before_val, after_val)) \
                 in enumerate(zip(pad_width, kwargs['end_values'])):
-            newmat = _prepend_ramp(newmat, pad_before, before_val, axis)
-            newmat = _append_ramp(newmat, pad_after, after_val, axis)
+            newmat = _do_prepend(newmat, _prepend_ramp(newmat, pad_before, before_val, axis), axis)
+            newmat = _do_append(newmat, _append_ramp(newmat, pad_after, after_val, axis), axis)
 
     elif mode == 'maximum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_max(newmat, pad_before, chunk_before, axis)
-            newmat = _append_max(newmat, pad_after, chunk_after, axis)
+            newmat = _do_prepend(newmat, _prepend_max(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _append_max(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'mean':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_mean(newmat, pad_before, chunk_before, axis)
-            newmat = _append_mean(newmat, pad_after, chunk_after, axis)
+            newmat = _do_prepend(newmat, _prepend_mean(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _append_mean(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'median':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_med(newmat, pad_before, chunk_before, axis)
-            newmat = _append_med(newmat, pad_after, chunk_after, axis)
+            newmat = _do_prepend(newmat, _prepend_med(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _append_med(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'minimum':
         for axis, ((pad_before, pad_after), (chunk_before, chunk_after)) \
                 in enumerate(zip(pad_width, kwargs['stat_length'])):
-            newmat = _prepend_min(newmat, pad_before, chunk_before, axis)
-            newmat = _append_min(newmat, pad_after, chunk_after, axis)
+            newmat = _do_prepend(newmat, _leading_min(newmat, pad_before, chunk_before, axis), axis)
+            newmat = _do_append(newmat, _trailing_min(newmat, pad_after, chunk_after, axis), axis)
 
     elif mode == 'reflect':
         for axis, (pad_before, pad_after) in enumerate(pad_width):
@@ -1327,8 +1327,8 @@ def pad(array, pad_width, mode, **kwargs):
                     (pad_after > 0)) and newmat.shape[axis] == 1:
                 # Extending singleton dimension for 'reflect' is legacy
                 # behavior; it really should raise an error.
-                newmat = _prepend_edge(newmat, pad_before, axis)
-                newmat = _append_edge(newmat, pad_after, axis)
+                newmat = _do_prepend(newmat, _prepend_edge(newmat, pad_before, axis), axis)
+                newmat = _do_append(newmat, _append_edge(newmat, pad_after, axis), axis)
                 continue
 
             method = kwargs['reflect_type']


### PR DESCRIPTION
This might make it easier to make small refactors towards #11126 - this aims to be a much lower surface-area change.

This change should affect neither performance nor result.