### PR TITLE
DOC: Mention and try to explain pairwise summation in sum

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2122,9 +2122,9 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     >>> np.sum([])
     0.0
 
-    The numerical precision of sum (and ``np.add.reduce``) is in general
-    limited by directly adding each number individually to the result
-    causing rounding errors in every step.
+    For floating point numbers the numerical precision of sum (and
+    ``np.add.reduce``) is in general limited by directly adding each number
+    individually to the result causing rounding errors in every step.
     However, often numpy will use a  numerically better approach
     (pairwise summation) leading to improved precision in many use cases.
     This improved precision is always provided when no ``axis`` is given.
@@ -2132,8 +2132,8 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     Technically, to provide the best speed possible, the improved precision
     is only used when the summation is along the fast axis in memory.
     Note that the exact precision may vary depending on other parameters.
-    In contrast to NumPy, Python's ``sum`` function uses a slower but more
-    precise approach to summation.
+    In contrast to NumPy, Python's ``math.fsum`` function uses a slower but
+    more precise approach to summation.
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2125,8 +2125,8 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     For floating point numbers the numerical precision of sum (and
     ``np.add.reduce``) is in general limited by directly adding each number
     individually to the result causing rounding errors in every step.
-    However, often numpy will use a  numerically better approach
-    (pairwise summation) leading to improved precision in many use cases.
+    However, often numpy will use a  numerically better approach (partial
+    pairwise summation) leading to improved precision in many use-cases.
     This improved precision is always provided when no ``axis`` is given.
     When ``axis`` is given, it will depend on which axis is summed.
     Technically, to provide the best speed possible, the improved precision
@@ -2134,6 +2134,10 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     Note that the exact precision may vary depending on other parameters.
     In contrast to NumPy, Python's ``math.fsum`` function uses a slower but
     more precise approach to summation.
+    Especially when summing a large number of lower precision floating point
+    numbers, such as ``float32``, numerical errors can become significant.
+    In such cases it can be advisable to use `dtype="float64"` to use a higher
+    precision for the output.
 
     Examples
     --------

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2104,6 +2104,8 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     --------
     ndarray.sum : Equivalent method.
 
+    add.reduce : Equivalent functionality of `add`.
+
     cumsum : Cumulative sum of array elements.
 
     trapz : Integration of array values using the composite trapezoidal rule.
@@ -2119,6 +2121,19 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
 
     >>> np.sum([])
     0.0
+
+    The numerical precision of sum (and ``np.add.reduce``) is in general
+    limited by directly adding each number individually to the result
+    causing rounding errors in every step.
+    However, often numpy will use a  numerically better approach
+    (pairwise summation) leading to improved precision in many use cases.
+    This improved precision is always provided when no ``axis`` is given.
+    When ``axis`` is given, it will depend on which axis is summed.
+    Technically, to provide the best speed possible, the improved precision
+    is only used when the summation is along the fast axis in memory.
+    Note that the exact precision may vary depending on other parameters.
+    In contrast to NumPy, Python's ``sum`` function uses a slower but more
+    precise approach to summation.
 
     Examples
     --------


### PR DESCRIPTION
Note that this behavour is of course inherited into `np.add.reduce` and
many other reductions such as `mean` or users of this reduction, such
as `cov`. This is ignored here.

Closes gh-11331, gh-9393, gh-13734

---

To be honest, not sure I am too happy with it, but it is one of those things that comes up every couple of months.