### PR TITLE
BUG: __array_interface__ offset was always ignored

### DIFF
--- a/doc/release/1.16.3-notes.rst
+++ b/doc/release/1.16.3-notes.rst
@@ -41,3 +41,8 @@ Improvements
 
 Changes
 =======
+
+``__array_interface__`` offset now works as documented
+------------------------------------------------------
+The interface may use an ``offset`` value that was mistakenly ignored.
+

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2481,7 +2481,7 @@ PyArray_FromInterface(PyObject *origin)
         }
 #endif
         /* Get offset number from interface specification */
-        attr = PyDict_GetItemString(origin, "offset");
+        attr = PyDict_GetItemString(iface, "offset");
         if (attr) {
             npy_longlong num = PyLong_AsLongLong(attr);
             if (error_converting(num)) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7102,6 +7102,22 @@ def test_array_interface_empty_shape():
     assert_equal(arr1, arr2)
     assert_equal(arr1, arr3)
 
+def test_array_interface_offset():
+    arr = np.array([1, 2, 3], dtype='int32')
+    interface = dict(arr.__array_interface__)
+    if sys.version_info[0] < 3:
+        interface['data'] = buffer(arr)
+    else:
+        interface['data'] = memoryview(arr)
+    interface['shape'] = (2,)
+    interface['offset'] = 4
+
+
+    class DummyArray(object):
+        __array_interface__ = interface
+
+    arr1 = np.asarray(DummyArray())
+    assert_equal(arr1, arr[1:])
 
 def test_flat_element_deletion():
     it = np.ones(3).flat


### PR DESCRIPTION
Backport of #13036.

[`__array_interface__`](https://6063-908607-gh.circle-artifacts.com/0/home/circleci/repo/doc/build/html/reference/arrays.interface.html#python-side) can accept an optional `offset` value when `data` is `None` or a `buffer`. Due to a bug, the key was looked for on the object rather than it's interface `dict`. Since `PyDict_GetItemString` first checks if the object is a `PyDictObject`, the lookup would always fail.

Searching for open issues about `offset` did not yield anything that looked like this was reported.

Added a test and a comment in the release notes.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
