### PR TITLE
MAINT: Add version deprecated to some deprecation messages.

### DIFF
--- a/numpy/testing/decorators.py
+++ b/numpy/testing/decorators.py
@@ -8,8 +8,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 
 # 2018-04-04, numpy 1.15.0
-warnings.warn("Importing from numpy.testing.decorators is deprecated, "
-              "import from numpy.testing instead.",
+warnings.warn("Importing from numpy.testing.decorators is deprecated "
+              "since numpy 1.15.0, import from numpy.testing instead.",
               DeprecationWarning, stacklevel=2)
 
 from ._private.decorators import *

--- a/numpy/testing/noseclasses.py
+++ b/numpy/testing/noseclasses.py
@@ -7,8 +7,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 
 # 2018-04-04, numpy 1.15.0
-warnings.warn("Importing from numpy.testing.noseclasses is deprecated, "
-              "import from numpy.testing instead",
+warnings.warn("Importing from numpy.testing.noseclasses is deprecated "
+              "since 1.15.0, import from numpy.testing instead",
               DeprecationWarning, stacklevel=2)
 
 from ._private.noseclasses import *

--- a/numpy/testing/nosetester.py
+++ b/numpy/testing/nosetester.py
@@ -8,8 +8,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 
 # 2018-04-04, numpy 1.15.0
-warnings.warn("Importing from numpy.testing.nosetester is deprecated, "
-              "import from numpy.testing instead.",
+warnings.warn("Importing from numpy.testing.nosetester is deprecated "
+              "since 1.15.0, import from numpy.testing instead.",
               DeprecationWarning, stacklevel=2)
 
 from ._private.nosetester import *

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -8,8 +8,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 
 # 2018-04-04, numpy 1.15.0
-warnings.warn("Importing from numpy.testing.utils is deprecated, "
-              "import from numpy.testing instead.",
+warnings.warn("Importing from numpy.testing.utils is deprecated "
+              "since 1.15.0, import from numpy.testing instead.",
               ImportWarning, stacklevel=2)
 
 from ._private.utils import *


### PR DESCRIPTION
Otherwise the deprecation message is not that helpful as I have to dig
through the source to find out since when and whether conditional import
is necessary in my code. I may not have numpy on my dev machine (this
message was on CI). So it's one extra step for the consumer.

That's also for you, you have more chance of having consumer update
their code when they have more informations in the deprecation message,
so you can drop old code faster !

At least kudo to Charles Harris for including a comments just above,
that prevented me from having to git blame and go spelunking for knowing
which versions were or not affected.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
