### PR TITLE
BUG: fix the numpy.copy function to copy dtype as well! (issue:#12817)

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -766,9 +766,11 @@ def copy(a, order='K'):
 
     Notes
     -----
-    This is equivalent to:
+    This is NOT equivalent to:
 
     >>> np.array(a, copy=True)  #doctest: +SKIP
+
+    since the numpy.copy function will also create an independent dtype instance.
 
     Examples
     --------
@@ -786,8 +788,20 @@ def copy(a, order='K'):
     >>> x[0] == z[0]
     False
 
+    and the types are independant when using numpy.copy
+    >>> x.dtype is y.dtype
+    True
+    >>> x.dtype is z.dtype
+    False
+    >>> x.dtype == z.dtype
+    True
+
     """
-    return array(a, order=order, copy=True)
+    import copy as cp
+    copied_type = cp.copy(a.dtype)
+    copied_a = array(a, order=order, copy=True)
+    copied_a.dtype = copied_type
+    return copied_a
 
 # Basic operations
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -260,6 +260,10 @@ class TestCopy(object):
         assert_equal(a[0, 0], 1)
         assert_equal(a_copy[0, 0], 10)
 
+        # testing independent of dtypes
+        assert a.dtype == a_copy.dtype
+        assert a.dtype is not a_copy.dtype
+
     def test_order(self):
         # It turns out that people rely on np.copy() preserving order by
         # default; changing this broke scikit-learn:


### PR DESCRIPTION
BUG: fix the numpy.copy function to copy dtype as well! (issue:#12817)