### PR TITLE
BLD: fix include list for sdist building

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,15 +11,18 @@ include site.cfg.example
 include numpy/random/mtrand/generate_mtrand_c.py
 recursive-include numpy/random/mtrand *.pyx *.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
+# Note that sub-directories that don't have __init__ are apparently not
+# included by 'recursive-include', so list those separately
+recursive-include numpy *
 recursive-include numpy/_build_utils *
-recursive-include numpy/linalg/lapack_lite *.c *.h
+recursive-include numpy/linalg/lapack_lite *
 include runtests.py
 include tox.ini pytest.ini .coveragerc
 recursive-include tools *
 # Add sdist files whose use depends on local configuration.
 include numpy/core/src/common/cblasfuncs.c
 include numpy/core/src/common/python_xerbla.c
-# Adding scons build related files not found by distutils
+# Adding build related files not found by distutils
 recursive-include numpy/core/code_generators *.py *.txt
 recursive-include numpy/core *.in *.h
 # Add documentation and benchmarks: we don't use add_data_dir since we do not


### PR DESCRIPTION
Closes gh-11927

To verify the changes I ran `python setup.py sdist` on `master` and on the branch this PR was made from, unpacked each sdist and ran this script:
```
import os


def get_filelist(root):
    allfiles = []
    for path, subdirs, files in os.walk(root):
        for name in files:
            allfiles.append(os.path.join(path, name)[len(root):])

    return allfiles


path1 = 'numpy_master/numpy-1.17.0.dev0+48b0f3c/'
path2 = 'numpy_manifest/numpy-1.17.0.dev0+a6bc29d/'

files_master = get_filelist(path1)
files_new = get_filelist(path2)

print("Files now in sdist that weren't included previously:")
for name in files_new:
    if not name in files_master:
        print(name)

print("\n\nFiles now left out:")
for name in files_master:
    if not name in files_new:
        print(name)
```

The result:
```
Files now in sdist that weren't included previously:
cythonize.dat
numpy/linalg/lapack_lite/fortran.py
numpy/linalg/lapack_lite/f2c_d_lapack.f.patch
numpy/linalg/lapack_lite/clapack_scrub.py
numpy/linalg/lapack_lite/LICENSE.txt
numpy/linalg/lapack_lite/f2c_s_lapack.f.patch
numpy/linalg/lapack_lite/f2c_config.c.patch
numpy/linalg/lapack_lite/f2c_z_lapack.f.patch
numpy/linalg/lapack_lite/README.rst
numpy/linalg/lapack_lite/f2c_lapack.f.patch
numpy/linalg/lapack_lite/make_lite.py
numpy/linalg/lapack_lite/f2c_c_lapack.f.patch
numpy/linalg/lapack_lite/wrapped_routines


Files now left out:

```

I think those should all be included.

The `LICENSE.txt` file was the important one pointed out in the bug report. The missing `cythonize.dat` was also not good, that must have triggered recompilation of Cython files for source builds that we didn't intend have happen.
