### PR TITLE
BUG: fix refcount leak in PyArray_AdaptFlexibleDType

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -256,7 +256,8 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                              */
                             PyArray_Descr *dtype = NULL;
                             PyArrayObject *arr = NULL;
-                            int result, ndim = 0;
+                            int result;
+                            int ndim = 0;
                             npy_intp dims[NPY_MAXDIMS];
                             list = PyArray_ToList((PyArrayObject *)data_obj);
                             result = PyArray_GetArrayParamsFromObject(

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -149,11 +149,6 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
 {
     PyArray_DatetimeMetaData *meta;
     int flex_type_num;
-    PyArrayObject *arr = NULL;
-    PyArray_Descr *dtype = NULL;
-    int ndim = 0;
-    npy_intp dims[NPY_MAXDIMS];
-    int result;
 
     if (*flex_dtype == NULL) {
         if (!PyErr_Occurred()) {
@@ -168,7 +163,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
 
     /* Flexible types with expandable size */
     if (PyDataType_ISUNSIZED(*flex_dtype)) {
-        /* First replace the flex dtype */
+        /* First replace the flex_dtype */
         PyArray_DESCR_REPLACE(*flex_dtype);
         if (*flex_dtype == NULL) {
             return;
@@ -259,6 +254,10 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                              * GetArrayParamsFromObject won't iterate over
                              * array.
                              */
+                            PyArray_Descr *dtype = NULL;
+                            PyArrayObject *arr = NULL;
+                            int result, ndim = 0;
+                            npy_intp dims[NPY_MAXDIMS];
                             list = PyArray_ToList((PyArrayObject *)data_obj);
                             result = PyArray_GetArrayParamsFromObject(
                                     list,
@@ -273,6 +272,8 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                                     size = dtype->elsize;
                                 }
                             }
+                            Py_XDECREF(dtype);
+                            Py_XDECREF(arr);
                             Py_DECREF(list);
                         }
                         else if (PyArray_IsPythonScalar(data_obj)) {


### PR DESCRIPTION
Backport of #11967.

Fixes #11951. Variable were initialized but never decrefed. I am not sure how to write a test since they are new instances that never escape out of the local function, so sys.get_refcount cannot see them. Do they somehow show up in the gc module on CPython?

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
