### PR TITLE
MAINT: Change the type of error in numpy.ndarray.fill

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3003,12 +3003,13 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('fill',
     """
     a.fill(value)
 
-    Fill the array with a scalar value.
+    Fill the array with a value.
 
     Parameters
     ----------
     value : scalar
-        All elements of `a` will be assigned this value.
+        All elements of `a` will be assigned this value. If `a` is not a
+        (Python) object, `value` must be a scalar value.
 
     Examples
     --------

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -500,7 +500,7 @@ PyArray_FillWithScalar(PyArrayObject *arr, PyObject *obj)
         }
 
         if (PyArray_NDIM(src_arr) != 0) {
-            PyErr_SetString(PyExc_ValueError,
+            PyErr_SetString(PyExc_TypeError,
                     "Input object to FillWithScalar is not a scalar");
             Py_DECREF(src_arr);
             return -1;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -398,6 +398,8 @@ class TestAttributes(object):
             x.fill(1)
             y[...] = 1
             assert_equal(x, y)
+            if t != "O":
+                assert_raises(TypeError, x.fill, np.array([1]))
 
     def test_fill_max_uint64(self):
         x = np.empty((3, 2, 1), dtype=np.uint64)


### PR DESCRIPTION
I think it is a ``TypeError`` when the value is not a scalar.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
