### PR TITLE
LICENSE: split license file in standard BSD 3-clause and bundled.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -28,33 +28,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-The NumPy repository and source distributions bundle several libraries that are
-compatibly licensed.  We list these here.
-
-Name: Numpydoc
-Files: doc/sphinxext/numpydoc/*
-License: 2-clause BSD
-  For details, see doc/sphinxext/LICENSE.txt
-
-Name: scipy-sphinx-theme
-Files: doc/scipy-sphinx-theme/*
-License: 3-clause BSD, PSF and Apache 2.0
-  For details, see doc/scipy-sphinx-theme/LICENSE.txt
-
-Name: lapack-lite
-Files: numpy/linalg/lapack_lite/*
-License: 3-clause BSD
-  For details, see numpy/linalg/lapack_lite/LICENSE.txt
-
-Name: tempita
-Files: tools/npy_tempita/*
-License: BSD derived
-  For details, see tools/npy_tempita/license.txt
-
-Name: dragon4
-Files: numpy/core/src/multiarray/dragon4.c
-License: One of a kind
-  For license text, see numpy/core/src/multiarray/dragon4.c

--- a/LICENSE_bundled.txt
+++ b/LICENSE_bundled.txt
@@ -1,0 +1,27 @@
+The NumPy repository and source distributions bundle several libraries that are
+compatibly licensed.  We list these here.
+
+Name: Numpydoc
+Files: doc/sphinxext/numpydoc/*
+License: 2-clause BSD
+  For details, see doc/sphinxext/LICENSE.txt
+
+Name: scipy-sphinx-theme
+Files: doc/scipy-sphinx-theme/*
+License: 3-clause BSD, PSF and Apache 2.0
+  For details, see doc/scipy-sphinx-theme/LICENSE.txt
+
+Name: lapack-lite
+Files: numpy/linalg/lapack_lite/*
+License: 3-clause BSD
+  For details, see numpy/linalg/lapack_lite/LICENSE.txt
+
+Name: tempita
+Files: tools/npy_tempita/*
+License: BSD derived
+  For details, see tools/npy_tempita/license.txt
+
+Name: dragon4
+Files: numpy/core/src/multiarray/dragon4.c
+License: One of a kind
+  For license text, see numpy/core/src/multiarray/dragon4.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@
 include MANIFEST.in
 include pytest.ini
 include *.txt
+include README.md
 include site.cfg.example
 recursive-include numpy/random/mtrand *.pyx *.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -39,3 +39,6 @@ prune benchmarks/numpy
 # Exclude generated files
 prune */__pycache__
 global-exclude *.pyc *.pyo *.pyd *.swp *.bak *~
+# Exclude license file that we append to the main license when running
+# `python setup.py sdist`
+exclude LICENSE_bundled.txt

--- a/setup.py
+++ b/setup.py
@@ -207,15 +207,10 @@ class concat_license_files():
                 f1.write('\n\n')
                 f1.write(self.bundled_text)
 
-        os.remove(self.f2)
-
     def __exit__(self, exception_type, exception_value, traceback):
         """Restore content of both files"""
         with open(self.f1, 'w') as f:
             f.write(self.bsd_text)
-
-        with open(self.f2, 'w') as f:
-            f.write(self.bundled_text)
 
 
 from distutils.command.sdist import sdist

--- a/setup.py
+++ b/setup.py
@@ -186,12 +186,45 @@ def check_submodules():
             raise ValueError('Submodule not clean: %s' % line)
 
 
+class concat_license_files():
+    """Merge LICENSE.txt and LICENSE_bundled.txt for sdist creation
+
+    Done this way to keep LICENSE.txt in repo as exact BSD 3-clause (see
+    gh-13447).  This makes GitHub state correctly how NumPy is licensed.
+    """
+    def __init__(self):
+        self.f1 = 'LICENSE.txt'
+        self.f2 = 'LICENSE_bundled.txt'
+
+    def __enter__(self):
+        """Concatenate files and remove LICENSE_bundled.txt"""
+        with open(self.f1, 'r') as f1:
+            self.bsd_text = f1.read()
+
+        with open(self.f1, 'a') as f1:
+            with open(self.f2, 'r') as f2:
+                self.bundled_text = f2.read()
+                f1.write('\n\n')
+                f1.write(self.bundled_text)
+
+        os.remove(self.f2)
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """Restore content of both files"""
+        with open(self.f1, 'w') as f:
+            f.write(self.bsd_text)
+
+        with open(self.f2, 'w') as f:
+            f.write(self.bundled_text)
+
+
 from distutils.command.sdist import sdist
 class sdist_checked(sdist):
     """ check submodules on sdist to prevent incomplete tarballs """
     def run(self):
         check_submodules()
-        sdist.run(self)
+        with concat_license_files():
+            sdist.run(self)
 
 
 def generate_cython():


### PR DESCRIPTION
Reason: the GitHub license detection method relies on the LICENSE
file matching for at least 95% with a standard license.
Adding even one more sentence changes the license displayed in the
GitHub UI and also in the GitHub API that can be queried from
BSD to "other".

See https://github.com/numpy/numpy/issues/13447 for more details.

Note that this split license is what GitHub recommends to do,
and is also what we do for wheels, where we append to the license
file at build time.