### PR TITLE
Mark NEP 22 as accepted, and add "Informational" NEPs to NEP 1

### DIFF
--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -31,12 +31,18 @@ feature proposal [1]_.
 Types
 ^^^^^
 
-There are two kinds of NEP:
+There are three kinds of NEPs:
 
 1. A **Standards Track** NEP describes a new feature or implementation
    for NumPy.
 
-2. A **Process** NEP describes a process surrounding NumPy, or
+2. An **Informational** NEP describes a NumPy design issue, or provides
+   general guidelines or information to the Python community, but does not
+   propose a new feature. Informational NEPs do not necessarily represent a
+   NumPy community consensus or recommendation, so users and implementers are
+   free to ignore Informational NEPs or follow their advice.
+
+3. A **Process** NEP describes a process surrounding NumPy, or
    proposes a change to (or an event in) a process.  Process NEPs are
    like Standards Track NEPs but apply to areas other than the NumPy
    language itself.  They may propose an implementation, but not to

--- a/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
+++ b/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
@@ -3,9 +3,10 @@ NEP 22 — Duck typing for NumPy arrays – high level overview
 ===========================================================
 
 :Author: Stephan Hoyer <shoyer@google.com>, Nathaniel J. Smith <njs@pobox.com>
-:Status: Draft
+:Status: Accepted
 :Type: Informational
 :Created: 2018-03-22
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2018-September/078752.html
 
 Abstract
 --------


### PR DESCRIPTION
The text on informational NEPs is borrowed from PEP 1: https://www.python.org/dev/peps/pep-0001/#id32