### PR TITLE
BUG: check return value from PyArray_PromoteTypes

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -2028,7 +2028,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
 {
     int i, n, allscalars = 0;
     PyArrayObject **mps = NULL;
-    PyObject *otmp;
+    PyObject *otmp = NULL;
     PyArray_Descr *intype = NULL, *stype = NULL;
     PyArray_Descr *newtype = NULL;
     NPY_SCALARKIND scalarkind = NPY_NOSCALAR, intypekind = NPY_NOSCALAR;
@@ -2112,6 +2112,9 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
             newtype = PyArray_PromoteTypes(intype, stype);
             Py_XDECREF(intype);
             intype = newtype;
+            if (newtype == NULL) {
+                goto fail;
+            }
         }
         for (i = 0; i < n; i++) {
             Py_XDECREF(mps[i]);
@@ -2147,6 +2150,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
  fail:
     Py_XDECREF(intype);
     Py_XDECREF(stype);
+    Py_XDECREF(otmp);
     *retn = 0;
     for (i = 0; i < n; i++) {
         Py_XDECREF(mps[i]);

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -2028,7 +2028,6 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
 {
     int i, n, allscalars = 0;
     PyArrayObject **mps = NULL;
-    PyObject *otmp = NULL;
     PyArray_Descr *intype = NULL, *stype = NULL;
     PyArray_Descr *newtype = NULL;
     NPY_SCALARKIND scalarkind = NPY_NOSCALAR, intypekind = NPY_NOSCALAR;
@@ -2067,9 +2066,13 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     }
 
     for (i = 0; i < n; i++) {
-        otmp = PySequence_GetItem(op, i);
+        PyObject *otmp = PySequence_GetItem(op, i);
+        if (otmp == NULL) {
+            goto fail;
+        }
         if (!PyArray_CheckAnyScalar(otmp)) {
             newtype = PyArray_DescrFromObject(otmp, intype);
+            Py_DECREF(otmp);
             Py_XDECREF(intype);
             if (newtype == NULL) {
                 goto fail;
@@ -2079,6 +2082,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
         }
         else {
             newtype = PyArray_DescrFromObject(otmp, stype);
+            Py_DECREF(otmp);
             Py_XDECREF(stype);
             if (newtype == NULL) {
                 goto fail;
@@ -2088,7 +2092,6 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
             mps[i] = (PyArrayObject *)Py_None;
             Py_INCREF(Py_None);
         }
-        Py_XDECREF(otmp);
     }
     if (intype == NULL) {
         /* all scalars */
@@ -2126,8 +2129,9 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     /* Make sure all arrays are actual array objects. */
     for (i = 0; i < n; i++) {
         int flags = NPY_ARRAY_CARRAY;
+        PyObject *otmp = PySequence_GetItem(op, i);
 
-        if ((otmp = PySequence_GetItem(op, i)) == NULL) {
+        if (otmp == NULL) {
             goto fail;
         }
         if (!allscalars && ((PyObject *)(mps[i]) == Py_None)) {
@@ -2136,8 +2140,8 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
             Py_DECREF(Py_None);
         }
         Py_INCREF(intype);
-        mps[i] = (PyArrayObject*)
-            PyArray_FromAny(otmp, intype, 0, 0, flags, NULL);
+        mps[i] = (PyArrayObject*)PyArray_FromAny(otmp, intype, 0, 0,
+                                                 flags, NULL);
         Py_DECREF(otmp);
         if (mps[i] == NULL) {
             goto fail;
@@ -2150,7 +2154,6 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
  fail:
     Py_XDECREF(intype);
     Py_XDECREF(stype);
-    Py_XDECREF(otmp);
     *retn = 0;
     for (i = 0; i < n; i++) {
         Py_XDECREF(mps[i]);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1416,6 +1416,10 @@ class TestMethods(object):
         A = ind.choose((x, y2))
         assert_equal(A, [[2, 2, 3], [2, 2, 3]])
 
+        oned = np.ones(1)
+        # gh-12031, caused SEGFAULT
+        assert_raises(TypeError, oned.choose,np.void(0), [oned])
+
     def test_prod(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
         ba2 = [[1, 2, 3, 4], [5, 6, 7, 9], [10, 3, 4, 5]]


### PR DESCRIPTION
Fixes #12031. by checking the return value from `PyArray_PromoteTypes`. Also make sure to decref `otmp` on error.