### PR TITLE
ENH: Add sparse option to np.core.numeric.indices

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1610,7 +1610,7 @@ def indices(dimensions, dtype=int, sparse=False):
     """
     Return an array representing the indices of a grid.
 
-    Compute an array where the subarrays contain index values 0,1,...
+    Compute an array where the subarrays contain index values 0, 1, ...
     varying only along the corresponding axis.
 
     Parameters
@@ -1643,7 +1643,7 @@ def indices(dimensions, dtype=int, sparse=False):
     The output shape in the dense case is obtained by prepending the number
     of dimensions in front of the tuple of dimensions, i.e. if `dimensions`
     is a tuple ``(r0, ..., rN-1)`` of length ``N``, the output shape is
-     ``(N, r0, ..., rN-1)``.
+    ``(N, r0, ..., rN-1)``.
 
     The subarrays ``grid[k]`` contains the N-D array of indices along the
     ``k-th`` axis. Explicitly::

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1691,19 +1691,14 @@ def indices(dimensions, dtype=int, sparse=False):
     dimensions = tuple(dimensions)
     N = len(dimensions)
     shape = (1,)*N
+    indices = tuple(arange(dim, dtype=dtype).reshape(
+                shape[:i] + (dim,) + shape[i+1:]) for i, dim in enumerate(dimensions))
     if sparse:
-        res = tuple()
+        return indices
     else:
-        res = empty((N,)+dimensions, dtype=dtype)
-    for i, dim in enumerate(dimensions):
-        idx = arange(dim, dtype=dtype).reshape(
-            shape[:i] + (dim,) + shape[i+1:]
-        )
-        if sparse:
-            res = res + (idx,)
-        else:
-            res[i] = idx
-    return res
+        if indices == ():
+            return np.array([])
+        return np.stack(np.broadcast_arrays(*indices))
 
 
 @set_module('numpy')

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1139,7 +1139,7 @@ def roll(a, shift, axis=None):
     array([8, 9, 0, 1, 2, 3, 4, 5, 6, 7])
     >>> np.roll(x, -2)
     array([2, 3, 4, 5, 6, 7, 8, 9, 0, 1])
-    
+
     >>> x2 = np.reshape(x, (2,5))
     >>> x2
     array([[0, 1, 2, 3, 4],
@@ -1606,7 +1606,7 @@ little_endian = (sys.byteorder == 'little')
 
 
 @set_module('numpy')
-def indices(dimensions, dtype=int):
+def indices(dimensions, dtype=int, sparse=False):
     """
     Return an array representing the indices of a grid.
 
@@ -1619,22 +1619,30 @@ def indices(dimensions, dtype=int):
         The shape of the grid.
     dtype : dtype, optional
         Data type of the result.
+    sparse : boolean, optional
+        Return a sparse representation of the grid instead of a dense
+        representation
 
     Returns
     -------
-    grid : ndarray
-        The array of grid indices,
-        ``grid.shape = (len(dimensions),) + tuple(dimensions)``.
+    grid : one ndarray or tuple of ndarrays
+        If sparse is False:
+            Returns one array of grid indices,
+            ``grid.shape = (len(dimensions),) + tuple(dimensions)``.
+        If sparse is True:
+            Returns a tuple of arrays, with
+            ``grid[i].shape = (1,...,1,dimensions[i],1,...,1)`` with
+            dimensions[i] in the ith place
 
     See Also
     --------
-    mgrid, meshgrid
+    mgrid, ogrid, meshgrid
 
     Notes
     -----
-    The output shape is obtained by prepending the number of dimensions
-    in front of the tuple of dimensions, i.e. if `dimensions` is a tuple
-    ``(r0, ..., rN-1)`` of length ``N``, the output shape is
+    The output shape in the dense case is obtained by prepending the number
+    of dimensions in front of the tuple of dimensions, i.e. if `dimensions`
+    is a tuple ``(r0, ..., rN-1)`` of length ``N``, the output shape is
     ``(N,r0,...,rN-1)``.
 
     The subarrays ``grid[k]`` contains the N-D array of indices along the
@@ -1654,7 +1662,7 @@ def indices(dimensions, dtype=int):
     array([[0, 1, 2],
            [0, 1, 2]])
 
-    The indices can be used as an index into an array.
+    The indices can be used as an index into an array, if sparse is False.
 
     >>> x = np.arange(20).reshape(5, 4)
     >>> row, col = np.indices((2, 3))
@@ -1665,15 +1673,36 @@ def indices(dimensions, dtype=int):
     Note that it would be more straightforward in the above example to
     extract the required elements directly with ``x[:2, :3]``.
 
+    If sparse is set to true, the grid will be returned in a sparse
+    representation.
+
+    >>> i, j = np.indices((2, 3), sparse=True)
+    >>> i.shape
+    (2, 1)
+    >>> j.shape
+    (1, 3)
+    >>> i        # row indices
+    array([[0],
+           [1]])
+    >>> j        # column indices
+    array([[0, 1, 2]])
+
     """
     dimensions = tuple(dimensions)
     N = len(dimensions)
     shape = (1,)*N
-    res = empty((N,)+dimensions, dtype=dtype)
+    if sparse:
+        res = tuple()
+    else:
+        res = empty((N,)+dimensions, dtype=dtype)
     for i, dim in enumerate(dimensions):
-        res[i] = arange(dim, dtype=dtype).reshape(
+        idx = arange(dim, dtype=dtype).reshape(
             shape[:i] + (dim,) + shape[i+1:]
         )
+        if sparse:
+            res = res + (idx,)
+        else:
+            res[i] = idx
     return res
 
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1691,14 +1691,19 @@ def indices(dimensions, dtype=int, sparse=False):
     dimensions = tuple(dimensions)
     N = len(dimensions)
     shape = (1,)*N
-    indices = tuple(arange(dim, dtype=dtype).reshape(
-                shape[:i] + (dim,) + shape[i+1:]) for i, dim in enumerate(dimensions))
     if sparse:
-        return indices
+        res = tuple()
     else:
-        if indices == ():
-            return np.array([])
-        return np.stack(np.broadcast_arrays(*indices))
+        res = empty((N,)+dimensions, dtype=dtype)
+    for i, dim in enumerate(dimensions):
+        idx = arange(dim, dtype=dtype).reshape(
+            shape[:i] + (dim,) + shape[i+1:]
+        )
+        if sparse:
+            res = res + (idx,)
+        else:
+            res[i] = idx
+    return res
 
 
 @set_module('numpy')

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1621,7 +1621,7 @@ def indices(dimensions, dtype=int, sparse=False):
         Data type of the result.
     sparse : boolean, optional
         Return a sparse representation of the grid instead of a dense
-        representation
+        representation. Default is False.
 
     Returns
     -------
@@ -1631,7 +1631,7 @@ def indices(dimensions, dtype=int, sparse=False):
             ``grid.shape = (len(dimensions),) + tuple(dimensions)``.
         If sparse is True:
             Returns a tuple of arrays, with
-            ``grid[i].shape = (1,...,1,dimensions[i],1,...,1)`` with
+            ``grid[i].shape = (1, ..., 1, dimensions[i], 1, ..., 1)`` with
             dimensions[i] in the ith place
 
     See Also
@@ -1643,7 +1643,7 @@ def indices(dimensions, dtype=int, sparse=False):
     The output shape in the dense case is obtained by prepending the number
     of dimensions in front of the tuple of dimensions, i.e. if `dimensions`
     is a tuple ``(r0, ..., rN-1)`` of length ``N``, the output shape is
-    ``(N,r0,...,rN-1)``.
+     ``(N, r0, ..., rN-1)``.
 
     The subarrays ``grid[k]`` contains the N-D array of indices along the
     ``k-th`` axis. Explicitly::

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1662,7 +1662,7 @@ def indices(dimensions, dtype=int, sparse=False):
     array([[0, 1, 2],
            [0, 1, 2]])
 
-    The indices can be used as an index into an array, if sparse is False.
+    The indices can be used as an index into an array.
 
     >>> x = np.arange(20).reshape(5, 4)
     >>> row, col = np.indices((2, 3))

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1648,7 +1648,7 @@ def indices(dimensions, dtype=int, sparse=False):
     The subarrays ``grid[k]`` contains the N-D array of indices along the
     ``k-th`` axis. Explicitly::
 
-        grid[k,i0,i1,...,iN-1] = ik
+        grid[k, i0, i1, ..., iN-1] = ik
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1623,6 +1623,8 @@ def indices(dimensions, dtype=int, sparse=False):
         Return a sparse representation of the grid instead of a dense
         representation. Default is False.
 
+        .. versionadded:: 1.17
+
     Returns
     -------
     grid : one ndarray or tuple of ndarrays

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2659,7 +2659,7 @@ def test_outer_out_param():
 class TestIndices(object):
 
     def test_simple(self):
-        [X, Y] = np.indices((4,3))
+        X, Y = np.indices((4, 3))
         assert_array_equal(X, np.array([[0, 0, 0],
                                         [1, 1, 1],
                                         [2, 2, 2],
@@ -2689,7 +2689,7 @@ class TestIndices(object):
 
     def test_return_type(self):
         for dtype in (np.int, np.float32, np.float64):
-            I = np.indices((4,3), dtype=dtype)
+            I = np.indices((4, 3), dtype=dtype)
 
             assert_(I.dtype == dtype)
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2679,6 +2679,8 @@ class TestIndices(object):
     def test_scalar_input(self):
         assert_array_equal([], np.indices(()))
         assert_array_equal([], np.indices((), sparse=True))
+        assert_array_equal([[]], np.indices((0,)))
+        assert_array_equal([[]], np.indices((0,), sparse=True))
 
     def test_sparse(self):
         [X, Y] = np.indices((4,3), sparse=True)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2656,6 +2656,47 @@ def test_outer_out_param():
     assert_equal(np.outer(arr2, arr3, out2), out2)
 
 
+class TestIndices(object):
+
+    def test_simple(self):
+        [X, Y] = np.indices((4,3))
+        assert_array_equal(X, np.array([[0, 0, 0],
+                                        [1, 1, 1],
+                                        [2, 2, 2],
+                                        [3, 3, 3]]))
+        assert_array_equal(Y, np.array([[0, 1, 2],
+                                        [0, 1, 2],
+                                        [0, 1, 2],
+                                        [0, 1, 2]]))
+
+    def test_single_input(self):
+        [X] = np.indices((4,))
+        assert_array_equal(X, np.array([0, 1, 2, 3]))
+
+        [X] = np.indices((4,), sparse=True)
+        assert_array_equal(X, np.array([0, 1, 2, 3]))
+
+    def test_scalar_input(self):
+        assert_array_equal([], np.indices(()))
+        assert_array_equal([], np.indices((), sparse=True))
+
+    def test_sparse(self):
+        [X, Y] = np.indices((4,3), sparse=True)
+        assert_array_equal(X, np.array([[0], [1], [2], [3]]))
+        assert_array_equal(Y, np.array([[0, 1, 2]]))
+
+    def test_return_type(self):
+        for dtype in (np.int, np.float32, np.float64):
+            I = np.indices((4,3), dtype=dtype)
+
+            assert_(I.dtype == dtype)
+
+            X, Y = np.indices((4,3), dtype=dtype, sparse=True)
+
+            assert_(X.dtype == dtype)
+            assert_(Y.dtype == dtype)
+
+
 class TestRequire(object):
     flag_names = ['C', 'C_CONTIGUOUS', 'CONTIGUOUS',
                   'F', 'F_CONTIGUOUS', 'FORTRAN',
@@ -2788,7 +2829,7 @@ class TestTensordot(object):
         td = np.tensordot(a, b, (1, 0))
         assert_array_equal(td, np.dot(a, b))
         assert_array_equal(td, np.einsum('ij,jk', a, b))
-        
+
     def test_zero_dimensional(self):
         # gh-12130
         arr_0d = np.array(1)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2659,22 +2659,22 @@ def test_outer_out_param():
 class TestIndices(object):
 
     def test_simple(self):
-        X, Y = np.indices((4, 3))
-        assert_array_equal(X, np.array([[0, 0, 0],
+        [x, y] = np.indices((4, 3))
+        assert_array_equal(x, np.array([[0, 0, 0],
                                         [1, 1, 1],
                                         [2, 2, 2],
                                         [3, 3, 3]]))
-        assert_array_equal(Y, np.array([[0, 1, 2],
+        assert_array_equal(y, np.array([[0, 1, 2],
                                         [0, 1, 2],
                                         [0, 1, 2],
                                         [0, 1, 2]]))
 
     def test_single_input(self):
-        [X] = np.indices((4,))
-        assert_array_equal(X, np.array([0, 1, 2, 3]))
+        [x] = np.indices((4,))
+        assert_array_equal(x, np.array([0, 1, 2, 3]))
 
-        [X] = np.indices((4,), sparse=True)
-        assert_array_equal(X, np.array([0, 1, 2, 3]))
+        [x] = np.indices((4,), sparse=True)
+        assert_array_equal(x, np.array([0, 1, 2, 3]))
 
     def test_scalar_input(self):
         assert_array_equal([], np.indices(()))
@@ -2683,20 +2683,21 @@ class TestIndices(object):
         assert_array_equal([[]], np.indices((0,), sparse=True))
 
     def test_sparse(self):
-        [X, Y] = np.indices((4,3), sparse=True)
-        assert_array_equal(X, np.array([[0], [1], [2], [3]]))
-        assert_array_equal(Y, np.array([[0, 1, 2]]))
+        [x, y] = np.indices((4,3), sparse=True)
+        assert_array_equal(x, np.array([[0], [1], [2], [3]]))
+        assert_array_equal(y, np.array([[0, 1, 2]]))
 
     def test_return_type(self):
         for dtype in (np.int, np.float32, np.float64):
-            I = np.indices((4, 3), dtype=dtype)
+            for dims in [(), (0,), (4, 3)]:
+                inds = np.indices(dims, dtype=dtype)
 
-            assert_(I.dtype == dtype)
+                assert_(inds.dtype == dtype)
 
-            X, Y = np.indices((4,3), dtype=dtype, sparse=True)
+                inds = np.indices(dims, dtype=dtype, sparse=True)
 
-            assert_(X.dtype == dtype)
-            assert_(Y.dtype == dtype)
+                for arr in inds:
+                    assert_(arr.dtype == dtype)
 
 
 class TestRequire(object):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2687,17 +2687,14 @@ class TestIndices(object):
         assert_array_equal(x, np.array([[0], [1], [2], [3]]))
         assert_array_equal(y, np.array([[0, 1, 2]]))
 
-    def test_return_type(self):
-        for dtype in (np.int, np.float32, np.float64):
-            for dims in [(), (0,), (4, 3)]:
-                inds = np.indices(dims, dtype=dtype)
+    @pytest.mark.parametrize("dtype", [np.int, np.float32, np.float64])
+    @pytest.mark.parametrize("dims", [(), (0,), (4, 3)])
+    def test_return_type(self, dtype, dims):
+        inds = np.indices(dims, dtype=dtype)
+        assert_(inds.dtype == dtype)
 
-                assert_(inds.dtype == dtype)
-
-                inds = np.indices(dims, dtype=dtype, sparse=True)
-
-                for arr in inds:
-                    assert_(arr.dtype == dtype)
+        for arr in np.indices(dims, dtype=dtype, sparse=True):
+            assert_(arr.dtype == dtype)
 
 
 class TestRequire(object):


### PR DESCRIPTION
This adds a `sparse` keyword-option to `np.core.numeric.indices`. This is inspired by the same option in the `np.meshgrid` function.

The same functionality can in principle already be achieved by using the `np.ogrid` index tricks like this:
```
def indices_sparse(dimensions):
    return np.ogrid[tuple(slice(0, l) for l in dimensions)]
```
However, the implementation of `ogrid` is much more complicated than the simple change to `np.core.numeric.indices` in this PR.