### PR TITLE
DOC: Clarify polyfit/polyval differences

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -441,6 +441,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     method is recommended for new code as it is more stable numerically. See
     the documentation of the method for more information.
 
+    Note that we generally recommend the very similar function
+    `numpy.polynomial.polynomial.polyfit`, which returns its coefficients in
+    increasing order of degree, and organizes its `full` output differently.
+    Returning the coefficients in decreasing order is an historical accident.
+
     Parameters
     ----------
     x : array_like, shape (M,)
@@ -676,6 +681,12 @@ def polyval(p, x):
     If `x` is a sequence, then `p(x)` is returned for each element of `x`.
     If `x` is another polynomial then the composite polynomial `p(x(t))`
     is returned.
+
+    Note that we generally recommend the very similar function
+    `numpy.polynomial.polynomial.polyval`, which takes its coefficients in
+    the preferred order (increasing degree).
+    Handling coefficients in decreasing order of degree is an historical
+    accident.
 
     Parameters
     ----------

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -437,13 +437,13 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     to points `(x, y)`. Returns a vector of coefficients `p` that minimises
     the squared error in the order `deg`, `deg-1`, ... `0`.
 
-    N.B. The `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
-    method is recommended for new code as it is more stable numerically. See
-    the documentation of the method for more information.
+    .. note:: The `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
+        method is recommended for new code as it is more stable numerically. See
+        the documentation of the method for more information.
 
-    Note also that this function is distinct from
-    `numpy.polynomial.polynomial.polyfit`, which uses the same implementation
-    as `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>`.
+        Note also that this function is distinct from
+        `numpy.polynomial.polynomial.polyfit`, which uses the same implementation
+        as `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>`.
 
     Parameters
     ----------

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -437,14 +437,13 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     to points `(x, y)`. Returns a vector of coefficients `p` that minimises
     the squared error in the order `deg`, `deg-1`, ... `0`.
 
-    The `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
+    N.B. The `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
     method is recommended for new code as it is more stable numerically. See
     the documentation of the method for more information.
 
-    Note that we generally recommend the very similar function
-    `numpy.polynomial.polynomial.polyfit`, which returns its coefficients in
-    increasing order of degree, and organizes its `full` output differently.
-    Returning the coefficients in decreasing order is an historical accident.
+    Note also that this function is distinct from
+    `numpy.polynomial.polynomial.polyfit`, which uses the same implementation
+    as `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>`.
 
     Parameters
     ----------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1209,12 +1209,12 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
 
     where `n` is `deg`.
 
-    N.B. This function is distinct from (and preferred over, due to its numerical stability)
-    `numpy.polyfit`.
+    .. note:: This function is distinct from (and preferred over, due to its numerical
+        stability) `numpy.polyfit`.
 
-    Note also that the `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
-    method (which uses the same implementation) is recommended for new code as a single
-    point of access to polynomial fitting.
+        Note also that the `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>`
+        class method (which uses the same implementation) is recommended for new code as
+        a single point of access to polynomial fitting.
 
     Parameters
     ----------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -662,6 +662,10 @@ def polyval(x, c, tensor=True):
     Trailing zeros in the coefficients will be used in the evaluation, so
     they should be avoided if efficiency is a concern.
 
+    This function is preferred over the very similar `numpy.polyval`, which
+    takes its coefficients in decreasing order of degree due to an historical
+    accident.
+
     Parameters
     ----------
     x : array_like, compatible object
@@ -1204,6 +1208,10 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     .. math::  p(x) = c_0 + c_1 * x + ... + c_n * x^n,
 
     where `n` is `deg`.
+
+    This function is preferred over the very similar `numpy.polyfit`, which
+    returns its coefficients in decreasing order of degree (due to an historical
+    accident), and organizes its `full` output differently.
 
     Parameters
     ----------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1209,9 +1209,12 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
 
     where `n` is `deg`.
 
-    This function is preferred over the very similar `numpy.polyfit`, which
-    returns its coefficients in decreasing order of degree (due to an historical
-    accident), and organizes its `full` output differently.
+    N.B. This function is distinct from (and preferred over, due to its numerical stability)
+    `numpy.polyfit`.
+
+    Note also that the `Polynomial.fit <numpy.polynomial.polynomial.Polynomial.fit>` class
+    method (which uses the same implementation) is recommended for new code as a single
+    point of access to polynomial fitting.
 
     Parameters
     ----------


### PR DESCRIPTION
See #7478

There exists duplication of purpose between the very similar functions
`numpy.poly(fit|val)` and `numpy.polynomial.polynomial.poly(fit|val)`:
in particular, the order of coefficients and how `full` output is
handled.
This commit clarifies the differences and explicitly makes references
to them in the docstring.
