### PR TITLE
MAINT: Replace integers in places where booleans are expected

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1641,5 +1641,5 @@ def set_string_function(f, repr=True):
     else:
         return multiarray.set_string_function(f, repr)
 
-set_string_function(_default_array_str, 0)
-set_string_function(_default_array_repr, 1)
+set_string_function(_default_array_str, False)
+set_string_function(_default_array_repr, True)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -163,7 +163,7 @@ class format_parser(object):
         self._createdescr(byteorder)
         self.dtype = self._descr
 
-    def _parseFormats(self, formats, aligned=0):
+    def _parseFormats(self, formats, aligned=False):
         """ Parse the field formats """
 
         if formats is None:

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -49,7 +49,7 @@ class TestLogspace(object):
         assert_(len(y) == 50)
         y = logspace(0, 6, num=100)
         assert_(y[-1] == 10 ** 6)
-        y = logspace(0, 6, endpoint=0)
+        y = logspace(0, 6, endpoint=False)
         assert_(y[-1] < 10 ** 6)
         y = logspace(0, 6, num=7)
         assert_array_equal(y, [1, 10, 100, 1e3, 1e4, 1e5, 1e6])
@@ -229,7 +229,7 @@ class TestLinspace(object):
         assert_(len(y) == 50)
         y = linspace(2, 10, num=100)
         assert_(y[-1] == 10)
-        y = linspace(2, 10, endpoint=0)
+        y = linspace(2, 10, endpoint=False)
         assert_(y[-1] < 10)
         assert_raises(ValueError, linspace, 0, 10, num=-1)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -422,41 +422,41 @@ class TestUnique(object):
             assert_array_equal(v, b, msg)
 
             msg = base_msg.format('return_index', dt)
-            v, j = unique(a, 1, 0, 0)
+            v, j = unique(a, True, False, False)
             assert_array_equal(v, b, msg)
             assert_array_equal(j, i1, msg)
 
             msg = base_msg.format('return_inverse', dt)
-            v, j = unique(a, 0, 1, 0)
+            v, j = unique(a, False, True, False)
             assert_array_equal(v, b, msg)
             assert_array_equal(j, i2, msg)
 
             msg = base_msg.format('return_counts', dt)
-            v, j = unique(a, 0, 0, 1)
+            v, j = unique(a, False, False, True)
             assert_array_equal(v, b, msg)
             assert_array_equal(j, c, msg)
 
             msg = base_msg.format('return_index and return_inverse', dt)
-            v, j1, j2 = unique(a, 1, 1, 0)
+            v, j1, j2 = unique(a, True, True, False)
             assert_array_equal(v, b, msg)
             assert_array_equal(j1, i1, msg)
             assert_array_equal(j2, i2, msg)
 
             msg = base_msg.format('return_index and return_counts', dt)
-            v, j1, j2 = unique(a, 1, 0, 1)
+            v, j1, j2 = unique(a, True, False, True)
             assert_array_equal(v, b, msg)
             assert_array_equal(j1, i1, msg)
             assert_array_equal(j2, c, msg)
 
             msg = base_msg.format('return_inverse and return_counts', dt)
-            v, j1, j2 = unique(a, 0, 1, 1)
+            v, j1, j2 = unique(a, False, True, True)
             assert_array_equal(v, b, msg)
             assert_array_equal(j1, i2, msg)
             assert_array_equal(j2, c, msg)
 
             msg = base_msg.format(('return_index, return_inverse '
                                    'and return_counts'), dt)
-            v, j1, j2, j3 = unique(a, 1, 1, 1)
+            v, j1, j2, j3 = unique(a, True, True, True)
             assert_array_equal(v, b, msg)
             assert_array_equal(j1, i1, msg)
             assert_array_equal(j2, i2, msg)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1105,7 +1105,7 @@ class TestAngle(object):
             np.arctan(3.0 / 1.0),
             np.arctan(1.0), 0, np.pi / 2, np.pi, -np.pi / 2.0,
             -np.arctan(3.0 / 1.0), np.pi - np.arctan(3.0 / 1.0)]
-        z = angle(x, deg=1)
+        z = angle(x, deg=True)
         zo = np.array(yo) * 180 / np.pi
         assert_array_almost_equal(y, yo, 11)
         assert_array_almost_equal(z, zo, 11)
@@ -1920,9 +1920,9 @@ class TestCov(object):
                                          [-np.inf, np.inf]]))
 
     def test_1D_rowvar(self):
-        assert_allclose(cov(self.x3), cov(self.x3, rowvar=0))
+        assert_allclose(cov(self.x3), cov(self.x3, rowvar=False))
         y = np.array([0.0780, 0.3107, 0.2111, 0.0334, 0.8501])
-        assert_allclose(cov(self.x3, y), cov(self.x3, y, rowvar=0))
+        assert_allclose(cov(self.x3, y), cov(self.x3, y, rowvar=False))
 
     def test_1D_variance(self):
         assert_allclose(cov(self.x3, ddof=1), np.var(self.x3, ddof=1))

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -190,7 +190,7 @@ class TestGrid(object):
         assert_almost_equal(a[1]-a[0], 2.0/9.0, 11)
 
     def test_linspace_equivalence(self):
-        y, st = np.linspace(2, 10, retstep=1)
+        y, st = np.linspace(2, 10, retstep=True)
         assert_almost_equal(st, 8/49.0)
         assert_array_almost_equal(y, mgrid[2:10:50j], 13)
 

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -21,8 +21,8 @@ class TestRegression(object):
         # Ticket #91
         x = np.random.random((3, 3))
         y = x.copy()
-        np.cov(x, rowvar=1)
-        np.cov(y, rowvar=0)
+        np.cov(x, rowvar=True)
+        np.cov(y, rowvar=False)
         assert_array_equal(x, y)
 
     def test_mem_digitize(self):
@@ -56,7 +56,7 @@ class TestRegression(object):
 
     def test_poly1d_nan_roots(self):
         # Ticket #396
-        p = np.poly1d([np.nan, np.nan, 1], r=0)
+        p = np.poly1d([np.nan, np.nan, 1], r=False)
         assert_raises(np.linalg.LinAlgError, getattr, p, "r")
 
     def test_mem_polymul(self):

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1730,7 +1730,7 @@ def cond(x, p=None):
     1.4142135623730951
     >>> LA.cond(a, -2)
     0.70710678118654746 # may vary
-    >>> min(LA.svd(a, compute_uv=0))*min(LA.svd(LA.inv(a), compute_uv=0))
+    >>> min(LA.svd(a, compute_uv=False))*min(LA.svd(LA.inv(a), compute_uv=False))
     0.70710678118654746 # may vary
 
     """
@@ -2314,7 +2314,7 @@ def _multi_svd_norm(x, row_axis, col_axis, op):
 
     """
     y = moveaxis(x, (row_axis, col_axis), (-2, -1))
-    result = op(svd(y, compute_uv=0), axis=-1)
+    result = op(svd(y, compute_uv=False), axis=-1)
     return result
 
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -650,7 +650,7 @@ class SVDBaseTests(object):
 class SVDCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):
-        u, s, vt = linalg.svd(a, 0)
+        u, s, vt = linalg.svd(a, False)
         assert_allclose(a, dot_generalized(np.asarray(u) * np.asarray(s)[..., None, :],
                                            np.asarray(vt)),
                         rtol=get_rtol(u.dtype))
@@ -677,7 +677,7 @@ class TestSVD(SVDCases, SVDBaseTests):
 class SVDHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
 
     def do(self, a, b, tags):
-        u, s, vt = linalg.svd(a, 0, hermitian=True)
+        u, s, vt = linalg.svd(a, False, hermitian=True)
         assert_allclose(a, dot_generalized(np.asarray(u) * np.asarray(s)[..., None, :],
                                            np.asarray(vt)),
                         rtol=get_rtol(u.dtype))
@@ -897,7 +897,7 @@ class LstsqCases(LinalgSquareTestCase, LinalgNonsquareTestCase):
     def do(self, a, b, tags):
         arr = np.asarray(a)
         m, n = arr.shape
-        u, s, vt = linalg.svd(a, 0)
+        u, s, vt = linalg.svd(a, False)
         x, residuals, rank, sv = linalg.lstsq(a, b, rcond=-1)
         if m == 0:
             assert_((x == 0).all())

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1060,7 +1060,7 @@ class _MaskedBinaryOperation(_MaskedUFunc):
         if t.shape == ():
             t = t.reshape(1)
             if m is not nomask:
-                m = make_mask(m, copy=1)
+                m = make_mask(m, copy=True)
                 m.shape = (1,)
 
         if m is nomask:
@@ -7281,7 +7281,7 @@ def choose(indices, choices, out=None, mode='raise'):
     # Construct the mask
     outputmask = np.choose(c, masks, mode=mode)
     outputmask = make_mask(mask_or(outputmask, getmask(indices)),
-                           copy=0, shrink=True)
+                           copy=False, shrink=True)
     # Get the choices.
     d = np.choose(c, data, mode=mode, out=out).view(MaskedArray)
     if out is not None:
@@ -7533,7 +7533,7 @@ def outer(a, b):
         return masked_array(d)
     ma = getmaskarray(a)
     mb = getmaskarray(b)
-    m = make_mask(1 - np.outer(1 - ma, 1 - mb), copy=0)
+    m = make_mask(1 - np.outer(1 - ma, 1 - mb), copy=False)
     return masked_array(d, mask=m)
 outer.__doc__ = doc_note(np.outer.__doc__,
                          "Masked values are replaced by 0.")

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -347,7 +347,7 @@ class TestMaskedArray(object):
         m = make_mask(n)
         m2 = make_mask(m)
         assert_(m is m2)
-        m3 = make_mask(m, copy=1)
+        m3 = make_mask(m, copy=True)
         assert_(m is not m3)
 
         x1 = np.arange(5)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -148,7 +148,7 @@ class TestAverage(object):
         ott = array([0., 1., 2., 3.], mask=[True, False, False, False])
         assert_equal(2.0, average(ott, axis=0))
         assert_equal(2.0, average(ott, weights=[1., 1., 2., 1.]))
-        result, wts = average(ott, weights=[1., 1., 2., 1.], returned=1)
+        result, wts = average(ott, weights=[1., 1., 2., 1.], returned=True)
         assert_equal(2.0, result)
         assert_(wts == 4.0)
         ott[:] = masked
@@ -159,7 +159,7 @@ class TestAverage(object):
         assert_equal(average(ott, axis=0), [2.0, 0.0])
         assert_equal(average(ott, axis=1).mask[0], [True])
         assert_equal([2., 0.], average(ott, axis=0))
-        result, wts = average(ott, axis=0, returned=1)
+        result, wts = average(ott, axis=0, returned=True)
         assert_equal(wts, [1., 0.])
 
     def test_testAverage2(self):
@@ -200,14 +200,14 @@ class TestAverage(object):
         # Yet more tests of average!
         a = arange(6)
         b = arange(6) * 3
-        r1, w1 = average([[a, b], [b, a]], axis=1, returned=1)
+        r1, w1 = average([[a, b], [b, a]], axis=1, returned=True)
         assert_equal(shape(r1), shape(w1))
         assert_equal(r1.shape, w1.shape)
-        r2, w2 = average(ones((2, 2, 3)), axis=0, weights=[3, 1], returned=1)
+        r2, w2 = average(ones((2, 2, 3)), axis=0, weights=[3, 1], returned=True)
         assert_equal(shape(w2), shape(r2))
-        r2, w2 = average(ones((2, 2, 3)), returned=1)
+        r2, w2 = average(ones((2, 2, 3)), returned=True)
         assert_equal(shape(w2), shape(r2))
-        r2, w2 = average(ones((2, 2, 3)), weights=ones((2, 2, 3)), returned=1)
+        r2, w2 = average(ones((2, 2, 3)), weights=ones((2, 2, 3)), returned=True)
         assert_equal(shape(w2), shape(r2))
         a2d = array([[1, 2], [0, 4]], float)
         a2dm = masked_array(a2d, [[False, False], [True, False]])

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -263,7 +263,7 @@ class TestMa(object):
         m = make_mask(n)
         m2 = make_mask(m)
         assert_(m is m2)
-        m3 = make_mask(m, copy=1)
+        m3 = make_mask(m, copy=True)
         assert_(m is not m3)
 
         x1 = np.arange(5)
@@ -570,7 +570,7 @@ class TestMa(object):
         ott = array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
         assert_(eq(2.0, average(ott, axis=0)))
         assert_(eq(2.0, average(ott, weights=[1., 1., 2., 1.])))
-        result, wts = average(ott, weights=[1., 1., 2., 1.], returned=1)
+        result, wts = average(ott, weights=[1., 1., 2., 1.], returned=True)
         assert_(eq(2.0, result))
         assert_(wts == 4.0)
         ott[:] = masked
@@ -581,7 +581,7 @@ class TestMa(object):
         assert_(eq(average(ott, axis=0), [2.0, 0.0]))
         assert_(average(ott, axis=1)[0] is masked)
         assert_(eq([2., 0.], average(ott, axis=0)))
-        result, wts = average(ott, axis=0, returned=1)
+        result, wts = average(ott, axis=0, returned=True)
         assert_(eq(wts, [1., 0.]))
 
     def test_testAverage2(self):
@@ -622,14 +622,14 @@ class TestMa(object):
 
         a = arange(6)
         b = arange(6) * 3
-        r1, w1 = average([[a, b], [b, a]], axis=1, returned=1)
+        r1, w1 = average([[a, b], [b, a]], axis=1, returned=True)
         assert_equal(shape(r1), shape(w1))
         assert_equal(r1.shape, w1.shape)
-        r2, w2 = average(ones((2, 2, 3)), axis=0, weights=[3, 1], returned=1)
+        r2, w2 = average(ones((2, 2, 3)), axis=0, weights=[3, 1], returned=True)
         assert_equal(shape(w2), shape(r2))
-        r2, w2 = average(ones((2, 2, 3)), returned=1)
+        r2, w2 = average(ones((2, 2, 3)), returned=True)
         assert_equal(shape(w2), shape(r2))
-        r2, w2 = average(ones((2, 2, 3)), weights=ones((2, 2, 3)), returned=1)
+        r2, w2 = average(ones((2, 2, 3)), weights=ones((2, 2, 3)), returned=True)
         assert_(shape(w2) == shape(r2))
         a2d = array([[1, 2], [0, 4]], float)
         a2dm = masked_array(a2d, [[0, 0], [1, 0]])

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -909,7 +909,7 @@ def chebder(c, m=1, scl=1, axis=0):
     array([12.,  96.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     cnt = pu._deprecate_as_int(m, "the order of derivation")
@@ -1026,7 +1026,7 @@ def chebint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([-1.,  1., -1., -1.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if not np.iterable(k):
@@ -1131,7 +1131,7 @@ def chebval(x, c, tensor=True):
     --------
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1404,7 +1404,7 @@ def chebvander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -627,7 +627,7 @@ def hermder(c, m=1, scl=1, axis=0):
     array([1., 2., 3.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     cnt = pu._deprecate_as_int(m, "the order of derivation")
@@ -738,7 +738,7 @@ def hermint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([ 1.66666667, -0.5       ,  0.125     ,  0.08333333,  0.0625    ]) # may vary
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if not np.iterable(k):
@@ -846,7 +846,7 @@ def hermval(x, c, tensor=True):
            [115.,  203.]])
 
     """
-    c = np.array(c, ndmin=1, copy=0)
+    c = np.array(c, ndmin=1, copy=False)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1130,7 +1130,7 @@ def hermvander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -622,7 +622,7 @@ def hermeder(c, m=1, scl=1, axis=0):
     array([1.,  2.,  3.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     cnt = pu._deprecate_as_int(m, "the order of derivation")
@@ -733,7 +733,7 @@ def hermeint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([ 1.83333333,  0.        ,  0.5       ,  0.33333333,  0.25      ]) # may vary
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if not np.iterable(k):
@@ -841,7 +841,7 @@ def hermeval(x, c, tensor=True):
            [31., 54.]])
 
     """
-    c = np.array(c, ndmin=1, copy=0)
+    c = np.array(c, ndmin=1, copy=False)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1124,7 +1124,7 @@ def hermevander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -624,7 +624,7 @@ def lagder(c, m=1, scl=1, axis=0):
     array([1.,  2.,  3.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
 
@@ -739,7 +739,7 @@ def lagint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([ 11.16666667,  -5.        ,  -3.        ,   2.        ]) # may vary
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if not np.iterable(k):
@@ -848,7 +848,7 @@ def lagval(x, c, tensor=True):
            [-4.5, -2. ]])
 
     """
-    c = np.array(c, ndmin=1, copy=0)
+    c = np.array(c, ndmin=1, copy=False)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1131,7 +1131,7 @@ def lagvander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -669,7 +669,7 @@ def legder(c, m=1, scl=1, axis=0):
     array([  9.,  60.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     cnt = pu._deprecate_as_int(m, "the order of derivation")
@@ -786,7 +786,7 @@ def legint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([ 0.66666667,  0.8       ,  1.33333333,  1.2       ]) # may vary
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if not np.iterable(k):
@@ -891,7 +891,7 @@ def legval(x, c, tensor=True):
     --------
 
     """
-    c = np.array(c, ndmin=1, copy=0)
+    c = np.array(c, ndmin=1, copy=False)
     if c.dtype.char in '?bBhHiIlLqQpP':
         c = c.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1165,7 +1165,7 @@ def legvander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -491,7 +491,7 @@ def polyder(c, m=1, scl=1, axis=0):
     array([  6.,  24.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         # astype fails with NA
         c = c + 0.0
@@ -599,7 +599,7 @@ def polyint(c, m=1, k=[], lbnd=0, scl=1, axis=0):
     array([ 0., -2., -2., -2.])
 
     """
-    c = np.array(c, ndmin=1, copy=1)
+    c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':
         # astype doesn't preserve mask attribute.
         c = c + 0.0
@@ -721,7 +721,7 @@ def polyval(x, c, tensor=True):
     array([2.,  7.])
 
     """
-    c = np.array(c, ndmin=1, copy=0)
+    c = np.array(c, ndmin=1, copy=False)
     if c.dtype.char in '?bBhHiIlLqQpP':
         # astype fails with NA
         c = c + 0.0
@@ -811,7 +811,7 @@ def polyvalfromroots(x, r, tensor=True):
     >>> polyvalfromroots(b, r, tensor=False)
     array([-0.,  0.])
     """
-    r = np.array(r, ndmin=1, copy=0)
+    r = np.array(r, ndmin=1, copy=False)
     if r.dtype.char in '?bBhHiIlLqQpP':
         r = r.astype(np.double)
     if isinstance(x, (tuple, list)):
@@ -1076,7 +1076,7 @@ def polyvander(x, deg):
     if ideg < 0:
         raise ValueError("deg must be non-negative")
 
-    x = np.array(x, copy=0, ndmin=1) + 0.0
+    x = np.array(x, copy=False, ndmin=1) + 0.0
     dims = (ideg + 1,) + x.shape
     dtyp = x.dtype
     v = np.empty(dims, dtype=dtyp)

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -173,7 +173,7 @@ def as_series(alist, trim=True):
     [array([2.]), array([1.1, 0. ])]
 
     """
-    arrays = [np.array(a, ndmin=1, copy=0) for a in alist]
+    arrays = [np.array(a, ndmin=1, copy=False) for a in alist]
     if min([a.size for a in arrays]) == 0:
         raise ValueError("Coefficient array is empty")
     if any([a.ndim != 1 for a in arrays]):
@@ -195,7 +195,7 @@ def as_series(alist, trim=True):
             dtype = np.common_type(*arrays)
         except Exception:
             raise ValueError("Coefficient arrays have no common type")
-        ret = [np.array(a, copy=1, dtype=dtype) for a in arrays]
+        ret = [np.array(a, copy=True, dtype=dtype) for a in arrays]
     return ret
 
 
@@ -429,7 +429,7 @@ def _vander2d(vander_f, x, y, deg):
         _deprecate_as_int(d, "degrees")
         for d in deg
     ]
-    x, y = np.array((x, y), copy=0) + 0.0
+    x, y = np.array((x, y), copy=False) + 0.0
 
     vx = vander_f(x, degx)
     vy = vander_f(y, degy)
@@ -452,7 +452,7 @@ def _vander3d(vander_f, x, y, z, deg):
         _deprecate_as_int(d, "degrees")
         for d in deg
     ]
-    x, y, z = np.array((x, y, z), copy=0) + 0.0
+    x, y, z = np.array((x, y, z), copy=False) + 0.0
 
     vx = vander_f(x, degx)
     vy = vander_f(y, degy)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1145,7 +1145,7 @@ def assert_string_equal(actual, desired):
     if desired == actual:
         return
 
-    diff = list(difflib.Differ().compare(actual.splitlines(1), desired.splitlines(1)))
+    diff = list(difflib.Differ().compare(actual.splitlines(True), desired.splitlines(True)))
     diff_list = []
     while diff:
         d1 = diff.pop(0)


### PR DESCRIPTION
Personally I don't like non-booleans where booleans are expected. However it's also creating more code, so I'm not sure if it's actually an improvement.

I paid attention to the places which might behave different depending on the actual type instead of just the boolean representation but I cannot guarantee that a mistake might have slipped through.