### PR TITLE
BLD: pin sphinx to 1.7.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install cython sphinx matplotlib
+            pip install cython sphinx==1.7.9 matplotlib
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 


### PR DESCRIPTION
Sphinx 1.8.0 requires updating style templates. Ours is from scipy/scipy-sphinx-theme, and has not (as of this PR) been updated. This causes issue #12044 (broken quicksearch) for us which has been opened upstream as issue scipy/scipy-sphinx-theme#9 and is being discussed in sphinx at issue sphinx-doc/sphinx#5460 as well.

I propose pinning sphinx to version 1.7.9 until the dust settles around the 1.8 transition.