### PR TITLE
BUG: Do not double-quote arguments to the command line

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -19,7 +19,7 @@ from numpy.distutils import log
 from numpy.distutils.compat import get_exception
 from numpy.distutils.exec_command import filepath_from_subprocess_output
 from numpy.distutils.misc_util import cyg2win32, is_sequence, mingw32, \
-                                      quote_args, get_num_build_jobs, \
+                                      get_num_build_jobs, \
                                       _commandline_dep_string
 
 # globals for parallel build management
@@ -772,8 +772,13 @@ ccompiler.new_compiler = new_compiler
 
 _distutils_gen_lib_options = gen_lib_options
 def gen_lib_options(compiler, library_dirs, runtime_library_dirs, libraries):
-    library_dirs = quote_args(library_dirs)
-    runtime_library_dirs = quote_args(runtime_library_dirs)
+    # the version of this function provided by CPython allows the following
+    # to return lists, which are unpacked automatically:
+    # - compiler.runtime_library_dir_option
+    # our version extends the behavior to:
+    # - compiler.library_dir_option
+    # - compiler.library_option
+    # - compiler.find_library_file
     r = _distutils_gen_lib_options(compiler, library_dirs,
                                    runtime_library_dirs, libraries)
     lib_opts = []
@@ -793,11 +798,6 @@ for _cc in ['msvc9', 'msvc', '_msvc', 'bcpp', 'cygwinc', 'emxc', 'unixc']:
     if _m is not None:
         setattr(_m, 'gen_lib_options', gen_lib_options)
 
-_distutils_gen_preprocess_options = gen_preprocess_options
-def gen_preprocess_options (macros, include_dirs):
-    include_dirs = quote_args(include_dirs)
-    return _distutils_gen_preprocess_options(macros, include_dirs)
-ccompiler.gen_preprocess_options = gen_preprocess_options
 
 ##Fix distutils.util.split_quoted:
 # NOTE:  I removed this fix in revision 4481 (see ticket #619), but it appears


### PR DESCRIPTION
After the recent patch to CCompiler.spawn, the file-paths no longer need manual quoting - that's handled as needed within subprocess.

Fixes #12411

---

Quoting the CPython 3.6 source code, this seems to be intended:
```
# XXX *don't* need to be clever about quoting the
# macro value here, because we're going to avoid the
# shell at all costs when we spawn the command!
```

----

let's see if this works on posix...