### PR TITLE
ENH: Add axis argument to random.permutation and random.shuffle

### DIFF
--- a/changelog/13829.enhancement.rst
+++ b/changelog/13829.enhancement.rst
@@ -1,0 +1,6 @@
+Add ``axis`` argument for ``random.permutation`` and ``random.shuffle``
+-----------------------------------------------------------------------
+
+Previously the ``random.permutation`` and ``random.shuffle`` functions
+can only shuffle an array along the first axis; they now have a
+new argument ``axis`` which allows shuffle along a specified axis.

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -4,6 +4,7 @@ import operator
 import warnings
 
 import numpy as np
+from numpy.core.multiarray import normalize_axis_index
 
 from .bounded_integers import _integers_types
 from .pcg64 import PCG64
@@ -3783,20 +3784,21 @@ cdef class Generator:
         return diric
 
     # Shuffling and permutations:
-    def shuffle(self, object x):
+    def shuffle(self, object x, axis=0):
         """
         shuffle(x)
 
         Modify a sequence in-place by shuffling its contents.
 
-        This function only shuffles the array along the first axis of a
-        multi-dimensional array. The order of sub-arrays is changed but
-        their contents remains the same.
+        The order of sub-arrays is changed but their contents remains the same.
 
         Parameters
         ----------
         x : array_like
             The array or list to be shuffled.
+        axis : int, optional
+            The axis which `x` is shuffled along. Default is 0.
+            It is only supported on `ndarray` objects.
 
         Returns
         -------
@@ -3810,8 +3812,6 @@ cdef class Generator:
         >>> arr
         [1 7 5 2 9 4 3 6 0 8] # random
 
-        Multi-dimensional arrays are only shuffled along the first axis:
-
         >>> arr = np.arange(9).reshape((3, 3))
         >>> rng.shuffle(arr)
         >>> arr
@@ -3819,11 +3819,19 @@ cdef class Generator:
                [6, 7, 8],
                [0, 1, 2]])
 
+        >>> arr = np.arange(9).reshape((3, 3))
+        >>> rng.shuffle(arr, axis=1)
+        >>> arr
+        array([[2, 0, 1], # random
+               [5, 3, 4],
+               [8, 6, 7]])
         """
         cdef:
             np.npy_intp i, j, n = len(x), stride, itemsize
             char* x_ptr
             char* buf_ptr
+
+        axis = normalize_axis_index(axis, np.ndim(x))
 
         if type(x) is np.ndarray and x.ndim == 1 and x.size:
             # Fast, statically typed path: shuffle the underlying buffer.
@@ -3847,6 +3855,7 @@ cdef class Generator:
                 else:
                     self._shuffle_raw(n, 1, itemsize, stride, x_ptr, buf_ptr)
         elif isinstance(x, np.ndarray) and x.ndim and x.size:
+            x = np.swapaxes(x, 0, axis)
             buf = np.empty_like(x[0, ...])
             with self.lock:
                 for i in reversed(range(1, n)):
@@ -3859,6 +3868,9 @@ cdef class Generator:
                     x[i] = buf
         else:
             # Untyped path.
+            if axis != 0:
+                raise NotImplementedError("Axis argument is only supported "
+                                          "on ndarray objects")
             with self.lock:
                 for i in reversed(range(1, n)):
                     j = random_interval(&self._bitgen, i)
@@ -3914,13 +3926,11 @@ cdef class Generator:
             data[j] = data[i]
             data[i] = temp
 
-    def permutation(self, object x):
+    def permutation(self, object x, axis=0):
         """
         permutation(x)
 
         Randomly permute a sequence, or return a permuted range.
-        If `x` is a multi-dimensional array, it is only shuffled along its
-        first index. 
 
         Parameters
         ----------
@@ -3928,6 +3938,8 @@ cdef class Generator:
             If `x` is an integer, randomly permute ``np.arange(x)``.
             If `x` is an array, make a copy and shuffle the elements
             randomly.
+        axis : int, optional
+            The axis which `x` is shuffled along. Default is 0.
 
         Returns
         -------
@@ -3953,16 +3965,22 @@ cdef class Generator:
         Traceback (most recent call last):
             ...
         numpy.AxisError: x must be an integer or at least 1-dimensional
-        """
 
+        >>> arr = np.arange(9).reshape((3, 3))
+        >>> rng.permutation(arr, axis=1)
+        array([[0, 2, 1], # random
+               [3, 5, 4],
+               [6, 8, 7]])
+
+        """
         if isinstance(x, (int, np.integer)):
             arr = np.arange(x)
             self.shuffle(arr)
             return arr
 
         arr = np.asarray(x)
-        if arr.ndim < 1:
-            raise np.AxisError("x must be an integer or at least 1-dimensional")
+
+        axis = normalize_axis_index(axis, arr.ndim)
 
         # shuffle has fast-path for 1-d
         if arr.ndim == 1:
@@ -3973,9 +3991,11 @@ cdef class Generator:
             return arr
 
         # Shuffle index array, dtype to ensure fast path
-        idx = np.arange(arr.shape[0], dtype=np.intp)
+        idx = np.arange(arr.shape[axis], dtype=np.intp)
         self.shuffle(idx)
-        return arr[idx]
+        slices = [slice(None)]*arr.ndim
+        slices[axis] = idx
+        return arr[tuple(slices)]
 
 
 def default_rng(seed=None):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -732,6 +732,20 @@ class TestRandomDist(object):
             desired = conv([4, 1, 9, 8, 0, 5, 3, 6, 2, 7])
             assert_array_equal(actual, desired)
 
+    def test_shuffle_custom_axis(self):
+        random = Generator(MT19937(self.seed))
+        actual = np.arange(16).reshape((4, 4))
+        random.shuffle(actual, axis=1)
+        desired = np.array([[ 0,  3,  1,  2],
+                            [ 4,  7,  5,  6],
+                            [ 8, 11,  9, 10],
+                            [12, 15, 13, 14]])
+        assert_array_equal(actual, desired)
+        random = Generator(MT19937(self.seed))
+        actual = np.arange(16).reshape((4, 4))
+        random.shuffle(actual, axis=-1)
+        assert_array_equal(actual, desired)
+
     def test_shuffle_masked(self):
         # gh-3263
         a = np.ma.masked_values(np.reshape(range(20), (5, 4)) % 3 - 1, -1)
@@ -745,6 +759,16 @@ class TestRandomDist(object):
             random.shuffle(b)
             assert_equal(
                 sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
+
+    def test_shuffle_exceptions(self):
+        random = Generator(MT19937(self.seed))
+        arr = np.arange(10)
+        assert_raises(np.AxisError, random.shuffle, arr, 1)
+        arr = np.arange(9).reshape((3, 3))
+        assert_raises(np.AxisError, random.shuffle, arr, 3)
+        assert_raises(TypeError, random.shuffle, arr, slice(1, 2, None))
+        arr = [[1, 2, 3], [4, 5, 6]]
+        assert_raises(NotImplementedError, random.shuffle, arr, 1)
 
     def test_permutation(self):
         random = Generator(MT19937(self.seed))
@@ -770,6 +794,27 @@ class TestRandomDist(object):
 
         actual = random.permutation(integer_val)
         assert_array_equal(actual, desired)
+
+    def test_permutation_custom_axis(self):
+        a = np.arange(16).reshape((4, 4))
+        desired = np.array([[ 0,  3,  1,  2],
+                            [ 4,  7,  5,  6],
+                            [ 8, 11,  9, 10],
+                            [12, 15, 13, 14]])
+        random = Generator(MT19937(self.seed))
+        actual = random.permutation(a, axis=1)
+        assert_array_equal(actual, desired)
+        random = Generator(MT19937(self.seed))
+        actual = random.permutation(a, axis=-1)
+        assert_array_equal(actual, desired)
+
+    def test_permutation_exceptions(self):
+        random = Generator(MT19937(self.seed))
+        arr = np.arange(10)
+        assert_raises(np.AxisError, random.permutation, arr, 1)
+        arr = np.arange(9).reshape((3, 3))
+        assert_raises(np.AxisError, random.permutation, arr, 3)
+        assert_raises(TypeError, random.permutation, arr, slice(1, 2, None))
 
     def test_beta(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
The `random.permutation` function now can only shuffle the first axis of a multi-dimensional array. I add an argument for the function and allow it to shuffle along a given axis.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
