### PR TITLE
MAINT: Use exec() instead array_function_dispatch to improve tracebacks

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -157,13 +157,15 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
                 implementation, {name}, relevant_args, args, kwargs)
         """).format(name=implementation.__name__)
 
+        source_object = compile(
+            source, filename='<__array_function__ internals>', mode='exec')
         scope = {
             'implementation': implementation,
             'dispatcher': dispatcher,
             'functools': functools,
             'implement_array_function': implement_array_function,
         }
-        exec(source, scope)
+        exec(source_object, scope)
 
         public_api = scope[implementation.__name__]
 

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -1,6 +1,7 @@
 """Implementation of __array_function__ overrides from NEP-18."""
 import collections
 import functools
+import textwrap
 
 from numpy.core._multiarray_umath import (
     add_docstring, implement_array_function, _get_implementing_args)
@@ -143,11 +144,28 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         if docs_from_dispatcher:
             add_docstring(implementation, dispatcher.__doc__)
 
+        # Equivalently, we could define this function directly instead of using
+        # exec. This version has the advantage of giving the helper function a
+        # more interpettable name. Otherwise, the original function does not
+        # show up at all in many cases, e.g., if it's written in C or if the
+        # dispatcher gets an invalid keyword argument.
+        source = textwrap.dedent("""
         @functools.wraps(implementation)
-        def public_api(*args, **kwargs):
+        def {name}(*args, **kwargs):
             relevant_args = dispatcher(*args, **kwargs)
             return implement_array_function(
-                implementation, public_api, relevant_args, args, kwargs)
+                implementation, {name}, relevant_args, args, kwargs)
+        """).format(name=implementation.__name__)
+
+        scope = {
+            'implementation': implementation,
+            'dispatcher': dispatcher,
+            'functools': functools,
+            'implement_array_function': implement_array_function,
+        }
+        exec(source, scope)
+
+        public_api = scope[implementation.__name__]
 
         if module is not None:
             public_api.__module__ = module


### PR DESCRIPTION
xref GH-12028

Current behavior:

```
>>> np.dot(None, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/shoyer/dev/numpy/numpy/core/overrides.py", line 175, in public_api
    implementation, public_api, relevant_args, args, kwargs)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'

>>> np.stack([], invalid=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/shoyer/dev/numpy/numpy/core/overrides.py", line 148, in public_api
    relevant_args = dispatcher(*args, **kwargs)
TypeError: _stack_dispatcher() got an unexpected keyword argument 'invalid'
```

With this change:

```
>>> np.dot(None, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 6, in dot
TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'

>>> np.stack([], invalid=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 4, in stack
TypeError: _stack_dispatcher() got an unexpected keyword argument 'invalid'
```

This fixes an issue pointed out by @mattip