### PR TITLE
TST: Ignore DeprecationWarning during nose imports

### DIFF
--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -13,7 +13,9 @@ from numpy.testing import (
 
 
 try:
-    import nose  # noqa: F401
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        import nose  # noqa: F401
 except ImportError:
     HAVE_NOSE = False
 else:


### PR DESCRIPTION
Backport of #13862 .

Nose is outdated and causes a DeprecationWarning during import,
a change in pytest seems to now trip over the warning, so ignore
it (in a slightly ugly manner)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
