### PR TITLE
ENH: vectorize np.abs for unsigned ints and half, improving performance up to 12x

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1027,13 +1027,10 @@ NPY_NO_EXPORT void
  * #c    = u,u,u,ul,ull#
  */
 
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 @TYPE@_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *((@type@ *)op1) = in1;
-    }
+    UNARY_LOOP_FAST(@type@, @type@, *out = in);
 }
 
 NPY_NO_EXPORT NPY_GCC_OPT_3 void
@@ -2231,13 +2228,10 @@ HALF_conjugate(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNU
     }
 }
 
-NPY_NO_EXPORT void
+NPY_NO_EXPORT NPY_GCC_OPT_3 void
 HALF_absolute(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
-    UNARY_LOOP {
-        const npy_half in1 = *(npy_half *)ip1;
-        *((npy_half *)op1) = in1&0x7fffu;
-    }
+    UNARY_LOOP_FAST(npy_half, npy_half, *out = in&0x7fffu);
 }
 
 NPY_NO_EXPORT void


### PR DESCRIPTION
When calling `np.abs()`, the various unsigned int types are all slower than their signed counterpart despite specialized functions:
```
[100.00%] ··· bench_ufunc.UFuncs.time_absolute                                                                                                                  
[100.00%] ··· ================= ============
                    dtype
              ----------------- ------------
                     bool        4.96±0.1μs
                    uint8        59.0±0.4μs      <--- unsigned with specialized func
                     int8        32.5±0.3μs      <--- signed, unspecialized func is 2x faster
                    uint16       44.9±0.8μs
                    int16        26.8±0.1μs
                    uint32        60.5±1μs
                    int32        22.2±0.3μs
                    uint64       48.4±0.9μs
                    int64         62.8±1μs
                   float16       59.9±0.9μs
                   float32       18.4±0.3μs
                   float64       35.4±0.3μs
                  complex128      551±10μs
              ================= ============
```
This can be fixed by simply using the `UNARY_LOOP_FAST` macro and enabling `-O3`:
```
asv compare upstream/master HEAD -s --only-changed --sort ratio
       before           after         ratio
     [8529dfaa]       [ea22dbba]
     <absolute~1>       <absolute>
-      48.4±0.9μs       35.0±0.6μs     0.72  bench_ufunc.UFuncs.time_absolute('uint64')
-        60.5±1μs       18.0±0.3μs     0.30  bench_ufunc.UFuncs.time_absolute('uint32')
-      44.9±0.8μs      9.36±0.08μs     0.21  bench_ufunc.UFuncs.time_absolute('uint16')
-      59.9±0.9μs      10.0±0.08μs     0.17  bench_ufunc.UFuncs.time_absolute('float16')
-      59.0±0.4μs      4.66±0.06μs     0.08  bench_ufunc.UFuncs.time_absolute('uint8')
```
The `float16` type similarly benefits as it operates via bit-mask.

