### PR TITLE
BUG: Make ``Generator._masked`` flag default to ``False``.

### DIFF
--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -439,7 +439,7 @@ cdef class Generator:
         # Implementation detail: the old API used a masked method to generate
         # bounded uniform integers. Lemire's method is preferable since it is
         # faster. randomgen allows a choice, we will always use the faster one.
-        cdef bint _masked = True
+        cdef bint _masked = False
 
         if key == 'int32':
             ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -21,19 +21,19 @@ def endpoint(request):
 class TestSeed(object):
     def test_scalar(self):
         s = Generator(MT19937(0))
-        assert_equal(s.integers(1000), 548)  # 684
+        assert_equal(s.integers(1000), 548)
         s = Generator(MT19937(4294967295))
-        assert_equal(s.integers(1000), 97)  # 419)
+        assert_equal(s.integers(1000), 97)
 
     def test_array(self):
         s = Generator(MT19937(range(10)))
-        assert_equal(s.integers(1000), 410)  # 468)
+        assert_equal(s.integers(1000), 410)
         s = Generator(MT19937(np.arange(10)))
-        assert_equal(s.integers(1000), 410)  # 468)
+        assert_equal(s.integers(1000), 410)
         s = Generator(MT19937([0]))
-        assert_equal(s.integers(1000), 844)  # 973)
+        assert_equal(s.integers(1000), 844)
         s = Generator(MT19937([4294967295]))
-        assert_equal(s.integers(1000), 635)  # 265)
+        assert_equal(s.integers(1000), 635)
 
     def test_invalid_scalar(self):
         # seed must be an unsigned 32 bit integer
@@ -324,14 +324,14 @@ class TestIntegers(object):
         # in the range [0, 6) for all but bool, where the range
         # is [0, 2). Hashes are for little endian numbers.
         tgt = {'bool': '7dd3170d7aa461d201a65f8bcf3944b0',
-               'int16': '2d26cafb53cb0f5acbb9b3fe86b36991',  # '1b7741b80964bb190c50d541dca1cac1',
-               'int32': '54f153d6ae944ce0dde49a66602959bb',  # '4dc9fcc2b395577ebb51793e58ed1a05',
-               'int64': '47a068f62fda47f6034aa745e39a1b0d',  # '17db902806f448331b5a758d7d2ee672',
-               'int8': '1d71d3947cd98598b4f00a77c117d62a',  # '27dd30c4e08a797063dffac2490b0be6',
-               'uint16': '2d26cafb53cb0f5acbb9b3fe86b36991',  # '1b7741b80964bb190c50d541dca1cac1',
-               'uint32': '54f153d6ae944ce0dde49a66602959bb',  # '4dc9fcc2b395577ebb51793e58ed1a05',
-               'uint64': '47a068f62fda47f6034aa745e39a1b0d',  # '17db902806f448331b5a758d7d2ee672',
-               'uint8': '1d71d3947cd98598b4f00a77c117d62a'}  # '27dd30c4e08a797063dffac2490b0be6'}
+               'int16': '2d26cafb53cb0f5acbb9b3fe86b36991',
+               'int32': '54f153d6ae944ce0dde49a66602959bb',
+               'int64': '47a068f62fda47f6034aa745e39a1b0d',
+               'int8': '1d71d3947cd98598b4f00a77c117d62a',
+               'uint16': '2d26cafb53cb0f5acbb9b3fe86b36991',
+               'uint32': '54f153d6ae944ce0dde49a66602959bb',
+               'uint64': '47a068f62fda47f6034aa745e39a1b0d',
+               'uint8': '1d71d3947cd98598b4f00a77c117d62a'}
 
         for dt in self.itype[1:]:
             random.bit_generator.seed(1234)
@@ -345,8 +345,6 @@ class TestIntegers(object):
                                  dtype=dt).byteswap()
 
             res = hashlib.md5(val.view(np.int8)).hexdigest()
-            print("res =", res)
-            print("tgt[np.dtype(dt).name] =", tgt[np.dtype(dt).name])
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianness
@@ -354,8 +352,6 @@ class TestIntegers(object):
         val = self.rfunc(0, 2 - endpoint, size=1000, endpoint=endpoint,
                          dtype=bool).view(np.int8)
         res = hashlib.md5(val).hexdigest()
-        print("res =", res)
-        print("tgt[np.dtype(bool).name] =", tgt[np.dtype(bool).name])
         assert_(tgt[np.dtype(bool).name] == res)
 
     def test_repeatability_broadcasting(self, endpoint):
@@ -486,6 +482,7 @@ class TestIntegers(object):
         with pytest.raises(ValueError):
             random.integers(0, 200, size=10, dtype=other_byteord_dt)
 
+
 class TestRandomDist(object):
     # Make sure the random distribution returns the correct value for a
     # given seed
@@ -498,7 +495,7 @@ class TestRandomDist(object):
         actual = random.integers(-99, 99, size=(3, 2))
         desired = np.array([[23, -32],
                             [18, -70],
-                            [76, -53]])  # [[31, 3], [-52, 41], [-48, -66]]
+                            [76, -53]])
         assert_array_equal(actual, desired)
 
     def test_integers_masked(self):
@@ -508,13 +505,13 @@ class TestRandomDist(object):
         actual = random.integers(0, 99, size=(3, 2), dtype=np.uint32)
         desired = np.array([[61, 33],
                             [58, 14],
-                            [87, 23]], dtype=np.uint32)  # [[2, 47], [12, 51], [33, 43]]
+                            [87, 23]], dtype=np.uint32)
         assert_array_equal(actual, desired)
 
     def test_integers_closed(self):
         random.bit_generator.seed(self.seed)
         actual = random.integers(-99, 99, size=(3, 2), endpoint=True)
-        desired = np.array([[24, -32], [18, -70], [77, -53]])  # [[31, 3], [-52, 41], [-48, -66]]
+        desired = np.array([[24, -32], [18, -70], [77, -53]])
         assert_array_equal(actual, desired)
 
     def test_integers_max_int(self):
@@ -561,7 +558,7 @@ class TestRandomDist(object):
     def test_choice_uniform_replace(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice(4, 4)
-        desired = np.array([2, 1, 2, 0], dtype=np.int64)  # [2, 3, 2, 3]
+        desired = np.array([2, 1, 2, 0], dtype=np.int64)
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
@@ -585,19 +582,19 @@ class TestRandomDist(object):
     def test_choice_noninteger(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice(['a', 'b', 'c', 'd'], 4)
-        desired = np.array(['c', 'b', 'c', 'a'])  # ['c', 'd', 'c', 'd']
+        desired = np.array(['c', 'b', 'c', 'a'])
         assert_array_equal(actual, desired)
 
     def test_choice_multidimensional_default_axis(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 3)
-        desired = np.array([[4, 5], [2, 3], [4, 5]])  # [[4, 5], [6, 7], [4, 5]]
+        desired = np.array([[4, 5], [2, 3], [4, 5]])
         assert_array_equal(actual, desired)
 
     def test_choice_multidimensional_custom_axis(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 1, axis=1)
-        desired = np.array([[1], [3], [5], [7]])  # [[0], [2], [4], [6]]
+        desired = np.array([[1], [3], [5], [7]])
         assert_array_equal(actual, desired)
 
     def test_choice_exceptions(self):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -21,19 +21,19 @@ def endpoint(request):
 class TestSeed(object):
     def test_scalar(self):
         s = Generator(MT19937(0))
-        assert_equal(s.integers(1000), 684)
+        assert_equal(s.integers(1000), 548)  # 684
         s = Generator(MT19937(4294967295))
-        assert_equal(s.integers(1000), 419)
+        assert_equal(s.integers(1000), 97)  # 419)
 
     def test_array(self):
         s = Generator(MT19937(range(10)))
-        assert_equal(s.integers(1000), 468)
+        assert_equal(s.integers(1000), 410)  # 468)
         s = Generator(MT19937(np.arange(10)))
-        assert_equal(s.integers(1000), 468)
+        assert_equal(s.integers(1000), 410)  # 468)
         s = Generator(MT19937([0]))
-        assert_equal(s.integers(1000), 973)
+        assert_equal(s.integers(1000), 844)  # 973)
         s = Generator(MT19937([4294967295]))
-        assert_equal(s.integers(1000), 265)
+        assert_equal(s.integers(1000), 635)  # 265)
 
     def test_invalid_scalar(self):
         # seed must be an unsigned 32 bit integer
@@ -324,14 +324,14 @@ class TestIntegers(object):
         # in the range [0, 6) for all but bool, where the range
         # is [0, 2). Hashes are for little endian numbers.
         tgt = {'bool': '7dd3170d7aa461d201a65f8bcf3944b0',
-               'int16': '1b7741b80964bb190c50d541dca1cac1',
-               'int32': '4dc9fcc2b395577ebb51793e58ed1a05',
-               'int64': '17db902806f448331b5a758d7d2ee672',
-               'int8': '27dd30c4e08a797063dffac2490b0be6',
-               'uint16': '1b7741b80964bb190c50d541dca1cac1',
-               'uint32': '4dc9fcc2b395577ebb51793e58ed1a05',
-               'uint64': '17db902806f448331b5a758d7d2ee672',
-               'uint8': '27dd30c4e08a797063dffac2490b0be6'}
+               'int16': '2d26cafb53cb0f5acbb9b3fe86b36991',  # '1b7741b80964bb190c50d541dca1cac1',
+               'int32': '54f153d6ae944ce0dde49a66602959bb',  # '4dc9fcc2b395577ebb51793e58ed1a05',
+               'int64': '47a068f62fda47f6034aa745e39a1b0d',  # '17db902806f448331b5a758d7d2ee672',
+               'int8': '1d71d3947cd98598b4f00a77c117d62a',  # '27dd30c4e08a797063dffac2490b0be6',
+               'uint16': '2d26cafb53cb0f5acbb9b3fe86b36991',  # '1b7741b80964bb190c50d541dca1cac1',
+               'uint32': '54f153d6ae944ce0dde49a66602959bb',  # '4dc9fcc2b395577ebb51793e58ed1a05',
+               'uint64': '47a068f62fda47f6034aa745e39a1b0d',  # '17db902806f448331b5a758d7d2ee672',
+               'uint8': '1d71d3947cd98598b4f00a77c117d62a'}  # '27dd30c4e08a797063dffac2490b0be6'}
 
         for dt in self.itype[1:]:
             random.bit_generator.seed(1234)
@@ -345,6 +345,8 @@ class TestIntegers(object):
                                  dtype=dt).byteswap()
 
             res = hashlib.md5(val.view(np.int8)).hexdigest()
+            print("res =", res)
+            print("tgt[np.dtype(dt).name] =", tgt[np.dtype(dt).name])
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianness
@@ -352,6 +354,8 @@ class TestIntegers(object):
         val = self.rfunc(0, 2 - endpoint, size=1000, endpoint=endpoint,
                          dtype=bool).view(np.int8)
         res = hashlib.md5(val).hexdigest()
+        print("res =", res)
+        print("tgt[np.dtype(bool).name] =", tgt[np.dtype(bool).name])
         assert_(tgt[np.dtype(bool).name] == res)
 
     def test_repeatability_broadcasting(self, endpoint):
@@ -492,9 +496,9 @@ class TestRandomDist(object):
     def test_integers(self):
         random.bit_generator.seed(self.seed)
         actual = random.integers(-99, 99, size=(3, 2))
-        desired = np.array([[31, 3],
-                            [-52, 41],
-                            [-48, -66]])
+        desired = np.array([[23, -32],
+                            [18, -70],
+                            [76, -53]])  # [[31, 3], [-52, 41], [-48, -66]]
         assert_array_equal(actual, desired)
 
     def test_integers_masked(self):
@@ -502,17 +506,15 @@ class TestRandomDist(object):
         # uint32 in an interval.
         random.bit_generator.seed(self.seed)
         actual = random.integers(0, 99, size=(3, 2), dtype=np.uint32)
-        desired = np.array([[2, 47],
-                            [12, 51],
-                            [33, 43]], dtype=np.uint32)
+        desired = np.array([[61, 33],
+                            [58, 14],
+                            [87, 23]], dtype=np.uint32)  # [[2, 47], [12, 51], [33, 43]]
         assert_array_equal(actual, desired)
 
     def test_integers_closed(self):
         random.bit_generator.seed(self.seed)
         actual = random.integers(-99, 99, size=(3, 2), endpoint=True)
-        desired = np.array([[31, 3],
-                            [-52, 41],
-                            [-48, -66]])
+        desired = np.array([[24, -32], [18, -70], [77, -53]])  # [[31, 3], [-52, 41], [-48, -66]]
         assert_array_equal(actual, desired)
 
     def test_integers_max_int(self):
@@ -559,7 +561,7 @@ class TestRandomDist(object):
     def test_choice_uniform_replace(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice(4, 4)
-        desired = np.array([2, 3, 2, 3], dtype=np.int64)
+        desired = np.array([2, 1, 2, 0], dtype=np.int64)  # [2, 3, 2, 3]
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
@@ -583,19 +585,19 @@ class TestRandomDist(object):
     def test_choice_noninteger(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice(['a', 'b', 'c', 'd'], 4)
-        desired = np.array(['c', 'd', 'c', 'd'])
+        desired = np.array(['c', 'b', 'c', 'a'])  # ['c', 'd', 'c', 'd']
         assert_array_equal(actual, desired)
 
     def test_choice_multidimensional_default_axis(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 3)
-        desired = np.array([[4, 5], [6, 7], [4, 5]])
+        desired = np.array([[4, 5], [2, 3], [4, 5]])  # [[4, 5], [6, 7], [4, 5]]
         assert_array_equal(actual, desired)
 
     def test_choice_multidimensional_custom_axis(self):
         random.bit_generator.seed(self.seed)
         actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 1, axis=1)
-        desired = np.array([[0], [2], [4], [6]])
+        desired = np.array([[1], [3], [5], [7]])  # [[0], [2], [4], [6]]
         assert_array_equal(actual, desired)
 
     def test_choice_exceptions(self):


### PR DESCRIPTION
Fixes #13769.

The Lemire method is the documented default for generating integers.

The change causes some of the random tests to fail because the stream of bounded integers are different for Lemire's methods than for masked rejection sampling. In randomgen we added reference results for Lemire's method.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->