### PR TITLE
DEV: add ctags option file

### DIFF
--- a/.ctags.d
+++ b/.ctags.d
@@ -1,0 +1,1 @@
+--langmaps=c:+.src


### PR DESCRIPTION
When running `ctags -R`, the resulting tags file ignores `*.c.src` files. Adding this option file should make ctags include the files.

TBD: getting ctags to understand `MyPyLong_As@Type@ (PyObject *obj)`, curently it is parsed as `Type(PyObject *obj)`