### PR TITLE
MAINT: remove unused `_assertSquareness()`

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -199,11 +199,6 @@ def _assertRankAtLeast2(*arrays):
             raise LinAlgError('%d-dimensional array given. Array must be '
                     'at least two-dimensional' % a.ndim)
 
-def _assertSquareness(*arrays):
-    for a in arrays:
-        if max(a.shape) != min(a.shape):
-            raise LinAlgError('Array must be square')
-
 def _assertNdSquareness(*arrays):
     for a in arrays:
         m, n = a.shape[-2:]


### PR DESCRIPTION
Test [uncovered](https://codecov.io/gh/numpy/numpy/src/master/numpy/linalg/linalg.py#L202) obscure `linalg` assertion function `_assertSquareness`, which is also not used at all in NumPy source.

We may ultimately opt for removal, but I'll aim conservatively with this PR adding tests initially.