### PR TITLE
DOC: fix generalized eigenproblem reference in "NumPy for MATLAB users"

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -547,7 +547,7 @@ Linear Algebra Equivalents
      - eigenvalues and eigenvectors of ``a``
 
    * - ``[V,D]=eig(a,b)``
-     - ``V,D = np.linalg.eig(a,b)``
+     - ``D,V = scipy.linalg.eig(a,b)``
      - eigenvalues and eigenvectors of ``a``, ``b``
 
    * - ``[V,D]=eigs(a,k)``


### PR DESCRIPTION
The ["NumPy for MATLAB users" guide](https://docs.scipy.org/doc/numpy-1.15.0/user/numpy-for-matlab-users.html) claimed that [`numpy.linalg.eig`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eig.html) solves generalized eigenvalue problems. This is not true.

Instead we need [`scipy.linalg.eig`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eig.html), the output arguments of which are reversed compared to MATLAB's `eig`. We already had `scipy.linalg` references one line later for QR, LU and other decompositions, so this is a very minor change.