### PR TITLE
DOC: Improve `numpy.memmap` docs.

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -104,14 +104,14 @@ class memmap(ndarray):
 
     See also
     --------
-    `lib.format.open_memmap <https://github.com/numpy/numpy/blob/v1.16.1/numpy/lib/format.py>`_ : Create or load a memory-mapped ``.npy`` file.
+    lib.format.open_memmap: Create or load a memory-mapped ``.npy`` file.
 
     Notes
     -----
     The memmap object can be used anywhere an ndarray is accepted.
     Given a memmap ``fp``, ``isinstance(fp, numpy.ndarray)`` returns
     ``True``.
-    
+
     Memory-mapped files cannot be larger than 2GB on 32-bit systems.
 
     When a memmap causes a file to be created or extended beyond its

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -104,7 +104,7 @@ class memmap(ndarray):
 
     See also
     --------
-    lib.format.open_memmap : Create or load a memory-mapped ``.npy`` file.
+    `lib.format.open_memmap <https://github.com/numpy/numpy/blob/v1.16.1/numpy/lib/format.py>`_ : Create or load a memory-mapped ``.npy`` file.
 
     Notes
     -----

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -165,6 +165,12 @@ from numpy.compat import (
     asbytes, asstr, isfileobj, long, os_fspath, pickle
     )
 
+__all__ = ['magic', 'read_magic', 'dtype_to_descr', 'descr_to_detype',
+           'header_data_from_array_1_0', 'write_array_header_1_0',
+           'write_array_header_2_0', 'read_array_header_1_0',
+           'read_array_header_2_0', 'write_array', 'read_array',
+           'open_memmap']
+
 
 MAGIC_PREFIX = b'\x93NUMPY'
 MAGIC_LEN = len(MAGIC_PREFIX) + 2


### PR DESCRIPTION
Fix #12926. 

The current docs for creating a large `.npy` file using the memmap module is unclear. It will be more helpful if one can click a link to see the usage of `lib.format.open_memmap` function. I was not able to find a page or section on the online docs for `lib.format.open_memmap`. So, I added a link to the GitHub file for now.

- Add a link to `lib.format.open_memmap` function on GitHub
- Create a page or section under `lib.format` to detail the usage of `open_memmap` function.
