### PR TITLE
MAINT, DEP: Fix deprecated ``assertEquals()``

### DIFF
--- a/tools/swig/test/testFlat.py
+++ b/tools/swig/test/testFlat.py
@@ -37,7 +37,7 @@ class FlatTestCase(unittest.TestCase):
         x = np.frombuffer(pack_output, dtype=self.typeCode)
         y = x.copy()
         process(y)
-        self.assertEquals(np.all((x+1)==y),True)
+        self.assertEqual(np.all((x+1)==y),True)
 
     def testProcess3D(self):
         "Test Process function 3D array"
@@ -50,7 +50,7 @@ class FlatTestCase(unittest.TestCase):
         x.shape = (2,3,4)
         y = x.copy()
         process(y)
-        self.assertEquals(np.all((x+1)==y),True)
+        self.assertEqual(np.all((x+1)==y),True)
 
     def testProcess3DTranspose(self):
         "Test Process function 3D array, FORTRAN order"
@@ -63,7 +63,7 @@ class FlatTestCase(unittest.TestCase):
         x.shape = (2,3,4)
         y = x.copy()
         process(y.T)
-        self.assertEquals(np.all((x.T+1)==y.T),True)
+        self.assertEqual(np.all((x.T+1)==y.T),True)
 
     def testProcessNoncontiguous(self):
         "Test Process function with non-contiguous array, which should raise an error"

--- a/tools/swig/test/testFortran.py
+++ b/tools/swig/test/testFortran.py
@@ -31,14 +31,14 @@ class FortranTestCase(unittest.TestCase):
         second = Fortran.__dict__[self.typeStr + "SecondElement"]
         matrix = np.asfortranarray(np.arange(9).reshape(3, 3),
                                    self.typeCode)
-        self.assertEquals(second(matrix), 3)
+        self.assertEqual(second(matrix), 3)
 
     def testSecondElementObject(self):
         "Test Fortran matrix initialized from nested list fortranarray"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         second = Fortran.__dict__[self.typeStr + "SecondElement"]
         matrix = np.asfortranarray([[0, 1, 2], [3, 4, 5], [6, 7, 8]], self.typeCode)
-        self.assertEquals(second(matrix), 3)
+        self.assertEqual(second(matrix), 3)
 
 ######################################################################
 

--- a/tools/swig/test/testMatrix.py
+++ b/tools/swig/test/testMatrix.py
@@ -30,7 +30,7 @@ class MatrixTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         det = Matrix.__dict__[self.typeStr + "Det"]
         matrix = [[8, 7], [6, 9]]
-        self.assertEquals(det(matrix), 30)
+        self.assertEqual(det(matrix), 30)
 
     # Test (type IN_ARRAY2[ANY][ANY]) typemap
     def testDetBadList(self):
@@ -69,7 +69,7 @@ class MatrixTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         max = Matrix.__dict__[self.typeStr + "Max"]
         matrix = [[6, 5, 4], [3, 2, 1]]
-        self.assertEquals(max(matrix), 6)
+        self.assertEqual(max(matrix), 6)
 
     # Test (type* IN_ARRAY2, int DIM1, int DIM2) typemap
     def testMaxBadList(self):
@@ -99,7 +99,7 @@ class MatrixTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         min = Matrix.__dict__[self.typeStr + "Min"]
         matrix = [[9, 8], [7, 6], [5, 4]]
-        self.assertEquals(min(matrix), 4)
+        self.assertEqual(min(matrix), 4)
 
     # Test (int DIM1, int DIM2, type* IN_ARRAY2) typemap
     def testMinBadList(self):
@@ -130,7 +130,7 @@ class MatrixTestCase(unittest.TestCase):
         scale = Matrix.__dict__[self.typeStr + "Scale"]
         matrix = np.array([[1, 2, 3], [2, 1, 2], [3, 2, 1]], self.typeCode)
         scale(matrix, 4)
-        self.assertEquals((matrix == [[4, 8, 12], [8, 4, 8], [12, 8, 4]]).all(), True)
+        self.assertEqual((matrix == [[4, 8, 12], [8, 4, 8], [12, 8, 4]]).all(), True)
 
     # Test (type INPLACE_ARRAY2[ANY][ANY]) typemap
     def testScaleWrongDim(self):
@@ -236,8 +236,8 @@ class MatrixTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         luSplit = Matrix.__dict__[self.typeStr + "LUSplit"]
         lower, upper = luSplit([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        self.assertEquals((lower == [[1, 0, 0], [4, 5, 0], [7, 8, 9]]).all(), True)
-        self.assertEquals((upper == [[0, 2, 3], [0, 0, 6], [0, 0, 0]]).all(), True)
+        self.assertEqual((lower == [[1, 0, 0], [4, 5, 0], [7, 8, 9]]).all(), True)
+        self.assertEqual((upper == [[0, 2, 3], [0, 0, 6], [0, 0, 0]]).all(), True)
 
 ######################################################################
 

--- a/tools/swig/test/testSuperTensor.py
+++ b/tools/swig/test/testSuperTensor.py
@@ -73,7 +73,7 @@ class SuperTensorTestCase(unittest.TestCase):
         print(self.typeStr, "... ", file=sys.stderr)
         max = SuperTensor.__dict__[self.typeStr + "Max"]
         supertensor = [[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]]
-        self.assertEquals(max(supertensor), 8)
+        self.assertEqual(max(supertensor), 8)
 
     # Test (type* IN_ARRAY3, int DIM1, int DIM2, int DIM3) typemap
     def testMaxBadList(self):
@@ -103,7 +103,7 @@ class SuperTensorTestCase(unittest.TestCase):
         print(self.typeStr, "... ", file=sys.stderr)
         min = SuperTensor.__dict__[self.typeStr + "Min"]
         supertensor = [[[[9, 8], [7, 6]], [[5, 4], [3, 2]]], [[[9, 8], [7, 6]], [[5, 4], [3, 2]]]]
-        self.assertEquals(min(supertensor), 2)
+        self.assertEqual(min(supertensor), 2)
 
     # Test (int DIM1, int DIM2, int DIM3, type* IN_ARRAY3) typemap
     def testMinBadList(self):
@@ -135,7 +135,7 @@ class SuperTensorTestCase(unittest.TestCase):
         supertensor = np.arange(3*3*3*3, dtype=self.typeCode).reshape((3, 3, 3, 3))
         answer = supertensor.copy()*4
         scale(supertensor, 4)
-        self.assertEquals((supertensor == answer).all(), True)
+        self.assertEqual((supertensor == answer).all(), True)
 
     # Test (type INPLACE_ARRAY3[ANY][ANY][ANY]) typemap
     def testScaleWrongType(self):
@@ -252,8 +252,8 @@ class SuperTensorTestCase(unittest.TestCase):
         answer_upper = [[[[0, 0], [0, 1]], [[0, 1], [1, 1]]], [[[0, 1], [1, 1]], [[1, 1], [1, 1]]]]
         answer_lower = [[[[1, 1], [1, 0]], [[1, 0], [0, 0]]], [[[1, 0], [0, 0]], [[0, 0], [0, 0]]]]
         lower, upper = luSplit(supertensor)
-        self.assertEquals((lower == answer_lower).all(), True)
-        self.assertEquals((upper == answer_upper).all(), True)
+        self.assertEqual((lower == answer_lower).all(), True)
+        self.assertEqual((upper == answer_upper).all(), True)
 
 ######################################################################
 

--- a/tools/swig/test/testTensor.py
+++ b/tools/swig/test/testTensor.py
@@ -34,7 +34,7 @@ class TensorTestCase(unittest.TestCase):
         tensor = [[[0, 1], [2, 3]],
                   [[3, 2], [1, 0]]]
         if isinstance(self.result, int):
-            self.assertEquals(norm(tensor), self.result)
+            self.assertEqual(norm(tensor), self.result)
         else:
             self.assertAlmostEqual(norm(tensor), self.result, 6)
 
@@ -79,7 +79,7 @@ class TensorTestCase(unittest.TestCase):
         max = Tensor.__dict__[self.typeStr + "Max"]
         tensor = [[[1, 2], [3, 4]],
                   [[5, 6], [7, 8]]]
-        self.assertEquals(max(tensor), 8)
+        self.assertEqual(max(tensor), 8)
 
     # Test (type* IN_ARRAY3, int DIM1, int DIM2, int DIM3) typemap
     def testMaxBadList(self):
@@ -111,7 +111,7 @@ class TensorTestCase(unittest.TestCase):
         min = Tensor.__dict__[self.typeStr + "Min"]
         tensor = [[[9, 8], [7, 6]],
                   [[5, 4], [3, 2]]]
-        self.assertEquals(min(tensor), 2)
+        self.assertEqual(min(tensor), 2)
 
     # Test (int DIM1, int DIM2, int DIM3, type* IN_ARRAY3) typemap
     def testMinBadList(self):
@@ -145,7 +145,7 @@ class TensorTestCase(unittest.TestCase):
                           [[0, 1, 0], [1, 0, 1], [0, 1, 0]],
                           [[1, 0, 1], [0, 1, 0], [1, 0, 1]]], self.typeCode)
         scale(tensor, 4)
-        self.assertEquals((tensor == [[[4, 0, 4], [0, 4, 0], [4, 0, 4]],
+        self.assertEqual((tensor == [[[4, 0, 4], [0, 4, 0], [4, 0, 4]],
                                       [[0, 4, 0], [4, 0, 4], [0, 4, 0]],
                                       [[4, 0, 4], [0, 4, 0], [4, 0, 4]]]).all(), True)
 
@@ -264,9 +264,9 @@ class TensorTestCase(unittest.TestCase):
         luSplit = Tensor.__dict__[self.typeStr + "LUSplit"]
         lower, upper = luSplit([[[1, 1], [1, 1]],
                                 [[1, 1], [1, 1]]])
-        self.assertEquals((lower == [[[1, 1], [1, 0]],
+        self.assertEqual((lower == [[[1, 1], [1, 0]],
                                      [[1, 0], [0, 0]]]).all(), True)
-        self.assertEquals((upper == [[[0, 0], [0, 1]],
+        self.assertEqual((upper == [[[0, 0], [0, 1]],
                                      [[0, 1], [1, 1]]]).all(), True)
 
 ######################################################################

--- a/tools/swig/test/testVector.py
+++ b/tools/swig/test/testVector.py
@@ -29,7 +29,7 @@ class VectorTestCase(unittest.TestCase):
         "Test length function"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         length = Vector.__dict__[self.typeStr + "Length"]
-        self.assertEquals(length([5, 12, 0]), 13)
+        self.assertEqual(length([5, 12, 0]), 13)
 
     # Test the (type IN_ARRAY1[ANY]) typemap
     def testLengthBadList(self):
@@ -64,7 +64,7 @@ class VectorTestCase(unittest.TestCase):
         "Test prod function"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         prod = Vector.__dict__[self.typeStr + "Prod"]
-        self.assertEquals(prod([1, 2, 3, 4]), 24)
+        self.assertEqual(prod([1, 2, 3, 4]), 24)
 
     # Test the (type* IN_ARRAY1, int DIM1) typemap
     def testProdBadList(self):
@@ -92,7 +92,7 @@ class VectorTestCase(unittest.TestCase):
         "Test sum function"
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         sum = Vector.__dict__[self.typeStr + "Sum"]
-        self.assertEquals(sum([5, 6, 7, 8]), 26)
+        self.assertEqual(sum([5, 6, 7, 8]), 26)
 
     # Test the (int DIM1, type* IN_ARRAY1) typemap
     def testSumBadList(self):
@@ -122,7 +122,7 @@ class VectorTestCase(unittest.TestCase):
         reverse = Vector.__dict__[self.typeStr + "Reverse"]
         vector = np.array([1, 2, 4], self.typeCode)
         reverse(vector)
-        self.assertEquals((vector == [4, 2, 1]).all(), True)
+        self.assertEqual((vector == [4, 2, 1]).all(), True)
 
     # Test the (type INPLACE_ARRAY1[ANY]) typemap
     def testReverseWrongDim(self):
@@ -225,8 +225,8 @@ class VectorTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         eoSplit = Vector.__dict__[self.typeStr + "EOSplit"]
         even, odd = eoSplit([1, 2, 3])
-        self.assertEquals((even == [1, 0, 3]).all(), True)
-        self.assertEquals((odd  == [0, 2, 0]).all(), True)
+        self.assertEqual((even == [1, 0, 3]).all(), True)
+        self.assertEqual((odd  == [0, 2, 0]).all(), True)
 
     # Test the (type* ARGOUT_ARRAY1, int DIM1) typemap
     def testTwos(self):
@@ -234,7 +234,7 @@ class VectorTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         twos = Vector.__dict__[self.typeStr + "Twos"]
         vector = twos(5)
-        self.assertEquals((vector == [2, 2, 2, 2, 2]).all(), True)
+        self.assertEqual((vector == [2, 2, 2, 2, 2]).all(), True)
 
     # Test the (type* ARGOUT_ARRAY1, int DIM1) typemap
     def testTwosNonInt(self):
@@ -249,7 +249,7 @@ class VectorTestCase(unittest.TestCase):
         print(self.typeStr, "... ", end=' ', file=sys.stderr)
         threes = Vector.__dict__[self.typeStr + "Threes"]
         vector = threes(6)
-        self.assertEquals((vector == [3, 3, 3, 3, 3, 3]).all(), True)
+        self.assertEqual((vector == [3, 3, 3, 3, 3, 3]).all(), True)
 
     # Test the (type* ARGOUT_ARRAY1, int DIM1) typemap
     def testThreesNonInt(self):


### PR DESCRIPTION
See https://docs.python.org/2/library/unittest.html#deprecated-aliases

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
