### PR TITLE
ENH: adding new function, `np.nanptp`

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -554,24 +554,12 @@ def _nanptp_dispatcher(a, axis=None):
 
 @array_function_dispatch(_nanptp_dispatcher)
 def nanptp(a, axis=None):
-    # find nanmin and nanmax for ptp range
-    # not using nanmin and nanmax fn calls because of 
-    # irrelevant warnings thrown
-    if type(a) is np.ndarray and a.dtype != np.object_:
-        # Fast, but not safe for subclasses of ndarray, or object arrays,
-        # which do not implement isnan (gh-9009), or fmax correctly (gh-8975)
-        res = np.fmax.reduce(a, axis=axis) - np.fmin.reduce(a, axis=axis)
-    else:
-        # Slow, but safe for subclasses of ndarray
-        a_minus, _ = _replace_nan(a, -np.inf)
-        a_plus, _ = _replace_nan(a, np.inf)
-        res = np.amax(a_plus, axis=axis) - np.amin(a_minus, axis=axis)
-    # Check for invalid peak-to-peak detections
+    res = nanmax(a, axis=axis) - nanmin(a, axis=axis)
     valid_mask = ~np.isnan(a)
     invalid_ptp = (valid_mask.sum(axis=axis) < 2)
     if np.any(invalid_ptp):
         warnings.warn("Slice without valid peak-to-peak encountered",
-                      RuntimeWarning)
+                      RuntimeWarning, stacklevel=2)
         res = _copyto(res, np.nan, invalid_ptp)
     return res
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -554,15 +554,25 @@ def _nanptp_dispatcher(a, axis=None):
 
 @array_function_dispatch(_nanptp_dispatcher)
 def nanptp(a, axis=None):
-    amin = nanmin(a, axis)
-    amax = nanmax(a, axis)
-    res = amax - amin
-    valid_mask = (~np.isnan(a))
+    # find nanmin and nanmax for ptp range
+    # not using nanmin and nanmax fn calls because of 
+    # irrelevant warnings thrown
+    if type(a) is np.ndarray and a.dtype != np.object_:
+        # Fast, but not safe for subclasses of ndarray, or object arrays,
+        # which do not implement isnan (gh-9009), or fmax correctly (gh-8975)
+        res = np.fmax.reduce(a, axis=axis) - np.fmin.reduce(a, axis=axis)
+    else:
+        # Slow, but safe for subclasses of ndarray
+        a_minus, _ = _replace_nan(a, -np.inf)
+        a_plus, _ = _replace_nan(a, np.inf)
+        res = np.amax(a_plus, axis=axis) - np.amin(a_minus, axis=axis)
+    # Check for invalid peak-to-peak detections
+    valid_mask = ~np.isnan(a)
     invalid_ptp = (valid_mask.sum(axis=axis) < 2)
     if np.any(invalid_ptp):
-        warnings.warn("Slice without peak to peak encountered",
+        warnings.warn("Slice without valid peak-to-peak encountered",
                       RuntimeWarning)
-        res[invalid_ptp] = np.nan
+        res = _copyto(res, np.nan, invalid_ptp)
     return res
 
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -591,11 +591,8 @@ def nanptp(a, axis=None):
     6.0
     >>> np.nanptp(a, axis=0)
     array([6., 1.])
-
-    The command below will raise a RuntimeWarning
-    
     >>> np.nanptp(a, axis=1)
-    array([ 1., nan, 4.])
+    array([ 1., 0., 4.])
 
     When positive infinity and/or negative infinity are present:
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -554,6 +554,55 @@ def _nanptp_dispatcher(a, axis=None):
 
 @array_function_dispatch(_nanptp_dispatcher)
 def nanptp(a, axis=None):
+    """
+    Range of values (maximum - minimum) along an axis, ignoring any NaNs.
+    When slices with less than two non-NaN values are encountered,
+    a ``RuntimeWarning`` is raised and Nan is returned for that slice.
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing numbers whose peak-to-peak is desired. If `a` is not an
+        array, a conversion is attempted.
+    axis : {int, tuple of int, None}, optional
+        Axis or axes along which the minimum is computed. The default is to compute
+        the minimum of the flattened array.
+
+    Returns
+    -------
+    nanptp : ndarray
+        An array with the same shape as `a`, with the specified axis
+        removed.  If `a` is a 0-d array, or if axis is None, np.nan is
+        returned, and a warning raised.  The same dtype as `a` is returned.
+
+    Notes
+    -----
+    NumPy uses the IEEE Standard for Binary Floating-Point for Arithmetic
+    (IEEE 754). This means that Not a Number is not equivalent to infinity.
+    Positive infinity is treated as a very large number and negative
+    infinity is treated as a very small (i.e. negative) number.
+
+    If the input has a integer type the function is equivalent to np.ptp.
+
+    Examples
+    --------
+    >>> a = np.array([[1, 2], [3, np.nan], [-3, 1]])
+    >>> np.nanptp(a)
+    6.0
+    >>> np.nanmin(a, axis=0)
+    array([6., 1.])
+    >>> np.nanmin(a, axis=1)
+    RuntimeWarning: Slice without valid peak-to-peak encountered
+    array([ 1., nan, 4.])
+
+    When positive infinity and/or negative infinity are present:
+
+    >>> np.nanptp([1, 2, np.nan, np.inf])
+    inf
+    >>> np.nanptp([1, 2, np.nan, np.NINF])
+    inf
+
+    """
     res = nanmax(a, axis=axis) - nanmin(a, axis=axis)
     valid_mask = ~np.isnan(a)
     invalid_ptp = (valid_mask.sum(axis=axis) < 2)

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -606,12 +606,6 @@ def nanptp(a, axis=None):
 
     """
     res = nanmax(a, axis=axis) - nanmin(a, axis=axis)
-    valid_mask = ~np.isnan(a)
-    invalid_ptp = (valid_mask.sum(axis=axis) < 2)
-    if np.any(invalid_ptp):
-        warnings.warn("Slice without valid peak-to-peak encountered",
-                      RuntimeWarning, stacklevel=2)
-        res = _copyto(res, np.nan, invalid_ptp)
     return res
 
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -16,6 +16,7 @@ Functions
 - `nanvar` -- variance of non-NaN values
 - `nanstd` -- standard deviation of non-NaN values
 - `nanmedian` -- median of non-NaN values
+- `nanptp` -- peak to peak of non-NaN values
 - `nanquantile` -- qth quantile of non-NaN values
 - `nanpercentile` -- qth percentile of non-NaN values
 
@@ -34,9 +35,9 @@ array_function_dispatch = functools.partial(
 
 
 __all__ = [
-    'nansum', 'nanmax', 'nanmin', 'nanargmax', 'nanargmin', 'nanmean',
-    'nanmedian', 'nanpercentile', 'nanvar', 'nanstd', 'nanprod',
-    'nancumsum', 'nancumprod', 'nanquantile'
+    'nansum', 'nanmax', 'nanmin', 'nanargmax', 'nanargmin', 'nanptp',
+    'nanmean', 'nanmedian', 'nanpercentile', 'nanvar', 'nanstd',
+    'nanprod', 'nancumsum', 'nancumprod', 'nanquantile'
     ]
 
 
@@ -66,6 +67,7 @@ def _nan_mask(a, out=None):
     y = np.isnan(a, out=out)
     y = np.invert(y, out=y)
     return y
+
 
 def _replace_nan(a, val):
     """
@@ -543,6 +545,24 @@ def nanargmax(a, axis=None):
         mask = np.all(mask, axis=axis)
         if np.any(mask):
             raise ValueError("All-NaN slice encountered")
+    return res
+
+
+def _nanptp_dispatcher(a, axis=None):
+    return (a,)
+
+
+@array_function_dispatch(_nanptp_dispatcher)
+def nanptp(a, axis=None):
+    amin = nanmin(a, axis)
+    amax = nanmax(a, axis)
+    res = amax - amin
+    valid_mask = (~np.isnan(a))
+    invalid_ptp = (valid_mask.sum(axis=axis) < 2)
+    if np.any(invalid_ptp):
+        warnings.warn("Slice without peak to peak encountered",
+                      RuntimeWarning)
+        res[invalid_ptp] = np.nan
     return res
 
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -16,9 +16,9 @@ Functions
 - `nanvar` -- variance of non-NaN values
 - `nanstd` -- standard deviation of non-NaN values
 - `nanmedian` -- median of non-NaN values
-- `nanptp` -- peak to peak of non-NaN values
 - `nanquantile` -- qth quantile of non-NaN values
 - `nanpercentile` -- qth percentile of non-NaN values
+- `nanptp` -- peak to peak of non-NaN values
 
 """
 from __future__ import division, absolute_import, print_function

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -589,10 +589,12 @@ def nanptp(a, axis=None):
     >>> a = np.array([[1, 2], [3, np.nan], [-3, 1]])
     >>> np.nanptp(a)
     6.0
-    >>> np.nanmin(a, axis=0)
+    >>> np.nanptp(a, axis=0)
     array([6., 1.])
-    >>> np.nanmin(a, axis=1)
-    RuntimeWarning: Slice without valid peak-to-peak encountered
+
+    The command below will raise a RuntimeWarning
+    
+    >>> np.nanptp(a, axis=1)
     array([ 1., nan, 4.])
 
     When positive infinity and/or negative infinity are present:

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -233,6 +233,46 @@ class TestNanFunctions_ArgminArgmax(object):
             assert_(res.shape == ())
 
 
+class TestNanFunctions_Nanptp(object):
+
+    def test_mutation(self):
+        # Check that passed array is not modified.
+        ndat = _ndat.copy()
+        np.nanptp(ndat)
+        assert_equal(ndat, _ndat)
+
+    def test_dtype_from_input(self):
+        codes = 'efdgFDG'
+        for c in codes:
+            mat = np.eye(3, dtype=c)
+            tgt = np.ptp(mat, axis=1).dtype.type
+            res = np.nanptp(mat, axis=1).dtype.type
+            assert_(res is tgt)
+            # scalar case
+            tgt = np.ptp(mat, axis=None).dtype.type
+            res = np.nanptp(mat, axis=None).dtype.type
+            assert_(res is tgt)
+
+    def test_result_values(self):
+        tgt = [np.ptp(d) for d in _rdat]
+        res = np.nanptp(_ndat, axis=1)
+        assert_almost_equal(res, tgt)
+
+    def test_scalar(self):
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            assert_(np.isnan(np.nanptp(0.)))
+
+    def test_allnans(self):
+        mat = np.array([np.nan]*9).reshape(3, 3)
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            for axis in [None, 0, 1]:
+                assert_(np.isnan(np.nanptp(mat, axis=axis)).all())
+            # Check scalar
+            assert_(np.isnan(np.nanptp(np.nan)))
+
+
 class TestNanFunctions_IntTypes(object):
 
     int_types = (np.int8, np.int16, np.int32, np.int64, np.uint8,
@@ -263,6 +303,11 @@ class TestNanFunctions_IntTypes(object):
         tgt = np.argmax(self.mat)
         for mat in self.integer_arrays():
             assert_equal(np.nanargmax(mat), tgt)
+
+    def test_nanptp(self):
+        tgt = np.ptp(self.mat)
+        for mat in self.integer_arrays():
+            assert_equal(np.nanptp(mat), tgt)
 
     def test_nansum(self):
         tgt = np.sum(self.mat)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -261,7 +261,7 @@ class TestNanFunctions_Nanptp(object):
     def test_scalar(self):
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
-            assert_(np.isnan(np.nanptp(0.)))
+            assert_(np.nanptp(1.) == 0.)
 
     def test_allnans(self):
         mat = np.array([np.nan]*9).reshape(3, 3)


### PR DESCRIPTION
This PR adds an `nan` compatible analog function to `ptp`: `nanptp`

Do let me know if there are any areas for improvement. 
