### PR TITLE
BUG: Fix of `var` method for complex arrays

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -115,10 +115,11 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
     x = asanyarray(arr - arrmean)
-    if not issubclass(arr.dtype.type, nt.integer):
-        x = um.multiply(x, um.conjugate(x), out=x).real
-    else:
+    if issubclass(arr.dtype.type, (nt.floating, nt.integer)):
         x = um.multiply(x, x, out=x)
+    else:
+        x = um.multiply(x, um.conjugate(x), out=x).real
+
     ret = umr_sum(x, axis, dtype, out, keepdims)
 
     # Compute degrees of freedom and make sure it is not negative.

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -115,7 +115,10 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
     x = asanyarray(arr - arrmean)
-    x = um.multiply(x,um.conjugate(x),out=x).real
+    if not issubclass(arr.dtype.type, nt.integer):
+        x = um.multiply(x, um.conjugate(x), out=x).real
+    else:
+        x = um.multiply(x, x, out=x)
     ret = umr_sum(x, axis, dtype, out, keepdims)
 
     # Compute degrees of freedom and make sure it is not negative.

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -115,10 +115,10 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
     x = asanyarray(arr - arrmean)
-    x = um.multiply(x,x,out=x)
-    ret = umr_sum(x,axis,dtype,out,keepdims)
+    x = um.multiply(x, x, out=x)
+    ret = umr_sum(x, axis, dtype, out, keepdims)
 
-    # Compute degrees of freedom and make sure it is not negative. 
+    # Compute degrees of freedom and make sure it is not negative.
     rcount = max([rcount - ddof, 0])
 
     # divide by degrees of freedom
@@ -129,6 +129,7 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         ret = ret.dtype.type(ret / rcount)
     else:
         ret = ret / rcount
+
     return ret
 
 def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -115,13 +115,10 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
     x = asanyarray(arr - arrmean)
-    if issubclass(arr.dtype.type, nt.complexfloating):
-        x = um.multiply(x, um.conjugate(x), out=x).real
-    else:
-        x = um.multiply(x, x, out=x)
-    ret = umr_sum(x, axis, dtype, out, keepdims)
+    x = um.multiply(x,x,out=x)
+    ret = umr_sum(x,axis,dtype,out,keepdims)
 
-    # Compute degrees of freedom and make sure it is not negative.
+    # Compute degrees of freedom and make sure it is not negative. 
     rcount = max([rcount - ddof, 0])
 
     # divide by degrees of freedom
@@ -132,7 +129,6 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         ret = ret.dtype.type(ret / rcount)
     else:
         ret = ret / rcount
-
     return ret
 
 def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -115,7 +115,7 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
     x = asanyarray(arr - arrmean)
-    x = um.multiply(x, x, out=x)
+    x = um.multiply(x,um.conjugate(x),out=x).real
     ret = umr_sum(x, axis, dtype, out, keepdims)
 
     # Compute degrees of freedom and make sure it is not negative.

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -216,6 +216,9 @@ class TestNonarrayArgs(object):
             assert_(np.isnan(np.var([])))
             assert_(w[0].category is RuntimeWarning)
 
+        B = np.array([None, 0])
+        B[0] = 1j
+        assert_almost_equal(np.var(B), 0.25)
 
 class TestIsscalar(object):
     def test_isscalar(self):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -210,16 +210,15 @@ class TestNonarrayArgs(object):
         assert_almost_equal(np.var(A), 2.9166666666666665)
         assert_almost_equal(np.var(A, 0), np.array([2.25, 2.25, 2.25]))
         assert_almost_equal(np.var(A, 1), np.array([0.66666667, 0.66666667]))
+        # gh-13177. Regression test to check if imaginary data in object arrays are treated correctly.
+        B = np.array([None, 0])
+        B[0] = 1j
+        assert_almost_equal(np.var(B), 0.25)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_(np.isnan(np.var([])))
             assert_(w[0].category is RuntimeWarning)
-
-        # Regression test for gh-13177, that object arrays are treated correctly.
-        B = np.array([None, 0])
-        B[0] = 1j
-        assert_almost_equal(np.var(B), 0.25)
 
 class TestIsscalar(object):
     def test_isscalar(self):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -216,6 +216,7 @@ class TestNonarrayArgs(object):
             assert_(np.isnan(np.var([])))
             assert_(w[0].category is RuntimeWarning)
 
+        # Regression test for gh-13177, that object arrays are treated correctly.
         B = np.array([None, 0])
         B[0] = 1j
         assert_almost_equal(np.var(B), 0.25)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -210,15 +210,15 @@ class TestNonarrayArgs(object):
         assert_almost_equal(np.var(A), 2.9166666666666665)
         assert_almost_equal(np.var(A, 0), np.array([2.25, 2.25, 2.25]))
         assert_almost_equal(np.var(A, 1), np.array([0.66666667, 0.66666667]))
-        # gh-13177. Regression test to check if imaginary data in object arrays are treated correctly.
-        B = np.array([None, 0])
-        B[0] = 1j
-        assert_almost_equal(np.var(B), 0.25)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', RuntimeWarning)
             assert_(np.isnan(np.var([])))
             assert_(w[0].category is RuntimeWarning)
+
+        B = np.array([None, 0])
+        B[0] = 1j
+        assert_almost_equal(np.var(B), 0.25)
 
 class TestIsscalar(object):
     def test_isscalar(self):


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
### Closes bug #13110 
The earlier code had an incorrect optimisation for variance and that has been changed. Seems to be a very pervasive bug for complex number arrays.


