### PR TITLE
TEST: pin mingw version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ jobs:
       cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
-      choco install -y mingw --forcex86 --force
+      choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
   - script: python -m pip install cython nose pytz pytest


### PR DESCRIPTION
Backport of #12863.

Temporarily fix #12856 by pinning the mingw version to 5.3. Without this we get version 8. We should be using the latest toolchain, but need to transition in a controlled manner
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
