### PR TITLE
TST: activate shippable maintenance branches

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,7 @@
 branches:
     only:
        - master
+       - maintenance/*
 
 language: python
 


### PR DESCRIPTION
Backport of #12578.

Adjusted the shippable yml config file to run ARMv8 CI on all PRs to all maintenance/* branches. This was requested by @charris with impending 1.16rc workflow / activity.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
