### PR TITLE
TEST: add duration report to tests, speed up two outliers

### DIFF
--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -554,15 +554,11 @@ class TestHistogramOptimBinNums(object):
             return a / (a + b)
 
         ll = [[nbins_ratio(seed, size) for size in np.geomspace(start=10, stop=100, num=4).round().astype(int)]
-              for seed in range(256)]
+              for seed in range(10)]
 
         # the average difference between the two methods decreases as the dataset size increases.
-        assert_almost_equal(abs(np.mean(ll, axis=0) - 0.5),
-                            [0.1065248,
-                             0.0968844,
-                             0.0331818,
-                             0.0178057],
-                            decimal=3)
+        avg = abs(np.mean(ll, axis=0) - 0.5)
+        assert_almost_equal(avg, [0.15, 0.09, 0.08, 0.03], decimal=2)
 
     def test_simple_range(self):
         """

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1498,6 +1498,7 @@ class TestAssertNoGcCycles(object):
         with assert_raises(AssertionError):
             assert_no_gc_cycles(make_cycle)
 
+    @pytest.mark.slow
     def test_fails(self):
         """
         Test that in cases where the garbage cannot be collected, we raise an

--- a/tools/test-installed-numpy.py
+++ b/tools/test-installed-numpy.py
@@ -32,6 +32,9 @@ parser.add_option("-m", "--mode",
                   action="store", dest="mode", default="fast",
                   help="'fast', 'full', or something that could be "
                        "passed to pytest [default: %default]")
+parser.add_option("-n", "--durations",
+                  dest="durations", default=-1,
+                  help="show time to run slowest N tests [default: -1]")
 (options, args) = parser.parse_args()
 
 import numpy
@@ -54,6 +57,7 @@ result = numpy.test(options.mode,
                     verbose=options.verbose,
                     extra_argv=args,
                     doctests=options.doctests,
+                    durations=int(options.durations),
                     coverage=options.coverage)
 
 if result:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -83,9 +83,9 @@ run_test()
   export PYTHONWARNINGS=default
   if [ -n "$RUN_FULL_TESTS" ]; then
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
-    $PYTHON ../tools/test-installed-numpy.py -v --mode=full $COVERAGE_FLAG
+    $PYTHON ../tools/test-installed-numpy.py -v --durations 10 --mode=full $COVERAGE_FLAG
   else
-    $PYTHON ../tools/test-installed-numpy.py -v
+    $PYTHON ../tools/test-installed-numpy.py -v --durations 10
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then


### PR DESCRIPTION
Add duration report. On my machine there are a two tests that each take more than 5 seconds to run (out of a total of 70 secs), see if it repeats on the travis CI runs. 
