### PR TITLE
DOC, BLD: fix doc build issues in preparation for the next numpydoc release

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5884,9 +5884,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('T',
     albeit unimplemented, all the attributes of the ndarray class so as to
     provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -5898,9 +5896,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('base',
     albeit unimplemented, all the attributes of the ndarray class so as to
     a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -5950,9 +5946,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('all',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -5964,9 +5958,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('any',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -5978,9 +5970,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('argmax',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -5992,9 +5982,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('argmin',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6006,9 +5994,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('argsort',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6020,9 +6006,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('astype',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6034,9 +6018,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('byteswap',
     albeit unimplemented, all the attributes of the ndarray class so as to
     provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6048,9 +6030,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('choose',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6062,9 +6042,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('clip',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6076,9 +6054,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('compress',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6090,9 +6066,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('conjugate',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6104,9 +6078,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('copy',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6118,9 +6090,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('cumprod',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6132,9 +6102,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('cumsum',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6146,9 +6114,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('diagonal',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6160,9 +6126,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('dump',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6174,9 +6138,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('dumps',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6188,9 +6150,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('fill',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6202,9 +6162,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('flatten',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6216,9 +6174,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('getfield',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6230,9 +6186,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('item',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6244,9 +6198,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('itemset',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6258,9 +6210,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('max',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6272,9 +6222,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('mean',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6286,9 +6234,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('min',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6333,9 +6279,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('nonzero',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6347,9 +6291,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('prod',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6361,9 +6303,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('ptp',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6375,9 +6315,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('put',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6389,9 +6327,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('ravel',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6403,9 +6339,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('repeat',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6417,9 +6351,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('reshape',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6431,9 +6363,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('resize',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6445,9 +6375,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('round',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6459,9 +6387,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('searchsorted',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6473,9 +6399,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('setfield',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6487,9 +6411,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('setflags',
     albeit unimplemented, all the attributes of the ndarray class so as to
     provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6501,9 +6423,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('sort',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6515,9 +6435,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('squeeze',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6529,9 +6447,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('std',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6543,9 +6459,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('sum',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6557,9 +6471,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('swapaxes',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6571,9 +6483,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('take',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6585,9 +6495,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('tofile',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6599,9 +6507,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('tolist',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6613,9 +6519,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('tostring',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6627,9 +6531,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('trace',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6641,9 +6543,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('transpose',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6655,9 +6555,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('var',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 
@@ -6669,9 +6567,7 @@ add_newdoc('numpy.core.numerictypes', 'generic', ('view',
     albeit unimplemented, all the attributes of the ndarray class
     so as to provide a uniform API.
 
-    See Also
-    --------
-    The corresponding attribute of the derived class of interest.
+    See also the corresponding attribute of the derived class of interest.
 
     """))
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3390,7 +3390,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
 
     See Also
     --------
-    std , mean, nanmean, nanstd, nanvar
+    std, mean, nanmean, nanstd, nanvar
     numpy.doc.ufuncs : Section "Output arguments"
 
     Notes

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -347,7 +347,7 @@ def issubsctype(arg1, arg2):
 
     See Also
     --------
-    issctype, issubdtype,obj2sctype
+    issctype, issubdtype, obj2sctype
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -377,7 +377,7 @@ def average(a, axis=None, weights=None, returned=False):
     Traceback (most recent call last):
         ...
     TypeError: Axis must be specified when shapes of a and weights differ.
-    
+
     >>> a = np.ones(5, dtype=np.float128)
     >>> w = np.ones(5, dtype=np.complex64)
     >>> avg = np.average(a, weights=w)
@@ -1431,7 +1431,7 @@ def angle(z, deg=False):
     angle : ndarray or scalar
         The counterclockwise angle from the positive real axis on
         the complex plane, with dtype as numpy.float64.
-        
+
         ..versionchanged:: 1.16.0
             This function works on subclasses of ndarray like `ma.array`.
 
@@ -1929,6 +1929,30 @@ class vectorize(object):
     vectorized : callable
         Vectorized function.
 
+    See Also
+    --------
+    frompyfunc : Takes an arbitrary Python function and returns a ufunc
+
+    Notes
+    -----
+    The `vectorize` function is provided primarily for convenience, not for
+    performance. The implementation is essentially a for loop.
+
+    If `otypes` is not specified, then a call to the function with the
+    first argument will be used to determine the number of outputs.  The
+    results of this call will be cached if `cache` is `True` to prevent
+    calling the function twice.  However, to implement the cache, the
+    original function must be wrapped which will slow down subsequent
+    calls, so only do this if your function is expensive.
+
+    The new keyword argument interface and `excluded` argument support
+    further degrades performance.
+
+    References
+    ----------
+    .. [1] NumPy Reference, section `Generalized Universal Function API
+           <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_.
+
     Examples
     --------
     >>> def myfunc(a, b):
@@ -1988,8 +2012,8 @@ class vectorize(object):
 
     >>> import scipy.stats
     >>> pearsonr = np.vectorize(scipy.stats.pearsonr,
-    ...                 signature='(n),(n)->(),()') 
-    >>> pearsonr([[0, 1, 2, 3]], [[1, 2, 3, 4], [4, 3, 2, 1]]) 
+    ...                 signature='(n),(n)->(),()')
+    >>> pearsonr([[0, 1, 2, 3]], [[1, 2, 3, 4], [4, 3, 2, 1]])
     (array([ 1., -1.]), array([ 0.,  0.]))
 
     Or for a vectorized convolution:
@@ -2001,31 +2025,7 @@ class vectorize(object):
            [0., 0., 1., 2., 1., 0.],
            [0., 0., 0., 1., 2., 1.]])
 
-    See Also
-    --------
-    frompyfunc : Takes an arbitrary Python function and returns a ufunc
-
-    Notes
-    -----
-    The `vectorize` function is provided primarily for convenience, not for
-    performance. The implementation is essentially a for loop.
-
-    If `otypes` is not specified, then a call to the function with the
-    first argument will be used to determine the number of outputs.  The
-    results of this call will be cached if `cache` is `True` to prevent
-    calling the function twice.  However, to implement the cache, the
-    original function must be wrapped which will slow down subsequent
-    calls, so only do this if your function is expensive.
-
-    The new keyword argument interface and `excluded` argument support
-    further degrades performance.
-
-    References
-    ----------
-    .. [1] NumPy Reference, section `Generalized Universal Function API
-           <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_.
     """
-
     def __init__(self, pyfunc, otypes=None, doc=None, excluded=None,
                  cache=False, signature=None):
         self.pyfunc = pyfunc
@@ -2602,7 +2602,7 @@ def blackman(M):
     Plot the window and the frequency response:
 
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.blackman(51)
+    >>> window = np.blackman(51) + 1e-10  # eps shift to avoid division by zero
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Blackman window")
@@ -2709,7 +2709,7 @@ def bartlett(M):
     Plot the window and its frequency response (requires SciPy and matplotlib):
 
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.bartlett(51)
+    >>> window = np.bartlett(51) + 1e-10  # eps shift to avoid division by zero
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Bartlett window")
@@ -2810,7 +2810,7 @@ def hanning(M):
 
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.hanning(51)
+    >>> window = np.hanning(51) + 1e-10  # eps shift to avoid division by zero
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Hann window")

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2602,7 +2602,7 @@ def blackman(M):
     Plot the window and the frequency response:
 
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.blackman(51) + 1e-10  # eps shift to avoid division by zero
+    >>> window = np.blackman(51)
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Blackman window")
@@ -2618,7 +2618,9 @@ def blackman(M):
     >>> A = fft(window, 2048) / 25.5
     >>> mag = np.abs(fftshift(A))
     >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(mag)
+    >>> with np.errstate(divide='ignore', invalid='ignore'):
+    ...     response = 20 * np.log10(mag)
+    ...
     >>> response = np.clip(response, -100, 100)
     >>> plt.plot(freq, response)
     [<matplotlib.lines.Line2D object at 0x...>]
@@ -2709,7 +2711,7 @@ def bartlett(M):
     Plot the window and its frequency response (requires SciPy and matplotlib):
 
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.bartlett(51) + 1e-10  # eps shift to avoid division by zero
+    >>> window = np.bartlett(51)
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Bartlett window")
@@ -2725,7 +2727,9 @@ def bartlett(M):
     >>> A = fft(window, 2048) / 25.5
     >>> mag = np.abs(fftshift(A))
     >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(mag)
+    >>> with np.errstate(divide='ignore', invalid='ignore'):
+    ...     response = 20 * np.log10(mag)
+    ...
     >>> response = np.clip(response, -100, 100)
     >>> plt.plot(freq, response)
     [<matplotlib.lines.Line2D object at 0x...>]
@@ -2810,7 +2814,7 @@ def hanning(M):
 
     >>> import matplotlib.pyplot as plt
     >>> from numpy.fft import fft, fftshift
-    >>> window = np.hanning(51) + 1e-10  # eps shift to avoid division by zero
+    >>> window = np.hanning(51)
     >>> plt.plot(window)
     [<matplotlib.lines.Line2D object at 0x...>]
     >>> plt.title("Hann window")
@@ -2826,7 +2830,9 @@ def hanning(M):
     >>> A = fft(window, 2048) / 25.5
     >>> mag = np.abs(fftshift(A))
     >>> freq = np.linspace(-0.5, 0.5, len(A))
-    >>> response = 20 * np.log10(mag)
+    >>> with np.errstate(divide='ignore', invalid='ignore'):
+    ...     response = 20 * np.log10(mag)
+    ...
     >>> response = np.clip(response, -100, 100)
     >>> plt.plot(freq, response)
     [<matplotlib.lines.Line2D object at 0x...>]

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -548,6 +548,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
 
     Examples
     --------
+    >>> import warnings
     >>> x = np.array([0.0, 1.0, 2.0, 3.0,  4.0,  5.0])
     >>> y = np.array([0.0, 0.8, 0.9, 0.1, -0.8, -1.0])
     >>> z = np.polyfit(x, y, 3)
@@ -566,9 +567,10 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
 
     High-order polynomials may oscillate wildly:
 
-    >>> p30 = np.poly1d(np.polyfit(x, y, 30))
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore', np.RankWarning)
+    ...     p30 = np.poly1d(np.polyfit(x, y, 30))
     ...
-    >>> # RankWarning: Polyfit may be poorly conditioned...
     >>> p30(4)
     -0.80000000000000204 # may vary
     >>> p30(5)

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -567,7 +567,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     High-order polynomials may oscillate wildly:
 
     >>> p30 = np.poly1d(np.polyfit(x, y, 30))
-    ... 
+    ...
     >>> # RankWarning: Polyfit may be poorly conditioned...
     >>> p30(4)
     -0.80000000000000204 # may vary
@@ -632,7 +632,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     # warn on rank reduction, which indicates an ill conditioned matrix
     if rank != order and not full:
         msg = "Polyfit may be poorly conditioned"
-        warnings.warn(msg, RankWarning, stacklevel=2)
+        warnings.warn(msg, RankWarning, stacklevel=3)
 
     if full:
         return c, resids, rank, s, rcond
@@ -874,8 +874,7 @@ def polymul(a1, a2):
     See Also
     --------
     poly1d : A one-dimensional polynomial class.
-    poly, polyadd, polyder, polydiv, polyfit, polyint, polysub,
-    polyval
+    poly, polyadd, polyder, polydiv, polyfit, polyint, polysub, polyval
     convolve : Array convolution. Same output as polymul, but has parameter
                for overlap mode.
 
@@ -937,7 +936,7 @@ def polydiv(u, v):
 
     See Also
     --------
-    poly, polyadd, polyder, polydiv, polyfit, polyint, polymul, polysub,
+    poly, polyadd, polyder, polydiv, polyfit, polyint, polymul, polysub
     polyval
 
     Notes

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1532,7 +1532,7 @@ def flatnotmasked_edges(a):
 
     See Also
     --------
-    flatnotmasked_contiguous, notmasked_contiguous, notmasked_edges,
+    flatnotmasked_contiguous, notmasked_contiguous, notmasked_edges
     clump_masked, clump_unmasked
 
     Notes
@@ -1593,7 +1593,7 @@ def notmasked_edges(a, axis=None):
 
     See Also
     --------
-    flatnotmasked_contiguous, flatnotmasked_edges, notmasked_contiguous,
+    flatnotmasked_contiguous, flatnotmasked_edges, notmasked_contiguous
     clump_masked, clump_unmasked
 
     Examples
@@ -1638,7 +1638,7 @@ def flatnotmasked_contiguous(a):
 
     See Also
     --------
-    flatnotmasked_edges, notmasked_contiguous, notmasked_edges,
+    flatnotmasked_edges, notmasked_contiguous, notmasked_edges
     clump_masked, clump_unmasked
 
     Notes
@@ -1698,7 +1698,7 @@ def notmasked_contiguous(a, axis=None):
 
     See Also
     --------
-    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges,
+    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges
     clump_masked, clump_unmasked
 
     Notes
@@ -1803,7 +1803,7 @@ def clump_unmasked(a):
 
     See Also
     --------
-    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges,
+    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges
     notmasked_contiguous, clump_masked
 
     Examples
@@ -1842,7 +1842,7 @@ def clump_masked(a):
 
     See Also
     --------
-    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges,
+    flatnotmasked_edges, flatnotmasked_contiguous, notmasked_edges
     notmasked_contiguous, clump_unmasked
 
     Examples

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -528,8 +528,7 @@ def chebfromroots(roots):
 
     See Also
     --------
-    polyfromroots, legfromroots, lagfromroots, hermfromroots,
-    hermefromroots.
+    polyfromroots, legfromroots, lagfromroots, hermfromroots, hermefromroots
 
     Examples
     --------

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1461,7 +1461,7 @@ def chebvander2d(x, y, deg):
 
     See Also
     --------
-    chebvander, chebvander3d. chebval2d, chebval3d
+    chebvander, chebvander3d, chebval2d, chebval3d
 
     Notes
     -----
@@ -1515,7 +1515,7 @@ def chebvander3d(x, y, z, deg):
 
     See Also
     --------
-    chebvander, chebvander3d. chebval2d, chebval3d
+    chebvander, chebvander3d, chebval2d, chebval3d
 
     Notes
     -----

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -272,8 +272,7 @@ def hermfromroots(roots):
 
     See Also
     --------
-    polyfromroots, legfromroots, lagfromroots, chebfromroots,
-    hermefromroots.
+    polyfromroots, legfromroots, lagfromroots, chebfromroots, hermefromroots
 
     Examples
     --------

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1186,7 +1186,7 @@ def hermvander2d(x, y, deg):
 
     See Also
     --------
-    hermvander, hermvander3d. hermval2d, hermval3d
+    hermvander, hermvander3d, hermval2d, hermval3d
 
     Notes
     -----
@@ -1240,7 +1240,7 @@ def hermvander3d(x, y, z, deg):
 
     See Also
     --------
-    hermvander, hermvander3d. hermval2d, hermval3d
+    hermvander, hermvander3d, hermval2d, hermval3d
 
     Notes
     -----

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1179,7 +1179,7 @@ def hermevander2d(x, y, deg):
 
     See Also
     --------
-    hermevander, hermevander3d. hermeval2d, hermeval3d
+    hermevander, hermevander3d, hermeval2d, hermeval3d
 
     Notes
     -----
@@ -1233,7 +1233,7 @@ def hermevander3d(x, y, z, deg):
 
     See Also
     --------
-    hermevander, hermevander3d. hermeval2d, hermeval3d
+    hermevander, hermevander3d, hermeval2d, hermeval3d
 
     Notes
     -----

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -273,8 +273,7 @@ def hermefromroots(roots):
 
     See Also
     --------
-    polyfromroots, legfromroots, lagfromroots, hermfromroots,
-    chebfromroots.
+    polyfromroots, legfromroots, lagfromroots, hermfromroots, chebfromroots
 
     Examples
     --------

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1186,7 +1186,7 @@ def lagvander2d(x, y, deg):
 
     See Also
     --------
-    lagvander, lagvander3d. lagval2d, lagval3d
+    lagvander, lagvander3d, lagval2d, lagval3d
 
     Notes
     -----
@@ -1240,7 +1240,7 @@ def lagvander3d(x, y, z, deg):
 
     See Also
     --------
-    lagvander, lagvander3d. lagval2d, lagval3d
+    lagvander, lagvander3d, lagval2d, lagval3d
 
     Notes
     -----

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -269,8 +269,7 @@ def lagfromroots(roots):
 
     See Also
     --------
-    polyfromroots, legfromroots, chebfromroots, hermfromroots,
-    hermefromroots.
+    polyfromroots, legfromroots, chebfromroots, hermfromroots, hermefromroots
 
     Examples
     --------

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1222,7 +1222,7 @@ def legvander2d(x, y, deg):
 
     See Also
     --------
-    legvander, legvander3d. legval2d, legval3d
+    legvander, legvander3d, legval2d, legval3d
 
     Notes
     -----
@@ -1276,7 +1276,7 @@ def legvander3d(x, y, z, deg):
 
     See Also
     --------
-    legvander, legvander3d. legval2d, legval3d
+    legvander, legvander3d, legval2d, legval3d
 
     Notes
     -----

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -301,8 +301,7 @@ def legfromroots(roots):
 
     See Also
     --------
-    polyfromroots, chebfromroots, lagfromroots, hermfromroots,
-    hermefromroots.
+    polyfromroots, chebfromroots, lagfromroots, hermfromroots, hermefromroots
 
     Examples
     --------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1130,7 +1130,7 @@ def polyvander2d(x, y, deg):
 
     See Also
     --------
-    polyvander, polyvander3d. polyval2d, polyval3d
+    polyvander, polyvander3d, polyval2d, polyval3d
 
     """
     return pu._vander2d(polyvander, x, y, deg)
@@ -1179,7 +1179,7 @@ def polyvander3d(x, y, z, deg):
 
     See Also
     --------
-    polyvander, polyvander3d. polyval2d, polyval3d
+    polyvander, polyvander3d, polyval2d, polyval3d
 
     Notes
     -----


### PR DESCRIPTION
The main issue was that numpydoc got really picky about `See Also` sections. Also I managed to track down the last warnings that still show up in the CI doc build.

The ones that don't show up in the CI build but I can't get rid of no matter my version of numpydoc or removing `__call__` from `doc/source/_templates/autosummary/class.rst` are these:
```
/home/rgommers/code/numpy/doc/source/reference/routines.polynomials.polynomial.rst:23:<autosummary>:: WARNING: toctree contains reference to nonexisting document 'reference/generated/numpy.polynomial.polynomial.Polynomial.__call__'
/home/rgommers/code/numpy/doc/source/reference/routines.testing.rst:56:<autosummary>:: WARNING: toctree contains reference to nonexisting document 'reference/generated/numpy.testing.suppress_warnings.__call__'
```

At least there's no difference between numpydoc versions, and the generated docs look fine.

EDIT: for the See Also changes of generic, here's an example of how they are rendered incorrectly at the moment: https://www.numpy.org/devdocs/reference/generated/numpy.generic.clip.html#numpy.generic.clip