### PR TITLE
DOC: update doc of `ndarray.T`

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2450,8 +2450,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('strides',
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('T',
     """
-    Same as self.transpose(), except that self is returned if
-    self.ndim < 2.
+    The transposed array.
+
+    Same as ``self.transpose()``.
 
     Examples
     --------
@@ -2467,6 +2468,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('T',
     array([ 1.,  2.,  3.,  4.])
     >>> x.T
     array([ 1.,  2.,  3.,  4.])
+
+    See Also
+    --------
+    transpose
 
     """))
 


### PR DESCRIPTION
`ndarray.T` is simply a shorthand of `transpose` without `axes` option.
`PyArray_Transpose` returns a new view of the input array, regardless of
`ndim`.

Close #13094.