### PR TITLE
MAINT: remove wrapper functions from numpy.core.multiarray

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -64,7 +64,7 @@ zeros.__module__ = 'numpy'
 # support introspection.
 array_function_from_c_func_and_dispatcher = functools.partial(
     overrides.array_function_from_dispatcher,
-    module='numpy', copy_docs=True, verify=False)
+    module='numpy', docs_from_dispatcher=True, verify=False)
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.empty_like)

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -191,6 +191,10 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         if the dispatcher's signature needs to deviate for some particular
         reason, e.g., because the function has a signature like
         ``func(*args, **kwargs)``.
+    docs_from_dispatcher : bool, optional
+        If True, copy docs from the dispatcher function onto the dispatched
+        function, rather than from the implementation. This is useful for
+        functions defined in C, which otherwise don't have docstrings.
 
     Returns
     -------
@@ -233,11 +237,11 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
 
 
 def array_function_from_dispatcher(
-        implementation, module=None, verify=True, copy_docs=True):
+        implementation, module=None, verify=True, docs_from_dispatcher=True):
     """Like array_function_dispatcher, but with function arguments flipped."""
 
     def decorator(dispatcher):
         return array_function_dispatch(
             dispatcher, module, verify=verify,
-            docs_from_dispatcher=copy_docs)(implementation)
+            docs_from_dispatcher=docs_from_dispatcher)(implementation)
     return decorator

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1163,10 +1163,12 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
      * __array_function__ is enabled by default.
      */
 
-    /* Continue to support the older "dims" argument in place
+    /*
+     * Continue to support the older "dims" argument in place
      * of the "shape" argument. Issue an appropriate warning
      * if "dims" is detected in keywords, then replace it with
-     * the new "shape" argument and continue processing as usual */
+     * the new "shape" argument and continue processing as usual.
+     */
      if (kwds) {
         PyObject *dims_item, *shape_item;
         dims_item = PyDict_GetItemString(kwds, "dims");

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1158,8 +1158,10 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
 
     char *kwlist[] = {"indices", "shape", "order", NULL};
 
-    /* TODO: remove this in favor of warning raised in the dispatcher when
-     * __array_function__ is enabled by default. */
+    /*
+     * TODO: remove this in favor of warning raised in the dispatcher when
+     * __array_function__ is enabled by default.
+     */
 
     /* Continue to support the older "dims" argument in place
      * of the "shape" argument. Issue an appropriate warning

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1158,6 +1158,27 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
 
     char *kwlist[] = {"indices", "shape", "order", NULL};
 
+    /* TODO: remove this in favor of warning raised in the dispatcher when
+     * __array_function__ is enabled by default. */
+
+    /* Continue to support the older "dims" argument in place
+     * of the "shape" argument. Issue an appropriate warning
+     * if "dims" is detected in keywords, then replace it with
+     * the new "shape" argument and continue processing as usual */
+     if (kwds) {
+        PyObject *dims_item, *shape_item;
+        dims_item = PyDict_GetItemString(kwds, "dims");
+        shape_item = PyDict_GetItemString(kwds, "shape");
+        if (dims_item != NULL && shape_item == NULL) {
+            if (DEPRECATE("'shape' argument should be"
+                          " used instead of 'dims'") < 0) {
+                return NULL;
+            }
+            PyDict_SetItemString(kwds, "shape", dims_item);
+            PyDict_DelItemString(kwds, "dims");
+        }
+    }
+
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|O&:unravel_index",
                     kwlist,
                     &indices0,


### PR DESCRIPTION
The original motivation for the style of these wrapper functions, introduced
in gh-12175, was to preserve introspection. But it turns out NumPy's functions
defined in C don't support introspection anyways, so the extra wrapper
functions are entirely pointless.

This version reverts the additional wrapper functions, which put default
arguments in two places and introduced slow-down due to the overhead of
another function call.

I've retained docstrings in multiarray.py, since it's definitely more readable
to keep docstrings and dispatchers together rather than leaving docstrings in
_add_newdocs.py.

One bonus of this approach is that dispatcher functions have the same name
as their implementations, so `np.concatenate(unknown=True)` gives an
error message mentioning "concatenate" rather than "_concatenate_dispatcher":
`TypeError: concatenate() got an unexpected keyword argument 'unknown'`

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
