### PR TITLE
ENH: check getfield arguments to prevent invalid memory access

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -209,4 +209,9 @@ Previously `np.core.umath` and `np.core.multiarray` were the c-extension
 modules, they are now python wrappers to the single `np.core/_multiarray_math`
 c-extension module.
 
+``getfield`` validity checks extended
+----------------------------------------
+`numpy.ndarray.getfield` now checks the dtype and offset arguments to prevent
+accessing invalid memory locations.
+
 .. _`NEP 15` : http://www.numpy.org/neps/nep-0015-merge-multiarray-umath.html

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7658,3 +7658,19 @@ def test_uintalignment_and_alignment():
     # check that copy code doesn't complain in debug mode
     dst = np.zeros((2,2), dtype='c8')
     dst[:,1] = src[:,1]  # assert in lowlevel_strided_loops fails?
+
+def test_getfield():
+    a = np.arange(32, dtype='uint16')
+    if sys.byteorder == 'little':
+        i = 0
+        j = 1
+    else:
+        i = 1
+        j = 0
+    b = a.getfield('int8', i)
+    assert_equal(b, a)
+    b = a.getfield('int8', j)
+    assert_equal(b, 0)
+    pytest.raises(ValueError, a.getfield, 'uint8', -1)
+    pytest.raises(ValueError, a.getfield, 'uint8', 16)
+    pytest.raises(ValueError, a.getfield, 'uint64', 0)


### PR DESCRIPTION
Closes #12105. `getfield` is a version of `view` that allows viewing the data block through a different dtype with an optional offset. This PR prevents the new dtype and offset from accessing invalid data.