### PR TITLE
BUG: Ensure Windows choice returns int32

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -807,7 +807,9 @@ cdef class RandomState:
                 cdf /= cdf[-1]
                 uniform_samples = self.random_sample(shape)
                 idx = cdf.searchsorted(uniform_samples, side='right')
-                idx = np.array(idx, copy=False)  # searchsorted returns a scalar
+                # searchsorted returns a scalar
+                # force cast to int for LLP64
+                idx = np.array(idx, copy=False).astype(int, casting='unsafe')
             else:
                 idx = self.randint(0, pop_size, size=shape)
         else:
@@ -822,7 +824,7 @@ cdef class RandomState:
                     raise ValueError("Fewer non-zero entries in p than size")
                 n_uniq = 0
                 p = p.copy()
-                found = np.zeros(shape, dtype=np.int64)
+                found = np.zeros(shape, dtype=int)
                 flat_found = found.ravel()
                 while n_uniq < size:
                     x = self.rand(size - n_uniq)

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -170,3 +170,14 @@ class TestRegression(object):
         rs1 = np.random.RandomState(123456789)
         rs2 = np.random.RandomState(seed=123456789)
         assert rs1.randint(0, 100) == rs2.randint(0, 100)
+
+    def test_choice_retun_dtype(self):
+        # GH 9867
+        c = np.random.choice(10, p=[.1]*10, size=2)
+        assert c.dtype == np.dtype(int)
+        c = np.random.choice(10, p=[.1]*10, replace=False, size=2)
+        assert c.dtype == np.dtype(int)
+        c = np.random.choice(10, size=2)
+        assert c.dtype == np.dtype(int)
+        c = np.random.choice(10, replace=False, size=2)
+        assert c.dtype == np.dtype(int)


### PR DESCRIPTION
Downcast from searchsorted on Windows to ensure int32 is returned

closes #9867
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
