### PR TITLE
MAINT: Improve error message when shape is wrongly specified.

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -213,6 +213,9 @@ def ones(shape, dtype=None, order='C'):
            [1.,  1.]])
 
     """
+    if isinstance(dtype, int):
+        raise TypeError('Did you mean to use a tuple as shape?')
+
     a = empty(shape, dtype, order)
     multiarray.copyto(a, 1, casting='unsafe')
     return a

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -89,6 +89,9 @@ def ones(shape, dtype=None, order='C'):
     matrix([[1.,  1.]])
 
     """
+    if isinstance(dtype, int):
+        raise TypeError('Did you mean to use a tuple as shape?')
+
     a = ndarray.__new__(matrix, shape, dtype, order=order)
     a.fill(1)
     return a
@@ -133,6 +136,10 @@ def zeros(shape, dtype=None, order='C'):
     matrix([[0.,  0.]])
 
     """
+
+    if isinstance(dtype, int):
+        raise TypeError('Did you mean to use a tuple as shape?')
+
     a = ndarray.__new__(matrix, shape, dtype, order=order)
     a.fill(0)
     return a


### PR DESCRIPTION
Improved exception message when two integers are passed as arguments which are pretended to be shape

`np.zeros(2, 3) # => TypeError: Did you mean to use a tuple as shape?'`