### PR TITLE
BUG: Handle weird bytestrings in dtype()

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4414,7 +4414,17 @@ PyArray_DescrFromType(int type)
 {
     PyArray_Descr *ret = NULL;
 
-    if (type < NPY_NTYPES) {
+    if (type < 0) {
+        /*
+         * It's not valid for type to be less than 0.
+         * If that happens, then no other branch of
+         * this if/else chain should be followed.
+         * This is effectively a no-op that ensures
+         * the default error is raised.
+         */
+        ret = NULL;
+    }
+    else if (type < NPY_NTYPES) {
         ret = _builtin_descrs[type];
     }
     else if (type == NPY_NOTYPE) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1547,7 +1547,7 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
         /* A typecode like 'd' */
         if (len == 1) {
             /* Python byte string characters are unsigned */
-            check_num = ((unsigned char *)type)[0];
+            check_num = (unsigned char) type[0];
         }
         /* A kind + size like 'f8' */
         else {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1546,7 +1546,8 @@ PyArray_DescrConverter(PyObject *obj, PyArray_Descr **at)
 
         /* A typecode like 'd' */
         if (len == 1) {
-            check_num = type[0];
+            /* Python byte string characters are unsigned */
+            check_num = ((unsigned char *)type)[0];
         }
         /* A kind + size like 'f8' */
         else {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -115,7 +115,7 @@ class TestBuiltin(object):
         assert_dtype_equal(np.dtype(b'f'), np.dtype('float32'))
 
         # Bytes with non-ascii values raise errors
-        assert_raises(TypeError, np.dtype, bytes([255]))
+        assert_raises(TypeError, np.dtype, b'\xff')
         assert_raises(TypeError, np.dtype, b's\xff')
 
     def test_bad_param(self):


### PR DESCRIPTION
I've taken a go at a fix for #13902:
 * Explicit check for negative type value in PyArray_DescrFromType
 * PyArray_DescrConverter casts to unsigned char to match python bytes
 * Add some tests

Please tweak as you see fit :D 