### PR TITLE
BUG: Always return views from structured_to_unstructured when possible

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -972,7 +972,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
 
     # next cast to a packed format with all fields converted to new dtype
     packed_fields = np.dtype({'names': names,
-                              'formats': [(out_dtype, c) for c in counts]})
+                              'formats': [(out_dtype, dt.shape) for dt in dts]})
     arr = arr.astype(packed_fields, copy=copy, casting=casting)
 
     # finally is it safe to view the packed fields as the unstructured type
@@ -1065,7 +1065,7 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
 
     # first view as a packed structured array of one dtype
     packed_fields = np.dtype({'names': names,
-                              'formats': [(arr.dtype, c) for c in counts]})
+                              'formats': [(arr.dtype, dt.shape) for dt in dts]})
     arr = np.ascontiguousarray(arr).view(packed_fields)
 
     # next cast to an unpacked but flattened format with varied dtypes

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -243,6 +243,15 @@ class TestRecFunctions(object):
         assert_(dd.base is d)
         assert_(ddd.base is d)
 
+        # including uniform fields with subarrays unpacked
+        d = np.array([(1, [2,  3], [[ 4,  5], [ 6,  7]]),
+                      (8, [9, 10], [[11, 12], [13, 14]])],
+                     dtype=[('x0', 'i4'), ('x1', ('i4', 2)), ('x2', ('i4', (2, 2)))])
+        dd = structured_to_unstructured(d)
+        ddd = unstructured_to_structured(dd, d.dtype)
+        assert_(dd.base is d)
+        assert_(ddd.base is d)
+
         # test that nested fields with identical names don't break anything
         point = np.dtype([('x', int), ('y', int)])
         triangle = np.dtype([('a', point), ('b', point), ('c', point)])


### PR DESCRIPTION
Backport of #13332.

Also applies to unstructured_to_structured

While producing correct resutls, the test added in this commit would previously make an unecessary copy, causing the assertion to fail.
The cause was `astype` was being asked to convert from a subarray of shape `(x, y)` to one of `(x*y,)`, which it cannot do without making a copy.

This changes the approach used to skip the step of flattening subarrays to 1d

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
