### PR TITLE
MAINT: improve the accuracy of `np.sinc` for real arguments

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -934,6 +934,12 @@ defdict = {
           TD(O),
           signature='(n?,k),(k,m?)->(n?,m?)',
           ),
+'sinc' :
+    Ufunc(1, 1, None,
+          docstrings.get('numpy.core.umath.sinc'),
+          None,
+          TD(inexact, f='sinc', astype={'e':'f'}),
+          ),
 }
 
 if sys.version_info[0] >= 3:

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -938,7 +938,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.sinc'),
           None,
-          TD(inexact, f='sinc', astype={'e':'f'}),
+          TD(inexact, f='sinc', astype={'e': 'f'}),
           ),
 }
 

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3972,3 +3972,70 @@ add_newdoc('numpy.core.umath', 'lcm',
     array([ 0, 20, 20, 60, 20, 20])
 
     """)
+
+
+add_newdoc('numpy.core.umath', 'sinc',
+    """
+    Return the sinc function.
+
+    The sinc function is :math:`\\sin(\\pi x)/(\\pi x)`.
+
+    Parameters
+    ----------
+    x : array_like
+        Input array.
+    $PARAMS
+
+    Returns
+    -------
+    out : ndarray or scalar
+        The sinc function at each element of `x`.
+        $OUT_SCALAR_1
+
+    Notes
+    -----
+    ``sinc(0)`` is the limit value 1.
+
+    The name sinc is short for "sine cardinal" or "sinus cardinalis".
+
+    The sinc function is used in various signal processing applications,
+    including in anti-aliasing, in the construction of a Lanczos resampling
+    filter, and in interpolation.
+
+    For bandlimited interpolation of discrete-time signals, the ideal
+    interpolation kernel is proportional to the sinc function.
+
+    References
+    ----------
+    .. [1] Weisstein, Eric W. "Sinc Function." From MathWorld--A Wolfram Web
+           Resource. http://mathworld.wolfram.com/SincFunction.html
+    .. [2] Wikipedia, "Sinc function",
+           https://en.wikipedia.org/wiki/Sinc_function
+
+    Examples
+    --------
+    It is zero at all nonzero integers.
+
+    >>> np.sinc([-2, -1, 0, 1, 2]))
+    array([0., 0., 1., 0., 0.])
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(-4, 4, 41)
+    >>> plt.plot(x, np.sinc(x))
+    [<matplotlib.lines.Line2D object at 0x...>]
+    >>> plt.title("Sinc Function")
+    Text(0.5, 1.0, 'Sinc Function')
+    >>> plt.ylabel("Amplitude")
+    Text(0, 0.5, 'Amplitude')
+    >>> plt.xlabel("X")
+    Text(0.5, 0, 'X')
+    >>> plt.show()
+
+    It works in 2-D as well:
+
+    >>> x = np.linspace(-4, 4, 401)
+    >>> xx = np.outer(x, x)
+    >>> plt.imshow(np.sinc(xx))
+    <matplotlib.image.AxesImage object at 0x...>
+
+    """)

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -4016,7 +4016,7 @@ add_newdoc('numpy.core.umath', 'sinc',
     --------
     It is zero at all nonzero integers.
 
-    >>> np.sinc([-2, -1, 0, 1, 2]))
+    >>> np.sinc([-2, -1, 0, 1, 2])
     array([0., 0., 1., 0., 0.])
 
     >>> import matplotlib.pyplot as plt

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -349,6 +349,7 @@ NPY_INPLACE double npy_logaddexp(double x, double y);
 NPY_INPLACE double npy_logaddexp2(double x, double y);
 NPY_INPLACE double npy_divmod(double x, double y, double *modulus);
 NPY_INPLACE double npy_heaviside(double x, double h0);
+NPY_INPLACE double npy_sinc(double x);
 
 NPY_INPLACE float npy_deg2radf(float x);
 NPY_INPLACE float npy_rad2degf(float x);
@@ -356,6 +357,7 @@ NPY_INPLACE float npy_logaddexpf(float x, float y);
 NPY_INPLACE float npy_logaddexp2f(float x, float y);
 NPY_INPLACE float npy_divmodf(float x, float y, float *modulus);
 NPY_INPLACE float npy_heavisidef(float x, float h0);
+NPY_INPLACE float npy_sincf(float x);
 
 NPY_INPLACE npy_longdouble npy_deg2radl(npy_longdouble x);
 NPY_INPLACE npy_longdouble npy_rad2degl(npy_longdouble x);
@@ -364,6 +366,7 @@ NPY_INPLACE npy_longdouble npy_logaddexp2l(npy_longdouble x, npy_longdouble y);
 NPY_INPLACE npy_longdouble npy_divmodl(npy_longdouble x, npy_longdouble y,
                            npy_longdouble *modulus);
 NPY_INPLACE npy_longdouble npy_heavisidel(npy_longdouble x, npy_longdouble h0);
+NPY_INPLACE npy_longdouble npy_sincl(npy_longdouble x);
 
 #define npy_degrees npy_rad2deg
 #define npy_degreesf npy_rad2degf

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -557,6 +557,37 @@ NPY_INPLACE @type@ npy_cbrt@c@(@type@ x)
     }
 }
 
+NPY_INPLACE @type@
+npy_sinc@c@(@type@ x)
+{
+    @type@ r;
+
+    if (npy_isnan(x)) {
+	return (@type@) NPY_NAN;
+    }
+    else if (npy_isinf(x)) {
+	return 0;
+    }
+    else if (x == 0) {
+	return 1;
+    }
+
+    if (x < 0) {
+	x = -x;
+    }
+
+    r = npy_fmod@c@(x, 2);
+    if (r < 0.5@c@) {
+	return npy_sin@c@(NPY_PI@c@*r) / (NPY_PI@c@*x);
+    }
+    else if (r > 1.5@c@) {
+	return npy_sin@c@(NPY_PI@c@*(r - 2)) / (NPY_PI@c@*x);
+    }
+    else {
+	return npy_sin@c@(NPY_PI@c@*(1 - r)) / (NPY_PI@c@*x);
+    }
+}
+
 #define LOGE2    NPY_LOGE2@c@
 #define LOG2E    NPY_LOG2E@c@
 #define RAD2DEG  (180.0@c@/NPY_PI@c@)

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -576,6 +576,10 @@ npy_sinc@c@(@type@ x)
 	x = -x;
     }
 
+    /*
+     * Use the same argument reduction as `sinpi`; compare to the
+     * `sinpi` implementations in e.g. mpmath or Boost.
+     */
     r = npy_fmod@c@(x, 2);
     if (r < 0.5@c@) {
 	return npy_sin@c@(NPY_PI@c@*r) / (NPY_PI@c@*x);

--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -473,4 +473,51 @@ nc_tanh@c@(@ctype@ *x, @ctype@ *r)
     return;
 }
 
+static NPY_INLINE
+@ctype@
+cdiv@c@(@ctype@ a, @ctype@ b)
+{
+    @ftype@ ar, ai, br, bi, abs_br, abs_bi;
+    ar = npy_creal@c@(a);
+    ai = npy_cimag@c@(a);
+    br = npy_creal@c@(b);
+    bi = npy_cimag@c@(b);
+    abs_br = npy_fabs@c@(br);
+    abs_bi = npy_fabs@c@(bi);
+
+    if (abs_br >= abs_bi) {
+        if (abs_br == 0 && abs_bi == 0) {
+            /* divide by zeros should yield a complex inf or nan */
+            return npy_cpack@c@(ar/abs_br, ai/abs_bi);
+        }
+        else {
+            @ftype@ rat = bi/br;
+            @ftype@ scl = 1.0@c@/(br+bi*rat);
+            return npy_cpack@c@((ar + ai*rat)*scl, (ai - ar*rat)*scl);
+        }
+    }
+    else {
+        @ftype@ rat = br/bi;
+        @ftype@ scl = 1.0@c@/(bi + br*rat);
+        return npy_cpack@c@((ar*rat + ai)*scl, (ai*rat - ar)*scl);
+    }
+}
+
+static void
+nc_sinc@c@(@ctype@ *z, @ctype@ *out)
+{
+    @ctype@ zpi;
+    @ftype@ x, y;
+
+    x = z->real;
+    y = z->imag;
+    if (x == 0 && y == 0) {
+	*out = npy_cpack@c@(1, 0);
+	return;
+    }
+
+    zpi = npy_cpack@c@(NPY_PI@c@*x, NPY_PI@c@*y);
+    *out = cdiv@c@(npy_csin@c@(zpi), zpi);
+    return;
+}
 /**end repeat**/

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1330,6 +1330,29 @@ class TestHeavside(object):
         assert_equal(h, expected1.astype(np.float32))
 
 
+class TestSinc:
+
+    def test_special_cases(self):
+        assert_(ncu.sinc(0) == 1)
+        assert_(ncu.sinc(0 + 0j) == 1)
+        assert_(ncu.sinc(np.inf) == 0)
+        assert_(ncu.sinc(-np.inf) == 0)
+        assert_(np.isnan(ncu.sinc(np.nan)))
+        # Test a large zero
+        assert_(ncu.sinc(1e10) == 0)
+
+    def test_real(self):
+        x = np.linspace(-5, 5, 100)
+        assert_allclose(ncu.sinc(x), ncu.sin(np.pi*x)/(np.pi*x), atol=1e-16)
+
+    def test_complex(self):
+        x = np.linspace(-5, 5, 100)
+        y = np.linspace(-5, 5, 100)
+        x, y = np.meshgrid(x, y)
+        z = x + 1j*y
+        assert_allclose(ncu.sinc(z), ncu.sin(np.pi*z)/(np.pi*z))
+
+
 class TestSign(object):
     def test_sign(self):
         a = np.array([np.inf, -np.inf, np.nan, 0.0, 3.0, -3.0])

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -15,7 +15,7 @@ from numpy.testing import (
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_array_max_ulp, assert_allclose, assert_no_warnings, suppress_warnings,
     _gen_alignment_data
-    )
+)
 
 def on_powerpc():
     """ True if we are running on a Power PC platform."""
@@ -1341,16 +1341,36 @@ class TestSinc:
         # Test a large zero
         assert_(ncu.sinc(1e10) == 0)
 
-    def test_real(self):
-        x = np.linspace(-5, 5, 100)
-        assert_allclose(ncu.sinc(x), ncu.sin(np.pi*x)/(np.pi*x), atol=1e-16)
+    @pytest.mark.parametrize('dtype', [np.float64, np.float32, np.float16])
+    def test_real(self, dtype):
+        x = np.linspace(-5, 5, 100, dtype=dtype)
+        # The naive implementation will have large absolute error
+        # around the zeros, so give a nonzero `atol` here.
+        assert_allclose(
+            ncu.sinc(x),
+            ncu.sin(np.pi*x)/(np.pi*x),
+            atol=np.finfo(dtype=dtype).eps,
+        )
 
-    def test_complex(self):
-        x = np.linspace(-5, 5, 100)
-        y = np.linspace(-5, 5, 100)
+    @pytest.mark.parametrize('dtype', [np.complex128, np.complex64])
+    def test_complex(self, dtype):
+        x = np.linspace(-5, 5, 100, dtype=dtype)
+        y = np.linspace(-5, 5, 100, dtype=dtype)
         x, y = np.meshgrid(x, y)
         z = x + 1j*y
         assert_allclose(ncu.sinc(z), ncu.sin(np.pi*z)/(np.pi*z))
+
+    def test_relative_error_near_zeros(self):
+        x = 2 + 0.1**np.arange(10, 15)
+        # Exact values generated from mpmath
+        exact = np.array([
+            5.00000041345185516e-11,
+            5.00000041367685459e-12,
+            5.00044450290920494e-13,
+            4.99600361081295452e-14,
+            5.10702591327569405e-15,
+        ])
+        assert_array_max_ulp(ncu.sinc(x), exact, maxulp=1)
 
 
 class TestSign(object):

--- a/numpy/core/umath.py
+++ b/numpy/core/umath.py
@@ -32,4 +32,4 @@ __all__ = [
     'nextafter', 'not_equal', 'pi', 'positive', 'power', 'rad2deg', 'radians',
     'reciprocal', 'remainder', 'right_shift', 'rint', 'seterrobj', 'sign',
     'signbit', 'sin', 'sinh', 'spacing', 'sqrt', 'square', 'subtract', 'tan',
-    'tanh', 'true_divide', 'trunc']
+    'tanh', 'true_divide', 'trunc', 'sinc']

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -58,7 +58,7 @@ __all__ = [
     'diff', 'gradient', 'angle', 'unwrap', 'sort_complex', 'disp', 'flip',
     'rot90', 'extract', 'place', 'vectorize', 'asarray_chkfinite', 'average',
     'bincount', 'digitize', 'cov', 'corrcoef',
-    'msort', 'median', 'sinc', 'hamming', 'hanning', 'bartlett',
+    'msort', 'median', 'hamming', 'hanning', 'bartlett',
     'blackman', 'kaiser', 'trapz', 'i0', 'add_newdoc', 'add_docstring',
     'meshgrid', 'delete', 'insert', 'append', 'interp', 'add_newdoc_ufunc',
     'quantile'
@@ -3239,91 +3239,6 @@ def kaiser(M, beta):
     n = arange(0, M)
     alpha = (M-1)/2.0
     return i0(beta * sqrt(1-((n-alpha)/alpha)**2.0))/i0(float(beta))
-
-
-def _sinc_dispatcher(x):
-    return (x,)
-
-
-@array_function_dispatch(_sinc_dispatcher)
-def sinc(x):
-    """
-    Return the sinc function.
-
-    The sinc function is :math:`\\sin(\\pi x)/(\\pi x)`.
-
-    Parameters
-    ----------
-    x : ndarray
-        Array (possibly multi-dimensional) of values for which to to
-        calculate ``sinc(x)``.
-
-    Returns
-    -------
-    out : ndarray
-        ``sinc(x)``, which has the same shape as the input.
-
-    Notes
-    -----
-    ``sinc(0)`` is the limit value 1.
-
-    The name sinc is short for "sine cardinal" or "sinus cardinalis".
-
-    The sinc function is used in various signal processing applications,
-    including in anti-aliasing, in the construction of a Lanczos resampling
-    filter, and in interpolation.
-
-    For bandlimited interpolation of discrete-time signals, the ideal
-    interpolation kernel is proportional to the sinc function.
-
-    References
-    ----------
-    .. [1] Weisstein, Eric W. "Sinc Function." From MathWorld--A Wolfram Web
-           Resource. http://mathworld.wolfram.com/SincFunction.html
-    .. [2] Wikipedia, "Sinc function",
-           https://en.wikipedia.org/wiki/Sinc_function
-
-    Examples
-    --------
-    >>> import matplotlib.pyplot as plt
-    >>> x = np.linspace(-4, 4, 41)
-    >>> np.sinc(x)
-     array([-3.89804309e-17,  -4.92362781e-02,  -8.40918587e-02, # may vary
-            -8.90384387e-02,  -5.84680802e-02,   3.89804309e-17,
-            6.68206631e-02,   1.16434881e-01,   1.26137788e-01,
-            8.50444803e-02,  -3.89804309e-17,  -1.03943254e-01,
-            -1.89206682e-01,  -2.16236208e-01,  -1.55914881e-01,
-            3.89804309e-17,   2.33872321e-01,   5.04551152e-01,
-            7.56826729e-01,   9.35489284e-01,   1.00000000e+00,
-            9.35489284e-01,   7.56826729e-01,   5.04551152e-01,
-            2.33872321e-01,   3.89804309e-17,  -1.55914881e-01,
-           -2.16236208e-01,  -1.89206682e-01,  -1.03943254e-01,
-           -3.89804309e-17,   8.50444803e-02,   1.26137788e-01,
-            1.16434881e-01,   6.68206631e-02,   3.89804309e-17,
-            -5.84680802e-02,  -8.90384387e-02,  -8.40918587e-02,
-            -4.92362781e-02,  -3.89804309e-17])
-
-    >>> plt.plot(x, np.sinc(x))
-    [<matplotlib.lines.Line2D object at 0x...>]
-    >>> plt.title("Sinc Function")
-    Text(0.5, 1.0, 'Sinc Function')
-    >>> plt.ylabel("Amplitude")
-    Text(0, 0.5, 'Amplitude')
-    >>> plt.xlabel("X")
-    Text(0.5, 0, 'X')
-    >>> plt.show()
-
-    It works in 2-D as well:
-
-    >>> x = np.linspace(-4, 4, 401)
-    >>> xx = np.outer(x, x)
-    >>> plt.imshow(np.sinc(xx))
-    <matplotlib.image.AxesImage object at 0x...>
-
-    """
-    x = np.asanyarray(x)
-    y = pi * where(x == 0, 1.0e-20, x)
-    return sin(y)/y
 
 
 def _msort_dispatcher(a):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -21,7 +21,7 @@ from numpy.core.numeric import (
     )
 from numpy.core.umath import (
     pi, add, arctan2, frompyfunc, cos, less_equal, sqrt, sin,
-    mod, exp, not_equal, subtract
+    mod, exp, not_equal, subtract, sinc,
     )
 from numpy.core.fromnumeric import (
     ravel, nonzero, partition, mean, any, sum

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -21,7 +21,7 @@ from numpy.lib import (
     add_newdoc_ufunc, angle, average, bartlett, blackman, corrcoef, cov,
     delete, diff, digitize, extract, flipud, gradient, hamming, hanning,
     i0, insert, interp, kaiser, meshgrid, msort, piecewise, place, rot90,
-    select, setxor1d, sinc, trapz, trim_zeros, unwrap, unique, vectorize
+    select, setxor1d, trapz, trim_zeros, unwrap, unique, vectorize
     )
 
 from numpy.compat import long
@@ -1743,23 +1743,6 @@ class TestTrapz(object):
 
         xm = np.ma.array(x, mask=mask)
         assert_almost_equal(trapz(y, xm), r)
-
-
-class TestSinc(object):
-
-    def test_simple(self):
-        assert_(sinc(0) == 1)
-        w = sinc(np.linspace(-1, 1, 100))
-        # check symmetry
-        assert_array_almost_equal(w, flipud(w), 7)
-
-    def test_array_like(self):
-        x = [0, 0.5]
-        y1 = sinc(np.array(x))
-        y2 = sinc(list(x))
-        y3 = sinc(tuple(x))
-        assert_array_equal(y1, y2)
-        assert_array_equal(y1, y3)
 
 
 class TestUnique(object):


### PR DESCRIPTION
Since NumPy implements the normalized sinc function, argument
reduction can be performed in the `sin` factor without significant
loss of precision for large arguments. To keep the implementation
sane, `sinc` is reimplemented as a ufunc. For consistency the complex
version is also reimplemented as a ufunc, though the implementation
remains the same as before.

A couple of further notes:

- computing the `sin` factor is essentially the same as what one would do when implementing `sinpi`, compare to e.g. https://github.com/scipy/scipy/blob/master/scipy/special/_trig.pxd#L16
- since `cdiv` is declared `static` in `npy_math_complex.c.src` it isn't available in `funcs.inc.src`, so for now I copy-pasted the implementation into `funcs.inc.src`. It should probably be factored out into a header file somewhere, but I figured I would wait to solicit opinions on where.
