### PR TITLE
BUG: squeeze corner case, list arg + specified axis

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1385,7 +1385,7 @@ def squeeze(a, axis=None):
     try:
         squeeze = a.squeeze
     except AttributeError:
-        squeeze = lambda **kwargs: _wrapit(a, 'squeeze', **kwargs)
+        squeeze = functools.partial(_wrapit, obj=a, method='squeeze')
     if axis is None:
         return squeeze()
     else:

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1385,7 +1385,7 @@ def squeeze(a, axis=None):
     try:
         squeeze = a.squeeze
     except AttributeError:
-        squeeze = functools.partial(_wrapit, obj=a, method='squeeze')
+        return _wrapit(a, 'squeeze', axis=axis)
     if axis is None:
         return squeeze()
     else:

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1385,7 +1385,7 @@ def squeeze(a, axis=None):
     try:
         squeeze = a.squeeze
     except AttributeError:
-        return _wrapit(a, 'squeeze')
+        squeeze = lambda **kwargs: _wrapit(a, 'squeeze', **kwargs)
     if axis is None:
         return squeeze()
     else:

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -152,7 +152,15 @@ class TestNonarrayArgs(object):
 
     def test_squeeze(self):
         A = [[[1, 1, 1], [2, 2, 2], [3, 3, 3]]]
-        assert_(np.squeeze(A).shape == (3, 3))
+        assert_equal(np.squeeze(A).shape, (3, 3))
+        assert_equal(np.squeeze(np.zeros((1, 3, 1))).shape, (3,))
+        assert_equal(np.squeeze(np.zeros((1, 3, 1)), axis=0).shape, (3, 1))
+        assert_equal(np.squeeze(np.zeros((1, 3, 1)), axis=-1).shape, (1, 3))
+        assert_equal(np.squeeze(np.zeros((1, 3, 1)), axis=2).shape, (1, 3))
+        assert_equal(np.squeeze([np.zeros((3, 1))]).shape, (3,))
+        assert_equal(np.squeeze([np.zeros((3, 1))], axis=0).shape, (3, 1))
+        assert_equal(np.squeeze([np.zeros((3, 1))], axis=2).shape, (1, 3))
+        assert_equal(np.squeeze([np.zeros((3, 1))], axis=-1).shape, (1, 3))
 
     def test_std(self):
         A = [[1, 2, 3], [4, 5, 6]]


### PR DESCRIPTION
Old implementation fails when squeezing via `_wrapit` (when squeezing e.g. a list/tuple) since `axis` is ignored.