### PR TITLE
DEV: remove travis 32 bit job since it is running on azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,6 @@ matrix:
       dist: xenial  # Required for Python 3.7
       sudo: true    # travis-ci/travis-ci#9069
       env: INSTALL_PICKLE5=1
-    - python: 3.6
-      env: USE_CHROOT=1 ARCH=i386 DIST=bionic
-      sudo: true
-      addons:
-        apt:
-          update: true
-          packages:
-            - dpkg
-            - debootstrap
     - python: 3.5
       dist: xenial  # Required for python3.5-dbg
       sudo: true    # travis-ci/travis-ci#9069


### PR DESCRIPTION
We now have an [Azure job](https://dev.azure.com/numpy/numpy/_build/results?buildId=1222) to test linux 32 bit, let's remove the job it replaces from travis