### PR TITLE
WIP, TST: fix 1 Azure Windows warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,9 +176,10 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build NumPy'
-  - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
+  - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=$(System.DefaultWorkingDirectory)/junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
+      searchFolder: '$(System.DefaultWorkingDirectory)/junit/'
       testRunTitle: 'Publish test results for Python $(PYTHON_VERSION) $(BITS)-bit $(TEST_MODE) Windows'


### PR DESCRIPTION
@charris [noted Azure Windows warnings](https://github.com/numpy/numpy/pull/12498#issuecomment-445063962). In PR CI runs there are two types of such Warnings on Azure Windows jobs: 1 warning related to complete blocking of the publication of the test results, and the other about lacking build info.

This PR should fix 1 of those warning categories, and a reviewer should be able to navigate to the Azure page and confirm that this PR was 1 warning per Windows publish event vs. 2 warnings per Windows publish event on other recent PRs. The remaining warning is related to build data as discussed in #12530, and I'll likely handle that separately.

A reviewer should also be able to confirm that the test tab on Azure summary page for PR CI runs include > 50,000 tests vs. only about 14,000 tests (Linux + Mac only) on recent PR CI runs. Runs after merging to master were less problematic--they are only missing the build info for Windows, so 1 warning only there already.

The idea behind the fix is simply to be more explicit about the path used for generating & searching for junit xml test files on Windows jobs. Paths just work out better for Posix images, for now anyway, so no special treatment needed for them.