### PR TITLE
TST: expand cases in test_issctype()

### DIFF
--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -480,6 +480,9 @@ class Test_sctype2char(object):
     (list, False),
     (1.1, False),
     (str, True),
+    (np.dtype(np.float64), True),
+    (np.dtype((np.int16, (3, 4))), True),
+    (np.dtype([('a', np.int8)]), True),
     ])
 def test_issctype(rep, expected):
     # ensure proper identification of scalar


### PR DESCRIPTION
@eric-wieser [requested](https://github.com/numpy/numpy/pull/12109#pullrequestreview-162767017) additional test cases for `test_issctype()`.

There's still a small [uncovered code path](https://codecov.io/gh/numpy/numpy/src/master/numpy/core/numerictypes.py#L225...233) in the tested function, but causing `issctype()` to raise the `Exception` that triggers that path seems tricky without some sophisticated mocking.
