### PR TITLE
BUG: disable flaky sanity checks

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -806,6 +806,7 @@ static NPY_GCC_OPT_3 void
     _TYPE2 dst_value;
 #endif
 
+#ifndef NPY_EXTRA_SANITY_CHECKS
 #if @aligned@
    /* sanity check */
 #  if !@is_complex1@
@@ -814,6 +815,7 @@ static NPY_GCC_OPT_3 void
 #  if !@is_complex2@
     assert(N == 0 || npy_is_aligned(dst, _ALIGN(_TYPE2)));
 #  endif
+#endif
 #endif
 
     /*printf("@prefix@_cast_@name1@_to_@name2@\n");*/


### PR DESCRIPTION
Adding 12 to the [stress test for alignment](https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py#L8003) is exposing bugs in the `assert` that the alignment is correct. PR #12626 is intended to fix the additional cases exposed in the stress test, but seems to have a problem:

- it fixes the `asserts` where `sizeof(npy_longdouble) == 16` and its alignment is 8
- it breaks the `asserts` where `sizeof(npy_longdouble) == 12` (32 bit linux) and its alignment is 4.

Note that the actual decision aligned/not aligned has not changed, only the `assert`s to check that everything is OK. Those `assert`s only fire when compiling with `-UNDEBUG` to undefine `NDEBUG` and allow the `assert` statements to work.

I propose we temporarily disable the asserts to allow work to continue, until #12626 can be merged.