### PR TITLE
added template-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,10 @@ numpy/core/include/numpy/config.h
 numpy/core/include/numpy/multiarray_api.txt
 numpy/core/include/numpy/ufunc_api.txt
 numpy/core/lib/
+numpy/core/src/common/npy_binsearch.h
+numpy/core/src/common/npy_partition.h
+numpy/core/src/common/npy_sort.h
+numpy/core/src/common/templ_common.h
 numpy/core/src/multiarray/_multiarray_tests.c
 numpy/core/src/multiarray/arraytypes.c
 numpy/core/src/multiarray/einsum.c
@@ -150,6 +154,7 @@ numpy/core/src/umath/_umath_tests.c
 numpy/core/src/umath/scalarmath.c
 numpy/core/src/umath/funcs.inc
 numpy/core/src/umath/loops.[ch]
+numpy/core/src/umath/matmul.[ch]
 numpy/core/src/umath/operand_flag_tests.c
 numpy/core/src/umath/simd.inc
 numpy/core/src/umath/struct_ufunc_test.c


### PR DESCRIPTION
Expanded `.gitignore` to include results of expansion of new `core/common/*.h.src` files, as well as `core/src/umath/matmul.[ch]`.