### PR TITLE
WIP: Improve the speed of searchsorted.

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -35,7 +35,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7"],
+    "pythons": [ "3.6" ],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -158,3 +158,25 @@ class Where(Benchmark):
 
     def time_2_broadcast(self):
         np.where(self.cond, self.d, 0)
+
+class Search(Benchmark):
+    params = [[10, 100, 1000, 10000],
+              [10, 100, 1000, 10000],
+              ['l', 'r'],
+              ['sorted', 'random'],
+              ['f8'],]
+
+    param_names = ['needlesize', 'haystacksize', 'side', 'needletype', 'dtype']
+
+    def setup(self, needlesize, haystacksize, side, needletype, dtype):
+        self.sorted = np.arange(needlesize, dtype=dtype)
+        self.random = np.random.RandomState(3333).choice(needlesize, size=needlesize).astype(dtype)
+        if needletype == 'sorted':
+            self.needle = self.sorted
+        else:
+            self.needle = self.random
+        self.haystack = np.arange(haystacksize)
+        self.side = side
+
+    def time_1(self, *args):
+        np.searchsorted(self.haystack, self.needle, self.side)

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -66,9 +66,8 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
         }
 
         last_key_val = key_val;
-
+        npy_intp mid_idx = min_idx;
         while (min_idx < max_idx) {
-            const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const @type@ mid_val = *(const @type@ *)(arr + mid_idx*arr_str);
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
@@ -76,6 +75,7 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
             else {
                 max_idx = mid_idx;
             }
+            mid_idx = min_idx + ((max_idx - min_idx) >> 1);
         }
         *(npy_intp *)ret = min_idx;
     }

--- a/site.cfg
+++ b/site.cfg
@@ -1,0 +1,227 @@
+# This file provides configuration information about non-Python dependencies for
+# numpy.distutils-using packages. Create a file like this called "site.cfg" next
+# to your package's setup.py file and fill in the appropriate sections. Not all
+# packages will use all sections so you should leave out sections that your
+# package does not use.
+
+# To assist automatic installation like easy_install, the user's home directory
+# will also be checked for the file ~/.numpy-site.cfg .
+
+# The format of the file is that of the standard library's ConfigParser module.
+# No interpolation is allowed, RawConfigParser class being used to load it.
+#
+#   https://docs.python.org/library/configparser.html
+#
+# Each section defines settings that apply to one particular dependency. Some of
+# the settings are general and apply to nearly any section and are defined here.
+# Settings specific to a particular section will be defined near their section.
+#
+#   libraries
+#       Comma-separated list of library names to add to compile the extension
+#       with. Note that these should be just the names, not the filenames. For
+#       example, the file "libfoo.so" would become simply "foo".
+#           libraries = lapack,f77blas,cblas,atlas
+#
+#   library_dirs
+#       List of directories to add to the library search path when compiling
+#       extensions with this dependency. Use the character given by os.pathsep
+#       to separate the items in the list. Note that this character is known to
+#       vary on some unix-like systems; if a colon does not work, try a comma.
+#       This also applies to include_dirs and src_dirs (see below).
+#       On UN*X-type systems (OS X, most BSD and Linux systems):
+#           library_dirs = /usr/lib:/usr/local/lib
+#       On Windows:
+#           library_dirs = c:\mingw\lib,c:\atlas\lib
+#       On some BSD and Linux systems:
+#           library_dirs = /usr/lib,/usr/local/lib
+#
+#   include_dirs
+#       List of directories to add to the header file search path.
+#           include_dirs = /usr/include:/usr/local/include
+#
+#   src_dirs 
+#       List of directories that contain extracted source code for the
+#       dependency. For some dependencies, numpy.distutils will be able to build
+#       them from source if binaries cannot be found. The FORTRAN BLAS and
+#       LAPACK libraries are one example. However, most dependencies are more
+#       complicated and require actual installation that you need to do
+#       yourself.
+#           src_dirs = /home/rkern/src/BLAS_SRC:/home/rkern/src/LAPACK_SRC
+#
+#   search_static_first
+#       Boolean (one of (0, false, no, off) for False or (1, true, yes, on) for
+#       True) to tell numpy.distutils to prefer static libraries (.a) over
+#       shared libraries (.so). It is turned off by default.
+#           search_static_first = false
+#
+#   runtime_library_dirs/rpath
+#       List of directories that contains the libraries that should be 
+#       used at runtime, thereby disregarding the LD_LIBRARY_PATH variable.
+#       See 'library_dirs' for formatting on different platforms.
+#           runtime_library_dirs = /opt/blas/lib:/opt/lapack/lib
+#       or equivalently
+#           rpath = /opt/blas/lib:/opt/lapack/lib
+#
+#   extra_compile_args
+#       Add additional arguments to the compilation of sources.
+#       Simple variable with no parsing done. 
+#       Provide a single line with all complete flags.
+#           extra_compile_args = -g -ftree-vectorize
+#
+#   extra_link_args
+#       Add additional arguments when libraries/executables
+#       are linked.
+#       Simple variable with no parsing done. 
+#       Provide a single line with all complete flags.
+#           extra_link_args = -lgfortran
+#
+
+# Defaults
+# ========
+# The settings given here will apply to all other sections if not overridden.
+# This is a good place to add general library and include directories like
+# /usr/local/{lib,include}
+#
+[all]
+library_dirs = /usr/local/lib/2
+include_dirs = /usr/local/include/3
+#
+
+# Atlas
+# -----
+# Atlas is an open source optimized implementation of the BLAS and Lapack
+# routines. NumPy will try to build against Atlas by default when available in
+# the system library dirs. To build numpy against a custom installation of
+# Atlas you can add an explicit section such as the following. Here we assume
+# that Atlas was configured with ``prefix=/opt/atlas``.
+#
+# [atlas]
+# library_dirs = /opt/atlas/lib
+# include_dirs = /opt/atlas/include
+
+# OpenBLAS
+# --------
+# OpenBLAS is another open source optimized implementation of BLAS and Lapack
+# and can be seen as an alternative to Atlas. To build numpy against OpenBLAS
+# instead of Atlas, use this section instead of the above, adjusting as needed
+# for your configuration (in the following example we installed OpenBLAS with
+# ``make install PREFIX=/opt/OpenBLAS``.
+# OpenBLAS is generically installed as a shared library, to force the OpenBLAS
+# library linked to also be used at runtime you can utilize the 
+# runtime_library_dirs variable.
+#
+# **Warning**: OpenBLAS, by default, is built in multithreaded mode. Due to the
+# way Python's multiprocessing is implemented, a multithreaded OpenBLAS can
+# cause programs using both to hang as soon as a worker process is forked on
+# POSIX systems (Linux, Mac).
+# This is fixed in Openblas 0.2.9 for the pthread build, the OpenMP build using
+# GNU openmp is as of gcc-4.9 not fixed yet.
+# Python 3.4 will introduce a new feature in multiprocessing, called the
+# "forkserver", which solves this problem. For older versions, make sure
+# OpenBLAS is built using pthreads or use Python threads instead of
+# multiprocessing.
+# (This problem does not exist with multithreaded ATLAS.)
+#
+# https://docs.python.org/library/multiprocessing.html#contexts-and-start-methods
+# https://github.com/xianyi/OpenBLAS/issues/294
+#
+# [openblas]
+# libraries = openblas
+# library_dirs = /opt/OpenBLAS/lib
+# include_dirs = /opt/OpenBLAS/include
+# runtime_library_dirs = /opt/OpenBLAS/lib
+
+# BLIS
+# ----
+# BLIS (https://github.com/flame/blis) also provides a BLAS interface.  It's a
+# relatively new library, its performance in some cases seems to match that of
+# MKL and OpenBLAS, but it hasn't been benchmarked with NumPy or Scipy yet.
+#
+# Notes on compiling BLIS itself:
+#   - the CBLAS interface (needed by NumPy) isn't built by default; define
+#     BLIS_ENABLE_CBLAS to build it.
+#   - ``./configure auto`` doesn't support 32-bit builds, see gh-7294 for
+#     details.
+# Notes on compiling NumPy against BLIS:
+#   - ``include_dirs`` below should be the directory where the BLIS cblas.h
+#     header is installed.
+#
+# [blis]
+# libraries = blis
+# library_dirs = /home/username/blis/lib
+# include_dirs = /home/username/blis/include/blis
+# runtime_library_dirs = /home/username/blis/lib
+
+# MKL
+#---- 
+# Intel MKL is Intel's very optimized yet proprietary implementation of BLAS and 
+# Lapack. Find the latest info on building numpy with Intel MKL in this article:
+# https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl
+# Assuming you installed the mkl in /opt/intel/compilers_and_libraries_2018/linux/mkl, 
+# for 64 bits code at Linux: 
+#[mkl] 
+#library_dirs = /opt/intel/compilers_and_libraries_2018/linux/mkl/lib/intel64
+#include_dirs = /opt/intel/compilers_and_libraries_2018/linux/mkl/include 
+#mkl_libs = mkl_rt 
+# lapack_libs =  
+# 
+# For 32 bit code at Linux: 
+[mkl]
+# junk to skip default include paths
+library_dirs = /opt/intel/compilers_and_libraries_2018/linux/mkl/lib/ia32
+include_dirs = /opt/intel/compilers_and_libraries_2018/linux/mkl/include 
+mkl_libs = mkl_rt 
+# lapack_libs =  
+# 
+# On win-64, the following options compiles numpy with the MKL library 
+# dynamically linked. 
+# [mkl] 
+# include_dirs = C:\Program Files (x86)\IntelSWTools\compilers_and_libraries_2018\windows\mkl\include
+# library_dirs = C:\Program Files (x86)\IntelSWTools\compilers_and_libraries_2018\windows\mkl\lib\intel64
+# mkl_libs = mkl_rt 
+# lapack_libs =
+
+# ACCELERATE
+# ----------
+# Accelerate/vecLib is an OSX framework providing a BLAS and LAPACK implementations.
+#
+# [accelerate]
+# libraries = Accelerate, vecLib
+# #libraries = None
+
+# UMFPACK
+# -------
+# The UMFPACK library is used in scikits.umfpack to factor large sparse matrices. 
+# It, in turn, depends on the AMD library for reordering the matrices for
+# better performance.  Note that the AMD library has nothing to do with AMD
+# (Advanced Micro Devices), the CPU company.
+#
+# UMFPACK is not used by numpy.
+#
+#   https://www.cise.ufl.edu/research/sparse/umfpack/
+#   https://www.cise.ufl.edu/research/sparse/amd/
+#   https://scikit-umfpack.github.io/scikit-umfpack/
+#
+#[amd]
+#amd_libs = amd
+#
+#[umfpack]
+#umfpack_libs = umfpack
+
+# FFT libraries
+# -------------
+# There are two FFT libraries that we can configure here: FFTW (2 and 3) and djbfft.
+# Note that these libraries are not used by for numpy or scipy.
+#
+#   http://fftw.org/
+#   https://cr.yp.to/djbfft.html
+#
+# Given only this section, numpy.distutils will try to figure out which version
+# of FFTW you are using.
+#[fftw]
+#libraries = fftw3
+#
+# For djbfft, numpy.distutils will look for either djbfft.a or libdjbfft.a . 
+#[djbfft]
+#include_dirs = /usr/local/djbfft/include
+#library_dirs = /usr/local/djbfft/lib


### PR DESCRIPTION
Improving the speed of searchsorted.

By peeking the current item in the haystack first we roughly recover a O(n + m) algorithm instead of O(n log m) when the haystack is sorted. For small n and m it is slower.

This PR needs to be cleaned up, and improved. There probably are better heuristics to decide when to use O(n +m) and when to use O(n logm).

Inputs are welcome.

Benchmarks:

I am having difficulty running asv on master due to the compilation error in https://github.com/numpy/numpy/issues/11853

so only a simple comparison for now.

After:
```
Previous HEAD position was eca9936d1... Add benchmark for Search.
Switched to branch 'fastersearch'
(base) [yfeng1@waterfall numpy]$ !py
python runtests.py --bench Search
Building, see build.log...
Build OK
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Building for existing-py_home_yfeng1_anaconda3_install_bin_python
[  0.00%] ·· Benchmarking existing-py_home_yfeng1_anaconda3_install_bin_python
[100.00%] ··· Running bench_function_base.Search.time_1                                                                               ok
[100.00%] ···· 
               ============ ============== ================= ================= ================= =================
               --                                                 side / needletype / dtype                       
               --------------------------- -----------------------------------------------------------------------
                needlesize   haystacksize   l / sorted / f8   l / random / f8   r / sorted / f8   r / random / f8 
               ============ ============== ================= ================= ================= =================
                   1000          1000           14.17μs           49.62μs           12.79μs           48.18μs     
                   1000         10000           21.90μs           81.12μs           20.60μs           79.99μs     
                   1000         100000          82.65μs           195.03μs          82.83μs           192.62μs    
                   1000        1000000           1.35ms            1.51ms            1.34ms            1.52ms     
                  10000          1000           41.77μs           596.70μs          38.65μs           584.59μs    
                  10000         10000           152.83μs          819.17μs          140.88μs          835.26μs    
                  10000         100000          224.80μs           1.50ms           216.97μs           1.49ms     
                  10000        1000000           2.02ms            4.08ms            2.00ms            4.15ms     
                  100000         1000           219.59μs           5.79ms           220.17μs           5.71ms     
                  100000        10000           436.52μs           8.18ms           391.23μs           8.07ms     
                  100000        100000           1.82ms           14.47ms            1.63ms           14.30ms     
                  100000       1000000           3.45ms           30.56ms            3.33ms           30.12ms     
                 1000000         1000            2.05ms           58.13ms            2.05ms           57.47ms     
                 1000000        10000            2.28ms           81.98ms            2.27ms           82.95ms     
                 1000000        100000           4.71ms           145.07ms           4.58ms           143.52ms    
                 1000000       1000000          22.75ms           266.39ms          19.95ms           267.09ms    
               ============ ============== ================= ================= ================= =================
```
before
```
HEAD is now at eca9936d1... Add benchmark for Search.
(base) [yfeng1@waterfall numpy]$ !p
python runtests.py --bench Search
Building, see build.log...
Build OK
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Building for existing-py_home_yfeng1_anaconda3_install_bin_python
[  0.00%] ·· Benchmarking existing-py_home_yfeng1_anaconda3_install_bin_python
[100.00%] ··· Running bench_function_base.Search.time_1                                                                               ok
[100.00%] ···· 
               ============ ============== ================= ================= ================= =================
               --                                                 side / needletype / dtype                       
               --------------------------- -----------------------------------------------------------------------
                needlesize   haystacksize   l / sorted / f8   l / random / f8   r / sorted / f8   r / random / f8 
               ============ ============== ================= ================= ================= =================
                   1000          1000           14.40μs           55.83μs           14.14μs           51.88μs     
                   1000         10000           22.96μs           85.93μs           23.58μs           83.82μs     
                   1000         100000          89.63μs           195.00μs          90.94μs           193.37μs    
                   1000        1000000           1.24ms            1.40ms            1.24ms            1.40ms     
                  10000          1000           125.83μs          585.63μs          124.70μs          574.02μs    
                  10000         10000           161.67μs          822.46μs          163.26μs          816.22μs    
                  10000         100000          249.13μs           1.49ms           243.95μs           1.47ms     
                  10000        1000000           2.08ms            4.25ms            1.97ms            4.22ms     
                  100000         1000            1.13ms            5.83ms            1.15ms            5.72ms     
                  100000        10000            1.61ms            8.15ms            1.61ms            8.08ms     
                  100000        100000           1.96ms           14.29ms            1.96ms           14.34ms     
                  100000       1000000           3.77ms           29.60ms            3.64ms           29.72ms     
                 1000000         1000           11.11ms           58.44ms           11.27ms           57.28ms     
                 1000000        10000           15.09ms           81.65ms           15.39ms           80.74ms     
                 1000000        100000          20.13ms           144.49ms          19.97ms           143.42ms    
                 1000000       1000000          24.42ms           264.65ms          24.61ms           263.74ms    
               ============ ============== ================= ================= ================= =================


```