### PR TITLE
Fix numpy lookfor for extension modules where path is None

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -901,7 +901,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
                 _all = None
 
             # import sub-packages
-            if import_modules and hasattr(item, '__path__'):
+            if import_modules and getattr(item, '__path__', None):
                 for pth in item.__path__:
                     for mod_path in os.listdir(pth):
                         this_py = os.path.join(pth, mod_path)


### PR DESCRIPTION
I apologize in advance for the unsatisfactory nature of this PR, but I would appreciate some guidance.

For scikit-image, we've been co-opting `numpy.lookfor` for a long time to find functions inside of the library.  It stopped working this week.  The culprit was a binary module, for which `item.__path__` was not defined.

This patch ignores items for which `item.__path__` doesn't at least translate to a non-empty string.  But I am not sure how to test this approach.  Any thoughts?