### PR TITLE
ENH: Add AVX2 and AVX512 functionality for numpy.sqrt

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -941,6 +941,43 @@ sse2_binary_scalar2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, @type@ * ip2, npy
 static void
 sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 {
+#ifdef __AVX512F__
+    /* align output to VECTOR_SIZE_BYTES bytes */
+    LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
+        op[i] = @scalarf@(ip[i]);
+    }
+    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) || npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
+    if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
+        LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
+            @vtype512@ d = @vpre512@_load_@vsuf@(&ip[i]);
+            @vpre512@_store_@vsuf@(&op[i], @vpre512@_sqrt_@vsuf@(d));
+        }
+    }
+    else {
+        LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
+            @vtype512@ d = @vpre512@_loadu_@vsuf@(&ip[i]);
+            @vpre512@_store_@vsuf@(&op[i], @vpre512@_sqrt_@vsuf@(d));
+        }
+    }
+#elif __AVX2__
+    /* align output to VECTOR_SIZE_BYTES bytes */
+    LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
+        op[i] = @scalarf@(ip[i]);
+    }
+    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) || npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
+    if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
+        LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
+            @vtype256@ d = @vpre256@_load_@vsuf@(&ip[i]);
+            @vpre256@_store_@vsuf@(&op[i], @vpre256@_sqrt_@vsuf@(d));
+        }
+    }
+    else {
+        LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
+            @vtype256@ d = @vpre256@_loadu_@vsuf@(&ip[i]);
+            @vpre256@_store_@vsuf@(&op[i], @vpre256@_sqrt_@vsuf@(d));
+        }
+    }
+#else
     /* align output to VECTOR_SIZE_BYTES bytes */
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
         op[i] = @scalarf@(ip[i]);
@@ -959,6 +996,7 @@ sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
             @vpre@_store_@vsuf@(&op[i], @vpre@_sqrt_@vsuf@(d));
         }
     }
+#endif
     LOOP_BLOCKED_END {
         op[i] = @scalarf@(ip[i]);
     }

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -946,7 +946,8 @@ sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
         op[i] = @scalarf@(ip[i]);
     }
-    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) || npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
+    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
+	    npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
     if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
             @vtype512@ d = @vpre512@_load_@vsuf@(&ip[i]);
@@ -964,7 +965,8 @@ sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
         op[i] = @scalarf@(ip[i]);
     }
-    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) || npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
+    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
+	    npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
     if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
             @vtype256@ d = @vpre256@_load_@vsuf@(&ip[i]);


### PR DESCRIPTION
In microbenchmarks which measured TSC cycles for SSE2, AVX2 and AVX512
versions of the sqrt function, AVX2 and AVX512 showed a 1.99x and 3.6x
performance improvement over SSE2. The experiments were performed on
Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz. Detailed numbers are listed
below:

| Arraysize | Speed up with AVX2 | Speed up with AVX512 |
|-----------|--------------------|----------------------|
| 5000      | 1.99173            | 3.76                 |
| 20000     | 1.99784            | 3.69                 |
| 40000     | 1.99861            | 3.85                 |
| 80000     | 1.99891            | 3.85                 |
| 160000    | 1.99957            | 3.86                 |
| 320000    | 1.99521            | 3.86                 |
| 640000    | 1.99623            | 3.86                 |
| 1280000   | 1.99966            | 3.81                 |
| 2560000   | 1.96163            | 3.38                 |
| 5120000   | 1.92656            | 3.24                 |
| 10240000  | 1.92680            | 3.17                 |
| 20480000  | 1.92289            | 3.12                 |

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
