### PR TITLE
Add links for GitHub Sponsors button.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+tidelift: pypi/numpy
+custom: https://www.numpy.org/#support-numpy


### PR DESCRIPTION
This allows us to enable the new GitHub Sponsors feature. It links to our main page, where we have our donate button, and to Tidelift as the one standard platform we use that the Sponsors feature supports.

Here's a screenshot for the Bokeh repo, which has the Sponsors button enabled and a link showing up when you click on it:

<img width="549" alt="image" src="https://user-images.githubusercontent.com/98330/58759984-85bb1480-8532-11e9-9fa6-38e3891c5d5e.png">

I expect the Sponsors feature to become very widely known and used, so it may help drive contributions.