### PR TITLE
BUG: Catch stderr when checking compiler version

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -639,7 +639,7 @@ def CCompiler_get_version(self, force=False, ok_status=[0]):
             return version
 
     try:
-        output = subprocess.check_output(version_cmd)
+        output = subprocess.check_output(version_cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         output = exc.output
         status = exc.returncode


### PR DESCRIPTION
Backport of #12831.

Fixes  #10569, maybe.

## How does the error occur?
When I'm compiling scipy with 
```sh
python3 setup.py config --compiler=intelem --fcompiler=intelem build_clib --compiler=intelem --fcompiler=intelem build_ext
```
, numpy will search for the intel fortran compiler.
When found, numpy will call
```
['/opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort', '-FI', '-V', '-c', '/tmp/tmp89hcqec6/qovhj4fn.f', '-o', '/tmp/tmp89hcqec6/qovhj4fn.o']
```
with `subprocess.check_output` and match the output with the pattern
`Intel.*?Fortran.*?(?:%s).*?Version' % (type,)` where `type` is `'EM64T-based|Intel\\(R\\) 64|64|IA-64|64-bit'`.
However, the output of the version checking command is:
```
 Intel(R) Fortran 19.0-1560
```
It doesn't match the pattern and will raise the `CompilerNotFound` error.

## How does this PR fix it?
It seems that the output matching the pattern is in the stderr of the version checking command:
```
Intel(R) Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 19.0.1.144 Build 20181018
Copyright (C) 1985-2018 Intel Corporation.  All rights reserved.
```
So I re-direct the stderr to stdout and everything work fine.

## Should I merge this?
No, I don't think so.
This approach affects all the compilers and I have only tested one.
I think a better approach is to make the `'/tmp/tmp89hcqec6/qovhj4fn.f'` giving output matching the pattern. I wish to help but I know zero about fortran. So I can't help you more.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
