### PR TITLE
BUG: Fix unhandled exception in CBLAS detection

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1743,6 +1743,8 @@ class blas_info(system_info):
                     res = "blas"
             except distutils.ccompiler.CompileError:
                 res = None
+            except distutils.ccompiler.LinkError:
+                res = None
         finally:
             shutil.rmtree(tmpdir)
         return res


### PR DESCRIPTION
BUG: unhandled exception in CBLAS detection

In the function "has_cblas", it tries firstly to link to libcblas, if encountering linker error, it tries to link to libblas. When the second link fails, an exception distutils.ccompiler.LinkError will not be handled.
If neither libcblas or libblas is linkable,  it consider CBLAS is inexistent, avoiding unhandled exception.


