### PR TITLE
ENH/WIP: introduce a where keyword for reductions.

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -908,6 +908,9 @@ npyiter_check_per_op_flags(npy_uint32 op_flags, npyiter_opitflags *op_itflags)
         }
 
         *op_itflags = NPY_OP_ITFLAG_READ;
+        if (op_flags & NPY_ITER_UPDATEIFCOPY) {
+            *op_itflags |= NPY_OP_ITFLAG_CAST;
+        }
     }
     else if (op_flags & NPY_ITER_READWRITE) {
         /* The read/write flags are mutually exclusive */

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1758,7 +1758,7 @@ class TestUfunc(object):
         # too little
         assert_raises(TypeError, f)
         # too much
-        assert_raises(TypeError, f, d, 0, None, None, False, 0, 1)
+        assert_raises(TypeError, f, d, 0, None, None, False, 0, True, 1)
         # invalid axis
         assert_raises(TypeError, f, d, "invalid")
         assert_raises(TypeError, f, d, axis="invalid")


### PR DESCRIPTION
This introduces a `where` keyword for reductions - which would greatly help things like `MaskedArray`.

For lack of better ideas, the masking is done by setting elements that are not to be used to the identity. For this purposes, I have to ensure the operand reduced over is buffered - and this is now done with the drastic hack of (ab)using `NPY_ITER_READONLY|NPY_ITER_UPDATEIFCOPY` - I could not find a better way to tell the iterator to always buffer.

Work in progress - mostly here to request for comments, surely this can be done better...