### PR TITLE
BUG: ufunc.at iteration variable size fix

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5572,7 +5572,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     PyUFuncGenericFunction innerloop;
     void *innerloopdata;
-    int i;
+    npy_intp i;
     int nop;
 
     /* override vars */


### PR DESCRIPTION
The iteration variable has to be intp of course, unfortunately
a test is too slow to be practical (even as a slow test).

This code needs more refactoring, but since it is a minimal fix...

Closes gh-13286