### PR TITLE
BUG: Fall back to 'ascii' locale in build (if needed)

### DIFF
--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -67,8 +67,10 @@ def filepath_from_subprocess_output(output):
 
     Inherited from `exec_command`, and possibly incorrect.
     """
-    output = output.decode(locale.getpreferredencoding(False),
-                           errors='replace')
+    mylocale = locale.getpreferredencoding(False)
+    if mylocale is None:
+        mylocale = 'ascii'
+    output = output.decode(mylocale, errors='replace')
     output = output.replace('\r\n', '\n')
     # Another historical oddity
     if output[-1:] == '\n':
@@ -278,9 +280,10 @@ def _exec_command(command, use_shell=None, use_tee = None, **env):
         return 127, ''
 
     text, err = proc.communicate()
-    text = text.decode(locale.getpreferredencoding(False),
-                       errors='replace')
-
+    mylocale = locale.getpreferredencoding(False)
+    if mylocale is None:
+        mylocale = 'ascii'
+    text = text.decode(mylocale, errors='replace')
     text = text.replace('\r\n', '\n')
     # Another historical oddity
     if text[-1:] == '\n':


### PR DESCRIPTION
If locale.getpreferredencoding(False) returns Null,
the build fails, since commit 5652b0785.
This seems to be not really necessary; here we
provide a fallback to 'ascii' locale if needed, and allow the build
to proceed.

Closes #12403.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
