### PR TITLE
ENH: Implement setting the number of threads used by BLAS

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2755,7 +2755,7 @@ def _multi_dot(arrays, order, i, j):
 
 
 _noop_set_num_threads = lambda *args, **kwargs: None
-_noop_get_num_threads = lambda *args, **kwargs: 1
+_noop_get_num_threads = lambda *args, **kwargs: -1
 
 if cdll is None:
     set_num_threads = set_module('numpy.linalg')(_noop_set_num_threads)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -21,6 +21,7 @@ import functools
 import operator
 import warnings
 import contextlib
+import sys
 
 try:
     from ctypes import cdll, c_int
@@ -40,6 +41,7 @@ from numpy.core.overrides import set_module
 from numpy.core import overrides
 from numpy.lib.twodim_base import triu, eye
 from numpy.linalg import lapack_lite, _umath_linalg
+from numpy import __config__
 
 
 array_function_dispatch = functools.partial(
@@ -2776,7 +2778,14 @@ else:
         """
         _set_num_threads = _cached_threads_funcs[0]
         if _set_num_threads is None:
-            blas = cdll[lapack_lite.__file__]
+            if sys.platform == 'win32':
+                # On Windows, we have to check BLAS dll
+                try:
+                    blas = cdll[__config__.blas_opt_info['libraries'][0]]
+                except Exception:
+                    blas = None
+            else:
+                blas = cdll[lapack_lite.__file__]
             if blas is None:
                 _set_num_threads = _noop_set_num_threads
             else:
@@ -2802,7 +2811,14 @@ else:
         """
         _get_num_threads = _cached_threads_funcs[1]
         if _get_num_threads is None:
-            blas = cdll[lapack_lite.__file__]
+            if sys.platform == 'win32':
+                # On Windows, we have to check BLAS dll
+                try:
+                    blas = cdll[__config__.blas_opt_info['libraries'][0]]
+                except Exception:
+                    blas = None
+            else:
+                blas = cdll[lapack_lite.__file__]
             if blas is None:
                 _get_num_threads = _noop_get_num_threads
             else:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2002,3 +2002,17 @@ def test_unsupported_commontype():
     arr = np.array([[1, -2], [2, 5]], dtype='float16')
     with assert_raises_regex(TypeError, "unsupported in linalg"):
         linalg.cholesky(arr)
+
+class TestThreads(object):
+
+    def test_set_threads(self):
+        old_threads = linalg.get_num_threads()
+        linalg.set_num_threads(1)
+        new_threads = linalg.get_num_threads()
+        linalg.set_num_threads(old_threads)
+        assert_equal(new_threads, 1)
+
+    def test_num_threads(self):
+        with linalg.num_threads(1):
+            new_threads = linalg.get_num_threads()
+        assert_equal(new_threads, 1)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2007,12 +2007,16 @@ class TestThreads(object):
 
     def test_set_threads(self):
         old_threads = linalg.get_num_threads()
+        if old_threads < 0:
+            pytest.skip("Cannot change number of BLAS threads.")
         linalg.set_num_threads(1)
         new_threads = linalg.get_num_threads()
         linalg.set_num_threads(old_threads)
         assert_equal(new_threads, 1)
 
     def test_num_threads(self):
+        if linalg.get_num_threads() < 0:
+            pytest.skip("Cannot change number of BLAS threads.")
         with linalg.num_threads(1):
             new_threads = linalg.get_num_threads()
         assert_equal(new_threads, 1)


### PR DESCRIPTION
This commit adds the following methods in numpy.linalg:
 * get_num_threads() returns the number of threads used by BLAS.
 * set_num_threads(n) sets the number of threads which will be used
   by further calls to BLAS.
 * num_threads(n) is a context manager to temporarily change the
   number of threads which will be used by BLAS.

Closes: #11826

OpenBLAS and MKL are supported.  It is possible to globally change
the number of threads via environment variables, but it is sometimes
desirable to temporarily lower the number of threads if this improves
performance.