### PR TITLE
ENH: Create boolean and integer ufuncs for isnan, isinf, and isfinite.

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -163,6 +163,12 @@ thereby saving a level of indentation
 In some cases where ``np.interp`` would previously return ``np.nan``, it now
 returns an appropriate infinity.
 
+Specialized ``np.isnan``, ``np.isinf``, and ``np.isfinite`` ufuncs for bool and int types
+-----------------------------------------------------------------------------------------
+The boolean and integer types are incapable of storing ``np.nan`` and ``np.inf`` values,
+which allows us to provide specialized ufuncs that are up to 250x faster than the current
+approach.
+
 
 Changes
 =======

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -827,7 +827,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isnan'),
           None,
-          TD(inexact, out='?'),
+          TD(nodatetime_or_obj, out='?'),
           ),
 'isnat':
     Ufunc(1, 1, None,
@@ -839,13 +839,13 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isinf'),
           None,
-          TD(inexact, out='?'),
+          TD(nodatetime_or_obj, out='?'),
           ),
 'isfinite':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isfinite'),
           None,
-          TD(inexact, out='?'),
+          TD(nodatetime_or_obj, out='?'),
           ),
 'signbit':
     Ufunc(1, 1, None,

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -644,6 +644,19 @@ BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UN
 }
 
 
+/**begin repeat
+ * #kind = isnan, isinf, isfinite#
+ * #func = npy_isnan, npy_isinf, npy_isfinite#
+ * #val = NPY_FALSE, NPY_FALSE, NPY_TRUE#
+ **/
+NPY_NO_EXPORT void
+BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    OUTPUT_LOOP_FAST(npy_bool, *out = @val@);
+}
+
+/**end repeat**/
+
 /*
  *****************************************************************************
  **                           INTEGER LOOPS
@@ -874,6 +887,18 @@ NPY_NO_EXPORT void
 
     }
 }
+
+/**begin repeat1
+ * #kind = isnan, isinf, isfinite#
+ * #func = npy_isnan, npy_isinf, npy_isfinite#
+ * #val = NPY_FALSE, NPY_FALSE, NPY_TRUE#
+ **/
+NPY_NO_EXPORT void
+@TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    OUTPUT_LOOP_FAST(npy_bool, *out = @val@);
+}
+/**end repeat1**/
 
 /**end repeat**/
 

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -38,6 +38,13 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 NPY_NO_EXPORT void
 BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
 
+/**begin repeat
+ * #kind = isnan, isinf, isfinite#
+ **/
+NPY_NO_EXPORT void
+BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+/**end repeat**/
+
 /*
  *****************************************************************************
  **                           INTEGER LOOPS
@@ -145,6 +152,13 @@ NPY_NO_EXPORT void
 
 NPY_NO_EXPORT void
 @S@@TYPE@_lcm(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+/**begin repeat2
+ * #kind = isnan, isinf, isfinite#
+ **/
+NPY_NO_EXPORT void
+@S@@TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+/**end repeat2**/
 
 /**end repeat1**/
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1915,3 +1915,24 @@ class TestUfunc(object):
         exc = pytest.raises(TypeError, np.sqrt, None)
         # minimally check the exception text
         assert 'loop of ufunc does not support' in str(exc)
+
+    @pytest.mark.parametrize('nat', [np.datetime64('nat'), np.timedelta64('nat')])
+    def test_nat_is_not_finite(self, nat):
+        try:
+            assert not np.isfinite(nat)
+        except TypeError:
+            pass  # ok, just not implemented
+
+    @pytest.mark.parametrize('nat', [np.datetime64('nat'), np.timedelta64('nat')])
+    def test_nat_is_nan(self, nat):
+        try:
+            assert np.isnan(nat)
+        except TypeError:
+            pass  # ok, just not implemented
+
+    @pytest.mark.parametrize('nat', [np.datetime64('nat'), np.timedelta64('nat')])
+    def test_nat_is_not_inf(self, nat):
+        try:
+            assert not np.isinf(nat)
+        except TypeError:
+            pass  # ok, just not implemented


### PR DESCRIPTION
For the following sample code:
```python
import numpy as np
arr = np.full(10**5, 0, bool)

for i in range(10000):
    np.isnan(arr)

```
We get the following call graph from `pprof`:
![old](https://user-images.githubusercontent.com/440095/52988621-d8722580-33b4-11e9-9aa4-cd619a3f626c.png)

This PR eliminates the trip through `npy_half` by providing specialized `npy_bool` implementations of `isnan`, `isinf`, and `isfinite` Given the limited values supported by `npy_bool`, we can trivially specify the result for all inputs. Doing so initially provided a ~20x speedup and now is closer to ~250x:
```
$ asv compare HEAD^ HEAD -s

Benchmarks that have improved:

       before           after         ratio
     [95db8c28]       [e861372b]
     <bool_ufunc~1>       <bool_ufunc>
-     1.23±0.01ms      5.03±0.09μs     0.00  bench_ufunc.IsNan.time_isnan('bool')
-        65.8±8μs       5.28±0.1μs     0.08  bench_ufunc.IsNan.time_isnan('int16')
-      87.9±0.7μs      5.32±0.05μs     0.06  bench_ufunc.IsNan.time_isnan('int32')
-         145±1μs      5.40±0.08μs     0.04  bench_ufunc.IsNan.time_isnan('int64')

Benchmarks that have stayed the same:

       before           after         ratio
     [95db8c28]       [e861372b]
     <bool_ufunc~1>       <bool_ufunc>
        119±0.6μs        118±0.4μs     1.00  bench_ufunc.IsNan.time_isnan('complex128')
          240±1μs          243±5μs     1.01  bench_ufunc.IsNan.time_isnan('complex256')
          106±1μs        105±0.3μs     0.99  bench_ufunc.IsNan.time_isnan('complex64')
         568±10μs          567±6μs     1.00  bench_ufunc.IsNan.time_isnan('float16')
         27.4±2μs      27.7±0.08μs     1.01  bench_ufunc.IsNan.time_isnan('float32')
       47.3±0.4μs       47.5±0.2μs     1.00  bench_ufunc.IsNan.time_isnan('float64')
          141±2μs        141±0.5μs     1.00  bench_ufunc.IsNan.time_isnan('longfloat')
```
The call graph is also greatly simplified:
![fixed](https://user-images.githubusercontent.com/440095/52988888-ebd1c080-33b5-11e9-8707-73e1812888bd.png)


