### PR TITLE
ENH: allow ducktypes to skip asarray in arrayprint.py

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -473,9 +473,13 @@ def _array2string(a, options, separator=' ', prefix=""):
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in
     # _formatArray with subclasses which return 0d arrays in place of scalars
-    data = asarray(a)
-    if a.shape == ():
-        a = data
+    if isinstance(a, ndarray):
+        data = asarray(a)
+        if a.shape == ():
+            a = data
+    else:
+        # ducktypes are passed through unchanged
+        data = a
 
     if a.size > options['threshold']:
         summary_insert = "..."


### PR DESCRIPTION
For purposes of testing the new `__array_function__`, I would like for the internal implementation of `array2string` not call `asarray` on ducktypes, so that I can easily reuse this implementation in test ducktypes.

This has no effect at all on any users: It does not change how ndarrays and ndarray subclasses print, and is only a hidden (not user-visible) internal change.