### PR TITLE
DOC: Don't override MaskedArray.view documentation with the one from ndarray.view

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3077,7 +3077,7 @@ class MaskedArray(ndarray):
 
     def view(self, dtype=None, type=None, fill_value=None):
         """
-        Return a view of the MaskedArray data
+        Return a view of the MaskedArray data.
 
         Parameters
         ----------
@@ -3091,6 +3091,14 @@ class MaskedArray(ndarray):
         type : Python type, optional
             Type of the returned view, either ndarray or a subclass.  The
             default None results in type preservation.
+        fill_value : scalar, optional
+            The value to use for invalid entries (None by default).
+            If None, then this argument is inferred from the passed `dtype`, or
+            in its absence the original array, as discussed in the notes below.
+
+        See Also
+        --------
+        numpy.ndarray.view : Equivalent method on ndarray object.
 
         Notes
         -----
@@ -3156,7 +3164,6 @@ class MaskedArray(ndarray):
             else:
                 output.fill_value = fill_value
         return output
-    view.__doc__ = ndarray.view.__doc__
 
     def __getitem__(self, indx):
         """


### PR DESCRIPTION
To document the fill_value parameter (see  #2703) it's needed to display the correct docstring of the function instead of overwriting it with the docstring of ndarray.view.