### PR TITLE
TEST, ENH: fix tests and ctypes code for PyPy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,3 +198,16 @@ jobs:
     inputs:
       testResultsFiles: '**/test-*.xml'
       testRunTitle: 'Publish test results for Python $(python.version)'
+
+- job: Linux_PyPy
+  pool:
+    vmIMage: 'ubuntu-16.04'
+  steps:
+  - script: source tools/pypy-test.sh
+    displayName: 'Run PyPy Build / Tests'
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for PyPy'
+      failTaskOnFailedTests: true

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -8,6 +8,7 @@ from __future__ import division, absolute_import, print_function
 
 import re
 import sys
+import platform
 
 from numpy.compat import unicode
 from numpy.core.overrides import set_module
@@ -16,6 +17,8 @@ try:
     import ctypes
 except ImportError:
     ctypes = None
+
+IS_PYPY = platform.python_implementation() == 'PyPy'
 
 if (sys.byteorder == 'little'):
     _nbo = b'<'
@@ -889,7 +892,12 @@ def npy_ctypes_check(cls):
     try:
         # ctypes class are new-style, so have an __mro__. This probably fails
         # for ctypes classes with multiple inheritance.
-        ctype_base = cls.__mro__[-2]
+        if IS_PYPY:
+            # (..., _ctypes.basics._CData, Bufferable, object)
+            ctype_base = cls.__mro__[-3]
+        else:
+            # # (..., _ctypes._CData, object)
+            ctype_base = cls.__mro__[-2]
         # right now, they're part of the _ctypes module
         return 'ctypes' in ctype_base.__module__
     except Exception:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7160,6 +7160,7 @@ def test_array_interface_empty_shape():
     assert_equal(arr1, arr2)
     assert_equal(arr1, arr3)
 
+@pytest.mark.skipif(IS_PYPY, reason='PyDict_GetItemString(.., "data") segfaults')
 def test_array_interface_offset():
     arr = np.array([1, 2, 3], dtype='int32')
     interface = dict(arr.__array_interface__)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -36,7 +36,7 @@ from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
     assert_allclose, IS_PYPY, HAS_REFCOUNT, assert_array_less, runstring,
-    temppath, suppress_warnings
+    temppath, suppress_warnings, break_cycles,
     )
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
@@ -131,6 +131,7 @@ class TestFlags(object):
         assert_(vals.flags.writeable)
 
     @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 always copies")
+    @pytest.mark.skipif(IS_PYPY, reason="PyPy always copies")
     def test_writeable_pickle(self):
         import pickle
         # Small arrays will be copied without setting base.
@@ -3816,7 +3817,7 @@ class TestPickling(object):
                         a, pickle.loads(pickle.dumps(a, protocol=proto)),
                         err_msg="%r" % a)
             del a, DATA, carray
-            gc.collect()
+            break_cycles()
             # check for reference leaks (gh-12793)
             for ref in refs:
                 assert ref() is None
@@ -7201,7 +7202,7 @@ class TestMemEventHook(object):
         # needs to be larger then limit of small memory cacher in ctors.c
         a = np.zeros(1000)
         del a
-        gc.collect()
+        break_cycles()
         _multiarray_tests.test_pydatamem_seteventhook_end()
 
 class TestMapIter(object):
@@ -7773,12 +7774,12 @@ class TestCTypes(object):
 
         # `ctypes_ptr` should hold onto `arr`
         del arr
-        gc.collect()
+        break_cycles()
         assert_(arr_ref() is not None, "ctypes pointer did not hold onto a reference")
 
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
-        gc.collect()
+        break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
 
@@ -7960,15 +7961,15 @@ class TestArrayFinalize(object):
         assert_(isinstance(obj_subarray, RaisesInFinalize))
 
         # reference should still be held by obj_arr
-        gc.collect()
+        break_cycles()
         assert_(obj_ref() is not None, "object should not already be dead")
 
         del obj_arr
-        gc.collect()
+        break_cycles()
         assert_(obj_ref() is not None, "obj_arr should not hold the last reference")
 
         del obj_subarray
-        gc.collect()
+        break_cycles()
         assert_(obj_ref() is None, "no references should remain")
 
 

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -5,7 +5,7 @@ import itertools
 
 import pytest
 import numpy as np
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_equal, assert_raises, IS_PYPY
 
 # This is the structure of the table used for plain objects:
 #
@@ -491,6 +491,7 @@ def test_issctype(rep, expected):
 
 @pytest.mark.skipif(sys.flags.optimize > 1,
                     reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")
+@pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
 class TestDocStrings(object):
     def test_platform_dependent_aliases(self):
         if np.int64 is np.int_:

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 from . import util
 
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, IS_PYPY
 
 class TestBlockDocString(util.F2PyTest):
     code = """
@@ -18,6 +18,7 @@ class TestBlockDocString(util.F2PyTest):
 
     @pytest.mark.skipif(sys.platform=='win32',
                         reason='Fails with MinGW64 Gfortran (Issue #9673)')
+    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
     def test_block_docstring(self):
         expected = "'i'-array(2,3)\n"
         assert_equal(self.module.block.__doc__, expected)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import ma
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_almost_equal,
-    assert_array_almost_equal, assert_raises, assert_allclose,
+    assert_array_almost_equal, assert_raises, assert_allclose, IS_PYPY,
     assert_warns, assert_raises_regex, suppress_warnings, HAS_REFCOUNT,
     )
 import numpy.lib.function_base as nfb
@@ -3106,6 +3106,7 @@ class TestAdd_newdoc_ufunc(object):
 class TestAdd_newdoc(object):
 
     @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")
+    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
     def test_add_doc(self):
         # test np.add_newdoc
         tgt = "Current flat index into the array."

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Exit if a command fails
+set -e
+set -o pipefail
+# Print expanded commands
+set -x
+
+sudo apt-get -yq update
+sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5
+F77=gfortran-5 F90=gfortran-5 \
+
+# Download the proper OpenBLAS x64 precompiled library
+OPENBLAS=openblas-v0.3.5-274-g6a8b4269-manylinux1_x86_64.tar.gz
+echo getting $OPENBLAS
+wget -q https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/$OPENBLAS -O openblas.tar.gz
+mkdir -p openblas
+(cd openblas; tar -xf ../openblas.tar.gz)
+export LD_LIBRARY_PATH=$PWD/openblas/usr/local/lib
+export LIB=$PWD/openblas/usr/local/lib
+export INCLUDE=$PWD/openblas/usr/local/include
+
+# Use a site.cfg to build with local openblas
+cat << EOF > site.cfg
+[openblas]
+libraries = openblas
+library_dirs = $PWD/openblas/usr/local/lib:$LIB
+include_dirs = $PWD/openblas/usr/local/lib:$LIB
+runtime_library_dirs = $PWD/openblas/usr/local/lib
+EOF
+
+echo getting PyPy 2.7 nightly
+wget -q http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux64.tar.bz2 -O pypy.tar.bz2
+mkdir -p pypy
+(cd pypy; tar --strip-components=1 -xf ../pypy.tar.bz2)
+pypy/bin/pypy -mensurepip
+pypy/bin/pypy -m pip install --upgrade pip setuptools
+pypy/bin/pypy -m pip install --user cython==0.29.0 pytest pytz --no-warn-script-location
+
+echo
+echo pypy version 
+pypy/bin/pypy -c "import sys; print(sys.version)"
+echo
+
+pypy/bin/pypy runtests.py -vv --show-build-log -- -rsx \
+      --junitxml=junit/test-results.xml --durations 10
+
+echo Make sure the correct openblas has been linked in
+
+pypy/bin/pip install .
+(cd pypy; bin/pypy -c "$TEST_GET_CONFIG")


### PR DESCRIPTION
Add a test run of PyPy2.7 on the LTS 1.16.x branch.
Skip failing `tp_doc` tests, extend gc.collect and fix `npy_ctypes_check`. Fixes #13807.

Backport of the relevant parts of #12594 for this branch.
