### PR TITLE
DOC: clarify the extend of __array_function__ support in NumPy 1.16

### DIFF
--- a/doc/release/1.16.0-notes.rst
+++ b/doc/release/1.16.0-notes.rst
@@ -20,7 +20,7 @@ easier going forward.
 Highlights
 ==========
 
-* Experimental support for overriding numpy functions,
+* Experimental (opt-in only) support for overriding numpy functions,
   see ``__array_function__`` below.
 
 * The ``matmul`` function is now a ufunc. This provides better
@@ -518,14 +518,16 @@ accessing invalid memory locations.
 
 NumPy functions now support overrides with ``__array_function__``
 -----------------------------------------------------------------
-It is now possible to override the implementation of almost all NumPy functions
-on non-NumPy arrays by defining a ``__array_function__`` method, as described
-in `NEP 18`_. The sole exception are functions for explicitly casting to NumPy
-arrays such as ``np.array``. As noted in the NEP, this feature remains
-experimental and the details of how to implement such overrides may change in
-the future.
+NumPy has a new experimental mechanism for overriding the implementation of
+almost all NumPy functions on non-NumPy arrays by defining an
+``__array_function__`` method, as described in `NEP 18`_.
 
-.. _`NEP 15` : http://www.numpy.org/neps/nep-0015-merge-multiarray-umath.html
+This feature is not yet been enabled by default, but has been released to
+facilitate experimentation by potential users. See the NEP for details on
+setting the appropriate environment variable. We expect the NumPy 1.17 release
+will enable overrides by default, which will also be more performant due to a
+new implementation written in C.
+
 .. _`NEP 18` : http://www.numpy.org/neps/nep-0018-array-function-protocol.html
 
 Arrays based off readonly buffers cannot be set ``writeable``


### PR DESCRIPTION
Backport of #12733.

I'm sorry I didn't get this in earlier! Hopefully this will make it clearer to
users ``__array_function__`` is only opt-in for now.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
