### PR TITLE
TST: Ignore DeprecationWarning during nose imports

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1859,7 +1859,7 @@ class TestUfunc(object):
         # gh-7961
         exc = pytest.raises(TypeError, np.sqrt, None)
         # minimally check the exception text
-        assert 'loop of ufunc does not support' in str(exc)
+        assert exc.match('loop of ufunc does not support')
 
     @pytest.mark.parametrize('nat', [np.datetime64('nat'), np.timedelta64('nat')])
     def test_nat_is_not_finite(self, nat):

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -13,7 +13,9 @@ from numpy.testing import (
 
 
 try:
-    import nose  # noqa: F401
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        import nose  # noqa: F401
 except ImportError:
     HAVE_NOSE = False
 else:


### PR DESCRIPTION
Nose is outdated and causes a DeprecationWarning during import,
a change in pytest seems to now trip over the warning, so ignore
it (in a slightly ugly manner)


---

Should fix the general azure failures that just cropped up.