### PR TITLE
BUG: fix to check before apply `shlex.split`

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -466,10 +466,8 @@ class FCompiler(CCompiler):
         noarch = self.distutils_vars.get('noarch', noopt)
         debug = self.distutils_vars.get('debug', False)
 
-        f77 = shlex.split(self.command_vars.compiler_f77,
-                          posix=(os.name == 'posix'))
-        f90 = shlex.split(self.command_vars.compiler_f90,
-                          posix=(os.name == 'posix'))
+        f77 = self.command_vars.compiler_f77
+        f90 = self.command_vars.compiler_f90
 
         f77flags = []
         f90flags = []
@@ -477,8 +475,10 @@ class FCompiler(CCompiler):
         fixflags = []
 
         if f77:
+            f77 = shlex.split(f77, posix=(os.name == 'posix'))
             f77flags = self.flag_vars.f77
         if f90:
+            f90 = shlex.split(f90, posix=(os.name == 'posix'))
             f90flags = self.flag_vars.f90
             freeflags = self.flag_vars.free
         # XXX Assuming that free format is default for f90 compiler.
@@ -490,8 +490,8 @@ class FCompiler(CCompiler):
         # environment variable has been customized by CI or a user
         # should perhaps eventually be more throughly tested and more
         # robustly handled
-        fix = shlex.split(fix, posix=(os.name == 'posix'))
         if fix:
+            fix = shlex.split(fix, posix=(os.name == 'posix'))
             fixflags = self.flag_vars.fix + f90flags
 
         oflags, aflags, dflags = [], [], []


### PR DESCRIPTION
`shlex.split` will try to read stdin if `None` is passed,
so change to check before apply it.

see #12823