### PR TITLE
Prevent traceback chaining in _wrapfunc.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -52,17 +52,20 @@ def _wrapit(obj, method, *args, **kwds):
 
 
 def _wrapfunc(obj, method, *args, **kwds):
+    bound = getattr(obj, method, None)
+    if bound is None:
+        return _wrapit(obj, method, *args, **kwds)
+
     try:
-        return getattr(obj, method)(*args, **kwds)
-
-    # An AttributeError occurs if the object does not have
-    # such a method in its class.
-
-    # A TypeError occurs if the object does have such a method
-    # in its class, but its signature is not identical to that
-    # of NumPy's. This situation has occurred in the case of
-    # a downstream library like 'pandas'.
-    except (AttributeError, TypeError):
+        return bound(*args, **kwds)
+    except TypeError:
+        # A TypeError occurs if the object does have such a method in its
+        # class, but its signature is not identical to that of NumPy's. This
+        # situation has occurred in the case of a downstream library like
+        # 'pandas'.
+        #
+        # Call _wrapit from within the except clause to ensure a potential
+        # exception has a traceback chain.
         return _wrapit(obj, method, *args, **kwds)
 
 


### PR DESCRIPTION
The traceback of `np.reshape([1, 2, 3], 2)` is shortened from
```
Traceback (most recent call last):
  File ".../numpy/core/fromnumeric.py", line 56, in _wrapfunc
    return getattr(obj, method)(*args, **kwds)
AttributeError: 'list' object has no attribute 'reshape'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../numpy/core/overrides.py", line 151, in public_api
    implementation, public_api, relevant_args, args, kwargs)
  File ".../numpy/core/fromnumeric.py", line 296, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File ".../numpy/core/fromnumeric.py", line 66, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File ".../numpy/core/fromnumeric.py", line 46, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
ValueError: cannot reshape array of size 3 into shape (2,)
```
to
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../numpy/core/overrides.py", line 151, in public_api
    implementation, public_api, relevant_args, args, kwargs)
  File ".../numpy/core/fromnumeric.py", line 300, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File ".../numpy/core/fromnumeric.py", line 70, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File ".../numpy/core/fromnumeric.py", line 46, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
ValueError: cannot reshape array of size 3 into shape (2,)
```

(The chained exception is really just an implementation detail.)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
