### PR TITLE
TST: fail Azure CI if test failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
       testRunTitle: 'Publish test results for Python 3.6-32 bit full Linux'
 - job: macOS
   pool:
@@ -105,7 +105,7 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
       testRunTitle: 'Publish test results for Python 3.6 64-bit full Mac OS'
 - job: Windows
   pool:
@@ -208,5 +208,5 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-*.xml'
-      failTaskOnFailedTests: false
+      failTaskOnFailedTests: true
       testRunTitle: 'Publish test results for Python $(PYTHON_VERSION) $(BITS)-bit $(TEST_MODE) Windows'


### PR DESCRIPTION
For comment / note here from Chuck: https://github.com/numpy/numpy/pull/13245#issuecomment-479214934

Note that a nice summary of the failed tests is showing up in that PR now, but the problem is that Azure shows green instead of red as final result.

We need to set `failTaskOnFailedTests` to `true` for Azure CI Publish stage to fail when one or more unit tests fail, so we get both the nice summary of failed tests, and a red "x" if there is a failure detected after publishing.

I didn't actually change that setting in #13217, it was already the default, but because we no longer hard fail CI when the tests fail, we do need to hard fail **after** publishing if a failure is detected.

If a reviewer wants to be thorough they can intentionally introduce / remove a failure here for behavioural assessment on Azure.