### PR TITLE
TST: Add a failer test for NPY_RELAXED_STRIDES_DEBUG=1

### DIFF
--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -443,3 +443,8 @@ def test_reference_types():
 
     actual, _ = broadcast_arrays(input_array, np.ones(3))
     assert_array_equal(expected, actual)
+
+
+def test_bogus_strides():
+    a = np.zeros((3, 1, 3), dtype='double')
+    assert a.strides == (24, 24, 8)


### PR DESCRIPTION
This simple test should pass, but it doesn't when `NPY_RELAXED_STRIDES_DEBUG`. Discovered in the development of #11971 

It seems that the stride gets set to `sys.maxsize == 9223372036854775807`