### PR TITLE
DOC: Fix arg type for np.pad, fix #9489

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1026,7 +1026,7 @@ def pad(array, pad_width, mode, **kwargs):
         length for all axes.
 
         Default is ``None``, to use the entire axis.
-    constant_values : sequence or int, optional
+    constant_values : sequence or scalar, optional
         Used in 'constant'.  The values to set the padded values for each
         axis.
 
@@ -1040,7 +1040,7 @@ def pad(array, pad_width, mode, **kwargs):
         all axes.
 
         Default is 0.
-    end_values : sequence or int, optional
+    end_values : sequence or scalar, optional
         Used in 'linear_ramp'.  The values used for the ending value of the
         linear_ramp and that will form the edge of the padded array.
 

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1030,13 +1030,13 @@ def pad(array, pad_width, mode, **kwargs):
         Used in 'constant'.  The values to set the padded values for each
         axis.
 
-        ((before_1, after_1), ... (before_N, after_N)) unique pad constants
+        ``((before_1, after_1), ... (before_N, after_N))`` unique pad constants
         for each axis.
 
-        ((before, after),) yields same before and after constants for each
+        ``((before, after),)`` yields same before and after constants for each
         axis.
 
-        (constant,) or int is a shortcut for before = after = constant for
+        ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
         all axes.
 
         Default is 0.
@@ -1044,13 +1044,13 @@ def pad(array, pad_width, mode, **kwargs):
         Used in 'linear_ramp'.  The values used for the ending value of the
         linear_ramp and that will form the edge of the padded array.
 
-        ((before_1, after_1), ... (before_N, after_N)) unique end values
+        ``((before_1, after_1), ... (before_N, after_N))`` unique end values
         for each axis.
 
-        ((before, after),) yields same before and after end values for each
+        ``((before, after),)`` yields same before and after end values for each
         axis.
 
-        (constant,) or int is a shortcut for before = after = end value for
+        ``(constant,)`` or ``constant`` is a shortcut for ``before = after = constant`` for
         all axes.
 
         Default is 0.


### PR DESCRIPTION
Both the `constant_values` and `end_values` arguments can have non-integer numerical types. The example in #9489 works, as does:
```python
>>> import numpy as np
>>> arr = np.array([1.0, 2.0, 3.0])
>>> np.pad(arr, (5, 5), mode='linear_ramp', end_values=(np.float32(5.0),np.float32(-4.0)))
array([ 5. ,  4.2,  3.4,  2.6,  1.8,  1. ,  2. ,  3. ,  1.6,  0.2, -1.2,
       -2.6, -4. ])
```