### PR TITLE
ENH: Cast covariance to double in random mvnormal

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -4408,6 +4408,7 @@ cdef class RandomState:
             Behavior when the covariance matrix is not positive semidefinite.
         tol : float, optional
             Tolerance when checking the singular values in covariance matrix.
+            cov is cast to double before the check.
 
         Returns
         -------
@@ -4519,6 +4520,8 @@ cdef class RandomState:
         # not zero. We continue to use the SVD rather than Cholesky in
         # order to preserve current outputs.
 
+        # GH10839, ensure double to make tol meaningful
+        cov = cov.astype(np.double)
         (u, s, v) = svd(cov)
 
         if check_valid != 'ignore':

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -712,6 +712,12 @@ class TestRandomDist(object):
         assert_raises(ValueError, np.random.multivariate_normal, mean, cov,
                       check_valid='raise')
 
+        cov = np.array([[1, 0.1],[0.1, 1]], dtype=np.float32)
+        with suppress_warnings() as sup:
+            np.random.multivariate_normal(mean, cov)
+            w = sup.record(RuntimeWarning)
+            assert len(w) == 0
+
     def test_negative_binomial(self):
         np.random.seed(self.seed)
         actual = np.random.negative_binomial(n=100, p=.12345, size=(3, 2))


### PR DESCRIPTION
Cast the covariance in the multivariate normal to double
so that the interpretation of tol is cleaner.

closes #10839
