### PR TITLE
DOC, MAINT: Make `PYVER = 3` in doc/Makefile.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER = 3.6
+PYVER = 3
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.


### PR DESCRIPTION
The current Python version is 3.6, which is too specific. I got caught by
that when python3.7 turned out to be my new python3 after upgrading
fedora.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
