### PR TITLE
MAINT: remove superfluous setting in can_cast_safely_table.

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4024,7 +4024,6 @@ initialize_casting_tables(void)
     }
 
     _npy_can_cast_safely_table[NPY_STRING][NPY_UNICODE] = 1;
-    _npy_can_cast_safely_table[NPY_BOOL][NPY_TIMEDELTA] = 1;
 
 #ifndef NPY_SIZEOF_BYTE
 #define NPY_SIZEOF_BYTE 1


### PR DESCRIPTION
Very small fix found in #13646. Separated out since that PR was closed.