### PR TITLE
BUG: test_path() now uses Path.resolve()

### DIFF
--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -81,7 +81,10 @@ class TestMemmap(object):
         tmpname = mktemp('', 'mmap', dir=self.tempdir)
         fp = memmap(Path(tmpname), dtype=self.dtype, mode='w+',
                        shape=self.shape)
-        abspath = os.path.realpath(os.path.abspath(tmpname))
+        # os.path.realpath does not resolve symlinks on Windows
+        # see: https://bugs.python.org/issue9949
+        # use Path.resolve, just as memmap class does internally
+        abspath = str(Path(tmpname).resolve())
         fp[:] = self.data[:]
         assert_equal(abspath, str(fp.filename.resolve()))
         b = fp[:1]


### PR DESCRIPTION
Backport of #12072.

There's an [open CPython bug](https://bugs.python.org/issue9949) that `os.path.realpath()` does not follow symlinks on Windows, and this has been causing issues in the Azure Windows CI testing. The NumPy `memmap` class [uses `resolve()` internally](https://github.com/numpy/numpy/blob/master/numpy/core/memmap.py#L274).

The scope of this PR does not include modernizing other parts of the test, including use of discouraged `mktemp`, as noted in #12071.
