### PR TITLE
DEP: warn when saving requires pickle

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -33,6 +33,13 @@ The internal use of these functions has been refactored and there are better
 alternatives. Relace ``exec_command`` with `subprocess.Popen` and
 ``temp_file_name`` with `tempfile.mkstemp`.
 
+Pickling while saving will require explicit opt-in
+--------------------------------------------------
+The functions ``np.savez``, ``np.save``, ``np.save_compressed``, and ``np.lib.
+format.write_array`` all take an `allow_pickle` keyword which now defaults to
+`None` and issues a warning for code that depends on the previous
+`allow_pickle=True` default. The default behavior will switch to ``False`` in
+a future version.
 
 Future Changes
 ==============
@@ -76,7 +83,6 @@ non-functional. This code was removed. If needed, use
 --------------------------------------------------------------------------------
 If the out argument to these functions is provided and has memory overlap with
 the other arguments, it is now buffered to avoid order-dependent behavior.
-
 
 C API changes
 =============

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -566,7 +566,7 @@ def _read_array_header(fp, version):
 
     return d['shape'], d['fortran_order'], dtype
 
-def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
+def write_array(fp, array, version=None, allow_pickle=None, pickle_kwargs=None):
     """
     Write an array to an NPY file, including a header.
 
@@ -585,7 +585,10 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
         The version number of the format. None means use the oldest
         supported version that is able to store the data.  Default: None
     allow_pickle : bool, optional
-        Whether to allow writing pickled data. Default: True
+        Whether to allow writing pickled data. Default: None
+        In NumPy <= 1.16.1 the value defaulted to True. This default is being
+        deprecated in 1.17, with a value of None now triggering a warning,
+        and in 1.19 `allow_pickle` will default to False.
     pickle_kwargs : dict, optional
         Additional keyword arguments to pass to pickle.dump, excluding
         'protocol'. These are only useful when pickling objects in object
@@ -620,6 +623,13 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
         # We contain Python objects so we cannot write out the data
         # directly.  Instead, we will pickle it out with version 2 of the
         # pickle protocol.
+        if allow_pickle is None:
+            # NumPy 1.17.0: remove in 1.19 after deprecation
+            allow_pickle = True
+            msg = ("Object arrays will not be saved by default in the future"
+                    " because `allow_pickle` will default to False. You should"
+                    " add `allow_pickle=True` explicitly to eliminate this"
+                    " warning.")
         if not allow_pickle:
             raise ValueError("Object arrays cannot be saved when "
                              "allow_pickle=False")

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -424,7 +424,7 @@ class BytesIOSRandomSize(BytesIO):
 
 def roundtrip(arr):
     f = BytesIO()
-    format.write_array(f, arr)
+    format.write_array(f, arr, allow_pickle=True)
     f2 = BytesIO(f.getvalue())
     arr2 = format.read_array(f2)
     return arr2

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -86,7 +86,7 @@ class RoundtripTest(object):
             Arrays stored to file.
 
         """
-        save_kwds = kwargs.get('save_kwds', {})
+        save_kwds = kwargs.get('save_kwds', {"allow_pickle": True})
         load_kwds = kwargs.get('load_kwds', {})
         file_on_disk = kwargs.get('file_on_disk', False)
 


### PR DESCRIPTION
mitigates the saving part of #12759 by warning if allow_pickle not specified

see also https://nvd.nist.gov/vuln/detail/CVE-2019-6446

Broken out of #12889