### PR TITLE
MAINT: Fix warnings in radixsort.c.src: comparing integers of different signs

### DIFF
--- a/numpy/core/src/npysort/radixsort.c.src
+++ b/numpy/core/src/npysort/radixsort.c.src
@@ -50,9 +50,10 @@ nth_byte_@suff@(@type@ key, npy_intp l) {
 radixsort0_@suff@(@type@ *arr, @type@ *aux, npy_intp num)
 {
     npy_intp cnt[sizeof(@type@)][1 << 8] = { { 0 } };
-    npy_intp i, l;
+    npy_intp i;
+    size_t l;
     @type@ key0 = KEY_OF(arr[0]);
-    npy_intp ncols = 0;
+    size_t ncols = 0;
     npy_ubyte cols[sizeof(@type@)];
 
     for (i = 0; i < num; i++) {
@@ -139,9 +140,10 @@ npy_intp*
 aradixsort0_@suff@(@type@ *arr, npy_intp *aux, npy_intp *tosort, npy_intp num)
 {
     npy_intp cnt[sizeof(@type@)][1 << 8] = { { 0 } };
-    npy_intp i, l;
+    npy_intp i;
+    size_t l;
     @type@ key0 = KEY_OF(arr[0]);
-    npy_intp ncols = 0;
+    size_t ncols = 0;
     npy_ubyte cols[sizeof(@type@)];
 
     for (i = 0; i < num; i++) {


### PR DESCRIPTION
Eliminate many compiler warnings of the form:

    numpy/core/src/npysort/radixsort.c.src:61:23: warning: comparison of integers of different signs: 'npy_intp' (aka 'long') and 'unsigned long' [-Wsign-compare]
            for (l = 0; l < sizeof(npy_ubyte); l++) {
                        ~ ^ ~~~~~~~~~~~~~~~~~
    numpy/core/src/npysort/radixsort.c.src:66:19: warning: comparison of integers of different signs: 'npy_intp' (aka 'long') and 'unsigned long' [-Wsign-compare]
        for (l = 0; l < sizeof(npy_ubyte); l++) {
                    ~ ^ ~~~~~~~~~~~~~~~~~

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
