### PR TITLE
TST: pin Azure brew version for stability.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
   # two C compilers, but with homebrew looks like we're
   # now stuck getting the full gcc toolchain instead of
   # just pulling in gfortran
-  - script: brew install gcc
+  - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc
     displayName: 'make gfortran available on mac os vm'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'


### PR DESCRIPTION
Backport of #12704.

Recent PRs (i.e., #12702 ) are showing Azure CI failures related to homebrew failing to update itself before it tries to install gcc (so that gfortran is available).

This PR prevents the (default behavior) homebrew self-update and seems to install gcc in a stable manner for now.

In the future this command will probably evolve to pin to a specific version of gcc to match the wheels workflow as the gcc 8.x toolchain for gfortran is far newer than we should need. But mac OS azure compiles with clang and doesn't use openblas for now anyway.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
