### PR TITLE
DOC: Add release notes for ctypes improvements

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -311,6 +311,21 @@ This is possible thanks to the new
 :c:function:`PyUFunc_FromFuncAndDataAndSignatureAndIdentity`, which allows
 arbitrary values to be used as identities now.
 
+Improved conversion from ctypes objects
+---------------------------------------
+Numpy has always supported taking a value or type from ``ctypes`` and
+converting it into an array or dtype, but only behaved correctly for simpler
+types. As of this release, this caveat is lifted - now:
+
+* The ``_pack_`` attribute of ``ctypes.Structure``, used to emulate C's
+  ``__attribute__((packed))``, is respected.
+* Endianness of all ctypes objects is preserved
+* ``ctypes.Union`` is supported
+* Unrepresentable constructs raise exceptions, rather than producing
+  dangerously incorrect results:
+  * Bitfields are no longer interpreted as sub-arrays
+  * Pointers are no longer replaced with the type that they point to
+
 
 Changes
 =======


### PR DESCRIPTION
Fixes #12272

---

Note: This is pre-empting a patch to address #12273, which I'm hoping we can pull a new contributor in for. We should not merge it without waiting for that to happen, or removing the line about `Union`s from these release notes.