### PR TITLE
BUG: regression for array([pandas.DataFrame()])

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2454,3 +2454,23 @@ class TestRegression(object):
             __array_interface__ = {}
 
         np.array([T()])
+
+    def test_2d__array__shape(self):
+        class T(object):
+            def __array__(self):
+                return np.ndarray(shape=(0,0))
+
+            # Make sure __array__ is used instead of Sequence methods.
+            def __iter__(self):
+                return iter([])
+
+            def __getitem__(self, idx):
+                raise AssertionError("__getitem__ was called")
+
+            def __len__(self):
+                return 0
+
+
+        t = T()
+        #gh-13659, would raise in broadcasting [x=t for x in result]
+        np.array([t])


### PR DESCRIPTION
Fixes #13399

Add failing test. 
Fix by not converting 0-len object to ndarray, which is compatible with behaviour before #13399