### PR TITLE
MAINT: remove warning for pre-1.9 numpy

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -606,11 +606,6 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
     _check_version(version)
     used_ver = _write_array_header(fp, header_data_from_array_1_0(array),
                                    version)
-    # this warning can be removed when 1.9 has aged enough
-    if version != (2, 0) and used_ver == (2, 0):
-        warnings.warn("Stored array in format 2.0. It can only be"
-                      "read by NumPy >= 1.9", UserWarning, stacklevel=2)
-
     if array.itemsize == 0:
         buffersize = 0
     else:

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -633,10 +633,7 @@ def test_version_2_0():
     d = np.ones(1000, dtype=dt)
 
     format.write_array(f, d, version=(2, 0))
-    with warnings.catch_warnings(record=True) as w:
-        warnings.filterwarnings('always', '', UserWarning)
-        format.write_array(f, d)
-        assert_(w[0].category is UserWarning)
+    format.write_array(f, d)
 
     # check alignment of data portion
     f.seek(0)


### PR DESCRIPTION
Numpy 1.9 introduced a new format for np.write_array, version 2,0 which lifts the limit on array size from format version 1,0. At the time a warning was added. Since redhat v6 now ships numpy 1.10 as the oldest version for our supported python versions (numpy 1.7 is still being used with python 27) we can safely remove the warning now.

Perhaps this should be labelled as a DEP: not a MAINT:, but the original warning was not a deprecation.