### PR TITLE
BUG: Fix testsuite failures on ppc and riscv

### DIFF
--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -422,7 +422,7 @@ class TestConversion(object):
 
     @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                         reason="long double is same as double")
-    @pytest.mark.skipif(platform.machine().startswith("ppc64"),
+    @pytest.mark.skipif(platform.machine().startswith("ppc"),
                         reason="IBM double double")
     def test_int_from_huge_longdouble(self):
         # Produce a longdouble that would overflow a double,

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2399,7 +2399,7 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'power', 'ppc64', 's390x', 'sparc')):
+    if machine.startswith(('aarch64', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
         if p <= 20:
             return 16
     else:


### PR DESCRIPTION
Backport  of #13095.

<https://build.opensuse.org/package/live_build_log/openSUSE:Factory:PowerPC/python-numpy/standard/ppc>:

=================================== FAILURES ===================================
_________________ TestConversion.test_int_from_huge_longdouble _________________

self = <numpy.core.tests.test_scalarmath.TestConversion object at 0xef02fef0>

    @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                        reason="long double is same as double")
    @pytest.mark.skipif(platform.machine().startswith("ppc64"),
                        reason="IBM double double")
    def test_int_from_huge_longdouble(self):
        # Produce a longdouble that would overflow a double,
        # use exponent that avoids bug in Darwin pow function.
        exp = np.finfo(np.double).maxexp - 1
>       huge_ld = 2 * 1234 * np.longdouble(2) ** exp
E       RuntimeWarning: overflow encountered in longdouble_scalars

exp        = 1023
self       = <numpy.core.tests.test_scalarmath.TestConversion object at 0xef02fef0>

../../../BUILDROOT/python-numpy-1.16.1-3.1.ppc/usr/lib/python2.7/site-packages/numpy/core/tests/test_scalarmath.py:431: RuntimeWarning
______________________________ TestKind.test_all _______________________________

self = <numpy.f2py.tests.test_kind.TestKind object at 0xeede8d50>

    @pytest.mark.slow
    def test_all(self):
        selectedrealkind = self.module.selectedrealkind
        selectedintkind = self.module.selectedintkind
    
        for i in range(40):
            assert_(selectedintkind(i) in [selected_int_kind(i), -1],
                    'selectedintkind(%s): expected %r but got %r' %
                    (i, selected_int_kind(i), selectedintkind(i)))
    
        for i in range(20):
            assert_(selectedrealkind(i) in [selected_real_kind(i), -1],
                    'selectedrealkind(%s): expected %r but got %r' %
>                   (i, selected_real_kind(i), selectedrealkind(i)))
E           AssertionError: selectedrealkind(16): expected 10 but got 16

i          = 16
selectedintkind = <fortran object>
selectedrealkind = <fortran object>
self       = <numpy.f2py.tests.test_kind.TestKind object at 0xeede8d50>

../../../BUILDROOT/python-numpy-1.16.1-3.1.ppc/usr/lib/python2.7/site-packages/numpy/f2py/tests/test_kind.py:34: AssertionError
= 2 failed, 7227 passed, 132 skipped, 11 xfailed, 2 xpassed in 490.92 seconds ==
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
