### PR TITLE
TST: use condition directive for Azure 2.7 check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,12 +122,12 @@ jobs:
       architecture: $(PYTHON_ARCH)
    # as noted by numba project, currently need
    # specific VC install for Python 2.7
-   # NOTE: had some issues splitting powershell
-   # command into bits and / or using condition
-   # directive, so squeezing operation to a single
-   # line for now
-  - powershell: if ($env:PYTHON_VERSION -eq 2.7) {$wc = New-Object net.webclient; $wc.Downloadfile("https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi", "VCForPython27.msi"); Start-Process "VCForPython27.msi" /qn -Wait}
+  - powershell: |
+      $wc = New-Object net.webclient
+      $wc.Downloadfile("https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi", "VCForPython27.msi")
+      Start-Process "VCForPython27.msi" /qn -Wait
     displayName: 'Install VC 9.0'
+    condition: eq(variables['PYTHON_VERSION'], '2.7')
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: python -m pip install cython nose pytz pytest


### PR DESCRIPTION
The Azure `condition` directive and multi-line powershell commands work just fine now as evidenced by my recent work on the [SciPy Azure CI PR](https://github.com/scipy/scipy/pull/9542) & the recent adoption of the `condition` directive in the `numba` project CI.

This replaces the long single-line jumble with in-line version checking, and produces a nice mouse-over dialog box in Azure GUI when skipped in CI for non-2.7 test runs.

Of course, 2.7 support is on the way out and if this isn't a sufficiently useful clean-up I suppose we may just mutate this PR into removing 2.7 from the matrix, but I'll leave that up to reviewers.