### PR TITLE
MAINT: improved error message when no `__array_function__` implementation found

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -224,6 +224,15 @@ The ``help`` function, when applied to numeric types such as `np.intc`,
 `np.int_`, and `np.longlong`, now lists all of the aliased names for that type,
 distinguishing between platform -dependent and -independent aliases.
 
+``__module__`` attribute now points to public modules
+-----------------------------------------------------
+The ``__module__`` attribute on most NumPy functions has been updated to refer
+to the preferred public module from which to access a function, rather than
+the module in which the function happens to be defined. This produces more
+informative displays for functions in tools such as IPython, e.g., instead of
+``<function 'numpy.core.fromnumeric.sum'>`` you now see
+``<function 'numpy.sum'>``.
+
 Large allocations marked as suitable for transparent hugepages
 --------------------------------------------------------------
 On systems that support transparent hugepages over the madvise system call

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -506,7 +506,7 @@ def _array2string_dispatcher(
     return (a,)
 
 
-@array_function_dispatch(_array2string_dispatcher)
+@array_function_dispatch(_array2string_dispatcher, module='numpy')
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
                  style=np._NoValue, formatter=None, threshold=None,
@@ -1386,7 +1386,7 @@ def _array_repr_dispatcher(
     return (arr,)
 
 
-@array_function_dispatch(_array_repr_dispatcher)
+@array_function_dispatch(_array_repr_dispatcher, module='numpy')
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1480,7 +1480,7 @@ def _array_str_dispatcher(
     return (a,)
 
 
-@array_function_dispatch(_array_str_dispatcher)
+@array_function_dispatch(_array_str_dispatcher, module='numpy')
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     """
     Return a string representation of the data in an array.

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -17,12 +17,13 @@ The preferred alias for `defchararray` is `numpy.char`.
 """
 from __future__ import division, absolute_import, print_function
 
+import functools
 import sys
 from .numerictypes import string_, unicode_, integer, object_, bool_, character
 from .numeric import ndarray, compare_chararrays
 from .numeric import array as narray
 from numpy.core.multiarray import _vec_string
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.compat import asbytes, long
 import numpy
 
@@ -47,6 +48,10 @@ else:
     _unicode = unicode
     _bytes = str
 _len = len
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy.char')
+
 
 def _use_unicode(*args):
     """

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3,16 +3,17 @@
 """
 from __future__ import division, absolute_import, print_function
 
+import functools
 import types
 import warnings
 
 import numpy as np
 from .. import VisibleDeprecationWarning
 from . import multiarray as mu
+from . import overrides
 from . import umath as um
 from . import numerictypes as nt
 from .numeric import asarray, array, asanyarray, concatenate
-from .overrides import array_function_dispatch
 from . import _methods
 
 _dt_ = nt.sctype2char
@@ -31,6 +32,9 @@ __all__ = [
 _gentype = types.GeneratorType
 # save away Python sum
 _sum_ = sum
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 # functions that are now methods

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -6,8 +6,10 @@ by importing from the extension module.
 
 """
 
+import functools
+
+from . import overrides
 from . import _multiarray_umath
-from .overrides import array_function_dispatch
 import numpy as np
 from numpy.core._multiarray_umath import *
 from numpy.core._multiarray_umath import (
@@ -36,6 +38,9 @@ __all__ = [
     'set_string_function', 'set_typeDict', 'shares_memory', 'test_interrupt',
     'tracemalloc_domain', 'typeinfo', 'unpackbits', 'unravel_index', 'vdot',
     'where', 'zeros']
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 def _empty_like_dispatcher(prototype, dtype=None, order=None, subok=None):

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -6,6 +6,7 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc
+import functools
 import itertools
 import operator
 import sys
@@ -27,8 +28,8 @@ from .multiarray import (
 if sys.version_info[0] < 3:
     from .multiarray import newbuffer, getbuffer
 
+from . import overrides
 from . import umath
-from .overrides import array_function_dispatch
 from .umath import (multiply, invert, sin, UFUNC_BUFSIZE_DEFAULT,
                     ERR_IGNORE, ERR_WARN, ERR_RAISE, ERR_CALL, ERR_PRINT,
                     ERR_LOG, ERR_DEFAULT, PINF, NAN)
@@ -53,6 +54,10 @@ if sys.version_info[0] >= 3:
 else:
     import cPickle as pickle
     import __builtin__ as builtins
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 def loads(*args, **kwargs):

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -105,9 +105,10 @@ def array_function_implementation_or_override(
         if result is not NotImplemented:
             return result
 
-    raise TypeError('no implementation found for {} on types that implement '
+    func_name = '{}.{}'.format(public_api.__module__, public_api.__name__)
+    raise TypeError("no implementation found for '{}' on types that implement "
                     '__array_function__: {}'
-                    .format(public_api, list(map(type, overloaded_args))))
+                    .format(func_name, list(map(type, overloaded_args))))
 
 
 ArgSpec = collections.namedtuple('ArgSpec', 'args varargs keywords defaults')
@@ -135,7 +136,7 @@ def verify_matching_signatures(implementation, dispatcher):
                                'default argument values')
 
 
-def array_function_dispatch(dispatcher, verify=True):
+def array_function_dispatch(dispatcher, module=None, verify=True):
     """Decorator for adding dispatch with the __array_function__ protocol."""
     def decorator(implementation):
         # TODO: only do this check when the appropriate flag is enabled or for
@@ -149,6 +150,10 @@ def array_function_dispatch(dispatcher, verify=True):
             relevant_args = dispatcher(*args, **kwargs)
             return array_function_implementation_or_override(
                 implementation, public_api, relevant_args, args, kwargs)
+
+        if module is not None:
+            public_api.__module__ = module
+
         return public_api
 
     return decorator

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -306,3 +306,21 @@ class TestArrayFunctionImplementation(object):
         with assert_raises_regex(
                 TypeError, "no implementation found for 'my.func'"):
             func(MyArray())
+
+
+class TestNumPyFunctions(object):
+
+    def test_module(self):
+        assert_equal(np.sum.__module__, 'numpy')
+        assert_equal(np.char.equal.__module__, 'numpy.char')
+        assert_equal(np.fft.fft.__module__, 'numpy.fft')
+        assert_equal(np.linalg.solve.__module__, 'numpy.linalg')
+
+    def test_override_sum(self):
+        MyArray, implements = _new_duck_type_and_implements()
+
+        @implements(np.sum)
+        def _(array):
+            return 'yes'
+
+        assert_equal(np.sum(MyArray()), 'yes')

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -296,12 +296,13 @@ class TestArrayFunctionImplementation(object):
     def test_not_implemented(self):
         MyArray, implements = _new_duck_type_and_implements()
 
-        @array_function_dispatch(lambda array: (array,))
+        @array_function_dispatch(lambda array: (array,), module='my')
         def func(array):
             return array
 
         array = np.array(1)
         assert_(func(array) is array)
 
-        with assert_raises_regex(TypeError, 'no implementation found'):
+        with assert_raises_regex(
+                TypeError, "no implementation found for 'my.func'"):
             func(MyArray())

--- a/numpy/fft/fftpack.py
+++ b/numpy/fft/fftpack.py
@@ -35,15 +35,21 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['fft', 'ifft', 'rfft', 'irfft', 'hfft', 'ihfft', 'rfftn',
            'irfftn', 'rfft2', 'irfft2', 'fft2', 'ifft2', 'fftn', 'ifftn']
 
+import functools
+
 from numpy.core import (array, asarray, zeros, swapaxes, shape, conjugate,
                         take, sqrt)
 from numpy.core.multiarray import normalize_axis_index
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from . import fftpack_lite as fftpack
 from .helper import _FFTCache
 
 _fft_cache = _FFTCache(max_size_in_mb=100, max_item_count=32)
 _real_fft_cache = _FFTCache(max_size_in_mb=100, max_item_count=32)
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy.fft')
 
 
 def _raw_fft(a, n=None, axis=-1, init_function=fftpack.cffti,

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -24,7 +24,7 @@ def _fftshift_dispatcher(x, axes=None):
     return (x,)
 
 
-@array_function_dispatch(_fftshift_dispatcher)
+@array_function_dispatch(_fftshift_dispatcher, module='numpy.fft')
 def fftshift(x, axes=None):
     """
     Shift the zero-frequency component to the center of the spectrum.
@@ -81,7 +81,7 @@ def fftshift(x, axes=None):
     return roll(x, shift, axes)
 
 
-@array_function_dispatch(_fftshift_dispatcher)
+@array_function_dispatch(_fftshift_dispatcher, module='numpy.fft')
 def ifftshift(x, axes=None):
     """
     The inverse of `fftshift`. Although identical for even-length `x`, the

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -995,7 +995,7 @@ def _pad_dispatcher(array, pad_width, mode, **kwargs):
     return (array,)
 
 
-@array_function_dispatch(_pad_dispatcher)
+@array_function_dispatch(_pad_dispatcher, module='numpy')
 def pad(array, pad_width, mode, **kwargs):
     """
     Pads an array.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -27,8 +27,14 @@ To do: Optionally return indices analogously to unique for all functions.
 """
 from __future__ import division, absolute_import, print_function
 
+import functools
+
 import numpy as np
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 __all__ = [

--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -13,9 +13,14 @@ otherwise stated.
 from __future__ import division, absolute_import, print_function
 
 from decimal import Decimal
+import functools
 
 import numpy as np
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 __all__ = ['fv', 'pmt', 'nper', 'ipmt', 'ppmt', 'pv', 'rate',

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -6,6 +6,7 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc
+import functools
 import re
 import sys
 import warnings
@@ -26,7 +27,7 @@ from numpy.core.fromnumeric import (
     ravel, nonzero, partition, mean, any, sum
     )
 from numpy.core.numerictypes import typecodes
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.core.function_base import add_newdoc
 from numpy.lib.twodim_base import diag
 from .utils import deprecate
@@ -43,6 +44,11 @@ if sys.version_info[0] < 3:
     import __builtin__ as builtins
 else:
     import builtins
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
+
 
 # needed in this module for compatibility
 from numpy.lib.histograms import histogram, histogramdd

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import functools
 import sys
 import math
 
@@ -13,8 +14,12 @@ from . import function_base
 import numpy.matrixlib as matrixlib
 from .function_base import diff
 from numpy.core.multiarray import ravel_multi_index, unravel_index
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.lib.stride_tricks import as_strided
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 __all__ = [

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -22,10 +22,15 @@ Functions
 """
 from __future__ import division, absolute_import, print_function
 
+import functools
 import warnings
 import numpy as np
 from numpy.lib import function_base
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 __all__ = [

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -8,17 +8,22 @@ __all__ = ['poly', 'roots', 'polyint', 'polyder', 'polyadd',
            'polysub', 'polymul', 'polydiv', 'polyval', 'poly1d',
            'polyfit', 'RankWarning']
 
+import functools
 import re
 import warnings
 import numpy.core.numeric as NX
 
 from numpy.core import (isscalar, abs, finfo, atleast_1d, hstack, dot, array,
                         ones)
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.lib.twodim_base import diag, vander
 from numpy.lib.function_base import trim_zeros
 from numpy.lib.type_check import iscomplex, real, imag, mintypecode
 from numpy.linalg import eigvals, lstsq, inv
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 class RankWarning(UserWarning):

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import functools
 import warnings
 
 import numpy.core.numeric as _nx
@@ -8,7 +9,7 @@ from numpy.core.numeric import (
     )
 from numpy.core.fromnumeric import product, reshape, transpose
 from numpy.core.multiarray import normalize_axis_index
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.core import vstack, atleast_3d
 from numpy.lib.index_tricks import ndindex
 from numpy.matrixlib.defmatrix import matrix  # this raises all the right alarm bells
@@ -20,6 +21,10 @@ __all__ = [
     'apply_along_axis', 'kron', 'tile', 'get_array_wrap', 'take_along_axis',
     'put_along_axis'
     ]
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 def _make_along_axis_idx(arr_shape, indices, axis):

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -140,7 +140,7 @@ def _broadcast_to_dispatcher(array, shape, subok=None):
     return (array,)
 
 
-@array_function_dispatch(_broadcast_to_dispatcher)
+@array_function_dispatch(_broadcast_to_dispatcher, module='numpy')
 def broadcast_to(array, shape, subok=False):
     """Broadcast an array to a new shape.
 
@@ -205,7 +205,7 @@ def _broadcast_arrays_dispatcher(*args, **kwargs):
     return args
 
 
-@array_function_dispatch(_broadcast_arrays_dispatcher)
+@array_function_dispatch(_broadcast_arrays_dispatcher, module='numpy')
 def broadcast_arrays(*args, **kwargs):
     """
     Broadcast any number of arrays against each other.

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -3,12 +3,14 @@
 """
 from __future__ import division, absolute_import, print_function
 
+import functools
+
 from numpy.core.numeric import (
     absolute, asanyarray, arange, zeros, greater_equal, multiply, ones,
     asarray, where, int8, int16, int32, int64, empty, promote_types, diagonal,
     nonzero
     )
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.core import iinfo, transpose
 
 
@@ -16,6 +18,10 @@ __all__ = [
     'diag', 'diagflat', 'eye', 'fliplr', 'flipud', 'tri', 'triu',
     'tril', 'vander', 'histogram2d', 'mask_indices', 'tril_indices',
     'tril_indices_from', 'triu_indices', 'triu_indices_from', ]
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 i1 = iinfo(int8)

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -2,6 +2,7 @@
 
 """
 from __future__ import division, absolute_import, print_function
+import functools
 import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
@@ -11,10 +12,16 @@ __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
 
 import numpy.core.numeric as _nx
 from numpy.core.numeric import asarray, asanyarray, array, isnan, zeros
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from .ufunclike import isneginf, isposinf
 
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
+
+
 _typecodes_by_elsize = 'GDFgdfQqLlIiHhBb?'
+
 
 def mintypecode(typechars,typeset='GDFgdf',default='d'):
     """

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -60,7 +60,7 @@ def _dispatcher(x, out=None):
     return (x, out)
 
 
-@array_function_dispatch(_dispatcher, verify=False)
+@array_function_dispatch(_dispatcher, verify=False, module='numpy')
 @_fix_out_named_y
 def fix(x, out=None):
     """
@@ -107,7 +107,7 @@ def fix(x, out=None):
     return res
 
 
-@array_function_dispatch(_dispatcher, verify=False)
+@array_function_dispatch(_dispatcher, verify=False, module='numpy')
 @_fix_out_named_y
 def isposinf(x, out=None):
     """
@@ -176,7 +176,7 @@ def isposinf(x, out=None):
         return nx.logical_and(is_inf, signbit, out)
 
 
-@array_function_dispatch(_dispatcher, verify=False)
+@array_function_dispatch(_dispatcher, verify=False, module='numpy')
 @_fix_out_named_y
 def isneginf(x, out=None):
     """

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -16,6 +16,7 @@ __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
            'svd', 'eig', 'eigh', 'lstsq', 'norm', 'qr', 'cond', 'matrix_rank',
            'LinAlgError', 'multi_dot']
 
+import functools
 import operator
 import warnings
 
@@ -28,9 +29,14 @@ from numpy.core import (
     swapaxes, divide, count_nonzero, isnan
 )
 from numpy.core.multiarray import normalize_axis_index
-from numpy.core.overrides import array_function_dispatch
+from numpy.core import overrides
 from numpy.lib.twodim_base import triu, eye
 from numpy.linalg import lapack_lite, _umath_linalg
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy.linalg')
+
 
 # For Python2/3 compatibility
 _N = b'N'


### PR DESCRIPTION
Fixes #12213

Before:
```
In [1]: import numpy as np

In [2]: class MyArray:
   ...:     def __array_function__(*args, **kwargs):
   ...:         return NotImplemented
   ...:

In [3]: np.sum(MyArray())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-c8a80bb1d37e> in <module>()
----> 1 np.sum(MyArray())

~/dev/numpy/numpy/core/overrides.py in public_api(*args, **kwargs)
    149             relevant_args = dispatcher(*args, **kwargs)
    150             return array_function_implementation_or_override(
--> 151                 implementation, public_api, relevant_args, args, kwargs)
    152
    153         # TODO: remove this when we drop Python 2 support (functools.wraps

~/dev/numpy/numpy/core/overrides.py in array_function_implementation_or_override(implementation, public_api, relevant_args, args, kwargs)
    108     raise TypeError('no implementation found for {} on types that implement '
    109                     '__array_function__: {}'
--> 110                     .format(public_api, list(map(type, overloaded_args))))
    111
    112

TypeError: no implementation found for <function sum at 0x10e070bf8> on types that implement __array_function__: [<class '__main__.MyArray'>]
```
After:
```
In [3]: np.sum(MyArray())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-c8a80bb1d37e> in <module>()
----> 1 np.sum(MyArray())

~/dev/numpy/numpy/core/overrides.py in public_api(*args, **kwargs)
    149             relevant_args = dispatcher(*args, **kwargs)
    150             return array_function_implementation_or_override(
--> 151                 implementation, public_api, relevant_args, args, kwargs)
    152
    153         # TODO: remove this when we drop Python 2 support (functools.wraps

~/dev/numpy/numpy/core/overrides.py in array_function_implementation_or_override(implementation, public_api, relevant_args, args, kwargs)
    108     raise TypeError('no implementation found for {} on types that implement '
    109                     '__array_function__: {}'
--> 110                     .format(public_api, list(map(type, overloaded_args))))
    111
    112

TypeError: no implementation found for 'numpy.sum' on types that implement __array_function__: [<class '__main__.MyArray'>]
```