### PR TITLE
BUG: Add ValueError for read-only array in clip() function #12242

### DIFF
--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -903,6 +903,9 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
     char *max_data, *min_data;
     PyObject *zero;
 
+    if (PyArray_FailUnlessWriteable(self, "output array") < 0) {
+        return NULL;
+    }
     /* Treat None the same as NULL */
     if (min == Py_None) {
         min = NULL;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1784,6 +1784,14 @@ class TestClip(object):
         assert_equal(d.clip(min=-2, max=np.nan), d)
         assert_equal(d.clip(min=np.nan, max=10), d)
 
+    def test_clip_writeable(self):
+        with assert_raises(ValueError):
+            a = self._generate_data(self.nr, self.nc)
+            a.flags.writeable = False
+            m = 1
+            M = 2
+            self.clip(a, m, M, a)
+
 
 class TestAllclose(object):
     rtol = 1e-5


### PR DESCRIPTION

Implemented the ValueError for a non-writeable array in numpy/calculation.c
Added test for ValueError in numpy/core/tests/test_numeric.py