### PR TITLE
WIP: refactor dtype to be a type subclass

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,3 +221,19 @@ jobs:
       testResultsFiles: '**/test-*.xml'
       testRunTitle: 'Publish test results for PyPy3'
       failTaskOnFailedTests: true
+- job: Linux_Python_36_USE_DTYPE_AS_PYOBJECT_0
+  pool:
+    vmIMage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      python3 -m pip install --upgrade pip setuptools
+      python3 -m pip install --user cython pytest pytz
+    displayName: 'Install prerequisites'
+  - script: |
+      export USE_DTYPE_AS_PYOBJECT=0
+      python3 runtests.py -- -rsx --junitxml=junit/test-results.xml
+    displayName: 'Run USE_DTYPE_AS_PYOBJECT=0 Build / Tests'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for USE_DTYPE_AS_PYOBJECT Linux'

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -598,7 +598,11 @@ typedef struct {
         PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)
 
 typedef struct _PyArray_Descr {
+#ifdef USE_DTYPE_AS_PYOBJECT
         PyObject_HEAD
+#else
+        PyTypeObject descrtype;
+#endif
         /*
          * the type object representing an
          * instance of this type -- should not

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -601,6 +601,7 @@ typedef struct _PyArray_Descr {
 #ifdef USE_DTYPE_AS_PYOBJECT
         PyObject_HEAD
 #else
+        /* may need to be PyHeapTypeObject for new tp_as_* functions? */
         PyTypeObject descrtype;
 #endif
         /*

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -66,6 +66,10 @@ set_numeric_ops.__module__ = 'numpy'
 seterrobj.__module__ = 'numpy'
 zeros.__module__ = 'numpy'
 
+if isinstance(dtype(int), type):
+    # new dtypes, register the pickle protocol
+    import copyreg
+    copyreg.pickle(dtype, dtype.__reduce__)
 
 # We can't verify dispatcher signatures because NumPy's C functions don't
 # support introspection.

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -28,6 +28,11 @@ NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "
 NPY_RELAXED_STRIDES_DEBUG = (os.environ.get('NPY_RELAXED_STRIDES_DEBUG', "0") != "0")
 NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CHECKING
 
+# Put USE_DTYPE_AS_PYOBJECT=0 in the environment if you want to use
+# new dtype code.
+# TODO: flip the default to 0 once new dtypes are ready
+USE_DTYPE_AS_PYOBJECT = (os.environ.get('USE_DTYPE_AS_PYOBJECT', "1") != "0")
+
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force
 # config.h generation inside an Extension class, and as such sharing
@@ -459,6 +464,10 @@ def configuration(parent_package='',top_path=None):
             if NPY_RELAXED_STRIDES_DEBUG:
                 moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
 
+            # Use old-style, non-subclassable dtypes
+            if USE_DTYPE_AS_PYOBJECT:
+                moredefs.append(('USE_DTYPE_AS_PYOBJECT', 1))
+
             # Get long double representation
             rep = check_long_double_representation(config_cmd)
             moredefs.append(('HAVE_LDOUBLE_%s' % rep, 1))
@@ -552,6 +561,10 @@ def configuration(parent_package='',top_path=None):
 
             if NPY_RELAXED_STRIDES_DEBUG:
                 moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
+
+            # Use old-style, non-subclassable dtypes
+            if USE_DTYPE_AS_PYOBJECT:
+                moredefs.append(('USE_DTYPE_AS_PYOBJECT', 1))
 
             # Check whether we can use inttypes (C99) formats
             if config_cmd.check_decl('PRIdPTR', headers=['inttypes.h']):

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4441,11 +4441,13 @@ set_typeinfo(PyObject *dict)
     dtype = PyObject_New(PyArray_Descr, &PyArrayDescr_Type);
 #else
     dtype = PyObject_GC_New(PyArray_Descr, &PyArrayDescr_Type);
-#endif
     /* Don't copy PyObject_HEAD part */
-    memcpy((char *)dtype + sizeof(PyObject),
-           (char *)&PyArrayDescr_Type + sizeof(PyObject),
+    memset((char *)dtype + sizeof(PyObject),
+           0,
            sizeof(PyArray_Descr) - sizeof(PyObject));
+    dtype->descrtype.tp_name = "numpy.@NAME@Descr";
+    dtype->descrtype.tp_flags = Py_TPFLAGS_DEFAULT;
+#endif
     dtype->typeobj  = &Py@NAME@ArrType_Type;
     dtype->kind  = NPY_@kind@LTR;
     dtype->type  = NPY_@name1@LTR;

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4115,10 +4115,7 @@ _create_datetime_metadata(NPY_DATETIMEUNIT base, int num)
  * #from = VOID, STRING, UNICODE#
  * #suff = void, string, unicode#
  * #sort = 0, 1, 1#
- * #align = char, char, npy_ucs4#
  * #NAME = Void, String, Unicode#
- * #endian = |, |, =#
- * #flags = 0, 0, NPY_NEEDS_INIT#
  */
 static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     {
@@ -4185,44 +4182,8 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_ArgFunc*)@from@_argmin
 };
 
-/*
- * FIXME: check for PY3K
- */
-static PyArray_Descr @from@_Descr = {
-    PyObject_HEAD_INIT(&PyArrayDescr_Type)
-    /* typeobj */
-    &Py@NAME@ArrType_Type,
-    /* kind */
-    NPY_@from@LTR,
-    /* type */
-    NPY_@from@LTR,
-    /* byteorder */
-    '@endian@',
-    /* flags, unicode needs init as py3.3 does not like printing garbage  */
-    @flags@,
-    /* type_num */
-    NPY_@from@,
-    /* elsize */
-    0,
-    /* alignment */
-    _ALIGN(@align@),
-    /* subarray */
-    NULL,
-    /* fields */
-    NULL,
-    /* names */
-    NULL,
-    /* f */
-    &_Py@NAME@_ArrFuncs,
-    /* metadata */
-    NULL,
-    /* c_metadata */
-    NULL,
-    /* hash */
-    -1,
-};
-
 /**end repeat**/
+
 
 /**begin repeat
  *
@@ -4335,74 +4296,12 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_ArgFunc*)@from@_argmin
 };
 
-/*
- * FIXME: check for PY3K
- */
-NPY_NO_EXPORT PyArray_Descr @from@_Descr = {
-    PyObject_HEAD_INIT(&PyArrayDescr_Type)
-    /* typeobj */
-    &Py@NAME@ArrType_Type,
-    /* kind */
-    NPY_@kind@LTR,
-    /* type */
-    NPY_@from@LTR,
-    /* byteorder */
-    '@endian@',
-    /* flags */
-    @isobject@,
-    /* type_num */
-    NPY_@from@,
-    /* elsize */
-    sizeof(@fromtype@),
-    /* alignment */
-    _ALIGN(@fromtype@),
-    /* subarray */
-    NULL,
-    /* fields */
-    NULL,
-    /* names */
-    NULL,
-    /* f */
-    &_Py@NAME@_ArrFuncs,
-    /* metadata */
-    NULL,
-    /* c_metadata */
-    NULL,
-    /* hash */
-    -1,
-};
-
 /**end repeat**/
 
 #define _MAX_LETTER 128
 static char _letter_to_num[_MAX_LETTER];
 
-static PyArray_Descr *_builtin_descrs[] = {
-    &BOOL_Descr,
-    &BYTE_Descr,
-    &UBYTE_Descr,
-    &SHORT_Descr,
-    &USHORT_Descr,
-    &INT_Descr,
-    &UINT_Descr,
-    &LONG_Descr,
-    &ULONG_Descr,
-    &LONGLONG_Descr,
-    &ULONGLONG_Descr,
-    &FLOAT_Descr,
-    &DOUBLE_Descr,
-    &LONGDOUBLE_Descr,
-    &CFLOAT_Descr,
-    &CDOUBLE_Descr,
-    &CLONGDOUBLE_Descr,
-    &OBJECT_Descr,
-    &STRING_Descr,
-    &UNICODE_Descr,
-    &VOID_Descr,
-    &DATETIME_Descr,
-    &TIMEDELTA_Descr,
-    &HALF_Descr
-};
+static PyArray_Descr *_builtin_descrs[24];
 
 /*NUMPY_API
  * Get the PyArray_Descr structure for a type.
@@ -4512,20 +4411,75 @@ set_typeinfo(PyObject *dict)
      *          CFLOAT, CDOUBLE, CLONGDOUBLE,
      *          OBJECT, STRING, UNICODE, VOID,
      *          DATETIME,TIMEDELTA#
+     * #NAME = Bool,
+     *         Byte, UByte, Short, UShort, Int, UInt,
+     *         Long, ULong, LongLong, ULongLong,
+     *         Half, Float, Double, LongDouble,
+     *         CFloat, CDouble, CLongDouble,
+     *         Object, String, Unicode, Void,
+     *         Datetime, Timedelta#
+     * #kind = GENBOOL,
+     *         SIGNED, UNSIGNED, SIGNED, UNSIGNED, SIGNED, UNSIGNED,
+     *         SIGNED, UNSIGNED, SIGNED, UNSIGNED,
+     *         FLOATING, FLOATING, FLOATING, FLOATING,
+     *         COMPLEX, COMPLEX, COMPLEX,
+     *         OBJECT, STRING, UNICODE, VOID,
+     *         DATETIME, TIMEDELTA#
+     * #endian = |*3, =*15, |, |, =, |, =*2#
+     * #flags= 0*18, NPY_OBJECT_DTYPE_FLAGS,0, NPY_NEEDS_INIT, 0*3#
+     * #fromtype = npy_bool,
+     *             npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
+     *             npy_long, npy_ulong, npy_longlong, npy_ulonglong,
+     *             npy_half, npy_float, npy_double, npy_longdouble,
+     *             npy_cfloat, npy_cdouble, npy_clongdouble,
+     *             PyObject *, char, npy_ucs4, char,
+     *             npy_datetime, npy_timedelta#
+     * #DO_ELSIZE = 1*19, 0*3, 1*2#
      */
 
-    /**begin repeat1
-     *
-     * #name2 = HALF, DATETIME, TIMEDELTA#
-     */
+#if USE_DTYPE_AS_PYOBJECT
+    dtype = PyObject_New(PyArray_Descr, &PyArrayDescr_Type);
+#else
+    dtype = PyObject_GC_New(PyArray_Descr, &PyArrayDescr_Type);
+#endif
+    /* Don't copy PyObject_HEAD part */
+    memcpy((char *)dtype + sizeof(PyObject),
+           (char *)&PyArrayDescr_Type + sizeof(PyObject),
+           sizeof(PyArray_Descr) - sizeof(PyObject));
+    dtype->typeobj  = &Py@NAME@ArrType_Type;
+    dtype->kind  = NPY_@kind@LTR;
+    dtype->type  = NPY_@name1@LTR;
+    dtype->byteorder  = '@endian@';
+    /* unicode needs init as py3.3 does not like printing garbage  */
+    dtype->flags  = @flags@;
+    dtype->type_num  = NPY_@name1@;
+#if @DO_ELSIZE@
+    dtype->elsize  = sizeof(@fromtype@);
+#else
+    dtype->elsize = 0;
+#endif
+    dtype->alignment  = _ALIGN(@fromtype@);
+    dtype->subarray  = NULL;
+    dtype->fields  = Py_None;
+    dtype->names  = NULL;
+    dtype->f  = &_Py@NAME@_ArrFuncs;
+    dtype->metadata  = NULL;
+    dtype->c_metadata  = NULL;
+    dtype->hash  = -1;
+    _builtin_descrs[NPY_@name1@] = dtype;
 
-    dtype = _builtin_descrs[NPY_@name1@];
     if (dtype->f->castdict == NULL) {
         dtype->f->castdict = PyDict_New();
         if (dtype->f->castdict == NULL) {
             return -1;
         }
     }
+
+    /**begin repeat1
+     *
+     * #name2 = HALF, DATETIME, TIMEDELTA#
+     */
+
     key = PyInt_FromLong(NPY_@name2@);
     if (key == NULL) {
         return -1;
@@ -4579,29 +4533,6 @@ set_typeinfo(PyObject *dict)
     /**end repeat**/
 
     _letter_to_num[NPY_STRINGLTR2] = NPY_STRING;
-
-    /**begin repeat
-      * #name = BOOL,
-      *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
-      *         LONG, ULONG, LONGLONG, ULONGLONG,
-      *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
-      *         CFLOAT, CDOUBLE, CLONGDOUBLE,
-      *         OBJECT, STRING, UNICODE, VOID,
-      *         DATETIME, TIMEDELTA#
-      */
-
-    @name@_Descr.fields = Py_None;
-
-    /**end repeat**/
-
-
-    /**begin repeat
-      * #name = STRING, UNICODE, VOID#
-      */
-
-    PyDataType_MAKEUNSIZED(&@name@_Descr);
-
-    /**end repeat**/
 
     /* Set a dictionary with type information */
     infodict = PyDict_New();

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4437,10 +4437,8 @@ set_typeinfo(PyObject *dict)
      * #DO_ELSIZE = 1*19, 0*3, 1*2#
      */
 
-#if USE_DTYPE_AS_PYOBJECT
     dtype = PyObject_New(PyArray_Descr, &PyArrayDescr_Type);
-#else
-    dtype = PyObject_GC_New(PyArray_Descr, &PyArrayDescr_Type);
+#ifndef USE_DTYPE_AS_PYOBJECT
     /* Don't copy PyObject_HEAD part */
     memset((char *)dtype + sizeof(PyObject),
            0,
@@ -4539,7 +4537,6 @@ set_typeinfo(PyObject *dict)
     /* Set a dictionary with type information */
     infodict = PyDict_New();
     if (infodict == NULL) return -1;
-
 
     /**begin repeat
      *

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4184,7 +4184,6 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
 
 /**end repeat**/
 
-
 /**begin repeat
  *
  * #from = BOOL,

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3601,7 +3601,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     0,                                          /* tp_call */
     (reprfunc)arraydescr_str,                   /* tp_str */
     PyObject_GenericGetAttr,                    /* tp_getattro */
-    0,                                          /* tp_setattro */
+    PyObject_GenericSetAttr,                    /* tp_setattro */
     0,                                          /* tp_as_buffer */
 #ifdef USE_DTYPE_AS_PYOBJECT
     Py_TPFLAGS_DEFAULT,                         /* tp_flags */

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1762,11 +1762,7 @@ error:
 NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrNew(PyArray_Descr *base)
 {
-#if USE_DTYPE_AS_PYOBJECT
     PyArray_Descr *newdescr = PyObject_New(PyArray_Descr, &PyArrayDescr_Type);
-#else
-    PyArray_Descr *newdescr = PyObject_GC_New(PyArray_Descr, &PyArrayDescr_Type);
-#endif
 
     if (newdescr == NULL) {
         return NULL;
@@ -3576,14 +3572,6 @@ static PyMappingMethods descr_as_mapping = {
 };
 
 /****************** End of Mapping Protocol ******************************/
-#ifdef USE_DTYPE_AS_PYOBJECT
-#pragma message "USE_DTYPE_AS_PYOBJECT defined, using old dtypes"
-#define BASETYPE 0
-#else
-#pragma message "USE_DTYPE_AS_PYOBJECT not defined, using new dtypes"
-/* may need to be PyHeapTypeObject to allow overriding tp_as_* functions? */
-#define BASETYPE &PyType_Type
-#endif
 
 NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
 #if defined(NPY_PY3K)
@@ -3631,7 +3619,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     arraydescr_methods,                         /* tp_methods */
     arraydescr_members,                         /* tp_members */
     arraydescr_getsets,                         /* tp_getset */
-    BASETYPE,                                   /* tp_base */
+    0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */
@@ -3653,3 +3641,4 @@ NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     0,                                          /* tp_del */
     0,                                          /* tp_version_tag */
 };
+

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4639,6 +4639,13 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
         goto err;
     }
 
+#ifdef USE_DTYPE_AS_PYOBJECT
+#pragma message "USE_DTYPE_AS_PYOBJECT defined, using old dtypes"
+#else
+#pragma message "USE_DTYPE_AS_PYOBJECT not defined, using new dtypes"
+    PyArrayDescr_Type.tp_base = &PyType_Type;
+    PyArrayDescr_Type.tp_free = PyObject_Free;
+#endif
     PyArrayDescr_Type.tp_hash = PyArray_DescrHash;
     if (PyType_Ready(&PyArrayDescr_Type) < 0) {
         goto err;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4739,10 +4739,10 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
         goto err;
     }
 
-    if (set_typeinfo(d) != 0) {
+    if (initumath(m) != 0) {
         goto err;
     }
-    if (initumath(m) != 0) {
+    if (set_typeinfo(d) != 0) {
         goto err;
     }
     return RETVAL(m);


### PR DESCRIPTION
Replaces #12430. This first step is to refactor the global descr creation to use PyObject_New. Note the new define `USE_DTYPE_AS_PYOBJECT` which preserves the old behavior. Once the new dtype works we can flip the default.