### PR TITLE
MAINT: rename helper functions for consistency

### DIFF
--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -66,7 +66,7 @@ def _from_ctypes_structure(t):
         return np.dtype(fields, align=True)
 
 
-def dtype_from_ctypes_scalar(t):
+def _from_ctypes_scalar(t):
     """
     Return the dtype type with endianness included if it's the case
     """
@@ -78,7 +78,7 @@ def dtype_from_ctypes_scalar(t):
         return np.dtype(t._type_)
 
 
-def dtype_from_ctypes_union(t):
+def _from_ctypes_union(t):
     formats = []
     offsets = []
     names = []
@@ -105,9 +105,9 @@ def dtype_from_ctypes_type(t):
     elif issubclass(t, _ctypes.Structure):
         return _from_ctypes_structure(t)
     elif issubclass(t, _ctypes.Union):
-        return dtype_from_ctypes_union(t)
+        return _from_ctypes_union(t)
     elif isinstance(t._type_, str):
-        return dtype_from_ctypes_scalar(t)
+        return _from_ctypes_scalar(t)
     else:
         raise NotImplementedError(
             "Unknown ctypes type {}".format(t.__name__))


### PR DESCRIPTION
Some cleanup after #12405 and #12342 