### PR TITLE
Revert "NEP: Revert "NEP: Mark NEP 18 as accepted""

### DIFF
--- a/doc/neps/nep-0018-array-function-protocol.rst
+++ b/doc/neps/nep-0018-array-function-protocol.rst
@@ -7,9 +7,10 @@ NEP 18 — A dispatch mechanism for NumPy's high level array functions
 :Author: Marten van Kerkwijk <mhvk@astro.utoronto.ca>
 :Author: Hameer Abbasi <hameerabbasi@yahoo.com>
 :Author: Eric Wieser <wieser.eric@gmail.com>
-:Status: Draft
+:Status: Accepted
 :Type: Standards Track
 :Created: 2018-05-29
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2018-August/078493.html
 
 Abstact
 -------


### PR DESCRIPTION
Reverts numpy/numpy#11934

Actually marking this as accepted now after the revisions in https://github.com/numpy/numpy/pull/11943