### PR TITLE
WIP/DRAFT, MAINT: Do not use operand arrays in type resolving

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -152,6 +152,23 @@ class Scalar(Benchmark):
         (self.y + self.z)
 
 
+class MixedArrayScalar(Benchmark):
+    def setup(self):
+        self.ax = np.asarray([1.0])
+        self.ay = np.asarray([(1.0 + 1j)])
+        self.x = np.asarray(1.0)
+        self.z = complex(1.0, 1.0)
+
+    def time_add_scalar(self):
+        (self.ax + self.x)
+
+    def time_add_scalar_conv(self):
+        (self.ax + 1.0)
+
+    def time_add_scalar_conv_complex(self):
+        (self.ay + self.z)
+
+
 class ArgPack(object):
     __slots__ = ['args', 'kwargs']
     def __init__(self, *args, **kwargs):

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -155,12 +155,16 @@ class Scalar(Benchmark):
 class MixedArrayScalar(Benchmark):
     def setup(self):
         self.ax = np.asarray([1.0])
+        self.ax_float32 = np.asarray([1.0], dtype=np.float32)
         self.ay = np.asarray([(1.0 + 1j)])
         self.x = np.asarray(1.0)
         self.z = complex(1.0, 1.0)
 
     def time_add_scalar(self):
         (self.ax + self.x)
+
+    def time_add_scalar_min_scalar_logic(self):
+        (self.ax_float32 + self.x)
 
     def time_add_scalar_conv(self):
         (self.ax + 1.0)

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1126,8 +1126,8 @@ def make_ufuncs(funcdict):
 
         mlist.append(fmt.format(**args))
         if uf.typereso is not None:
-            mlist.append(
-                r"((PyUFuncObject *)f)->type_resolver = &%s;" % uf.typereso)
+            mlist.append(r"((PyUFuncObject *)f)->noops_type_resolver = &%s;" %
+                                uf.typereso)
         mlist.append(r"""PyDict_SetItemString(dictionary, "%s", f);""" % name)
         mlist.append(r"""Py_DECREF(f);""")
         code3list.append('\n'.join(mlist))

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1677,26 +1677,26 @@ PyArray_MinScalarType(PyArrayObject *arr)
  * determine when to use the min_scalar_type function. This groups
  * 'kind' into boolean, integer, floating point, and everything else.
  */
-static int
+NPY_NO_EXPORT int
 dtype_kind_to_simplified_ordering(char kind)
 {
     switch (kind) {
         /* Boolean kind */
         case 'b':
-            return 0;
+            return 1;
         /* Unsigned int kind */
         case 'u':
         /* Signed int kind */
         case 'i':
-            return 1;
+            return 2;
         /* Float kind */
         case 'f':
         /* Complex kind */
         case 'c':
-            return 2;
+            return 3;
         /* Anything else */
         default:
-            return 3;
+            return 4;
     }
 }
 

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -606,7 +606,7 @@ dtype_kind_to_ordering(char kind)
 }
 
 /* Converts a type number from unsigned to signed */
-static int
+NPY_NO_EXPORT int
 type_num_unsigned_to_signed(int type_num)
 {
     switch (type_num) {

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -47,4 +47,7 @@ type_num_unsigned_to_signed(int type_num);
 NPY_NO_EXPORT PyArray_Descr *
 PyArray_MinScalarType_internal(PyArrayObject *arr, int *is_small_unsigned);
 
+NPY_NO_EXPORT PyArray_Descr *
+PyArray_PromoteTypeSequence(PyArray_Descr **types, npy_intp ntypes);
+
 #endif

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -39,6 +39,9 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                             PyArray_Descr *flex_dtype);
 
 NPY_NO_EXPORT int
+dtype_kind_to_simplified_ordering(char kind);
+
+NPY_NO_EXPORT int
 type_num_unsigned_to_signed(int type_num);
 
 NPY_NO_EXPORT PyArray_Descr *

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -38,4 +38,10 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                             PyArray_Descr *flex_dtype);
 
+NPY_NO_EXPORT int
+type_num_unsigned_to_signed(int type_num);
+
+NPY_NO_EXPORT PyArray_Descr *
+PyArray_MinScalarType_internal(PyArrayObject *arr, int *is_small_unsigned);
+
 #endif

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1170,6 +1170,12 @@ _parse_signature_obj(PyUFuncObject *ufunc,
         }
         Py_XDECREF(str_obj);
     }
+    else {
+        // TODO: no test failed for this path missing (n_specified returned
+        //       uninitialized).
+        return -1;
+    }
+
     return n_specified;
 
 fail:
@@ -3771,7 +3777,7 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
          * resolution.
          * Behaviour is slightly strange but unused within numpy now.
          */
-        PyObject *type_tup;
+        PyObject *type_tup = NULL;
         if (odtype != NULL) {
             type_tup = PyTuple_Pack(3, odtype, odtype, Py_None);
             if (type_tup == NULL) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -518,9 +518,10 @@ _apply_array_wrap(
 
 
 /*
- * TODO: Refactor this to be reused by ResultType, which includes the same.
+ * TODO: Refactor this to be reused by ResultType, which includes the
+ *        same in convert_datatype.c lines 1742ff after `use_min_scalar = 0;`
  *
- * Checks if arrays (and "scalars"/O-d arrays) are in the same category.
+ * Checks if arrays (and "scalars"/0-d arrays) are in the same category.
  * If the arrays are in the same or a larger category, we allow demotion
  * of scalars to the lowest possible dtype.
  * In that case, it returns the category defined above. The integer
@@ -530,7 +531,7 @@ _apply_array_wrap(
 static int
 should_use_min_scalar(int nop, PyArrayObject **op)
 {
-    int i, use_min_scalar, kind;
+    int use_min_scalar;
     int all_scalars = 1, max_scalar_kind = -1, max_array_kind = -1;
 
     /*
@@ -540,8 +541,8 @@ should_use_min_scalar(int nop, PyArrayObject **op)
      */
     use_min_scalar = 0;
     if (nop > 1) {
-        for(i = 0; i < nop; ++i) {
-            kind = dtype_kind_to_simplified_ordering(
+        for (int i = 0; i < nop; ++i) {
+            int kind = dtype_kind_to_simplified_ordering(
                                 PyArray_DESCR(op[i])->kind);
             if (PyArray_NDIM(op[i]) == 0) {
                 if (kind > max_scalar_kind) {
@@ -3788,7 +3789,7 @@ reduce_type_resolver(PyUFuncObject *ufunc, PyArrayObject *arr,
         retcode = ufunc->type_resolver(
                             ufunc, NPY_UNSAFE_CASTING,
                             op, type_tup, dtypes);
-        Py_DECREF(type_tup);
+        Py_XDECREF(type_tup);
     }
     else {
         /*

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -572,7 +572,6 @@ should_use_min_scalar(int nop, PyArrayObject **op)
                 if (kind > max_array_kind) {
                     max_array_kind = kind;
                 }
-
             }
         }
 
@@ -1214,7 +1213,7 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
                     NPY_ORDER *out_order,
                     NPY_CASTING *out_casting,
                     PyObject **out_extobj,
-                    PyArray_Descr **specified_types,  /* specified dtypes */
+                    PyArray_Descr **specified_types,  /* specified dtypes must be NULL initialized */
                     int *out_subok,  /* bool */
                     PyArrayObject **out_wheremask, /* PyArray of bool */
                     PyObject **out_axes,  /* type: List[Tuple[T]] */
@@ -1434,9 +1433,6 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
                 PyErr_SetString(PyExc_RuntimeError,
                                 "cannot specify both 'signature' and 'dtype'");
                 goto fail;
-            }
-            for (i = 0; i < nop; i++) {
-                specified_types[i] = NULL;
             }
             specified_types[nin] = dtype;
         }
@@ -2924,7 +2920,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     /* Initialize all dtypes and __array_prepare__ call-backs to NULL */
     for (i = 0; i < nop; ++i) {
-        dtypes[i] = NULL;  // TODO: Right now not strictly necessary.
+        dtypes[i] = NULL;
         arr_prep[i] = NULL;
     }
     /* Initialize possibly variable parts to the values from the ufunc */

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -24,6 +24,7 @@
 #include "ufunc_type_resolution.h"
 #include "ufunc_object.h"
 #include "common.h"
+#include "convert_datatype.h"
 
 #include "mem_overlap.h"
 #if defined(HAVE_CBLAS)
@@ -529,15 +530,7 @@ PyUFunc_SimpleUniformOperationTypeResolver(
             out_dtypes[0] = ensure_dtype_nbo(op_dtypes[0]);
         }
         else {
-            // TODO: SHOULD USE PromoteTypeSequence, but crashes for me
-            //       for no apparent reason (runs fine in valgrind even)...
-            // out_dtypes[0] = PyArray_PromoteTypeSequence(op_dtypes, ufunc->nin);
-            if (ufunc->nin == 2) {
-                out_dtypes[0] = PyArray_PromoteTypes(op_dtypes[0], op_dtypes[1]);
-            }
-            else {
-                out_dtypes[0] = PyArray_ResultType(0, NULL, ufunc->nin, op_dtypes);
-            }
+            out_dtypes[0] = PyArray_PromoteTypeSequence(op_dtypes, ufunc->nin);
         }
         if (out_dtypes[0] == NULL) {
             return -1;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -574,12 +574,12 @@ PyUFunc_AbsoluteTypeResolver(PyUFuncObject *ufunc,
 {
     /* Use the default for complex types, to find the loop producing float */
     if (PyTypeNum_ISCOMPLEX(op_dtypes[0]->type_num)) {
-        return PyUFunc_DefaultTypeResolver(ufunc, casting, op_dtypes,
-                                           out_dtypes);
+        return PyUFunc_DefaultTypeResolver(
+                ufunc, casting, op_dtypes, out_dtypes);
     }
     else {
-        return PyUFunc_SimpleUniformOperationTypeResolver(ufunc, casting,
-                                                          op_dtypes, out_dtypes);
+        return PyUFunc_SimpleUniformOperationTypeResolver(
+                ufunc, casting, op_dtypes, out_dtypes);
     }
 }
 
@@ -690,7 +690,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
     /* TODO: Dtypes are currently simply ignored, this is nothing new... */
     for (i = 0; i < 3; i++) {
         Py_XDECREF(out_dtypes[i]); // TODO make a helper for such mini-loops?
-        out_dtypes[i] = 0;
+        out_dtypes[i] = NULL;
     }
 
     if (type_num1 == NPY_TIMEDELTA) {

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -74,7 +74,7 @@ npy_casting_to_string(NPY_CASTING casting)
  * Always returns -1 to indicate the exception was raised, for convenience
  */
 static int
-raise_binary_type_reso_error(PyUFuncObject *ufunc, PyArrayObject **operands) {
+raise_binary_type_reso_error(PyUFuncObject *ufunc, PyArray_Descr **op_dtypes) {
     static PyObject *exc_type = NULL;
     PyObject *exc_value;
 
@@ -86,11 +86,7 @@ raise_binary_type_reso_error(PyUFuncObject *ufunc, PyArrayObject **operands) {
     }
 
     /* produce an error object */
-    exc_value = Py_BuildValue(
-        "O(OO)", ufunc,
-        (PyObject *)PyArray_DESCR(operands[0]),
-        (PyObject *)PyArray_DESCR(operands[1])
-    );
+    exc_value = Py_BuildValue("O(OO)", ufunc, op_dtypes[0], op_dtypes[1]);
     if (exc_value == NULL){
         return -1;
     }

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -4,106 +4,91 @@
 NPY_NO_EXPORT int
 PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                                            NPY_CASTING casting,
-                                           PyArrayObject **operands,
-                                           PyObject *type_tup,
+                                           PyArray_Descr **op_dtypes,
                                            PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_OnesLikeTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_SimpleUniformOperationTypeResolver(PyUFuncObject *ufunc,
                                           NPY_CASTING casting,
-                                          PyArrayObject **operands,
-                                          PyObject *type_tup,
+                                          PyArray_Descr **op_dtypes,
                                           PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_AbsoluteTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
                           NPY_CASTING casting,
-                          PyArrayObject **operands,
-                          PyObject *type_tup,
+                          PyArray_Descr **op_dtypes,
                           PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_IsFiniteTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
                                 NPY_CASTING casting,
-                                PyArrayObject **operands,
-                                PyObject *type_tup,
+                                PyArray_Descr **op_dtypes,
                                 PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_MultiplicationTypeResolver(PyUFuncObject *ufunc,
                                    NPY_CASTING casting,
-                                   PyArrayObject **operands,
-                                   PyObject *type_tup,
+                                   PyArray_Descr **op_dtypes,
                                    PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_MixedDivisionTypeResolver(PyUFuncObject *ufunc,
                                   NPY_CASTING casting,
-                                  PyArrayObject **operands,
-                                  PyObject *type_tup,
+                                  PyArray_Descr **op_dtypes,
                                   PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_TrueDivisionTypeResolver(PyUFuncObject *ufunc,
                                  NPY_CASTING casting,
-                                 PyArrayObject **operands,
-                                 PyObject *type_tup,
+                                 PyArray_Descr **op_dtypes,
                                  PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
-                             PyArrayObject **operands,
-                             PyObject *type_tup,
+                             PyArray_Descr **op_dtypes,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_RemainderTypeResolver(PyUFuncObject *ufunc,
                               NPY_CASTING casting,
-                              PyArrayObject **operands,
-                              PyObject *type_tup,
+                              PyArray_Descr **op_dtypes,
                               PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_DivmodTypeResolver(PyUFuncObject *ufunc,
                               NPY_CASTING casting,
-                              PyArrayObject **operands,
-                              PyObject *type_tup,
+                              PyArray_Descr **op_dtypes,
                               PyArray_Descr **out_dtypes);
 
 /*
@@ -114,25 +99,11 @@ PyUFunc_DivmodTypeResolver(PyUFuncObject *ufunc,
  */
 NPY_NO_EXPORT int
 linear_search_type_resolver(PyUFuncObject *self,
-                            PyArrayObject **op,
+                            PyArray_Descr **op_dtypes,
                             NPY_CASTING input_casting,
-                            NPY_CASTING output_casting,
+                            NPY_CASTING casting,
                             int any_object,
-                            PyArray_Descr **out_dtype);
-
-/*
- * Does a linear search for the inner loop of the ufunc specified by type_tup.
- *
- * Note that if an error is returned, the caller must free the non-zero
- * references in out_dtype.  This function does not do its own clean-up.
- */
-NPY_NO_EXPORT int
-type_tuple_type_resolver(PyUFuncObject *self,
-                         PyObject *type_tup,
-                         PyArrayObject **op,
-                         NPY_CASTING casting,
-                         int any_object,
-                         PyArray_Descr **out_dtype);
+                            PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
 PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,


### PR DESCRIPTION
This is very drafty (although it seems to work). In the end, it is likely that this will just be a study case for me...
I am just putting it here, in case we wish to discuss it. Of course if we add a new type solver slot, it should maybe be hidden from public...

There basically two refactors inside this branch:
 1. The `type_tup` which is used when either `dtype=...` or `signature=...` is given is replaced by already filling in `out_dtype` before the `TypeResolver`. This seems nicer then passing around a tuple (that can sometimes be a string). It could in principle slightly change behaviour, because I fix the first output and not the first input for a single dtype.
There is one annoyance with it: Apparently we need to ensure NBO, which is currently still handled by overriding the `out_dtype` in type resolution (should be looked into). 

2. Pass dtypes instead of array objects into the TypeResolver functions. This requires figuring out the right dtypes in advance. It is strictly speaking not possible to capture the full logic in advance, though.

Other then that, removes some duplicate code. The result seems around 20% faster for small reductions, most other code is comparable or slightly faster (because they do not need to build that tuple probably).

----

Anyway, the first cleanup, seems reasonable to me in any case, although maybe not strictly necessary if we end up making a huge overhaul. Whether or not we can move out the scalar logic to early on, was the reason for my mail(s). Although, there is still the solution of completing the type hierarchy using `uint7` as a dtype that will never be used. 

TODO List before it could go anywhere:
 - [ ] General cleanup.
 - [ ] Decide on whether we can move the "scalar logic" to the beginning at all.
 - [ ] See what to do about the new slot (hiding?), and fix naming
 - [ ] Check test coverage, and coverage of "TODO" coments in code
 - [ ] Test against scipy/other downstream packages (especially if they may have more complex ufuncs)