### PR TITLE
ENH: Support __length_hint__ in PyArray_FromIter

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -4008,7 +4008,16 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                 "Must specify length when using variable-size data-type.");
         goto done;
     }
-    elcount = (count < 0) ? 0 : count;
+    if (count < 0) {
+        elcount = PyObject_LengthHint(obj, 0);
+        if (elcount < 0) {
+            goto done;
+        }
+    }
+    else {
+        elcount = count;
+    }
+
     elsize = dtype->elsize;
 
     /*


### PR DESCRIPTION
This should avoid unecessary allocations when called on iterators that have a good guess of their length.

This API call has been supported since Python 3.4

Closes #13661

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
