### PR TITLE
BUG: do not force emulation of 128-bit arithmetic.

### DIFF
--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -58,9 +58,8 @@ def configuration(parent_package='', top_path=None):
     # Use legacy integer variable sizes
     LEGACY_DEFS = [('NP_RANDOM_LEGACY', '1')]
     PCG64_DEFS = []
-    if 1 or sys.maxsize < 2 ** 32 or os.name == 'nt':
-        # Force emulated mode here
-        PCG64_DEFS += [('PCG_FORCE_EMULATED_128BIT_MATH', '1')]
+    # One can force emulated 128-bit arithmetic if one wants.
+    #PCG64_DEFS += [('PCG_FORCE_EMULATED_128BIT_MATH', '1')]
 
     config.add_extension('entropy',
                          sources=['entropy.c', 'src/entropy/entropy.c'] +

--- a/numpy/random/src/pcg64/pcg64.c
+++ b/numpy/random/src/pcg64/pcg64.c
@@ -32,7 +32,9 @@
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -117,7 +119,7 @@ extern inline uint32_t pcg64_next32(pcg64_state *state);
 
 extern void pcg64_advance(pcg64_state *state, uint64_t *step) {
   pcg128_t delta;
-#if __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
+#ifndef PCG_EMULATED_128BIT_MATH
   delta = (((pcg128_t)step[0]) << 64) | step[1];
 #else
   delta.high = step[0];
@@ -128,7 +130,7 @@ extern void pcg64_advance(pcg64_state *state, uint64_t *step) {
 
 extern void pcg64_set_seed(pcg64_state *state, uint64_t *seed, uint64_t *inc) {
   pcg128_t s, i;
-#if __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
+#ifndef PCG_EMULATED_128BIT_MATH
   s = (((pcg128_t)seed[0]) << 64) | seed[1];
   i = (((pcg128_t)inc[0]) << 64) | inc[1];
 #else
@@ -148,7 +150,7 @@ extern void pcg64_get_state(pcg64_state *state, uint64_t *state_arr,
    *    64 bits of a uint128_t variable
    *
    */
-#if __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
+#ifndef PCG_EMULATED_128BIT_MATH
   state_arr[0] = (uint64_t)(state->pcg_state->state >> 64);
   state_arr[1] = (uint64_t)(state->pcg_state->state & 0xFFFFFFFFFFFFFFFFULL);
   state_arr[2] = (uint64_t)(state->pcg_state->inc >> 64);
@@ -171,7 +173,7 @@ extern void pcg64_set_state(pcg64_state *state, uint64_t *state_arr,
    *    64 bits of a uint128_t variable
    *
    */
-#if __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
+#ifndef PCG_EMULATED_128BIT_MATH
   state->pcg_state->state = (((pcg128_t)state_arr[0]) << 64) | state_arr[1];
   state->pcg_state->inc = (((pcg128_t)state_arr[2]) << 64) | state_arr[3];
 #else

--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -32,7 +32,9 @@
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -72,9 +74,6 @@ typedef struct {
   uint64_t low;
 } pcg128_t;
 
-#define PCG_DEFAULT_MULTIPLIER_HIGH 2549297995355413924ULL
-#define PCG_DEFAULT_MULTIPLIER_LOW 4865540595714422341ULL
-
 static inline pcg128_t PCG_128BIT_CONSTANT(uint64_t high, uint64_t low) {
   pcg128_t result;
   result.high = high;
@@ -91,6 +90,9 @@ typedef struct {
   pcg128_t state;
   pcg128_t inc;
 } pcg_state_setseq_128;
+
+#define PCG_DEFAULT_MULTIPLIER_HIGH 2549297995355413924ULL
+#define PCG_DEFAULT_MULTIPLIER_LOW 4865540595714422341ULL
 
 #define PCG_DEFAULT_MULTIPLIER_128                                             \
   PCG_128BIT_CONSTANT(PCG_DEFAULT_MULTIPLIER_HIGH, PCG_DEFAULT_MULTIPLIER_LOW)
@@ -205,6 +207,13 @@ static inline void pcg_setseq_128_step_r(pcg_state_setseq_128 *rng) {
 static inline uint64_t pcg_output_xsl_rr_128_64(pcg128_t state) {
   return pcg_rotr_64(((uint64_t)(state >> 64u)) ^ (uint64_t)state,
                      state >> 122u);
+}
+
+static inline uint64_t
+pcg_setseq_128_xsl_rr_64_random_r(pcg_state_setseq_128* rng)
+{
+    pcg_setseq_128_step_r(rng);
+    return pcg_output_xsl_rr_128_64(rng->state);
 }
 
 static inline void pcg_setseq_128_srandom_r(pcg_state_setseq_128 *rng,


### PR DESCRIPTION
Fixes #13857 

I removed the check in the `setup.py` file as I think the logic in the header file does sufficient checks already. We'll see what the CI says.