### PR TITLE
BUG: test, fix matmul, dot for vector array with stride[i]=0

### DIFF
--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -188,12 +188,16 @@ _bad_strides(PyArrayObject *ap)
     int itemsize = PyArray_ITEMSIZE(ap);
     int i, N=PyArray_NDIM(ap);
     npy_intp *strides = PyArray_STRIDES(ap);
+    npy_intp *dims = PyArray_DIMS(ap);
 
     if (((npy_intp)(PyArray_DATA(ap)) % itemsize) != 0) {
         return 1;
     }
     for (i = 0; i < N; i++) {
         if ((strides[i] < 0) || (strides[i] % itemsize) != 0) {
+            return 1;
+        }
+        if ((strides[i] == 0 && dims[i] >1)) {
             return 1;
         }
     }

--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -197,7 +197,7 @@ _bad_strides(PyArrayObject *ap)
         if ((strides[i] < 0) || (strides[i] % itemsize) != 0) {
             return 1;
         }
-        if ((strides[i] == 0 && dims[i] >1)) {
+        if ((strides[i] == 0 && dims[i] > 1)) {
             return 1;
         }
     }

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -312,8 +312,10 @@ NPY_NO_EXPORT void
     npy_bool i2blasable = i2_c_blasable || i2_f_blasable;
     npy_bool o_c_blasable = is_blasable2d(os_m, os_p, dm, dp, sz);
     npy_bool o_f_blasable = is_blasable2d(os_p, os_m, dp, dm, sz);
-    npy_bool vector_matrix = ((dm == 1) && i2blasable);
-    npy_bool matrix_vector = ((dp == 1)  && i1blasable);
+    npy_bool vector_matrix = ((dm == 1) && i2blasable &&
+                              is_blasable2d(is1_n, sz, dn, 1, sz));
+    npy_bool matrix_vector = ((dp == 1)  && i1blasable &&
+                              is_blasable2d(is2_n, sz, dn, 1, sz));
 #endif
 
     for (iOuter = 0; iOuter < dOuter; iOuter++,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2713,6 +2713,20 @@ class TestMethods(object):
             assert_equal(func(edf, edf.T), eddtf)
             assert_equal(func(edf.T, edf), edtdf)
 
+    @pytest.mark.parametrize('func', (np.dot, np.matmul))
+    def test_no_dgemv(self, func):
+        # check vector arg for contiguous before gemv
+        # gh-12156
+        a = np.arange(8.0).reshape(2, 4)
+        b = np.broadcast_to(1., (4, 1))
+        ret1 = func(a, b)
+        ret2 = func(a, b.copy())
+        assert_equal(ret1, ret2)
+
+        ret1 = func(b.T, a.T)
+        ret2 = func(b.T.copy(), a.T)
+        assert_equal(ret1, ret2)
+
     def test_dot(self):
         a = np.array([[1, 0], [0, 1]])
         b = np.array([[0, 1], [1, 0]])


### PR DESCRIPTION
Fixes #12156. 

- Test added for 0-strided vector array
- Fixed new matmul logic to detect this condition by adding logic from assert inside `@typ@_gemv` to checks before calling `@typ@_gemv
- Fixed old dot logic to check for this condition in helper function
- Verified (by using gdb) that `gemv` is used where possible in `matmul`, and that copying is done as necessary in `dot`