### PR TITLE
ENH: Add a pinvh function to linalg.

### DIFF
--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -797,6 +797,21 @@ class TestPinv(PinvCases):
     pass
 
 
+class PinvhCases(HermitianTestCase,
+                 HermitianGeneralizedTestCase):
+
+    def do(self, a, b, tags):
+        a_ginv = linalg.pinvh(a)
+        # `a @ a_ginv == I` does not hold if a is singular
+        dot = matmul
+        assert_almost_equal(dot(dot(a, a_ginv), a), a, single_decimal=5, double_decimal=11)
+        assert_(consistent_subclass(a_ginv, a))
+
+
+class TestPinvh(PinvhCases):
+    pass
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->

This is a faster version of `linalg.pinv` for Hermitian matrices. It is like the Scipy version of `pinvh`, but supports stacked matrices like Numpy's `pinv`.