### PR TITLE
TST: use OpenBLAS v0.3.5 for POWER8 CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
       env:
        # for matrix annotation only
        - PPC64_LE=1
+       # use POWER8 OpenBLAS build, not system ATLAS
+       - ATLAS=None
 
 before_install:
   - ./tools/travis-before-install.sh

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -25,6 +25,17 @@ if [ -n "$INSTALL_PICKLE5" ]; then
   pip install pickle5
 fi
 
+if [ -n "$PPC64_LE" ]; then
+  # build script for POWER8 OpenBLAS available here:
+  # https://github.com/tylerjereddy/openblas-static-gcc/blob/master/power8
+  # built on GCC compile farm machine named gcc112
+  # manually uploaded tarball to an unshared Dropbox location
+  wget -O openblas-power8.tar.gz https://www.dropbox.com/s/zcwhk7c2zptwy0s/openblas-v0.3.5-ppc64le-power8.tar.gz?dl=0
+  tar zxvf openblas-power8.tar.gz
+  sudo cp -r ./64/lib/* /usr/lib
+  sudo cp ./64/include/* /usr/include
+fi
+
 pip install --upgrade pip setuptools
 pip install nose pytz cython pytest
 if [ -n "$USE_ASV" ]; then pip install asv; fi


### PR DESCRIPTION
We currently use the system ATLAS for our `ppc64le` Travis CI builds. This PR switches the backend to match our OpenBLAS-based wheels, for example.

For reviewers:
- the [POWER8 build script](https://github.com/tylerjereddy/openblas-static-gcc/blob/master/power8/build_openblas.sh) produces a tarball that is currently stored manually on my Dropbox--suggestions for putting this somewhere more robust (i.e, the rackspace we use for MacPython)? and with what credentials to upload there (usually API secret key through Travis, so not sure)?
- please check that you agree with me that `OpenBLAS` is indeed being used as the backend for that matrix entry now

<details>

The OpenBLAS for POWER8 is not yet statically linked to the gcc / gfortran runtime--we likely need access to [`libgfortran.a` built with `-fPIC`](https://github.com/JuliaLang/julia/issues/326#issuecomment-191781005) on the GCC compile farm. Anyway, none of our other platform OpenBLAS builds on MacPython are statically linked either.

</details>