### PR TITLE
MAINT: Blacklist some MSVC complex functions.

### DIFF
--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -30,7 +30,7 @@
 
 #endif
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
 
 #undef HAVE_CASIN
 #undef HAVE_CASINF
@@ -44,6 +44,18 @@
 #undef HAVE_CATANH
 #undef HAVE_CATANHF
 #undef HAVE_CATANHL
+#undef HAVE_CSQRT
+#undef HAVE_CSQRTF
+#undef HAVE_CSQRTL
+#undef HAVE_CLOG
+#undef HAVE_CLOGF
+#undef HAVE_CLOGL
+#undef HAVE_CACOS
+#undef HAVE_CACOSF
+#undef HAVE_CACOSL
+#undef HAVE_CACOSH
+#undef HAVE_CACOSHF
+#undef HAVE_CACOSHL
 
 #endif
 


### PR DESCRIPTION
Extend the blacklist to MSVC 2017 and add functions

- CSQRT
- CSQRTF
- CSQRTL
- CLOG
- CLOGF
- CLOGL
- CACOS
- CACOSF
- CACOSL
- CACOSH
- CACOSHF
- CACOSHL

See comment from cgholke at issue #11855. Maybe closes #12078.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
