### PR TITLE
Doctest testing

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -318,7 +318,7 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
     Examples
     --------
     >>> from numpy.testing import assert_equal
-    >>> assert_equal([4,5], [4,6])
+    >>> assert_equal([4, 5], [4, 6])
     Traceback (most recent call last):
     ...
     AssertionError:
@@ -513,17 +513,19 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
     >>> import numpy.testing as npt
     >>> npt.assert_almost_equal(2.3333333333333, 2.33333334)
     >>> npt.assert_almost_equal(2.3333333333333, 2.33333334, decimal=10)
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.AssertionError'>:
-    Items are not equal:
+    AssertionError:
+    Arrays are not almost equal to 10 decimals
      ACTUAL: 2.3333333333333002
      DESIRED: 2.3333333399999998
 
     >>> npt.assert_almost_equal(np.array([1.0,2.3333333333333]),
     ...                         np.array([1.0,2.33333334]), decimal=9)
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.AssertionError'>:
-    Arrays are not almost equal
+    AssertionError:
+    Arrays are not almost equal to 9 decimals
     (mismatch 50.0%)
      x: array([ 1.        ,  2.33333333])
      y: array([ 1.        ,  2.33333334])
@@ -631,9 +633,11 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     ...                                significant=8)
     >>> np.testing.assert_approx_equal(0.12345670e-20, 0.12345672e-20,
     ...                                significant=8)
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.AssertionError'>:
+    AssertionError:
     Items are not equal to 8 significant digits:
+
      ACTUAL: 1.234567e-021
      DESIRED: 1.2345672000000001e-021
 
@@ -846,17 +850,18 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     The first assert does not raise an exception:
 
     >>> from numpy.testing import assert_array_equal
-    >>> assert_array_equal([1.0,2.33333,np.nan],
-    ...                    [np.exp(0),2.33333, np.nan])
+    >>> assert_array_equal([1.0, 2.33333, np.nan],
+    ...                    [np.exp(0), 2.33333, np.nan])
 
     Assert fails with numerical inprecision with floats:
 
-    >>> assert_array_equal([1.0,np.pi,np.nan],
+    >>> assert_array_equal([1.0, np.pi, np.nan],
     ...                    [1, np.sqrt(np.pi)**2, np.nan])
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.ValueError'>:
     AssertionError:
     Arrays are not equal
+
     (mismatch 50.0%)
      x: array([ 1.        ,  3.14159265,         NaN])
      y: array([ 1.        ,  3.14159265,         NaN])
@@ -865,7 +870,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     functions for these cases instead:
 
     >>> from numpy.testing import assert_allclose
-    >>> assert_allclose([1.0,np.pi,np.nan],
+    >>> assert_allclose([1.0, np.pi, np.nan],
     ...                 [1, np.sqrt(np.pi)**2, np.nan],
     ...                 rtol=1e-10, atol=0)
 
@@ -925,24 +930,28 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
     the first assert does not raise an exception
 
     >>> from numpy.testing import assert_array_almost_equal
-    >>> assert_array_almost_equal([1.0,2.333,np.nan],
-    ...                           [1.0,2.333,np.nan])
+    >>> assert_array_almost_equal([1.0, 2.333, np.nan],
+    ...                           [1.0, 2.333, np.nan])
 
-    >>> assert_array_almost_equal([1.0,2.33333,np.nan],
-    ...                           [1.0,2.33339,np.nan], decimal=5)
+    >>> assert_array_almost_equal([1.0, 2.33333, np.nan],
+    ...                           [1.0, 2.33339, np.nan], decimal=5)
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.AssertionError'>:
     AssertionError:
-    Arrays are not almost equal
+    Arrays are not almost equal to 5 decimals
+
     (mismatch 50.0%)
      x: array([ 1.     ,  2.33333,      NaN])
      y: array([ 1.     ,  2.33339,      NaN])
 
-    >>> assert_array_almost_equal([1.0,2.33333,np.nan],
-    ...                           [1.0,2.33333, 5], decimal=5)
-    <type 'exceptions.ValueError'>:
-    ValueError:
-    Arrays are not almost equal
+    >>> assert_array_almost_equal([1.0, 2.33333, np.nan],
+    ...                           [1.0, 2.33333, 5], decimal=5)
+    Traceback (most recent call last):
+    ...
+    AssertionError:
+    Arrays are not almost equal to 5 decimals
+
+    x and y nan location mismatch:
      x: array([ 1.     ,  2.33333,      NaN])
      y: array([ 1.     ,  2.33333,  5.     ])
 
@@ -1025,25 +1034,31 @@ def assert_array_less(x, y, err_msg='', verbose=True):
     --------
     >>> np.testing.assert_array_less([1.0, 1.0, np.nan], [1.1, 2.0, np.nan])
     >>> np.testing.assert_array_less([1.0, 1.0, np.nan], [1, 2.0, np.nan])
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.ValueError'>:
+    AssertionError:
     Arrays are not less-ordered
+
     (mismatch 50.0%)
      x: array([  1.,   1.,  NaN])
      y: array([  1.,   2.,  NaN])
 
     >>> np.testing.assert_array_less([1.0, 4.0], 3)
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.ValueError'>:
+    AssertionError:
     Arrays are not less-ordered
+
     (mismatch 50.0%)
      x: array([ 1.,  4.])
      y: array(3)
 
     >>> np.testing.assert_array_less([1.0, 2.0, 3.0], [4])
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.ValueError'>:
+    AssertionError:
     Arrays are not less-ordered
+
     (shapes (3,), (1,) mismatch)
      x: array([ 1.,  2.,  3.])
      y: array([4])

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -317,11 +317,14 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
 
     Examples
     --------
-    >>> np.testing.assert_equal([4,5], [4,6])
+    >>> from numpy.testing import assert_equal
+    >>> assert_equal([4,5], [4,6])
+    Traceback (most recent call last):
     ...
-    <type 'exceptions.AssertionError'>:
+    AssertionError:
     Items are not equal:
     item=1
+
      ACTUAL: 5
      DESIRED: 6
 
@@ -625,9 +628,9 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
     --------
     >>> np.testing.assert_approx_equal(0.12345677777777e-20, 0.1234567e-20)
     >>> np.testing.assert_approx_equal(0.12345670e-20, 0.12345671e-20,
-                                       significant=8)
+    ...                                significant=8)
     >>> np.testing.assert_approx_equal(0.12345670e-20, 0.12345672e-20,
-                                       significant=8)
+    ...                                significant=8)
     ...
     <type 'exceptions.AssertionError'>:
     Items are not equal to 8 significant digits:
@@ -842,13 +845,14 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     --------
     The first assert does not raise an exception:
 
-    >>> np.testing.assert_array_equal([1.0,2.33333,np.nan],
-    ...                               [np.exp(0),2.33333, np.nan])
+    >>> from numpy.testing import assert_array_equal
+    >>> assert_array_equal([1.0,2.33333,np.nan],
+    ...                    [np.exp(0),2.33333, np.nan])
 
     Assert fails with numerical inprecision with floats:
 
-    >>> np.testing.assert_array_equal([1.0,np.pi,np.nan],
-    ...                               [1, np.sqrt(np.pi)**2, np.nan])
+    >>> assert_array_equal([1.0,np.pi,np.nan],
+    ...                    [1, np.sqrt(np.pi)**2, np.nan])
     ...
     <type 'exceptions.ValueError'>:
     AssertionError:
@@ -860,9 +864,10 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     Use `assert_allclose` or one of the nulp (number of floating point values)
     functions for these cases instead:
 
-    >>> np.testing.assert_allclose([1.0,np.pi,np.nan],
-    ...                            [1, np.sqrt(np.pi)**2, np.nan],
-    ...                            rtol=1e-10, atol=0)
+    >>> from numpy.testing import assert_allclose
+    >>> assert_allclose([1.0,np.pi,np.nan],
+    ...                 [1, np.sqrt(np.pi)**2, np.nan],
+    ...                 rtol=1e-10, atol=0)
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
@@ -919,11 +924,12 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
     --------
     the first assert does not raise an exception
 
-    >>> np.testing.assert_array_almost_equal([1.0,2.333,np.nan],
-                                             [1.0,2.333,np.nan])
+    >>> from numpy.testing import assert_array_almost_equal
+    >>> assert_array_almost_equal([1.0,2.333,np.nan],
+    ...                           [1.0,2.333,np.nan])
 
-    >>> np.testing.assert_array_almost_equal([1.0,2.33333,np.nan],
-    ...                                      [1.0,2.33339,np.nan], decimal=5)
+    >>> assert_array_almost_equal([1.0,2.33333,np.nan],
+    ...                           [1.0,2.33339,np.nan], decimal=5)
     ...
     <type 'exceptions.AssertionError'>:
     AssertionError:
@@ -932,8 +938,8 @@ def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):
      x: array([ 1.     ,  2.33333,      NaN])
      y: array([ 1.     ,  2.33339,      NaN])
 
-    >>> np.testing.assert_array_almost_equal([1.0,2.33333,np.nan],
-    ...                                      [1.0,2.33333, 5], decimal=5)
+    >>> assert_array_almost_equal([1.0,2.33333,np.nan],
+    ...                           [1.0,2.33333, 5], decimal=5)
     <type 'exceptions.ValueError'>:
     ValueError:
     Arrays are not almost equal
@@ -1438,6 +1444,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
 
     Examples
     --------
+    >>> from numpy.testing import assert_allclose
     >>> x = [1e-5, 1e-3, 1e-1]
     >>> y = np.arccos(np.cos(x))
     >>> assert_allclose(x, y, rtol=1e-5, atol=0)
@@ -1894,6 +1901,7 @@ class clear_and_catch_warnings(warnings.catch_warnings):
     Examples
     --------
     >>> import warnings
+    >>> from numpy.testing import clear_and_catch_warnings
     >>> with clear_and_catch_warnings(modules=[np.core.fromnumeric]):
     ...     warnings.simplefilter('always')
     ...     warnings.filterwarnings('ignore', module='np.core.fromnumeric')
@@ -1991,7 +1999,7 @@ class suppress_warnings(object):
     >>> sup = suppress_warnings()
     >>> sup.filter(module=np.ma.core)  # module must match exact
     >>> @sup
-    >>> def some_function():
+    ... def some_function():
     ...     # do something which causes a warning in np.ma.core
     ...     pass
     """

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -76,6 +76,7 @@ PUBLIC_SUBMODULES = [
     'polynomial',
     'matrixlib',
     'random',
+    'testing',
 ]
 
 # Docs for these modules are included in the parent module
@@ -98,6 +99,11 @@ DOCTEST_SKIPLIST = set([
     # remote / local file IO with DataSource is problematic in doctest:
     'numpy.lib.DataSource',
     'numpy.lib.Repository',
+    # pseudocode
+    'numpy.testing.suppress_warnings',
+    # semi-obsolete stuff
+    'numpy.testing.run_module_suite',
+    'numpy.testing.measure',
 ])
 
 # these names are not required to be present in ALL despite being in


### PR DESCRIPTION
Run refguide-checker on public docstrings in `np.testing`, fix up examples (fixes are all mostly trivial)
