### PR TITLE
DOC: Properly format Return section of ogrid Docstring,

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -271,7 +271,7 @@ class OGridClass(nd_grid):
     Returns
     -------
     mesh-grid
-        `ndarrays` with only one dimension :math:`\\neq 1`
+        `ndarrays` with only one dimension not equal to 1
 
     See Also
     --------

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -269,8 +269,9 @@ class OGridClass(nd_grid):
     the stop value **is inclusive**.
 
     Returns
-    ----------
-    mesh-grid `ndarrays` with only one dimension :math:`\\neq 1`
+    -------
+    mesh-grid
+        `ndarrays` with only one dimension :math:`\\neq 1`
 
     See Also
     --------


### PR DESCRIPTION
Without the newline and indent, the markup is not interpreted.

Note that in the see-also `np.lib.index_tricks.nd_grid` is reference but
not linked as it appear to not be autogenerated, but this is another
issue.

 Before/After screenshot

![screen shot 2019-02-13 at 1 42 07 pm](https://user-images.githubusercontent.com/335567/52746863-65714500-2f97-11e9-8ec9-98e9bd760c7c.png)


![screen shot 2019-02-13 at 1 54 59 pm](https://user-images.githubusercontent.com/335567/52746861-65714500-2f97-11e9-9a74-676039d01cfe.png)

