### PR TITLE
TST, MAINT: Fix some failing tests on azure-pipelines mac and windows.

### DIFF
--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -1,5 +1,8 @@
 from __future__ import division, absolute_import, print_function
 
+import platform
+import pytest
+
 from . import util
 from numpy.testing import assert_equal
 
@@ -23,6 +26,10 @@ void foo(int* x) {{
 end python module {module}
     """.format(module=module_name)
 
+    @pytest.mark.skipif(platform.system() == 'Darwin',
+                        reason="Prone to error when run with "
+                               "numpy/f2py/tests on mac os, "
+                               "but not when run in isolation")
     def test_multiline(self):
         assert_equal(self.module.foo(), 42)
 

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -60,6 +60,7 @@ def run_command(cmd, check_code=True):
 
 
 @pytest.mark.skipif(is_inplace, reason="Cannot test f2py command inplace")
+@pytest.mark.xfail(reason="Test is unreliable")
 def test_f2py():
     # test that we can run f2py script
     if sys.platform == 'win32':


### PR DESCRIPTION
These fixes are backported from master.

- Mark test_f2py as xfail. The test is unreliable, as the installation path
  may depend on the environment in ways we cannot control.
- Skip test_semicolon_split on Mac. The tests fails for reasons not yet
  determined.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
