### PR TITLE
BUG: Fix crash when calling savetxt on a padded array

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1376,7 +1376,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
 
             # Complex dtype -- each field indicates a separate column
             else:
-                ncol = len(X.dtype.descr)
+                ncol = len(X.dtype.names)
         else:
             ncol = X.shape[1]
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -347,12 +347,22 @@ class TestSaveTxt(object):
         assert_raises(ValueError, np.savetxt, c, np.array(1))
         assert_raises(ValueError, np.savetxt, c, np.array([[[1], [2]]]))
 
-    def test_record(self):
+    def test_structured(self):
         a = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
         c = BytesIO()
         np.savetxt(c, a, fmt='%d')
         c.seek(0)
         assert_equal(c.readlines(), [b'1 2\n', b'3 4\n'])
+
+    def test_structured_padded(self):
+        # gh-13297
+        a = np.array([(1, 2, 3),(4, 5, 6)], dtype=[
+            ('foo', 'i4'), ('bar', 'i4'), ('baz', 'i4')
+        ])
+        c = BytesIO()
+        c.seek(0)
+        np.savetxt(c, a[['foo', 'baz']])
+        assert_equal(c.readlines(), [b'1 3\n', b'4 6\n'])
 
     @pytest.mark.skipif(Path is None, reason="No pathlib.Path")
     def test_multifield_view(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -360,8 +360,8 @@ class TestSaveTxt(object):
             ('foo', 'i4'), ('bar', 'i4'), ('baz', 'i4')
         ])
         c = BytesIO()
+        np.savetxt(c, a[['foo', 'baz']], fmt='%d')
         c.seek(0)
-        np.savetxt(c, a[['foo', 'baz']])
         assert_equal(c.readlines(), [b'1 3\n', b'4 6\n'])
 
     @pytest.mark.skipif(Path is None, reason="No pathlib.Path")


### PR DESCRIPTION
Backport of #13301.

As a general rule, every use of .descr is broken.

Fixes #13297

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
