### PR TITLE
BUG: Fix np.rec.fromarrays on arrays which are already structured

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -597,7 +597,10 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
     array([1, 2, 3, 4])
     """
 
-    arrayList = [sb.asarray(x) for x in arrayList]
+    arrayList = [
+        x if isinstance(x, ndarray) else sb.asarray(x) 
+        for x in arrayList
+    ]
 
     if shape is None or shape == 0:
         shape = arrayList[0].shape
@@ -610,8 +613,6 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
         # and determine the formats.
         formats = []
         for obj in arrayList:
-            if not isinstance(obj, ndarray):
-                raise ValueError("item in the array list must be an ndarray.")
             formats.append(obj.dtype.str)
 
     if dtype is not None:

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -597,10 +597,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
     array([1, 2, 3, 4])
     """
 
-    arrayList = [
-        x if isinstance(x, ndarray) else sb.asarray(x) 
-        for x in arrayList
-    ]
+    arrayList = [sb.asarray(x) for x in arrayList]
 
     if shape is None or shape == 0:
         shape = arrayList[0].shape
@@ -613,7 +610,7 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
         # and determine the formats.
         formats = []
         for obj in arrayList:
-            formats.append(obj.dtype.str)
+            formats.append(obj.dtype)
 
     if dtype is not None:
         descr = sb.dtype(dtype)
@@ -769,7 +766,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     >>> r.shape
     (10,)
     """
-    
+
     if dtype is None and formats is None:
         raise TypeError("fromfile() needs a 'dtype' or 'formats' argument")
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -438,7 +438,6 @@ class TestRecord(object):
         assert_raises(ValueError, lambda: arr[['nofield']])
 
     def test_frommarrays_using_subarrays(self):
-        # https://github.com/numpy/numpy/issues/4806
         arrays = [
             np.arange(10),
             np.ones(10, dtype=[('a', '<u2'), ('b', '<f4')]),

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -437,6 +437,14 @@ class TestRecord(object):
         arr = np.zeros((3,), dtype=[('x', int), ('y', int)])
         assert_raises(ValueError, lambda: arr[['nofield']])
 
+    def test_frommarrays_using_subarrays(self):
+        # https://github.com/numpy/numpy/issues/4806
+        arrays = [
+            np.arange(10),
+            np.ones(10, dtype=[('a', '<u2'), ('b', '<f4')]),
+        ]
+        arr = np.rec.fromarrays(arrays) # ValueError?
+
 
 def test_find_duplicate():
     l1 = [1, 2, 3, 4, 5, 6]

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -437,12 +437,12 @@ class TestRecord(object):
         arr = np.zeros((3,), dtype=[('x', int), ('y', int)])
         assert_raises(ValueError, lambda: arr[['nofield']])
 
-    def test_frommarrays_using_subarrays(self):
+    def test_fromarrays_nested_structured_arrays(self):
         arrays = [
             np.arange(10),
             np.ones(10, dtype=[('a', '<u2'), ('b', '<f4')]),
         ]
-        arr = np.rec.fromarrays(arrays) # ValueError?
+        arr = np.rec.fromarrays(arrays)  # ValueError?
 
 
 def test_find_duplicate():


### PR DESCRIPTION
* skip redundant check (all input arrays are at that point instances of _ndarray_)
* use _dtype_ instead of _dtype.str_

There is an improvement of ~3% 

```
· Running 14 total benchmarks (2 commits * 1 environments * 7 benchmarks)
[  0.00%] · For numpy commit 18435496 <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.6-six..
[  0.00%] ·· Benchmarking virtualenv-py3.6-six
[  3.57%] ··· Running (bench_records.Records.time_fromarrays_formats_as_list--).......
[ 25.00%] · For numpy commit 2c402b5c <danielhrisca-fromarrays> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.6-six..
[ 25.00%] ·· Benchmarking virtualenv-py3.6-six
[ 28.57%] ··· Running (bench_records.Records.time_fromarrays_formats_as_list--).......
[ 50.00%] · For numpy commit 2c402b5c <danielhrisca-fromarrays> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.6-six
[ 53.57%] ··· bench_records.Records.time_fromarrays_formats_as_list                                                                 83.4±0.4ms
[ 57.14%] ··· bench_records.Records.time_fromarrays_formats_as_string                                                                108±0.3ms
[ 60.71%] ··· bench_records.Records.time_fromarrays_w_dtype                                                                         66.0±0.4ms
[ 64.29%] ··· bench_records.Records.time_fromarrays_wo_dtype                                                                        86.9±0.5ms
[ 67.86%] ··· bench_records.Records.time_fromstring_formats_as_list                                                                 16.6±0.1ms
[ 71.43%] ··· bench_records.Records.time_fromstring_formats_as_string                                                                 42.3±1ms
[ 75.00%] ··· bench_records.Records.time_fromstring_w_dtype                                                                        5.53±0.04μs
[ 75.00%] · For numpy commit 18435496 <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.6-six..
[ 75.00%] ·· Benchmarking virtualenv-py3.6-six
[ 78.57%] ··· bench_records.Records.time_fromarrays_formats_as_list                                                                 85.5±0.2ms
[ 82.14%] ··· bench_records.Records.time_fromarrays_formats_as_string                                                                110±0.3ms
[ 85.71%] ··· bench_records.Records.time_fromarrays_w_dtype                                                                         68.5±0.2ms
[ 89.29%] ··· bench_records.Records.time_fromarrays_wo_dtype                                                                        89.9±0.1ms
[ 92.86%] ··· bench_records.Records.time_fromstring_formats_as_list                                                                 16.5±0.1ms
[ 96.43%] ··· bench_records.Records.time_fromstring_formats_as_string                                                               42.1±0.9ms
[100.00%] ··· bench_records.Records.time_fromstring_w_dtype                                                                        5.66±0.07μs
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
