### PR TITLE
ENH: ndrange, like range, but multidimensional

### DIFF
--- a/doc/release/upcoming_changes/12094.new_function.rst
+++ b/doc/release/upcoming_changes/12094.new_function.rst
@@ -1,0 +1,7 @@
+``ndrange`` a multi-dimensional range-like object
+-------------------------------------------------
+``ndrange`` behaves much like the Python 3 ``range`` object and allows
+multi-dimensional slicing, iteration, reversal and efficient membership lookup.
+``ndrange`` now supersedes the ``ndindex`` object for generating multi-index
+iterators. ``ndindex`` will continue to be maintained for backward
+compatibility.

--- a/doc/source/reference/routines.indexing.rst
+++ b/doc/source/reference/routines.indexing.rst
@@ -63,6 +63,7 @@ Iterating over arrays
    nditer
    ndenumerate
    ndindex
+   ndrange
    nested_iters
    flatiter
    iterable

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -231,9 +231,9 @@ else:
         savez_compressed, unpackbits, fromregex
     )
     from .lib._index_tricks_impl import (
-        diag_indices_from, diag_indices, fill_diagonal, ndindex, ndenumerate,
-        ix_, c_, r_, s_, ogrid, mgrid, unravel_index, ravel_multi_index,
-        index_exp
+        diag_indices_from, diag_indices, fill_diagonal, ndindex, ndrange,
+        ndenumerate, ix_, c_, r_, s_, ogrid, mgrid, unravel_index,
+        ravel_multi_index, index_exp
     )
 
     from . import matrixlib as _mat


### PR DESCRIPTION
I've been using numpy arrays as a way to store collections of items in 2D. Mostly because of the powerful slicing numpy offers.

It became useful to iterate through the collection in various ways, often wanting to use pythonic tools like `range`.

I wrote what I think is a cool `ndrange` class that behaves like `range` (I hope) but in ND. 

If this is in the scope of Numpy, I would appreciate feedback on how this might be merged in.

### Performance concerns
@ahaldane asked on the mailing list if it would be better to implement this on top of nditer like `ndindex` is currently implemented for performance reasons.

It seems that `itertools.product + range` (proposed ndrange implementation) is faster than `ndinter + multi_index` (current ndindex implementation)
```python
In [3]: %%timeit 
   ...: for it in np.ndrange((100, 100)): 
   ...:     pass 
   ...:      
   ...:                                                                         
238 µs ± 1.63 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [4]: %%timeit 
   ...: for it in np.ndindex((100, 100)): 
   ...:     pass 
   ...:      
   ...:                                                                         
3.67 ms ± 44.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

It seems that `ndindex` can be sped up by introducing
```python
    def __init__(self, *shape):
        # [...]
        # defining a generator expression here as opposed to doing this
        # in the __next__ seems to speed ndindex by a factor of 1.7
        self._index_iter = (self._it.multi_index for _ in self._it)
    def __next__(self):
         return next(self._index_iter)
```
This seems like a bad optimization for CPython though.
More details can be found here https://gist.github.com/hmaarrfk/a273b3d77cbec6e7b0d1c4f33ea65dd0


### Previous attempts
I tried to extend the ndindex class, but it just became very ugly,
https://github.com/hmaarrfk/numpy/pull/1/files#diff-1bd953557a98073031ce66d05dbde3c8R661
and containment was strange because `ndindex` could be consumed itself. What would it mean to check if (0, 0, 0) was in `ndindex` after a few items had been consumed.

~~This just won't fly in python 2 because range or xrange objects cannot be sliced into the way they are in python 3.~~ I enabled python 2.7 support, but it isn't as elegant as 3.X support.

Todo:
  - [x] Add docstrings
  - [x] harden tests for failers
  - [x] decide on how to handle lists as inputs
  - [ ] Remove development comments
  - [x] Finish the rest of testing for the properties of ndrange
  - [x] Add tests for ravel
  - [ ] Are flat and ravel required to return standard numpy classes?
  - [x] Squash the PRs into ENH, TST (once the fate of ravel and flat is determined).
  - [x] Enforce that `step` cannot be provided as a parameter when `start` and `stop` aren't both specified. `ndrange(5, step=2)` should be illegal.

Fixes: https://github.com/numpy/numpy/issues/6393
[12094-before_rebase.patch.txt](https://github.com/numpy/numpy/files/8935285/12094-before_rebase.patch.txt)


~Patch from 2018 before rebase~ The conflicts were minor, i just rebased...
