### PR TITLE
DOC: clarify the suffix of single/extended precision math constants

### DIFF
--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -80,8 +80,9 @@ Floating point classification
 Useful math constants
 ~~~~~~~~~~~~~~~~~~~~~
 
-The following math constants are available in npy_math.h. Single and extended
-precision are also available by adding the f and l suffixes respectively.
+The following math constants are available in ``npy_math.h``. Single
+and extended precision are also available by adding the ``f`` and
+``l`` suffixes respectively.
 
 .. c:var:: NPY_E
 

--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -81,7 +81,7 @@ Useful math constants
 ~~~~~~~~~~~~~~~~~~~~~
 
 The following math constants are available in npy_math.h. Single and extended
-precision are also available by adding the F and L suffixes respectively.
+precision are also available by adding the f and l suffixes respectively.
 
 .. c:var:: NPY_E
 


### PR DESCRIPTION
Closes gh-9922.

Looks like only `NPY_NAN`, `NPY_INFINITY`, `NPY_PZERO` and `NPY_NZERO` use the `F` and `L` suffixes, and they are documented separately:

https://github.com/numpy/numpy/blob/master/doc/source/reference/c-api.coremath.rst#floating-point-classification
