### PR TITLE
MAINT: Fix errors seen on new python 3.8

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3702,17 +3702,6 @@ class TestSubscripting(object):
 
 
 class TestPickling(object):
-    def test_highest_available_pickle_protocol(self):
-        try:
-            import pickle5
-        except ImportError:
-            pickle5 = None
-
-        if sys.version_info[:2] >= (3, 8) or pickle5 is not None:
-            assert pickle.HIGHEST_PROTOCOL >= 5
-        else:
-            assert pickle.HIGHEST_PROTOCOL < 5
-
     @pytest.mark.skipif(pickle.HIGHEST_PROTOCOL >= 5,
                         reason=('this tests the error messages when trying to'
                                 'protocol 5 although it is not available'))

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -515,7 +515,7 @@ class TestRandomDist(object):
 
     def test_binomial(self):
         np.random.seed(self.seed)
-        actual = np.random.binomial(100.123, .456, size=(3, 2))
+        actual = np.random.binomial(100, .456, size=(3, 2))
         desired = np.array([[37, 43],
                             [42, 48],
                             [46, 45]])
@@ -612,7 +612,7 @@ class TestRandomDist(object):
 
     def test_hypergeometric(self):
         np.random.seed(self.seed)
-        actual = np.random.hypergeometric(10.1, 5.5, 14, size=(3, 2))
+        actual = np.random.hypergeometric(10, 5, 14, size=(3, 2))
         desired = np.array([[10, 10],
                             [10, 10],
                             [9, 9]])
@@ -922,6 +922,8 @@ class TestRandomDist(object):
         class ThrowingInteger(np.ndarray):
             def __int__(self):
                 raise TypeError
+
+            __index__ = __int__
 
         throwing_int = np.array(1).view(ThrowingInteger)
         assert_raises(TypeError, np.random.hypergeometric, throwing_int, 1, 1)

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -44,7 +44,7 @@ if sys.version_info >= (3, 4):
             if p.ls[-1] == 'warn' and (
                     len(p.ls) == 1 or p.ls[-2] == 'warnings'):
 
-                if "testing/tests/test_warnings.py" is self.__filename:
+                if "testing/tests/test_warnings.py" == self.__filename:
                     # This file
                     return
 


### PR DESCRIPTION
One of this is a small issue exposed by new warnings, the others are
simply adapting our test suit to stricter integer coercion rules
(avoiding float -> int conversions).

The last one is that we assumed pickle protocl 5 would be in 3.8, but
it seems that it did not make the cut.

Closes gh-13412

---

Marking as draft, since the pickle 5 protocol was approved for inclusion in 3.8, so I am not sure this is correct or python 3.8a3 is just lagging behind there. @pitrou do you know this quickly?