### PR TITLE
ENH: add c-imported modules to namespace for freeze analysis

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -53,7 +53,6 @@ del env_added
 del os
 
 from . import umath
-from . import _internal  # for freeze programs
 from . import numerictypes as nt
 multiarray.set_typeDict(nt.sctypeDict)
 from . import numeric
@@ -83,6 +82,11 @@ from .numeric import absolute as abs
 # do this after everything else, to minimize the chance of this misleadingly
 # appearing in an import-time traceback
 from . import _add_newdocs
+# add these for module-freeze analysis (like PyInstaller)
+from . import _dtype_ctypes
+from . import _internal
+from . import _dtype
+from . import _methods
 
 __all__ = ['char', 'rec', 'memmap']
 __all__ += numeric.__all__


### PR DESCRIPTION
When freezing the numpy module, analyzers like `PyInstall` do not see the import done in `method.c`:  `PyImport_ImportModule("numpy.core._dtype_ctypes")`. Add a python import so the module is picked up and included in the frozen manifest. Related to pyinstaller/pyinstaller#3982 (even though they have a work-around in pyinstaller/pyinstaller#3985)

See details for a possible test
<details>
A test for this would be  

```
cmd ='''pip install pyinstaller
echo "import numpy; print(numpy.ones(10))" > /tmp/test.py
pyinstaller /tmp/test
dist/test/test'''
res = subprocess.check_call(shlex.split(cmd))
```
but the test I tried setting up a virtual environment proved too fragile.