### PR TITLE
BUG: Avoid leading underscores in C function names.

### DIFF
--- a/numpy/random/src/pcg64/pcg64.c
+++ b/numpy/random/src/pcg64/pcg64.c
@@ -97,17 +97,17 @@ pcg128_t pcg_advance_lcg_128(pcg128_t state, pcg128_t delta, pcg128_t cur_mult,
   pcg128_t acc_plus = PCG_128BIT_CONSTANT(0u, 0u);
   while ((delta.high > 0) || (delta.low > 0)) {
     if (delta.low & 1) {
-      acc_mult = _pcg128_mult(acc_mult, cur_mult);
-      acc_plus = _pcg128_add(_pcg128_mult(acc_plus, cur_mult), cur_plus);
+      acc_mult = pcg128_mult(acc_mult, cur_mult);
+      acc_plus = pcg128_add(pcg128_mult(acc_plus, cur_mult), cur_plus);
     }
-    cur_plus = _pcg128_mult(_pcg128_add(cur_mult, PCG_128BIT_CONSTANT(0u, 1u)),
+    cur_plus = pcg128_mult(pcg128_add(cur_mult, PCG_128BIT_CONSTANT(0u, 1u)),
                             cur_plus);
-    cur_mult = _pcg128_mult(cur_mult, cur_mult);
+    cur_mult = pcg128_mult(cur_mult, cur_mult);
     delta.low >>= 1;
     delta.low += delta.high & 1;
     delta.high >>= 1;
   }
-  return _pcg128_add(_pcg128_mult(acc_mult, state), acc_plus);
+  return pcg128_add(pcg128_mult(acc_mult, state), acc_plus);
 }
 
 #endif

--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -104,7 +104,7 @@ static inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot) {
 
 #ifdef PCG_EMULATED_128BIT_MATH
 
-static inline pcg128_t _pcg128_add(pcg128_t a, pcg128_t b) {
+static inline pcg128_t pcg128_add(pcg128_t a, pcg128_t b) {
   pcg128_t result;
 
   result.low = a.low + b.low;
@@ -136,7 +136,7 @@ static inline void _pcg_mult64(uint64_t x, uint64_t y, uint64_t *z1,
 #endif
 }
 
-static inline pcg128_t _pcg128_mult(pcg128_t a, pcg128_t b) {
+static inline pcg128_t pcg128_mult(pcg128_t a, pcg128_t b) {
   uint64_t h1;
   pcg128_t result;
 
@@ -147,7 +147,7 @@ static inline pcg128_t _pcg128_mult(pcg128_t a, pcg128_t b) {
 }
 
 static inline void pcg_setseq_128_step_r(pcg_state_setseq_128 *rng) {
-  rng->state = _pcg128_add(_pcg128_mult(rng->state, PCG_DEFAULT_MULTIPLIER_128),
+  rng->state = pcg128_add(pcg128_mult(rng->state, PCG_DEFAULT_MULTIPLIER_128),
                            rng->inc);
 }
 
@@ -163,7 +163,7 @@ static inline void pcg_setseq_128_srandom_r(pcg_state_setseq_128 *rng,
   rng->inc.high |= initseq.low & 0x800000000000ULL;
   rng->inc.low = (initseq.low << 1u) | 1u;
   pcg_setseq_128_step_r(rng);
-  rng->state = _pcg128_add(rng->state, initstate);
+  rng->state = pcg128_add(rng->state, initstate);
   pcg_setseq_128_step_r(rng);
 }
 


### PR DESCRIPTION
They are reserved in the C and POSIX standards, and aren't providing us much value here.