### PR TITLE
MAINT: Block algorithm with a single copy per call to `block`

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -246,6 +246,14 @@ Previously we had a broken default that sometimes would not report underflow,
 overflow, and invalid floating point operations. Now we can support non-glibc
 distrubutions like Alpine Linux as long as they ship `fenv.h`.
 
+Speedup ``np.block`` for large arrays
+-------------------------------------
+Large arrays (greater than ``512 * 512``) now use a blocking algorithm based on
+copying the data directly into the appropriate slice of the resulting array.
+This results in significant speedups for these large arrays, particularly for
+arrays being blocked along more than 2 dimensions.
+
+
 Changes
 =======
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -3,6 +3,8 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['atleast_1d', 'atleast_2d', 'atleast_3d', 'block', 'hstack',
            'stack', 'vstack']
 
+import functools
+import operator
 
 from . import numeric as _nx
 from .numeric import array, asanyarray, newaxis
@@ -432,6 +434,10 @@ def _block_check_depths_match(arrays, parent_index=[]):
         refer to it, and the last index along the empty axis will be `None`.
     max_arr_ndim : int
         The maximum of the ndims of the arrays nested in `arrays`.
+    final_size: int
+        The number of elements in the final array. This is used the motivate
+        the choice of algorithm used using benchmarking wisdom.
+
     """
     if type(arrays) is tuple:
         # not strictly necessary, but saves us from:
@@ -450,8 +456,9 @@ def _block_check_depths_match(arrays, parent_index=[]):
         idxs_ndims = (_block_check_depths_match(arr, parent_index + [i])
                       for i, arr in enumerate(arrays))
 
-        first_index, max_arr_ndim = next(idxs_ndims)
-        for index, ndim in idxs_ndims:
+        first_index, max_arr_ndim, final_size = next(idxs_ndims)
+        for index, ndim, size in idxs_ndims:
+            final_size += size
             if ndim > max_arr_ndim:
                 max_arr_ndim = ndim
             if len(index) != len(first_index):
@@ -466,13 +473,15 @@ def _block_check_depths_match(arrays, parent_index=[]):
             # propagate our flag that indicates an empty list at the bottom
             if index[-1] is None:
                 first_index = index
-        return first_index, max_arr_ndim
+
+        return first_index, max_arr_ndim, final_size
     elif type(arrays) is list and len(arrays) == 0:
         # We've 'bottomed out' on an empty list
-        return parent_index + [None], 0
+        return parent_index + [None], 0, 0
     else:
         # We've 'bottomed out' - arrays is either a scalar or an array
-        return parent_index, _nx.ndim(arrays)
+        size = _nx.size(arrays)
+        return parent_index, _nx.ndim(arrays), size
 
 
 def _atleast_nd(a, ndim):
@@ -481,9 +490,132 @@ def _atleast_nd(a, ndim):
     return array(a, ndmin=ndim, copy=False, subok=True)
 
 
+def _accumulate(values):
+    # Helper function because Python 2.7 doesn't have
+    # itertools.accumulate
+    value = 0
+    accumulated = []
+    for v in values:
+        value += v
+        accumulated.append(value)
+    return accumulated
+
+
+def _concatenate_shapes(shapes, axis):
+    """Given array shapes, return the resulting shape and slices prefixes.
+
+    These help in nested concatation.
+    Returns
+    -------
+    shape: tuple of int
+        This tuple satisfies:
+        ```
+        shape, _ = _concatenate_shapes([arr.shape for shape in arrs], axis)
+        shape == concatenate(arrs, axis).shape
+        ```
+
+    slice_prefixes: tuple of (slice(start, end), )
+        For a list of arrays being concatenated, this returns the slice
+        in the larger array at axis that needs to be sliced into.
+
+        For example, the following holds:
+        ```
+        ret = concatenate([a, b, c], axis)
+        _, (sl_a, sl_b, sl_c) = concatenate_slices([a, b, c], axis)
+
+        ret[(slice(None),) * axis + sl_a] == a
+        ret[(slice(None),) * axis + sl_b] == b
+        ret[(slice(None),) * axis + sl_c] == c
+        ```
+
+        Thses are called slice prefixes since they are used in the recursive
+        blocking algorithm to compute the left-most slices during the
+        recursion. Therefore, they must be prepended to rest of the slice
+        that was computed deeper in the recusion.
+
+        These are returned as tuples to ensure that they can quickly be added
+        to existing slice tuple without creating a new tuple everytime.
+
+    """
+    # Cache a result that will be reused.
+    shape_at_axis = [shape[axis] for shape in shapes]
+
+    # Take a shape, any shape
+    first_shape = shapes[0]
+    first_shape_pre = first_shape[:axis]
+    first_shape_post = first_shape[axis+1:]
+
+    if any(shape[:axis] != first_shape_pre or
+           shape[axis+1:] != first_shape_post for shape in shapes):
+        raise ValueError(
+            'Mismatched array shapes in block along axis {}.'.format(axis))
+
+    shape = (first_shape_pre + (sum(shape_at_axis),) + first_shape[axis+1:])
+
+    offsets_at_axis = _accumulate(shape_at_axis)
+    slice_prefixes = [(slice(start, end),)
+                      for start, end in zip([0] + offsets_at_axis,
+                                            offsets_at_axis)]
+    return shape, slice_prefixes
+
+
+def _block_info_recursion(arrays, max_depth, result_ndim, depth=0):
+    """
+    Returns the shape of the final array, along with a list
+    of slices and a list of arrays that can be used for assignment inside the
+    new array
+
+    Parameters
+    ----------
+    arrays : nested list of arrays
+        The arrays to check
+    max_depth : list of int
+        The number of nested lists
+    result_ndim: int
+        The number of dimensions in thefinal array.
+
+    Returns
+    -------
+    shape : tuple of int
+        The shape that the final array will take on.
+    slices: list of tuple of slices
+        The slices into the full array required for assignment. These are
+        required to be prepended with ``(Ellipsis, )`` to obtain to correct
+        final index.
+    arrays: list of ndarray
+        The data to assign to each slice of the full array
+
+    """
+    if depth < max_depth:
+        shapes, slices, arrays = zip(
+            *[_block_info_recursion(arr, max_depth, result_ndim, depth+1)
+              for arr in arrays])
+
+        axis = result_ndim - max_depth + depth
+        shape, slice_prefixes = _concatenate_shapes(shapes, axis)
+
+        # Prepend the slice prefix and flatten the slices
+        slices = [slice_prefix + the_slice
+                  for slice_prefix, inner_slices in zip(slice_prefixes, slices)
+                  for the_slice in inner_slices]
+
+        # Flatten the array list
+        arrays = functools.reduce(operator.add, arrays)
+
+        return shape, slices, arrays
+    else:
+        # We've 'bottomed out' - arrays is either a scalar or an array
+        # type(arrays) is not list
+        # Return the slice and the array inside a list to be consistent with
+        # the recursive case.
+        arr = _atleast_nd(arrays, result_ndim)
+        return arr.shape, [()], [arr]
+
+
 def _block(arrays, max_depth, result_ndim, depth=0):
     """
-    Internal implementation of block. `arrays` is the argument passed to
+    Internal implementation of block based on repeated concatenation.
+    `arrays` is the argument passed to
     block. `max_depth` is the depth of nested lists within `arrays` and
     `result_ndim` is the greatest of the dimensions of the arrays in
     `arrays` and the depth of the lists in `arrays` (see block docstring
@@ -648,7 +780,38 @@ def block(arrays):
 
 
     """
-    bottom_index, arr_ndim = _block_check_depths_match(arrays)
+    arrays, list_ndim, result_ndim, final_size = _block_setup(arrays)
+
+    # It was found through benchmarking that making an array of final size
+    # around 256x256 was faster by straight concatenation on a
+    # i7-7700HQ processor and dual channel ram 2400MHz.
+    # It didn't seem to matter heavily on the dtype used.
+    #
+    # A 2D array using repeated concatenation requires 2 copies of the array.
+    #
+    # The fastest algorithm will depend on the ratio of CPU power to memory
+    # speed.
+    # One can monitor the results of the benchmark
+    # https://pv.github.io/numpy-bench/#bench_shape_base.Block2D.time_block2d
+    # to tune this parameter until a C version of the `_block_info_recursion`
+    # algorithm is implemented which would likely be faster than the python
+    # version.
+    if list_ndim * final_size > (2 * 512 * 512):
+        return _block_slicing(arrays, list_ndim, result_ndim)
+    else:
+        return _block_concatenate(arrays, list_ndim, result_ndim)
+
+
+# Theses helper functions are mostly used for testing.
+# They allow us to write tests that directly call `_block_slicing`
+# or `_block_concatenate` wtihout blocking large arrays to forse the wisdom
+# to trigger the desired path.
+def _block_setup(arrays):
+    """
+    Returns
+    (`arrays`, list_ndim, result_ndim, final_size)
+    """
+    bottom_index, arr_ndim, final_size = _block_check_depths_match(arrays)
     list_ndim = len(bottom_index)
     if bottom_index and bottom_index[-1] is None:
         raise ValueError(
@@ -656,7 +819,31 @@ def block(arrays):
                 _block_format_index(bottom_index)
             )
         )
-    result = _block(arrays, list_ndim, max(arr_ndim, list_ndim))
+    result_ndim = max(arr_ndim, list_ndim)
+    return arrays, list_ndim, result_ndim, final_size
+
+
+def _block_slicing(arrays, list_ndim, result_ndim):
+    shape, slices, arrays = _block_info_recursion(
+        arrays, list_ndim, result_ndim)
+    dtype = _nx.result_type(*[arr.dtype for arr in arrays])
+
+    # Test preferring F only in the case that all input arrays are F
+    F_order = all(arr.flags['F_CONTIGUOUS'] for arr in arrays)
+    C_order =  all(arr.flags['C_CONTIGUOUS'] for arr in arrays)
+    order = 'F' if F_order and not C_order else 'C'
+    result = _nx.empty(shape=shape, dtype=dtype, order=order)
+    # Note: In a c implementation, the function
+    # PyArray_CreateMultiSortedStridePerm could be used for more advanced
+    # guessing of the desired order.
+
+    for the_slice, arr in zip(slices, arrays):
+        result[(Ellipsis,) + the_slice] = arr
+    return result
+
+
+def _block_concatenate(arrays, list_ndim, result_ndim):
+    result = _block(arrays, list_ndim, result_ndim)
     if list_ndim == 0:
         # Catch an edge case where _block returns a view because
         # `arrays` is a single numpy array and not a list of numpy arrays.

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -647,3 +647,33 @@ class TestBlock(object):
                               [3., 3., 3.]]])
 
         assert_equal(result, expected)
+
+    def test_block_memory_order(self, block):
+        # 3D
+        arr_c = np.zeros((3,)*3, order='C')
+        arr_f = np.zeros((3,)*3, order='F')
+
+        b_c = [[[arr_c, arr_c],
+                [arr_c, arr_c]],
+               [[arr_c, arr_c],
+                [arr_c, arr_c]]]
+
+        b_f = [[[arr_f, arr_f],
+                [arr_f, arr_f]],
+               [[arr_f, arr_f],
+                [arr_f, arr_f]]]
+
+        assert block(b_c).flags['C_CONTIGUOUS']
+        assert block(b_f).flags['F_CONTIGUOUS']
+
+        arr_c = np.zeros((3, 3), order='C')
+        arr_f = np.zeros((3, 3), order='F')
+        # 2D
+        b_c = [[arr_c, arr_c],
+               [arr_c, arr_c]]
+
+        b_f = [[arr_f, arr_f],
+               [arr_f, arr_f]]
+
+        assert block(b_c).flags['C_CONTIGUOUS']
+        assert block(b_f).flags['F_CONTIGUOUS']

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -6,6 +6,9 @@ from numpy.core import (
     array, arange, atleast_1d, atleast_2d, atleast_3d, block, vstack, hstack,
     newaxis, concatenate, stack
     )
+
+from numpy.core.shape_base import (_block_setup,
+                                   _block_concatenate, _block_slicing)
 from numpy.testing import (
     assert_, assert_raises, assert_array_equal, assert_equal,
     assert_raises_regex, assert_almost_equal
@@ -372,14 +375,63 @@ def test_stack():
                         stack, [np.arange(2), np.arange(3)])
 
 
+# See for more information on how to parametrize a whole class
+# https://docs.pytest.org/en/latest/example/parametrize.html#parametrizing-test-methods-through-per-class-configuration
+def pytest_generate_tests(metafunc):
+    # called once per each test function
+    if hasattr(metafunc.cls, 'params'):
+        arglist = metafunc.cls.params
+        argnames = sorted(arglist[0])
+        metafunc.parametrize(argnames,
+                             [[funcargs[name] for name in argnames]
+                              for funcargs in arglist])
+
+
+# blocking small arrays and large arrays go through different paths.
+# the algorithm is triggered depending on the number of element
+# copies required.
+# We define a test fixture that forces most tests to go through
+# both code paths.
+# Ultimately, this should be removed if a single algorithm is found
+# to be faster for both small and large arrays.s
+def _block_force_concatenate(arrays):
+    arrays, list_ndim, result_ndim, _ = _block_setup(arrays)
+    return _block_concatenate(arrays, list_ndim, result_ndim)
+
+
+def _block_force_slicing(arrays):
+    arrays, list_ndim, result_ndim, _ = _block_setup(arrays)
+    return _block_slicing(arrays, list_ndim, result_ndim)
+
+
 class TestBlock(object):
-    def test_returns_copy(self):
+    params = [dict(block=block),
+              dict(block=_block_force_concatenate),
+              dict(block=_block_force_slicing)]
+
+    def test_returns_copy(self, block):
         a = np.eye(3)
-        b = np.block(a)
+        b = block(a)
         b[0, 0] = 2
         assert b[0, 0] != a[0, 0]
 
-    def test_block_simple_row_wise(self):
+    def test_block_total_size_estimate(self, block):
+        _, _, _, total_size = _block_setup([1])
+        assert total_size == 1
+
+        _, _, _, total_size = _block_setup([[1]])
+        assert total_size == 1
+
+        _, _, _, total_size = _block_setup([[1, 1]])
+        assert total_size == 2
+
+        _, _, _, total_size = _block_setup([[1], [1]])
+        assert total_size == 2
+
+        _, _, _, total_size = _block_setup([[1, 2], [3, 4]])
+        assert total_size == 4
+
+    def test_block_simple_row_wise(self, block):
         a_2d = np.ones((2, 2))
         b_2d = 2 * a_2d
         desired = np.array([[1, 1, 2, 2],
@@ -387,7 +439,7 @@ class TestBlock(object):
         result = block([a_2d, b_2d])
         assert_equal(desired, result)
 
-    def test_block_simple_column_wise(self):
+    def test_block_simple_column_wise(self, block):
         a_2d = np.ones((2, 2))
         b_2d = 2 * a_2d
         expected = np.array([[1, 1],
@@ -397,7 +449,7 @@ class TestBlock(object):
         result = block([[a_2d], [b_2d]])
         assert_equal(expected, result)
 
-    def test_block_with_1d_arrays_row_wise(self):
+    def test_block_with_1d_arrays_row_wise(self, block):
         # # # 1-D vectors are treated as row arrays
         a = np.array([1, 2, 3])
         b = np.array([2, 3, 4])
@@ -405,7 +457,7 @@ class TestBlock(object):
         result = block([a, b])
         assert_equal(expected, result)
 
-    def test_block_with_1d_arrays_multiple_rows(self):
+    def test_block_with_1d_arrays_multiple_rows(self, block):
         a = np.array([1, 2, 3])
         b = np.array([2, 3, 4])
         expected = np.array([[1, 2, 3, 2, 3, 4],
@@ -413,7 +465,7 @@ class TestBlock(object):
         result = block([[a, b], [a, b]])
         assert_equal(expected, result)
 
-    def test_block_with_1d_arrays_column_wise(self):
+    def test_block_with_1d_arrays_column_wise(self, block):
         # # # 1-D vectors are treated as row arrays
         a_1d = np.array([1, 2, 3])
         b_1d = np.array([2, 3, 4])
@@ -422,7 +474,7 @@ class TestBlock(object):
         result = block([[a_1d], [b_1d]])
         assert_equal(expected, result)
 
-    def test_block_mixed_1d_and_2d(self):
+    def test_block_mixed_1d_and_2d(self, block):
         a_2d = np.ones((2, 2))
         b_1d = np.array([2, 2])
         result = block([[a_2d], [b_1d]])
@@ -431,7 +483,7 @@ class TestBlock(object):
                              [2, 2]])
         assert_equal(expected, result)
 
-    def test_block_complicated(self):
+    def test_block_complicated(self, block):
         # a bit more complicated
         one_2d = np.array([[1, 1, 1]])
         two_2d = np.array([[2, 2, 2]])
@@ -455,7 +507,7 @@ class TestBlock(object):
                         [zero_2d]])
         assert_equal(result, expected)
 
-    def test_nested(self):
+    def test_nested(self, block):
         one = np.array([1, 1, 1])
         two = np.array([[2, 2, 2], [2, 2, 2], [2, 2, 2]])
         three = np.array([3, 3, 3])
@@ -464,9 +516,9 @@ class TestBlock(object):
         six = np.array([6, 6, 6, 6, 6])
         zero = np.zeros((2, 6))
 
-        result = np.block([
+        result = block([
             [
-                np.block([
+                block([
                    [one],
                    [three],
                    [four]
@@ -485,7 +537,7 @@ class TestBlock(object):
 
         assert_equal(result, expected)
 
-    def test_3d(self):
+    def test_3d(self, block):
         a000 = np.ones((2, 2, 2), int) * 1
 
         a100 = np.ones((3, 2, 2), int) * 2
@@ -498,7 +550,7 @@ class TestBlock(object):
 
         a111 = np.ones((3, 3, 3), int) * 8
 
-        result = np.block([
+        result = block([
             [
                 [a000, a001],
                 [a010, a011],
@@ -540,53 +592,53 @@ class TestBlock(object):
 
         assert_array_equal(result, expected)
 
-    def test_block_with_mismatched_shape(self):
+    def test_block_with_mismatched_shape(self, block):
         a = np.array([0, 0])
         b = np.eye(2)
-        assert_raises(ValueError, np.block, [a, b])
-        assert_raises(ValueError, np.block, [b, a])
+        assert_raises(ValueError, block, [a, b])
+        assert_raises(ValueError, block, [b, a])
 
-    def test_no_lists(self):
-        assert_equal(np.block(1),         np.array(1))
-        assert_equal(np.block(np.eye(3)), np.eye(3))
+    def test_no_lists(self, block):
+        assert_equal(block(1),         np.array(1))
+        assert_equal(block(np.eye(3)), np.eye(3))
 
-    def test_invalid_nesting(self):
+    def test_invalid_nesting(self, block):
         msg = 'depths are mismatched'
-        assert_raises_regex(ValueError, msg, np.block, [1, [2]])
-        assert_raises_regex(ValueError, msg, np.block, [1, []])
-        assert_raises_regex(ValueError, msg, np.block, [[1], 2])
-        assert_raises_regex(ValueError, msg, np.block, [[], 2])
-        assert_raises_regex(ValueError, msg, np.block, [
+        assert_raises_regex(ValueError, msg, block, [1, [2]])
+        assert_raises_regex(ValueError, msg, block, [1, []])
+        assert_raises_regex(ValueError, msg, block, [[1], 2])
+        assert_raises_regex(ValueError, msg, block, [[], 2])
+        assert_raises_regex(ValueError, msg, block, [
             [[1], [2]],
             [[3, 4]],
             [5]  # missing brackets
         ])
 
-    def test_empty_lists(self):
-        assert_raises_regex(ValueError, 'empty', np.block, [])
-        assert_raises_regex(ValueError, 'empty', np.block, [[]])
-        assert_raises_regex(ValueError, 'empty', np.block, [[1], []])
+    def test_empty_lists(self, block):
+        assert_raises_regex(ValueError, 'empty', block, [])
+        assert_raises_regex(ValueError, 'empty', block, [[]])
+        assert_raises_regex(ValueError, 'empty', block, [[1], []])
 
-    def test_tuple(self):
-        assert_raises_regex(TypeError, 'tuple', np.block, ([1, 2], [3, 4]))
-        assert_raises_regex(TypeError, 'tuple', np.block, [(1, 2), (3, 4)])
+    def test_tuple(self, block):
+        assert_raises_regex(TypeError, 'tuple', block, ([1, 2], [3, 4]))
+        assert_raises_regex(TypeError, 'tuple', block, [(1, 2), (3, 4)])
 
-    def test_different_ndims(self):
+    def test_different_ndims(self, block):
         a = 1.
         b = 2 * np.ones((1, 2))
         c = 3 * np.ones((1, 1, 3))
 
-        result = np.block([a, b, c])
+        result = block([a, b, c])
         expected = np.array([[[1., 2., 2., 3., 3., 3.]]])
 
         assert_equal(result, expected)
 
-    def test_different_ndims_depths(self):
+    def test_different_ndims_depths(self, block):
         a = 1.
         b = 2 * np.ones((1, 2))
         c = 3 * np.ones((1, 2, 3))
 
-        result = np.block([[a, b], [c]])
+        result = block([[a, b], [c]])
         expected = np.array([[[1., 2., 2.],
                               [3., 3., 3.],
                               [3., 3., 3.]]])

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -598,6 +598,9 @@ class TestBlock(object):
         assert_raises(ValueError, block, [a, b])
         assert_raises(ValueError, block, [b, a])
 
+        to_block = [[np.ones((2,3)), np.ones((2,2))],
+                    [np.ones((2,2)), np.ones((2,2))]]
+        assert_raises(ValueError, block, to_block)
     def test_no_lists(self, block):
         assert_equal(block(1),         np.array(1))
         assert_equal(block(np.eye(3)), np.eye(3))


### PR DESCRIPTION
Block used to make repeated calls to concatenate. For a 3D block, this would copy the arrays 3 times. 1 time for each dimension of the block. This is 2 times too many.

This proposed algorithm does so with 1 memory copy. 

Wisdom allows numpy to guess which algorithm is better performing and chooses that one automatically. We can add a switch, to let the user decide.

TODO:
- [x] Add tests that trigger both code paths.
- [x] Ensure that the docstrings are sensible.
- [x] Decide on how to test the other branch of block function.
- [x] Decide on how to treat F order matricies (or mixes of dimensions).
- [x] Decide on how to deal with masked array objects. concatenate supports them. Seems like we still don't know how to deal with subclasses. See https://github.com/numpy/numpy/issues/8881 and  https://github.com/numpy/numpy/issues/9270

XREF: Other issues I found regarding concatenate that we might want to test for
- endianness: https://github.com/numpy/numpy/issues/7829 -- should test
- Empty lists: https://github.com/numpy/numpy/issues/1586  -- Block doesn't support empty lists
- F/C ordering: See https://github.com/numpy/numpy/pull/11971#discussion_r223183338, and previous https://github.com/numpy/numpy/pull/9209#discussion_r138170238 and issue https://github.com/numpy/numpy/pull/2696

The general steps are:
1. Sanitize the input.
1. Cast each block as a numpy array of the final dimension
2. Calculate the shape of each block
3. Concatenate the shapes
5. Keep track of the slice of a particular block within the larger whole.
4. Combines dtypes to find the `dtype` of the result.
6. Create the new array.
7. Copy the blocks in.

A benchmark was added to estimate the 2D blocking performance in a straightforward manner.

# Approach details
# 2D results
For small arrays, this approach seems to suffer from large overhead. Benchmarks show that "small arrays" are anything as large as `256x256` arrays a modern i7 from 2017.

The performance of `master` is optimized in PR #11991.  This shaves the overhead time for a 2x2 block from 20us to 15 us. Benchmarks in this section are compared to that PR. The overhead for this method is 30 us when blocking a small 2x2 array.

My general sense is that small arrays are pretty important. While the `concatenate` approach was "wasteful" for large arrays, it was quick for small arrays. There is probably room for both approaches.

<details>
<summary>Benchmark results compared to PR #11991 </summary>

```
       before           after         ratio
     [1af752aa]       [0b1d866f]
     <block_optimize_order>       <block_single_assignment>
+      15.6±0.3μs       30.0±0.8μs     1.92  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (2, 2))
+     15.8±0.08μs         30.2±1μs     1.91  bench_shape_base.Block2D.time_block2d((16, 16), 'uint32', (2, 2))
+      39.4±0.2μs         73.1±2μs     1.85  bench_shape_base.Block2D.time_block2d((32, 32), 'uint8', (4, 4))
+      16.9±0.3μs         31.1±1μs     1.84  bench_shape_base.Block2D.time_block2d((32, 32), 'uint64', (2, 2))
+      16.8±0.3μs       31.0±0.9μs     1.84  bench_shape_base.Block2D.time_block2d((32, 32), 'uint32', (2, 2))
+      40.3±0.3μs       73.7±0.9μs     1.83  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (4, 4))
+      16.4±0.6μs       29.8±0.7μs     1.82  bench_shape_base.Block2D.time_block2d((32, 32), 'uint8', (2, 2))
+      16.9±0.3μs       30.8±0.9μs     1.82  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (2, 2))
+      39.6±0.7μs       71.8±0.9μs     1.81  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (4, 4))
+      16.2±0.3μs       29.3±0.5μs     1.81  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (2, 2))
+      16.6±0.1μs       30.0±0.3μs     1.80  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (2, 2))
+      41.4±0.3μs         74.5±2μs     1.80  bench_shape_base.Block2D.time_block2d((16, 16), 'uint32', (4, 4))
+      42.3±0.7μs         75.7±2μs     1.79  bench_shape_base.Block2D.time_block2d((32, 32), 'uint64', (4, 4))
+      16.6±0.6μs       29.7±0.4μs     1.79  bench_shape_base.Block2D.time_block2d((16, 16), 'uint64', (2, 2))
+      18.1±0.1μs       32.3±0.8μs     1.79  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (2, 2))
+      17.3±0.6μs       30.9±0.3μs     1.78  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (2, 2))
+      41.7±0.6μs         74.2±2μs     1.78  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (4, 4))
+      40.8±0.9μs       72.0±0.7μs     1.77  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (4, 4))
+      42.7±0.4μs       75.0±0.3μs     1.76  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (4, 4))
+        41.9±1μs         72.9±2μs     1.74  bench_shape_base.Block2D.time_block2d((16, 16), 'uint64', (4, 4))
+        41.9±1μs       72.8±0.5μs     1.74  bench_shape_base.Block2D.time_block2d((32, 32), 'uint32', (4, 4))
+        46.0±1μs         79.8±2μs     1.73  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (4, 4))
+      18.2±0.3μs       31.4±0.7μs     1.72  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (2, 2))
+      44.1±0.9μs       75.1±0.8μs     1.70  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (4, 4))
+        45.1±1μs         75.7±2μs     1.68  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (4, 4))
+        44.0±1μs         73.4±2μs     1.67  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (4, 4))
+      49.4±0.3μs       79.3±0.4μs     1.60  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (4, 4))
+      20.6±0.4μs       32.9±0.4μs     1.60  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (2, 2))
+      19.7±0.5μs       31.4±0.2μs     1.59  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (2, 2))
+        50.0±2μs         78.9±3μs     1.58  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (4, 4))
+      54.3±0.2μs         81.4±1μs     1.50  bench_shape_base.Block2D.time_block2d((128, 128), 'uint64', (4, 4))
+      23.5±0.6μs         34.6±1μs     1.47  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (2, 2))
+        57.8±1μs         85.0±2μs     1.47  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (4, 4))
+      24.5±0.7μs       35.4±0.4μs     1.45  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (2, 2))
+      28.3±0.3μs         38.4±1μs     1.36  bench_shape_base.Block2D.time_block2d((128, 128), 'uint64', (2, 2))
+      29.8±0.2μs         40.2±1μs     1.35  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (2, 2))
-       175±200μs          150±4μs     0.85  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint8', (4, 4))
-      72.0±100μs       59.6±0.8μs     0.83  bench_shape_base.Block2D.time_block2d((512, 512), 'uint16', (2, 2))
-      70.8±100μs       56.9±0.1μs     0.80  bench_shape_base.Block2D.time_block2d((256, 256), 'uint64', (2, 2))
-       167±200μs          133±1μs     0.80  bench_shape_base.Block2D.time_block2d((512, 512), 'uint32', (4, 4))
-       132±200μs         89.4±3μs     0.68  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint8', (2, 2))
-       131±200μs       82.4±0.8μs     0.63  bench_shape_base.Block2D.time_block2d((512, 512), 'uint32', (2, 2))
-       377±500μs        191±0.8μs     0.51  bench_shape_base.Block2D.time_block2d((512, 512), 'uint64', (4, 4))
-       403±500μs          203±4μs     0.51  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint16', (4, 4))
-      1.20±0.8ms         472±20μs     0.39  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint32', (4, 4))
-        6.14±2ms         985±20μs     0.16  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint64', (4, 4))
-        6.28±2ms         983±50μs     0.16  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint64', (2, 2))
-        2.94±1ms         360±20μs     0.12  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint32', (2, 2))
-      1.27±0.5ms          146±3μs     0.12  bench_shape_base.Block2D.time_block2d((1024, 1024), 'uint16', (2, 2))
-      1.32±0.5ms          126±4μs     0.10  bench_shape_base.Block2D.time_block2d((512, 512), 'uint64', (2, 2))
```
</details>

## A few small micro optimizations

This PR builds on-top of pretty optimized code already in numpy. Getting the performance close hard/impossible.

List comprehensions are really expensive. Unfortunately, blocking allows for really fancy block shapes, which means that we cant do much but to use them in python.

A few things can be optimized:

1. Generators are slow. Thanks @eric-wieser for teaching me about that.
2. Empty lists are falsy. You can use this to test for unlikely cases using list comprehensions.
3. Creating tuples is expensive. Create them once, reuse them.

I'm unsure how these optimizations affect the performance in PyPy 

# 3D results:
For large arrays, the benchmark https://github.com/numpy/numpy/pull/11965 shows that there is now little room to improve compared to a straight concatenate operation. This is really expected since here we are probably copying the arrays more than the cost it takes to generate the slices.

<details>
<summary> benchmarks </summary>
The benchmarks show results for a final array of size `5 n`^3. Therefore, for n=10, the final array has 125,000 elements, each 8 bytes (int 64), so close to 1MB. `n=100` is closer to 1GB

New results
```
===== ========== =============
--              mode          
----- ------------------------
  n     block     concatenate 
===== ========== =============
  1    74.0±2μs    2.03±0.1μs 
  10   150±6μs      37.6±1μs  
 100   366±7ms      393±10ms  
===== ========== =============
```

(I'm pretty convinced that the difference in time here between block and concatenate for n=100 is artificial, though not sure how to prove it.)

Improvement compared to the old results

```
asv continuous -E conda:3.6 -b Block.time_3d master block_single_concatenate_call 
```
```
       before           after         ratio
     [b5f56572]       [a2b4b356]
     <master>         <block_single_concatenate_call>
+      40.7±0.2μs         74.0±2μs     1.82  bench_shape_base.Block.time_3d(1, 'block')
-      1.10±0.02s          366±7ms     0.33  bench_shape_base.Block.time_3d(100, 'block')
-        681±20μs          150±6μs     0.22  bench_shape_base.Block.time_3d(10, 'block')
```

</details>

# Extensions
## Unblocking
@eric-wieser discussed the possibility of using this algorithm to `unblock` arrays. This is rather straightforward to implement once we lock down the implementation. Details are in the comments below

## User friendly options
Finally, this probably lends itself well to offering options like `order`, which would allow one to choose the order of the final array, or even to specify the array that they want to provide through an `out` parameter.


Closures are avoided entirely, so I  think that gh-10620 is not an issue.