### PR TITLE
API: Optimize np.isin and np.in1d for integer arrays and add `kind=`

### DIFF
--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -137,3 +137,22 @@ class Unique(Benchmark):
 
     def time_unique(self, array_size, percent_nans):
         np.unique(self.arr)
+
+
+class Isin(Benchmark):
+    """Benchmarks for `numpy.isin`."""
+
+    param_names = ["size", "highest_element"]
+    params = [
+        [10, 100000, 3000000],
+        [10, 10000, int(1e8)]
+    ]
+
+    def setup(self, size, highest_element):
+        self.array = np.random.randint(
+                low=0, high=highest_element, size=size)
+        self.in_array = np.random.randint(
+                low=0, high=highest_element, size=size)
+
+    def time_isin(self, size, highest_element):
+        np.isin(self.array, self.in_array)

--- a/doc/release/upcoming_changes/12065.performance.rst
+++ b/doc/release/upcoming_changes/12065.performance.rst
@@ -1,0 +1,8 @@
+Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
+----------------------------------------------------------------
+``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
+(up to >10x faster) when it is fed two integer arrays.
+The algorithm bares similarities to a counting sort in that it
+uses the ``test_elements`` argument to index a boolean helper
+array with ``True`` values where elements exist. The ``element``
+argument simply indexes this array of booleans.

--- a/doc/release/upcoming_changes/12065.performance.rst
+++ b/doc/release/upcoming_changes/12065.performance.rst
@@ -1,7 +1,7 @@
 Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
 ----------------------------------------------------------------
 ``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
-(up to >10x faster) when it is fed two integer arrays.
+(up to >10x faster) when it is passed two integer arrays.
 The algorithm has similarities to a counting sort in that it
 uses the ``ar2`` (``test_elements`` in ``np.isin``) argument to
 index a boolean array, setting them to ``True`` where elements exist.

--- a/doc/release/upcoming_changes/12065.performance.rst
+++ b/doc/release/upcoming_changes/12065.performance.rst
@@ -2,7 +2,10 @@ Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
 ----------------------------------------------------------------
 ``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
 (up to >10x faster) when it is fed two integer arrays.
-The algorithm bears similarities to a counting sort in that it
-uses the ``test_elements`` argument to index a boolean helper
-array with ``True`` values where elements exist. The ``element``
-argument simply indexes this array of booleans.
+The algorithm has similarities to a counting sort in that it
+uses the ``ar2`` (``test_elements`` in ``np.isin``) argument to
+index a boolean array, setting them to ``True`` where elements exist.
+The ``ar1`` (``elements`` in ``np.isin``) argument then indexes
+this array of booleans. Different memory scaling is also encountered,
+and can be smaller or larger depending on configuration; this is described
+in the docstring.

--- a/doc/release/upcoming_changes/12065.performance.rst
+++ b/doc/release/upcoming_changes/12065.performance.rst
@@ -2,10 +2,5 @@ Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
 ----------------------------------------------------------------
 ``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
 (up to >10x faster) when it is passed two integer arrays.
-The algorithm has similarities to a counting sort in that it
-uses the ``ar2`` (``test_elements`` in ``np.isin``) argument to
-index a boolean array, setting them to ``True`` where elements exist.
-The ``ar1`` (``elements`` in ``np.isin``) argument then indexes
-this array of booleans. Different memory scaling is also encountered,
-and can be smaller or larger depending on configuration; this is described
-in the docstring.
+This is often automatically used, but you can use ``kind="sort"`` or 
+``kind="table"`` to force the old or new method, respectively.

--- a/doc/release/upcoming_changes/12065.performance.rst
+++ b/doc/release/upcoming_changes/12065.performance.rst
@@ -2,7 +2,7 @@ Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
 ----------------------------------------------------------------
 ``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
 (up to >10x faster) when it is fed two integer arrays.
-The algorithm bares similarities to a counting sort in that it
+The algorithm bears similarities to a counting sort in that it
 uses the ``test_elements`` argument to index a boolean helper
 array with ``True`` values where elements exist. The ``element``
 argument simply indexes this array of booleans.

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -459,15 +459,6 @@ We now use additional free CI services, thanks to the companies that provide:
 These are in addition to our continued use of travis, appveyor (for wheels) and
 LGTM
 
-Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
-----------------------------------------------------------------
-``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
-(up to >10x faster) when it is fed two integer arrays.
-The algorithm bares similarities to a counting sort in that it
-uses the ``test_elements`` argument to index a boolean helper
-array with ``True`` values where elements exist. The ``element``
-argument simply indexes this array of booleans.
-
 Changes
 =======
 

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -459,6 +459,7 @@ We now use additional free CI services, thanks to the companies that provide:
 These are in addition to our continued use of travis, appveyor (for wheels) and
 LGTM
 
+
 Changes
 =======
 

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -459,6 +459,14 @@ We now use additional free CI services, thanks to the companies that provide:
 These are in addition to our continued use of travis, appveyor (for wheels) and
 LGTM
 
+Faster version of ``np.isin`` and ``np.in1d`` for integer arrays
+----------------------------------------------------------------
+``np.in1d`` (used by ``np.isin``) can now switch to a faster algorithm
+(up to >10x faster) when it is fed two integer arrays.
+The algorithm bares similarities to a counting sort in that it
+uses the ``test_elements`` argument to index a boolean helper
+array with ``True`` values where elements exist. The ``element``
+argument simply indexes this array of booleans.
 
 Changes
 =======

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -593,6 +593,46 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     # Ensure that iteration through object arrays yields size-1 arrays
     if ar2.dtype == object:
         ar2 = ar2.reshape(-1, 1)
+    # Check if we can use a fast integer algorithm:
+    integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
+                      np.issubdtype(ar2.dtype, np.integer))
+
+    if integer_arrays:
+        ar2_min = np.min(ar2)
+        ar2_max = np.max(ar2)
+        ar2_range = ar2_max - ar2_min
+        ar2_size = ar2.size
+
+        # Optimal performance is for approximately
+        # log10(size) > (log10(range) - 2.27) / 0.927, see discussion on
+        # https://github.com/numpy/numpy/pull/12065
+        optimal_parameters = (
+                np.log10(ar2_size + 1) >
+                ((np.log10(ar2_range + 1) - 2.27) / 0.927)
+            )
+
+        if optimal_parameters:
+
+            if invert:
+                outgoing_array = np.ones_like(ar1, dtype=np.bool_)
+            else:
+                outgoing_array = np.zeros_like(ar1, dtype=np.bool_)
+
+            # Make elements 1 where the integer exists in ar2
+            if invert:
+                isin_helper_ar = np.ones(ar2_range + 1, dtype=np.bool_)
+                isin_helper_ar[ar2 - ar2_min] = 0
+            else:
+                isin_helper_ar = np.zeros(ar2_range + 1, dtype=np.bool_)
+                isin_helper_ar[ar2 - ar2_min] = 1
+
+            # Mask out elements we know won't work
+            basic_mask = (ar1 <= ar2_max) & (ar1 >= ar2_min)
+            outgoing_array[basic_mask] = isin_helper_ar[ar1[basic_mask] -
+                                                        ar2_min]
+
+            return outgoing_array
+
 
     # Check if one of the arrays may contain arbitrary objects
     contains_object = ar1.dtype.hasobject or ar2.dtype.hasobject

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -641,20 +641,18 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
             try:
                 ar2_range = ar2_max - ar2_min
 
-                # Optimal performance is for approximately
-                # log10(size) > (log10(range) - 2.27) / 0.927.
-                # However, here we set the requirement that
-                # the intermediate array can only be 6x
-                # the combined memory allocation of the original
-                # arrays.
-                # (see discussion on 
-                # https://github.com/numpy/numpy/pull/12065)
-                below_memory_constraint = (
-                    ar2_range <= 6 * (ar1_size + ar2_size)
-                )
                 range_safe_from_overflow = True
             except FloatingPointError:
                 range_safe_from_overflow = False
+
+        # Optimal performance is for approximately
+        # log10(size) > (log10(range) - 2.27) / 0.927.
+        # However, here we set the requirement that
+        # the intermediate array can only be 6x
+        # the combined memory allocation of the original
+        # arrays. See discussion on 
+        # https://github.com/numpy/numpy/pull/12065.
+        below_memory_constraint = ar2_range <= 6 * (ar1_size + ar2_size)
 
         if (
             range_safe_from_overflow and 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -672,6 +672,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
                                                         ar2_min]
 
             return outgoing_array
+        elif kind == 'dictionary':  # not range_safe_from_overflow
+            raise RuntimeError(
+                "You have specified kind='dictionary', "
+                "but the range of values in `ar2` exceeds the "
+                "maximum integer of the datatype. "
+                "Please set `kind` to None or 'mergesort'."
+            )
     elif kind == 'dictionary':
         raise ValueError(
             "The 'dictionary' method is only "

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -547,8 +547,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         to (but is faster than) ``np.invert(in1d(a, b))``.
     kind : {None, 'sort', 'table'}, optional
         The algorithm to use. This will not affect the final result,
-        but will affect the speed. Default will select automatically
-        based on memory considerations.
+        but will affect the speed and memory use. The default, None,
+        will select automatically based on memory considerations.
 
         * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
@@ -560,7 +560,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        * If `None`, will automatically choose 'table' if
+        * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'sort'. This is done to not use
@@ -761,8 +761,8 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         than) ``np.invert(np.isin(a, b))``.
     kind : {None, 'sort', 'table'}, optional
         The algorithm to use. This will not affect the final result,
-        but will affect the speed. Default will select automatically
-        based on memory considerations.
+        but will affect the speed and memory use. The default, None,
+        will select automatically based on memory considerations.
 
         * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
@@ -774,7 +774,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        * If `None`, will automatically choose 'table' if
+        * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'sort'. This is done to not use

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -616,6 +616,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))
 
+    if method not in ['auto', 'sort', 'dictionary']:
+        raise ValueError(
+            "Invalid method: {0}. ".format(method)
+            + "Please use 'auto', 'sort' or 'dictionary'.")
+
     if integer_arrays and method in ['auto', 'dictionary']:
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
@@ -659,6 +664,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
                                                         ar2_min]
 
             return outgoing_array
+    elif method == 'dictionary':
+        raise ValueError(
+            "'dictionary' method is only supported for non-integer arrays. "
+            "Please select 'sort' or 'auto' for the method."
+        )
 
 
     # Check if one of the arrays may contain arbitrary objects

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -559,13 +559,15 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
-          but may use greater memory.
+          but may use greater memory. `assume_unique` has no effect
+          when the 'table' option is used.
         * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'sort'. This is done to not use
           a large amount of memory by default, even though
-          'table' may be faster in most cases.
+          'table' may be faster in most cases. If 'table' is chosen,
+          `assume_unique` will have no effect.
 
         .. versionadded:: 1.8.0
 
@@ -773,13 +775,15 @@ def isin(element, test_elements, assume_unique=False, invert=False,
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
-          but may use greater memory.
+          but may use greater memory. `assume_unique` has no effect
+          when the 'table' option is used.
         * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'sort'. This is done to not use
           a large amount of memory by default, even though
-          'table' may be faster in most cases.
+          'table' may be faster in most cases. If 'table' is chosen,
+          `assume_unique` will have no effect.
 
 
     Returns

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -551,7 +551,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar
-          to a radix sort. This is only available for boolean and
+          to a counting sort. This is only available for boolean and
           integer arrays.
         - If 'auto', will automatically choose the method which is
           expected to perform the fastest, which depends
@@ -751,7 +751,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar
-          to a radix sort. This is only available for boolean and
+          to a counting sort. This is only available for boolean and
           integer arrays.
         - If 'auto', will automatically choose the method which is
           expected to perform the fastest, which depends

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -736,12 +736,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
 
 
 def _isin_dispatcher(element, test_elements, assume_unique=None, invert=None,
-                     kind=None):
+                     *, kind=None):
     return (element, test_elements)
 
 
 @array_function_dispatch(_isin_dispatcher)
-def isin(element, test_elements, assume_unique=False, invert=False,
+def isin(element, test_elements, assume_unique=False, invert=False, *,
          kind=None):
     """
     Calculates ``element in test_elements``, broadcasting over `element` only.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -549,7 +549,6 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
-
         - If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
@@ -565,7 +564,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'mergesort'. This is done to not use
           a large amount of memory by default, even though
-           'dictionary' may be faster in most cases.
+          'dictionary' may be faster in most cases.
 
         .. versionadded:: 1.8.0
 
@@ -763,7 +762,6 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
-
         - If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
@@ -779,7 +777,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'mergesort'. This is done to not use
           a large amount of memory by default, even though
-           'dictionary' may be faster in most cases.
+          'dictionary' may be faster in most cases.
 
 
     Returns

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -593,6 +593,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     # Ensure that iteration through object arrays yields size-1 arrays
     if ar2.dtype == object:
         ar2 = ar2.reshape(-1, 1)
+    # Convert booleans to uint8 so we can use the fast integer algorithm
+    if ar1.dtype == np.bool_:
+        ar1 = ar1.view(np.uint8)
+    if ar2.dtype == np.bool_:
+        ar2 = ar2.view(np.uint8)
+
     # Check if we can use a fast integer algorithm:
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -608,9 +608,9 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
     if ar2.dtype == object:
         ar2 = ar2.reshape(-1, 1)
     # Convert booleans to uint8 so we can use the fast integer algorithm
-    if ar1.dtype == np.bool_:
+    if ar1.dtype == bool:
         ar1 = ar1.view(np.uint8)
-    if ar2.dtype == np.bool_:
+    if ar2.dtype == bool:
         ar2 = ar2.view(np.uint8)
 
     # Check if we can use a fast integer algorithm:
@@ -647,16 +647,16 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
         if optimal_parameters or method == 'dictionary':
 
             if invert:
-                outgoing_array = np.ones_like(ar1, dtype=np.bool_)
+                outgoing_array = np.ones_like(ar1, dtype=bool)
             else:
-                outgoing_array = np.zeros_like(ar1, dtype=np.bool_)
+                outgoing_array = np.zeros_like(ar1, dtype=bool)
 
             # Make elements 1 where the integer exists in ar2
             if invert:
-                isin_helper_ar = np.ones(ar2_range + 1, dtype=np.bool_)
+                isin_helper_ar = np.ones(ar2_range + 1, dtype=bool)
                 isin_helper_ar[ar2 - ar2_min] = 0
             else:
-                isin_helper_ar = np.zeros(ar2_range + 1, dtype=np.bool_)
+                isin_helper_ar = np.zeros(ar2_range + 1, dtype=bool)
                 isin_helper_ar[ar2 - ar2_min] = 1
 
             # Mask out elements we know won't work

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -667,7 +667,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
             return outgoing_array
     elif method == 'dictionary':
         raise ValueError(
-            "'dictionary' method is only supported for non-integer arrays. "
+            "'dictionary' method is only "
+            "supported for boolean or integer arrays. "
             "Please select 'sort' or 'auto' for the method."
         )
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -545,12 +545,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         False where an element of `ar1` is in `ar2` and True otherwise).
         Default is False. ``np.in1d(a, b, invert=True)`` is equivalent
         to (but is faster than) ``np.invert(in1d(a, b))``.
-   kind : {None, 'sort', 'dictionary'}, optional
+   kind : {None, 'mergesort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
 
-        - If 'sort', will use a mergesort-based approach. This will have
+        - If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
         - If 'dictionary', will use a key-dictionary approach similar
@@ -563,7 +563,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         - If `None`, will automatically choose 'dictionary' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
-          otherwise will use 'sort'. This is done to not use
+          otherwise will use 'mergesort'. This is done to not use
           a large amount of memory by default, even though
            'dictionary' may be faster in most cases.
 
@@ -625,10 +625,10 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))
 
-    if kind not in {None, 'sort', 'dictionary'}:
+    if kind not in {None, 'mergesort', 'dictionary'}:
         raise ValueError(
             "Invalid kind: {0}. ".format(kind)
-            + "Please use None, 'sort' or 'dictionary'.")
+            + "Please use None, 'mergesort' or 'dictionary'.")
 
     if integer_arrays and kind in {None, 'dictionary'}:
         ar2_min = np.min(ar2)
@@ -681,7 +681,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         raise ValueError(
             "The 'dictionary' method is only "
             "supported for boolean or integer arrays. "
-            "Please select 'sort' or None for kind."
+            "Please select 'mergesort' or None for kind."
         )
 
 
@@ -757,12 +757,12 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         calculating `element not in test_elements`. Default is False.
         ``np.isin(a, b, invert=True)`` is equivalent to (but faster
         than) ``np.invert(np.isin(a, b))``.
-   kind : {None, 'sort', 'dictionary'}, optional
+   kind : {None, 'mergesort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
 
-        - If 'sort', will use a mergesort-based approach. This will have
+        - If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
         - If 'dictionary', will use a key-dictionary approach similar
@@ -775,7 +775,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         - If `None`, will automatically choose 'dictionary' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
-          otherwise will use 'sort'. This is done to not use
+          otherwise will use 'mergesort'. This is done to not use
           a large amount of memory by default, even though
            'dictionary' may be faster in most cases.
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -517,12 +517,12 @@ def setxor1d(ar1, ar2, assume_unique=False):
 
 
 def _in1d_dispatcher(ar1, ar2, assume_unique=None, invert=None,
-                     _slow_integer=None):
+                     method='auto'):
     return (ar1, ar2)
 
 
 @array_function_dispatch(_in1d_dispatcher)
-def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
+def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
     """
     Test whether each element of a 1-D array is also present in a second array.
 
@@ -545,10 +545,18 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
         False where an element of `ar1` is in `ar2` and True otherwise).
         Default is False. ``np.in1d(a, b, invert=True)`` is equivalent
         to (but is faster than) ``np.invert(in1d(a, b))``.
-    _slow_integer : bool/None, optional
-        If True, defaults to the old algorithm for integers. This is
-        used for debugging and testing purposes. The default, None,
-        selects the best based on estimated performance.
+    method : {'auto', 'sort', 'dictionary'}, optional
+        The algorithm to use. This will not affect the final result,
+        but will affect the speed.
+
+        - If 'sort', will use a sort-based approach.
+        - If 'dictionary', will use a key-dictionary approach similar
+          to a radix sort.
+        - If 'auto', will automatically choose the method which is
+          expected to perform the fastest, which depends
+          on the size and range of `ar2`. For larger sizes,
+          'dictionary' is chosen. For larger range or smaller
+          sizes, 'sort' is chosen.
 
         .. versionadded:: 1.8.0
 
@@ -608,7 +616,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))
 
-    if integer_arrays and _slow_integer in [None, False]:
+    if integer_arrays and method in ['auto', 'dictionary']:
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
         ar2_size = ar2.size
@@ -630,7 +638,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
                 optimal_parameters = False
 
         # Use the fast integer algorithm
-        if optimal_parameters or _slow_integer == False:
+        if optimal_parameters or method == 'dictionary':
 
             if invert:
                 outgoing_array = np.ones_like(ar1, dtype=np.bool_)
@@ -697,13 +705,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
 
 
 def _isin_dispatcher(element, test_elements, assume_unique=None, invert=None,
-                     _slow_integer=None):
+                     method='auto'):
     return (element, test_elements)
 
 
 @array_function_dispatch(_isin_dispatcher)
 def isin(element, test_elements, assume_unique=False, invert=False,
-         _slow_integer=None):
+         method='auto'):
     """
     Calculates ``element in test_elements``, broadcasting over `element` only.
     Returns a boolean array of the same shape as `element` that is True
@@ -725,10 +733,18 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         calculating `element not in test_elements`. Default is False.
         ``np.isin(a, b, invert=True)`` is equivalent to (but faster
         than) ``np.invert(np.isin(a, b))``.
-    _slow_integer : bool/None, optional
-        If True, defaults to the old algorithm for integers. This is
-        used for debugging and testing purposes. The default, None,
-        selects the best based on measured performance.
+    method : {'auto', 'sort', 'dictionary'}, optional
+        The algorithm to use. This will not affect the final result,
+        but will affect the speed.
+
+        - If 'sort', will use a sort-based approach.
+        - If 'dictionary', will use a key-dictionary approach similar
+          to a radix sort.
+        - If 'auto', will automatically choose the method which is
+          expected to perform the fastest, which depends
+          on the size and range of `ar2`. For larger sizes,
+          'dictionary' is chosen. For larger range or smaller
+          sizes, 'sort' is chosen.
 
     Returns
     -------
@@ -802,8 +818,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
     """
     element = np.asarray(element)
     return in1d(element, test_elements, assume_unique=assume_unique,
-                invert=invert, _slow_integer=_slow_integer
-                ).reshape(element.shape)
+                invert=invert, method=method).reshape(element.shape)
 
 
 def _union1d_dispatcher(ar1, ar2):

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -633,26 +633,20 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
     if integer_arrays and kind in {None, 'dictionary'}:
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
-        ar1_size = ar1.size
-        ar2_size = ar2.size
 
-        # Check for integer overflow
-        with np.errstate(over='raise'):
-            try:
-                ar2_range = ar2_max - ar2_min
+        ar2_range = int(ar2_max) - int(ar2_min)
 
-                range_safe_from_overflow = True
-            except FloatingPointError:
-                range_safe_from_overflow = False
+        # Constraints on whether we can actually use the dictionary method:
+        range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
+        below_memory_constraint = ar2_range <= 6 * (ar1.size + ar2.size)
 
         # Optimal performance is for approximately
         # log10(size) > (log10(range) - 2.27) / 0.927.
-        # However, here we set the requirement that
+        # However, here we set the requirement that by default
         # the intermediate array can only be 6x
         # the combined memory allocation of the original
         # arrays. See discussion on 
         # https://github.com/numpy/numpy/pull/12065.
-        below_memory_constraint = ar2_range <= 6 * (ar1_size + ar2_size)
 
         if (
             range_safe_from_overflow and 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -549,15 +549,21 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default is 'auto'.
 
-        - If 'sort', will use a sort-based approach.
+        - If 'sort', will use a mergesort-based approach. This will have
+          a memory usage of roughly 6 times the sum of the sizes of
+          `ar1` and `ar2`, not accounting for size of dtypes.
         - If 'dictionary', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
-          integer arrays.
+          integer arrays. This will have a memory usage of the
+          size of `ar1` plus the max-min value of `ar2`. This tends
+          to be the faster method if the following formula is true:
+          `log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927`,
+          but may use greater memory.
         - If 'auto', will automatically choose the method which is
-          expected to perform the fastest, which depends
-          on the size and range of `ar2`. For larger sizes or
-          smaller range, 'dictionary' is chosen.
-          For larger range or smaller sizes, 'sort' is chosen.
+          expected to perform the fastest, using the above
+          formula. For larger sizes or smaller range,
+          'dictionary' is chosen. For larger range or smaller
+          sizes, 'sort' is chosen.
 
         .. versionadded:: 1.8.0
 
@@ -749,13 +755,19 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default is 'auto'.
 
-        - If 'sort', will use a sort-based approach.
+        - If 'sort', will use a mergesort-based approach. This will have
+          a memory usage of roughly 6 times the sum of the sizes of
+          `ar1` and `ar2`, not accounting for size of dtypes.
         - If 'dictionary', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
-          integer arrays.
+          integer arrays. This will have a memory usage of the
+          size of `ar1` plus the max-min value of `ar2`. This tends
+          to be the faster method if the following formula is true:
+          `log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927`,
+          but may use greater memory.
         - If 'auto', will automatically choose the method which is
-          expected to perform the fastest, which depends
-          on the size and range of `ar2`. For larger sizes,
+          expected to perform the fastest, using the above
+          formula. For larger sizes or smaller range,
           'dictionary' is chosen. For larger range or smaller
           sizes, 'sort' is chosen.
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -623,9 +623,9 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         ar2 = ar2.reshape(-1, 1)
     # Convert booleans to uint8 so we can use the fast integer algorithm
     if ar1.dtype == bool:
-        ar1 = ar1.view(np.uint8)
+        ar1 = ar1 + np.uint8(0)
     if ar2.dtype == bool:
-        ar2 = ar2.view(np.uint8)
+        ar2 = ar2 + np.uint8(0)
 
     # Check if we can use a fast integer algorithm:
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -619,7 +619,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, _slow_integer=None):
                 ar2_range = ar2_max - ar2_min
 
                 # Optimal performance is for approximately
-                # log10(size) > (log10(range) - 2.27) / 0.927, see discussion on
+                # log10(size) > (log10(range) - 2.27) / 0.927.
+                # See discussion on
                 # https://github.com/numpy/numpy/pull/12065
                 optimal_parameters = (
                         np.log10(ar2_size) >

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -545,27 +545,27 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         False where an element of `ar1` is in `ar2` and True otherwise).
         Default is False. ``np.in1d(a, b, invert=True)`` is equivalent
         to (but is faster than) ``np.invert(in1d(a, b))``.
-    kind : {None, 'mergesort', 'dictionary'}, optional
+    kind : {None, 'sort', 'table'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
 
-        * If 'mergesort', will use a mergesort-based approach. This will have
+        * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        * If 'dictionary', will use a key-dictionary approach similar
+        * If 'table', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        * If `None`, will automatically choose 'dictionary' if
+        * If `None`, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
-          otherwise will use 'mergesort'. This is done to not use
+          otherwise will use 'sort'. This is done to not use
           a large amount of memory by default, even though
-          'dictionary' may be faster in most cases.
+          'table' may be faster in most cases.
 
         .. versionadded:: 1.8.0
 
@@ -625,18 +625,18 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))
 
-    if kind not in {None, 'mergesort', 'dictionary'}:
+    if kind not in {None, 'sort', 'table'}:
         raise ValueError(
             "Invalid kind: {0}. ".format(kind)
-            + "Please use None, 'mergesort' or 'dictionary'.")
+            + "Please use None, 'sort' or 'table'.")
 
-    if integer_arrays and kind in {None, 'dictionary'}:
+    if integer_arrays and kind in {None, 'table'}:
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
 
         ar2_range = int(ar2_max) - int(ar2_min)
 
-        # Constraints on whether we can actually use the dictionary method:
+        # Constraints on whether we can actually use the table method:
         range_safe_from_overflow = ar2_range < np.iinfo(ar2.dtype).max
         below_memory_constraint = ar2_range <= 6 * (ar1.size + ar2.size)
 
@@ -650,7 +650,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
 
         if (
             range_safe_from_overflow and 
-            (below_memory_constraint or kind == 'dictionary')
+            (below_memory_constraint or kind == 'table')
         ):
 
             if invert:
@@ -672,18 +672,18 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
                                                         ar2_min]
 
             return outgoing_array
-        elif kind == 'dictionary':  # not range_safe_from_overflow
+        elif kind == 'table':  # not range_safe_from_overflow
             raise RuntimeError(
-                "You have specified kind='dictionary', "
+                "You have specified kind='table', "
                 "but the range of values in `ar2` exceeds the "
                 "maximum integer of the datatype. "
-                "Please set `kind` to None or 'mergesort'."
+                "Please set `kind` to None or 'sort'."
             )
-    elif kind == 'dictionary':
+    elif kind == 'table':
         raise ValueError(
-            "The 'dictionary' method is only "
+            "The 'table' method is only "
             "supported for boolean or integer arrays. "
-            "Please select 'mergesort' or None for kind."
+            "Please select 'sort' or None for kind."
         )
 
 
@@ -759,27 +759,27 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         calculating `element not in test_elements`. Default is False.
         ``np.isin(a, b, invert=True)`` is equivalent to (but faster
         than) ``np.invert(np.isin(a, b))``.
-    kind : {None, 'mergesort', 'dictionary'}, optional
+    kind : {None, 'sort', 'table'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
 
-        * If 'mergesort', will use a mergesort-based approach. This will have
+        * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        * If 'dictionary', will use a key-dictionary approach similar
+        * If 'table', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
           ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        * If `None`, will automatically choose 'dictionary' if
+        * If `None`, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
-          otherwise will use 'mergesort'. This is done to not use
+          otherwise will use 'sort'. This is done to not use
           a large amount of memory by default, even though
-          'dictionary' may be faster in most cases.
+          'table' may be faster in most cases.
 
 
     Returns

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -517,7 +517,7 @@ def setxor1d(ar1, ar2, assume_unique=False):
 
 
 def _in1d_dispatcher(ar1, ar2, assume_unique=None, invert=None,
-                     method='auto'):
+                     method=None):
     return (ar1, ar2)
 
 
@@ -716,7 +716,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
 
 
 def _isin_dispatcher(element, test_elements, assume_unique=None, invert=None,
-                     method='auto'):
+                     method=None):
     return (element, test_elements)
 
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -556,11 +556,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         * If 'table', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
-          size of `ar1` plus the max-min value of `ar2`. This tends
-          to be the faster method if the following formula is true:
-          ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
-          but may use greater memory. `assume_unique` has no effect
-          when the 'table' option is used.
+          size of `ar1` plus the max-min value of `ar2`. `assume_unique`
+          has no effect when the 'table' option is used.
         * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
@@ -592,6 +589,13 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
     container:  As ``ar2`` is converted to an array, in those cases
     ``asarray(ar2)`` is an object array rather than the expected array of
     contained values.
+
+    Using ``kind='table'`` tends to be faster than `kind='sort'` if the
+    following relationship is true:
+    ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
+    but may use greater memory. The default value for `kind` will
+    be automatically selected based only on memory usage, so one may
+    manually set ``kind='table'`` if memory constraints can be relaxed.
 
     .. versionadded:: 1.4.0
 
@@ -772,11 +776,8 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         * If 'table', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
-          size of `ar1` plus the max-min value of `ar2`. This tends
-          to be the faster method if the following formula is true:
-          ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
-          but may use greater memory. `assume_unique` has no effect
-          when the 'table' option is used.
+          size of `ar1` plus the max-min value of `ar2`. `assume_unique`
+          has no effect when the 'table' option is used.
         * If None, will automatically choose 'table' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
@@ -811,6 +812,13 @@ def isin(element, test_elements, assume_unique=False, invert=False,
     array of the values contained in `test_elements`. This is a consequence
     of the `array` constructor's way of handling non-sequence collections.
     Converting the set to a list usually gives the desired behavior.
+
+    Using ``kind='table'`` tends to be faster than `kind='sort'` if the
+    following relationship is true:
+    ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
+    but may use greater memory. The default value for `kind` will
+    be automatically selected based only on memory usage, so one may
+    manually set ``kind='table'`` if memory constraints can be relaxed.
 
     .. versionadded:: 1.13.0
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -553,7 +553,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        * If 'table', will use a key-dictionary approach similar
+        * If 'table', will use a lookup table approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. `assume_unique`
@@ -772,7 +772,7 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
         * If 'sort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        * If 'table', will use a key-dictionary approach similar
+        * If 'table', will use a lookup table approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. `assume_unique`

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -555,9 +555,9 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
           integer arrays.
         - If 'auto', will automatically choose the method which is
           expected to perform the fastest, which depends
-          on the size and range of `ar2`. For larger sizes,
-          'dictionary' is chosen. For larger range or smaller
-          sizes, 'sort' is chosen.
+          on the size and range of `ar2`. For larger sizes or
+          smaller range, 'dictionary' is chosen.
+          For larger range or smaller sizes, 'sort' is chosen.
 
         .. versionadded:: 1.8.0
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -549,17 +549,18 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
-        - If 'mergesort', will use a mergesort-based approach. This will have
+
+        * If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        - If 'dictionary', will use a key-dictionary approach similar
+        * If 'dictionary', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
-          `log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927`,
+          ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        - If `None`, will automatically choose 'dictionary' if
+        * If `None`, will automatically choose 'dictionary' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'mergesort'. This is done to not use
@@ -758,21 +759,22 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         calculating `element not in test_elements`. Default is False.
         ``np.isin(a, b, invert=True)`` is equivalent to (but faster
         than) ``np.invert(np.isin(a, b))``.
-   kind : {None, 'mergesort', 'dictionary'}, optional
+    kind : {None, 'mergesort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.
-        - If 'mergesort', will use a mergesort-based approach. This will have
+
+        * If 'mergesort', will use a mergesort-based approach. This will have
           a memory usage of roughly 6 times the sum of the sizes of
           `ar1` and `ar2`, not accounting for size of dtypes.
-        - If 'dictionary', will use a key-dictionary approach similar
+        * If 'dictionary', will use a key-dictionary approach similar
           to a counting sort. This is only available for boolean and
           integer arrays. This will have a memory usage of the
           size of `ar1` plus the max-min value of `ar2`. This tends
           to be the faster method if the following formula is true:
-          `log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927`,
+          ``log10(len(ar2)) > (log10(max(ar2)-min(ar2)) - 2.27) / 0.927``,
           but may use greater memory.
-        - If `None`, will automatically choose 'dictionary' if
+        * If `None`, will automatically choose 'dictionary' if
           the required memory allocation is less than or equal to
           6 times the sum of the sizes of `ar1` and `ar2`,
           otherwise will use 'mergesort'. This is done to not use

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -545,7 +545,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
         False where an element of `ar1` is in `ar2` and True otherwise).
         Default is False. ``np.in1d(a, b, invert=True)`` is equivalent
         to (but is faster than) ``np.invert(in1d(a, b))``.
-   kind : {None, 'mergesort', 'dictionary'}, optional
+    kind : {None, 'mergesort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
         but will affect the speed. Default will select automatically
         based on memory considerations.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -547,7 +547,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
         to (but is faster than) ``np.invert(in1d(a, b))``.
     method : {'auto', 'sort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
-        but will affect the speed.
+        but will affect the speed. Default is 'auto'.
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar
@@ -746,7 +746,7 @@ def isin(element, test_elements, assume_unique=False, invert=False,
         than) ``np.invert(np.isin(a, b))``.
     method : {'auto', 'sort', 'dictionary'}, optional
         The algorithm to use. This will not affect the final result,
-        but will affect the speed.
+        but will affect the speed. Default is 'auto'.
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -551,7 +551,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar
-          to a radix sort.
+          to a radix sort. This is only available for boolean and
+          integer arrays.
         - If 'auto', will automatically choose the method which is
           expected to perform the fastest, which depends
           on the size and range of `ar2`. For larger sizes,
@@ -749,7 +750,8 @@ def isin(element, test_elements, assume_unique=False, invert=False,
 
         - If 'sort', will use a sort-based approach.
         - If 'dictionary', will use a key-dictionary approach similar
-          to a radix sort.
+          to a radix sort. This is only available for boolean and
+          integer arrays.
         - If 'auto', will automatically choose the method which is
           expected to perform the fastest, which depends
           on the size and range of `ar2`. For larger sizes,

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -652,11 +652,14 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
                 below_memory_constraint = (
                     ar2_range <= 6 * (ar1_size + ar2_size)
                 )
+                range_safe_from_overflow = True
             except FloatingPointError:
-                below_memory_constraint = False
+                range_safe_from_overflow = False
 
-        # Use the fast integer algorithm
-        if below_memory_constraint or kind == 'dictionary':
+        if (
+            range_safe_from_overflow and 
+            (below_memory_constraint or kind == 'dictionary')
+        ):
 
             if invert:
                 outgoing_array = np.ones_like(ar1, dtype=bool)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -516,13 +516,13 @@ def setxor1d(ar1, ar2, assume_unique=False):
     return aux[flag[1:] & flag[:-1]]
 
 
-def _in1d_dispatcher(ar1, ar2, assume_unique=None, invert=None,
+def _in1d_dispatcher(ar1, ar2, assume_unique=None, invert=None, *,
                      kind=None):
     return (ar1, ar2)
 
 
 @array_function_dispatch(_in1d_dispatcher)
-def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
+def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     """
     Test whether each element of a 1-D array is also present in a second array.
 
@@ -633,8 +633,7 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, kind=None):
 
     if kind not in {None, 'sort', 'table'}:
         raise ValueError(
-            "Invalid kind: {0}. ".format(kind)
-            + "Please use None, 'sort' or 'table'.")
+            f"Invalid kind: '{kind}'. Please use None, 'sort' or 'table'.")
 
     if integer_arrays and kind in {None, 'table'}:
         ar2_min = np.min(ar2)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -617,12 +617,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, method='auto'):
     integer_arrays = (np.issubdtype(ar1.dtype, np.integer) and
                       np.issubdtype(ar2.dtype, np.integer))
 
-    if method not in ['auto', 'sort', 'dictionary']:
+    if method not in {'auto', 'sort', 'dictionary'}:
         raise ValueError(
             "Invalid method: {0}. ".format(method)
             + "Please use 'auto', 'sort' or 'dictionary'.")
 
-    if integer_arrays and method in ['auto', 'dictionary']:
+    if integer_arrays and method in {'auto', 'dictionary'}:
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)
         ar2_size = ar2.size

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -454,7 +454,7 @@ class TestSetOps:
         # This hits it without the use of method='dictionary'
         a = np.array([5, 4, 5, 3, 4, 4, 1e9], dtype=np.int64)
         b = np.array([2, 3, 4, 1e9], dtype=np.int64)
-        expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=np.bool)
+        expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=bool)
         assert_array_equal(expected, in1d(a, b))
         assert_array_equal(np.invert(expected), in1d(a, b, invert=True))
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -258,21 +258,21 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="dictionary")
+            c = in1d(a, b, assume_unique=True, method="sort")
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="dictionary")
+            c = in1d(a, b, assume_unique=True, method="sort")
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="dictionary")
+            c = in1d(a, b, assume_unique=True, method="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
@@ -281,7 +281,7 @@ class TestSetOps:
                   False, True, False, False, False]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="dictionary")
+            c = in1d(a, b, method="sort")
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
@@ -289,7 +289,7 @@ class TestSetOps:
                   True, False, True, True]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="dictionary")
+            c = in1d(a, b, method="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
@@ -297,7 +297,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="dictionary")
+            c = in1d(a, b, method="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
@@ -305,7 +305,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="dictionary")
+            c = in1d(a, b, method="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
@@ -313,7 +313,7 @@ class TestSetOps:
             ec = np.array([False, False])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="dictionary")
+            c = in1d(a, b, method="sort")
             assert_array_equal(c, ec)
 
         a = np.array([5])
@@ -321,7 +321,7 @@ class TestSetOps:
         ec = np.array([False])
         c = in1d(a, b)
         assert_array_equal(c, ec)
-        c = in1d(a, b, method="dictionary")
+        c = in1d(a, b, method="sort")
         assert_array_equal(c, ec)
 
         assert_array_equal(in1d([], []), [])
@@ -413,7 +413,7 @@ class TestSetOps:
             b = [2, 3, 4] * mult
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, method="dictionary"))
+                               in1d(a, b, invert=True, method="sort"))
 
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5],
@@ -422,7 +422,7 @@ class TestSetOps:
             b = np.array(b, dtype=np.float32)
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, method="dictionary"))
+                               in1d(a, b, invert=True, method="sort"))
 
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
@@ -436,16 +436,16 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, method="dictionary"),
+        assert_array_equal(in1d(a, b, assume_unique=True, method="sort"),
                            ec)
         assert_array_equal(in1d(a, b, assume_unique=False,
-                                method="dictionary"),
+                                method="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                method="dictionary"),
+                                method="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                method="dictionary"),
+                                method="sort"),
                            ec)
 
     def test_in1d_hit_alternate_algorithm(self):
@@ -472,11 +472,11 @@ class TestSetOps:
         assert_array_equal(expected,
                            in1d(a, b))
         assert_array_equal(expected,
-                           in1d(a, b, method="dictionary"))
+                           in1d(a, b, method="sort"))
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, method="dictionary"))
+                           in1d(a, b, invert=True, method="sort"))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -435,10 +435,16 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, _slow_integer=True), ec)
-        assert_array_equal(in1d(a, b, assume_unique=False, _slow_integer=True), ec)
-        assert_array_equal(in1d(a, long_b, assume_unique=True, _slow_integer=True), ec)
-        assert_array_equal(in1d(a, long_b, assume_unique=False, _slow_integer=True), ec)
+        assert_array_equal(in1d(a, b, assume_unique=True, _slow_integer=True),
+                           ec)
+        assert_array_equal(in1d(a, b, assume_unique=False, _slow_integer=True),
+                           ec)
+        assert_array_equal(in1d(a, long_b, assume_unique=True,
+                                _slow_integer=True),
+                           ec)
+        assert_array_equal(in1d(a, long_b, assume_unique=False,
+                                _slow_integer=True),
+                           ec)
 
     def test_in1d_hit_alternate_algorithm(self):
         """Hit the standard isin code with integers"""
@@ -461,10 +467,14 @@ class TestSetOps:
         a = np.array([True, False])
         b = np.array([False, False, False])
         expected = np.array([False, True])
-        assert_array_equal(expected, in1d(a, b))
-        assert_array_equal(expected, in1d(a, b, _slow_integer=True))
-        assert_array_equal(np.invert(expected), in1d(a, b, invert=True))
-        assert_array_equal(np.invert(expected), in1d(a, b, invert=True, _slow_integer=True))
+        assert_array_equal(expected,
+                           in1d(a, b))
+        assert_array_equal(expected,
+                           in1d(a, b, _slow_integer=True))
+        assert_array_equal(np.invert(expected),
+                           in1d(a, b, invert=True))
+        assert_array_equal(np.invert(expected),
+                           in1d(a, b, invert=True, _slow_integer=True))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -205,7 +205,7 @@ class TestSetOps:
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b, old_algorithm=None):
-            kind = "sort" if old_algorithm else "auto"
+            kind = "mergesort" if old_algorithm else None
             x = isin(a, b, kind=kind)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
@@ -258,21 +258,21 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="sort")
+            c = in1d(a, b, assume_unique=True, kind="mergesort")
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="sort")
+            c = in1d(a, b, assume_unique=True, kind="mergesort")
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="sort")
+            c = in1d(a, b, assume_unique=True, kind="mergesort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
@@ -281,7 +281,7 @@ class TestSetOps:
                   False, True, False, False, False]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="sort")
+            c = in1d(a, b, kind="mergesort")
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
@@ -289,7 +289,7 @@ class TestSetOps:
                   True, False, True, True]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="sort")
+            c = in1d(a, b, kind="mergesort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
@@ -297,7 +297,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="sort")
+            c = in1d(a, b, kind="mergesort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
@@ -305,7 +305,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="sort")
+            c = in1d(a, b, kind="mergesort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
@@ -313,7 +313,7 @@ class TestSetOps:
             ec = np.array([False, False])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="sort")
+            c = in1d(a, b, kind="mergesort")
             assert_array_equal(c, ec)
 
         a = np.array([5])
@@ -321,7 +321,7 @@ class TestSetOps:
         ec = np.array([False])
         c = in1d(a, b)
         assert_array_equal(c, ec)
-        c = in1d(a, b, kind="sort")
+        c = in1d(a, b, kind="mergesort")
         assert_array_equal(c, ec)
 
         assert_array_equal(in1d([], []), [])
@@ -413,7 +413,7 @@ class TestSetOps:
             b = [2, 3, 4] * mult
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, kind="sort"))
+                               in1d(a, b, invert=True, kind="mergesort"))
 
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5],
@@ -422,7 +422,7 @@ class TestSetOps:
             b = np.array(b, dtype=np.float32)
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, kind="sort"))
+                               in1d(a, b, invert=True, kind="mergesort"))
 
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
@@ -436,16 +436,16 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, kind="sort"),
+        assert_array_equal(in1d(a, b, assume_unique=True, kind="mergesort"),
                            ec)
         assert_array_equal(in1d(a, b, assume_unique=False,
-                                kind="sort"),
+                                kind="mergesort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                kind="sort"),
+                                kind="mergesort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                kind="sort"),
+                                kind="mergesort"),
                            ec)
 
     def test_in1d_hit_alternate_algorithm(self):
@@ -472,11 +472,11 @@ class TestSetOps:
         assert_array_equal(expected,
                            in1d(a, b))
         assert_array_equal(expected,
-                           in1d(a, b, kind="sort"))
+                           in1d(a, b, kind="mergesort"))
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, kind="sort"))
+                           in1d(a, b, invert=True, kind="mergesort"))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -232,10 +232,11 @@ class TestSetOps:
         assert_isin_equal(5, 6)
 
         # empty array-like:
-        x = []
-        assert_isin_equal(x, b)
-        assert_isin_equal(a, x)
-        assert_isin_equal(x, x)
+        if kind in {None, "sort"}:
+            x = []
+            assert_isin_equal(x, b)
+            assert_isin_equal(a, x)
+            assert_isin_equal(x, x)
 
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_in1d(self, kind):
@@ -296,7 +297,8 @@ class TestSetOps:
         c = in1d(a, b, kind=kind)
         assert_array_equal(c, ec)
 
-        assert_array_equal(in1d([], [], kind=kind), [])
+        if kind in {None, "sort"}:
+            assert_array_equal(in1d([], [], kind=kind), [])
 
     def test_in1d_char_array(self):
         a = np.array(['a', 'b', 'c', 'd', 'e', 'c', 'e', 'b'])

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -205,8 +205,8 @@ class TestSetOps:
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b, old_algorithm=None):
-            method = "sort" if old_algorithm else "auto"
-            x = isin(a, b, method=method)
+            kind = "sort" if old_algorithm else "auto"
+            x = isin(a, b, kind=kind)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
 
@@ -258,21 +258,21 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="sort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="sort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, method="sort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
@@ -281,7 +281,7 @@ class TestSetOps:
                   False, True, False, False, False]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="sort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
@@ -289,7 +289,7 @@ class TestSetOps:
                   True, False, True, True]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="sort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
@@ -297,7 +297,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="sort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
@@ -305,7 +305,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="sort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
@@ -313,7 +313,7 @@ class TestSetOps:
             ec = np.array([False, False])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, method="sort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
         a = np.array([5])
@@ -321,7 +321,7 @@ class TestSetOps:
         ec = np.array([False])
         c = in1d(a, b)
         assert_array_equal(c, ec)
-        c = in1d(a, b, method="sort")
+        c = in1d(a, b, kind="sort")
         assert_array_equal(c, ec)
 
         assert_array_equal(in1d([], []), [])
@@ -413,7 +413,7 @@ class TestSetOps:
             b = [2, 3, 4] * mult
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, method="sort"))
+                               in1d(a, b, invert=True, kind="sort"))
 
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5],
@@ -422,7 +422,7 @@ class TestSetOps:
             b = np.array(b, dtype=np.float32)
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, method="sort"))
+                               in1d(a, b, invert=True, kind="sort"))
 
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
@@ -436,22 +436,22 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, method="sort"),
+        assert_array_equal(in1d(a, b, assume_unique=True, kind="sort"),
                            ec)
         assert_array_equal(in1d(a, b, assume_unique=False,
-                                method="sort"),
+                                kind="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                method="sort"),
+                                kind="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                method="sort"),
+                                kind="sort"),
                            ec)
 
     def test_in1d_hit_alternate_algorithm(self):
         """Hit the standard isin code with integers"""
         # Need extreme range to hit standard code
-        # This hits it without the use of method='dictionary'
+        # This hits it without the use of kind='dictionary'
         a = np.array([5, 4, 5, 3, 4, 4, 1e9], dtype=np.int64)
         b = np.array([2, 3, 4, 1e9], dtype=np.int64)
         expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=bool)
@@ -472,11 +472,11 @@ class TestSetOps:
         assert_array_equal(expected,
                            in1d(a, b))
         assert_array_equal(expected,
-                           in1d(a, b, method="sort"))
+                           in1d(a, b, kind="sort"))
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, method="sort"))
+                           in1d(a, b, invert=True, kind="sort"))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -205,8 +205,8 @@ class TestSetOps:
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b, old_algorithm=None):
-            method = "sort" if old_algorithm else "dictionary"
-            x = isin(a, b, method=old_algorithm)
+            method = "sort" if old_algorithm else "auto"
+            x = isin(a, b, method=method)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -438,7 +438,8 @@ class TestSetOps:
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
         assert_array_equal(in1d(a, b, assume_unique=True, method="dictionary"),
                            ec)
-        assert_array_equal(in1d(a, b, assume_unique=False, method="dictionary"),
+        assert_array_equal(in1d(a, b, assume_unique=False,
+                                method="dictionary"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
                                 method="dictionary"),

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -205,7 +205,7 @@ class TestSetOps:
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b, old_algorithm=None):
-            kind = "mergesort" if old_algorithm else None
+            kind = "sort" if old_algorithm else None
             x = isin(a, b, kind=kind)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
@@ -258,21 +258,21 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="mergesort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="mergesort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, kind="mergesort")
+            c = in1d(a, b, assume_unique=True, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
@@ -281,7 +281,7 @@ class TestSetOps:
                   False, True, False, False, False]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="mergesort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
@@ -289,7 +289,7 @@ class TestSetOps:
                   True, False, True, True]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="mergesort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
@@ -297,7 +297,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="mergesort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
@@ -305,7 +305,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="mergesort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
@@ -313,7 +313,7 @@ class TestSetOps:
             ec = np.array([False, False])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, kind="mergesort")
+            c = in1d(a, b, kind="sort")
             assert_array_equal(c, ec)
 
         a = np.array([5])
@@ -321,7 +321,7 @@ class TestSetOps:
         ec = np.array([False])
         c = in1d(a, b)
         assert_array_equal(c, ec)
-        c = in1d(a, b, kind="mergesort")
+        c = in1d(a, b, kind="sort")
         assert_array_equal(c, ec)
 
         assert_array_equal(in1d([], []), [])
@@ -413,7 +413,7 @@ class TestSetOps:
             b = [2, 3, 4] * mult
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, kind="mergesort"))
+                               in1d(a, b, invert=True, kind="sort"))
 
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5],
@@ -422,7 +422,7 @@ class TestSetOps:
             b = np.array(b, dtype=np.float32)
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, kind="mergesort"))
+                               in1d(a, b, invert=True, kind="sort"))
 
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
@@ -436,22 +436,22 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, kind="mergesort"),
+        assert_array_equal(in1d(a, b, assume_unique=True, kind="sort"),
                            ec)
         assert_array_equal(in1d(a, b, assume_unique=False,
-                                kind="mergesort"),
+                                kind="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                kind="mergesort"),
+                                kind="sort"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                kind="mergesort"),
+                                kind="sort"),
                            ec)
 
     def test_in1d_hit_alternate_algorithm(self):
         """Hit the standard isin code with integers"""
         # Need extreme range to hit standard code
-        # This hits it without the use of kind='dictionary'
+        # This hits it without the use of kind='table'
         a = np.array([5, 4, 5, 3, 4, 4, 1e9], dtype=np.int64)
         b = np.array([2, 3, 4, 1e9], dtype=np.int64)
         expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=bool)
@@ -472,11 +472,11 @@ class TestSetOps:
         assert_array_equal(expected,
                            in1d(a, b))
         assert_array_equal(expected,
-                           in1d(a, b, kind="mergesort"))
+                           in1d(a, b, kind="sort"))
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, kind="mergesort"))
+                           in1d(a, b, invert=True, kind="sort"))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]
@@ -545,35 +545,35 @@ class TestSetOps:
     def test_in1d_errors(self):
         """Test that in1d raises expected errors."""
 
-        # Error 1: `kind` is not one of 'mergesort' 'dictionary' or None.
+        # Error 1: `kind` is not one of 'sort' 'table' or None.
         ar1 = np.array([1, 2, 3, 4, 5])
         ar2 = np.array([2, 4, 6, 8, 10])
         assert_raises(ValueError, in1d, ar1, ar2, kind='quicksort')
 
-        # Error 2: `kind="dictionary"` does not work for non-integral arrays.
+        # Error 2: `kind="table"` does not work for non-integral arrays.
         obj_ar1 = np.array([1, 'a', 3, 'b', 5], dtype=object)
         obj_ar2 = np.array([1, 'a', 3, 'b', 5], dtype=object)
-        assert_raises(ValueError, in1d, obj_ar1, obj_ar2, kind='dictionary')
+        assert_raises(ValueError, in1d, obj_ar1, obj_ar2, kind='table')
 
         for dtype in [np.int32, np.int64]:
             ar1 = np.array([-1, 2, 3, 4, 5], dtype=dtype)
             # The range of this array will overflow:
             overflow_ar2 = np.array([-1, np.iinfo(dtype).max], dtype=dtype)
 
-            # Error 3: `kind="dictionary"` will trigger a runtime error
+            # Error 3: `kind="table"` will trigger a runtime error
             #  if there is an integer overflow expected when computing the
             #  range of ar2
             assert_raises(
                 RuntimeError,
-                in1d, ar1, overflow_ar2, kind='dictionary'
+                in1d, ar1, overflow_ar2, kind='table'
             )
 
             # Non-error: `kind=None` will *not* trigger a runtime error
             #  if there is an integer overflow, it will switch to
-            #  the `mergesort` algorithm.
+            #  the `sort` algorithm.
             result = np.in1d(ar1, overflow_ar2, kind=None)
             assert_array_equal(result, [True] + [False] * 4)
-            result = np.in1d(ar1, overflow_ar2, kind='mergesort')
+            result = np.in1d(ar1, overflow_ar2, kind='sort')
             assert_array_equal(result, [True] + [False] * 4)
 
     def test_union1d(self):

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -205,7 +205,8 @@ class TestSetOps:
         isin_slow = np.vectorize(_isin_slow, otypes=[bool], excluded={1})
 
         def assert_isin_equal(a, b, old_algorithm=None):
-            x = isin(a, b, _slow_integer=old_algorithm)
+            method = "sort" if old_algorithm else "dictionary"
+            x = isin(a, b, method=old_algorithm)
             y = isin_slow(a, b)
             assert_array_equal(x, y)
 
@@ -257,21 +258,21 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, _slow_integer=True)
+            c = in1d(a, b, assume_unique=True, method="dictionary")
             assert_array_equal(c, ec)
 
             a[0] = 8
             ec = np.array([False, False, True, True])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, _slow_integer=True)
+            c = in1d(a, b, assume_unique=True, method="dictionary")
             assert_array_equal(c, ec)
 
             a[0], a[3] = 4, 8
             ec = np.array([True, False, True, False])
             c = in1d(a, b, assume_unique=True)
             assert_array_equal(c, ec)
-            c = in1d(a, b, assume_unique=True, _slow_integer=True)
+            c = in1d(a, b, assume_unique=True, method="dictionary")
             assert_array_equal(c, ec)
 
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5])
@@ -280,7 +281,7 @@ class TestSetOps:
                   False, True, False, False, False]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, _slow_integer=True)
+            c = in1d(a, b, method="dictionary")
             assert_array_equal(c, ec)
 
             b = b + [5, 5, 4] * mult
@@ -288,7 +289,7 @@ class TestSetOps:
                   True, False, True, True]
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, _slow_integer=True)
+            c = in1d(a, b, method="dictionary")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 2])
@@ -296,7 +297,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, _slow_integer=True)
+            c = in1d(a, b, method="dictionary")
             assert_array_equal(c, ec)
 
             a = np.array([5, 7, 1, 1, 2])
@@ -304,7 +305,7 @@ class TestSetOps:
             ec = np.array([True, False, True, True, True])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, _slow_integer=True)
+            c = in1d(a, b, method="dictionary")
             assert_array_equal(c, ec)
 
             a = np.array([5, 5])
@@ -312,7 +313,7 @@ class TestSetOps:
             ec = np.array([False, False])
             c = in1d(a, b)
             assert_array_equal(c, ec)
-            c = in1d(a, b, _slow_integer=True)
+            c = in1d(a, b, method="dictionary")
             assert_array_equal(c, ec)
 
         a = np.array([5])
@@ -320,7 +321,7 @@ class TestSetOps:
         ec = np.array([False])
         c = in1d(a, b)
         assert_array_equal(c, ec)
-        c = in1d(a, b, _slow_integer=True)
+        c = in1d(a, b, method="dictionary")
         assert_array_equal(c, ec)
 
         assert_array_equal(in1d([], []), [])
@@ -412,7 +413,7 @@ class TestSetOps:
             b = [2, 3, 4] * mult
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, _slow_integer=True))
+                               in1d(a, b, invert=True, method="dictionary"))
 
         for mult in (1, 10):
             a = np.array([5, 4, 5, 3, 4, 4, 3, 4, 3, 5, 2, 1, 5, 5],
@@ -421,7 +422,7 @@ class TestSetOps:
             b = np.array(b, dtype=np.float32)
             assert_array_equal(np.invert(in1d(a, b)), in1d(a, b, invert=True))
             assert_array_equal(np.invert(in1d(a, b)),
-                               in1d(a, b, invert=True, _slow_integer=True))
+                               in1d(a, b, invert=True, method="dictionary"))
 
     def test_in1d_ravel(self):
         # Test that in1d ravels its input arrays. This is not documented
@@ -435,21 +436,21 @@ class TestSetOps:
         assert_array_equal(in1d(a, b, assume_unique=False), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True), ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False), ec)
-        assert_array_equal(in1d(a, b, assume_unique=True, _slow_integer=True),
+        assert_array_equal(in1d(a, b, assume_unique=True, method="dictionary"),
                            ec)
-        assert_array_equal(in1d(a, b, assume_unique=False, _slow_integer=True),
+        assert_array_equal(in1d(a, b, assume_unique=False, method="dictionary"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=True,
-                                _slow_integer=True),
+                                method="dictionary"),
                            ec)
         assert_array_equal(in1d(a, long_b, assume_unique=False,
-                                _slow_integer=True),
+                                method="dictionary"),
                            ec)
 
     def test_in1d_hit_alternate_algorithm(self):
         """Hit the standard isin code with integers"""
         # Need extreme range to hit standard code
-        # This hits it without the use of _slow_integer
+        # This hits it without the use of method='dictionary'
         a = np.array([5, 4, 5, 3, 4, 4, 1e9], dtype=np.int64)
         b = np.array([2, 3, 4, 1e9], dtype=np.int64)
         expected = np.array([0, 1, 0, 1, 1, 1, 1], dtype=np.bool)
@@ -470,11 +471,11 @@ class TestSetOps:
         assert_array_equal(expected,
                            in1d(a, b))
         assert_array_equal(expected,
-                           in1d(a, b, _slow_integer=True))
+                           in1d(a, b, method="dictionary"))
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True))
         assert_array_equal(np.invert(expected),
-                           in1d(a, b, invert=True, _slow_integer=True))
+                           in1d(a, b, invert=True, method="dictionary"))
 
     def test_in1d_first_array_is_object(self):
         ar1 = [None]


### PR DESCRIPTION
This commit adds some simple functionality to np.isin and np.in1d that greatly increases performance when both arrays are integral. It works by creating a boolean array with elements set to 1 where the parent array (ar2) has elements and 0 otherwise. This array is then indexed by the child array (ar1) to create the output.