### PR TITLE
ENH: use rotated companion matrix to reduce error

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1743,7 +1743,8 @@ def chebroots(c):
     if len(c) == 2:
         return np.array([-c[0]/c[1]])
 
-    m = chebcompanion(c)
+    # rotated companion matrix reduces error
+    m = chebcompanion(c)[::-1,::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1476,7 +1476,8 @@ def hermroots(c):
     if len(c) == 2:
         return np.array([-.5*c[0]/c[1]])
 
-    m = hermcompanion(c)
+    # rotated companion matrix reduces error
+    m = hermcompanion(c)[::-1,::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1471,7 +1471,8 @@ def hermeroots(c):
     if len(c) == 2:
         return np.array([-c[0]/c[1]])
 
-    m = hermecompanion(c)
+    # rotated companion matrix reduces error
+    m = hermecompanion(c)[::-1,::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1475,7 +1475,8 @@ def lagroots(c):
     if len(c) == 2:
         return np.array([1 + c[0]/c[1]])
 
-    m = lagcompanion(c)
+    # rotated companion matrix reduces error
+    m = lagcompanion(c)[::-1,::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1505,7 +1505,8 @@ def legroots(c):
     if len(c) == 2:
         return np.array([-c[0]/c[1]])
 
-    m = legcompanion(c)
+    # rotated companion matrix reduces error
+    m = legcompanion(c)[::-1,::-1]
     r = la.eigvals(m)
     r.sort()
     return r

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1429,7 +1429,7 @@ def polyroots(c):
         return np.array([-c[0]/c[1]])
 
     m = polycompanion(c)
-    r = la.eigvals(m)
+    r = la.eigvals(m[::-1,::-1])
     r.sort()
     return r
 

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1428,8 +1428,9 @@ def polyroots(c):
     if len(c) == 2:
         return np.array([-c[0]/c[1]])
 
-    m = polycompanion(c)
-    r = la.eigvals(m[::-1,::-1])
+    # rotated companion matrix reduces error
+    m = polycompanion(c)[::-1,::-1]
+    r = la.eigvals(m)
     r.sort()
     return r
 


### PR DESCRIPTION
I work with a research team on developing a higher dimensional root finding algorithm. We happened to learn that in the one-dimensional case, using the rotated companion matrix produces smaller errors.
Here is some sample code and the results.

```python
import numpy as np

from numpy.polynomial.polynomial import polyroots, polycompanion, polyfromroots
from numpy.polynomial import polyutils as pu
from numpy import linalg as la


def polyroots2(c):
    # c is a trimmed copy
    [c] = pu.as_series([c])
    if len(c) < 2:
        return np.array([], dtype=c.dtype)
    if len(c) == 2:
        return np.array([-c[0]/c[1]])

    m = polycompanion(c)
    r = la.eigvals(m[::-1,::-1])
    r.sort()
    return r

def sort_diff(a,b):
    return np.array(sorted(a)) - np.array(sorted(b))

k = 1
deg = 30
seed = 786
unif = np.random.uniform
def error(solver):
    err = []
    np.random.seed(seed)
    for _ in range(1000):
        roots = unif(-k,k,size=deg) + 1j*unif(-k,k,size=deg)
        c = polyfromroots(roots)
        r = solver(c)
        err.extend(sort_diff(roots, r).tolist())
    return err

err1 = error(polyroots)
err2 = error(polyroots2)

print('\t\tAbsolute Error')
print("Original mean: {:1.3e}".format(np.abs(err1).mean()))
print("Rotated mean : {:1.3e}".format(np.abs(err2).mean()))
print()
print("Original max : {:1.3e}".format(np.abs(err1).max()))
print("Rotated max  : {:1.3e}".format(np.abs(err2).max()))`
```

```
		Absolute Error
Original mean: 4.636e-09
Rotated mean : 5.357e-10

Original max : 4.550e-05
Rotated max  : 5.126e-06
```