### PR TITLE
BUG: Add missing free in ufunc dealloc

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5279,6 +5279,8 @@ ufunc_dealloc(PyUFuncObject *ufunc)
 {
     PyArray_free(ufunc->core_num_dims);
     PyArray_free(ufunc->core_dim_ixs);
+    PyArray_free(ufunc->core_dim_sizes);
+    PyArray_free(ufunc->core_dim_flags);
     PyArray_free(ufunc->core_offsets);
     PyArray_free(ufunc->core_signature);
     PyArray_free(ufunc->ptr);


### PR DESCRIPTION
Fixup cleanup of ufunc (definitely lost in valgrind). See also gh-12615, tested with valgrind and this seems all ufunc related lost memory right now.