### PR TITLE
BUG: Some PyPy versions lack PyStructSequence_InitType2.

### DIFF
--- a/numpy/core/src/multiarray/typeinfo.c
+++ b/numpy/core/src/multiarray/typeinfo.c
@@ -104,8 +104,10 @@ PyArray_typeinforanged(
     return entry;
 }
 
-/* Backport, only needed here */
-#if PY_VERSION_HEX < 0x03040000
+/* Python version only needed for backport to 2.7 */
+#if (PY_VERSION_HEX < 0x03040000) \
+    || (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM < 0x07020000))
+
     static int
     PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc) {
         PyStructSequence_InitType(type, desc);


### PR DESCRIPTION
Backport of #13388.

Define `PyStructSequence_InitType2` for those PyPy versions that
don't support it.

Closes gh-13384.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
