### PR TITLE
ENH: When histogramming data with integer dtype, force bin width >= 1.

### DIFF
--- a/doc/release/upcoming_changes/12150.improvement.rst
+++ b/doc/release/upcoming_changes/12150.improvement.rst
@@ -1,0 +1,5 @@
+``histogram`` auto-binning now returns bin sizes >=1 for integer input data
+---------------------------------------------------------------------------
+For integer input data, bin sizes smaller than 1 result in spurious empty
+bins.  This is now avoided when the number of bins is computed using one of the
+algorithms provided by `histogram_bin_edges`.

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -410,6 +410,8 @@ def _get_bin_edges(a, bins, range, weights):
             # Do not call selectors on empty arrays
             width = _hist_bin_selectors[bin_name](a, (first_edge, last_edge))
             if width:
+                if np.issubdtype(a.dtype, np.integer) and width < 1:
+                    width = 1
                 n_equal_bins = int(np.ceil(_unsigned_subtract(last_edge, first_edge) / width))
             else:
                 # Width can be zero for some estimators, e.g. FD when
@@ -624,6 +626,9 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
         The simplest and fastest estimator. Only takes into account the
         data size.
+
+    Additionally, if the data is of integer dtype, then the binwidth will never
+    be less than 1.
 
     Examples
     --------

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -469,7 +469,7 @@ class TestHistogramOptimBinNums:
                          'doane': 3, 'sqrt': 2, 'stone': 1}}
 
         for testlen, expectedResults in small_dat.items():
-            testdat = np.arange(testlen)
+            testdat = np.arange(testlen).astype(float)
             for estimator, expbins in expectedResults.items():
                 a, b = np.histogram(testdat, estimator)
                 assert_equal(len(a), expbins, err_msg="For the {0} estimator "
@@ -591,6 +591,30 @@ class TestHistogramOptimBinNums:
         hist32, edges32 = np.histogram(a.astype(np.int32), bins=bins)
         assert_array_equal(hist, hist32)
         assert_array_equal(edges, edges32)
+
+    @pytest.mark.parametrize("bins", ['auto', 'fd', 'doane', 'scott',
+                                      'stone', 'rice', 'sturges'])
+    def test_integer(self, bins):
+        """
+        Test that bin width for integer data is at least 1.
+        """
+        with suppress_warnings() as sup:
+            if bins == 'stone':
+                sup.filter(RuntimeWarning)
+            assert_equal(
+                np.histogram_bin_edges(np.tile(np.arange(9), 1000), bins),
+                np.arange(9))
+
+    def test_integer_non_auto(self):
+        """
+        Test that the bin-width>=1 requirement *only* applies to auto binning.
+        """
+        assert_equal(
+            np.histogram_bin_edges(np.tile(np.arange(9), 1000), 16),
+            np.arange(17) / 2)
+        assert_equal(
+            np.histogram_bin_edges(np.tile(np.arange(9), 1000), [.1, .2]),
+            [.1, .2])
 
     def test_simple_weighted(self):
         """


### PR DESCRIPTION
Bins of width < 1 don't make sense for integer data, they just add a
bunch of spurious, unpopulated bins.  (Perhaps an even better
improvement would be to make sure that, when using integer data, the
binwidth is also integer, so that each bin always covers the same number
of possible values, but I guess that's possibly a more domain-specific
issue.)

Before the PR:

    In [1]: np.histogram_bin_edges(np.tile(np.arange(10), 1000), "auto")
    Out[1]:
    array([0.  , 0.45, 0.9 , 1.35, 1.8 , 2.25, 2.7 , 3.15, 3.6 , 4.05, 4.5 ,
           4.95, 5.4 , 5.85, 6.3 , 6.75, 7.2 , 7.65, 8.1 , 8.55, 9.  ])

After:

    In [1]: np.histogram_bin_edges(np.tile(np.arange(10), 1000), "auto")
    Out[1]: array([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.])

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
