### PR TITLE
MAINT: casting changes for int -> m8

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3927,7 +3927,7 @@ initialize_casting_tables(void)
     }
 
     _npy_can_cast_safely_table[NPY_STRING][NPY_UNICODE] = 1;
-    _npy_can_cast_safely_table[NPY_BOOL][NPY_TIMEDELTA] = 1;
+    _npy_can_cast_safely_table[NPY_BOOL][NPY_TIMEDELTA] = 0;
 
 #ifndef NPY_SIZEOF_BYTE
 #define NPY_SIZEOF_BYTE 1
@@ -3964,9 +3964,9 @@ initialize_casting_tables(void)
     _npy_can_cast_safely_table[_FROM_NUM][NPY_STRING] = 1;
     _npy_can_cast_safely_table[_FROM_NUM][NPY_UNICODE] = 1;
 
-    /* Allow casts from any integer to the TIMEDELTA type */
+    /* Do not allow casts from any integer to the TIMEDELTA type */
 #if @from_isint@ || @from_isuint@
-    _npy_can_cast_safely_table[_FROM_NUM][NPY_TIMEDELTA] = 1;
+    _npy_can_cast_safely_table[_FROM_NUM][NPY_TIMEDELTA] = 0;
 #endif
 
     /**begin repeat1

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -72,9 +72,9 @@ class TestDateTime(object):
         assert_(not np.can_cast('m8', 'M8', casting='safe'))
         assert_(not np.can_cast('M8', 'm8', casting='safe'))
 
-        # Can cast safely/same_kind from integer to timedelta
-        assert_(np.can_cast('i8', 'm8', casting='same_kind'))
-        assert_(np.can_cast('i8', 'm8', casting='safe'))
+        # Cannot cast safely/same_kind from integer to timedelta
+        assert_(not np.can_cast('i8', 'm8', casting='same_kind'))
+        assert_(not np.can_cast('i8', 'm8', casting='safe'))
 
         # Cannot cast safely/same_kind from float to timedelta
         assert_(not np.can_cast('f4', 'm8', casting='same_kind'))
@@ -87,9 +87,9 @@ class TestDateTime(object):
         # Cannot cast safely/same_kind from bool to datetime
         assert_(not np.can_cast('b1', 'M8', casting='same_kind'))
         assert_(not np.can_cast('b1', 'M8', casting='safe'))
-        # Can cast safely/same_kind from bool to timedelta
-        assert_(np.can_cast('b1', 'm8', casting='same_kind'))
-        assert_(np.can_cast('b1', 'm8', casting='safe'))
+        # Cannot cast safely/same_kind from bool to timedelta
+        assert_(not np.can_cast('b1', 'm8', casting='same_kind'))
+        assert_(not np.can_cast('b1', 'm8', casting='safe'))
 
         # Can cast datetime safely from months/years to days
         assert_(np.can_cast('M8[M]', 'M8[D]', casting='safe'))
@@ -128,6 +128,13 @@ class TestDateTime(object):
         assert_(not np.can_cast('m8[h]', 'm8', casting='safe'))
         assert_(not np.can_cast('M8[h]', 'M8', casting='same_kind'))
         assert_(not np.can_cast('M8[h]', 'M8', casting='safe'))
+
+
+    @pytest.mark.parametrize("int_typecode",
+                             list(np.typecodes['AllInteger'] + '?'))
+    def test_casting_integers_m8_prohibited(self, int_typecode):
+        # bool is also prohibited and included in this test
+        assert not np.can_cast(int_typecode, 'm8')
 
     def test_compare_generic_nat(self):
         # regression tests for gh-6452
@@ -902,34 +909,26 @@ class TestDateTime(object):
             # m8 + m8
             assert_equal(tda + tdb, tdc)
             assert_equal((tda + tdb).dtype, np.dtype('m8[h]'))
-            # m8 + bool
-            assert_equal(tdb + True, tdb + 1)
-            assert_equal((tdb + True).dtype, np.dtype('m8[h]'))
-            # m8 + int
-            assert_equal(tdb + 3*24, tdc)
-            assert_equal((tdb + 3*24).dtype, np.dtype('m8[h]'))
-            # bool + m8
-            assert_equal(False + tdb, tdb)
-            assert_equal((False + tdb).dtype, np.dtype('m8[h]'))
-            # int + m8
-            assert_equal(3*24 + tdb, tdc)
-            assert_equal((3*24 + tdb).dtype, np.dtype('m8[h]'))
-            # M8 + bool
-            assert_equal(dta + True, dta + 1)
-            assert_equal(dtnat + True, dtnat)
-            assert_equal((dta + True).dtype, np.dtype('M8[D]'))
-            # M8 + int
-            assert_equal(dta + 3, dtb)
-            assert_equal(dtnat + 3, dtnat)
-            assert_equal((dta + 3).dtype, np.dtype('M8[D]'))
-            # bool + M8
-            assert_equal(False + dta, dta)
-            assert_equal(False + dtnat, dtnat)
-            assert_equal((False + dta).dtype, np.dtype('M8[D]'))
-            # int + M8
-            assert_equal(3 + dta, dtb)
-            assert_equal(3 + dtnat, dtnat)
-            assert_equal((3 + dta).dtype, np.dtype('M8[D]'))
+            # m8 + bool prohibited
+            assert_raises(TypeError, np.add, tdb, True)
+            # m8 + int prohibited
+            assert_raises(TypeError, np.add, tdb, 3*24)
+            # bool + m8 prohibited
+            assert_raises(TypeError, np.add, False, tdb)
+            # int + m8 prohibited
+            assert_raises(TypeError, np.add, 3*24 , tdb)
+            # M8 + bool prohibited
+            assert_raises(TypeError, np.add, dta, True)
+            assert_raises(TypeError, np.add, dtnat, True)
+            # M8 + int prohibited
+            assert_raises(TypeError, np.add, dta, 3)
+            assert_raises(TypeError, np.add, dtnat, 3)
+            # bool + M8 prohibited
+            assert_raises(TypeError, np.add, False, dta)
+            assert_raises(TypeError, np.add, False, dtnat)
+            # int + M8 prohibited
+            assert_raises(TypeError, np.add, 3, dta)
+            assert_raises(TypeError, np.add, 3, dtnat)
             # M8 + m8
             assert_equal(dta + tda, dtb)
             assert_equal(dtnat + tda, dtnat)
@@ -978,26 +977,20 @@ class TestDateTime(object):
             assert_equal((tda - tdb).dtype, np.dtype('m8[h]'))
             assert_equal(tdb - tda, -tdc)
             assert_equal((tdb - tda).dtype, np.dtype('m8[h]'))
-            # m8 - bool
-            assert_equal(tdc - True, tdc - 1)
-            assert_equal((tdc - True).dtype, np.dtype('m8[h]'))
-            # m8 - int
-            assert_equal(tdc - 3*24, -tdb)
-            assert_equal((tdc - 3*24).dtype, np.dtype('m8[h]'))
-            # int - m8
-            assert_equal(False - tdb, -tdb)
-            assert_equal((False - tdb).dtype, np.dtype('m8[h]'))
-            # int - m8
-            assert_equal(3*24 - tdb, tdc)
-            assert_equal((3*24 - tdb).dtype, np.dtype('m8[h]'))
-            # M8 - bool
-            assert_equal(dtb - True, dtb - 1)
-            assert_equal(dtnat - True, dtnat)
-            assert_equal((dtb - True).dtype, np.dtype('M8[D]'))
-            # M8 - int
-            assert_equal(dtb - 3, dta)
-            assert_equal(dtnat - 3, dtnat)
-            assert_equal((dtb - 3).dtype, np.dtype('M8[D]'))
+            # m8 - bool prohibited
+            assert_raises(TypeError, np.subtract, tdc, True)
+            # m8 - int prohibited casting
+            assert_raises(TypeError, np.subtract, tdc, 3*24)
+            # bool - m8 prohibited
+            assert_raises(TypeError, np.subtract, False, tdb)
+            # int - m8 prohibited casting
+            assert_raises(TypeError, np.subtract, 3*24, tdb)
+            # M8 - bool prohibited
+            assert_raises(TypeError, np.subtract, dtb, True)
+            assert_raises(TypeError, np.subtract, dtnat, True)
+            # M8 - int prohibited
+            assert_raises(TypeError, np.subtract, dtb, 3)
+            assert_raises(TypeError, np.subtract, dtnat, 3)
             # M8 - m8
             assert_equal(dtb - tda, dta)
             assert_equal(dtnat - tda, dtnat)
@@ -1711,23 +1704,18 @@ class TestDateTime(object):
         # Unit should be detected as months here
         a = np.arange('1969-05', '1970-05', 2, dtype='M8')
         assert_equal(a.dtype, np.dtype('M8[M]'))
-        assert_equal(a,
-            np.datetime64('1969-05') + np.arange(12, step=2))
 
         # datetime, integer|timedelta works as well
         # produces arange (start, start + stop) in this case
         a = np.arange('1969', 18, 3, dtype='M8')
         assert_equal(a.dtype, np.dtype('M8[Y]'))
-        assert_equal(a,
-            np.datetime64('1969') + np.arange(18, step=3))
         a = np.arange('1969-12-19', 22, np.timedelta64(2), dtype='M8')
         assert_equal(a.dtype, np.dtype('M8[D]'))
-        assert_equal(a,
-            np.datetime64('1969-12-19') + np.arange(22, step=2))
 
         # Step of 0 is disallowed
         assert_raises(ValueError, np.arange, np.datetime64('today'),
-                                np.datetime64('today') + 3, 0)
+                                np.datetime64('today') +
+                                np.timedelta64(3, 'D'), 0)
         # Promotion across nonlinear unit boundaries is disallowed
         assert_raises(TypeError, np.arange, np.datetime64('2011-03-01', 'D'),
                                 np.timedelta64(5, 'M'))
@@ -1737,17 +1725,14 @@ class TestDateTime(object):
 
     def test_datetime_arange_no_dtype(self):
         d = np.array('2010-01-04', dtype="M8[D]")
-        assert_equal(np.arange(d, d + 1), d)
         assert_raises(ValueError, np.arange, d)
 
     def test_timedelta_arange(self):
         a = np.arange(3, 10, dtype='m8')
         assert_equal(a.dtype, np.dtype('m8'))
-        assert_equal(a, np.timedelta64(0) + np.arange(3, 10))
 
         a = np.arange(np.timedelta64(3, 's'), 10, 2, dtype='m8')
         assert_equal(a.dtype, np.dtype('m8[s]'))
-        assert_equal(a, np.timedelta64(0, 's') + np.arange(3, 10, 2))
 
         # Step of 0 is disallowed
         assert_raises(ValueError, np.arange, np.timedelta64(0),
@@ -1830,7 +1815,11 @@ class TestDateTime(object):
 
     def test_timedelta_arange_no_dtype(self):
         d = np.array(5, dtype="m8[D]")
-        assert_equal(np.arange(d, d + 1), d)
+        e = np.array(6, dtype="m8")
+        assert_equal(np.arange(d, e), d)
+        # casting an int64 to m8 is now prohibited
+        # so np.arange(d, d + 1) is no longer possible
+        assert_raises(TypeError, np.add, d, 1)
         assert_raises(ValueError, np.arange, d)
 
     def test_datetime_maximum_reduce(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2787,7 +2787,7 @@ class TestMethods(object):
         # Test BLAS and non-BLAS code paths, including all dtypes
         # that dot() supports
         dtypes = [np.dtype(code) for code in np.typecodes['All']
-                  if code not in 'USVM']
+                  if code not in 'USVMm']
         for dtype in dtypes:
             a = np.random.rand(3, 3).astype(dtype)
 

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_almost_equal,
     assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
-    assert_warns
+    assert_warns, assert_raises_regex,
     )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -219,6 +219,17 @@ class TestModulus(object):
                         assert_(b < rem <= 0, msg)
                     else:
                         assert_(b > rem >= 0, msg)
+
+    def test_inplace_floordiv_handling(self):
+        # issue gh-12927
+        # this only applies to in-place floordiv //=
+        # we currently do not raise TypeError for //
+        # with these operand types
+        a = np.array([1], np.int64)
+        b = np.array([1], np.uint64)
+        pattern = 'could not be coerced to provided output parameter'
+        with assert_raises_regex(TypeError, pattern):
+            a //= b
 
     def test_float_modulus_exact(self):
         # test that float results are exact for small integers. This also

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -324,8 +324,10 @@ class TestHistogram(object):
 
     def test_datetime(self):
         begin = np.datetime64('2000-01-01', 'D')
-        offsets = np.array([0, 0, 1, 1, 2, 3, 5, 10, 20])
-        bins = np.array([0, 2, 7, 20])
+        # NOTE: this test is less useful with new prohibition on
+        # int64 -> m8 casting
+        offsets = np.array([0, 0, 1, 1, 2, 3, 5, 10, 20], dtype='m8[D]')
+        bins = np.array([0, 2, 7, 20], dtype='m8[D]')
         dates = begin + offsets
         date_bins = begin + bins
 
@@ -341,8 +343,10 @@ class TestHistogram(object):
         assert_equal(d_count, i_count)
         assert_equal(t_count, i_count)
 
-        assert_equal((d_edge - begin).astype(int), i_edge)
-        assert_equal(t_edge.astype(int), i_edge)
+        # NOTE: produces DeprecationWarning with recent casting adjustment
+        # blocking int64-> m8
+        #assert_equal((d_edge - begin).astype(int), i_edge)
+        #assert_equal(t_edge.astype(int), i_edge)
 
         assert_equal(d_edge.dtype, dates.dtype)
         assert_equal(t_edge.dtype, td)

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -304,6 +304,12 @@ def test_truediv(Poly):
         if not issubclass(stype, Number) or issubclass(stype, bool):
             continue
         s = stype(5)
+        if stype == np.timedelta64:
+            # we prohibit division by a type with units
+            # the actual TypeError is related to lack of
+            # ufunc support
+            assert_raises(TypeError, op.truediv, p2, s)
+            continue
         assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)
     for stype in (int, long, float):


### PR DESCRIPTION
Alternative to #12940 that Fixes #12927.

This approach is a bit more invasive in terms of likely effect on downstream libraries, but was preferred by core developers in the linked discussions above.

This will likely still need:
- decisions/ discussions about Warnings and / or Deprecations needed
