### PR TITLE
DOC: fix references in docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -n -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
         dist dist-build gitwash-update

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -n -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
         dist dist-build gitwash-update

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -821,17 +821,17 @@ Dealing with types
 General check of Python Type
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. c:function:: PyArray_Check(op)
+.. c:function:: PyArray_Check(PyObject *op)
 
     Evaluates true if *op* is a Python object whose type is a sub-type
     of :c:data:`PyArray_Type`.
 
-.. c:function:: PyArray_CheckExact(op)
+.. c:function:: PyArray_CheckExact(PyObject *op)
 
     Evaluates true if *op* is a Python object with type
     :c:data:`PyArray_Type`.
 
-.. c:function:: PyArray_HasArrayInterface(op, out)
+.. c:function:: PyArray_HasArrayInterface(PyObject *op, PyObject *out)
 
     If ``op`` implements any part of the array interface, then ``out``
     will contain a new reference to the newly created ndarray using
@@ -3261,19 +3261,19 @@ Memory management
     Macros to allocate, free, and reallocate memory. These macros are used
     internally to create arrays.
 
-.. c:function:: npy_intp*  PyDimMem_NEW(nd)
+.. c:function:: npy_intp*  PyDimMem_NEW(int nd)
 
-.. c:function:: PyDimMem_FREE(npy_intp* ptr)
+.. c:function:: PyDimMem_FREE(char* ptr)
 
-.. c:function:: npy_intp* PyDimMem_RENEW(npy_intp* ptr, npy_intp newnd)
+.. c:function:: npy_intp* PyDimMem_RENEW(void* ptr, size_t newnd)
 
     Macros to allocate, free, and reallocate dimension and strides memory.
 
-.. c:function:: PyArray_malloc(nbytes)
+.. c:function:: void* PyArray_malloc(size_t nbytes)
 
-.. c:function:: PyArray_free(ptr)
+.. c:function:: PyArray_free(void* ptr)
 
-.. c:function:: PyArray_realloc(ptr, nbytes)
+.. c:function:: void* PyArray_realloc(npy_intp* ptr, size_t nbytes)
 
     These macros use different memory allocators, depending on the
     constant :c:data:`NPY_USE_PYMEM`. The system malloc is used when
@@ -3475,31 +3475,31 @@ Other constants
 Miscellaneous Macros
 ^^^^^^^^^^^^^^^^^^^^
 
-.. c:function:: PyArray_SAMESHAPE(a1, a2)
+.. c:function:: PyArray_SAMESHAPE(PyArrayObject *a1, PyArrayObject *a2)
 
     Evaluates as True if arrays *a1* and *a2* have the same shape.
 
-.. c:function:: PyArray_MAX(a,b)
+.. c:macro:: PyArray_MAX(a,b)
 
     Returns the maximum of *a* and *b*. If (*a*) or (*b*) are
     expressions they are evaluated twice.
 
-.. c:function:: PyArray_MIN(a,b)
+.. c:macro:: PyArray_MIN(a,b)
 
     Returns the minimum of *a* and *b*. If (*a*) or (*b*) are
     expressions they are evaluated twice.
 
-.. c:function:: PyArray_CLT(a,b)
+.. c:macro:: PyArray_CLT(a,b)
 
-.. c:function:: PyArray_CGT(a,b)
+.. c:macro:: PyArray_CGT(a,b)
 
-.. c:function:: PyArray_CLE(a,b)
+.. c:macro:: PyArray_CLE(a,b)
 
-.. c:function:: PyArray_CGE(a,b)
+.. c:macro:: PyArray_CGE(a,b)
 
-.. c:function:: PyArray_CEQ(a,b)
+.. c:macro:: PyArray_CEQ(a,b)
 
-.. c:function:: PyArray_CNE(a,b)
+.. c:macro:: PyArray_CNE(a,b)
 
     Implements the complex comparisons between two complex numbers
     (structures with a real and imag member) using NumPy's definition

--- a/doc/source/reference/c-api.dtype.rst
+++ b/doc/source/reference/c-api.dtype.rst
@@ -308,13 +308,45 @@ to the front of the integer name.
 
     (unsigned) char
 
-.. c:type:: npy_(u)short
+.. c:type:: npy_short
 
-    (unsigned) short
+    short
 
-.. c:type:: npy_(u)int
+.. c:type:: npy_ushort
 
-    (unsigned) int
+    unsigned short
+
+.. c:type:: npy_uint
+
+    unsigned int
+
+.. c:type:: npy_int
+
+    int
+
+.. c:type:: npy_int16
+
+    16-bit integer
+
+.. c:type:: npy_uint16
+
+    16-bit unsigned integer
+
+.. c:type:: npy_int32
+
+    32-bit integer
+
+.. c:type:: npy_uint32
+
+    32-bit unsigned integer
+
+.. c:type:: npy_int64
+
+    64-bit integer
+
+.. c:type:: npy_uint64
+
+    64-bit unsigned integer
 
 .. c:type:: npy_(u)long
 
@@ -324,22 +356,31 @@ to the front of the integer name.
 
     (unsigned long long int)
 
-.. c:type:: npy_(u)intp
+.. c:type:: npy_intp
 
-    (unsigned) Py_intptr_t (an integer that is the size of a pointer on
+    Py_intptr_t (an integer that is the size of a pointer on
+    the platform).
+
+.. c:type:: npy_uintp
+
+    unsigned Py_intptr_t (an integer that is the size of a pointer on
     the platform).
 
 
 (Complex) Floating point
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. c:type:: npy_half
+
+    16-bit float
+
 .. c:type:: npy_(c)float
 
-    float
+    32-bit float
 
 .. c:type:: npy_(c)double
 
-    double
+    64-bit double
 
 .. c:type:: npy_(c)longdouble
 


### PR DESCRIPTION
Turning on `-n` in `sphinx-build` results in over 1000 warnings about bad references in docs. Trying to break these down with various grep statements, it seems about 200 are from `numpy.ma`, about 150 from `polynomial` and about 150 from `c:type`. That is under half of the WARNINGS. 

My workflow is to run
```
(cd ..; pip install .); make clean; make html 2>&1 |tee /tmp/build.txt
less /tmp/build.txt
```
and look for the most common lines. Unfortunately this takes quite a while.

Anyone who wishes to contribute can issue PRs against the `doc-references` branch in numpy/mattip. I have marked this as Easy since many of the WARNINGS are quite easy to fix. The first commit gives an idea of some of the problems in the c-api documentation.

Reviewers can get an idea of how bad things are by looking at the circle-ci devdoc build step.