### PR TITLE
BUG: fix compilation of 3rd party modules with Py_LIMITED_API enabled

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -233,10 +233,10 @@ static NPY_INLINE int
 NPY_TITLE_KEY_check(PyObject *key, PyObject *value)
 {
     PyObject *title;
-    if (PyTuple_GET_SIZE(value) != 3) {
+    if (PyTuple_Size(value) != 3) {
         return 0;
     }
-    title = PyTuple_GET_ITEM(value, 2);
+    title = PyTuple_GetItem(value, 2);
     if (key == title) {
         return 1;
     }


### PR DESCRIPTION
There are no macros `PyTuple_GET_SIZE` and `PyTuple_GET_ITEM` available when compiling with enabled `Py_LIMITED_API`.

Breaking change has been made in PR #10860. Before the change these macros had been used only in `NPY_TITLE_KEY` macro and had not been compiled not used. After the change they have been moved to a function and now are always visible to compiler. Other projects using numpy C-API can not be compiled with `Py_LIMITED_API` macro enabled because of this problem.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
