### PR TITLE
 BUG: fix benchmark suite importability on Numpy<1.17 

### DIFF
--- a/benchmarks/benchmarks/bench_random.py
+++ b/benchmarks/benchmarks/bench_random.py
@@ -4,7 +4,13 @@ from .common import Benchmark
 
 import numpy as np
 
-from numpy.random import RandomState, Generator
+from numpy.random import RandomState
+
+try:
+    from numpy.random import Generator
+except ImportError:
+    pass
+
 
 class Random(Benchmark):
     params = ['normal', 'uniform', 'weibull 1', 'binomial 10 0.5',

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -111,6 +111,7 @@ run_test()
 
   if [ -n "$USE_ASV" ]; then
     pushd ../benchmarks
+    $PYTHON `which asv` check --python=same
     $PYTHON `which asv` machine --machine travis
     $PYTHON `which asv` dev 2>&1| tee asv-output.log
     if grep -q Traceback asv-output.log; then


### PR DESCRIPTION
Fix benchmark suite importability on Numpy<1.17.

In order to be able to reproduce historical results, the benchmark suite should be importable (and preferably also run) on as many Numpy versions as possible.

Also, add a CI check running `asv check` to lint the benchmark suite.