### PR TITLE
BUG: Check paths are unicode, bytes or path-like

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -219,7 +219,7 @@ else:
         path representation is not str or bytes, TypeError is raised. If the
         provided path is not str, bytes, or os.PathLike, TypeError is raised.
         """
-        if isinstance(path, basestring):
+        if isinstance(path, (unicode, bytes)):
             return path
 
         # Work from the object's type to match method resolution of other magic

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -219,7 +219,7 @@ else:
         path representation is not str or bytes, TypeError is raised. If the
         provided path is not str, bytes, or os.PathLike, TypeError is raised.
         """
-        if isinstance(path, (str, bytes)):
+        if isinstance(path, basestring):
             return path
 
         # Work from the object's type to match method resolution of other magic

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -235,7 +235,7 @@ else:
             else:
                 raise TypeError("expected str, bytes or os.PathLike object, "
                                 "not " + path_type.__name__)
-        if isinstance(path_repr, (str, bytes)):
+        if isinstance(path_repr, (unicode, bytes)):
             return path_repr
         else:
             raise TypeError("expected {}.__fspath__() to return str or bytes, "

--- a/numpy/compat/tests/test_compat.py
+++ b/numpy/compat/tests/test_compat.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 from os.path import join
 
-from numpy.compat import isfileobj
+from numpy.compat import isfileobj, os_fspath
 from numpy.testing import assert_
 from numpy.testing import tempdir
 
@@ -19,3 +19,8 @@ def test_isfileobj():
 
         with open(filename, 'rb') as f:
             assert_(isfileobj(f))
+
+
+def test_os_fspath_strings():
+    for string_path in (b'/a/b/c.d', u'/a/b/c.d'):
+        assert_(os_fspath(string_path) == string_path)


### PR DESCRIPTION
In Python 2.7, `numpy.compat.py3k.os_fspath` checks `(str, bytes)`, which excludes `unicode` strings. This commit checks against `basestring`, which is PY2/3 compatible.

Fixes #12749

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
