### PR TITLE
DOC: Added maximum_sctype to documentation

### DIFF
--- a/doc/source/reference/routines.dtype.rst
+++ b/doc/source/reference/routines.dtype.rst
@@ -17,10 +17,8 @@ Data type routines
 
 Creating data types
 -------------------
-
 .. autosummary::
    :toctree: generated/
-
 
    dtype
    format_parser
@@ -53,3 +51,4 @@ Miscellaneous
    typename
    sctype2char
    mintypecode
+   maximum_sctype

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -140,6 +140,7 @@ genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
                    'complex32', 'complex64', 'complex128', 'complex160',
                    'complex192', 'complex256', 'complex512', 'object']
 
+@set_module('numpy')
 def maximum_sctype(t):
     """
     Return the scalar type of highest precision of the same kind as the input.

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -43,7 +43,6 @@ def test_numpy_namespace():
         'get_include': 'numpy.lib.utils.get_include',
         'int_asbuffer': 'numpy.core._multiarray_umath.int_asbuffer',
         'mafromtxt': 'numpy.lib.npyio.mafromtxt',
-        'maximum_sctype': 'numpy.core.numerictypes.maximum_sctype',
         'ndfromtxt': 'numpy.lib.npyio.ndfromtxt',
         'recfromcsv': 'numpy.lib.npyio.recfromcsv',
         'recfromtxt': 'numpy.lib.npyio.recfromtxt',


### PR DESCRIPTION
`maximum_sctype` is probably OK to be in the docs since it is referenced in multiple places, e.g.:

- https://docs.scipy.org/doc/numpy/reference/generated/numpy.obj2sctype.html
- https://docs.scipy.org/doc/numpy/reference/generated/numpy.mintypecode.html

I have attempted to fix the non-generation of the doc by adding it to the autodoc page under https://docs.scipy.org/doc/numpy/reference/routines.dtype.html, and removing it from the undocumented list.

The issue originally came up in https://stackoverflow.com/a/48412971/2988730