### PR TITLE
MAINT: Use textwrap.dedent for multiline strings

### DIFF
--- a/numpy/distutils/command/autodist.py
+++ b/numpy/distutils/command/autodist.py
@@ -3,23 +3,24 @@
 """
 from __future__ import division, absolute_import, print_function
 
+import textwrap
 
 # We put them here since they could be easily reused outside numpy.distutils
 
 def check_inline(cmd):
     """Return the inline identifier (may be empty)."""
     cmd._check_compiler()
-    body = """
-#ifndef __cplusplus
-static %(inline)s int static_func (void)
-{
-    return 0;
-}
-%(inline)s int nostatic_func (void)
-{
-    return 0;
-}
-#endif"""
+    body = textwrap.dedent("""
+        #ifndef __cplusplus
+        static %(inline)s int static_func (void)
+        {
+            return 0;
+        }
+        %(inline)s int nostatic_func (void)
+        {
+            return 0;
+        }
+        #endif""")
 
     for kw in ['inline', '__inline__', '__inline']:
         st = cmd.try_compile(body % {'inline': kw}, None, None)
@@ -28,15 +29,16 @@ static %(inline)s int static_func (void)
 
     return ''
 
+
 def check_restrict(cmd):
     """Return the restrict identifier (may be empty)."""
     cmd._check_compiler()
-    body = """
-static int static_func (char * %(restrict)s a)
-{
-    return 0;
-}
-"""
+    body = textwrap.dedent("""
+        static int static_func (char * %(restrict)s a)
+        {
+            return 0;
+        }
+        """)
 
     for kw in ['restrict', '__restrict__', '__restrict']:
         st = cmd.try_compile(body % {'restrict': kw}, None, None)
@@ -45,72 +47,76 @@ static int static_func (char * %(restrict)s a)
 
     return ''
 
+
 def check_compiler_gcc4(cmd):
     """Return True if the C compiler is GCC 4.x."""
     cmd._check_compiler()
-    body = """
-int
-main()
-{
-#if (! defined __GNUC__) || (__GNUC__ < 4)
-#error gcc >= 4 required
-#endif
-    return 0;
-}
-"""
+    body = textwrap.dedent("""
+        int
+        main()
+        {
+        #if (! defined __GNUC__) || (__GNUC__ < 4)
+        #error gcc >= 4 required
+        #endif
+            return 0;
+        }
+        """)
     return cmd.try_compile(body, None, None)
 
 
 def check_gcc_function_attribute(cmd, attribute, name):
     """Return True if the given function attribute is supported."""
     cmd._check_compiler()
-    body = """
-#pragma GCC diagnostic error "-Wattributes"
-#pragma clang diagnostic error "-Wattributes"
+    body = textwrap.dedent("""
+        #pragma GCC diagnostic error "-Wattributes"
+        #pragma clang diagnostic error "-Wattributes"
 
-int %s %s(void*);
+        int %s %s(void*);
 
-int
-main()
-{
-    return 0;
-}
-""" % (attribute, name)
+        int
+        main()
+        {
+            return 0;
+        }
+        """) % (attribute, name)
     return cmd.try_compile(body, None, None) != 0
+
 
 def check_gcc_function_attribute_with_intrinsics(cmd, attribute, name, code,
                                                 include):
     """Return True if the given function attribute is supported with
     intrinsics."""
     cmd._check_compiler()
-    body = """
-#include<%s>
-int %s %s(void)
-{
-    %s;
-    return 0;
-}
+    body = textwrap.dedent("""
+        #include<%s>
+        int %s %s(void)
+        {
+            %s;
+            return 0;
+        }
 
-int
-main()
-{
-    return 0;
-}
-""" % (include, attribute, name, code)
+        int
+        main()
+        {
+            return 0;
+        }
+        """) % (include, attribute, name, code)
     return cmd.try_compile(body, None, None) != 0
+
+
 def check_gcc_variable_attribute(cmd, attribute):
     """Return True if the given variable attribute is supported."""
     cmd._check_compiler()
-    body = """
-#pragma GCC diagnostic error "-Wattributes"
-#pragma clang diagnostic error "-Wattributes"
+    body = textwrap.dedent("""
+        #pragma GCC diagnostic error "-Wattributes"
+        #pragma clang diagnostic error "-Wattributes"
 
-int %s foo;
+        int %s foo;
 
-int
-main()
-{
-    return 0;
-}
-""" % (attribute, )
+        int
+        main()
+        {
+            return 0;
+        }
+        """) % (attribute, )
     return cmd.try_compile(body, None, None) != 0

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -8,6 +8,7 @@ import os, signal
 import warnings
 import sys
 import subprocess
+import textwrap
 
 from distutils.command.config import config as old_config
 from distutils.command.config import LANG_EXT
@@ -53,18 +54,18 @@ class config(old_config):
                     self.compiler.initialize()
                 except IOError:
                     e = get_exception()
-                    msg = """\
-Could not initialize compiler instance: do you have Visual Studio
-installed?  If you are trying to build with MinGW, please use "python setup.py
-build -c mingw32" instead.  If you have Visual Studio installed, check it is
-correctly installed, and the right version (VS 2008 for python 2.6, 2.7 and 3.2,
-VS 2010 for >= 3.3).
+                    msg = textwrap.dedent("""\
+                        Could not initialize compiler instance: do you have Visual Studio
+                        installed?  If you are trying to build with MinGW, please use "python setup.py
+                        build -c mingw32" instead.  If you have Visual Studio installed, check it is
+                        correctly installed, and the right version (VS 2008 for python 2.6, 2.7 and 3.2,
+                        VS 2010 for >= 3.3).
 
-Original exception was: %s, and the Compiler class was %s
-============================================================================""" \
+                        Original exception was: %s, and the Compiler class was %s
+                        ============================================================================""") \
                         % (e, self.compiler.__class__.__name__)
-                    print ("""\
-============================================================================""")
+                    print(textwrap.dedent("""\
+                        ============================================================================"""))
                     raise distutils.errors.DistutilsPlatformError(msg)
 
             # After MSVC is initialized, add an explicit /MANIFEST to linker
@@ -173,31 +174,31 @@ Original exception was: %s, and the Compiler class was %s
     def check_decl(self, symbol,
                    headers=None, include_dirs=None):
         self._check_compiler()
-        body = """
-int main(void)
-{
-#ifndef %s
-    (void) %s;
-#endif
-    ;
-    return 0;
-}""" % (symbol, symbol)
+        body = textwrap.dedent("""
+            int main(void)
+            {
+            #ifndef %s
+                (void) %s;
+            #endif
+                ;
+                return 0;
+            }""") % (symbol, symbol)
 
         return self.try_compile(body, headers, include_dirs)
 
     def check_macro_true(self, symbol,
                          headers=None, include_dirs=None):
         self._check_compiler()
-        body = """
-int main(void)
-{
-#if %s
-#else
-#error false or undefined macro
-#endif
-    ;
-    return 0;
-}""" % (symbol,)
+        body = textwrap.dedent("""
+            int main(void)
+            {
+            #if %s
+            #else
+            #error false or undefined macro
+            #endif
+                ;
+                return 0;
+            }""") % (symbol,)
 
         return self.try_compile(body, headers, include_dirs)
 
@@ -208,14 +209,14 @@ int main(void)
         self._check_compiler()
 
         # First check the type can be compiled
-        body = r"""
-int main(void) {
-  if ((%(name)s *) 0)
-    return 0;
-  if (sizeof (%(name)s))
-    return 0;
-}
-""" % {'name': type_name}
+        body = textwrap.dedent(r"""
+            int main(void) {
+              if ((%(name)s *) 0)
+                return 0;
+              if (sizeof (%(name)s))
+                return 0;
+            }
+            """) % {'name': type_name}
 
         st = False
         try:
@@ -235,33 +236,33 @@ int main(void) {
         self._check_compiler()
 
         # First check the type can be compiled
-        body = r"""
-typedef %(type)s npy_check_sizeof_type;
-int main (void)
-{
-    static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) >= 0)];
-    test_array [0] = 0
+        body = textwrap.dedent(r"""
+            typedef %(type)s npy_check_sizeof_type;
+            int main (void)
+            {
+                static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) >= 0)];
+                test_array [0] = 0
 
-    ;
-    return 0;
-}
-"""
+                ;
+                return 0;
+            }
+            """)
         self._compile(body % {'type': type_name},
                 headers, include_dirs, 'c')
         self._clean()
 
         if expected:
-            body = r"""
-typedef %(type)s npy_check_sizeof_type;
-int main (void)
-{
-    static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) == %(size)s)];
-    test_array [0] = 0
+            body = textwrap.dedent(r"""
+                typedef %(type)s npy_check_sizeof_type;
+                int main (void)
+                {
+                    static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) == %(size)s)];
+                    test_array [0] = 0
 
-    ;
-    return 0;
-}
-"""
+                    ;
+                    return 0;
+                }
+                """)
             for size in expected:
                 try:
                     self._compile(body % {'type': type_name, 'size': size},
@@ -272,17 +273,17 @@ int main (void)
                     pass
 
         # this fails to *compile* if size > sizeof(type)
-        body = r"""
-typedef %(type)s npy_check_sizeof_type;
-int main (void)
-{
-    static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) <= %(size)s)];
-    test_array [0] = 0
+        body = textwrap.dedent(r"""
+            typedef %(type)s npy_check_sizeof_type;
+            int main (void)
+            {
+                static int test_array [1 - 2 * !(((long) (sizeof (npy_check_sizeof_type))) <= %(size)s)];
+                test_array [0] = 0
 
-    ;
-    return 0;
-}
-"""
+                ;
+                return 0;
+            }
+            """)
 
         # The principle is simple: we first find low and high bounds of size
         # for the type, where low/high are looked up on a log scale. Then, we

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -13,6 +13,7 @@ import os
 import sys
 import subprocess
 import re
+import textwrap
 
 # Overwrite certain distutils.ccompiler functions:
 import numpy.distutils.ccompiler
@@ -571,21 +572,21 @@ def msvc_manifest_xml(maj, min):
     # embedded in the binary...
     # This template was copied directly from the python 2.6 binary (using
     # strings.exe from mingw on python.exe).
-    template = """\
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity type="win32" name="Microsoft.VC%(maj)d%(min)d.CRT" version="%(fullver)s" processorArchitecture="*" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
-    </dependentAssembly>
-  </dependency>
-</assembly>"""
+    template = textwrap.dedent("""\
+        <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+          <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+            <security>
+              <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+              </requestedPrivileges>
+            </security>
+          </trustInfo>
+          <dependency>
+            <dependentAssembly>
+              <assemblyIdentity type="win32" name="Microsoft.VC%(maj)d%(min)d.CRT" version="%(fullver)s" processorArchitecture="*" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
+            </dependentAssembly>
+          </dependency>
+        </assembly>""")
 
     return template % {'fullver': fullver, 'maj': maj, 'min': min}
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -128,6 +128,7 @@ import re
 import copy
 import warnings
 import subprocess
+import textwrap
 
 from glob import glob
 from functools import reduce
@@ -1224,11 +1225,11 @@ class atlas_info(system_info):
         else:
             dict_append(info, **atlas)
             dict_append(info, define_macros=[('ATLAS_WITHOUT_LAPACK', None)])
-            message = """
-*********************************************************************
-    Could not find lapack library within the ATLAS installation.
-*********************************************************************
-"""
+            message = textwrap.dedent("""
+                *********************************************************************
+                    Could not find lapack library within the ATLAS installation.
+                *********************************************************************
+                """)
             warnings.warn(message, stacklevel=2)
             self.set_info(**info)
             return
@@ -1251,15 +1252,15 @@ class atlas_info(system_info):
         if lapack_lib is not None:
             sz = os.stat(lapack_lib)[6]
             if sz <= 4000 * 1024:
-                message = """
-*********************************************************************
-    Lapack library (from ATLAS) is probably incomplete:
-      size of %s is %sk (expected >4000k)
+                message = textwrap.dedent("""
+                    *********************************************************************
+                        Lapack library (from ATLAS) is probably incomplete:
+                          size of %s is %sk (expected >4000k)
 
-    Follow the instructions in the KNOWN PROBLEMS section of the file
-    numpy/INSTALL.txt.
-*********************************************************************
-""" % (lapack_lib, sz / 1024)
+                        Follow the instructions in the KNOWN PROBLEMS section of the file
+                        numpy/INSTALL.txt.
+                    *********************************************************************
+                    """) % (lapack_lib, sz / 1024)
                 warnings.warn(message, stacklevel=2)
             else:
                 info['language'] = 'f77'
@@ -1537,16 +1538,16 @@ def get_atlas_version(**config):
                                 library_dirs=library_dirs,
                                 use_tee=(system_info.verbosity > 0))
             if not s:
-                warnings.warn("""
-*****************************************************
-Linkage with ATLAS requires gfortran. Use
+                warnings.warn(textwrap.dedent("""
+                    *****************************************************
+                    Linkage with ATLAS requires gfortran. Use
 
-  python setup.py config_fc --fcompiler=gnu95 ...
+                      python setup.py config_fc --fcompiler=gnu95 ...
 
-when building extension libraries that use ATLAS.
-Make sure that -lgfortran is used for C++ extensions.
-*****************************************************
-""", stacklevel=2)
+                    when building extension libraries that use ATLAS.
+                    Make sure that -lgfortran is used for C++ extensions.
+                    *****************************************************
+                    """), stacklevel=2)
                 dict_append(info, language='f90',
                             define_macros=[('ATLAS_REQUIRES_GFORTRAN', None)])
     except Exception:  # failed to get version from file -- maybe on Windows
@@ -1874,13 +1875,14 @@ class blas_info(system_info):
         # cblas or blas
         c = customized_ccompiler()
         tmpdir = tempfile.mkdtemp()
-        s = """#include <cblas.h>
-        int main(int argc, const char *argv[])
-        {
-            double a[4] = {1,2,3,4};
-            double b[4] = {5,6,7,8};
-            return cblas_ddot(4, a, 1, b, 1) > 10;
-        }"""
+        s = textwrap.dedent("""\
+            #include <cblas.h>
+            int main(int argc, const char *argv[])
+            {
+                double a[4] = {1,2,3,4};
+                double b[4] = {5,6,7,8};
+                return cblas_ddot(4, a, 1, b, 1) > 10;
+            }""")
         src = os.path.join(tmpdir, 'source.c')
         try:
             with open(src, 'wt') as f:
@@ -1999,12 +2001,13 @@ class openblas_lapack_info(openblas_info):
         c = customized_ccompiler()
 
         tmpdir = tempfile.mkdtemp()
-        s = """void zungqr_();
-        int main(int argc, const char *argv[])
-        {
-            zungqr_();
-            return 0;
-        }"""
+        s = textwrap.dedent("""\
+            void zungqr_();
+            int main(int argc, const char *argv[])
+            {
+                zungqr_();
+                return 0;
+            }""")
         src = os.path.join(tmpdir, 'source.c')
         out = os.path.join(tmpdir, 'a.out')
         # Add the additional "extra" arguments
@@ -2074,12 +2077,13 @@ class flame_info(system_info):
         c = customized_ccompiler()
 
         tmpdir = tempfile.mkdtemp()
-        s = """void zungqr_();
-        int main(int argc, const char *argv[])
-        {
-            zungqr_();
-            return 0;
-        }"""
+        s = textwrap.dedent("""\
+            void zungqr_();
+            int main(int argc, const char *argv[])
+            {
+                zungqr_();
+                return 0;
+            }""")
         src = os.path.join(tmpdir, 'source.c')
         out = os.path.join(tmpdir, 'a.out')
         # Add the additional "extra" arguments


### PR DESCRIPTION
This makes it easier to visually jump between functions.

A couple places have changed to not emit leading whitespace where they previously did. Since this is C code and not fortran, that doesn't matter.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
