### PR TITLE
DOC: add missing routines to reference guide

### DIFF
--- a/doc/source/reference/routines.char.rst
+++ b/doc/source/reference/routines.char.rst
@@ -56,6 +56,7 @@ comparison.
    less_equal
    greater
    less
+   compare_chararrays
 
 String information
 ------------------
@@ -90,4 +91,3 @@ Convenience class
    array
    asarray
    chararray
-   compare_chararrays

--- a/doc/source/reference/routines.char.rst
+++ b/doc/source/reference/routines.char.rst
@@ -90,3 +90,4 @@ Convenience class
    array
    asarray
    chararray
+   compare_chararrays

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -51,13 +51,6 @@ Deprecation warning
 
    deprecate
 
-Display message
----------------
-.. autosummary::
-   :toctree: generated/
-
-   disp
-
 Details of used variables
 -------------------------
 .. autosummary::

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -51,11 +51,12 @@ Deprecation warning
 
    deprecate
 
-Details of used variables
--------------------------
+Matlab-like Functions
+---------------------
 .. autosummary::
    :toctree: generated/
- 
+   
+   disp
    who
 
 

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -18,7 +18,8 @@ Memory ranges
 
 .. autosummary::
    :toctree: generated/
-
+   
+   byte_bounds
    shares_memory
    may_share_memory
 
@@ -35,3 +36,33 @@ NumPy version comparison
    :toctree: generated/
 
    lib.NumpyVersion
+
+NumPy header files location
+----------------------------
+.. autosummary::
+   :toctree: generated/
+   
+   get_include
+
+Deprecation warning
+-------------------
+.. autosummary::
+   :toctree: generated/
+
+   deprecate
+
+Display message
+---------------
+.. autosummary::
+   :toctree: generated/
+
+   disp
+
+Details of used variables
+-------------------------
+.. autosummary::
+   :toctree: generated/
+ 
+   who
+
+

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -529,7 +529,7 @@ original, but they have different default values.
    The output is always a :class:`~numpy.ma.MaskedArray`
 :func:`~numpy.recfromtxt`
    Returns a standard :class:`numpy.recarray` (if ``usemask=False``) or a
-   :class:`~numpy.ma.MaskedRecords` array (if ``usemaske=True``).  The
+   :class:`~numpy.ma.MaskedRecords` array (if ``usemask=True``).  The
    default dtype is ``dtype=None``, meaning that the types of each column
    will be automatically determined.
 :func:`~numpy.recfromcsv`

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1726,7 +1726,9 @@ def place(arr, mask, vals):
 def disp(mesg, device=None, linefeed=True):
     """
     Display a message on a device.
-
+    
+    ..deprecated:: 1.17.0
+ 
     Parameters
     ----------
     mesg : str
@@ -1755,6 +1757,10 @@ def disp(mesg, device=None, linefeed=True):
     '"Display" in a file\\n'
 
     """
+    # NumPy 1.17.0, 2019-04-04
+    warnings.warn(
+        "numpy.lib.function_base.disp is deprecated",
+        DeprecationWarning, stacklevel=2)
     if device is None:
         device = sys.stdout
     if linefeed:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1727,7 +1727,8 @@ def disp(mesg, device=None, linefeed=True):
     """
     Display a message on a device.
     
-    ..deprecated:: 1.17.0
+    .. deprecated:: 1.17.0
+       disp() is deprecated, use print() instead
  
     Parameters
     ----------
@@ -1757,9 +1758,10 @@ def disp(mesg, device=None, linefeed=True):
     '"Display" in a file\\n'
 
     """
-    # NumPy 1.17.0, 2019-04-04
+    # NumPy 1.17.0, 2019-04-04, gh-13214
     warnings.warn(
-        "numpy.lib.function_base.disp is deprecated",
+        "numpy.lib.function_base.disp is deprecated,"
+        "use print instead.",
         DeprecationWarning, stacklevel=2)
     if device is None:
         device = sys.stdout

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2255,6 +2255,7 @@ def mafromtxt(fname, **kwargs):
     return genfromtxt(fname, **kwargs)
 
 
+@set_module('numpy')
 def recfromtxt(fname, **kwargs):
     """
     Load ASCII data from a file and return it in a record array.
@@ -2262,6 +2263,9 @@ def recfromtxt(fname, **kwargs):
     If ``usemask=False`` a standard `recarray` is returned,
     if ``usemask=True`` a MaskedRecords array is returned.
 
+    .. deprecated:: 1.17.0
+    recfromtxt() is deprecated, use genfromtxt() with dtype=None
+ 
     Parameters
     ----------
     fname, kwargs : For a description of input parameters, see `genfromtxt`.
@@ -2276,6 +2280,12 @@ def recfromtxt(fname, **kwargs):
     array will be determined from the data.
 
     """
+    # NumPy 1.17.0, 2019-04-11, gh-13214
+    warnings.warn(
+    "numpy.lib.npyio.recfromtxt is deprecated,"
+    "use numpy.lib.npyio.genfromtxt with dtype=None instead",
+    DeprecationWarning, stacklevel=2)
+
     kwargs.setdefault("dtype", None)
     usemask = kwargs.get('usemask', False)
     output = genfromtxt(fname, **kwargs)
@@ -2287,6 +2297,7 @@ def recfromtxt(fname, **kwargs):
     return output
 
 
+@set_module('numpy')
 def recfromcsv(fname, **kwargs):
     """
     Load ASCII data stored in a comma-separated file.
@@ -2294,6 +2305,10 @@ def recfromcsv(fname, **kwargs):
     The returned array is a record array (if ``usemask=False``, see
     `recarray`) or a masked record array (if ``usemask=True``,
     see `ma.mrecords.MaskedRecords`).
+
+    .. deprecated:: 1.17.0
+    recfromcsv() is deprecated, use genfromtxt() with dtype=None 
+    and delimiter=","
 
     Parameters
     ----------
@@ -2309,6 +2324,13 @@ def recfromcsv(fname, **kwargs):
     array will be determined from the data.
 
     """
+    # NumPy 1.17.0, 2019-04-11, gh-13214
+    warnings.warn(
+    "numpy.lib.npyio.recfromcsv is deprecated,"
+    "use numpy.lib.npyio.genfromtxt with dtype=None"
+    "and delimiter=',' instead.",
+    DeprecationWarning, stacklevel=2)
+
     # Set default kwargs for genfromtxt as relevant to csv import.
     kwargs.setdefault("case_sensitive", "lower")
     kwargs.setdefault("names", True)


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
These have their relevant docstrings. I'll add them to the reference guide.  
- [x] ```'compare_chararrays': 'numpy.core._multiarray_umath.compare_chararrays',```
- [ ] ```'add_newdoc': 'numpy.core.function_base.add_newdoc',```
- [x] ```'byte_bounds': 'numpy.lib.utils.byte_bounds',```
- [x] ```'deprecate': 'numpy.lib.utils.deprecate',```
- [x] ```'get_include': 'numpy.lib.utils.get_include',```
- [x] ```'who': 'numpy.lib.utils.who',```

To Deprecate: 
- [x] ```'disp': 'numpy.lib.function_base.disp',```
- [ ] ```'recfromcsv': 'numpy.lib.npyio.recfromcsv',``` 
- [ ] ```'recfromtxt': 'numpy.lib.npyio.recfromtxt',```
- [ ] ```'safe_eval': 'numpy.lib.utils.safe_eval'```
- [ ] ```'Tester': 'numpy.testing._private.nosetester.NoseTester',```