### PR TITLE
BLD: fix doc build for distribution.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,10 @@
 # Makefile for Sphinx documentation
 #
 
-PYVER = 3
+# This needs to be major.minor, just "3" doesn't work - it will result in
+# issues with the amendments to PYTHONPATH and install paths (see DIST_VARS).
+# If you're using a different Python version, just change the number here.
+PYVER = 3.6
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.
@@ -58,7 +61,7 @@ gitwash-update:
 #
 
 
-INSTALL_DIR = $(CURDIR)/build/inst-dist/
+INSTALL_DIR = $(CURDIR)/build/inst-dist
 INSTALL_PPH = $(INSTALL_DIR)/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/lib/python$(PYVER)/dist-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/dist-packages
 UPLOAD_DIR=/srv/docs_scipy_org/doc/numpy-$(RELEASE)
 


### PR DESCRIPTION
This reverts gh-12508 for now. It caused this hard to understand issue when running `make dist`:
```
install -d /home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/site-packages /home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/site-packages /home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/dist-packages /home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/dist-packages
PYTHONPATH=/home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/site-packages:/home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/site-packages:/home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/dist-packages:/home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/dist-packages python3 `which easy_install` --prefix=/home/rgommers/code/numpy/doc/build/inst-dist ../dist/*.egg
TEST FAILED: /home/rgommers/code/numpy/doc/build/inst-dist/lib/python3.6/site-packages does NOT support .pth files
error: bad install directory or PYTHONPATH

You are attempting to install a package to a directory that is not
on PYTHONPATH and which Python does not read ".pth" files from.  The
installation directory you specified (via --install-dir, --prefix, or
the distutils default setting) was:

    /home/rgommers/code/numpy/doc/build/inst-dist/lib/python3.6/site-packages

and your PYTHONPATH environment variable currently contains:

    '/home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/site-packages:/home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/site-packages:/home/rgommers/code/numpy/doc/build/inst-dist/lib/python3/dist-packages:/home/rgommers/code/numpy/doc/build/inst-dist/local/lib/python3/dist-packages'

Here are some of your options for correcting the problem:

* You can choose a different installation directory, i.e., one that is
  on PYTHONPATH or supports .pth files

* You can add the installation directory to the PYTHONPATH environment
  variable.  (It must then also be on PYTHONPATH whenever you run
  Python and want to use the package(s) you are installing.)

* You can set up the installation directory to support ".pth" files by
  using one of the approaches described here:

  https://setuptools.readthedocs.io/en/latest/easy_install.html#custom-installation-locations


Please make the appropriate changes for your system and try again.
make[1]: *** [Makefile:87: dist-build] Error 1
make[1]: Leaving directory '/home/rgommers/code/numpy/doc'
make: *** [Makefile:68: dist] Error 2
```

We can look for a better solution later, but at least `make dist` works now and some docs are added.