### PR TITLE
MAINT: Update pavement to use python3 in shell commands.

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -116,7 +116,7 @@ def sdist(options):
     # do not play well together.
     # Cython is run over all Cython files in setup.py, so generated C files
     # will be included.
-    sh('python setup.py sdist --formats=gztar,zip')
+    sh('python3 setup.py sdist --formats=gztar,zip')
 
     # Copy the superpack into installers dir
     idirs = options.installers.installersdir


### PR DESCRIPTION
This may not work for everyone, but I needed it so build the source release of 1.17 since Python 3 is now required.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
