### PR TITLE
BUG: Fix build for glibc on ARC and uclibc.

### DIFF
--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -681,7 +681,8 @@ void npy_set_floatstatus_invalid(void)
     fp_raise_xcp(FP_INVALID);
 }
 
-#elif defined(_MSC_VER) || (defined(__osf__) && defined(__alpha))
+#elif defined(_MSC_VER) || (defined(__osf__) && defined(__alpha)) || \
+      defined (__UCLIBC__)
 
 /*
  * By using a volatile floating point value,

--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -682,7 +682,7 @@ void npy_set_floatstatus_invalid(void)
 }
 
 #elif defined(_MSC_VER) || (defined(__osf__) && defined(__alpha)) || \
-      defined (__UCLIBC__)
+      defined (__UCLIBC__) || (defined(__arc__) && defined(__GLIBC__))
 
 /*
  * By using a volatile floating point value,


### PR DESCRIPTION
fenv.h is not available on uclibc, arc architecture on glibc does not support FPU exceptions
