### PR TITLE
MAINT: Add a RuntimeError to prove _typestr` is unused

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -774,6 +774,7 @@ for key in _sctype2char_dict.keys():
 for key, val in _typestr.items():
     if val not in sctypeDict:
         sctypeDict[val] = key
+        raise RuntimeError('{!r}: {!r} was not in sctype'.format(key, val))
 
 # Add additional strings to the sctypeDict
 


### PR DESCRIPTION
Follow up will be to remove the preceding lines of code, once CI proves this is never hit on any platform.

This dates way back to 668950285c407593a368336ff2e737c5da84af7d, so probably has just been made redundant by one of the ~10 other loops in this file that try to assign names to types.
