### PR TITLE
BUG: fix PyDataType_ISBOOL

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1670,7 +1670,7 @@ PyArray_CLEARFLAGS(PyArrayObject *arr, int flags)
 #define PyTypeNum_ISOBJECT(type) ((type) == NPY_OBJECT)
 
 
-#define PyDataType_ISBOOL(obj) PyTypeNum_ISBOOL(_PyADt(obj))
+#define PyDataType_ISBOOL(obj) PyTypeNum_ISBOOL(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_ISUNSIGNED(obj) PyTypeNum_ISUNSIGNED(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_ISSIGNED(obj) PyTypeNum_ISSIGNED(((PyArray_Descr*)(obj))->type_num)
 #define PyDataType_ISINTEGER(obj) PyTypeNum_ISINTEGER(((PyArray_Descr*)(obj))->type_num )


### PR DESCRIPTION
The `PyDataType_ISBOOL` macro still uses `_PyADt`, but that value was removed in commit [db8442b04 from 2006](https://github.com/numpy/numpy/commit/db8442b04f2b8dcc714dd974d0bd6407e9e054ef#diff-cd3f97239a111d2b450c900ff12f35a6L1392). So the macro was broken for quite a while, and nobody complained. I propose fixing it, although deleting `PyDataType_ISBOOL` entirely is another alternative.