### PR TITLE
ENH: allow for mixed-case histogram bin methods

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -374,7 +374,7 @@ def _get_bin_edges(a, bins, range, weights):
     bin_edges = None
 
     if isinstance(bins, basestring):
-        bin_name = bins
+        bin_name = bins.lower()
         # if `bins` is a string for an automatic method,
         # this will replace it with the number of bins calculated
         if bin_name not in _hist_bin_selectors:

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -430,7 +430,7 @@ class TestHistogramOptimBinNums(object):
     """
 
     def test_empty(self):
-        estimator_list = ['fd', 'scott', 'rice', 'sturges',
+        estimator_list = ['fd', 'FD', 'scott', 'rice', 'sturges',
                           'doane', 'sqrt', 'auto', 'stone']
         # check it can deal with empty data
         for estimator in estimator_list:


### PR DESCRIPTION
The `numpy.histogram` and `numpy.histogram_bin_edges` bins flag will now allow for mixed-case strings, so `bins='FD'` or `bins='Scott'` will work as is used in the [doc notes](https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram_bin_edges.html#numpy.histogram_bin_edges), which describes the options as `Auto`,`FD`, etc. 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
