### PR TITLE
MAINT: Further fixups to uint alignment checks

### DIFF
--- a/doc/source/reference/alignment.rst
+++ b/doc/source/reference/alignment.rst
@@ -97,7 +97,7 @@ Here is how the variables above are used:
 
 Note that the strided-copy and strided-cast code are deeply intertwined and so
 any arrays being processed by them must be both uint and true aligned, even
-though te copy-code only needs uint alignment and the cast code only true
+though the copy-code only needs uint alignment and the cast code only true
 alignment.  If there is ever a big rewrite of this code it would be good to
 allow them to use different alignments.
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -24,6 +24,38 @@
 
 #include "array_assign.h"
 
+/* Check both uint and true alignment */
+NPY_NO_EXPORT int
+copycast_isaligned(int ndim, npy_intp *shape,
+        PyArray_Descr *dtype, char *data, npy_intp *strides)
+{
+    int aligned;
+    int big_aln, small_aln;
+
+    int uint_aln = npy_uint_alignment(dtype->elsize);
+    int true_aln = dtype->alignment;
+
+    /* uint alignment can be 0, meaning not uint alignable */
+    if (uint_aln == 0) {
+        return 0;
+    }
+
+    if (true_aln >= uint_aln) {
+        big_aln = true_aln;
+        small_aln = uint_aln;
+    }
+    else {
+        big_aln = uint_aln;
+        small_aln = true_aln;
+    }
+
+    aligned = raw_array_is_aligned(ndim, shape, data, strides, big_aln);
+    if (aligned && big_aln % small_aln != 0) {
+        aligned = raw_array_is_aligned(ndim, shape, data, strides, small_aln);
+    }
+    return aligned;
+}
+
 /*
  * Assigns the array from 'src' to 'dst'. The strides must already have
  * been broadcast.
@@ -48,15 +80,9 @@ raw_array_assign_array(int ndim, npy_intp *shape,
 
     NPY_BEGIN_THREADS_DEF;
 
-    /* Check both uint and true alignment */
-    aligned = raw_array_is_aligned(ndim, shape, dst_data, dst_strides,
-                                   npy_uint_alignment(dst_dtype->elsize)) &&
-              raw_array_is_aligned(ndim, shape, dst_data, dst_strides,
-                                   dst_dtype->alignment) &&
-              raw_array_is_aligned(ndim, shape, src_data, src_strides,
-                                   npy_uint_alignment(src_dtype->elsize));
-              raw_array_is_aligned(ndim, shape, src_data, src_strides,
-                                   src_dtype->alignment);
+    aligned =
+        copycast_isaligned(ndim, shape, dst_dtype, dst_data, dst_strides) &&
+        copycast_isaligned(ndim, shape, src_dtype, src_data, src_strides);
 
     /* Use raw iteration with no heap allocation */
     if (PyArray_PrepareTwoRawArrayIter(
@@ -137,15 +163,9 @@ raw_array_wheremasked_assign_array(int ndim, npy_intp *shape,
 
     NPY_BEGIN_THREADS_DEF;
 
-    /* Check both uint and true alignment */
-    aligned = raw_array_is_aligned(ndim, shape, dst_data, dst_strides,
-                                   npy_uint_alignment(dst_dtype->elsize)) &&
-              raw_array_is_aligned(ndim, shape, dst_data, dst_strides,
-                                   dst_dtype->alignment) &&
-              raw_array_is_aligned(ndim, shape, src_data, src_strides,
-                                   npy_uint_alignment(src_dtype->elsize));
-              raw_array_is_aligned(ndim, shape, src_data, src_strides,
-                                   src_dtype->alignment);
+    aligned =
+        copycast_isaligned(ndim, shape, dst_dtype, dst_data, dst_strides) &&
+        copycast_isaligned(ndim, shape, src_dtype, src_data, src_strides);
 
     /* Use raw iteration with no heap allocation */
     if (PyArray_PrepareThreeRawArrayIter(

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1132,7 +1132,7 @@ npyiter_prepare_one_operand(PyArrayObject **op,
         /* Check if the operand is aligned */
         if (op_flags & NPY_ITER_ALIGNED) {
             /* Check alignment */
-            if (!(IsUintAligned(*op) && IsAligned(*op))) {
+            if (!IsAligned(*op)) {
                 NPY_IT_DBG_PRINT("Iterator: Setting NPY_OP_ITFLAG_CAST "
                                     "because of NPY_ITER_ALIGNED\n");
                 *op_itflags |= NPY_OP_ITFLAG_CAST;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3064,7 +3064,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
 
-    NPY_UF_DBG_PRINT1("Returning code %d\n", reval);
+    NPY_UF_DBG_PRINT1("Returning code %d\n", retval);
 
     return retval;
 


### PR DESCRIPTION
Backport of #12677.

A few more fixes following on #12626, based on testing on a ppc64be system.

First, on this system some einsum tests failed due typo in that PR: ; should have been &&. This wasn't caught by x64 unit tests, so I've added a test that should cover those code paths.

Second, I figured out that some of the fix in #12626 wasn't quite right: I had misunderstood what the NPY_ITER_ALIGNED flag is supposed to do. My understanding now is that is a request to guarantee that the nditer buffers are "true" aligned. (uint alignment is only an internal numpy thing which users shouldn't know about), which nditer it does by forcing a buffer/cast if that flag is requested, since all new buffers are true aligned. With that understanding, it now seems that the NPY_OP_ITFLAG_ALIGNED flag is not needed: Its only use was as a precalculated computation of the aligned parameter of PyArray_GetDTypeTransferFunction, but that is more safely computed on the spot, based on both uint and true alignment of the op. So I've removed all uses of NPY_OP_ITFLAG_ALIGNED.

This latter change was indirectly discovered from staring at the code while trying to bug-hunt failed alignment asserts on ppc64be. But those turned out to be irrelevant glibc problems from #10491. At least it got me to read a lot of code over more thoroughly: I also made sure that the ufunc code doesn't need alignment fixes.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
