### PR TITLE
BUG: fix f2py problem to build wrappers using PGI's Fortran

### DIFF
--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -33,7 +33,7 @@ class PGroupFCompiler(FCompiler):
             'compiler_f77': ["pgfortran"],
             'compiler_fix': ["pgfortran", "-Mfixed"],
             'compiler_f90': ["pgfortran"],
-            'linker_so': ["pgfortran", "-shared", "-fpic"],
+            'linker_so': ["pgfortran"],
             'archiver': ["ar", "-cr"],
             'ranlib': ["ranlib"]
         }
@@ -55,6 +55,10 @@ class PGroupFCompiler(FCompiler):
     if platform == 'darwin':
         def get_flags_linker_so(self):
             return ["-dynamic", '-undefined', 'dynamic_lookup']
+
+    else:
+        def get_flags_linker_so(self):
+            return ["-shared", '-fpic']
 
     def runtime_library_dir_option(self, dir):
         return '-R"%s"' % dir


### PR DESCRIPTION
Backport of #12631.

Good evening, I would like to report the following small contribution:

The compilation of the test file (fib.f):

`   
   
     SUBROUTINE FIB(A,N)
      INTEGER N 
      REAL*8 A(N)
      DO I=1,N
         IF (I.EQ.1) THEN
            A(I) = 0.0D0
         ELSEIF (I.EQ.2) THEN
            A(I) = 1.0D0
         ELSE 
            A(I) = A(I-1) + A(I-2)
         ENDIF
      ENDDO
      END
`

using f2py and the PGI compiler:

`f2py -c fib.f90 -m fib --fcompiler=pg`

leads to the error:

`
pgfortran:f77: fib.f
/opt/pgi/linux86-64/18.10/bin/pgfortran -shared -fpic -shared -fpic /tmp/tmpoiui5fxw/tmp/tmpoiui5fxw/src.linux-x86_64-3.7/fibmodule.o /tmp/tmpoiui5fxw/tmp/tmpoiui5fxw/src.linux-x86_64-3.7/fortranobject.o /tmp/tmpoiui5fxw/fib.o -o ./fib.cpython-37m-x86_64-linux-gnu.so
/usr/bin/ld: duplicate version tag `VERSION_1810'
/usr/bin/ld: duplicate version tag `VERSION_1810'
error: Command "/opt/pgi/linux86-64/18.10/bin/pgfortran -shared -fpic -shared -fpic /tmp/tmpoiui5fxw/tmp/tmpoiui5fxw/src.linux-x86_64-3.7/fibmodule.o /tmp/tmpoiui5fxw/tmp/tmpoiui5fxw/src.linux-x86_64-3.7/fortranobject.o /tmp/tmpoiui5fxw/fib.o -o ./fib.cpython-37m-x86_64-linux-gnu.so" failed with exit status 2
`

The cause seems to be the duplicated flags `-shared -fpic`.  Erasing
them from the `linker_so` defined in `pg.py` and adding a
`get_flags_linker_so` function for `platform != 'darwin'` solves the
issue:

`
pgfortran:f77: fib.f
/opt/pgi/linux86-64/18.10/bin/pgfortran -shared -fpic /tmp/tmplm1mi7gf/tmp/tmplm1mi7gf/src.linux-x86_64-3.7/fibmodule.o /tmp/tmplm1mi7gf/tmp/tmplm1mi7gf/src.linux-x86_64-3.7/fortranobject.o /tmp/tmplm1mi7gf/fib.o -o ./fib.cpython-37m-x86_64-linux-gnu.so
`





<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
