### PR TITLE
DOC: remove misplaced section at bottom of governance people page

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -60,8 +60,3 @@ Institutional Partners
 
 * Quansight (Ralf Gommers, Hameer Abbasi)
 
-
-Document history
-----------------
-
-https://github.com/numpy/numpy/commits/master/doc/source/dev/governance/governance.rst


### PR DESCRIPTION
Thanks to @mattip for pointing this out. The removed bit is a copy
of what's on the main governance page (where it belongs).
So just deleting here.

[ci skip] [skip ci]
**no ci**