### PR TITLE
BUG: Fix testing of f2py.compile from strings.

### DIFF
--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -106,3 +106,20 @@ def test_f2py_init_compile_bad_cmd():
         assert_equal(ret_val, 127)
     finally:
         sys.executable = temp
+
+
+@pytest.mark.parametrize('fsource',
+        ['program test_f2py\nend program test_f2py',
+         b'program test_f2py\nend program test_f2py',])
+def test_compile_from_strings(tmpdir, fsource):
+    # Make sure we can compile str and bytes gh-12796
+    cwd = os.getcwd()
+    try:
+        os.chdir(str(tmpdir))
+        ret_val = numpy.f2py.compile(
+                fsource,
+                modulename='test_compile_from_strings',
+                extension='.f90')
+        assert_equal(ret_val, 0)
+    finally:
+        os.chdir(cwd)

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -27,17 +27,3 @@ class TestIntentInOut(util.F2PyTest):
         x = np.arange(3, dtype=np.float32)
         self.module.foo(x)
         assert_equal(x, [3, 1, 2])
-
-@pytest.mark.parametrize('code', [
-        'program test_f2py\nend program test_f2py',
-        b'program test_f2py\nend program test_f2py',
-    ])
-def test_compile(tmpdir, code):
-    # Make sure we can compile str and bytes gh-12796
-    cwd = os.getcwd()
-    try:
-        os.chdir(str(tmpdir))
-        ret = np.f2py.compile(code, modulename='test1_f2py', extension='.f90')
-        assert_equal(ret, 0)
-    finally:
-        os.chdir(cwd)


### PR DESCRIPTION
The test should not be run if there is no Fortran compiler. This PR
moves it to `numpy/f2py/tests/test_compile_function.py`, which is
appropriate for the test and a place where the presence of the needed
compilers is already checked for.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
