### PR TITLE
BUG: Don't allow buggy Intel optimizations for operators + - * /

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1737,6 +1737,9 @@ NPY_NO_EXPORT void
  * The recursion depth is O(lg n) as well.
  * when updating also update similar complex floats summation
  */
+#if defined(__INTEL_COMPILER) && defined(_WIN32) // See GH Pull 12991
+    #pragma intel optimization_level 1
+#endif
 static @type@
 pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
 {

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1816,6 +1816,9 @@ pairwise_sum_@TYPE@(char *a, npy_intp n, npy_intp stride)
  * # OP = +, -, *, /#
  * # PW = 1, 0, 0, 0#
  */
+#ifdef __INTEL_COMPILER // See GH Ticket #11796
+    #pragma intel optimization_level 2
+#endif
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {


### PR DESCRIPTION
Reduce optimization level on intel compilers to prevent incorrect optimizations for these operators.  Closes #11796.

**Note**: including a lot of output here from tests / original example since replicating this issue is difficult for maintainers who don't have access to the intel compilers.

Tests run with this commit:

```console
$ python runtests.py --tests  numpy.core.tests.test_regression
Building, see build.log...
Build OK
NumPy version 1.17.0.dev0+1993054
NumPy relaxed strides checking option: True
...................................................................................................................................................... [ 58%]
.........................................................................................................                                              [100%]
255 passed in 0.60 seconds
```

And the original example by @stevesimmons seems to work as expected now

```console
$ python runtests.py --python
Building, see build.log...
Build OK
Enabling display of all warnings
Python 3.7.2 (default, Feb 17 2019, 05:40:22) 
[GCC Intel(R) C++ gcc 6.3 mode] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import numpy as np
>>> acc = np.divide.accumulate
>>> a = np.ones(8, dtype=np.float64)
>>> print(acc(a, out=2*np.ones_like(a)))
[1. 1. 1. 1. 1. 1. 1. 1.]
>>> print(acc(a))
[1. 1. 1. 1. 1. 1. 1. 1.]
>>> print(acc(a))
[1. 1. 1. 1. 1. 1. 1. 1.]
>>> print(acc(a))
[1. 1. 1. 1. 1. 1. 1. 1.]
>>> print(acc(a, out=2*np.ones_like(a)))
[1. 1. 1. 1. 1. 1. 1. 1.]
```

If we set that back to 3

```diff
-    #pragma intel optimization_level 2
+    #pragma intel optimization_level 3
```
then it fails with the original two I experienced

```console
python runtests.py --tests  numpy.core.tests.test_regression                            
Building, see build.log...                                                                                                                                    
Build OK                                                                                                                                                      
NumPy version 1.17.0.dev0+1993054                                                                                                                             
NumPy relaxed strides checking option: True                                                                                                                   
..........................................................F.........................F................................................................. [ 58%] 
.........................................................................................................                                              [100%] 
========================================================================== FAILURES ==========================================================================
______________________________________________________________ TestRegression.test_method_args _______________________________________________________________
                                                                                                                                                              
self = <numpy.core.tests.test_regression.TestRegression object at 0x154900be7198>                                                                             
                                                                                                                                                              
    def test_method_args(self):                                                                                                                               
     # ....
>               assert_(abs(res1-res2).max() < 1e-8, func)
E               AssertionError: cumsum

arr        = array([[0.69183767, 0.56056054, 0.5194162 , 0.5138226 , 0.96845997,
        0.26740585, 0.78204654],
       [0.4527793...183, 0.39322357],
       [0.36166581, 0.53629936, 0.97162809, 0.01306439, 0.57704599,
        0.26044573, 0.23755532]])
arr2       = array([[0.69183767, 0.56056054, 0.5194162 , 0.5138226 , 0.96845997,
        0.26740585, 0.78204654],
       [0.4527793...183, 0.39322357],
       [0.36166581, 0.53629936, 0.97162809, 0.01306439, 0.57704599,
        0.26044573, 0.23755532]])
func       = 'cumsum'
func_meth  = 'cumsum'
funcs1     = ['argmax', 'argmin', 'sum', ('product', 'prod'), ('sometrue', 'any'), ('alltrue', 'all'), ...]
funcs2     = ['compress', 'take', 'repeat']
res1       = array([0.69183767, 1.25239821, 0.75136076, 1.26518336, 1.13586136,
       1.40326721, 1.67526206, 2.12804145, 1.384186...93804  , 0.52497727, 0.88664308,
       0.70719416, 1.67882225, 0.30845577, 0.88550176, 1.2054634 ,
       1.44301872])
res2       = array([0.69183767, 1.25239821, 0.5194162 , 1.0332388 , 0.96845997,
       1.23586582, 0.78204654, 1.23482594, 0.751752...6583269, 0.39322357, 0.75488937,
       0.53629936, 1.50792745, 0.01306439, 0.59011038, 0.26044573,
       0.49800105])
self       = <numpy.core.tests.test_regression.TestRegression object at 0x154900be7198>

numpy/core/tests/test_regression.py:532: AssertionError
____________________________________________________ TestRegression.test_noncommutative_reduce_accumulate ____________________________________________________

self = <numpy.core.tests.test_regression.TestRegression object at 0x154900bb60f0>                                                                            

    def test_noncommutative_reduce_accumulate(self):
        # ...
        todivide = np.array([2.0, 0.5, 0.25])
        # ...
        assert_array_equal(np.divide.accumulate(todivide),
>           np.array([2., 4., 16.]))
E       AssertionError: 
E       Arrays are not equal
E       
E       Mismatch: 33.3%
E       Max absolute difference: 16.
E       Max relative difference: 1.
E        x: array([2.e+000, 4.e+000, 4.e-323])
E        y: array([ 2.,  4., 16.])

self       = <numpy.core.tests.test_regression.TestRegression object at 0x154900bb60f0>                                                                      
todivide   = array([2.  , 0.5 , 0.25])
tosubtract = array([0, 1, 2, 3, 4])

numpy/core/tests/test_regression.py:705: AssertionError
2 failed, 253 passed in 0.74 seconds
```

and the original example is reproduced:

```console
$ python runtests.py --python
Building, see build.log...
Build OK
Enabling display of all warnings
Python 3.7.2 (default, Feb 17 2019, 05:40:22) 
[GCC Intel(R) C++ gcc 6.3 mode] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import numpy as np
>>> acc = np.divide.accumulate
>>> a = np.ones(8, dtype=np.float64)
>>> print(acc(a, out=2*np.ones_like(a)))
[1. 1. 2. 2. 2. 2. 2. 2.]
>>> print(acc(a))
[1. 1. 1. 1. 2. 2. 2. 2.]
>>> print(acc(a))
[1. 1. 1. 1. 1. 1. 2. 2.]
>>> print(acc(a))
[1. 1. 1. 1. 1. 1. 1. 1.]
>>> print(acc(a, out=2*np.ones_like(a)))
[1. 1. 2. 2. 2. 2. 2. 2.]
```
