### PR TITLE
BUG: use npy_intp instead of int for indexing array

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1440,7 +1440,7 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
     }
     /* next check for a list of field names */
     else if (PySequence_Check(ind) && !PyTuple_Check(ind)) {
-        int seqlen, i;
+        npy_intp seqlen, i;
         PyObject *name = NULL, *tup;
         PyObject *fields, *names;
         PyArray_Descr *view_dtype;


### PR DESCRIPTION
BUG: Closes #13842

Fix wrong type for index and size variables.
Already merged in master by this commit: https://github.com/numpy/numpy/commit/51ee4543823457b03bda56e33801177f31fc58f6