### PR TITLE
BUG: parse shell escaping in extra_compile_args and extra_link_args

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -153,6 +153,7 @@ from numpy.distutils.misc_util import (is_sequence, is_string,
 from numpy.distutils.command.config import config as cmd_config
 from numpy.distutils.compat import get_exception
 from numpy.distutils import customized_ccompiler
+from numpy.distutils import _shell_utils
 import distutils.ccompiler
 import tempfile
 import shutil
@@ -619,8 +620,9 @@ class system_info(object):
         for key in ['extra_compile_args', 'extra_link_args']:
             # Get values
             opt = self.cp.get(self.section, key)
+            opt = _shell_utils.NativeParser.split(opt)
             if opt:
-                tmp = {key : [opt]}
+                tmp = {key: opt}
                 dict_append(info, **tmp)
         return info
 

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -11,6 +11,7 @@ from numpy.distutils import ccompiler, customized_ccompiler
 from numpy.testing import assert_, assert_equal
 from numpy.distutils.system_info import system_info, ConfigParser
 from numpy.distutils.system_info import default_lib_dirs, default_include_dirs
+from numpy.distutils import _shell_utils
 
 
 def get_class(name, notfound_action=1):
@@ -29,7 +30,7 @@ simple_site = """
 [ALL]
 library_dirs = {dir1:s}{pathsep:s}{dir2:s}
 libraries = {lib1:s},{lib2:s}
-extra_compile_args = -I/fake/directory
+extra_compile_args = -I/fake/directory -I"/path with/spaces" -Os
 runtime_library_dirs = {dir1:s}
 
 [temp1]
@@ -40,7 +41,7 @@ runtime_library_dirs = {dir1:s}
 [temp2]
 library_dirs = {dir2:s}
 libraries = {lib2:s}
-extra_link_args = -Wl,-rpath={lib2:s}
+extra_link_args = -Wl,-rpath={lib2_escaped:s}
 rpath = {dir2:s}
 """
 site_cfg = simple_site
@@ -137,7 +138,8 @@ class TestSystemInfoReading(object):
             'lib1': self._lib1,
             'dir2': self._dir2,
             'lib2': self._lib2,
-            'pathsep': os.pathsep
+            'pathsep': os.pathsep,
+            'lib2_escaped': _shell_utils.NativeParser.join([self._lib2])
         })
         # Write site.cfg
         fd, self._sitecfg = mkstemp()
@@ -181,7 +183,7 @@ class TestSystemInfoReading(object):
         assert_equal(tsi.get_libraries(), [self._lib1, self._lib2])
         assert_equal(tsi.get_runtime_lib_dirs(), [self._dir1])
         extra = tsi.calc_extra_info()
-        assert_equal(extra['extra_compile_args'], ['-I/fake/directory'])
+        assert_equal(extra['extra_compile_args'], ['-I/fake/directory', '-I/path with/spaces', '-Os'])
 
     def test_temp1(self):
         # Read in all information in the temp1 block

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -64,14 +64,14 @@
 #
 #   extra_compile_args
 #       Add additional arguments to the compilation of sources.
-#       Simple variable with no parsing done. 
+#       Split into arguments in a platform-appropriate way.
 #       Provide a single line with all complete flags.
 #           extra_compile_args = -g -ftree-vectorize
 #
 #   extra_link_args
 #       Add additional arguments when libraries/executables
 #       are linked.
-#       Simple variable with no parsing done. 
+#       Split into arguments in a platform-appropriate way.
 #       Provide a single line with all complete flags.
 #           extra_link_args = -lgfortran
 #


### PR DESCRIPTION
Thanks to a change in exec_command, these strings are no longer passed onto the shell.
Since config files do not support list values, our best bet is to perform shell-splitting immediately.

Likely fixes gh-12659

[Backport here](https://github.com/numpy/numpy/compare/maintenance/1.16.x...eric-wieser:distutils-shlex-split)

Note that azure CI fails because this doesn't contain either of #12903 or #12909, in the interest of having a common merge base for backporting. Had we taken the merge-base approach in those PRs, it would be possible to merge the commit in directly.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->

---

To be clear: this is blocked by a decision on #12979