### PR TITLE
BUG: General fixes to f2py reference counts (dereferencing)

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1049,8 +1049,10 @@ static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofarg
     CFUNCSMESS(\"create_cb_arglist\\n\");
     tot=opt=ext=siz=0;
     /* Get the total number of arguments */
-    if (PyFunction_Check(fun))
+    if (PyFunction_Check(fun)) {
         tmp_fun = fun;
+        Py_INCREF(tmp_fun);
+    }
     else {
         di = 1;
         if (PyObject_HasAttrString(fun,\"im_func\")) {
@@ -1062,6 +1064,7 @@ static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofarg
                 tmp_fun = PyObject_GetAttrString(tmp,\"im_func\");
             else {
                 tmp_fun = fun; /* built-in function */
+                Py_INCREF(tmp_fun);
                 tot = maxnofargs;
                 if (xa != NULL)
                     tot += PyTuple_Size((PyObject *)xa);
@@ -1073,6 +1076,7 @@ static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofarg
             if (xa != NULL)
                 tot += PyTuple_Size((PyObject *)xa);
             tmp_fun = fun;
+            Py_INCREF(tmp_fun);
         }
         else if (F2PyCapsule_Check(fun)) {
             tot = maxnofargs;
@@ -1083,6 +1087,7 @@ static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofarg
                 goto capi_fail;
             }
             tmp_fun = fun;
+            Py_INCREF(tmp_fun);
         }
     }
 if (tmp_fun==NULL) {
@@ -1091,13 +1096,19 @@ goto capi_fail;
 }
 #if PY_VERSION_HEX >= 0x03000000
     if (PyObject_HasAttrString(tmp_fun,\"__code__\")) {
-        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"__code__\"),\"co_argcount\"))
+        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"__code__\"),\"co_argcount\")) {
 #else
     if (PyObject_HasAttrString(tmp_fun,\"func_code\")) {
-        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"func_code\"),\"co_argcount\"))
+        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"func_code\"),\"co_argcount\")) {
 #endif
-            tot = PyInt_AsLong(PyObject_GetAttrString(tmp,\"co_argcount\")) - di;
-        Py_XDECREF(tmp);
+            PyObject *tmp_argcount = PyObject_GetAttrString(tmp,\"co_argcount\");
+            Py_DECREF(tmp);
+            if (tmp_argcount == NULL) {
+                goto capi_fail;
+            }
+            tot = PyInt_AsLong(tmp_argcount) - di;
+            Py_DECREF(tmp_argcount);
+        }
     }
     /* Get the number of optional arguments */
 #if PY_VERSION_HEX >= 0x03000000
@@ -1136,10 +1147,12 @@ goto capi_fail;
             PyTuple_SET_ITEM(*args,i,tmp);
         }
     CFUNCSMESS(\"create_cb_arglist-end\\n\");
+    Py_DECREF(tmp_fun);
     return 1;
 capi_fail:
     if ((PyErr_Occurred())==NULL)
         PyErr_SetString(#modulename#_error,errmess);
+    Py_XDECREF(tmp_fun);
     return 0;
 }
 """

--- a/numpy/f2py/common_rules.py
+++ b/numpy/f2py/common_rules.py
@@ -124,8 +124,9 @@ def buildhooks(m):
         cadd('\t%s(f2pyinit%s,F2PYINIT%s)(f2py_setup_%s);'
              % (F_FUNC, lower_name, name.upper(), name))
         cadd('}\n')
-        iadd('\tF2PyDict_SetItemString(d, \"%s\", PyFortranObject_New(f2py_%s_def,f2py_init_%s));' % (
-            name, name, name))
+        iadd('\ttmp = PyFortranObject_New(f2py_%s_def,f2py_init_%s);' % (name, name))
+        iadd('\tF2PyDict_SetItemString(d, \"%s\", tmp);' % name)
+        iadd('\tPy_DECREF(tmp);')
         tname = name.replace('_', '\\_')
         dadd('\\subsection{Common block \\texttt{%s}}\n' % (tname))
         dadd('\\begin{description}')

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -223,8 +223,14 @@ PyMODINIT_FUNC init#modulename#(void) {
 #endif
 \t\t\"This module '#modulename#' is auto-generated with f2py (version:#f2py_version#).\\nFunctions:\\n\"\n#docs#\".\");
 \tPyDict_SetItemString(d, \"__doc__\", s);
-\t#modulename#_error = PyErr_NewException (\"#modulename#.error\", NULL, NULL);
 \tPy_DECREF(s);
+\t#modulename#_error = PyErr_NewException (\"#modulename#.error\", NULL, NULL);
+\t/*
+\t * Store the error object inside the dict, so that it could get deallocated.
+\t * (in practice, this is a module, so it likely will not and cannot.)
+\t */
+\tPyDict_SetItemString(d, \"_#modulename#_error\", #modulename#_error);
+\tPy_DECREF(#modulename#_error);
 \tfor(i=0;f2py_routine_defs[i].name!=NULL;i++) {
 \t\ttmp = PyFortranObject_NewAsAttr(&f2py_routine_defs[i]);
 \t\tPyDict_SetItemString(d, f2py_routine_defs[i].name, tmp);
@@ -239,7 +245,6 @@ PyMODINIT_FUNC init#modulename#(void) {
 \tif (! PyErr_Occurred())
 \t\ton_exit(f2py_report_on_exit,(void*)\"#modulename#\");
 #endif
-
 \treturn RETVAL;
 }
 #ifdef __cplusplus

--- a/numpy/f2py/src/test/foomodule.c
+++ b/numpy/f2py/src/test/foomodule.c
@@ -115,7 +115,7 @@ static PyMethodDef foo_module_methods[] = {
 
 void initfoo() {
     int i;
-    PyObject *m, *d, *s;
+    PyObject *m, *d, *s, *tmp;
     import_array();
 
     m = Py_InitModule("foo", foo_module_methods);
@@ -125,11 +125,17 @@ void initfoo() {
     PyDict_SetItemString(d, "__doc__", s);
 
     /* Fortran objects: */
-    PyDict_SetItemString(d, "mod", PyFortranObject_New(f2py_mod_def,f2py_init_mod));
-    PyDict_SetItemString(d, "foodata", PyFortranObject_New(f2py_foodata_def,f2py_init_foodata));
-    for(i=0;f2py_routines_def[i].name!=NULL;i++)
-        PyDict_SetItemString(d, f2py_routines_def[i].name,
-                             PyFortranObject_NewAsAttr(&f2py_routines_def[i]));
+    tmp = PyFortranObject_New(f2py_mod_def,f2py_init_mod);
+    PyDict_SetItemString(d, "mod", tmp);
+    Py_DECREF(tmp);
+    tmp = PyFortranObject_New(f2py_foodata_def,f2py_init_foodata);
+    PyDict_SetItemString(d, "foodata", tmp);
+    Py_DECREF(tmp);
+    for(i=0;f2py_routines_def[i].name!=NULL;i++) {
+        tmp = PyFortranObject_NewAsAttr(&f2py_routines_def[i]);
+        PyDict_SetItemString(d, f2py_routines_def[i].name, tmp);
+        Py_DECREF(tmp);
+    }
 
     Py_DECREF(s);
 

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -97,7 +97,7 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
     PyTuple_SetItem(dimensions,i,PyInt_FromLong(PyArray_DIM(arr,i)));
     PyTuple_SetItem(strides,i,PyInt_FromLong(PyArray_STRIDE(arr,i)));
   }
-  return Py_BuildValue("siOOO(cciii)ii",s,PyArray_NDIM(arr),
+  return Py_BuildValue("siNNO(cciii)ii",s,PyArray_NDIM(arr),
                        dimensions,strides,
                        (PyArray_BASE(arr)==NULL?Py_None:PyArray_BASE(arr)),
                        PyArray_DESCR(arr)->kind,
@@ -154,61 +154,69 @@ PyMODINIT_FUNC inittest_array_from_pyobj_ext(void) {
   PyDict_SetItemString(d, "__doc__", s);
   wrap_error = PyErr_NewException ("wrap.error", NULL, NULL);
   Py_DECREF(s);
-  PyDict_SetItemString(d, "F2PY_INTENT_IN", PyInt_FromLong(F2PY_INTENT_IN));
-  PyDict_SetItemString(d, "F2PY_INTENT_INOUT", PyInt_FromLong(F2PY_INTENT_INOUT));
-  PyDict_SetItemString(d, "F2PY_INTENT_OUT", PyInt_FromLong(F2PY_INTENT_OUT));
-  PyDict_SetItemString(d, "F2PY_INTENT_HIDE", PyInt_FromLong(F2PY_INTENT_HIDE));
-  PyDict_SetItemString(d, "F2PY_INTENT_CACHE", PyInt_FromLong(F2PY_INTENT_CACHE));
-  PyDict_SetItemString(d, "F2PY_INTENT_COPY", PyInt_FromLong(F2PY_INTENT_COPY));
-  PyDict_SetItemString(d, "F2PY_INTENT_C", PyInt_FromLong(F2PY_INTENT_C));
-  PyDict_SetItemString(d, "F2PY_OPTIONAL", PyInt_FromLong(F2PY_OPTIONAL));
-  PyDict_SetItemString(d, "F2PY_INTENT_INPLACE", PyInt_FromLong(F2PY_INTENT_INPLACE));
-  PyDict_SetItemString(d, "NPY_BOOL", PyInt_FromLong(NPY_BOOL));
-  PyDict_SetItemString(d, "NPY_BYTE", PyInt_FromLong(NPY_BYTE));
-  PyDict_SetItemString(d, "NPY_UBYTE", PyInt_FromLong(NPY_UBYTE));
-  PyDict_SetItemString(d, "NPY_SHORT", PyInt_FromLong(NPY_SHORT));
-  PyDict_SetItemString(d, "NPY_USHORT", PyInt_FromLong(NPY_USHORT));
-  PyDict_SetItemString(d, "NPY_INT", PyInt_FromLong(NPY_INT));
-  PyDict_SetItemString(d, "NPY_UINT", PyInt_FromLong(NPY_UINT));
-  PyDict_SetItemString(d, "NPY_INTP", PyInt_FromLong(NPY_INTP));
-  PyDict_SetItemString(d, "NPY_UINTP", PyInt_FromLong(NPY_UINTP));
-  PyDict_SetItemString(d, "NPY_LONG", PyInt_FromLong(NPY_LONG));
-  PyDict_SetItemString(d, "NPY_ULONG", PyInt_FromLong(NPY_ULONG));
-  PyDict_SetItemString(d, "NPY_LONGLONG", PyInt_FromLong(NPY_LONGLONG));
-  PyDict_SetItemString(d, "NPY_ULONGLONG", PyInt_FromLong(NPY_ULONGLONG));
-  PyDict_SetItemString(d, "NPY_FLOAT", PyInt_FromLong(NPY_FLOAT));
-  PyDict_SetItemString(d, "NPY_DOUBLE", PyInt_FromLong(NPY_DOUBLE));
-  PyDict_SetItemString(d, "NPY_LONGDOUBLE", PyInt_FromLong(NPY_LONGDOUBLE));
-  PyDict_SetItemString(d, "NPY_CFLOAT", PyInt_FromLong(NPY_CFLOAT));
-  PyDict_SetItemString(d, "NPY_CDOUBLE", PyInt_FromLong(NPY_CDOUBLE));
-  PyDict_SetItemString(d, "NPY_CLONGDOUBLE", PyInt_FromLong(NPY_CLONGDOUBLE));
-  PyDict_SetItemString(d, "NPY_OBJECT", PyInt_FromLong(NPY_OBJECT));
-  PyDict_SetItemString(d, "NPY_STRING", PyInt_FromLong(NPY_STRING));
-  PyDict_SetItemString(d, "NPY_UNICODE", PyInt_FromLong(NPY_UNICODE));
-  PyDict_SetItemString(d, "NPY_VOID", PyInt_FromLong(NPY_VOID));
-  PyDict_SetItemString(d, "NPY_NTYPES", PyInt_FromLong(NPY_NTYPES));
-  PyDict_SetItemString(d, "NPY_NOTYPE", PyInt_FromLong(NPY_NOTYPE));
-  PyDict_SetItemString(d, "NPY_USERDEF", PyInt_FromLong(NPY_USERDEF));
 
-  PyDict_SetItemString(d, "CONTIGUOUS", PyInt_FromLong(NPY_ARRAY_C_CONTIGUOUS));
-  PyDict_SetItemString(d, "FORTRAN", PyInt_FromLong(NPY_ARRAY_F_CONTIGUOUS));
-  PyDict_SetItemString(d, "OWNDATA", PyInt_FromLong(NPY_ARRAY_OWNDATA));
-  PyDict_SetItemString(d, "FORCECAST", PyInt_FromLong(NPY_ARRAY_FORCECAST));
-  PyDict_SetItemString(d, "ENSURECOPY", PyInt_FromLong(NPY_ARRAY_ENSURECOPY));
-  PyDict_SetItemString(d, "ENSUREARRAY", PyInt_FromLong(NPY_ARRAY_ENSUREARRAY));
-  PyDict_SetItemString(d, "ALIGNED", PyInt_FromLong(NPY_ARRAY_ALIGNED));
-  PyDict_SetItemString(d, "WRITEABLE", PyInt_FromLong(NPY_ARRAY_WRITEABLE));
-  PyDict_SetItemString(d, "UPDATEIFCOPY", PyInt_FromLong(NPY_ARRAY_UPDATEIFCOPY));
-  PyDict_SetItemString(d, "WRITEBACKIFCOPY", PyInt_FromLong(NPY_ARRAY_WRITEBACKIFCOPY));
+#define ADDCONST(NAME, CONST)              \
+    s = PyInt_FromLong(CONST);             \
+    PyDict_SetItemString(d, NAME, s);      \
+    Py_DECREF(s)
 
-  PyDict_SetItemString(d, "BEHAVED", PyInt_FromLong(NPY_ARRAY_BEHAVED));
-  PyDict_SetItemString(d, "BEHAVED_NS", PyInt_FromLong(NPY_ARRAY_BEHAVED_NS));
-  PyDict_SetItemString(d, "CARRAY", PyInt_FromLong(NPY_ARRAY_CARRAY));
-  PyDict_SetItemString(d, "FARRAY", PyInt_FromLong(NPY_ARRAY_FARRAY));
-  PyDict_SetItemString(d, "CARRAY_RO", PyInt_FromLong(NPY_ARRAY_CARRAY_RO));
-  PyDict_SetItemString(d, "FARRAY_RO", PyInt_FromLong(NPY_ARRAY_FARRAY_RO));
-  PyDict_SetItemString(d, "DEFAULT", PyInt_FromLong(NPY_ARRAY_DEFAULT));
-  PyDict_SetItemString(d, "UPDATE_ALL", PyInt_FromLong(NPY_ARRAY_UPDATE_ALL));
+  ADDCONST("F2PY_INTENT_IN", F2PY_INTENT_IN);
+  ADDCONST("F2PY_INTENT_INOUT", F2PY_INTENT_INOUT);
+  ADDCONST("F2PY_INTENT_OUT", F2PY_INTENT_OUT);
+  ADDCONST("F2PY_INTENT_HIDE", F2PY_INTENT_HIDE);
+  ADDCONST("F2PY_INTENT_CACHE", F2PY_INTENT_CACHE);
+  ADDCONST("F2PY_INTENT_COPY", F2PY_INTENT_COPY);
+  ADDCONST("F2PY_INTENT_C", F2PY_INTENT_C);
+  ADDCONST("F2PY_OPTIONAL", F2PY_OPTIONAL);
+  ADDCONST("F2PY_INTENT_INPLACE", F2PY_INTENT_INPLACE);
+  ADDCONST("NPY_BOOL", NPY_BOOL);
+  ADDCONST("NPY_BYTE", NPY_BYTE);
+  ADDCONST("NPY_UBYTE", NPY_UBYTE);
+  ADDCONST("NPY_SHORT", NPY_SHORT);
+  ADDCONST("NPY_USHORT", NPY_USHORT);
+  ADDCONST("NPY_INT", NPY_INT);
+  ADDCONST("NPY_UINT", NPY_UINT);
+  ADDCONST("NPY_INTP", NPY_INTP);
+  ADDCONST("NPY_UINTP", NPY_UINTP);
+  ADDCONST("NPY_LONG", NPY_LONG);
+  ADDCONST("NPY_ULONG", NPY_ULONG);
+  ADDCONST("NPY_LONGLONG", NPY_LONGLONG);
+  ADDCONST("NPY_ULONGLONG", NPY_ULONGLONG);
+  ADDCONST("NPY_FLOAT", NPY_FLOAT);
+  ADDCONST("NPY_DOUBLE", NPY_DOUBLE);
+  ADDCONST("NPY_LONGDOUBLE", NPY_LONGDOUBLE);
+  ADDCONST("NPY_CFLOAT", NPY_CFLOAT);
+  ADDCONST("NPY_CDOUBLE", NPY_CDOUBLE);
+  ADDCONST("NPY_CLONGDOUBLE", NPY_CLONGDOUBLE);
+  ADDCONST("NPY_OBJECT", NPY_OBJECT);
+  ADDCONST("NPY_STRING", NPY_STRING);
+  ADDCONST("NPY_UNICODE", NPY_UNICODE);
+  ADDCONST("NPY_VOID", NPY_VOID);
+  ADDCONST("NPY_NTYPES", NPY_NTYPES);
+  ADDCONST("NPY_NOTYPE", NPY_NOTYPE);
+  ADDCONST("NPY_USERDEF", NPY_USERDEF);
+
+  ADDCONST("CONTIGUOUS", NPY_ARRAY_C_CONTIGUOUS);
+  ADDCONST("FORTRAN", NPY_ARRAY_F_CONTIGUOUS);
+  ADDCONST("OWNDATA", NPY_ARRAY_OWNDATA);
+  ADDCONST("FORCECAST", NPY_ARRAY_FORCECAST);
+  ADDCONST("ENSURECOPY", NPY_ARRAY_ENSURECOPY);
+  ADDCONST("ENSUREARRAY", NPY_ARRAY_ENSUREARRAY);
+  ADDCONST("ALIGNED", NPY_ARRAY_ALIGNED);
+  ADDCONST("WRITEABLE", NPY_ARRAY_WRITEABLE);
+  ADDCONST("UPDATEIFCOPY", NPY_ARRAY_UPDATEIFCOPY);
+  ADDCONST("WRITEBACKIFCOPY", NPY_ARRAY_WRITEBACKIFCOPY);
+
+  ADDCONST("BEHAVED", NPY_ARRAY_BEHAVED);
+  ADDCONST("BEHAVED_NS", NPY_ARRAY_BEHAVED_NS);
+  ADDCONST("CARRAY", NPY_ARRAY_CARRAY);
+  ADDCONST("FARRAY", NPY_ARRAY_FARRAY);
+  ADDCONST("CARRAY_RO", NPY_ARRAY_CARRAY_RO);
+  ADDCONST("FARRAY_RO", NPY_ARRAY_FARRAY_RO);
+  ADDCONST("DEFAULT", NPY_ARRAY_DEFAULT);
+  ADDCONST("UPDATE_ALL", NPY_ARRAY_UPDATE_ALL);
+
+#undef ADDCONST(
 
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap");

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -29,6 +29,7 @@ def setup_module():
 @pytest.mark.parametrize(
     "extra_args", [['--noopt', '--debug'], '--noopt --debug', '']
     )
+@pytest.mark.leaks_references(reason="Imported module seems never deleted.")
 def test_f2py_init_compile(extra_args):
     # flush through the f2py __init__ compile() function code path as a
     # crude test for input handling following migration from
@@ -81,6 +82,9 @@ def test_f2py_init_compile(extra_args):
             return_check = import_module(modname)
             calc_result = return_check.foo()
             assert_equal(calc_result, 15)
+            # Removal from sys.modules, is not as such necessary. Even with
+            # removal, the module (dict) stays alive.
+            del sys.modules[modname]
 
 
 def test_f2py_init_compile_failure():

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -31,6 +31,7 @@ except ImportError:
 #
 
 _module_dir = None
+_module_num = 5403
 
 
 def _cleanup():
@@ -59,13 +60,14 @@ def get_module_dir():
 
 def get_temp_module_name():
     # Assume single-threaded, and the module dir usable only by this thread
+    global _module_num
     d = get_module_dir()
-    for j in range(5403, 9999999):
-        name = "_test_ext_module_%d" % j
-        fn = os.path.join(d, name)
-        if name not in sys.modules and not os.path.isfile(fn + '.py'):
-            return name
-    raise RuntimeError("Failed to create a temporary module name")
+    name = "_test_ext_module_%d" % _module_num
+    _module_num += 1
+    if name in sys.modules:
+        # this should not be possible, but check anyway
+        raise RuntimeError("Temporary module name already in use.")
+    return name
 
 
 def _memoize(func):


### PR DESCRIPTION
Continuation of gh-12624, I am not sure how much I will keep working on this. I think the changes should be mostly/all fine. But the error handlig is not improved, only the reference counting dirtily. So sometimes I am not sure if this might actually make things worse and `XDECREF` should be used at least.

A lot of this could probably simply use a bit of an audit and love...

There is a single (probably) leak left in `test_compile_functions.py` after this, if I see it right.