### PR TITLE
MAINT: Update tox for supported Python versions

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -147,9 +147,9 @@ That also takes extra arguments, like ``--pdb`` which drops you into the Python
 debugger when a test fails or an exception is raised.
 
 Running tests with `tox`_ is also supported.  For example, to build NumPy and
-run the test suite with Python 3.4, use::
+run the test suite with Python 3.7, use::
 
-    $ tox -e py34
+    $ tox -e py37
 
 For more extensive information, see :ref:`testing-guidelines`
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@
 #     - Use pip to install the numpy sdist into the virtualenv
 #     - Run the numpy tests
 # To run against a specific subset of Python versions, use:
-#   tox -e py27
+#   tox -e py37
 
 # Extra arguments will be passed to test-installed-numpy.py. To run
 # the full testsuite:
@@ -26,21 +26,17 @@
 
 [tox]
 envlist =
-  py27,py34,py35,py36,
-  py27-not-relaxed-strides,py34-not-relaxed-strides
+  py35,py36,py37,
+  py37-not-relaxed-strides
 
 [testenv]
 deps=
-  nose
+  pytest
 changedir={envdir}
 commands={envpython} {toxinidir}/tools/test-installed-numpy.py --mode=full {posargs:}
 
-[testenv:py27-not-relaxed-strides]
-basepython=python2.7
-env=NPY_RELAXED_STRIDES_CHECKING=0
-
-[testenv:py34-not-relaxed-strides]
-basepython=python3.4
+[testenv:py37-not-relaxed-strides]
+basepython=python3.7
 env=NPY_RELAXED_STRIDES_CHECKING=0
 
 # Not run by default. Set up the way you want then use 'tox -e debug'


### PR DESCRIPTION
Update the tox configuration file to reflect the current supported versions of Python.  One "not-relaxed-strides" test is kept for py37 only.

Also add `pytest` to `deps`, as "ImportError: No module named 'pytest'" was thrown while verifying.

Lastly, relevant docs are also updated.