### PR TITLE
DEP: Deprecate collapsing shape-1 dtype fields to scalars.

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -47,6 +47,16 @@ a manner are very rare in practice and only available through the NumPy C-API.
 Future Changes
 ==============
 
+Shape-1 fields in dtypes won't be collapsed to scalars in a future version
+--------------------------------------------------------------------------
+
+Currently, a field specified as ``[(name, dtype, 1)]`` or ``"1type"`` is
+interpreted as a scalar field (i.e., the same as ``[(name, dtype)]`` or
+``[(name, dtype, ()]``). This now raises a FutureWarning; in a future version,
+it will be interpreted as a shape-(1,) field, i.e. the same as ``[(name,
+dtype, (1,))]`` or ``"(1,)type"`` (consistently with ``[(name, dtype, n)]``
+/ ``"ntype"`` with ``n>1``, which is already equivalent to ``[(name, dtype,
+(n,)]`` / ``"(n,)type"``).
 
 Expired deprecations
 ====================

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -533,3 +533,11 @@ class Test_GetSet_NumericOps(_DeprecationTestCase):
         # other tests.
         self.assert_deprecated(np.set_numeric_ops, kwargs={})
         assert_raises(ValueError, np.set_numeric_ops, add='abc')
+
+
+class TestShape1Fields(_DeprecationTestCase):
+    warning_cls = FutureWarning
+
+    # 2019-05-20, 1.17.0
+    def test_shape_1_fields(self):
+        self.assert_deprecated(np.dtype, args=([('a', int, 1)],))

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -358,7 +358,10 @@ class TestSubarray(object):
     def test_shape_equal(self):
         """Test some data types that are equal"""
         assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', tuple())))
-        assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
+        # FutureWarning during deprecation period; after it is passed this
+        # should instead check that "(1)f8" == "1f8" == ("f8", 1).
+        with pytest.warns(FutureWarning):
+            assert_dtype_equal(np.dtype('f8'), np.dtype(('f8', 1)))
         assert_dtype_equal(np.dtype((int, 2)), np.dtype((int, (2,))))
         assert_dtype_equal(np.dtype(('<f4', (3, 2))), np.dtype(('<f4', (3, 2))))
         d = ([('a', 'f4', (1, 2)), ('b', 'f8', (3, 1))], (3, 2))
@@ -447,7 +450,7 @@ class TestSubarray(object):
 
     def test_alignment(self):
         #Check that subarrays are aligned
-        t1 = np.dtype('1i4', align=True)
+        t1 = np.dtype('(1,)i4', align=True)
         t2 = np.dtype('2i4', align=True)
         assert_equal(t1.alignment, t2.alignment)
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -43,7 +43,7 @@ class TestResize(object):
 
     def test_reshape_from_zero(self):
         # See also gh-6740
-        A = np.zeros(0, dtype=[('a', np.float32, 1)])
+        A = np.zeros(0, dtype=[('a', np.float32)])
         Ar = np.resize(A, (2, 1))
         assert_array_equal(Ar, np.zeros((2, 1), Ar.dtype))
         assert_equal(A.dtype, Ar.dtype)

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -65,7 +65,7 @@ class TestScalarPEP3118(object):
         assert_(isinstance(x, np.void))
         mv_x = memoryview(x)
         expected_size = 16 * np.dtype((np.unicode_, 1)).itemsize
-        expected_size += 2 * np.dtype((np.float64, 1)).itemsize
+        expected_size += 2 * np.dtype(np.float64).itemsize
         assert_equal(mv_x.itemsize, expected_size)
         assert_equal(mv_x.ndim, 0)
         assert_equal(mv_x.shape, ())

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -221,7 +221,8 @@ class MaskedRecords(MaskedArray, object):
             except IndexError:
                 # Couldn't find a mask: use the default (nomask)
                 pass
-            hasmasked = _mask.view((bool, (len(_mask.dtype) or 1))).any()
+            tp_len = len(_mask.dtype)
+            hasmasked = _mask.view((bool, ((tp_len,) if tp_len else ()))).any()
         if (obj.shape or hasmasked):
             obj = obj.view(MaskedArray)
             obj._baseclass = ndarray

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -481,8 +481,7 @@ class TestRandomDist(object):
                                 .view(np.recarray)),
                      # gh-4270
                      lambda x: np.asarray([(i, i) for i in x],
-                                          [("a", object, 1),
-                                           ("b", np.int32, 1)])]:
+                                          [("a", object), ("b", np.int32)])]:
             np.random.seed(self.seed)
             alist = conv([1, 2, 3, 4, 5, 6, 7, 8, 9, 0])
             np.random.shuffle(alist)


### PR DESCRIPTION
See discussion at https://github.com/numpy/numpy/issues/13112.

Currently, a field specified as `[(name, dtype, 1)]` is interpreted as
a scalar field (i.e., the same as `[(name, dtype)]` or `[(name, dtype,
()]`). This now raises a DeprecationWarning; in a future version, it
will be interpreted as a shape-(1,) field, i.e. the same as `[(name,
dtype, (1,))]` (consistently with `[(name, dtype, n)]` with `n>1`, which
is already equivalent to `[(name, dtype, (n,)]`).

@eric-wieser: This currently fails test_recfunctions::TestRecFunctions::test_structured_to_unstructured (apparently an extra copy is now being made), but it's not clear to me why.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
