### PR TITLE
BUG: fix an unsafe PyTuple_GET_ITEM call

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -187,7 +187,7 @@ array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (n <= 1) {
-        if (PyTuple_GET_ITEM(args, 0) == Py_None) {
+        if (n != 0 && PyTuple_GET_ITEM(args, 0) == Py_None) {
             return PyArray_View(self, NULL, NULL);
         }
         if (!PyArg_ParseTuple(args, "O&:reshape", PyArray_IntpConverter,


### PR DESCRIPTION
I happened to notice unsafe code which attempts to access index 0 of a tuple with size 0.

It could cause a segfault if the tuple is at the end of a memory page, I guess. Not sure how to write a test though since I can't get that to happen easily.