### PR TITLE
PERF: Use intrinsic rotr on Windows

### DIFF
--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -51,6 +51,7 @@
 #include <inttypes.h>
 
 #ifdef _WIN32
+#include <stdlib.h>
 #define inline __forceinline
 #endif
 
@@ -99,7 +100,11 @@ typedef struct {
   }
 
 static inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot) {
+#ifdef _WIN32
+  return _rotr64(value, rot);
+#else
   return (value >> rot) | (value << ((-rot) & 63));
+#endif
 }
 
 #ifdef PCG_EMULATED_128BIT_MATH


### PR DESCRIPTION
Use _rotr64 on Windows to avoid compiler generated rotr instructions

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
