### PR TITLE
WIP: TST: Add xfailing tests for rewrite of numpy.pad

### DIFF
--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1260,3 +1260,38 @@ class TestTypeError1(object):
         kwargs = dict(mode='mean', stat_length=(3, ))
         assert_raises(TypeError, pad, arr, ((2, 3, 4), (3, 2)),
                       **kwargs)
+
+
+@pytest.mark.xfail(reason="not yet implemented, see gh-11358")
+def test_unsupported_mode():
+    """Test error message for unsupported pad modes."""
+    with pytest.raises(ValueError, message="mode '.*' is not supported"):
+        pad([1, 2, 3], 1, mode="unknown")
+    with pytest.raises(ValueError, message="mode '.*' is not supported"):
+        pad([1, 2, 3], 1, mode=3)
+    with pytest.raises(ValueError, message="mode '.*' is not supported"):
+        pad([1, 2, 3], 1, mode=None)
+
+
+@pytest.mark.xfail(reason="not yet implemented, see gh-11358")
+def test_order():
+    """Test if C and F order is preserved for all pad modes."""
+    modes = [
+        'constant',
+        'edge',
+        'linear_ramp',
+        'maximum',
+        'mean',
+        'median',
+        'minimum',
+        'reflect',
+        'symmetric',
+        'wrap',
+        'empty',
+    ]
+    for mode in modes:
+        x = np.ones((5, 10), order='C')
+        assert np.pad(x, 5, mode).flags["C_CONTIGUOUS"]
+
+        x = np.ones((5, 10), order='F')
+        assert np.pad(x, 5, mode).flags["F_CONTIGUOUS"]


### PR DESCRIPTION
Split from #11358.

These tests describe not yet implemented behavior for the pad function:
- pad should raise a explicit error if the "mode" argument is not
  supported.
- pad should preserve the memory-layout (C/F order) of its input when
  padding.

The test coverage is actually at 100%. Coverage.py says that [line 1292](https://codecov.io/gh/numpy/numpy/src/master/numpy/lib/arraypad.py#L1289) is not covered which is actually covered by [this test](https://github.com/numpy/numpy/blob/e26c2990c4828d6f7f2f588d75cd01eecafd53f3/numpy/lib/tests/test_arraypad.py#L792). One can check this with a debugger or by inserting the line `print(pad_before > 0 or pad_after > 0)` before the `continue` statement which is printed and actually corrects coverage.py's output. I believe this may be a bug with coverage.py or am I not noticing something obvious?

Coverage for the rewrite in #11358 is nearly at 100 % too but I still want to cover a few only partially reached lines. Therefore this is still marked as WIP.