### PR TITLE
BLD: Windows absolute path DLL loading

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,13 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build NumPy'
+  - bash: |
+      pushd . && cd .. && target=$(python -c "import numpy, os; print(os.path.abspath(os.path.join(os.path.dirname(numpy.__file__), '.libs')))") && popd
+      pip download -d destination --only-binary --no-deps numpy==1.14
+      cd destination && unzip numpy*.whl && cp numpy/.libs/*.dll $target
+      ls $target
+    displayName: 'Add extraneous & older DLL to numpy/.libs to probe DLL handling robustness'
+    condition: eq(variables['PYTHON_VERSION'], '3.6')
   - script: pushd . && cd .. && python -c "from ctypes import windll; windll.kernel32.SetDefaultDllDirectories(0x00000800); import numpy" && popd
     displayName: 'For gh-12667; Windows DLL resolution'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,8 @@ jobs:
           pip install $_.FullName
       }
     displayName: 'Build NumPy'
+  - script: pushd . && cd .. && python -c "from ctypes import windll; windll.kernel32.SetDefaultDllDirectories(0x00000800); import numpy" && popd
+    displayName: 'For gh-12667; Windows DLL resolution'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
   - task: PublishTestResults@2

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -10,17 +10,18 @@ import os
 # path resolution portability with an absolute path DLL load
 if os.name == 'nt':
     from ctypes import WinDLL
-    from pathlib import Path
+    import glob
     # convention for storing / loading the DLL from
     # numpy/.libs/, if present
-    libs_path = Path(Path(__file__).absolute().parents[1], '.libs')
+    libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             '..', '.libs'))
     DLL_filenames = []
-    if libs_path.exists():
-        for filename in libs_path.glob('*openblas*dll'):
+    if os.path.isdir(libs_path):
+        for filename in glob.glob(os.path.join(libs_path, '*openblas*dll')):
             # NOTE: would it change behavior to load ALL
             # DLLs at this path vs. the name restriction?
-            WinDLL(str(filename.absolute()))
-            DLL_filenames.append(str(filename))
+            WinDLL(os.path.abspath(filename))
+            DLL_filenames.append(filename)
     if len(DLL_filenames) > 1:
         import warnings
         warnings.warn("loaded more than 1 DLL from .libs:",

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -14,11 +14,19 @@ if os.name == 'nt':
     # convention for storing / loading the DLL from
     # numpy/.libs/, if present
     libs_path = Path(Path(__file__).absolute().parents[1], '.libs')
+    DLL_filenames = []
     if libs_path.exists():
         for filename in libs_path.glob('*openblas*dll'):
             # NOTE: would it change behavior to load ALL
             # DLLs at this path vs. the name restriction?
             WinDLL(str(filename.absolute()))
+            DLL_filenames.append(str(filename))
+    if len(DLL_filenames) > 1:
+        import warnings
+        warnings.warn("loaded more than 1 DLL from .libs:",
+                      stacklevel=1)
+        for DLL_filename in DLL_filenames:
+            warnings.warn(DLL_filename, stacklevel=1)
 
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -24,10 +24,9 @@ if os.name == 'nt':
             DLL_filenames.append(filename)
     if len(DLL_filenames) > 1:
         import warnings
-        warnings.warn("loaded more than 1 DLL from .libs:",
+        warnings.warn("loaded more than 1 DLL from .libs:\n%s" %
+                      "\n".join(DLL_filenames),
                       stacklevel=1)
-        for DLL_filename in DLL_filenames:
-            warnings.warn(DLL_filename, stacklevel=1)
 
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -3,9 +3,25 @@ from __future__ import division, absolute_import, print_function
 from .info import __doc__
 from numpy.version import version as __version__
 
+import os
+
+# on Windows NumPy loads an important OpenBLAS-related DLL
+# and the code below aims to alleviate issues with DLL
+# path resolution portability with an absolute path DLL load
+if os.name == 'nt':
+    from ctypes import WinDLL
+    from pathlib import Path
+    # convention for storing / loading the DLL from
+    # numpy/.libs/, if present
+    libs_path = Path(Path(__file__).absolute().parents[1], '.libs')
+    if libs_path.exists():
+        for filename in libs_path.glob('*openblas*dll'):
+            # NOTE: would it change behavior to load ALL
+            # DLLs at this path vs. the name restriction?
+            WinDLL(str(filename.absolute()))
+
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core
-import os
 env_added = []
 for envkey in ['OPENBLAS_MAIN_FREE', 'GOTOBLAS_MAIN_FREE']:
     if envkey not in os.environ:


### PR DESCRIPTION
Alternative to #12994 

As discussed in #12667 by @rgommers, this may have the advantage of not bricking SciPy / ecosystem projects since it confines the "guaranteed" openblas-related DLL load to numpy/core instead of the distutils machinery change.