### PR TITLE
MAINT: replace SETREF with assignment to ret array in ndarray.flat

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -667,8 +667,9 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     }
     Py_DECREF(indtype);
     Py_DECREF(obj);
-    Py_SETREF(new, iter_subscript_int(self, (PyArrayObject *)new));
-    return new;
+    ret = (PyArrayObject *)iter_subscript_int(self, (PyArrayObject *)new);
+    Py_DECREF(new);
+    return (PyObject *)ret;
 
 
  fail:


### PR DESCRIPTION
Brief follow-up to https://github.com/numpy/numpy/pull/13176, following [the original comment by @mhvk](https://github.com/numpy/numpy/pull/13176#discussion_r268438828) and [an addition by @eric-wieser](https://github.com/numpy/numpy/pull/13176#issuecomment-478845724).

Replace the call to `Py_SETREF` with an assignment to a dedicated `ret` array.