### PR TITLE
TST: test_tofile_fromfile now uses initialized memory

### DIFF
--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -332,15 +332,14 @@ class TestPathUsage(object):
     def test_tofile_fromfile(self):
         with temppath(suffix='.bin') as path:
             path = Path(path)
-            a = np.empty(10, dtype='f8,i4,a5')
+            np.random.seed(123)
+            a = np.random.rand(10).astype('f8,i4,a5')
             a[5] = (0.5,10,'abcde')
-            a.newbyteorder('<')
             with path.open("wb") as fd:
                 a.tofile(fd)
             x = np.core.records.fromfile(path,
                                          formats='f8,i4,a5',
-                                         shape=10,
-                                         byteorder='<')
+                                         shape=10)
             assert_array_equal(x, a)
 
 


### PR DESCRIPTION
Try removing `pathlib` from Shippable CI config since apparently  no other NumPy CI config uses this, it is apparently prone to causing issues, and depending on the backport maintenance of a Python 3 standard library module may be a bad idea anyway.

An alternative may be to switch to the newer `pathlib2` 2.x backport, but I don't think we've done that for any other CI either.

Maybe good to check the test skip counts for shippable in this PR -- I think for 2.x quite a few more show up without pathlib so that was my original reasoning for using it.