### PR TITLE
BUG: graceful DataSource __del__ when __init__ fails

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -323,7 +323,7 @@ class DataSource (object):
 
     def __del__(self):
         # Remove temp directories
-        if self._istmpdest:
+        if hasattr(self, '_istmpdest') and self._istmpdest:
             shutil.rmtree(self._destpath)
 
     def _iszip(self, filename):

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -361,3 +361,18 @@ class TestOpenFunc(object):
         fp = datasource.open(local_file)
         assert_(fp)
         fp.close()
+
+def test_del_attr_handling():
+    # DataSource __del__ can be called
+    # even if __init__ fails when the
+    # Exception object is caught by the
+    # caller as happens in refguide_check
+    # is_deprecated() function
+
+    ds = datasource.DataSource()
+    # simulate failed __init__ by removing key attribute
+    # produced within __init__ and expected by __del__
+    del ds._istmpdest
+    # should not raise an AttributeError if __del__
+    # gracefully handles failed __init__:
+    ds.__del__()


### PR DESCRIPTION
The [`__init__` method of DataSource](https://github.com/numpy/numpy/blob/master/numpy/lib/_datasource.py#L314) initializes instance attributes that are expected to exist during the cleanup performed by its `__del__` method.

While this sounds sensible, if `__init__` fails for any reason and `self._istmpdest` is an attribute that doesn't exist, an `AttributeError` can be raised when trying to clean up the object with `__del__`. This probably only happens if the original source of the `Exception` in `__init__` is caught, so that the final reference to the instance object can be removed via `__del__`.

The above scenario can be observed to happen in the [Azure CI for the refguide check PR](https://dev.azure.com/numpy/numpy/_build/results?buildId=826&view=logs) in the macOS Job under "Run Refguide Check" slot.

Specifically, in #12253 the ported version of `refguide_check` has the function [`is_deprecated()`](https://github.com/numpy/numpy/pull/12253/files#diff-d5ff24498c294c9ac32f57f408e1d519R240), which calls `DataSource()` with an invalid keyword argument, preventing the `__init__` completion, and catching the `TypeError` with `except Exception`, which likely triggers `__del__` and produces the Traceback observed in the CI result.

This doesn't actually cause refguide_check to fail, but it would be nice to clean up that mess visible in the refguide check run report if possible.