### PR TITLE
BUG: Do not double-quote arguments passed on to the linker

### DIFF
--- a/numpy/distutils/fcompiler/absoft.py
+++ b/numpy/distutils/fcompiler/absoft.py
@@ -66,7 +66,7 @@ class AbsoftFCompiler(FCompiler):
 
     def library_dir_option(self, dir):
         if os.name=='nt':
-            return ['-link', '/PATH:"%s"' % (dir)]
+            return ['-link', '/PATH:%s' % (dir)]
         return "-L" + dir
 
     def library_option(self, lib):

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -269,8 +269,11 @@ class GnuFCompiler(FCompiler):
             # Linux/Solaris/Unix support RPATH, Windows and AIX do not
             raise NotImplementedError
 
+        # TODO: could use -Xlinker here, if it's supported
+        assert "," not in dir
+
         sep = ',' if sys.platform == 'darwin' else '='
-        return '-Wl,-rpath%s"%s"' % (sep, dir)
+        return '-Wl,-rpath%s%s' % (sep, dir)
 
 
 class Gnu95FCompiler(GnuFCompiler):

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -23,7 +23,10 @@ class BaseIntelFCompiler(FCompiler):
                                            f + '.f', '-o', f + '.o']
 
     def runtime_library_dir_option(self, dir):
-        return '-Wl,-rpath="%s"' % dir
+        # TODO: could use -Xlinker here, if it's supported
+        assert "," not in dir
+
+        return '-Wl,-rpath=%s' % dir
 
 
 class IntelFCompiler(BaseIntelFCompiler):

--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -57,7 +57,7 @@ class PGroupFCompiler(FCompiler):
             return ["-dynamic", '-undefined', 'dynamic_lookup']
 
     def runtime_library_dir_option(self, dir):
-        return '-R"%s"' % dir
+        return '-R%s' % dir
 
 
 if sys.version_info >= (3, 5):

--- a/numpy/distutils/fcompiler/sun.py
+++ b/numpy/distutils/fcompiler/sun.py
@@ -44,7 +44,7 @@ class SunFCompiler(FCompiler):
         return opt
 
     def runtime_library_dir_option(self, dir):
-        return '-R"%s"' % dir
+        return '-R%s' % dir
 
 if __name__ == '__main__':
     from distutils import log


### PR DESCRIPTION
After the recent patch to CCompiler.spawn, the file-paths no longer need manual quoting - that's handled as needed within subprocess.

This also states our assumption that our paths do not contain commas.
If we care about this, we could adopt the approach used by https://github.com/rust-lang/rust/issues/38795.

Tested locally by looking at the error messages of `subprocess.check_call(["gcc", r'-Wl,spaces and no quotes'])`

Fixes #12882

[Backport here](https://github.com/numpy/numpy/compare/maintenance/1.16.x...eric-wieser:distutils-debug?expand=1)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
