### PR TITLE
BUG: ndarrays pickled by 1.16 cannot be loaded by 1.15.4 and lower

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -40,6 +40,10 @@ __all__ = [
     'tracemalloc_domain', 'typeinfo', 'unpackbits', 'unravel_index', 'vdot',
     'where', 'zeros']
 
+# For backward compatibility, make sure pickle imports these functions from here
+_reconstruct.__module__ = 'numpy.core.multiarray'
+scalar.__module__ = 'numpy.core.multiarray'
+
 
 arange.__module__ = 'numpy'
 array.__module__ = 'numpy'


### PR DESCRIPTION
Backport of #12842.

Fixes #12837 
When pickling ndarrays, the pickle protocol adds the reconstructing function's __module__` name to the pickled string so it can be called. The function (which is `_reconstruct`) now lives in `numpy.core._multiarray_umath`, but in pre-1.16 numpy it was in `numpy.core.multiarray`. Also for scalar objects, the function `scalar` moved.

The fix is very simple, changing the `__module__` attribute of `_reconstruct` and `scalar`

In `array_reduce_ex`, used when the pickle protocol is 5, the function will be `numpy.core.numeric._frombuffer`, which will not exist on pre-1.16 numpy (added in commit 64a855f421, Oct 2018). I don't think we can work around that. People who do not have that function will have to modify their numpy if they wish to import protocol-5 pickled ndarrays.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
