### PR TITLE
ENH: Add project URLs to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -370,6 +370,10 @@ def setup_package():
         url = "https://www.numpy.org",
         author = "Travis E. Oliphant et al.",
         download_url = "https://pypi.python.org/pypi/numpy",
+        project_urls={
+            "Bug Tracker": "https://github.com/numpy/numpy/issues",
+            "Source Code": "https://github.com/numpy/numpy",
+        },
         license = 'BSD',
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],


### PR DESCRIPTION
This backports the addition of project URLs (see #13310) to the 1.16.x branch. I've removed the docs URL as it would need to be dynamically generated with the version number, and it appears not all versions have a docs page.

Having these links will help apps like Dependabot and Pyup find this repo when creating PRs that update numpy.