### PR TITLE
BUILD: use system python3 in the chroot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       sudo: true    # travis-ci/travis-ci#9069
       env: INSTALL_PICKLE5=1
     - python: 3.6
-      env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=3.6
+      env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=python3 PIP=pip3
       sudo: true
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       sudo: true    # travis-ci/travis-ci#9069
       env: INSTALL_PICKLE5=1
     - python: 3.6
-      env: USE_CHROOT=1 ARCH=i386 DIST=bionic PYTHON=python3 PIP=pip3
+      env: USE_CHROOT=1 ARCH=i386 DIST=bionic
       sudo: true
       addons:
         apt:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -101,8 +101,8 @@ setup_chroot()
 
   # install needed packages
   sudo chroot $DIR bash -c "apt-get install -qq -y \
-    libatlas-base-dev gfortran python-dev python-nose python-pip cython \
-    python-pytest"
+    libatlas-base-dev gfortran python-dev python3-dev python-pip python3-pip \
+    cython  python3-pytest python-pytest"
 }
 
 run_test()
@@ -112,7 +112,7 @@ run_test()
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then
-    pip install pytest-cov
+    $PIP install pytest-cov
     COVERAGE_FLAG=--coverage
   fi
 
@@ -191,11 +191,11 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   . venv-for-wheel/bin/activate
   # Move out of source directory to avoid finding local numpy
   pushd dist
-  pip install --pre --no-index --upgrade --find-links=. numpy
-  pip install nose pytest
+  $PIP install --pre --no-index --upgrade --find-links=. numpy
+  $PIP install nose pytest
 
   if [ -n "$INSTALL_PICKLE5" ]; then
-    pip install pickle5
+    $PIP install pickle5
   fi
 
   popd
@@ -215,10 +215,10 @@ elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
   . venv-for-wheel/bin/activate
   # Move out of source directory to avoid finding local numpy
   pushd dist
-  pip install numpy*
-  pip install nose pytest
+  $PIP install numpy*
+  $PIP install nose pytest
   if [ -n "$INSTALL_PICKLE5" ]; then
-    pip install pickle5
+    $PIP install pickle5
   fi
 
   popd
@@ -229,9 +229,9 @@ elif [ -n "$USE_CHROOT" ] && [ $# -eq 0 ]; then
   # the chroot'ed environment will not have the current locale,
   # avoid any warnings which may disturb testing
   export LANG=C LC_ALL=C
-  # run again in chroot with this time testing
+  # run again in chroot with this time testing with python3
   sudo linux32 chroot $DIR bash -c \
-    "cd numpy && PYTHON=python PIP=pip IN_CHROOT=1 $0 test"
+    "cd numpy && PYTHON=$PYTHON PIP=$PIP IN_CHROOT=1 $0 test"
 else
   setup_base
   run_test

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -101,8 +101,8 @@ setup_chroot()
 
   # install needed packages
   sudo chroot $DIR bash -c "apt-get install -qq -y \
-    libatlas-base-dev gfortran python-dev python3-dev python-pip python3-pip \
-    cython  python3-pytest python-pytest"
+    libatlas-base-dev gfortran python3-dev python3-pip \
+    cython  python3-pytest"
 }
 
 run_test()
@@ -231,7 +231,7 @@ elif [ -n "$USE_CHROOT" ] && [ $# -eq 0 ]; then
   export LANG=C LC_ALL=C
   # run again in chroot with this time testing with python3
   sudo linux32 chroot $DIR bash -c \
-    "cd numpy && PYTHON=$PYTHON PIP=$PIP IN_CHROOT=1 $0 test"
+    "cd numpy && PYTHON=python3 PIP=pip3 IN_CHROOT=1 $0 test"
 else
   setup_base
   run_test


### PR DESCRIPTION
The chroot travis test used python2. Update it to use python3.