### PR TITLE
TST: activate shippable maintenance branches

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,7 @@
 branches:
     only:
        - master
+       - maintenance/*
 
 language: python
 


### PR DESCRIPTION
Adjusted the shippable yml config file to run ARMv8 CI on all PRs to all `maintenance/*` branches. This was [requested](https://github.com/numpy/numpy/pull/12573#issuecomment-447712458) by @charris with impending `1.16rc` workflow / activity.

The changes here are based on the [official shippable docs for branches](http://docs.shippable.com/platform/workflow/config/#branches) & the example yml file above that.

I guess we won't really know for sure until we try the changes though.