### PR TITLE
MAINT: removed unused vars in f2py test code

### DIFF
--- a/numpy/f2py/src/test/foomodule.c
+++ b/numpy/f2py/src/test/foomodule.c
@@ -116,8 +116,6 @@ static PyMethodDef foo_module_methods[] = {
 void initfoo() {
     int i;
     PyObject *m, *d, *s;
-    PyTypeObject *t;
-    PyObject *f;
     import_array();
 
     m = Py_InitModule("foo", foo_module_methods);


### PR DESCRIPTION
Static analysis caught a few unused C variables here.