### PR TITLE
MAINT: add test for 12-byte alignment

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8000,10 +8000,10 @@ class TestAlignment(object):
             raise ValueError()
 
     def test_various_alignments(self):
-        for align in [1, 2, 3, 4, 8, 16, 32, 64, None]:
+        for align in [1, 2, 3, 4, 8, 12, 16, 32, 64, None]:
             for n in [0, 1, 3, 11]:
                 for order in ["C", "F", None]:
-                    for dtype in np.typecodes["All"]:
+                    for dtype in list(np.typecodes["All"]) + ['i4,i4,i4']:
                         if dtype == 'O':
                             # object dtype can't be misaligned
                             continue


### PR DESCRIPTION
Backport of #12618.

Followup to #12611 to add a test for a 12-byte, 12-byte-aligned array.
I checked it crashes on x64 before #12611.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
