### PR TITLE
TST: fix vmImage dispatch in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 jobs:
 - job: Linux_Python_36_32bit_full_with_asserts
   pool:
-    vmIMage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-16.04'
   steps:
   - script: |
            docker pull i386/ubuntu:bionic
@@ -41,7 +41,7 @@ jobs:
     # the docs even though i.e., numba uses another in their
     # azure config for mac os -- Microsoft has indicated
     # they will patch this issue
-    vmIMage: macOS-10.13
+    vmImage: macOS-10.13
   steps:
   # the @0 refers to the (major) version of the *task* on Microsoft's
   # end, not the order in the build matrix nor anything to do
@@ -93,7 +93,7 @@ jobs:
       testRunTitle: 'Publish test results for Python 3.6 64-bit full Mac OS'
 - job: Windows
   pool:
-    vmIMage: 'VS2017-Win2016'
+    vmImage: 'VS2017-Win2016'
   variables:
       # openblas URLs from numpy-wheels
       # appveyor / Windows config


### PR DESCRIPTION
See Microsoft dev comments ( @ericsciple ) at: https://github.com/scipy/scipy/pull/9523#issuecomment-459426148

Similar PR for SciPy: https://github.com/scipy/scipy/pull/9736

Seems to create an expanded list of Azure entries (1 per job) in CI list though for SciPy -- perhaps will do the same here. Not sure if we really want that, but let's see if we can at least get tests passing for now.
