### PR TITLE
TST: Add a test for np.pad where constant_values is an object

### DIFF
--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -511,7 +511,7 @@ class TestConstant(object):
         arr = np.pad(arr, pad_width=1, mode='constant',
                      constant_values=(obj_b, obj_c))
 
-        expected = np.empty((3, ), dtype=object)
+        expected = np.empty((3,), dtype=object)
         expected[0] = obj_b
         expected[1] = obj_a
         expected[2] = obj_c

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -507,13 +507,15 @@ class TestConstant(object):
         obj_a = object()
         arr[0] = obj_a
         obj_b = object()
-        arr = np.pad(arr, pad_width=1, mode='constant', constant_values=obj_b)
+        obj_c = object()
+        arr = np.pad(arr, pad_width=1, mode='constant',
+                     constant_values=(obj_b, obj_c))
 
         expected = np.empty((3, ), dtype=object)
         expected[0] = obj_b
         expected[1] = obj_a
-        expected[2] = obj_b
-        
+        expected[2] = obj_c
+
         assert_array_equal(arr, expected)
 
 class TestLinearRamp(object):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -502,6 +502,16 @@ class TestConstant(object):
         expected = np.full(7, int64_max, dtype=np.int64)
         assert_array_equal(test, expected)
 
+    def test_check_object_array(self):
+        arr = np.empty(1, dtype=object)
+        obj = object()
+        arr = np.pad(arr, pad_width=1, mode='constant', constant_values=obj)
+
+        expected = np.empty((3, ), dtype=object)
+        expected[...] = obj
+        expected[1] = None
+
+        assert_array_equal(arr, expected)
 
 class TestLinearRamp(object):
     def test_check_simple(self):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -504,13 +504,16 @@ class TestConstant(object):
 
     def test_check_object_array(self):
         arr = np.empty(1, dtype=object)
-        obj = object()
-        arr = np.pad(arr, pad_width=1, mode='constant', constant_values=obj)
+        obj_a = object()
+        arr[0] = obj_a
+        obj_b = object()
+        arr = np.pad(arr, pad_width=1, mode='constant', constant_values=obj_b)
 
         expected = np.empty((3, ), dtype=object)
-        expected[...] = obj
-        expected[1] = None
-
+        expected[0] = obj_b
+        expected[1] = obj_a
+        expected[2] = obj_b
+        
         assert_array_equal(arr, expected)
 
 class TestLinearRamp(object):


### PR DESCRIPTION
Relates to https://github.com/numpy/numpy/pull/11358#discussion_r217890065

Padding an array of objects used to be supported.
This PR aims to immortalize that requirement in a test. 

cc: @lagru @eric-wieser 