### PR TITLE
BUG: Fix bad error message in np.memmap

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -246,7 +246,7 @@ class memmap(ndarray):
 
             bytes = long(offset + size*_dbytes)
 
-            if mode == 'w+' or (mode == 'r+' and flen < bytes):
+            if mode in ('w+', 'r+') and flen < bytes:
                 fid.seek(bytes - 1, 0)
                 fid.write(b'\0')
                 fid.flush()

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -204,3 +204,13 @@ class TestMemmap(object):
         self.tmpfp.write(b'a'*16)
         mm = memmap(self.tmpfp, dtype='float64')
         assert_equal(mm.shape, (2,))
+
+    def test_empty_array(self):
+        # gh-12653
+        with pytest.raises(ValueError, match='empty file'):
+            memmap(self.tmpfp, shape=(0,4), mode='w+')
+
+        self.tmpfp.write(b'\0')
+
+        # ok now the file is not empty
+        memmap(self.tmpfp, shape=(0,4), mode='w+')


### PR DESCRIPTION
This previously raisd `OSError: [Errno 22] Invalid argument` while trying to seek to byte -1 of the file.

It now raises `ValueError: cannot mmap an empty file`

The simple fix is not to write the file at all if we know it's already long enough.

In future we could consider allowing memmap to do an extra write behind the scenes to ensure the fiel is not empty, but that seems out of scope.

Fixes gh-12653

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
