### PR TITLE
MAINT: IntpFromSequence cannot return a wrong length here.

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -129,7 +129,8 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
     }
     seq->len = len;
     nd = PyArray_IntpFromIndexSequence(obj, (npy_intp *)seq->ptr, len);
-    if (nd == -1 || nd != len) {
+    assert(len == nd);
+    if (nd == -1) {
         npy_free_cache_dim_obj(*seq);
         seq->ptr = NULL;
         return NPY_FAIL;


### PR DESCRIPTION
As per Matti's comment, removing the path and adding an assert instead,
since it is clearer to read.

Closes gh-10813