### PR TITLE
BENCH: Re-write sorting benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -98,44 +98,122 @@ class Select(Benchmark):
 class Sort(Benchmark):
     params = [
         ['quick', 'merge', 'heap'],
-        ['float32', 'int32', 'uint32']
+        ['float32', 'int32', 'uint32'],
+        [
+            'ordered',
+            'reversed',
+            'uniform',
+            'sorted_block_10',
+            'sorted_block_100',
+            'sorted_block_1000',
+            'swapped_pair_1_percent',
+            'swapped_pair_10_percent',
+            'swapped_pair_50_percent',
+            'random_unsorted_area_50_percent',
+            'random_unsorted_area_10_percent',
+            'random_unsorted_area_1_percent',
+            'random_bubble_1_fold',
+            'random_bubble_5_fold',
+            'random_bubble_10_fold',
+        ],
     ]
-    param_names = ['kind', 'dtype']
+    param_names = ['kind', 'dtype', 'array_type']
 
-    def setup(self, kind, dtype):
-        self.e = np.arange(10000, dtype=dtype)
-        self.o = np.arange(10001, dtype=dtype)
-        np.random.seed(25)
-        np.random.shuffle(self.o)
-        # quicksort implementations can have issues with equal elements
-        self.equal = np.ones(10000, dtype=dtype)
-        self.many_equal = np.sort(np.arange(10000) % 10).astype(dtype)
+    ARRAY_SIZE = 10000
 
-        try:
-            np.sort(self.e, kind=kind)
-        except TypeError:
-            raise NotImplementedError()
+    def setup(self, kind, dtype, array_type):
+        np.random.seed(1234)
+        self.arr = getattr(self, 'array_' + array_type)(self.ARRAY_SIZE, dtype)
 
-    def time_sort(self, kind, dtype):
-        np.sort(self.e, kind=kind)
+    def time_sort_inplace(self, kind, dtype, array_type):
+        self.arr.sort(kind=kind)
 
-    def time_sort_random(self, kind, dtype):
-        np.sort(self.o, kind=kind)
+    def time_sort(self, kind, dtype, array_type):
+        np.sort(self.arr, kind=kind)
 
-    def time_sort_inplace(self, kind, dtype):
-        self.e.sort(kind=kind)
+    def time_argsort(self, kind, dtype, array_type):
+        np.argsort(self.arr, kind=kind)
 
-    def time_sort_equal(self, kind, dtype):
-        self.equal.sort(kind=kind)
+    def array_random(self, size, dtype):
+        arr = np.arange(size, dtype=dtype)
+        np.random.shuffle(arr)
+        return arr
+    
+    def array_ordered(self, size, dtype):
+        return np.arange(size, dtype=dtype)
 
-    def time_sort_many_equal(self, kind, dtype):
-        self.many_equal.sort(kind=kind)
+    def array_reversed(self, size, dtype):
+        return np.arange(size-1, -1, -1, dtype=dtype)
 
-    def time_argsort(self, kind, dtype):
-        self.e.argsort(kind=kind)
+    def array_uniform(self, size, dtype):
+        return np.ones(size, dtype=dtype)
 
-    def time_argsort_random(self, kind, dtype):
-        self.o.argsort(kind=kind)
+    def array_sorted_block_10(self, size, dtype):
+        return self.sorted_block(size, dtype, 10)
+
+    def array_sorted_block_100(self, size, dtype):
+        return self.sorted_block(size, dtype, 100)
+
+    def array_sorted_block_1000(self, size, dtype):
+        return self.sorted_block(size, dtype, 1000)
+
+    def array_swapped_pair_1_percent(self, size, dtype):
+        return self.swapped_pair(size, dtype, 0.01)
+
+    def array_swapped_pair_10_percent(self, size, dtype):
+        return self.swapped_pair(size, dtype, 0.1)
+
+    def array_swapped_pair_50_percent(self, size, dtype):
+        return self.swapped_pair(size, dtype, 0.5)
+
+    AREA_SIZE = 10
+
+    def array_random_unsorted_area_50_percent(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 0.5, self.AREA_SIZE)
+
+    def array_random_unsorted_area_10_percent(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 0.1, self.AREA_SIZE)
+
+    def array_random_unsorted_area_1_percent(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 0.01, self.AREA_SIZE)
+
+    BUBBLE_SIZE = 10
+
+    def array_random_bubble_1_fold(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 1, size / self.BUBBLE_SIZE)
+
+    def array_random_bubble_5_fold(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 5, size / self.BUBBLE_SIZE)
+
+    def array_random_bubble_10_fold(self, size, dtype):
+        return self.random_unsorted_area(size, dtype, 10, size / self.BUBBLE_SIZE)
+
+    def swapped_pair(self, size, dtype, swap_frac):
+        a = np.arange(size, dtype=dtype)
+        for _ in range(int(size * swap_frac)):
+            x, y = np.random.randint(0, size, 2)
+            a[x], a[y] = a[y], a[x]
+        return a
+
+    def sorted_block(self, size, dtype, block_size):
+        a = np.arange(size, dtype=dtype)
+        b = []
+        if size < block_size:
+            return a
+        block_num = size // block_size
+        for i in range(block_num):
+            b.extend(a[i::block_num])
+        return np.array(b)
+
+    def random_unsorted_area(self, size, dtype, frac, area_num):
+        area_num = int(area_num)
+        a = np.arange(size, dtype=dtype)
+        unsorted_len = int(size * frac / area_num)
+        for _ in range(area_num):
+            start = np.random.randint(size-unsorted_len)
+            end = start + unsorted_len
+            np.random.shuffle(a[start:end])
+        return a
 
 
 class SortWorst(Benchmark):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -162,7 +162,7 @@ class SortGenerator(object):
     def random_unsorted_area(cls, size, dtype, frac, area_size=None):
         """
         This type of array has random unsorted areas such that they
-        compose ``frac`` percent of the original array.
+        compose the fraction ``frac`` of the original array.
         """
         if area_size is None:
             area_size = cls.AREA_SIZE

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -96,9 +96,35 @@ class Select(Benchmark):
 
 
 class Sort(Benchmark):
+    """
+    This benchmark tests sorting performance with several
+    different types of arrays that are likely to appear in
+    real-world applications.
+
+    ordered
+        Perfectly ordered array
+    reversed
+        A reversed array
+    uniform
+        A array where all values are the same
+    sorted_block_X
+        An array that is entirely composed of sorted blocks
+        of size X
+    swapped_pair_X_percent
+        An array which has random pairs swapped. The number
+        of swapped pairs is X% of the size of the array
+    random_unsorted_area_X_percent
+        This kind of array has random unsorted areas which
+        take up X% of the original array, the size of one
+        area is AREA_SIZE
+    random_bubble_X_fold
+        ?
+    """
     params = [
+        # In NumPy 1.17 and newer, 'merge' can be one of several
+        # stable sorts
         ['quick', 'merge', 'heap'],
-        ['float32', 'int32', 'uint32'],
+        ['float64', 'int64', 'uint64'],
         [
             'ordered',
             'reversed',
@@ -119,7 +145,13 @@ class Sort(Benchmark):
     ]
     param_names = ['kind', 'dtype', 'array_type']
 
+    # The size of the benchmarked arrays.
     ARRAY_SIZE = 10000
+    # The size of the unsorted area in the "random unsorted area"
+    # benchmarks
+    AREA_SIZE = 10
+    # ?
+    BUBBLE_SIZE = 10
 
     def setup(self, kind, dtype, array_type):
         np.random.seed(1234)
@@ -166,8 +198,6 @@ class Sort(Benchmark):
     def array_swapped_pair_50_percent(self, size, dtype):
         return self.swapped_pair(size, dtype, 0.5)
 
-    AREA_SIZE = 10
-
     def array_random_unsorted_area_50_percent(self, size, dtype):
         return self.random_unsorted_area(size, dtype, 0.5, self.AREA_SIZE)
 
@@ -176,8 +206,6 @@ class Sort(Benchmark):
 
     def array_random_unsorted_area_1_percent(self, size, dtype):
         return self.random_unsorted_area(size, dtype, 0.01, self.AREA_SIZE)
-
-    BUBBLE_SIZE = 10
 
     def array_random_bubble_1_fold(self, size, dtype):
         return self.random_unsorted_area(size, dtype, 1, size / self.BUBBLE_SIZE)

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -103,21 +103,21 @@ class SortGenerator(object):
     BUBBLE_SIZE = 10
 
     @staticmethod
-    def random(size, dtype):
+    def _random(size, dtype):
         arr = np.arange(size, dtype=dtype)
         np.random.shuffle(arr)
         return arr
     
     @staticmethod
-    def ordered(size, dtype):
+    def _ordered(size, dtype):
         return np.arange(size, dtype=dtype)
 
     @staticmethod
-    def reversed(size, dtype):
+    def _reversed(size, dtype):
         return np.arange(size-1, -1, -1, dtype=dtype)
 
     @staticmethod
-    def uniform(size, dtype):
+    def _uniform(size, dtype):
         return np.ones(size, dtype=dtype)
 
     @staticmethod
@@ -155,21 +155,29 @@ class SortGenerator(object):
         import re
         import functools
         token_specification = [
+            (r'random',
+                lambda match: cls._random(size, dtype)),
+            (r'ordered',
+                lambda match: cls._ordered(size, dtype)),
+            (r'reversed',
+                lambda match: cls._reversed(size, dtype)),
+            (r'uniform',
+                lambda match: cls._uniform(size, dtype)),
             (r'sorted\_block\_([0-9]+)',
-                lambda size, dtype, x: cls._type_sorted_block(size, dtype, x)),
+                lambda match: cls._type_sorted_block(size, dtype, int(match.group(1)))),
             (r'swapped\_pair\_([0-9]+)\_percent',
-                lambda size, dtype, x: cls._type_swapped_pair(size, dtype, x / 100.0)),
+                lambda match: cls._type_swapped_pair(size, dtype, int(match.group(1)) / 100.0)),
             (r'random\_unsorted\_area\_([0-9]+)\_percent',
-                lambda size, dtype, x: cls._type_random_unsorted_area(size, dtype, x / 100.0, cls.AREA_SIZE)),
+                lambda match: cls._type_random_unsorted_area(size, dtype, int(match.group(1)) / 100.0, cls.AREA_SIZE)),
             (r'random_bubble\_([0-9]+)\_fold',
-                lambda size, dtype, x: cls._type_random_unsorted_area(size, dtype, x * cls.BUBBLE_SIZE / size, cls.BUBBLE_SIZE)),
+                lambda match: cls._type_random_unsorted_area(size, dtype, int(match.group(1)) * cls.BUBBLE_SIZE / size, cls.BUBBLE_SIZE)),
         ]
 
         for pattern, function in token_specification:
             match = re.fullmatch(pattern, array_type)
 
             if match is not None:
-                return function(size, dtype, int(match.group(1)))
+                return function(match)
 
         raise ValueError("Incorrect array_type specified.")
 


### PR DESCRIPTION
This PR re-writes the sorting benchmarks to be more comprehensive.

Note that the new benchmarks will have to be run on all previous commits. Unfortunately I don't see a way around this.

Taken from @liwt31's sorting repo: https://github.com/liwt31/numpy-sort-benchmark

@liwt31: Please let me know if this isn't okay, and I'll close the PR.

cc @charris