### PR TITLE
BUG: fix memory leak of buffer format string

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -560,7 +560,6 @@ _buffer_info_new(PyObject *obj)
     err = _buffer_format_string(descr, &fmt, obj, NULL, NULL);
     Py_DECREF(descr);
     if (err != 0) {
-        free(fmt.s);
         goto fail;
     }
     if (_append_char(&fmt, '\0') < 0) {
@@ -571,6 +570,7 @@ _buffer_info_new(PyObject *obj)
     return info;
 
 fail:
+    free(fmt.s);
     free(info);
     return NULL;
 }


### PR DESCRIPTION
#11694 (and backport #11785) added a special case for datetime64 and timedelta63 scalars. This case used `_append_char` earlier than before so now `_tmp_string_t` must be freed in the fail label.