### PR TITLE
BUG: distutils/system_info.py fix missing subprocess import (#13523)

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -126,6 +126,8 @@ import os
 import re
 import copy
 import warnings
+import subprocess
+
 from glob import glob
 from functools import reduce
 if sys.version_info[0] < 3:
@@ -298,13 +300,12 @@ else:
             default_x11_include_dirs.extend(['/usr/lib/X11/include',
                                              '/usr/include/X11'])
 
-    import subprocess as sp
     tmp = None
     try:
         # Explicitly open/close file to avoid ResourceWarning when
         # tests are run in debug mode Python 3.
         tmp = open(os.devnull, 'w')
-        p = sp.Popen(["gcc", "-print-multiarch"], stdout=sp.PIPE,
+        p = subprocess.Popen(["gcc", "-print-multiarch"], stdout=subprocess.PIPE,
                      stderr=tmp)
     except (OSError, DistutilsError):
         # OSError if gcc is not installed, or SandboxViolation (DistutilsError


### PR DESCRIPTION
Backport of #13523.

I had an issue installing numpy from an enthought package called enable on MacOS high sierra and python 3.5 and python 3.6. It seems that subprocess is not imported where needed in the system_info.py file.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
