### PR TITLE
MAINT, TST: unreachable Python code paths

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,10 @@ jobs:
     displayName: 'make gfortran available on mac os vm'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install cython nose pytz pytest pickle5
+  - script: python -m pip install cython nose pytz pytest pickle5 vulture
     displayName: 'Install dependencies; some are optional to avoid test skips'
+  - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
+    displayName: 'Check for unreachable code paths in Python modules'
   # NOTE: init_dgelsd failed init issue with current ACCELERATE /
   # LAPACK configuration on Azure macos image; at the time of writing
   # this plagues homebrew / macports NumPy builds, but we will

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -718,10 +718,7 @@ def modsign2map(m):
 
 def cb_sign2map(a, var, index=None):
     ret = {'varname': a}
-    if index is None or 1:  # disable 7712 patch
-        ret['varname_i'] = ret['varname']
-    else:
-        ret['varname_i'] = ret['varname'] + '_' + str(index)
+    ret['varname_i'] = ret['varname']
     ret['ctype'] = getctype(var)
     if ret['ctype'] in c2capi_map:
         ret['atype'] = c2capi_map[ret['ctype']]


### PR DESCRIPTION
Use [vulture](https://github.com/jendrikseipp/vulture) to check for unreachable code paths in NumPy Python modules by parsing the abstract syntax tree.

Fix up the single such case in our code base, with the confirmed lack of hit visible in [codecov missing line](https://codecov.io/gh/numpy/numpy/src/master/numpy/f2py/capi_maps.py#L724).

The enclosing conditional is basically an `if 1:`.

codecov should prevent this category of issue moving forward, but we sometimes have to ignore codecov for various reasons, so maybe doesn't hurt to have this static check which runs in < 5 seconds.