### PR TITLE
BUG: Protect generators from log(0.0)

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -83,6 +83,17 @@ The functions ``np.load``, and ``np.lib.format.read_array`` take an
 `allow_pickle` keyword which now defaults to ``False`` in response to
 `CVE-2019-6446 <https://nvd.nist.gov/vuln/detail/CVE-2019-6446>`_.
 
+Potential changes to the random stream
+--------------------------------------
+Due to bugs in the application of log to random floating point numbers,
+the stream may change when sampling from ``np.random.beta``, ``np.random.binomial``,
+``np.random.laplace``, ``np.random.logistic``, ``np.random.logseries`` or
+``np.random.multinomial`` if a 0 is generated in the underlying MT19937 random stream.
+There is a 1 in :math:`10^{53}` chance of this occurring, and so the probability that
+the stream changes for any given seed is extremely small. If a 0 is encountered in the
+underlying generator, then the incorrect value produced (either ``np.inf``
+or ``np.nan``) is now dropped.
+
 C API changes
 =============
 

--- a/numpy/random/mtrand/distributions.c
+++ b/numpy/random/mtrand/distributions.c
@@ -198,9 +198,10 @@ double rk_beta(rk_state *state, double a, double b)
             X = pow(U, 1.0/a);
             Y = pow(V, 1.0/b);
 
-            if ((X + Y) <= 1.0)
+            /* Reject if both U and V are 0.0, which is approx 1 in 10^106 */
+            if (((X + Y) <= 1.0) && ((U + V) > 0.0))
             {
-                if (X +Y > 0)
+                if (X + Y > 0)
                 {
                     return X / (X + Y);
                 }
@@ -329,13 +330,15 @@ long rk_binomial_btpe(rk_state *state, long n, double p)
   Step30:
     if (u > p3) goto Step40;
     y = (long)floor(xl + log(v)/laml);
-    if (y < 0) goto Step10;
+    /* Reject if v == 0.0 since cast of inf not well defined */
+    if ((y < 0) || (v == 0.0)) goto Step10;
     v = v*(u-p2)*laml;
     goto Step50;
 
   Step40:
     y = (long)floor(xr - log(v)/lamr);
-    if (y > n) goto Step10;
+    /* Reject if v == 0.0 since cast of inf not well defined */
+    if ((y > n) || (v == 0.0)) goto Step10;
     v = v*(u-p3)*lamr;
 
   Step50:
@@ -666,12 +669,17 @@ double rk_laplace(rk_state *state, double loc, double scale)
     double U;
 
     U = rk_double(state);
-    if (U < 0.5)
+    if (U >= 0.5)
+    {
+        U = loc - scale * log(2.0 - U - U);
+
+    } else if (U > 0.0)
     {
         U = loc + scale * log(U + U);
     } else
     {
-        U = loc - scale * log(2.0 - U - U);
+        /* Reject if U == 0.0 */
+        return rk_laplace(state, loc, scale);
     }
     return U;
 }
@@ -681,7 +689,9 @@ double rk_gumbel(rk_state *state, double loc, double scale)
     double U;
 
     U = 1.0 - rk_double(state);
-    return loc - scale * log(-log(U));
+    if (U < 1.0)
+        return loc - scale * log(-log(U));
+    return rk_gumbel(state, loc, scale);
 }
 
 double rk_logistic(rk_state *state, double loc, double scale)
@@ -689,7 +699,9 @@ double rk_logistic(rk_state *state, double loc, double scale)
     double U;
 
     U = rk_double(state);
-    return loc + scale * log(U/(1.0 - U));
+    if (U > 0.0)
+        return loc + scale * log(U/(1.0 - U));
+    return rk_logistic(state, loc, scale);
 }
 
 double rk_lognormal(rk_state *state, double mean, double sigma)
@@ -914,7 +926,8 @@ long rk_logseries(rk_state *state, double p)
         q = 1.0 - exp(r*U);
         if (V <= q*q) {
             result = (long)floor(1 + log(V)/log(q));
-            if (result < 1) {
+            /* Reject if v == 0.0 since cast of inf not well defined */
+            if ((result < 1) || (V == 0.0)) {
                 continue;
             }
             else {


### PR DESCRIPTION
Ensure log(0.0) doesn't produce inf/nan values when generating random values

These are all edge cases where 

a. Either NaN, inf, or an undefined value are returned.  Each has approx probability 1 in 10**53 of happening
b. They all technically change the stream, and so it may be the case that this PR cannot be accepted. This PR only changes the stream for the invalid values, in which case the invalid value is rejected so that the stream is "as-if" the bad value is skipped, and otherwise the same.

@mattip I'm submitting this so that it can receive some thought since these bugs are all in #13163 . If this is acceptable, then I'll make a PR against the branch.

@rkern Do you think these are worth fixing?
