### PR TITLE
MAINT: Ensure that a copy of the array is returned when calling `block`.

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -620,4 +620,11 @@ def block(arrays):
                 _block_format_index(bottom_index)
             )
         )
-    return _block(arrays, list_ndim, max(arr_ndim, list_ndim))
+    result = _block(arrays, list_ndim, max(arr_ndim, list_ndim))
+    if list_ndim == 0:
+        # Catch an edge case where _block returns a view because
+        # `arrays` is a single numpy array and not a list of numpy arrays.
+        # This might copy scalars or lists twice, but this isn't a likely
+        # usecase for those interested in performance
+        result = result.copy()
+    return result

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -191,6 +191,12 @@ class TestVstack(object):
 
 
 class TestConcatenate(object):
+    def test_returns_copy(self):
+        a = np.eye(3)
+        b = np.concatenate([a])
+        b[0, 0] = 2
+        assert b[0, 0] != a[0, 0]
+
     def test_exceptions(self):
         # test axis must be in bounds
         for ndim in [1, 2, 3]:
@@ -367,6 +373,12 @@ def test_stack():
 
 
 class TestBlock(object):
+    def test_returns_copy(self):
+        a = np.eye(3)
+        b = np.block(a)
+        b[0, 0] = 2
+        assert b[0, 0] != a[0, 0]
+
     def test_block_simple_row_wise(self):
         a_2d = np.ones((2, 2))
         b_2d = 2 * a_2d


### PR DESCRIPTION
In the case that a user calls
np.block(array),
the old block function would return a view into the array.

This ensures that a new array is returned
@eric-wieser 

~~In thinking about this, I realized that we can probably use this to our advantage and just avoid calling concatenate (which forcibly copies the array).~~

~~This should help the performance when somebody calls `np.block([[[[[a]]]]])`.~~

Developed in light of recent benchmarking results discussed in: https://github.com/numpy/numpy/pull/11971#issuecomment-422508525