### PR TITLE
DOC: Randomstate docstring fixes

### DIFF
--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -3530,9 +3530,9 @@ cdef class RandomState:
         Parameters
         ----------
         mean : float or array_like of floats
-            Distribution mean, should be > 0.
+            Distribution mean, must be > 0.
         scale : float or array_like of floats
-            Scale parameter, should be >= 0.
+            Scale parameter, must be > 0.
         size : int or tuple of ints, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn.  If size is ``None`` (default),

--- a/numpy/random/mtrand/mtrand.pyx
+++ b/numpy/random/mtrand/mtrand.pyx
@@ -2328,17 +2328,9 @@ cdef class RandomState:
 
         where :math:`Y_{q}` is the Chi-square with q degrees of freedom.
 
-        In Delhi (2007), it is noted that the noncentral chi-square is
-        useful in bombing and coverage problems, the probability of
-        killing the point target given by the noncentral chi-squared
-        distribution.
-
         References
         ----------
-        .. [1] Delhi, M.S. Holla, "On a noncentral chi-square distribution in
-               the analysis of weapon systems effectiveness", Metrika,
-               Volume 15, Number 1 / December, 1970.
-        .. [2] Wikipedia, "Noncentral chi-squared distribution"
+        .. [1] Wikipedia, "Noncentral chi-squared distribution"
                https://en.wikipedia.org/wiki/Noncentral_chi-squared_distribution
 
         Examples
@@ -2368,7 +2360,6 @@ cdef class RandomState:
         >>> values = plt.hist(np.random.noncentral_chisquare(3, 20, 100000),
         ...                   bins=200, density=True)
         >>> plt.show()
-
         """
         cdef ndarray odf, ononc
         cdef double fdf, fnonc

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -1354,6 +1354,8 @@ class TestBroadcast(object):
         assert_array_almost_equal(actual, desired, decimal=14)
         assert_raises(ValueError, wald, bad_mean, scale * 3)
         assert_raises(ValueError, wald, mean, bad_scale * 3)
+        assert_raises(ValueError, wald, 0.0, 1)
+        assert_raises(ValueError, wald, 0.5, 0.0)
 
     def test_triangular(self):
         left = [1]


### PR DESCRIPTION
Small doc string fixes in RandomState.  I removed a reference which is neither canonical nor helpful for understanding the generation of noncentral chi2 random variables.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
