### PR TITLE
DEV: Fix lgtm.com C/C++ build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -12,3 +12,7 @@ extraction:
     python_setup:
         requirements:
           - cython>=0.29
+  cpp:
+    index:
+      build_command:
+        - python3 setup.py build


### PR DESCRIPTION
As reported on https://discuss.lgtm.com/t/analysis-fails-something-about-python3-5/1606, integration with lgtm.com C/C++ analysis is currently broken. This PR attempts to fix it by invoking Python 3 where the lgtm.com autobuild system would invoke Python 2 by default.