### PR TITLE
DOC: Use Cython >= 0.29.11 for Python 3.8 support

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -8,7 +8,7 @@ Python versions supported are 3.5-3.7, note that Python 2.7 has been dropped.
 Python 3.8b1 should work with the released source packages, but there are no
 future guarantees.
 
-Downstream developers should use Cython >= 0.29.10 for Python 3.8 support and
+Downstream developers should use Cython >= 0.29.11 for Python 3.8 support and
 OpenBLAS >= 3.7 (not currently out) to avoid problems on the Skylake
 architecture. The NumPy wheels on PyPI are built from the OpenBLAS development
 branch in order to avoid those problems.


### PR DESCRIPTION
Cython 0.29.11 contains a compatibility fix for Python 3.8 beta 2.

See: https://bugs.python.org/issue37221
