### PR TITLE
BUG: random: Fix handling of a=0 for numpy.random.weibull.

### DIFF
--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -650,6 +650,9 @@ double rk_pareto(rk_state *state, double a)
 
 double rk_weibull(rk_state *state, double a)
 {
+    if (a == 0.0) {
+        return 0.0;
+    }
     return pow(rk_standard_exponential(state), 1./a);
 }
 

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2785,7 +2785,7 @@ cdef class RandomState:
         Parameters
         ----------
         a : float or array_like of floats
-            Shape of the distribution. Should be greater than zero.
+            Shape parameter of the distribution.  Must be nonnegative.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  If size is ``None`` (default),

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -942,7 +942,8 @@ class TestRandomDist(object):
         assert_array_almost_equal(actual, desired, decimal=15)
 
     def test_weibull_0(self):
-        assert_equal(np.random.weibull(a=0), 0)
+        np.random.seed(self.seed)
+        assert_equal(np.random.weibull(a=0, size=12), np.zeros(12))
         assert_raises(ValueError, np.random.weibull, a=-0.)
 
     def test_zipf(self):


### PR DESCRIPTION
Before this fix, `np.random.weibull(a=0)` often returned inf (and
in theory could have returned 1).  It should only return 0.

Closes gh-12371.
