### PR TITLE
BUG: test, fix loading structured dtypes with padding

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -291,12 +291,8 @@ def descr_to_dtype(descr):
 
     names, formats, offsets = zip(*fields)
     # names may be (title, names) tuples
-    names = list(names)
-    titles = [None] * len(names)
-    for i, n in enumerate(names):
-        if isinstance(n, tuple):
-            titles[i] = n[0]
-            names[i] = n[1]
+    nametups = (n  if isinstance(n, tuple) else (None, n) for n in names)
+    titles, names = zip(*nametups)
     return numpy.dtype({'names': names, 'formats': formats, 'titles': titles,
                         'offsets': offsets, 'itemsize': offset})
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -533,7 +533,11 @@ dt2 = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'i4'],
 dt3 = np.dtype({'names': ['c', 'd'], 'formats': ['i4', dt2]})
 # field with '' name
 dt4 = np.dtype({'names': ['a', '', 'b'], 'formats': ['i4']*3})
-@pytest.mark.parametrize("dt", [dt1, dt2, dt3, dt4])
+# titles
+dt5 = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'i4'],
+                'offsets': [1, 6], 'titles': ['aa', 'bb']})
+
+@pytest.mark.parametrize("dt", [dt1, dt2, dt3, dt4, dt5])
 def test_load_padded_dtype(dt):
     arr = np.zeros(3, dt)
     for i in range(3):

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -524,6 +524,26 @@ def test_compressed_roundtrip():
     assert_array_equal(arr, arr1)
 
 
+# aligned
+dt1 = np.dtype('i1, i4, i1', align=True)
+# non-aligned, explicit offsets
+dt2 = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'i4'],
+                'offsets': [1, 6]})
+# nested struct-in-struct
+dt3 = np.dtype({'names': ['c', 'd'], 'formats': ['i4', dt2]})
+# field with '' name
+dt4 = np.dtype({'names': ['a', '', 'b'], 'formats': ['i4']*3})
+@pytest.mark.parametrize("dt", [dt1, dt2, dt3, dt4])
+def test_load_padded_dtype(dt):
+    arr = np.zeros(3, dt)
+    for i in range(3):
+        arr[i] = i + 5
+    npz_file = os.path.join(tempdir, 'aligned.npz')
+    np.savez(npz_file, arr=arr)
+    arr1 = np.load(npz_file)['arr']
+    assert_array_equal(arr, arr1)
+
+
 def test_python2_python3_interoperability():
     if sys.version_info[0] >= 3:
         fname = 'win64python2.npy'
@@ -532,7 +552,6 @@ def test_python2_python3_interoperability():
     path = os.path.join(os.path.dirname(__file__), 'data', fname)
     data = np.load(path)
     assert_array_equal(data, np.ones(2))
-
 
 def test_pickle_python2_python3():
     # Test that loading object arrays saved on Python 2 works both on


### PR DESCRIPTION
Replaces PR #10931 which it draws heavily from. Fixes #2215. 

The original PR has a discussion of why this is not the best fix, it assumes a field `('', |Vn)` - where `n` is the void size - is a padding field when someone could theoretically be using such a field for data. It also will force a possibly aligned dtype to now be not aligned, but unfortunately that information is not preserved in the storage format. 

I think this is the least evil of the possibilities, although we could consider saving the padding fields with a unique name. It would have to be better than the existing choice: `f1`, `f2`, ... which in the original issue clashed with names commonly used by users