### PR TITLE
DOC: Add as_ctypes_type to the documentation

### DIFF
--- a/doc/release/1.16.1-notes.rst
+++ b/doc/release/1.16.1-notes.rst
@@ -80,9 +80,9 @@ Improvements
 
 Further improvements to ``ctypes`` support in ``np.ctypeslib``
 --------------------------------------------------------------
-A new ``np.ctypeslib.as_ctypes_type`` function has been added, which can be
+A new `numpy.ctypeslib.as_ctypes_type` function has been added, which can be
 used to converts a `dtype` into a best-guess `ctypes` type. Thanks to this
-new function, ``np.ctypeslib.as_ctypes`` now supports a much wider range of
+new function, `numpy.ctypeslib.as_ctypes` now supports a much wider range of
 array types, including structures, booleans, and integers of non-native
 endianness.
 

--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -152,9 +152,9 @@ lengths has improved and is on par with complex-valued FFTs.
 
 Further improvements to ``ctypes`` support in ``np.ctypeslib``
 --------------------------------------------------------------
-A new ``np.ctypeslib.as_ctypes_type`` function has been added, which can be
+A new `numpy.ctypeslib.as_ctypes_type` function has been added, which can be
 used to converts a `dtype` into a best-guess `ctypes` type. Thanks to this
-new function, ``np.ctypeslib.as_ctypes`` now supports a much wider range of
+new function, `numpy.ctypeslib.as_ctypes` now supports a much wider range of
 array types, including structures, booleans, and integers of non-native
 endianness.
 

--- a/doc/source/reference/routines.ctypeslib.rst
+++ b/doc/source/reference/routines.ctypeslib.rst
@@ -8,6 +8,7 @@ C-Types Foreign Function Interface (:mod:`numpy.ctypeslib`)
 
 .. autofunction:: as_array
 .. autofunction:: as_ctypes
+.. autofunction:: as_ctypes_type
 .. autofunction:: ctypes_load_library
 .. autofunction:: load_library
 .. autofunction:: ndpointer

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -462,7 +462,7 @@ if ctypes is not None:
 
 
     def as_ctypes_type(dtype):
-        """
+        r"""
         Convert a dtype into a ctypes type.
 
         Parameters
@@ -472,7 +472,7 @@ if ctypes is not None:
 
         Returns
         -------
-        ctypes
+        ctype
             A ctype scalar, union, array, or struct
 
         Raises
@@ -485,13 +485,17 @@ if ctypes is not None:
         This function does not losslessly round-trip in either direction.
 
         ``np.dtype(as_ctypes_type(dt))`` will:
+
          - insert padding fields
          - reorder fields to be sorted by offset
          - discard field titles
 
         ``as_ctypes_type(np.dtype(ctype))`` will:
-         - discard the class names of ``Structure``s and ``Union``s
-         - convert single-element ``Union``s into single-element ``Structure``s
+
+         - discard the class names of `ctypes.Structure`\ s and
+           `ctypes.Union`\ s
+         - convert single-element `ctypes.Union`\ s into single-element
+           `ctypes.Structure`\ s
          - insert padding fields
 
         """


### PR DESCRIPTION
This is mentioned in the release notes, so probably should be discoverable.

Change those references to links too.
