### PR TITLE
TST: prefer pytest.skip() over SkipTest

### DIFF
--- a/numpy/core/tests/_locales.py
+++ b/numpy/core/tests/_locales.py
@@ -6,7 +6,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import locale
 
-from numpy.testing import SkipTest
+import pytest
 
 __ALL__ = ['CommaDecimalPointLocale']
 
@@ -52,7 +52,7 @@ class CommaDecimalPointLocale(object):
     tests with locale.LC_NUMERIC set to a locale where commas (',') are used as
     the decimal point instead of periods ('.'). On exit the locale is restored
     to the initial locale. It also serves as context manager with the same
-    effect. If no such locale is available, it raises SkipTest in both cases.
+    effect. If no such locale is available, the test is skipped.
 
     .. versionadded:: 1.15.0
 
@@ -61,7 +61,7 @@ class CommaDecimalPointLocale(object):
 
     def setup(self):
         if self.tst_locale is None:
-            raise SkipTest("No French locale available")
+            pytest.skip("No French locale available")
         locale.setlocale(locale.LC_NUMERIC, locale=self.tst_locale)
 
     def teardown(self):
@@ -69,7 +69,7 @@ class CommaDecimalPointLocale(object):
 
     def __enter__(self):
         if self.tst_locale is None:
-            raise SkipTest("No French locale available")
+            pytest.skip("No French locale available")
         locale.setlocale(locale.LC_NUMERIC, locale=self.tst_locale)
 
     def __exit__(self, type, value, traceback):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -33,7 +33,7 @@ from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
     assert_allclose, IS_PYPY, HAS_REFCOUNT, assert_array_less, runstring,
-    SkipTest, temppath, suppress_warnings
+    temppath, suppress_warnings
     )
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
@@ -4864,8 +4864,8 @@ class TestRecord(object):
 
         # non-ascii unicode field indexing is well behaved
         if not is_py3:
-            raise SkipTest('non ascii unicode field indexing skipped; '
-                           'raises segfault on python 2.x')
+            pytest.skip('non ascii unicode field indexing skipped; '
+                        'raises segfault on python 2.x')
         else:
             assert_raises(ValueError, a.__setitem__, u'\u03e0', 1)
             assert_raises(ValueError, a.__getitem__, u'\u03e0')

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 import numpy as np
-from numpy.testing import assert_, assert_equal, SkipTest
+from numpy.testing import assert_, assert_equal
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
 

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import sys
 import copy
+import pytest
 
 from numpy import (
     array, alltrue, ndarray, zeros, dtype, intp, clongdouble

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -8,7 +8,7 @@ import copy
 from numpy import (
     array, alltrue, ndarray, zeros, dtype, intp, clongdouble
     )
-from numpy.testing import assert_, assert_equal, SkipTest
+from numpy.testing import assert_, assert_equal
 from numpy.core.multiarray import typeinfo
 from . import util
 
@@ -24,7 +24,7 @@ def setup_module():
 
     # Check compiler availability first
     if not util.has_c_compiler():
-        raise SkipTest("No C compiler available")
+        pytest.skip("No C compiler available")
 
     if wrap is None:
         config_code = """

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -20,7 +20,7 @@ import pytest
 import numpy.f2py
 
 from numpy.compat import asbytes, asstr
-from numpy.testing import SkipTest, temppath
+from numpy.testing import temppath
 from importlib import import_module
 
 try:
@@ -322,14 +322,14 @@ class F2PyTest(object):
 
     def setup(self):
         if sys.platform == 'win32':
-            raise SkipTest('Fails with MinGW64 Gfortran (Issue #9673)')
+            pytest.skip('Fails with MinGW64 Gfortran (Issue #9673)')
 
         if self.module is not None:
             return
 
         # Check compiler availability first
         if not has_c_compiler():
-            raise SkipTest("No C compiler available")
+            pytest.skip("No C compiler available")
 
         codes = []
         if self.sources:
@@ -345,9 +345,9 @@ class F2PyTest(object):
             elif fn.endswith('.f90'):
                 needs_f90 = True
         if needs_f77 and not has_f77_compiler():
-            raise SkipTest("No Fortran 77 compiler available")
+            pytest.skip("No Fortran 77 compiler available")
         if needs_f90 and not has_f90_compiler():
-            raise SkipTest("No Fortran 90 compiler available")
+            pytest.skip("No Fortran 90 compiler available")
 
         # Build the module
         if self.code is not None:

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -8,7 +8,7 @@ from shutil import rmtree
 
 import numpy.lib._datasource as datasource
 from numpy.testing import (
-    assert_, assert_equal, assert_raises, assert_warns, SkipTest
+    assert_, assert_equal, assert_raises, assert_warns
     )
 
 if sys.version_info[0] >= 3:
@@ -137,7 +137,7 @@ class TestDataSourceOpen(object):
             import gzip
         except ImportError:
             # We don't have the gzip capabilities to test.
-            raise SkipTest
+            pytest.skip()
         # Test datasource's internal file_opener for Gzip files.
         filepath = os.path.join(self.tmpdir, 'foobar.txt.gz')
         fp = gzip.open(filepath, 'w')
@@ -153,7 +153,7 @@ class TestDataSourceOpen(object):
             import bz2
         except ImportError:
             # We don't have the bz2 capabilities to test.
-            raise SkipTest
+            pytest.skip()
         # Test datasource's internal file_opener for BZip2 files.
         filepath = os.path.join(self.tmpdir, 'foobar.txt.bz2')
         fp = bz2.BZ2File(filepath, 'w')
@@ -170,7 +170,7 @@ class TestDataSourceOpen(object):
             import bz2
         except ImportError:
             # We don't have the bz2 capabilities to test.
-            raise SkipTest
+            pytest.skip()
         # Test datasource's internal file_opener for BZip2 files.
         filepath = os.path.join(self.tmpdir, 'foobar.txt.bz2')
         fp = bz2.BZ2File(filepath, 'w')

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -287,7 +287,7 @@ from io import BytesIO
 import numpy as np
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises, assert_raises_regex,
-    raises, SkipTest
+    raises
     )
 from numpy.lib import format
 
@@ -807,7 +807,7 @@ def test_bad_header():
 
 def test_large_file_support():
     if (sys.platform == 'win32' or sys.platform == 'cygwin'):
-        raise SkipTest("Unknown if Windows has sparse filesystems")
+        pytest.skip("Unknown if Windows has sparse filesystems")
     # try creating a large sparse file
     tf_name = os.path.join(tempdir, 'sparse_file')
     try:
@@ -817,7 +817,7 @@ def test_large_file_support():
         import subprocess as sp
         sp.check_call(["truncate", "-s", "5368709120", tf_name])
     except Exception:
-        raise SkipTest("Could not create 5GB large file")
+        pytest.skip("Could not create 5GB large file")
     # write a small array to the end
     with open(tf_name, "wb") as f:
         f.seek(5368709120)
@@ -839,7 +839,7 @@ def test_large_archive():
     try:
         a = np.empty((2**30, 2), dtype=np.uint8)
     except MemoryError:
-        raise SkipTest("Could not create large file")
+        pytest.skip("Could not create large file")
 
     fname = os.path.join(tempdir, "large_archive")
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -21,7 +21,7 @@ from numpy.lib._iotools import ConverterError, ConversionWarning
 from numpy.compat import asbytes, bytes, unicode, Path
 from numpy.ma.testutils import assert_equal
 from numpy.testing import (
-    assert_warns, assert_, SkipTest, assert_raises_regex, assert_raises,
+    assert_warns, assert_, assert_raises_regex, assert_raises,
     assert_allclose, assert_array_equal, temppath, tempdir, IS_PYPY,
     HAS_REFCOUNT, suppress_warnings, assert_no_gc_cycles,
     )
@@ -2033,8 +2033,8 @@ M   33  21.99
             encoding = locale.getpreferredencoding()
             utf8.encode(encoding)
         except (UnicodeError, ImportError):
-            raise SkipTest('Skipping test_utf8_file_nodtype_unicode, '
-                           'unable to encode utf8 in preferred encoding')
+            pytest.skip('Skipping test_utf8_file_nodtype_unicode, '
+                        'unable to encode utf8 in preferred encoding')
 
         with temppath() as path:
             with io.open(path, "wt") as f:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -19,7 +19,7 @@ from numpy.linalg import matrix_power, norm, matrix_rank, multi_dot, LinAlgError
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal,
-    assert_almost_equal, assert_allclose, SkipTest, suppress_warnings
+    assert_almost_equal, assert_allclose, suppress_warnings
     )
 
 
@@ -1751,7 +1751,7 @@ def test_xerbla_override():
         pid = os.fork()
     except (OSError, AttributeError):
         # fork failed, or not running on POSIX
-        raise SkipTest("Not POSIX or fork failed.")
+        pytest.skip("Not POSIX or fork failed.")
 
     if pid == 0:
         # child; close i/o file handles
@@ -1786,7 +1786,7 @@ def test_xerbla_override():
         # parent
         pid, status = os.wait()
         if os.WEXITSTATUS(status) != XERBLA_OK:
-            raise SkipTest('Numpy xerbla not linked in.')
+            pytest.skip('Numpy xerbla not linked in.')
 
 
 def test_sdot_bug_8577():


### PR DESCRIPTION
Fixes #12013.

Before this PR usage of `SkipTest()` would lead to skip output like this: `SKIP [11] /home/treddy/miniconda2/envs/numpy_dev_py3/lib/python3.6/site-packages/_pytest/nose.py:24: No French locale available`

We now avoid the `pytest` `nose / unittest` compatbility layer for test skipping, which allows us to get a better trace of the test skip location:
- `SKIP [10] /mnt/c/Users/treddy/github_projects/numpy/build/testenv/lib/python3.6/site-packages/numpy/core/tests/_locales.py:65: No French locale available`
- `SKIP [1] /mnt/c/Users/treddy/github_projects/numpy/build/testenv/lib/python3.6/site-packages/numpy/core/tests/_locales.py:73: No French locale available`

Can test locally with explicit skip output using i.e., `python runtests.py --mode=full -- -n 3 -rsx`, and a similar command in shippable is used on master so that should be updated on this branch with new trace to line location.

Also, reduce confusion regarding routing through  `nose.py`.

Not a complete removal of `SkipTest()` because there seems to be some nose compatibility stuff of our own related to decorators, which looks harder to migrate, if we want to at all for that.

While many of the changes are minor, there may be a preference to split into smaller PRs on i.e., a per-file basis.