### PR TITLE
BENCH: set ones in any/all benchmarks to 1 instead of 0

### DIFF
--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -32,7 +32,7 @@ class AnyAll(Benchmark):
         # avoid np.zeros's lazy allocation that would
         # cause page faults during benchmark
         self.zeros = np.full(100000, 0, bool)
-        self.ones = np.full(100000, 0, bool)
+        self.ones = np.full(100000, 1, bool)
 
     def time_all_fast(self):
         self.zeros.all()


### PR DESCRIPTION
Currently, if you run the `AnyAll` benchmark suite, you get these weird results:
```
$ asv run -b AnyAll
· Creating environments........
· Discovering benchmarks.......
·· Uninstalling from conda-py3.6-six.
·· Building 27ae8f8a <master> for conda-py3.6-six....................................................................
·· Installing 27ae8f8a <master> into conda-py3.6-six...
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks).
[  0.00%] · For numpy commit 27ae8f8a <master>:
[  0.00%] ·· Benchmarking conda-py3.6-six
[ 12.50%] ··· Running (bench_reduce.AnyAll.time_all_fast--)....
[ 62.50%] ··· bench_reduce.AnyAll.time_all_fast            4.66±0.08μs
[ 75.00%] ··· bench_reduce.AnyAll.time_all_slow            4.68±0.09μs
[ 87.50%] ··· bench_reduce.AnyAll.time_any_fast            10.4±0.3μs
[100.00%] ··· bench_reduce.AnyAll.time_any_slow            10.1±0.1μs
```
There's no substantive variation between the fast and slow versions of each benchmark, which lead me to notice that we're providing the same data in both cases. Actually setting the `ones` array to `1` instead of `0` produces these results:
```
$ asv run -b AnyAll
· Creating environments.
· Discovering benchmarks
· Running 4 total benchmarks (1 commits * 1 environments * 4 benchmarks).
[  0.00%] · For numpy commit 27ae8f8a <master>:
[  0.00%] ·· Benchmarking conda-py3.6-six
[ 12.50%] ··· Running (bench_reduce.AnyAll.time_all_fast--)....
[ 62.50%] ··· bench_reduce.AnyAll.time_all_fast             4.69±0.06μs
[ 75.00%] ··· bench_reduce.AnyAll.time_all_slow             10.1±0.1μs
[ 87.50%] ··· bench_reduce.AnyAll.time_any_fast             4.68±0.1μs
[100.00%] ··· bench_reduce.AnyAll.time_any_slow             10.3±0.2μs
```