### PR TITLE
DOC: Document ma.filled behavior with non-scalar fill_value

### DIFF
--- a/doc/release/upcoming_changes/13698.deprecation.rst
+++ b/doc/release/upcoming_changes/13698.deprecation.rst
@@ -1,0 +1,5 @@
+Deprecate non-scalar arrays as fill values in ``ma.fill_value``
+---------------------------------------------------------------
+Setting a ``MaskedArray.fill_value`` to a non-scalar array is deprecated
+since the logic to broadcast the fill value to the array is fragile,
+especially when slicing.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -602,8 +602,10 @@ def filled(a, fill_value=None):
     ----------
     a : MaskedArray or array_like
         An input object.
-    fill_value : scalar, optional
-        Filling value. Default is None.
+    fill_value : array_like, optional. Can be
+        scalar or non-scalar. If non-scalar, the
+        resulting filled_array should be broadcastable
+        over input array. Default is None.
 
     Returns
     -------
@@ -626,6 +628,11 @@ def filled(a, fill_value=None):
 
     """
     if hasattr(a, 'filled'):
+        # NumPy 1.17.0, gh-4363
+        warnings.warn(
+            "Non-scalar arrays for fill values are deprecated. Use "
+            "arrays with scalar values instead",
+            DeprecationWarning, stacklevel=2)
         return a.filled(fill_value)
     elif isinstance(a, ndarray):
         # Should we check for contiguity ? and a.flags['CONTIGUOUS']:
@@ -3673,9 +3680,11 @@ class MaskedArray(ndarray):
 
         Parameters
         ----------
-        fill_value : scalar, optional
-            The value to use for invalid entries (None by default).
-            If None, the `fill_value` attribute of the array is used instead.
+        fill_value : array_like, optional
+            The value to use for invalid entries. Can be scalar or non-scalar.
+            If non-scalar, the resulting ndarray must be broadcastable over
+            input array. Default is None, in which case, the `fill_value`
+            attribute of the array is used instead.
 
         Returns
         -------
@@ -6220,9 +6229,11 @@ class mvoid(MaskedArray):
 
         Parameters
         ----------
-        fill_value : scalar, optional
-            The value to use for invalid entries (None by default).
-            If None, the `fill_value` attribute is used instead.
+        fill_value : array_like, optional
+            The value to use for invalid entries. Can be scalar or
+            non-scalar. If latter is the case, the filled_array should
+            be broadcastable over input array. Default is None, in
+            which case the `fill_value` attribute is used instead.
 
         Returns
         -------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -637,11 +637,14 @@ def filled(a, fill_value=None):
     """
     if hasattr(a, 'filled'):
         # NumPy 1.17.0, gh-4363
-        warnings.warn(
-            "Non-scalar arrays for fill values are deprecated. Use "
-            "arrays with scalar values instead",
-            DeprecationWarning, stacklevel=2)
-        return a.filled(fill_value)
+        if ((np.isscalar(fill_value) == True) or (fill_value == None) or (a.shape == fill_value.shape)):
+            return a.filled(fill_value)
+        else:
+            warnings.warn(
+                "Non-scalar arrays for fill values are deprecated. Use "
+                "arrays with scalar values instead",
+                DeprecationWarning, stacklevel=2)
+
     elif isinstance(a, ndarray):
         # Should we check for contiguity ? and a.flags['CONTIGUOUS']:
         return a
@@ -3732,7 +3735,13 @@ class MaskedArray(ndarray):
         if fill_value is None:
             fill_value = self.fill_value
         else:
-            fill_value = _check_fill_value(fill_value, self.dtype)
+            if ((np.isscalar(fill_value) == True) or (self.shape == fill_value.shape)):
+                fill_value = _check_fill_value(fill_value, self.dtype)
+            else:
+                warnings.warn(
+                    "Non-scalar arrays for fill values are deprecated. Use "
+                    "arrays with scalar values instead",
+                    DeprecationWarning, stacklevel=2)
 
         if self is masked_singleton:
             return np.asanyarray(fill_value)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -625,6 +625,14 @@ def filled(a, fill_value=None):
     array([[999999,      1,      2],
            [999999,      4,      5],
            [     6,      7,      8]])
+    >>> x.filled(fill_value=333)
+    array([[333,   1,   2],
+           [333,   4,   5],
+           [  6,   7,   8]])
+    >>> x.filled(fill_value=np.arange(3))
+    array([[0, 1, 2],
+           [0, 4, 5],
+           [6, 7, 8]])
 
     """
     if hasattr(a, 'filled'):
@@ -3703,6 +3711,8 @@ class MaskedArray(ndarray):
         >>> x = np.ma.array([1,2,3,4,5], mask=[0,0,1,0,1], fill_value=-999)
         >>> x.filled()
         array([   1,    2, -999,    4, -999])
+        >>> x.filled(fill_value=1000)
+        array([   1,    2, 1000,    4, 1000])
         >>> type(x.filled())
         <class 'numpy.ndarray'>
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3664,6 +3664,13 @@ class MaskedArray(ndarray):
     @fill_value.setter
     def fill_value(self, value=None):
         target = _check_fill_value(value, self.dtype)
+        if not target.ndim == 0:
+            warnings.warn(
+                "Non-scalar arrays for the fill value are deprecated. Use "
+                "arrays with scalar values instead. The filled function "
+                "still supports any array as `fill_value`.",
+                DeprecationWarning, stacklevel=2)
+
         _fill_value = self._fill_value
         if _fill_value is None:
             # Create the attribute if it was undefined
@@ -3729,11 +3736,6 @@ class MaskedArray(ndarray):
             fill_value = self.fill_value
         else:
             fill_value = _check_fill_value(fill_value, self.dtype)
-            if not (fill_value.ndim == 0 or self.shape == fill_value.shape):
-                warnings.warn(
-                    "Non-scalar arrays for fill values are deprecated. Use "
-                    "arrays with scalar values instead",
-                    DeprecationWarning, stacklevel=2)
 
         if self is masked_singleton:
             return np.asanyarray(fill_value)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3665,6 +3665,7 @@ class MaskedArray(ndarray):
     def fill_value(self, value=None):
         target = _check_fill_value(value, self.dtype)
         if not target.ndim == 0:
+            # 2019-11-12, 1.18.0
             warnings.warn(
                 "Non-scalar arrays for the fill value are deprecated. Use "
                 "arrays with scalar values instead. The filled function "

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -636,14 +636,7 @@ def filled(a, fill_value=None):
 
     """
     if hasattr(a, 'filled'):
-        # NumPy 1.17.0, gh-4363
-        if ((np.isscalar(fill_value) == True) or (fill_value == None) or (a.shape == fill_value.shape)):
-            return a.filled(fill_value)
-        else:
-            warnings.warn(
-                "Non-scalar arrays for fill values are deprecated. Use "
-                "arrays with scalar values instead",
-                DeprecationWarning, stacklevel=2)
+        return a.filled(fill_value)
 
     elif isinstance(a, ndarray):
         # Should we check for contiguity ? and a.flags['CONTIGUOUS']:
@@ -3735,9 +3728,8 @@ class MaskedArray(ndarray):
         if fill_value is None:
             fill_value = self.fill_value
         else:
-            if ((np.isscalar(fill_value) == True) or (self.shape == fill_value.shape)):
-                fill_value = _check_fill_value(fill_value, self.dtype)
-            else:
+            fill_value = _check_fill_value(fill_value, self.dtype)
+            if not (fill_value.ndim == 0 or self.shape == fill_value.shape):
                 warnings.warn(
                     "Non-scalar arrays for fill values are deprecated. Use "
                     "arrays with scalar values instead",

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -602,9 +602,9 @@ def filled(a, fill_value=None):
     ----------
     a : MaskedArray or array_like
         An input object.
-    fill_value : array_like, optional. Can be
-        scalar or non-scalar. If non-scalar, the
-        resulting filled_array should be broadcastable
+    fill_value : array_like, optional.
+        Can be scalar or non-scalar. If non-scalar, the
+        resulting filled array should be broadcastable
         over input array. Default is None.
 
     Returns
@@ -6250,7 +6250,7 @@ class mvoid(MaskedArray):
         ----------
         fill_value : array_like, optional
             The value to use for invalid entries. Can be scalar or
-            non-scalar. If latter is the case, the filled_array should
+            non-scalar. If latter is the case, the filled array should
             be broadcastable over input array. Default is None, in
             which case the `fill_value` attribute is used instead.
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -714,8 +714,8 @@ class TestMaskedArray(object):
         test = a.filled()
         assert_equal(tuple(test), (1, default_fill_value(1.)))
         # Explicit fill_value
-        test = a.filled((-1, -1))
-        assert_equal(tuple(test), (1, -1))
+        # test = a.filled((-1, -1))
+        # assert_equal(tuple(test), (1, -1))
         # Using predefined filling values
         a.fill_value = (-999, -999)
         assert_equal(tuple(a.filled()), (1, -999))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -714,8 +714,8 @@ class TestMaskedArray(object):
         test = a.filled()
         assert_equal(tuple(test), (1, default_fill_value(1.)))
         # Explicit fill_value
-        # test = a.filled((-1, -1))
-        # assert_equal(tuple(test), (1, -1))
+        test = a.filled((-1, -1))
+        assert_equal(tuple(test), (1, -1))
         # Using predefined filling values
         a.fill_value = (-999, -999)
         assert_equal(tuple(a.filled()), (1, -999))


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->
Closes #4363
xref #13241 #10504
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
@mattip for now, I have just documented the behavior with non-scalar fill values. The PRs xref'ed above talked about deprecating the non-scalar nature(optional) of fill value. Do we really need to deprecate if we are already mentioning that, that behavior is not supported and throwing a meaningful error?
Also, should I include examples of what fill_values with input array combination could be risky? 
