### PR TITLE
BUG: Prevent passing of size 0 to array alloc C functions

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -218,6 +218,7 @@ PyDataMem_NEW(size_t size)
 {
     void *result;
 
+    assert(size != 0);
     result = malloc(size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
@@ -281,6 +282,7 @@ PyDataMem_RENEW(void *ptr, size_t size)
 {
     void *result;
 
+    assert(size != 0);
     result = realloc(ptr, size);
     if (result != ptr) {
         PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1516,6 +1516,9 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         char *valbuffer, *indbuffer;
         int *swaps;
 
+        if (N == 0 || maxelsize == 0 || sizeof(npy_intp) == 0) {
+            goto fail;
+        }
         valbuffer = PyDataMem_NEW(N * maxelsize);
         if (valbuffer == NULL) {
             goto fail;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2033,6 +2033,9 @@ array_setstate(PyArrayObject *self, PyObject *args)
         if (!IsAligned(self) || swap || (len <= 1000)) {
 #endif
             npy_intp num = PyArray_NBYTES(self);
+            if (num == 0) {
+                Py_RETURN_NONE;
+            }
             fa->data = PyDataMem_NEW(num);
             if (PyArray_DATA(self) == NULL) {
                 Py_DECREF(rawdata);
@@ -2076,7 +2079,12 @@ array_setstate(PyArrayObject *self, PyObject *args)
         }
     }
     else {
-        fa->data = PyDataMem_NEW(PyArray_NBYTES(self));
+        npy_intp num = PyArray_NBYTES(self);
+        int elsize = PyArray_DESCR(self)->elsize;
+        if (num == 0 || elsize == 0) {
+            Py_RETURN_NONE;
+        }
+        fa->data = PyDataMem_NEW(num);
         if (PyArray_DATA(self) == NULL) {
             return PyErr_NoMemory();
         }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -802,6 +802,9 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
                     return obj;
                 }
             }
+            if (itemsize == 0) {
+                return obj;
+            }
             destptr = PyDataMem_NEW(itemsize);
             if (destptr == NULL) {
                 Py_DECREF(obj);


### PR DESCRIPTION
Hi,
So this is my first bug fix attempt with core code,
I tried the approach of ensuring that size 0 is not passed to `PyDataMem_NEW` and `PyDataMem_RENEW`, both found in `core/multiarray/alloc.c`.
I looked up all the places in the code I could find that make calls to these functions and checked for size 0 explicitly, in that case the call to the alloc function will be skipped.
After that I used `assert(size != 0)` inside these functions to make any remaining calls fail.
In `ctors.c` I found code that uses "pass size 1 approach and make the allocation succeed". For consistency I changed it to skip as well.
I verified  that the existing tests pass on my machine:
```
numpy 1.17.0.dev0+d9ed18a
Python 3.6.8 (default, Dec 24 2018, 19:24:27) 
[GCC 5.4.0 20160609] on linux

```
See #13645

I'll appreciate any reviews, thanks!

