### PR TITLE
DOC: document existence of linalg backends

### DIFF
--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -5,6 +5,19 @@
 Linear algebra (:mod:`numpy.linalg`)
 ************************************
 
+The NumPy linear algebra functions rely on BLAS and LAPACK to provide efficient
+low level implementations of standard linear algebra algorithms. Those
+libraries may be provided by NumPy itself using C versions of a subset of their
+reference implementations but, when possible, highly optimized libraries that
+take advantage of specialized processor functionality are preferred. Examples
+of such libraries are OpenBLAS_, MKL (TM), and ATLAS. Because those libraries
+are multithreaded and processor dependent, environmental variables and external
+packages such as threadpoolctl_ may be needed to control the number of threads
+or specify the processor architecture.
+
+.. _OpenBLAS: https://www.openblas.net/
+.. _threadpoolctl: https://github.com/joblib/threadpoolctl
+
 .. currentmodule:: numpy
 
 Matrix and vector products


### PR DESCRIPTION
Continuing #13136, document the existance of solutions to control the number of threads used by the linalg backends. Since I couldn't find any documentation of backends, I added a short description to the index of `linalg` as well.

xref #9312 which began linking in the documentation of `show_config` 