### PR TITLE
MAINT, DOC: fix Azure README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![AppVeyor](https://img.shields.io/appveyor/ci/charris/numpy/master.svg?label=AppVeyor)](
     https://ci.appveyor.com/project/charris/numpy)
 [![Azure](https://dev.azure.com/numpy/numpy/_apis/build/status/azure-pipeline%20numpy.numpy)](
-    https://dev.azure.com/numpy/numpy/_apis/build/status/azure-pipeline%20numpy.numpy?branchName=master)
+    https://dev.azure.com/numpy/numpy/_build/latest?definitionId=5)
 [![codecov](https://codecov.io/gh/numpy/numpy/branch/master/graph/badge.svg)](
     https://codecov.io/gh/numpy/numpy)
 


### PR DESCRIPTION
Our `README` file / repo landing page currently has an Azure badge that links to nothing more than a new page with the Azure badge image.

This PR follows the [latest Azure docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started-yaml?view=vsts#add-a-ci-status-badge-to-your-repository) for placing the badge / link in a project readme, and seems to work.

More than likely happened either because of our early-adoption of the service and / or the various adjustments we had to make to the configurations / pipelines to get things working just right.