### PR TITLE
BUG: Fixed maximum relative error reporting in assert_allclose

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -337,44 +337,6 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue):
     return res
 
 
-def _nanmax(a, axis=None, out=None, keepdims=np._NoValue):
-    """
-    Helper function for nanmax, for use in `np.testing` to avoid warnings.
-
-    Returns
-    -------
-    nanmax : ndarray
-        An array with the same shape as `a`, with the specified axis removed.
-        If `a` is a 0-d array, or if axis is None, an ndarray scalar is
-        returned.  The same dtype as `a` is returned.
-    warning_msg : {string, None}
-        None if no warning should be raised, the warning message if an all-NaN slice is encountered.
-    """
-    kwargs = {}
-    if keepdims is not np._NoValue:
-        kwargs['keepdims'] = keepdims
-    warning_msg = None
-    if type(a) is np.ndarray and a.dtype != np.object_:
-        # Fast, but not safe for subclasses of ndarray, or object arrays,
-        # which do not implement isnan (gh-9009), or fmax correctly (gh-8975)
-        res = np.fmax.reduce(a, axis=axis, out=out, **kwargs)
-        if np.isnan(res).any():
-            warning_msg = "All-NaN slice encountered"
-    else:
-        # Slow, but safe for subclasses of ndarray
-        a, mask = _replace_nan(a, -np.inf)
-        res = np.amax(a, axis=axis, out=out, **kwargs)
-        if mask is None:
-            return res, None
-
-        # Check for all-NaN axis
-        mask = np.all(mask, axis=axis, **kwargs)
-        if np.any(mask):
-            res = _copyto(res, np.nan, mask)
-            warning_msg = "All-NaN axis encountered"
-    return res, warning_msg
-
-
 def _nanmax_dispatcher(a, axis=None, out=None, keepdims=None):
     return (a, out)
 
@@ -464,10 +426,29 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue):
     inf
 
     """
-    res, warning_msg = _nanmax(a, axis, out, keepdims)
-    if warning_msg is not None:
-        warnings.warn(warning_msg, RuntimeWarning,
-                      stacklevel=3)
+    kwargs = {}
+    if keepdims is not np._NoValue:
+        kwargs['keepdims'] = keepdims
+    if type(a) is np.ndarray and a.dtype != np.object_:
+        # Fast, but not safe for subclasses of ndarray, or object arrays,
+        # which do not implement isnan (gh-9009), or fmax correctly (gh-8975)
+        res = np.fmax.reduce(a, axis=axis, out=out, **kwargs)
+        if np.isnan(res).any():
+            warnings.warn("All-NaN slice encountered", RuntimeWarning,
+                          stacklevel=3)
+    else:
+        # Slow, but safe for subclasses of ndarray
+        a, mask = _replace_nan(a, -np.inf)
+        res = np.amax(a, axis=axis, out=out, **kwargs)
+        if mask is None:
+            return res
+
+        # Check for all-NaN axis
+        mask = np.all(mask, axis=axis, **kwargs)
+        if np.any(mask):
+            res = _copyto(res, np.nan, mask)
+            warnings.warn("All-NaN axis encountered", RuntimeWarning,
+                          stacklevel=3)
     return res
 
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -704,7 +704,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          equal_inf=True):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate
-    from numpy import nanmax
+    from numpy.lib.nanfunctions import _nanmax
 
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -824,10 +824,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                     # used by assert_allclose (found in np.isclose)
                     # NaNs are disregarded to ensure that we report correct max
                     # relative error between two arrays with zeros in the same position
-                    with warnings.catch_warnings():
-                        # Ignore warning in case of both array are full of zeros
-                        warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
-                        max_rel_error = nanmax(error / abs(y))
+                    rel_error = error / abs(y)
+                    max_rel_error, _ = _nanmax(rel_error)
                     if error.dtype == 'object':
                         remarks.append('Max relative difference: '
                                         + str(max_rel_error))

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -704,6 +704,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          equal_inf=True):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate
+    from numpy import nanmax
 
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -821,7 +822,12 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
 
                     # note: this definition of relative error matches that one
                     # used by assert_allclose (found in np.isclose)
-                    max_rel_error = (error / abs(y)).max()
+                    # NaNs are disregarded to ensure that we report correct max
+                    # relative error between two arrays with zeros in the same position
+                    with warnings.catch_warnings():
+                        # Ignore warning in case of both array are full of zeros
+                        warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+                        max_rel_error = nanmax(error / abs(y))
                     if error.dtype == 'object':
                         remarks.append('Max relative difference: '
                                         + str(max_rel_error))

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -703,7 +703,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                          header='', precision=6, equal_nan=True,
                          equal_inf=True):
     __tracebackhide__ = True  # Hide traceback for py.test
-    from numpy.core import array, array2string, isnan, inf, bool_, errstate
+    from numpy.core import array, array2string, isnan, inf, bool_, errstate, all
 
     x = array(x, copy=False, subok=True)
     y = array(y, copy=False, subok=True)
@@ -822,7 +822,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
                     # note: this definition of relative error matches that one
                     # used by assert_allclose (found in np.isclose)
                     # Filter values where the divisor would be zero
-                    nonzero = y != 0
+                    nonzero = bool_(y != 0)
                     if all(~nonzero):
                         max_rel_error = array(inf)
                     else:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -887,8 +887,7 @@ class TestAssertAllclose(object):
         with pytest.raises(AssertionError) as exc_info:
             assert_allclose(a, b)
         msg = str(exc_info.value)
-        assert_('Mismatch: 50%\nMax absolute difference: 1\n'
-                'Max relative difference: 0.5' in msg)
+        assert_('Max relative difference: 0.5' in msg)
 
 
 class TestArrayAlmostEqualNulp(object):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -880,6 +880,16 @@ class TestAssertAllclose(object):
         assert_array_less(a, b)
         assert_allclose(a, b)
 
+    def test_report_max_relative_error(self):
+        a = np.array([0, 1])
+        b = np.array([0, 2])
+
+        with pytest.raises(AssertionError) as exc_info:
+            assert_allclose(a, b)
+        msg = str(exc_info.value)
+        assert_('Mismatch: 50%\nMax absolute difference: 1\n'
+                'Max relative difference: 0.5' in msg)
+
 
 class TestArrayAlmostEqualNulp(object):
 


### PR DESCRIPTION
Fixed maximum relative error reporting in `assert_allclose`.

In cases where the two arrays have zeros at the same positions it will
no longer report nan as the max relative error.

Fixes #13801.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
