### PR TITLE
ENH: add hex version, move code to common

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -19,6 +19,12 @@ Highlights
 New functions
 =============
 
+``get_numpy_version_as_hex``
+----------------------------------------
+Added `numpy.version.get_numpy_version_as_hex` which returns a hex string
+similar to ``PY_VERSION_HEX`` in the CPython headers. The value is cached in C
+for fast version comparison and initialized at import.
+
 
 Deprecations
 ============

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -58,6 +58,7 @@ API_FILES = [join('multiarray', 'alloc.c'),
              join('umath', 'ufunc_object.c'),
              join('umath', 'ufunc_type_resolution.c'),
              join('umath', 'reduction.c'),
+             join('common', 'npy_version.c'),
             ]
 THIS_DIR = os.path.dirname(__file__)
 API_FILES = [os.path.join(THIS_DIR, '..', 'src', a) for a in API_FILES]

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -715,9 +715,13 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_multiarray_tests',
                     sources=[join('src', 'multiarray', '_multiarray_tests.c.src'),
-                             join('src', 'common', 'mem_overlap.c')],
+                             join('src', 'common', 'mem_overlap.c'),
+                             join('src', 'common', 'npy_version.c'),
+                            ],
                     depends=[join('src', 'common', 'mem_overlap.h'),
-                             join('src', 'common', 'npy_extint128.h')],
+                             join('src', 'common', 'npy_extint128.h'),
+                             join('src', 'common', 'npy_version.h'),
+                            ],
                     libraries=['npymath'])
 
     #######################################################################
@@ -733,6 +737,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'common', 'npy_config.h'),
             join('src', 'common', 'npy_extint128.h'),
             join('src', 'common', 'npy_longdouble.h'),
+            join('src', 'common', 'npy_version.h'),
             join('src', 'common', 'templ_common.h.src'),
             join('src', 'common', 'ucsnarrow.h'),
             join('src', 'common', 'ufunc_override.h'),
@@ -743,6 +748,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'common', 'array_assign.c'),
             join('src', 'common', 'mem_overlap.c'),
             join('src', 'common', 'npy_longdouble.c'),
+            join('src', 'common', 'npy_version.c'),
             join('src', 'common', 'templ_common.h.src'),
             join('src', 'common', 'ucsnarrow.c'),
             join('src', 'common', 'ufunc_override.c'),

--- a/numpy/core/src/common/npy_version.c
+++ b/numpy/core/src/common/npy_version.c
@@ -1,0 +1,80 @@
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+#include <numpy/ndarraytypes.h>
+
+#include "npy_config.h"
+#include "npy_pycompat.h"
+
+/*NUMPY_API
+ *
+ * Included at the very first so not auto-grabbed and thus not labeled.
+ */
+NPY_NO_EXPORT unsigned int
+PyArray_GetNDArrayCVersion(void)
+{
+    return (unsigned int)NPY_ABI_VERSION;
+}
+
+/*NUMPY_API
+ * Returns the built-in (at compilation time) C API version
+ */
+NPY_NO_EXPORT unsigned int
+PyArray_GetNDArrayCFeatureVersion(void)
+{
+    return (unsigned int)NPY_API_VERSION;
+}
+
+/*
+ * Return equivalent of PY_VERSION_HEX for NumPy's version
+ */
+NPY_NO_EXPORT long
+get_numpy_version_as_hex(void)
+{
+    static long ver = 0;
+    PyObject *_version, *_func, *result, *tmp;
+    char *buf, *endbuf;
+    Py_ssize_t len;
+    int retval;
+    if (ver != 0) {
+        return ver;
+    }
+    _version = PyImport_ImportModule("numpy.version");
+    if (_version == NULL) {
+        return -1L;
+    }
+    _func = PyObject_GetAttrString(_version, "get_numpy_version_as_hex");
+    Py_DECREF(_version);
+    if (_func == NULL) {
+        return -1L;
+    }
+    result = PyObject_CallFunction(_func, NULL);
+    Py_DECREF(_func);
+    if (result == NULL) {
+        return -1L;
+    }
+#if defined(NPY_PY3K)
+    /* FIXME: XXX -- should it use UTF-8 here? */
+    tmp = PyUnicode_AsUTF8String(result);
+    Py_DECREF(result);
+    if (tmp == NULL) {
+        return -1;
+    }
+#else
+    tmp = result;
+#endif
+    retval = PyBytes_AsStringAndSize(tmp, &buf, &len);
+    Py_INCREF(tmp);
+    if (retval < 0) {
+        return -1L;
+    }
+    ver = strtol(buf, &endbuf, 16);
+    if (buf == endbuf || ver == LONG_MAX || ver <= 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "invalid hex value from version.get_numpy_version_as_hex()");
+        ver = 0L;
+        return -1L;
+    }
+    return ver;
+}

--- a/numpy/core/src/common/npy_version.h
+++ b/numpy/core/src/common/npy_version.h
@@ -1,0 +1,7 @@
+#ifndef _NPY_VERSION_H_
+#define _NPY_VERSION_H_
+
+NPY_NO_EXPORT long
+get_numpy_version_as_hex(void);
+
+#endif

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -9,6 +9,7 @@
 #include "common.h"
 #include "mem_overlap.h"
 #include "npy_extint128.h"
+#include "npy_version.h"
 #include "common.h"
 
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
@@ -1709,6 +1710,16 @@ get_fpu_mode(PyObject *NPY_UNUSED(self), PyObject *args)
 #endif
 }
 
+static PyObject *
+get_hex_version(PyObject *NPY_UNUSED(self), PyObject* NPY_UNUSED(args))
+{
+    long ver = get_numpy_version_as_hex();
+    if (ver < 0) {
+        return NULL;
+    }
+    return PyLong_FromLong(ver);
+}
+
 /*
  * npymath wrappers
  */
@@ -1963,6 +1974,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"get_fpu_mode",
         get_fpu_mode,
         METH_VARARGS, get_fpu_mode_doc},
+    {"get_hex_version",
+        get_hex_version,
+        METH_NOARGS, NULL},
 /**begin repeat
  * #name = cabs, carg#
  */

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2871,25 +2871,6 @@ array_arange(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws) {
     return range;
 }
 
-/*NUMPY_API
- *
- * Included at the very first so not auto-grabbed and thus not labeled.
- */
-NPY_NO_EXPORT unsigned int
-PyArray_GetNDArrayCVersion(void)
-{
-    return (unsigned int)NPY_ABI_VERSION;
-}
-
-/*NUMPY_API
- * Returns the built-in (at compilation time) C API version
- */
-NPY_NO_EXPORT unsigned int
-PyArray_GetNDArrayCFeatureVersion(void)
-{
-    return (unsigned int)NPY_API_VERSION;
-}
-
 static PyObject *
 array__get_ndarray_c_version(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
 {

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,10 @@ release = %(isrelease)s
 
 if not release:
     version = full_version
+
+def get_numpy_version_as_hex():
+    major, minor, micro = short_version.split('.')
+    return hex(int(major) << 24 | int(minor) << 16 | int(micro) << 8)
 """
     FULLVERSION, GIT_REVISION = get_version_info()
 


### PR DESCRIPTION
Add a hex version to `version.py` as well as caching it in C when first called. This is a step toward using the current NumPy version in `PyUFuncObject`, as requested in PR #11175.

The hex version is based on the `PY_VERSION_HEX` macro from CPython.

I also aggregated the other functions that deal with versions into `common/npy_version.c`