### PR TITLE
BUG: missing git raises an OSError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ def git_version():
     try:
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
         GIT_REVISION = out.strip().decode('ascii')
-    except subprocess.SubprocessError:
+    except (subprocess.SubprocessError, OSError):
         GIT_REVISION = "Unknown"
 
     return GIT_REVISION


### PR DESCRIPTION
Need to deal with two errors when trying to determine the git commit of HEAD: if git is not found, check_output will raise an `OSError`, if the command fails because there is no git repo it will raise a `subprocess.SubprocessError`.

Fixes #13448 
