### PR TITLE
MAINT: delay initialization of getlimits (circular imports)

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -164,7 +164,7 @@ else:
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits
-    core.getlimits._init_getlimits()
+    core.getlimits._register_known_types()
 
     __all__.extend(['__version__', 'show_config'])
     __all__.extend(core.__all__)

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -163,6 +163,8 @@ else:
         from __builtin__ import bool, int, float, complex, object, unicode, str
 
     from .core import round, abs, max, min
+    # now that numpy modules are imported, can initialize limits
+    core.getlimits._init_getlimits()
 
     __all__.extend(['__version__', 'show_config'])
     __all__.extend(core.__all__)

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -57,101 +57,110 @@ class MachArLike(object):
         self._str_xmax = float_to_str(self.xmax)
         self._str_resolution = float_to_str(self.resolution)
 
-def _init_getlimits():
+_convert_to_float = {
+    ntypes.csingle: ntypes.single,
+    ntypes.complex_: ntypes.float_,
+    ntypes.clongfloat: ntypes.longfloat
+    }
 
-    global _convert_to_float, _title_fmt, _MACHAR_PARAMS
-    _convert_to_float = {
-        ntypes.csingle: ntypes.single,
-        ntypes.complex_: ntypes.float_,
-        ntypes.clongfloat: ntypes.longfloat
-        }
+# Parameters for creating MachAr / MachAr-like objects
+_title_fmt = 'numpy {} precision floating point number'
+_MACHAR_PARAMS = {
+    ntypes.double: dict(
+        itype = ntypes.int64,
+        fmt = '%24.16e',
+        title = _title_fmt.format('double')),
+    ntypes.single: dict(
+        itype = ntypes.int32,
+        fmt = '%15.7e',
+        title = _title_fmt.format('single')),
+    ntypes.longdouble: dict(
+        itype = ntypes.longlong,
+        fmt = '%s',
+        title = _title_fmt.format('long double')),
+    ntypes.half: dict(
+        itype = ntypes.int16,
+        fmt = '%12.5e',
+        title = _title_fmt.format('half'))}
 
-    # Parameters for creating MachAr / MachAr-like objects
-    _title_fmt = 'numpy {} precision floating point number'
-    _MACHAR_PARAMS = {
-        ntypes.double: dict(
-            itype = ntypes.int64,
-            fmt = '%24.16e',
-            title = _title_fmt.format('double')),
-        ntypes.single: dict(
-            itype = ntypes.int32,
-            fmt = '%15.7e',
-            title = _title_fmt.format('single')),
-        ntypes.longdouble: dict(
-            itype = ntypes.longlong,
-            fmt = '%s',
-            title = _title_fmt.format('long double')),
-        ntypes.half: dict(
-            itype = ntypes.int16,
-            fmt = '%12.5e',
-            title = _title_fmt.format('half'))}
+# Key to identify the floating point type.  Key is result of
+# ftype('-0.1').newbyteorder('<').tobytes()
+# See:
+# https://perl5.git.perl.org/perl.git/blob/3118d7d684b56cbeb702af874f4326683c45f045:/Configure
+_KNOWN_TYPES = {}
+def _register_type(machar, bytepat):
+    _KNOWN_TYPES[bytepat] = machar
+_float_ma = {}
 
+def _register_known_types():
     # Known parameters for float16
     # See docstring of MachAr class for description of parameters.
-    global _f16, _float16_ma
-    _f16 = ntypes.float16
-    _float16_ma = MachArLike(_f16,
-                             machep=-10,
-                             negep=-11,
-                             minexp=-14,
-                             maxexp=16,
-                             it=10,
-                             iexp=5,
-                             ibeta=2,
-                             irnd=5,
-                             ngrd=0,
-                             eps=exp2(_f16(-10)),
-                             epsneg=exp2(_f16(-11)),
-                             huge=_f16(65504),
-                             tiny=_f16(2 ** -14))
+    f16 = ntypes.float16
+    float16_ma = MachArLike(f16,
+                            machep=-10,
+                            negep=-11,
+                            minexp=-14,
+                            maxexp=16,
+                            it=10,
+                            iexp=5,
+                            ibeta=2,
+                            irnd=5,
+                            ngrd=0,
+                            eps=exp2(f16(-10)),
+                            epsneg=exp2(f16(-11)),
+                            huge=f16(65504),
+                            tiny=f16(2 ** -14))
+    _register_type(float16_ma, b'f\xae')
+    _float_ma[16] = float16_ma
 
     # Known parameters for float32
-    global _f32, _float32_ma
-    _f32 = ntypes.float32
-    _float32_ma = MachArLike(_f32,
-                             machep=-23,
-                             negep=-24,
-                             minexp=-126,
-                             maxexp=128,
-                             it=23,
-                             iexp=8,
-                             ibeta=2,
-                             irnd=5,
-                             ngrd=0,
-                             eps=exp2(_f32(-23)),
-                             epsneg=exp2(_f32(-24)),
-                             huge=_f32((1 - 2 ** -24) * 2**128),
-                             tiny=exp2(_f32(-126)))
+    f32 = ntypes.float32
+    float32_ma = MachArLike(f32,
+                            machep=-23,
+                            negep=-24,
+                            minexp=-126,
+                            maxexp=128,
+                            it=23,
+                            iexp=8,
+                            ibeta=2,
+                            irnd=5,
+                            ngrd=0,
+                            eps=exp2(f32(-23)),
+                            epsneg=exp2(f32(-24)),
+                            huge=f32((1 - 2 ** -24) * 2**128),
+                            tiny=exp2(f32(-126)))
+    _register_type(float32_ma, b'\xcd\xcc\xcc\xbd')
+    _float_ma[32] = float32_ma
 
     # Known parameters for float64
-    global _f64, _epsned_f64, _tiny_f64, _float64_ma
-    _f64 = ntypes.float64
-    _epsneg_f64 = 2.0 ** -53.0
-    _tiny_f64 = 2.0 ** -1022.0
-    _float64_ma = MachArLike(_f64,
-                             machep=-52,
-                             negep=-53,
-                             minexp=-1022,
-                             maxexp=1024,
-                             it=52,
-                             iexp=11,
-                             ibeta=2,
-                             irnd=5,
-                             ngrd=0,
-                             eps=2.0 ** -52.0,
-                             epsneg=_epsneg_f64,
-                             huge=(1.0 - _epsneg_f64) / _tiny_f64 * _f64(4),
-                             tiny=_tiny_f64)
+    f64 = ntypes.float64
+    epsneg_f64 = 2.0 ** -53.0
+    tiny_f64 = 2.0 ** -1022.0
+    float64_ma = MachArLike(f64,
+                            machep=-52,
+                            negep=-53,
+                            minexp=-1022,
+                            maxexp=1024,
+                            it=52,
+                            iexp=11,
+                            ibeta=2,
+                            irnd=5,
+                            ngrd=0,
+                            eps=2.0 ** -52.0,
+                            epsneg=epsneg_f64,
+                            huge=(1.0 - epsneg_f64) / tiny_f64 * f64(4),
+                            tiny=tiny_f64)
+    _register_type(float64_ma, b'\x9a\x99\x99\x99\x99\x99\xb9\xbf')
+    _float_ma[64] = float64_ma
 
     # Known parameters for IEEE 754 128-bit binary float
-    global _ld, _epsneg, _tiny_f128, _huge_f128, _float128_ma
-    _ld = ntypes.longdouble
-    _epsneg_f128 = exp2(_ld(-113))
-    _tiny_f128 = exp2(_ld(-16382))
+    ld = ntypes.longdouble
+    epsneg_f128 = exp2(ld(-113))
+    tiny_f128 = exp2(ld(-16382))
     # Ignore runtime error when this is not f128
     with numeric.errstate(all='ignore'):
-        _huge_f128 = (_ld(1) - _epsneg_f128) / _tiny_f128 * _ld(4)
-    _float128_ma = MachArLike(_ld,
+        huge_f128 = (ld(1) - epsneg_f128) / tiny_f128 * ld(4)
+    float128_ma = MachArLike(ld,
                              machep=-112,
                              negep=-113,
                              minexp=-16382,
@@ -161,42 +170,49 @@ def _init_getlimits():
                              ibeta=2,
                              irnd=5,
                              ngrd=0,
-                             eps=exp2(_ld(-112)),
-                             epsneg=_epsneg_f128,
-                             huge=_huge_f128,
-                             tiny=_tiny_f128)
+                             eps=exp2(ld(-112)),
+                             epsneg=epsneg_f128,
+                             huge=huge_f128,
+                             tiny=tiny_f128)
+    # IEEE 754 128-bit binary float
+    _register_type(float128_ma,
+        b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf')
+    _register_type(float128_ma,
+        b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf')
+    _float_ma[128] = float128_ma
 
     # Known parameters for float80 (Intel 80-bit extended precision)
-    global _epsned_f80, _tiny_f80, _huge_f80, _float80_ma
-    _epsneg_f80 = exp2(_ld(-64))
-    _tiny_f80 = exp2(_ld(-16382))
+    epsneg_f80 = exp2(ld(-64))
+    tiny_f80 = exp2(ld(-16382))
     # Ignore runtime error when this is not f80
     with numeric.errstate(all='ignore'):
-        _huge_f80 = (_ld(1) - _epsneg_f80) / _tiny_f80 * _ld(4)
-    _float80_ma = MachArLike(_ld,
-                             machep=-63,
-                             negep=-64,
-                             minexp=-16382,
-                             maxexp=16384,
-                             it=63,
-                             iexp=15,
-                             ibeta=2,
-                             irnd=5,
-                             ngrd=0,
-                             eps=exp2(_ld(-63)),
-                             epsneg=_epsneg_f80,
-                             huge=_huge_f80,
-                             tiny=_tiny_f80)
+        huge_f80 = (ld(1) - epsneg_f80) / tiny_f80 * ld(4)
+    float80_ma = MachArLike(ld,
+                            machep=-63,
+                            negep=-64,
+                            minexp=-16382,
+                            maxexp=16384,
+                            it=63,
+                            iexp=15,
+                            ibeta=2,
+                            irnd=5,
+                            ngrd=0,
+                            eps=exp2(ld(-63)),
+                            epsneg=epsneg_f80,
+                            huge=huge_f80,
+                            tiny=tiny_f80)
+    # float80, first 10 bytes containing actual storage
+    _register_type(float80_ma, b'\xcd\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf')
+    _float_ma[80] = float80_ma
 
     # Guessed / known parameters for double double; see:
     # https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format#Double-double_arithmetic
     # These numbers have the same exponent range as float64, but extended number of
     # digits in the significand.
-    global _huge_dd, _float_dd_ma
-    _huge_dd = (umath.nextafter(_ld(inf), _ld(0))
+    huge_dd = (umath.nextafter(ld(inf), ld(0))
                 if hasattr(umath, 'nextafter')  # Missing on some platforms?
-                else _float64_ma.huge)
-    _float_dd_ma = MachArLike(_ld,
+                else float64_ma.huge)
+    float_dd_ma = MachArLike(ld,
                               machep=-105,
                               negep=-106,
                               minexp=-1022,
@@ -206,33 +222,17 @@ def _init_getlimits():
                               ibeta=2,
                               irnd=5,
                               ngrd=0,
-                              eps=exp2(_ld(-105)),
-                              epsneg= exp2(_ld(-106)),
-                              huge=_huge_dd,
-                              tiny=exp2(_ld(-1022)))
-
-
-    global _KNOWN_TYPES
-    # Key to identify the floating point type.  Key is result of
-    # ftype('-0.1').newbyteorder('<').tobytes()
-    # See:
-    # https://perl5.git.perl.org/perl.git/blob/3118d7d684b56cbeb702af874f4326683c45f045:/Configure
-    _KNOWN_TYPES = {
-        b'\x9a\x99\x99\x99\x99\x99\xb9\xbf' : _float64_ma,
-        b'\xcd\xcc\xcc\xbd' : _float32_ma,
-        b'f\xae' : _float16_ma,
-        # float80, first 10 bytes containing actual storage
-        b'\xcd\xcc\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf' : _float80_ma,
-        # double double; low, high order (e.g. PPC 64)
-        b'\x9a\x99\x99\x99\x99\x99Y<\x9a\x99\x99\x99\x99\x99\xb9\xbf' :
-        _float_dd_ma,
-        # double double; high, low order (e.g. PPC 64 le)
-        b'\x9a\x99\x99\x99\x99\x99\xb9\xbf\x9a\x99\x99\x99\x99\x99Y<' :
-        _float_dd_ma,
-        # IEEE 754 128-bit binary float
-        b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf' :
-        _float128_ma,
-    }
+                              eps=exp2(ld(-105)),
+                              epsneg= exp2(ld(-106)),
+                              huge=huge_dd,
+                              tiny=exp2(ld(-1022)))
+    # double double; low, high order (e.g. PPC 64)
+    _register_type(float_dd_ma,
+        b'\x9a\x99\x99\x99\x99\x99Y<\x9a\x99\x99\x99\x99\x99\xb9\xbf')
+    # double double; high, low order (e.g. PPC 64 le)
+    _register_type(float_dd_ma,
+        b'\x9a\x99\x99\x99\x99\x99\xb9\xbf\x9a\x99\x99\x99\x99\x99Y<')
+    _float_ma['dd'] = float_dd_ma
 
 
 def _get_machar(ftype):

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -7,10 +7,7 @@ import numpy as np
 from numpy.core import finfo, iinfo
 from numpy import half, single, double, longdouble
 from numpy.testing import assert_equal, assert_, assert_raises
-from numpy.core.getlimits import (
-    _discovered_machar, _float16_ma, _float32_ma, _float64_ma, _float128_ma,
-    _float80_ma
-    )
+from numpy.core.getlimits import _discovered_machar, _float_ma
 
 ##################################################
 
@@ -101,9 +98,9 @@ def assert_ma_equal(discovered, ma_like):
 
 def test_known_types():
     # Test we are correctly compiling parameters for known types
-    for ftype, ma_like in ((np.float16, _float16_ma),
-                           (np.float32, _float32_ma),
-                           (np.float64, _float64_ma)):
+    for ftype, ma_like in ((np.float16, _float_ma[16]),
+                           (np.float32, _float_ma[32]),
+                           (np.float64, _float_ma[64])):
         assert_ma_equal(_discovered_machar(ftype), ma_like)
     # Suppress warning for broken discovery of double double on PPC
     with np.errstate(all='ignore'):
@@ -111,10 +108,10 @@ def test_known_types():
     bytes = np.dtype(np.longdouble).itemsize
     if (ld_ma.it, ld_ma.maxexp) == (63, 16384) and bytes in (12, 16):
         # 80-bit extended precision
-        assert_ma_equal(ld_ma, _float80_ma)
+        assert_ma_equal(ld_ma, _float_ma[80])
     elif (ld_ma.it, ld_ma.maxexp) == (112, 16384) and bytes == 16:
         # IEE 754 128-bit
-        assert_ma_equal(ld_ma, _float128_ma)
+        assert_ma_equal(ld_ma, _float_ma[128])
 
 
 def test_plausible_finfo():


### PR DESCRIPTION
During module initialization, getlimits.py previously called numpy code before all of numpy was loaded,
which often causes circular import issues. This PR delays getlimits init.

This partly reverts and also continues PR #9113. Here, I made the whole of getlimits delay initialization. It's not good for any numpy code at all to be run before numpy is fully loaded.

Fixes #12063