### PR TITLE
TST: skip test_callstatement() on MacOS

### DIFF
--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -56,5 +56,8 @@ void foo(int* x) {{
 end python module {module}
     """.format(module=module_name)
 
+    @pytest.mark.skipif(platform.system() == 'Darwin',
+                        reason="Can Fail in Azure MacOS CI "
+                               "see gh-12066")
     def test_callstatement(self):
         assert_equal(self.module.foo(), 42)


### PR DESCRIPTION
Related to #12066 and observed [in logs](https://dev.azure.com/numpy/numpy/_build/results?buildId=11&view=logs) from #12067. 

This assumes that the error there is not related to the change in the patch, but I'm quite certain I've seen this error before when working on my fork for Azure mac os. It seems less common than the other one I've already placed a Darwin-specific skip decorator on, but we probably don't want stochastic fails in our CI.

Ideally we'd understand the reason, but this is both a new CI platform and I'm using parallel testing more than we have before for CI so any unit test that is state dependent on related or unrelated tests will likely be more vulnerable to execution order issues and so on.