### PR TITLE
BENCH: quiet DeprecationWarning

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -97,8 +97,8 @@ class Temporaries(Benchmark):
 
 
 class CorrConv(Benchmark):
-    params = [[50, 1000, 1e5],
-              [10, 100, 1000, 1e4],
+    params = [[50, 1000, int(1e5)],
+              [10, 100, 1000, int(1e4)],
               ['valid', 'same', 'full']]
     param_names = ['size1', 'size2', 'mode']
 

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -106,4 +106,4 @@ class Lstsq(Benchmark):
         self.b = get_indexes_rand()[:100].astype(np.float64)
 
     def time_numpy_linalg_lstsq_a__b_float64(self):
-        np.linalg.lstsq(self.a, self.b)
+        np.linalg.lstsq(self.a, self.b, rcond=-1)


### PR DESCRIPTION
Float is deprecated for `num` of `linspace`, this warning is printed [during benchmarks](https://travis-ci.org/numpy/numpy/jobs/478915486#L4467)