### PR TITLE
DOC: Remove duplicated sentence in numpy.multiply

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2594,8 +2594,7 @@ add_newdoc('numpy.core.umath', 'multiply',
     Returns
     -------
     y : ndarray
-        The product of `x1` and `x2`, element-wise. Returns a scalar if
-        both `x1` and `x2` are scalars.
+        The product of `x1` and `x2`, element-wise.
         $OUT_SCALAR_2
 
     Notes


### PR DESCRIPTION
The return value documentation was duplicated.

See https://docs.scipy.org/doc/numpy/reference/generated/numpy.multiply.html - `$OUT_SCALAR_2` already contains the information.