### PR TITLE
MAINT: Explicitely cause pagefaults to happen before starting the benchmarks

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -60,3 +60,11 @@ Some things to consider:
 - Preparing arrays etc. should generally be put in the ``setup`` method rather
   than the ``time_`` methods, to avoid counting preparation time together with
   the time of the benchmarked operation.
+
+- Be mindful that large arrays created with ``np.empty`` or ``np.zeros`` might
+  not be allocated in physical memory until the memory is accessed. If this is
+  desired behaviour, make sure to comment it in your setup function. If
+  you are benchmarking an algorithm, it is unlikely that a user will be
+  executing said algorithm on a newly created empty/zero array. One can force
+  pagefaults to occur in the setup phase either by calling ``np.ones`` or
+  ``arr.fill(value)`` after creating the array,

--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -19,7 +19,10 @@ class Pad(Benchmark):
     ]
 
     def setup(self, shape, pad_width, mode):
-        self.array = np.empty(shape)
+        # avoid np.zeros or np.empty's lazy allocation.
+        # np.full causes pagefaults to occur during setup
+        # instead of during the benchmark
+        self.array = np.full(shape, 0)
 
     def time_pad(self, shape, pad_width, mode):
         np.pad(self.array, pad_width, mode)

--- a/benchmarks/benchmarks/bench_ma.py
+++ b/benchmarks/benchmarks/bench_ma.py
@@ -89,7 +89,9 @@ class Concatenate(Benchmark):
     ]
 
     def setup(self, mode, n):
-        normal = np.zeros((n, n), int)
+        # avoid np.zeros's lazy allocation that cause page faults during benchmark.
+        # np.fill will cause pagefaults to happen during setup.
+        normal = np.full((n, n), 0, int)
         unmasked = np.ma.zeros((n, n), int)
         masked = np.ma.array(normal, mask=True)
 

--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -29,8 +29,10 @@ class AddReduceSeparate(Benchmark):
 
 class AnyAll(Benchmark):
     def setup(self):
-        self.zeros = np.zeros(100000, bool)
-        self.ones = np.ones(100000, bool)
+        # avoid np.zeros's lazy allocation that would
+        # cause page faults during benchmark
+        self.zeros = np.full(100000, 0, bool)
+        self.ones = np.full(100000, 0, bool)
 
     def time_all_fast(self):
         self.zeros.all()

--- a/benchmarks/benchmarks/bench_shape_base.py
+++ b/benchmarks/benchmarks/bench_shape_base.py
@@ -23,7 +23,9 @@ class Block(Benchmark):
         self.four_1d = np.ones(6 * n)
         self.five_0d = np.ones(1 * n)
         self.six_1d = np.ones(5 * n)
-        self.zero_2d = np.zeros((2 * n, 6 * n))
+        # avoid np.zeros's lazy allocation that might cause
+        # page faults during benchmark
+        self.zero_2d = np.full((2 * n, 6 * n), 0)
 
         self.one = np.ones(3 * n)
         self.two = 2 * np.ones((3, 3 * n))
@@ -31,7 +33,9 @@ class Block(Benchmark):
         self.four = 4 * np.ones(3 * n)
         self.five = 5 * np.ones(1 * n)
         self.six = 6 * np.ones(5 * n)
-        self.zero = np.zeros((2 * n, 6 * n))
+        # avoid np.zeros's lazy allocation that might cause
+        # page faults during benchmark
+        self.zero = np.full((2 * n, 6 * n), 0)
 
     def time_block_simple_row_wise(self, n):
         np.block([self.a_2d, self.b_2d])


### PR DESCRIPTION
This PR ensures that the that simulate the data that will be processed are actually allocated in *physical* memory.

calls to np.empty (malloc) or np.zero (calloc) can often return without actually creating physical memory. Page faults would therefore happen in real time.
Any call that explicitely traverses the memory will cause the OS to finallly allocate the memory.

`np.ones` copies `1` to the memory and therefore cause all the pagefaults to happen during the setup phase.

explicitly  filling or copying a whole array is an other good way to ensure the benchmark doesn't page fault on the *input* array during the timed portion.

Relates to PR #11358