### PR TITLE
BUG: test, fix NPY_VISIBILITY_HIDDEN on gcc, which becomes NPY_NO_EXPORT

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -379,8 +379,9 @@ def check_mathlib(config_cmd):
 def visibility_define(config):
     """Return the define value to use for NPY_VISIBILITY_HIDDEN (may be empty
     string)."""
-    if config.check_compiler_gcc4():
-        return '__attribute__((visibility("hidden")))'
+    hide = '__attribute__((visibility("hidden")))'
+    if config.check_gcc_function_attribute(hide, 'hideme'):
+        return hide
     else:
         return ''
 

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2066,3 +2066,9 @@ init_multiarray_tests(void)
     }
     return RETVAL;
 }
+
+NPY_NO_EXPORT int
+test_not_exported(void)
+{
+    return 1;
+}

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -4,7 +4,10 @@ import sys
 
 import numpy as np
 import pytest
-
+try:
+    import ctypes
+except ImportError:
+    ctypes = None
 
 def check_dir(module, module_name=None):
     """Returns a mapping of all objects with the wrong __module__ attribute."""
@@ -75,3 +78,12 @@ def test_numpy_linalg():
 def test_numpy_fft():
     bad_results = check_dir(np.fft)
     assert bad_results == {}
+
+@pytest.mark.skipif(ctypes is None,
+                    reason="ctypes not available in this python")
+def test_NPY_NO_EXPORT():
+    cdll = ctypes.CDLL(np.core._multiarray_tests.__file__)
+    # Make sure an arbitrary NPY_NO_EXPORT function is actually hidden
+    f = getattr(cdll, 'test_not_exported', None)
+    assert f is None, ("'test_not_exported' is mistakenly exported, "
+                      "NPY_NO_EXPORT does not work")


### PR DESCRIPTION
Fixes #12438. by not limiting the hidden attribute to gcc 4. ~Could be future -proofed by making sure the arbitrary function chosen actually appears in the source files with the `NPY_NO_EXPORT` attribute, or by building a specific shared object for this test, but this at least solves the current issues.~ 

Edit: create a function in `_multiarray_tests`