### PR TITLE
ENH: array does not need to be writable to use as input to take

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -262,6 +262,11 @@ copying the data directly into the appropriate slice of the resulting array.
 This results in significant speedups for these large arrays, particularly for
 arrays being blocked along more than 2 dimensions.
 
+Speedup ``np.take`` for read-only arrays
+----------------------------------------
+The implementation of ``np.take`` no longer makes an unnecessary copy of the
+source array when its ``writeable`` flag is set to ``False``.
+
 
 Changes
 =======

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -45,7 +45,7 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
 
     indices = NULL;
     self = (PyArrayObject *)PyArray_CheckAxis(self0, &axis,
-                                    NPY_ARRAY_CARRAY);
+                                    NPY_ARRAY_CARRAY_RO);
     if (self == NULL) {
         return NULL;
     }


### PR DESCRIPTION
`np.take` is significantly slower for non-writeable input arrays due to requesting `NPY_ARRAY_CARRAY` instead of `NPY_ARRAY_CARRAY_RO` from `PyArray_CheckAxis`.  

Before:
```
In [8]: import numpy as np

In [9]: a = np.arange(1e8)

In [10]: %timeit a.take([5])
1.64 µs ± 80 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [11]: a.setflags(write=False)

In [12]: %timeit a.take([5])
1.41 s ± 17.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After:
```
In [1]: import numpy as np

In [2]:  a = np.arange(1e8)

In [3]: %timeit a.take([5])
1.53 µs ± 18.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: a.setflags(write=False)

In [5]: %timeit a.take([5])
1.55 µs ± 22.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```