### PR TITLE
TST: Added tests for np.tensordot()

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2748,3 +2748,7 @@ class TestTensordot(object):
         td = np.tensordot(a, b, (1, 0))
         assert_array_equal(td, np.dot(a, b))
         assert_array_equal(td, np.einsum('ij,jk', a, b))
+        # Test resolution to issue #12130
+        arr_0d = np.array(1)
+        ret = np.tensordot(arr_0d, arr_0d, ([], []))  # contracting no axes is well defined
+        assert_array_equal(ret, arr_0d)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2748,7 +2748,9 @@ class TestTensordot(object):
         td = np.tensordot(a, b, (1, 0))
         assert_array_equal(td, np.dot(a, b))
         assert_array_equal(td, np.einsum('ij,jk', a, b))
-        # Test resolution to issue #12130
+        
+    def test_zero_dimensional(self):
+        # gh-12130
         arr_0d = np.array(1)
         ret = np.tensordot(arr_0d, arr_0d, ([], []))  # contracting no axes is well defined
         assert_array_equal(ret, arr_0d)


### PR DESCRIPTION
Added test for np.tensordot() to test the function when there are no well defined axes present.

Ref: Github issue #12130 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
