### PR TITLE
ENH: alternative (ctypes) approach to openblas version access

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,10 @@ trigger:
     include:
       - master
       - maintenance/*
+
+variables:
+  OPENBLAS_VERSION: "0.3.5.dev"
+
 jobs:
 - job: Linux_Python_36_32bit_full_with_asserts
   pool:
@@ -26,7 +30,10 @@ jobs:
            cp ./usr/local/include/* /usr/include && \
            cd ../numpy && \
            F77=gfortran-5 F90=gfortran-5 \
-           CFLAGS='-UNDEBUG -std=c99' python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
+           CFLAGS='-UNDEBUG -std=c99' python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml && \
+           cd .. && \
+           export PYTHONPATH=/numpy/build/testenv/lib/python3.6/site-packages && \
+           python3 -c \"import numpy; from numpy.distutils.system_info import get_info; assert get_info('openblas')['versions'][0] == '$(OPENBLAS_VERSION)', 'received versions: ' + ' '.join(get_info('openblas')['versions']) + ' and expected $(OPENBLAS_VERSION)'\""
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     inputs:
@@ -81,7 +88,7 @@ jobs:
     displayName: 'install pre-built openblas'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install cython nose pytz pytest pickle5 vulture docutils sphinx>=1.8.3 numpydoc matplotlib
+  - script: python -m pip install cython nose pytz pytest pickle5 vulture docutils sphinx>=1.8.3 numpydoc
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
     displayName: 'Check for unreachable code paths in Python modules'
@@ -95,10 +102,18 @@ jobs:
       ATLAS: None
       ACCELERATE: None
       CC: /usr/bin/clang
+  # wait until after dev build of NumPy to pip
+  # install matplotlib to avoid pip install of older numpy
+  - script: python -m pip install matplotlib
+    displayName: 'Install matplotlib before refguide run'
   - script: python runtests.py -g --refguide-check
     displayName: 'Run Refuide Check'
-  - script: python runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml
+  - script: python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run Full NumPy Test Suite'
+  - bash: |
+      cd .. &&
+      python -c "import numpy; from numpy.distutils.system_info import get_info; assert get_info('openblas')['versions'][0] == '$(OPENBLAS_VERSION)', 'received versions: ' + ' '.join(get_info('openblas')['versions']) + ' and expected $(OPENBLAS_VERSION)'"
+    displayName: 'Post-mortem OpenBLAS version confirmation'
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
@@ -161,14 +176,26 @@ jobs:
       Expand-Archive "openblas.zip" $tmpdir
       $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
       Write-Host "Python Version: $pyversion"
-      $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
-      Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
+      # for OpenBLAS version detection and proper build / test behavior
+      # we need to use OpenBLAS static library (.a), dynamic library (.dll), and
+      # the import library for the DLL (.dll.a extension renamed to .lib)
+      $target_dll = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.dll"
+      $target_importlib = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.lib"
+      $target_static = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
+      cp $tmpdir\$(BITS)\bin\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.dll $target_dll
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.dll.a $target_importlib
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target_static
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
-      choco install -y mingw --forcex86 --force --version=5.3.0
+      # need a version of mingw with requisite DLLs
+      choco install -y mingw --forcex86 --force --version=7.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
+  - powershell: |
+      # need a version of mingw with requisite DLLs
+      choco install -y mingw --force --version=7.3.0
+    displayName: 'Install 64-bit mingw for 64-bit builds'
+    condition: eq(variables['BITS'], 64)
   - script: python -m pip install cython nose pytz pytest
     displayName: 'Install dependencies; some are optional to avoid test skips'
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
@@ -180,9 +207,10 @@ jobs:
          $env:NPY_DISTUTILS_APPEND_FLAGS = 1
          $env:CFLAGS = "-m32"
          $env:LDFLAGS = "-m32"
-         $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
          refreshenv
       }
+         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+
       pip wheel -v -v -v --wheel-dir=dist .
 
       ls dist -r | Foreach-Object {
@@ -200,6 +228,11 @@ jobs:
     displayName: 'For gh-12667; Windows DLL resolution'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
+  - powershell: |
+      cd D:/a
+      $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
+      python -c "import numpy; from numpy.distutils.system_info import get_info; assert get_info('openblas')['versions'][0] == '$(OPENBLAS_VERSION)', 'received versions: ' + ' '.join(get_info('openblas')['versions']) + ' and expected $(OPENBLAS_VERSION)'"
+    displayName: 'Post-mortem OpenBLAS version confirmation'
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
       - maintenance/*
 
 variables:
-  OPENBLAS_VERSION: "0.3.5.dev"
+  OPENBLAS_VERSION: "0.3.5"
 
 jobs:
 - job: Linux_Python_36_32bit_full_with_asserts
@@ -24,8 +24,8 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-manylinux1_i686.tar.gz && \
+           tar zxvf openblas-v0.3.5-manylinux1_i686.tar.gz && \
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../numpy && \
@@ -80,8 +80,8 @@ jobs:
   # matches our MacOS wheel builds -- currently based
   # primarily on file size / name details
   - script: |
-      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz"
-      tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-macosx_10_9_x86_64-gf_1becaaa.tar.gz"
+      tar -zxvf openblas-v0.3.5-macosx_10_9_x86_64-gf_1becaaa.tar.gz
       # manually link to appropriate system paths
       cp ./usr/local/lib/* /usr/local/lib/
       cp ./usr/local/include/* /usr/local/include/
@@ -124,8 +124,8 @@ jobs:
   variables:
       # openblas URLs from numpy-wheels
       # appveyor / Windows config
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-win_amd64-gcc_7_1_0.zip"
   strategy:
     maxParallel: 6
     matrix:
@@ -182,9 +182,9 @@ jobs:
       $target_dll = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.dll"
       $target_importlib = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.lib"
       $target_static = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
-      cp $tmpdir\$(BITS)\bin\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.dll $target_dll
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.dll.a $target_importlib
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target_static
+      cp $tmpdir\$(BITS)\bin\libopenblas_v0.3.5-gcc_7_1_0.dll $target_dll
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-gcc_7_1_0.dll.a $target_importlib
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-gcc_7_1_0.a $target_static
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       # need a version of mingw with requisite DLLs

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -38,7 +38,8 @@ class Extension(old_Extension):
             f2py_options=None,
             module_dirs=None,
             extra_f77_compile_args=None,
-            extra_f90_compile_args=None,):
+            extra_f90_compile_args=None,
+            versions=None):
 
         old_Extension.__init__(
                 self, name, [],

--- a/numpy/distutils/tests/test_openblasconfig.py
+++ b/numpy/distutils/tests/test_openblasconfig.py
@@ -1,0 +1,27 @@
+from __future__ import division, absolute_import, print_function
+
+import pytest
+import platform
+from distutils.version import LooseVersion
+
+import numpy as np
+from numpy.distutils import system_info
+
+@pytest.mark.skipif('versions' not in system_info.get_info('openblas'),
+                     reason="Requires openblas")
+def test_openblas_versions_type():
+    # the 'versions' key in the openblas get_info
+    # dict should correspond to a list
+    actual = system_info.get_info('openblas')['versions']
+    assert isinstance(actual, list)
+
+@pytest.mark.skipif('versions' not in system_info.get_info('openblas'),
+                     reason="Requires openblas")
+def test_openblas_version_constraints():
+    # verify that the OpenBLAS version is >= 0.3.4
+    # as this was the point of implementation of version
+    # access in C API
+    actual_versions = system_info.get_info('openblas')['versions']
+    for version in actual_versions:
+        assert ((LooseVersion(version) >= LooseVersion("0.3.4")) or
+                version is None)


### PR DESCRIPTION
This is the alternative approach to #12523, which currently has a lot of debug code and actually breaks the Windows builds --  you can take a look in the Azure output if you want.

I've not had success getting this to work on Windows, even if I put all the DLL / lib files at the same path.

Open to suggestions, otherwise the extension building in the original PR may be preferred so that we can be agnostic to static / dynamic details. Not sure any approach is really going to be fully portable to all the scenarios that other libraries may have for openblas version access.