### PR TITLE
ENH: improve performance of numpy.core.records.fromarrays

### DIFF
--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function
+
+from .common import Benchmark
+
+import numpy as np
+
+        
+class Records(Benchmark):
+    def setup(self):
+        self.l50 = np.arange(1000)
+        self.fields_number = 10000
+        self.arrays = [self.l50 for _ in range(self.fields_number)]
+        self.formats = [self.l50.dtype.str for _ in range(self.fields_number)]
+        self.formats_str = ','.join(self.formats)
+        self.dtype_ = np.dtype(
+            [
+                ('field_{}'.format(i), self.l50.dtype.str)
+                for i in range(self.fields_number)
+            ]
+        )
+        
+    def time_fromarrays_w_dtype(self):
+        np.core.records.fromarrays(self.arrays, dtype=self.dtype_)
+        
+    def time_fromarrays_wo_dtype(self):
+        np.core.records.fromarrays(self.arrays)
+        
+    def time_fromarrays_formats_as_list(self):
+        np.core.records.fromarrays(self.arrays, formats=self.formats)
+        
+    def time_fromarrays_formats_as_string(self):
+        np.core.records.fromarrays(self.arrays, formats=self.formats_str)

--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -5,7 +5,7 @@ from .common import Benchmark
 
 import numpy as np
 
-      
+
 class Records(Benchmark):
     def setup(self):
         self.l50 = np.arange(1000)
@@ -23,37 +23,37 @@ class Records(Benchmark):
         for file in ('test1.bin', 'test2.bin', 'test3.bin'):
             with open(file, 'w+b') as f:
                 f.write(self.buffer)
-        
+
     def teardown(self):
         for file in ('test1.bin', 'test2.bin', 'test3.bin'):
             os.remove(file)
-        
+
     def time_fromarrays_w_dtype(self):
         np.core.records.fromarrays(self.arrays, dtype=self.dtype_)
-        
+
     def time_fromarrays_wo_dtype(self):
         np.core.records.fromarrays(self.arrays)
-        
+
     def time_fromarrays_formats_as_list(self):
         np.core.records.fromarrays(self.arrays, formats=self.formats)
-        
+
     def time_fromarrays_formats_as_string(self):
         np.core.records.fromarrays(self.arrays, formats=self.formats_str)
-        
+
     def time_fromstring_w_dtype(self):
         np.core.records.fromstring(self.buffer, dtype=self.dtype_)
-        
+
     def time_fromstring_formats_as_list(self):
         np.core.records.fromstring(self.buffer, formats=self.formats)
-        
+
     def time_fromstring_formats_as_string(self):
         np.core.records.fromstring(self.buffer, formats=self.formats_str)
-           
+
     def time_fromfile_w_dtype(self):
         np.core.records.fromfile('test1.bin', dtype=self.dtype_)
-        
+
     def time_fromfile_formats_as_list(self):
         np.core.records.fromfile('test2.bin', formats=self.formats)
-        
+
     def time_fromfile_formats_as_string(self):
         np.core.records.fromfile('test3.bin', formats=self.formats_str)

--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -20,13 +20,6 @@ class Records(Benchmark):
             ]
         )
         self.buffer = self.l50.tostring() * self.fields_number
-        for file in ('test1.bin', 'test2.bin', 'test3.bin'):
-            with open(file, 'w+b') as f:
-                f.write(self.buffer)
-
-    def teardown(self):
-        for file in ('test1.bin', 'test2.bin', 'test3.bin'):
-            os.remove(file)
 
     def time_fromarrays_w_dtype(self):
         np.core.records.fromarrays(self.arrays, dtype=self.dtype_)

--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -41,12 +41,3 @@ class Records(Benchmark):
 
     def time_fromstring_formats_as_string(self):
         np.core.records.fromstring(self.buffer, formats=self.formats_str)
-
-    def time_fromfile_w_dtype(self):
-        np.core.records.fromfile('test1.bin', dtype=self.dtype_)
-
-    def time_fromfile_formats_as_list(self):
-        np.core.records.fromfile('test2.bin', formats=self.formats)
-
-    def time_fromfile_formats_as_string(self):
-        np.core.records.fromfile('test3.bin', formats=self.formats_str)

--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
+import os
 
 from .common import Benchmark
 
 import numpy as np
 
-        
+      
 class Records(Benchmark):
     def setup(self):
         self.l50 = np.arange(1000)
@@ -18,6 +19,14 @@ class Records(Benchmark):
                 for i in range(self.fields_number)
             ]
         )
+        self.buffer = self.l50.tostring() * self.fields_number
+        for file in ('test1.bin', 'test2.bin', 'test3.bin'):
+            with open(file, 'w+b') as f:
+                f.write(self.buffer)
+        
+    def teardown(self):
+        for file in ('test1.bin', 'test2.bin', 'test3.bin'):
+            os.remove(file)
         
     def time_fromarrays_w_dtype(self):
         np.core.records.fromarrays(self.arrays, dtype=self.dtype_)
@@ -30,3 +39,21 @@ class Records(Benchmark):
         
     def time_fromarrays_formats_as_string(self):
         np.core.records.fromarrays(self.arrays, formats=self.formats_str)
+        
+    def time_fromstring_w_dtype(self):
+        np.core.records.fromstring(self.buffer, dtype=self.dtype_)
+        
+    def time_fromstring_formats_as_list(self):
+        np.core.records.fromstring(self.buffer, formats=self.formats)
+        
+    def time_fromstring_formats_as_string(self):
+        np.core.records.fromstring(self.buffer, formats=self.formats_str)
+           
+    def time_fromfile_w_dtype(self):
+        np.core.records.fromfile('test1.bin', dtype=self.dtype_)
+        
+    def time_fromfile_formats_as_list(self):
+        np.core.records.fromfile('test2.bin', formats=self.formats)
+        
+    def time_fromfile_formats_as_string(self):
+        np.core.records.fromfile('test3.bin', formats=self.formats_str)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -584,7 +584,9 @@ class recarray(ndarray):
 
 def fromarrays(arrayList, dtype=None, shape=None, formats=None,
                names=None, titles=None, aligned=False, byteorder=None):
-    """ create a record array from a (flat) list of arrays
+    """ create a record array from a (flat) list of arrays. 
+    If both `dtype` and `formats` are `None` then the input arrays must have 
+    the same shape.
 
     >>> x1=np.array([1,2,3,4])
     >>> x2=np.array(['a','dd','xyz','12'])
@@ -612,10 +614,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
         for obj in arrayList:
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
-            shape_ = obj.shape[1:] or ''
-            # keep the 1.15.4 behaviour for now
-            shape_ = ''
-            formats.append('{}{}'.format(shape_, obj.dtype.str))
+            formats.append(obj.dtype.str)
 
     if dtype is not None:
         descr = sb.dtype(dtype)
@@ -770,7 +769,9 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     (0.5, 10, 'abcde')
     >>> r.shape
     (10,)
-    """
+    """  
+    if dtype is None and formats is None:
+        raise ValueError("Must have dtype= or formats=")
 
     if (shape is None or shape == 0):
         shape = (-1,)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -767,7 +767,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     (0.5, 10, 'abcde')
     >>> r.shape
     (10,)
-    """  
+    """
 
     if (shape is None or shape == 0):
         shape = (-1,)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -612,8 +612,8 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
         for obj in arrayList:
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
-            shape = obj.shape[1:] or ''
-            formats.append('{}{}'.format(shape, obj.dtype.str))
+            shape_ = obj.shape[1:] or ''
+            formats.append('{}{}'.format(shape_, obj.dtype.str))
 
     if dtype is not None:
         descr = sb.dtype(dtype)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -584,9 +584,7 @@ class recarray(ndarray):
 
 def fromarrays(arrayList, dtype=None, shape=None, formats=None,
                names=None, titles=None, aligned=False, byteorder=None):
-    """ create a record array from a (flat) list of arrays. 
-    If both `dtype` and `formats` are `None` then the input arrays must have 
-    the same shape.
+    """ create a record array from a (flat) list of arrays
 
     >>> x1=np.array([1,2,3,4])
     >>> x2=np.array(['a','dd','xyz','12'])
@@ -601,7 +599,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
 
     arrayList = [sb.asarray(x) for x in arrayList]
 
-    if shape in (None, 0, ''):
+    if (shape is None or shape == 0):
         shape = arrayList[0].shape
 
     if isinstance(shape, int):
@@ -770,8 +768,6 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     >>> r.shape
     (10,)
     """  
-    if dtype is None and formats is None:
-        raise ValueError("Must have dtype= or formats=")
 
     if (shape is None or shape == 0):
         shape = (-1,)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -169,8 +169,13 @@ class format_parser(object):
         if isinstance(formats, list):
             if len(formats) < 2:
                 formats.append('')
-            formats = ','.join(formats)
-        dtype = sb.dtype(formats, aligned)
+            dtype = sb.dtype(
+                {'formats': formats,
+                 'names': ['f{}'.format(i) for i in range(len(formats))]},
+                aligned,
+            )
+        else:
+            dtype = sb.dtype(formats, aligned)
         fields = dtype.fields
         if fields is None:
             dtype = sb.dtype([('f1', dtype)], aligned)
@@ -611,7 +616,6 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
             formats.append(obj.dtype.str)
-        formats = ','.join(formats)
 
     if dtype is not None:
         descr = sb.dtype(dtype)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -167,11 +167,8 @@ class format_parser(object):
         if formats is None:
             raise ValueError("Need formats argument")
         if isinstance(formats, list):
-            if len(formats) < 2:
-                formats.append('')
             dtype = sb.dtype(
-                {'formats': formats,
-                 'names': ['f{}'.format(i) for i in range(len(formats))]},
+                [('f{}'.format(i), format_) for i, format_ in enumerate(formats)],
                 aligned,
             )
         else:

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -613,6 +613,8 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
             shape_ = obj.shape[1:] or ''
+            # keep the 1.15.4 behaviour for now
+            shape_ = ''
             formats.append('{}{}'.format(shape_, obj.dtype.str))
 
     if dtype is not None:

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -612,7 +612,8 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
         for obj in arrayList:
             if not isinstance(obj, ndarray):
                 raise ValueError("item in the array list must be an ndarray.")
-            formats.append(obj.dtype.str)
+            shape = obj.shape[1:] or ''
+            formats.append('{}{}'.format(shape, obj.dtype.str))
 
     if dtype is not None:
         descr = sb.dtype(dtype)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -599,7 +599,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
 
     arrayList = [sb.asarray(x) for x in arrayList]
 
-    if (shape is None or shape == 0):
+    if shape is None or shape == 0:
         shape = arrayList[0].shape
 
     if isinstance(shape, int):

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -599,7 +599,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
 
     arrayList = [sb.asarray(x) for x in arrayList]
 
-    if shape is None or shape == 0:
+    if shape in (None, 0, ''):
         shape = arrayList[0].shape
 
     if isinstance(shape, int):


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->

### Description
Further improve performance of numpy.core.records.fromarrays: 
* the arrays dtypes were converted to strings, and finally a new comma delimited string was created from those
* the comma separated string was parsed in _format\_parser.\_parseFormats_ basically using regex to extract the formats basically undoing the first step
* the new implementation avoids generating the comma separated string and instead creates the dtype using a list of (field name, field dtype) 
* added benchmark for records

### benchmark

```
       before           after         ratio
     [de28edd8]       [1d1fb908]
     <v1.15.4^0>       <master>  
-     6.79±0.04μs       5.72±0.2μs     0.84  bench_records.Records.time_fromstring_w_dtype
-       177±0.4ms       69.5±0.3ms     0.39  bench_records.Records.time_fromarrays_w_dtype
-         1.29±0s        111±0.6ms     0.09  bench_records.Records.time_fromarrays_formats_as_string
-         1.30±0s       91.1±0.3ms     0.07  bench_records.Records.time_fromarrays_wo_dtype
-      1.28±0.01s       86.0±0.4ms     0.07  bench_records.Records.time_fromarrays_formats_as_list
-      1.12±0.01s       41.4±0.2ms     0.04  bench_records.Records.time_fromstring_formats_as_string
-      1.12±0.01s       16.8±0.2ms     0.01  bench_records.Records.time_fromstring_formats_as_list
```
