### PR TITLE
BUILD: fail documentation build if numpy version does not match

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -28,7 +28,7 @@ ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
   $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
-        dist dist-build gitwash-update
+        dist dist-build gitwash-update version-check
 
 #------------------------------------------------------------------------------
 
@@ -53,7 +53,7 @@ ifeq "$(GITVER)" "Unknown"
 	# @echo sdist build with unlabeled sources
 else ifneq ($(NUMPYVER),$(GITVER))
 	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
-	@echo set GITVER to $(NUMPYVER) to override
+	@echo use '"make dist"' or '"set GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
 	@exit 1
 else
 	# for testing

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,10 +10,14 @@
 PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".format(v[0], v[1]))')
 PYTHON = python$(PYVER)
 
+NUMPYVER:=$(shell python3 -c "import numpy; print(numpy.version.git_revision[:10])")
+GITVER ?= $(shell cd ..; python3 -c "from setup import git_version; \
+				print(git_version()[:10])")
+
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = LANG=C sphinx-build
-PAPER         =
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= LANG=C sphinx-build
+PAPER         ?=
 
 FILES=
 
@@ -43,6 +47,16 @@ help:
 
 clean:
 	-rm -rf build/* source/reference/generated
+
+version-check:
+ifneq ($(NUMPYVER),$(GITVER))
+	@echo installed numpy $(NUMPYVER) != current repo git version $(GITVER)
+	@echo set GITVER to $(NUMPYVER) to override
+	@exit 1
+else
+	# for testing
+	# @echo installed numpy $(NUMPYVER) matches git version $(GITVER); exit 1
+endif
 
 gitwash-update:
 	rm -rf source/dev/gitwash
@@ -119,7 +133,7 @@ build/generate-stamp: $(wildcard source/reference/*.rst)
 	mkdir -p build
 	touch build/generate-stamp
 
-html: generate
+html: generate version-check
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html $(FILES)
 	$(PYTHON) postprocess.py html build/html/*.html
@@ -132,7 +146,7 @@ html-scipyorg:
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
-pickle: generate
+pickle: generate version-check
 	mkdir -p build/pickle build/doctrees
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) build/pickle $(FILES)
 	@echo
@@ -142,7 +156,7 @@ pickle: generate
 
 web: pickle
 
-htmlhelp: generate
+htmlhelp: generate version-check
 	mkdir -p build/htmlhelp build/doctrees
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) build/htmlhelp $(FILES)
 	@echo
@@ -153,11 +167,11 @@ htmlhelp-build: htmlhelp build/htmlhelp/numpy.chm
 %.chm: %.hhp
 	-hhc.exe $^
 
-qthelp: generate
+qthelp: generate version-check
 	mkdir -p build/qthelp build/doctrees
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) build/qthelp $(FILES)
 
-latex: generate
+latex: generate version-check
 	mkdir -p build/latex build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex $(FILES)
 	$(PYTHON) postprocess.py tex build/latex/*.tex
@@ -167,18 +181,18 @@ latex: generate
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
 
-coverage: build
+coverage: build version-check
 	mkdir -p build/coverage build/doctrees
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) build/coverage $(FILES)
 	@echo "Coverage finished; see c.txt and python.txt in build/coverage"
 
-changes: generate
+changes: generate version-check
 	mkdir -p build/changes build/doctrees
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) build/changes $(FILES)
 	@echo
 	@echo "The overview file is in build/changes."
 
-linkcheck: generate
+linkcheck: generate version-check
 	mkdir -p build/linkcheck build/doctrees
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) build/linkcheck $(FILES)
 	@echo

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -49,8 +49,10 @@ clean:
 	-rm -rf build/* source/reference/generated
 
 version-check:
-ifneq ($(NUMPYVER),$(GITVER))
-	@echo installed numpy $(NUMPYVER) != current repo git version $(GITVER)
+ifeq "$(GITVER)" "Unknown"
+	# @echo sdist build with unlabeled sources
+else ifneq ($(NUMPYVER),$(GITVER))
+	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
 	@echo set GITVER to $(NUMPYVER) to override
 	@exit 1
 else

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -53,7 +53,7 @@ ifeq "$(GITVER)" "Unknown"
 	# @echo sdist build with unlabeled sources
 else ifneq ($(NUMPYVER),$(GITVER))
 	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
-	@echo use '"make dist"' or '"set GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
+	@echo use '"make dist"' or '"GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
 	@exit 1
 else
 	# for testing

--- a/setup.py
+++ b/setup.py
@@ -73,13 +73,13 @@ def git_version():
         env['LANGUAGE'] = 'C'
         env['LANG'] = 'C'
         env['LC_ALL'] = 'C'
-        out = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env)
         return out
 
     try:
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')
-    except OSError:
+    except subprocess.SubprocessError:
         GIT_REVISION = "Unknown"
 
     return GIT_REVISION


### PR DESCRIPTION
when locally building documentation, the numpy version installed in python should match the version of the documentation. This adds a check that the versions match, and will indicate how to override the check if it fails.

Also conditionally set some options so they can be overridden by environment variables, should allow for instance `SPHINXOPTS='-n' make html` which previously did not override the empty `SPHINXOPTS` option

xref #13331 