### PR TITLE
DOC: mention PyArray_GetField steals a reference

### DIFF
--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1660,10 +1660,11 @@ Conversion
 .. c:function:: PyObject* PyArray_GetField( \
         PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
-    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). Return
-    a new array of the given *dtype* using the data in the current
-    array at a specified *offset* in bytes. The *offset* plus the
-    itemsize of the new array type must be less than *self*
+    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*).
+    This function :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
+    to ``PyArray_Descr`` and return a new array of the given *dtype* 
+    using the data in the current array at a specified *offset* in bytes. 
+    The *offset* plus the itemsize of the new array type must be less than *self*
     ->descr->elsize or an error is raised. The same shape and strides
     as the original array are used. Therefore, this function has the
     effect of returning a field from a structured array. But, it can also

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1652,10 +1652,9 @@ Conversion
 
 .. c:function:: PyObject* PyArray_GetField( \
         PyArrayObject* self, PyArray_Descr* dtype, int offset)
-
-    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). This function 
-    :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
-    to ``PyArray_Descr`` and return a new array of the given *dtype* 
+        
+    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). 
+    This function **steals a reference** to ``PyArray_Descr``and returns a new array of the given *dtype* 
     using the data in the current array at a specified *offset* in bytes. 
     The *offset* plus the itemsize of the new array type must be less than *self*
     ->descr->elsize or an error is raised. The same shape and strides

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1660,8 +1660,8 @@ Conversion
 .. c:function:: PyObject* PyArray_GetField( \
         PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
-    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*).
-    This function :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
+    Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). This function 
+    :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
     to ``PyArray_Descr`` and return a new array of the given *dtype* 
     using the data in the current array at a specified *offset* in bytes. 
     The *offset* plus the itemsize of the new array type must be less than *self*

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1661,7 +1661,7 @@ Conversion
         PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
     Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). This function 
-   :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
+    :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
     to ``PyArray_Descr`` and return a new array of the given *dtype* 
     using the data in the current array at a specified *offset* in bytes. 
     The *offset* plus the itemsize of the new array type must be less than *self*

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -288,13 +288,6 @@ From scratch
     are passed in they must be consistent with the dimensions, the
     itemsize, and the data of the array.
 
-.. c:function:: PyObject* PyArray_SimpleNew(int nd, npy_intp* dims, int typenum)
-
-    Create a new uninitialized array of type, *typenum*, whose size in
-    each of *nd* dimensions is given by the integer array, *dims*.
-    This function cannot be used to create a flexible-type array (no
-    itemsize given).
-
 .. c:function:: PyObject* PyArray_SimpleNewFromData( \
         int nd, npy_intp* dims, int typenum, void* data)
 

--- a/doc/source/reference/c-api.array.rst
+++ b/doc/source/reference/c-api.array.rst
@@ -1661,7 +1661,7 @@ Conversion
         PyArrayObject* self, PyArray_Descr* dtype, int offset)
 
     Equivalent to :meth:`ndarray.getfield<numpy.ndarray.getfield>` (*self*, *dtype*, *offset*). This function 
-    :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
+   :meth:`steals a reference<https://stackoverflow.com/questions/23644926/what-is-reference-stealing-and-borrowing>`
     to ``PyArray_Descr`` and return a new array of the given *dtype* 
     using the data in the current array at a specified *offset* in bytes. 
     The *offset* plus the itemsize of the new array type must be less than *self*


### PR DESCRIPTION
Updates Document mentions that PyArray_GetField steals a reference to its descr argument
along with the meaning of steals to reference.