### PR TITLE
DOC: Add note to ``nonzero`` docstring.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1764,7 +1764,10 @@ def nonzero(a):
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
-    row-major, C-style order. 
+    row-major, C-style order. The corresponding non-zero  
+    values can be obtained with::
+    
+         a[nonzero(a)]
 
     To group the indices by element, rather than dimension, use::
 
@@ -1796,7 +1799,9 @@ def nonzero(a):
     Notes
     -----
     To obtain the non-zero values, it is recommended to use ``x[y.astype(bool)]`` 
-    which will correctly handle 0-d arrays.    
+    which will correctly handle 0-d arrays. In most cases y is already a boolean 
+    array, so astype is not necessary. Also a.nonzero() returns a tuple of length 1
+    when a has zero dimensions. 
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1761,6 +1761,8 @@ def nonzero(a):
     """
     Return the indices of the elements that are non-zero.
 
+    NOTE - In place of using x[y.nonzero()], it is recommended to use x[y.astype(bool)].
+
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1798,7 +1798,7 @@ def nonzero(a):
         
     Notes
     -----
-    To obtain the non-zero values, it is recommended to use ``x[y.astype(bool)]`` 
+    To obtain the non-zero values, it is recommended to use ``x[x.astype(bool)]`` 
     which will correctly handle 0-d arrays. In most cases y is already a boolean 
     array, so astype is not necessary. 
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1767,7 +1767,7 @@ def nonzero(a):
     row-major, C-style order. The corresponding non-zero  
     values can be obtained with::
     
-         a[nonzero(a)]
+        a[nonzero(a)]
 
     To group the indices by element, rather than dimension, use::
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1766,7 +1766,7 @@ def nonzero(a):
     dimension. The values in `a` are always tested and returned in
     row-major, C-style order. The corresponding non-zero  
     values can be obtained with::
-    
+        
         a[nonzero(a)]
 
     To group the indices by element, rather than dimension, use::

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1800,8 +1800,7 @@ def nonzero(a):
     -----
     To obtain the non-zero values, it is recommended to use ``x[y.astype(bool)]`` 
     which will correctly handle 0-d arrays. In most cases y is already a boolean 
-    array, so astype is not necessary. Also a.nonzero() returns a tuple of length 1
-    when a has zero dimensions. 
+    array, so astype is not necessary. 
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1799,8 +1799,7 @@ def nonzero(a):
     Notes
     -----
     To obtain the non-zero values, it is recommended to use ``x[x.astype(bool)]`` 
-    which will correctly handle 0-d arrays. In most cases y is already a boolean 
-    array, so astype is not necessary. 
+    which will correctly handle 0-d arrays. 
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1766,7 +1766,7 @@ def nonzero(a):
     dimension. The values in `a` are always tested and returned in
     row-major, C-style order. The corresponding non-zero
     values can be obtained with::
-    
+
         a[nonzero(a)]
 
     To group the indices by element, rather than dimension, use::

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1764,10 +1764,7 @@ def nonzero(a):
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
-    row-major, C-style order. The corresponding non-zero
-    values can be obtained with::
-
-        a[nonzero(a)]
+    row-major, C-style order. 
 
     To group the indices by element, rather than dimension, use::
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1761,8 +1761,6 @@ def nonzero(a):
     """
     Return the indices of the elements that are non-zero.
 
-    NOTE - In place of using x[y.nonzero()], it is recommended to use x[y.astype(bool)].
-
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
@@ -1797,6 +1795,11 @@ def nonzero(a):
         Equivalent ndarray method.
     count_nonzero :
         Counts the number of non-zero elements in the input array.
+        
+    Notes
+    -----
+    To obtain the non-zero values, it is recommended to use ``x[y.astype(bool)]`` 
+    which will correctly handle 0-d arrays.    
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1766,7 +1766,7 @@ def nonzero(a):
     dimension. The values in `a` are always tested and returned in
     row-major, C-style order. The corresponding non-zero  
     values can be obtained with::
-        
+    
         a[nonzero(a)]
 
     To group the indices by element, rather than dimension, use::

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1764,7 +1764,7 @@ def nonzero(a):
     Returns a tuple of arrays, one for each dimension of `a`,
     containing the indices of the non-zero elements in that
     dimension. The values in `a` are always tested and returned in
-    row-major, C-style order. The corresponding non-zero  
+    row-major, C-style order. The corresponding non-zero
     values can be obtained with::
     
         a[nonzero(a)]


### PR DESCRIPTION
Document problems with using `x.nonzero` for indexing, i.e., never use x[y.nonzero()], use x[y.astype(bool)] instead.

Fixes #13522
