### PR TITLE
DOC: note re defaults allclose to assert_allclose

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1441,10 +1441,9 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
     Raises an AssertionError if two objects are not equal up to desired
     tolerance.
 
-    The test is equivalent to ``allclose(actual, desired, rtol, atol)`` (but
-    note that ``allclose`` has with ``rtol=1e-05`` and ``atol=1e-08`` different
-    default values). It compares the difference between `actual` and `desired`
-    to ``atol + rtol * abs(desired)``.
+    The test is equivalent to ``allclose(actual, desired, rtol, atol)`` (note
+    that ``allclose`` has different default values). It compares the difference
+    between `actual` and `desired` to ``atol + rtol * abs(desired)``.
 
     .. versionadded:: 1.5.0
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1441,9 +1441,10 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
     Raises an AssertionError if two objects are not equal up to desired
     tolerance.
 
-    The test is equivalent to ``allclose(actual, desired, rtol, atol)``.
-    It compares the difference between `actual` and `desired` to
-    ``atol + rtol * abs(desired)``.
+    The test is equivalent to ``allclose(actual, desired, rtol, atol)`` (but
+    note that ``allclose`` has with ``rtol=1e-05`` and ``atol=1e-08`` different
+    default values). It compares the difference between `actual` and `desired`
+    to ``atol + rtol * abs(desired)``.
 
     .. versionadded:: 1.5.0
 


### PR DESCRIPTION
I just got bitten by the difference of the default values for `rtol` and `atol` in `allclose` and `assert_allclose` today, again, not the first time. So I thought I add a little note.

I assume in `allclose` no notion of `assert_allclose` is desired, what makes sense. However, mention it in the docs of `assert_allclose`  explicitly might make it a tad easier to be found.

There are various discussions about this, e.g., the discussions in issues #3183, #7726, #10161, or http://numpy-discussion.10968.n7.nabble.com/allclose-vs-assert-allclose-td38018.html.

**This PR is not going into the pros and cons etc, it just adds a little clarification to the docstring of `assert_allclose`.**