### PR TITLE
DOC: fix docstring for floor_divide

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1313,7 +1313,7 @@ add_newdoc('numpy.core.umath', 'floor_divide',
     """
     Return the largest integer smaller or equal to the division of the inputs.
     It is equivalent to the Python ``//`` operator and pairs with the
-    Python ``%`` (`remainder`), function so that ``b = a % b + b * (a // b)``
+    Python ``%`` (`remainder`), function so that ``a = a % b + b * (a // b)``
     up to roundoff.
 
     Parameters
@@ -2607,7 +2607,7 @@ add_newdoc('numpy.core.umath', 'matmul',
 
     >>> a = np.array([[1, 0],
     ...               [0, 1]])
-    >>> b = np.array([[4, 1], 
+    >>> b = np.array([[4, 1],
     ...               [2, 2]])
     >>> np.matmul(a, b)
     array([[4, 1],

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1313,7 +1313,7 @@ add_newdoc('numpy.core.umath', 'floor_divide',
     """
     Return the largest integer smaller or equal to the division of the inputs.
     It is equivalent to the Python ``//`` operator and pairs with the
-    Python ``%`` (`remainder`), function so that ``b = a % b + b * (a // b)``
+    Python ``%`` (`remainder`), function so that ``a = a % b + b * (a // b)``
     up to roundoff.
 
     Parameters

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1313,7 +1313,7 @@ add_newdoc('numpy.core.umath', 'floor_divide',
     """
     Return the largest integer smaller or equal to the division of the inputs.
     It is equivalent to the Python ``//`` operator and pairs with the
-    Python ``%`` (`remainder`), function so that ``a = a % b + b * (a // b)``
+    Python ``%`` (`remainder`), function so that ``b = a % b + b * (a // b)``
     up to roundoff.
 
     Parameters

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -602,9 +602,8 @@ def filled(a, fill_value=None):
     ----------
     a : MaskedArray or array_like
         An input object.
-    fill_value : {var}, optional
-        Value used to fill in the masked values that can be any shape.
-        Default is None.
+    fill_value : scalar, optional
+        Filling value. Default is None.
 
     Returns
     -------
@@ -2739,9 +2738,8 @@ class MaskedArray(ndarray):
         plain `MaskedArray`. Default is True.
     ndmin : int, optional
         Minimum number of dimensions. Default is 0.
-    fill_value : {var}, optional
-        Value used to fill in the masked values that can be any shape.
-        Default is None.
+    fill_value : scalar, optional
+        Value used to fill in the masked values when necessary.
         If None, a default based on the data-type is used.
     keep_mask : bool, optional
         Whether to combine `mask` with the mask of the input data, if any
@@ -3668,9 +3666,8 @@ class MaskedArray(ndarray):
 
         Parameters
         ----------
-        fill_value : {var}, optional
-            Value used to fill in the masked values that can be any shape.
-            Default is None.
+        fill_value : scalar, optional
+            The value to use for invalid entries (None by default).
             If None, the `fill_value` attribute of the array is used instead.
 
         Returns
@@ -6205,9 +6202,8 @@ class mvoid(MaskedArray):
 
         Parameters
         ----------
-        fill_value : {var}, optional
-            Value used to fill in the masked values that can be any shape.
-            Default is None.
+        fill_value : scalar, optional
+            The value to use for invalid entries (None by default).
             If None, the `fill_value` attribute is used instead.
 
         Returns

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -602,8 +602,9 @@ def filled(a, fill_value=None):
     ----------
     a : MaskedArray or array_like
         An input object.
-    fill_value : scalar, optional
-        Filling value. Default is None.
+    fill_value : {var}, optional
+        Value used to fill in the masked values that can be any shape.
+        Default is None.
 
     Returns
     -------
@@ -2738,8 +2739,9 @@ class MaskedArray(ndarray):
         plain `MaskedArray`. Default is True.
     ndmin : int, optional
         Minimum number of dimensions. Default is 0.
-    fill_value : scalar, optional
-        Value used to fill in the masked values when necessary.
+    fill_value : {var}, optional
+        Value used to fill in the masked values that can be any shape.
+        Default is None.
         If None, a default based on the data-type is used.
     keep_mask : bool, optional
         Whether to combine `mask` with the mask of the input data, if any
@@ -3450,7 +3452,7 @@ class MaskedArray(ndarray):
         # We could try to force a reshape, but that wouldn't work in some
         # cases.
         return self._mask
-    
+
     @mask.setter
     def mask(self, value):
         self.__setmask__(value)
@@ -3666,8 +3668,9 @@ class MaskedArray(ndarray):
 
         Parameters
         ----------
-        fill_value : scalar, optional
-            The value to use for invalid entries (None by default).
+        fill_value : {var}, optional
+            Value used to fill in the masked values that can be any shape.
+            Default is None.
             If None, the `fill_value` attribute of the array is used instead.
 
         Returns
@@ -6202,8 +6205,9 @@ class mvoid(MaskedArray):
 
         Parameters
         ----------
-        fill_value : scalar, optional
-            The value to use for invalid entries (None by default).
+        fill_value : {var}, optional
+            Value used to fill in the masked values that can be any shape.
+            Default is None.
             If None, the `fill_value` attribute is used instead.
 
         Returns


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->
Corrected the mistake in the docstring for floor_divide: change 'b' to 'a'.
However, my IDE has also deleted the unnecessary spaces. Is it ok, or should I delete it?
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
