### PR TITLE
TST: enable dispatcher test coverage

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -113,6 +113,7 @@ run_test()
 
   if [ -n "$RUN_COVERAGE" ]; then
     $PIP install pytest-cov
+    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
     COVERAGE_FLAG=--coverage
   fi
 


### PR DESCRIPTION
Activate `NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1` for our singular full test suite coverage job.

Based on feedback from @shoyer, we probably want to have this flag enabled as the exception rather than the rule, so this is only the second case in all our CI matrices where the flag is activated.

A reviewer should notice that less tests are skipped if this flag is working properly vs. current master for the coverage job in Travis.