### PR TITLE
DEP: deprecate ascontiguousarray and asfortranarray

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -483,10 +483,7 @@ def asarray(a, dtype=None, order=None):
     See Also
     --------
     asanyarray : Similar function which passes through subclasses.
-    ascontiguousarray : Convert input to a contiguous array.
     asfarray : Convert input to a floating point ndarray.
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
     asarray_chkfinite : Similar function which checks input for NaNs and Infs.
     fromiter : Create an array from an iterator.
     fromfunction : Construct an array by executing a function on grid
@@ -552,10 +549,7 @@ def asanyarray(a, dtype=None, order=None):
     See Also
     --------
     asarray : Similar function which always returns ndarrays.
-    ascontiguousarray : Convert input to a contiguous array.
     asfarray : Convert input to a floating point ndarray.
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
     asarray_chkfinite : Similar function which checks input for NaNs and
                         Infs.
     fromiter : Create an array from an iterator.
@@ -583,6 +577,9 @@ def asanyarray(a, dtype=None, order=None):
 def ascontiguousarray(a, dtype=None):
     """
     Return a contiguous array in memory (C order).
+    
+    .. warning:: np.ascontiguousarray is depreciated since numpy 1.16, 
+                 use np.asarray with order='C' instead
 
     Parameters
     ----------
@@ -595,12 +592,12 @@ def ascontiguousarray(a, dtype=None):
     -------
     out : ndarray
         Contiguous array of same shape and content as `a`, with type `dtype`
-        if specified.
+        if specified. If `a` is scalar, 1d array with single element 
+        is returned.
 
     See Also
     --------
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
+    asarray: Convert the input to an array.
     require : Return an ndarray that satisfies requirements.
     ndarray.flags : Information about the memory layout of the array.
 
@@ -614,12 +611,20 @@ def ascontiguousarray(a, dtype=None):
     True
 
     """
+    # NumPy 1.16.0, 2018-10-21
+    warnings.warn(
+        "np.ascontiguousarray is deprecated, use np.asarray with order='C'"
+        " instead",
+        DeprecationWarning, stacklevel=2)
     return array(a, dtype, copy=False, order='C', ndmin=1)
 
 
 def asfortranarray(a, dtype=None):
     """
     Return an array laid out in Fortran order in memory.
+
+    .. warning:: np.asfortranarray is depreciated since numpy 1.16, 
+                 use np.asarray with order='F' instead
 
     Parameters
     ----------
@@ -632,10 +637,11 @@ def asfortranarray(a, dtype=None):
     -------
     out : ndarray
         The input `a` in Fortran, or column-major, order.
+        If `a` is scalar, 1d array with single element is returned.
 
     See Also
     --------
-    ascontiguousarray : Convert input to a contiguous (C order) array.
+    asarray: Convert the input to an array.
     asanyarray : Convert input to an ndarray with either row or
         column-major memory order.
     require : Return an ndarray that satisfies requirements.
@@ -651,6 +657,11 @@ def asfortranarray(a, dtype=None):
     True
 
     """
+    # NumPy 1.16.0, 2018-10-21
+    warnings.warn(
+        "np.asfortranarray is deprecated, use np.asarray with order='F'"
+        " instead",
+        DeprecationWarning, stacklevel=2)
     return array(a, dtype, copy=False, order='F', ndmin=1)
 
 
@@ -683,9 +694,6 @@ def require(a, dtype=None, requirements=None):
     --------
     asarray : Convert input to an ndarray.
     asanyarray : Convert to an ndarray, but pass through ndarray subclasses.
-    ascontiguousarray : Convert input to a contiguous array.
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
     ndarray.flags : Information about the memory layout of the array.
 
     Notes

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -347,13 +347,15 @@ class TestArrayConstruction(object):
 
     def test_array_cont(self):
         d = np.ones(10)[::2]
-        assert_(np.ascontiguousarray(d).flags.c_contiguous)
-        assert_(np.ascontiguousarray(d).flags.f_contiguous)
-        assert_(np.asfortranarray(d).flags.c_contiguous)
-        assert_(np.asfortranarray(d).flags.f_contiguous)
+        with assert_warns(DeprecationWarning):
+            assert_(np.ascontiguousarray(d).flags.c_contiguous)
+            assert_(np.ascontiguousarray(d).flags.f_contiguous)
+            assert_(np.asfortranarray(d).flags.c_contiguous)
+            assert_(np.asfortranarray(d).flags.f_contiguous)
         d = np.ones((10, 10))[::2,::2]
-        assert_(np.ascontiguousarray(d).flags.c_contiguous)
-        assert_(np.asfortranarray(d).flags.f_contiguous)
+        with assert_warns(DeprecationWarning):
+            assert_(np.ascontiguousarray(d).flags.c_contiguous)
+            assert_(np.asfortranarray(d).flags.f_contiguous)
 
 
 class TestAssignment(object):
@@ -5469,7 +5471,7 @@ class TestDot(object):
                 return self*other
 
         U_non_cont = np.transpose([[1., 1.], [1., 2.]])
-        U_cont = np.ascontiguousarray(U_non_cont)
+        U_cont = np.asarray(U_non_cont, order='C')
         x = np.array([Vec([1., 0.]), Vec([0., 1.])])
         zeros = np.array([Vec([0., 0.]), Vec([0., 0.])])
         zeros_test = np.dot(U_cont, x) - np.dot(U_non_cont, x)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -270,7 +270,7 @@ def unique(ar, return_index=False, return_inverse=False,
     # Must reshape to a contiguous 2D array for this to work...
     orig_shape, orig_dtype = ar.shape, ar.dtype
     ar = ar.reshape(orig_shape[0], -1)
-    ar = np.ascontiguousarray(ar)
+    ar = np.asarray(ar, order='C')
     dtype = [('f{i}'.format(i=i), ar.dtype) for i in range(ar.shape[1])]
 
     try:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -455,10 +455,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
     --------
     asarray : Create and array.
     asanyarray : Similar function which passes through subclasses.
-    ascontiguousarray : Convert input to a contiguous array.
     asfarray : Convert input to a floating point ndarray.
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
     fromiter : Create an array from an iterator.
     fromfunction : Construct an array by executing a function on grid
                    positions.

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -123,12 +123,12 @@ class RoundtripTest(object):
     def check_roundtrips(self, a):
         self.roundtrip(a)
         self.roundtrip(a, file_on_disk=True)
-        self.roundtrip(np.asfortranarray(a))
-        self.roundtrip(np.asfortranarray(a), file_on_disk=True)
+        self.roundtrip(np.asarray(a, order='F'))
+        self.roundtrip(np.asarray(a, order='F'), file_on_disk=True)
         if a.shape[0] > 1:
             # neither C nor Fortran contiguous for 2D arrays or more
-            self.roundtrip(np.asfortranarray(a)[1:])
-            self.roundtrip(np.asfortranarray(a)[1:], file_on_disk=True)
+            self.roundtrip(np.asarray(a, order='F')[1:])
+            self.roundtrip(np.asarray(a, order='F')[1:], file_on_disk=True)
 
     def test_array(self):
         a = np.array([], float)
@@ -162,7 +162,7 @@ class RoundtripTest(object):
         a = np.array([[1, 2.5], [4, 7.3]])
         self.roundtrip(a, file_on_disk=True, load_kwds={'mmap_mode': 'r'})
 
-        a = np.asfortranarray([[1, 2.5], [4, 7.3]])
+        a = np.asarray([[1, 2.5], [4, 7.3]], order='F')
         self.roundtrip(a, file_on_disk=True, load_kwds={'mmap_mode': 'r'})
 
     def test_record(self):

--- a/tools/swig/test/testFortran.py
+++ b/tools/swig/test/testFortran.py
@@ -29,15 +29,16 @@ class FortranTestCase(unittest.TestCase):
         "Test Fortran matrix initialized from reshaped NumPy fortranarray"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         second = Fortran.__dict__[self.typeStr + "SecondElement"]
-        matrix = np.asfortranarray(np.arange(9).reshape(3, 3),
-                                   self.typeCode)
+        matrix = np.asarray(np.arange(9).reshape(3, 3), 
+                            dtype=self.typeCode, order='F')
         self.assertEquals(second(matrix), 3)
 
     def testSecondElementObject(self):
         "Test Fortran matrix initialized from nested list fortranarray"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         second = Fortran.__dict__[self.typeStr + "SecondElement"]
-        matrix = np.asfortranarray([[0, 1, 2], [3, 4, 5], [6, 7, 8]], self.typeCode)
+        matrix = np.astype([[0, 1, 2], [3, 4, 5], [6, 7, 8]], 
+                            dtype=self.typeCode, order='F')
         self.assertEquals(second(matrix), 3)
 
 ######################################################################


### PR DESCRIPTION
Fixes #5300, both np.ascontiguousarray and np.asfortranarray are
depreciated in favor of  np.asarray(..., order=...)
because of their buggy behavior for scalars.
There is no timeline for dropping functions, but we need to 
discourage users from using these functions.