### PR TITLE
TST: Register markers in conftest.py.

### DIFF
--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -13,6 +13,13 @@ _old_fpu_mode = None
 _collect_results = {}
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+        "valgrind_error: Tests that are known to error under valgrind.")
+    config.addinivalue_line("markers",
+        "slow: Tests that are very slow.")
+
+
 #FIXME when yield tests are gone.
 @pytest.hookimpl()
 def pytest_itemcollected(item):

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,7 +24,3 @@ filterwarnings =
 
 env =
     PYTHONHASHSEED=0
-
-markers =
-    valgrind_error: Known to cause errors under valgrind
-    slow: Tests which are slow


### PR DESCRIPTION
Backport of #13550.

Register the markers 'slow' and 'valgrind' in the `conftest.py` file
instead of `pytest.ini` as the latter file is not always present.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
