### PR TITLE
ENH: Added option to suppress stout/err capture in tests

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -73,7 +73,8 @@ class PytestTester(object):
         self.module_name = module_name
 
     def __call__(self, label='fast', verbose=1, extra_argv=None,
-                 doctests=False, coverage=False, durations=-1, tests=None):
+                 doctests=False, coverage=False, durations=-1, capture=None,
+                 tests=None):
         """
         Run tests for module using pytest.
 
@@ -95,6 +96,10 @@ class PytestTester(object):
         durations : int, optional
             If < 0, do nothing, If 0, report time of all tests, if > 0,
             report the time of the slowest `timer` tests. Default is -1.
+        capture : {None, 'sys', 'fd', 'suppress'}, optional
+            Sets the stdout/stderr capturing level used by pytest,
+            according to https://docs.pytest.org/en/latest/capture.html#setting-capturing-methods-or-disabling-capturing
+            If `None`, use the default (usually `'fd'`).
         tests : test or list of tests
             Tests to be executed with pytest '--pyargs'
 
@@ -191,6 +196,11 @@ class PytestTester(object):
 
         if durations >= 0:
             pytest_args += ["--durations=%s" % durations]
+
+        if capture == 'suppress':
+            pytest_args += ['-s']
+        elif capture is not None:
+            pytest_args += ['--capture=%s' % capture]
 
         if tests is None:
             tests = [self.module_name]

--- a/runtests.py
+++ b/runtests.py
@@ -116,6 +116,9 @@ def main(argv):
                               "--bench-compare=COMMIT to override HEAD with "
                               "COMMIT. Note that you need to commit your "
                               "changes first!"))
+    parser.add_argument("--capture", "-c", action="store", default=None,
+                        choices=["fd", "sys", "suppress"],
+                        help="Set capturing of stdout and stderr during tests.")
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to Nose, Python or shell")
     args = parser.parse_args(argv)
@@ -296,6 +299,7 @@ def main(argv):
                       doctests=args.doctests,
                       coverage=args.coverage,
                       durations=args.durations,
+                      capture=args.capture,
                       tests=tests)
     finally:
         os.chdir(cwd)


### PR DESCRIPTION
This is an update to allow users to suppress the usual capturing of stdout/stderr that pytest does.

I am not completely sure how to write tests for this, but I did (and can again) run the different options to show that:

- With no flag or `-c fd`, the tests run as always, everything gets captured
- With `-c sys`, Python `print` statements are captured, but C `printf` calls are not.
- With `-c suppress`, both Python `print`s and C `printf`s are not captured.

This is useful for people like me, who have not figured out how to set up gdb with python properly yet, as well as for folks making small changes, where a quick printout is worth something. In particular, I have found this useful for quickly dealing with segfaults. 