### PR TITLE
Fix lgtm.com C/C++ build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -12,3 +12,7 @@ extraction:
     python_setup:
         requirements:
           - cython>=0.29
+  cpp:
+    index:
+      build_command:
+        - python3 setup.py build


### PR DESCRIPTION
Backport of #12527.

As reported on https://discuss.lgtm.com/t/analysis-fails-something-about-python3-5/1606, integration with lgtm.com C/C++ analysis is currently broken. This PR attempts to fix it by invoking Python 3 where the lgtm.com autobuild system would invoke Python 2 by default.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
