### PR TITLE
DOC: Remove sep in the examples of fromstring

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1062,9 +1062,9 @@ add_newdoc('numpy.core.multiarray', 'fromstring',
 
     Examples
     --------
-    >>> np.fromstring('1 2', dtype=int, sep=' ')
+    >>> np.fromstring('1 2', dtype=int)
     array([1, 2])
-    >>> np.fromstring('1, 2', dtype=int, sep=',')
+    >>> np.fromstring('1, 2', dtype=int)
     array([1, 2])
 
     """)


### PR DESCRIPTION
The parameter `sep` in `numpy.fromstring` is deprecated since version 1.14. It could be better to remove it from the examples.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
