### PR TITLE
ENH: Do not emit compiler warning if forcing old API

### DIFF
--- a/numpy/core/include/numpy/npy_1_7_deprecated_api.h
+++ b/numpy/core/include/numpy/npy_1_7_deprecated_api.h
@@ -5,6 +5,8 @@
 #error "Should never include npy_*_*_deprecated_api directly."
 #endif
 
+/* Emit a warning if the user did not specifically request the old API */
+#ifndef NPY_NO_DEPRECATED_API
 #if defined(_WIN32)
 #define _WARN___STR2__(x) #x
 #define _WARN___STR1__(x) _WARN___STR2__(x)
@@ -16,6 +18,7 @@
          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION"
 #endif
 /* TODO: How to do this warning message for other compilers? */
+#endif
 
 /*
  * This header exists to collect all dangerous/deprecated NumPy API


### PR DESCRIPTION
If a user does not define `NPY_NO_DEPRECATED_API`, we emit a warning encouraging them to choose an api version. If they choose `NPY_1_7_API_VERSION` or earlier, we include a special header with many old API interfaces. This is still needed for correct operation with cython, see cython/cython#2640 for a possible solution. Until we can truly deprecate the old APIs (or decide to revert the deprecation), choosing the old API should not emit a compiler warning.