### PR TITLE
BUG: fix reference count error on invalid input to ndarray.flat

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -539,6 +539,7 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     char *dptr;
     int size;
     PyObject *obj = NULL;
+    PyObject *new;
     PyArray_CopySwapFunc *copyswap;
 
     if (ind == Py_Ellipsis) {
@@ -653,22 +654,23 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
         return (PyObject *)ret;
     }
 
-    /* Check for integer array */
-    if (PyArray_ISINTEGER((PyArrayObject *)obj)) {
-        PyObject *new;
-        Py_INCREF(indtype);
-        new = PyArray_FromAny(obj, indtype, 0, 0,
-                          NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
-        if (new == NULL) {
-            goto fail;
-        }
-        Py_DECREF(indtype);
-        Py_DECREF(obj);
-        obj = new;
-        new = iter_subscript_int(self, (PyArrayObject *)obj);
-        Py_DECREF(obj);
-        return new;
+    /* Only integer arrays left */
+    if (!PyArray_ISINTEGER((PyArrayObject *)obj)) {
+        goto fail;
     }
+
+    Py_INCREF(indtype);
+    new = PyArray_FromAny(obj, indtype, 0, 0,
+                      NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
+    if (new == NULL) {
+        goto fail;
+    }
+    Py_DECREF(indtype);
+    Py_DECREF(obj);
+    obj = new;
+    new = iter_subscript_int(self, (PyArrayObject *)obj);
+    Py_DECREF(obj);
+    return new;
 
 
  fail:

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -666,9 +666,6 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
         Py_DECREF(obj);
         return (PyObject *)ret;
     }
-    else {
-        Py_DECREF(indtype);
-    }
 
 
  fail:

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -640,31 +640,32 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
         obj = ind;
     }
 
-    if (PyArray_Check(obj)) {
-        /* Check for Boolean object */
-        if (PyArray_TYPE((PyArrayObject *)obj) == NPY_BOOL) {
-            ret = iter_subscript_Bool(self, (PyArrayObject *)obj);
-            Py_DECREF(indtype);
-        }
-        /* Check for integer array */
-        else if (PyArray_ISINTEGER((PyArrayObject *)obj)) {
-            PyObject *new;
-            new = PyArray_FromAny(obj, indtype, 0, 0,
-                              NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
-            if (new == NULL) {
-                goto fail;
-            }
-            Py_DECREF(obj);
-            obj = new;
-            new = iter_subscript_int(self, (PyArrayObject *)obj);
-            Py_DECREF(obj);
-            return new;
-        }
-        else {
+    /* Any remaining valid input is an array or has been turned into one */
+    if (!PyArray_Check(obj)) {
+        goto fail;
+    }
+
+    /* Check for Boolean array */
+    if (PyArray_TYPE((PyArrayObject *)obj) == NPY_BOOL) {
+        ret = iter_subscript_Bool(self, (PyArrayObject *)obj);
+        Py_DECREF(indtype);
+        Py_DECREF(obj);
+        return (PyObject *)ret;
+    }
+
+    /* Check for integer array */
+    if (PyArray_ISINTEGER((PyArrayObject *)obj)) {
+        PyObject *new;
+        new = PyArray_FromAny(obj, indtype, 0, 0,
+                          NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
+        if (new == NULL) {
             goto fail;
         }
         Py_DECREF(obj);
-        return (PyObject *)ret;
+        obj = new;
+        new = iter_subscript_int(self, (PyArrayObject *)obj);
+        Py_DECREF(obj);
+        return new;
     }
 
 

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -667,9 +667,7 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     }
     Py_DECREF(indtype);
     Py_DECREF(obj);
-    obj = new;
-    new = iter_subscript_int(self, (PyArrayObject *)obj);
-    Py_DECREF(obj);
+    Py_SETREF(new, iter_subscript_int(self, (PyArrayObject *)new));
     return new;
 
 

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -656,11 +656,13 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     /* Check for integer array */
     if (PyArray_ISINTEGER((PyArrayObject *)obj)) {
         PyObject *new;
+        Py_INCREF(indtype);
         new = PyArray_FromAny(obj, indtype, 0, 0,
                           NPY_ARRAY_FORCECAST | NPY_ARRAY_ALIGNED, NULL);
         if (new == NULL) {
             goto fail;
         }
+        Py_DECREF(indtype);
         Py_DECREF(obj);
         obj = new;
         new = iter_subscript_int(self, (PyArrayObject *)obj);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4881,12 +4881,13 @@ class TestFlat(object):
         rc_indtype = sys.getrefcount(indtype)
         for ind in inds:
             rc_ind = sys.getrefcount(ind)
-            try:
-                self.a.flat[ind]
-            except IndexError:
-                pass
-            assert_(sys.getrefcount(ind) == rc_ind)
-            assert_(sys.getrefcount(indtype) == rc_indtype)
+            for _ in range(100):
+                try:
+                    self.a.flat[ind]
+                except IndexError:
+                    pass
+            assert_(abs(sys.getrefcount(ind) - rc_ind) < 50)
+            assert_(abs(sys.getrefcount(indtype) - rc_indtype) < 50)
 
 
 class TestResize(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4873,6 +4873,21 @@ class TestFlat(object):
         assert_(e.flags.writebackifcopy is False)
         assert_(f.flags.writebackifcopy is False)
 
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_refcount(self):
+        # includes regression test for reference count error gh-13165
+        inds = [np.intp(0), np.array([True]*self.a.size), np.array([0]), None]
+        indtype = np.dtype(np.intp)
+        rc_indtype = sys.getrefcount(indtype)
+        for ind in inds:
+            rc_ind = sys.getrefcount(ind)
+            try:
+                self.a.flat[ind]
+            except IndexError:
+                pass
+            assert_(sys.getrefcount(ind) == rc_ind)
+            assert_(sys.getrefcount(indtype) == rc_indtype)
+
 
 class TestResize(object):
     def test_basic(self):


### PR DESCRIPTION
According to https://github.com/numpy/numpy/issues/13165 there's a reference count error when invalid inputs are given to `ndarray.flat`. The fix is to remove a superfluous `Py_DECREF` call in the invalid input case.

My reasoning for the fix is that [here](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L630) we get a new reference to the new dtype as `indtype`, but in case of blatantly invalid input (say, `None` or a string) we only enter [this block](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L638-L641) and then next [we decrease the refcount of `indtype`](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L669-L671). I believe the bug was caused by the double deallocation together with the final `Py_XDECREF` call at the end. The `else` branch I removed was only tripped in cases where the input was invalid (otherwise we either return from the corresponding `if` branch or jump to the `fail` label from there). In every valid case we return with either [calling `Py_DECREF(indtype)` exactly once](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L647) or [passing on its reference](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L652-L653), and in non-trivially-invalid cases [we used to skip the now-removed `else` branch](https://github.com/numpy/numpy/blob/251c526672f897543176b966229ecde96bb89a9d/numpy/core/src/multiarray/iterators.c#L663-L665).

I intended to add a regression test [as suggested by @seberg](https://github.com/numpy/numpy/issues/13165#issuecomment-475157997), but the bug causes a reference count error to be printed after the interpreter finishes. I don't know how I could test this (the `IndexError` is raised fine so a test would conclude just fine).

Closes https://github.com/numpy/numpy/issues/13165.