### PR TITLE
 ENH: Make the contents of dtype.fields namedtuple-like

### DIFF
--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -10,6 +10,8 @@ array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 NPY_NO_EXPORT PyArray_Descr *
 _arraydescr_from_dtype_attr(PyObject *obj);
 
+NPY_NO_EXPORT int
+arraydescr_init_structsequences(PyObject *multiarray_dict);
 
 NPY_NO_EXPORT int
 is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4729,6 +4729,11 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
         goto err;
     }
 
+    /* Create the struct_field types */
+    if (arraydescr_init_structsequences(d) < 0) {
+        return RETVAL(NULL);
+    }
+
     if (!intern_strings()) {
         goto err;
     }

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -292,6 +292,25 @@ class TestRecord(object):
         for n in d.names:
             assert_equal(d.fields[n][0], np.dtype('?'))
 
+    def test_field_attributes(self):
+        """
+        Test that the items in dtype.fields are namedtuple-like
+        """
+        d = np.dtype([('x', np.int16), (('y', 'the y title'), np.int16)])
+
+        x_info = d.fields['x']
+        x_offset, x_dtype = x_info
+        assert_equal(x_info.offset, x_offset)
+        assert_equal(x_info.dtype, x_dtype)
+        assert_equal(x_info.title, None)
+
+        y_info = d.fields['y']
+        y_offset, y_dtype, y_title = y_info
+        assert_equal(y_info.offset, y_info)
+        assert_equal(y_info.dtype, y_dtype)
+        assert_equal(y_info.title, y_title)
+
+
     def test_nonint_offsets(self):
         # gh-8059
         def make_dtype(off):

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -861,14 +861,14 @@ def repack_fields(a, align=False, recurse=False):
 
     fieldinfo = []
     for name in a.names:
-        tup = a.fields[name]
+        field = a.fields[name]
         if recurse:
-            fmt = repack_fields(tup[0], align=align, recurse=True)
+            fmt = repack_fields(field.dtype, align=align, recurse=True)
         else:
-            fmt = tup[0]
+            fmt = field.dtype
 
-        if len(tup) == 3:
-            name = (tup[2], name)
+        if field.title is not None:
+            name = (field.title, name)
 
         fieldinfo.append((name, fmt))
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1284,10 +1284,10 @@ def _replace_dtype_fields_recursive(dtype, primitive_dtype):
         descr = []
         for name in dtype.names:
             field = dtype.fields[name]
-            if len(field) == 3:
+            if field.title is not None:
                 # Prepend the title to the name
-                name = (field[-1], name)
-            descr.append((name, _recurse(field[0], primitive_dtype)))
+                name = (field.title, name)
+            descr.append((name, _recurse(field.dtype, primitive_dtype)))
         new_dtype = np.dtype(descr)
 
     # Is this some kind of composite a la (float,2)


### PR DESCRIPTION
Taking what I learned when making `typeinfo` namedtuples. Makes introspecting `fields` noisier but more obvious:
```python
>>> dt = np.dtype([('no_title', '?'), ((object(), 'has_title'), '?'), ((None, 'none_title'), '?')])
>>> dt.fields
mappingproxy({'has_title': numpy.core.multiarray.structured_field_titled(dtype=dtype('bool'), offset=1, title=<object object at 0x000001DFD139F6A0>),
              'no_title': numpy.core.multiarray.structured_field(dtype=dtype('bool'), offset=0),
              'none_title': numpy.core.multiarray.structured_field(dtype=dtype('bool'), offset=2)})
>>> td.fields['none_title'].offset
2
```