### PR TITLE
DEP: raise on a call to deprecated numpy.lib.function_base.unique

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -59,6 +59,9 @@ Expired deprecations
 * NaT comparisons now return ``False`` without a warning, finishing a
   deprecation cycle begun in NumPy 1.11.
 
+* ``np.lib.function_base.unique`` was removed, finishing a deprecation cycle
+  begun in NumPy 1.4. Use `numpy.unique` instead.
+
 Compatibility notes
 ===================
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1621,25 +1621,6 @@ def trim_zeros(filt, trim='fb'):
                 last = last - 1
     return filt[first:last]
 
-
-@deprecate
-def unique(x):
-    """
-    This function is deprecated.  Use numpy.lib.arraysetops.unique()
-    instead.
-    """
-    try:
-        tmp = x.flatten()
-        if tmp.size == 0:
-            return tmp
-        tmp.sort()
-        idx = concatenate(([True], tmp[1:] != tmp[:-1]))
-        return tmp[idx]
-    except AttributeError:
-        items = sorted(set(x))
-        return asarray(items)
-
-
 def _extract_dispatcher(condition, arr):
     return (condition, arr)
 


### PR DESCRIPTION
As [suggested](https://github.com/numpy/numpy/issues/11521#issuecomment-438886448) in #11521, calls to `numpy.lib.function_base.unique`, which was deprecated in 1.4, ~will now raise.~ was removed.

Edit: removed, not raising.