### PR TITLE
TST: Reproducer for SkylakeX Issue gh-13401

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,3 +223,54 @@ jobs:
       testResultsFiles: '**/test-*.xml'
       testRunTitle: 'Publish test results for PyPy3'
       failTaskOnFailedTests: true
+
+- job: Intel_SDE
+  pool:
+    # have to use Mac to reproduce
+    # issue in 13401 because manylinux1
+    # gcc too old to enable our ecosystem OpenBLAS
+    # binaries to switch to SkylakeX kernel
+    vmImage: 'macOS-10.13'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+        versionSpec: '3.7'
+        architecture: 'x64'
+  - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
+    displayName: 'select Xcode version'
+  - script: |
+      python -m pip install --upgrade pip cython pytest setuptools wheel
+    displayName: 'install NumPy dependencies'
+  - script: |
+      brew install gcc49
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libgfortran.3.dylib /usr/local/lib/libgfortran.3.dylib
+      ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libquadmath.0.dylib /usr/local/lib/libquadmath.0.dylib
+    displayName: 'install gfortran'
+  - script: |
+       mkdir openblas && cd openblas
+       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+       tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+       cp ./usr/local/lib/* /usr/local/lib/
+       cp ./usr/local/include/* /usr/local/include/
+       cd ..
+    displayName: 'install OpenBLAS'
+  - script: |
+      python -m pip wheel -v -v -v --wheel-dir=dist .
+      ls -tlrh dist
+      python -m pip install dist/numpy*.whl
+    displayName: 'Build / Install NumPy'
+  - script: |
+      pushd ..
+      python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'OpenBLAS 0.3.5.dev' in res"
+      popd
+    displayName: 'verify OpenBLAS version'
+  - script: |
+      mkdir SDE && cd SDE
+      wget -O sde-external-8.35.0-2019-03-11-mac.tar.bz2 https://www.dropbox.com/s/rkgx577cb7pxc8c/sde-external-8.35.0-2019-03-11-mac.tar.bz2?dl=0
+      tar -xjvf sde-external-8.35.0-2019-03-11-mac.tar.bz2
+      # check that Skylake X is actually reported by OpenBLAS:
+      ./sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'SkylakeX' in res"
+      cd ..
+      # will only report 1 failure beyond my new test, even in full mode
+      ./SDE/sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./SDE/sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python runtests.py -n -s "linalg"
+    displayName: 'Intel SDE testing for linalg / OpenBLAS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,13 +264,12 @@ jobs:
       python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'OpenBLAS 0.3.5.dev' in res"
       popd
     displayName: 'verify OpenBLAS version'
-  - script: |
+  - bash: |
       mkdir SDE && cd SDE
       wget -O sde-external-8.35.0-2019-03-11-mac.tar.bz2 https://www.dropbox.com/s/rkgx577cb7pxc8c/sde-external-8.35.0-2019-03-11-mac.tar.bz2?dl=0
       tar -xjvf sde-external-8.35.0-2019-03-11-mac.tar.bz2
       # check that Skylake X is actually reported by OpenBLAS:
       ./sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'SkylakeX' in res"
       cd ..
-      # will only report 1 failure beyond my new test, even in full mode
-      ./SDE/sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./SDE/sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python runtests.py -n -s "linalg"
+      ./SDE/sde-external-8.35.0-2019-03-11-mac/sde64 -cpuid_in ./SDE/sde-external-8.35.0-2019-03-11-mac/misc/cpuid/skx/cpuid.def -- python runtests.py -n -s "linalg" --mode=full
     displayName: 'Intel SDE testing for linalg / OpenBLAS'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,8 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.3-186-g701ea883-manylinux1_i686.tar.gz && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-manylinux1_i686.tar.gz && \
+           tar zxvf openblas-v0.3.5-267-g3f427c0c-manylinux1_i686.tar.gz && \
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../numpy && \
@@ -75,8 +75,8 @@ jobs:
   # matches our MacOS wheel builds -- currently based
   # primarily on file size / name details
   - script: |
-      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz"
-      tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz"
+      tar -zxvf openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
       # manually link to appropriate system paths
       cp ./usr/local/lib/* /usr/local/lib/
       cp ./usr/local/include/* /usr/local/include/
@@ -113,8 +113,8 @@ jobs:
   variables:
       # openblas URLs from numpy-wheels
       # appveyor / Windows config
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-win_amd64-gcc_7_1_0.zip"
   strategy:
     maxParallel: 6
     matrix:
@@ -167,7 +167,7 @@ jobs:
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.3-186-g701ea883-gcc_7_1_0.a $target
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-267-g3f427c0c-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       choco install -y mingw --forcex86 --force --version=5.3.0
@@ -248,8 +248,8 @@ jobs:
     displayName: 'install gfortran'
   - script: |
        mkdir openblas && cd openblas
-       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
-       tar -zxvf openblas-v0.3.3-186-g701ea883-macosx_10_9_intel-gf_1becaaa.tar.gz
+       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       tar -zxvf openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
        cp ./usr/local/lib/* /usr/local/lib/
        cp ./usr/local/include/* /usr/local/include/
        cd ..
@@ -261,7 +261,7 @@ jobs:
     displayName: 'Build / Install NumPy'
   - script: |
       pushd ..
-      python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'OpenBLAS 0.3.5.dev' in res"
+      python -c "import numpy, ctypes, os; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'OpenBLAS 0.3.7.dev' in res"
       popd
     displayName: 'verify OpenBLAS version'
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,8 @@ jobs:
            apt-get -y install gfortran-5 wget && \
            cd .. && \
            mkdir openblas && cd openblas && \
-           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-manylinux1_i686.tar.gz && \
-           tar zxvf openblas-v0.3.5-267-g3f427c0c-manylinux1_i686.tar.gz && \
+           wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-manylinux1_i686.tar.gz && \
+           tar zxvf openblas-v0.3.5-274-g6a8b4269-manylinux1_i686.tar.gz && \
            cp -r ./usr/local/lib/* /usr/lib && \
            cp ./usr/local/include/* /usr/include && \
            cd ../numpy && \
@@ -75,8 +75,8 @@ jobs:
   # matches our MacOS wheel builds -- currently based
   # primarily on file size / name details
   - script: |
-      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz"
-      tar -zxvf openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+      wget "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz"
+      tar -zxvf openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz
       # manually link to appropriate system paths
       cp ./usr/local/lib/* /usr/local/lib/
       cp ./usr/local/include/* /usr/local/include/
@@ -113,8 +113,8 @@ jobs:
   variables:
       # openblas URLs from numpy-wheels
       # appveyor / Windows config
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win_amd64-gcc_7_1_0.zip"
   strategy:
     maxParallel: 6
     matrix:
@@ -167,7 +167,7 @@ jobs:
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"
-      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-267-g3f427c0c-gcc_7_1_0.a $target
+      cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-274-g6a8b4269-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
       choco install -y mingw --forcex86 --force --version=5.3.0
@@ -248,8 +248,8 @@ jobs:
     displayName: 'install gfortran'
   - script: |
        mkdir openblas && cd openblas
-       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
-       tar -zxvf openblas-v0.3.5-267-g3f427c0c-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       wget https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz
+       tar -zxvf openblas-v0.3.5-274-g6a8b4269-macosx_10_9_x86_64-gf_1becaaa.tar.gz
        cp ./usr/local/lib/* /usr/local/lib/
        cp ./usr/local/include/* /usr/local/include/
        cd ..

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2002,3 +2002,10 @@ def test_unsupported_commontype():
     arr = np.array([[1, -2], [2, 5]], dtype='float16')
     with assert_raises_regex(TypeError, "unsupported in linalg"):
         linalg.cholesky(arr)
+
+def test_issue_13401():
+    np.random.seed(0)
+    X = np.random.randn(100, 100) * 10
+    u, s, v = np.linalg.svd(X)
+    assert np.mean(X - u @ np.diag(s) @ v) < 1.0
+    assert np.std(X - u @ np.diag(s) @ v) < 1.0

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1828,6 +1828,7 @@ def test_xerbla_override():
             pytest.skip('Numpy xerbla not linked in.')
 
 
+@pytest.mark.skip(reason='gh-13478')
 def test_sdot_bug_8577():
     # Regression test that loading certain other libraries does not
     # result to wrong results in float32 linear algebra.
@@ -2007,5 +2008,5 @@ def test_issue_13401():
     np.random.seed(0)
     X = np.random.randn(100, 100) * 10
     u, s, v = np.linalg.svd(X)
-    assert np.mean(X - u @ np.diag(s) @ v) < 1.0
-    assert np.std(X - u @ np.diag(s) @ v) < 1.0
+    assert np.abs(np.mean(X - u @ np.diag(s) @ v)) < 1e-12
+    assert np.std(X - u @ np.diag(s) @ v) < 1e-12


### PR DESCRIPTION
CI-based Intel SDE (SkylakeX emulation) reproducer for #13401.

Many thanks to @isuruf and @martin-frbg for help upstream. For gory details: https://github.com/xianyi/OpenBLAS/issues/2108

This only works for Mac because our MacPython (ecosystem) Linux OpenBLAS was built via `maylinux1` containers where the gcc version is not high enough to empower the AVX switch that triggers the problem in OpenBLAS. So, from the standpoint of our recently-released wheels, Linux should be ok for this matter, consistent with pip install reports in the original issue only failing on Mac. 

`conda` is another story--there you can induce the failure on Linux by using recent OpenBLAS built outside manylinux1 constraints as @isuruf observed today.

This is really just the beginning of something that is going somewhere (?) and perhaps not in NumPy repo proper. When BLIS does this they go through a for loop of emulation archs: https://github.com/flame/blis/blob/master/travis/do_sde.sh

Perhaps the short-term objective here is simply a public CI run that fails because of the reported OpenBLAS issue, and provides a platform for us to try the latest OpenBLAS binary (build in our MacPython ecosystem) to see if it helps for that specific issue.

Plans beyond that are perhaps contentious, as discussed in #13401, but maybe seeing this will help drive that discussion in one direction or another. One problem upstream is that there may not be a maintainer with sufficient OpenBLAS repo access rights to set up new CI for Azure, etc. But they are open to the idea, it seems.