### PR TITLE
DOC: typo in docstring numpy.random.beta, shape parameters must be positive not non-negative

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1679,9 +1679,9 @@ cdef class RandomState:
         Parameters
         ----------
         a : float or array_like of floats
-            Alpha, non-negative.
+            Alpha, positive (>0).
         b : float or array_like of floats
-            Beta, non-negative.
+            Beta, positive (>0).
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  If size is ``None`` (default),


### PR DESCRIPTION
Shape parameters of $\Beta(a,b)$ must be positive not non-negative.

See https://en.wikipedia.org/wiki/Beta_distribution

<img width="506" alt="capture d ecran 2018-11-07 a 12 08 18" src="https://user-images.githubusercontent.com/29331143/48128363-89313a80-e286-11e8-9f0e-c96a8f603ff1.png">


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
