### PR TITLE
BUG: fix refcount issue caused by #12524

### DIFF
--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -106,6 +106,7 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         seq = PySequence_Fast(*out_kwd_obj,
                               "Could not convert object to sequence");
         if (seq == NULL) {
+            *out_kwd_obj = NULL;
             return -1;
         }
         *out_objs = PySequence_Fast_ITEMS(seq);

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -79,7 +79,8 @@ NPY_NO_EXPORT int
 PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject ***out_objs)
 {
     if (kwds == NULL) {
-        *out_kwd_obj = NULL;
+        Py_INCREF(Py_None);
+        *out_kwd_obj = Py_None;
         return 0;
     }
     if (!PyDict_CheckExact(kwds)) {
@@ -92,6 +93,8 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
     /* borrowed reference */
     *out_kwd_obj = PyDict_GetItemString(kwds, "out");
     if (*out_kwd_obj == NULL) {
+        Py_INCREF(Py_None);
+        *out_kwd_obj = Py_None;
         return 0;
     }
     if (PyTuple_CheckExact(*out_kwd_obj)) {

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -100,17 +100,14 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
          * PySequence_Fast* functions. This is required for PyPy
          */
         PyObject *seq;
-        int ret;
-        Py_INCREF(*out_kwd_obj);
         seq = PySequence_Fast(*out_kwd_obj,
                               "Could not convert object to sequence");
         if (seq == NULL) {
             return -1;
         }
         *out_objs = PySequence_Fast_ITEMS(seq);
-        ret = PySequence_Fast_GET_SIZE(seq);
-        Py_SETREF(*out_kwd_obj, seq);
-        return ret;
+        *out_kwd_obj = seq;
+        return PySequence_Fast_GET_SIZE(seq);
     }
     else {
         Py_INCREF(*out_kwd_obj);

--- a/numpy/core/src/common/ufunc_override.h
+++ b/numpy/core/src/common/ufunc_override.h
@@ -28,7 +28,7 @@ PyUFunc_HasOverride(PyObject *obj);
  * Get possible out argument from kwds, and returns the number of outputs
  * contained within it: if a tuple, the number of elements in it, 1 otherwise.
  * The out argument itself is returned in out_kwd_obj, and the outputs
- * in the out_obj array (all as borrowed references).
+ * in the out_obj array (as borrowed references).
  *
  * Returns 0 if no outputs found, -1 if kwds is not a dict (with an error set).
  */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1026,12 +1026,11 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     /* check outputs, if any */
     nout = PyUFuncOverride_GetOutObjects(kwds, &out_kwd_obj, &out_objs);
     if (nout < 0) {
-        Py_XDECREF(out_kwd_obj);
         return -1;
     }
     for (i = 0; i < nout; i++) {
         if (PyUFunc_HasOverride(out_objs[i])) {
-            Py_XDECREF(out_kwd_obj);
+            Py_DECREF(out_kwd_obj);
             return 1;
         }
     }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1026,13 +1026,16 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
     /* check outputs, if any */
     nout = PyUFuncOverride_GetOutObjects(kwds, &out_kwd_obj, &out_objs);
     if (nout < 0) {
+        Py_XDECREF(out_kwd_obj);
         return -1;
     }
     for (i = 0; i < nout; i++) {
         if (PyUFunc_HasOverride(out_objs[i])) {
+            Py_XDECREF(out_kwd_obj);
             return 1;
         }
     }
+    Py_XDECREF(out_kwd_obj);
     return 0;
 }
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1034,7 +1034,7 @@ any_array_ufunc_overrides(PyObject *args, PyObject *kwds)
             return 1;
         }
     }
-    Py_XDECREF(out_kwd_obj);
+    Py_DECREF(out_kwd_obj);
     return 0;
 }
 

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -86,7 +86,7 @@ get_array_ufunc_overrides(PyObject *args, PyObject *kwds,
             ++num_override_args;
         }
     }
-    Py_XDECREF(out_kwd_obj);
+    Py_DECREF(out_kwd_obj);
     return num_override_args;
 
 fail:
@@ -94,7 +94,7 @@ fail:
         Py_DECREF(with_override[i]);
         Py_DECREF(methods[i]);
     }
-    Py_XDECREF(out_kwd_obj);
+    Py_DECREF(out_kwd_obj);
     return -1;
 }
 

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -39,6 +39,7 @@ get_array_ufunc_overrides(PyObject *args, PyObject *kwds,
 
     nout = PyUFuncOverride_GetOutObjects(kwds, &out_kwd_obj, &out_objs);
     if (nout < 0) {
+        Py_XDECREF(out_kwd_obj);
         return -1;
     }
 
@@ -86,6 +87,7 @@ get_array_ufunc_overrides(PyObject *args, PyObject *kwds,
             ++num_override_args;
         }
     }
+    Py_XDECREF(out_kwd_obj);
     return num_override_args;
 
 fail:
@@ -93,6 +95,7 @@ fail:
         Py_DECREF(with_override[i]);
         Py_DECREF(methods[i]);
     }
+    Py_XDECREF(out_kwd_obj);
     return -1;
 }
 

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -39,7 +39,6 @@ get_array_ufunc_overrides(PyObject *args, PyObject *kwds,
 
     nout = PyUFuncOverride_GetOutObjects(kwds, &out_kwd_obj, &out_objs);
     if (nout < 0) {
-        Py_XDECREF(out_kwd_obj);
         return -1;
     }
 


### PR DESCRIPTION
Backport of #12544 .

PR #12524 introduced a refcount issue. Changing the interface to PyUFuncOverride_GetOutObjects so that *out_kwd_obj is never a borrowed reference should fix it.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
