### PR TITLE
DOC: Fix markup in 1.16.0 release notes. 

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -321,11 +321,11 @@ single elementary function for four related but different signatures,
 The ``out`` argument to these functions is now always tested for memory overlap
 to avoid corrupted results when memory overlap occurs.
 
-New value ``unscaled`` for option ``cov`` in ``np.polyfit''
+New value ``unscaled`` for option ``cov`` in ``np.polyfit``
 -----------------------------------------------------------
 A further possible value has been added to the ``cov`` parameter of the
 ``np.polyfit`` function. With ``cov='unscaled'`` the scaling of the covariance
-matrix is disabled completely (similar to setting ``absolute_sigma=True'' in
+matrix is disabled completely (similar to setting ``absolute_sigma=True`` in
 ``scipy.optimize.curve_fit``). This would be useful in occasions, where the
 weights are given by 1/sigma with sigma being the (known) standard errors of
 (Gaussian distributed) data points, in which case the unscaled matrix is


### PR DESCRIPTION
Should fix these issues (screenshot below).

<img width="799" alt="screen shot 2018-12-23 at 00 08 08" src="https://user-images.githubusercontent.com/3019665/50380935-e28ed680-0646-11e9-8c96-33e49d31f7ba.png">

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
