### PR TITLE
MAINT: remove duplicate imports

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -13,7 +13,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    assert_raises, suppress_warnings, HAS_REFCOUNT
+    suppress_warnings, HAS_REFCOUNT
     )
 
 

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -5,8 +5,6 @@ import sys
 import copy
 import pytest
 
-import pytest
-
 from numpy import (
     array, alltrue, ndarray, zeros, dtype, intp, clongdouble
     )


### PR DESCRIPTION
Continuation of PR #11893 

Running 
```
flake8 --select F811 `find numpy -name "*.py"`
``` 
exposed duplicate imports.