### PR TITLE
TST: add Azure CI triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,10 @@
+trigger:
+  # start a new build for every push
+  batch: False
+  branches:
+    include:
+      - master
+      - maintenance/*
 jobs:
 - job: macOS
   pool:


### PR DESCRIPTION
Add [Azure triggers](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=example#trigger) as [requested](https://github.com/numpy/numpy/issues/12158#issuecomment-430448159) by @charris.

This may increase the likelihood that maintenance branch CI will "just work" so Chuck / others don't lose time fiddling with backport PRs and so on. 

EDIT: The trigger filters can be set on the pipeline, hopefully this will automatically enable CI on new maintenance branches without explicitly adding them to the filter. We cannot really test this until 1.16.x is branched.
