### PR TITLE
ENH,WIP: alternative method to implement a where argument to ufunc reductions

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -908,6 +908,9 @@ npyiter_check_per_op_flags(npy_uint32 op_flags, npyiter_opitflags *op_itflags)
         }
 
         *op_itflags = NPY_OP_ITFLAG_READ;
+        if (op_flags & NPY_ITER_UPDATEIFCOPY) {
+            *op_itflags |= NPY_OP_ITFLAG_CAST;
+        }
     }
     else if (op_flags & NPY_ITER_READWRITE) {
         /* The read/write flags are mutually exclusive */

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -444,9 +444,9 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
 
     /* Iterator parameters */
     NpyIter *iter = NULL;
-    PyArrayObject *op[4];
-    PyArray_Descr *op_dtypes[4];
-    npy_uint32 flags, op_flags[4];
+    PyArrayObject *op[3];
+    PyArray_Descr *op_dtypes[3];
+    npy_uint32 flags, op_flags[3];
 
     /* More than one axis means multiple orders are possible */
     if (!reorderable && count_axes(PyArray_NDIM(operand), axis_flags) > 1) {
@@ -532,13 +532,9 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
         }
         op_flags[2] = NPY_ITER_READONLY |
                       NPY_ITER_ALIGNED;
-        op[3] = (PyArrayObject *)PyArray_FromScalar(identity, operand_dtype);
-        op_dtypes[3] = operand_dtype;
-        op_flags[3] = NPY_ITER_READONLY |
-                      NPY_ITER_ALIGNED;
     }
 
-    iter = NpyIter_AdvancedNew(wheremask == NULL ? 2 : 4, op, flags,
+    iter = NpyIter_AdvancedNew(wheremask == NULL ? 2 : 3, op, flags,
                                NPY_KEEPORDER, casting,
                                op_flags,
                                op_dtypes,

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1758,7 +1758,7 @@ class TestUfunc(object):
         # too little
         assert_raises(TypeError, f)
         # too much
-        assert_raises(TypeError, f, d, 0, None, None, False, 0, 1)
+        assert_raises(TypeError, f, d, 0, None, None, False, 0, True, 1)
         # invalid axis
         assert_raises(TypeError, f, d, "invalid")
         assert_raises(TypeError, f, d, axis="invalid")

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -3,6 +3,8 @@ from __future__ import division, absolute_import, print_function
 import warnings
 import itertools
 
+import pytest
+
 import numpy as np
 import numpy.core._umath_tests as umt
 import numpy.linalg._umath_linalg as uml
@@ -1395,6 +1397,24 @@ class TestUfunc(object):
         a = np.array([10], dtype=object)
         res = np.add.reduce(a, initial=5)
         assert_equal(res, 15)
+
+    @pytest.mark.parametrize('axis', (0, 1, (0, 1)))
+    @pytest.mark.parametrize('where', (np.array([True, False, True]),
+                                       np.array([[True], [False], [True]]),
+                                       np.array([[True, False, True],
+                                                 [False, True, False],
+                                                 [False, False, True]])))
+    def test_reduction_with_where(self, axis, where):
+        a = np.arange(9.).reshape(3, 3)
+        a_copy = a.copy()
+        a_check = np.zeros_like(a)
+        np.positive(a, out=a_check, where=where)
+
+        res = np.add.reduce(a, axis=axis, where=where)
+        check = a_check.sum(axis)
+        assert_equal(res, check)
+        # Check we do not overwrite elements of a internally.
+        assert_array_equal(a, a_copy)
 
     def test_identityless_reduction_nonreorderable(self):
         a = np.array([[8.0, 2.0, 2.0], [1.0, 0.5, 0.25]])


### PR DESCRIPTION
@seberg - here's an attempt where I force the iterator to feed an axis being reduced to the inner loop. Right now, it just does it, which causes a test failure that expects something else.

An advantage of this approach is that it is now more reasonable to ask people to provide `initial` for reductions that do not have an identity - it will now not be used to fill in masked items.

But it needs a better way to force the iterator to
1. Always buffer the input;
2. Ensure the external loop gets an axis that is being reduced over.