### PR TITLE
DOC: Clarify rcond normalization in linalg.pinv

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1900,9 +1900,9 @@ def pinv(a, rcond=1e-15, hermitian=False):
         Matrix or stack of matrices to be pseudo-inverted.
     rcond : (...) array_like of float
         Cutoff for small singular values.
-        Singular values smaller (in modulus) than
-        `rcond` * largest_singular_value (again, in modulus)
-        are set to zero. Broadcasts against the stack of matrices
+        Singular values less than or equal to
+        ``rcond * largest_singular_value`` are set to zero.
+        Broadcasts against the stack of matrices.
     hermitian : bool, optional
         If True, `a` is assumed to be Hermitian (symmetric if real-valued),
         enabling a more efficient method for finding singular values.


### PR DESCRIPTION
Closes #13497.

Caveat: This may not be the clearest for the degenerate case of all zero singular values (i.e., the 0 matrix will stay that way).

(Unrelated FYI: The links in the PR template currently give a 404. I found a working version of the link here: https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message)