### PR TITLE
DOC: correction to numpy.pad docstring

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1146,7 +1146,6 @@ def pad(array, pad_width, mode='constant', **kwargs):
     ...     pad_value = kwargs.get('padder', 10)
     ...     vector[:pad_width[0]] = pad_value
     ...     vector[-pad_width[1]:] = pad_value
-    ...     return
     >>> a = np.arange(6)
     >>> a = a.reshape((2, 3))
     >>> np.pad(a, 2, pad_with)

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1075,9 +1075,8 @@ def pad(array, pad_width, mode='constant', **kwargs):
     think about with a rank 2 array where the corners of the padded array
     are calculated by using padded values from the first axis.
 
-    The padding function, if used, should return a rank 1 array equal in
-    length to the vector argument with padded values replaced. It has the
-    following signature::
+    The padding function, if used, should modify a rank 1 array in-place. It
+    has the following signature::
 
         padding_func(vector, iaxis_pad_width, iaxis, kwargs)
 
@@ -1147,7 +1146,7 @@ def pad(array, pad_width, mode='constant', **kwargs):
     ...     pad_value = kwargs.get('padder', 10)
     ...     vector[:pad_width[0]] = pad_value
     ...     vector[-pad_width[1]:] = pad_value
-    ...     return vector
+    ...     return
     >>> a = np.arange(6)
     >>> a = a.reshape((2, 3))
     >>> np.pad(a, 2, pad_with)

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -1084,7 +1084,7 @@ def pad(array, pad_width, mode='constant', **kwargs):
 
         vector : ndarray
             A rank 1 array already padded with zeros.  Padded values are
-            vector[:pad_tuple[0]] and vector[-pad_tuple[1]:].
+            vector[:iaxis_pad_width[0]] and vector[-iaxis_pad_width[1]:].
         iaxis_pad_width : tuple
             A 2-tuple of ints, iaxis_pad_width[0] represents the number of
             values padded at the beginning of vector where

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1124,7 +1124,6 @@ def test_legacy_vector_functionality():
     def _padwithtens(vector, pad_width, iaxis, kwargs):
         vector[:pad_width[0]] = 10
         vector[-pad_width[1]:] = 10
-        return
 
     a = np.arange(6).reshape(2, 3)
     a = np.pad(a, 2, _padwithtens)

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1124,7 +1124,7 @@ def test_legacy_vector_functionality():
     def _padwithtens(vector, pad_width, iaxis, kwargs):
         vector[:pad_width[0]] = 10
         vector[-pad_width[1]:] = 10
-        return vector
+        return
 
     a = np.arange(6).reshape(2, 3)
     a = np.pad(a, 2, _padwithtens)


### PR DESCRIPTION
When a custom function is provided to `numpy.pad`, the docstring states that this function should return a rank 1 vector.  However, it actually seems that it is required that the rank 1 vector input be modified in-place and it is not necessary to return an array.

I also updated a test case to make sure it is consistent with the modified description proposed here.

Two slight modifications to the example from the docstring illustrate this behavior.

1.) Padding fails if a copy of `vector` is made internally:

```Python
def pad_with(vector, pad_width, iaxis, kwargs):
    pad_value = kwargs.get('padder', 10)
    vector = vector.copy()
    vector[:pad_width[0]] = pad_value
    vector[-pad_width[1]:] = pad_value
    return vector
a = np.arange(6)
a = a.reshape((2, 3))
np.pad(a, 2, pad_with)
```
> Out:
   array([[0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 1, 2, 0, 0],
       [0, 0, 3, 4, 5, 0, 0],
       [0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0]])


2.) Padding works if modification is done in-place, even without any return value:
```Python
def pad_with(vector, pad_width, iaxis, kwargs):
    pad_value = kwargs.get('padder', 10)
    vector[:pad_width[0]] = pad_value
    vector[-pad_width[1]:] = pad_value
    return
a = np.arange(6)
a = a.reshape((2, 3))
np.pad(a, 2, pad_with)
```
> Out:
array([[10, 10, 10, 10, 10, 10, 10],
       [10, 10, 10, 10, 10, 10, 10],
       [10, 10,  0,  1,  2, 10, 10],
       [10, 10,  3,  4,  5, 10, 10],
       [10, 10, 10, 10, 10, 10, 10],
       [10, 10, 10, 10, 10, 10, 10]])
