### PR TITLE
MAINT Avoid some memory copies in numpy.polynomial.hermite

### DIFF
--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1704,7 +1704,7 @@ def _normed_hermite_n(x, n):
 
     """
     if n == 0:
-        return np.ones(x.shape)/np.sqrt(np.sqrt(np.pi))
+        return np.full(x.shape, 1/np.sqrt(np.sqrt(np.pi)))
 
     c0 = 0.
     c1 = 1./np.sqrt(np.sqrt(np.pi))

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1698,7 +1698,7 @@ def _normed_hermite_e_n(x, n):
 
     """
     if n == 0:
-        return np.ones(x.shape)/np.sqrt(np.sqrt(2*np.pi))
+        return np.full(x.shape, 1/np.sqrt(np.sqrt(2*np.pi)))
 
     c0 = 0.
     c1 = 1./np.sqrt(np.sqrt(2*np.pi))


### PR DESCRIPTION
This avoids a few memory copies in `numpypolynomial.hermite*` by using `np.full` instead of `cst*np.ones`, with hopefully some marginal run time benefits.