### PR TITLE
WIP,BUG: ensure that casting to void is properly checked.

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -422,9 +422,9 @@ PyArray_CanCastSafely(int fromtype, int totype)
         case NPY_BOOL:
         case NPY_DATETIME:
         case NPY_TIMEDELTA:
+        case NPY_VOID:
             return 0;
         case NPY_OBJECT:
-        case NPY_VOID:
             return 1;
     }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4008,8 +4008,10 @@ initialize_casting_tables(void)
     memset(_npy_can_cast_safely_table, 0, sizeof(_npy_can_cast_safely_table));
 
     for (i = 0; i < NPY_NTYPES; ++i) {
-        /* Identity */
-        _npy_can_cast_safely_table[i][i] = 1;
+        /* Identity, OK except for VOID, where it depends on the fields */
+        if (i != NPY_VOID) {
+            _npy_can_cast_safely_table[i][i] = 1;
+        }
         if (i != NPY_DATETIME) {
             /*
              * Bool -> <Anything> except datetime (since
@@ -4017,14 +4019,12 @@ initialize_casting_tables(void)
              */
             _npy_can_cast_safely_table[NPY_BOOL][i] = 1;
         }
-        /* <Anything> -> Object */
+        /* <Anything> -> Object is possible */
         _npy_can_cast_safely_table[i][NPY_OBJECT] = 1;
-        /* <Anything> -> Void */
-        _npy_can_cast_safely_table[i][NPY_VOID] = 1;
+        /* <Anything> -> Void is not possible without further checks */
     }
 
     _npy_can_cast_safely_table[NPY_STRING][NPY_UNICODE] = 1;
-    _npy_can_cast_safely_table[NPY_BOOL][NPY_TIMEDELTA] = 1;
 
 #ifndef NPY_SIZEOF_BYTE
 #define NPY_SIZEOF_BYTE 1


### PR DESCRIPTION
As noted in #11114, currently the following clearly wrong things happen:
```
np.can_cast(1., 'i2,i2', casting='safe')
# True
# while
np.can_cast(1., 'i2', casting='safe')
# False
np.array(1000.).astype('i1,i1', casting='safe')
# array((-24, -24), dtype=[('f0', 'i1'), ('f1', 'i1')])
# while
np.array(1000.).astype('i1', casting='safe')
# TypeError: Cannot cast array from dtype('float64') to dtype('int8') according to the rule 'safe'
```
The present PR fixes it, and doesn't cause errors locally, but that is mostly because no tests are doing with casting to/from void. I'd happily add those, but what should and should not work?

EDIT: Should add that I'm not at all sure this is the right solution. Perhaps more likely the check should be different whenever from or to has fields.

fixes #11114

