### PR TITLE
Methods ones and zeros don't require a tuple as shape anymore

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -166,7 +166,7 @@ def zeros_like(a, dtype=None, order='K', subok=True):
 
 
 @set_module('numpy')
-def ones(shape, dtype=None, order='C'):
+def ones(*shape, dtype=None, order='C'):
     """
     Return a new array of given shape and type, filled with ones.
 
@@ -213,7 +213,7 @@ def ones(shape, dtype=None, order='C'):
            [1.,  1.]])
 
     """
-    a = empty(shape, dtype, order)
+    a = empty(tuple(shape), dtype, order)
     multiarray.copyto(a, 1, casting='unsafe')
     return a
 

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -13,7 +13,7 @@ NPY_RELAXED_STRIDES_CHECKING = np.ones((10, 1), order='C').flags.f_contiguous
 
 def test_array_array():
     tobj = type(object)
-    ones11 = np.ones((1, 1), np.float64)
+    ones11 = np.ones((1, 1), dtype=np.float64)
     tndarray = type(ones11)
     # Test is_ndarray
     assert_equal(np.array(ones11, dtype=np.float64), ones11)

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -48,7 +48,7 @@ def empty(shape, dtype=None, order='C'):
     """
     return ndarray.__new__(matrix, shape, dtype, order=order)
 
-def ones(shape, dtype=None, order='C'):
+def ones(*shape, dtype=None, order='C'):
     """
     Matrix of ones.
 
@@ -88,12 +88,16 @@ def ones(shape, dtype=None, order='C'):
     >>> np.matlib.ones(2)
     matrix([[1.,  1.]])
 
+    >>> np.matlib.ones(2, 3)
+    matrix([[1.,  1.,  1.],
+            [1.,  1.,  1.]])
     """
-    a = ndarray.__new__(matrix, shape, dtype, order=order)
+
+    a = ndarray.__new__(matrix, tuple(shape), dtype, order=order)
     a.fill(1)
     return a
 
-def zeros(shape, dtype=None, order='C'):
+def zeros(*shape, dtype=None, order='C'):
     """
     Return a matrix of given shape and type, filled with zeros.
 
@@ -132,8 +136,12 @@ def zeros(shape, dtype=None, order='C'):
     >>> np.matlib.zeros(2)
     matrix([[0.,  0.]])
 
+    >>> np.matlib.zeros(2, 3)
+    matrix([[0.,  0.,  0.],
+            [0.,  0.,  0.]])
+
     """
-    a = ndarray.__new__(matrix, shape, dtype, order=order)
+    a = ndarray.__new__(matrix, tuple(shape), dtype, order=order)
     a.fill(0)
     return a
 

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -202,14 +202,14 @@ class TestCasting(object):
         mA = matrix(A)
 
         mB = mA.copy()
-        O = np.ones((10, 10), np.float64) * 0.1
+        O = np.ones((10, 10), dtype=np.float64) * 0.1
         mB = mB + O
         assert_(mB.dtype.type == np.float64)
         assert_(np.all(mA != mB))
         assert_(np.all(mB == mA+0.1))
 
         mC = mA.copy()
-        O = np.ones((10, 10), np.complex128)
+        O = np.ones((10, 10), dtype=np.complex128)
         mC = mC * O
         assert_(mC.dtype.type == np.complex128)
         assert_(np.all(mA != mB))

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -24,12 +24,20 @@ def test_ones():
 
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
+    assert_array_equal(numpy.matlib.ones(2, 3),
+                       np.matrix([[ 1.,  1.,  1.],
+                                 [ 1.,  1.,  1.]]))
+
 def test_zeros():
     assert_array_equal(numpy.matlib.zeros((2, 3)),
                        np.matrix([[ 0.,  0.,  0.],
                                  [ 0.,  0.,  0.]]))
 
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
+
+    assert_array_equal(numpy.matlib.zeros(2, 3),
+                       np.matrix([[ 0.,  0.,  0.],
+                                 [ 0.,  0.,  0.]]))
 
 def test_identity():
     x = numpy.matlib.identity(2, dtype=int)


### PR DESCRIPTION
Accepts shape as arguments related to @karpathy [comment in twitter](https://twitter.com/karpathy/status/1099793055853375489)
