### PR TITLE
BUG, MAINT: f2py: Add a cast to avoid a compiler warning.

### DIFF
--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -135,7 +135,7 @@ format_def(char *buf, Py_ssize_t size, FortranDataDef def)
 
     if (def.data == NULL) {
         static const char notalloc[] = ", not allocated";
-        if (size < sizeof(notalloc)) {
+        if ((size_t) size < sizeof(notalloc)) {
             return -1;
         }
         memcpy(p, notalloc, sizeof(notalloc));


### PR DESCRIPTION
The warning

    [...]/fortranobject.c:138:18: warning: comparison of integers of different signs: 'Py_ssize_t' (aka 'long') and 'unsigned long' [-Wsign-compare]
            if (size < sizeof(notalloc)) {
                ~~~~ ^ ~~~~~~~~~~~~~~~~

occurs 17 times when scipy is built.  The change in this pull request casts
`size` to `size_t` before comparing it to `sizeof(...)`.  A previous check
has already eliminated the possibility that `size` is negative, so this cast
is safe.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
