### PR TITLE
MAINT: fix depreciation message typo for np.sum

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2061,7 +2061,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, initial=np._No
         # 2018-02-25, 1.15.0
         warnings.warn(
             "Calling np.sum(generator) is deprecated, and in the future will give a different result. "
-            "Use np.sum(np.from_iter(generator)) or the python sum builtin instead.",
+            "Use np.sum(np.fromiter(generator)) or the python sum builtin instead.",
             DeprecationWarning, stacklevel=2)
 
         res = _sum_(a)


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->

The current depreciation message for `np.sum` references the non-existent `np.from_iter`. This corrects it to `np.fromiter`.