### PR TITLE
BUG: ma.tostring should respect the order parameter

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5935,7 +5935,7 @@ class MaskedArray(ndarray):
         returns bytes not strings.
         """
 
-        return self.tobytes(fill_value, order='C')
+        return self.tobytes(fill_value, order=order)
 
     def tobytes(self, fill_value=None, order='C'):
         """

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -87,3 +87,7 @@ class TestRegression(object):
         # See gh-12464. Indexing with empty list should give empty result.
         ma = np.ma.MaskedArray([(1, 1.), (2, 2.), (3, 3.)], dtype='i4,f4')
         assert_array_equal(ma[[]], ma[:0])
+
+    def test_masked_array_tostring_fortran(self):
+        ma = np.ma.arange(4).reshape((2,2))
+        assert_array_equal(ma.tostring(order='F'), ma.T.tostring())


### PR DESCRIPTION
Fixes scipy/scipy#4776

Masked arrays ignore fortran ordering, breaking `scipy.io.savemat`.