### PR TITLE
BLD: move -std=c99 addition to CFLAGS to Azure config

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -14,8 +14,7 @@ Prerequisites
 
 Building NumPy requires the following software installed:
 
-1) For Python 2, Python__ 2.7.x or newer.
-   For Python 3, Python__ 3.4.x or newer.
+1) For Python 3, Python__ 3.5.x or newer.
 
    On Debian and derivative (Ubuntu): python python-dev
 
@@ -27,8 +26,8 @@ Building NumPy requires the following software installed:
 
    Python must also be compiled with the zlib module enabled.
 
-2) Cython >= 0.19 (for development versions of numpy, not for released
-                   versions)
+2) Cython >= 0.29.2 (for development versions of numpy, not for released
+                     versions)
 3) pytest__ (optional) 1.15 or later
 
    This is required for testing numpy, but not for using it.
@@ -61,8 +60,6 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that the ``python`` command here is the system default Python, generally
-python 2, the ``python3`` command may be needed to install on python 3.
 See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_
 for more details.
 
@@ -79,8 +76,13 @@ skipped when running the test suite if no Fortran compiler is available.  For
 building Scipy a Fortran compiler is needed though, so we include some details
 on Fortran compilers in the rest of this section.
 
-On OS X and Linux, all common compilers will work.  Note that for Fortran,
-``gfortran`` is strongly preferred over ``g77``, but if you happen to have both
+On OS X and Linux, all common compilers will work.  Note that C99 support is
+required.  For compilers that don't support the C99 language standard by
+default (such as ``gcc`` versions < 5.0), it should be enabled.  For ``gcc``::
+
+    export CFLAGS='-std=c99'
+
+For Fortran, ``gfortran`` works, ``g77`` does not.  In case ``g77`` is
 installed then ``g77`` will be detected and used first.  To explicitly select
 ``gfortran`` in that case, do::
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
            cd ../numpy && \
            NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1 \
            F77=gfortran-5 F90=gfortran-5 \
-           CFLAGS=-UNDEBUG python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
+           CFLAGS='-UNDEBUG -std=c99' python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     inputs:

--- a/runtests.py
+++ b/runtests.py
@@ -351,8 +351,6 @@ def build_project(args):
                 '-Werror=unused-function',
             ])
             env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
-            # NumPy > 1.16 should be C99 compatible.
-            env['CFLAGS'] = '-std=c99' + ' ' + env.get('CFLAGS', '')
     if args.debug or args.gcov:
         # assume everyone uses gcc/gfortran
         env['OPT'] = '-O0 -ggdb'


### PR DESCRIPTION
See gh-12610 for details. Note, I removed this for TravisCI for now as a test, I want to see how big a problem we have for building from source at the moment.