### PR TITLE
TST: Mark check for f2py script xfail.

### DIFF
--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -9,6 +9,7 @@ import os
 import pytest
 from os.path import join as pathjoin, isfile, dirname, basename
 from subprocess import Popen, PIPE
+import warnings
 
 import numpy as np
 from numpy.compat.py3k import basestring
@@ -92,7 +93,14 @@ def test_f2py():
         version = sys.version_info
         major = str(version.major)
         minor = str(version.minor)
+        f2py_success = try_f2py_commands(('f2py',))
         f2py_cmds = ('f2py', 'f2py' + major, 'f2py' + major + '.' + minor)
-        success = try_f2py_commands(f2py_cmds)
-        msg = "Warning: not all of %s, %s, and %s are found in path" % f2py_cmds
-        assert_(success == 3, msg)
+        all_success = try_f2py_commands(f2py_cmds)
+        if all_success == 3:
+            return
+        elif f2py_success == 1:
+            msg = "f2py fails"
+            warnings.warn(msg)
+        else:
+            msg = "No {}, {}, {} found".format(f2py_cmds)
+            assert_(f2py_success > 0, msg)

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -61,6 +61,7 @@ def run_command(cmd, check_code=True):
 
 
 @pytest.mark.skipif(is_inplace, reason="Cannot test f2py command inplace")
+@pytest.mark.xfail(reason="Test is unreliable")
 def test_f2py():
     # test that we can run f2py script
 
@@ -93,14 +94,7 @@ def test_f2py():
         version = sys.version_info
         major = str(version.major)
         minor = str(version.minor)
-        f2py_success = try_f2py_commands(('f2py',))
         f2py_cmds = ('f2py', 'f2py' + major, 'f2py' + major + '.' + minor)
-        all_success = try_f2py_commands(f2py_cmds)
-        if all_success == 3:
-            return
-        elif f2py_success == 1:
-            msg = "f2py fails"
-            warnings.warn(msg)
-        else:
-            msg = "No {}, {}, {} found".format(f2py_cmds)
-            assert_(f2py_success > 0, msg)
+        success = try_f2py_commands(f2py_cmds)
+        msg = "Warning: not all of %s, %s, and %s are found in path" % f2py_cmds
+        assert_(success == 3, msg)

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -9,7 +9,6 @@ import os
 import pytest
 from os.path import join as pathjoin, isfile, dirname, basename
 from subprocess import Popen, PIPE
-import warnings
 
 import numpy as np
 from numpy.compat.py3k import basestring


### PR DESCRIPTION
Context:

When running the tests via `python [ROOT DIR]/runtests.py` on windows linux subsystem a test fails with respect to f2py, f2py3, f2py3.6.

This is despite the fact that f2py exists in the my path, however I don't have f2py3 or f2py3.6 which shouldn't be required for the tests to pass.

closes gh-10016