### PR TITLE
MAINT: implement assert_array_compare without converting array to python list

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -784,7 +784,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
 
         if isinstance(val, bool):
             cond = val
-            reduced = array(val)
+            reduced = array([val])
         else:
             reduced = val.ravel()
             cond = reduced.all()

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -20,7 +20,8 @@ from warnings import WarningMessage
 import pprint
 
 from numpy.core import(
-     float32, empty, arange, array_repr, ndarray, isnat, array)
+     intp, float32, empty, arange, array_repr, ndarray, isnat, array,
+     logical_not)
 from numpy.lib.utils import deprecate
 
 if sys.version_info[0] >= 3:
@@ -784,18 +785,18 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
 
         if isinstance(val, bool):
             cond = val
-            reduced = [0]
+            reduced = array([0])
         else:
             reduced = val.ravel()
             cond = reduced.all()
-            reduced = reduced.tolist()
 
         # The below comparison is a hack to ensure that fully masked
         # results, for which val.ravel().all() returns np.ma.masked,
         # do not trigger a failure (np.ma.masked != True evaluates as
         # np.ma.masked, which is falsy).
         if cond != True:
-            mismatch = 100.0 * reduced.count(0) / ox.size
+            logical_not(reduced, out=reduced)
+            mismatch = 100.0 * reduced.sum(dtype=intp) / ox.size
             remarks = ['Mismatch: {:.3g}%'.format(mismatch)]
 
             with errstate(invalid='ignore', divide='ignore'):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -20,8 +20,7 @@ from warnings import WarningMessage
 import pprint
 
 from numpy.core import(
-     intp, float32, empty, arange, array_repr, ndarray, isnat, array,
-     logical_not)
+     intp, float32, empty, arange, array_repr, ndarray, isnat, array)
 from numpy.lib.utils import deprecate
 
 if sys.version_info[0] >= 3:
@@ -785,7 +784,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
 
         if isinstance(val, bool):
             cond = val
-            reduced = array([0])
+            reduced = array(val)
         else:
             reduced = val.ravel()
             cond = reduced.all()
@@ -795,8 +794,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
         # do not trigger a failure (np.ma.masked != True evaluates as
         # np.ma.masked, which is falsy).
         if cond != True:
-            logical_not(reduced, out=reduced)
-            mismatch = 100.0 * reduced.sum(dtype=intp) / ox.size
+            mismatch = 100. * (reduced.size - reduced.sum(dtype=intp)) / ox.size
             remarks = ['Mismatch: {:.3g}%'.format(mismatch)]
 
             with errstate(invalid='ignore', divide='ignore'):


### PR DESCRIPTION
I'm testing equality between large arrays (several GB).

The cast to a list in test function really blows up the computation due to the fact that we are casting every entry in a boolean array into a python object.

The following achieves the same thing, without the python list cast.

FYI: I tried to use `count_nonzero` but that gave the error in the detail below

<details>

```
_______________________ TestEqual.test_subclass_that_does_not_implement_npall _______________________

self = <numpy.testing.tests.test_utils.TestEqual object at 0x7fed7fc8c128>

    def test_subclass_that_does_not_implement_npall(self):
        class MyArray(np.ndarray):
            def __array_function__(self, *args, **kwargs):
                return NotImplemented
    
        a = np.array([1., 2.]).view(MyArray)
        b = np.array([2., 3.]).view(MyArray)
        with assert_raises(TypeError):
            np.all(a)
        self._test_equal(a, a)
>       self._test_not_equal(a, b)

MyArray    = <class 'numpy.testing.tests.test_utils.TestArrayEqual.test_subclass_that_does_not_implement_npall.<locals>.MyArray'>
a          = MyArray([1., 2.])
b          = MyArray([2., 3.])
self       = <numpy.testing.tests.test_utils.TestEqual object at 0x7fed7fc8c128>

numpy/testing/tests/test_utils.py:192: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
numpy/testing/tests/test_utils.py:29: in _test_not_equal
    self._assert_func(a, b)
numpy/testing/_private/utils.py:351: in assert_equal
    return assert_array_equal(actual, desired, err_msg, verbose)
numpy/testing/_private/utils.py:901: in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
numpy/testing/_private/utils.py:803: in assert_array_compare
    mismatch = 100.0 * count_nonzero(reduced) / ox.size
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    @functools.wraps(implementation)
    def public_api(*args, **kwargs):
        relevant_args = dispatcher(*args, **kwargs)
        return implement_array_function(
>           implementation, public_api, relevant_args, args, kwargs)
E       TypeError: no implementation found for 'numpy.count_nonzero' on types that implement __array_function__: [<class 'numpy.testing.tests.test_utils.TestArrayEqual.test_subclass_that_does_not_implement_npall.<locals>.MyArray'>]


numpy/core/overrides.py:150: TypeError
============================= 2 failed, 8311 deselected in 3.77 seconds =============================
```
</details>

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
