### PR TITLE
TST: Install pickle5 for CI testing with python 3.6/7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,11 +39,13 @@ environment:
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
       TEST_MODE: full
+      INSTALL_PICKLE5: 1
 
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       TEST_MODE: full
+      INSTALL_PICKLE5: 1
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -100,6 +102,8 @@ install:
 
   # Upgrade to the latest pip.
   - 'python -m pip install -U pip setuptools wheel'
+
+  - if [%INSTALL_PICKLE5%]==[1] echo pickle5 >> tools/ci/appveyor/requirements.txt
 
   # Install the numpy test dependencies.
   - 'pip install -U --timeout 5 --retries 2 -r tools/ci/appveyor/requirements.txt'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
     - python: 3.7
       dist: xenial  # Required for Python 3.7
       sudo: true    # travis-ci/travis-ci#9069
+      env: INSTALL_PICKLE5=1
     - python: 3.6
       env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=3.6
       sudo: true
@@ -61,7 +62,7 @@ matrix:
             - python3-dev
             - python3-setuptools
     - python: 3.6
-      env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1
+      env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1 INSTALL_PICKLE5=1
     - python: 2.7
       env: USE_WHEEL=1 RUN_FULL_TESTS=1 PYTHON_OPTS="-3 -OO"
     - python: 3.6

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,6 +107,7 @@ jobs:
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
   # vs. manual setup.py and then runtests.py for testing only
   - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
+    displayName: 'Install optional pickle5 backport (only for python3.6 and 3.7)'
   - script: python runtests.py --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Build NumPy & Run Full NumPy Test Suite'
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: 'make gfortran available on mac os vm'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install cython nose pytz pytest
+  - script: python -m pip install cython nose pytz pytest pickle5
     displayName: 'Install dependencies; some are optional to avoid test skips'
   # NOTE: init_dgelsd failed init issue with current ACCELERATE /
   # LAPACK configuration on Azure macos image; at the time of writing
@@ -80,10 +80,12 @@ jobs:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
+          INSTALL_PICKLE5: 1
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
+          INSTALL_PICKLE5: 1
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -104,6 +106,7 @@ jobs:
     displayName: 'Install dependencies; some are optional to avoid test skips'
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
   # vs. manual setup.py and then runtests.py for testing only
+  - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
   - script: python runtests.py --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Build NumPy & Run Full NumPy Test Suite'
   - task: PublishTestResults@2

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -20,6 +20,11 @@ fi
 
 source venv/bin/activate
 python -V
+
+if [ -n "$INSTALL_PICKLE5" ]; then
+  pip install pickle5
+fi
+
 pip install --upgrade pip setuptools
 pip install nose pytz cython pytest
 if [ -n "$USE_ASV" ]; then pip install asv; fi

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -193,6 +193,11 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   pushd dist
   pip install --pre --no-index --upgrade --find-links=. numpy
   pip install nose pytest
+
+  if [ -n "$INSTALL_PICKLE5" ]; then
+    pip install pickle5
+  fi
+
   popd
   run_test
 elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
@@ -212,6 +217,10 @@ elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
   pushd dist
   pip install numpy*
   pip install nose pytest
+  if [ -n "$INSTALL_PICKLE5" ]; then
+    pip install pickle5
+  fi
+
   popd
   run_test
 elif [ -n "$USE_CHROOT" ] && [ $# -eq 0 ]; then


### PR DESCRIPTION
This PR gathers the changes to the CI images/script needed to test correctly the contents of the PR #12011, that implements pickle protocol 5 for numpy arrays. 

For python 3.6 and 3.7,  using pickle protocol 5 is possible only thanks to the `pickle5` module. As we enable the use of `pickle5` in the aforementioned PR,, we install the pickle5 module in some setups involving python 3.6 and 3.7 in order to test those functionalities.

Pinging @ogrisel and @mattip 