### PR TITLE
BENCH: Add a relatable 2D benchmark for block

### DIFF
--- a/benchmarks/benchmarks/bench_shape_base.py
+++ b/benchmarks/benchmarks/bench_shape_base.py
@@ -78,8 +78,8 @@ class Block2D(Benchmark):
     def setup(self, shape, dtype, n_chunks):
 
         self.block_list = [
-             [np.full(shape=[s//n_chunk for s, n_chunk in zip(shape, n_chunks)],
-                     fill_value=1, dtype=dtype) for _ in range(n_chunks[1])]
+             [np.ones(shape=[s//n_chunk for s, n_chunk in zip(shape, n_chunks)],
+                      dtype=dtype) for _ in range(n_chunks[1])]
             for _ in range(n_chunks[0])
         ]
 


### PR DESCRIPTION
The existing benchmarks for block are not easy to understand in terms of what they might mean for common use cases in the case of 2D blocking.

These benchmarks make the performance of common use cases more clear in terms of final array size and dtype used

xref #11991

cc: @eric-wieser 

