### PR TITLE
 MAINT: Eliminate the private `numerictypes._typestr`

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -762,20 +762,6 @@ ScalarType = tuple(ScalarType)
 for key in _sctype2char_dict.keys():
     cast[key] = lambda x, k=key: array(x, copy=False).astype(k)
 
-# Create the typestring lookup dictionary
-_typestr = _typedict()
-for key in _sctype2char_dict.keys():
-    if issubclass(key, allTypes['flexible']):
-        _typestr[key] = _sctype2char_dict[key]
-    else:
-        _typestr[key] = empty((1,), key).dtype.str[1:]
-
-# Make sure all typestrings are in sctypeDict
-for key, val in _typestr.items():
-    if val not in sctypeDict:
-        sctypeDict[val] = key
-        raise RuntimeError('{!r}: {!r} was not in sctype'.format(key, val))
-
 # Add additional strings to the sctypeDict
 
 if sys.version_info[0] >= 3:

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -774,6 +774,7 @@ for key in _sctype2char_dict.keys():
 for key, val in _typestr.items():
     if val not in sctypeDict:
         sctypeDict[val] = key
+        raise RuntimeError('{!r}: {!r} was not in sctype'.format(key, val))
 
 # Add additional strings to the sctypeDict
 

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -29,7 +29,6 @@ from numpy.core.records import (
         )
 
 _byteorderconv = np.core.records._byteorderconv
-_typestr = ntypes._typestr
 
 import numpy.ma as ma
 from numpy.ma import (
@@ -46,24 +45,6 @@ __all__ = [
     ]
 
 reserved_fields = ['_data', '_mask', '_fieldmask', 'dtype']
-
-
-def _getformats(data):
-    """
-    Returns the formats of arrays in arraylist as a comma-separated string.
-
-    """
-    if hasattr(data, 'dtype'):
-        return ",".join([desc[1] for desc in data.dtype.descr])
-
-    formats = ''
-    for obj in data:
-        obj = np.asarray(obj)
-        formats += _typestr[obj.dtype.type]
-        if issubclass(obj.dtype.type, ntypes.flexible):
-            formats += repr(obj.itemsize)
-        formats += ','
-    return formats[:-1]
 
 
 def _checknames(descr, names=None):


### PR DESCRIPTION
Follows on from and closes #12007. CI should show travis + appveyor passing on both commits below to prove that the removed code was never used.