### PR TITLE
MAINT: Remove an unnessary backslash between two string literals

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -120,7 +120,7 @@ else:
         """
         if ctypes.__version__ < '1.0.1':
             import warnings
-            warnings.warn("All features of ctypes interface may not work " \
+            warnings.warn("All features of ctypes interface may not work "
                           "with ctypes < 1.0.1", stacklevel=2)
 
         ext = os.path.splitext(libname)[1]


### PR DESCRIPTION
The backslash can be omitted if the string literals are in parenthesis - which is the case here.