### PR TITLE
MAINT: refactor PyArray_AdaptFlexibleDType to return a meaningful value

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -47,7 +47,7 @@ PyArray_CastToType(PyArrayObject *arr, PyArray_Descr *dtype, int is_f_order)
     PyObject *out;
 
     /* If the requested dtype is flexible, adapt it */
-    PyArray_AdaptFlexibleDType((PyObject *)arr, PyArray_DESCR(arr), &dtype);
+    dtype = PyArray_AdaptFlexibleDType((PyObject *)arr, PyArray_DESCR(arr), dtype);
     if (dtype == NULL) {
         return NULL;
     }
@@ -130,7 +130,7 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
 /*
  * This function calls Py_DECREF on flex_dtype, and replaces it with
  * a new dtype that has been adapted based on the values in data_dtype
- * and data_obj. If the flex_dtype is not flexible, it leaves it as is.
+ * and data_obj. If the flex_dtype is not flexible, it returns it as-is.
  *
  * Usually, if data_obj is not an array, dtype should be the result
  * given by the PyArray_GetArrayParamsFromObject function.
@@ -138,40 +138,38 @@ PyArray_GetCastFunc(PyArray_Descr *descr, int type_num)
  * The data_obj may be NULL if just a dtype is known for the source.
  *
  * If *flex_dtype is NULL, returns immediately, without setting an
- * exception. This basically assumes an error was already set previously.
+ * exception, leaving any previous error handling intact.
  *
  * The current flexible dtypes include NPY_STRING, NPY_UNICODE, NPY_VOID,
  * and NPY_DATETIME with generic units.
  */
-NPY_NO_EXPORT void
+NPY_NO_EXPORT PyArray_Descr *
 PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
-                            PyArray_Descr **flex_dtype)
+                            PyArray_Descr *flex_dtype)
 {
     PyArray_DatetimeMetaData *meta;
+    PyArray_Descr *retval = NULL;
     int flex_type_num;
 
-    if (*flex_dtype == NULL) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_RuntimeError,
-                    "NumPy AdaptFlexibleDType was called with NULL flex_dtype "
-                    "but no error set");
-        }
-        return;
+    if (flex_dtype == NULL) {
+        return retval;
     }
 
-    flex_type_num = (*flex_dtype)->type_num;
+    flex_type_num = (flex_dtype)->type_num;
 
     /* Flexible types with expandable size */
-    if (PyDataType_ISUNSIZED(*flex_dtype)) {
+    retval = flex_dtype;
+    if (PyDataType_ISUNSIZED(flex_dtype)) {
         /* First replace the flex_dtype */
-        PyArray_DESCR_REPLACE(*flex_dtype);
-        if (*flex_dtype == NULL) {
-            return;
+        retval = PyArray_DescrNew(flex_dtype);
+        Py_DECREF(flex_dtype);
+        if (retval == NULL) {
+            return retval;
         }
 
         if (data_dtype->type_num == flex_type_num ||
                                     flex_type_num == NPY_VOID) {
-            (*flex_dtype)->elsize = data_dtype->elsize;
+            (retval)->elsize = data_dtype->elsize;
         }
         else if (flex_type_num == NPY_STRING || flex_type_num == NPY_UNICODE) {
             npy_intp size = 8;
@@ -199,7 +197,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                     }
                     else if (data_dtype->elsize > 8 ||
                              data_dtype->elsize < 0) {
-                        /* 
+                        /*
                          * Element size should never be greater than 8 or
                          * less than 0 for integer type, but just in case...
                          */
@@ -237,9 +235,8 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                                 PyObject *s = PyObject_Str(list);
                                 if (s == NULL) {
                                     Py_DECREF(list);
-                                    Py_DECREF(*flex_dtype);
-                                    *flex_dtype = NULL;
-                                    return;
+                                    Py_DECREF(retval);
+                                    return NULL;
                                 }
                                 else {
                                     size = PyObject_Length(s);
@@ -262,9 +259,16 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                             list = PyArray_ToList((PyArrayObject *)data_obj);
                             result = PyArray_GetArrayParamsFromObject(
                                     list,
-                                    *flex_dtype,
+                                    retval,
                                     0, &dtype,
                                     &ndim, dims, &arr, NULL);
+                            if (result < 0) {
+                                Py_XDECREF(dtype);
+                                Py_XDECREF(arr);
+                                Py_DECREF(list);
+                                Py_DECREF(retval);
+                                return NULL;
+                            }
                             if (result == 0 && dtype != NULL) {
                                 if (flex_type_num == NPY_UNICODE) {
                                     size = dtype->elsize / 4;
@@ -280,9 +284,8 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                         else if (PyArray_IsPythonScalar(data_obj)) {
                             PyObject *s = PyObject_Str(data_obj);
                             if (s == NULL) {
-                                Py_DECREF(*flex_dtype);
-                                *flex_dtype = NULL;
-                                return;
+                                Py_DECREF(retval);
+                                return NULL;
                             }
                             else {
                                 size = PyObject_Length(s);
@@ -301,9 +304,8 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                 case NPY_DATETIME:
                     meta = get_datetime_metadata_from_dtype(data_dtype);
                     if (meta == NULL) {
-                        Py_DECREF(*flex_dtype);
-                        *flex_dtype = NULL;
-                        return;
+                        Py_DECREF(retval);
+                        return NULL;
                     }
                     size = get_datetime_iso_8601_strlen(0, meta->base);
                     break;
@@ -313,10 +315,10 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
             }
 
             if (flex_type_num == NPY_STRING) {
-                (*flex_dtype)->elsize = size;
+                retval->elsize = size;
             }
             else if (flex_type_num == NPY_UNICODE) {
-                (*flex_dtype)->elsize = size * 4;
+                retval->elsize = size * 4;
             }
         }
         else {
@@ -326,18 +328,16 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
              */
             PyErr_SetString(PyExc_TypeError,
                     "don't know how to adapt flex dtype");
-            *flex_dtype = NULL;
-            return;
+            Py_DECREF(retval);
+            return NULL;
         }
     }
     /* Flexible type with generic time unit that adapts */
     else if (flex_type_num == NPY_DATETIME ||
                 flex_type_num == NPY_TIMEDELTA) {
-        meta = get_datetime_metadata_from_dtype(*flex_dtype);
+        meta = get_datetime_metadata_from_dtype(flex_dtype);
         if (meta == NULL) {
-            Py_DECREF(*flex_dtype);
-            *flex_dtype = NULL;
-            return;
+            return NULL;
         }
 
         if (meta->base == NPY_FR_GENERIC) {
@@ -345,22 +345,21 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                     data_dtype->type_num == NPY_TIMEDELTA) {
                 meta = get_datetime_metadata_from_dtype(data_dtype);
                 if (meta == NULL) {
-                    Py_DECREF(*flex_dtype);
-                    *flex_dtype = NULL;
-                    return;
+                    return NULL;
                 }
 
-                Py_DECREF(*flex_dtype);
-                *flex_dtype = create_datetime_dtype(flex_type_num, meta);
+                retval = create_datetime_dtype(flex_type_num, meta);
+                Py_DECREF(flex_dtype);
             }
             else if (data_obj != NULL) {
                 /* Detect the unit from the input's data */
-                Py_DECREF(*flex_dtype);
-                *flex_dtype = find_object_datetime_type(data_obj,
+                retval = find_object_datetime_type(data_obj,
                                                     flex_type_num);
+                Py_DECREF(flex_dtype);
             }
         }
     }
+    return retval;
 }
 
 /*
@@ -518,7 +517,7 @@ PyArray_CanCastTo(PyArray_Descr *from, PyArray_Descr *to)
          * stringified value of the object.
          */
         else if (to_type_num == NPY_STRING || to_type_num == NPY_UNICODE) {
-            /* 
+            /*
              * Boolean value cast to string type is 5 characters max
              * for string 'False'.
              */
@@ -531,7 +530,7 @@ PyArray_CanCastTo(PyArray_Descr *from, PyArray_Descr *to)
             if (PyDataType_ISUNSIZED(to)) {
                 ret = 1;
             }
-            /* 
+            /*
              * Need at least 5 characters to convert from boolean
              * to 'True' or 'False'.
              */
@@ -1166,7 +1165,11 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type1);
                 PyDataType_MAKEUNSIZED(temp);
-                PyArray_AdaptFlexibleDType(NULL, type2, &temp);
+
+                temp = PyArray_AdaptFlexibleDType(NULL, type2, temp);
+                if (temp == NULL) {
+                    return NULL;
+                }
                 if (temp->elsize > type1->elsize) {
                     ret = ensure_dtype_nbo(temp);
                 }
@@ -1204,7 +1207,10 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type1);
                 PyDataType_MAKEUNSIZED(temp);
-                PyArray_AdaptFlexibleDType(NULL, type2, &temp);
+                temp = PyArray_AdaptFlexibleDType(NULL, type2, temp);
+                if (temp == NULL) {
+                    return NULL;
+                }
                 if (temp->elsize > type1->elsize) {
                     ret = ensure_dtype_nbo(temp);
                 }
@@ -1252,7 +1258,10 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type2);
                 PyDataType_MAKEUNSIZED(temp);
-                PyArray_AdaptFlexibleDType(NULL, type1, &temp);
+                temp = PyArray_AdaptFlexibleDType(NULL, type1, temp);
+                if (temp == NULL) {
+                    return NULL;
+                }
                 if (temp->elsize > type2->elsize) {
                     ret = ensure_dtype_nbo(temp);
                 }
@@ -1269,7 +1278,10 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
                 PyArray_Descr *ret = NULL;
                 PyArray_Descr *temp = PyArray_DescrNew(type2);
                 PyDataType_MAKEUNSIZED(temp);
-                PyArray_AdaptFlexibleDType(NULL, type1, &temp);
+                temp = PyArray_AdaptFlexibleDType(NULL, type1, temp);
+                if (temp == NULL) {
+                    return NULL;
+                }
                 if (temp->elsize > type2->elsize) {
                     ret = ensure_dtype_nbo(temp);
                 }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -47,11 +47,9 @@ PyArray_CastToType(PyArrayObject *arr, PyArray_Descr *dtype, int is_f_order)
     PyObject *out;
 
     /* If the requested dtype is flexible, adapt it */
-    if (dtype != NULL) {
-        dtype = PyArray_AdaptFlexibleDType((PyObject *)arr, PyArray_DESCR(arr), dtype);
-        if (dtype == NULL) {
-            return NULL;
-        }
+    dtype = PyArray_AdaptFlexibleDType((PyObject *)arr, PyArray_DESCR(arr), dtype);
+    if (dtype == NULL) {
+        return NULL;
     }
     out = PyArray_NewFromDescr(Py_TYPE(arr), dtype,
                                PyArray_NDIM(arr),

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -21,13 +21,21 @@ can_cast_scalar_to(PyArray_Descr *scal_type, char *scal_data,
 /*
  * This function calls Py_DECREF on flex_dtype, and replaces it with
  * a new dtype that has been adapted based on the values in data_dtype
- * and data_obj. If the flex_dtype is not flexible, it leaves it as is.
+ * and data_obj. If the flex_dtype is not flexible, it returns it as-is.
+ *
+ * Usually, if data_obj is not an array, dtype should be the result
+ * given by the PyArray_GetArrayParamsFromObject function.
+ *
+ * The data_obj may be NULL if just a dtype is known for the source.
+ *
+ * If *flex_dtype is NULL, returns immediately, without setting an
+ * exception, leaving any previous error handling intact.
  *
  * The current flexible dtypes include NPY_STRING, NPY_UNICODE, NPY_VOID,
  * and NPY_DATETIME with generic units.
  */
-NPY_NO_EXPORT void
+NPY_NO_EXPORT PyArray_Descr *
 PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
-                            PyArray_Descr **flex_dtype);
+                            PyArray_Descr *flex_dtype);
 
 #endif

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1816,11 +1816,9 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     }
 
     /* If the requested dtype is flexible, adapt it */
-    if (newtype != NULL) {
-        PyArray_AdaptFlexibleDType(op,
+    newtype = PyArray_AdaptFlexibleDType(op,
                     (dtype == NULL) ? PyArray_DESCR(arr) : dtype,
-                    &newtype);
-    }
+                    newtype);
 
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1816,9 +1816,14 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     }
 
     /* If the requested dtype is flexible, adapt it */
-    newtype = PyArray_AdaptFlexibleDType(op,
+    if (newtype != NULL) {
+        newtype = PyArray_AdaptFlexibleDType(op,
                     (dtype == NULL) ? PyArray_DESCR(arr) : dtype,
                     newtype);
+        if (newtype == NULL) {
+            return NULL;
+        }
+    }
 
     /* If we got dimensions and dtype instead of an array */
     if (arr == NULL) {

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -1112,7 +1112,7 @@ get_datetime_to_unicode_transfer_function(int aligned,
 
     /* Get an ASCII string data type, adapted to match the UNICODE one */
     str_dtype = PyArray_DescrFromType(NPY_STRING);
-    PyArray_AdaptFlexibleDType(NULL, dst_dtype, &str_dtype);
+    str_dtype = PyArray_AdaptFlexibleDType(NULL, dst_dtype, str_dtype);
     if (str_dtype == NULL) {
         return NPY_FAIL;
     }
@@ -1234,7 +1234,7 @@ get_unicode_to_datetime_transfer_function(int aligned,
 
     /* Get an ASCII string data type, adapted to match the UNICODE one */
     str_dtype = PyArray_DescrFromType(NPY_STRING);
-    PyArray_AdaptFlexibleDType(NULL, src_dtype, &str_dtype);
+    str_dtype = PyArray_AdaptFlexibleDType(NULL, src_dtype, str_dtype);
     if (str_dtype == NULL) {
         return NPY_FAIL;
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -823,8 +823,8 @@ array_astype(PyArrayObject *self, PyObject *args, PyObject *kwds)
         PyArrayObject *ret;
 
         /* If the requested dtype is flexible, adapt it */
-        PyArray_AdaptFlexibleDType((PyObject *)self, PyArray_DESCR(self),
-                                                                    &dtype);
+        dtype = PyArray_AdaptFlexibleDType((PyObject *)self,
+                                           PyArray_DESCR(self), dtype);
         if (dtype == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1101,8 +1101,8 @@ npyiter_prepare_one_operand(PyArrayObject **op,
             /* We just have a borrowed reference to op_request_dtype */
             Py_INCREF(op_request_dtype);
             /* If the requested dtype is flexible, adapt it */
-            PyArray_AdaptFlexibleDType((PyObject *)(*op), PyArray_DESCR(*op),
-                                        &op_request_dtype);
+            op_request_dtype = PyArray_AdaptFlexibleDType((PyObject *)(*op), PyArray_DESCR(*op),
+                                        op_request_dtype);
             if (op_request_dtype == NULL) {
                 return 0;
             }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1102,7 +1102,7 @@ npyiter_prepare_one_operand(PyArrayObject **op,
             Py_INCREF(op_request_dtype);
             /* If the requested dtype is flexible, adapt it */
             op_request_dtype = PyArray_AdaptFlexibleDType((PyObject *)(*op), PyArray_DESCR(*op),
-                                        op_request_dtype);
+                                                          op_request_dtype);
             if (op_request_dtype == NULL) {
                 return 0;
             }


### PR DESCRIPTION
Fixes #11969 by changing the signature and adding checks.

I added a check for `PyArray_GetArrayParamsFromObject` returning an error, but could not build a test to check it. The function will hit the [`PySequenceCheck`](https://github.com/numpy/numpy/blob/v1.15.2/numpy/core/src/multiarray/ctors.c#L1658) branch, and then can only fail on memory error, or if `PyArray_DescrFromType()` fails, which it never does.