### PR TITLE
DOC: Change note in `where`

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -315,7 +315,7 @@ def where(condition, x=None, y=None):
 
     .. note::
         When only `condition` is provided, this function is a shorthand for
-        ``np.asarray(condition).nonzero()``. Using `nonzero` directly should be
+        ``np.asarray((condition).nonzero())``. Using `nonzero` directly should be
         preferred, as it behaves correctly for subclasses. The rest of this
         documentation covers only the case where all three arguments are
         provided.


### PR DESCRIPTION
The note in the definition of where says " When only `condition` is provided, this function is a shorthand for
        ``np.asarray(condition).nonzero()``". However, this is not true as `np.asarray(condition).nonzero()` returns a tuple. 

In my opinion, it should be `np.asarray((condition).nonzero())` 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
