### PR TITLE
BUG: add support for unicode paths in os_fspath

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -214,12 +214,12 @@ else:
 
     def os_fspath(path):
         """Return the path representation of a path-like object.
-        If str or bytes is passed in, it is returned unchanged. Otherwise the
+        If str or unicode or bytes is passed in, it is returned unchanged. Otherwise the
         os.PathLike interface is used to get the path representation. If the
         path representation is not str or bytes, TypeError is raised. If the
-        provided path is not str, bytes, or os.PathLike, TypeError is raised.
+        provided path is not str, unicode, bytes, or os.PathLike, TypeError is raised.
         """
-        if isinstance(path, (str, bytes)):
+        if isinstance(path, (str, unicode, bytes)):
             return path
 
         # Work from the object's type to match method resolution of other magic
@@ -235,7 +235,7 @@ else:
             else:
                 raise TypeError("expected str, bytes or os.PathLike object, "
                                 "not " + path_type.__name__)
-        if isinstance(path_repr, (str, bytes)):
+        if isinstance(path_repr, (str, unicode, bytes)):
             return path_repr
         else:
             raise TypeError("expected {}.__fspath__() to return str or bytes, "


### PR DESCRIPTION
It looks like the recent `os_fspath` function does not allow unicode paths to be used in Python 2.x. I don't know if this is a design decision, but perhaps this is a bug?

```
# python --version
Python 2.7.12
# pip freeze | grep numpy
numpy==1.16.0
```

```python
import numpy as np
np.savez_compressed('test') # OK
np.savez_compressed(u'test')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "numpy/lib/npyio.py", line 691, in savez_compressed
    _savez(file, args, kwds, True)
  File "numpy/lib/npyio.py", line 700, in _savez
    file = os_fspath(file)
  File "numpy/compat/py3k.py", line 237, in os_fspath
    "not " + path_type.__name__)
TypeError: expected str, bytes or os.PathLike object, not unicode
```

The proposed fix simply adds `unicode` as an allowed type.