### PR TITLE
TST: add ppc64le to Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,11 @@ matrix:
     - python: 3.6
       env:
        - NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1
+    - os: linux-ppc64le
+      python: 3.6
+      env:
+       # for matrix annotation only
+       - PPC64_LE=1
 
 before_install:
   - ./tools/travis-before-install.sh


### PR DESCRIPTION
Add `ppc64le` Linux testing to Travis CI. Part of the effort in #12688.

I don't have Travis hooks active on my fork, so this WIP CI testing / dev could get annoying, but I'll start working on this here for now, for convenience.

Related template: https://github.com/ghatwala/travis-jobdeploytest/blob/master/.travis.yml