### PR TITLE
DEP: deprecate empty field names

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -48,6 +48,13 @@ As part of `NEP 15`, they have been deprecated along with the C-API functions
 the inner loop functions in built-in ufuncs should use
 :c:func:`PyUFunc_ReplaceLoopBySignature`.
 
+Empty names in dtypes have been deprecated
+------------------------------------------
+It has been possible to create a record array with an empty field name, i.e.
+``np.dtype({'names': ['a', '', 'b'], 'formats': ['i4']*3})``. This conflicts
+with internal usage of empty field names for padding, and unnamed fields cannot
+be accessed by name. Such use has been deprecated.
+
 Future Changes
 ==============
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1059,7 +1059,7 @@ _convert_from_dict(PyObject *obj, int align)
     totalsize = 0;
     for (i = 0; i < n; i++) {
         PyObject *tup, *descr, *ind, *title, *name, *off;
-        int len, ret, _align = 1;
+        int len, ret, tmp, _align = 1;
         PyArray_Descr *newdescr;
 
         /* Build item to insert (descr, offset, [title])*/
@@ -1169,7 +1169,19 @@ _convert_from_dict(PyObject *obj, int align)
             Py_DECREF(tup);
             goto fail;
         }
-
+        tmp = PyObject_IsTrue(name);
+        if (tmp < 0) {
+            Py_DECREF(tup);
+            goto fail;
+        }
+        else if (tmp == 0) {
+            /* 2018-11-12 1.16 */
+            if (DEPRECATE("Blank field names are deprecated and will result in "
+                          "an error in the future.") < 0) {
+                Py_DECREF(tup);
+                goto fail;
+            }
+        }
         /* Insert into dictionary */
         if (PyDict_GetItem(fields, name) != NULL) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -519,10 +519,12 @@ class TestPositiveOnNonNumerical(_DeprecationTestCase):
     def test_positive_on_non_number(self):
         self.assert_deprecated(operator.pos, args=(np.array('foo'),))
 
+
 class TestFromstring(_DeprecationTestCase):
     # 2017-10-19, 1.14
     def test_fromstring(self):
         self.assert_deprecated(np.fromstring, args=('\x00'*80,))
+
 
 class Test_GetSet_NumericOps(_DeprecationTestCase):
     # 2018-09-20, 1.16.0
@@ -534,3 +536,11 @@ class Test_GetSet_NumericOps(_DeprecationTestCase):
         # other tests.
         self.assert_deprecated(np.set_numeric_ops, kwargs={})
         assert_raises(ValueError, np.set_numeric_ops, add='abc')
+
+
+class TestDtypeEmptyFieldName(_DeprecationTestCase):
+    # 2018-11-12, 1.16
+    def test_empty_fieldname(self):
+        d = {'names': ['a', '', 'b'], 'formats': ['i4']*3}
+        self.assert_deprecated(np.dtype, args=(d,))
+

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.core._rational_tests import rational
 from numpy.testing import (
     assert_equal, assert_array_equal, assert_raises, assert_,
-    assert_raises_regex
+    assert_raises_regex, suppress_warnings
     )
 from numpy.lib.stride_tricks import (
     as_strided, broadcast_arrays, _broadcast_shape, broadcast_to
@@ -324,7 +324,9 @@ def test_as_strided():
     assert_equal(a.dtype, a_view.dtype)
 
     # Make sure that the only type that could fail is properly handled
-    dt = np.dtype({'names': [''], 'formats': ['V4']})
+    with suppress_warnings() as sup:
+        sup.filter(DeprecationWarning, '')
+        dt = np.dtype({'names': [''], 'formats': ['V4']})
     a = np.empty((4,), dtype=dt)
     a_view = as_strided(a, shape=(3, 4), strides=(0, a.itemsize))
     assert_equal(a.dtype, a_view.dtype)


### PR DESCRIPTION
Split off from PR #12358. Empty field names are confusing, users should construct record arrays with name, format, offset dictionaries instead.