### PR TITLE
DOC: Change 'num' to 'np'

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -693,19 +693,19 @@ this is just an example, not a statement of "best practices"):
 
 ::
 
-    # Make all numpy available via shorter 'num' prefix
-    import numpy as num
+    # Make all numpy available via shorter 'np' prefix
+    import numpy as np
     # Make all matlib functions accessible at the top level via M.func()
     import numpy.matlib as M
     # Make some matlib functions accessible directly at the top level via, e.g. rand(3,3)
     from numpy.matlib import rand,zeros,ones,empty,eye
     # Define a Hermitian function
     def hermitian(A, **kwargs):
-        return num.transpose(A,**kwargs).conj()
+        return np.transpose(A,**kwargs).conj()
     # Make some shortcuts for transpose,hermitian:
-    #    num.transpose(A) --> T(A)
+    #    np.transpose(A) --> T(A)
     #    hermitian(A) --> H(A)
-    T = num.transpose
+    T = np.transpose
     H = hermitian
 
 Links


### PR DESCRIPTION
Stumbled upon this *NumPy for Matlab users* guide. Even though it says *Note: this is just an example, not a statement of "best practices"* I think it would still be better to use `np` instead of `num`, as this is the most common abbreviation you'll find in examples etc.