### PR TITLE
BUG: fix unravel_index when dimension is greater than 'intp'

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1261,7 +1261,13 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
         goto fail;
     }
 
-    unravel_size = PyArray_MultiplyList(dimensions.ptr, dimensions.len);
+    unravel_size = PyArray_OverflowMultiplyList(dimensions.ptr, dimensions.len);
+    if (unravel_size == -1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "dimensions are too large; arrays and shapes with "
+                        "a total size greater than 'intp' are not supported.");
+        goto fail;
+    }
 
     indices = astype_anyint(indices0);
     if (indices == NULL) {

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -106,6 +106,9 @@ class TestRavelUnravelIndex(object):
                 np.ravel_multi_index(arr, (41, 7, 120, 36, 2706, 8, 6)),
                 [5627771580, 117259570957])
 
+        # test unravel_index for big indices (issue #9538)
+        assert_raises(ValueError, np.unravel_index, 1, (2**32-1, 2**31+1))
+
         # test overflow checking for too big array (issue #7546)
         dummy_arr = ([0],[0])
         half_max = np.iinfo(np.intp).max // 2


### PR DESCRIPTION
this PR fixes #9538 