### PR TITLE
BUG: Make new-lines in compiler error messages print to the console

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -17,7 +17,9 @@ from distutils.version import LooseVersion
 
 from numpy.distutils import log
 from numpy.distutils.compat import get_exception
-from numpy.distutils.exec_command import filepath_from_subprocess_output
+from numpy.distutils.exec_command import (
+    filepath_from_subprocess_output, forward_bytes_to_stdout
+)
 from numpy.distutils.misc_util import cyg2win32, is_sequence, mingw32, \
                                       get_num_build_jobs, \
                                       _commandline_dep_string
@@ -159,11 +161,9 @@ def CCompiler_spawn(self, cmd, display=None):
 
     if is_sequence(cmd):
         cmd = ' '.join(list(cmd))
-    try:
-        print(o)
-    except UnicodeError:
-        # When installing through pip, `o` can contain non-ascii chars
-        pass
+
+    forward_bytes_to_stdout(o)
+
     if re.search(b'Too many open files', o):
         msg = '\nTry rerunning setup command until build succeeds.'
     else:

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -81,6 +81,29 @@ def filepath_from_subprocess_output(output):
         output = output.encode('ascii', errors='replace')
     return output
 
+
+def forward_bytes_to_stdout(val):
+    """
+    Forward bytes from a subprocess call to the console, without attempting to
+    decode them.
+
+    The assumption is that the subprocess call already returned bytes in
+    a suitable encoding.
+    """
+    if sys.version_info.major < 3:
+        # python 2 has binary output anyway
+        sys.stdout.write(val)
+    elif hasattr(sys.stdout, 'buffer'):
+        # use the underlying binary output if there is one
+        sys.stdout.buffer.write(val)
+    elif hasattr(sys.stdout, 'encoding'):
+        # round-trip the encoding if necessary
+        sys.stdout.write(val.decode(sys.stdout.encoding))
+    else:
+        # make a best-guess at the encoding
+        sys.stdout.write(val.decode('utf8', errors='replace'))
+
+
 def temp_file_name():
     fo, name = make_temp_file()
     fo.close()


### PR DESCRIPTION
Backport of #12522.

Previously this would show `b'first_line\nsecond_line'`

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
