### PR TITLE
TST: skip TestPinv 32-bit

### DIFF
--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -9,6 +9,7 @@ import itertools
 import traceback
 import textwrap
 import subprocess
+import platform
 import pytest
 
 import numpy as np
@@ -813,7 +814,10 @@ class PinvCases(LinalgSquareTestCase,
 
 
 class TestPinv(PinvCases):
-    pass
+    mark = pytest.mark.skipif((platform.system() == "Linux" and
+                               sys.maxsize < 2**32),
+                               reason="see NumPy gh-12862")
+    PinvCases.test_generalized_sq_cases.pytestmark = mark
 
 
 class PinvHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):


### PR DESCRIPTION
Fixes #12862, since recent core dev discussions have favored skipping this on 32-bit Linux.

A few core devs have likely sunk too much time into trying to debug this sporadic failure, which only affects 32-bit Linux on the NumPy wheels repo.

Sadly, our dev CI is not sensitive to this, but the failed build logs availble in the linked issue should make the identity of the problem test clear to a reviewer.

Technically, we could also have a finer-grained skip that only operates on the complex64 dtype or even just relaxes the precision requirement for linux 32-bit. Not sure it is worth the energy though.