### PR TITLE
DEP: deprecate asscalar

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -36,6 +36,10 @@ and not documented. They will be removed in the 1.18 release. Use
 These were deprecated in 1.10, had no tests, and seem to no longer work in
 1.15 anyway.
 
+`numpy.asscalar` has been deprecated
+------------------------------------
+It is an alias to the more powerful `numpy.ndarray.item`, not tested, and fails
+for scalars.
 
 Future Changes
 ==============

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -493,7 +493,7 @@ def asscalar(a):
     """
 
     # 2018-10-10, 1.16
-    warnings.warn('np.asscalar(a) will be removed in v1.18 of numpy, use '
+    warnings.warn('np.asscalar(a) is deprecated since NumPy v1.16, use '
                   'a.item() instead', DeprecationWarning, stacklevel=1)
     return a.item()
 

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -2,6 +2,7 @@
 
 """
 from __future__ import division, absolute_import, print_function
+import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'isreal', 'nan_to_num', 'real', 'real_if_close',
@@ -469,6 +470,10 @@ def asscalar(a):
     """
     Convert an array of size 1 to its scalar equivalent.
 
+    .. deprecated:: 1.16
+
+        Deprecated, use `numpy.ndarray.item()` instead.
+
     Parameters
     ----------
     a : ndarray
@@ -486,6 +491,10 @@ def asscalar(a):
     24
 
     """
+
+    # 2018-10-10, 1.16
+    warnings.warn('np.asscalar(a) will be removed in v1.18 of numpy, use '
+                  'a.item() instead', DeprecationWarning, stacklevel=1)
     return a.item()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4701 (issue). Closes #11856 (PR). Closes #10256 (PR). Closes #10659 (PR).

This issue was labelled "easy" which led to the multiple PRs to fix it. I propose to deprecate it instead, as it is neither used nor tested in numpy, and is a thin wrapper to [`ndarray.item()`](http://www.numpy.org/devdocs/reference/generated/numpy.ndarray.item.html) but accepts none of the `args`.

SciPy does not use `asscalar`, astropy has two uses of `asscalar` which would need fixing.