### PR TITLE
BUG: Fix crash in error message formatting introduced by gh-11230

### DIFF
--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2156,10 +2156,11 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
 
             icombinemap[idim] = -1;
             if (new_dims[i] != dim) {
+                char orig_label = labels[idim + label];
                 PyErr_Format(PyExc_ValueError,
                              "dimensions in operand %d for collapsing "
                              "index '%c' don't match (%d != %d)",
-                             iop, label, (int)new_dims[i], (int)dim);
+                             iop, orig_label, (int)new_dims[i], (int)dim);
                 return NULL;
             }
             new_strides[i] += stride;

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -5,7 +5,7 @@ import itertools
 import numpy as np
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_almost_equal,
-    assert_raises, suppress_warnings
+    assert_raises, suppress_warnings, assert_raises_regex
     )
 
 # Setup for optimize einsum
@@ -90,6 +90,11 @@ class TestEinsum(object):
                           optimize=do_opt)
             assert_raises(ValueError, np.einsum, "i->i", [[0, 1], [0, 1]],
                           out=np.arange(4).reshape(2, 2), optimize=do_opt)
+            with assert_raises_regex(ValueError, "'b'"):
+                # gh-11221 - 'c' erroneously appeared in the error message
+                a = np.ones((3, 3, 4, 5, 6))
+                b = np.ones((3, 4, 5))
+                np.einsum('aabcb,abc', a, b)
 
     def test_einsum_views(self):
         # pass-through


### PR DESCRIPTION
(link: gh-11230)

Fixes gh-11221, and now produces:

```python
>>> a = np.ones((3, 3, 4, 5, 6))
>>> b = np.ones((3, 4, 5))
>>> np.einsum('aabcb,abc', a, b)
ValueError: dimensions in operand 0 for collapsing index 'b' don't match (4 != 6)
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
