### PR TITLE
ENH: mark that large allocations can use huge pages

### DIFF
--- a/benchmarks/benchmarks/bench_io.py
+++ b/benchmarks/benchmarks/bench_io.py
@@ -21,6 +21,10 @@ class Copy(Benchmark):
     def time_memcpy(self, typename):
         self.d[...] = self.e_d
 
+    def time_memcpy_large_out_of_place(self, typename):
+        l = np.ones(1024**2, dtype=np.dtype(typename))
+        l.copy()
+
     def time_cont_assign(self, typename):
         self.d[...] = 1
 

--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -133,6 +133,21 @@ The ``help`` function, when applied to numeric types such as `np.intc`,
 `np.int_`, and `np.longlong`, now lists all of the aliased names for that type,
 distinguishing between platform -dependent and -independent aliases.
 
+Large allocations marked as suitable for transparent hugepages
+--------------------------------------------------------------
+On systems that support transparent hugepages over the madvise system call
+numpy now marks that large memory allocations can be backed by hugepages which
+reduces page fault overhead and can in some fault heavy cases improve
+performance significantly.
+On Linux for huge pages to be used the setting
+`/sys/kernel/mm/transparent_hugepage/enabled` must be at least `madvise`.
+Systems which already have it set to `always` will not see much difference as
+the kernel will automatically use huge pages where appropriate.
+
+Users of very old Linux kernels (~3.x and older) should make sure that
+`/sys/kernel/mm/transparent_hugepage/defrag` is not set to `always` to avoid
+performance problems due concurrency issues in the memory defragmentation.
+
 
 Changes
 =======

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -153,7 +153,8 @@ def check_math_capabilities(config, moredefs, mathlibs):
 
     for h in OPTIONAL_HEADERS:
         if config.check_func("", decl=False, call=False, headers=[h]):
-            moredefs.append((fname2def(h).replace(".", "_"), 1))
+            h = h.replace(".", "_").replace(os.path.sep, "_")
+            moredefs.append((fname2def(h), 1))
 
     for tup in OPTIONAL_INTRINSICS:
         headers = None

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -110,7 +110,7 @@ OPTIONAL_STDFUNCS = ["expm1", "log1p", "acosh", "asinh", "atanh",
         "rint", "trunc", "exp2", "log2", "hypot", "atan2", "pow",
         "copysign", "nextafter", "ftello", "fseeko",
         "strtoll", "strtoull", "cbrt", "strtold_l", "fallocate",
-        "backtrace"]
+        "backtrace", "madvise"]
 
 
 OPTIONAL_HEADERS = [
@@ -120,6 +120,7 @@ OPTIONAL_HEADERS = [
                 "features.h",  # for glibc version linux
                 "xlocale.h",  # see GH#8367
                 "dlfcn.h", # dladdr
+                "sys/mman.h", #madvise
 ]
 
 # optional gcc compiler builtins and their call arguments and optional a


### PR DESCRIPTION
On distributions with `/sys/kernel/mm/transparent_hugepage/enabled` set to
madvise we do not automatically get our memory backed by huge pages.
Explicitly madvise these regions so they can use larger pages.

This improves performance of the common large array allocation/free
cycle in numpy as page fault overhead is reduced.

    asv continuous -E virtualenv:3.6 --bench bench_io.Copy HEAD^ HEAD

      2.64±0.3ms      1.99±0.06ms     0.75  bench_io.Copy.time_memcpy_large_out_of_place('float32')
      5.51±0.2ms       3.74±0.3ms     0.68  bench_io.Copy.time_memcpy_large_out_of_place('float64')
     4.76±0.02μs      3.02±0.04μs     0.63  bench_io.Copy.time_cont_assign('float32')
      5.55±0.1ms       3.31±0.1ms     0.60  bench_io.Copy.time_memcpy_large_out_of_place('complex64')
      11.3±0.2ms       6.26±0.2ms     0.56  bench_io.Copy.time_memcpy_large_out_of_place('complex128')

Closes gh-11919
