### PR TITLE
TST, MAINT: Skip some f2py tests on Mac.

### DIFF
--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import platform
 import pytest
 
 from numpy import array
@@ -52,6 +53,11 @@ class TestReturnReal(util.F2PyTest):
             pass
 
 
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"
     module_name = "c_ext_return_real"

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -6,6 +6,10 @@ import pytest
 from . import util
 from numpy.testing import assert_equal
 
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestMultiline(util.F2PyTest):
     suffix = ".pyf"
     module_name = "multiline"
@@ -26,13 +30,14 @@ void foo(int* x) {{
 end python module {module}
     """.format(module=module_name)
 
-    @pytest.mark.skipif(platform.system() == 'Darwin',
-                        reason="Prone to error when run with "
-                               "numpy/f2py/tests on mac os, "
-                               "but not when run in isolation")
     def test_multiline(self):
         assert_equal(self.module.foo(), 42)
 
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestCallstatement(util.F2PyTest):
     suffix = ".pyf"
     module_name = "callstatement"


### PR DESCRIPTION
There is a not yet understood problem in testing f2py C modules (*.pyf)
files on the Mac that manifests as erratic module import failures.
This disables those tests until we can figure out what the problem is.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
