### PR TITLE
ENH: Better links in documentation

### DIFF
--- a/doc/source/reference/maskedarray.generic.rst
+++ b/doc/source/reference/maskedarray.generic.rst
@@ -2,7 +2,7 @@
 
 .. _maskedarray.generic:
 
-
+.. module:: numpy.ma
 
 The :mod:`numpy.ma` module
 ==========================

--- a/doc/source/reference/routines.ctypeslib.rst
+++ b/doc/source/reference/routines.ctypeslib.rst
@@ -1,3 +1,5 @@
+.. module:: numpy.ctypeslib
+
 ***********************************************************
 C-Types Foreign Function Interface (:mod:`numpy.ctypeslib`)
 ***********************************************************

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -1,5 +1,7 @@
 .. _routines.linalg:
 
+.. module:: numpy.linalg
+
 Linear algebra (:mod:`numpy.linalg`)
 ************************************
 

--- a/doc/source/reference/routines.matlib.rst
+++ b/doc/source/reference/routines.matlib.rst
@@ -1,3 +1,5 @@
+.. module:: numpy.matlib
+
 Matrix library (:mod:`numpy.matlib`)
 ************************************
 

--- a/doc/source/reference/routines.polynomials.package.rst
+++ b/doc/source/reference/routines.polynomials.package.rst
@@ -1,3 +1,5 @@
+.. module:: numpy.polynomial
+
 Polynomial Package
 ==================
 

--- a/doc/source/reference/routines.polynomials.polynomial.rst
+++ b/doc/source/reference/routines.polynomials.polynomial.rst
@@ -1,3 +1,5 @@
+.. module:: numpy.polynomial.polynomial
+
 Polynomial Module (:mod:`numpy.polynomial.polynomial`)
 ======================================================
 

--- a/doc/source/reference/routines.random.rst
+++ b/doc/source/reference/routines.random.rst
@@ -1,5 +1,7 @@
 .. _routines.random:
 
+.. module:: numpy.random
+
 Random sampling (:mod:`numpy.random`)
 *************************************
 

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -1,5 +1,7 @@
 .. _numpy-testing:
 
+.. module:: numpy.testing
+
 Test Support (:mod:`numpy.testing`)
 ===================================
 


### PR DESCRIPTION
Cleaning up SciPy doc builds in https://github.com/scipy/scipy/pull/9623 I hit warnings/errors like:
```
scipy/doc/source/tutorial/linalg.rst:21: WARNING: py:obj reference target not found: numpy.linalg
scipy/doc/source/tutorial/stats.rst:161: WARNING: py:mod reference target not found: numpy.random
```
This is because there are several submodules/namespaces without proper intersphinx links. This adds the ones I could find via looking at `git grep "currentmodule"` to see what modules are used internally during NumPy documentation. (This also caught the two I needed for SciPy, namely `linalg` and `random`. Submodules documented with `automodule` do not suffer from this problem because automodule takes care of adding the links.) You can see that they show up in `objects.inv` after doing a new build with `python -msphinx.ext.intersphinx build/html/objects.inv`:
```
py:module
	...
	numpy.linalg                             reference/routines.linalg.html#module-numpy.linalg
	...
```