### PR TITLE
WIP, BLD: Test (break) NumPy import from wheel install by obscuring DLL resolution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,8 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build NumPy'
+  - script: pushd . && cd .. && python -c "from ctypes import windll; windll.kernel32.SetDefaultDllDirectories(0x00000800); import numpy" && popd
+    displayName: 'For gh-12667; Windows DLL resolution'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
   - task: PublishTestResults@2

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -119,7 +119,7 @@ class build_ext (old_build_ext):
         self.compiler.show_customization()
 
         # Setup directory for storing generated extra DLL files on Windows
-        self.extra_dll_dir = os.path.join(self.build_temp, '.libs')
+        self.extra_dll_dir = os.path.join(self.build_temp, 'core')
         if not os.path.isdir(self.extra_dll_dir):
             os.makedirs(self.extra_dll_dir)
 
@@ -270,7 +270,7 @@ class build_ext (old_build_ext):
             for ext in self.extensions
         }
         for pkg_root in pkg_roots:
-            shared_lib_dir = os.path.join(pkg_root, '.libs')
+            shared_lib_dir = os.path.join(pkg_root, 'core')
             if not self.inplace:
                 shared_lib_dir = os.path.join(self.build_lib, shared_lib_dir)
             for fn in os.listdir(self.extra_dll_dir):

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2289,20 +2289,6 @@ def generate_config_py(target):
     f.write('# It contains system_info results at the time of building this package.\n')
     f.write('__all__ = ["get_info","show"]\n\n')
 
-    # For gfortran+msvc combination, extra shared libraries may exist
-    f.write("""
-
-import os
-import sys
-
-extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
-
-if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
-    os.environ.setdefault('PATH', '')
-    os.environ['PATH'] += os.pathsep + extra_dll_dir
-
-""")
-
     for k, i in system_info.saved_results.items():
         f.write('%s=%r\n' % (k, i))
     f.write(r'''


### PR DESCRIPTION
Fixes #12667

The simplest & apparently favored fix for failed NumPy imports on (conda) Windows proposed in #12667 is to ensure that requisite DLL(s) are physically present in the `numpy/core` path.

Before trying a fix that moves the DLL path(s) within a built NumPy wheel, I thought it might be sensible to have a "test" that tries to mimic the conda-related import failures described in the above issue.

Not sure if this is too aggressive, by [confining DLL search resolution](https://docs.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-setdefaultdlldirectories) to `system32`, but it does seem to nicely generate an `ImportError: DLL load failed`.

I guess the answer to "is this too aggressive?" is if the physical placement of the DLL(s) at the core path restores the functional `numpy` import.