### PR TITLE
DOC, BUILD: fail on doc build warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,14 +39,14 @@ jobs:
             . venv/bin/activate
             cd doc
             git submodule update --init
-            make html
+            make html -halt-on-error
 
       - run:
           name: build neps
           command: |
             . venv/bin/activate
             cd doc/neps
-            make html
+            make html -halt-on-error
 
       - store_artifacts:
           path: doc/build/html/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,14 +39,14 @@ jobs:
             . venv/bin/activate
             cd doc
             git submodule update --init
-            make html -halt-on-error
+            make html
 
       - run:
           name: build neps
           command: |
             . venv/bin/activate
             cd doc/neps
-            make html -halt-on-error
+            make html
 
       - store_artifacts:
           path: doc/build/html/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d -WT build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -WT -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
         dist dist-build gitwash-update

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,7 +16,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d -WT build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
         dist dist-build gitwash-update

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -714,6 +714,7 @@ add_newdoc('numpy.core', 'broadcast', ('numiter',
 
     """))
 
+
 add_newdoc('numpy.core', 'broadcast', ('shape',
     """
     Shape of broadcasted result.


### PR DESCRIPTION
Fail documentation builds if there are any warnings.

It turns out my optimism after #13002 was not quite justified. There are a few `warnings` not `WARNINGS` still when building documentation, those cause the build to fail when using `-WT`.

@rgommers suggested using `--keep-going`. Unfortunately this is a sphinx 1.8+ feature, which we cannot use due to scipy/scipy-sphinx-theme#9, which we really should fix.

EDIT: the `scipy-sphinx-theme` related issue was fixed in Sphinx; Sphinx 1.8.3+ is backward compatible.