### PR TITLE
MAINT: Refactor PyArray_IntpFromIndexSequence into PyArray_IntpFromIndexArray

### DIFF
--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -145,7 +145,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
         /* if not a sequence, produce a clearer message */
         if (fast_seq == Py_None && PyErr_ExceptionMatches(PyExc_TypeError)) {
             PyErr_SetString(PyExc_TypeError,
-                "expected sequence object or a single integer");
+                "expected an integer or a sequence of integers");
         }
         goto fail;
     }
@@ -1008,7 +1008,7 @@ PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals)
         if (fast_seq == Py_None && PyErr_ExceptionMatches(PyExc_TypeError)) {
             /* if not a sequence, produce a clearer message */
             PyErr_SetString(PyExc_TypeError,
-                "expected sequence object or a single integer");
+                "expected an integer or a sequence of integers");
         }
         goto fail;
     }

--- a/numpy/core/src/multiarray/conversion_utils.h
+++ b/numpy/core/src/multiarray/conversion_utils.h
@@ -27,8 +27,8 @@ PyArray_PyIntAsInt(PyObject *o);
 NPY_NO_EXPORT npy_intp
 PyArray_PyIntAsIntp(PyObject *o);
 
-NPY_NO_EXPORT npy_intp
-PyArray_IntpFromIndexSequence(PyObject *seq, npy_intp *vals, npy_intp maxvals);
+NPY_NO_EXPORT int
+PyArray_IntpFromIndexArray(PyObject *const *items, npy_intp *vals, npy_intp nd);
 
 NPY_NO_EXPORT int
 PyArray_IntpFromSequence(PyObject *seq, npy_intp *vals, int maxvals);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1924,7 +1924,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
         return NULL;
     }
 
-    /* Parse the shape argument. This is like PyArray_IntpConverter, but does
+    /*
+     * Parse the shape argument. This is like PyArray_IntpConverter, but does
      * not attempt int -> tuple promotion, and allocates them on the stack.
      */
     {

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2241,13 +2241,13 @@ class TestCreationFuncs(object):
         dim = 1
         beg = sys.getrefcount(dim)
         np.zeros([dim]*10)
-        assert_(sys.getrefcount(dim) == beg)
+        assert_equal(sys.getrefcount(dim), beg)
         np.ones([dim]*10)
-        assert_(sys.getrefcount(dim) == beg)
+        assert_equal(sys.getrefcount(dim), beg)
         np.empty([dim]*10)
-        assert_(sys.getrefcount(dim) == beg)
+        assert_equal(sys.getrefcount(dim), beg)
         np.full([dim]*10, 0)
-        assert_(sys.getrefcount(dim) == beg)
+        assert_equal(sys.getrefcount(dim), beg)
 
 
 class TestLikeFuncs(object):


### PR DESCRIPTION
There was some clumsy juggling of lengths in PyArray_IntpConverter where we ask for the length of the argument twice, and try to handle wrapping the object twice too.

This fixes some bugs that probably no one ever will or did see:
* A corrupt pickle file with an `shape` array that is too long would be silently truncated
* An object that returns different `__len__`s each time it is asked will no longer fail
* IntpFromSequence would overflow it's output buffer if nd == 0

This collapses `PyArray_IntpFromIndexSequence` back into `PyArray_IntpFromSequence`, since the former no longer has any callers (and is internal)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
