### PR TITLE
MAINT: Convert property to @property

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -505,6 +505,7 @@ class iinfo(object):
         if self.kind not in 'iu':
             raise ValueError("Invalid integer data type %r." % (self.kind,))
 
+    @property
     def min(self):
         """Minimum value of given dtype."""
         if self.kind == 'u':
@@ -517,8 +518,7 @@ class iinfo(object):
                 iinfo._min_vals[self.key] = val
             return val
 
-    min = property(min)
-
+    @property
     def max(self):
         """Maximum value of given dtype."""
         try:
@@ -530,8 +530,6 @@ class iinfo(object):
                 val = int((1 << (self.bits-1)) - 1)
             iinfo._max_vals[self.key] = val
         return val
-
-    max = property(max)
 
     def __str__(self):
         """String representation."""

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3667,6 +3667,7 @@ class MaskedArray(ndarray):
             # Don't overwrite the attribute, just fill it (for propagation)
             _fill_value[()] = target
 
+    # kept for compatibility
     get_fill_value = fill_value.fget
     set_fill_value = fill_value.fset
 
@@ -4343,7 +4344,7 @@ class MaskedArray(ndarray):
         Return the imaginary part of the masked array.
 
         The returned array is a view on the imaginary part of the `MaskedArray`
-        whose `get_imag` method is called.
+        whose `imag` method is called.
 
         Parameters
         ----------
@@ -4356,12 +4357,12 @@ class MaskedArray(ndarray):
 
         See Also
         --------
-        get_real, real, imag
+        real, get_real, get_imag
 
         Examples
         --------
         >>> x = np.ma.array([1+1.j, -2j, 3.45+1.6j], mask=[False, True, False])
-        >>> x.get_imag()
+        >>> x.imag
         masked_array(data=[1.0, --, 1.6],
                      mask=[False,  True, False],
                fill_value=1e+20)
@@ -4371,6 +4372,7 @@ class MaskedArray(ndarray):
         result.__setmask__(self._mask)
         return result
 
+    # kept for compatibility
     get_imag = imag.fget
 
     @property
@@ -4392,12 +4394,12 @@ class MaskedArray(ndarray):
 
         See Also
         --------
-        get_imag, real, imag
+        imag, get_real, get_imag
 
         Examples
         --------
         >>> x = np.ma.array([1+1.j, -2j, 3.45+1.6j], mask=[False, True, False])
-        >>> x.get_real()
+        >>> x.real
         masked_array(data=[1.0, --, 3.45],
                      mask=[False,  True, False],
                fill_value=1e+20)
@@ -4407,6 +4409,7 @@ class MaskedArray(ndarray):
         result.__setmask__(self._mask)
         return result
 
+    # kept for compatibility
     get_real = real.fget
 
     def count(self, axis=None, keepdims=np._NoValue):
@@ -5905,11 +5908,8 @@ class MaskedArray(ndarray):
     repeat = _arraymethod('repeat')
     squeeze = _arraymethod('squeeze')
     swapaxes = _arraymethod('swapaxes')
+    T = property(fget=lambda self: self.transpose())
     transpose = _arraymethod('transpose')
-
-    @property
-    def T(self):
-        return self.transpose()
 
     def tolist(self, fill_value=None):
         """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4313,18 +4313,9 @@ class MaskedArray(ndarray):
     @property
     def imag(self):
         """
-        Get and set the imaginary part of the masked array.
+        The imaginary part of the masked array.
 
-        The returned array is a view on the imaginary part of this `MaskedArray`.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        result : MaskedArray
-            The imaginary part of the masked array.
+        This property is a view on the imaginary part of this `MaskedArray`.
 
         See Also
         --------
@@ -4349,18 +4340,9 @@ class MaskedArray(ndarray):
     @property
     def real(self):
         """
-        Get and set the real part of the masked array.
+        The real part of the masked array.
 
-        The returned array is a view on the real part of this `MaskedArray`.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        result : MaskedArray
-            The real part of the masked array.
+        This property is a view on the real part of this `MaskedArray`.
 
         See Also
         --------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3455,7 +3455,8 @@ class MaskedArray(ndarray):
 
     mask = property(fget=_get_mask, fset=__setmask__, doc="Mask")
 
-    def _get_recordmask(self):
+    @property
+    def recordmask(self):
         """
         Return the mask of the records.
 
@@ -3467,16 +3468,13 @@ class MaskedArray(ndarray):
             return _mask
         return np.all(flatten_structured_array(_mask), axis=-1)
 
-    def _set_recordmask(self):
+    @recordmask.setter
+    def recordmask(self, mask):
         """
-        Return the mask of the records.
-
-        A record is masked when all the fields are masked.
+        Set the mask of the records.
 
         """
         raise NotImplementedError("Coming soon: setting the mask per records!")
-
-    recordmask = property(fget=_get_recordmask)
 
     def harden_mask(self):
         """
@@ -3508,8 +3506,10 @@ class MaskedArray(ndarray):
         self._hardmask = False
         return self
 
-    hardmask = property(fget=lambda self: self._hardmask,
-                        doc="Hardness of the mask")
+    @property
+    def hardmask(self):
+        """ Hardness of the mask """
+        return self._hardmask
 
     def unshare_mask(self):
         """
@@ -3529,8 +3529,10 @@ class MaskedArray(ndarray):
             self._sharedmask = False
         return self
 
-    sharedmask = property(fget=lambda self: self._sharedmask,
-                          doc="Share status of the mask (read-only).")
+    @property
+    def sharedmask(self):
+        """ Share status of the mask (read-only). """
+        return self._sharedmask
 
     def shrink_mask(self):
         """
@@ -3563,8 +3565,10 @@ class MaskedArray(ndarray):
         self._mask = _shrink_mask(self._mask)
         return self
 
-    baseclass = property(fget=lambda self: self._baseclass,
-                         doc="Class of the underlying data (read-only).")
+    @property
+    def baseclass(self):
+        """ Class of the underlying data (read-only). """
+        return self._baseclass
 
     def _get_data(self):
         """Return the current data, as a view of the original
@@ -3576,19 +3580,19 @@ class MaskedArray(ndarray):
     _data = property(fget=_get_data)
     data = property(fget=_get_data)
 
-    def _get_flat(self):
-        "Return a flat iterator."
+    @property
+    def flat(self):
+        """ Return a flat iterator. """
         return MaskedIterator(self)
 
-    def _set_flat(self, value):
-        "Set a flattened version of self to value."
+    @flat.setter
+    def flat(self, value):
+        """ Set a flattened version of self to value. """
         y = self.ravel()
         y[:] = value
 
-    flat = property(fget=_get_flat, fset=_set_flat,
-                    doc="Flat version of the array.")
-
-    def get_fill_value(self):
+    @property
+    def fill_value(self):
         """
         Return the filling value of the masked array.
 
@@ -3623,7 +3627,8 @@ class MaskedArray(ndarray):
             return self._fill_value[()]
         return self._fill_value
 
-    def set_fill_value(self, value=None):
+    @fill_value.setter
+    def fill_value(self, value=None):
         """
         Set the filling value of the masked array.
 
@@ -3662,8 +3667,8 @@ class MaskedArray(ndarray):
             # Don't overwrite the attribute, just fill it (for propagation)
             _fill_value[()] = target
 
-    fill_value = property(fget=get_fill_value, fset=set_fill_value,
-                          doc="Filling value.")
+    get_fill_value = fill_value.fget
+    set_fill_value = fill_value.fset
 
     def filled(self, fill_value=None):
         """
@@ -4332,8 +4337,8 @@ class MaskedArray(ndarray):
             raise MaskError('Cannot convert masked element to a Python long.')
         return long(self.item())
 
-
-    def get_imag(self):
+    @property
+    def imag(self):
         """
         Return the imaginary part of the masked array.
 
@@ -4366,9 +4371,10 @@ class MaskedArray(ndarray):
         result.__setmask__(self._mask)
         return result
 
-    imag = property(fget=get_imag, doc="Imaginary part.")
+    get_imag = imag.fget
 
-    def get_real(self):
+    @property
+    def real(self):
         """
         Return the real part of the masked array.
 
@@ -4400,7 +4406,8 @@ class MaskedArray(ndarray):
         result = self._data.real.view(type(self))
         result.__setmask__(self._mask)
         return result
-    real = property(fget=get_real, doc="Real part")
+
+    get_real = real.fget
 
     def count(self, axis=None, keepdims=np._NoValue):
         """
@@ -5898,8 +5905,11 @@ class MaskedArray(ndarray):
     repeat = _arraymethod('repeat')
     squeeze = _arraymethod('squeeze')
     swapaxes = _arraymethod('swapaxes')
-    T = property(fget=lambda self: self.transpose())
     transpose = _arraymethod('transpose')
+
+    @property
+    def T(self):
+        return self.transpose()
 
     def tolist(self, fill_value=None):
         """
@@ -6156,11 +6166,10 @@ class mvoid(MaskedArray):
             _data.fill_value = fill_value
         return _data
 
-    def _get_data(self):
+    @property
+    def _data(self):
         # Make sure that the _data part is a np.void
         return super(mvoid, self)._data[()]
-
-    _data = property(fget=_get_data)
 
     def __getitem__(self, indx):
         """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3445,15 +3445,16 @@ class MaskedArray(ndarray):
 
     _set_mask = __setmask__
 
-    def _get_mask(self):
-        """Return the current mask.
-
-        """
+    @property
+    def mask(self):
+        """ Current mask. """
         # We could try to force a reshape, but that wouldn't work in some
         # cases.
         return self._mask
-
-    mask = property(fget=_get_mask, fset=__setmask__, doc="Mask")
+    
+    @mask.setter
+    def mask(self, value):
+        self.__setmask__(value)
 
     @property
     def recordmask(self):
@@ -3470,10 +3471,6 @@ class MaskedArray(ndarray):
 
     @recordmask.setter
     def recordmask(self, mask):
-        """
-        Set the mask of the records.
-
-        """
         raise NotImplementedError("Coming soon: setting the mask per records!")
 
     def harden_mask(self):
@@ -3582,24 +3579,19 @@ class MaskedArray(ndarray):
 
     @property
     def flat(self):
-        """ Return a flat iterator. """
+        """ Return a flat iterator, or set a flattened version of self to value. """
         return MaskedIterator(self)
 
     @flat.setter
     def flat(self, value):
-        """ Set a flattened version of self to value. """
         y = self.ravel()
         y[:] = value
 
     @property
     def fill_value(self):
         """
-        Return the filling value of the masked array.
-
-        Returns
-        -------
-        fill_value : scalar
-            The filling value.
+        The filling value of the masked array is a scalar. When setting, None
+        will set to a default based on the data type.
 
         Examples
         --------
@@ -3612,8 +3604,17 @@ class MaskedArray(ndarray):
         (1e+20+0j)
 
         >>> x = np.ma.array([0, 1.], fill_value=-np.inf)
-        >>> x.get_fill_value()
+        >>> x.fill_value
         -inf
+        >>> x.fill_value = np.pi
+        >>> x.fill_value
+        3.1415926535897931 # may vary
+
+        Reset to default:
+
+        >>> x.fill_value = None
+        >>> x.fill_value
+        1e+20
 
         """
         if self._fill_value is None:
@@ -3629,35 +3630,6 @@ class MaskedArray(ndarray):
 
     @fill_value.setter
     def fill_value(self, value=None):
-        """
-        Set the filling value of the masked array.
-
-        Parameters
-        ----------
-        value : scalar, optional
-            The new filling value. Default is None, in which case a default
-            based on the data type is used.
-
-        See Also
-        --------
-        ma.set_fill_value : Equivalent function.
-
-        Examples
-        --------
-        >>> x = np.ma.array([0, 1.], fill_value=-np.inf)
-        >>> x.fill_value
-        -inf
-        >>> x.set_fill_value(np.pi)
-        >>> x.fill_value
-        3.1415926535897931 # may vary
-
-        Reset to default:
-
-        >>> x.set_fill_value()
-        >>> x.fill_value
-        1e+20
-
-        """
         target = _check_fill_value(value, self.dtype)
         _fill_value = self._fill_value
         if _fill_value is None:
@@ -4341,10 +4313,9 @@ class MaskedArray(ndarray):
     @property
     def imag(self):
         """
-        Return the imaginary part of the masked array.
+        Get and set the imaginary part of the masked array.
 
-        The returned array is a view on the imaginary part of the `MaskedArray`
-        whose `imag` method is called.
+        The returned array is a view on the imaginary part of this `MaskedArray`.
 
         Parameters
         ----------
@@ -4357,7 +4328,7 @@ class MaskedArray(ndarray):
 
         See Also
         --------
-        real, get_real, get_imag
+        real
 
         Examples
         --------
@@ -4378,10 +4349,9 @@ class MaskedArray(ndarray):
     @property
     def real(self):
         """
-        Return the real part of the masked array.
+        Get and set the real part of the masked array.
 
-        The returned array is a view on the real part of the `MaskedArray`
-        whose `get_real` method is called.
+        The returned array is a view on the real part of this `MaskedArray`.
 
         Parameters
         ----------
@@ -4394,7 +4364,7 @@ class MaskedArray(ndarray):
 
         See Also
         --------
-        imag, get_real, get_imag
+        imag
 
         Examples
         --------

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -167,23 +167,21 @@ class MaskedRecords(MaskedArray, object):
             _dict['_baseclass'] = recarray
         return
 
-    def _getdata(self):
+    @property
+    def _data(self):
         """
         Returns the data as a recarray.
 
         """
         return ndarray.view(self, recarray)
 
-    _data = property(fget=_getdata)
-
-    def _getfieldmask(self):
+    @property
+    def _fieldmask(self):
         """
         Alias to mask.
 
         """
         return self._mask
-
-    _fieldmask = property(fget=_getfieldmask)
 
     def __len__(self):
         """

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -66,11 +66,11 @@ class MSubArray(SubArray, MaskedArray):
         _data.info = subarr.info
         return _data
 
-    def _get_series(self):
+    @property
+    def _series(self):
         _view = self.view(MaskedArray)
         _view._sharedmask = False
         return _view
-    _series = property(fget=_get_series)
 
 msubarray = MSubArray
 

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -791,7 +791,8 @@ class matrix(N.ndarray):
         """
         return N.ndarray.ptp(self, axis, out)._align(axis)
 
-    def getI(self):
+    @property
+    def I(self):
         """
         Returns the (multiplicative) inverse of invertible `self`.
 
@@ -835,7 +836,8 @@ class matrix(N.ndarray):
             from numpy.dual import pinv as func
         return asmatrix(func(self))
 
-    def getA(self):
+    @property
+    def A(self):
         """
         Return `self` as an `ndarray` object.
 
@@ -864,7 +866,8 @@ class matrix(N.ndarray):
         """
         return self.__array__()
 
-    def getA1(self):
+    @property
+    def A1(self):
         """
         Return `self` as a flattened `ndarray`.
 
@@ -931,8 +934,8 @@ class matrix(N.ndarray):
         """
         return N.ndarray.ravel(self, order=order)
 
-
-    def getT(self):
+    @property
+    def T(self):
         """
         Returns the transpose of the matrix.
 
@@ -964,7 +967,8 @@ class matrix(N.ndarray):
         """
         return self.transpose()
 
-    def getH(self):
+    @property
+    def H(self):
         """
         Returns the (complex) conjugate transpose of `self`.
 
@@ -998,11 +1002,12 @@ class matrix(N.ndarray):
         else:
             return self.transpose()
 
-    T = property(getT, None)
-    A = property(getA, None)
-    A1 = property(getA1, None)
-    H = property(getH, None)
-    I = property(getI, None)
+    # kept for compatibility
+    getT = T.fget
+    getA = A.fget
+    getA1 = A1.fget
+    getH = H.fget
+    getI = I.fget
 
 def _from_string(str, gdict, ldict):
     rows = str.split(';')

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -22,11 +22,11 @@ class MMatrix(MaskedArray, np.matrix,):
         MaskedArray.__array_finalize__(self, obj)
         return
 
-    def _get_series(self):
+    @property
+    def _series(self):
         _view = self.view(MaskedArray)
         _view._sharedmask = False
         return _view
-    _series = property(fget=_get_series)
 
 
 class TestMaskedMatrix(object):

--- a/tools/npy_tempita/_looper.py
+++ b/tools/npy_tempita/_looper.py
@@ -77,53 +77,53 @@ class loop_pos(object):
         return '<loop pos=%r at %r>' % (
             self.seq[self.pos], self.pos)
 
+    @property
     def index(self):
         return self.pos
-    index = property(index)
 
+    @property
     def number(self):
         return self.pos + 1
-    number = property(number)
 
+    @property
     def item(self):
         return self.seq[self.pos]
-    item = property(item)
 
+    @property
     def __next__(self):
         try:
             return self.seq[self.pos + 1]
         except IndexError:
             return None
-    __next__ = property(__next__)
 
     if sys.version < "3":
         next = __next__
 
+    @property
     def previous(self):
         if self.pos == 0:
             return None
         return self.seq[self.pos - 1]
-    previous = property(previous)
 
+    @property
     def odd(self):
         return not self.pos % 2
-    odd = property(odd)
 
+    @property
     def even(self):
         return self.pos % 2
-    even = property(even)
 
+    @property
     def first(self):
         return self.pos == 0
-    first = property(first)
 
+    @property
     def last(self):
         return self.pos == len(self.seq) - 1
-    last = property(last)
 
+    @property
     def length(self):
         return len(self.seq)
-    length = property(length)
 
     def first_group(self, getter=None):
         """


### PR DESCRIPTION
Cleanup based on https://github.com/numpy/numpy/issues/13024.

Remaining `= property` code is in numpy/ma/core.py:

* `mask = property(fget=_get_mask, fset=__setmask__, doc="Mask")` -- should I rewrite `__setmask__` as the `mask.setter`? It has a `copy=False` default arg though so seems like we need this method defined with the extra arg.
* `_data = property(fget=_get_data)` and `data = property(fget=_get_data)`, these ones were giving a bit of trouble, not sure why. Do we want all of these defined or do we ultimately want just data defined, and update the places that are using `_data`?

Hoping to get familiar with numpy's code base over time and contribute!