### PR TITLE
BLD: Make CI pass again with pytest 4.5

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,7 @@ filterwarnings =
 
 env =
     PYTHONHASHSEED=0
+
+markers =
+    valgrind_error: Known to cause errors under valgrind
+    slow: Tests which are slow


### PR DESCRIPTION
Backport of #13534.

We need to register valgrind_error and slow as pytest markers to avoid warnings from pytest >= 4.5.0 that are turned into errors.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
