### PR TITLE
MAINT: speed up `_block` by avoiding a recursive closure

### DIFF
--- a/benchmarks/benchmarks/bench_shape_base.py
+++ b/benchmarks/benchmarks/bench_shape_base.py
@@ -65,6 +65,24 @@ class Block(Benchmark):
         np.block(np.eye(3 * n))
 
 
+class Block2D(Benchmark):
+    params = [[(16, 16), (32, 32), (64, 64), (128, 128), (256, 256), (512, 512), (1024, 1024)],
+              ['uint8', 'uint16', 'uint32', 'uint64'],
+              [(2, 2), (4, 4)]]
+    param_names = ['shape', 'dtype', 'n_chunks']
+
+    def setup(self, shape, dtype, n_chunks):
+
+        self.block_list = [
+             [np.full(shape=[s//n_chunk for s, n_chunk in zip(shape, n_chunks)],
+                     fill_value=1, dtype=dtype) for _ in range(n_chunks[1])]
+            for _ in range(n_chunks[0])
+        ]
+
+    def time_block2d(self, shape, dtype, n_chunks):
+        np.block(self.block_list)
+
+
 class Block3D(Benchmark):
     params = [1, 10, 100]
     param_names = ['size']


### PR DESCRIPTION
This is a small PR that speeds up the case of blocking small arrays by 10-20% in CPython 3.6 by avoiding closures.

This only makes PR https://github.com/numpy/numpy/pull/11971 a harder sell, but I think these optimizations are worthwhile for people blocking small arrays.

<details>
<summary>Benchmarks Python 3.6 conda(-forge?)</summary>

```
       before           after         ratio
     [d126ff7a]       [535d337d]
     <master>         <block_optimize_order>
-      32.8±0.3μs       28.6±0.4μs     0.87  bench_shape_base.Block2D.time_block2d((128, 128), 'uint64', (2, 2))
-        67.7±4μs       57.4±0.5μs     0.85  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (4, 4))
-      27.9±0.1μs       23.4±0.2μs     0.84  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (2, 2))
-        60.3±4μs       50.7±0.9μs     0.84  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (4, 4))
-      57.9±0.6μs       48.6±0.7μs     0.84  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (4, 4))
-        39.1±1μs         32.7±1μs     0.84  bench_shape_base.Block.time_block_complicated(10)
-      50.6±0.4μs         42.2±1μs     0.83  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (4, 4))
-      35.7±0.8μs       29.6±0.4μs     0.83  bench_shape_base.Block.time_no_lists(100)
-      53.9±0.4μs       44.6±0.3μs     0.83  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (4, 4))
-        65.1±2μs       53.7±0.6μs     0.82  bench_shape_base.Block2D.time_block2d((128, 128), 'uint64', (4, 4))
-        23.3±1μs       19.1±0.1μs     0.82  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (2, 2))
-      53.6±0.6μs       43.7±0.4μs     0.82  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (4, 4))
-      27.5±0.5μs       22.4±0.2μs     0.81  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (2, 2))
-      41.0±0.2μs       33.2±0.3μs     0.81  bench_shape_base.Block.time_3d(1)
-        35.4±1μs       28.6±0.3μs     0.81  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (2, 2))
-      22.1±0.5μs       17.6±0.2μs     0.80  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (2, 2))
-        49.8±1μs       39.4±0.4μs     0.79  bench_shape_base.Block2D.time_block2d((32, 32), 'uint8', (4, 4))
-      11.7±0.5μs       9.23±0.4μs     0.79  bench_shape_base.Block.time_no_lists(10)
-        52.3±3μs       40.8±0.3μs     0.78  bench_shape_base.Block2D.time_block2d((32, 32), 'uint64', (4, 4))
-      17.5±0.5μs       13.6±0.2μs     0.78  bench_shape_base.Block.time_block_simple_column_wise(10)
-        37.3±1μs       28.9±0.2μs     0.77  bench_shape_base.Block.time_block_complicated(1)
-        23.1±1μs       17.8±0.2μs     0.77  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (2, 2))
-      21.7±0.8μs       16.7±0.1μs     0.77  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (2, 2))
-      11.1±0.5μs       8.48±0.1μs     0.76  bench_shape_base.Block.time_no_lists(1)
-      21.2±0.7μs      16.1±0.08μs     0.76  bench_shape_base.Block2D.time_block2d((32, 32), 'uint32', (2, 2))
-        55.5±4μs       42.1±0.5μs     0.76  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (4, 4))
-        56.4±1μs       42.6±0.1μs     0.75  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (4, 4))
-      26.1±0.7μs       19.7±0.2μs     0.75  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (2, 2))
-      21.0±0.3μs       15.8±0.3μs     0.75  bench_shape_base.Block2D.time_block2d((16, 16), 'uint32', (2, 2))
-        53.2±1μs       39.7±0.7μs     0.75  bench_shape_base.Block2D.time_block2d((16, 16), 'uint32', (4, 4))
-        52.4±2μs       39.1±0.4μs     0.75  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (4, 4))
-      21.5±0.1μs       15.9±0.2μs     0.74  bench_shape_base.Block2D.time_block2d((16, 16), 'uint64', (2, 2))
-      22.1±0.5μs       16.3±0.1μs     0.74  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (2, 2))
-        53.4±2μs       39.4±0.3μs     0.74  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (4, 4))
-      10.5±0.2μs       7.71±0.1μs     0.73  bench_shape_base.Block.time_block_simple_row_wise(10)
-      21.0±0.2μs       15.2±0.1μs     0.73  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (2, 2))
-        54.4±2μs       38.9±0.4μs     0.72  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (4, 4))
-        57.1±1μs       40.8±0.4μs     0.71  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (4, 4))
-        55.6±3μs       39.7±0.4μs     0.71  bench_shape_base.Block2D.time_block2d((16, 16), 'uint64', (4, 4))
-      22.2±0.4μs      15.8±0.09μs     0.71  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (2, 2))
-      23.1±0.2μs       16.4±0.1μs     0.71  bench_shape_base.Block2D.time_block2d((32, 32), 'uint64', (2, 2))
-      22.2±0.7μs       15.7±0.1μs     0.70  bench_shape_base.Block2D.time_block2d((32, 32), 'uint8', (2, 2))
-        22.2±2μs       15.4±0.6μs     0.69  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (2, 2))
-        58.1±5μs       40.1±0.4μs     0.69  bench_shape_base.Block2D.time_block2d((32, 32), 'uint32', (4, 4))
```
</details>

<details>
<summary>Benchmarks python 3.5 conda(-forge?)</summary>

```

       before           after         ratio
     [d126ff7a]       [91391c1a]
     <master>         <block_optimize_order>
-       59.6±10μs       47.4±0.8μs     0.79  bench_shape_base.Block2D.time_block2d((512, 512), 'uint8', (2, 2))
-        78.1±1μs         60.6±2μs     0.78  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (4, 4))
-        57.7±5μs         44.2±1μs     0.77  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (4, 4))
-        57.7±3μs         43.8±1μs     0.76  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (4, 4))
-        55.5±3μs       42.1±0.6μs     0.76  bench_shape_base.Block2D.time_block2d((16, 16), 'uint32', (4, 4))
-        63.0±6μs         46.0±4μs     0.73  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (4, 4))
-        27.9±4μs         20.2±1μs     0.72  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (2, 2))
-        111±20μs         79.7±2μs     0.72  bench_shape_base.Block2D.time_block2d((512, 512), 'uint8', (4, 4))
-        59.1±1μs       41.4±0.7μs     0.70  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (4, 4))
-        71.3±5μs         49.6±2μs     0.70  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (4, 4))
-        21.5±3μs      14.4±0.07μs     0.67  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (2, 2))
-        66.3±3μs         44.1±1μs     0.67  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (4, 4))
-        63.5±7μs       41.7±0.3μs     0.66  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (4, 4))
```
</details>

<details>
<summary>Benchmarks Python 2.7 conda(-forge)</summary>

```
       before           after         ratio
     [d126ff7a]       [91391c1a]
     <master>         <block_optimize_order>
-      28.8±0.4μs       25.4±0.2μs     0.88  bench_shape_base.Block2D.time_block2d((256, 256), 'uint16', (2, 2))
-        68.8±2μs         60.2±1μs     0.87  bench_shape_base.Block2D.time_block2d((256, 256), 'uint32', (4, 4))
-      42.1±0.7μs       36.9±0.4μs     0.87  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (4, 4))
-        42.2±1μs       36.4±0.7μs     0.86  bench_shape_base.Block2D.time_block2d((256, 256), 'uint32', (2, 2))
-      52.5±0.3μs       45.3±0.4μs     0.86  bench_shape_base.Block2D.time_block2d((128, 128), 'uint64', (4, 4))
-      48.1±0.4μs       41.1±0.3μs     0.86  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (4, 4))
-      46.9±0.3μs       39.7±0.3μs     0.85  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (4, 4))
-      22.1±0.2μs       18.6±0.4μs     0.84  bench_shape_base.Block2D.time_block2d((128, 128), 'uint32', (2, 2))
-      37.3±0.2μs       31.4±0.7μs     0.84  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (4, 4))
-      23.9±0.3μs       20.2±0.1μs     0.84  bench_shape_base.Block2D.time_block2d((256, 256), 'uint8', (2, 2))
-      38.0±0.5μs       32.0±0.5μs     0.84  bench_shape_base.Block2D.time_block2d((32, 32), 'uint8', (4, 4))
-      42.6±0.4μs       35.9±0.4μs     0.84  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (4, 4))
-      43.4±0.4μs       36.3±0.3μs     0.84  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (4, 4))
-      40.8±0.2μs       34.2±0.4μs     0.84  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (4, 4))
-      19.3±0.2μs       16.0±0.2μs     0.83  bench_shape_base.Block2D.time_block2d((128, 128), 'uint16', (2, 2))
-      17.5±0.1μs       14.5±0.1μs     0.83  bench_shape_base.Block2D.time_block2d((128, 128), 'uint8', (2, 2))
-      40.3±0.6μs       33.4±0.2μs     0.83  bench_shape_base.Block2D.time_block2d((64, 64), 'uint16', (4, 4))
-      37.8±0.2μs       31.2±0.3μs     0.83  bench_shape_base.Block2D.time_block2d((16, 16), 'uint16', (4, 4))
-      17.8±0.4μs       14.7±0.2μs     0.83  bench_shape_base.Block2D.time_block2d((64, 64), 'uint32', (2, 2))
-      18.6±0.2μs       15.3±0.1μs     0.83  bench_shape_base.Block2D.time_block2d((64, 64), 'uint64', (2, 2))
-      39.1±0.9μs       31.9±0.5μs     0.82  bench_shape_base.Block2D.time_block2d((16, 16), 'uint64', (4, 4))
-      15.8±0.4μs       12.9±0.1μs     0.81  bench_shape_base.Block2D.time_block2d((32, 32), 'uint32', (2, 2))
-      14.8±0.4μs       12.0±0.3μs     0.81  bench_shape_base.Block2D.time_block2d((16, 16), 'uint8', (2, 2))
-      16.3±0.2μs       13.2±0.4μs     0.81  bench_shape_base.Block2D.time_block2d((32, 32), 'uint16', (2, 2))
-     15.9±0.05μs      12.8±0.09μs     0.80  bench_shape_base.Block2D.time_block2d((64, 64), 'uint8', (2, 2))
```

</details>

Pinging @eric-wieser  who helped me with #11971
and @jakirkham and @j-towns who contributed to np.block in #9667.
