### PR TITLE
MAINT: Update ndarrayobject.h `__cplusplus` block.

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -5,13 +5,7 @@
 #ifndef NPY_NDARRAYOBJECT_H
 #define NPY_NDARRAYOBJECT_H
 #ifdef __cplusplus
-#define CONFUSE_EMACS {
-#define CONFUSE_EMACS2 }
-extern "C" CONFUSE_EMACS
-#undef CONFUSE_EMACS
-#undef CONFUSE_EMACS2
-/* ... otherwise a semi-smart identer (like emacs) tries to indent
-       everything when you're typing */
+extern "C" {
 #endif
 
 #include <Python.h>
@@ -284,9 +278,7 @@ PyArray_XDECREF_ERR(PyArrayObject *arr)
 
 
 #ifdef __cplusplus
-#define CONFUSE_EMACS2 }
-CONFUSE_EMACS2
-#undef CONFUSE_EMACS2
+}
 #endif
 
 

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -284,7 +284,9 @@ PyArray_XDECREF_ERR(PyArrayObject *arr)
 
 
 #ifdef __cplusplus
-}
+#define CONFUSE_EMACS2 }
+CONFUSE_EMACS2
+#undef CONFUSE_EMACS2
 #endif
 
 


### PR DESCRIPTION
Complete (in the same way than done in line 8 to 14) the __cplusplus check to avoid the following warning:
C:/numpy/core/include/numpy/ndarrayobject.h:243: Excess closing brace in C++ code (or abuse of the C++ preprocessor)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
