### PR TITLE
BUG: IndexError for empty list on structured MaskedArray.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -780,7 +780,7 @@ def fix_invalid(a, mask=nomask, copy=True, fill_value=None):
 
 def is_string_or_list_of_strings(val):
     return (isinstance(val, basestring) or
-            (isinstance(val, list) and
+            (isinstance(val, list) and val and
              builtins.all(isinstance(s, basestring) for s in val)))
 
 ###############################################################################
@@ -6340,7 +6340,7 @@ class MaskedConstant(MaskedArray):
 
     def __copy__(self):
         return self
-		
+
     def __deepcopy__(self, memo):
         return self
 
@@ -7089,7 +7089,7 @@ def where(condition, x=_NoValue, y=_NoValue):
     Parameters
     ----------
     condition : array_like, bool
-        Where True, yield `x`, otherwise yield `y`. 
+        Where True, yield `x`, otherwise yield `y`.
     x, y : array_like, optional
         Values from which to choose. `x`, `y` and `condition` need to be
         broadcastable to some shape.

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -84,3 +84,8 @@ class TestRegression(object):
         assert_(a.mask.shape == (2,))
         assert_(b.shape == (2, 2))
         assert_(b.mask.shape == (2, 2))
+
+    def test_empty_list_on_structured(self):
+        # See gh-12464. Indexing with empty list should give empty result.
+        ma = np.ma.MaskedArray([(1, 1.), (2, 2.), (3, 3.)], dtype='i4,f4')
+        assert_array_equal(ma[[]], ma[:0])


### PR DESCRIPTION
This should give an empty result, not an error.  The problem was that the empty list was interpreted as a list of strings.

Found by astropy testing (https://github.com/astropy/astropy/issues/8199)

Would be good to include in 1.16.0...