### PR TITLE
MAINT:  Better error messages for zeros, ones, empty.

### DIFF
--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -46,6 +46,10 @@ def empty(shape, dtype=None, order='C'):
             [ 6586976, 22740995]])
 
     """
+    if isinstance(dtype, int):
+        raise ValueError(
+            "Argument dtype can not be an integer. "
+            "Did you mean to pass a list or tuple for the shape?")
     return ndarray.__new__(matrix, shape, dtype, order=order)
 
 def ones(shape, dtype=None, order='C'):
@@ -89,6 +93,10 @@ def ones(shape, dtype=None, order='C'):
     matrix([[1.,  1.]])
 
     """
+    if isinstance(dtype, int):
+        raise ValueError(
+            "Argument dtype can not be an integer. "
+            "Did you mean to pass a list or tuple for the shape?")
     a = ndarray.__new__(matrix, shape, dtype, order=order)
     a.fill(1)
     return a
@@ -133,6 +141,10 @@ def zeros(shape, dtype=None, order='C'):
     matrix([[0.,  0.]])
 
     """
+    if isinstance(dtype, int):
+        raise ValueError(
+            "Argument dtype can not be an integer. "
+            "Did you mean to pass a list or tuple for the shape?")
     a = ndarray.__new__(matrix, shape, dtype, order=order)
     a.fill(0)
     return a

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -10,12 +10,15 @@ except ImportError:
 
 import numpy as np
 import numpy.matlib
-from numpy.testing import assert_array_equal, assert_
+from numpy.testing import assert_array_equal, assert_, assert_raises
 
 def test_empty():
     x = numpy.matlib.empty((2,))
     assert_(isinstance(x, np.matrix))
     assert_(x.shape, (1, 2))
+
+def test_bad_empty():
+    assert_raises(numpy.matlib.empty(2, 2), ValueError)
 
 def test_ones():
     assert_array_equal(numpy.matlib.ones((2, 3)),
@@ -24,12 +27,18 @@ def test_ones():
 
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
+def test_bad_ones():
+    assert_raises(numpy.matlib.ones(2, 2), ValueError)
+
 def test_zeros():
     assert_array_equal(numpy.matlib.zeros((2, 3)),
                        np.matrix([[ 0.,  0.,  0.],
                                  [ 0.,  0.,  0.]]))
 
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
+
+def test_bad_zeros():
+    assert_raises(numpy.matlib.zeros(2, 2), ValueError)
 
 def test_identity():
     x = numpy.matlib.identity(2, dtype=int)

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -18,7 +18,7 @@ def test_empty():
     assert_(x.shape, (1, 2))
 
 def test_bad_empty():
-    assert_raises(ValueError, numpy.matlib.empty, [2, 2])
+    assert_raises(ValueError, numpy.matlib.empty, 2, 2)
 
 def test_ones():
     assert_array_equal(numpy.matlib.ones((2, 3)),
@@ -28,7 +28,7 @@ def test_ones():
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
 def test_bad_ones():
-    assert_raises(ValueError, numpy.matlib.ones, [2, 2])
+    assert_raises(ValueError, numpy.matlib.ones, 2, 2)
 
 def test_zeros():
     assert_array_equal(numpy.matlib.zeros((2, 3)),
@@ -38,7 +38,7 @@ def test_zeros():
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
 def test_bad_zeros():
-    assert_raises(ValueError, numpy.matlib.zeros, [2, 2])
+    assert_raises(ValueError, numpy.matlib.zeros, 2, 2)
 
 def test_identity():
     x = numpy.matlib.identity(2, dtype=int)

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -18,7 +18,7 @@ def test_empty():
     assert_(x.shape, (1, 2))
 
 def test_bad_empty():
-    assert_raises(numpy.matlib.empty(2, 2), ValueError)
+    assert_raises(ValueError, numpy.matlib.empty, [2, 2])
 
 def test_ones():
     assert_array_equal(numpy.matlib.ones((2, 3)),
@@ -28,7 +28,7 @@ def test_ones():
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
 def test_bad_ones():
-    assert_raises(numpy.matlib.ones(2, 2), ValueError)
+    assert_raises(ValueError, numpy.matlib.ones, [2, 2])
 
 def test_zeros():
     assert_array_equal(numpy.matlib.zeros((2, 3)),
@@ -38,7 +38,7 @@ def test_zeros():
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
 def test_bad_zeros():
-    assert_raises(numpy.matlib.zeros(2, 2), ValueError)
+    assert_raises(ValueError, numpy.matlib.zeros, [2, 2])
 
 def test_identity():
     x = numpy.matlib.identity(2, dtype=int)


### PR DESCRIPTION
Added a more clear error message when calling np.zeros, ones, empty for a common mistake.

This happens a lot, especially since np.random.randn doesn't accept a list/tuple.

This was orginally requested by Andrej Karpathy on twitter. https://twitter.com/karpathy/status/1099793055853375489


‏
