### PR TITLE
DOC: document C99 requirement in dev guide

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -8,7 +8,9 @@ Recommended development setup
 
 Since NumPy contains parts written in C and Cython that need to be
 compiled before use, make sure you have the necessary compilers and Python
-development headers installed - see :ref:`building-from-source`.
+development headers installed - see :ref:`building-from-source`. Building
+NumPy as of version ``1.17`` requires a C99 compliant compiler. For
+some older compilers this may require ``export CFLAGS='-std=c99'``.
 
 Having compiled code also means that importing NumPy from the development
 sources needs some additional steps, which are explained below.  For the rest


### PR DESCRIPTION
Fixes #12766 

Ralf already documented the C99 requirement in an `INSTALL` doc file in #12620, so this is just adding similar content to the developer docs based on the request in the linked issue. I suppose there's always some discussion to be had about the best place to put this stuff.