### PR TITLE
DOC: Fix desc. of Ellipsis behavior in reference

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -111,9 +111,10 @@ concepts to remember include:
               [5],
               [6]]])
 
-- :const:`Ellipsis` expand to the number of ``:`` objects needed to
-  make a selection tuple of the same length as ``x.ndim``. There may
-  only be a single ellipsis present.
+- :const:`Ellipsis` expands to the number of ``:`` objects needed for the
+  selection tuple to index all dimensions. In most cases, this means that
+  length of the expanded selection tuple is ``x.ndim``. There may only be a
+  single ellipsis present.
 
   .. admonition:: Example
 


### PR DESCRIPTION
`Ellipsis` expands to make the selection tuple be consistent with the
number of dimensions of the array being indexed. `newaxis` objects are
not included because they do not correspond to axes in the array being
indexed. This commit fixes the docs to clarify that `newaxis` objects
are not included when expanding `Ellipsis`.

For example,

```python
>>> import numpy as np
>>> x = np.zeros((3, 3, 3))
>>> x[:, ..., :2, np.newaxis].shape
(3, 3, 2, 1)
>>> x[:, :, :2, np.newaxis].shape
(3, 3, 2, 1)
```

The `Ellipsis` expands to a single `:` so that the selection tuple can
index the 3-D array. The length of the expanded selection tuple is 4,
not 3 as the docs indicated before this commit.

Edit: I'm not sure what the deal is with the coverage CI failure. I haven't changed any code; I've just fixed the docs. Coverage CI appears to be broken for other recent PRs too.