### PR TITLE
DOC: Remove explicit .next method calls with built-in next function calls

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -448,7 +448,7 @@ object, then the Python code::
         some code involving val
         ...
 
-calls ``val = myiter.next()`` repeatedly until :exc:`StopIteration` is
+calls ``val = next(myiter)`` repeatedly until :exc:`StopIteration` is
 raised by the iterator. There are several ways to iterate over an
 array that may be useful: default iteration, flat iteration, and
 :math:`N`-dimensional enumeration.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -94,7 +94,7 @@ add_newdoc('numpy.core', 'flatiter', ('coords',
     >>> fl = x.flat
     >>> fl.coords
     (0, 0)
-    >>> fl.next()
+    >>> next(fl)
     0
     >>> fl.coords
     (0, 1)
@@ -113,7 +113,7 @@ add_newdoc('numpy.core', 'flatiter', ('index',
     >>> fl = x.flat
     >>> fl.index
     0
-    >>> fl.next()
+    >>> next(fl)
     0
     >>> fl.index
     1
@@ -666,7 +666,7 @@ add_newdoc('numpy.core', 'broadcast', ('iters',
     >>> y = np.array([[4], [5], [6]])
     >>> b = np.broadcast(x, y)
     >>> row, col = b.iters
-    >>> row.next(), col.next()
+    >>> next(row), next(col)
     (1, 4)
 
     """))

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -54,7 +54,7 @@ class PushbackIterator(object):
 
     Return an iterator for which items can be pushed back into.
     Call the .pushback(item) method to have item returned as the next
-    value of .next().
+    value of next().
     """
     def __init__(self, iterable):
         object.__init__(self)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2681,15 +2681,13 @@ class MaskedIterator(object):
         --------
         >>> x = np.ma.array([3, 2], mask=[0, 1])
         >>> fl = x.flat
-        >>> fl.next()
+        >>> next(fl)
         3
-        >>> fl.next()
+        >>> next(fl)
         masked
-        >>> fl.next()
+        >>> next(fl)
         Traceback (most recent call last):
-          File "<stdin>", line 1, in <module>
-          File "/home/ralf/python/numpy/numpy/ma/core.py", line 2243, in next
-            d = self.dataiter.next()
+          ...
         StopIteration
 
         """


### PR DESCRIPTION
In some cases the documentation examples failed with an AttributeError because the next method was not there. In a few other cases it still worked but may be more future-proof and ideomatic if they used the next function instead of the next method.