### PR TITLE
TST: openblas for Azure MacOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,21 +59,33 @@ jobs:
   # two C compilers, but with homebrew looks like we're
   # now stuck getting the full gcc toolchain instead of
   # just pulling in gfortran
-  - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc
+  - script: |
+      # same version of gfortran as the wheel builds
+      brew install gcc49
+      # manually link critical gfortran libraries
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libgfortran.3.dylib /usr/local/lib/libgfortran.3.dylib
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libquadmath.0.dylib /usr/local/lib/libquadmath.0.dylib
+      # manually symlink gfortran-4.9 to plain gfortran
+      # for f2py
+      ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
     displayName: 'make gfortran available on mac os vm'
+  # use the pre-built openblas binary that most closely
+  # matches our MacOS wheel builds -- currently based
+  # primarily on file size / name details
+  - script: |
+      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz"
+      tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+      # manually link to appropriate system paths
+      cp ./usr/local/lib/* /usr/local/lib/
+      cp ./usr/local/include/* /usr/local/include/
+    displayName: 'install pre-built openblas'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: python -m pip install cython nose pytz pytest pickle5 vulture docutils sphinx>=1.8.3 numpydoc matplotlib
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
     displayName: 'Check for unreachable code paths in Python modules'
-  # NOTE: init_dgelsd failed init issue with current ACCELERATE /
-  # LAPACK configuration on Azure macos image; at the time of writing
-  # this plagues homebrew / macports NumPy builds, but we will
-  # circumvent for now by aggressively disabling acceleration for
-  # macos NumPy builds / tests; ACCELERATE=None on its own is not
-  # sufficient
-  # also, might as well prefer usage of clang over gcc proper
+  # prefer usage of clang over gcc proper
   # to match likely scenario on many user mac machines
   - script: python setup.py build -j 4 install
     displayName: 'Build NumPy'


### PR DESCRIPTION
**Objective**: test the MacOS configuration that most closely matches what many users have access to (wheels built with `openblas`) & perhaps slightly reduce the testing dissonance between development CI & numpy-wheel CI builds, by building with `openblas`.

<details>

[Reference to `brew install openblas`](https://github.com/matthew-brett/multibuild/blob/devel/library_builders.sh#L99) in `multibuild` repo

Previously, in [a master branch run](https://dev.azure.com/numpy/numpy/_build/results?buildId=1024&view=logs) for MacOS / Python 3.6 Azure: `7218 passed, 39 skipped, 10 xfailed, 1 xpassed in 309.53 seconds`

Azure CI result for MacOS with openblas in this branch should be: `7217 passed, 40 skipped, 10 xfailed, 1 xpassed in 298.79 seconds`
  - 1 extra test skip related to `xerbla` & not clear if this is skipped in our matching Python 3.6 MacOS [wheel build log](https://api.travis-ci.org/v3/job/460421265/log.txt) where test skips aren't verbose, but far more tests are skipped (`167` to `170`).

The `Build NumPy` stage should now clearly show `openblas` as `FOUND` by distutils, and the end of this stage should no longer print the warnings about various missing linalg acceleration libraries.


</details>