### PR TITLE
Provide information about what kind is actually not integer kind

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -513,7 +513,7 @@ class iinfo(object):
         self.bits = self.dtype.itemsize * 8
         self.key = "%s%d" % (self.kind, self.bits)
         if self.kind not in 'iu':
-            raise ValueError("Invalid integer data type.")
+            raise ValueError("Invalid integer data type %r." % (self.kind,))
 
     def min(self):
         """Minimum value of given dtype."""


### PR DESCRIPTION
Otherwise it is hard to impossible to figure out what is the actual
value which fails the test.

See e.g. failing on 3.4 (only) tests of nibabel:
https://ci.appveyor.com/project/nipy/nibabel/build/1.0.498/job/eechfm1kxroa0rju#L598