### PR TITLE
BUG: Handle subarrays in descr_to_dtype

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -267,10 +267,15 @@ def descr_to_dtype(descr):
 
     This function reverses the process, eliminating the empty padding fields.
     '''
-    if isinstance(descr, (str, dict, tuple)):
+    if isinstance(descr, (str, dict)):
         # No padding removal needed
         return numpy.dtype(descr)
-
+    elif isinstance(descr, tuple):
+        if isinstance(descr[0], list):
+            # subtype, will always have a shape descr[1]
+            dt = descr_to_dtype(descr[0])
+            return numpy.dtype((dt, descr[1]))
+        return numpy.dtype(descr)
     fields = []
     offset = 0
     for field in descr:

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -267,15 +267,13 @@ def descr_to_dtype(descr):
 
     This function reverses the process, eliminating the empty padding fields.
     '''
-    if isinstance(descr, (str, dict)):
+    if isinstance(descr, str):
         # No padding removal needed
         return numpy.dtype(descr)
     elif isinstance(descr, tuple):
-        if isinstance(descr[0], list):
-            # subtype, will always have a shape descr[1]
-            dt = descr_to_dtype(descr[0])
-            return numpy.dtype((dt, descr[1]))
-        return numpy.dtype(descr)
+        # subtype, will always have a shape descr[1]
+        dt = descr_to_dtype(descr[0])
+        return numpy.dtype((dt, descr[1]))
     fields = []
     offset = 0
     for field in descr:

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -261,12 +261,13 @@ def dtype_to_descr(dtype):
 def descr_to_dtype(descr):
     '''
     descr may be stored as dtype.descr, which is a list of
-    (name, format, [shape]) tuples. Offsets are not explicitly saved, rather
-    empty fields with name,format == '', '|Vn' are added as padding.
+    (name, format, [shape]) tuples where format may be a str or a tuple.
+    Offsets are not explicitly saved, rather empty fields with
+    name, format == '', '|Vn' are added as padding.
 
     This function reverses the process, eliminating the empty padding fields.
     '''
-    if isinstance(descr, (str, dict)):
+    if isinstance(descr, (str, dict, tuple)):
         # No padding removal needed
         return numpy.dtype(descr)
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -629,6 +629,50 @@ def test_pickle_disallow():
     assert_raises(ValueError, np.save, path, np.array([None], dtype=object),
                   allow_pickle=False)
 
+@pytest.mark.parametrize('dt', [
+    np.dtype(np.dtype([('a', np.int8),
+                       ('b', np.int16),
+                       ('c', np.int32),
+                      ], align=True),
+             (3,)),
+    np.dtype([('x', ([('a', '|i1'),
+                      ('', '|V3'),
+                      ('b', '|i1'),
+                      ('', '|V3'),
+                     ],
+                     (3,)),
+               (4,),
+             )]),
+    np.dtype([('x', np.dtype({'names':['a','b'],
+                              'formats':['i1','i1'],
+                              'offsets':[0,4],
+                              'itemsize':8,
+                             },
+                    (3,)),
+               (4,),
+             )]),
+    np.dtype([('x',
+                   ('<f8', (5,)),
+                   (2,),
+               )]),
+    np.dtype([('x', np.dtype((
+        np.dtype((
+            np.dtype({'names':['a','b'],
+                      'formats':['i1','i1'],
+                      'offsets':[0,4],
+                      'itemsize':8}),
+            (3,)
+            )),
+        (4,)
+        )))
+        ])
+    ])
+def test_descr_to_dtype(dt):
+    dt1 = format.descr_to_dtype(dt.descr)
+    assert_equal_(dt1, dt)
+    arr1 = np.zeros(3, dt)
+    arr2 = roundtrip(arr1)
+    assert_array_equal(arr1, arr2)
 
 def test_version_2_0():
     f = BytesIO()

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -411,6 +411,7 @@ record_arrays = [
     np.array(NbufferT, dtype=np.dtype(Ndescr).newbyteorder('<')),
     np.array(PbufferT, dtype=np.dtype(Pdescr).newbyteorder('>')),
     np.array(NbufferT, dtype=np.dtype(Ndescr).newbyteorder('>')),
+    np.zeros(1, dtype=[('c', ('<f8', (5,)), (2,))])
 ]
 
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -635,14 +635,6 @@ def test_pickle_disallow():
                        ('c', np.int32),
                       ], align=True),
              (3,)),
-    np.dtype([('x', ([('a', '|i1'),
-                      ('', '|V3'),
-                      ('b', '|i1'),
-                      ('', '|V3'),
-                     ],
-                     (3,)),
-               (4,),
-             )]),
     np.dtype([('x', np.dtype({'names':['a','b'],
                               'formats':['i1','i1'],
                               'offsets':[0,4],
@@ -665,8 +657,27 @@ def test_pickle_disallow():
             )),
         (4,)
         )))
-        ])
+        ]),
+    np.dtype([
+        ('a', np.dtype((
+            np.dtype((
+                np.dtype((
+                    np.dtype([
+                        ('a', int),
+                        ('b', np.dtype({'names':['a','b'],
+                                        'formats':['i1','i1'],
+                                        'offsets':[0,4],
+                                        'itemsize':8})),
+                    ]),
+                    (3,),
+                )),
+                (4,),
+            )),
+            (5,),
+        )))
+        ]),
     ])
+
 def test_descr_to_dtype(dt):
     dt1 = format.descr_to_dtype(dt.descr)
     assert_equal_(dt1, dt)


### PR DESCRIPTION
Fixes #13431.

There are alternative spellings of `dtype=[('c', '<f8', (2, 5))]`, handle the `dtype=[('c', ('<f8', (5,)), (2,))]` variant.