### PR TITLE
BUG: Use C call to sysctlbyname for AVX detection on MacOS

### DIFF
--- a/numpy/_build_utils/src/apple_sgemv_fix.c
+++ b/numpy/_build_utils/src/apple_sgemv_fix.c
@@ -29,6 +29,9 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <string.h>
 
 /* ----------------------------------------------------------------- */
 /* Original cblas_sgemv */
@@ -66,12 +69,21 @@ static int AVX_and_10_9 = 0;
 /* Dynamic check for AVX support
  * __builtin_cpu_supports("avx") is available in gcc 4.8,
  * but clang and icc do not currently support it. */
-#define cpu_supports_avx()\
-(system("sysctl -n machdep.cpu.features | grep -q AVX") == 0)
-
+#define cpu_supports_avx() ({\
+	int enabled, r;\
+	size_t length = sizeof(enabled);\
+	r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);\
+	r == 0 && enabled != 0;\
+})
+	
 /* Check if we are using MacOS X version 10.9 */
-#define using_mavericks()\
-(system("sw_vers -productVersion | grep -q 10\\.9\\.") == 0)
+#define using_mavericks() ({\
+	int r;\
+	char str[32] = {0};\
+	size_t size = sizeof(str);\
+	r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);\
+	r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0;\
+})
 
 __attribute__((destructor))
 static void unloadlib(void)

--- a/numpy/_build_utils/src/apple_sgemv_fix.c
+++ b/numpy/_build_utils/src/apple_sgemv_fix.c
@@ -70,25 +70,25 @@ static int AVX_and_10_9 = 0;
  * __builtin_cpu_supports("avx") is available in gcc 4.8,
  * but clang and icc do not currently support it. */
 static inline int cpu_supports_avx() {
-	int enabled, r;
-	size_t length = sizeof(enabled);
-	r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);
-	if ( r == 0 && enabled != 0) 
-		return 1;
-	else
-		return 0;
+    int enabled, r;
+    size_t length = sizeof(enabled);
+    r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);
+    if ( r == 0 && enabled != 0) 
+        return 1;
+    else
+        return 0;
 }
 	
 /* Check if we are using MacOS X version 10.9 */
 static inline int using_mavericks() {
-	int r;
-	char str[32] = {0};
-	size_t size = sizeof(str);
-	r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);
-	if ( r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0)
-		return 1;
-	else
-		return 0;
+    int r;
+    char str[32] = {0};
+    size_t size = sizeof(str);
+    r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);
+    if ( r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0)
+        return 1;
+    else
+        return 0;
 }
 
 __attribute__((destructor))

--- a/numpy/_build_utils/src/apple_sgemv_fix.c
+++ b/numpy/_build_utils/src/apple_sgemv_fix.c
@@ -69,26 +69,34 @@ static int AVX_and_10_9 = 0;
 /* Dynamic check for AVX support
  * __builtin_cpu_supports("avx") is available in gcc 4.8,
  * but clang and icc do not currently support it. */
-static inline int cpu_supports_avx() {
+static inline int 
+cpu_supports_avx() 
+{
     int enabled, r;
     size_t length = sizeof(enabled);
     r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);
-    if ( r == 0 && enabled != 0) 
+    if ( r == 0 && enabled != 0) {
         return 1;
-    else
+    }
+    else {
         return 0;
+    }
 }
 	
 /* Check if we are using MacOS X version 10.9 */
-static inline int using_mavericks() {
+static inline int 
+using_mavericks() 
+{
     int r;
     char str[32] = {0};
     size_t size = sizeof(str);
     r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);
-    if ( r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0)
+    if ( r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0) {
         return 1;
-    else
+    }
+    else {
         return 0;
+    }
 }
 
 __attribute__((destructor))

--- a/numpy/_build_utils/src/apple_sgemv_fix.c
+++ b/numpy/_build_utils/src/apple_sgemv_fix.c
@@ -69,21 +69,27 @@ static int AVX_and_10_9 = 0;
 /* Dynamic check for AVX support
  * __builtin_cpu_supports("avx") is available in gcc 4.8,
  * but clang and icc do not currently support it. */
-#define cpu_supports_avx() ({\
-	int enabled, r;\
-	size_t length = sizeof(enabled);\
-	r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);\
-	r == 0 && enabled != 0;\
-})
+static inline int cpu_supports_avx() {
+	int enabled, r;
+	size_t length = sizeof(enabled);
+	r = sysctlbyname("hw.optional.avx1_0", &enabled, &length, NULL, 0);
+	if ( r == 0 && enabled != 0) 
+		return 1;
+	else
+		return 0;
+}
 	
 /* Check if we are using MacOS X version 10.9 */
-#define using_mavericks() ({\
-	int r;\
-	char str[32] = {0};\
-	size_t size = sizeof(str);\
-	r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);\
-	r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0;\
-})
+static inline int cpu_supports_avx() {
+	int r;
+	char str[32] = {0};
+	size_t size = sizeof(str);
+	r = sysctlbyname("kern.osproductversion", str, &size, NULL, 0);
+	if ( r == 0 && strncmp(str, "10.9", strlen("10.9")) == 0)
+		return 1;
+	else
+		return 0;
+}
 
 __attribute__((destructor))
 static void unloadlib(void)

--- a/numpy/_build_utils/src/apple_sgemv_fix.c
+++ b/numpy/_build_utils/src/apple_sgemv_fix.c
@@ -80,7 +80,7 @@ static inline int cpu_supports_avx() {
 }
 	
 /* Check if we are using MacOS X version 10.9 */
-static inline int cpu_supports_avx() {
+static inline int using_mavericks() {
 	int r;
 	char str[32] = {0};
 	size_t size = sizeof(str);


### PR DESCRIPTION
Fixes #7801.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
