### PR TITLE
ENH: improve error message for ragged-array creation failure

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1849,6 +1849,13 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
             *out_arr = NULL;
             return 0;
         }
+        if (is_object && (requested_dtype != NULL) && 
+                (requested_dtype->type_num != NPY_OBJECT)) {
+            PyErr_SetString(PyExc_ValueError,
+               "cannot create an array from unequal-length (ragged) sequences");
+            Py_DECREF(*out_dtype);
+            return -1;
+        }
         /* If object arrays are forced */
         if (is_object) {
             Py_DECREF(*out_dtype);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -44,7 +44,7 @@ from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
     assert_allclose, IS_PYPY, HAS_REFCOUNT, assert_array_less, runstring,
-    temppath, suppress_warnings, break_cycles,
+    temppath, suppress_warnings, break_cycles, assert_raises_regex,
     )
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
@@ -497,6 +497,9 @@ class TestArrayConstruction(object):
         assert_(np.ascontiguousarray(d).flags.c_contiguous)
         assert_(np.asfortranarray(d).flags.f_contiguous)
 
+    def test_ragged(self):
+        assert_raises_regex(ValueError, 'ragged',
+                             np.array, [[1], [2, 3]], dtype=int)
 
 class TestAssignment(object):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
Fixes #5303, #6584 for the case where `np.array` gets a ragged-sequence input and a dtype is specified. This does not try to fix the case for where no dtype is specified. 

Previously `np.array([[1], [2, 3]], dtype=int)` would emit a "setting an array element with a sequence" message, now changed to "cannot create an array from unequal-length (ragged) sequences". This also is the error for structured dtypes where previously the error was "TypeError: expected a readable buffer object"

Test added.