### PR TITLE
DOC: add more info to failure message

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -44,17 +44,12 @@ except ImportError as exc:
 
 IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
 
-Importing the multiarray numpy extension module failed.  Most
-likely you are trying to import a failed build of numpy.
-Here is how to proceed:
-- If you're working with a numpy git repository, try `git clean -xdf`
-  (removes all files not under version control) and rebuild numpy.
-- If you are simply trying to use the numpy version that you have installed:
-  your installation is broken - please reinstall numpy.
-- If you have already reinstalled and that did not fix the problem, then:
-  1. Check that you are using the Python you expect (you're using %s),
+Importing the numpy c-extensions failed.
+- Try uninstalling and reinstalling numpy.
+- If you have already done that, then:
+  1. Check that you expected to use Python%d.%d from "%s",
      and that you have no directories in your PATH or PYTHONPATH that can
-     interfere with the Python and numpy versions you're trying to use.
+     interfere with the Python and numpy version "%s" you're trying to use.
   2. If (1) looks fine, you can open a new issue at
      https://github.com/numpy/numpy/issues.  Please include details on:
      - how you installed Python
@@ -63,11 +58,15 @@ Here is how to proceed:
      - whether or not you have multiple versions of Python installed
      - if you built from source, your compiler versions and ideally a build log
 
-     Note: this error has many possible causes, so please don't comment on
-     an existing issue about this - open a new one instead.
+- If you're working with a numpy git repository, try `git clean -xdf`
+  (removes all files not under version control) and rebuild numpy.
+
+Note: this error has many possible causes, so please don't comment on
+an existing issue about this - open a new one instead.
 
 Original error was: %s
-""" % (sys.executable, exc)
+""" % (sys.version_info[0], sys.version_info[1], sys.executable,
+        __version__, exc)
     raise ImportError(msg)
 finally:
     for envkey in env_added:


### PR DESCRIPTION
Add version information to the error message when import fails. Also shorten the message and de-emphasize build failures from a git checkout