### PR TITLE
BUG: ufunc.at iteration variable size fix

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5501,7 +5501,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     PyUFuncGenericFunction innerloop;
     void *innerloopdata;
-    int i;
+    npy_intp i;
     int nop;
 
     /* override vars */


### PR DESCRIPTION
Backport of #13323.

The iteration variable has to be intp of course, unfortunately
a test is too slow to be practical (even as a slow test).

This code needs more refactoring, but since it is a minimal fix...

Closes gh-13286

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
