### PR TITLE
BUG: Update MSVC compiler version for IntelCCompiler

### DIFF
--- a/numpy/distutils/_msvccompiler.py
+++ b/numpy/distutils/_msvccompiler.py
@@ -1,0 +1,64 @@
+from __future__ import division, absolute_import, print_function
+
+import os
+from distutils._msvccompiler import MSVCCompiler as _MSVCCompiler
+
+from .system_info import platform_bits
+
+
+def _merge(old, new):
+    """Concatenate two environment paths avoiding repeats.
+
+    Here `old` is the environment string before the base class initialize
+    function is called and `new` is the string after the call. The new string
+    will be a fixed string if it is not obtained from the current environment,
+    or the same as the old string if obtained from the same environment. The aim
+    here is not to append the new string if it is already contained in the old
+    string so as to limit the growth of the environment string.
+
+    Parameters
+    ----------
+    old : string
+        Previous environment string.
+    new : string
+        New environment string.
+
+    Returns
+    -------
+    ret : string
+        Updated environment string.
+
+    """
+    if not old:
+        return new
+    if new in old:
+        return old
+
+    # Neither new nor old is empty. Give old priority.
+    return ';'.join([old, new])
+
+
+class MSVCCompiler(_MSVCCompiler):
+    def __init__(self, verbose=0, dry_run=0, force=0):
+        _MSVCCompiler.__init__(self, verbose, dry_run, force)
+
+    def initialize(self, plat_name=None):
+        # The 'lib' and 'include' variables may be overwritten
+        # by MSVCCompiler.initialize, so save them for later merge.
+        environ_lib = os.getenv('lib')
+        environ_include = os.getenv('include')
+        _MSVCCompiler.initialize(self, plat_name)
+
+        # Merge current and previous values of 'lib' and 'include'
+        os.environ['lib'] = _merge(environ_lib, os.environ['lib'])
+        os.environ['include'] = _merge(environ_lib, os.environ['include'])
+        # msvc9 building for 32 bits requires SSE2 to work around a
+        # compiler bug.
+        if platform_bits == 32:
+            self.compile_options += ['/arch:SSE2']
+            self.compile_options_debug += ['/arch:SSE2']
+
+    def manifest_setup_ldargs(self, output_filename, build_temp, ld_args):
+        ld_args.append('/MANIFEST')
+        _MSVCCompiler.manifest_setup_ldargs(self, output_filename,
+                                            build_temp, ld_args)

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -2,13 +2,20 @@ from __future__ import division, absolute_import, print_function
 
 import platform
 
+from distutils.spawn import find_executable as find_exe
 from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
 from numpy.distutils.ccompiler import simple_version_match
 if platform.system() == 'Windows':
     from numpy.distutils._msvccompiler import MSVCCompiler
-    from distutils._msvccompiler import _find_exe
 
+def _find_exe(exe, paths=None):
+    executable = find_exe(exe, paths)
+    if not executable:
+        """If the executable is not found just return the original
+        program name,'exe'. """
+        executable = exe
+    return executable
 
 class IntelCCompiler(UnixCCompiler):
     """A modified Intel compiler compatible with a GCC-built Python."""

--- a/numpy/distutils/intelccompiler.py
+++ b/numpy/distutils/intelccompiler.py
@@ -6,7 +6,8 @@ from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.exec_command import find_executable
 from numpy.distutils.ccompiler import simple_version_match
 if platform.system() == 'Windows':
-    from numpy.distutils.msvc9compiler import MSVCCompiler
+    from numpy.distutils._msvccompiler import MSVCCompiler
+    from distutils._msvccompiler import _find_exe
 
 
 class IntelCCompiler(UnixCCompiler):
@@ -92,9 +93,9 @@ if platform.system() == 'Windows':
 
         def initialize(self, plat_name=None):
             MSVCCompiler.initialize(self, plat_name)
-            self.cc = self.find_exe('icl.exe')
-            self.lib = self.find_exe('xilib')
-            self.linker = self.find_exe('xilink')
+            self.cc = _find_exe('icl.exe')
+            self.lib = _find_exe('xilib')
+            self.linker = _find_exe('xilink')
             self.compile_options = ['/nologo', '/O3', '/MD', '/W3',
                                     '/Qstd=c99']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',


### PR DESCRIPTION
Build numpy with intelw compiler currently fails with the error:
Microsoft Visual C++ 14.1 is required. Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.microsoft.com/downloads/
even when the VS toolset 14.1 is installed. The IntelCCompiler uses
an old MSVC version to compile. This commit updates the MSCV compiler version, which fixes the error.