### PR TITLE
WIP, TST: add static analysis to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,8 @@ jobs:
   # two C compilers, but with homebrew looks like we're
   # now stuck getting the full gcc toolchain instead of
   # just pulling in gfortran
-  - script: brew install gcc
-    displayName: 'make gfortran available on mac os vm'
+  - script: brew install gcc cppcheck
+    displayName: 'Install gfortran and cppcheck'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: python -m pip install cython nose pytz pytest pickle5
@@ -55,6 +55,12 @@ jobs:
       ATLAS: None
       ACCELERATE: None
       CC: /usr/bin/clang
+  - script: cppcheck --suppressions-list=tools/cppcheck_suppressions.txt --enable=all --xml -inumpy/linalg/lapack_lite -itools/swig . >& cppcheck_results.txt
+    displayName: 'Run cppcheck static analysis on C files'
+  # the grep checks for cppcheck issues below parse out xml error id tags
+  # in the future, we may prefer to use an xml parser instead of grep
+  - script: /bin/bash -c "! grep 'syntaxError' cppcheck_results.txt"
+    displayName: 'Parse cppcheck results for syntax errors'
   - script: python runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run Full NumPy Test Suite'
   - task: PublishTestResults@2

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1128,7 +1128,7 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
 
         op = (cmp_op == Py_EQ ? n_ops.logical_and : n_ops.logical_or);
         while (PyDict_Next(PyArray_DESCR(self)->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             a = array_subscript_asarray(self, key);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1968,7 +1968,7 @@ _arraydescr_isnative(PyArray_Descr *self)
         int offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(self->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
@@ -2460,7 +2460,7 @@ _descr_find_object(PyArray_Descr *self)
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(self->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
@@ -2982,7 +2982,7 @@ PyArray_DescrNewByteorder(PyArray_Descr *self, char newendian)
         newfields = PyDict_New();
         /* make new dictionary with replaced PyArray_Descr Objects */
         while (PyDict_Next(self->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyUString_Check(key) || !PyTuple_Check(value) ||

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1420,7 +1420,7 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
         int offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -41,7 +41,7 @@ PyArray_Item_INCREF(char *data, PyArray_Descr *descr)
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(descr->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
@@ -77,7 +77,7 @@ PyArray_Item_XDECREF(char *data, PyArray_Descr *descr)
             Py_ssize_t pos = 0;
 
             while (PyDict_Next(descr->fields, &pos, &key, &value)) {
-                if NPY_TITLE_KEY(key, value) {
+                if (NPY_TITLE_KEY(key, value)) {
                     continue;
                 }
                 if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
@@ -265,7 +265,7 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -317,7 +317,7 @@ _putzero(char *optr, PyObject *zero, PyArray_Descr *dtype)
         int offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
-            if NPY_TITLE_KEY(key, value) {
+            if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {

--- a/tools/cppcheck_suppressions.txt
+++ b/tools/cppcheck_suppressions.txt
@@ -1,0 +1,47 @@
+// suppress all warnings related to C template files
+*:*.src
+
+// ignore warnings about large numbers of #ifdef configs
+toomanyconfigs:*
+
+// ignore variable scope warnings -- CPython dev team
+// also ignored these when using cppcheck
+variableScope:*
+
+// ignore config style warnings (#define directives that
+// cppcheck doesn't like, but are probably fine)
+ConfigurationNotChecked:*
+
+// we have some pointer casts that could perhaps be typed
+// slightly more conservatively
+invalidPointerCast:*
+
+// false positives for variables that are never used
+unreadVariable:*
+
+// we probably don't want to start removing unused struct
+// members
+unusedStructMember:*
+
+// ignore all warnings for Cython generated random code
+*:numpy/random/mtrand/mtrand.c
+
+// unused function (dead code) detection is not reliable yet
+// ignore for all files -- probably related to having Python
+// interaction on top of regular C code
+unusedFunction:*
+
+// some redundant variable assignments do look ok
+// after manual inspection
+redundantAssignment:numpy/core/src/common/mem_overlap.c
+redundantAssignment:numpy/core/src/multiarray/calculation.c
+redundantAssignment:numpy/core/src/multiarray/common.c
+redundantAssignment:numpy/core/src/multiarray/convert_datatype.c
+redundantAssignment:numpy/core/src/multiarray/ctors.c
+redundantAssignment:numpy/core/src/multiarray/descriptor.c
+redundantAssignment:numpy/core/src/multiarray/item_selection.c
+redundantAssignment:numpy/core/src/multiarray/iterators.c
+redundantAssignment:numpy/core/src/multiarray/mapping.c
+redundantAssignment:numpy/core/src/multiarray/methods.c
+
+


### PR DESCRIPTION
Adds the open source [cppcheck static code analyzer](https://github.com/danmar/cppcheck) to an Azure CI job & parses a subset of the issues that can be detected for now using `grep` exit codes for success, a bit like our compiler warning checks.

This PR also includes the attempted fixes to satisfy the above subset of the static analysis checks, and the [raw static analysis log file](https://github.com/numpy/numpy/files/2531900/cppcheck_results.txt) contains more issues with tags in parentheses like `(performance)`, `(portability)` and so on.

The full static analysis job is a few minutes faster than the full test suite jobs, with `cppcheck` itself requiring around 6 minutes to recursively probe our codebase with all flags active.

There are some corners of our codebase like `lapack_lite`, `swig`, and `random` for which I've intentionally avoided diving in too much, at least for now, despite the static analyzer going nuts on those.