### PR TITLE
MAINT: set `__module__` for more `array_function_dispatch` uses

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -700,7 +700,7 @@ def _einsum_path_dispatcher(*operands, **kwargs):
     return operands
 
 
-@array_function_dispatch(_einsum_path_dispatcher)
+@array_function_dispatch(_einsum_path_dispatcher, module='numpy')
 def einsum_path(*operands, **kwargs):
     """
     einsum_path(subscripts, *operands, optimize='greedy')
@@ -1001,7 +1001,7 @@ def _einsum_dispatcher(*operands, **kwargs):
 
 
 # Rewrite einsum to handle different cases
-@array_function_dispatch(_einsum_dispatcher)
+@array_function_dispatch(_einsum_dispatcher, module='numpy')
 def einsum(*operands, **kwargs):
     """
     einsum(subscripts, *operands, out=None, dtype=None, order='K',

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -7,9 +7,13 @@ import functools
 import operator
 
 from . import numeric as _nx
+from . import overrides
 from .numeric import array, asanyarray, newaxis
 from .multiarray import normalize_axis_index
-from .overrides import array_function_dispatch
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 def _atleast_1d_dispatcher(*arys):


### PR DESCRIPTION
I noticed a few more functions using ``array_function_dispatch`` where I had
not set the module in https://github.com/numpy/numpy/pull/12251.

I used this script::

    import types

    def check_module(module):
        for name in dir(module):
            item = getattr(module, name)
            if isinstance(item, types.FunctionType):
                print(f'{item.__module__}.{item.__name__}')

    >>> import numpy
    >>> check_module(numpy)
    ...

Note that functions without overrides like ``numpy.ones`` still display the
module in which they are defined, e.g., ``numpy.core.numeric.ones``. We should
probably fix that, too, probably most cleanly adding a decorator that sets
``__module__``, e.g.,

    def set_module(module):
        def decorator(func):
            func.__module__ = module
            return func
        return decorator

    ...

    @set_module('numpy')
    def ones(shape, dtype=None, order='C'):
        ...

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
