### PR TITLE
BUG: fix improper use of C-API

### DIFF
--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -93,15 +93,18 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         return 0;
     }
     if (PyTuple_CheckExact(*out_kwd_obj)) {
+        /*
+         * The C-API recommends calling PySequence_Fast before any of the other
+         * PySequence_Fast* functions. This is required for PyPy
+         */
         PyObject *seq = PySequence_Fast(*out_kwd_obj, "cannot convert");
         int ret;
         if (seq == NULL) {
             return -1;
         }
-        Py_DECREF(*out_kwd_obj);
         *out_objs = PySequence_Fast_ITEMS(seq);
         ret = PySequence_Fast_GET_SIZE(seq);
-        *out_kwd_obj = seq;
+        Py_SETREF(*out_kwd_obj, seq);
         return ret;
     }
     else {

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -93,8 +93,16 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         return 0;
     }
     if (PyTuple_CheckExact(*out_kwd_obj)) {
-        *out_objs = PySequence_Fast_ITEMS(*out_kwd_obj);
-        return PySequence_Fast_GET_SIZE(*out_kwd_obj);
+        PyObject *seq = PySequence_Fast(*out_kwd_obj, "cannot convert");
+        int ret;
+        if (seq == NULL) {
+            return -1;
+        }
+        Py_DECREF(*out_kwd_obj);
+        *out_objs = PySequence_Fast_ITEMS(seq);
+        ret = PySequence_Fast_GET_SIZE(seq);
+        *out_kwd_obj = seq;
+        return ret;
     }
     else {
         *out_objs = out_kwd_obj;

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -97,7 +97,7 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
          * The C-API recommends calling PySequence_Fast before any of the other
          * PySequence_Fast* functions. This is required for PyPy
          */
-        PyObject *seq = PySequence_Fast(*out_kwd_obj, "cannot convert");
+        PyObject *seq = PySequence_Fast(*out_kwd_obj, "Could not convert object to sequence");
         int ret;
         if (seq == NULL) {
             return -1;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -441,11 +441,16 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     }
 
     /* Recursive case, first check the sequence contains only one type */
+    /*
+     * The C-API recommends calling PySequence_Fast before any of the other
+     * PySequence_Fast* functions. This is required for PyPy
+     */
     seq = PySequence_Fast(obj, "Could not convert object to sequence");
     if (seq == NULL) {
         goto fail;
     }
     size = PySequence_Fast_GET_SIZE(seq);
+    /* objects is borrowed, do not release seq */
     objects = PySequence_Fast_ITEMS(seq);
     common_type = size > 0 ? Py_TYPE(objects[0]) : NULL;
     for (i = 1; i < size; ++i) {

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -440,7 +440,6 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         return 0;
     }
 
-    /* Recursive case, first check the sequence contains only one type */
     /*
      * The C-API recommends calling PySequence_Fast before any of the other
      * PySequence_Fast* functions. This is required for PyPy
@@ -449,6 +448,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
     if (seq == NULL) {
         goto fail;
     }
+
+    /* Recursive case, first check the sequence contains only one type */
     size = PySequence_Fast_GET_SIZE(seq);
     /* objects is borrowed, do not release seq */
     objects = PySequence_Fast_ITEMS(seq);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1003,6 +1003,7 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     int i;
     int nin, nout;
     PyObject *out_kwd_obj;
+    PyObject *fast;
     PyObject **in_objs, **out_objs;
 
     /* check inputs */
@@ -1010,12 +1011,18 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     if (nin < 0) {
         return -1;
     }
-    in_objs = PySequence_Fast_ITEMS(args);
+    fast = PySequence_Fast(args, "could not convert args for fast access");
+    if (fast == NULL) {
+        return -1;
+    }
+    in_objs = PySequence_Fast_ITEMS(fast);
     for (i = 0; i < nin; ++i) {
         if (PyUFunc_HasOverride(in_objs[i])) {
+            Py_DECREF(fast);
             return 1;
         }
     }
+    Py_DECREF(fast);
     /* check outputs, if any */
     nout = PyUFuncOverride_GetOutObjects(kwds, &out_kwd_obj, &out_objs);
     if (nout < 0) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1011,7 +1011,7 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     if (nin < 0) {
         return -1;
     }
-    fast = PySequence_Fast(args, "could not convert args for fast access");
+    fast = PySequence_Fast(args, "Could not convert object to sequence");
     if (fast == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4570,8 +4570,9 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
      */
     PyArray_Type.tp_hash = PyObject_HashNotImplemented;
 
-    if (PyType_Ready(&PyUFunc_Type) < 0)
+    if (PyType_Ready(&PyUFunc_Type) < 0) {
         goto err;
+    }
 
     /* Load the ufunc operators into the array module's namespace */
     if (InitOperators(d) < 0) {
@@ -4583,8 +4584,9 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
     }
     initialize_casting_tables();
     initialize_numeric_types();
-    if(initscalarmath(m) < 0)
+    if(initscalarmath(m) < 0) {
         goto err;
+    }
 
     if (PyType_Ready(&PyArray_Type) < 0) {
         goto err;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -982,7 +982,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     for (i = 0; i < PyArray_NDIM(ap2) - 2; i++) {
         dimensions[j++] = PyArray_DIMS(ap2)[i];
     }
-    if(PyArray_NDIM(ap2) > 1) {
+    if (PyArray_NDIM(ap2) > 1) {
         dimensions[j++] = PyArray_DIMS(ap2)[PyArray_NDIM(ap2)-1];
     }
 
@@ -1318,7 +1318,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
      */
     if (inverted) {
         st = _pyarray_revert(ret);
-        if(st) {
+        if (st) {
             goto clean_ret;
         }
     }
@@ -1365,7 +1365,7 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
     }
 
     ret = _pyarray_correlate(ap1, ap2, typenum, mode, &unused);
-    if(ret == NULL) {
+    if (ret == NULL) {
         goto fail;
     }
     Py_DECREF(ap1);
@@ -1654,7 +1654,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
     }
 
 full_path:
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|O&O&O&O&i:array", kwd,
+    if (!PyArg_ParseTupleAndKeywords(args, kws, "O|O&O&O&O&i:array", kwd,
                 &op,
                 PyArray_DescrConverter2, &type,
                 PyArray_BoolConverter, &copy,
@@ -2489,7 +2489,7 @@ einsum_sub_op_from_lists(PyObject *args,
                         "operand and a subscripts list to einsum");
         return -1;
     }
-    else if(nop >= NPY_MAXARGS) {
+    else if (nop >= NPY_MAXARGS) {
         PyErr_SetString(PyExc_ValueError, "too many operands");
         return -1;
     }
@@ -2724,7 +2724,7 @@ array_arange(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws) {
     static char *kwd[]= {"start", "stop", "step", "dtype", NULL};
     PyArray_Descr *typecode = NULL;
 
-    if(!PyArg_ParseTupleAndKeywords(args, kws, "O|OOO&:arange", kwd,
+    if (!PyArg_ParseTupleAndKeywords(args, kws, "O|OOO&:arange", kwd,
                 &o_start,
                 &o_stop,
                 &o_step,
@@ -2762,7 +2762,7 @@ array__get_ndarray_c_version(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObje
 {
     static char *kwlist[] = {NULL};
 
-    if(!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist )) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist )) {
         return NULL;
     }
     return PyInt_FromLong( (long) PyArray_GetNDArrayCVersion() );
@@ -2835,7 +2835,7 @@ array_set_string_function(PyObject *NPY_UNUSED(self), PyObject *args,
     int repr = 1;
     static char *kwlist[] = {"f", "repr", NULL};
 
-    if(!PyArg_ParseTupleAndKeywords(args, kwds, "|Oi:set_string_function", kwlist, &op, &repr)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oi:set_string_function", kwlist, &op, &repr)) {
         return NULL;
     }
     /* reset the array_repr function to built-in */
@@ -3145,7 +3145,7 @@ array_promote_types(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArray_Descr *d1 = NULL;
     PyArray_Descr *d2 = NULL;
     PyObject *ret = NULL;
-    if(!PyArg_ParseTuple(args, "O&O&:promote_types",
+    if (!PyArg_ParseTuple(args, "O&O&:promote_types",
                 PyArray_DescrConverter2, &d1, PyArray_DescrConverter2, &d2)) {
         goto finish;
     }
@@ -3171,7 +3171,7 @@ array_min_scalar_type(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArrayObject *array;
     PyObject *ret = NULL;
 
-    if(!PyArg_ParseTuple(args, "O:min_scalar_type", &array_in)) {
+    if (!PyArg_ParseTuple(args, "O:min_scalar_type", &array_in)) {
         return NULL;
     }
 
@@ -3248,7 +3248,7 @@ array_datetime_data(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyArray_Descr *dtype;
     PyArray_DatetimeMetaData *meta;
 
-    if(!PyArg_ParseTuple(args, "O&:datetime_data",
+    if (!PyArg_ParseTuple(args, "O&:datetime_data",
                 PyArray_DescrConverter, &dtype)) {
         return NULL;
     }
@@ -3267,7 +3267,7 @@ new_buffer(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     int size;
 
-    if(!PyArg_ParseTuple(args, "i:buffer", &size)) {
+    if (!PyArg_ParseTuple(args, "i:buffer", &size)) {
         return NULL;
     }
     return PyBuffer_New(size);
@@ -4584,7 +4584,7 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
     }
     initialize_casting_tables();
     initialize_numeric_types();
-    if(initscalarmath(m) < 0) {
+    if (initscalarmath(m) < 0) {
         goto err;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4570,6 +4570,9 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
      */
     PyArray_Type.tp_hash = PyObject_HashNotImplemented;
 
+    if (PyType_Ready(&PyUFunc_Type) < 0)
+        goto err;
+
     /* Load the ufunc operators into the array module's namespace */
     if (InitOperators(d) < 0) {
         goto err;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -268,10 +268,6 @@ int initumath(PyObject *m)
     UFUNC_FLOATING_POINT_SUPPORT = 0;
 #endif
 
-    /* Initialize the types */
-    if (PyType_Ready(&PyUFunc_Type) < 0)
-        return -1;
-
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
 


### PR DESCRIPTION
In running tests on PyPy, there were failures due to improper use of the C-API:
- Calling `InitOperators` to initialize the generated `ufuncs` before calling `PyType_Ready(PyUFunc_Type)`
- Using the `PySequence_Fast*` functions before calling [`PySequence_Fast`](https://docs.python.org/3.6/c-api/sequence.html#c.PySequence_Fast) which works on CPython but does not always work on PyPy

We could prevent these mistakes by getting PyPy into our CI testing, but there are still test failures due to 
- insufficient ctypes and memoryview support in PyPy
- late writing docstrings into types and objects via `_multiarray_umath.add_docstring`