### PR TITLE
BUG/MAINT: Tidy typeinfo.h and .c

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4722,11 +4722,9 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
     set_flaginfo(d);
 
     /* Create the typeinfo types */
-    typeinfo_init_structsequences();
-    PyDict_SetItemString(d,
-        "typeinfo", (PyObject *)&PyArray_typeinfoType);
-    PyDict_SetItemString(d,
-        "typeinforanged", (PyObject *)&PyArray_typeinforangedType);
+    if (typeinfo_init_structsequences(d) < 0) {
+        goto err;
+    }
 
     if (!intern_strings()) {
         goto err;

--- a/numpy/core/src/multiarray/typeinfo.c
+++ b/numpy/core/src/multiarray/typeinfo.c
@@ -3,8 +3,7 @@
  * Unfortunately, we need two different types to cover the cases where min/max
  * do and do not appear in the tuple.
  */
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "typeinfo.h"
 
 /* In python 2, this is not exported from Python.h */
 #include <structseq.h>
@@ -14,8 +13,8 @@
 #include "npy_pycompat.h"
 
 
-PyTypeObject PyArray_typeinfoType;
-PyTypeObject PyArray_typeinforangedType;
+static PyTypeObject PyArray_typeinfoType;
+static PyTypeObject PyArray_typeinforangedType;
 
 static PyStructSequence_Field typeinfo_fields[] = {
     {"char",      "The character used to represent the type"},
@@ -51,7 +50,7 @@ static PyStructSequence_Desc typeinforanged_desc = {
     7,                                                     /* n_in_sequence */
 };
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 PyArray_typeinfo(
     char typechar, int typenum, int nbits, int align,
     PyTypeObject *type_obj)
@@ -77,7 +76,7 @@ PyArray_typeinfo(
     return entry;
 }
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 PyArray_typeinforanged(
     char typechar, int typenum, int nbits, int align,
     PyObject *max, PyObject *min, PyTypeObject *type_obj)
@@ -105,10 +104,36 @@ PyArray_typeinforanged(
     return entry;
 }
 
-void typeinfo_init_structsequences(void)
+/* Backport, only needed here */
+#if PY_VERSION_HEX < 0x03040000
+    static int
+    PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc) {
+        PyStructSequence_InitType(type, desc);
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        return 0;
+    }
+#endif
+
+NPY_NO_EXPORT int
+typeinfo_init_structsequences(PyObject *multiarray_dict)
 {
-    PyStructSequence_InitType(
-        &PyArray_typeinfoType, &typeinfo_desc);
-    PyStructSequence_InitType(
-        &PyArray_typeinforangedType, &typeinforanged_desc);
+    if (PyStructSequence_InitType2(
+            &PyArray_typeinfoType, &typeinfo_desc) < 0) {
+        return -1;
+    }
+    if (PyStructSequence_InitType2(
+            &PyArray_typeinforangedType, &typeinforanged_desc) < 0) {
+        return -1;
+    }
+    if (PyDict_SetItemString(multiarray_dict,
+            "typeinfo", (PyObject *)&PyArray_typeinfoType) < 0) {
+        return -1;
+    }
+    if (PyDict_SetItemString(multiarray_dict,
+            "typeinforanged", (PyObject *)&PyArray_typeinforangedType) < 0) {
+        return -1;
+    }
+    return 0;
 }

--- a/numpy/core/src/multiarray/typeinfo.h
+++ b/numpy/core/src/multiarray/typeinfo.h
@@ -1,17 +1,19 @@
 #ifndef _NPY_PRIVATE_TYPEINFO_H_
 #define _NPY_PRIVATE_TYPEINFO_H_
 
-void typeinfo_init_structsequences(void);
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "npy_config.h"
 
-extern PyTypeObject PyArray_typeinfoType;
-extern PyTypeObject PyArray_typeinforangedType;
+NPY_VISIBILITY_HIDDEN int
+typeinfo_init_structsequences(PyObject *multiarray_dict);
 
-PyObject *
+NPY_VISIBILITY_HIDDEN PyObject *
 PyArray_typeinfo(
     char typechar, int typenum, int nbits, int align,
     PyTypeObject *type_obj);
 
-PyObject *
+NPY_VISIBILITY_HIDDEN PyObject *
 PyArray_typeinforanged(
     char typechar, int typenum, int nbits, int align,
     PyObject *max, PyObject *min, PyTypeObject *type_obj);


### PR DESCRIPTION
Backport of #13346.

* Add missing headers that happened to be included before this file
* Fix accidentally exported symbols
* Move registering types in `multiarray.__dict__` to the source file that creates the types
* Add missing error checking to make up for PyStructSequence_InitType2 not being available

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
