### PR TITLE
DOC: Show the default value of deletechars in the signature of genfromtxt

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1549,7 +1549,8 @@ def fromregex(file, regexp, dtype, encoding=None):
 def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                skip_header=0, skip_footer=0, converters=None,
                missing_values=None, filling_values=None, usecols=None,
-               names=None, excludelist=None, deletechars=None,
+               names=None, excludelist=None,
+               deletechars=''.join(sorted(NameValidator.defaultdeletechars)),
                replace_space='_', autostrip=False, case_sensitive=True,
                defaultfmt="f%i", unpack=None, usemask=False, loose=True,
                invalid_raise=True, max_rows=None, encoding='bytes'):


### PR DESCRIPTION
Alternative to gh-13397

[before](https://docs.scipy.org/doc/numpy/reference/generated/numpy.genfromtxt.html), [after](https://7079-908607-gh.circle-artifacts.com/0/home/circleci/repo/doc/build/html/reference/generated/numpy.genfromtxt.html)

It looks to me like sphinx has some pretty poor formatting rules that format `foo(a, b=(1, 2))` as if both commas were argument separators