### PR TITLE
MAINT: Unify polydiv

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -225,15 +225,15 @@ def _zseries_div(z1, z2):
     """
     z1 = z1.copy()
     z2 = z2.copy()
-    len1 = len(z1)
-    len2 = len(z2)
-    if len2 == 1:
+    lc1 = len(z1)
+    lc2 = len(z2)
+    if lc2 == 1:
         z1 /= z2
         return z1, z1[:1]*0
-    elif len1 < len2:
+    elif lc1 < lc2:
         return z1[:1]*0, z1
     else:
-        dlen = len1 - len2
+        dlen = lc1 - lc2
         scl = z2[0]
         z2 /= scl
         quo = np.empty(dlen + 1, dtype=z1.dtype)
@@ -244,16 +244,16 @@ def _zseries_div(z1, z2):
             quo[i] = z1[i]
             quo[dlen - i] = r
             tmp = r*z2
-            z1[i:i+len2] -= tmp
-            z1[j:j+len2] -= tmp
+            z1[i:i+lc2] -= tmp
+            z1[j:j+lc2] -= tmp
             i += 1
             j -= 1
         r = z1[i]
         quo[i] = r
         tmp = r*z2
-        z1[i:i+len2] -= tmp
+        z1[i:i+lc2] -= tmp
         quo /= scl
-        rem = z1[i+1:i-1+len2].copy()
+        rem = z1[i+1:i-1+lc2].copy()
         return quo, rem
 
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -793,6 +793,7 @@ def chebdiv(c1, c2):
     if c2[-1] == 0:
         raise ZeroDivisionError()
 
+    # note: this is more efficient than `pu._div(chebmul, c1, c2)`
     lc1 = len(c1)
     lc2 = len(c2)
     if lc1 < lc2:

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -550,26 +550,7 @@ def hermdiv(c1, c2):
     (array([1., 2., 3.]), array([1., 1.]))
 
     """
-    # c1, c2 are trimmed copies
-    [c1, c2] = pu.as_series([c1, c2])
-    if c2[-1] == 0:
-        raise ZeroDivisionError()
-
-    lc1 = len(c1)
-    lc2 = len(c2)
-    if lc1 < lc2:
-        return c1[:1]*0, c1
-    elif lc2 == 1:
-        return c1/c2[-1], c1[:1]*0
-    else:
-        quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
-        rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
-            p = hermmul([0]*i + [1], c2)
-            q = rem[-1]/p[-1]
-            rem = rem[:-1] - q*p[:-1]
-            quo[i] = q
-        return quo, pu.trimseq(rem)
+    return pu._div(hermmul, c1, c2)
 
 
 def hermpow(c, pow, maxpower=16):

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -545,26 +545,7 @@ def hermediv(c1, c2):
     (array([1., 2., 3.]), array([1., 2.]))
 
     """
-    # c1, c2 are trimmed copies
-    [c1, c2] = pu.as_series([c1, c2])
-    if c2[-1] == 0:
-        raise ZeroDivisionError()
-
-    lc1 = len(c1)
-    lc2 = len(c2)
-    if lc1 < lc2:
-        return c1[:1]*0, c1
-    elif lc2 == 1:
-        return c1/c2[-1], c1[:1]*0
-    else:
-        quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
-        rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
-            p = hermemul([0]*i + [1], c2)
-            q = rem[-1]/p[-1]
-            rem = rem[:-1] - q*p[:-1]
-            quo[i] = q
-        return quo, pu.trimseq(rem)
+    return pu._div(hermemul, c1, c2)
 
 
 def hermepow(c, pow, maxpower=16):

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -547,26 +547,7 @@ def lagdiv(c1, c2):
     (array([1., 2., 3.]), array([1., 1.]))
 
     """
-    # c1, c2 are trimmed copies
-    [c1, c2] = pu.as_series([c1, c2])
-    if c2[-1] == 0:
-        raise ZeroDivisionError()
-
-    lc1 = len(c1)
-    lc2 = len(c2)
-    if lc1 < lc2:
-        return c1[:1]*0, c1
-    elif lc2 == 1:
-        return c1/c2[-1], c1[:1]*0
-    else:
-        quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
-        rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
-            p = lagmul([0]*i + [1], c2)
-            q = rem[-1]/p[-1]
-            rem = rem[:-1] - q*p[:-1]
-            quo[i] = q
-        return quo, pu.trimseq(rem)
+    return pu._div(lagmul, c1, c2)
 
 
 def lagpow(c, pow, maxpower=16):

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -590,26 +590,7 @@ def legdiv(c1, c2):
     (array([-0.07407407,  1.66666667]), array([-1.03703704, -2.51851852])) # may vary
 
     """
-    # c1, c2 are trimmed copies
-    [c1, c2] = pu.as_series([c1, c2])
-    if c2[-1] == 0:
-        raise ZeroDivisionError()
-
-    lc1 = len(c1)
-    lc2 = len(c2)
-    if lc1 < lc2:
-        return c1[:1]*0, c1
-    elif lc2 == 1:
-        return c1/c2[-1], c1[:1]*0
-    else:
-        quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
-        rem = c1
-        for i in range(lc1 - lc2, - 1, -1):
-            p = legmul([0]*i + [1], c2)
-            q = rem[-1]/p[-1]
-            rem = rem[:-1] - q*p[:-1]
-            quo[i] = q
-        return quo, pu.trimseq(rem)
+    return pu._div(legmul, c1, c2)
 
 
 def legpow(c, pow, maxpower=16):

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -397,18 +397,18 @@ def polydiv(c1, c2):
     if c2[-1] == 0:
         raise ZeroDivisionError()
 
-    len1 = len(c1)
-    len2 = len(c2)
-    if len2 == 1:
-        return c1/c2[-1], c1[:1]*0
-    elif len1 < len2:
+    lc1 = len(c1)
+    lc2 = len(c2)
+    if lc1 < lc2:
         return c1[:1]*0, c1
+    elif lc2 == 1:
+        return c1/c2[-1], c1[:1]*0
     else:
-        dlen = len1 - len2
+        dlen = lc1 - lc2
         scl = c2[-1]
         c2 = c2[:-1]/scl
         i = dlen
-        j = len1 - 1
+        j = lc1 - 1
         while i >= 0:
             c1[i:j] -= c2*c1[j]
             i -= 1

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -397,6 +397,7 @@ def polydiv(c1, c2):
     if c2[-1] == 0:
         raise ZeroDivisionError()
 
+    # note: this is more efficient than `pu._div(polymul, c1, c2)`
     lc1 = len(c1)
     lc2 = len(c2)
     if lc1 < lc2:

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -537,3 +537,39 @@ def _gridnd(val_f, c, *args):
     for xi in args:
         c = val_f(xi, c)
     return c
+
+
+def _div(mul_f, c1, c2):
+    """
+    Helper function used to implement the ``<type>div`` functions.
+
+    Implementation uses repeated subtraction of c2 multiplied by the nth basis.
+    For some polynomial types, a more efficient approach may be possible.
+
+    Parameters
+    ----------
+    mul_f : function(array_like, array_like) -> array_like
+        The ``<type>mul`` function, such as ``polymul``
+    c1, c2 :
+        See the ``<type>div`` functions for more detail
+    """
+    # c1, c2 are trimmed copies
+    [c1, c2] = as_series([c1, c2])
+    if c2[-1] == 0:
+        raise ZeroDivisionError()
+
+    lc1 = len(c1)
+    lc2 = len(c2)
+    if lc1 < lc2:
+        return c1[:1]*0, c1
+    elif lc2 == 1:
+        return c1/c2[-1], c1[:1]*0
+    else:
+        quo = np.empty(lc1 - lc2 + 1, dtype=c1.dtype)
+        rem = c1
+        for i in range(lc1 - lc2, - 1, -1):
+            p = mul_f([0]*i + [1], c2)
+            q = rem[-1]/p[-1]
+            rem = rem[:-1] - q*p[:-1]
+            quo[i] = q
+        return quo, trimseq(rem)


### PR DESCRIPTION
Also found by LGTM.

While this does generalize to all polynomial types, `cheb` and `poly` have some optimizations that may as well be left alone. This does adjust the variable names in those optimizations to be a little more consistent (in a separate commit).

cc @charris, since this is now the 4th PR like this of mine you've looked at (#13107, #13078, #13079)

