### PR TITLE
TST: Added test_fftpocket.py::test_axes

### DIFF
--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -138,6 +138,16 @@ class TestFFT1D(object):
             x_herm, np.fft.ihfft(np.fft.hfft(x_herm, norm="ortho"),
                                  norm="ortho"))
 
+    @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
+                                    np.fft.rfftn, np.fft.irfftn])
+    def test_axes(self, op):
+        x = random((30, 20, 10))
+        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
+        for a in axes:
+            op_tr = op(np.transpose(x, a))
+            tr_op = np.transpose(op(x, axes=a), a)
+            assert_array_almost_equal(op_tr, tr_op)
+
     def test_all_1d_norm_preserving(self):
         # verify that round-trip transforms are norm-preserving
         x = random(30)


### PR DESCRIPTION
Test for ND transforms with axes for invariance of
permutation of axes.

This is based on the test added to `mkl_fft` in https://github.com/IntelPython/mkl_fft/pull/38 but extended to `fftn`, `ifftn`, `rfftn` and `irfftn`.

@charris 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
