### PR TITLE
MAINT: `_set_out_array()` syntax fix

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -747,7 +747,7 @@ _set_out_array(PyObject *obj, PyArrayObject **store)
         /* Translate None to NULL */
         return 0;
     }
-    if PyArray_Check(obj) {
+    if (PyArray_Check(obj)) {
         /* If it's an array, store it */
         if (PyArray_FailUnlessWriteable((PyArrayObject *)obj,
                                         "output array") < 0) {


### PR DESCRIPTION
A minor syntax fix detected using the `cppcheck` static code analyzer. I'm sure there's a good reason this doesn't cause major errors in current compilation (older C std or something?).

I was hoping to use static analysis to facilitate detection of "dead code" / unused functions but so far it produces a lot of false positives for various reasons, especially because of our custom template syntax / language.
