### PR TITLE
BUILD: use numpy-wheels/openblas_support.py to create _distributor_init.py

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,6 +172,10 @@ jobs:
       architecture: $(PYTHON_ARCH)
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
+  - script: python -m pip install cython nose pytz pytest
+    displayName: 'Install dependencies; some are optional to avoid test skips'
+  - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
+    displayName: 'Install optional pickle5 backport (only for python3.6 and 3.7)'
   - powershell: |
       $wc = New-Object net.webclient
       $wc.Downloadfile("$(OPENBLAS)", "openblas.zip")
@@ -187,12 +191,15 @@ jobs:
       choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
-  - script: python -m pip install cython nose pytz pytest
-    displayName: 'Install dependencies; some are optional to avoid test skips'
+  - powershell: |
+      $wc = New-Object net.webclient
+      $gh_base = "https://raw.githubusercontent.com/MacPython/numpy-wheels/master/"
+      $wc.Downloadfile($gh_base + "openblas_support.py", "$pwd\openblas_support.py")
+      python -c "import openblas_support; openblas_support.make_init('numpy')"
+      del openblas_support.py
+    displayName: 'Create _distributor_init.py for OpenBlas'
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
   # vs. manual setup.py and then runtests.py for testing only
-  - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
-    displayName: 'Install optional pickle5 backport (only for python3.6 and 3.7)'
   - powershell: |
       If ($(BITS) -eq 32) {
          $env:NPY_DISTUTILS_APPEND_FLAGS = 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,13 +191,6 @@ jobs:
       choco install -y mingw --forcex86 --force --version=5.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
-  - powershell: |
-      $wc = New-Object net.webclient
-      $gh_base = "https://raw.githubusercontent.com/MacPython/numpy-wheels/master/"
-      $wc.Downloadfile($gh_base + "openblas_support.py", "$pwd\openblas_support.py")
-      python -c "import openblas_support; openblas_support.make_init('numpy')"
-      del openblas_support.py
-    displayName: 'Create _distributor_init.py for OpenBlas'
   # NOTE: for Windows builds it seems much more tractable to use runtests.py
   # vs. manual setup.py and then runtests.py for testing only
   - powershell: |
@@ -208,6 +201,7 @@ jobs:
          $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
          refreshenv
       }
+      python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
       pip wheel -v -v -v --wheel-dir=dist .
 
       ls dist -r | Foreach-Object {

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -5,29 +5,6 @@ from numpy.version import version as __version__
 
 import os
 
-# on Windows NumPy loads an important OpenBLAS-related DLL
-# and the code below aims to alleviate issues with DLL
-# path resolution portability with an absolute path DLL load
-if os.name == 'nt':
-    from ctypes import WinDLL
-    import glob
-    # convention for storing / loading the DLL from
-    # numpy/.libs/, if present
-    libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                             '..', '.libs'))
-    DLL_filenames = []
-    if os.path.isdir(libs_path):
-        for filename in glob.glob(os.path.join(libs_path, '*openblas*dll')):
-            # NOTE: would it change behavior to load ALL
-            # DLLs at this path vs. the name restriction?
-            WinDLL(os.path.abspath(filename))
-            DLL_filenames.append(filename)
-    if len(DLL_filenames) > 1:
-        import warnings
-        warnings.warn("loaded more than 1 DLL from .libs:\n%s" %
-                      "\n".join(DLL_filenames),
-                      stacklevel=1)
-
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core
 env_added = []

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -1,0 +1,42 @@
+import os
+import textwrap
+
+def make_init(dirname):
+    '''
+    Create a _distributor_init.py file for OpenBlas
+    '''
+    with open(os.path.join(dirname, '_distributor_init.py'), 'wt') as fid:
+        fid.write(textwrap.dedent("""
+            '''
+            Helper to preload windows dlls to prevent dll not found errors.
+            Once a DLL is preloaded, its namespace is made available to any
+            subsequent DLL. This file originated in the numpy-wheels repo,
+            and is created as part of the scripts that build the wheel.
+            '''
+            import os
+            from ctypes import WinDLL
+            import glob
+            if os.name == 'nt':
+                # convention for storing / loading the DLL from
+                # numpy/.libs/, if present
+                try:
+                    basedir = os.path.dirname(__file__)
+                except:
+                    pass
+                else:
+                    libs_dir = os.path.abspath(os.path.join(basedir, '.libs'))
+                    DLL_filenames = []
+                    if os.path.isdir(libs_dir):
+                        for filename in glob.glob(os.path.join(libs_dir,
+                                                             '*openblas*dll')):
+                            # NOTE: would it change behavior to load ALL
+                            # DLLs at this path vs. the name restriction?
+                            WinDLL(os.path.abspath(filename))
+                            DLL_filenames.append(filename)
+                if len(DLL_filenames) > 1:
+                    import warnings
+                    warnings.warn("loaded more than 1 DLL from .libs:\\n%s" %
+                              "\\n".join(DLL_filenames),
+                              stacklevel=1)
+    """))
+


### PR DESCRIPTION
WIP until ~MacPython/numpy-wheels#50 is merged~ MacPython/numpy-wheels#49 is fixed since it downloads the file from there to copy wheel-building behaviour (on windows CI runs only).

Fixes #13764, reverts parts of #13019