### PR TITLE
MAINT: Removed unused and confusingly indirect imports from mingw32ccompiler

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -29,7 +29,6 @@ else:
 
 import distutils.cygwinccompiler
 from distutils.version import StrictVersion
-from numpy.distutils.ccompiler import gen_preprocess_options, gen_lib_options
 from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import get_build_version as get_build_msvc_version
 from distutils.errors import (DistutilsExecError, CompileError,


### PR DESCRIPTION
Both of these functions are better exposed through `distutils.ccompiler`, but neither are used anyway