### PR TITLE
DOC: remove python2-only methods, small cleanups

### DIFF
--- a/doc/C_STYLE_GUIDE.rst.txt
+++ b/doc/C_STYLE_GUIDE.rst.txt
@@ -201,7 +201,7 @@ Naming conventions
   In the future the names should be of the form ``Npy*_PublicFunction``,
   where the star is something appropriate.
 
-* Public Macros should have a NPY_ prefix and then use upper case,
+* Public Macros should have a ``NPY_`` prefix and then use upper case,
   for example, ``NPY_DOUBLE``.
 
 * Private functions should be lower case with underscores, for example:

--- a/doc/DISTUTILS.rst.txt
+++ b/doc/DISTUTILS.rst.txt
@@ -427,7 +427,7 @@ Extra features in NumPy Distutils
 '''''''''''''''''''''''''''''''''
 
 Specifying config_fc options for libraries in setup.py script
-------------------------------------------------------------
+-------------------------------------------------------------
 
 It is possible to specify config_fc options in setup.py scripts.
 For example, using

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -595,8 +595,8 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    ndarray.__setitem__
    ndarray.__contains__
 
-Conversion; the operations :func:`complex()`, :func:`int()` and
-:func:`float()`.
+Conversion; the operations :func:`int()`, :func:`float()` and
+:func:`complex()`.
 . They work only on arrays that have one element in them
 and return the appropriate scalar.
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -461,12 +461,12 @@ Truth value of an array (:func:`bool()`):
 .. autosummary::
    :toctree: generated/
 
-   ndarray.__nonzero__
+   ndarray.__bool__
 
 .. note::
 
    Truth-value testing of an array invokes
-   :meth:`ndarray.__nonzero__`, which raises an error if the number of
+   :meth:`ndarray.__bool__`, which raises an error if the number of
    elements in the array is larger than 1, because the truth value
    of such arrays is ambiguous. Use :meth:`.any() <ndarray.any>` and
    :meth:`.all() <ndarray.all>` instead to be clear about what is meant
@@ -492,7 +492,6 @@ Arithmetic:
    ndarray.__add__
    ndarray.__sub__
    ndarray.__mul__
-   ndarray.__div__
    ndarray.__truediv__
    ndarray.__floordiv__
    ndarray.__mod__
@@ -527,7 +526,6 @@ Arithmetic, in-place:
    ndarray.__iadd__
    ndarray.__isub__
    ndarray.__imul__
-   ndarray.__idiv__
    ndarray.__itruediv__
    ndarray.__ifloordiv__
    ndarray.__imod__
@@ -597,19 +595,17 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
    ndarray.__setitem__
    ndarray.__contains__
 
-Conversion; the operations :func:`complex()`, :func:`int()`,
-:func:`long()`, :func:`float()`, :func:`oct()`, and
-:func:`hex()`. They work only on arrays that have one element in them
+Conversion; the operations :func:`complex()`, :func:`int()` and
+:func:`float()`.
+. They work only on arrays that have one element in them
 and return the appropriate scalar.
 
 .. autosummary::
    :toctree: generated/
 
    ndarray.__int__
-   ndarray.__long__
    ndarray.__float__
-   ndarray.__oct__
-   ndarray.__hex__
+   ndarray.__complex__
 
 String representations:
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -184,10 +184,8 @@ Conversion
    :toctree: generated/
 
    MaskedArray.__float__
-   MaskedArray.__hex__
    MaskedArray.__int__
    MaskedArray.__long__
-   MaskedArray.__oct__
 
    MaskedArray.view
    MaskedArray.astype
@@ -311,7 +309,7 @@ Truth value of an array (:func:`bool()`):
 .. autosummary::
    :toctree: generated/
 
-   MaskedArray.__nonzero__
+   MaskedArray.__bool__
 
 
 Arithmetic:
@@ -328,7 +326,6 @@ Arithmetic:
    MaskedArray.__mul__
    MaskedArray.__rmul__
    MaskedArray.__div__
-   MaskedArray.__rdiv__
    MaskedArray.__truediv__
    MaskedArray.__rtruediv__
    MaskedArray.__floordiv__

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -5,14 +5,6 @@ Miscellaneous routines
 
 .. currentmodule:: numpy
 
-Buffer objects
---------------
-.. autosummary::
-   :toctree: generated/
-
-   getbuffer
-   newbuffer
-
 Performance tuning
 ------------------
 .. autosummary::

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -609,6 +609,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     'Sqrt'
         .. math:: n_h = \sqrt n
+
         The simplest and fastest estimator. Only takes into account the
         data size.
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -461,7 +461,8 @@ def _histogram_bin_edges_dispatcher(a, bins=None, range=None, weights=None):
 @array_function_dispatch(_histogram_bin_edges_dispatcher)
 def histogram_bin_edges(a, bins=10, range=None, weights=None):
     r"""
-    Function to calculate only the edges of the bins used by the `histogram` function.
+    Function to calculate only the edges of the bins used by the `histogram`
+    function.
 
     Parameters
     ----------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2634,7 +2634,7 @@ def multi_dot(arrays):
         def cost(A, B):
             return A.shape[0] * A.shape[1] * B.shape[1]
 
-    Let's assume we have three matrices
+    Assume we have three matrices
     :math:`A_{10x100}, B_{100x5}, C_{5x50}`.
 
     The costs for the two different parenthesizations are as follows::


### PR DESCRIPTION
A bit of cleanup to reduce the number of warnings when building documentation. Python3 dropped some buffer and dunder methods, and `__nonzero__` becamame `__bool__`. 

Many warnings of the type

```
lib/python3.6/site-packages/numpy/core/_internal.py:docstring of 
numpy.core._internal._ctypes.shape:1: WARNING: duplicate object
description of numpy.core._internal._ctypes.shape, other instance in 
numpy/doc/source/reference/generated/numpy.core.defchararray.chararray.ctypes.rst,
use :noindex: for one of them
```
It seems this is a known problem with sphinx and referencing the same docstring from two classes