### PR TITLE
WIP, ENH: add openblas runtime version inspection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,9 @@ jobs:
 - job: Linux_Python_36_32bit_full
   pool:
     vmIMage: 'ubuntu-16.04'
+  variables:
+      # None for OpenBLAS < 0.3.4
+      OPENBLAS_VERSION: None
   steps:
   - script: |
            docker pull i386/ubuntu:bionic
@@ -19,7 +22,10 @@ jobs:
            pip3 install setuptools nose cython==0.29.0 pytest pytz pickle5 && \
            apt-get -y install libopenblas-dev gfortran && \
            NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1 \
-           python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
+           python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml && \
+           cd .. && \
+           export PYTHONPATH=/numpy/build/testenv/lib/python3.6/site-packages && \
+           python3 -c \"import numpy; from numpy.distutils.system_info import get_info; assert(get_info('openblas')['version'] == $(OPENBLAS_VERSION))\""
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     inputs:
@@ -90,6 +96,7 @@ jobs:
       # appveyor / Windows config
       OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_VERSION: "0.3.5.dev"
   strategy:
     maxParallel: 6
     matrix:
@@ -170,6 +177,10 @@ jobs:
     displayName: 'Build NumPy'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
+  - script: |
+      cd D:/a
+      python -c "import numpy; from numpy.distutils.system_info import get_info; assert get_info('openblas')['version'].decode() == '$(OPENBLAS_VERSION)', 'received versions: ' + get_info('openblas')['version'].decode() + ' and $(OPENBLAS_VERSION)'"
+    displayName: 'Post-mortem OpenBLAS version confirmation'
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'

--- a/numpy/core/src/common/npy_cblas.h
+++ b/numpy/core/src/common/npy_cblas.h
@@ -26,6 +26,12 @@ enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
 enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 
 /*
+ * Access openblas build information, including version number
+ * for openblas >= 0.3.4
+ */
+char *openblas_get_config(void);
+
+/*
  * ===========================================================================
  * Prototypes for level 1 BLAS functions (complex are recast as routines)
  * ===========================================================================

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -50,6 +50,28 @@ from .info import __doc__
 
 from .linalg import *
 
+import numpy.distutils.system_info as sinfo
+if len(sinfo.get_info('openblas')) > 2:
+    # openblas >= 0.3.4 provides version information;
+    # numpy/distutils/system_info has already initialized
+    # at this stage, so just update the dictionary for
+    # openblas info
+    from numpy.linalg import openblas_config
+    openblas_config_str = openblas_config._openblas_info()
+    openblas_config_list = openblas_config_str.split()
+    # slightly obscure API for system_info objects;
+    # they weren't really intended for public modification
+    # as the docs clearly indicate
+    info = sinfo.system_info.saved_results['openblas_info']
+    new_info = {}
+    if openblas_config_list[0] == b"OpenBLAS":
+        # version string will be present
+        new_info['version'] = openblas_config_list[1]
+    else:
+        # older OpenBLAS config API
+        new_info['version'] = None
+    info.update(new_info)
+
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)
 del PytestTester

--- a/numpy/linalg/openblas_config.c
+++ b/numpy/linalg/openblas_config.c
@@ -1,0 +1,38 @@
+/* -*- c -*- */
+
+#include <Python.h>
+#include <npy_cblas.h>
+
+static PyObject *
+_openblas_info(PyObject *self, PyObject *args) {
+    char *result;
+    result = openblas_get_config();
+    return PyBytes_FromString(result);
+}
+
+static PyMethodDef methods[] = {
+    {"_openblas_info", _openblas_info, METH_VARARGS,
+     "Call openblas_get_config"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "openblas_config",
+        NULL,
+        -1,
+        methods,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+};
+
+PyMODINIT_FUNC PyInit_openblas_config(void) {
+    PyObject *m;
+    m = PyModule_Create(&moduledef);
+    if (!m) {
+        return NULL;
+    }
+    return m;
+}

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -53,6 +53,16 @@ def configuration(parent_package='', top_path=None):
         extra_info=lapack_info,
         libraries=['npymath'],
     )
+
+    if len(get_info('openblas')) > 2:
+        # if openblas is being used to compile NumPy
+        # build an extension to gather more information
+        # about the openblas version used
+        config.add_extension('openblas_config',
+                             sources=['openblas_config.c'],
+                             extra_info=lapack_info,
+                             libraries=['openblas'],
+                             )
     return config
 
 if __name__ == '__main__':

--- a/numpy/linalg/tests/test_openblasconfig.py
+++ b/numpy/linalg/tests/test_openblasconfig.py
@@ -1,0 +1,47 @@
+from __future__ import division, absolute_import, print_function
+
+import pytest
+import platform
+from distutils.version import LooseVersion
+
+import numpy as np
+from numpy.distutils import system_info
+
+@pytest.mark.skipif(len(system_info.get_info('openblas')) < 2,
+                     reason="Requires openblas")
+def test_openblas_info_return_type():
+    # _openblas_info() should return a bytes
+    # object containing information about
+    # the openblas that was linked to NumPy;
+    from numpy.linalg import openblas_config
+    actual = openblas_config._openblas_info()
+    assert isinstance(actual, bytes)
+
+@pytest.mark.skipif(len(system_info.get_info('openblas')) < 2,
+                    reason="Requires openblas")
+def test_openblas_private_info():
+    # directly probe the private function
+    # that accesses the openblas version used
+    # to compile NumPy
+    from numpy.linalg import openblas_config
+    info_string = openblas_config._openblas_info()
+    info_list = info_string.split()
+    if info_list[0] == b'OpenBLAS':
+        # true for OpenBLAS >= 0.3.4
+        version = info_list[1].decode()
+        assert LooseVersion(version) >= LooseVersion("0.3.4")
+
+@pytest.mark.skipif(len(system_info.get_info('openblas')) < 2,
+                    reason="Requires openblas")
+def test_openblas_get_info():
+    # test for the presence of the 'version' key
+    # in the openblas info dict, and its appropriate
+    # value
+    openblas_dict = system_info.get_info('openblas')
+    version = openblas_dict['version']
+
+    # for openblas < 0.3.4 there is no version
+    # information provided, so NumPy will default
+    # to None
+    assert (version == None or
+            LooseVersion(version.decode()) >= LooseVersion("0.3.4"))


### PR DESCRIPTION
**Background**: The process of building wheels for different platforms can be a little hard to follow sometimes, and even inspecting a NumPy wheel to determine which version of `openblas` it has been linked against can be highly non-trivial. This very recently lead to the upstream merge [of a PR that adds a version number](https://github.com/xianyi/OpenBLAS/pull/1890) to an extension function in `openblas`. 

While we may eventually want to try to convince the `openblas` team to go a step farther and add the git commit hash for further clarity, we should be able to leverage the version string as a first pass verification & to provide the base infrastructure for runtime openblas version information inspection.

**Questions / Thoughts**:
1. we may want to provide direct access to the version information in `numpy.distutils.system_info.get_info('openblas')` which currently generates
a dictionary that might be expanded with a few new keys like this?
```python
{'libraries': ['openblas', 'openblas'], 
'library_dirs': ['/usr/lib'],
'language': 'c', 
'define_macros': [('HAVE_CBLAS', None)]
'version': '0.3.5dev', # should we add this?
'hash': something, # maybe some day?
}
```

2. We'd need a graceful way to handle the complete absence of openblas, and versions of openblas prior to the `0.3.4` release where the build info string does not include the version number. Basically, something flexible like the dictionary above is probably ok I guess.

3. In all likelihood the WIP code here is in the wrong files / paths -- should it all be diverted to distutils?

4. Do people want to be able to access the openblas version number in C-level code? I.e., make code path decisions in C based on openblas version? I suspect this would get ugly pretty fast given that we are not exclusive to supporting an openblas backend, but better to ask this now than to need it later & have diverging methods to inspect the openblas version info.

5. My current primary envisioned use case is quite simple -- in our development CI we have a variable i.e., OPENBLAS_VERSION -- this will pull in the appropriate wheel build URL, and then after we install NumPy from the assembled wheel we do a runtime sanity check that we have the correct linking (no interference from CI system changes, and provide absolute check / feedback to avoid sifting through complexities on MacPython wheels, etc. -- eventually perhaps upstreaming the check to post-mortem on wheels before they upload).