### PR TITLE
MAINT: Improve error message for legal but unsupported PEP3118 types

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -482,6 +482,12 @@ _pep3118_standard_map = {
 }
 _pep3118_standard_typechars = ''.join(_pep3118_standard_map.keys())
 
+_pep3118_unsupported_map = {
+    'u': 'UCS-2 strings',
+    '&': 'pointers',
+    't': 'bitfields',
+    'X': 'function pointers',
+}
 
 class _Stream(object):
     def __init__(self, s):
@@ -593,6 +599,11 @@ def __dtype_from_pep3118(stream, is_subdtype):
                 stream.byteorder, stream.byteorder)
             value = dtype(numpy_byteorder + dtypechar)
             align = value.alignment
+        elif stream.next in _pep3118_unsupported_map:
+            desc = _pep3118_unsupported_map[stream.next]
+            raise NotImplementedError(
+                "Unrepresentable PEP 3118 data type {!r} ({})"
+                .format(stream.next, desc))
         else:
             raise ValueError("Unknown PEP 3118 data type specifier %r" % stream.s)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6788,7 +6788,7 @@ class TestNewBufferProtocol(object):
             ValueError, "format string",
             np.array, m)
 
-    def test_error_message(self):
+    def test_error_message_unsupported(self):
         # wchar has no corresponding numpy type - if this changes in future, we
         # need a better way to construct an invalid memoryview format.
         t = ctypes.c_wchar * 4
@@ -6797,7 +6797,10 @@ class TestNewBufferProtocol(object):
 
         exc = cm.exception
         if sys.version_info.major > 2:
-            with assert_raises_regex(ValueError, "Unknown .* specifier 'u'"):
+            with assert_raises_regex(
+                NotImplementedError,
+                r"Unrepresentable .* 'u' \(UCS-2 strings\)"
+            ):
                 raise exc.__cause__
 
     def test_ctypes_integer_via_memoryview(self):


### PR DESCRIPTION
Relates to #12369

Traceback is now:

```
In [1]: from array import array
   ...: import numpy as np
   ...:
   ...: buf = array('u', ['q', 'w', 'e', 'r', 't'])
   ...: view = memoryview(buf)
   ...:

In [2]: np.array(view)
NotImplementedError: Unrepresentable PEP 3118 data type 'u' (UCS-2 strings)

The above exception was the direct cause of the following exception:

ValueError: 'u' is not a valid PEP 3118 buffer format string
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
