### PR TITLE
TST: use openblas for Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,11 @@ jobs:
 - job: Windows
   pool:
     vmIMage: 'VS2017-Win2016'
+  variables:
+      # openblas URLs from numpy-wheels
+      # appveyor / Windows config
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win_amd64-gcc_7_1_0.zip"
   strategy:
     maxParallel: 6
     matrix:
@@ -92,28 +97,40 @@ jobs:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
+          OPENBLAS: $(OPENBLAS_32)
+          BITS: 32
         Python37-32bit-fast:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
+          OPENBLAS: $(OPENBLAS_32)
+          BITS: 32
         Python27-64bit-fast:
           PYTHON_VERSION: '2.7'
           PYTHON_ARCH: 'x64'
           TEST_MODE: fast
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
         Python35-64bit-full:
           PYTHON_VERSION: '3.5'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
         Python36-64bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
           INSTALL_PICKLE5: 1
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
           TEST_MODE: full
           INSTALL_PICKLE5: 1
+          OPENBLAS: $(OPENBLAS_64)
+          BITS: 64
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -130,14 +147,43 @@ jobs:
     condition: eq(variables['PYTHON_VERSION'], '2.7')
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
+  - powershell: |
+      $wc = New-Object net.webclient
+      $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
+      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+      Expand-Archive "openblas.zip" $tmpdir
+      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
+      Write-Host "Python Version: $pyversion"
+      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
+      Write-Host "target path: $target"
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.0-gcc_7_1_0.a $target
+    displayName: 'Download / Install OpenBLAS'
+  - powershell: |
+      choco install -y mingw --forcex86 --force
+    displayName: 'Install 32-bit mingw for 32-bit builds'
+    condition: eq(variables['BITS'], 32)
   - script: python -m pip install cython nose pytz pytest
     displayName: 'Install dependencies; some are optional to avoid test skips'
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
   # vs. manual setup.py and then runtests.py for testing only
   - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
     displayName: 'Install optional pickle5 backport (only for python3.6 and 3.7)'
-  - script: python runtests.py --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
-    displayName: 'Build NumPy & Run Full NumPy Test Suite'
+  - powershell: |
+      If ($(BITS) -eq 32) {
+         $env:NPY_DISTUTILS_APPEND_FLAGS = 1
+         $env:CFLAGS = "-m32"
+         $env:LDFLAGS = "-m32"
+         $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
+         refreshenv
+      }
+      pip wheel -v -v -v --wheel-dir=dist .
+
+      ls dist -r | Foreach-Object {
+          pip install $_.FullName
+      }
+    displayName: 'Build NumPy'
+  - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
+    displayName: 'Run NumPy Test Suite'
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'


### PR DESCRIPTION
Add `openblas` library to NumPy Windows Azure CI builds, based largely on our wheels appveyor config & recent efforts to do [something similar](https://github.com/scipy/scipy/pull/9542/) for SciPy.

This should hopefully reduce dissonance between development and wheels CI, albeit not perfectly, but at least a step in that direction.

I spot-checked the results for one of the Windows cases vs. current master and results looked the same modulo now detecting `openblas` in distutils output. Good if a reviewer double-checks that consistency for one or two matrix entries.