### PR TITLE
BLD: Make CI pass again with pytest 4.5

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,7 @@ filterwarnings =
 
 env =
     PYTHONHASHSEED=0
+
+markers =
+    valgrind_error: Known to cause errors under valgrind
+    slow: Tests which are slow


### PR DESCRIPTION
We need to register `valgrind_error` and `slow` as pytest markers to avoid warnings from pytest >= 4.5.0 that are turned into errors.