### PR TITLE
DOC: Document/ Deprecate functions exposed in "numpy" namespace

### DIFF
--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -394,6 +394,13 @@ There are a couple of places that need further attention:
   In some cases, this returns a buffer object on Python 2. On Python 3,
   there is no stand-alone buffer object, so we return a byte array instead.
 
+- multiarray.int_asbuffer
+
+  Converts an integer to a void* pointer -- in Python.
+
+  Should we just remove this for Py3? It doesn't seem like it is used
+  anywhere, and it doesn't sound very useful.
+
 
 The Py2/Py3 compatible PyBufferMethods definition looks like::
 

--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -394,13 +394,6 @@ There are a couple of places that need further attention:
   In some cases, this returns a buffer object on Python 2. On Python 3,
   there is no stand-alone buffer object, so we return a byte array instead.
 
-- multiarray.int_asbuffer
-
-  Converts an integer to a void* pointer -- in Python.
-
-  Should we just remove this for Py3? It doesn't seem like it is used
-  anywhere, and it doesn't sound very useful.
-
 
 The Py2/Py3 compatible PyBufferMethods definition looks like::
 

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -521,12 +521,6 @@ provides several convenience functions derived from
 :func:`~numpy.genfromtxt`.  These functions work the same way as the
 original, but they have different default values.
 
-:func:`~numpy.ndfromtxt`
-   Always set ``usemask=False``.
-   The output is always a standard :class:`numpy.ndarray`.
-:func:`~numpy.mafromtxt`
-   Always set ``usemask=True``.
-   The output is always a :class:`~numpy.ma.MaskedArray`
 :func:`~numpy.recfromtxt`
    Returns a standard :class:`numpy.recarray` (if ``usemask=False``) or a
    :class:`~numpy.ma.MaskedRecords` array (if ``usemaske=True``).  The

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2225,6 +2225,9 @@ def ndfromtxt(fname, **kwargs):
     """
     Load ASCII data stored in a file and return it as a single array.
 
+    .. deprecated:: 1.17
+        np.ndfromtxt is deprecated
+
     Parameters
     ----------
     fname, kwargs : For a description of input parameters, see `genfromtxt`.
@@ -2235,12 +2238,19 @@ def ndfromtxt(fname, **kwargs):
 
     """
     kwargs['usemask'] = False
+    # Numpy 1.17
+    warnings.warn(
+        "np.ndfromtxt is deprecated",
+        DeprecationWarning, stacklevel=2)
     return genfromtxt(fname, **kwargs)
 
 
 def mafromtxt(fname, **kwargs):
     """
     Load ASCII data stored in a text file and return a masked array.
+
+    .. deprecated:: 1.17
+        np.mafromtxt is deprecated
 
     Parameters
     ----------
@@ -2252,6 +2262,10 @@ def mafromtxt(fname, **kwargs):
 
     """
     kwargs['usemask'] = True
+    # Numpy 1.17
+    warnings.warn(
+        "np.mafromtxt is deprecated",
+        DeprecationWarning, stacklevel=2)
     return genfromtxt(fname, **kwargs)
 
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2226,7 +2226,10 @@ def ndfromtxt(fname, **kwargs):
     Load ASCII data stored in a file and return it as a single array.
 
     .. deprecated:: 1.17
-        np.ndfromtxt is deprecated
+        ndfromtxt` is a deprecated alias of `genfromtxt` which
+        overwrites the ``usemask`` argument with `False` even when
+        explicitly called as ``ndfromtxt(..., usemask=True)``.
+        Use `genfromtxt` instead.
 
     Parameters
     ----------
@@ -2240,7 +2243,8 @@ def ndfromtxt(fname, **kwargs):
     kwargs['usemask'] = False
     # Numpy 1.17
     warnings.warn(
-        "np.ndfromtxt is deprecated",
+        "np.ndfromtxt is a deprecated alias of np.genfromtxt, "
+        "prefer the latter.",
         DeprecationWarning, stacklevel=2)
     return genfromtxt(fname, **kwargs)
 
@@ -2250,7 +2254,10 @@ def mafromtxt(fname, **kwargs):
     Load ASCII data stored in a text file and return a masked array.
 
     .. deprecated:: 1.17
-        np.mafromtxt is deprecated
+        np.mafromtxt is a deprecated alias of `genfromtxt` which
+        overwrites the ``usemask`` argument with `True` even when
+        explicitly called as ``mafromtxt(..., usemask=False)``.
+        Use `genfromtxt` instead.
 
     Parameters
     ----------
@@ -2264,7 +2271,8 @@ def mafromtxt(fname, **kwargs):
     kwargs['usemask'] = True
     # Numpy 1.17
     warnings.warn(
-        "np.mafromtxt is deprecated",
+        "np.mafromtxt is a deprecated alias of np.genfromtxt, "
+        "prefer the latter.",
         DeprecationWarning, stacklevel=2)
     return genfromtxt(fname, **kwargs)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1192,7 +1192,7 @@ class TestFromTxt(LoadTxtBase):
     def test_record(self):
         # Test w/ explicit dtype
         data = TextIO('1 2\n3 4')
-        test = np.ndfromtxt(data, dtype=[('x', np.int32), ('y', np.int32)])
+        test = np.genfromtxt(data, dtype=[('x', np.int32), ('y', np.int32)])
         control = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
         assert_equal(test, control)
         #
@@ -1201,14 +1201,14 @@ class TestFromTxt(LoadTxtBase):
                       'formats': ('S1', 'i4', 'f4')}
         control = np.array([('M', 64.0, 75.0), ('F', 25.0, 60.0)],
                            dtype=descriptor)
-        test = np.ndfromtxt(data, dtype=descriptor)
+        test = np.genfromtxt(data, dtype=descriptor)
         assert_equal(test, control)
 
     def test_array(self):
         # Test outputting a standard ndarray
         data = TextIO('1 2\n3 4')
         control = np.array([[1, 2], [3, 4]], dtype=int)
-        test = np.ndfromtxt(data, dtype=int)
+        test = np.genfromtxt(data, dtype=int)
         assert_array_equal(test, control)
         #
         data.seek(0)
@@ -1221,11 +1221,11 @@ class TestFromTxt(LoadTxtBase):
         control = np.array([1, 2, 3, 4], int)
         #
         data = TextIO('1\n2\n3\n4\n')
-        test = np.ndfromtxt(data, dtype=int)
+        test = np.genfromtxt(data, dtype=int)
         assert_array_equal(test, control)
         #
         data = TextIO('1,2,3,4\n')
-        test = np.ndfromtxt(data, dtype=int, delimiter=',')
+        test = np.genfromtxt(data, dtype=int, delimiter=',')
         assert_array_equal(test, control)
 
     def test_comments(self):
@@ -1233,11 +1233,11 @@ class TestFromTxt(LoadTxtBase):
         control = np.array([1, 2, 3, 5], int)
         # Comment on its own line
         data = TextIO('# comment\n1,2,3,5\n')
-        test = np.ndfromtxt(data, dtype=int, delimiter=',', comments='#')
+        test = np.genfromtxt(data, dtype=int, delimiter=',', comments='#')
         assert_equal(test, control)
         # Comment at the end of a line
         data = TextIO('1,2,3,5# comment\n')
-        test = np.ndfromtxt(data, dtype=int, delimiter=',', comments='#')
+        test = np.genfromtxt(data, dtype=int, delimiter=',', comments='#')
         assert_equal(test, control)
 
     def test_skiprows(self):
@@ -1246,7 +1246,7 @@ class TestFromTxt(LoadTxtBase):
         kwargs = dict(dtype=int, delimiter=',')
         #
         data = TextIO('comment\n1,2,3,5\n')
-        test = np.ndfromtxt(data, skip_header=1, **kwargs)
+        test = np.genfromtxt(data, skip_header=1, **kwargs)
         assert_equal(test, control)
         #
         data = TextIO('# comment\n1,2,3,5\n')
@@ -1293,7 +1293,7 @@ class TestFromTxt(LoadTxtBase):
         data = TextIO('gender age weight\nM 64.0 75.0\nF 25.0 60.0')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            test = np.ndfromtxt(data, dtype=None, names=True)
+            test = np.genfromtxt(data, dtype=None, names=True)
             assert_(w[0].category is np.VisibleDeprecationWarning)
         control = {'gender': np.array([b'M', b'F']),
                    'age': np.array([64.0, 25.0]),
@@ -1307,7 +1307,7 @@ class TestFromTxt(LoadTxtBase):
         data = TextIO('A 64 75.0 3+4j True\nBCD 25 60.0 5+6j False')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            test = np.ndfromtxt(data, dtype=None)
+            test = np.genfromtxt(data, dtype=None)
             assert_(w[0].category is np.VisibleDeprecationWarning)
         control = [np.array([b'A', b'BCD']),
                    np.array([64, 25]),
@@ -1321,7 +1321,7 @@ class TestFromTxt(LoadTxtBase):
     def test_auto_dtype_uniform(self):
         # Tests whether the output dtype can be uniformized
         data = TextIO('1 2 3 4\n5 6 7 8\n')
-        test = np.ndfromtxt(data, dtype=None)
+        test = np.genfromtxt(data, dtype=None)
         control = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
         assert_equal(test, control)
 
@@ -1329,7 +1329,7 @@ class TestFromTxt(LoadTxtBase):
         # Check that a nested dtype isn't MIA
         data = TextIO('1,2,3.0\n4,5,6.0\n')
         fancydtype = np.dtype([('x', int), ('y', [('t', int), ('s', float)])])
-        test = np.ndfromtxt(data, dtype=fancydtype, delimiter=',')
+        test = np.genfromtxt(data, dtype=fancydtype, delimiter=',')
         control = np.array([(1, (2, 3.0)), (4, (5, 6.0))], dtype=fancydtype)
         assert_equal(test, control)
 
@@ -1339,7 +1339,7 @@ class TestFromTxt(LoadTxtBase):
                       'formats': ('S1', 'i4', 'f4')}
         data = TextIO(b'M 64.0 75.0\nF 25.0 60.0')
         names = ('gender', 'age', 'weight')
-        test = np.ndfromtxt(data, dtype=descriptor, names=names)
+        test = np.genfromtxt(data, dtype=descriptor, names=names)
         descriptor['names'] = names
         control = np.array([('M', 64.0, 75.0),
                             ('F', 25.0, 60.0)], dtype=descriptor)
@@ -1386,7 +1386,7 @@ M   33  21.99
         data = TextIO('A B C D\n aaaa 121 45 9.1')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            test = np.ndfromtxt(data, usecols=('A', 'C', 'D'),
+            test = np.genfromtxt(data, usecols=('A', 'C', 'D'),
                                 names=True, dtype=None)
             assert_(w[0].category is np.VisibleDeprecationWarning)
         control = np.array(('aaaa', 45, 9.1),
@@ -1396,7 +1396,7 @@ M   33  21.99
     def test_converters_with_usecols(self):
         # Test the combination user-defined converters and usecol
         data = TextIO('1,2,3,,5\n6,7,8,9,10\n')
-        test = np.ndfromtxt(data, dtype=int, delimiter=',',
+        test = np.genfromtxt(data, dtype=int, delimiter=',',
                             converters={3: lambda s: int(s or - 999)},
                             usecols=(1, 3,))
         control = np.array([[2, -999], [7, 9]], int)
@@ -1407,7 +1407,7 @@ M   33  21.99
         data = TextIO('A B C D\n aaaa 121 45 9.1')
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            test = np.ndfromtxt(data, usecols=('A', 'C', 'D'), names=True,
+            test = np.genfromtxt(data, usecols=('A', 'C', 'D'), names=True,
                                 dtype=None,
                                 converters={'C': lambda s: 2 * int(s)})
             assert_(w[0].category is np.VisibleDeprecationWarning)
@@ -1420,7 +1420,7 @@ M   33  21.99
         converter = {
             'date': lambda s: strptime(s, '%Y-%m-%d %H:%M:%SZ')}
         data = TextIO('2009-02-03 12:00:00Z, 72214.0')
-        test = np.ndfromtxt(data, delimiter=',', dtype=None,
+        test = np.genfromtxt(data, delimiter=',', dtype=None,
                             names=['date', 'stid'], converters=converter)
         control = np.array((datetime(2009, 2, 3), 72214.),
                            dtype=[('date', np.object_), ('stid', float)])
@@ -1431,7 +1431,7 @@ M   33  21.99
         converter = {
             'date': lambda s: np.datetime64(strptime(s, '%Y-%m-%d %H:%M:%SZ'))}
         data = TextIO('2009-02-03 12:00:00Z, 72214.0')
-        test = np.ndfromtxt(data, delimiter=',', dtype=None,
+        test = np.genfromtxt(data, delimiter=',', dtype=None,
                             names=['date', 'stid'], converters=converter)
         control = np.array((datetime(2009, 2, 3), 72214.),
                            dtype=[('date', 'datetime64[us]'), ('stid', float)])
@@ -1440,12 +1440,12 @@ M   33  21.99
     def test_unused_converter(self):
         # Test whether unused converters are forgotten
         data = TextIO("1 21\n  3 42\n")
-        test = np.ndfromtxt(data, usecols=(1,),
+        test = np.genfromtxt(data, usecols=(1,),
                             converters={0: lambda s: int(s, 16)})
         assert_equal(test, [21, 42])
         #
         data.seek(0)
-        test = np.ndfromtxt(data, usecols=(1,),
+        test = np.genfromtxt(data, usecols=(1,),
                             converters={1: lambda s: int(s, 16)})
         assert_equal(test, [33, 66])
 
@@ -1472,12 +1472,12 @@ M   33  21.99
 
     def test_dtype_with_converters(self):
         dstr = "2009; 23; 46"
-        test = np.ndfromtxt(TextIO(dstr,),
+        test = np.genfromtxt(TextIO(dstr,),
                             delimiter=";", dtype=float, converters={0: bytes})
         control = np.array([('2009', 23., 46)],
                            dtype=[('f0', '|S4'), ('f1', float), ('f2', float)])
         assert_equal(test, control)
-        test = np.ndfromtxt(TextIO(dstr,),
+        test = np.genfromtxt(TextIO(dstr,),
                             delimiter=";", dtype=float, converters={0: float})
         control = np.array([2009., 23., 46],)
         assert_equal(test, control)
@@ -1541,7 +1541,7 @@ M   33  21.99
     def test_spacedelimiter(self):
         # Test space delimiter
         data = TextIO("1  2  3  4   5\n6  7  8  9  10")
-        test = np.ndfromtxt(data)
+        test = np.genfromtxt(data)
         control = np.array([[1., 2., 3., 4., 5.],
                             [6., 7., 8., 9., 10.]])
         assert_equal(test, control)
@@ -1555,7 +1555,7 @@ M   33  21.99
 
     def test_missing(self):
         data = TextIO('1,2,3,,5\n')
-        test = np.ndfromtxt(data, dtype=int, delimiter=',',
+        test = np.genfromtxt(data, dtype=int, delimiter=',',
                             converters={3: lambda s: int(s or - 999)})
         control = np.array([1, 2, 3, -999, 5], int)
         assert_equal(test, control)
@@ -1577,18 +1577,18 @@ M   33  21.99
         data = TextIO()
         np.savetxt(data, control)
         data.seek(0)
-        test = np.ndfromtxt(data, dtype=float, usecols=(1,))
+        test = np.genfromtxt(data, dtype=float, usecols=(1,))
         assert_equal(test, control[:, 1])
         #
         control = np.array([[1, 2, 3], [3, 4, 5]], float)
         data = TextIO()
         np.savetxt(data, control)
         data.seek(0)
-        test = np.ndfromtxt(data, dtype=float, usecols=(1, 2))
+        test = np.genfromtxt(data, dtype=float, usecols=(1, 2))
         assert_equal(test, control[:, 1:])
         # Testing with arrays instead of tuples.
         data.seek(0)
-        test = np.ndfromtxt(data, dtype=float, usecols=np.array([1, 2]))
+        test = np.genfromtxt(data, dtype=float, usecols=np.array([1, 2]))
         assert_equal(test, control[:, 1:])
 
     def test_usecols_as_css(self):
@@ -1604,7 +1604,7 @@ M   33  21.99
         data = TextIO("JOE 70.1 25.3\nBOB 60.5 27.9")
         names = ['stid', 'temp']
         dtypes = ['S4', 'f8']
-        test = np.ndfromtxt(
+        test = np.genfromtxt(
             data, usecols=(0, 2), dtype=list(zip(names, dtypes)))
         assert_equal(test['stid'], [b"JOE", b"BOB"])
         assert_equal(test['temp'], [25.3, 27.9])
@@ -1637,7 +1637,7 @@ M   33  21.99
         # Check that a nested dtype isn't MIA
         data = TextIO('1,2,3.0\n4,5,6.0\n')
         fancydtype = np.dtype([('x', int), ('y', [('t', int), ('s', float)])])
-        test = np.mafromtxt(data, dtype=fancydtype, delimiter=',')
+        test = np.genfromtxt(data, dtype=fancydtype, delimiter=',', usemask=True)
         control = ma.array([(1, (2, 3.0)), (4, (5, 6.0))], dtype=fancydtype)
         assert_equal(test, control)
 
@@ -1645,7 +1645,7 @@ M   33  21.99
         c = TextIO("aaaa  1.0  8.0  1 2 3 4 5 6")
         dt = np.dtype([('name', 'S4'), ('x', float), ('y', float),
                        ('block', int, (2, 3))])
-        x = np.ndfromtxt(c, dtype=dt)
+        x = np.genfromtxt(c, dtype=dt)
         a = np.array([('aaaa', 1.0, 8.0, [[1, 2, 3], [4, 5, 6]])],
                      dtype=dt)
         assert_array_equal(x, a)
@@ -1653,7 +1653,7 @@ M   33  21.99
     def test_withmissing(self):
         data = TextIO('A,B\n0,1\n2,N/A')
         kwargs = dict(delimiter=",", missing_values="N/A", names=True)
-        test = np.mafromtxt(data, dtype=None, **kwargs)
+        test = np.genfromtxt(data, dtype=None, usemask=True, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
                            dtype=[('A', int), ('B', int)])
@@ -1661,7 +1661,7 @@ M   33  21.99
         assert_equal(test.mask, control.mask)
         #
         data.seek(0)
-        test = np.mafromtxt(data, **kwargs)
+        test = np.genfromtxt(data, usemask=True, **kwargs)
         control = ma.array([(0, 1), (2, -1)],
                            mask=[(False, False), (False, True)],
                            dtype=[('A', float), ('B', float)])
@@ -1673,7 +1673,7 @@ M   33  21.99
         basekwargs = dict(dtype=None, delimiter=",", names=True,)
         mdtype = [('A', int), ('B', float), ('C', complex)]
         #
-        test = np.mafromtxt(TextIO(data), missing_values="N/A",
+        test = np.genfromtxt(TextIO(data), missing_values="N/A",
                             **basekwargs)
         control = ma.array([(0, 0.0, 0j), (1, -999, 1j),
                             (-9, 2.2, -999j), (3, -99, 3j)],
@@ -1682,16 +1682,17 @@ M   33  21.99
         assert_equal(test, control)
         #
         basekwargs['dtype'] = mdtype
-        test = np.mafromtxt(TextIO(data),
-                            missing_values={0: -9, 1: -99, 2: -999j}, **basekwargs)
+        test = np.genfromtxt(TextIO(data),
+                            missing_values={0: -9, 1: -99, 2: -999j}, usemask=True, **basekwargs)
         control = ma.array([(0, 0.0, 0j), (1, -999, 1j),
                             (-9, 2.2, -999j), (3, -99, 3j)],
                            mask=[(0, 0, 0), (0, 1, 0), (1, 0, 1), (0, 1, 0)],
                            dtype=mdtype)
         assert_equal(test, control)
         #
-        test = np.mafromtxt(TextIO(data),
+        test = np.genfromtxt(TextIO(data),
                             missing_values={0: -9, 'B': -99, 'C': -999j},
+                            usemask=True,
                             **basekwargs)
         control = ma.array([(0, 0.0, 0j), (1, -999, 1j),
                             (-9, 2.2, -999j), (3, -99, 3j)],
@@ -1729,8 +1730,8 @@ M   33  21.99
 
     def test_withmissing_float(self):
         data = TextIO('A,B\n0,1.5\n2,-999.00')
-        test = np.mafromtxt(data, dtype=None, delimiter=',',
-                            missing_values='-999.0', names=True,)
+        test = np.genfromtxt(data, dtype=None, delimiter=',',
+                            missing_values='-999.0', names=True, usemask=True)
         control = ma.array([(0, 1.5), (2, -1.)],
                            mask=[(False, False), (False, True)],
                            dtype=[('A', int), ('B', float)])
@@ -1769,14 +1770,14 @@ M   33  21.99
         ret = {}
 
         def f(_ret={}):
-            _ret['mtest'] = np.ndfromtxt(mdata, invalid_raise=False, **kwargs)
+            _ret['mtest'] = np.genfromtxt(mdata, invalid_raise=False, **kwargs)
         assert_warns(ConversionWarning, f, _ret=ret)
         mtest = ret['mtest']
         assert_equal(len(mtest), 45)
         assert_equal(mtest, np.ones(45, dtype=[(_, int) for _ in 'abcde']))
         #
         mdata.seek(0)
-        assert_raises(ValueError, np.ndfromtxt, mdata,
+        assert_raises(ValueError, np.genfromtxt, mdata,
                       delimiter=",", names=True)
 
     def test_invalid_raise_with_usecols(self):
@@ -1793,14 +1794,14 @@ M   33  21.99
         ret = {}
 
         def f(_ret={}):
-            _ret['mtest'] = np.ndfromtxt(mdata, usecols=(0, 4), **kwargs)
+            _ret['mtest'] = np.genfromtxt(mdata, usecols=(0, 4), **kwargs)
         assert_warns(ConversionWarning, f, _ret=ret)
         mtest = ret['mtest']
         assert_equal(len(mtest), 45)
         assert_equal(mtest, np.ones(45, dtype=[(_, int) for _ in 'ae']))
         #
         mdata.seek(0)
-        mtest = np.ndfromtxt(mdata, usecols=(0, 1), **kwargs)
+        mtest = np.genfromtxt(mdata, usecols=(0, 1), **kwargs)
         assert_equal(len(mtest), 50)
         control = np.ones(50, dtype=[(_, int) for _ in 'ab'])
         control[[10 * _ for _ in range(5)]] = (2, 2)
@@ -1819,7 +1820,7 @@ M   33  21.99
     def test_default_field_format(self):
         # Test default format
         data = "0, 1, 2.3\n4, 5, 6.7"
-        mtest = np.ndfromtxt(TextIO(data),
+        mtest = np.genfromtxt(TextIO(data),
                              delimiter=",", dtype=None, defaultfmt="f%02i")
         ctrl = np.array([(0, 1, 2.3), (4, 5, 6.7)],
                         dtype=[("f00", int), ("f01", int), ("f02", float)])
@@ -1828,7 +1829,7 @@ M   33  21.99
     def test_single_dtype_wo_names(self):
         # Test single dtype w/o names
         data = "0, 1, 2.3\n4, 5, 6.7"
-        mtest = np.ndfromtxt(TextIO(data),
+        mtest = np.genfromtxt(TextIO(data),
                              delimiter=",", dtype=float, defaultfmt="f%02i")
         ctrl = np.array([[0., 1., 2.3], [4., 5., 6.7]], dtype=float)
         assert_equal(mtest, ctrl)
@@ -1836,7 +1837,7 @@ M   33  21.99
     def test_single_dtype_w_explicit_names(self):
         # Test single dtype w explicit names
         data = "0, 1, 2.3\n4, 5, 6.7"
-        mtest = np.ndfromtxt(TextIO(data),
+        mtest = np.genfromtxt(TextIO(data),
                              delimiter=",", dtype=float, names="a, b, c")
         ctrl = np.array([(0., 1., 2.3), (4., 5., 6.7)],
                         dtype=[(_, float) for _ in "abc"])
@@ -1845,7 +1846,7 @@ M   33  21.99
     def test_single_dtype_w_implicit_names(self):
         # Test single dtype w implicit names
         data = "a, b, c\n0, 1, 2.3\n4, 5, 6.7"
-        mtest = np.ndfromtxt(TextIO(data),
+        mtest = np.genfromtxt(TextIO(data),
                              delimiter=",", dtype=float, names=True)
         ctrl = np.array([(0., 1., 2.3), (4., 5., 6.7)],
                         dtype=[(_, float) for _ in "abc"])
@@ -1854,7 +1855,7 @@ M   33  21.99
     def test_easy_structured_dtype(self):
         # Test easy structured dtype
         data = "0, 1, 2.3\n4, 5, 6.7"
-        mtest = np.ndfromtxt(TextIO(data), delimiter=",",
+        mtest = np.genfromtxt(TextIO(data), delimiter=",",
                              dtype=(int, float, float), defaultfmt="f_%02i")
         ctrl = np.array([(0, 1., 2.3), (4, 5., 6.7)],
                         dtype=[("f_00", int), ("f_01", float), ("f_02", float)])
@@ -1866,14 +1867,14 @@ M   33  21.99
         kwargs = dict(delimiter=",", dtype=None)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            mtest = np.ndfromtxt(TextIO(data), **kwargs)
+            mtest = np.genfromtxt(TextIO(data), **kwargs)
             assert_(w[0].category is np.VisibleDeprecationWarning)
         ctrl = np.array([('01/01/2003  ', 1.3, '   abcde')],
                         dtype=[('f0', '|S12'), ('f1', float), ('f2', '|S8')])
         assert_equal(mtest, ctrl)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', '', np.VisibleDeprecationWarning)
-            mtest = np.ndfromtxt(TextIO(data), autostrip=True, **kwargs)
+            mtest = np.genfromtxt(TextIO(data), autostrip=True, **kwargs)
             assert_(w[0].category is np.VisibleDeprecationWarning)
         ctrl = np.array([('01/01/2003', 1.3, 'abcde')],
                         dtype=[('f0', '|S10'), ('f1', float), ('f2', '|S5')])
@@ -1934,12 +1935,12 @@ M   33  21.99
         # w/ dtype=None
         ctrl = np.array([(0, 1, 2), (3, 4, 5)],
                         dtype=[(_, int) for _ in ('A', 'f0', 'C')])
-        test = np.ndfromtxt(TextIO(data), dtype=None, **kwargs)
+        test = np.genfromtxt(TextIO(data), dtype=None, **kwargs)
         assert_equal(test, ctrl)
         # w/ default dtype
         ctrl = np.array([(0, 1, 2), (3, 4, 5)],
                         dtype=[(_, float) for _ in ('A', 'f0', 'C')])
-        test = np.ndfromtxt(TextIO(data), **kwargs)
+        test = np.genfromtxt(TextIO(data), **kwargs)
 
     def test_names_auto_completion(self):
         # Make sure that names are properly completed
@@ -1975,13 +1976,13 @@ M   33  21.99
         kwargs = dict(delimiter=(5, 5, 4), names=True, dtype=None)
         ctrl = np.array([(0, 1, 2.3), (45, 67, 9.)],
                         dtype=[('A', int), ('B', int), ('C', float)])
-        test = np.ndfromtxt(TextIO(data), **kwargs)
+        test = np.genfromtxt(TextIO(data), **kwargs)
         assert_equal(test, ctrl)
         #
         kwargs = dict(delimiter=5, names=True, dtype=None)
         ctrl = np.array([(0, 1, 2.3), (45, 67, 9.)],
                         dtype=[('A', int), ('B', int), ('C', float)])
-        test = np.ndfromtxt(TextIO(data), **kwargs)
+        test = np.genfromtxt(TextIO(data), **kwargs)
         assert_equal(test, ctrl)
 
     def test_filling_values(self):
@@ -1989,7 +1990,7 @@ M   33  21.99
         data = b"1, 2, 3\n1, , 5\n0, 6, \n"
         kwargs = dict(delimiter=",", dtype=None, filling_values=-999)
         ctrl = np.array([[1, 2, 3], [1, -999, 5], [0, 6, -999]], dtype=int)
-        test = np.ndfromtxt(TextIO(data), **kwargs)
+        test = np.genfromtxt(TextIO(data), **kwargs)
         assert_equal(test, ctrl)
 
     def test_comments_is_none(self):
@@ -2278,7 +2279,7 @@ M   33  21.99
 
         data = TextIO('73786976294838206464 17179869184 1024')
 
-        test = np.ndfromtxt(data, dtype=None)
+        test = np.genfromtxt(data, dtype=None)
 
         assert_equal(test.dtype.names, ['f0', 'f1', 'f2'])
 
@@ -2368,9 +2369,8 @@ class TestPathUsage(object):
                 f.write(u'1 2\n3 4')
 
             control = np.array([[1, 2], [3, 4]], dtype=int)
-            test = np.ndfromtxt(path, dtype=int)
-            with assert_warns(VisibleDeprecationWarning):
-                assert_array_equal(test, control)
+            test = np.genfromtxt(path, dtype=int)
+            assert_array_equal(test, control)
 
     def test_mafromtxt(self):
         # From `test_fancy_dtype_alt` above
@@ -2379,10 +2379,9 @@ class TestPathUsage(object):
             with path.open('w') as f:
                 f.write(u'1,2,3.0\n4,5,6.0\n')
 
-            test = np.mafromtxt(path, delimiter=',')
+            test = np.genfromtxt(path, delimiter=',', usemask=True)
             control = ma.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
-            with assert_warns(VisibleDeprecationWarning):
-                assert_equal(test, control)
+            assert_equal(test, control)
 
     def test_recfromtxt(self):
         with temppath(suffix='.txt') as path:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2369,7 +2369,8 @@ class TestPathUsage(object):
 
             control = np.array([[1, 2], [3, 4]], dtype=int)
             test = np.ndfromtxt(path, dtype=int)
-            assert_array_equal(test, control)
+            with assert_warns(VisibleDeprecationWarning):
+                assert_array_equal(test, control)
 
     def test_mafromtxt(self):
         # From `test_fancy_dtype_alt` above
@@ -2380,7 +2381,8 @@ class TestPathUsage(object):
 
             test = np.mafromtxt(path, delimiter=',')
             control = ma.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)])
-            assert_equal(test, control)
+            with assert_warns(VisibleDeprecationWarning):
+                assert_equal(test, control)
 
     def test_recfromtxt(self):
         with temppath(suffix='.txt') as path:

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1098,9 +1098,6 @@ def safe_eval(source):
     Evaluate a string containing a Python literal expression without
     allowing the execution of arbitrary non-literal code.
 
-    .. deprecate:: 1.17
-        safe_eval is deprecated
-
     Parameters
     ----------
     source : str

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1098,6 +1098,9 @@ def safe_eval(source):
     Evaluate a string containing a Python literal expression without
     allowing the execution of arbitrary non-literal code.
 
+    .. deprecate:: 1.17
+        safe_eval is deprecated
+
     Parameters
     ----------
     source : str
@@ -1137,6 +1140,9 @@ def safe_eval(source):
     # Local import to speed up numpy's import time.
     import ast
 
+    # Numpy 1.17
+    warnings.warn("SafeEval is deprecated in 1.17",
+                      DeprecationWarning, stacklevel=2)
     return ast.literal_eval(source)
 
 

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1139,10 +1139,6 @@ def safe_eval(source):
     """
     # Local import to speed up numpy's import time.
     import ast
-
-    # Numpy 1.17
-    warnings.warn("SafeEval is deprecated in 1.17",
-                      DeprecationWarning, stacklevel=2)
     return ast.literal_eval(source)
 
 


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->
Related to #12385 
The checklist for future work on this PR is as follows:
Deprecate - 
- [x] 'mafromtxt`
- [x] 'ndfromtxt'

@rgommers Please review and let me know the required changes. Thanks a lot!
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
