### PR TITLE
BUG: Fix incorrect GIL release in array.nonzero

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2394,9 +2394,6 @@ PyArray_Nonzero(PyArrayObject *self)
                     get_multi_index(iter, multi_index);
                     multi_index += ndim;
                 }
-                if (needs_api && PyErr_Occurred()) {
-                    break;
-                }
             } while(iternext(iter));
         }
         else {

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2378,8 +2378,7 @@ PyArray_Nonzero(PyArrayObject *self)
             return NULL;
         }
         
-        /* See if we need to check the error state due to iternext() */
-        needs_api |= NpyIter_IterationNeedsAPI(iter);
+        needs_api = NpyIter_IterationNeedsAPI(iter);
 
         NPY_BEGIN_THREADS_NDITER(iter);
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1259,12 +1259,13 @@ class TestNonzero(object):
 
         class ThrowsAfter:
             def __init__(self, iters):
-                ThrowsAfter.iters_left = iters
+                self.iters_left = iters
 
             def __bool__(self):
-                if ThrowsAfter.iters_left == 0:
+                if self.iters_left == 0:
                     raise ValueError("called `iters` times")
-                ThrowsAfter.iters_left -= 1
+
+                self.iters_left -= 1
                 return True
 
         """
@@ -1275,16 +1276,17 @@ class TestNonzero(object):
         """
 
         # assert that an exception in first pass is handled correctly
-        a = np.array([ThrowsAfter(5) for i in range(5)])
+        a = np.array([ThrowsAfter(5)]*10)
         assert_raises(ValueError, np.nonzero, a)
 
         # raise exception in second pass for 1-dimensional loop
-        a = np.array([ThrowsAfter(15) for i in range(10)])
+        a = np.array([ThrowsAfter(15)]*10)
         assert_raises(ValueError, np.nonzero, a)
 
         # raise exception in second pass for n-dimensional loop
-        a = np.array([[ThrowsAfter(15) for i in range(10)]])
+        a = np.array([[ThrowsAfter(15)]]*10)
         assert_raises(ValueError, np.nonzero, a)
+
 
 class TestIndex(object):
     def test_boolean(self):


### PR DESCRIPTION
Added checks to array.nonzero to ensure GIL is not released if it is needed. 

In reference to #13753.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
