### PR TITLE
ENH: `average` to allow better use w/ custom objects

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -400,7 +400,7 @@ def average(a, axis=None, weights=None, returned=False):
         avg = np.multiply(a, wgt, dtype=result_dtype).sum(axis)/scl
 
     if returned:
-        if scl.shape != avg.shape:
+        if np.shape(scl) != np.shape(avg):
             scl = np.broadcast_to(scl, avg.shape).copy()
         return avg, scl
     else:


### PR DESCRIPTION
A simple syntax change to enable better use of `average` with custom Python objects. 

This works because if `weights is None`, then `avg.dtype` can be `"O"` when working with custom Python objects.

The fix does nothing but change how `np.shape` is called, so that it will work with objects that don't necessarily have shapes, like base Python floats, custom Python objects, etc.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
