### PR TITLE
TST: Backport azure-pipeline testing fixes for Mac

### DIFF
--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import platform
 import pytest
 
 from numpy import array
@@ -52,6 +53,11 @@ class TestReturnReal(util.F2PyTest):
             pass
 
 
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"
     module_name = "c_ext_return_real"
@@ -85,9 +91,9 @@ end python module c_ext_return_real
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t4,t8,s4,s8".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't4,t8,s4,s8'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF77ReturnReal(TestReturnReal):
@@ -140,9 +146,9 @@ cf2py    intent(out) td
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t4,t8,td,s0,s4,s8,sd".split(","):
-            self.check_function(getattr(self.module, name))
+    @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module, name))
 
 
 class TestF90ReturnReal(TestReturnReal):
@@ -199,6 +205,6 @@ end module f90_return_real
     """
 
     @pytest.mark.slow
-    def test_all(self):
-        for name in "t0,t4,t8,td,s0,s4,s8,sd".split(","):
-            self.check_function(getattr(self.module.f90_return_real, name))
+    @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
+    def test_all(self, name):
+        self.check_function(getattr(self.module.f90_return_real, name))

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -6,6 +6,10 @@ import pytest
 from . import util
 from numpy.testing import assert_equal
 
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestMultiline(util.F2PyTest):
     suffix = ".pyf"
     module_name = "multiline"
@@ -26,13 +30,14 @@ void foo(int* x) {{
 end python module {module}
     """.format(module=module_name)
 
-    @pytest.mark.skipif(platform.system() == 'Darwin',
-                        reason="Prone to error when run with "
-                               "numpy/f2py/tests on mac os, "
-                               "but not when run in isolation")
     def test_multiline(self):
         assert_equal(self.module.foo(), 42)
 
+
+@pytest.mark.skipif(
+    platform.system() == 'Darwin',
+    reason="Prone to error when run with numpy/f2py/tests on mac os, "
+           "but not when run in isolation")
 class TestCallstatement(util.F2PyTest):
     suffix = ".pyf"
     module_name = "callstatement"


### PR DESCRIPTION
The azure-pipeline Mac testing fails unpredictably for some of the f2py
tests. The following tests are checked out from master to get the fixes.

- test_return_real.py
- test_semicolon_split.py

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
