### PR TITLE
MAINT: Speed up np.maximum/np.minimum by up to 15x when operating on two inputs

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -60,6 +60,31 @@ class UFunc(Benchmark):
         [self.f(*arg) for arg in self.args]
 
 
+class UFuncBenchmark(Benchmark):
+    params = ['bool', 'uint8', 'int8', 'int32', 'uint64', 'int64', 'float16',
+              'float32', 'float64', 'complex128', 'datetime64[ns]',
+              'timedelta64[ns]']
+    param_names = ['dtype']
+
+    def setup(self, dtype):
+        self.arr = np.full(100000, 1, dtype=dtype)
+        self.val = self.arr[0]
+
+
+class MinMax(UFuncBenchmark):
+    def time_fmax(self, dtype):
+        np.fmax(self.arr, self.arr)
+
+    def time_fmin(self, dtype):
+        np.fmin(self.arr, self.arr)
+
+    def time_maximum(self, dtype):
+        np.maximum(self.arr, self.arr)
+
+    def time_minimum(self, dtype):
+        np.minimum(self.arr, self.arr)
+
+
 class Custom(Benchmark):
     def setup(self):
         self.b = np.ones(20000, dtype=bool)

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -814,7 +814,7 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
  * #OP =  >, <#
  **/
 
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     if (IS_BINARY_REDUCE) {
@@ -825,11 +825,8 @@ NPY_NO_EXPORT void
         *((@type@ *)iop1) = io1;
     }
     else {
-        BINARY_LOOP {
-            const @type@ in1 = *(@type@ *)ip1;
-            const @type@ in2 = *(@type@ *)ip2;
-            *((@type@ *)op1) = (in1 @OP@ in2) ? in1 : in2;
-        }
+        BINARY_LOOP_FAST(@type@, @type@,
+                         *out = (in1 @OP@ in2) ? in1 : in2);
     }
 }
 
@@ -1826,7 +1823,7 @@ NPY_NO_EXPORT void
  * #kind = maximum, minimum#
  * #OP =  >=, <=#
  **/
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     /*  */
@@ -1841,13 +1838,9 @@ NPY_NO_EXPORT void
         }
     }
     else {
-        BINARY_LOOP {
-            @type@ in1 = *(@type@ *)ip1;
-            const @type@ in2 = *(@type@ *)ip2;
-            /* Order of operations important for MSVC 2015 */
-            in1 = (in1 @OP@ in2 || npy_isnan(in1)) ? in1 : in2;
-            *((@type@ *)op1) = in1;
-        }
+        BINARY_LOOP_FAST(@type@, @type@,
+                         /* Order of operations important for MSVC 2015 */
+                         *out = (in1 @OP@ in2 || npy_isnan(in1)) ? in1 : in2);
     }
     npy_clear_floatstatus_barrier((char*)dimensions);
 }
@@ -1857,7 +1850,7 @@ NPY_NO_EXPORT void
  * #kind = fmax, fmin#
  * #OP =  >=, <=#
  **/
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     /*  */
@@ -1870,12 +1863,10 @@ NPY_NO_EXPORT void
         *((@type@ *)iop1) = io1;
     }
     else {
-        BINARY_LOOP {
-            const @type@ in1 = *(@type@ *)ip1;
-            const @type@ in2 = *(@type@ *)ip2;
-            /* Order of operations important for MSVC 2015 */
-            *((@type@ *)op1) = (in1 @OP@ in2 || npy_isnan(in2)) ? in1 : in2;
-        }
+        BINARY_LOOP_FAST(@type@, @type@,
+                         /* Order of operations important for MSVC 2015 */
+                         *out = (in1 @OP@ in2 || npy_isnan(in2)) ? in1 : in2;
+                         );
     }
     npy_clear_floatstatus_barrier((char*)dimensions);
 }


### PR DESCRIPTION
For calls of the form `np.min(arr_1, arr_2)`, the runtime does not scale with `sizeof(type)` as we would generally expect:
```
[100.00%] ··· bench_ufunc.MinMax.time_minimum                                                                                                                             ok
[100.00%] ··· ================= ============
                    dtype
              ----------------- ------------
                     bool        6.54±0.2μs    <----|
                    uint8         88.9±2μs     <----|--- these are the same size
                     int8         85.1±1μs     <----|
                    int32         75.9±2μs
                    uint64        82.3±1μs
                    int64         82.6±1μs
                   float16        795±20μs
                   float32        102±3μs
                   float64        86.7±1μs
                  complex128      178±4μs
                datetime64[ns]    101±2μs
               timedelta64[ns]    101±2μs
              ================= ============
```
Notably, the integer types all take about the same amount of time to run irrespective of the size of the data, which indicates we're not constrained on memory bandwidth. Using the existing `BINARY_LOOP_FAST` macro and enabling `-O3` is sufficient to get some broad speedups:

```
asv compare HEAD^ HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [db5fcc8e]       [34a8d2f9]
     <maximum_speedup~1>       <maximum_speedup>
-        99.4±2μs         78.3±3μs     0.79  bench_ufunc.MinMax.time_fmin('datetime64[ns]')
-        97.3±1μs         75.7±3μs     0.78  bench_ufunc.MinMax.time_minimum('datetime64[ns]')
-        99.1±2μs         76.3±1μs     0.77  bench_ufunc.MinMax.time_maximum('timedelta64[ns]')
-        99.2±1μs         75.3±3μs     0.76  bench_ufunc.MinMax.time_minimum('timedelta64[ns]')
-        83.1±3μs         62.3±1μs     0.75  bench_ufunc.MinMax.time_maximum('float64')
-        105±10μs         78.3±3μs     0.75  bench_ufunc.MinMax.time_fmax('timedelta64[ns]')
-        82.1±2μs         61.1±3μs     0.74  bench_ufunc.MinMax.time_minimum('float64')
-         102±2μs        71.3±10μs     0.70  bench_ufunc.MinMax.time_fmax('float64')
-        83.5±3μs         31.4±2μs     0.38  bench_ufunc.MinMax.time_maximum('float32')
-        73.2±3μs       25.4±0.5μs     0.35  bench_ufunc.MinMax.time_maximum('int32')
-      76.8±0.7μs       26.5±0.7μs     0.35  bench_ufunc.MinMax.time_fmax('int32')
-        76.6±4μs       25.7±0.5μs     0.34  bench_ufunc.MinMax.time_minimum('int32')
-        77.9±4μs       25.2±0.7μs     0.32  bench_ufunc.MinMax.time_fmin('int32')
-        98.2±2μs         31.7±1μs     0.32  bench_ufunc.MinMax.time_minimum('float32')
-        98.7±3μs       31.4±0.8μs     0.32  bench_ufunc.MinMax.time_fmax('float32')
-        98.8±2μs       30.3±0.8μs     0.31  bench_ufunc.MinMax.time_fmin('float32')
-        78.5±2μs       7.08±0.2μs     0.09  bench_ufunc.MinMax.time_minimum('int8')
-       95.7±20μs         8.59±1μs     0.09  bench_ufunc.MinMax.time_fmin('int8')
-      88.5±0.6μs      7.18±0.09μs     0.08  bench_ufunc.MinMax.time_maximum('int8')
-        89.7±2μs       7.11±0.3μs     0.08  bench_ufunc.MinMax.time_fmax('int8')
-        81.6±1μs       5.37±0.2μs     0.07  bench_ufunc.MinMax.time_fmax('uint8')
-      80.5±0.5μs       5.23±0.2μs     0.06  bench_ufunc.MinMax.time_maximum('uint8')
-        87.1±1μs       5.38±0.1μs     0.06  bench_ufunc.MinMax.time_minimum('uint8')
-       92.1±20μs       5.37±0.4μs     0.06  bench_ufunc.MinMax.time_fmin('uint8')

Benchmarks that have stayed the same:

       before           after         ratio
     [db5fcc8e]       [34a8d2f9]
     <maximum_speedup~1>       <maximum_speedup>
         907±20μs         975±20μs     1.07  bench_ufunc.MinMax.time_maximum('float16')
          171±7μs         183±10μs     1.07  bench_ufunc.MinMax.time_minimum('complex128')
          817±9μs         872±70μs     1.07  bench_ufunc.MinMax.time_minimum('float16')
       6.01±0.1μs       6.31±0.2μs     1.05  bench_ufunc.MinMax.time_minimum('bool')
         78.9±2μs         82.2±2μs     1.04  bench_ufunc.MinMax.time_minimum('uint64')
        861±200μs         895±20μs     1.04  bench_ufunc.MinMax.time_fmin('float16')
       11.1±0.3μs       11.5±0.8μs     1.03  bench_reduce.MinMax.time_min(<class 'numpy.float64'>)
       11.0±0.4μs       11.3±0.1μs     1.03  bench_reduce.MinMax.time_max(<class 'numpy.float64'>)
       7.55±0.2μs       7.75±0.1μs     1.03  bench_reduce.MinMax.time_min(<class 'numpy.float32'>)
         953±10μs         969±10μs     1.02  bench_ufunc.MinMax.time_fmax('float16')
          206±5μs          207±7μs     1.01  bench_ufunc.MinMax.time_fmax('complex128')
       5.83±0.3μs       5.86±0.1μs     1.00  bench_ufunc.MinMax.time_fmax('bool')
       17.0±0.3μs       17.1±0.6μs     1.00  bench_reduce.MinMax.time_min(<class 'numpy.int64'>)
       7.80±0.4μs       7.83±0.3μs     1.00  bench_reduce.MinMax.time_max(<class 'numpy.float32'>)
       17.2±0.3μs       17.2±0.4μs     1.00  bench_reduce.MinMax.time_max(<class 'numpy.int64'>)
      5.93±0.06μs       5.90±0.2μs     1.00  bench_ufunc.MinMax.time_maximum('bool')
          176±3μs          175±8μs     0.99  bench_ufunc.MinMax.time_maximum('complex128')
       6.63±0.8μs       6.44±0.1μs     0.97  bench_ufunc.MinMax.time_fmin('bool')
          206±4μs          198±3μs     0.96  bench_ufunc.MinMax.time_fmin('complex128')
         83.7±6μs         80.0±2μs     0.96  bench_ufunc.MinMax.time_fmin('uint64')
       72.4±0.8μs         68.3±2μs     0.94  bench_ufunc.MinMax.time_minimum('int64')
         73.9±2μs         69.2±2μs     0.94  bench_ufunc.MinMax.time_fmax('int64')
         76.4±1μs         71.2±2μs     0.93  bench_ufunc.MinMax.time_maximum('int64')
       76.4±0.8μs         70.0±5μs     0.92  bench_ufunc.MinMax.time_fmin('int64')
         73.5±2μs         66.9±2μs     0.91  bench_ufunc.MinMax.time_fmax('uint64')
       77.8±0.6μs         69.9±2μs    ~0.90  bench_ufunc.MinMax.time_maximum('uint64')
         94.1±5μs         82.4±8μs    ~0.88  bench_ufunc.MinMax.time_fmin('timedelta64[ns]')
         98.1±3μs         82.8±5μs    ~0.84  bench_ufunc.MinMax.time_fmax('datetime64[ns]')
         84.9±3μs         66.2±6μs    ~0.78  bench_ufunc.MinMax.time_fmin('float64')
          100±2μs         74.7±4μs    ~0.74  bench_ufunc.MinMax.time_maximum('datetime64[ns]')
```
Please note that this does not impact the more common `np.min(arr)` reduction call - I will have a separate PR addressing those functions in the near future.