### PR TITLE
TST: always publish Azure tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,11 @@ jobs:
            F77=gfortran-5 F90=gfortran-5 \
            CFLAGS='-UNDEBUG -std=c99' python3 runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
+    continueOnError: true
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: false
       testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: macOS
   pool:
@@ -99,9 +101,11 @@ jobs:
     displayName: 'Run Refuide Check'
   - script: python runtests.py --mode=full -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run Full NumPy Test Suite'
+    continueOnError: true
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: false
       testRunTitle: 'Publish test results for Python 3.6 64-bit full Mac OS'
 - job: Windows
   pool:
@@ -200,7 +204,9 @@ jobs:
     displayName: 'For gh-12667; Windows DLL resolution'
   - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run NumPy Test Suite'
+    continueOnError: true
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: false
       testRunTitle: 'Publish test results for Python $(PYTHON_VERSION) $(BITS)-bit $(TEST_MODE) Windows'


### PR DESCRIPTION
Fixes #13210 

See associated docs for [Publish Test Results](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml) and [task control options](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#task-control-options).

The key is likely setting `continueOnError: true`, as docs suggest it should default to false--preventing the upload if tests fail. `failTaskOnFailedTests: false` should be the default, but let's be explicit on that too.
