### PR TITLE
MAINT: Update changelog.py for Python 3.

### DIFF
--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -42,8 +42,10 @@ import codecs
 from git import Repo
 from github import Github
 
-UTF8Writer = codecs.getwriter('utf8')
-sys.stdout = UTF8Writer(sys.stdout)
+if sys.version_info.major < 3:
+    UTF8Writer = codecs.getwriter('utf8')
+    sys.stdout = UTF8Writer(sys.stdout)
+
 this_repo = Repo(os.path.join(os.path.dirname(__file__), ".."))
 
 author_msg =\


### PR DESCRIPTION
- Don't use UTF8Writer in Python 3.
~- Don't use print() for blank lines.~

This is left compatible with Python 2 as someone may use it with
that version and there is no need to force the change.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
