### PR TITLE
ENH: use towncrier to build the release note

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -1,0 +1,51 @@
+:orphan:
+
+Changelog
+=========
+
+This directory contains "news fragments" which are short files that contain a
+small **ReST**-formatted text that will be added to the next what's new page.
+
+Make sure to use full sentences with correct case and punctuation, and please
+try to use Sphinx intersphinx using backticks. The fragment should have a
+header line and an underline using ``------``
+
+Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
+``<PULL REQUEST>`` is a pull request number, and ``<TYPE>`` is one of:
+
+* ``new_function``: New user facing functions.
+* ``deprecation``: Changes existing code to emit a DeprecationWarning.
+* ``future``: Changes existing code to emit a FutureWarning.
+* ``expired``: Removal of a deprecated part of the API.
+* ``compatibility``: A change which requires users to change code and is not
+  backwards compatible. (Not to be used for removal of deprecated features.)
+* ``c_api``: Changes in the Numpy C-API exported functions
+* ``new_features``: New user facing features like ``kwargs``.
+* ``improvements``: Performance and edge-case changes
+* ``changes``: Other changes
+
+So for example: ``123.new_features.rst`` would have the content:
+
+```
+my_new_feature option for `my_favorite_function`
+------------------------------------------------
+The ``my_new_feature`` option is now available for `my_favorite_function`.
+To use it, write ``np.my_favorite_function(..., my_new_feature=True)``.
+```
+
+Note the use of single-backticks to get an internal link (assuming
+``my_favorite_function`` is exported from the ``numpy`` namespace), and double-
+backticks for code.
+
+If you are unsure what pull request type to use, don't hesitate to ask in your
+PR.
+
+You can install ``towncrier`` and run ``towncrier --draft --version NumPy``
+if you want to get a preview of how your change will look in the final release
+notes.
+
+.. note::
+
+    This README was adapted from the pytest changelog readme under the terms of
+    the MIT licence.
+

--- a/changelog/template.rst
+++ b/changelog/template.rst
@@ -1,0 +1,33 @@
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+{{ text }} ({{ values|join(', ') }})
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -11,7 +11,7 @@ useful info can be found.
 
 Source tree
 -----------
-* INSTALL.txt
+* INSTALL.rst.txt
 * release.sh
 * pavement.py
 
@@ -257,12 +257,19 @@ updated for a major release.
 
 Check the release notes
 -----------------------
+Use `towncrier`_ to build the release note, copy it to the proper name, and
+commit the changes. This will remove all the fragments from ``changelog/*.rst``
+and add ``doc/release/latest-note.rst`` which must be renamed with the proper
+version number::
+
+    python -mtowncrier --version "Numpy 1.11.0"
+    git mv doc/release/latest-note.rst doc/release/1.11.0-notes.rst
+    git commit -m"Create release note"
+
 Check that the release notes are up-to-date.
 
-Write or update the release notes in a file named for the release, such as
-``doc/release/1.11.0-notes.rst``.
-
-Mention at least the following:
+Update the release notes with a Highlights section. Mention some of the
+following:
 
   - major new features
   - deprecated and removed features
@@ -270,8 +277,7 @@ Mention at least the following:
   - for SciPy, supported NumPy version(s)
   - outlook for the near future
 
-Also make sure that as soon as the branch is made, there is a new release
-notes file in the master branch for the next release.
+.. _towncrier: https://github.com/hawkowl/towncrier
 
 Update the release status and create a release "tag"
 ----------------------------------------------------

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -38,6 +38,11 @@ to the maintenance branch, and later will be forward ported to master.
 Finish the Release Note
 -----------------------
 
+.. note:
+
+  This has changed now that we use ``towncrier``. See the instructions for
+  creating the release note in ``changelog/README.rst``.
+
 Fill out the release note ``doc/release/1.14.5-notes.rst`` calling out
 significant changes.
 

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -28,7 +28,7 @@ In short:
 
    - *Core developers* If you want to push changes without
      further review, see the notes :ref:`below <pushing-to-main>`.
-     
+
 This way of working helps to keep work well organized and the history
 as clear as possible.
 
@@ -69,7 +69,7 @@ Overview
    git status # Optional
    git diff # Optional
    git add modified_file
-   git commit 
+   git commit
    # push the branch to your own Github repo
    git push origin my-new-feature
 
@@ -112,38 +112,38 @@ In more detail
    properly formatted and sufficiently detailed commit message. After saving
    your message and closing the editor, your commit will be saved. For trivial
    commits, a short commit message can be passed in through the command line
-   using the ``-m`` flag. For example, ``git commit -am "ENH: Some message"``. 
-   
+   using the ``-m`` flag. For example, ``git commit -am "ENH: Some message"``.
+
    In some cases, you will see this form of the commit command: ``git commit
    -a``. The extra ``-a`` flag automatically commits all modified files and
    removes all deleted files. This can save you some typing of numerous ``git
    add`` commands; however, it can add unwanted changes to a commit if you're
    not careful. For more information, see `why the -a flag?`_ - and the
-   helpful use-case description in the `tangled working copy problem`_.  
+   helpful use-case description in the `tangled working copy problem`_.
 
 #. Push the changes to your forked repo on github_::
 
       git push origin my-new-feature
 
    For more information, see `git push`_.
-    
+
 .. note::
-    
+
    Assuming you have followed the instructions in these pages, git will create
    a default link to your github_ repo called ``origin``.  In git >= 1.7 you
    can ensure that the link to origin is permanently set by using the
    ``--set-upstream`` option::
-   
+
       git push --set-upstream origin my-new-feature
-   
+
    From now on git_ will know that ``my-new-feature`` is related to the
    ``my-new-feature`` branch in your own github_ repo. Subsequent push calls
    are then simplified to the following::
 
       git push
-   
+
    You have to use ``--set-upstream`` for each new branch that you create.
-    
+
 
 It may be the case that while you were working on your edits, new commits have
 been added to ``upstream`` that affect your work. In this case, follow the
@@ -194,12 +194,17 @@ Asking for your changes to be merged with the main repo
 =======================================================
 
 When you feel your work is finished, you can create a pull request (PR). Github
-has a nice help page that outlines the process for `filing pull requests`_. 
+has a nice help page that outlines the process for `filing pull requests`_.
 
 If your changes involve modifications to the API or addition/modification of a
-function, you should initiate a code review. This involves sending an email to
-the `NumPy mailing list`_ with a link to your PR along with a description of
-and a motivation for your changes.
+function, you should
+
+- send an email to the `NumPy mailing list`_ with a link to your PR along with
+  a description of and a motivation for your changes. This may generate
+  changes and feedback. It might be prudent to start with this step if your
+  change may be controversial.
+- add a release note to the ``changelog`` directory, following the instructions
+  and format in the ``changelog/README.rst`` file.
 
 .. _rebasing-on-master:
 
@@ -500,7 +505,7 @@ them to ``upstream`` as follows:
 
         git push upstream my-feature-branch:master
 
-.. note:: 
+.. note::
 
     It's usually a good idea to use the ``-n`` flag to ``git push`` to check
     first that you're about to push the changes you want to the place you

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,59 @@
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel", "cython"]  # PEP 508 specification
 
+
+[tool.towncrier]
+    # Do no set this since it is hard to import numpy inside the source directory
+    # Use "--version Numpy" instead
+    #project = "numpy"
+    filename = "doc/release/latest-note.rst"
+    directory = "changelog/"
+    issue_format = "`#{issue} <https://github.com/numpy/numpy/pull/{issue}>`__"
+    template = "changelog/template.rst"
+    underlines="~="
+
+    [[tool.towncrier.type]]
+        directory = "new_function"
+        name = "New functions"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "deprecation"
+        name = "Deprecations"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "future"
+      name = "Future Changes"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "expired"
+      name = "Expired deprecations"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "coompatibility"
+      name = "Compatibility notes"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "c_api"
+      name = "C API changes"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "new_features"
+      name = "New Features"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "improvements"
+      name = "Improvements"
+      showcontent = true
+
+    [[tool.towncrier.type]]
+      directory = "changes"
+      name = "Changes"
+      showcontent = true
+


### PR DESCRIPTION
Add infrastructure and instructions to use towncrier to build the release note from a directory of fragments.

`python -mtowncrier --draft` (once there are some fragments in `./changelog`) will preview the current release note status. 

Running `python -mtowncrier` will overwrite `./doc/release/latest-note.rst`, delete all the fragments from `./changelog`, and stage the changes for a git commit. 

A fragment is a file in `./changelog` with a name like `139999.changes.rst` with a title line and content like

```
Use ``towncrier`` to build the release note
-------------------------------------------
Use ``towncrier`` to build the release note out of fragments in a directory
```