### PR TITLE
ENH: allow arrays for start and stop in {lin,log,geom}space

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -20,7 +20,7 @@ New functions
 =============
 
  * New functions in the `numpy.lib.recfunctions` module to ease the structured
-   assignment changes: `assign_fields_by_name`, `structured_to_unstructured`, 
+   assignment changes: `assign_fields_by_name`, `structured_to_unstructured`,
    `unstructured_to_structured`, `apply_along_fields`, and `require_fields`.
    See the user guide at <https://docs.scipy.org/doc/numpy/user/basics.rec.html>
    for more info.
@@ -388,6 +388,13 @@ overlapping fields and padding.
 ``__matmul__`` operator can now be overridden by ``__array_ufunc__``. Its
 implementation has also changed, ensuring it uses the same BLAS routines as
 `numpy.dot`, ensuring its performance is similar for large matrices.
+
+Start and stop arrays for ``linspace``, ``logspace`` and ``geomspace``
+----------------------------------------------------------------------
+These functions used to be limited to scalar stop and start values, but can
+now take arrays, which will be properly broadcast and result in an output
+which has one axis prepended.  This can be used, e.g., to obtain linearly
+interpolated points between sets of points.
 
 Changes
 =======

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -45,11 +45,14 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     The endpoint of the interval can optionally be excluded.
 
+    .. versionchanged:: 1.16.0
+        Non-scalar `start` and `stop` are now supported.
+
     Parameters
     ----------
-    start : scalar or array_like
+    start : array_like
         The starting value of the sequence.
-    stop : scalar or array_like
+    stop : array_like
         The end value of the sequence, unless `endpoint` is set to False.
         In that case, the sequence consists of all but the last of ``num + 1``
         evenly spaced samples, so that `stop` is excluded.  Note that the step
@@ -191,11 +194,14 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
     (`base` to the power of `start`) and ends with ``base ** stop``
     (see `endpoint` below).
 
+    .. versionchanged:: 1.16.0
+        Non-scalar `start` and `stop` are now supported.
+
     Parameters
     ----------
-    start : float or array_like
+    start : array_like
         ``base ** start`` is the starting value of the sequence.
-    stop : float or array_like
+    stop : array_like
         ``base ** stop`` is the final value of the sequence, unless `endpoint`
         is False.  In that case, ``num + 1`` values are spaced over the
         interval in log-space, of which all but the last (a sequence of
@@ -287,11 +293,14 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     This is similar to `logspace`, but with endpoints specified directly.
     Each output sample is a constant multiple of the previous.
 
+    .. versionchanged:: 1.16.0
+        Non-scalar `start` and `stop` are now supported.
+
     Parameters
     ----------
-    start : scalar or array_like
+    start : array_like
         The starting value of the sequence.
-    stop : scalar or array_like
+    stop : array_like
         The final value of the sequence, unless `endpoint` is False.
         In that case, ``num + 1`` values are spaced over the
         interval in log-space, of which all but the last (a sequence of

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -29,13 +29,14 @@ def _index_deprecate(i, stacklevel=2):
     return i
 
 
-def _linspace_dispatcher(
-        start, stop, num=None, endpoint=None, retstep=None, dtype=None):
+def _linspace_dispatcher(start, stop, num=None, endpoint=None, retstep=None,
+                         dtype=None, axis=None):
     return (start, stop)
 
 
 @array_function_dispatch(_linspace_dispatcher)
-def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
+def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
+             axis=0):
     """
     Return evenly spaced numbers over a specified interval.
 
@@ -67,14 +68,19 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
 
         .. versionadded:: 1.9.0
 
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start
+        or stop are array-like.  By default (0), the samples will be along a
+        new axis inserted at the beginning. Use -1 to get an axis at the end.
+
+        .. versionadded:: 1.16.0
+
     Returns
     -------
     samples : ndarray
         There are `num` equally spaced samples in the closed interval
         ``[start, stop]`` or the half-open interval ``[start, stop)``
-        (depending on whether `endpoint` is True or False).  If start
-        or stop are array-like, then the samples will be along a new
-        axis inserted at the beginning.
+        (depending on whether `endpoint` is True or False).
     step : float, optional
         Only returned if `retstep` is True
 
@@ -161,19 +167,23 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
     if endpoint and num > 1:
         y[-1] = stop
 
+    if axis != 0:
+        y = _nx.moveaxis(y, 0, axis)
+
     if retstep:
         return y.astype(dtype, copy=False), step
     else:
         return y.astype(dtype, copy=False)
 
 
-def _logspace_dispatcher(
-        start, stop, num=None, endpoint=None, base=None, dtype=None):
+def _logspace_dispatcher(start, stop, num=None, endpoint=None, base=None,
+                         dtype=None, axis=None):
     return (start, stop)
 
 
 @array_function_dispatch(_logspace_dispatcher)
-def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
+def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
+             axis=0):
     """
     Return numbers spaced evenly on a log scale.
 
@@ -202,13 +212,18 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     dtype : dtype
         The type of the output array.  If `dtype` is not given, infer the data
         type from the other input arguments.
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start
+        or stop are array-like.  By default (0), the samples will be along a
+        new axis inserted at the beginning. Use -1 to get an axis at the end.
+
+        .. versionadded:: 1.16.0
+
 
     Returns
     -------
     samples : ndarray
-        `num` samples, equally spaced on a log scale.  If start or stop are
-        array-like, then the samples will be along a new axis inserted at
-        the beginning.
+        `num` samples, equally spaced on a log scale.
 
     See Also
     --------
@@ -253,18 +268,19 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     >>> plt.show()
 
     """
-    y = linspace(start, stop, num=num, endpoint=endpoint)
+    y = linspace(start, stop, num=num, endpoint=endpoint, axis=axis)
     if dtype is None:
         return _nx.power(base, y)
-    return _nx.power(base, y).astype(dtype)
+    return _nx.power(base, y).astype(dtype, copy=False)
 
 
-def _geomspace_dispatcher(start, stop, num=None, endpoint=None, dtype=None):
+def _geomspace_dispatcher(start, stop, num=None, endpoint=None, dtype=None,
+                          axis=None):
     return (start, stop)
 
 
 @array_function_dispatch(_geomspace_dispatcher)
-def geomspace(start, stop, num=50, endpoint=True, dtype=None):
+def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     """
     Return numbers spaced evenly on a log scale (a geometric progression).
 
@@ -288,13 +304,17 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None):
     dtype : dtype
         The type of the output array.  If `dtype` is not given, infer the data
         type from the other input arguments.
+    axis : int, optional
+        The axis in the result to store the samples.  Relevant only if start
+        or stop are array-like.  By default (0), the samples will be along a
+        new axis inserted at the beginning. Use -1 to get an axis at the end.
+
+        .. versionadded:: 1.16.0
 
     Returns
     -------
     samples : ndarray
-        `num` samples, equally spaced on a log scale.  If start or stop are
-        array-like, then the samples will be along a new axis inserted at
-        the beginning.
+        `num` samples, equally spaced on a log scale.
 
     See Also
     --------
@@ -392,6 +412,8 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None):
     log_stop = _nx.log10(stop)
     result = out_sign * logspace(log_start, log_stop, num=num,
                                  endpoint=endpoint, base=10.0, dtype=dtype)
+    if axis != 0:
+        result = _nx.moveaxis(result, 0, axis)
 
     return result.astype(dtype, copy=False)
 

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -285,9 +285,7 @@ class TestLinspace(object):
 
             @property
             def __array_interface__(self):
-                # Ideally should be `'shape': ()` but the current interface
-                # does not allow that
-                return {'shape': (1,), 'typestr': '<i4', 'data': self._data,
+                return {'shape': (), 'typestr': '<i4', 'data': self._data,
                         'version': 3}
 
             def __mul__(self, other):

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 from numpy import (
     logspace, linspace, geomspace, dtype, array, sctypes, arange, isnan,
-    ndarray, sqrt, nextafter
+    ndarray, sqrt, nextafter, stack
     )
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal, assert_allclose,
@@ -53,6 +53,18 @@ class TestLogspace(object):
         assert_(y[-1] < 10 ** 6)
         y = logspace(0, 6, num=7)
         assert_array_equal(y, [1, 10, 100, 1e3, 1e4, 1e5, 1e6])
+
+    def test_start_stop_array(self):
+        start = array([0., 1.])
+        stop = array([6., 7.])
+        t1 = logspace(start, stop, 6)
+        t2 = stack([logspace(_start, _stop, 6)
+                    for _start, _stop in zip(start, stop)], axis=1)
+        assert_equal(t1, t2)
+        t3 = logspace(start, stop[0], 6)
+        t4 = stack([logspace(_start, stop[0], 6)
+                    for _start in start], axis=1)
+        assert_equal(t3, t4)
 
     def test_dtype(self):
         y = logspace(0, 6, dtype='float32')
@@ -156,7 +168,7 @@ class TestGeomspace(object):
         y = geomspace(1, 1e6, dtype=complex)
         assert_equal(y.dtype, dtype('complex'))
 
-    def test_array_scalar(self):
+    def test_start_stop_array_scalar(self):
         lim1 = array([120, 100], dtype="int8")
         lim2 = array([-120, -100], dtype="int8")
         lim3 = array([1200, 1000], dtype="uint16")
@@ -171,6 +183,19 @@ class TestGeomspace(object):
         assert_allclose(t1, t4, rtol=1e-2)
         assert_allclose(t2, t5, rtol=1e-2)
         assert_allclose(t3, t6, rtol=1e-5)
+
+    def test_start_stop_array(self):
+        # Try to use all special cases.
+        start = array([1.e0, 32., 1j, -4j, 1+1j, -1])
+        stop = array([1.e4, 2., 16j, -324j, 10000+10000j, 1])
+        t1 = geomspace(start, stop, 5)
+        t2 = stack([geomspace(_start, _stop, 5)
+                    for _start, _stop in zip(start, stop)], axis=1)
+        assert_equal(t1, t2)
+        t3 = geomspace(start, stop[0], 5)
+        t4 = stack([geomspace(_start, stop[0], 5)
+                    for _start in start], axis=1)
+        assert_equal(t3, t4)
 
     def test_physical_quantities(self):
         a = PhysicalQuantity(1.0)
@@ -227,7 +252,7 @@ class TestLinspace(object):
         y = linspace(0, 6, dtype='int32')
         assert_equal(y.dtype, dtype('int32'))
 
-    def test_array_scalar(self):
+    def test_start_stop_array_scalar(self):
         lim1 = array([-120, 100], dtype="int8")
         lim2 = array([120, -100], dtype="int8")
         lim3 = array([1200, 1000], dtype="uint16")
@@ -240,6 +265,18 @@ class TestLinspace(object):
         assert_equal(t1, t4)
         assert_equal(t2, t5)
         assert_equal(t3, t6)
+
+    def test_start_stop_array(self):
+        start = array([-120, 120], dtype="int8")
+        stop = array([100, -100], dtype="int8")
+        t1 = linspace(start, stop, 5)
+        t2 = stack([linspace(_start, _stop, 5)
+                    for _start, _stop in zip(start, stop)], axis=1)
+        assert_equal(t1, t2)
+        t3 = linspace(start, stop[0], 5)
+        t4 = stack([linspace(_start, stop[0], 5)
+                    for _start in start], axis=1)
+        assert_equal(t3, t4)
 
     def test_complex(self):
         lim1 = linspace(1 + 2j, 3 + 4j, 5)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -65,6 +65,8 @@ class TestLogspace(object):
         t4 = stack([logspace(_start, stop[0], 6)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
+        t5 = logspace(start, stop, 6, axis=-1)
+        assert_equal(t5, t2.T)
 
     def test_dtype(self):
         y = logspace(0, 6, dtype='float32')
@@ -196,6 +198,8 @@ class TestGeomspace(object):
         t4 = stack([geomspace(_start, stop[0], 5)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
+        t5 = geomspace(start, stop, 5, axis=-1)
+        assert_equal(t5, t2.T)
 
     def test_physical_quantities(self):
         a = PhysicalQuantity(1.0)
@@ -277,6 +281,8 @@ class TestLinspace(object):
         t4 = stack([linspace(_start, stop[0], 5)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
+        t5 = linspace(start, stop, 5, axis=-1)
+        assert_equal(t5, t2.T)
 
     def test_complex(self):
         lim1 = linspace(1 + 2j, 3 + 4j, 5)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -289,13 +289,13 @@ class TestHistogram(object):
     def test_object_array_of_0d(self):
         # gh-7864
         assert_raises(ValueError,
-            histogram, [np.array([0.4]) for i in range(10)] + [-np.inf])
+            histogram, [np.array(0.4) for i in range(10)] + [-np.inf])
         assert_raises(ValueError,
-            histogram, [np.array([0.4]) for i in range(10)] + [np.inf])
+            histogram, [np.array(0.4) for i in range(10)] + [np.inf])
 
         # these should not crash
-        np.histogram([np.array([0.5]) for i in range(10)] + [.500000000000001])
-        np.histogram([np.array([0.5]) for i in range(10)] + [.5])
+        np.histogram([np.array(0.5) for i in range(10)] + [.500000000000001])
+        np.histogram([np.array(0.5) for i in range(10)] + [.5])
 
     def test_some_nan_values(self):
         # gh-7503


### PR DESCRIPTION
As discussed on the mailing list, perhaps it would be good for `linspace` to allow `start` and `stop` to be arrays, which are broadcast against each other. For now, this is just a proof of concept - which presumes the final axis that is counted is the first one.  With it, two tests failed, which seem both false positives (in that the tests were not written very well, in one case with a note stating that).

EDIT: TODO from mailing: add `axis` argument (probably with `0` as a default; should be axis in output, so `-1` is last). Could be simple transpose at end, or use reshaping of inputs.

Anyway, with this:
```
In [4]: np.linspace(np.array([1., 2.]), np.array([3., 4.]), 5)
Out[4]: 
array([[1. , 2. ],
       [1.5, 2.5],
       [2. , 3. ],
       [2.5, 3.5],
       [3. , 4. ]])

In [5]: np.linspace(np.array([1., 2.]), np.array([[3.], [4.]]), 5)
Out[5]: 
array([[[1.  , 2.  ],
        [1.  , 2.  ]],

       [[1.5 , 2.25],
        [1.75, 2.5 ]],

       [[2.  , 2.5 ],
        [2.5 , 3.  ]],

       [[2.5 , 2.75],
        [3.25, 3.5 ]],

       [[3.  , 3.  ],
        [4.  , 4.  ]]])
```