### PR TITLE
ENH: Correct handling of infinities in np.interp (option B)

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -128,6 +128,12 @@ but with this change, you can do::
 
 thereby saving a level of indentation
 
+``np.interp`` handles infinities more robustly
+----------------------------------------------
+In some cases where ``np.interp`` would previously return ``np.nan``, it now
+returns an appropriate infinity.
+
+
 Changes
 =======
 


### PR DESCRIPTION
Alternative to gh-12978, using a method that does not need a lot of special cases.
If we find cases this does not cover, we might want to switch back to the other approach.

Fixes gh-12951.

cc @seberg