### PR TITLE
MAINT: Allow subclasses in `ndarray.__array_function__`.

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -161,11 +161,8 @@ def _array_function(self, func, types, args, kwargs):
     # TODO: rewrite this in C
     # Cannot handle items that have __array_function__ other than our own.
     for t in types:
-        if t is not mu.ndarray:
-            method = getattr(t, '__array_function__', _NDARRAY_ARRAY_FUNCTION)
-            if method is not _NDARRAY_ARRAY_FUNCTION:
-                return NotImplemented
+        if not issubclass(t, mu.ndarray) and hasattr(t, '__array_function__'):
+            return NotImplemented
 
-    # Arguments contain no overrides, so we can safely call the
-    # overloaded function again.
-    return func(*args, **kwargs)
+    # The regular implementation can handle this, so we call it directly.
+    return func.__wrapped__(*args, **kwargs)


### PR DESCRIPTION
The Liskov substitution principle suggests it should.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
