### PR TITLE
DEP: promise to remove a file in 1.17

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -58,6 +58,8 @@ Future Changes
 
 * NumPy 1.17 will drop support for Python 2.7.
 
+* NumPy 1.17 will drop the ``noprefix.h`` header file
+
 Expired deprecations
 ====================
 


### PR DESCRIPTION
PR #12402 will remove the `noprefix.h` header file. Notify users already in 1.16 that this will happen in 1.17