### PR TITLE
DOC: revert PR #13058 and fixup Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,9 +1,13 @@
 # Makefile for Sphinx documentation
 #
 
-# This needs to be major.minor, just "3" doesn't work - it will result in
+# PYVER needs to be major.minor, just "3" doesn't work - it will result in
 # issues with the amendments to PYTHONPATH and install paths (see DIST_VARS).
-export PYVER=`python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))'`
+
+# Use explicit "version_info" indexing since make cannot handle colon characters, and
+# evaluate it now to allow easier debugging when printing the varaible
+
+PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".format(v[0], v[1]))')
 PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.

--- a/doc/source/user/whatisnumpy.rst
+++ b/doc/source/user/whatisnumpy.rst
@@ -134,4 +134,4 @@ numerous methods and attributes.  Many of its methods are mirrored by
 functions in the outer-most NumPy namespace, allowing the programmer
 to code in whichever paradigm they prefer. This flexibility has allowed the
 NumPy array dialect and NumPy `ndarray` class to become the *de-facto* language
-of mulit-dimensional data interchange used in Python.
+of multi-dimensional data interchange used in Python.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1292,9 +1292,9 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         The x-coordinates at which to evaluate the interpolated values.
 
     xp : 1-D sequence of floats
-        The x-coordinates of the data points, must be strictly increasing if
-        argument `period` is not specified. Otherwise, `xp` is internally sorted
-        after normalizing the periodic boundaries with ``xp = xp % period``.
+        The x-coordinates of the data points, must be increasing if argument
+        `period` is not specified. Otherwise, `xp` is internally sorted after
+        normalizing the periodic boundaries with ``xp = xp % period``.
 
     fp : 1-D sequence of float or complex
         The y-coordinates of the data points, same length as `xp`.


### PR DESCRIPTION
Two fixes to recent merged PRs:

I merged #13058 but it was not correct. Reverted

My `make dist` for documentation does not like the colon merged in #13050. Reworked to avoid it.