### PR TITLE
MAINT: fix 'in' -> 'is' typo

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -472,7 +472,7 @@ def is_sequence(seq):
     return True
 
 def is_glob_pattern(s):
-    return is_string(s) and ('*' in s or '?' is s)
+    return is_string(s) and ('*' in s or '?' in s)
 
 def as_list(seq):
     if is_sequence(seq):


### PR DESCRIPTION
This is generating a SyntaxWarning.

It looks like it has been like this from
2006 (8869df5b1cba1ffeda6d772eee1a7507fe18bdef) when this first came
into the code base.

The other fix would be `'?' == s`, but I think `in` makes more sense.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->