### PR TITLE
MAINT: Tidy up error message for accumulate and reduceat

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4535,11 +4535,17 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
 
     /* Convert the 'axis' parameter into a list of axes */
     if (axes_in == NULL) {
-        naxes = 1;
-        axes[0] = 0;
+        /* apply defaults */
+        if (ndim == 0) {
+            naxes = 0;
+        }
+        else {
+            naxes = 1;
+            axes[0] = 0;
+        }
     }
-    /* Convert 'None' into all the axes */
     else if (axes_in == Py_None) {
+        /* Convert 'None' into all the axes */
         naxes = ndim;
         for (i = 0; i < naxes; ++i) {
             axes[i] = i;
@@ -4564,39 +4570,27 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
             axes[i] = (int)axis;
         }
     }
-    /* Try to interpret axis as an integer */
     else {
+        /* Try to interpret axis as an integer */
         int axis = PyArray_PyIntAsInt(axes_in);
         /* TODO: PyNumber_Index would be good to use here */
         if (error_converting(axis)) {
             goto fail;
         }
-        /* Special case letting axis={0 or -1} slip through for scalars */
+        /*
+         * As a special case for backwards compatibility in 'sum',
+         * 'prod', et al, also allow a reduction for scalars even
+         * though this is technically incorrect.
+         */
         if (ndim == 0 && (axis == 0 || axis == -1)) {
-            axis = 0;
+            naxes = 0;
         }
         else if (check_and_adjust_axis(&axis, ndim) < 0) {
             goto fail;
         }
-        axes[0] = (int)axis;
-        naxes = 1;
-    }
-
-    /* Check to see if input is zero-dimensional. */
-    if (ndim == 0) {
-        /*
-         * A reduction with no axes is still valid but trivial.
-         * As a special case for backwards compatibility in 'sum',
-         * 'prod', et al, also allow a reduction where axis=0, even
-         * though this is technically incorrect.
-         */
-        naxes = 0;
-
-        if (!(operation == UFUNC_REDUCE &&
-                    (naxes == 0 || (naxes == 1 && axes[0] == 0)))) {
-            PyErr_Format(PyExc_TypeError, "cannot %s on a scalar",
-                         _reduce_type[operation]);
-            goto fail;
+        else {
+            axes[0] = (int)axis;
+            naxes = 1;
         }
     }
 
@@ -4640,6 +4634,10 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
         Py_XDECREF(wheremask);
         break;
     case UFUNC_ACCUMULATE:
+        if (ndim == 0) {
+            PyErr_SetString(PyExc_TypeError, "cannot accumulate on a scalar");
+            goto fail;
+        }
         if (naxes != 1) {
             PyErr_SetString(PyExc_ValueError,
                         "accumulate does not allow multiple axes");
@@ -4649,6 +4647,10 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
                                                   otype->type_num);
         break;
     case UFUNC_REDUCEAT:
+        if (ndim == 0) {
+            PyErr_SetString(PyExc_TypeError, "cannot reduceat on a scalar");
+            goto fail;
+        }
         if (naxes != 1) {
             PyErr_SetString(PyExc_ValueError,
                         "reduceat does not allow multiple axes");


### PR DESCRIPTION
This makes `np.add.accumulate(0, axis=())` match `np.add.accumulate(0)` - both now give `TypeError: cannot accumulate on a scalar`.

This also fixes an LGTM complaing about `naxes == 1` being always false due to the line before it that sets `naxes = 0`.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
