### PR TITLE
 BUG: Fix regression on np.dtype(ctypes.c_void_p)

### DIFF
--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -66,7 +66,7 @@ def _from_ctypes_structure(t):
         return np.dtype(fields, align=True)
 
 
-def dtype_from_ctypes_scalar(t):
+def _from_ctypes_scalar(t):
     """
     Return the dtype type with endianness included if it's the case
     """
@@ -78,7 +78,7 @@ def dtype_from_ctypes_scalar(t):
         return np.dtype(t._type_)
 
 
-def dtype_from_ctypes_union(t):
+def _from_ctypes_union(t):
     formats = []
     offsets = []
     names = []
@@ -105,9 +105,9 @@ def dtype_from_ctypes_type(t):
     elif issubclass(t, _ctypes.Structure):
         return _from_ctypes_structure(t)
     elif issubclass(t, _ctypes.Union):
-        return dtype_from_ctypes_union(t)
+        return _from_ctypes_union(t)
     elif isinstance(t._type_, str):
-        return dtype_from_ctypes_scalar(t)
+        return _from_ctypes_scalar(t)
     else:
         raise NotImplementedError(
             "Unknown ctypes type {}".format(t.__name__))

--- a/numpy/core/_dtype_ctypes.py
+++ b/numpy/core/_dtype_ctypes.py
@@ -70,9 +70,9 @@ def _from_ctypes_scalar(t):
     """
     Return the dtype type with endianness included if it's the case
     """
-    if t.__ctype_be__ is t:
+    if getattr(t, '__ctype_be__', None) is t:
         return np.dtype('>' + t._type_)
-    elif t.__ctype_le__ is t:
+    elif getattr(t, '__ctype_le__', None) is t:
         return np.dtype('<' + t._type_)
     else:
         return np.dtype(t._type_)
@@ -106,7 +106,7 @@ def dtype_from_ctypes_type(t):
         return _from_ctypes_structure(t)
     elif issubclass(t, _ctypes.Union):
         return _from_ctypes_union(t)
-    elif isinstance(t._type_, str):
+    elif isinstance(getattr(t, '_type_', None), str):
         return _from_ctypes_scalar(t)
     else:
         raise NotImplementedError(

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -807,6 +807,9 @@ class TestFromCTypes(object):
         p_uint8 = ctypes.POINTER(ctypes.c_uint8)
         assert_raises(TypeError, np.dtype, p_uint8)
 
+    def test_void_pointer(self):
+        self.check(ctypes.c_void_p, np.uintp)
+
     def test_union(self):
         class Union(ctypes.Union):
             _fields_ = [


### PR DESCRIPTION
This folds in #12410  too, because why not.