### PR TITLE
ENH: override support for np.linspace and friends

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -1,15 +1,20 @@
 from __future__ import division, absolute_import, print_function
 
+import functools
 import warnings
 import operator
 
 from . import numeric as _nx
 from .numeric import (result_type, NaN, shares_memory, MAY_SHARE_BOUNDS,
-                      TooHardError,asanyarray)
+                      TooHardError, asanyarray)
 from numpy.core.multiarray import add_docstring
-from numpy.core.overrides import set_module
+from numpy.core import overrides
 
 __all__ = ['logspace', 'linspace', 'geomspace']
+
+
+array_function_dispatch = functools.partial(
+    overrides.array_function_dispatch, module='numpy')
 
 
 def _index_deprecate(i, stacklevel=2):
@@ -24,7 +29,12 @@ def _index_deprecate(i, stacklevel=2):
     return i
 
 
-@set_module('numpy')
+def _linspace_dispatcher(
+        start, stop, num=None, endpoint=None, retstep=None, dtype=None):
+    return (start, stop)
+
+
+@array_function_dispatch(_linspace_dispatcher)
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
     """
     Return evenly spaced numbers over a specified interval.
@@ -156,7 +166,12 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None):
         return y.astype(dtype, copy=False)
 
 
-@set_module('numpy')
+def _logspace_dispatcher(
+        start, stop, num=None, endpoint=None, base=None, dtype=None):
+    return (start, stop)
+
+
+@array_function_dispatch(_logspace_dispatcher)
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     """
     Return numbers spaced evenly on a log scale.
@@ -241,7 +256,11 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None):
     return _nx.power(base, y).astype(dtype)
 
 
-@set_module('numpy')
+def _geomspace_dispatcher(start, stop, num=None, endpoint=None, dtype=None):
+    return (start, stop)
+
+
+@array_function_dispatch(_geomspace_dispatcher)
 def geomspace(start, stop, num=50, endpoint=True, dtype=None):
     """
     Return numbers spaced evenly on a log scale (a geometric progression).


### PR DESCRIPTION
Fixes gh-12379

This doesn't support overrides in `np.arange()` (since it's less clear that makes sense)

Note that potentially we should wait until https://github.com/numpy/numpy/pull/12388 goes in before merging this.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
