### PR TITLE
BLD, TST: implicit func errors

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -26,6 +26,7 @@ fi
 
 # make some warnings fatal, mostly to match windows compilers
 werrors="-Werror=vla -Werror=nonnull -Werror=pointer-arith"
+werrors="$werrors -Werror=implicit-function-declaration"
 
 # build with c99 by default
 


### PR DESCRIPTION
Fixes #13437 

Otherwise, the compiler may just put in `int f()` with an easily-missed warning and core devs may go through several debug cycles before realizing that a function prototype needs to be included.

Stackoverflow discussion re: it should be considered an error: https://stackoverflow.com/a/9182835/2942522