### PR TITLE
BUG: report old multiarray module

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -52,8 +52,6 @@ del envkey
 del env_added
 del os
 
-from . import umath
-
 ############### HACK for broken installations #########################
 
 # Test that multiarray is a pure python module wrapping _multiarray_umath,
@@ -109,6 +107,9 @@ if not getattr(multiarray, '_multiarray_umath', None):
     import warnings
     warnings.warn(msg, ImportWarning, stacklevel=1)
     del warnings
+
+# when this HACK is removed, keep this line
+from . import umath
 
 if not getattr(umath, '_multiarray_umath', None):
     # The games in the previous block failed. Give up.

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -52,6 +52,18 @@ del envkey
 del env_added
 del os
 
+# Test that multiarray is a pure python module wrapping _multiarray_umath,
+# and not the old c-extension module.
+if not getattr(multiarray, '_multiarray_umath', None):
+    msg = ("Something is wrong with the NumPy installation. "
+           "While importing 'multiarray' we detected an older version of "
+           "numpy. One method of fixing this is to repeatedly 'pip uninstall' "
+           "numpy until none is found, then reinstall this version. If you "
+           "know how to recreate this error, please file an issue at "
+           "https://github.com/numpy/numpy/issues and xref "
+           "https://github.com/numpy/numpy/issues/12736")
+    raise ImportError(msg)
+
 from . import umath
 from . import _internal  # for freeze programs
 from . import numerictypes as nt

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -86,7 +86,6 @@ if not getattr(multiarray, '_multiarray_umath', None):
         except Exception as e:
             print(e)
             raise ImportError(msg)
-        del importlib.util
     elif sys.version_info[:2] == (2, 7):
         import imp
         try:
@@ -97,13 +96,11 @@ if not getattr(multiarray, '_multiarray_umath', None):
         except Exception as e:
             print(e)
             raise ImportError(msg)
-        del imp
     else:
         raise ImportError(msg)
     del sys, osp
     import warnings
     warnings.warn(msg, ImportWarning, stacklevel=1)
-    del warnings
 
 # when this HACK is removed, keep this line
 from . import umath

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -59,10 +59,7 @@ del os
 msg = ("Something is wrong with the NumPy installation. "
        "While importing 'multiarray' we detected an older version of "
        "numpy. One method of fixing this is to repeatedly 'pip uninstall' "
-       "numpy until none is found, then reinstall this version. If you "
-       "know how to recreate this error, please file an issue at "
-       "https://github.com/numpy/numpy/issues and xref "
-       "https://github.com/numpy/numpy/issues/12736")
+       "numpy until none is found, then reinstall this version.")
 if not getattr(multiarray, '_multiarray_umath', None):
     # Old multiarray. Can we override it?
     import sys, os.path as osp

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -7,11 +7,11 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 
-from numpy.core import multiarray as mu
-from numpy.core import umath as um
-from numpy.core.numeric import asanyarray
-from numpy.core import numerictypes as nt
-from numpy._globals import _NoValue
+from . import multiarray as mu
+from . import umath as um
+from .numeric import asanyarray
+from . import numerictypes as nt
+from .._globals import _NoValue
 
 # save those O(100) nanoseconds!
 umr_maximum = um.maximum.reduce

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -960,6 +960,14 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_operand_flag_tests',
                     sources=[join('src', 'umath', '_operand_flag_tests.c.src')])
 
+    #######################################################################
+    #                        _multiarray_module_test module               #
+    #######################################################################
+
+    config.add_extension('_multiarray_module_test',
+                    sources=[join('src', 'multiarray',
+                                         '_multiarray_module_test.c')])
+
     config.add_data_dir('tests')
     config.add_data_dir('tests/data')
 

--- a/numpy/core/src/multiarray/_multiarray_module_test.c
+++ b/numpy/core/src/multiarray/_multiarray_module_test.c
@@ -1,0 +1,129 @@
+#include "Python.h"
+
+/*
+ * This is a dummy module. It will be used to ruin the import of multiarray
+ * during testing. It exports two entry points, one to make the build happy,
+ * and a multiarray one for the actual test. The content of the module is
+ * irrelevant to the test.
+ *
+ * The code is from
+ * https://docs.python.org/3/howto/cporting.html
+ * or
+ * https://github.com/python/cpython/blob/v3.7.0/Doc/howto/cporting.rst
+ */
+
+#if defined _WIN32 || defined __CYGWIN__ || defined __MINGW32__
+  #if defined __GNUC__ || defined __clang__
+    #define DLL_PUBLIC __attribute__ ((dllexport))
+  #else
+    #define DLL_PUBLIC __declspec(dllexport)
+  #endif
+#elif defined __GNUC__  || defined __clang__
+  #define DLL_PUBLIC __attribute__ ((visibility ("default")))
+#else
+    /* Enhancement: error now instead ? */
+    #define DLL_PUBLIC
+#endif
+
+struct module_state {
+    PyObject *error;
+};
+
+#if PY_MAJOR_VERSION >= 3
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+static PyObject *
+error_out(PyObject *m) {
+    struct module_state *st = GETSTATE(m);
+    PyErr_SetString(st->error, "something bad happened");
+    return NULL;
+}
+
+static PyMethodDef multiarray_methods[] = {
+    {"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
+    {NULL, NULL}
+};
+
+#if PY_MAJOR_VERSION >= 3
+
+static int multiarray_traverse(PyObject *m, visitproc visit, void *arg) {
+    Py_VISIT(GETSTATE(m)->error);
+    return 0;
+}
+
+static int multiarray_clear(PyObject *m) {
+    Py_CLEAR(GETSTATE(m)->error);
+    return 0;
+}
+
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "multiarray",
+        NULL,
+        sizeof(struct module_state),
+        multiarray_methods,
+        NULL,
+        multiarray_traverse,
+        multiarray_clear,
+        NULL
+};
+
+#define INITERROR return NULL
+
+DLL_PUBLIC PyObject *
+PyInit_multiarray(void)
+
+#else
+#define INITERROR return
+
+void
+DLL_PUBLIC initmultiarray(void)
+#endif
+{
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+#else
+    PyObject *module = Py_InitModule("multiarray", multiarray_methods);
+#endif
+    struct module_state *st;
+    if (module == NULL)
+        INITERROR;
+    st = GETSTATE(module);
+
+    st->error = PyErr_NewException("multiarray.Error", NULL, NULL);
+    if (st->error == NULL) {
+        Py_DECREF(module);
+        INITERROR;
+    }
+
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
+}
+
+/*
+ * Define a dummy entry point to make MSVC happy
+ * Python's build system will export this function automatically
+ */
+#if PY_MAJOR_VERSION >= 3
+
+PyObject *
+PyInit__multiarray_module_test(void)
+{
+    return PyInit_multiarray();
+}
+
+#else
+
+void
+init_multiarray_module_test(void)
+{
+    initmultiarray();
+}
+
+#endif                                                    

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7960,6 +7960,8 @@ def test_multiarray_module():
     cextension = np.core._multiarray_umath.__file__
     testfile = cextension.replace('_multiarray_umath', '_multiarray_module_test')
     badfile = cextension.replace('_multiarray_umath', 'multiarray')
+    assert not os.path.exists(badfile), '%s exists, this numpy ' \
+                                    'installation is faulty' % badfile
     try:
         shutil.copy(testfile, badfile)
         p = subprocess.Popen([sys.executable, '-Walways::ImportWarning', '-c',


### PR DESCRIPTION
Related to #12736.

~Use relative imports to ensure we are loading modules from the current directory, and d~Detect use of an old `multiarray` module.

This might solve the issue reported when users are updating numpy and `import numpy` finds an old `multiarray` c-extension module rather than the new pure-python wrapper. It will also produce a message with more helpful information.

I tested this by running `python runtests.py` which succeeded, then copied an old `multiarray` c-extension module to the `build/testenv/<...>/numpy.core` directory`. Running `python runtests.py` again failed (as expected) with the new `ImportError`

Edit: no need to change imports