### PR TITLE
BUG: Fix rounding of denormals in double and float to half casts  …

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -27,6 +27,13 @@ Expired deprecations
 Compatibility notes
 ===================
 
+float16 subnormal rounding
+--------------------------
+Casting from a different floating point precision to float16 used incorrect
+rounding in some edge cases. This means in rare cases, subnormal results will
+now be rounded up instead of down, changing the last bit (ULP) of the result.
+
+
 
 C API changes
 =============

--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -307,9 +307,11 @@ npy_uint16 npy_floatbits_to_halfbits(npy_uint32 f)
         /*
          * If the last bit in the half significand is 0 (already even), and
          * the remaining bit pattern is 1000...0, then we do not add one
-         * to the bit after the half significand.  In all other cases, we do.
+         * to the bit after the half significand. However, since we may have
+         * previously lost up to 11 bits, we need to check these as well.
+         * In all other cases, we can just add one.
          */
-        if ((f_sig&0x00003fffu) != 0x00001000u) {
+        if (((f_sig&0x00003fffu) != 0x00001000u) || (f&0x008ffu)) {
             f_sig += 0x00001000u;
         }
 #else
@@ -416,7 +418,12 @@ npy_uint16 npy_doublebits_to_halfbits(npy_uint64 d)
             npy_set_floatstatus_underflow();
         }
 #endif
-        d_sig >>= (1009 - d_exp);
+        /*
+         * Unlike floats, doubles has enough room to shift left to align
+         * significand. This changes the constant compared to normal branch.
+         */
+        assert(d_exp - 998 >= 0);
+        d_sig <<= (d_exp - 998);
         /* Handle rounding by adding 1 to the bit beyond half precision */
 #if NPY_HALF_ROUND_TIES_TO_EVEN
         /*
@@ -424,13 +431,13 @@ npy_uint16 npy_doublebits_to_halfbits(npy_uint64 d)
          * the remaining bit pattern is 1000...0, then we do not add one
          * to the bit after the half significand.  In all other cases, we do.
          */
-        if ((d_sig&0x000007ffffffffffULL) != 0x0000020000000000ULL) {
-            d_sig += 0x0000020000000000ULL;
+        if ((d_sig&0x003fffffffffffffULL) != 0x0010000000000000ULL) {
+            d_sig += 0x0010000000000000ULL;
         }
 #else
-        d_sig += 0x0000020000000000ULL;
+        d_sig += 0x0000e00000000000ULL;
 #endif
-        h_sig = (npy_uint16) (d_sig >> 42);
+        h_sig = (npy_uint16) (d_sig >> 53);
         /*
          * If the rounding causes a bit to spill into h_exp, it will
          * increment h_exp from zero to one and h_sig will be zero.

--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -311,7 +311,7 @@ npy_uint16 npy_floatbits_to_halfbits(npy_uint32 f)
          * previously lost up to 11 bits, we need to check these as well.
          * In all other cases, we can just add one.
          */
-        if (((f_sig&0x00003fffu) != 0x00001000u) || (f&0x008ffu)) {
+        if (((f_sig&0x00003fffu) != 0x00001000u) || (f&0x000007ffu)) {
             f_sig += 0x00001000u;
         }
 #else
@@ -435,7 +435,7 @@ npy_uint16 npy_doublebits_to_halfbits(npy_uint64 d)
             d_sig += 0x0010000000000000ULL;
         }
 #else
-        d_sig += 0x0000e00000000000ULL;
+        d_sig += 0x0010000000000000ULL;
 #endif
         h_sig = (npy_uint16) (d_sig >> 53);
         /*

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -72,9 +72,13 @@ class TestHalf(object):
     @pytest.mark.parametrize("offset", [None, "up", "down"])
     @pytest.mark.parametrize("shift", [None, "up", "down"])
     @pytest.mark.parametrize("float_t", [np.float32, np.float64])
-    def test_half_conversion_denormal_rounding(self, float_t, shift, offset):
+    def test_half_conversion_rounding(self, float_t, shift, offset):
         # Assumes that round to even is used during casting.
-        f16s_patterns = np.arange(0, 0x401, dtype=np.uint16)
+        max_pattern = np.float16(np.finfo(np.float16).max).view(np.uint16)
+
+        # Test all (positive) finite numbers, denormals are most interesting
+        # however:
+        f16s_patterns = np.arange(0, max_pattern+1, dtype=np.uint16)
         f16s_float = f16s_patterns.view(np.float16).astype(float_t)
 
         # Shift the values by half a bit up or a down (or do not shift),


### PR DESCRIPTION
Previously the significand was shifted right to align denormals of
different magnitude. This loses some bits that can make a difference
for rounding. This is fixed:
 1. For floats, by inspecting the original last bits when this may
    make a difference (should happen rarely)
 2. For doubles by shifting the bits left to align the denromals and
    thus not lose the lowest orginal bits.

-----

I am not sure if the double branch is not being a bit too smart and it is nicer to just also use the `||` logic from above, since it uses different constants compared to the normal branch because of this.

I do not know if there may be nicer ways with larger code changes, but I could not think of one.

This closes gh-12721