### PR TITLE
WIP, MAINT: restore int64 //= unit64 behavior

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1755,6 +1755,21 @@ ufunc_loop_matches(PyUFuncObject *self,
             if (tmp == NULL) {
                 return -1;
             }
+            if (strcmp(self->name, "floor_divide") == 0 &&
+                PyArray_DESCR(op[0])->type_num == 7 &&
+                PyArray_DESCR(op[1])->type_num == 8) {
+                /*
+                 * This is an in-place floor division
+                 * operation for which we do not support
+                 * the casting via augmented operator
+                 * see gh-12927
+                 */
+                *out_no_castable_output = 1;
+                *out_err_src_typecode = tmp->type;
+                *out_err_dst_typecode = PyArray_DESCR(op[i])->type;
+                Py_DECREF(tmp);
+                return 0;
+            }
             if (!PyArray_CanCastTypeTo(tmp, PyArray_DESCR(op[i]),
                                                         output_casting)) {
                 if (!(*out_no_castable_output)) {

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_almost_equal,
     assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
-    assert_warns
+    assert_warns, assert_raises_regex,
     )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -219,6 +219,17 @@ class TestModulus(object):
                         assert_(b < rem <= 0, msg)
                     else:
                         assert_(b > rem >= 0, msg)
+
+    def test_inplace_floordiv_handling(self):
+        # issue gh-12927
+        # this only applies to in-place floordiv //=
+        # we currently do not raise TypeError for //
+        # with these operand types
+        a = np.array([1], np.int64)
+        b = np.array([1], np.uint64)
+        pattern = 'could not be coerced to provided output parameter'
+        with assert_raises_regex(TypeError, pattern):
+            a //= b
 
     def test_float_modulus_exact(self):
         # test that float results are exact for small integers. This also


### PR DESCRIPTION
Fixes #12927.

I'll leave a deceptively short explanation for now -- this patches to restore the **in-place** floor division behavior change described in the above issue. Regular floor division for those operand types is allowed and already enforced by our unit tests.

I don't know how much thought has been put it in to the possible effects of augmented assignment operations like `//=` enforcing unexpected constraints on the output data type or if these warrant some kind of `ifloordiv` Ufunc registration / type resolution adjustments.