### PR TITLE
TST: coverage for _commonType()

### DIFF
--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1965,3 +1965,10 @@ class TestTensorinv(object):
         ainv = linalg.tensorinv(a, ind=1)
         b = np.ones(24)
         assert_allclose(np.tensordot(ainv, b, 1), np.linalg.tensorsolve(a, b))
+
+
+def test_unsupported_commontype():
+    # linalg gracefully handles unsupported type
+    arr = np.array([[1, -2], [2, 5]], dtype='float16')
+    with assert_raises_regex(TypeError, "unsupported in linalg"):
+        linalg.cholesky(arr)


### PR DESCRIPTION
Test [uncovered path](https://codecov.io/gh/numpy/numpy/src/master/numpy/linalg/linalg.py#L148) in `np.linalg.linalg._commonType()`, where input array is of an unsupported type.

I couldn't think of more unsupported types offhand, but there may be other subclasses of `inexact` smaller than single precision that I've forgotten about.