### PR TITLE
[FFT][BUG] do not set special compiler flags for pocketfft

### DIFF
--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -8,9 +8,7 @@ def configuration(parent_package='',top_path=None):
     config.add_data_dir('tests')
 
     # Configure pocketfft_internal
-    config.add_extension('pocketfft_internal',
-                         sources=['pocketfft.c']
-                         )
+    config.add_extension('pocketfft_internal', sources=['pocketfft.c'])
 
     return config
 


### PR DESCRIPTION
I read in https://hackmd.io/30eMeRnDQCSW7yDOG05gxA?view# that the custom compiler flag set by pocketfft causes problems. This flag is a debugging relic and has no influence on code generation, so I have removed it.
