### PR TITLE
MAINT: Rewrite shape normalization in pad function

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -885,105 +885,63 @@ def _pad_wrap(arr, pad_amt, axis=-1):
     return np.concatenate((wrap_chunk1, arr, wrap_chunk2), axis=axis)
 
 
-def _normalize_shape(ndarray, shape, cast_to_int=True):
+def _as_pairs(x, ndim, as_index=False):
     """
-    Private function which does some checks and normalizes the possibly
-    much simpler representations of 'pad_width', 'stat_length',
-    'constant_values', 'end_values'.
+    Broadcast `x` to an array with the shape (`ndim`, 2).
+
+    A helper function for `pad` that prepares and validates arguments like
+    `pad_width` for iteration in pairs.
 
     Parameters
     ----------
-    narray : ndarray
-        Input ndarray
-    shape : {sequence, array_like, float, int}, optional
-        The width of padding (pad_width), the number of elements on the
-        edge of the narray used for statistics (stat_length), the constant
-        value(s) to use when filling padded regions (constant_values), or the
-        endpoint target(s) for linear ramps (end_values).
-        ((before_1, after_1), ... (before_N, after_N)) unique number of
-        elements for each axis where `N` is rank of `narray`.
-        ((before, after),) yields same before and after constants for each
-        axis.
-        (constant,) or val is a shortcut for before = after = constant for
-        all axes.
-    cast_to_int : bool, optional
-        Controls if values in ``shape`` will be rounded and cast to int
-        before being returned.
+    x : {None, scalar, array-like}
+        The object to broadcast to the shape (`ndim`, 2).
+    ndim : int
+        Number of pairs the broadcasted `x` will have.
+    as_index : bool, optional
+        If `x` is not None, try to round each element of `x` to an integer and
+        ensure every element is positive.
 
     Returns
     -------
-    normalized_shape : tuple of tuples
-        val                               => ((val, val), (val, val), ...)
-        [[val1, val2], [val3, val4], ...] => ((val1, val2), (val3, val4), ...)
-        ((val1, val2), (val3, val4), ...) => no change
-        [[val1, val2], ]                  => ((val1, val2), (val1, val2), ...)
-        ((val1, val2), )                  => ((val1, val2), (val1, val2), ...)
-        [[val ,     ], ]                  => ((val, val), (val, val), ...)
-        ((val ,     ), )                  => ((val, val), (val, val), ...)
+    pairs : nested iterables, shape (`ndim`, 2)
+        The broadcasted version of `x`.
 
+    Raises
+    ------
+    ValueError
+        If `as_index` is True and `x` contains negative elements.
+        Or if `x` is not broadcastable to the shape (`ndim`, 2).
     """
-    ndims = ndarray.ndim
+    if x is None:
+        # Pass through None as a special case, otherwise np.round(x) fails
+        # with an AttributeError
+        return ((None, None),) * ndim
 
-    # Shortcut shape=None
-    if shape is None:
-        return ((None, None), ) * ndims
+    x = np.array(x)
 
-    # Convert any input `info` to a NumPy array
-    shape_arr = np.asarray(shape)
+    if as_index:
+        x = np.round(x).astype(np.intp, copy=False)
 
-    try:
-        shape_arr = np.broadcast_to(shape_arr, (ndims, 2))
-    except ValueError:
-        fmt = "Unable to create correctly shaped tuple from %s"
-        raise ValueError(fmt % (shape,))
+    if x.size == 1 and x.ndim < 3:
+        # Use faster path if x was supplied as a single value
+        x = x.ravel()  # Ensure x[0] works for x.ndim == 0, 1, 2
+        if as_index and x < 0:
+            raise ValueError("index can't contain negative values")
+        return ((x[0], x[0]),) * ndim
 
-    # Cast if necessary
-    if cast_to_int is True:
-        shape_arr = np.round(shape_arr).astype(int)
+    if x.size == 2 and x.shape != (2, 1):
+        # Use faster path if x was supplied with a single value for each side
+        # Except special case when each dimension has a single value which
+        # should be broadcasted to a pair, e.g. [[1], [2]] -> [[1, 1], [2, 2]]
+        x = x.ravel()  # Ensure x[0], x[1] works
+        if as_index and (x[0] < 0 or x[1] < 0):
+            raise ValueError("index can't contain negative values")
+        return ((x[0], x[1]),) * ndim
 
-    # Convert list of lists to tuple of tuples
-    return tuple(tuple(axis) for axis in shape_arr.tolist())
-
-
-def _validate_lengths(narray, number_elements):
-    """
-    Private function which does some checks and reformats pad_width and
-    stat_length using _normalize_shape.
-
-    Parameters
-    ----------
-    narray : ndarray
-        Input ndarray
-    number_elements : {sequence, int}, optional
-        The width of padding (pad_width) or the number of elements on the edge
-        of the narray used for statistics (stat_length).
-        ((before_1, after_1), ... (before_N, after_N)) unique number of
-        elements for each axis.
-        ((before, after),) yields same before and after constants for each
-        axis.
-        (constant,) or int is a shortcut for before = after = constant for all
-        axes.
-
-    Returns
-    -------
-    _validate_lengths : tuple of tuples
-        int                               => ((int, int), (int, int), ...)
-        [[int1, int2], [int3, int4], ...] => ((int1, int2), (int3, int4), ...)
-        ((int1, int2), (int3, int4), ...) => no change
-        [[int1, int2], ]                  => ((int1, int2), (int1, int2), ...)
-        ((int1, int2), )                  => ((int1, int2), (int1, int2), ...)
-        [[int ,     ], ]                  => ((int, int), (int, int), ...)
-        ((int ,     ), )                  => ((int, int), (int, int), ...)
-
-    """
-    normshp = _normalize_shape(narray, number_elements)
-    for i in normshp:
-        chk = [1 if x is None else x for x in i]
-        chk = [1 if x >= 0 else -1 for x in chk]
-        if (chk[0] < 0) or (chk[1] < 0):
-            fmt = "%s cannot contain negative values."
-            raise ValueError(fmt % (number_elements,))
-    return normshp
+    if as_index and x.min() < 0:
+            raise ValueError("index can't contain negative values")
+    return np.broadcast_to(x, (ndim, 2)).tolist()
 
 
 ###############################################################################
@@ -1197,7 +1155,7 @@ def pad(array, pad_width, mode, **kwargs):
         raise TypeError('`pad_width` must be of integral type.')
 
     narray = np.array(array)
-    pad_width = _validate_lengths(narray, pad_width)
+    pad_width = _as_pairs(pad_width, narray.ndim, as_index=True)
 
     allowedkwargs = {
         'constant': ['constant_values'],
@@ -1233,10 +1191,9 @@ def pad(array, pad_width, mode, **kwargs):
         # Need to only normalize particular keywords.
         for i in kwargs:
             if i == 'stat_length':
-                kwargs[i] = _validate_lengths(narray, kwargs[i])
+                kwargs[i] = _as_pairs(kwargs[i], narray.ndim, as_index=True)
             if i in ['end_values', 'constant_values']:
-                kwargs[i] = _normalize_shape(narray, kwargs[i],
-                                             cast_to_int=False)
+                kwargs[i] = _as_pairs(kwargs[i], narray.ndim)
     else:
         # Drop back to old, slower np.apply_along_axis mode for user-supplied
         # vector function

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -899,8 +899,8 @@ def _as_pairs(x, ndim, as_index=False):
     ndim : int
         Number of pairs the broadcasted `x` will have.
     as_index : bool, optional
-        If `x` is not None, try to round each element of `x` to an integer and
-        ensure every element is positive.
+        If `x` is not None, try to round each element of `x` to an integer
+        (dtype `np.intp`) and ensure every element is positive.
 
     Returns
     -------
@@ -936,7 +936,7 @@ def _as_pairs(x, ndim, as_index=False):
 
         if x.size == 2 and x.shape != (2, 1):
             # x was supplied with a single value for each side
-            # Except special case when each dimension has a single value
+            # but except case when each dimension has a single value
             # which should be broadcasted to a pair,
             # e.g. [[1], [2]] -> [[1, 1], [2, 2]] not [[1, 2], [1, 2]]
             x = x.ravel()  # Ensure x[0], x[1] works

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -9,6 +9,84 @@ import numpy as np
 from numpy.testing import (assert_array_equal, assert_raises, assert_allclose,
                            assert_equal)
 from numpy.lib import pad
+from numpy.lib.arraypad import _as_pairs
+
+
+class TestAsPairs(object):
+
+    def test_single_value(self):
+        """Test casting for a single value."""
+        expected = np.array([[3, 3]] * 10)
+        for x in (3, [3], [[3]]):
+            result = _as_pairs(x, 10)
+            assert_equal(result, expected)
+        # Test with dtype=object
+        obj = object()
+        assert_equal(
+            _as_pairs(obj, 10),
+            np.array([[obj, obj]] * 10)
+        )
+
+    def test_two_values(self):
+        """Test proper casting for two different values."""
+        expected = np.array([[3, 4]] * 10)
+        for x in ([3, 4], [[3, 4]]):
+            result = _as_pairs(x, 10)
+            assert_equal(result, expected)
+        # Special case: two values should be broadcasted into last dimension
+        assert_equal(
+            _as_pairs([[3], [4]], 2),
+            np.array([[3, 3], [4, 4]])
+        )
+        # With dtype=object
+        obj = object()
+        assert_equal(
+            _as_pairs(["a", obj], 10),
+            np.array([["a", obj]] * 10)
+        )
+
+    def test_with_none(self):
+        expected = ((None, None), (None, None), (None, None))
+        assert_equal(
+            _as_pairs(None, 3, as_index=False),
+            expected
+        )
+        assert_equal(
+            _as_pairs(None, 3, as_index=True),
+            expected
+        )
+
+    def test_pass_through(self):
+        """Test if `x` already matching desired output are passed through."""
+        expected = np.arange(12).reshape((6, 2))
+        assert_equal(
+            _as_pairs(expected, 6),
+            expected
+        )
+
+    def test_as_index(self):
+        """Test results if `as_index=True`."""
+        assert_equal(
+            _as_pairs([2.6, 3.3], 10, as_index=True),
+            np.array([[3, 3]] * 10, dtype=np.intp)
+        )
+        assert_equal(
+            _as_pairs([2.6, 4.49], 10, as_index=True),
+            np.array([[3, 4]] * 10, dtype=np.intp)
+        )
+        for x in (-3, [-3], [[-3]], [-3, 4], [3, -4], [[-3, 4]], [[4, -3]],
+                  [[1, 2]] * 9 + [[1, -2]]):
+            with pytest.raises(ValueError, match="negative values"):
+                _as_pairs(x, 10, as_index=True)
+
+    def test_exceptions(self):
+        """Ensure faulty usage is discovered."""
+        with pytest.raises(ValueError, match="more dimensions than allowed"):
+            _as_pairs([[[3]]], 10)
+        with pytest.raises(ValueError, match="could not be broadcast"):
+            _as_pairs([[1, 2], [3, 4]], 3)
+        with pytest.raises(ValueError, match="could not be broadcast"):
+            _as_pairs(np.ones((2, 3)), 3)
 
 
 class TestConditionalShortcuts(object):
@@ -534,6 +612,7 @@ class TestConstant(object):
         expected[2] = obj_c
 
         assert_array_equal(arr, expected)
+
 
 class TestLinearRamp(object):
     def test_check_simple(self):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -29,20 +29,27 @@ class TestAsPairs(object):
 
     def test_two_values(self):
         """Test proper casting for two different values."""
+        # Broadcasting in the first dimension with numbers
         expected = np.array([[3, 4]] * 10)
         for x in ([3, 4], [[3, 4]]):
             result = _as_pairs(x, 10)
             assert_equal(result, expected)
-        # Special case: two values should be broadcasted into last dimension
-        assert_equal(
-            _as_pairs([[3], [4]], 2),
-            np.array([[3, 3], [4, 4]])
-        )
-        # With dtype=object
+        # and with dtype=object
         obj = object()
         assert_equal(
             _as_pairs(["a", obj], 10),
             np.array([["a", obj]] * 10)
+        )
+
+        # Broadcasting in the second / last dimension with numbers
+        assert_equal(
+            _as_pairs([[3], [4]], 2),
+            np.array([[3, 3], [4, 4]])
+        )
+        # and with dtype=object
+        assert_equal(
+            _as_pairs([["a"], [obj]], 2),
+            np.array([["a", "a"], [obj, obj]])
         )
 
     def test_with_none(self):


### PR DESCRIPTION
Suggested in https://github.com/numpy/numpy/pull/11358#discussion_r217902060.

This rewrite joins the previous functions `_normalize_shape` and `_validate_length` as an intro to larger changes suggested in gh-11126. This function accelerates the benchmarks for `np.pad` by a factor of
0.57 to 0.90.

cc @eric-wieser 

<details>
  <summary>Benchmarks</summary>

```
$ asv continuous -E conda:3.6 -b Pad master pad-as-pairs
       before           after         ratio
     [88c01b8a]       [3a6182a]
     <master>         <pad-as-pairs>
-         134±4μs          120±3μs     0.90  bench_lib.Pad.time_pad((10, 100), 1, 'mean')
-      73.7±0.4μs         63.9±2μs     0.87  bench_lib.Pad.time_pad((10, 10, 10), 1, 'edge')
-         102±2μs         87.9±3μs     0.86  bench_lib.Pad.time_pad((10, 10, 10), 3, 'constant')
-        88.4±2μs         74.0±3μs     0.84  bench_lib.Pad.time_pad((10, 10, 10), 1, 'constant')
-        145±10μs          121±3μs     0.84  bench_lib.Pad.time_pad((10, 100), 3, 'mean')
-        57.2±2μs         47.7±2μs     0.83  bench_lib.Pad.time_pad((10, 10, 10), 3, 'wrap')
-         116±7μs         96.4±5μs     0.83  bench_lib.Pad.time_pad((10, 100), (0, 5), 'linear_ramp')
-      54.4±0.7μs         45.1±1μs     0.83  bench_lib.Pad.time_pad((10, 10, 10), 1, 'reflect')
-        81.1±2μs         67.1±2μs     0.83  bench_lib.Pad.time_pad((1000,), 1, 'mean')
-        42.3±1μs         34.0±2μs     0.80  bench_lib.Pad.time_pad((10, 100), 1, 'reflect')
-      29.1±0.9μs         23.4±1μs     0.80  bench_lib.Pad.time_pad((1000,), 3, 'wrap')
-        92.1±2μs         73.6±5μs     0.80  bench_lib.Pad.time_pad((10, 100), (0, 5), 'mean')
-        64.5±2μs       50.4±0.9μs     0.78  bench_lib.Pad.time_pad((10, 10, 10), (0, 5), 'reflect')
-      38.3±0.6μs         29.7±1μs     0.78  bench_lib.Pad.time_pad((10, 100), 3, 'wrap')
-        70.6±5μs         54.2±1μs     0.77  bench_lib.Pad.time_pad((10, 10, 10), 3, 'reflect')
-        70.1±5μs         53.6±2μs     0.76  bench_lib.Pad.time_pad((10, 100), 3, 'constant')
-        36.5±2μs       27.5±0.6μs     0.75  bench_lib.Pad.time_pad((1000,), 1, 'edge')
-        32.7±1μs       24.6±0.9μs     0.75  bench_lib.Pad.time_pad((1000,), 1, 'reflect')
-        69.5±9μs         51.8±2μs     0.75  bench_lib.Pad.time_pad((10, 100), 1, 'constant')
-      46.1±0.9μs         34.3±2μs     0.74  bench_lib.Pad.time_pad((10, 100), (0, 5), 'reflect')
-        36.7±2μs       27.3±0.5μs     0.74  bench_lib.Pad.time_pad((1000,), 3, 'edge')
-      29.2±0.4μs         21.5±1μs     0.74  bench_lib.Pad.time_pad((1000,), 1, 'wrap')
-        72.4±2μs         53.1±5μs     0.73  bench_lib.Pad.time_pad((1000,), (0, 5), 'linear_ramp')
-      32.3±0.8μs       23.6±0.6μs     0.73  bench_lib.Pad.time_pad((1000,), 3, 'reflect')
-        57.5±3μs       41.9±0.6μs     0.73  bench_lib.Pad.time_pad((10, 10, 10), (0, 5), 'wrap')
-      48.7±0.8μs       34.5±0.8μs     0.71  bench_lib.Pad.time_pad((1000,), 1, 'constant')
-        77.9±6μs         54.5±2μs     0.70  bench_lib.Pad.time_pad((10, 10, 10), (0, 5), 'constant')
-        70.5±4μs       48.7±0.8μs     0.69  bench_lib.Pad.time_pad((10, 10, 10), (0, 5), 'edge')
-      42.5±0.6μs       29.3±0.8μs     0.69  bench_lib.Pad.time_pad((10, 100), (0, 5), 'wrap')
-        44.5±1μs         30.4±1μs     0.68  bench_lib.Pad.time_pad((10, 100), (0, 5), 'edge')
-      48.8±0.6μs       33.2±0.5μs     0.68  bench_lib.Pad.time_pad((1000,), 3, 'constant')
-      35.5±0.7μs       24.0±0.8μs     0.68  bench_lib.Pad.time_pad((1000,), (0, 5), 'reflect')
-      32.4±0.6μs       20.1±0.5μs     0.62  bench_lib.Pad.time_pad((1000,), (0, 5), 'wrap')
-        33.2±1μs       20.5±0.6μs     0.62  bench_lib.Pad.time_pad((1000,), (0, 5), 'edge')
-        60.0±3μs       36.3±0.9μs     0.61  bench_lib.Pad.time_pad((10, 100), (0, 5), 'constant')
-      45.1±0.5μs       25.7±0.7μs     0.57  bench_lib.Pad.time_pad((1000,), (0, 5), 'constant')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

</details>