### PR TITLE
BENCH, BUG: fix Savez suite, previously was actually calling pickle.dump()

### DIFF
--- a/benchmarks/benchmarks/bench_io.py
+++ b/benchmarks/benchmarks/bench_io.py
@@ -66,7 +66,8 @@ class Savez(Benchmark):
         self.squares = get_squares()
 
     def time_vb_savez_squares(self):
-        np.savez('tmp.npz', self.squares)
+        np.savez('tmp.npz', **self.squares)
+
 
 class LoadtxtCSVComments(Benchmark):
     # benchmarks for np.loadtxt comment handling


### PR DESCRIPTION
The `bench_io.Savez.time_vb_savez_squares()` benchmark has a typo that leads to benchmarking `pickle.dump()` rather than any numpy write functions.

The `benchmarks.common.get_squares()` function returns a dict of arrays:
```python
In [4]: sq = get_squares()

In [5]: type(sq)
Out[5]: dict

In [6]: sq.keys()
Out[6]: dict_keys(['int16', 'float16', 'int32', 'float32', 'int64', 'float64', 'complex64', 'longfloat', 'complex128', 'complex256'])
```
Passing this to `np.savez()` as a positional argument results in the conversion to an object array dumped via `pickle.dump()`:
```python
In [18]: np.savez('tmp', sq)

In [19]: npz = np.load('tmp.npz')

In [20]: npz['arr_0'].dtype
Out[20]: dtype('O')
```

Instead, if we unpack the dict, we exercise the actual numpy formatting code:
```python
In [22]: np.savez('tmp', **sq)

In [23]: npz = np.load('tmp.npz')

In [24]: npz.keys()
Out[24]: KeysView(<numpy.lib.npyio.NpzFile object at 0x7f274c186860>)

In [25]: list(npz.keys())
Out[25]:
['int16',
 'float16',
 'int32',
 'float32',
 'int64',
 'float64',
 'complex64',
 'longfloat',
 'complex128',
 'complex256']

In [26]: npz['int16'].dtype
Out[26]: dtype('int16')
```

Since we're now benchmarking the `numpy` code for array writing, the benchmark is also considerably faster. Old benchmark:
```
[  0.01%] ··· bench_io.Savez.time_vb_savez_squares                        1.62±0.02s
```
New:
```
[  0.01%] ··· bench_io.Savez.time_vb_savez_squares                          267±3ms
```

Additionally, it appears we've seen a significant speedup since `v1.10`:
```
asv compare -s --only-changed v1.10.0 HEAD
       before           after         ratio
     [183fdb29]       [289d8048]
     <v1.10.0>        <bench_savez>
-       938±200ms          263±3ms     0.28  bench_io.Savez.time_vb_savez_squares
```