### PR TITLE
MAINT: Prepare master for 1.17.0 development.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,11 +30,6 @@ environment:
       PYTHON_ARCH: 32
       TEST_MODE: fast
 
-    - PYTHON: C:\Python27-x64
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 64
-      TEST_MODE: fast
-
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
@@ -91,7 +86,7 @@ install:
       $clnt.DownloadFile($env:OPENBLAS, $file)
       Get-FileHash $file | Format-List
 
-      Expand-Archive $file $tmpdir      
+      Expand-Archive $file $tmpdir
 
       rm $tmpdir\$env:PYTHON_ARCH\lib\*.dll.a
       $lib = ls $tmpdir\$env:PYTHON_ARCH\lib\*.a | ForEach { ls $_ } | Select-Object -first 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
                ahp7Qnm0rWRmA0z9SomuRUQOJQ6s684vU="
 
 python:
-  - 2.7
   - 3.5
   - 3.6
 matrix:
@@ -63,8 +62,6 @@ matrix:
             - python3-setuptools
     - python: 3.6
       env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1 INSTALL_PICKLE5=1
-    - python: 2.7
-      env: USE_WHEEL=1 RUN_FULL_TESTS=1 PYTHON_OPTS="-3 -OO"
     - python: 3.6
       env: USE_SDIST=1
     - python: 3.6

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,12 +105,6 @@ jobs:
           TEST_MODE: fast
           OPENBLAS: $(OPENBLAS_32)
           BITS: 32
-        Python27-64bit-fast:
-          PYTHON_VERSION: '2.7'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: fast
-          OPENBLAS: $(OPENBLAS_64)
-          BITS: 64
         Python35-64bit-full:
           PYTHON_VERSION: '3.5'
           PYTHON_ARCH: 'x64'

--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -1,0 +1,43 @@
+==========================
+NumPy 1.17.0 Release Notes
+==========================
+
+
+Highlights
+==========
+
+
+New functions
+=============
+
+
+Deprecations
+============
+
+
+Future Changes
+==============
+
+
+Expired deprecations
+====================
+
+
+Compatibility notes
+===================
+
+
+C API changes
+=============
+
+
+New Features
+============
+
+
+Improvements
+============
+
+
+Changes
+=======

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -2,6 +2,7 @@
 Release Notes
 *************
 
+.. include:: ../release/1.17.0-notes.rst
 .. include:: ../release/1.16.0-notes.rst
 .. include:: ../release/1.15.4-notes.rst
 .. include:: ../release/1.15.3-notes.rst

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # mtrand.pyx -- A Pyrex wrapper of Jean-Sebastien Roy's RandomKit
 #
 # Copyright 2005 Robert Kern (robert.kern@gmail.com)

--- a/numpy/random/mtrand/numpy.pxd
+++ b/numpy/random/mtrand/numpy.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # :Author:    Travis Oliphant
 from cpython.exc cimport PyErr_Print
 

--- a/pavement.py
+++ b/pavement.py
@@ -42,13 +42,12 @@ from paver.easy import Bunch, options, task, sh
 #-----------------------------------
 
 # Path to the release notes
-RELEASE_NOTES = 'doc/release/1.16.0-notes.rst'
+RELEASE_NOTES = 'doc/release/1.17.0-notes.rst'
 
 
 #-------------------------------------------------------
 # Hardcoded build/install dirs, virtualenv options, etc.
 #-------------------------------------------------------
-DEFAULT_PYTHON = "2.7"
 
 # Where to put the release installers
 options(installers=Bunch(releasedir="release",

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,13 @@ import subprocess
 import textwrap
 
 
-if sys.version_info[:2] < (2, 7) or (3, 0) <= sys.version_info[:2] < (3, 4):
-    raise RuntimeError("Python version 2.7 or >= 3.4 required.")
+if sys.version_info[:2] < (3, 5):
+    raise RuntimeError("Python version >= 3.5 required.")
 
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
+import builtins
 
+
+python_requires = '>=3.5'
 
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable
@@ -43,10 +42,7 @@ Intended Audience :: Developers
 License :: OSI Approved
 Programming Language :: C
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
@@ -60,7 +56,7 @@ Operating System :: MacOS
 """
 
 MAJOR               = 1
-MINOR               = 16
+MINOR               = 17
 MICRO               = 0
 ISRELEASED          = False
 VERSION             = '%d.%d.%d' % (MAJOR, MINOR, MICRO)

--- a/shippable.yml
+++ b/shippable.yml
@@ -6,12 +6,11 @@ language: python
 
 python:
     # use versions available for job image
-    # aarch64_u16pytall:v6.7.4 
+    # aarch64_u16pytall:v6.7.4
     # (what we currently have access to by default)
     # this is a bit restrictive in terms
     # of version availability / control,
     # but it is convenient
-    - 2.7
     - 3.7
 
 runtime:


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->
 MAINT: Prepare master for 1.17.0 development.
    
- Create 1.17.0-notes
- Update index.rst for new notes
- Update pavement.py
- Update setup.py
- Remove Python 2.7 and 3.4 CI testing.
- Add `# cython: language_level=3` to `*.pxd`, `*.pyx` files.
    
Note that this removes support for both Python2.7 and Python3.4 in
setup.py.


<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
