### PR TITLE
MAINT: Move pickle import to numpy.compat

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -8,7 +8,7 @@ __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
            'integer_types', 'is_pathlib_path', 'npy_load_module', 'Path',
-           'contextlib_nullcontext', 'os_fspath', 'os_PathLike']
+           'pickle', 'contextlib_nullcontext', 'os_fspath', 'os_PathLike']
 
 import sys
 try:
@@ -18,6 +18,11 @@ except ImportError:
 
 if sys.version_info[0] >= 3:
     import io
+
+    try:
+        import pickle5 as pickle
+    except ImportError:
+        import pickle
 
     long = int
     integer_types = (int,)
@@ -51,8 +56,9 @@ if sys.version_info[0] >= 3:
 
     strchar = 'U'
 
-
 else:
+    import cpickle as pickle
+
     bytes = str
     long = long
     basestring = basestring
@@ -75,7 +81,6 @@ else:
 
     def sixu(s):
         return unicode(s, 'unicode_escape')
-
 
 def getexception():
     return sys.exc_info()[1]

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -15,6 +15,7 @@ import numbers
 import contextlib
 
 import numpy as np
+from numpy.compat import pickle, basestring
 from . import multiarray
 from .multiarray import (
     _fastCopyAndTranspose as fastCopyAndTranspose, ALLOW_THREADS,
@@ -44,17 +45,8 @@ ufunc = type(sin)
 newaxis = None
 
 if sys.version_info[0] >= 3:
-    if sys.version_info[1] in (6, 7):
-        try:
-            import pickle5 as pickle
-        except ImportError:
-            import pickle
-    else:
-        import pickle
-    basestring = str
     import builtins
 else:
-    import cPickle as pickle
     import __builtin__ as builtins
 
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -9,7 +9,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_warns, suppress_warnings,
     assert_raises_regex,
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 # Use pytz to test out various time zones if available
 try:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy.core._rational_tests import rational
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT)
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 def assert_dtype_equal(a, b):
     assert_equal(a, b)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -21,7 +21,7 @@ import weakref
 import pytest
 from contextlib import contextmanager
 
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 if sys.version_info[0] >= 3:
     import builtins

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -9,7 +9,7 @@ from numpy.testing import (
 from numpy.core.overrides import (
     _get_implementing_args, array_function_dispatch,
     verify_matching_signatures)
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 import pytest
 
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -17,7 +17,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, temppath
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 
 class TestFromrecords(object):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -16,8 +16,7 @@ from numpy.testing import (
         assert_raises_regex, assert_warns, suppress_warnings,
         _assert_valid_refcount, HAS_REFCOUNT,
         )
-from numpy.compat import asbytes, asunicode, long
-from numpy.core.numeric import pickle
+from numpy.compat import asbytes, asunicode, long, pickle
 
 try:
     RecursionError

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -15,7 +15,7 @@ from numpy.testing import (
     assert_almost_equal, assert_array_almost_equal, assert_no_warnings,
     assert_allclose,
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 
 class TestUfuncKwargs(object):

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -162,9 +162,8 @@ import io
 import warnings
 from numpy.lib.utils import safe_eval
 from numpy.compat import (
-    asbytes, asstr, isfileobj, long, os_fspath
+    asbytes, asstr, isfileobj, long, os_fspath, pickle
     )
-from numpy.core.numeric import pickle
 
 
 MAGIC_PREFIX = b'\x93NUMPY'

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -24,9 +24,8 @@ from ._iotools import (
 
 from numpy.compat import (
     asbytes, asstr, asunicode, asbytes_nested, bytes, basestring, unicode,
-    os_fspath, os_PathLike
+    os_fspath, os_PathLike, pickle
     )
-from numpy.core.numeric import pickle
 
 if sys.version_info[0] >= 3:
     from collections.abc import Mapping

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -47,7 +47,7 @@ from numpy import expand_dims
 from numpy.core.multiarray import normalize_axis_index
 from numpy.core.numeric import normalize_axis_tuple
 from numpy.core._internal import recursive
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 
 __all__ = [

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -49,7 +49,7 @@ from numpy.ma.core import (
     ravel, repeat, reshape, resize, shape, sin, sinh, sometrue, sort, sqrt,
     subtract, sum, take, tan, tanh, transpose, where, zeros,
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 pi = np.pi
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -23,7 +23,7 @@ from numpy.ma.testutils import (
     assert_, assert_equal,
     assert_equal_records,
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 
 class TestMRecords(object):

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -21,7 +21,7 @@ from numpy.ma import (
     repeat, resize, shape, sin, sinh, sometrue, sort, sqrt, subtract, sum,
     take, tan, tanh, transpose, where, zeros,
     )
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 pi = np.pi
 

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -7,7 +7,7 @@ from numpy.ma.core import (masked_array, masked_values, masked, allequal,
                            MaskType, getmask, MaskedArray, nomask,
                            log, add, hypot, divide)
 from numpy.ma.extras import mr_
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 
 class MMatrix(MaskedArray, np.matrix,):

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 from numpy.testing import assert_raises, assert_, assert_equal
-from numpy.core.numeric import pickle
+from numpy.compat import pickle
 
 if sys.version_info[:2] >= (3, 4):
     from importlib import reload


### PR DESCRIPTION
The pickle module was being imported from numpy.core.numeric. It was
defined there in order to use pickle5 when available in Python3 and
cpickle in Python2. The numpy.compat module seems a better place for
that.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
