### PR TITLE
DOC: Use Cython  >= 0.29.11 for Python 3.8 support.

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -5,10 +5,10 @@ NumPy 1.17.0 Release Notes
 This NumPy release contains a number of new features that should substantially
 improve its performance and usefulness, see Highlights below for a summary. The
 Python versions supported are 3.5-3.7, note that Python 2.7 has been dropped.
-Python 3.8b1 should work with the released source packages, but there are no
+Python 3.8b2 should work with the released source packages, but there are no
 future guarantees.
 
-Downstream developers should use Cython >= 0.29.10 for Python 3.8 support and
+Downstream developers should use Cython >= 0.29.11 for Python 3.8 support and
 OpenBLAS >= 3.7 (not currently out) to avoid problems on the Skylake
 architecture. The NumPy wheels on PyPI are built from the OpenBLAS development
 branch in order to avoid those problems.


### PR DESCRIPTION
The latest Cython is needed for Python 3.8b2.

[ci skip]

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
