### PR TITLE
ENH: Support object arrays in matmul

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -197,6 +197,15 @@ The boolean and integer types are incapable of storing ``np.nan`` and ``np.inf``
 which allows us to provide specialized ufuncs that are up to 250x faster than the current
 approach.
 
+Support of object arrays in ``np.matmul``
+-----------------------------------------
+It is now possible to use ``np.matmul`` (or the ``@`` operator) with object arrays.
+For instance, it is now possible to do::
+
+    from fractions import Fraction
+    a = np.array([[Fraction(1, 2), Fraction(1, 3)], [Fraction(1, 3), Fraction(1, 2)]])
+    b = a @ a
+
 
 Changes
 =======

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -920,6 +920,7 @@ defdict = {
           docstrings.get('numpy.core.umath.matmul'),
           "PyUFunc_SimpleUniformOperationTypeResolver",
           TD(notimes_or_obj),
+          TD(O),
           signature='(n?,k),(k,m?)->(n?,m?)',
           ),
 }

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -295,7 +295,7 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
                     obj1 = Py_None;
                 }
                 if (obj2 == NULL) {
-                    ip2 = Py_None;
+                    obj2 = Py_None;
                 }
 
                 product = PyNumber_Multiply(obj1, obj2);

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -281,44 +281,45 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
     npy_intp ib2_p = is2_p * dp;
     npy_intp ob_p  = os_p * dp;
 
-    PyObject *tmp1, *tmp2, *tmp = NULL;
-    PyObject **tmp3;
+    PyObject *product, *sum_of_products = NULL;
 
     for (npy_intp m = 0; m < dm; m++) {
         for (npy_intp p = 0; p < dp; p++) {
-            if ( 0 == dn ) return;
+            if ( 0 == dn ) {
+                sum_of_products = PyLong_FromLong(0);
+            }
+
             for (npy_intp n = 0; n < dn; n++) {
-                if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
-                    tmp1 = Py_False;
-                    Py_INCREF(Py_False);
+                PyObject *obj1 = *(PyObject**)ip1, *obj2 = *(PyObject**)ip2;
+                if (obj1 == NULL) {
+                    ip1 = Py_None;
                 }
-                else {
-                    tmp1 = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
-                    if (!tmp1) {
-                        Py_XDECREF(tmp);
-                        return;
-                    }
+                if (obj2 == NULL) {
+                    ip2 = Py_None;
                 }
+
+                product = PyNumber_Multiply(obj1, obj2);
+                if (product == NULL) {
+                    Py_XDECREF(sum_of_products);
+                    return;
+                }
+
                 if (n == 0) {
-                    tmp = tmp1;
+                    sum_of_products = product;
                 }
                 else {
-                    tmp2 = PyNumber_Add(tmp, tmp1);
-                    Py_XDECREF(tmp);
-                    Py_XDECREF(tmp1);
-                    if (!tmp2) {
+                    Py_SETREF(sum_of_products, PyNumber_Add(sum_of_products, product));
+                    Py_DECREF(product);
+                    if (sum_of_products == NULL) {
                         return;
                     }
-                    tmp = tmp2;
                 }
 
                 ip2 += is2_n;
                 ip1 += is1_n;
             }
-            tmp3 = (PyObject**) op;
-            tmp2 = *tmp3;
-            *((PyObject **)op) = tmp;
-            Py_XDECREF(tmp2);
+
+            *((PyObject **)op) = sum_of_products;
             ip1 -= ib1_n;
             ip2 -= ib2_n;
             op  +=  os_p;

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -274,38 +274,51 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
                            void *_op, npy_intp os_m, npy_intp os_p,
                            npy_intp dm, npy_intp dn, npy_intp dp)                         
 {
-    npy_intp m, n, p;
-    npy_intp ib1_n, ib2_n, ib2_p, ob_p;
     char *ip1 = (char *)_ip1, *ip2 = (char *)_ip2, *op = (char *)_op;
 
-    ib1_n = is1_n * dn;
-    ib2_n = is2_n * dn;
-    ib2_p = is2_p * dp;
-    ob_p  = os_p * dp;
+    npy_intp ib1_n = is1_n * dn;
+    npy_intp ib2_n = is2_n * dn;
+    npy_intp ib2_p = is2_p * dp;
+    npy_intp ob_p  = os_p * dp;
 
-    PyObject *tmp1, *tmp2 = NULL;
+    PyObject *tmp1, *tmp2, *tmp = NULL;
+    PyObject **tmp3;
 
-    for (m = 0; m < dm; m++) {
-        for (p = 0; p < dp; p++) {
+    for (npy_intp m = 0; m < dm; m++) {
+        for (npy_intp p = 0; p < dp; p++) {
             if ( 0 == dn ) return;
-            // The first pass where n == 0 has to be separated from n>0 because
-            // there might not be a "zero" for objects, and even if there is we don't know it.
-            // This also means the degenerate case is not really well-defined.
+            for (npy_intp n = 0; n < dn; n++) {
+                if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
+                    tmp1 = Py_False;
+                    Py_INCREF(Py_False);
+                }
+                else {
+                    tmp1 = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
+                    if (!tmp1) {
+                        Py_XDECREF(tmp);
+                        return;
+                    }
+                }
+                if (n == 0) {
+                    tmp = tmp1;
+                }
+                else {
+                    tmp2 = PyNumber_Add(tmp, tmp1);
+                    Py_XDECREF(tmp);
+                    Py_XDECREF(tmp1);
+                    if (!tmp2) {
+                        return;
+                    }
+                    tmp = tmp2;
+                }
 
-            // n == 0 case
-            PyObject *tmp = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
-            ip2 += is2_n;
-            ip1 += is1_n;
-            // n > 0 cases
-            for (n = 1; n < dn; n++) {
-                tmp1 = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
-                tmp2 = PyNumber_Add(tmp, tmp1);
-                tmp = tmp2;
-                Py_XDECREF(tmp1);
                 ip2 += is2_n;
                 ip1 += is1_n;
             }
+            tmp3 = (PyObject**) op;
+            tmp2 = *tmp3;
             *((PyObject **)op) = tmp;
+            Py_XDECREF(tmp2);
             ip1 -= ib1_n;
             ip2 -= ib2_n;
             op  +=  os_p;
@@ -324,7 +337,7 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
  *          CFLOAT, CDOUBLE, CLONGDOUBLE,
  *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
  *          BYTE, SHORT, INT, LONG, LONGLONG,
- *          BOOL,OBJECT#
+ *          BOOL, OBJECT#
  *  #typ = npy_float,npy_double,npy_longdouble, npy_half,
  *         npy_cfloat, npy_cdouble, npy_clongdouble,
  *         npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -267,19 +267,71 @@ NPY_NO_EXPORT void
 
 /**end repeat**/
 
+
+NPY_NO_EXPORT void
+OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
+                           void *_ip2, npy_intp is2_n, npy_intp is2_p,
+                           void *_op, npy_intp os_m, npy_intp os_p,
+                           npy_intp dm, npy_intp dn, npy_intp dp)                         
+{
+    npy_intp m, n, p;
+    npy_intp ib1_n, ib2_n, ib2_p, ob_p;
+    char *ip1 = (char *)_ip1, *ip2 = (char *)_ip2, *op = (char *)_op;
+
+    ib1_n = is1_n * dn;
+    ib2_n = is2_n * dn;
+    ib2_p = is2_p * dp;
+    ob_p  = os_p * dp;
+
+    PyObject *tmp1, *tmp2 = NULL;
+
+    for (m = 0; m < dm; m++) {
+        for (p = 0; p < dp; p++) {
+            if ( 0 == dn ) return;
+            // The first pass where n == 0 has to be separated from n>0 because
+            // there might not be a "zero" for objects, and even if there is we don't know it.
+            // This also means the degenerate case is not really well-defined.
+
+            // n == 0 case
+            PyObject *tmp = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
+            ip2 += is2_n;
+            ip1 += is1_n;
+            // n > 0 cases
+            for (n = 1; n < dn; n++) {
+                tmp1 = PyNumber_Multiply(*((PyObject **)ip1), *((PyObject **)ip2));
+                tmp2 = PyNumber_Add(tmp, tmp1);
+                tmp = tmp2;
+                Py_XDECREF(tmp1);
+                ip2 += is2_n;
+                ip1 += is1_n;
+            }
+            *((PyObject **)op) = tmp;
+            ip1 -= ib1_n;
+            ip2 -= ib2_n;
+            op  +=  os_p;
+            ip2 += is2_p;
+        }
+        op -= ob_p;
+        ip2 -= ib2_p;
+        ip1 += is1_m;
+        op  +=  os_m;
+    }
+}
+
+
 /**begin repeat
  *  #TYPE = FLOAT, DOUBLE, LONGDOUBLE, HALF,
  *          CFLOAT, CDOUBLE, CLONGDOUBLE,
  *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
  *          BYTE, SHORT, INT, LONG, LONGLONG,
- *          BOOL#
+ *          BOOL,OBJECT#
  *  #typ = npy_float,npy_double,npy_longdouble, npy_half,
  *         npy_cfloat, npy_cdouble, npy_clongdouble,
  *         npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,
  *         npy_byte, npy_short, npy_int, npy_long, npy_longlong,
- *         npy_bool#
- * #IS_COMPLEX = 0, 0, 0, 0, 1, 1, 1, 0*11#
- * #USEBLAS = 1, 1, 0, 0, 1, 1, 0*12#
+ *         npy_bool,npy_object#
+ * #IS_COMPLEX = 0, 0, 0, 0, 1, 1, 1, 0*12#
+ * #USEBLAS = 1, 1, 0, 0, 1, 1, 0*13#
  */
 
 
@@ -398,5 +450,3 @@ NPY_NO_EXPORT void
 }
 
 /**end repeat**/
-
-

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -292,7 +292,7 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
             for (npy_intp n = 0; n < dn; n++) {
                 PyObject *obj1 = *(PyObject**)ip1, *obj2 = *(PyObject**)ip2;
                 if (obj1 == NULL) {
-                    ip1 = Py_None;
+                    obj1 = Py_None;
                 }
                 if (obj2 == NULL) {
                     ip2 = Py_None;

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -287,6 +287,9 @@ OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
         for (npy_intp p = 0; p < dp; p++) {
             if ( 0 == dn ) {
                 sum_of_products = PyLong_FromLong(0);
+                if (sum_of_products == NULL) {
+                    return;
+                }
             }
 
             for (npy_intp n = 0; n < dn; n++) {

--- a/numpy/core/src/umath/matmul.h.src
+++ b/numpy/core/src/umath/matmul.h.src
@@ -3,7 +3,7 @@
  *          CFLOAT, CDOUBLE, CLONGDOUBLE,
  *          UBYTE, USHORT, UINT, ULONG, ULONGLONG,
  *          BYTE, SHORT, INT, LONG, LONGLONG,
- *          BOOL#
+ *          BOOL, OBJECT#
  **/
 NPY_NO_EXPORT void
 @TYPE@_matmul(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6051,16 +6051,21 @@ class TestMatmul(MatmulCommon):
         assert_array_equal(np.matmul(a, b), c)
 
     def test_matmul_exception_multiply(self):
+        # test that matmul fails if `__mul__` is missing
+        class add_not_multiply():
+            def __add__(self, other):
+                return self
+        a = np.full((3,3), add_not_multiply())
         with assert_raises(TypeError):
-            a = np.full((3,3), None)  
             b = np.matmul(a, a)
 
     def test_matmul_exception_add(self):
+        # test that matmul fails if `__add__` is missing
         class multiply_not_add():
             def __mul__(self, other):
                 return self
+        a = np.full((3,3), multiply_not_add())
         with assert_raises(TypeError):
-            a = np.full((3,3), multiply_not_add())
             b = np.matmul(a, a)
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6028,7 +6028,7 @@ class TestMatmul(MatmulCommon):
 
         f = np.vectorize(fractions.Fraction)
         def random_ints():
-            return np.random.randint(1000, size=(10, 3, 3))
+            return np.random.randint(1, 1000, size=(10, 3, 3))
         M1 = f(random_ints(), random_ints()) 
         M2 = f(random_ints(), random_ints())
 
@@ -6043,6 +6043,25 @@ class TestMatmul(MatmulCommon):
         v = np.array([F(2,3), F(5,7)])
         res = self.matmul(v, v)
         assert_(type(res) is F)
+
+    def test_matmul_empty(self):
+        a = np.empty((3, 0), dtype=object)
+        b = np.empty((0, 3), dtype=object)
+        c = np.zeros((3, 3))
+        assert_array_equal(np.matmul(a, b), c)
+
+    def test_matmul_exception_multiply(self):
+        with assert_raises(TypeError):
+            a = np.full((3,3), None)  
+            b = np.matmul(a, a)
+
+    def test_matmul_exception_add(self):
+        class multiply_not_add():
+            def __mul__(self, other):
+                return self
+        with assert_raises(TypeError):
+            a = np.full((3,3), multiply_not_add())
+            b = np.matmul(a, a)
 
 
 


### PR DESCRIPTION
This attempts to support object arrays in matmul (aka `@`), see issue #11332

Things to check:
 - I am not sure that Python reference counting is done correctly.
 - For the edge case `a = np.array([], dtype="object")` the code `a @ a` returns `None`.
This is consistent with `np.dot(a, a)` (also `None`) but not necessarily with the
result of `b @ b` with `b = np.array([])` which is `0.0`.
 - There is no change to the documentation nor tests.

However, here is a minimal test:

```python
import numpy as np
from numpy.testing import assert_array_equal

class MockNumber(): 
    def __init__(self, value): 
        self.value = value 
    def __add__(self, other): 
        return MockNumber(self.value + other.value)
    def __sub__(self, other): 
        return MockNumber(self.value - other.value)
    def __mul__(self, other): 
        return MockNumber(self.value * other.value)
    def __eq__(self, other):
        return self.value == other.value
    def __str__(self):
        return f"MockNumber({str(self.value)})"
    def __repr__(self): 
        return f"MockNumber({str(self.value)})"


M1 = np.random.randint(0, 1000, (4, 3, 3))
M2 = np.random.randint(0, 1000, (4, 3, 3))

M3 = np.matmul(M1, M2)

to_MockNumber = np.vectorize(MockNumber)

N1 = to_MockNumber(M1)
N2 = to_MockNumber(M2)
N3_ref = to_MockNumber(M3)

N3 = np.matmul(N1, N2)

assert_array_equal(N3, N3_ref)
```

and an example

```python
a = np.array([[MockNumber(1),MockNumber(2)],[MockNumber(3),MockNumber(4)]], dtype="object") 
b = a @ a
print(b)
```