### PR TITLE
MAINT: core: Fix a compiler warning.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -654,8 +654,8 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         PyErr_NoMemory();
         goto fail;
     }
-    for (i = 0; i < len; i++) {
-        ufunc->core_dim_flags[i] = 0;
+    for (size_t j = 0; j < len; j++) {
+        ufunc->core_dim_flags[j] = 0;
     }
 
     i = _next_non_white_space(signature, 0);


### PR DESCRIPTION
This change fixes:

    gcc: numpy/core/src/umath/ufunc_object.c
    numpy/core/src/umath/ufunc_object.c:657:19: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i = 0; i < len; i++) {
                    ~ ^ ~~~

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
