### PR TITLE
DOC: correct "version added" in npymath docs

### DIFF
--- a/doc/source/reference/c-api.coremath.rst
+++ b/doc/source/reference/c-api.coremath.rst
@@ -259,7 +259,7 @@ and co.
 Half-precision functions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 2.0.0
+.. versionadded:: 1.6.0
 
 The header file <numpy/halffloat.h> provides functions to work with
 IEEE 754-2008 16-bit floating point values. While this format is


### PR DESCRIPTION
Addresses #13461 
Changed the "new in version" from 2.0.0 to 1.6.0 for half-precision functions