### PR TITLE
DOC, BUILD: fail the devdoc build if there are warnings

### DIFF
--- a/doc/DISTUTILS.rst.txt
+++ b/doc/DISTUTILS.rst.txt
@@ -319,11 +319,7 @@ and :c:data:`/**end repeat**/` lines, which may also be nested using
 consecutively numbered delimiting lines such as :c:data:`/**begin repeat1`
 and :c:data:`/**end repeat1**/`. String replacement specifications are started
 and terminated using :c:data:`#`. This may be clearer in the following
-template source example:
-
-.. code-block:: C
-   :linenos:
-   :emphasize-lines: 3, 13, 29, 31
+template source example::
 
     /* TIMEDELTA to non-float types */
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,8 @@ FILES=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
+  $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
         dist dist-build gitwash-update

--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -18,11 +18,11 @@ New functions
 Deprecations
 ============
 
-``np.polynomial`` functions warn when passed ``float``s in place of ``int``s
-----------------------------------------------------------------------------
-Previously functions in this module would accept ``float``s provided their
-values were integral. For consistency with the rest of numpy, doing so is now
-deprecated, and in future will raise a ``TypeError``.
+``np.polynomial`` functions warn when passed ``float`` in place of ``int``
+--------------------------------------------------------------------------
+Previously functions in this module would accept ``float`` values provided they
+were integral (``1.0``, ``2.0``, etc). For consistency with the rest of numpy,
+doing so is now deprecated, and in future will raise a ``TypeError``.
 
 Similarly, passing a float like ``0.5`` in place of an integer will now raise a
 ``TypeError`` instead of the previous ``ValueError``.


### PR DESCRIPTION
We can turn on `-WT --keep-going` to fail the documentation build if there are any warnings. This might add to the burden of merging a PR since sometimes new warnings are hard to track down, but it would be better to handle them at the "source".

The next step is to turn on `-n` which currently generates warnings on hundreds of bad references. xref #13114