### PR TITLE
WIP, MAINT: Make f2py tests threadsafe.

### DIFF
--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -87,7 +87,13 @@ end python module c_ext_return_real
     @pytest.mark.slow
     @pytest.mark.parametrize('name', 't4,t8,s4,s8'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        try:
+            self.check_function(getattr(self.module, name))
+        except:
+            print(self.module)
+            print(util.get_module_dir())
+            print(os.listdir(util.get_module_dir()))
+            raise
 
 
 class TestF77ReturnReal(TestReturnReal):

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -101,7 +101,7 @@ def _memoize(func):
 #
 
 
-@_memoize
+#@_memoize
 def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     """
     Compile and import a f2py module, built from the given files.
@@ -160,7 +160,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
     return import_module(module_name)
 
 
-@_memoize
+#@_memoize
 def build_code(source_code, options=[], skip=[], only=[], suffix=None,
                module_name=None):
     """
@@ -247,7 +247,7 @@ def has_f90_compiler():
 #
 
 
-@_memoize
+#@_memoize
 def build_module_distutils(source_files, config_code, module_name, **kw):
     """
     Build a module via distutils and import it.

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -320,7 +320,7 @@ class F2PyTest(object):
     module = None
     module_name = None
 
-    def setup(self):
+    def setup_class(self):
         if sys.platform == 'win32':
             pytest.skip('Fails with MinGW64 Gfortran (Issue #9673)')
 


### PR DESCRIPTION
There are currently test failure on the azure-pipeline Mac platform that may be threading related. The intent of this work is to cleanup the code and make it threadsafe.

- MAINT: Change setup to setup_class in the F2PyTest base class. ￼…
  
  The compile only needs to be run once for each test class instanciation,
  currently that is achieved by using a cache (see _memoize) but
  setup_class achieves the same thing.

More to come.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
