### PR TITLE
ENH: Add a hermitian argument to `pinv` and `svd`, matching `matrix_rank`

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -45,6 +45,12 @@ identity, it is necessary to also pass in an initial value (e.g.,
 ``nansum`` would be, ``np.sum(a, where=~np.isnan(a))``.
 
 
+``np.linalg.svd`` and ``np.linalg.pinv`` can be faster on hermitian inputs
+--------------------------------------------------------------------------
+These functions have learnt the ``hermitian`` argument, matching the one added
+to ``np.linalg.matrix_rank`` in 1.14.0.
+
+
 Improvements
 ============
 

--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -47,7 +47,7 @@ identity, it is necessary to also pass in an initial value (e.g.,
 
 ``np.linalg.svd`` and ``np.linalg.pinv`` can be faster on hermitian inputs
 --------------------------------------------------------------------------
-These functions have learnt the ``hermitian`` argument, matching the one added
+These functions now accept a ``hermitian`` argument, matching the one added
 to ``np.linalg.matrix_rank`` in 1.14.0.
 
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -633,6 +633,20 @@ class TestEig(EigCases):
         assert_(isinstance(a, np.ndarray))
 
 
+class SVDBaseTests(object):
+    hermitian = False
+
+    @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
+    def test_types(self, dtype):
+        x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
+        u, s, vh = linalg.svd(x)
+        assert_equal(u.dtype, dtype)
+        assert_equal(s.dtype, get_real_dtype(dtype))
+        assert_equal(vh.dtype, dtype)
+        s = linalg.svd(x, compute_uv=False, hermitian=self.hermitian)
+        assert_equal(s.dtype, get_real_dtype(dtype))
+
+
 class SVDCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):
@@ -644,30 +658,35 @@ class SVDCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
         assert_(consistent_subclass(vt, a))
 
 
-class TestSVD(SVDCases):
-    @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
-    def test_types(self, dtype):
-        x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
-        u, s, vh = linalg.svd(x)
-        assert_equal(u.dtype, dtype)
-        assert_equal(s.dtype, get_real_dtype(dtype))
-        assert_equal(vh.dtype, dtype)
-        s = linalg.svd(x, compute_uv=False)
-        assert_equal(s.dtype, get_real_dtype(dtype))
-
+class TestSVD(SVDCases, SVDBaseTests):
     def test_empty_identity(self):
         """ Empty input should put an identity matrix in u or vh """
         x = np.empty((4, 0))
-        u, s, vh = linalg.svd(x, compute_uv=True)
+        u, s, vh = linalg.svd(x, compute_uv=True, hermitian=self.hermitian)
         assert_equal(u.shape, (4, 4))
         assert_equal(vh.shape, (0, 0))
         assert_equal(u, np.eye(4))
 
         x = np.empty((0, 4))
-        u, s, vh = linalg.svd(x, compute_uv=True)
+        u, s, vh = linalg.svd(x, compute_uv=True, hermitian=self.hermitian)
         assert_equal(u.shape, (0, 0))
         assert_equal(vh.shape, (4, 4))
         assert_equal(vh, np.eye(4))
+
+
+class SVDHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
+
+    def do(self, a, b, tags):
+        u, s, vt = linalg.svd(a, 0, hermitian=True)
+        assert_allclose(a, dot_generalized(np.asarray(u) * np.asarray(s)[..., None, :],
+                                           np.asarray(vt)),
+                        rtol=get_rtol(u.dtype))
+        assert_(consistent_subclass(u, a))
+        assert_(consistent_subclass(vt, a))
+
+
+class TestSVDHermitian(SVDHermitianCases, SVDBaseTests):
+    hermitian = True
 
 
 class CondCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
@@ -794,6 +813,20 @@ class PinvCases(LinalgSquareTestCase,
 
 
 class TestPinv(PinvCases):
+    pass
+
+
+class PinvHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
+
+    def do(self, a, b, tags):
+        a_ginv = linalg.pinv(a, hermitian=True)
+        # `a @ a_ginv == I` does not hold if a is singular
+        dot = dot_generalized
+        assert_almost_equal(dot(dot(a, a_ginv), a), a, single_decimal=5, double_decimal=11)
+        assert_(consistent_subclass(a_ginv, a))
+
+
+class TestPinvHermitian(PinvHermitianCases):
     pass
 
 


### PR DESCRIPTION
Related to gh-9436 (pinging @perimosocordiae)

An alternative to #12665 with a lower maintenance burden (cc @jordan-melendez), although admittedly with some small sign-juggling overhead.

Runs in 60% of the time of the non-hermitian version for a mid-size test:
```python
In [1]: a = np.random.random((300, 300))

In [2]: a = a.T @ a

In [3]: %timeit np.linalg.svd(a)
287 ms ± 21.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit np.linalg.svd(a, hermitian=1)
168 ms ± 12 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
``
