### PR TITLE
BUG: special case object arrays when printing rel-, abs-error

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -801,14 +801,22 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                 try:
                     error = abs(x - y)
                     max_abs_error = error.max()
-                    remarks.append('Max absolute difference: '
-                                   + array2string(max_abs_error))
+                    if error.dtype == 'object':
+                        remarks.append('Max absolute difference: '
+                                        + str(max_abs_error))
+                    else:
+                        remarks.append('Max absolute difference: '
+                                        + array2string(max_abs_error))
 
                     # note: this definition of relative error matches that one
                     # used by assert_allclose (found in np.isclose)
                     max_rel_error = (error / abs(y)).max()
-                    remarks.append('Max relative difference: '
-                                   + array2string(max_rel_error))
+                    if error.dtype == 'object':
+                        remarks.append('Max relative difference: '
+                                        + str(max_rel_error))
+                    else:
+                        remarks.append('Max relative difference: '
+                                        + array2string(max_rel_error))
                 except TypeError:
                     pass
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -344,6 +344,13 @@ class TestEqual(TestArrayEqual):
         except AssertionError:
             assert_equal(msg2, msg_reference)
 
+    def test_object(self):
+        #gh-12942
+        import datetime
+        a = np.array([datetime.datetime(2000, 1, 1),
+                      datetime.datetime(2000, 1, 2)])
+        self._test_not_equal(a, a[::-1])
+
 
 class TestArrayAlmostEqual(_GenericTest):
 


### PR DESCRIPTION
Backport of #13642.

Fixes #12942. It would be better to just use `str(a)` instead of `array2string(a)`, but the formatting turns out wrong: `str(np.array(9.999999999621423e-06)) != np.array2string(np.array(9.999999999621423e-06))`
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
