### PR TITLE
BUG: Fix for #10533 np.dtype(ctype) does not respect endianness

### DIFF
--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -45,7 +45,7 @@ def _from_ctypes_structure(t):
         current_offset = 0
         for fname, ftyp in t._fields_:
             names.append(fname)
-            formats.append(dtype_from_ctypes_endianness(ftyp))
+            formats.append(dtype_from_ctypes_type(ftyp))
             # Each type has a default offset, this is platform dependent for some types.
             effective_pack = min(t._pack_, ctypes.alignment(ftyp))
             current_offset = ((current_offset + effective_pack - 1) // effective_pack) * effective_pack
@@ -60,22 +60,22 @@ def _from_ctypes_structure(t):
     else:
         fields = []
         for fname, ftyp in t._fields_:
-            fields.append((fname, dtype_from_ctypes_endianness(ftyp)))
+            fields.append((fname, dtype_from_ctypes_type(ftyp)))
 
         # by default, ctypes structs are aligned
         return np.dtype(fields, align=True)
 
 
-def dtype_from_ctypes_endianness(t):
+def dtype_from_ctypes_scalar(t):
     """
     Return the dtype type with endianness included if it's the case
     """
     if t.__name__.endswith('_be'):
-        return '>' + dtype_from_ctypes_type(t)
+        return np.dtype('>' + t._type_)
     elif t.__name__.endswith('_le'):
-        return '<' + dtype_from_ctypes_type(t)
+        return '<' + t._type_
     else:
-        return dtype_from_ctypes_type(t)
+        return t._type_
 
 
 def dtype_from_ctypes_type(t):
@@ -94,7 +94,7 @@ def dtype_from_ctypes_type(t):
             "conversion from ctypes.Union types like {} to dtype"
             .format(t.__name__))
     elif isinstance(t, type(ctypes.c_int)): # Could be any simple type instead of c_int, all return the same type
-        return np.dtype(dtype_from_ctypes_endianness(t))
+        return np.dtype(dtype_from_ctypes_scalar(t))
     elif isinstance(t._type_, str):
         return np.dtype(t._type_)
     else:

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -70,9 +70,9 @@ def dtype_from_ctypes_scalar(t):
     """
     Return the dtype type with endianness included if it's the case
     """
-    if t.__name__.endswith('_be'):
+    if t.__ctype_be__ is t:
         return '>' + t._type_
-    elif t.__name__.endswith('_le'):
+    elif t.__ctype_le__ is t:
         return '<' + t._type_
     else:
         return t._type_

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -71,11 +71,11 @@ def dtype_from_ctypes_scalar(t):
     Return the dtype type with endianness included if it's the case
     """
     if t.__ctype_be__ is t:
-        return '>' + t._type_
+        return np.dtype('>' + t._type_)
     elif t.__ctype_le__ is t:
-        return '<' + t._type_
+        return np.dtype('<' + t._type_)
     else:
-        return t._type_
+        return np.dtype(t._type_)
 
 
 def dtype_from_ctypes_type(t):
@@ -93,10 +93,8 @@ def dtype_from_ctypes_type(t):
         raise NotImplementedError(
             "conversion from ctypes.Union types like {} to dtype"
             .format(t.__name__))
-    elif isinstance(t, type(ctypes.c_int)): # Could be any simple type instead of c_int, all return the same type
-        return np.dtype(dtype_from_ctypes_scalar(t))
     elif isinstance(t._type_, str):
-        return np.dtype(t._type_)
+        return dtype_from_ctypes_scalar(t)
     else:
         raise NotImplementedError(
             "Unknown ctypes type {}".format(t.__name__))

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -33,7 +33,6 @@ def _from_ctypes_array(t):
 
 
 def _from_ctypes_structure(t):
-    # TODO: gh-10533
     for item in t._fields_:
         if len(item) > 2:
             raise TypeError(

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -46,7 +46,7 @@ def _from_ctypes_structure(t):
         current_offset = 0
         for fname, ftyp in t._fields_:
             names.append(fname)
-            formats.append(dtype_from_ctypes_type(ftyp))
+            formats.append(dtype_from_ctypes_endianness(ftyp))
             # Each type has a default offset, this is platform dependent for some types.
             effective_pack = min(t._pack_, ctypes.alignment(ftyp))
             current_offset = ((current_offset + effective_pack - 1) // effective_pack) * effective_pack
@@ -61,10 +61,22 @@ def _from_ctypes_structure(t):
     else:
         fields = []
         for fname, ftyp in t._fields_:
-            fields.append((fname, dtype_from_ctypes_type(ftyp)))
+            fields.append((fname, dtype_from_ctypes_endianness(ftyp)))
 
         # by default, ctypes structs are aligned
         return np.dtype(fields, align=True)
+
+
+def dtype_from_ctypes_endianness(t):
+    """
+    Return the dtype type with endianness included if it's the case
+    """
+    if t.__name__.endswith('_be'):
+        return '>' + dtype_from_ctypes_type(t)
+    elif t.__name__.endswith('_le'):
+        return '<' + dtype_from_ctypes_type(t)
+    else:
+        return dtype_from_ctypes_type(t)
 
 
 def dtype_from_ctypes_type(t):
@@ -82,6 +94,8 @@ def dtype_from_ctypes_type(t):
         raise NotImplementedError(
             "conversion from ctypes.Union types like {} to dtype"
             .format(t.__name__))
+    elif isinstance(t, type(ctypes.c_int)): # Could be any simple type instead of c_int, all return the same type
+        return np.dtype(dtype_from_ctypes_endianness(t))
     elif isinstance(t._type_, str):
         return np.dtype(t._type_)
     else:

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -71,7 +71,7 @@ def dtype_from_ctypes_scalar(t):
     Return the dtype type with endianness included if it's the case
     """
     if t.__name__.endswith('_be'):
-        return np.dtype('>' + t._type_)
+        return '>' + t._type_
     elif t.__name__.endswith('_le'):
         return '<' + t._type_
     else:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -858,15 +858,9 @@ class TestFromCTypes(object):
 
     def test_complex_big_endian_structure_packed(self):
         class BigEndStruct(ctypes.BigEndianStructure):
-            _fields_ = [('one', ctypes.c_uint8.__ctype_be__),('two', ctypes.c_uint32.__ctype_be__)]
+            _fields_ = [('one', ctypes.c_uint8),('two', ctypes.c_uint32)]
             _pack_ = 1
         expected = np.dtype([('one', 'u1'), ('two', '>u4')])
-        self.check(BigEndStruct, expected)
-
-    def test_complex_big_endian_structure(self):
-        class BigEndStruct(ctypes.BigEndianStructure):
-            _fields_ = [('one', ctypes.c_uint16.__ctype_be__),('two', ctypes.c_uint32.__ctype_be__)]
-        expected = np.dtype({'names':['one','two'], 'formats':['>u2','>u4'], 'offsets':[0,4], 'itemsize':8}, align=True)
         self.check(BigEndStruct, expected)
 
     def test_little_endian_structure(self):
@@ -880,7 +874,6 @@ class TestFromCTypes(object):
             ('b', '<H')
         ], align=True)
         self.check(PaddedStruct, expected)
-
 
     def test_big_endian_structure(self):
         class PaddedStruct(ctypes.BigEndianStructure):
@@ -897,25 +890,13 @@ class TestFromCTypes(object):
     def test_big_endian_simple_type(self):
         byte_order = np.dtype(ctypes.c_uint16.__ctype_be__).byteorder
         if sys.byteorder == 'little':
-           expected = '>'
+            expected = '>'
         else:
             expected = '='
         assert byte_order == expected
 
-    def test_little_endian_simple_type(self):
-        byte_order = np.dtype(ctypes.c_uint16.__ctype_le__).byteorder
-        if sys.byteorder != 'little':
-           expected = '<'
-        else:
-            expected = '='
-        assert byte_order == expected
-
-    def test_little_endian_uint8(self):
-        byte_order = np.dtype(ctypes.c_uint8.__ctype_le__).byteorder
-        expected = '|'
-        assert byte_order == expected
-
-    def test_big_endian_uint8(self):
-        byte_order = np.dtype(ctypes.c_uint8.__ctype_be__).byteorder
-        expected = '|'
-        assert byte_order == expected
+    def test_simple_endian_types(self):
+        assert_equal(np.dtype(ctypes.c_uint16.__ctype_le__), np.dtype('<u2'))
+        assert_equal(np.dtype(ctypes.c_uint16.__ctype_be__), np.dtype('>u2'))
+        assert_equal(np.dtype(ctypes.c_uint8.__ctype_le__), np.dtype('u1'))
+        assert_equal(np.dtype(ctypes.c_uint8.__ctype_be__), np.dtype('u1'))

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -856,12 +856,25 @@ class TestFromCTypes(object):
             itemsize=18))
         self.check(PackedStructure, expected)
 
-    def test_complex_big_endian_structure_packed(self):
+    def test_big_endian_structure_packed(self):
         class BigEndStruct(ctypes.BigEndianStructure):
-            _fields_ = [('one', ctypes.c_uint8),('two', ctypes.c_uint32)]
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
             _pack_ = 1
         expected = np.dtype([('one', 'u1'), ('two', '>u4')])
         self.check(BigEndStruct, expected)
+
+    def test_little_endian_structure_packed(self):
+        class LittleEndStruct(ctypes.LittleEndianStructure):
+            _fields_ = [
+                ('one', ctypes.c_uint8),
+                ('two', ctypes.c_uint32)
+            ]
+            _pack_ = 1
+        expected = np.dtype([('one', 'u1'), ('two', '<u4')])
+        self.check(LittleEndStruct, expected)
 
     def test_little_endian_structure(self):
         class PaddedStruct(ctypes.LittleEndianStructure):
@@ -887,16 +900,8 @@ class TestFromCTypes(object):
         ], align=True)
         self.check(PaddedStruct, expected)
 
-    def test_big_endian_simple_type(self):
-        byte_order = np.dtype(ctypes.c_uint16.__ctype_be__).byteorder
-        if sys.byteorder == 'little':
-            expected = '>'
-        else:
-            expected = '='
-        assert byte_order == expected
-
     def test_simple_endian_types(self):
-        assert_equal(np.dtype(ctypes.c_uint16.__ctype_le__), np.dtype('<u2'))
-        assert_equal(np.dtype(ctypes.c_uint16.__ctype_be__), np.dtype('>u2'))
-        assert_equal(np.dtype(ctypes.c_uint8.__ctype_le__), np.dtype('u1'))
-        assert_equal(np.dtype(ctypes.c_uint8.__ctype_be__), np.dtype('u1'))
+        self.check(ctypes.c_uint16.__ctype_le__, np.dtype('<u2'))
+        self.check(ctypes.c_uint16.__ctype_be__, np.dtype('>u2'))
+        self.check(ctypes.c_uint8.__ctype_le__, np.dtype('u1'))
+        self.check(ctypes.c_uint8.__ctype_be__, np.dtype('u1'))


### PR DESCRIPTION
See: #10533
Added some code that uses the __name__ of the ctypes type. Also
added some new test to make sure we'll know if the ctypes data
that allows this workaround breaks in the future.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
