### PR TITLE
BUILD: force LGTM to use cython>=0.29

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -7,3 +7,8 @@ path_classifiers:
     # "undefined export" alerts
     - numpy/random/__init__.py
 
+extraction:
+  python:
+    python_setup:
+        requirements:
+          - cython>=0.29


### PR DESCRIPTION
Use cython >= 0.29 for the LGTM analysis. Part of #12284