### PR TITLE
BENCH: don't fail at import time with old Numpy

### DIFF
--- a/benchmarks/benchmarks/bench_overrides.py
+++ b/benchmarks/benchmarks/bench_overrides.py
@@ -2,7 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 from .common import Benchmark
 
-from numpy.core.overrides import array_function_dispatch
+try:
+    from numpy.core.overrides import array_function_dispatch
+except ImportError:
+    # Don't fail at import time with old Numpy versions
+    def array_function_dispatch(*args, **kwargs):
+        def wrap(*args, **kwargs):
+            return None
+        return wrap
+
 import numpy as np
 
 


### PR DESCRIPTION
Backport of #12639.

The benchmark suite should be importable with any historical Numpy version we are likely to benchmark.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
