### PR TITLE
DOC: delete incorrect comment about random.random_integers

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -948,8 +948,7 @@ cdef class RandomState:
         --------
         random.random_integers : similar to `randint`, only for the closed
             interval [`low`, `high`], and 1 is the lowest value if `high` is
-            omitted. In particular, this other one is the one to use to generate
-            uniformly distributed discrete non-integers.
+            omitted.
 
         Examples
         --------


### PR DESCRIPTION
I do not think the following sentence for the documentation in `randint` is true: "In particular, this other one is the one to use to generate uniformly distributed discrete non-integers", since `random_integers` generates integers. It seems like a good idea to delete that sentence entirely.
