### PR TITLE
BUG: don't check alignment of size=0 arrays (RELAXED_STRIDES)

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -121,8 +121,8 @@ static void
 {
 #if @is_aligned@ && @elsize@ != 16
     /* sanity check */
-    assert(npy_is_aligned(dst, _ALIGN(@type@)));
-    assert(npy_is_aligned(src, _ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(dst, _ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(src, _ALIGN(@type@)));
 #endif
     /*printf("fn @prefix@_@oper@_size@elsize@\n");*/
     while (N > 0) {
@@ -201,8 +201,8 @@ static NPY_GCC_OPT_3 void
     }
 #if @is_aligned@ && @elsize@ != 16
     /* sanity check */
-    assert(npy_is_aligned(dst, _ALIGN(@type@)));
-    assert(npy_is_aligned(src, _ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(dst, _ALIGN(@type@)));
+    assert(N == 0 || npy_is_aligned(src, _ALIGN(@type@)));
 #endif
 #if @elsize@ == 1 && @dst_contig@
     memset(dst, *src, N);
@@ -809,10 +809,10 @@ static NPY_GCC_OPT_3 void
 #if @aligned@
    /* sanity check */
 #  if !@is_complex1@
-    assert(npy_is_aligned(src, _ALIGN(_TYPE1)));
+    assert(N == 0 || npy_is_aligned(src, _ALIGN(_TYPE1)));
 #  endif
 #  if !@is_complex2@
-    assert(npy_is_aligned(dst, _ALIGN(_TYPE2)));
+    assert(N == 0 || npy_is_aligned(dst, _ALIGN(_TYPE2)));
 #  endif
 #endif
 


### PR DESCRIPTION
The copy-loops shouldn't assert pointer alignment for size-0 arrays, especially when `RELAXED_STRIDES` is turned on.

Fixes #12503