### PR TITLE
MAINT: update function's `__module__` attribute in `deprecate`

### DIFF
--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -51,6 +51,10 @@ def test_deprecate_fn():
     assert_('new_func3' in new_func3.__doc__)
 
 
+def test_deprecate_module():
+    assert_(old_func.__module__ == __name__)
+
+
 def test_safe_eval_nameconstant():
     # Test if safe_eval supports Python 3.4 _ast.NameConstant
     utils.safe_eval('None')

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -5,6 +5,7 @@ import sys
 import types
 import re
 import warnings
+import functools
 
 from numpy.core.numerictypes import issubclass_, issubsctype, issubdtype
 from numpy.core.overrides import set_module
@@ -77,10 +78,7 @@ class _Deprecate(object):
         message = self.message
 
         if old_name is None:
-            try:
-                old_name = func.__name__
-            except AttributeError:
-                old_name = func.__name__
+            old_name = func.__name__
         if new_name is None:
             depdoc = "`%s` is deprecated!" % old_name
         else:
@@ -90,8 +88,8 @@ class _Deprecate(object):
         if message is not None:
             depdoc += "\n" + message
 
-        def newfunc(*args,**kwds):
-            """`arrayrange` is deprecated, use `arange` instead!"""
+        @functools.wraps(func)
+        def newfunc(*args, **kwds):
             warnings.warn(depdoc, DeprecationWarning, stacklevel=2)
             return func(*args, **kwds)
 
@@ -102,16 +100,7 @@ class _Deprecate(object):
         else:
             doc = '\n\n'.join([depdoc, doc])
         newfunc.__doc__ = doc
-        try:
-            d = func.__dict__
-        except AttributeError:
-            pass
-        else:
-            newfunc.__dict__.update(d)
-        try:
-            newfunc.__module__ = func.__module__
-        except AttributeError:
-            pass
+
         return newfunc
 
 def deprecate(*args, **kwargs):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -50,11 +50,6 @@ def get_include():
     return d
 
 
-def _set_function_name(func, name):
-    func.__name__ = name
-    return func
-
-
 class _Deprecate(object):
     """
     Decorator class to deprecate old functions.
@@ -100,7 +95,7 @@ class _Deprecate(object):
             warnings.warn(depdoc, DeprecationWarning, stacklevel=2)
             return func(*args, **kwds)
 
-        newfunc = _set_function_name(newfunc, old_name)
+        newfunc.__name__ = old_name
         doc = func.__doc__
         if doc is None:
             doc = depdoc
@@ -113,6 +108,10 @@ class _Deprecate(object):
             pass
         else:
             newfunc.__dict__.update(d)
+        try:
+            newfunc.__module__ = func.__module__
+        except AttributeError:
+            pass
         return newfunc
 
 def deprecate(*args, **kwargs):


### PR DESCRIPTION
Currently the location of the function definition is always reported
to be `numpy.lib.utils`; this changes it to be the location of the
actual definition when possible.

So for example this code:

```python
>>> from scipy.stats import frechet_r
>>> help(frechet_r.cdf)
```

gives:

```
Help on method frechet_r in module numpy.lib.utils:
...
```

on master but

```
Help on method frechet_r in module scipy.stats._continuous_distns:
...
```

on this branch. This won't help with things that don't have a `__module__` attribute,

```python
>>> import scipy.special as sc
>>> help(sc.hyp2f0)
```

still gives

```
Help on function hyp2f0 in module numpy.lib.utils:
...
```

but I don't know of a way around that?