### PR TITLE
TST, DOC: store circleci doc artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,8 @@ jobs:
             cd doc/neps
             make html
 
-     # - store_artifacts:
-     #     path: doc/build/html/
-     #     destination: devdocs
+      - store_artifacts:
+          path: doc/build/html/
 
 
      #  - store_artifacts:


### PR DESCRIPTION
Activate storage of circleci [doc artifacts](https://circleci.com/docs/2.0/artifacts/) so that devdocs that are built by circleci already can be viewed directly from a link in circleci to inspect changes.

This is done by SciPy already and tends to help reviewers quickly look at doc changes without having to compile locally. Although I think the links that are generated are initially only visible to core devs, I'm pretty sure they can share the links when critiquing doc changes in PRs, which may help communication on changes there.

This does cost us 4 minutes of extra time for the uploads, so 7->11 minutes total for circleci -- should still be shorter than i.e., full test suite runs in other CI jobs though. We could explore breaking out to separate circleci stuff in parallel if we really wanted, but maybe overkill for now.

Could think about activating the NEP doc artifact storage as well.

I noticed both sets of artifacts were commented out, which is perhaps my lingering concern here -- maybe someone did think about doing this and consciously decided not to?

Sample artifact from a test run on my fork here: https://2-116427166-gh.circle-artifacts.com/0/home/circleci/repo/doc/build/html/index.html