### PR TITLE
ENH: use __skip_array_function__ internally in NumPy

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -156,10 +156,11 @@ def zeros_like(a, dtype=None, order='K', subok=True, shape=None):
     array([0.,  0.,  0.])
 
     """
-    res = empty_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
+    res = empty_like.__skip_array_function__(
+        a, dtype=dtype, order=order, subok=subok, shape=shape)
     # needed instead of a 0 to get same result as zeros for for string dtypes
     z = zeros(1, dtype=res.dtype)
-    multiarray.copyto(res, z, casting='unsafe')
+    multiarray.copyto.__skip_array_function__(res, z, casting='unsafe')
     return res
 
 
@@ -212,7 +213,7 @@ def ones(shape, dtype=None, order='C'):
 
     """
     a = empty(shape, dtype, order)
-    multiarray.copyto(a, 1, casting='unsafe')
+    multiarray.copyto.__skip_array_function__(a, 1, casting='unsafe')
     return a
 
 
@@ -282,8 +283,9 @@ def ones_like(a, dtype=None, order='K', subok=True, shape=None):
     array([1.,  1.,  1.])
 
     """
-    res = empty_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-    multiarray.copyto(res, 1, casting='unsafe')
+    res = empty_like.__skip_array_function__(
+        a, dtype=dtype, order=order, subok=subok, shape=shape)
+    multiarray.copyto.__skip_array_function__(res, 1, casting='unsafe')
     return res
 
 
@@ -330,7 +332,7 @@ def full(shape, fill_value, dtype=None, order='C'):
     if dtype is None:
         dtype = array(fill_value).dtype
     a = empty(shape, dtype, order)
-    multiarray.copyto(a, fill_value, casting='unsafe')
+    multiarray.copyto.__skip_array_function__(a, fill_value, casting='unsafe')
     return a
 
 
@@ -397,8 +399,10 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None):
     array([0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
 
     """
-    res = empty_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-    multiarray.copyto(res, fill_value, casting='unsafe')
+    res = empty_like.__skip_array_function__(
+        a, dtype=dtype, order=order, subok=subok, shape=shape)
+    multiarray.copyto.__skip_array_function__(
+        res, fill_value, casting='unsafe')
     return res
 
 
@@ -575,7 +579,8 @@ def argwhere(a):
            [1, 2]])
 
     """
-    return transpose(nonzero(a))
+    return transpose.__skip_array_function__(
+        nonzero.__skip_array_function__(a))
 
 
 def _flatnonzero_dispatcher(a):
@@ -620,7 +625,8 @@ def flatnonzero(a):
     array([-2, -1,  1,  2])
 
     """
-    return np.nonzero(np.ravel(a))[0]
+    return np.nonzero.__skip_array_function__(
+        np.ravel.__skip_array_function__(a))[0]
 
 
 _mode_from_name_dict = {'v': 0,
@@ -2127,7 +2133,8 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     True
 
     """
-    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
+    res = all(isclose.__skip_array_function__(
+        a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
     return bool(res)
 
 
@@ -2231,12 +2238,12 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         return within_tol(x, y, atol, rtol)
     else:
         finite = xfin & yfin
-        cond = zeros_like(finite, subok=True)
+        cond = zeros_like.__skip_array_function__(finite, subok=True)
         # Because we're using boolean indexing, x & y must be the same shape.
         # Ideally, we'd just do x, y = broadcast_arrays(x, y). It's in
         # lib.stride_tricks, though, so we can't import it here.
-        x = x * ones_like(cond)
-        y = y * ones_like(cond)
+        x = x * ones_like.__skip_array_function__(cond)
+        y = y * ones_like.__skip_array_function__(cond)
         # Avoid subtraction with infinite/nan values...
         cond[finite] = within_tol(x[finite], y[finite], atol, rtol)
         # Check for equality of infinite values...

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -273,7 +273,8 @@ def vstack(tup):
            [4]])
 
     """
-    return _nx.concatenate([atleast_2d(_m) for _m in tup], 0)
+    return _nx.concatenate.__skip_array_function__(
+        [atleast_2d.__skip_array_function__(_m) for _m in tup], 0)
 
 
 @array_function_dispatch(_vhstack_dispatcher)
@@ -324,12 +325,12 @@ def hstack(tup):
            [3, 4]])
 
     """
-    arrs = [atleast_1d(_m) for _m in tup]
+    arrs = [atleast_1d.__skip_array_function__(_m) for _m in tup]
     # As a special case, dimension 0 of 1-dimensional arrays is "horizontal"
     if arrs and arrs[0].ndim == 1:
-        return _nx.concatenate(arrs, 0)
+        return _nx.concatenate.__skip_array_function__(arrs, 0)
     else:
-        return _nx.concatenate(arrs, 1)
+        return _nx.concatenate.__skip_array_function__(arrs, 1)
 
 
 def _stack_dispatcher(arrays, axis=None, out=None):
@@ -413,7 +414,8 @@ def stack(arrays, axis=0, out=None):
 
     sl = (slice(None),) * axis + (_nx.newaxis,)
     expanded_arrays = [arr[sl] for arr in arrays]
-    return _nx.concatenate(expanded_arrays, axis=axis, out=out)
+    return _nx.concatenate.__skip_array_function__(
+        expanded_arrays, axis=axis, out=out)
 
 
 def _block_format_index(index):
@@ -496,8 +498,8 @@ def _block_check_depths_match(arrays, parent_index=[]):
         return parent_index + [None], 0, 0
     else:
         # We've 'bottomed out' - arrays is either a scalar or an array
-        size = _nx.size(arrays)
-        return parent_index, _nx.ndim(arrays), size
+        size = _nx.size.__skip_array_function__(arrays)
+        return parent_index, _nx.ndim.__skip_array_function__(arrays), size
 
 
 def _atleast_nd(a, ndim):
@@ -640,7 +642,8 @@ def _block(arrays, max_depth, result_ndim, depth=0):
     if depth < max_depth:
         arrs = [_block(arr, max_depth, result_ndim, depth+1)
                 for arr in arrays]
-        return _nx.concatenate(arrs, axis=-(max_depth-depth))
+        return _nx.concatenate.__skip_array_function__(
+            arrs, axis=-(max_depth-depth))
     else:
         # We've 'bottomed out' - arrays is either a scalar or an array
         # type(arrays) is not list
@@ -858,7 +861,7 @@ def _block_slicing(arrays, list_ndim, result_ndim):
 
     # Test preferring F only in the case that all input arrays are F
     F_order = all(arr.flags['F_CONTIGUOUS'] for arr in arrays)
-    C_order =  all(arr.flags['C_CONTIGUOUS'] for arr in arrays)
+    C_order = all(arr.flags['C_CONTIGUOUS'] for arr in arrays)
     order = 'F' if F_order and not C_order else 'C'
     result = _nx.empty(shape=shape, dtype=dtype, order=order)
     # Note: In a c implementation, the function

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -804,7 +804,7 @@ def pad(array, pad_width, mode='constant', **kwargs):
             # function operates inplace on the padded array.
 
             # view with the iteration axis at the end
-            view = np.moveaxis(padded, axis, -1)
+            view = np.moveaxis.__skip_array_function__(padded, axis, -1)
 
             # compute indices for the iteration axes, and append a trailing
             # ellipsis to prevent 0d arrays decaying to scalars (gh-8642)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -134,26 +134,29 @@ def rot90(m, k=1, axes=(0,1)):
         raise ValueError("Axes must be different.")
 
     if (axes[0] >= m.ndim or axes[0] < -m.ndim
-        or axes[1] >= m.ndim or axes[1] < -m.ndim):
+            or axes[1] >= m.ndim or axes[1] < -m.ndim):
         raise ValueError("Axes={} out of range for array of ndim={}."
-            .format(axes, m.ndim))
+                         .format(axes, m.ndim))
 
     k %= 4
 
     if k == 0:
         return m[:]
     if k == 2:
-        return flip(flip(m, axes[0]), axes[1])
+        return flip.__skip_array_function__(
+            flip.__skip_array_function__(m, axes[0]), axes[1])
 
     axes_list = arange(0, m.ndim)
     (axes_list[axes[0]], axes_list[axes[1]]) = (axes_list[axes[1]],
                                                 axes_list[axes[0]])
 
     if k == 1:
-        return transpose(flip(m,axes[1]), axes_list)
+        return transpose.__skip_array_function__(
+            flip.__skip_array_function__(m, axes[1]), axes_list)
     else:
         # k == 3
-        return flip(transpose(m, axes_list), axes[1])
+        return flip.__skip_array_function__(
+            transpose.__skip_array_function__(m, axes_list), axes[1])
 
 
 def _flip_dispatcher(m, axis=None):
@@ -393,9 +396,11 @@ def average(a, axis=None, weights=None, returned=False):
         wgt = np.asanyarray(weights)
 
         if issubclass(a.dtype.type, (np.integer, np.bool_)):
-            result_dtype = np.result_type(a.dtype, wgt.dtype, 'f8')
+            result_dtype = np.result_type.__skip_array_function__(
+                a.dtype, wgt.dtype, 'f8')
         else:
-            result_dtype = np.result_type(a.dtype, wgt.dtype)
+            result_dtype = np.result_type.__skip_array_function__(
+                a.dtype, wgt.dtype)
 
         # Sanity checks
         if a.shape != wgt.shape:
@@ -606,7 +611,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
     if n == n2 - 1:  # compute the "otherwise" condition.
         condelse = ~np.any(condlist, axis=0, keepdims=True)
-        condlist = np.concatenate([condlist, condelse], axis=0)
+        condlist = np.concatenate.__skip_array_function__(
+            [condlist, condelse], axis=0)
         n += 1
     elif n != n2:
         raise ValueError(
@@ -690,13 +696,13 @@ def select(condlist, choicelist, default=0):
 
     # need to get the result type before broadcasting for correct scalar
     # behaviour
-    dtype = np.result_type(*choicelist)
+    dtype = np.result_type.__skip_array_function__(*choicelist)
 
     # Convert conditions to arrays and broadcast conditions and choices
     # as the shape is needed for the result. Doing it separately optimizes
     # for example when all choices are scalars.
-    condlist = np.broadcast_arrays(*condlist)
-    choicelist = np.broadcast_arrays(*choicelist)
+    condlist = np.broadcast_arrays.__skip_array_function__(*condlist)
+    choicelist = np.broadcast_arrays.__skip_array_function__(*choicelist)
 
     # If cond array is not an ndarray in boolean format or scalar bool, abort.
     deprecated_ints = False
@@ -733,7 +739,7 @@ def select(condlist, choicelist, default=0):
     choicelist = choicelist[-2::-1]
     condlist = condlist[::-1]
     for choice, cond in zip(choicelist, condlist):
-        np.copyto(result, choice, where=cond)
+        np.copyto.__skip_array_function__(result, choice, where=cond)
 
     return result
 
@@ -1512,14 +1518,16 @@ def unwrap(p, discont=pi, axis=-1):
     """
     p = asarray(p)
     nd = p.ndim
-    dd = diff(p, axis=axis)
+    dd = diff.__skip_array_function__(p, axis=axis)
     slice1 = [slice(None, None)]*nd     # full slices
     slice1[axis] = slice(1, None)
     slice1 = tuple(slice1)
     ddmod = mod(dd + pi, 2*pi) - pi
-    _nx.copyto(ddmod, pi, where=(ddmod == -pi) & (dd > 0))
+    _nx.copyto.__skip_array_function__(
+        ddmod, pi, where=(ddmod == -pi) & (dd > 0))
     ph_correct = ddmod - dd
-    _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
+    _nx.copyto.__skip_array_function__(
+        ph_correct, 0, where=abs(dd) < discont)
     up = array(p, copy=True, dtype='d')
     up[slice1] = p[slice1] + ph_correct.cumsum(axis)
     return up
@@ -1674,7 +1682,10 @@ def extract(condition, arr):
     array([0, 3, 6, 9])
 
     """
-    return _nx.take(ravel(arr), nonzero(ravel(condition))[0])
+    return _nx.take.__skip_array_function__(
+        ravel.__skip_array_function__(arr),
+        nonzero.__skip_array_function__(
+            ravel.__skip_array_function__(condition))[0])
 
 
 def _place_dispatcher(arr, mask, vals):
@@ -4697,9 +4708,9 @@ def append(arr, values, axis=None):
     if axis is None:
         if arr.ndim != 1:
             arr = arr.ravel()
-        values = ravel(values)
+        values = ravel.__skip_array_function__(values)
         axis = arr.ndim-1
-    return concatenate((arr, values), axis=axis)
+    return concatenate.__skip_array_function__((arr, values), axis=axis)
 
 
 def _digitize_dispatcher(x, bins, right=None):

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -448,7 +448,7 @@ def _search_sorted_inclusive(a, v):
 
     In the context of a histogram, this makes the last bin edge inclusive
     """
-    return np.concatenate((
+    return np.concatenate.__skip_array_function__((
         a.searchsorted(v[:-1], 'left'),
         a.searchsorted(v[-1:], 'right')
     ))
@@ -865,17 +865,18 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
         cum_n = np.zeros(bin_edges.shape, ntype)
         if weights is None:
             for i in _range(0, len(a), BLOCK):
-                sa = np.sort(a[i:i+BLOCK])
+                sa = np.sort.__skip_array_function__(a[i:i+BLOCK])
                 cum_n += _search_sorted_inclusive(sa, bin_edges)
         else:
             zero = np.zeros(1, dtype=ntype)
             for i in _range(0, len(a), BLOCK):
                 tmp_a = a[i:i+BLOCK]
                 tmp_w = weights[i:i+BLOCK]
-                sorting_index = np.argsort(tmp_a)
+                sorting_index = np.argsort.__skip_array_function__(tmp_a)
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]
-                cw = np.concatenate((zero, sw.cumsum()))
+                cw = np.concatenate.__skip_array_function__(
+                    (zero, sw.cumsum()))
                 bin_index = _search_sorted_inclusive(sa, bin_edges)
                 cum_n += cw[bin_index]
 
@@ -1000,7 +1001,7 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
         N, D = sample.shape
     except (AttributeError, ValueError):
         # Sample is a sequence of 1D arrays.
-        sample = np.atleast_2d(sample).T
+        sample = np.atleast_2d.__skip_array_function__(sample).T
         N, D = sample.shape
 
     nbin = np.empty(D, int)
@@ -1027,12 +1028,13 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
 
     # Create edge arrays
     for i in _range(D):
-        if np.ndim(bins[i]) == 0:
+        if np.ndim.__skip_array_function__(bins[i]) == 0:
             if bins[i] < 1:
                 raise ValueError(
                     '`bins[{}]` must be positive, when an integer'.format(i))
             smin, smax = _get_outer_edges(sample[:,i], range[i])
-            edges[i] = np.linspace(smin, smax, bins[i] + 1)
+            edges[i] = np.linspace.__skip_array_function__(
+                smin, smax, bins[i] + 1)
         elif np.ndim(bins[i]) == 1:
             edges[i] = np.asarray(bins[i])
             if np.any(edges[i][:-1] > edges[i][1:]):
@@ -1044,12 +1046,13 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
                 '`bins[{}]` must be a scalar or 1d array'.format(i))
 
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
-        dedges[i] = np.diff(edges[i])
+        dedges[i] = np.diff.__skip_array_function__(edges[i])
 
     # Compute the bin number each sample falls into.
     Ncount = tuple(
         # avoid np.digitize to work around gh-11022
-        np.searchsorted(edges[i], sample[:, i], side='right')
+        np.searchsorted.__skip_array_function__(
+            edges[i], sample[:, i], side='right')
         for i in _range(D)
     )
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -106,7 +106,7 @@ def _replace_nan(a, val):
         mask = None
 
     if mask is not None:
-        np.copyto(a, val, where=mask)
+        np.copyto.__skip_array_function__(a, val, where=mask)
 
     return a, mask
 
@@ -134,7 +134,7 @@ def _copyto(a, val, mask):
 
     """
     if isinstance(a, np.ndarray):
-        np.copyto(a, val, where=mask, casting='unsafe')
+        np.copyto.__skip_array_function__(a, val, where=mask, casting='unsafe')
     else:
         a = a.dtype.type(val)
     return a
@@ -163,7 +163,7 @@ def _remove_nan_1d(arr1d, overwrite_input=False):
     """
 
     c = np.isnan(arr1d)
-    s = np.nonzero(c)[0]
+    s = np.nonzero.__skip_array_function__(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning, stacklevel=4)
         return arr1d[:0], True
@@ -488,7 +488,7 @@ def nanargmin(a, axis=None):
 
     """
     a, mask = _replace_nan(a, np.inf)
-    res = np.argmin(a, axis=axis)
+    res = np.argmin.__skip_array_function__(a, axis=axis)
     if mask is not None:
         mask = np.all(mask, axis=axis)
         if np.any(mask):
@@ -538,7 +538,7 @@ def nanargmax(a, axis=None):
 
     """
     a, mask = _replace_nan(a, -np.inf)
-    res = np.argmax(a, axis=axis)
+    res = np.argmax.__skip_array_function__(a, axis=axis)
     if mask is not None:
         mask = np.all(mask, axis=axis)
         if np.any(mask):
@@ -641,7 +641,8 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
 
     """
     a, mask = _replace_nan(a, 0)
-    return np.sum(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return np.sum.__skip_array_function__(
+        a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
 
 def _nanprod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None):
@@ -711,7 +712,8 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
 
     """
     a, mask = _replace_nan(a, 1)
-    return np.prod(a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    return np.prod.__skip_array_function__(
+        a, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
 
 def _nancumsum_dispatcher(a, axis=None, dtype=None, out=None):
@@ -781,7 +783,8 @@ def nancumsum(a, axis=None, dtype=None, out=None):
 
     """
     a, mask = _replace_nan(a, 0)
-    return np.cumsum(a, axis=axis, dtype=dtype, out=out)
+    return np.cumsum.__skip_array_function__(
+        a, axis=axis, dtype=dtype, out=out)
 
 
 def _nancumprod_dispatcher(a, axis=None, dtype=None, out=None):
@@ -848,7 +851,8 @@ def nancumprod(a, axis=None, dtype=None, out=None):
 
     """
     a, mask = _replace_nan(a, 1)
-    return np.cumprod(a, axis=axis, dtype=dtype, out=out)
+    return np.cumprod.__skip_array_function__(
+        a, axis=axis, dtype=dtype, out=out)
 
 
 def _nanmean_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None):
@@ -932,7 +936,8 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     """
     arr, mask = _replace_nan(a, 0)
     if mask is None:
-        return np.mean(arr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+        return np.mean.__skip_array_function__(
+            arr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
 
     if dtype is not None:
         dtype = np.dtype(dtype)
@@ -941,8 +946,10 @@ def nanmean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     if out is not None and not issubclass(out.dtype.type, np.inexact):
         raise TypeError("If a is inexact, then out must be inexact")
 
-    cnt = np.sum(~mask, axis=axis, dtype=np.intp, keepdims=keepdims)
-    tot = np.sum(arr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    cnt = np.sum.__skip_array_function__(
+        ~mask, axis=axis, dtype=np.intp, keepdims=keepdims)
+    tot = np.sum.__skip_array_function__(
+        arr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
     avg = _divide_by_count(tot, cnt, out=out)
 
     isbad = (cnt == 0)
@@ -963,7 +970,8 @@ def _nanmedian1d(arr1d, overwrite_input=False):
     if arr1d.size == 0:
         return np.nan
 
-    return np.median(arr1d, overwrite_input=overwrite_input)
+    return np.median.__skip_array_function__(
+        arr1d, overwrite_input=overwrite_input)
 
 
 def _nanmedian(a, axis=None, out=None, overwrite_input=False):
@@ -986,7 +994,8 @@ def _nanmedian(a, axis=None, out=None, overwrite_input=False):
         # benchmarked with shuffled (50, 50, x) containing a few NaN
         if a.shape[axis] < 600:
             return _nanmedian_small(a, axis, out, overwrite_input)
-        result = np.apply_along_axis(_nanmedian1d, axis, a, overwrite_input)
+        result = np.apply_along_axis.__skip_array_function__(
+            _nanmedian1d, axis, a, overwrite_input)
         if out is not None:
             out[...] = result
         return result
@@ -1103,7 +1112,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
     # apply_along_axis in _nanmedian doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
-        return np.nanmean(a, axis, out=out, keepdims=keepdims)
+        return np.nanmean.__skip_array_function__(
+            a, axis, out=out, keepdims=keepdims)
 
     r, k = function_base._ureduce(a, func=_nanmedian, axis=axis, out=out,
                                   overwrite_input=overwrite_input)
@@ -1357,7 +1367,8 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # apply_along_axis in _nanpercentile doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
-        return np.nanmean(a, axis, out=out, keepdims=keepdims)
+        return np.nanmean.__skip_array_function__(
+            a, axis, out=out, keepdims=keepdims)
 
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,
@@ -1380,13 +1391,13 @@ def _nanquantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,
         part = a.ravel()
         result = _nanquantile_1d(part, q, overwrite_input, interpolation)
     else:
-        result = np.apply_along_axis(_nanquantile_1d, axis, a, q,
-                                     overwrite_input, interpolation)
+        result = np.apply_along_axis.__skip_array_function__(
+            _nanquantile_1d, axis, a, q, overwrite_input, interpolation)
         # apply_along_axis fills in collapsed axis with results.
         # Move that axis to the beginning to match percentile's
         # convention.
         if q.ndim != 0:
-            result = np.moveaxis(result, axis, 0)
+            result = np.moveaxis.__skip_array_function__(result, axis, 0)
 
     if out is not None:
         out[...] = result
@@ -1505,8 +1516,8 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
     """
     arr, mask = _replace_nan(a, 0)
     if mask is None:
-        return np.var(arr, axis=axis, dtype=dtype, out=out, ddof=ddof,
-                      keepdims=keepdims)
+        return np.var.__skip_array_function__(
+            arr, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
 
     if dtype is not None:
         dtype = np.dtype(dtype)
@@ -1525,8 +1536,10 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
     # keepdims=True, however matrix now raises an error in this case, but
     # the reason that it drops the keepdims kwarg is to force keepdims=True
     # so this used to work by serendipity.
-    cnt = np.sum(~mask, axis=axis, dtype=np.intp, keepdims=_keepdims)
-    avg = np.sum(arr, axis=axis, dtype=dtype, keepdims=_keepdims)
+    cnt = np.sum.__skip_array_function__(
+        ~mask, axis=axis, dtype=np.intp, keepdims=_keepdims)
+    avg = np.sum.__skip_array_function__(
+        arr, axis=axis, dtype=dtype, keepdims=_keepdims)
     avg = _divide_by_count(avg, cnt)
 
     # Compute squared deviation from mean.
@@ -1538,7 +1551,8 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
         sqr = np.multiply(arr, arr, out=arr)
 
     # Compute variance.
-    var = np.sum(sqr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
+    var = np.sum.__skip_array_function__(
+        sqr, axis=axis, dtype=dtype, out=out, keepdims=keepdims)
     if var.ndim < cnt.ndim:
         # Subclasses of ndarray may ignore keepdims, so check here.
         cnt = cnt.squeeze(axis)
@@ -1654,8 +1668,8 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
     array([0.,  0.5]) # may vary
 
     """
-    var = nanvar(a, axis=axis, dtype=dtype, out=out, ddof=ddof,
-                 keepdims=keepdims)
+    var = nanvar.__skip_array_function__(
+        a, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
     if isinstance(var, np.ndarray):
         std = np.sqrt(var, out=var)
     else:

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -7,7 +7,7 @@ import numpy.core.numeric as _nx
 from numpy.core.numeric import (
     asarray, zeros, outer, concatenate, array, asanyarray
     )
-from numpy.core.fromnumeric import product, reshape, transpose
+from numpy.core.fromnumeric import reshape, transpose
 from numpy.core.multiarray import normalize_axis_index
 from numpy.core import overrides
 from numpy.core import vstack, atleast_3d
@@ -634,7 +634,7 @@ def column_stack(tup):
         if arr.ndim < 2:
             arr = array(arr, copy=False, subok=True, ndmin=2).T
         arrays.append(arr)
-    return _nx.concatenate(arrays, 1)
+    return _nx.concatenate.__skip_array_function__(arrays, 1)
 
 
 def _dstack_dispatcher(tup):
@@ -692,7 +692,8 @@ def dstack(tup):
            [[3, 4]]])
 
     """
-    return _nx.concatenate([atleast_3d(_m) for _m in tup], 2)
+    return _nx.concatenate.__skip_array_function__(
+        [atleast_3d.__skip_array_function__(_m) for _m in tup], 2)
 
 
 def _replace_zero_by_x_arrays(sub_arys):
@@ -755,11 +756,12 @@ def array_split(ary, indices_or_sections, axis=0):
         div_points = _nx.array(section_sizes, dtype=_nx.intp).cumsum()
 
     sub_arys = []
-    sary = _nx.swapaxes(ary, axis, 0)
+    swapaxes = _nx.swapaxes.__skip_array_function__
+    sary = swapaxes(ary, axis, 0)
     for i in range(Nsections):
         st = div_points[i]
         end = div_points[i + 1]
-        sub_arys.append(_nx.swapaxes(sary[st:end], axis, 0))
+        sub_arys.append(swapaxes(sary[st:end], axis, 0))
 
     return sub_arys
 
@@ -843,7 +845,7 @@ def split(ary, indices_or_sections, axis=0):
         if N % sections:
             raise ValueError(
                 'array split does not result in an equal division')
-    res = array_split(ary, indices_or_sections, axis)
+    res = array_split.__skip_array_function__(ary, indices_or_sections, axis)
     return res
 
 
@@ -907,12 +909,12 @@ def hsplit(ary, indices_or_sections):
            [[6.,  7.]]])]
 
     """
-    if _nx.ndim(ary) == 0:
+    if _nx.ndim.__skip_array_function__(ary) == 0:
         raise ValueError('hsplit only works on arrays of 1 or more dimensions')
     if ary.ndim > 1:
-        return split(ary, indices_or_sections, 1)
+        return split.__skip_array_function__(ary, indices_or_sections, 1)
     else:
-        return split(ary, indices_or_sections, 0)
+        return split.__skip_array_function__(ary, indices_or_sections, 0)
 
 
 @array_function_dispatch(_hvdsplit_dispatcher)
@@ -959,9 +961,9 @@ def vsplit(ary, indices_or_sections):
             [6., 7.]]])]
 
     """
-    if _nx.ndim(ary) < 2:
+    if _nx.ndim.__skip_array_function__(ary) < 2:
         raise ValueError('vsplit only works on arrays of 2 or more dimensions')
-    return split(ary, indices_or_sections, 0)
+    return split.__skip_array_function__(ary, indices_or_sections, 0)
 
 
 @array_function_dispatch(_hvdsplit_dispatcher)
@@ -1004,9 +1006,9 @@ def dsplit(ary, indices_or_sections):
             [15.]]]),
     array([], shape=(2, 2, 0), dtype=float64)]
     """
-    if _nx.ndim(ary) < 3:
+    if _nx.ndim.__skip_array_function__(ary) < 3:
         raise ValueError('dsplit only works on arrays of 3 or more dimensions')
-    return split(ary, indices_or_sections, 2)
+    return split.__skip_array_function__(ary, indices_or_sections, 2)
 
 def get_array_prepare(*args):
     """Find the wrapper for the array with the highest priority.

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -194,7 +194,7 @@ def _broadcast_shape(*args):
         # ironically, np.broadcast does not properly handle np.broadcast
         # objects (it treats them as scalars)
         # use broadcasting to avoid allocating the full array
-        b = broadcast_to(0, b.shape)
+        b = broadcast_to.__skip_array_function__(0, b.shape)
         b = np.broadcast(b, *args[pos:(pos + 31)])
     return b.shape
 

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -280,7 +280,7 @@ def diag(v, k=0):
         res[:n-k].flat[i::n+1] = v
         return res
     elif len(s) == 2:
-        return diagonal(v, k)
+        return diagonal.__skip_array_function__(v, k)
     else:
         raise ValueError("Input must be 1- or 2-d.")
 
@@ -699,7 +699,8 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     if N != 1 and N != 2:
         xedges = yedges = asarray(bins)
         bins = [xedges, yedges]
-    hist, edges = histogramdd([x, y], bins, range, normed, weights, density)
+    hist, edges = histogramdd.__skip_array_function__(
+        [x, y], bins, range, normed, weights, density)
     return hist, edges[0], edges[1]
 
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -241,7 +241,7 @@ def transpose(a):
     -------
     aT : (...,N,M) ndarray
     """
-    return swapaxes(a, -1, -2)
+    return swapaxes.__skip_array_function__(a, -1, -2)
 
 # Linear equations
 
@@ -315,7 +315,7 @@ def tensorsolve(a, b, axes=None):
 
     a = a.reshape(-1, prod)
     b = b.ravel()
-    res = wrap(solve(a, b))
+    res = wrap(solve.__skip_array_function__(a, b))
     res.shape = oldshape
     return res
 
@@ -473,7 +473,7 @@ def tensorinv(a, ind=2):
     else:
         raise ValueError("Invalid ind argument.")
     a = a.reshape(prod, -1)
-    ia = inv(a)
+    ia = inv.__skip_array_function__(a)
     return ia.reshape(*invshape)
 
 
@@ -635,7 +635,7 @@ def matrix_power(a, n):
     if a.dtype != object:
         fmatmul = matmul
     elif a.ndim == 2:
-        fmatmul = dot
+        fmatmul = dot.__skip_array_function__
     else:
         raise NotImplementedError(
             "matrix_power not supported for stacks of object arrays")
@@ -2676,6 +2676,9 @@ def multi_dot(arrays):
         return result
 
 
+_dot = dot.__skip_array_function__
+
+
 def _multi_dot_three(A, B, C):
     """
     Find the best order for three arrays and do the multiplication.
@@ -2692,9 +2695,9 @@ def _multi_dot_three(A, B, C):
     cost2 = a1b0 * c1 * (a0 + b1c0)
 
     if cost1 < cost2:
-        return dot(dot(A, B), C)
+        return _dot(_dot(A, B), C)
     else:
-        return dot(A, dot(B, C))
+        return _dot(A, _dot(B, C))
 
 
 def _multi_dot_matrix_chain_order(arrays, return_costs=False):
@@ -2743,5 +2746,5 @@ def _multi_dot(arrays, order, i, j):
     if i == j:
         return arrays[i]
     else:
-        return dot(_multi_dot(arrays, order, i, order[i, j]),
-                   _multi_dot(arrays, order, order[i, j] + 1, j))
+        return _dot(_multi_dot(arrays, order, i, order[i, j]),
+                    _multi_dot(arrays, order, order[i, j] + 1, j))


### PR DESCRIPTION
This should speed up some functions considerably.

Note: I'm also intentionally using this even (especially!) in functions that do not directly call np.asarray() on their inputs. This is so that overrides of __array_function__ cannot effect the internals of NumPy functions, which would be leaking our implementation as our API.
