### PR TITLE
BUG: fix records.fromfile fails to read data >4 GB

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -787,7 +787,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     shapesize = shapeprod * itemsize
     if shapesize < 0:
         shape = list(shape)
-        shape[shape.index(-1)] = size / -shapesize
+        shape[shape.index(-1)] = size // -shapesize
         shape = tuple(shape)
         shapeprod = sb.array(shape).prod(dtype=nt.intp)
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -783,13 +783,13 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
 
     itemsize = descr.itemsize
 
-    shapeprod = sb.array(shape).prod()
+    shapeprod = sb.array(shape).prod(dtype=nt.intp)
     shapesize = shapeprod * itemsize
     if shapesize < 0:
         shape = list(shape)
         shape[shape.index(-1)] = size / -shapesize
         shape = tuple(shape)
-        shapeprod = sb.array(shape).prod()
+        shapeprod = sb.array(shape).prod(dtype=nt.intp)
 
     nbytes = shapeprod * itemsize
 


### PR DESCRIPTION
Use 64-bit integer accumulator for calculating the product of array shapes on 64-bit systems. Fixes #12442.

Probably needs a test, but that would require creating a >4 GB temp file (?).

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
