### PR TITLE
DOC: have notes in histogram_bin_edges match parameter style

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -555,14 +555,14 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     using the `ptp` of the data. The final bin count is obtained from
     ``np.round(np.ceil(range / h))``.
 
-    'Auto' (maximum of the 'Sturges' and 'FD' estimators)
+    'auto' (maximum of the 'sturges' and 'fd' estimators)
         A compromise to get a good value. For small datasets the Sturges
         value will usually be chosen, while larger datasets will usually
         default to FD.  Avoids the overly conservative behaviour of FD
         and Sturges for small and large datasets respectively.
         Switchover point is usually :math:`a.size \approx 1000`.
 
-    'FD' (Freedman Diaconis Estimator)
+    'fd' (Freedman Diaconis Estimator)
         .. math:: h = 2 \frac{IQR}{n^{1/3}}
 
         The binwidth is proportional to the interquartile range (IQR)
@@ -570,7 +570,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         conservative for small datasets, but is quite good for large
         datasets. The IQR is very robust to outliers.
 
-    'Scott'
+    'scott'
         .. math:: h = \sigma \sqrt[3]{\frac{24 * \sqrt{\pi}}{n}}
 
         The binwidth is proportional to the standard deviation of the
@@ -580,14 +580,14 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         outliers. Values are very similar to the Freedman-Diaconis
         estimator in the absence of outliers.
 
-    'Rice'
+    'rice'
         .. math:: n_h = 2n^{1/3}
 
         The number of bins is only proportional to cube root of
         ``a.size``. It tends to overestimate the number of bins and it
         does not take into account data variability.
 
-    'Sturges'
+    'sturges'
         .. math:: n_h = \log _{2}n+1
 
         The number of bins is the base 2 log of ``a.size``.  This
@@ -595,7 +595,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         larger, non-normal datasets. This is the default method in R's
         ``hist`` method.
 
-    'Doane'
+    'doane'
         .. math:: n_h = 1 + \log_{2}(n) +
                         \log_{2}(1 + \frac{|g_1|}{\sigma_{g_1}})
 
@@ -607,7 +607,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         estimates for non-normal datasets. This estimator attempts to
         account for the skew of the data.
 
-    'Sqrt'
+    'sqrt'
         .. math:: n_h = \sqrt n
 
         The simplest and fastest estimator. Only takes into account the


### PR DESCRIPTION
The parameter `bins` only accepts lowercase strings, but the [notes](https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram_bin_edges.html#numpy.histogram_bin_edges) are capitalized. This makes it easier to copy and paste 😄 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
