### PR TITLE
MAINT: move location of bitgen.h

### DIFF
--- a/numpy/core/include/numpy/random/bitgen.h
+++ b/numpy/core/include/numpy/random/bitgen.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Must match the declaration in numpy/random/common.pxd */
+
 typedef struct bitgen {
   void *state;
   uint64_t (*next_uint64)(void *st);

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -610,7 +610,7 @@ def configuration(parent_package='',top_path=None):
     config.add_include_dirs(join(local_dir, "src"))
     config.add_include_dirs(join(local_dir))
 
-    config.add_data_files('include/numpy/*.h')
+    config.add_data_dir('include/numpy')
     config.add_include_dirs(join('src', 'npymath'))
     config.add_include_dirs(join('src', 'multiarray'))
     config.add_include_dirs(join('src', 'umath'))

--- a/numpy/random/common.pxd
+++ b/numpy/random/common.pxd
@@ -5,7 +5,7 @@ from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
                           uintptr_t)
 from libc.math cimport sqrt
 
-cdef extern from "src/bitgen.h":
+cdef extern from "numpy/random/bitgen.h":
     struct bitgen:
         void *state
         uint64_t (*next_uint64)(void *st) nogil

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -36,7 +36,6 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('tests')
     config.add_data_files('common.pxd')
     config.add_data_files('bit_generator.pxd')
-    config.add_data_files('src/bitgen.h')
 
     EXTRA_LINK_ARGS = []
     # Math lib

--- a/numpy/random/src/distributions/distributions.h
+++ b/numpy/random/src/distributions/distributions.h
@@ -9,7 +9,7 @@
 #include "Python.h"
 #include "numpy/npy_common.h"
 #include "numpy/npy_math.h"
-#include "src/bitgen.h"
+#include "numpy/random/bitgen.h"
 
 /*
  * RAND_INT_TYPE is used to share integer generators with RandomState which


### PR DESCRIPTION
The `bitgen.h` file is needed for cython to build the BitGenerators, and is also used by `distributions.h`. Move it to be next to the other headers, and change `setup.py` to include it in the wheel.