### PR TITLE
MAINT: random: Fix a few compiler warnings.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -169,7 +169,7 @@ float random_standard_exponential_zig_f(bitgen_t *bitgen_state) {
 static NPY_INLINE double next_gauss_zig(bitgen_t *bitgen_state) {
   uint64_t r;
   int sign;
-  int64_t rabs;
+  uint64_t rabs;
   int idx;
   double x, xx, yy;
   for (;;) {
@@ -178,7 +178,7 @@ static NPY_INLINE double next_gauss_zig(bitgen_t *bitgen_state) {
     idx = r & 0xff;
     r >>= 8;
     sign = r & 0x1;
-    rabs = (int64_t)((r >> 1) & 0x000fffffffffffff);
+    rabs = (r >> 1) & 0x000fffffffffffff;
     x = rabs * wi_double[idx];
     if (sign & 0x1)
       x = -x;
@@ -215,7 +215,7 @@ void random_gauss_zig_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out) {
 float random_gauss_zig_f(bitgen_t *bitgen_state) {
   uint32_t r;
   int sign;
-  int32_t rabs;
+  uint32_t rabs;
   int idx;
   float x, xx, yy;
   for (;;) {
@@ -223,7 +223,7 @@ float random_gauss_zig_f(bitgen_t *bitgen_state) {
     r = next_uint32(bitgen_state);
     idx = r & 0xff;
     sign = (r >> 8) & 0x1;
-    rabs = (int32_t)((r >> 9) & 0x0007fffff);
+    rabs = (r >> 9) & 0x0007fffff;
     x = rabs * wi_float[idx];
     if (sign & 0x1)
       x = -x;

--- a/numpy/random/src/xoshiro256/xoshiro256.c
+++ b/numpy/random/src/xoshiro256/xoshiro256.c
@@ -6,6 +6,7 @@ worldwide. This software is distributed without any warranty.
 
 See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 
+#include <stddef.h>
 #include "xoshiro256.h"
 
 /* This is xoshiro256** 1.0, our all-purpose, rock-solid generator. It has
@@ -29,7 +30,7 @@ extern NPY_INLINE uint32_t xoshiro256_next32(xoshiro256_state *state);
 
 void xoshiro256_jump(xoshiro256_state *state)
 {
-	int i, b;
+	size_t i, b;
 	static const uint64_t JUMP[] = {0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa, 0x39abdc4529b1661c};
 
 	uint64_t s0 = 0;

--- a/numpy/random/src/xoshiro512/xoshiro512.c
+++ b/numpy/random/src/xoshiro512/xoshiro512.c
@@ -6,6 +6,7 @@ worldwide. This software is distributed without any warranty.
 
 See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 
+#include <stddef.h>
 #include "xoshiro512.h"
 
 /* This is xoshiro512** 1.0, an all-purpose, rock-solid generator. It has
@@ -32,7 +33,7 @@ static uint64_t s_placeholder[8];
 
 void xoshiro512_jump(xoshiro512_state *state) {
 
-  int i, b, w;
+  size_t i, b, w;
   static const uint64_t JUMP[] = {0x33ed89b6e7a353f9, 0x760083d7955323be,
                                   0x2837f2fbb5f22fae, 0x4b8c5674d309511c,
                                   0xb11ac47a7ba28c25, 0xf1be7667092bcc1c,


### PR DESCRIPTION
Fixes:

    gcc: numpy/random/src/xoshiro256/xoshiro256.c
    numpy/random/src/xoshiro256/xoshiro256.c:39:16: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
            for (i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
                        ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~

    gcc: numpy/random/src/xoshiro512/xoshiro512.c
    numpy/random/src/xoshiro512/xoshiro512.c:43:17: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
      for (i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
                  ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~
    numpy/random/src/xoshiro512/xoshiro512.c:46:23: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
            for (w = 0; w < sizeof s_placeholder / sizeof *s_placeholder; w++)
                        ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    gcc: numpy/random/src/distributions/distributions.c
    numpy/random/src/distributions/distributions.c:185:14: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'const uint64_t' (aka 'const unsigned long long') [-Wsign-compare]
        if (rabs < ki_double[idx])
            ~~~~ ^ ~~~~~~~~~~~~~~
    numpy/random/src/distributions/distributions.c:230:14: warning: comparison of integers of different signs: 'int32_t' (aka 'int') and 'const uint32_t' (aka 'const unsigned int') [-Wsign-compare]
        if (rabs < ki_float[idx])
            ~~~~ ^ ~~~~~~~~~~~~~

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
