### PR TITLE
TST: add macos azure testing to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,56 @@
+jobs:
+- job: macOS
+  pool:
+    # NOTE: at time of writing, there is a danger
+    # that using an invalid vmIMage string for macOS
+    # image silently redirects to a Windows build on Azure;
+    # for now, use the only image name officially present in
+    # the docs even though i.e., numba uses another in their
+    # azure config for mac os -- Microsoft has indicated
+    # they will patch this issue
+    vmIMage: macOS-10.13
+  steps:
+  # the @0 refers to the (major) version of the *task* on Microsoft's
+  # end, not the order in the build matrix nor anything to do
+  # with version of Python selected
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      addToPath: true
+      architecture: 'x64'
+  # NOTE: do we have a compelling reason to use older / newer
+  # versions of Xcode toolchain for testing?
+  - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
+    displayName: 'select Xcode version'
+  # NOTE: might be better if we could avoid installing
+  # two C compilers, but with homebrew looks like we're
+  # now stuck getting the full gcc toolchain instead of
+  # just pulling in gfortran
+  - script: brew install gcc
+    displayName: 'make gfortran available on mac os vm'
+  - script: python -m pip install --upgrade pip setuptools wheel
+    displayName: 'Install tools'
+  - script: python -m pip install cython nose pytest-xdist pytz
+    displayName: 'Install dependencies; some are optional to avoid test skips'
+  # NOTE: init_dgelsd failed init issue with current ACCELERATE /
+  # LAPACK configuration on Azure macos image; at the time of writing
+  # this plagues homebrew / macports NumPy builds, but we will
+  # circumvent for now by aggressively disabling acceleration for
+  # macos NumPy builds / tests; ACCELERATE=None on its own is not
+  # sufficient
+  # also, might as well prefer usage of clang over gcc proper
+  # to match likely scenario on many user mac machines
+  - script: python setup.py build -j 4 install
+    displayName: 'Build NumPy'
+    env:
+      BLAS: None
+      LAPACK: None
+      ATLAS: None
+      ACCELERATE: None
+      CC: /usr/bin/clang
+  - script: python runtests.py --mode=full -- -n auto -rsx --junitxml=junit/test-results.xml
+    displayName: 'Run Full NumPy Test Suite'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -1,5 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
+import platform
+import pytest
+
 from . import util
 from numpy.testing import assert_equal
 
@@ -23,6 +26,10 @@ void foo(int* x) {{
 end python module {module}
     """.format(module=module_name)
 
+    @pytest.mark.skipif(platform.system() == 'Darwin',
+                        reason="Prone to error when run with "
+                               "numpy/f2py/tests on mac os, "
+                               "but not when run in isolation")
     def test_multiline(self):
         assert_equal(self.module.foo(), 42)
 


### PR DESCRIPTION
Related to #12036.

I figured I'd start this with Mac OS for Azure because that platform is absent from our current github-integrated CI, which perhaps reduces the pressure to replicate a current matrix entry & allows restoration of a common platform to the test matrix with apparently short queues at the moment.

I tried to add detailed notes to the `yml` file. I think the discussion surrounding test & support for accelerate on mac is tricky, perhaps in no small part to the opacity of the resolution of bugs there and so on.

If we want to expand the matrix or try an `x86` arch target or whatever else I suppose that may be something to discuss. My impression is that we may want to focus the 10 free parallel jobs on Azure mostly to relieve current Windows bottlenecks.

[All tests are passing on my fork with this PR branch](https://dev.azure.com/tylerjereddy/numpy-test/_build/results?buildId=84&view=logs). You can see some helpful stats on the [test data page](https://dev.azure.com/tylerjereddy/numpy-test/_build/results?buildId=84&view=ms.vss-test-web.test-result-details), including the drop in test time from the previous run when a single core was used for pytest.

As usual, getting to "all green" on the tests with a new platform was a bit painful -- my compromise was to add 1 more `skipif` decorator on a single `f2py` test. `f2py` is always a "treat" to work with, but homebrew gfortran mostly seems to play ok with it.

If core devs / steering committe would like, I can look into trying to activate the github hook for azure so we can see it on this PR for NumPy repo proper -- otherwise, one of the "owners" may have to do that.

cc Microsoft folks who commented elsewhere: @ericsciple @chrisrpatterson