### PR TITLE
MAINT: Remove Python <= 3.4 logic and imports

### DIFF
--- a/benchmarks/benchmarks/bench_app.py
+++ b/benchmarks/benchmarks/bench_app.py
@@ -4,8 +4,6 @@ from .common import Benchmark
 
 import numpy as np
 
-from six.moves import xrange
-
 
 class LaplaceInplace(Benchmark):
     params = ['inplace', 'normal']
@@ -61,7 +59,7 @@ class MaxesOfDots(Benchmark):
         ntime = 200
 
         self.arrays = [np.random.normal(size=(ntime, nfeat))
-                       for i in xrange(nsubj)]
+                       for i in range(nsubj)]
 
     def maxes_of_dots(self, arrays):
         """

--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -4,8 +4,6 @@ from .common import Benchmark, get_squares_, get_indexes_, get_indexes_rand_
 
 from os.path import join as pjoin
 import shutil
-import sys
-import six
 from numpy import memmap, float32, array
 import numpy as np
 from tempfile import mkdtemp
@@ -25,13 +23,10 @@ class Indexing(Benchmark):
               'indexes_': get_indexes_(),
               'indexes_rand_': get_indexes_rand_()}
 
-        if sys.version_info[0] >= 3:
-            code = "def run():\n    for a in squares_.values(): a[%s]%s"
-        else:
-            code = "def run():\n    for a in squares_.itervalues(): a[%s]%s"
+        code = "def run():\n    for a in squares_.values(): a[%s]%s"
         code = code % (sel, op)
 
-        six.exec_(code, ns)
+        exec(code, ns)
         self.func = ns['run']
 
     def time_op(self, indexes, sel, op):

--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -8,12 +8,8 @@ Show a summary about which NumPy functions are documented and which are not.
 from __future__ import division, absolute_import, print_function
 
 import os, glob, re, sys, inspect, optparse
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc as collections_abc
+
 sys.path.append(os.path.join(os.path.dirname(__file__), 'sphinxext'))
 from sphinxext.phantom_import import import_phantom_module
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -156,11 +156,8 @@ else:
 
     # Make these accessible from numpy name-space
     # but not imported in from numpy import *
-    if sys.version_info[0] >= 3:
-        from builtins import bool, int, float, complex, object, str
-        unicode = str
-    else:
-        from __builtin__ import bool, int, float, complex, object, unicode, str
+    from builtins import bool, int, float, complex, object, str
+    unicode = str
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -12,76 +12,51 @@ __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
 
 import sys
 import os
+import io
+
+from pathlib import Path, PurePath
+
 try:
-    from pathlib import Path, PurePath
+    import pickle5 as pickle
 except ImportError:
-    Path = PurePath = None
+    import pickle
 
-if sys.version_info[0] >= 3:
-    import io
+long = int
+integer_types = (int,)
+basestring = str
+unicode = str
+bytes = bytes
+strchar = 'U'
 
-    try:
-        import pickle5 as pickle
-    except ImportError:
-        import pickle
 
-    long = int
-    integer_types = (int,)
-    basestring = str
-    unicode = str
-    bytes = bytes
+def asunicode(s):
+    if isinstance(s, bytes):
+        return s.decode('latin1')
+    return str(s)
 
-    def asunicode(s):
-        if isinstance(s, bytes):
-            return s.decode('latin1')
-        return str(s)
 
-    def asbytes(s):
-        if isinstance(s, bytes):
-            return s
-        return str(s).encode('latin1')
-
-    def asstr(s):
-        if isinstance(s, bytes):
-            return s.decode('latin1')
-        return str(s)
-
-    def isfileobj(f):
-        return isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter))
-
-    def open_latin1(filename, mode='r'):
-        return open(filename, mode=mode, encoding='iso-8859-1')
-
-    def sixu(s):
+def asbytes(s):
+    if isinstance(s, bytes):
         return s
+    return str(s).encode('latin1')
 
-    strchar = 'U'
 
-else:
-    import cpickle as pickle
+def asstr(s):
+    if isinstance(s, bytes):
+        return s.decode('latin1')
+    return str(s)
 
-    bytes = str
-    long = long
-    basestring = basestring
-    unicode = unicode
-    integer_types = (int, long)
-    asbytes = str
-    asstr = str
-    strchar = 'S'
 
-    def isfileobj(f):
-        return isinstance(f, file)
+def isfileobj(f):
+    return isinstance(f, (io.FileIO, io.BufferedReader, io.BufferedWriter))
 
-    def asunicode(s):
-        if isinstance(s, unicode):
-            return s
-        return str(s).decode('ascii')
 
-    def open_latin1(filename, mode='r'):
-        return open(filename, mode=mode)
+def open_latin1(filename, mode='r'):
+    return open(filename, mode=mode, encoding='iso-8859-1')
 
-    def sixu(s):
-        return unicode(s, 'unicode_escape')
+
+def sixu(s):
+    return s
 
 def getexception():
     return sys.exc_info()[1]
@@ -128,69 +103,32 @@ class contextlib_nullcontext(object):
         pass
 
 
-if sys.version_info[0] >= 3 and sys.version_info[1] >= 4:
-    def npy_load_module(name, fn, info=None):
-        """
-        Load a module.
+def npy_load_module(name, fn, info=None):
+    """
+    Load a module.
 
-        .. versionadded:: 1.11.2
+    .. versionadded:: 1.11.2
 
-        Parameters
-        ----------
-        name : str
-            Full module name.
-        fn : str
-            Path to module file.
-        info : tuple, optional
-            Only here for backward compatibility with Python 2.*.
+    Parameters
+    ----------
+    name : str
+        Full module name.
+    fn : str
+        Path to module file.
+    info : tuple, optional
+        Only here for backward compatibility with Python 2.*.
 
-        Returns
-        -------
-        mod : module
+    Returns
+    -------
+    mod : module
 
-        """
-        import importlib.machinery
-        return importlib.machinery.SourceFileLoader(name, fn).load_module()
-else:
-    def npy_load_module(name, fn, info=None):
-        """
-        Load a module.
-
-        .. versionadded:: 1.11.2
-
-        Parameters
-        ----------
-        name : str
-            Full module name.
-        fn : str
-            Path to module file.
-        info : tuple, optional
-            Information as returned by `imp.find_module`
-            (suffix, mode, type).
-
-        Returns
-        -------
-        mod : module
-
-        """
-        import imp
-        if info is None:
-            path = os.path.dirname(fn)
-            fo, fn, info = imp.find_module(name, [path])
-        else:
-            fo = open(fn, info[1])
-        try:
-            mod = imp.load_module(name, fo, fn, info)
-        finally:
-            fo.close()
-        return mod
+    """
+    import importlib.machinery
+    return importlib.machinery.SourceFileLoader(name, fn).load_module()
 
 # backport abc.ABC
 import abc
-if sys.version_info[:2] >= (3, 4):
-    abc_ABC = abc.ABC
-else:
-    abc_ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+abc_ABC = abc.ABC
 
 
 # Backport os.fs_path, os.PathLike, and PurePath.__fspath__

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -130,16 +130,11 @@ def _ufunc_reduce(func):
     return _ufunc_reconstruct, (whichmodule(func, name), name)
 
 
-import sys
-if sys.version_info[0] >= 3:
-    import copyreg
-else:
-    import copy_reg as copyreg
+import copyreg
 
 copyreg.pickle(ufunc, _ufunc_reduce, _ufunc_reconstruct)
 # Unclutter namespace (must keep _ufunc_reconstruct for unpickling)
 del copyreg
-del sys
 del _ufunc_reduce
 
 from numpy._pytesttester import PytestTester

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2082,7 +2082,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('ctypes',
     >>> x.ctypes.data_as(ctypes.POINTER(ctypes.c_long)).contents
     c_long(0)
     >>> x.ctypes.data_as(ctypes.POINTER(ctypes.c_longlong)).contents
-    c_longlong(4294967296L)
+    c_longlong(0)
     >>> x.ctypes.shape
     <numpy.core._internal.c_long_Array_2 object at 0x01FFD580>
     >>> x.ctypes.shape_as(ctypes.c_long)

--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -19,18 +19,10 @@ _kind_to_stem = {
     'V': 'void',
     'O': 'object',
     'M': 'datetime',
-    'm': 'timedelta'
+    'm': 'timedelta',
+    'S': 'bytes',
+    'U': 'str',
 }
-if sys.version_info[0] >= 3:
-    _kind_to_stem.update({
-        'S': 'bytes',
-        'U': 'str'
-    })
-else:
-    _kind_to_stem.update({
-        'S': 'string',
-        'U': 'unicode'
-    })
 
 
 def _kind_name(dtype):

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -23,7 +23,6 @@ and sometimes other mappings too.
 
 """
 import warnings
-import sys
 
 from numpy.compat import unicode
 from numpy._globals import VisibleDeprecationWarning
@@ -203,22 +202,15 @@ def _set_up_aliases():
                   ('bool_', 'bool'),
                   ('bytes_', 'string'),
                   ('string_', 'string'),
+                  ('str_', 'unicode'),
                   ('unicode_', 'unicode'),
                   ('object_', 'object')]
-    if sys.version_info[0] >= 3:
-        type_pairs.extend([('str_', 'unicode')])
-    else:
-        type_pairs.extend([('str_', 'string')])
     for alias, t in type_pairs:
         allTypes[alias] = allTypes[t]
         sctypeDict[alias] = sctypeDict[t]
     # Remove aliases overriding python types and modules
-    to_remove = ['ulong', 'object', 'int', 'float',
-                 'complex', 'bool', 'string', 'datetime', 'timedelta']
-    if sys.version_info[0] >= 3:
-        to_remove.extend(['bytes', 'str'])
-    else:
-        to_remove.extend(['unicode', 'long'])
+    to_remove = ['ulong', 'object', 'int', 'float', 'complex', 'bool',
+                 'string', 'bytes', 'str', 'datetime', 'timedelta']
 
     for t in to_remove:
         try:
@@ -267,11 +259,8 @@ _set_array_types()
 
 
 # Add additional strings to the sctypeDict
-_toadd = ['int', 'float', 'complex', 'bool', 'object']
-if sys.version_info[0] >= 3:
-    _toadd.extend(['str', 'bytes', ('a', 'bytes_')])
-else:
-    _toadd.extend(['string', ('str', 'string_'), 'unicode', ('a', 'string_')])
+_toadd = ['int', 'float', 'complex', 'bool', 'object',
+          'str', 'bytes', ('a', 'bytes_')]
 
 for name in _toadd:
     if isinstance(name, tuple):

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -5,12 +5,7 @@ This provides helpers which wrap `umath.geterrobj` and `umath.seterrobj`
 """
 from __future__ import division, absolute_import, print_function
 
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc as collections_abc
 import contextlib
 
 from .overrides import set_module

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -24,19 +24,12 @@ __docformat__ = 'restructuredtext'
 # scalars are printed inside an ndarray. Only the latter strs are currently
 # user-customizable.
 
-import sys
 import functools
 import numbers
-if sys.version_info[0] >= 3:
-    try:
-        from _thread import get_ident
-    except ImportError:
-        from _dummy_thread import get_ident
-else:
-    try:
-        from thread import get_ident
-    except ImportError:
-        from dummy_thread import get_ident
+try:
+    from _thread import get_ident
+except ImportError:
+    from _dummy_thread import get_ident
 
 import numpy as np
 from . import numerictypes as _nt

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -152,12 +152,8 @@ class Ufunc(object):
 # String-handling utilities to avoid locale-dependence.
 
 import string
-if sys.version_info[0] < 3:
-    UPPER_TABLE = string.maketrans(string.ascii_lowercase,
-                                   string.ascii_uppercase)
-else:
-    UPPER_TABLE = bytes.maketrans(bytes(string.ascii_lowercase, "ascii"),
-                                  bytes(string.ascii_uppercase, "ascii"))
+UPPER_TABLE = bytes.maketrans(bytes(string.ascii_lowercase, "ascii"),
+                              bytes(string.ascii_uppercase, "ascii"))
 
 def english_upper(s):
     """ Apply English case rules to convert ASCII strings to all upper case.
@@ -306,17 +302,7 @@ defdict = {
           ],
           TD(O, f='PyNumber_Multiply'),
           ),
-'divide':
-    Ufunc(2, 1, None, # One is only a unit to the right, not the left
-          docstrings.get('numpy.core.umath.divide'),
-          'PyUFunc_MixedDivisionTypeResolver',
-          TD(intfltcmplx),
-          [TypeDescription('m', FullTypeDescr, 'mq', 'm'),
-           TypeDescription('m', FullTypeDescr, 'md', 'm'),
-           TypeDescription('m', FullTypeDescr, 'mm', 'd'),
-          ],
-          TD(O, f='PyNumber_Divide'),
-          ),
+# 'divide' : aliased to true_divide in umathmodule.c.src:InitOtherOperators
 'floor_divide':
     Ufunc(2, 1, None, # One is only a unit to the right, not the left
           docstrings.get('numpy.core.umath.floor_divide'),
@@ -936,10 +922,6 @@ defdict = {
           ),
 }
 
-if sys.version_info[0] >= 3:
-    # Will be aliased to true_divide in umathmodule.c.src:InitOtherOperators
-    del defdict['divide']
-
 def indent(st, spaces):
     indentation = ' '*spaces
     indented = indentation + st.replace('\n', '\n'+indentation)
@@ -1074,15 +1056,11 @@ def make_ufuncs(funcdict):
         uf = funcdict[name]
         mlist = []
         docstring = textwrap.dedent(uf.docstring).strip()
-        if sys.version_info[0] < 3:
-            docstring = docstring.encode('string-escape')
-            docstring = docstring.replace(r'"', r'\"')
-        else:
-            docstring = docstring.encode('unicode-escape').decode('ascii')
-            docstring = docstring.replace(r'"', r'\"')
-            # XXX: I don't understand why the following replace is not
-            # necessary in the python 2 case.
-            docstring = docstring.replace(r"'", r"\'")
+        docstring = docstring.encode('unicode-escape').decode('ascii')
+        docstring = docstring.replace(r'"', r'\"')
+        # XXX: I don't understand why the following replace was not
+        # necessary for python 2.
+        docstring = docstring.replace(r"'", r"\'")
         # Split the docstring because some compilers (like MS) do not like big
         # string literal in C code. We split at endlines because textwrap.wrap
         # do not play well with \n

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -42,12 +42,8 @@ __all__ = [
 
 
 _globalvar = 0
-if sys.version_info[0] >= 3:
-    _unicode = str
-    _bytes = bytes
-else:
-    _unicode = unicode
-    _bytes = str
+_unicode = str
+_bytes = bytes
 _len = len
 
 array_function_dispatch = functools.partial(
@@ -1962,22 +1958,11 @@ class chararray(ndarray):
         # strings in the new array.
         itemsize = long(itemsize)
 
-        if sys.version_info[0] >= 3 and isinstance(buffer, _unicode):
-            # On Py3, unicode objects do not have the buffer interface
-            filler = buffer
-            buffer = None
-        else:
-            filler = None
-
+        # On Py3, unicode objects do not have the buffer interface
+        filler = buffer
         _globalvar = 1
-        if buffer is None:
-            self = ndarray.__new__(subtype, shape, (dtype, itemsize),
-                                   order=order)
-        else:
-            self = ndarray.__new__(subtype, shape, (dtype, itemsize),
-                                   buffer=buffer,
-                                   offset=offset, strides=strides,
-                                   order=order)
+        self = ndarray.__new__(subtype, shape, (dtype, itemsize),
+                               order=order)
         if filler is not None:
             self[...] = filler
         _globalvar = 0

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
+import builtins
 import functools
 import itertools
 import operator
@@ -21,8 +22,6 @@ from .multiarray import (
     min_scalar_type, ndarray, nditer, nested_iters, promote_types,
     putmask, result_type, set_numeric_ops, shares_memory, vdot, where,
     zeros, normalize_axis_index)
-if sys.version_info[0] < 3:
-    from .multiarray import newbuffer, getbuffer
 
 from . import overrides
 from . import umath
@@ -37,11 +36,6 @@ from ._ufunc_config import errstate
 bitwise_not = invert
 ufunc = type(sin)
 newaxis = None
-
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
 
 
 array_function_dispatch = functools.partial(
@@ -73,9 +67,6 @@ __all__ = [
     'BUFSIZE', 'ALLOW_THREADS', 'ComplexWarning', 'full', 'full_like',
     'matmul', 'shares_memory', 'may_share_memory', 'MAY_SHARE_BOUNDS',
     'MAY_SHARE_EXACT', 'TooHardError', 'AxisError']
-
-if sys.version_info[0] < 3:
-    __all__.extend(['getbuffer', 'newbuffer'])
 
 
 @set_module('numpy')

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -82,7 +82,6 @@ Exported symbols include:
 from __future__ import division, absolute_import, print_function
 
 import types as _types
-import sys
 import numbers
 import warnings
 
@@ -122,11 +121,8 @@ from ._dtype import _kind_name
 
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
-if sys.version_info[0] >= 3:
-    from builtins import bool, int, float, complex, object, str
-    unicode = str
-else:
-    from __builtin__ import bool, int, float, complex, object, unicode, str
+from builtins import bool, int, float, complex, object, str
+unicode = str
 
 
 # We use this later

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -309,32 +309,15 @@ def pyod(filename):
     We only implement enough to get the necessary information for long double
     representation, this is not intended as a compatible replacement for od.
     """
-    def _pyod2():
-        out = []
+    out = []
+    with open(filename, 'rb') as fid:
+        yo2 = [oct(o)[2:] for o in fid.read()]
+    for i in range(0, len(yo2), 16):
+        line = ['%07d' % int(oct(i)[2:])]
+        line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
+        out.append(" ".join(line))
+    return out
 
-        with open(filename, 'rb') as fid:
-            yo = [int(oct(int(binascii.b2a_hex(o), 16))) for o in fid.read()]
-        for i in range(0, len(yo), 16):
-            line = ['%07d' % int(oct(i))]
-            line.extend(['%03d' % c for c in yo[i:i+16]])
-            out.append(" ".join(line))
-        return out
-
-    def _pyod3():
-        out = []
-
-        with open(filename, 'rb') as fid:
-            yo2 = [oct(o)[2:] for o in fid.read()]
-        for i in range(0, len(yo2), 16):
-            line = ['%07d' % int(oct(i)[2:])]
-            line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
-            out.append(" ".join(line))
-        return out
-
-    if sys.version_info[0] < 3:
-        return _pyod2()
-    else:
-        return _pyod3()
 
 _BEFORE_SEQ = ['000', '000', '000', '000', '000', '000', '000', '000',
               '001', '043', '105', '147', '211', '253', '315', '357']

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -235,12 +235,8 @@ class TestArray2String(object):
                 return 'O'
 
         x = np.arange(3)
-        if sys.version_info[0] >= 3:
-            x_hex = "[0x0 0x1 0x2]"
-            x_oct = "[0o0 0o1 0o2]"
-        else:
-            x_hex = "[0x0L 0x1L 0x2L]"
-            x_oct = "[0L 01L 02L]"
+        x_hex = "[0x0 0x1 0x2]"
+        x_oct = "[0o0 0o1 0o2]"
         assert_(np.array2string(x, formatter={'all':_format_function}) ==
                 "[. o O]")
         assert_(np.array2string(x, formatter={'int_kind':_format_function}) ==
@@ -476,12 +472,8 @@ class TestPrintOptions(object):
 
         assert_equal(unicode(np.array(u'café', '<U4')), u'café')
 
-        if sys.version_info[0] >= 3:
-            assert_equal(repr(np.array('café', '<U4')),
-                         "array('café', dtype='<U4')")
-        else:
-            assert_equal(repr(np.array(u'café', '<U4')),
-                         "array(u'caf\\xe9', dtype='<U4')")
+        assert_equal(repr(np.array('café', '<U4')),
+                     "array('café', dtype='<U4')")
         assert_equal(str(np.array('test', np.str_)), 'test')
 
         a = np.zeros(1, dtype=[('a', '<i4', (3,))])
@@ -714,7 +706,7 @@ class TestPrintOptions(object):
             array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22.],
                   dtype=float32)"""))
 
-        styp = '<U4' if sys.version_info[0] >= 3 else '|S4'
+        styp = '<U4'
         assert_equal(repr(np.ones(3, dtype=styp)),
             "array(['1', '1', '1'], dtype='{}')".format(styp))
         assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
@@ -852,11 +844,7 @@ class TestPrintOptions(object):
         assert_raises(ValueError, np.set_printoptions, threshold=b'1')
 
 def test_unicode_object_array():
-    import sys
-    if sys.version_info[0] >= 3:
-        expected = "array(['é'], dtype=object)"
-    else:
-        expected = "array([u'\\xe9'], dtype=object)"
+    expected = "array(['é'], dtype=object)"
     x = np.array([u'\xe9'], dtype=object)
     assert_equal(repr(x), expected)
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -343,15 +343,8 @@ class TestMethods(object):
         assert_array_equal(C, tgt)
 
     def test_decode(self):
-        if sys.version_info[0] >= 3:
-            A = np.char.array([b'\\u03a3'])
-            assert_(A.decode('unicode-escape')[0] == '\u03a3')
-        else:
-            with suppress_warnings() as sup:
-                if sys.py3kwarning:
-                    sup.filter(DeprecationWarning, "'hex_codec'")
-                A = np.char.array(['736563726574206d657373616765'])
-                assert_(A.decode('hex_codec')[0] == 'secret message')
+        A = np.char.array([b'\\u03a3'])
+        assert_(A.decode('unicode-escape')[0] == '\u03a3')
 
     def test_encode(self):
         B = self.B.encode('unicode_escape')
@@ -362,18 +355,12 @@ class TestMethods(object):
         assert_(T[2, 0] == b'123      345 \0')
 
     def test_join(self):
-        if sys.version_info[0] >= 3:
-            # NOTE: list(b'123') == [49, 50, 51]
-            #       so that b','.join(b'123') results to an error on Py3
-            A0 = self.A.decode('ascii')
-        else:
-            A0 = self.A
+        # NOTE: list(b'123') == [49, 50, 51]
+        #       so that b','.join(b'123') results to an error on Py3
+        A0 = self.A.decode('ascii')
 
         A = np.char.join([',', '#'], A0)
-        if sys.version_info[0] >= 3:
-            assert_(issubclass(A.dtype.type, np.unicode_))
-        else:
-            assert_(issubclass(A.dtype.type, np.string_))
+        assert_(issubclass(A.dtype.type, np.unicode_))
         tgt = np.array([[' ,a,b,c, ', ''],
                         ['1,2,3,4,5', 'M#i#x#e#d#C#a#s#e'],
                         ['1,2,3, ,\t, ,3,4,5, ,\x00, ', 'U#P#P#E#R']])
@@ -443,15 +430,7 @@ class TestMethods(object):
                [b'12########## \t ##########45 \x00', b'UPPER']]
         assert_(issubclass(R.dtype.type, np.string_))
         assert_array_equal(R, tgt)
-
-        if sys.version_info[0] < 3:
-            # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(b'a', u'\u03a3')
-            tgt = [[u' \u03a3bc ', ''],
-                   ['12345', u'MixedC\u03a3se'],
-                   ['123 \t 345 \x00', 'UPPER']]
-            assert_(issubclass(R.dtype.type, np.unicode_))
-            assert_array_equal(R, tgt)
+        # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
 
     def test_rjust(self):
         assert_(issubclass(self.A.rjust(10).dtype.type, np.string_))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -6,7 +6,6 @@ to document how deprecations should eventually be turned into errors.
 from __future__ import division, absolute_import, print_function
 
 import datetime
-import sys
 import operator
 import warnings
 import pytest
@@ -235,15 +234,10 @@ class TestComparisonDeprecations(_DeprecationTestCase):
             struct = np.zeros(2, dtype="i4,i4")
             for arg2 in [struct, "a"]:
                 for f in [operator.lt, operator.le, operator.gt, operator.ge]:
-                    if sys.version_info[0] >= 3:
-                        # py3
-                        with warnings.catch_warnings() as l:
-                            warnings.filterwarnings("always")
-                            assert_raises(TypeError, f, arg1, arg2)
-                            assert_(not l)
-                    else:
-                        # py2
-                        assert_warns(DeprecationWarning, f, arg1, arg2)
+                    with warnings.catch_warnings() as l:
+                        warnings.filterwarnings("always")
+                        assert_raises(TypeError, f, arg1, arg2)
+                        assert_(not l)
 
 
 class TestDatetime64Timezone(_DeprecationTestCase):
@@ -386,8 +380,6 @@ class TestNumericStyleTypecodes(_DeprecationTestCase):
             'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
             'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0'
             ]
-        if sys.version_info[0] < 3:
-            deprecated_types.extend(['Unicode0', 'String0'])
 
         for dt in deprecated_types:
             self.assert_deprecated(np.dtype, exceptions=(TypeError,),
@@ -421,14 +413,6 @@ class TestClassicIntDivision(_DeprecationTestCase):
            'bool_', 'int_', 'intc', 'uint8', 'int8', 'uint64', 'int32', 'uint16',
            'intp', 'int64', 'uint32', 'int16'
             ]
-        if sys.version_info[0] < 3 and sys.py3kwarning:
-            import operator as op
-            dt2 = 'bool_'
-            for dt1 in deprecated_types:
-                a = np.array([1,2,3], dtype=dt1)
-                b = np.array([1,2,3], dtype=dt2)
-                self.assert_deprecated(op.div, args=(a,b))
-                dt2 = dt1
 
 
 class TestNonNumericConjugate(_DeprecationTestCase):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -847,11 +847,6 @@ class TestString(object):
         assert_equal(repr(dt), "dtype(('<i2', (1,)))")
         assert_equal(str(dt), "('<i2', (1,))")
 
-    @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Python 2 only")
-    def test_dtype_str_with_long_in_shape(self):
-        # Pull request #376, should not error
-        np.dtype('(1L,)i4')
-
     def test_base_dtype_with_object_type(self):
         # Issue gh-2798, should not error.
         np.array(['a'], dtype="O").astype(("O", [("name", "O")]))

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -1,6 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
 import itertools
 import pytest
 
@@ -12,9 +11,6 @@ from numpy.compat import long
 from numpy.testing import (
     assert_, assert_raises, assert_equal, assert_array_equal
     )
-
-if sys.version_info[0] >= 3:
-    xrange = range
 
 
 ndims = 2
@@ -141,9 +137,9 @@ def test_diophantine_fuzz():
                 # small enough so that brute force checking doesn't
                 # take too long)
                 try:
-                    ranges = tuple(xrange(0, a*ub+1, a) for a, ub in zip(A, U))
+                    ranges = tuple(range(0, a*ub+1, a) for a, ub in zip(A, U))
                 except OverflowError:
-                    # xrange on 32-bit Python 2 may overflow
+                    # range on 32-bit Python 2 may overflow
                     continue
 
                 size = 1
@@ -477,7 +473,7 @@ def check_internal_overlap(a, manual_expected=None):
 
     # Brute-force check
     m = set()
-    ranges = tuple(xrange(n) for n in a.shape)
+    ranges = tuple(range(n) for n in a.shape)
     for v in itertools.product(*ranges):
         offset = sum(s*w for s, w in zip(a.strides, v))
         if offset in m:

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -5,11 +5,11 @@ import os
 import shutil
 import mmap
 import pytest
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile, mktemp, mkdtemp
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
-from numpy.compat import Path
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (
@@ -76,7 +76,6 @@ class TestMemmap(object):
         del b
         del fp
 
-    @pytest.mark.skipif(Path is None, reason="No pathlib.Path")
     def test_path(self):
         tmpname = mktemp('', 'mmap', dir=self.tempdir)
         fp = memmap(Path(tmpname), dtype=self.dtype, mode='w+',

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -308,10 +308,7 @@ class ReadValuesNested(object):
         h = np.array(self._buffer, dtype=self._descr)
         assert_(h.dtype['Info']['value'].name == 'complex128')
         assert_(h.dtype['Info']['y2'].name == 'float64')
-        if sys.version_info[0] >= 3:
-            assert_(h.dtype['info']['Name'].name == 'str256')
-        else:
-            assert_(h.dtype['info']['Name'].name == 'unicode256')
+        assert_(h.dtype['info']['Name'].name == 'str256')
         assert_(h.dtype['info']['Value'].name == 'complex128')
 
     def test_nested2_descriptor(self):

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+from io import StringIO
 
 import pytest
 
@@ -8,11 +9,6 @@ import numpy as np
 from numpy.testing import assert_, assert_equal
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
-
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 _REF = {np.inf: 'inf', -np.inf: '-inf', np.nan: 'nan'}
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,18 +1,12 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc as collections_abc
 import textwrap
 from os import path
+from pathlib import Path
 import pytest
 
 import numpy as np
-from numpy.compat import Path
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, temppath
@@ -26,12 +20,8 @@ class TestFromrecords(object):
                             names='col1,col2,col3')
         assert_equal(r[0].item(), (456, 'dbe', 1.2))
         assert_equal(r['col1'].dtype.kind, 'i')
-        if sys.version_info[0] >= 3:
-            assert_equal(r['col2'].dtype.kind, 'U')
-            assert_equal(r['col2'].dtype.itemsize, 12)
-        else:
-            assert_equal(r['col2'].dtype.kind, 'S')
-            assert_equal(r['col2'].dtype.itemsize, 3)
+        assert_equal(r['col2'].dtype.kind, 'U')
+        assert_equal(r['col2'].dtype.itemsize, 12)
         assert_equal(r['col3'].dtype.kind, 'f')
 
     def test_fromrecords_0len(self):
@@ -325,7 +315,6 @@ class TestFromrecords(object):
         assert_equal(rec['f1'], [b'', b'', b''])
 
 
-@pytest.mark.skipif(Path is None, reason="No pathlib.Path")
 class TestPathUsage(object):
     # Test that pathlib.Path can be used
     def test_tofile_fromfile(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -462,15 +462,13 @@ class TestRegression(object):
              b"bI00\nS'O\\x81\\xb7Z\\xaa:\\xabY'\np22\ntp23\nb."),
         ]
 
-        if sys.version_info[:2] >= (3, 4):
-            # encoding='bytes' was added in Py3.4
-            for original, data in test_data:
-                result = pickle.loads(data, encoding='bytes')
-                assert_equal(result, original)
+        for original, data in test_data:
+            result = pickle.loads(data, encoding='bytes')
+            assert_equal(result, original)
 
-                if isinstance(result, np.ndarray) and result.dtype.names:
-                    for name in result.dtype.names:
-                        assert_(isinstance(name, str))
+            if isinstance(result, np.ndarray) and result.dtype.names:
+                for name in result.dtype.names:
+                    assert_(isinstance(name, str))
 
     def test_pickle_dtype(self):
         # Ticket #251
@@ -1081,14 +1079,8 @@ class TestRegression(object):
         # The dtype is float64, but the isbuiltin attribute is 0.
         data_dir = path.join(path.dirname(__file__), 'data')
         filename = path.join(data_dir, "astype_copy.pkl")
-        if sys.version_info[0] >= 3:
-            f = open(filename, 'rb')
+        with open(filename, 'rb') as f:
             xp = pickle.load(f, encoding='latin1')
-            f.close()
-        else:
-            f = open(filename)
-            xp = pickle.load(f)
-            f.close()
         xpd = xp.astype(np.float64)
         assert_((xp.__array_interface__['data'][0] !=
                 xpd.__array_interface__['data'][0]))
@@ -1205,10 +1197,7 @@ class TestRegression(object):
             msg = 'unicode offset: %d chars' % i
             t = np.dtype([('a', 'S%d' % i), ('b', 'U2')])
             x = np.array([(b'a', u'b')], dtype=t)
-            if sys.version_info[0] >= 3:
-                assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
-            else:
-                assert_equal(str(x), "[('a', u'b')]", err_msg=msg)
+            assert_equal(str(x), "[(b'a', 'b')]", err_msg=msg)
 
     def test_sign_for_complex_nan(self):
         # Ticket 794.
@@ -1788,11 +1777,6 @@ class TestRegression(object):
         assert_raises(RecursionError, int, a)
         assert_raises(RecursionError, long, a)
         assert_raises(RecursionError, float, a)
-        if sys.version_info.major == 2:
-            # in python 3, this falls back on operator.index, which fails on
-            # on dtype=object
-            assert_raises(RecursionError, oct, a)
-            assert_raises(RecursionError, hex, a)
         a[()] = None
 
     def test_object_array_circular_reference(self):
@@ -1819,11 +1803,6 @@ class TestRegression(object):
         assert_equal(int(a), int(0))
         assert_equal(long(a), long(0))
         assert_equal(float(a), float(0))
-        if sys.version_info.major == 2:
-            # in python 3, this falls back on operator.index, which fails on
-            # on dtype=object
-            assert_equal(oct(a), oct(0))
-            assert_equal(hex(a), hex(0))
 
     def test_object_array_self_copy(self):
         # An object array being copied into itself DECREF'ed before INCREF'ing
@@ -1927,13 +1906,12 @@ class TestRegression(object):
         assert_equal(s[0], "\x01")
 
     def test_pickle_bytes_overwrite(self):
-        if sys.version_info[0] >= 3:
-            for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
-                data = np.array([1], dtype='b')
-                data = pickle.loads(pickle.dumps(data, protocol=proto))
-                data[0] = 0xdd
-                bytestring = "\x01  ".encode('ascii')
-                assert_equal(bytestring[0:1], '\x01'.encode('ascii'))
+        for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
+            data = np.array([1], dtype='b')
+            data = pickle.loads(pickle.dumps(data, protocol=proto))
+            data[0] = 0xdd
+            bytestring = "\x01  ".encode('ascii')
+            assert_equal(bytestring[0:1], '\x01'.encode('ascii'))
 
     def test_pickle_py2_array_latin1_hack(self):
         # Check that unpickling hacks in Py3 that support
@@ -1944,12 +1922,11 @@ class TestRegression(object):
                 b"tp2\nS'b'\np3\ntp4\nRp5\n(I1\n(I1\ntp6\ncnumpy\ndtype\np7\n(S'i1'\np8\n"
                 b"I0\nI1\ntp9\nRp10\n(I3\nS'|'\np11\nNNNI-1\nI-1\nI0\ntp12\nbI00\nS'\\x81'\n"
                 b"p13\ntp14\nb.")
-        if sys.version_info[0] >= 3:
-            # This should work:
-            result = pickle.loads(data, encoding='latin1')
-            assert_array_equal(result, np.array([129], dtype='b'))
-            # Should not segfault:
-            assert_raises(Exception, pickle.loads, data, encoding='koi8-r')
+        # This should work:
+        result = pickle.loads(data, encoding='latin1')
+        assert_array_equal(result, np.array([129], dtype='b'))
+        # Should not segfault:
+        assert_raises(Exception, pickle.loads, data, encoding='koi8-r')
 
     def test_pickle_py2_scalar_latin1_hack(self):
         # Check that scalar unpickling hack in Py3 that supports
@@ -1976,25 +1953,24 @@ class TestRegression(object):
               b"tp8\nRp9\n."),
              'different'),
         ]
-        if sys.version_info[0] >= 3:
-            for original, data, koi8r_validity in datas:
-                result = pickle.loads(data, encoding='latin1')
-                assert_equal(result, original)
+        for original, data, koi8r_validity in datas:
+            result = pickle.loads(data, encoding='latin1')
+            assert_equal(result, original)
 
-                # Decoding under non-latin1 encoding (e.g.) KOI8-R can
-                # produce bad results, but should not segfault.
-                if koi8r_validity == 'different':
-                    # Unicode code points happen to lie within latin1,
-                    # but are different in koi8-r, resulting to silent
-                    # bogus results
-                    result = pickle.loads(data, encoding='koi8-r')
-                    assert_(result != original)
-                elif koi8r_validity == 'invalid':
-                    # Unicode code points outside latin1, so results
-                    # to an encoding exception
-                    assert_raises(ValueError, pickle.loads, data, encoding='koi8-r')
-                else:
-                    raise ValueError(koi8r_validity)
+            # Decoding under non-latin1 encoding (e.g.) KOI8-R can
+            # produce bad results, but should not segfault.
+            if koi8r_validity == 'different':
+                # Unicode code points happen to lie within latin1,
+                # but are different in koi8-r, resulting to silent
+                # bogus results
+                result = pickle.loads(data, encoding='koi8-r')
+                assert_(result != original)
+            elif koi8r_validity == 'invalid':
+                # Unicode code points outside latin1, so results
+                # to an encoding exception
+                assert_raises(ValueError, pickle.loads, data, encoding='koi8-r')
+            else:
+                raise ValueError(koi8r_validity)
 
     def test_structured_type_to_object(self):
         a_rec = np.array([(0, 1), (3, 2)], dtype='i4,i8')
@@ -2067,10 +2043,7 @@ class TestRegression(object):
         # Ticket #2081. Python compiled with two byte unicode
         # can lead to truncation if itemsize is not properly
         # adjusted for NumPy's four byte unicode.
-        if sys.version_info[0] >= 3:
-            a = np.array(['abcd'])
-        else:
-            a = np.array([u'abcd'])
+        a = np.array(['abcd'])
         assert_equal(a.dtype.itemsize, 16)
 
     def test_unique_stable(self):
@@ -2213,12 +2186,7 @@ class TestRegression(object):
         rhs = Foo()
         lhs = np.array(1)
         for f in [op.lt, op.le, op.gt, op.ge]:
-            if sys.version_info[0] >= 3:
-                assert_raises(TypeError, f, lhs, rhs)
-            elif not sys.py3kwarning:
-                # With -3 switch in python 2, DeprecationWarning is raised
-                # which we are not interested in
-                f(lhs, rhs)
+            assert_raises(TypeError, f, lhs, rhs)
         assert_(not op.eq(lhs, rhs))
         assert_(op.ne(lhs, rhs))
 

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -42,19 +42,6 @@ class TestFromString(object):
         flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
         assert_equal(flongdouble, -np.inf)
 
-    @pytest.mark.skipif((sys.version_info[0] >= 3)
-                        or (sys.platform == "win32"
-                            and platform.architecture()[0] == "64bit"),
-                        reason="numpy.intp('0xff', 16) not supported on Py3 "
-                               "or 64 bit Windows")
-    def test_intp(self):
-        # Ticket #99
-        i_width = np.int_(0).nbytes*2 - 1
-        np.intp('0x' + 'f'*i_width, 16)
-        assert_raises(OverflowError, np.intp, '0x' + 'f'*(i_width+1), 16)
-        assert_raises(ValueError, np.intp, '0x1', 32)
-        assert_equal(255, np.intp('0xFF', 16))
-
 
 class TestFromInt(object):
     def test_intp(self):

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -1,7 +1,6 @@
 """
 Test scalar buffer interface adheres to PEP 3118
 """
-import sys
 import numpy as np
 import pytest
 
@@ -31,8 +30,6 @@ scalars_and_codes = [
 scalars_only, codes_only = zip(*scalars_and_codes)
 
 
-@pytest.mark.skipif(sys.version_info.major < 3,
-                    reason="Python 2 scalars lack a buffer interface")
 class TestScalarPEP3118(object):
 
     @pytest.mark.parametrize('scalar', scalars_only, ids=codes_only)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -86,7 +86,7 @@ class TestBaseMath(object):
                 assert_almost_equal(np.square(inp2),
                                     np.multiply(inp2, inp2),  err_msg=msg)
                 # skip true divide for ints
-                if dt != np.int32 or (sys.version_info.major < 3 and not sys.py3kwarning):
+                if dt != np.int32:
                     assert_almost_equal(np.reciprocal(inp2),
                                         np.divide(1, inp2),  err_msg=msg)
 

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import pytest
-import sys
 import numpy as np
 from numpy.core import (
     array, arange, atleast_1d, atleast_2d, atleast_3d, block, vstack, hstack,
@@ -159,10 +158,8 @@ class TestHstack(object):
     def test_generator(self):
         with assert_warns(FutureWarning):
             hstack((np.arange(3) for _ in range(2)))
-        if sys.version_info.major > 2:
-            # map returns a list on Python 2
-            with assert_warns(FutureWarning):
-                hstack(map(lambda x: x, np.ones((3, 2))))
+        with assert_warns(FutureWarning):
+            hstack(map(lambda x: x, np.ones((3, 2))))
 
 
 class TestVstack(object):

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -1,45 +1,32 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-
 import numpy as np
 from numpy.compat import unicode
 from numpy.testing import assert_, assert_equal, assert_array_equal
 
 # Guess the UCS length for this python interpreter
-if sys.version_info[:2] >= (3, 3):
-    # Python 3.3 uses a flexible string representation
-    ucs4 = False
+# Python 3.3 uses a flexible string representation
+ucs4 = False
 
-    def buffer_length(arr):
-        if isinstance(arr, unicode):
-            arr = str(arr)
-            if not arr:
-                charmax = 0
-            else:
-                charmax = max([ord(c) for c in arr])
-            if charmax < 256:
-                size = 1
-            elif charmax < 65536:
-                size = 2
-            else:
-                size = 4
-            return size * len(arr)
-        v = memoryview(arr)
-        if v.shape is None:
-            return len(v) * v.itemsize
+def buffer_length(arr):
+    if isinstance(arr, unicode):
+        arr = str(arr)
+        if not arr:
+            charmax = 0
         else:
-            return np.prod(v.shape) * v.itemsize
-else:
-    if len(buffer(u'u')) == 4:
-        ucs4 = True
+            charmax = max([ord(c) for c in arr])
+        if charmax < 256:
+            size = 1
+        elif charmax < 65536:
+            size = 2
+        else:
+            size = 4
+        return size * len(arr)
+    v = memoryview(arr)
+    if v.shape is None:
+        return len(v) * v.itemsize
     else:
-        ucs4 = False
-
-    def buffer_length(arr):
-        if isinstance(arr, np.ndarray):
-            return len(arr.data)
-        return len(buffer(arr))
+        return np.prod(v.shape) * v.itemsize
 
 # In both cases below we need to make sure that the byte swapped value (as
 # UCS4) is still a valid unicode:
@@ -54,12 +41,8 @@ def test_string_cast():
     uni_arr1 = str_arr.astype('>U')
     uni_arr2 = str_arr.astype('<U')
 
-    if sys.version_info[0] < 3:
-        assert_array_equal(str_arr, uni_arr1)
-        assert_array_equal(str_arr, uni_arr2)
-    else:
-        assert_(str_arr != uni_arr1)
-        assert_(str_arr != uni_arr2)
+    assert_(str_arr != uni_arr1)
+    assert_(str_arr != uni_arr2)
     assert_array_equal(uni_arr1, uni_arr2)
 
 

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -85,11 +85,8 @@ def _needs_build(obj, cc_args, extra_postargs, pp_opts):
 
 
 def replace_method(klass, method_name, func):
-    if sys.version_info[0] < 3:
-        m = types.MethodType(func, None, klass)
-    else:
-        # Py3k does not have unbound method anymore, MethodType does not work
-        m = lambda self, *args, **kw: func(self, *args, **kw)
+    # Py3k does not have unbound method anymore, MethodType does not work
+    m = lambda self, *args, **kw: func(self, *args, **kw)
     setattr(klass, method_name, m)
 
 
@@ -273,12 +270,8 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
 
     if not sources:
         return []
-    # FIXME:RELATIVE_IMPORT
-    if sys.version_info[0] < 3:
-        from .fcompiler import FCompiler, is_f_file, has_f90_header
-    else:
-        from numpy.distutils.fcompiler import (FCompiler, is_f_file,
-                                               has_f90_header)
+    from numpy.distutils.fcompiler import (FCompiler, is_f_file,
+                                           has_f90_header)
     if isinstance(self, FCompiler):
         display = []
         for fc in ['f77', 'f90', 'fix']:

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -19,10 +19,7 @@ __all__ = ['cpu']
 import sys, re, types
 import os
 
-if sys.version_info[0] >= 3:
-    from subprocess import getstatusoutput
-else:
-    from commands import getstatusoutput
+from subprocess import getstatusoutput
 
 import warnings
 import platform
@@ -490,10 +487,7 @@ class Win32CPUInfo(CPUInfoBase):
         info = []
         try:
             #XXX: Bad style to use so long `try:...except:...`. Fix it!
-            if sys.version_info[0] >= 3:
-                import winreg
-            else:
-                import _winreg as winreg
+            import winreg
 
             prgx = re.compile(r"family\s+(?P<FML>\d+)\s+model\s+(?P<MDL>\d+)"
                               r"\s+stepping\s+(?P<STP>\d+)", re.IGNORECASE)

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -76,10 +76,6 @@ def filepath_from_subprocess_output(output):
     # Another historical oddity
     if output[-1:] == '\n':
         output = output[:-1]
-    # stdio uses bytes in python 2, so to avoid issues, we simply
-    # remove all non-ascii characters
-    if sys.version_info < (3, 0):
-        output = output.encode('ascii', errors='replace')
     return output
 
 
@@ -91,10 +87,7 @@ def forward_bytes_to_stdout(val):
     The assumption is that the subprocess call already returned bytes in
     a suitable encoding.
     """
-    if sys.version_info.major < 3:
-        # python 2 has binary output anyway
-        sys.stdout.write(val)
-    elif hasattr(sys.stdout, 'buffer'):
+    if hasattr(sys.stdout, 'buffer'):
         # use the underlying binary output if there is one
         sys.stdout.buffer.write(val)
     elif hasattr(sys.stdout, 'encoding'):
@@ -306,11 +299,6 @@ def _exec_command(command, use_shell=None, use_tee = None, **env):
     # Another historical oddity
     if text[-1:] == '\n':
         text = text[:-1]
-
-    # stdio uses bytes in python 2, so to avoid issues, we simply
-    # remove all non-ascii characters
-    if sys.version_info < (3, 0):
-        text = text.encode('ascii', errors='replace')
 
     if use_tee and text:
         print(text)

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -8,12 +8,10 @@ Overridden to support f2py.
 """
 from __future__ import division, absolute_import, print_function
 
-import sys
 import re
 from distutils.extension import Extension as old_Extension
 
-if sys.version_info[0] >= 3:
-    basestring = str
+basestring = str
 
 
 cxx_ext_re = re.compile(r'.*[.](cpp|cxx|cc)\Z', re.I).match

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -415,8 +415,7 @@ class Gnu95FCompiler(GnuFCompiler):
                         break
                     h.update(block)
         text = base64.b32encode(h.digest())
-        if sys.version_info[0] >= 3:
-            text = text.decode('ascii')
+        text = text.decode('ascii')
         return text.rstrip('=')
 
     def _link_wrapper_lib(self, objects, output_dir, extra_dll_dir,

--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -2,6 +2,7 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
+import functools
 
 from numpy.distutils.fcompiler import FCompiler, dummy_fortran_file
 from sys import platform
@@ -64,72 +65,59 @@ class PGroupFCompiler(FCompiler):
         return '-R%s' % dir
 
 
-if sys.version_info >= (3, 5):
-    import functools
+class PGroupFlangCompiler(FCompiler):
 
-    class PGroupFlangCompiler(FCompiler):
-        compiler_type = 'flang'
-        description = 'Portland Group Fortran LLVM Compiler'
-        version_pattern = r'\s*(flang|clang) version (?P<version>[\d.-]+).*'
+    compiler_type = 'flang'
+    description = 'Portland Group Fortran LLVM Compiler'
+    version_pattern = r'\s*(flang|clang) version (?P<version>[\d.-]+).*'
 
-        ar_exe = 'lib.exe'
-        possible_executables = ['flang']
+    ar_exe = 'lib.exe'
+    possible_executables = ['flang']
 
-        executables = {
-            'version_cmd': ["<F77>", "--version"],
-            'compiler_f77': ["flang"],
-            'compiler_fix': ["flang"],
-            'compiler_f90': ["flang"],
-            'linker_so': [None],
-            'archiver': [ar_exe, "/verbose", "/OUT:"],
-            'ranlib': None
-        }
+    executables = {
+        'version_cmd': ["<F77>", "--version"],
+        'compiler_f77': ["flang"],
+        'compiler_fix': ["flang"],
+        'compiler_f90': ["flang"],
+        'linker_so': [None],
+        'archiver': [ar_exe, "/verbose", "/OUT:"],
+        'ranlib': None
+    }
 
-        library_switch = '/OUT:'  # No space after /OUT:!
-        module_dir_switch = '-module '  # Don't remove ending space!
+    library_switch = '/OUT:'  # No space after /OUT:!
+    module_dir_switch = '-module '  # Don't remove ending space!
 
-        def get_libraries(self):
-            opt = FCompiler.get_libraries(self)
-            opt.extend(['flang', 'flangrti', 'ompstub'])
-            return opt
+    def get_libraries(self):
+        opt = FCompiler.get_libraries(self)
+        opt.extend(['flang', 'flangrti', 'ompstub'])
+        return opt
 
-        @functools.lru_cache(maxsize=128)
-        def get_library_dirs(self):
-            """List of compiler library directories."""
-            opt = FCompiler.get_library_dirs(self)
-            flang_dir = dirname(self.executables['compiler_f77'][0])
-            opt.append(normpath(join(flang_dir, '..', 'lib')))
+    @functools.lru_cache(maxsize=128)
+    def get_library_dirs(self):
+        """List of compiler library directories."""
+        opt = FCompiler.get_library_dirs(self)
+        flang_dir = dirname(self.executables['compiler_f77'][0])
+        opt.append(normpath(join(flang_dir, '..', 'lib')))
 
-            return opt
+        return opt
 
-        def get_flags(self):
-            return []
+    def get_flags(self):
+        return []
 
-        def get_flags_free(self):
-            return []
+    def get_flags_free(self):
+        return []
 
-        def get_flags_debug(self):
-            return ['-g']
+    def get_flags_debug(self):
+        return ['-g']
 
-        def get_flags_opt(self):
-            return ['-O3']
+    def get_flags_opt(self):
+        return ['-O3']
 
-        def get_flags_arch(self):
-            return []
+    def get_flags_arch(self):
+        return []
 
-        def runtime_library_dir_option(self, dir):
-            raise NotImplementedError
-
-else:
-    from numpy.distutils.fcompiler import CompilerNotFound
-
-    # No point in supporting on older Pythons because not ABI compatible
-    class PGroupFlangCompiler(FCompiler):
-        compiler_type = 'flang'
-        description = 'Portland Group Fortran LLVM Compiler'
-
-        def get_version(self):
-            raise CompilerNotFound('Flang unsupported on Python < 3.5')
+    def runtime_library_dir_option(self, dir):
+        raise NotImplementedError
 
 
 if __name__ == '__main__':

--- a/numpy/distutils/log.py
+++ b/numpy/distutils/log.py
@@ -1,4 +1,4 @@
-# Colored log, requires Python 2.3 or up.
+# Colored log
 from __future__ import division, absolute_import, print_function
 
 import sys
@@ -6,12 +6,8 @@ from distutils.log import *
 from distutils.log import Log as old_Log
 from distutils.log import _global_log
 
-if sys.version_info[0] < 3:
-    from .misc_util import (red_text, default_text, cyan_text, green_text,
-            is_sequence, is_string)
-else:
-    from numpy.distutils.misc_util import (red_text, default_text, cyan_text,
-            green_text, is_sequence, is_string)
+from numpy.distutils.misc_util import (red_text, default_text, cyan_text,
+                                       green_text, is_sequence, is_string)
 
 
 def _fix_args(args,flag=1):

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -18,10 +18,7 @@ import textwrap
 # Overwrite certain distutils.ccompiler functions:
 import numpy.distutils.ccompiler
 
-if sys.version_info[0] < 3:
-    from . import log
-else:
-    from numpy.distutils import log
+from numpy.distutils import log
 # NT stuff
 # 1. Make sure libpython<version>.a exists for gcc.  If not, build it.
 # 2. Force windows to use gcc (we're struggling with MSVC and g77 support)

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -926,18 +926,8 @@ class Configuration(object):
             else:
                 pn = dot_join(*([parent_name] + subpackage_name.split('.')[:-1]))
                 args = (pn,)
-                def fix_args_py2(args):
-                    if setup_module.configuration.__code__.co_argcount > 1:
-                        args = args + (self.top_path,)
-                    return args
-                def fix_args_py3(args):
-                    if setup_module.configuration.__code__.co_argcount > 1:
-                        args = args + (self.top_path,)
-                    return args
-                if sys.version_info[0] < 3:
-                    args = fix_args_py2(args)
-                else:
-                    args = fix_args_py3(args)
+                if setup_module.configuration.__code__.co_argcount > 1:
+                    args = args + (self.top_path,)
                 config = setup_module.configuration(*args)
             if config.name!=dot_join(parent_name, subpackage_name):
                 self.warn('Subpackage %r configuration returned as %r' % \
@@ -2198,10 +2188,7 @@ def get_info(pkgname, dirs=None):
     return info
 
 def is_bootstrapping():
-    if sys.version_info[0] >= 3:
-        import builtins
-    else:
-        import __builtin__ as builtins
+    import builtins
 
     try:
         builtins.__NUMPY_SETUP__

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -4,10 +4,7 @@ import sys
 import re
 import os
 
-if sys.version_info[0] < 3:
-    from ConfigParser import RawConfigParser
-else:
-    from configparser import RawConfigParser
+from configparser import RawConfigParser
 
 __all__ = ['FormatError', 'PkgNotFound', 'LibraryInfo', 'VariableSet',
         'read_config', 'parse_flags']

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -132,12 +132,8 @@ import textwrap
 
 from glob import glob
 from functools import reduce
-if sys.version_info[0] < 3:
-    from ConfigParser import NoOptionError
-    from ConfigParser import RawConfigParser as ConfigParser
-else:
-    from configparser import NoOptionError
-    from configparser import RawConfigParser as ConfigParser
+from configparser import NoOptionError
+from configparser import RawConfigParser as ConfigParser
 # It seems that some people are importing ConfigParser from here so is
 # good to keep its class name. Use of RawConfigParser is needed in
 # order to be able to load path names with percent in them, like
@@ -250,32 +246,29 @@ if sys.platform == 'win32':
         default_include_dirs.extend(
             os.path.join(library_root, d) for d in _include_dirs)
 
-    if sys.version_info >= (3, 3):
-        # VCpkg is the de-facto package manager on windows for C/C++
-        # libraries. If it is on the PATH, then we append its paths here.
-        # We also don't re-implement shutil.which for Python 2.7 because
-        # vcpkg doesn't support MSVC 2008.
-        vcpkg = shutil.which('vcpkg')
-        if vcpkg:
-            vcpkg_dir = os.path.dirname(vcpkg)
-            if platform.architecture() == '32bit':
-                specifier = 'x86'
-            else:
-                specifier = 'x64'
+    # VCpkg is the de-facto package manager on windows for C/C++
+    # libraries. If it is on the PATH, then we append its paths here.
+    vcpkg = shutil.which('vcpkg')
+    if vcpkg:
+        vcpkg_dir = os.path.dirname(vcpkg)
+        if platform.architecture() == '32bit':
+            specifier = 'x86'
+        else:
+            specifier = 'x64'
 
-            vcpkg_installed = os.path.join(vcpkg_dir, 'installed')
-            for vcpkg_root in [
-                os.path.join(vcpkg_installed, specifier + '-windows'),
-                os.path.join(vcpkg_installed, specifier + '-windows-static'),
-            ]:
-                add_system_root(vcpkg_root)
+        vcpkg_installed = os.path.join(vcpkg_dir, 'installed')
+        for vcpkg_root in [
+            os.path.join(vcpkg_installed, specifier + '-windows'),
+            os.path.join(vcpkg_installed, specifier + '-windows-static'),
+        ]:
+            add_system_root(vcpkg_root)
 
-        # Conda is another popular package manager that provides libraries
-        conda = shutil.which('conda')
-        if conda:
-            conda_dir = os.path.dirname(conda)
-            add_system_root(os.path.join(conda_dir, '..', 'Library'))
-            add_system_root(os.path.join(conda_dir, 'Library'))
+    # Conda is another popular package manager that provides libraries
+    conda = shutil.which('conda')
+    if conda:
+        conda_dir = os.path.dirname(conda)
+        add_system_root(os.path.join(conda_dir, '..', 'Library'))
+        add_system_root(os.path.join(conda_dir, 'Library'))
 
 else:
     default_lib_dirs = libpaths(['/usr/local/lib', '/opt/lib', '/usr/lib',
@@ -2015,8 +2008,6 @@ class openblas_lapack_info(openblas_info):
             extra_args = info['extra_link_args']
         except Exception:
             extra_args = []
-        if sys.version_info < (3, 5) and sys.version_info > (3, 0) and c.compiler_type == "msvc":
-            extra_args.append("/MANIFEST")
         try:
             with open(src, 'wt') as f:
                 f.write(s)

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -2,18 +2,13 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import sys
+from io import StringIO
 from tempfile import TemporaryFile
 
 from numpy.distutils import exec_command
 from numpy.distutils.exec_command import get_pythonexe
 from numpy.testing import tempdir, assert_, assert_warns
 
-# In python 3 stdout, stderr are text (unicode compliant) devices, so to
-# emulate them import StringIO from the io module.
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 class redirect_stdout(object):
     """Context manager to redirect stdout for exec_command test."""

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -8,14 +8,10 @@ import os
 
 from distutils.errors import DistutilsExecError, CompileError
 from distutils.unixccompiler import *
+from numpy.distutils import log
 from numpy.distutils.ccompiler import replace_method
 from numpy.distutils.compat import get_exception
 from numpy.distutils.misc_util import _commandline_dep_string
-
-if sys.version_info[0] < 3:
-    from . import log
-else:
-    from numpy.distutils import log
 
 # Note that UnixCCompiler._compile appeared in Python 2.3
 def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -21,7 +21,6 @@ f2py_version = __version__.version
 import copy
 import re
 import os
-import sys
 from .crackfortran import markoutercomma
 from . import cb_rules
 
@@ -149,11 +148,7 @@ c2buildvalue_map = {'double': 'd',
                     'complex_float': 'N',
                     'complex_double': 'N',
                     'complex_long_double': 'N',
-                    'string': 'z'}
-
-if sys.version_info[0] >= 3:
-    # Bytes, not Unicode strings
-    c2buildvalue_map['string'] = 'y'
+                    'string': 'y'}
 
 if using_newcore:
     # c2buildvalue_map=???

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -16,8 +16,6 @@ from . import util
 
 
 def setup_module():
-    if sys.platform == 'win32' and sys.version_info[0] < 3:
-        pytest.skip('Fails with MinGW64 Gfortran (Issue #9673)')
     if not util.has_c_compiler():
         pytest.skip("Needs C compiler")
     if not util.has_f77_compiler():

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -7,11 +7,7 @@ from numpy.testing import (
         assert_array_almost_equal, assert_array_equal, assert_raises,
         )
 import threading
-import sys
-if sys.version_info[0] >= 3:
-    import queue
-else:
-    import Queue as queue
+import queue
 
 
 def fft1(x):

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -37,7 +37,6 @@ Example::
 from __future__ import division, absolute_import, print_function
 
 import os
-import sys
 import warnings
 import shutil
 import io
@@ -176,19 +175,13 @@ class _FileOpeners(object):
 
         try:
             import bz2
-            if sys.version_info[0] >= 3:
-                self._file_openers[".bz2"] = bz2.open
-            else:
-                self._file_openers[".bz2"] = _python2_bz2open
+            self._file_openers[".bz2"] = bz2.open
         except ImportError:
             pass
 
         try:
             import gzip
-            if sys.version_info[0] >= 3:
-                self._file_openers[".gz"] = gzip.open
-            else:
-                self._file_openers[".gz"] = _python2_gzipopen
+            self._file_openers[".gz"] = gzip.open
         except ImportError:
             pass
 
@@ -377,10 +370,7 @@ class DataSource(object):
         """Test if path is a net location.  Tests the scheme and netloc."""
 
         # We do this here to reduce the 'import numpy' initial import time.
-        if sys.version_info[0] >= 3:
-            from urllib.parse import urlparse
-        else:
-            from urlparse import urlparse
+        from urllib.parse import urlparse
 
         # BUG : URLs require a scheme string ('http://') to be used.
         #       www.google.com will fail.
@@ -397,14 +387,10 @@ class DataSource(object):
         Creates a copy of the file in the datasource cache.
 
         """
-        # We import these here because importing urllib2 is slow and
+        # We import these here because importing urllib is slow and
         # a significant fraction of numpy's total import time.
-        if sys.version_info[0] >= 3:
-            from urllib.request import urlopen
-            from urllib.error import URLError
-        else:
-            from urllib2 import urlopen
-            from urllib2 import URLError
+        from urllib.request import urlopen
+        from urllib.error import URLError
 
         upath = self.abspath(path)
 
@@ -479,10 +465,7 @@ class DataSource(object):
 
         """
         # We do this here to reduce the 'import numpy' initial import time.
-        if sys.version_info[0] >= 3:
-            from urllib.parse import urlparse
-        else:
-            from urlparse import urlparse
+        from urllib.parse import urlparse
 
         # TODO:  This should be more robust.  Handles case where path includes
         #        the destpath, but not other sub-paths. Failing case:
@@ -549,14 +532,10 @@ class DataSource(object):
         if os.path.exists(path):
             return True
 
-        # We import this here because importing urllib2 is slow and
+        # We import this here because importing urllib is slow and
         # a significant fraction of numpy's total import time.
-        if sys.version_info[0] >= 3:
-            from urllib.request import urlopen
-            from urllib.error import URLError
-        else:
-            from urllib2 import urlopen
-            from urllib2 import URLError
+        from urllib.request import urlopen
+        from urllib.error import URLError
 
         # Test cached url
         upath = self.abspath(path)

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -5,16 +5,12 @@ from __future__ import division, absolute_import, print_function
 
 __docformat__ = "restructuredtext en"
 
-import sys
 import numpy as np
 import numpy.core.numeric as nx
 from numpy.compat import asbytes, asunicode, bytes, basestring
 
-if sys.version_info[0] >= 3:
-    from builtins import bool, int, float, complex, object, str
-    unicode = str
-else:
-    from __builtin__ import bool, int, float, complex, object, unicode, str
+from builtins import bool, int, float, complex, object, str
+unicode = str
 
 
 def _decode_line(line, encoding=None):

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -164,7 +164,6 @@ evolved with time and this document is more current.
 from __future__ import division, absolute_import, print_function
 
 import numpy
-import sys
 import io
 import warnings
 from numpy.lib.utils import safe_eval
@@ -212,10 +211,7 @@ def magic(major, minor):
         raise ValueError("major version must be 0 <= major < 256")
     if minor < 0 or minor > 255:
         raise ValueError("minor version must be 0 <= minor < 256")
-    if sys.version_info[0] < 3:
-        return MAGIC_PREFIX + chr(major) + chr(minor)
-    else:
-        return MAGIC_PREFIX + bytes([major, minor])
+    return MAGIC_PREFIX + bytes([major, minor])
 
 def read_magic(fp):
     """ Read the magic string to get the version of the file format.
@@ -233,10 +229,7 @@ def read_magic(fp):
     if magic_str[:-2] != MAGIC_PREFIX:
         msg = "the magic string is not correct; expected %r, got %r"
         raise ValueError(msg % (MAGIC_PREFIX, magic_str[:-2]))
-    if sys.version_info[0] < 3:
-        major, minor = map(ord, magic_str[-2:])
-    else:
-        major, minor = magic_str[-2:]
+    major, minor = magic_str[-2:]
     return major, minor
 
 def dtype_to_descr(dtype):
@@ -527,10 +520,7 @@ def _filter_header(s):
 
     """
     import tokenize
-    if sys.version_info[0] >= 3:
-        from io import StringIO
-    else:
-        from StringIO import StringIO
+    from io import StringIO
 
     tokens = []
     last_token_was_number = False
@@ -726,12 +716,10 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None):
         try:
             array = pickle.load(fp, **pickle_kwargs)
         except UnicodeError as err:
-            if sys.version_info[0] >= 3:
-                # Friendlier error message
-                raise UnicodeError("Unpickling a python object failed: %r\n"
-                                   "You may need to pass the encoding= option "
-                                   "to numpy.load" % (err,))
-            raise
+            # Friendlier error message
+            raise UnicodeError("Unpickling a python object failed: %r\n"
+                               "You may need to pass the encoding= option "
+                               "to numpy.load" % (err,))
     else:
         if isfileobj(fp):
             # We can use the fast fromfile() function.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1,11 +1,7 @@
 from __future__ import division, absolute_import, print_function
 
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import builtins
+import collections.abc as collections_abc
 import functools
 import re
 import sys
@@ -37,13 +33,6 @@ from numpy.core.multiarray import (
     )
 from numpy.core.umath import _add_newdoc_ufunc as add_newdoc_ufunc
 from numpy.compat import long
-
-if sys.version_info[0] < 3:
-    # Force range to be a generator, for np.delete's usage.
-    range = xrange
-    import __builtin__ as builtins
-else:
-    import builtins
 
 
 array_function_dispatch = functools.partial(

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -1,8 +1,6 @@
 """Mixin classes for custom array types that don't inherit from ndarray."""
 from __future__ import division, absolute_import, print_function
 
-import sys
-
 from numpy.core import umath as um
 
 # Nothing should be exposed in the top-level NumPy module.
@@ -154,9 +152,7 @@ class NDArrayOperatorsMixin(object):
     __mul__, __rmul__, __imul__ = _numeric_methods(um.multiply, 'mul')
     __matmul__, __rmatmul__, __imatmul__ = _numeric_methods(
         um.matmul, 'matmul')
-    if sys.version_info.major < 3:
-        # Python 3 uses only __truediv__ and __floordiv__
-        __div__, __rdiv__, __idiv__ = _numeric_methods(um.divide, 'div')
+    # Python 3 does not use __div__, __rdiv__, or __idiv__
     __truediv__, __rtruediv__, __itruediv__ = _numeric_methods(
         um.true_divide, 'truediv')
     __floordiv__, __rfloordiv__, __ifloordiv__ = _numeric_methods(

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -7,7 +7,6 @@ matplotlib.  They have been rewritten and extended for convenience.
 """
 from __future__ import division, absolute_import, print_function
 
-import sys
 import itertools
 import numpy as np
 import numpy.ma as ma
@@ -18,9 +17,6 @@ from numpy.core.overrides import array_function_dispatch
 from numpy.lib._iotools import _is_string_like
 from numpy.compat import basestring
 from numpy.testing import suppress_warnings
-
-if sys.version_info[0] < 3:
-    from future_builtins import zip
 
 _check_fill_value = np.ma.core._check_fill_value
 
@@ -343,12 +339,7 @@ def izip_records(seqarrays, fill_value=None, flatten=True):
     else:
         zipfunc = _izip_fields
 
-    if sys.version_info[0] >= 3:
-        zip_longest = itertools.zip_longest
-    else:
-        zip_longest = itertools.izip_longest
-
-    for tup in zip_longest(*seqarrays, fillvalue=fill_value):
+    for tup in itertools.zip_longest(*seqarrays, fillvalue=fill_value):
         yield tuple(zipfunc(tup))
 
 

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -1,8 +1,10 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import sys
 import pytest
+import urllib.request as urllib_request
+from urllib.parse import urlparse
+from urllib.error import URLError
 from tempfile import mkdtemp, mkstemp, NamedTemporaryFile
 from shutil import rmtree
 
@@ -10,16 +12,6 @@ import numpy.lib._datasource as datasource
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_warns
     )
-
-if sys.version_info[0] >= 3:
-    import urllib.request as urllib_request
-    from urllib.parse import urlparse
-    from urllib.error import URLError
-else:
-    import urllib2 as urllib_request
-    from urlparse import urlparse
-    from urllib2 import URLError
-
 
 def urlopen_stub(url, data=None):
     '''Stub to replace urlopen for testing.'''
@@ -162,24 +154,6 @@ class TestDataSourceOpen(object):
         fp = self.ds.open(filepath)
         result = fp.readline()
         fp.close()
-        assert_equal(magic_line, result)
-
-    @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Python 2 only")
-    def test_Bz2File_text_mode_warning(self):
-        try:
-            import bz2
-        except ImportError:
-            # We don't have the bz2 capabilities to test.
-            pytest.skip()
-        # Test datasource's internal file_opener for BZip2 files.
-        filepath = os.path.join(self.tmpdir, 'foobar.txt.bz2')
-        fp = bz2.BZ2File(filepath, 'w')
-        fp.write(magic_line)
-        fp.close()
-        with assert_warns(RuntimeWarning):
-            fp = self.ds.open(filepath, 'rt')
-            result = fp.readline()
-            fp.close()
         assert_equal(magic_line, result)
 
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -550,10 +550,7 @@ def test_load_padded_dtype(dt):
 
 
 def test_python2_python3_interoperability():
-    if sys.version_info[0] >= 3:
-        fname = 'win64python2.npy'
-    else:
-        fname = 'python3.npy'
+    fname = 'win64python2.npy'
     path = os.path.join(os.path.dirname(__file__), 'data', fname)
     data = np.load(path)
     assert_array_equal(data, np.ones(2))
@@ -563,13 +560,7 @@ def test_pickle_python2_python3():
     # Python 2 and Python 3 and vice versa
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
-    if sys.version_info[0] >= 3:
-        xrange = range
-    else:
-        import __builtin__
-        xrange = __builtin__.xrange
-
-    expected = np.array([None, xrange, u'\u512a\u826f',
+    expected = np.array([None, range, u'\u512a\u826f',
                          b'\xe4\xb8\x8d\xe8\x89\xaf'],
                         dtype=object)
 
@@ -585,34 +576,30 @@ def test_pickle_python2_python3():
             else:
                 data = data_f
 
-            if sys.version_info[0] >= 3:
-                if encoding == 'latin1' and fname.startswith('py2'):
-                    assert_(isinstance(data[3], str))
-                    assert_array_equal(data[:-1], expected[:-1])
-                    # mojibake occurs
-                    assert_array_equal(data[-1].encode(encoding), expected[-1])
-                else:
-                    assert_(isinstance(data[3], bytes))
-                    assert_array_equal(data, expected)
+            if encoding == 'latin1' and fname.startswith('py2'):
+                assert_(isinstance(data[3], str))
+                assert_array_equal(data[:-1], expected[:-1])
+                # mojibake occurs
+                assert_array_equal(data[-1].encode(encoding), expected[-1])
             else:
+                assert_(isinstance(data[3], bytes))
                 assert_array_equal(data, expected)
 
-        if sys.version_info[0] >= 3:
-            if fname.startswith('py2'):
-                if fname.endswith('.npz'):
-                    data = np.load(path, allow_pickle=True)
-                    assert_raises(UnicodeError, data.__getitem__, 'x')
-                    data.close()
-                    data = np.load(path, allow_pickle=True, fix_imports=False,
-                                   encoding='latin1')
-                    assert_raises(ImportError, data.__getitem__, 'x')
-                    data.close()
-                else:
-                    assert_raises(UnicodeError, np.load, path,
-                                  allow_pickle=True)
-                    assert_raises(ImportError, np.load, path,
-                                  allow_pickle=True, fix_imports=False,
-                                  encoding='latin1')
+        if fname.startswith('py2'):
+            if fname.endswith('.npz'):
+                data = np.load(path, allow_pickle=True)
+                assert_raises(UnicodeError, data.__getitem__, 'x')
+                data.close()
+                data = np.load(path, allow_pickle=True, fix_imports=False,
+                               encoding='latin1')
+                assert_raises(ImportError, data.__getitem__, 'x')
+                data.close()
+            else:
+                assert_raises(UnicodeError, np.load, path,
+                              allow_pickle=True)
+                assert_raises(ImportError, np.load, path,
+                              allow_pickle=True, fix_imports=False,
+                              encoding='latin1')
 
 
 def test_pickle_disallow():

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -26,7 +26,6 @@ from numpy.lib import (
 
 from numpy.compat import long
 
-PY2 = sys.version_info[0] == 2
 
 def get_mat(n):
     data = np.arange(n)
@@ -1547,11 +1546,8 @@ class TestLeaks(object):
                 a.f = np.frompyfunc(getattr(a, name), 1, 1)
                 out = a.f(np.arange(10))
             a = None
-            if PY2:
-                assert_equal(sys.getrefcount(A_func), refcount)
-            else:
-                # A.func is part of a reference cycle if incr is non-zero
-                assert_equal(sys.getrefcount(A_func), refcount + incr)
+            # A.func is part of a reference cycle if incr is non-zero
+            assert_equal(sys.getrefcount(A_func), refcount + incr)
             for i in range(5):
                 gc.collect()
             assert_equal(sys.getrefcount(A_func), refcount)

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -2,13 +2,9 @@ from __future__ import division, absolute_import, print_function
 
 import numbers
 import operator
-import sys
 
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises
-
-
-PY2 = sys.version_info.major < 3
 
 
 # NOTE: This class should be kept as an exact copy of the example from the
@@ -204,11 +200,10 @@ class TestNDArrayOperatorsMixin(object):
         array_like = ArrayLike(array)
         expected = ArrayLike(np.float64(5))
         _assert_equal_type_and_value(expected, np.matmul(array_like, array))
-        if not PY2:
-            _assert_equal_type_and_value(
-                expected, operator.matmul(array_like, array))
-            _assert_equal_type_and_value(
-                expected, operator.matmul(array, array_like))
+        _assert_equal_type_and_value(
+            expected, operator.matmul(array_like, array))
+        _assert_equal_type_and_value(
+            expected, operator.matmul(array, array_like))
 
     def test_ufunc_at(self):
         array = ArrayLike(np.array([1, 2, 3, 4]))

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -1,7 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import sys
 
 import numpy as np
 from numpy.testing import (
@@ -208,10 +207,7 @@ class TestRegression(object):
 
     def test_loadtxt_fields_subarrays(self):
         # For ticket #1936
-        if sys.version_info[0] >= 3:
-            from io import StringIO
-        else:
-            from StringIO import StringIO
+        from io import StringIO
 
         dt = [("a", 'u1', 2), ("b", 'u1', 2)]
         x = np.loadtxt(StringIO("0 1 2 3"), dtype=dt)

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -9,10 +9,7 @@ from numpy.testing import assert_, assert_equal, assert_raises_regex
 from numpy.lib import deprecate
 import numpy.lib.utils as utils
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -607,41 +607,6 @@ def info(object=None, maxwidth=76, output=sys.stdout, toplevel='numpy'):
                             )
                 print("  %s  --  %s" % (meth, methstr), file=output)
 
-    elif (sys.version_info[0] < 3
-            and isinstance(object, types.InstanceType)):
-        # check for __call__ method
-        # types.InstanceType is the type of the instances of oldstyle classes
-        print("Instance of class: ", object.__class__.__name__, file=output)
-        print(file=output)
-        if hasattr(object, '__call__'):
-            arguments = formatargspec(
-                    *getargspec(object.__call__.__func__)
-                    )
-            arglist = arguments.split(', ')
-            if len(arglist) > 1:
-                arglist[1] = "("+arglist[1]
-                arguments = ", ".join(arglist[1:])
-            else:
-                arguments = "()"
-
-            if hasattr(object, 'name'):
-                name = "%s" % object.name
-            else:
-                name = "<name>"
-            if len(name+arguments) > maxwidth:
-                argstr = _split_line(name, arguments, maxwidth)
-            else:
-                argstr = name + arguments
-
-            print(" " + argstr + "\n", file=output)
-            doc = inspect.getdoc(object.__call__)
-            if doc is not None:
-                print(inspect.getdoc(object.__call__), file=output)
-            print(inspect.getdoc(object), file=output)
-
-        else:
-            print(inspect.getdoc(object), file=output)
-
     elif inspect.ismethod(object):
         name = object.__name__
         arguments = formatargspec(
@@ -877,12 +842,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
     global _lookfor_caches
     # Local import to speed up numpy's import time.
     import inspect
-
-    if sys.version_info[0] >= 3:
-        # In Python3 stderr, stdout are text files.
-        from io import StringIO
-    else:
-        from StringIO import StringIO
+    from io import StringIO
 
     if module is None:
         module = "numpy"

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -3,15 +3,10 @@ from __future__ import division, absolute_import, print_function
 
 import sys, os
 import re
+from io import StringIO
 from plex import Scanner, Str, Lexicon, Opt, Bol, State, AnyChar, TEXT, IGNORE
 from plex.traditional import re as Re
 
-PY2 = sys.version_info < (3, 0)
-
-if PY2:
-    from io import BytesIO as UStringIO
-else:
-    from io import StringIO as UStringIO
 
 class MyScanner(Scanner):
     def __init__(self, info, name='<default>'):
@@ -27,8 +22,8 @@ def sep_seq(sequence, sep):
     return pat
 
 def runScanner(data, scanner_class, lexicon=None):
-    info = UStringIO(data)
-    outfo = UStringIO()
+    info = StringIO(data)
+    outfo = StringIO()
     if lexicon is not None:
         scanner = scanner_class(lexicon, info)
     else:
@@ -195,7 +190,7 @@ def cleanComments(source):
             return SourceLines
 
     state = SourceLines
-    for line in UStringIO(source):
+    for line in StringIO(source):
         state = state(line)
     comments.flushTo(lines)
     return lines.getValue()
@@ -223,7 +218,7 @@ def removeHeader(source):
         return OutOfHeader
 
     state = LookingForHeader
-    for line in UStringIO(source):
+    for line in StringIO(source):
         state = state(line)
     return lines.getValue()
 
@@ -232,7 +227,7 @@ def removeSubroutinePrototypes(source):
         r'/[*] Subroutine [*]/^\s*(?:(?:inline|static)\s+){0,2}(?!else|typedef|return)\w+\s+\*?\s*(\w+)\s*\([^0]+\)\s*;?'
     )
     lines = LineQueue()
-    for line in UStringIO(source):
+    for line in StringIO(source):
         if not expression.match(line):
             lines.add(line)
 
@@ -254,7 +249,7 @@ def removeBuiltinFunctions(source):
             return InBuiltInFunctions
 
     state = LookingForBuiltinFunctions
-    for line in UStringIO(source):
+    for line in StringIO(source):
         state = state(line)
     return lines.getValue()
 

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -21,12 +21,7 @@ import shutil
 import fortran
 import clapack_scrub
 
-PY2 = sys.version_info < (3, 0)
-
-if PY2:
-    from distutils.spawn import find_executable as which
-else:
-    from shutil import which
+from shutil import which
 
 # Arguments to pass to f2c. You'll always want -A for ANSI C prototypes
 # Others of interest: -a to not make variables static by default

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -22,17 +22,12 @@ Released for unlimited redistribution.
 # pylint: disable-msg=E1002
 from __future__ import division, absolute_import, print_function
 
-import sys
+import builtins
 import operator
 import warnings
 import textwrap
 import re
 from functools import reduce
-
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
 
 import numpy as np
 import numpy.core.umath as umath
@@ -3869,10 +3864,6 @@ class MaskedArray(ndarray):
     def __str__(self):
         return str(self._insert_masked_print())
 
-    if sys.version_info.major < 3:
-        def __unicode__(self):
-            return unicode(self._insert_masked_print())
-
     def __repr__(self):
         """
         Literal string representation.
@@ -4722,7 +4713,7 @@ class MaskedArray(ndarray):
 
         >>> x = np.ma.array([1, 2, 3])
         >>> x.ids()
-        (166691080, 3083169284L) # may vary
+        (166691080, 3083169284) # may vary
 
         """
         if self._mask is nomask:
@@ -6354,10 +6345,6 @@ class MaskedConstant(MaskedArray):
 
     def __str__(self):
         return str(masked_print_option._display)
-
-    if sys.version_info.major < 3:
-        def __unicode__(self):
-            return unicode(masked_print_option._display)
 
     def __repr__(self):
         if self is MaskedConstant.__singleton:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5001,11 +5001,6 @@ class TestMaskedConstant(object):
         assert_raises(MaskError, operator.setitem, a_i, (), np.ma.masked)
         assert_raises(MaskError, int, np.ma.masked)
 
-    @pytest.mark.skipif(sys.version_info.major == 3,
-                        reason="long doesn't exist in Python 3")
-    def test_coercion_long(self):
-        assert_raises(MaskError, long, np.ma.masked)
-
     def test_coercion_float(self):
         a_f = np.zeros((), float)
         assert_warns(UserWarning, operator.setitem, a_f, (), np.ma.masked)

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,11 +1,6 @@
 from __future__ import division, absolute_import, print_function
 
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc as collections_abc
 
 import numpy as np
 from numpy import matrix, asmatrix, bmat

--- a/numpy/matrixlib/tests/test_interaction.py
+++ b/numpy/matrixlib/tests/test_interaction.py
@@ -330,7 +330,6 @@ def test_array_equal_error_message_matrix():
         assert_equal(np.array([1, 2]), np.matrix([1, 2]))
     except AssertionError as e:
         msg = str(e)
-        msg2 = msg.replace("shapes (2L,), (1L, 2L)", "shapes (2,), (1, 2)")
         msg_reference = textwrap.dedent("""\
 
         Arrays are not equal
@@ -338,10 +337,7 @@ def test_array_equal_error_message_matrix():
         (shapes (2,), (1, 2) mismatch)
          x: array([1, 2])
          y: matrix([[1, 2]])""")
-        try:
-            assert_equal(msg, msg_reference)
-        except AssertionError:
-            assert_equal(msg2, msg_reference)
+        assert_equal(msg, msg_reference)
     else:
         raise AssertionError("Did not raise")
 

--- a/numpy/testing/_private/decorators.py
+++ b/numpy/testing/_private/decorators.py
@@ -15,12 +15,7 @@ function name, setup and teardown functions and so on - see
 """
 from __future__ import division, absolute_import, print_function
 
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc as collections_abc
 
 from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -450,20 +450,6 @@ class NoseTester(object):
                 warnings.simplefilter("always")
                 from ...distutils import cpuinfo
             sup.filter(category=UserWarning, module=cpuinfo)
-            # See #7949: Filter out deprecation warnings due to the -3 flag to
-            # python 2
-            if sys.version_info.major == 2 and sys.py3kwarning:
-                # This is very specific, so using the fragile module filter
-                # is fine
-                import threading
-                sup.filter(DeprecationWarning,
-                           r"sys\.exc_clear\(\) not supported in 3\.x",
-                           module=threading)
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __setslice__")
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
-                sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")
-                sup.filter(DeprecationWarning, message=r"CObject type is not supported in 3\.x")
-                sup.filter(DeprecationWarning, message=r"comparing unequal types not supported in 3\.x")
             # Filter out some deprecation warnings inside nose 1.3.7 when run
             # on python 3.5b2. See
             #     https://github.com/nose-devs/nose/issues/929

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -31,7 +31,6 @@ either expressed or implied, of David Wolever.
 
 """
 import re
-import sys
 import inspect
 import warnings
 from functools import wraps
@@ -45,30 +44,18 @@ except ImportError:
 
 from unittest import TestCase
 
-PY3 = sys.version_info[0] == 3
-PY2 = sys.version_info[0] == 2
 
-
-if PY3:
-    # Python 3 doesn't have an InstanceType, so just use a dummy type.
-    class InstanceType():
-        pass
-    lzip = lambda *a: list(zip(*a))
-    text_type = str
-    string_types = str,
-    bytes_type = bytes
-    def make_method(func, instance, type):
-        if instance is None:
-            return func
-        return MethodType(func, instance)
-else:
-    from types import InstanceType
-    lzip = zip
-    text_type = unicode
-    bytes_type = str
-    string_types = basestring,
-    def make_method(func, instance, type):
-        return MethodType(func, instance, type)
+# Python 3 doesn't have an InstanceType, so just use a dummy type.
+class InstanceType():
+    pass
+lzip = lambda *a: list(zip(*a))
+text_type = str
+string_types = str,
+bytes_type = bytes
+def make_method(func, instance, type):
+    if instance is None:
+        return func
+    return MethodType(func, instance)
 
 _param = namedtuple("param", "args kwargs")
 
@@ -366,14 +353,7 @@ class parameterized(object):
         # Python 3 doesn't let us pull the function out of a bound method.
         unbound_func = nose_func
         if test_self is not None:
-            # Under nose on Py2 we need to return an unbound method to make
-            # sure that the `self` in the method is properly shared with the
-            # `self` used in `setUp` and `tearDown`. But only there. Everyone
-            # else needs a bound method.
-            func_self = (
-                None if PY2 and detect_runner() == "nose" else
-                test_self
-            )
+            func_self = test_self
             nose_func = make_method(nose_func, func_self, type(test_self))
         return unbound_func, (nose_func, ) + p.args + (p.kwargs or {}, )
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -14,6 +14,7 @@ import warnings
 from functools import partial, wraps
 import shutil
 import contextlib
+from io import StringIO
 from tempfile import mkdtemp, mkstemp
 from unittest.case import SkipTest
 from warnings import WarningMessage
@@ -23,10 +24,6 @@ from numpy.core import(
      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
 from numpy.lib.utils import deprecate
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 __all__ = [
         'assert_equal', 'assert_almost_equal', 'assert_approx_equal',
@@ -1323,13 +1320,7 @@ def assert_raises_regex(exception_class, expected_regexp, *args, **kwargs):
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
-
-    if sys.version_info.major >= 3:
-        funcname = _d.assertRaisesRegex
-    else:
-        # Only present in Python 2.7, missing from unittest in 2.6
-        funcname = _d.assertRaisesRegexp
-
+    funcname = _d.assertRaisesRegex
     return funcname(exception_class, expected_regexp, *args, **kwargs)
 
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -332,7 +332,6 @@ class TestEqual(TestArrayEqual):
         with pytest.raises(AssertionError) as exc_info:
             self._assert_func(np.array([1, 2]), np.array([[1, 2]]))
         msg = str(exc_info.value)
-        msg2 = msg.replace("shapes (2L,), (1L, 2L)", "shapes (2,), (1, 2)")
         msg_reference = textwrap.dedent("""\
 
         Arrays are not equal
@@ -341,10 +340,7 @@ class TestEqual(TestArrayEqual):
          x: array([1, 2])
          y: array([[1, 2]])""")
 
-        try:
-            assert_equal(msg, msg_reference)
-        except AssertionError:
-            assert_equal(msg2, msg_reference)
+        assert_equal(msg, msg_reference)
 
     def test_object(self):
         #gh-12942

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -1,7 +1,5 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
-
 import numpy as np
 import pytest
 try:
@@ -22,9 +20,6 @@ def check_dir(module, module_name=None):
     return results
 
 
-@pytest.mark.skipif(
-    sys.version_info[0] < 3,
-    reason="NumPy exposes slightly different functions on Python 2")
 def test_numpy_namespace():
     # None of these objects are publicly documented.
     undocumented = {

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -1,14 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
-import sys
+from importlib import reload
 
 from numpy.testing import assert_raises, assert_, assert_equal
 from numpy.compat import pickle
-
-if sys.version_info[:2] >= (3, 4):
-    from importlib import reload
-else:
-    from imp import reload
 
 def test_numpy_reloading():
     # gh-7844. Also check that relevant globals retain their identity.

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -4,75 +4,74 @@ all of these occurrences but should catch almost all.
 """
 from __future__ import division, absolute_import, print_function
 
-import sys
 import pytest
 
-if sys.version_info >= (3, 4):
-    from pathlib import Path
-    import ast
-    import tokenize
-    import numpy
-
-    class ParseCall(ast.NodeVisitor):
-        def __init__(self):
-            self.ls = []
-
-        def visit_Attribute(self, node):
-            ast.NodeVisitor.generic_visit(self, node)
-            self.ls.append(node.attr)
-
-        def visit_Name(self, node):
-            self.ls.append(node.id)
+from pathlib import Path
+import ast
+import tokenize
+import numpy
 
 
-    class FindFuncs(ast.NodeVisitor):
-        def __init__(self, filename):
-            super().__init__()
-            self.__filename = filename
+class ParseCall(ast.NodeVisitor):
+    def __init__(self):
+        self.ls = []
 
-        def visit_Call(self, node):
-            p = ParseCall()
-            p.visit(node.func)
-            ast.NodeVisitor.generic_visit(self, node)
+    def visit_Attribute(self, node):
+        ast.NodeVisitor.generic_visit(self, node)
+        self.ls.append(node.attr)
 
-            if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-                if node.args[0].s == "ignore":
-                    raise AssertionError(
-                        "ignore filter should not be used; found in "
-                        "{} on line {}".format(self.__filename, node.lineno))
+    def visit_Name(self, node):
+        self.ls.append(node.id)
 
-            if p.ls[-1] == 'warn' and (
-                    len(p.ls) == 1 or p.ls[-2] == 'warnings'):
 
-                if "testing/tests/test_warnings.py" == self.__filename:
-                    # This file
-                    return
+class FindFuncs(ast.NodeVisitor):
+    def __init__(self, filename):
+        super().__init__()
+        self.__filename = filename
 
-                # See if stacklevel exists:
-                if len(node.args) == 3:
-                    return
-                args = {kw.arg for kw in node.keywords}
-                if "stacklevel" in args:
-                    return
+    def visit_Call(self, node):
+        p = ParseCall()
+        p.visit(node.func)
+        ast.NodeVisitor.generic_visit(self, node)
+
+        if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
+            if node.args[0].s == "ignore":
                 raise AssertionError(
-                    "warnings should have an appropriate stacklevel; found in "
+                    "ignore filter should not be used; found in "
                     "{} on line {}".format(self.__filename, node.lineno))
 
+        if p.ls[-1] == 'warn' and (
+                len(p.ls) == 1 or p.ls[-2] == 'warnings'):
 
-    @pytest.mark.slow
-    def test_warning_calls():
-        # combined "ignore" and stacklevel error
-        base = Path(numpy.__file__).parent
+            if "testing/tests/test_warnings.py" == self.__filename:
+                # This file
+                return
 
-        for path in base.rglob("*.py"):
-            if base / "testing" in path.parents:
-                continue
-            if path == base / "__init__.py":
-                continue
-            if path == base / "random" / "__init__.py":
-                continue
-            # use tokenize to auto-detect encoding on systems where no
-            # default encoding is defined (e.g. LANG='C')
-            with tokenize.open(str(path)) as file:
-                tree = ast.parse(file.read())
-                FindFuncs(path).visit(tree)
+            # See if stacklevel exists:
+            if len(node.args) == 3:
+                return
+            args = {kw.arg for kw in node.keywords}
+            if "stacklevel" in args:
+                return
+            raise AssertionError(
+                "warnings should have an appropriate stacklevel; found in "
+                "{} on line {}".format(self.__filename, node.lineno))
+
+
+@pytest.mark.slow
+def test_warning_calls():
+    # combined "ignore" and stacklevel error
+    base = Path(numpy.__file__).parent
+
+    for path in base.rglob("*.py"):
+        if base / "testing" in path.parents:
+            continue
+        if path == base / "__init__.py":
+            continue
+        if path == base / "random" / "__init__.py":
+            continue
+        # use tokenize to auto-detect encoding on systems where no
+        # default encoding is defined (e.g. LANG='C')
+        with tokenize.open(str(path)) as file:
+            tree = ast.parse(file.read())
+            FindFuncs(path).visit(tree)

--- a/runtests.py
+++ b/runtests.py
@@ -173,7 +173,7 @@ def main(argv):
             sys.modules['__main__'] = types.ModuleType('__main__')
             ns = dict(__name__='__main__',
                       __file__=extra_argv[0])
-            exec_(script, ns)
+            exec(script, ns)
             sys.exit(0)
         else:
             import code
@@ -466,26 +466,6 @@ def lcov_generate():
     else:
         print("HTML output generated under build/lcov/")
 
-
-#
-# Python 3 support
-#
-
-if sys.version_info[0] >= 3:
-    import builtins
-    exec_ = getattr(builtins, "exec")
-else:
-    def exec_(code, globs=None, locs=None):
-        """Execute code in a namespace."""
-        if globs is None:
-            frame = sys._getframe(1)
-            globs = frame.f_globals
-            if locs is None:
-                locs = frame.f_locals
-            del frame
-        elif locs is None:
-            locs = globs
-        exec("""exec code in globs, locs""")
 
 if __name__ == "__main__":
     main(argv=sys.argv[1:])

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -36,15 +36,9 @@ From the bash command line with $GITHUB token::
 from __future__ import print_function, division
 
 import os
-import sys
 import re
-import codecs
 from git import Repo
 from github import Github
-
-if sys.version_info.major < 3:
-    UTF8Writer = codecs.getwriter('utf8')
-    sys.stdout = UTF8Writer(sys.stdout)
 
 this_repo = Repo(os.path.join(os.path.dirname(__file__), ".."))
 

--- a/tools/npy_tempita/_looper.py
+++ b/tools/npy_tempita/_looper.py
@@ -63,9 +63,6 @@ class looper_iter(object):
         self.pos += 1
         return result
 
-    if sys.version < "3":
-        next = __next__
-
 
 class loop_pos(object):
 
@@ -95,9 +92,6 @@ class loop_pos(object):
             return self.seq[self.pos + 1]
         except IndexError:
             return None
-
-    if sys.version < "3":
-        next = __next__
 
     @property
     def previous(self):

--- a/tools/npy_tempita/compat3.py
+++ b/tools/npy_tempita/compat3.py
@@ -1,55 +1,33 @@
 from __future__ import absolute_import, division, print_function
 
-import sys
-
 __all__ = ['PY3', 'b', 'basestring_', 'bytes', 'next', 'is_unicode',
            'iteritems']
 
-PY3 = True if sys.version_info[0] == 3 else False
+PY3 = True
 
-if sys.version_info[0] < 3:
+def b(s):
+    if isinstance(s, str):
+        return s.encode('latin1')
+    return bytes(s)
 
-    def next(obj):
-        return obj.next()
+def iteritems(d, **kw):
+    return iter(d.items(**kw))
 
-    def iteritems(d, **kw):
-        return d.iteritems(**kw)
-
-    b = bytes = str
-    basestring_ = basestring
-
-else:
-
-    def b(s):
-        if isinstance(s, str):
-            return s.encode('latin1')
-        return bytes(s)
-
-    def iteritems(d, **kw):
-        return iter(d.items(**kw))
-
-    next = next
-    basestring_ = (bytes, str)
-    bytes = bytes
-
+next = next
+basestring_ = (bytes, str)
+bytes = bytes
 text = str
 
 
 def is_unicode(obj):
-    if sys.version_info[0] < 3:
-        return isinstance(obj, unicode)
-    else:
-        return isinstance(obj, str)
+    return isinstance(obj, str)
 
 
 def coerce_text(v):
     if not isinstance(v, basestring_):
-        if sys.version_info[0] < 3:
-            attr = '__unicode__'
-        else:
-            attr = '__str__'
+        attr = '__str__'
         if hasattr(v, attr):
-            return unicode(v)
+            return str(v)
         else:
             return bytes(v)
     return v

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -767,12 +767,8 @@ def check_doctests_testfile(fname, verbose, ns=None,
         return results
 
     full_name = fname
-    if sys.version_info.major <= 2:
-        with open(fname) as f:
-            text = f.read()
-    else:
-        with open(fname, encoding='utf-8') as f:
-            text = f.read()
+    with open(fname, encoding='utf-8') as f:
+        text = f.read()
 
     PSEUDOCODE = set(['some_function', 'some_module', 'import example',
                       'ctypes.CDLL',     # likely need compiling, skip it


### PR DESCRIPTION
This PR aims to remove and simplify Python code that was intended for Python 2 and Python <= 3.4, which are no longer supported.

The focus here is primarily around `if sys.version_info[0] >= 3` blocks, but also removes unnecessary ImportErrors for modules that are part of the Python >=3.5 standard library. Some comments regarding compatibility are retained, but not all.

Careful reviews and comments are most appreciated!