### PR TITLE
BUG: limit default for get_num_build_jobs() to 8

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -84,7 +84,7 @@ def get_num_build_jobs():
     Get number of parallel build jobs set by the --parallel command line
     argument of setup.py
     If the command did not receive a setting the environment variable
-    NPY_NUM_BUILD_JOBS checked. If that is unset, return the number of
+    NPY_NUM_BUILD_JOBS is checked. If that is unset, return the number of
     processors on the system, with a maximum of 8 (to prevent
     overloading the system if there a lot of CPUs).
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -84,7 +84,9 @@ def get_num_build_jobs():
     Get number of parallel build jobs set by the --parallel command line
     argument of setup.py
     If the command did not receive a setting the environment variable
-    NPY_NUM_BUILD_JOBS checked and if that is unset it returns 1.
+    NPY_NUM_BUILD_JOBS checked. If that is unset, return the number of
+    processors on the system, with a maximum of 8 (to prevent
+    overloading the system if there a lot of CPUs).
 
     Returns
     -------
@@ -97,6 +99,7 @@ def get_num_build_jobs():
         cpu_count = len(os.sched_getaffinity(0))
     except AttributeError:
         cpu_count = multiprocessing.cpu_count()
+    cpu_count = min(cpu_count, 8)
     envjobs = int(os.environ.get("NPY_NUM_BUILD_JOBS", cpu_count))
     dist = get_distribution()
     # may be None during configuration


### PR DESCRIPTION
The default value for `get_num_build_jobs()` is now the number of CPUs limited to a maximum of 8. This is to prevent overloading systems with a lot of CPUs. See ticket #12087
