### PR TITLE
TST: Azure Python version fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      testRunTitle: 'Publish test results for Python 3.6-32 bit'
+      testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: macOS
   pool:
     # NOTE: at time of writing, there is a danger
@@ -81,7 +81,7 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      testRunTitle: 'Publish test results for Python $(python.version)'
+      testRunTitle: 'Publish test results for Python 3.6 64-bit full Mac OS'
 - job: Windows
   pool:
     vmIMage: 'VS2017-Win2016'
@@ -187,4 +187,4 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      testRunTitle: 'Publish test results for Python $(python.version)'
+      testRunTitle: 'Publish test results for Python $(PYTHON_VERSION) $(BITS)-bit $(TEST_MODE) Windows'


### PR DESCRIPTION
Fixes #12298 by using proper string variable substitutions or just hard-coding for "single-matrix" runs (mac, linux have a single job). Also, reduce ambiguity with respect to architecture and fast / full test runs. 

The Azure `PublishTestResults` task was not able to substitute Python version strings so we're seeing reports like this for merge event CI runs:
![image](https://user-images.githubusercontent.com/7903078/49667751-d4b73f80-fa10-11e8-8ab0-c43868f24ef1.png)

For pull request CI runs it currently looks more like this:
![image](https://user-images.githubusercontent.com/7903078/49667810-0fb97300-fa11-11e8-97c2-b6cd426e02cf.png)

The 6 missing publication entries for PR runs are all for Windows, and @charris has already [noted](https://github.com/numpy/numpy/pull/12498#issuecomment-445063962) the Warnings on the test publication task for Windows. In fact, there are 12 such warnings on PRs (2 per windows job), and 6 such warnings for merge events (1 per Windows job).

My objective here is to deal with the simple linked issue first -- get those version strings working sensibly, and then look at the deeper issues on `PublishTestResults` Windows warnings after that.

On my branch, the changes in this PR produce this:
![image](https://user-images.githubusercontent.com/7903078/49668058-dcc3af00-fa11-11e8-92af-814e64e7b4e9.png)

And hopefully works similar for master branch PR here.