### PR TITLE
BUG: longdouble with elsize 12 is never uint alignable.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ trigger:
       - master
       - maintenance/*
 jobs:
-- job: Linux_Python_36_32bit_full
+- job: Linux_Python_36_32bit_full_with_asserts
   pool:
     vmIMage: 'ubuntu-16.04'
   steps:
@@ -19,6 +19,7 @@ jobs:
            pip3 install setuptools nose cython==0.29.0 pytest pytz pickle5 && \
            apt-get -y install libopenblas-dev gfortran && \
            NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1 \
+           F77=gfortran-5 F90=gfortran-5 CFLAGS=-UNDEBUG \
            python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2

--- a/numpy/core/src/common/array_assign.c
+++ b/numpy/core/src/common/array_assign.c
@@ -125,8 +125,12 @@ raw_array_is_aligned(int ndim, npy_intp *shape,
 
         return npy_is_aligned((void *)align_check, alignment);
     }
-    else {
+    else if (alignment == 1) {
         return 1;
+    }
+    else {
+        /* always return false for alignment == 0, which means unaligned */
+        return 0;
     }
 }
 

--- a/numpy/core/src/common/array_assign.c
+++ b/numpy/core/src/common/array_assign.c
@@ -129,7 +129,7 @@ raw_array_is_aligned(int ndim, npy_intp *shape,
         return 1;
     }
     else {
-        /* always return false for alignment == 0, which means unaligned */
+        /* always return false for alignment == 0, which means cannot-be-aligned */
         return 0;
     }
 }

--- a/numpy/core/src/common/array_assign.h
+++ b/numpy/core/src/common/array_assign.h
@@ -88,7 +88,8 @@ broadcast_strides(int ndim, npy_intp *shape,
 /*
  * Checks whether a data pointer + set of strides refers to a raw
  * array whose elements are all aligned to a given alignment.
- * alignment should be a power of two.
+ * alignment should be a power of two, or may be the sentinel value 0 to mean
+ * unaligned, in which case false is always returned.
  */
 NPY_NO_EXPORT int
 raw_array_is_aligned(int ndim, npy_intp *shape,

--- a/numpy/core/src/common/array_assign.h
+++ b/numpy/core/src/common/array_assign.h
@@ -87,9 +87,10 @@ broadcast_strides(int ndim, npy_intp *shape,
 
 /*
  * Checks whether a data pointer + set of strides refers to a raw
- * array whose elements are all aligned to a given alignment.
+ * array whose elements are all aligned to a given alignment. Returns
+ * 1 if data is aligned to alignment or 0 if not.
  * alignment should be a power of two, or may be the sentinel value 0 to mean
- * unaligned, in which case false is always returned.
+ * cannot-be-aligned, in which case 0 (false) is always returned.
  */
 NPY_NO_EXPORT int
 raw_array_is_aligned(int ndim, npy_intp *shape,

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -223,9 +223,6 @@ npy_uint_alignment(int itemsize)
         case 8:
             alignment = _ALIGN(npy_uint64);
             break;
-        case 12:
-            alignment = _ALIGN(npy_longdouble);
-            break;
         case 16:
             /*
              * 16 byte types are copied using 2 uint64 assignments.

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -223,6 +223,9 @@ npy_uint_alignment(int itemsize)
         case 8:
             alignment = _ALIGN(npy_uint64);
             break;
+        case 12:
+            alignment = _ALIGN(npy_longdouble);
+            break;
         case 16:
             /*
              * 16 byte types are copied using 2 uint64 assignments.


### PR DESCRIPTION
Backport of #12611.

Fix #12607 

It seems we hit an alignment assert on 32bit linux with longdouble dtype (which has elsize 12). Fix it in two stages (the first commit only extends CI to test asserts):

1. Add `-UNDEBUG` to the `CFLAGS` so that the assert statements are checked (debug mode)
2. Find and fix the underlying alignment issue

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
