### PR TITLE
BUG: reference cycle in np.vectorize

### DIFF
--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -120,7 +120,11 @@ typedef struct _tagPyUFuncObject {
          */
         int nin, nout, nargs;
 
-        /* Identity for reduction, either PyUFunc_One or PyUFunc_Zero */
+        /*
+         * Identity for reduction, any of PyUFunc_One, PyUFunc_Zero
+         * PyUFunc_MinusOne, PyUFunc_None, PyUFunc_ReorderableNone,
+         * PyUFunc_IdentityValue.
+         */
         int identity;
 
         /* Array of one-dimensional core loops */
@@ -301,7 +305,7 @@ typedef struct _tagPyUFuncObject {
  */
 #define PyUFunc_ReorderableNone -2
 /*
- * UFunc unit is in identity_value, and the order of operations can be reordered
+ * UFunc unit is an identity_value, and the order of operations can be reordered
  * This case allows reduction with multiple axes at once.
  */
 #define PyUFunc_IdentityValue -3

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4909,7 +4909,8 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
     if (ufunc->identity == PyUFunc_IdentityValue) {
         Py_INCREF(identity_value);
         ufunc->identity_value = identity_value;
-    } else {
+    }
+    else {
         ufunc->identity_value = NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4908,8 +4908,10 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
     ufunc->identity = identity;
     if (ufunc->identity == PyUFunc_IdentityValue) {
         Py_INCREF(identity_value);
+        ufunc->identity_value = identity_value;
+    } else {
+        ufunc->identity_value = NULL;
     }
-    ufunc->identity_value = identity_value;
 
     ufunc->functions = func;
     ufunc->data = data;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5296,6 +5296,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
 static void
 ufunc_dealloc(PyUFuncObject *ufunc)
 {
+    PyObject_GC_UnTrack((PyObject *)ufunc);
     PyArray_free(ufunc->core_num_dims);
     PyArray_free(ufunc->core_dim_ixs);
     PyArray_free(ufunc->core_offsets);
@@ -5307,7 +5308,6 @@ ufunc_dealloc(PyUFuncObject *ufunc)
         Py_DECREF(ufunc->identity_value);
     }
     if (ufunc->obj != NULL) {
-        PyObject_GC_UnTrack((PyObject *)ufunc);
         Py_DECREF(ufunc->obj);
     }
     PyObject_GC_Del(ufunc);
@@ -5320,12 +5320,11 @@ ufunc_repr(PyUFuncObject *ufunc)
 }
 
 static int
-ufunc_traverse(PyObject *self, visitproc visit, void *arg)
+ufunc_traverse(PyUFuncObject *self, visitproc visit, void *arg)
 {
-    PyUFuncObject *ufunc = (PyUFuncObject*)self;
-    Py_VISIT(ufunc->obj);
-    if (ufunc->identity == PyUFunc_IdentityValue) {
-        Py_VISIT(ufunc->identity_value);
+    Py_VISIT(self->obj);
+    if (self->identity == PyUFunc_IdentityValue) {
+        Py_VISIT(self->identity_value);
     }
     return 0;
 }

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -161,6 +161,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUS
 
     self->type_resolver = &object_ufunc_type_resolver;
     self->legacy_inner_loop_selector = &object_ufunc_loop_selector;
+    PyObject_GC_Track(self);
 
     return (PyObject *)self;
 }

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1505,11 +1505,11 @@ class TestLeaks(object):
         iters = 20
 
         def bound(self, *args):
-            return np.int(0)
+            return 0
 
         @staticmethod
         def unbound(*args):
-            return np.int(0)
+            return 0
 
         def npy_bound(self, a):
             return types.MethodType(np.frompyfunc(self.bound, 1, 1), a)
@@ -1527,8 +1527,8 @@ class TestLeaks(object):
         # exposed in gh-11867 as np.vectorized, but the problem stems from
         # frompyfunc.
         # class.attribute = np.frompyfunc(<method>) creates a
-        # reference cycle that requires a gc collection cycle to break
-        # (on CPython 3)
+        # reference cycle if <method> is a bound class method that requires a
+        # gc collection cycle to break (on CPython 3)
         import gc
 
         gc.disable()


### PR DESCRIPTION
Issue #11867 demonstrated a leak when using `np.vectorize` on a bound class method in CPython 3. The test demonstrates the issue.

~Still WIP since I have not found the root cause of the leak.~

Edit: adding GC_Track to ufunc allows the garbage collector to break the cycle