### PR TITLE
DEV: use abspath on windows

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -509,7 +509,11 @@ class build_ext (old_build_ext):
 
         # Wrap unlinkable objects to a linkable one
         if unlinkable_fobjects:
-            fobjects = [os.path.relpath(obj) for obj in unlinkable_fobjects]
+            if os.name == 'nt':
+                # relpath fails if we are on a different drive
+                fobjects = [os.path.abspath(obj) for obj in unlinkable_fobjects]
+            else:
+                fobjects = [os.path.relpath(obj) for obj in unlinkable_fobjects]
             wrapped = fcompiler.wrap_unlinkable_objects(
                     fobjects, output_dir=self.build_temp,
                     extra_dll_dir=self.extra_dll_dir)


### PR DESCRIPTION
Fixes #12530 where having build artifacts on different drives prevents use of `os.path.relpath`