### PR TITLE
WIP: use the decorator library for array_function_dispatch

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -4,6 +4,7 @@ TODO: rewrite this in C for performance.
 """
 import collections
 
+import functools
 from decorator import decorate
 
 from numpy.core._multiarray_umath import ndarray
@@ -145,10 +146,13 @@ def array_function_dispatch(dispatcher, verify=True):
         if verify:
             verify_matching_signatures(implementation, dispatcher)
 
+        @functools.partial(decorate, implementation)
         def public_api(implementation, *args, **kwargs):
             relevant_args = dispatcher(*args, **kwargs)
             return array_function_implementation_or_override(
                 implementation, public_api, relevant_args, args, kwargs)
-        return decorate(implementation, public_api)
+        public_api.__wrapped__ = implementation
+
+        return public_api
 
     return decorator

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -3,7 +3,8 @@
 TODO: rewrite this in C for performance.
 """
 import collections
-import functools
+
+from decorator import decorate
 
 from numpy.core._multiarray_umath import ndarray
 from numpy.compat._inspect import getargspec
@@ -144,11 +145,10 @@ def array_function_dispatch(dispatcher, verify=True):
         if verify:
             verify_matching_signatures(implementation, dispatcher)
 
-        @functools.wraps(implementation)
-        def public_api(*args, **kwargs):
+        def public_api(implementation, *args, **kwargs):
             relevant_args = dispatcher(*args, **kwargs)
             return array_function_implementation_or_override(
                 implementation, public_api, relevant_args, args, kwargs)
-        return public_api
+        return decorate(implementation, public_api)
 
     return decorator


### PR DESCRIPTION
xref https://github.com/numpy/numpy/issues/12028

This is one possible solution for https://github.com/numpy/numpy/issues/12225. It fixes introspection for NumPy functions, e.g., we now see
```
In [3]: inspect.getfullargspec(np.sum)
Out[3]: FullArgSpec(args=['a', 'axis', 'dtype', 'out', 'keepdims'], varargs=None, varkw=None, defaults=(None, None, None, <class 'numpy._globals._NoValue'>), kwonlyargs=[], kwonlydefaults=None, annotations={})
```