### PR TITLE
BUG: __array_interface__ offset was always ignored

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -18,7 +18,6 @@ New functions
 Deprecations
 ============
 
-
 Future Changes
 ==============
 
@@ -163,5 +162,9 @@ NumPy now always checks the ``__array_function__`` method to implement overrides
 of NumPy functions on non-NumPy arrays, as described in `NEP 18`_. The feature
 was available for testing with NumPy 1.16 if appropriate environment variables
 are set, but is now always enabled.
+
+``__array_interface__`` offset now works as documented
+------------------------------------------------------
+The interface may use an ``offset`` value that was mistakenly ignored.
 
 .. _`NEP 18` : http://www.numpy.org/neps/nep-0018-array-function-protocol.html

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2484,7 +2484,7 @@ PyArray_FromInterface(PyObject *origin)
         }
 #endif
         /* Get offset number from interface specification */
-        attr = PyDict_GetItemString(origin, "offset");
+        attr = PyDict_GetItemString(iface, "offset");
         if (attr) {
             npy_longlong num = PyLong_AsLongLong(attr);
             if (error_converting(num)) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7105,6 +7105,19 @@ def test_array_interface_empty_shape():
     assert_equal(arr1, arr2)
     assert_equal(arr1, arr3)
 
+def test_array_interface_offset():
+    arr = np.array([1, 2, 3], dtype='int32')
+    interface = dict(arr.__array_interface__)
+    interface['data'] = memoryview(arr)
+    interface['shape'] = (2,)
+    interface['offset'] = 4
+
+
+    class DummyArray(object):
+        __array_interface__ = interface
+
+    arr1 = np.asarray(DummyArray())
+    assert_equal(arr1, arr[1:])
 
 def test_flat_element_deletion():
     it = np.ones(3).flat


### PR DESCRIPTION
[`__array_interface__`](https://6063-908607-gh.circle-artifacts.com/0/home/circleci/repo/doc/build/html/reference/arrays.interface.html#python-side) can accept an optional `offset` value when `data` is `None` or a `buffer`. Due to a bug, the key was looked for on the object rather than it's interface `dict`. Since `PyDict_GetItemString` first checks if the object is a `PyDictObject`, the lookup would always fail.

Searching for open issues about `offset` did not yield anything that looked like this was reported.

Added a test and a comment in the release notes.