### PR TITLE
DOC: start pushing docs to numpy/numpy.github.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
               ./tools/ci/push_docs_to_repo.py doc/build/html \
                   $CIRCLE_BRANCH \
-                  git@github.com:numpy/doc.git \
+                  git@github.com:numpy/numpy.github.com.git \
                   --committer "numpy-circleci-bot" \
                   --email "numpy-circleci-bot@nomail" \
                   --message "Docs build of $CIRCLE_SHA1" 
@@ -97,10 +97,10 @@ jobs:
 
               ./tools/ci/push_docs_to_repo.py doc/neps/_build/html \
                   $CIRCLE_BRANCH \
-                  git@github.com:numpy/neps.git \
+                  git@github.com:numpy/numpy.github.com.git \
                   --committer "numpy-circleci-bot" \
                   --email "numpy-circleci-bot@nomail" \
-                  --message "Docs build of $CIRCLE_SHA1" \
+                  --message "Neps build of $CIRCLE_SHA1" \
                   --target neps
             else
               echo "Not on the master branch; skipping deployment"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,17 +63,17 @@ jobs:
       -  run:
           name: deploy devdocs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [[ "${CIRCLE_BRANCH}" =~ ^master$|^maintenance/[0-9]+\.[0-9]+\.x$ ]]; then
               touch doc/build/html/.nojekyll
 
               ./tools/ci/push_docs_to_repo.py doc/build/html \
-                  git@github.com:numpy/devdocs.git \
+                  $CIRCLE_BRANCH \
+                  git@github.com:numpy/doc.git \
                   --committer "numpy-circleci-bot" \
                   --email "numpy-circleci-bot@nomail" \
-                  --message "Docs build of $CIRCLE_SHA1" \
-                  --force
+                  --message "Docs build of $CIRCLE_SHA1" 
             else
-              echo "Not on the master branch; skipping deployment"
+              echo "Not on the correct branch; skipping deployment"
             fi
 
       - add_ssh_keys:
@@ -96,11 +96,12 @@ jobs:
               touch doc/neps/_build/html/.nojekyll
 
               ./tools/ci/push_docs_to_repo.py doc/neps/_build/html \
+                  $CIRCLE_BRANCH \
                   git@github.com:numpy/neps.git \
                   --committer "numpy-circleci-bot" \
                   --email "numpy-circleci-bot@nomail" \
                   --message "Docs build of $CIRCLE_SHA1" \
-                  --force
+                  --target neps
             else
               echo "Not on the master branch; skipping deployment"
             fi

--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -30,10 +30,10 @@ if not os.path.exists(args.dir):
     sys.exit(1)
 
 m = re.search('maintenance/([\d.]*)\.x', args.branch)
-if args.target == 'neps':
-    target = '.'
-if args.branch == 'master':
-    target = 'dev'
+if args.target:
+    target = args.target
+elif args.branch == 'master':
+    target = 'devdocs'
 elif m:
     target = m.groups()[0]
 else:


### PR DESCRIPTION
The first part of an effort to create a home for NumPy documentation under https://numpy.org ~/doc~. This PR points the CirclCI deploy script to upload to ~[numpy/doc](https://github.com/numpy/doc)~ [numpy/numpy.github.com](https://github.com/numpy/numpy.github.com) which is set up to feed github pages to the new location.

This was motivated by the need for automatically updating documentation so the canonical release note can be a link to a html page rather than a text-rendered version of the release.rst document. xref [this comment](https://github.com/numpy/numpy/pull/13893#discussion_r299628334) relating to the 1.17 release note.

I tested the scripts off-line to build the initial repo in https://github/numpy/doc. Hopefully I did not break the NEP repo, there is some special casing for it that I did not test.

If we backport this PR to the maintenance branches, the documentation will automatically be built and uploaded every time a change is made to one of those branches.

Still TODO in subsequent PR(s): 
- style the sites like https://www.numpy.org, 
- improve the index page at https://www.numpy.org/doc/index.html, 
- deprecate the pages at https://www.numpy.org/devdocs ~(make them redirect to the new location?),~ 
- ~fix any links pointing to devdocs~

Edit: The PR was changed to push directly to numpy/numpy.github.com, and the description was updated accordingly

