### PR TITLE
BLD: Remove Trusty dist in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ matrix:
        - NPY_LAPACK_ORDER=MKL,OPENBLAS,ATLAS,ACCELERATE,LAPACK
        - USE_ASV=1
     - python: 3.5
-      dist: trusty # remove after April 2019
       env: NPY_RELAXED_STRIDES_CHECKING=0
     - python: 3.6
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1


### PR DESCRIPTION
Ubuntu 14.04 LTS (Trusty) provided a long term support distribution of
Ubuntu with a 5-year support window. This window ended in April 2019
and Trusty is now no longer supported. This commit removes Trusty from
the Travis-CI build.