### PR TITLE
MAINT: Fix wrong spelling of ufunc

### DIFF
--- a/numpy/doc/ufuncs.py
+++ b/numpy/doc/ufuncs.py
@@ -13,9 +13,9 @@ example is the addition operator: ::
  >>> np.array([0,2,3,4]) + np.array([1,1,-1,2])
  array([1, 3, 2, 6])
 
-The unfunc module lists all the available ufuncs in numpy. Documentation on
+The ufunc module lists all the available ufuncs in numpy. Documentation on
 the specific ufuncs may be found in those modules. This documentation is
-intended to address the more general aspects of unfuncs common to most of
+intended to address the more general aspects of ufuncs common to most of
 them. All of the ufuncs that make use of Python operators (e.g., +, -, etc.)
 have equivalent functions defined (e.g. add() for +)
 


### PR DESCRIPTION
It's not really a documentation fix because as far as I can see the documentation there isn't part of the official documentation. However I found this typo when searching for the source of [the actual ufunc documentation](https://docs.scipy.org/doc/numpy/reference/ufuncs.html).