### PR TITLE
DOC: list Quansight rather than Quansight Labs as Institutional Partner.

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -58,7 +58,7 @@ Institutional Partners
 
 * UC Berkeley (Stefan van der Walt, Matti Picus, Tyler Reddy)
 
-* Quansight Labs (Ralf Gommers, Hameer Abbasi)
+* Quansight (Ralf Gommers, Hameer Abbasi)
 
 
 Document history

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1476,5 +1476,5 @@ Further reading
 -  The `Python tutorial <https://docs.python.org/tutorial/>`__
 -  :ref:`reference`
 -  `SciPy Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`__
--  `SciPy Lecture Notes <https://www.scipy-lectures.org>`__
+-  `SciPy Lecture Notes <https://scipy-lectures.org>`__
 -  A `matlab, R, IDL, NumPy/SciPy dictionary <http://mathesaurus.sf.net/>`__


### PR DESCRIPTION
It was pointed out to me that it makes more sense to list the company, rather than a division or program inside that company. 
(follow up to gh-13289)

Also fix a broken link I found.

```
[ci skip]
[skip ci]
**no ci**
```