### PR TITLE
MAINT: refactor: arraydescr_new now does not call PyArray_DescrNew 

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -257,9 +257,6 @@ _convert_from_tuple(PyObject *obj, int align)
             return NULL;
         }
         PyArray_DESCR_REPLACE(type);
-        if (type == NULL) {
-            return NULL;
-        }
         if (type->type_num == NPY_UNICODE) {
             type->elsize = itemsize << 2;
         }
@@ -1654,9 +1651,6 @@ finish:
 
     if (PyDataType_ISUNSIZED(*at) && (*at)->elsize != elsize) {
         PyArray_DESCR_REPLACE(*at);
-        if (*at == NULL) {
-            goto fail;
-        }
         (*at)->elsize = elsize;
     }
     if (endian != '=' && PyArray_ISNBO(endian)) {
@@ -1665,9 +1659,6 @@ finish:
     if (endian != '=' && (*at)->byteorder != '|'
         && (*at)->byteorder != endian) {
         PyArray_DESCR_REPLACE(*at);
-        if (*at == NULL) {
-            goto fail;
-        }
         (*at)->byteorder = endian;
     }
     return NPY_SUCCEED;


### PR DESCRIPTION
I started making dtype classes so that the `type(np.dtype('int32'))` is no longer `numpy.dtype` rather a new `numpy.int_type` type that inherits from `numpy.dtype`, the first step in the [plan](https://hackmd.io/cVdS9UyBRayZF-tIW1lC0g#) to refactor dtypes. Rather than a single large PR, I will try to do this in a set of smaller PRs, with an "opt-out" `#ifdef` ... `#else` ... `#endif` around the code.

This PR is the first in the series - a refactoring of the dependency between `arraydescr_new` and `PyArray_DescrNew` so that the latter now calls the former instead of the other way around. ~I also refactored the function to create `datetime64` metadata and moved it to a different place in the file.~

Benchmarking seemed to show no real difference in performance, although there is alot of variance in the `bench_core.CountNonzero.time_count_nonzero` tests