### PR TITLE
BUG: Add 'sparc' to platforms implementing 16 byte reals.

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2399,7 +2399,7 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'power', 'ppc64', 's390x')):
+    if machine.startswith(('aarch64', 'power', 'ppc64', 's390x', 'sparc')):
         if p <= 20:
             return 16
     else:


### PR DESCRIPTION
This is for the _selected_real_kind_func function in
f2py/crackfortran.py. See #12638.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
