### PR TITLE
TST: Update `travis-test.sh` for C99

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -25,8 +25,7 @@ if [ -n "$PYTHON_OPTS" ]; then
 fi
 
 # make some warnings fatal, mostly to match windows compilers
-werrors="-Werror=declaration-after-statement -Werror=vla "
-werrors+="-Werror=nonnull -Werror=pointer-arith"
+werrors="-Werror=vla -Werror=nonnull -Werror=pointer-arith"
 
 # build with c99 by default
 


### PR DESCRIPTION
Most of this was already done, but we were still raising an error for
declaration after a statement because the Windows Python 2.7 compiler
did not allow it. We can fix this now as NumPy >= 1.17 has dropped
Python 2.7 support.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
