### PR TITLE
MAINT: Review F401,F841,F842 flake8 errors (unused variables and imports)

### DIFF
--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -163,9 +163,7 @@ def skip_brackets(s, lbrac, rbrac):
 
 def split_arguments(argstr):
     arguments = []
-    bracket_counts = {'(': 0, '[': 0}
     current_argument = []
-    state = 0
     i = 0
     def finish_arg():
         if current_argument:

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -192,7 +192,9 @@ def do_generate_api(targets, sources):
     genapi.check_api_dict(multiarray_api_index)
 
     numpyapi_list = genapi.get_api_functions('NUMPY_API',
-                                              multiarray_funcs)
+                                             multiarray_funcs)
+
+    # FIXME: ordered_funcs_api is unused
     ordered_funcs_api = genapi.order_dict(multiarray_funcs)
 
     # Create dict name -> *Api instance

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -849,7 +849,6 @@ def einsum_path(*operands, **kwargs):
 
     # Python side parsing
     input_subscripts, output_subscript, operands = _parse_einsum_input(operands)
-    subscripts = input_subscripts + '->' + output_subscript
 
     # Build a few useful list and sets
     input_list = input_subscripts.split(',')

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -13,8 +13,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import (
-    assert_raises, assert_warns, assert_no_warnings, assert_array_equal,
-    assert_
+    assert_raises, assert_warns, assert_
     )
 
 try:

--- a/numpy/core/tests/test_extint128.py
+++ b/numpy/core/tests/test_extint128.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
 import itertools
 import contextlib
 import operator
@@ -8,7 +7,6 @@ import pytest
 
 import numpy as np
 import numpy.core._multiarray_tests as mt
-from numpy.compat import long
 
 from numpy.testing import assert_raises, assert_equal
 

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 from numpy import uint16, float16, float32, float64
-from numpy.testing import assert_, assert_equal, suppress_warnings
+from numpy.testing import assert_, assert_equal
 
 
 def assert_raises_fpe(strmatch, callable, *args, **kwargs):

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -10,7 +10,7 @@ from numpy.core import _umath_tests
 from numpy.lib.stride_tricks import as_strided
 from numpy.compat import long
 from numpy.testing import (
-    assert_, assert_raises, assert_equal, assert_array_equal, assert_allclose
+    assert_, assert_raises, assert_equal, assert_array_equal
     )
 
 if sys.version_info[0] >= 3:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4866,11 +4866,11 @@ class TestRecord(object):
         assert_equal(dt.names, ['p', 'q'])
 
     def test_multiple_field_name_occurrence(self):
-        def test_assign():
+        def test_dtype_init():
             np.dtype([("A", "f8"), ("B", "f8"), ("A", "f8")])
 
         # Error raised when multiple fields have the same name
-        assert_raises(ValueError, test_assign)
+        assert_raises(ValueError, test_dtype_init)
 
     @pytest.mark.skipif(sys.version_info[0] < 3, reason="Not Python 3")
     def test_bytes_fields(self):
@@ -7514,7 +7514,8 @@ class TestWritebackIfCopy(object):
     def test_clip_with_out(self):
         mat = np.eye(5)
         out = np.eye(5, dtype='i2')
-        np.clip(mat, a_min=-10, a_max=0, out=out)
+        res = np.clip(mat, a_min=-10, a_max=0, out=out)
+        assert_(res is out)
         assert_equal(np.sum(out), 0)
 
     def test_insert_noncontiguous(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3593,7 +3593,6 @@ class TestPickling(object):
                                 'protocol 5 although it is not available'))
     def test_correct_protocol5_error_message(self):
         array = np.arange(10)
-        f = io.BytesIO()
 
         if sys.version_info[:2] in ((3, 6), (3, 7)):
             # For the specific case of python3.6 and 3.7, raise a clear import
@@ -4868,7 +4867,7 @@ class TestRecord(object):
 
     def test_multiple_field_name_occurrence(self):
         def test_assign():
-            dtype = np.dtype([("A", "f8"), ("B", "f8"), ("A", "f8")])
+            np.dtype([("A", "f8"), ("B", "f8"), ("A", "f8")])
 
         # Error raised when multiple fields have the same name
         assert_raises(ValueError, test_assign)
@@ -4892,9 +4891,7 @@ class TestRecord(object):
     @pytest.mark.skipif(sys.version_info[0] < 3, reason="Not Python 3")
     def test_multiple_field_name_unicode(self):
         def test_assign_unicode():
-            dt = np.dtype([("\u20B9", "f8"),
-                           ("B", "f8"),
-                           ("\u20B9", "f8")])
+            np.dtype([("\u20B9", "f8"), ("B", "f8"), ("\u20B9", "f8")])
 
         # Error raised when multiple fields have the same name(unicode included)
         assert_raises(ValueError, test_assign_unicode)
@@ -6818,7 +6815,7 @@ class TestNewBufferProtocol(object):
         # gh-11150, due to bpo-10746
         for c_integer in {ctypes.c_int, ctypes.c_long, ctypes.c_longlong}:
             value = c_integer(42)
-            with warnings.catch_warnings(record=True) as w:
+            with warnings.catch_warnings(record=True):
                 warnings.filterwarnings('always', r'.*\bctypes\b', RuntimeWarning)
                 np.asarray(value)
 
@@ -6828,7 +6825,7 @@ class TestNewBufferProtocol(object):
             _fields_ = [('a', ctypes.c_uint8), ('b', ctypes.c_uint32)]
         f = foo(a=1, b=2)
 
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             warnings.filterwarnings('always', r'.*\bctypes\b', RuntimeWarning)
             arr = np.asarray(f)
 
@@ -7517,7 +7514,7 @@ class TestWritebackIfCopy(object):
     def test_clip_with_out(self):
         mat = np.eye(5)
         out = np.eye(5, dtype='i2')
-        res = np.clip(mat, a_min=-10, a_max=0, out=out)
+        np.clip(mat, a_min=-10, a_max=0, out=out)
         assert_equal(np.sum(out), 0)
 
     def test_insert_noncontiguous(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4930,11 +4930,11 @@ class TestRecord(object):
 
     @pytest.mark.skipif(sys.version_info[0] < 3, reason="Not Python 3")
     def test_multiple_field_name_unicode(self):
-        def test_assign_unicode():
+        def test_dtype_unicode():
             np.dtype([("\u20B9", "f8"), ("B", "f8"), ("\u20B9", "f8")])
 
         # Error raised when multiple fields have the same name(unicode included)
-        assert_raises(ValueError, test_assign_unicode)
+        assert_raises(ValueError, test_dtype_unicode)
 
     @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Not Python 2")
     def test_unicode_field_titles(self):

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1,14 +1,13 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import warnings
 import pytest
 
 import numpy as np
 import numpy.core._multiarray_tests as _multiarray_tests
 from numpy import array, arange, nditer, all
 from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, assert_raises, assert_warns,
+    assert_, assert_equal, assert_array_equal, assert_raises,
     HAS_REFCOUNT, suppress_warnings
     )
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -13,7 +13,7 @@ from numpy.random import rand, randint, randn
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
-    suppress_warnings, HAS_REFCOUNT
+    HAS_REFCOUNT
     )
 
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -7,7 +7,6 @@ try:
     import collections.abc as collections_abc
 except ImportError:
     import collections as collections_abc
-import warnings
 import textwrap
 from os import path
 import pytest
@@ -16,7 +15,7 @@ import numpy as np
 from numpy.compat import Path
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
-    assert_raises, assert_warns, temppath
+    assert_raises, temppath
     )
 from numpy.core.numeric import pickle
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2,9 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import copy
 import sys
-import platform
 import gc
-import warnings
 import tempfile
 import pytest
 from os import path
@@ -2409,7 +2407,7 @@ class TestRegression(object):
         t = np.dtype([((s, 'f1'), np.float64)])
         data = np.zeros(10, t)
         for i in range(10):
-            v = str(data[['f1']])
+            str(data[['f1']])
             if HAS_REFCOUNT:
                 assert_(base <= sys.getrefcount(s))
 

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -67,7 +67,6 @@ class TestCharacter(object):
 
     def test_char_repeat(self):
         np_s = np.string_('abc')
-        np_u = np.unicode_('abc')
         np_i = np.int(5)
         res_np = np_s * np_i
         res_s = b'abc' * 5

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -70,6 +70,6 @@ class TestCharacter(object):
         np_u = np.unicode_('abc')
         np_i = np.int(5)
         res_s = b'abc' * 5
-        res_u = 'abc' * 5
+        res_u = u'abc' * 5
         assert_(np_s * np_i == res_s)
         assert_(np_u * np_i == res_u)

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -67,7 +67,9 @@ class TestCharacter(object):
 
     def test_char_repeat(self):
         np_s = np.string_('abc')
+        np_u = np.unicode_('abc')
         np_i = np.int(5)
-        res_np = np_s * np_i
         res_s = b'abc' * 5
-        assert_(res_np == res_s)
+        res_u = 'abc' * 5
+        assert_(np_s * np_i == res_s)
+        assert_(np_u * np_i == res_u)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -184,6 +184,7 @@ class TestPower(object):
         a = 5
         b = 4
         c = 10
+        expected = pow(a, b, c)  # noqa: F841
         for t in (np.int32, np.float32, np.complex64):
             # note that 3-operand power only dispatches on the first argument
             assert_raises(TypeError, operator.pow, t(a), b, c)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import (
-    assert_, assert_equal, assert_raises, assert_almost_equal, assert_allclose,
+    assert_, assert_equal, assert_raises, assert_almost_equal,
     assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
     assert_warns
     )
@@ -184,7 +184,6 @@ class TestPower(object):
         a = 5
         b = 4
         c = 10
-        expected = pow(a, b, c)
         for t in (np.int32, np.float32, np.complex64):
             # note that 3-operand power only dispatches on the first argument
             assert_raises(TypeError, operator.pow, t(a), b, c)

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -10,7 +10,7 @@ import pytest
 
 from tempfile import TemporaryFile
 import numpy as np
-from numpy.testing import assert_, assert_equal, suppress_warnings, dec
+from numpy.testing import assert_, assert_equal, suppress_warnings
 
 class TestRealScalars(object):
     def test_str(self):

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import pytest
-import warnings
 import sys
 import numpy as np
 from numpy.core import (
@@ -12,7 +11,7 @@ from numpy.core.shape_base import (_block_dispatcher, _block_setup,
                                    _block_concatenate, _block_slicing)
 from numpy.testing import (
     assert_, assert_raises, assert_array_equal, assert_equal,
-    assert_raises_regex, assert_warns, assert_almost_equal
+    assert_raises_regex, assert_warns
     )
 
 from numpy.compat import long

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
 import platform
 import warnings
 import fnmatch
@@ -14,7 +13,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_allclose, assert_no_warnings, suppress_warnings,
-    _gen_alignment_data, assert_warns
+    _gen_alignment_data
     )
 
 
@@ -1298,6 +1297,7 @@ class TestSign(object):
         # In reference to github issue #6229
         def test_nan():
             foo = np.array([np.nan])
+            # FIXME: a not used
             a = np.sign(foo.astype(object))
 
         assert_raises(TypeError, test_nan)

--- a/numpy/distutils/__init__.py
+++ b/numpy/distutils/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-
 from .__version__ import version as __version__
 # Must import local ccompiler ASAP in order to get
 # customized CCompiler.spawn effective.

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -204,7 +204,6 @@ class build_src(build_ext.build_ext):
 
 
     def _build_npy_pkg_config(self, info, gd):
-        import shutil
         template, install_dir, subst_dict = info
         template_dir = os.path.dirname(template)
         for k, v in gd.items():
@@ -239,7 +238,6 @@ class build_src(build_ext.build_ext):
         if not install_cmd.finalized == 1:
             install_cmd.finalize_options()
         build_npkg = False
-        gd = {}
         if self.inplace == 1:
             top_prefix = '.'
             build_npkg = True

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -95,7 +95,7 @@ Original exception was: %s, and the Compiler class was %s
         try:
             ret = mth(*((self,)+args))
         except (DistutilsExecError, CompileError):
-            msg = str(get_exception())
+            str(get_exception())
             self.compiler = save_compiler
             raise CompileError
         self.compiler = save_compiler

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1691,7 +1691,6 @@ class Configuration(object):
         """
         if subst_dict is None:
             subst_dict = {}
-        basename = os.path.splitext(template)[0]
         template = os.path.join(self.package_path, template)
 
         if self.name in self.installed_pkg_config:
@@ -2225,7 +2224,6 @@ def is_bootstrapping():
         return True
     except AttributeError:
         return False
-        __NUMPY_SETUP__ = False
 
 
 #########################

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2224,8 +2224,6 @@ def is_bootstrapping():
         return True
     except AttributeError:
         return False
-        # FIXME: below code is never reached
-        __NUMPY_SETUP__ = False
 
 
 #########################

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2224,6 +2224,8 @@ def is_bootstrapping():
         return True
     except AttributeError:
         return False
+        # FIXME: below code is never reached
+        __NUMPY_SETUP__ = False
 
 
 #########################

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1124,6 +1124,8 @@ class atlas_info(system_info):
         lapack = None
         atlas_1 = None
         for d in lib_dirs:
+            # FIXME: lapack_atlas is unused
+            lapack_atlas = self.check_libs2(d, ['lapack_atlas'], [])
             atlas = self.check_libs2(d, atlas_libs, [])
             if atlas is not None:
                 lib_dirs2 = [d] + self.combine_paths(d, ['atlas*', 'ATLAS*'])

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1125,7 +1125,6 @@ class atlas_info(system_info):
         atlas_1 = None
         for d in lib_dirs:
             atlas = self.check_libs2(d, atlas_libs, [])
-            lapack_atlas = self.check_libs2(d, ['lapack_atlas'], [])
             if atlas is not None:
                 lib_dirs2 = [d] + self.combine_paths(d, ['atlas*', 'ATLAS*'])
                 lapack = self.check_libs2(lib_dirs2, lapack_libs, [])
@@ -2107,17 +2106,17 @@ class numerix_info(system_info):
         if which[0] is None:
             which = "numpy", "defaulted"
             try:
-                import numpy
+                import numpy  # noqa: F401
                 which = "numpy", "defaulted"
             except ImportError:
                 msg1 = str(get_exception())
                 try:
-                    import Numeric
+                    import Numeric  # noqa: F401
                     which = "numeric", "defaulted"
                 except ImportError:
                     msg2 = str(get_exception())
                     try:
-                        import numarray
+                        import numarray  # noqa: F401
                         which = "numarray", "defaulted"
                     except ImportError:
                         msg3 = str(get_exception())
@@ -2437,7 +2436,6 @@ class umfpack_info(system_info):
                         define_macros=[('SCIPY_UMFPACK_H', None)],
                         swig_opts=['-I' + inc_dir])
 
-        amd = get_info('amd')
         dict_append(info, **get_info('amd'))
 
         self.set_info(**info)
@@ -2533,6 +2531,7 @@ def show_all(argv=None):
             del show_only[show_only.index(name)]
         conf = c()
         conf.verbosity = 2
+        # FIXME: r not used
         r = conf.get_info()
     if show_only:
         log.info('Info classes not defined: %s', ','.join(show_only))

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -78,4 +78,4 @@ class TestSharedExtension(object):
 def test_installed_npymath_ini():
     # Regression test for gh-7707.  If npymath.ini wasn't installed, then this
     # will give an error.
-    info = get_info('npymath')
+    get_info('npymath')

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -78,4 +78,7 @@ class TestSharedExtension(object):
 def test_installed_npymath_ini():
     # Regression test for gh-7707.  If npymath.ini wasn't installed, then this
     # will give an error.
-    get_info('npymath')
+    info = get_info('npymath')
+
+    assert isinstance(info, dict)
+    assert "define_macros" in info

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import textwrap
 import sys
 import pytest
 from . import util

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
 import pytest
 
 import numpy as np

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -4,12 +4,8 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import os
-import uuid
 from importlib import import_module
 import pytest
-
-import numpy.f2py
 
 from numpy.testing import assert_equal
 from . import util

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import math
 import pytest
 
 import numpy as np

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -15,9 +15,7 @@ import shutil
 import atexit
 import textwrap
 import re
-import random
 import pytest
-import numpy.f2py
 
 from numpy.compat import asbytes, asstr
 from numpy.testing import temppath
@@ -26,7 +24,7 @@ from importlib import import_module
 try:
     from hashlib import md5
 except ImportError:
-    from md5 import new as md5
+    from md5 import new as md5  # noqa: F401
 
 #
 # Maintaining a temporary module directory

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -8,7 +8,7 @@ __docformat__ = "restructuredtext en"
 import sys
 import numpy as np
 import numpy.core.numeric as nx
-from numpy.compat import asbytes, asunicode, bytes, asbytes_nested, basestring
+from numpy.compat import asbytes, asunicode, bytes, basestring
 
 if sys.version_info[0] >= 3:
     from builtins import bool, int, float, complex, object, str

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -949,7 +949,6 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
 
     fields = _get_fields_and_offsets(arr.dtype)
     names, dts, counts, offsets = zip(*fields)
-    n_fields = len(names)
 
     if dtype is None:
         out_dtype = np.result_type(*[dt.base for dt in dts])

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
 import time
 from datetime import date
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -4,7 +4,6 @@
 from __future__ import division, absolute_import, print_function
 
 import numpy as np
-import sys
 
 from numpy.testing import (assert_array_equal, assert_equal,
                            assert_raises, assert_raises_regex)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -287,7 +287,6 @@ from io import BytesIO
 import numpy as np
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises, assert_raises_regex,
-    raises
     )
 from numpy.lib import format
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -11,17 +11,15 @@ from numpy import ma
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_almost_equal,
     assert_array_almost_equal, assert_raises, assert_allclose,
-    assert_array_max_ulp, assert_warns, assert_raises_regex, suppress_warnings,
-    HAS_REFCOUNT,
+    assert_warns, assert_raises_regex, suppress_warnings, HAS_REFCOUNT,
     )
 import numpy.lib.function_base as nfb
 from numpy.random import rand
 from numpy.lib import (
     add_newdoc_ufunc, angle, average, bartlett, blackman, corrcoef, cov,
     delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
-    histogram, histogramdd, i0, insert, interp, kaiser, meshgrid, msort,
-    piecewise, place, rot90, select, setxor1d, sinc, split, trapz, trim_zeros,
-    unwrap, unique, vectorize
+    i0, insert, interp, kaiser, meshgrid, msort, piecewise, place, rot90,
+    select, setxor1d, sinc, trapz, trim_zeros, unwrap, unique, vectorize
     )
 
 from numpy.compat import long

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -6,7 +6,7 @@ from numpy.lib.histograms import histogram, histogramdd, histogram_bin_edges
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_almost_equal,
     assert_array_almost_equal, assert_raises, assert_allclose,
-    assert_array_max_ulp, assert_warns, assert_raises_regex, suppress_warnings,
+    assert_array_max_ulp, assert_raises_regex, suppress_warnings,
     )
 
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -6,7 +6,6 @@ import os
 import threading
 import time
 import warnings
-import gc
 import io
 import re
 import pytest
@@ -18,7 +17,7 @@ import locale
 import numpy as np
 import numpy.ma as ma
 from numpy.lib._iotools import ConverterError, ConversionWarning
-from numpy.compat import asbytes, bytes, unicode, Path
+from numpy.compat import asbytes, bytes, Path
 from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     assert_warns, assert_, assert_raises_regex, assert_raises,
@@ -2049,7 +2048,6 @@ M   33  21.99
 
     def test_utf8_file(self):
         utf8 = b"\xcf\x96"
-        latin1 = b"\xf6\xfc\xf6"
         with temppath() as path:
             with open(path, "wb") as f:
                 f.write((b"test1,testNonethe" + utf8 + b",test3\n") * 2)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2205,6 +2205,7 @@ def lstsq(a, b, rcond="warn"):
         raise LinAlgError('Incompatible dimensions')
 
     t, result_t = _commonType(a, b)
+    # FIXME: real_t is unused
     real_t = _linalgRealType(t)
     result_real_t = _realType(result_t)
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -13,7 +13,7 @@ import pytest
 
 import numpy as np
 from numpy import array, single, double, csingle, cdouble, dot, identity, matmul
-from numpy import multiply, atleast_2d, inf, asarray, matrix
+from numpy import multiply, atleast_2d, inf, asarray
 from numpy import linalg
 from numpy.linalg import matrix_power, norm, matrix_rank, multi_dot, LinAlgError
 from numpy.linalg.linalg import _multi_dot_matrix_chain_order
@@ -955,7 +955,6 @@ class TestMatrixPower(object):
     dtnoinv = [object, np.dtype('e'), np.dtype('g'), np.dtype('G')]
 
     def test_large_power(self, dt):
-        power = matrix_power
         rshft = self.rshft_1.astype(dt)
         assert_equal(
             matrix_power(rshft, 2**100 + 2**10 + 2**5 + 0), self.rshft_0)
@@ -1619,8 +1618,6 @@ class TestQR(object):
     def test_qr_empty(self, m, n):
         k = min(m, n)
         a = np.empty((m, n))
-        a_type = type(a)
-        a_dtype = a.dtype
 
         self.check_qr(a)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -26,7 +26,7 @@ from numpy.testing import (
     assert_raises, assert_warns, suppress_warnings
     )
 from numpy import ndarray
-from numpy.compat import asbytes, asbytes_nested
+from numpy.compat import asbytes
 from numpy.ma.testutils import (
     assert_, assert_array_equal, assert_equal, assert_almost_equal,
     assert_equal_records, fail_if_equal, assert_not_equal,
@@ -233,7 +233,7 @@ class TestMaskedArray(object):
         x = np.array([('A', 0)], dtype={'names':['f0','f1'],
                                         'formats':['S4','i8'],
                                         'offsets':[0,8]})
-        data = array(x) # used to fail due to 'V' padding field in x.dtype.descr
+        array(x)  # used to fail due to 'V' padding field in x.dtype.descr
 
     def test_asarray(self):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -14,7 +14,7 @@ import itertools
 
 import numpy as np
 from numpy.testing import (
-    assert_warns, suppress_warnings, assert_raises,
+    assert_warns, suppress_warnings
     )
 from numpy.ma.testutils import (
     assert_, assert_array_equal, assert_equal, assert_almost_equal
@@ -29,9 +29,8 @@ from numpy.ma.extras import (
     ediff1d, apply_over_axes, apply_along_axis, compress_nd, compress_rowcols,
     mask_rowcols, clump_masked, clump_unmasked, flatnotmasked_contiguous,
     notmasked_contiguous, notmasked_edges, masked_all, masked_all_like, isin,
-    diagflat, stack, vstack, hstack
+    diagflat, stack, vstack
     )
-import numpy.ma.extras as mae
 
 
 class TestGeneric(object):

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -7,8 +7,6 @@
 """
 from __future__ import division, absolute_import, print_function
 
-import warnings
-
 import numpy as np
 import numpy.ma as ma
 from numpy import recarray

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -8,7 +8,6 @@ import numpy.core.fromnumeric as fromnumeric
 from numpy.testing import (
     assert_, assert_raises, assert_equal,
     )
-from numpy.ma.testutils import assert_array_equal
 from numpy.ma import (
     MaskType, MaskedArray, absolute, add, all, allclose, allequal, alltrue,
     arange, arccos, arcsin, arctan, arctan2, array, average, choose,

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import warnings
-
 import numpy as np
 from numpy.testing import (
     assert_, assert_array_equal, assert_allclose, suppress_warnings

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 try:
     # Accessing collections abstract classes from collections
     # has been deprecated since Python 3.3

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 import numpy as np
 from numpy.ma.testutils import (assert_, assert_equal, assert_raises,
                                 assert_array_equal)

--- a/numpy/matrixlib/tests/test_matrix_linalg.py
+++ b/numpy/matrixlib/tests/test_matrix_linalg.py
@@ -1,8 +1,6 @@
 """ Test functions for linalg module using the matrix class."""
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 import numpy as np
 
 from numpy.linalg.tests.test_linalg import (

--- a/numpy/matrixlib/tests/test_multiarray.py
+++ b/numpy/matrixlib/tests/test_multiarray.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_array_equal
 

--- a/numpy/matrixlib/tests/test_numeric.py
+++ b/numpy/matrixlib/tests/test_numeric.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_equal
 

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import pytest
-
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1096,7 +1096,7 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
             if n > 1:
                 tmp[2] = c[1]/4
             for j in range(2, n):
-                t = c[j]/(2*j + 1)
+                t = c[j]/(2*j + 1)  # FIXME: t never used
                 tmp[j + 1] = c[j]/(2*(j + 1))
                 tmp[j - 1] -= c[j]/(2*(j - 1))
             tmp[0] += k[i] - chebval(lbnd, tmp)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -19,7 +19,7 @@ from warnings import WarningMessage
 import pprint
 
 from numpy.core import(
-     bool_, float32, empty, arange, array_repr, ndarray, isnat, array)
+     float32, empty, arange, array_repr, ndarray, isnat, array)
 from numpy.lib.utils import deprecate
 
 if sys.version_info[0] >= 3:
@@ -687,7 +687,6 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          equal_inf=True):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, isnan, inf, bool_
-    from numpy.core.fromnumeric import all as npall
 
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -946,7 +945,7 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
-    from numpy.core import around, number, float_, result_type, array
+    from numpy.core import number, float_, result_type, array
     from numpy.core.numerictypes import issubdtype
     from numpy.core.fromnumeric import any as npany
 

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -13,7 +13,7 @@ from numpy.testing import (
 
 
 try:
-    import nose
+    import nose  # noqa: F401
 except ImportError:
     HAVE_NOSE = False
 else:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1432,7 +1432,7 @@ def test_tempdir():
 
 def test_temppath():
     with temppath() as fpath:
-        with open(fpath, 'w') as f:
+        with open(fpath, 'w'):
             pass
     assert_(not os.path.isfile(fpath))
 

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -7,7 +7,7 @@ from __future__ import division, print_function, absolute_import
 import sys
 import os
 import pytest
-from os.path import join as pathjoin, isfile, dirname, basename
+from os.path import join as pathjoin, isfile, dirname
 from subprocess import Popen, PIPE
 
 import numpy as np


### PR DESCRIPTION
In this PR I run the flake8 on checks corresponding to unused imports and variables,
```
flake8 --select=F401,F841,F842 numpy
```
and selectively removed those I thought should be harmless. For unused variables that looked suspicious, a `FIXME` comment was added.

Unused imports is an issue beyond code style as it makes dependencies between modules harder to understand (not that there much issues with that in numpy -- this PR mostly changes test files).


This should also help with LGTM.com warnings.