### PR TITLE
NEP: revise note for NEP 27

### DIFF
--- a/doc/neps/nep-0027-zero-rank-arrarys.rst
+++ b/doc/neps/nep-0027-zero-rank-arrarys.rst
@@ -7,15 +7,16 @@ NEP 27 — Zero Rank Arrays
 :Type: Informational
 :Created: 2006-06-10
 
-Abstract
---------
+.. note ::
 
-NumPy has both zero rank arrays and scalars. This design document, adapted from
-a `2006 wiki entry`_, describes what zero rank arrays are and why they exist.
-It was transcribed 2018-10-13 into a NEP and links were updated.
+    NumPy has both zero rank arrays and scalars. This design document, adapted
+    from a `2006 wiki entry`_, describes what zero rank arrays are and why they
+    exist. It was transcribed 2018-10-13 into a NEP and links were updated.
+    The pull request sparked `a lively discussion`_ about the continued need
+    for zero rank arrays and scalars in NumPy.
 
-Note that some of the information here is dated, for instance indexing of 0-D
-arrays now is now implemented and does not error.
+    Some of the information here is dated, for instance indexing of 0-D arrays
+    now is now implemented and does not error.
 
 Zero-Rank Arrays
 ----------------
@@ -249,3 +250,4 @@ The original document appeared on the scipy.org wiki, with no Copyright notice, 
 .. _`9024ff0`: https://github.com/numpy/numpy/commit/9024ff0dc052888b5922dde0f3e615607a9e99d7
 .. _`743d922`: https://github.com/numpy/numpy/commit/743d922bf5893acf00ac92e823fe12f460726f90
 .. _`b32744e`: https://github.com/numpy/numpy/commit/b32744e3fc5b40bdfbd626dcc1f72907d77c01c4
+.. _`a lively discussion`: https://github.com/numpy/numpy/pull/12166


### PR DESCRIPTION
I think marking this as an RST note makes the update a little more obvious:

<img width="703" alt="screen shot 2018-10-27 at 4 32 55 pm" src="https://user-images.githubusercontent.com/1217238/47610280-0dbdc680-da06-11e8-95d4-d37eced340dd.png">

Also, I added a link to the pull request discussion.

cc @mattip 