### PR TITLE
DOC: Updates to nditer usage instructions

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -386,12 +386,12 @@ add_newdoc('numpy.core', 'nditer',
     >>> luf(lambda i,j:i*i + j/2, a, b)
     array([  0.5,   1.5,   4.5,   9.5,  16.5])
 
-    If operand flags `"writeonly"` or `"readwrite"` are used the operands may
-    be views into the original data with the `WRITEBACKIFCOPY` flag. In this case
-    nditer must be used as a context manager or the nditer.close
-    method must be called before using the result. The temporary
-    data will be written back to the original data when the `__exit__`
-    function is called but not before:
+    If operand flags `"writeonly"` or `"readwrite"` are used the
+    operands may be views into the original data with the
+    `WRITEBACKIFCOPY` flag. In this case `nditer` must be used as a
+    context manager or the `nditer.close` method must be called before
+    using the result. The temporary data will be written back to the
+    original data when the `__exit__` function is called but not before:
 
     >>> a = np.arange(6, dtype='i4')[::-2]
     >>> with np.nditer(a, [],
@@ -412,6 +412,8 @@ add_newdoc('numpy.core', 'nditer',
     no longer write to `a`. If writeback semantics are not active, then
     `x.data` will still point at some part of `a.data`, and writing to
     one will affect the other.
+
+    Context management and the `close` method appeared in version 1.15.0.
 
     """)
 
@@ -567,6 +569,8 @@ add_newdoc('numpy.core', 'nditer', ('close',
     close()
 
     Resolve all writeback semantics in writeable operands.
+
+    .. versionadded:: 1.15.0
 
     See Also
     --------


### PR DESCRIPTION
More intuitive use of iterators. Context manager introduction version noted explicitly.

This is still a rough draft, and all advice is welcome.

Fixes #12764