### PR TITLE
Delay import of distutils.msvccompiler to avoid warning on non-Windows.

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -13,7 +13,6 @@ import multiprocessing
 
 import distutils
 from distutils.errors import DistutilsError
-from distutils.msvccompiler import get_build_architecture
 try:
     from threading import local as tlocal
 except ImportError:
@@ -2336,3 +2335,9 @@ def msvc_version(compiler):
         raise ValueError("Compiler instance is not msvc (%s)"\
                          % compiler.compiler_type)
     return compiler._MSVCCompiler__version
+
+def get_build_architecture():
+    # Importing distutils.msvccompiler triggers a warning on non-Windows
+    # systems, so delay the import to here.
+    from distutils.msvccompiler import get_build_architecture
+    return get_build_architecture()


### PR DESCRIPTION
*Importing* distutils.msvccompiler works on non-Windows systems, but
triggers a pointless "warning" (using distutils' own logging system;
"Can't read registry etc.")  Delay the import so that other uses of
distutils.misc_util are not affected.

When running distutils commands, the verbosity is set by default to 1
(`self.verbose = 1` in distutils/dist.py) so the warning does get
displayed.

To trigger the warning, subclass e.g. build_ext, override its
finalize_options method, import numpy.distutils.misc_util from there,
and then pass the new build_ext as cmdclass to setuptools.setup().

Partially reverts 15f52f5.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
