### PR TITLE
BUG: Fix f2py compile function testing.

### DIFF
--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -1,0 +1,121 @@
+"""See https://github.com/numpy/numpy/pull/11937.
+
+"""
+from __future__ import division, absolute_import, print_function
+
+import sys
+import os
+import uuid
+from importlib import import_module
+import pytest
+
+import numpy.f2py
+
+from numpy.testing import assert_equal
+from . import util
+
+
+@pytest.mark.xfail(sys.version_info[0] < 3 and os.name == 'nt',
+                   reason="our Appveyor CI configuration does not"
+                          " have Fortran compilers available for"
+                          " Python 2.x")
+@pytest.mark.parametrize("extra_args", [
+    # extra_args can be a list as of gh-11937
+    ['--noopt', '--debug'],
+    # test for string as well, using the same
+    # fcompiler options
+    '--noopt --debug',
+    # also test absence of extra_args
+    '',
+    ])
+def test_f2py_init_compile(extra_args):
+    # flush through the f2py __init__
+    # compile() function code path
+    # as a crude test for input handling
+    # following migration from exec_command()
+    # to subprocess.check_output() in gh-11937
+
+    # the Fortran 77 syntax requires 6 spaces
+    # before any commands, but more space may
+    # be added; gfortran can also compile
+    # with --ffree-form to remove the indentation
+    # requirement; here, the Fortran source is
+    # formatted to roughly match an example from
+    # the F2PY User Guide
+    fsource =  '''
+             integer function foo()
+             foo = 10 + 5
+             return
+             end
+             '''
+    # use various helper functions in util.py to
+    # enable robust build / compile and
+    # reimport cycle in test suite
+    d = util.get_module_dir()
+    modulename = util.get_temp_module_name()
+
+    cwd = os.getcwd()
+    target = os.path.join(d, str(uuid.uuid4()) + '.f')
+    # try running compile() with and without a
+    # source_fn provided so that the code path
+    # where a temporary file for writing Fortran
+    # source is created is also explored
+    for source_fn in [target, None]:
+
+        # mimic the path changing behavior used
+        # by build_module() in util.py, but don't
+        # actually use build_module() because it
+        # has its own invocation of subprocess
+        # that circumvents the f2py.compile code
+        # block under test
+        try:
+            os.chdir(d)
+            ret_val = numpy.f2py.compile(fsource,
+                                         modulename=modulename,
+                                         extra_args=extra_args,
+                                         source_fn=source_fn)
+        finally:
+            os.chdir(cwd)
+
+        # check for compile success return value
+        assert_equal(ret_val, 0)
+
+        # we are not currently able to import the
+        # Python-Fortran interface module on Windows /
+        # Appveyor, even though we do get successful
+        # compilation on that platform with Python 3.x
+        if os.name != 'nt':
+            # check for sensible result of Fortran function;
+            # that means we can import the module name in Python
+            # and retrieve the result of the sum operation
+            return_check = import_module(modulename)
+            calc_result = return_check.foo()
+            assert_equal(calc_result, 15)
+
+def test_f2py_init_compile_failure():
+    # verify an appropriate integer status
+    # value returned by f2py.compile() when
+    # invalid Fortran is provided
+    ret_val = numpy.f2py.compile(b"invalid")
+    assert_equal(ret_val, 1)
+
+def test_f2py_init_compile_bad_cmd():
+    # verify that usage of invalid command in
+    # f2py.compile() returns status value of 127
+    # for historic consistency with exec_command()
+    # error handling
+
+    # patch the sys Python exe path temporarily to
+    # induce an OSError downstream
+    # NOTE: how bad of an idea is this patching?
+    try:
+        temp = sys.executable
+        sys.executable = 'does not exist'
+
+        # the OSError should take precedence over the invalid
+        # Fortran
+        ret_val = numpy.f2py.compile(b"invalid")
+
+        assert_equal(ret_val, 127)
+    finally:
+        sys.executable = temp

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -15,107 +15,94 @@ from numpy.testing import assert_equal
 from . import util
 
 
-@pytest.mark.xfail(sys.version_info[0] < 3 and os.name == 'nt',
-                   reason="our Appveyor CI configuration does not"
-                          " have Fortran compilers available for"
-                          " Python 2.x")
-@pytest.mark.parametrize("extra_args", [
-    # extra_args can be a list as of gh-11937
-    ['--noopt', '--debug'],
-    # test for string as well, using the same
-    # fcompiler options
-    '--noopt --debug',
-    # also test absence of extra_args
-    '',
-    ])
-def test_f2py_init_compile(extra_args):
-    # flush through the f2py __init__
-    # compile() function code path
-    # as a crude test for input handling
-    # following migration from exec_command()
-    # to subprocess.check_output() in gh-11937
+def setup_module():
+    if sys.platform == 'win32' and sys.version_info[0] < 3:
+        pytest.skip('Fails with MinGW64 Gfortran (Issue #9673)')
+    if not util.has_c_compiler():
+        pytest.skip("Needs C compiler")
+    if not util.has_f77_compiler():
+        pytest.skip('Needs FORTRAN 77 compiler')
 
-    # the Fortran 77 syntax requires 6 spaces
-    # before any commands, but more space may
-    # be added; gfortran can also compile
-    # with --ffree-form to remove the indentation
-    # requirement; here, the Fortran source is
-    # formatted to roughly match an example from
-    # the F2PY User Guide
-    fsource =  '''
-             integer function foo()
-             foo = 10 + 5
-             return
-             end
-             '''
-    # use various helper functions in util.py to
-    # enable robust build / compile and
-    # reimport cycle in test suite
-    d = util.get_module_dir()
-    modulename = util.get_temp_module_name()
+
+# extra_args can be a list (since gh-11937) or string.
+# also test absence of extra_args
+@pytest.mark.parametrize(
+    "extra_args", [['--noopt', '--debug'], '--noopt --debug', '']
+    )
+def test_f2py_init_compile(extra_args):
+    # flush through the f2py __init__ compile() function code path as a
+    # crude test for input handling following migration from
+    # exec_command() to subprocess.check_output() in gh-11937
+
+    # the Fortran 77 syntax requires 6 spaces before any commands, but
+    # more space may be added/
+    fsource =  """
+        integer function foo()
+        foo = 10 + 5
+        return
+        end
+    """
+    # use various helper functions in util.py to enable robust build /
+    # compile and reimport cycle in test suite
+    moddir = util.get_module_dir()
+    modname = util.get_temp_module_name()
 
     cwd = os.getcwd()
-    target = os.path.join(d, str(uuid.uuid4()) + '.f')
-    # try running compile() with and without a
-    # source_fn provided so that the code path
-    # where a temporary file for writing Fortran
+    target = os.path.join(moddir, str(uuid.uuid4()) + '.f')
+    # try running compile() with and without a source_fn provided so
+    # that the code path where a temporary file for writing Fortran
     # source is created is also explored
     for source_fn in [target, None]:
-
-        # mimic the path changing behavior used
-        # by build_module() in util.py, but don't
-        # actually use build_module() because it
-        # has its own invocation of subprocess
-        # that circumvents the f2py.compile code
-        # block under test
+        # mimic the path changing behavior used by build_module() in
+        # util.py, but don't actually use build_module() because it has
+        # its own invocation of subprocess that circumvents the
+        # f2py.compile code block under test
         try:
-            os.chdir(d)
-            ret_val = numpy.f2py.compile(fsource,
-                                         modulename=modulename,
-                                         extra_args=extra_args,
-                                         source_fn=source_fn)
+            os.chdir(moddir)
+            ret_val = numpy.f2py.compile(
+                fsource,
+                modulename=modname,
+                extra_args=extra_args,
+                source_fn=source_fn
+                )
         finally:
             os.chdir(cwd)
 
         # check for compile success return value
         assert_equal(ret_val, 0)
 
-        # we are not currently able to import the
-        # Python-Fortran interface module on Windows /
-        # Appveyor, even though we do get successful
-        # compilation on that platform with Python 3.x
-        if os.name != 'nt':
-            # check for sensible result of Fortran function;
-            # that means we can import the module name in Python
-            # and retrieve the result of the sum operation
-            return_check = import_module(modulename)
+        # we are not currently able to import the Python-Fortran
+        # interface module on Windows / Appveyor, even though we do get
+        # successful compilation on that platform with Python 3.x
+        if sys.platform != 'win32':
+            # check for sensible result of Fortran function; that means
+            # we can import the module name in Python and retrieve the
+            # result of the sum operation
+            return_check = import_module(modname)
             calc_result = return_check.foo()
             assert_equal(calc_result, 15)
 
+
 def test_f2py_init_compile_failure():
-    # verify an appropriate integer status
-    # value returned by f2py.compile() when
-    # invalid Fortran is provided
+    # verify an appropriate integer status value returned by
+    # f2py.compile() when invalid Fortran is provided
     ret_val = numpy.f2py.compile(b"invalid")
     assert_equal(ret_val, 1)
 
+
 def test_f2py_init_compile_bad_cmd():
-    # verify that usage of invalid command in
-    # f2py.compile() returns status value of 127
-    # for historic consistency with exec_command()
+    # verify that usage of invalid command in f2py.compile() returns
+    # status value of 127 for historic consistency with exec_command()
     # error handling
 
-    # patch the sys Python exe path temporarily to
-    # induce an OSError downstream
-    # NOTE: how bad of an idea is this patching?
+    # patch the sys Python exe path temporarily to induce an OSError
+    # downstream NOTE: how bad of an idea is this patching?
     try:
         temp = sys.executable
         sys.executable = 'does not exist'
 
-        # the OSError should take precedence over the invalid
-        # Fortran
+        # the OSError should take precedence over invalid Fortran
         ret_val = numpy.f2py.compile(b"invalid")
-
         assert_equal(ret_val, 127)
     finally:
         sys.executable = temp

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -1,3 +1,6 @@
+"""See https://github.com/numpy/numpy/pull/10676.
+
+"""
 from __future__ import division, absolute_import, print_function
 
 import sys
@@ -10,6 +13,7 @@ import numpy.f2py
 
 from numpy.testing import assert_equal
 from . import util
+
 
 class TestQuotedCharacter(util.F2PyTest):
     code = """
@@ -33,108 +37,3 @@ Cf2py intent(out) OUT1, OUT2, OUT3, OUT4, OUT5, OUT6
                         reason='Fails with MinGW64 Gfortran (Issue #9673)')
     def test_quoted_character(self):
         assert_equal(self.module.foo(), (b"'", b'"', b';', b'!', b'(', b')'))
-
-@pytest.mark.xfail(sys.version_info[0] < 3 and os.name == 'nt',
-                   reason="our Appveyor CI configuration does not"
-                          " have Fortran compilers available for"
-                          " Python 2.x")
-@pytest.mark.parametrize("extra_args", [
-    # extra_args can be a list as of gh-11937
-    ['--noopt', '--debug'],
-    # test for string as well, using the same
-    # fcompiler options
-    '--noopt --debug',
-    # also test absence of extra_args
-    '',
-    ])
-def test_f2py_init_compile(extra_args):
-    # flush through the f2py __init__
-    # compile() function code path
-    # as a crude test for input handling
-    # following migration from exec_command()
-    # to subprocess.check_output() in gh-11937
-
-    # the Fortran 77 syntax requires 6 spaces
-    # before any commands, but more space may
-    # be added; gfortran can also compile
-    # with --ffree-form to remove the indentation
-    # requirement; here, the Fortran source is
-    # formatted to roughly match an example from
-    # the F2PY User Guide
-    fsource =  '''
-             integer function foo()
-             foo = 10 + 5
-             return
-             end
-             '''
-    # use various helper functions in util.py to
-    # enable robust build / compile and
-    # reimport cycle in test suite
-    d = util.get_module_dir()
-    modulename = util.get_temp_module_name()
-
-    cwd = os.getcwd()
-    target = os.path.join(d, str(uuid.uuid4()) + '.f')
-    # try running compile() with and without a
-    # source_fn provided so that the code path 
-    # where a temporary file for writing Fortran
-    # source is created is also explored
-    for source_fn in [target, None]:
-
-        # mimic the path changing behavior used
-        # by build_module() in util.py, but don't
-        # actually use build_module() because it
-        # has its own invocation of subprocess
-        # that circumvents the f2py.compile code
-        # block under test
-        try:
-            os.chdir(d)
-            ret_val = numpy.f2py.compile(fsource,
-                                         modulename=modulename,
-                                         extra_args=extra_args,
-                                         source_fn=source_fn)
-        finally:
-            os.chdir(cwd)
-
-        # check for compile success return value
-        assert_equal(ret_val, 0)
-
-        # we are not currently able to import the
-        # Python-Fortran interface module on Windows /
-        # Appveyor, even though we do get successful
-        # compilation on that platform with Python 3.x
-        if os.name != 'nt':
-            # check for sensible result of Fortran function;
-            # that means we can import the module name in Python
-            # and retrieve the result of the sum operation
-            return_check = import_module(modulename)
-            calc_result = return_check.foo()
-            assert_equal(calc_result, 15)
-
-def test_f2py_init_compile_failure():
-    # verify an appropriate integer status
-    # value returned by f2py.compile() when
-    # invalid Fortran is provided
-    ret_val = numpy.f2py.compile(b"invalid")
-    assert_equal(ret_val, 1)
-
-def test_f2py_init_compile_bad_cmd():
-    # verify that usage of invalid command in
-    # f2py.compile() returns status value of 127
-    # for historic consistency with exec_command()
-    # error handling
-
-    # patch the sys Python exe path temporarily to
-    # induce an OSError downstream
-    # NOTE: how bad of an idea is this patching?
-    try:
-        temp = sys.executable
-        sys.executable = 'does not exist'
-
-        # the OSError should take precedence over the invalid
-        # Fortran
-        ret_val = numpy.f2py.compile(b"invalid")
-
-        assert_equal(ret_val, 127)
-    finally:
-        sys.executable = temp


### PR DESCRIPTION

- Create new file `test_compile_function.py` for the test, transferring
  the content from `test_quoted_characters.py` where it was before. The
  tricky part here is maintaining the history in both files after the
  move.
    
- The tests were failing on platforms without a fortran compiler as that
  was not being checked for. Add that check among others and clean up the
  test functions a bit.



<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
