### PR TITLE
DOC: Fix documented default value of ``__array_priority__`` for subarrays.

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -118,7 +118,7 @@ all output arrays will be passed to the :obj:`~class.__array_prepare__` and
 the highest :obj:`~class.__array_priority__` of any other input to the
 universal function. The default :obj:`~class.__array_priority__` of the
 ndarray is 0.0, and the default :obj:`~class.__array_priority__` of a subtype
-is 1.0. Matrices have :obj:`~class.__array_priority__` equal to 10.0.
+is 0.0. Matrices have :obj:`~class.__array_priority__` equal to 10.0.
 
 All ufuncs can also take output arguments. If necessary, output will
 be cast to the data-type(s) of the provided output array(s). If a class


### PR DESCRIPTION
Changed default value of `__array_priority__` to correct value.

Previously fixed elsewhere: https://github.com/numpy/numpy/commit/a70842c58b11b4c3e56425d67e075a418db361f4

Evidence the value was wrong:

```python
import numpy as np

class B(np.ndarray):
    pass

np.ones(1).view(B).__array_priority__  # 0.0
```
