### PR TITLE
MAINT: Move `_kind_to_stem` to `np.core._dtype`, so that it can be used as part of `dtype.__repr__`

### DIFF
--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -5,7 +5,42 @@ String handling is much easier to do correctly in python.
 """
 from __future__ import division, absolute_import, print_function
 
+import sys
+
 import numpy as np
+
+
+_kind_to_stem = {
+    'u': 'uint',
+    'i': 'int',
+    'c': 'complex',
+    'f': 'float',
+    'b': 'bool',
+    'V': 'void',
+    'O': 'object',
+    'M': 'datetime',
+    'm': 'timedelta'
+}
+if sys.version_info[0] >= 3:
+    _kind_to_stem.update({
+        'S': 'bytes',
+        'U': 'str'
+    })
+else:
+    _kind_to_stem.update({
+        'S': 'string',
+        'U': 'unicode'
+    })
+
+
+def _kind_name(dtype):
+    try:
+        return _kind_to_stem[dtype.kind]
+    except KeyError:
+        raise RuntimeError(
+            "internal dtype error, unknown kind {!r}"
+            .format(dtype.kind)
+        )
 
 
 def __str__(dtype):
@@ -122,20 +157,7 @@ def _scalar_str(dtype, short):
 
         # Longer repr, like 'float64'
         else:
-            kindstrs = {
-                'u': "uint",
-                'i': "int",
-                'f': "float",
-                'c': "complex"
-            }
-            try:
-                kindstr = kindstrs[dtype.kind]
-            except KeyError:
-                raise RuntimeError(
-                    "internal dtype repr error, unknown kind {!r}"
-                    .format(dtype.kind)
-                )
-            return "'%s%d'" % (kindstr, 8*dtype.itemsize)
+            return "'%s%d'" % (_kind_name(dtype), 8*dtype.itemsize)
 
     elif dtype.isbuiltin == 2:
         return dtype.type.__name__

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -29,6 +29,7 @@ from numpy.compat import unicode
 from numpy._globals import VisibleDeprecationWarning
 from numpy.core._string_helpers import english_lower, english_capitalize
 from numpy.core.multiarray import typeinfo, dtype
+from numpy.core._dtype import _kind_name
 
 
 sctypeDict = {}      # Contains all leaf-node scalar types with aliases
@@ -61,28 +62,6 @@ for k, v in typeinfo.items():
 
 _concrete_types = set(v.type for k, v in _concrete_typeinfo.items())
 
-_kind_to_stem = {
-    'u': 'uint',
-    'i': 'int',
-    'c': 'complex',
-    'f': 'float',
-    'b': 'bool',
-    'V': 'void',
-    'O': 'object',
-    'M': 'datetime',
-    'm': 'timedelta'
-}
-if sys.version_info[0] >= 3:
-    _kind_to_stem.update({
-        'S': 'bytes',
-        'U': 'str'
-    })
-else:
-    _kind_to_stem.update({
-        'S': 'string',
-        'U': 'unicode'
-    })
-
 
 def _bits_of(obj):
     try:
@@ -100,8 +79,9 @@ def _bits_of(obj):
 def bitname(obj):
     """Return a bit-width name for a given type object"""
     bits = _bits_of(obj)
-    char = dtype(obj).kind
-    base = _kind_to_stem[char]
+    dt = dtype(obj)
+    char = dt.kind
+    base = _kind_name(dt)
 
     if base == 'object':
         bits = 0

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -116,8 +116,8 @@ from ._type_aliases import (
     _concrete_types,
     _concrete_typeinfo,
     _bits_of,
-    _kind_to_stem,
 )
+from ._dtype import _kind_name
 
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
@@ -181,8 +181,7 @@ def maximum_sctype(t):
     if g is None:
         return t
     t = g
-    bits = _bits_of(t)
-    base = _kind_to_stem[dtype(t).kind]
+    base = _kind_name(dtype(t))
     if base in sctypes:
         return sctypes[base][-1]
     else:


### PR DESCRIPTION
We could consider making this a public attribute of dtype objects in future, but dtype objects have enough random attributes that I'd rather not do that.