### PR TITLE
DOC: Tidy 1.17.0 release note newlines

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -20,10 +20,10 @@ Deprecations
 
 Deprecate ``numpy.distutils.exec_command`` and ``numpy.distutils.temp_file_name``
 ---------------------------------------------------------------------------------
-
 The internal use of these functions has been refactored and there are better
 alternatives. Relace ``exec_command`` with `subprocess.Popen` and
 ``temp_file_name`` with `tempfile.mkstemp`.
+
 
 Future Changes
 ==============
@@ -44,7 +44,6 @@ now be rounded up instead of down, changing the last bit (ULP) of the result.
 
 Signed zero when using divmod
 -----------------------------
-
 Starting in version 1.12.0, numpy incorrectly returned a negatively signed zero
 when using the ``divmod`` and ``floor_divide`` functions when the result was
 zero. For example::
@@ -60,10 +59,10 @@ zero::
 
 Do not lookup ``__buffer__`` attribute in `numpy.frombuffer`
 ------------------------------------------------------------
-
 Looking up ``__buffer__`` attribute in `numpy.frombuffer` was undocumented and
 non-functional. This code was removed. If needed, use
 ``frombuffer(memoryview(obj), ...)`` instead.
+
 
 C API changes
 =============
@@ -101,7 +100,6 @@ available bits add zero padding. Negative counts trim bits off the end instead
 of counting from the beginning. None counts implement the existing behavior of
 unpacking everything.
 
-
 ``np.linalg.svd`` and ``np.linalg.pinv`` can be faster on hermitian inputs
 --------------------------------------------------------------------------
 These functions now accept a ``hermitian`` argument, matching the one added
@@ -126,7 +124,6 @@ tolerances.
 
 Replacement of the `fftpack`-based FFT module by the `pocketfft` library
 ------------------------------------------------------------------------
-
 Both implementations have the same ancestor (Fortran77 `FFTPACK` by Paul N.
 Swarztrauber), but `pocketfft` contains additional modifications which
 improve both accuracy and performance in some circumstances. For FFT lengths
@@ -176,7 +173,6 @@ Changes
 
 ``median`` and ``percentile`` family of functions no longer warn about ``nan``
 ------------------------------------------------------------------------------
-
 `numpy.median`, `numpy.percentile`, and `numpy.quantile` used to emit a
 ``RuntimeWarning`` when encountering an `numpy.nan`. Since they return the
 ``nan`` value, the warning is redundant and has been removed.


### PR DESCRIPTION
I've found that automatic merges seem to go better if there are no blank lines between headers and the content below them.

This is consistent with the older release notes anyway

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
