### PR TITLE
ENH: Add 'bitorder' keyword to packbits, unpackbits

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -149,6 +149,11 @@ Floating point scalars implement ``as_integer_ratio`` to match the builtin float
 This returns a (numerator, denominator) pair, which can be used to construct a
 `fractions.Fraction`.
 
+`numpy.packbits` and `numpy.unpackbits` accept an ``order`` keyword
+-------------------------------------------------------------------
+The ``order`` keyword defaults to ``big``, and will order the **bits**
+accordingly. For ``'big'`` 3 will become ``[0, 0, 0, 0, 0, 0, 1, 1]``, and
+``[1, 1, 0, 0, 0, 0, 0, 0]`` for ``little``
 
 Improvements
 ============

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1114,7 +1114,7 @@ def putmask(a, mask, values):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.packbits)
-def packbits(a, axis=None, order='big'):
+def packbits(a, axis=None, bitorder='big'):
     """
     packbits(a, axis=None)
 
@@ -1130,9 +1130,11 @@ def packbits(a, axis=None, order='big'):
     axis : int, optional
         The dimension over which bit-packing is done.
         ``None`` implies packing the flattened array.
-    order : 'big' or 'little', only the first letter is checked
-        The order of the returned bits. The default is the common standard
-        where [0, 0, 0, 0, 0, 1, 1] => 3
+    bitorder : {'big', 'little'}, optional
+        The order of the input bits. 'big' will mimic bin(val),
+        ``[0, 0, 0, 0, 0, 0, 1, 1] => 3 = 0b00000011 => ``, 'little' will
+        reverse the order so ``[1, 1, 0, 0, 0, 0, 0, 0] => 3``.
+        Defaults to 'big'.
 
         .. versionadded:: 1.17.0
 
@@ -1170,7 +1172,7 @@ def packbits(a, axis=None, order='big'):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.unpackbits)
-def unpackbits(a, axis=None, count=None, order='big'):
+def unpackbits(a, axis=None, count=None, bitorder='big'):
     """
     unpackbits(a, axis=None, count=None)
 
@@ -1200,9 +1202,11 @@ def unpackbits(a, axis=None, count=None, order='big'):
 
         .. versionadded:: 1.17.0
 
-    order : 'big' or 'little', only the first letter is checked
-        The order of the returned bits. The default is the common standard
-        where 3 => [0, 0, 0, 0, 0, 1, 1]
+    bitorder : {'big', 'little'}, optional
+        The order of the returned bits. 'big' will mimic bin(val),
+        ``3 = 0b00000011 => [0, 0, 0, 0, 0, 0, 1, 1]``, 'little' will reverse
+        the order to ``[1, 1, 0, 0, 0, 0, 0, 0]``.
+        Defaults to 'big'.
 
         .. versionadded:: 1.17.0
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -8,6 +8,7 @@ by importing from the extension module.
 
 import functools
 import warnings
+import sys
 
 from . import overrides
 from . import _multiarray_umath
@@ -1113,7 +1114,7 @@ def putmask(a, mask, values):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.packbits)
-def packbits(a, axis=None):
+def packbits(a, axis=None, order='big'):
     """
     packbits(a, axis=None)
 
@@ -1129,6 +1130,11 @@ def packbits(a, axis=None):
     axis : int, optional
         The dimension over which bit-packing is done.
         ``None`` implies packing the flattened array.
+    order : 'big' or 'little', only the first letter is checked
+        The order of the returned bits. The default is the common standard
+        where 3 => [0, 0, 0, 0, 0, 1, 1]
+
+        .. versionadded:: 1.17.0
 
     Returns
     -------
@@ -1164,7 +1170,7 @@ def packbits(a, axis=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.unpackbits)
-def unpackbits(a, axis=None, count=None):
+def unpackbits(a, axis=None, count=None, order='big'):
     """
     unpackbits(a, axis=None, count=None)
 
@@ -1191,6 +1197,12 @@ def unpackbits(a, axis=None, count=None):
         default). Counts larger than the available number of bits will
         add zero padding to the output. Negative counts must not
         exceed the available number of bits.
+
+        .. versionadded:: 1.17.0
+
+    order : 'big' or 'little', only the first letter is checked
+        The order of the returned bits. The default is the common standard
+        where 3 => [0, 0, 0, 0, 0, 1, 1]
 
         .. versionadded:: 1.17.0
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1132,7 +1132,7 @@ def packbits(a, axis=None, order='big'):
         ``None`` implies packing the flattened array.
     order : 'big' or 'little', only the first letter is checked
         The order of the returned bits. The default is the common standard
-        where 3 => [0, 0, 0, 0, 0, 1, 1]
+        where [0, 0, 0, 0, 0, 1, 1] => 3
 
         .. versionadded:: 1.17.0
 

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1827,13 +1827,22 @@ unpack_bits(PyObject *input, int axis, PyObject *count_obj, char order)
     in_stride = PyArray_STRIDE(new, axis);
     out_stride = PyArray_STRIDE(out, axis);
 
+
+#if NPY_BYTE_ORDER == NPY_LITTLE_ENDIAN
+     if (order == 'l') {
+         unpack_lookup = &unpack_lookup_l;
+     }
+     else {
+         unpack_lookup = &unpack_lookup_b;
+     }
+#else
     if (order == 'l') {
-        unpack_lookup = &unpack_lookup_l;
-    }
-    else {
         unpack_lookup = &unpack_lookup_b;
     }
-
+    else {
+        unpack_lookup = &unpack_lookup_l;
+    }
+#endif
     NPY_BEGIN_THREADS_THRESHOLDED(PyArray_Size((PyObject *)out) / 8);
 
     while (PyArray_ITER_NOTDONE(it)) {


### PR DESCRIPTION
Fixes #11172

Adds an 'order' kwarg to packbits, unpackbits. Should this hit the mailing list? It is a small enhancement. I removed the separate handling of NPY_BYTE_ORDER, we only have little endian systems to test on, but it shouldn't matter for uint8 processing.