### PR TITLE
DOC: add Quansight Labs as an Institutional Partner

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -56,7 +56,7 @@ NumFOCUS Subcommittee
 Institutional Partners
 ----------------------
 
-* UC Berkeley (Stefan van der Walt)
+* UC Berkeley (Stefan van der Walt, Matti Picus, Tyler Reddy)
 
 * Quansight Labs (Ralf Gommers, Hameer Abbasi)
 

--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -56,7 +56,9 @@ NumFOCUS Subcommittee
 Institutional Partners
 ----------------------
 
-*  UC Berkeley (Stefan van der Walt)
+* UC Berkeley (Stefan van der Walt)
+
+* Quansight Labs (Ralf Gommers, Hameer Abbasi)
 
 
 Document history


### PR DESCRIPTION
`[ci skip]` `[skip ci]`

tl;dr @hameerabbasi and myself have funded time to work on NumPy, which qualifies Quansight Labs as an institutional partner

I'll post a message to the mailing list related to this.