### PR TITLE
DOC, TST: remove "agg" setting from docs

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -112,7 +112,6 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     >>> import matplotlib
     >>> import matplotlib.pyplot
-    >>> matplotlib.pyplot.switch_backend('agg')
     >>> import matplotlib.pyplot as plt
     >>> N = 8
     >>> y = np.zeros(N)
@@ -265,7 +264,6 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
 
     >>> import matplotlib
     >>> import matplotlib.pyplot
-    >>> matplotlib.pyplot.switch_backend('agg')
     >>> import matplotlib.pyplot as plt
     >>> N = 10
     >>> x1 = np.logspace(0.1, 1, N, endpoint=True)
@@ -380,7 +378,6 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     Graphical illustration of ``endpoint`` parameter:
 
     >>> import matplotlib
-    >>> matplotlib.use('agg')
     >>> import matplotlib.pyplot as plt
     >>> N = 10
     >>> y = np.zeros(N)

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -110,8 +110,6 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     Graphical illustration:
 
-    >>> import matplotlib
-    >>> import matplotlib.pyplot
     >>> import matplotlib.pyplot as plt
     >>> N = 8
     >>> y = np.zeros(N)
@@ -262,8 +260,6 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
 
     Graphical illustration:
 
-    >>> import matplotlib
-    >>> import matplotlib.pyplot
     >>> import matplotlib.pyplot as plt
     >>> N = 10
     >>> x1 = np.logspace(0.1, 1, N, endpoint=True)
@@ -377,7 +373,6 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
 
     Graphical illustration of ``endpoint`` parameter:
 
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> N = 10
     >>> y = np.zeros(N)

--- a/numpy/fft/pocketfft.py
+++ b/numpy/fft/pocketfft.py
@@ -164,7 +164,6 @@ def fft(a, n=None, axis=-1, norm=None):
     the `numpy.fft` documentation:
 
     >>> import matplotlib
-    >>> matplotlib.use('Agg')
     >>> import matplotlib.pyplot as plt
     >>> t = np.arange(256)
     >>> sp = np.fft.fft(np.sin(t))
@@ -259,7 +258,6 @@ def ifft(a, n=None, axis=-1, norm=None):
     Create and plot a band-limited signal with random phases:
 
     >>> import matplotlib
-    >>> matplotlib.use('agg')
     >>> import matplotlib.pyplot as plt
     >>> t = np.arange(400)
     >>> n = np.zeros((400,), dtype=complex)

--- a/numpy/fft/pocketfft.py
+++ b/numpy/fft/pocketfft.py
@@ -163,7 +163,6 @@ def fft(a, n=None, axis=-1, norm=None):
     in the real part and anti-symmetric in the imaginary part, as described in
     the `numpy.fft` documentation:
 
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> t = np.arange(256)
     >>> sp = np.fft.fft(np.sin(t))
@@ -257,7 +256,6 @@ def ifft(a, n=None, axis=-1, norm=None):
 
     Create and plot a band-limited signal with random phases:
 
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> t = np.arange(400)
     >>> n = np.zeros((400,), dtype=complex)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2593,7 +2593,6 @@ def blackman(M):
 
     Examples
     --------
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> np.blackman(12)
     array([-1.38777878e-17,   3.26064346e-02,   1.59903635e-01, # may vary
@@ -2810,8 +2809,6 @@ def hanning(M):
 
     Plot the window and its frequency response:
 
-    >>> import matplotlib
-    >>> import matplotlib.pyplot
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
     >>> window = np.hanning(51)
@@ -2912,8 +2909,6 @@ def hamming(M):
 
     Plot the window and the frequency response:
 
-    >>> import matplotlib
-    >>> import matplotlib.pyplot
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
     >>> window = np.hamming(51)
@@ -3189,7 +3184,6 @@ def kaiser(M, beta):
 
     Examples
     --------
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> np.kaiser(12, 14)
      array([7.72686684e-06, 3.46009194e-03, 4.65200189e-02, # may vary
@@ -3284,7 +3278,6 @@ def sinc(x):
 
     Examples
     --------
-    >>> import matplotlib
     >>> import matplotlib.pyplot as plt
     >>> x = np.linspace(-4, 4, 41)
     >>> np.sinc(x)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2594,7 +2594,6 @@ def blackman(M):
     Examples
     --------
     >>> import matplotlib
-    >>> matplotlib.use('agg')
     >>> import matplotlib.pyplot as plt
     >>> np.blackman(12)
     array([-1.38777878e-17,   3.26064346e-02,   1.59903635e-01, # may vary
@@ -2813,7 +2812,6 @@ def hanning(M):
 
     >>> import matplotlib
     >>> import matplotlib.pyplot
-    >>> matplotlib.pyplot.switch_backend('agg')
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
     >>> window = np.hanning(51)
@@ -2916,7 +2914,6 @@ def hamming(M):
 
     >>> import matplotlib
     >>> import matplotlib.pyplot
-    >>> matplotlib.pyplot.switch_backend('agg')
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
     >>> window = np.hamming(51)
@@ -3193,7 +3190,6 @@ def kaiser(M, beta):
     Examples
     --------
     >>> import matplotlib
-    >>> matplotlib.use('agg')
     >>> import matplotlib.pyplot as plt
     >>> np.kaiser(12, 14)
      array([7.72686684e-06, 3.46009194e-03, 4.65200189e-02, # may vary

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -646,7 +646,6 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     --------
     >>> import matplotlib
     >>> import matplotlib.pyplot
-    >>> matplotlib.pyplot.switch_backend('agg')
     >>> import matplotlib as mpl
     >>> import matplotlib.pyplot as plt
 

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -644,9 +644,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     Examples
     --------
-    >>> import matplotlib
-    >>> import matplotlib.pyplot
-    >>> import matplotlib as mpl
+    >>> from matplotlib.image import NonUniformImage
     >>> import matplotlib.pyplot as plt
 
     Construct a 2-D histogram with variable bin width. First define the bin
@@ -683,7 +681,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     >>> ax = fig.add_subplot(133, title='NonUniformImage: interpolated',
     ...         aspect='equal', xlim=xedges[[0, -1]], ylim=yedges[[0, -1]])
-    >>> im = mpl.image.NonUniformImage(ax, interpolation='bilinear')
+    >>> im = NonUniformImage(ax, interpolation='bilinear')
     >>> xcenters = (xedges[:-1] + xedges[1:]) / 2
     >>> ycenters = (yedges[:-1] + yedges[1:]) / 2
     >>> im.set_data(xcenters, ycenters, H)

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2168,7 +2168,6 @@ cdef class RandomState:
         >>> NF = np.histogram(nc_vals, bins=50, density=True)
         >>> c_vals = np.random.f(dfnum, dfden, 1000000)
         >>> F = np.histogram(c_vals, bins=50, density=True)
-        >>> import matplotlib
         >>> import matplotlib.pyplot as plt
         >>> plt.plot(F[1][1:], F[0])
         >>> plt.plot(NF[1][1:], NF[0])
@@ -2447,7 +2446,6 @@ cdef class RandomState:
         --------
         Draw samples and plot the distribution:
 
-        >>> import matplotlib
         >>> import matplotlib.pyplot as plt
         >>> s = np.random.standard_cauchy(1000000)
         >>> s = s[(s>-25) & (s<25)]  # truncate distribution so it plots well
@@ -3285,7 +3283,6 @@ cdef class RandomState:
 
         >>> loc, scale = 10, 1
         >>> s = np.random.logistic(loc, scale, 10000)
-        >>> import matplotlib
         >>> import matplotlib.pyplot as plt
         >>> count, bins, ignored = plt.hist(s, bins=50)
 
@@ -3487,7 +3484,6 @@ cdef class RandomState:
         --------
         Draw values from the distribution and plot the histogram
 
-        >>> import matplotlib
         >>> from matplotlib.pyplot import hist
         >>> values = hist(np.random.rayleigh(3, 100000), bins=200, density=True)
 
@@ -4243,7 +4239,6 @@ cdef class RandomState:
         >>> ngood, nbad, nsamp = 100, 2, 10
         # number of good, number of bad, and number of samples
         >>> s = np.random.hypergeometric(ngood, nbad, nsamp, 1000)
-        >>> import matplotlib
         >>> from matplotlib.pyplot import hist
         >>> hist(s)
         #   note that it is very unlikely to grab both bad items
@@ -4354,7 +4349,6 @@ cdef class RandomState:
 
         >>> a = .6
         >>> s = np.random.logseries(a, 10000)
-        >>> import matplotlib
         >>> import matplotlib.pyplot as plt
         >>> count, bins, ignored = plt.hist(s)
 
@@ -4736,7 +4730,6 @@ cdef class RandomState:
 
         >>> s = np.random.dirichlet((10, 5, 3), 20).transpose()
 
-        >>> import matplotlib
         >>> import matplotlib.pyplot as plt
         >>> plt.barh(range(20), s[0])
         >>> plt.barh(range(20), s[1], left=s[0], color='g')


### PR DESCRIPTION
Fixes #12492 

There's simply no reason to explicitly set the `"agg"` matplotlib backend in our docstrings because we now use `refguide_check.py` that does this by default internally. They were needed when I was using vanilla `doctest` so my fault they got introduced as part of the superset of changes originally merged.

So, this PR removes all such cases I could find--about twice as many as Ralf noted in the linked issue. It is a little tricky because of the case insensitivity and `use` & `switch_backend` can both be used. In short, this PR minimizes `git grep -i "Agg" | grep "matplotlib"` to the single case used in `refguide_check`.

We also have to be cautious that all docstrings touched here are actually executed by refguide to verify the changes--I confirmed this by breaking each one on purpose and confirming failure locally before removing `agg` setting.