### PR TITLE
Improve error message for negative valued argument

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -607,7 +607,8 @@ PyArray_Repeat(PyArrayObject *aop, PyObject *op, int axis)
     else {
         for (j = 0; j < n; j++) {
             if (counts[j] < 0) {
-                PyErr_SetString(PyExc_ValueError, "count < 0");
+                PyErr_SetString(PyExc_ValueError,
+                                "repeats may not contain negative values.");
                 goto fail;
             }
             total += counts[j];


### PR DESCRIPTION
`repeat` can take an array of numbers as value for it's `repeat`
argument. The error message if one of these is negative is `count < 0`.
The first time I encountered this, I did not understand the error since
this message is somewhat cryptic and uninformtiave. Replace it by
something better.
