### PR TITLE
MAINT: fix use of cache_dim

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -73,7 +73,7 @@ array_shape_set(PyArrayObject *self, PyObject *val)
     ((PyArrayObject_fields *)self)->nd = nd;
     if (nd > 0) {
         /* create new dimensions and strides */
-        ((PyArrayObject_fields *)self)->dimensions = npy_alloc_cache_dim(3*nd);
+        ((PyArrayObject_fields *)self)->dimensions = npy_alloc_cache_dim(2 * nd);
         if (PyArray_DIMS(self) == NULL) {
             Py_DECREF(ret);
             PyErr_SetString(PyExc_MemoryError,"");

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2006,7 +2006,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
     fa->nd = nd;
 
     if (nd > 0) {
-        fa->dimensions = npy_alloc_cache_dim(3*nd);
+        fa->dimensions = npy_alloc_cache_dim(2 * nd);
         if (fa->dimensions == NULL) {
             return PyErr_NoMemory();
         }
@@ -2035,8 +2035,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
             npy_intp num = PyArray_NBYTES(self);
             fa->data = PyDataMem_NEW(num);
             if (PyArray_DATA(self) == NULL) {
-                fa->nd = 0;
-                npy_free_cache_dim_array(self);
                 Py_DECREF(rawdata);
                 return PyErr_NoMemory();
             }
@@ -2078,9 +2076,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
     else {
         fa->data = PyDataMem_NEW(PyArray_NBYTES(self));
         if (PyArray_DATA(self) == NULL) {
-            fa->nd = 0;
-            fa->data = PyDataMem_NEW(PyArray_DESCR(self)->elsize);
-            npy_free_cache_dim_array(self);
             return PyErr_NoMemory();
         }
         if (PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_NEEDS_INIT)) {


### PR DESCRIPTION
in #13691 I noticed the strange cleanup code used when unable to allocate the data memory. Setting `fa->nd = 0` was part of the original code, and at some point the `npy_free_cache_dim_array(self);` line was added. But

- setting `nd = 0`means the call to `npy_free_cache_dim_array(self);` could free the wrong cache chunk, and
- `npy_free_cache_dim_array(self);` is called anyway when deallocating `self`
so I think none of this is needed here.

It is hard to write tests for this, we need to fail to allocate data memory when unpickling.


Additionally, `npy_alloc_cache_dim(3 * nd)` is wrong, it should always be `2 * nd`.
