### PR TITLE
BUG: Check that dtype or formats arguments are not None.

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -711,7 +711,7 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
     a string"""
 
     if dtype is None and formats is None:
-        raise ValueError("Must have dtype= or formats=")
+        raise TypeError("fromstring() needs a 'dtype' or 'formats' argument")
 
     if dtype is not None:
         descr = sb.dtype(dtype)
@@ -758,6 +758,9 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     >>> r.shape
     (10,)
     """
+    
+    if dtype is None and formats is None:
+        raise TypeError("fromfile() needs a 'dtype' or 'formats' argument")
 
     if (shape is None or shape == 0):
         shape = (-1,)


### PR DESCRIPTION
Backport of #12604.

Similar to `fromstring` function, the `dtype` and `format` arguments of `fromfile` should be validated first to see that at least one of them is not None.

The following snippet shows the current behaviour
```python
import numpy as np

l50 = np.arange(100)
fields_number = 10

buffer = l50.tostring() * fields_number
for file in ('test1.bin', ):
    with open(file, 'w+b') as f:
        f.write(buffer)
np.core.records.fromfile('test1.bin')
```
```Traceback (most recent call last):
  File "/home/daniel/.config/spyder-py3/temp.py", line 19, in <module>
    print(np.core.records.fromfile('test1.bin')    )
  File "/usr/lib/python3/dist-packages/numpy/core/records.py", line 762, in fromfile
    descr = format_parser(formats, names, titles, aligned, byteorder)._descr
  File "/usr/lib/python3/dist-packages/numpy/core/records.py", line 144, in __init__
    self._parseFormats(formats, aligned)
  File "/usr/lib/python3/dist-packages/numpy/core/records.py", line 153, in _parseFormats
    raise ValueError("Need formats argument")
ValueError: Need formats argument
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
