### PR TITLE
MAINT: Correct intrinsic use on Windows

### DIFF
--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -53,6 +53,10 @@
 #ifdef _WIN32
 #include <stdlib.h>
 #define inline __forceinline
+#if _MSC_VER >= 1900 && _M_AMD64
+#include <intrin.h>
+#pragma intrinsic(_umul128)
+#endif
 #endif
 
 #if __GNUC_GNU_INLINE__ && !defined(__cplusplus)


### PR DESCRIPTION
Add pragma and include for Windows PCG64
