### PR TITLE
ENH, MAINT: Fix behavior of int and bool in np.spacing

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -880,7 +880,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.spacing'),
           None,
-          TD(flts),
+          TD('?' + intflt),
           ),
 'modf':
     Ufunc(1, 2, None,

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3416,7 +3416,7 @@ add_newdoc('numpy.core.umath', 'spacing',
 
     Examples
     --------
-    >>> np.spacing(1) == np.finfo(np.float64).eps
+    >>> np.spacing(np.float64(1)) == np.finfo(np.float64).eps
     True
 
     """)

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -566,6 +566,11 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 }
 /**end repeat**/
 
+NPY_NO_EXPORT void
+BOOL_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    PyErr_SetString(PyExc_TypeError, "type of the input is not supported");
+}
 
 /**begin repeat
  * #kind = logical_and, logical_or#
@@ -717,6 +722,14 @@ NPY_NO_EXPORT void
 @TYPE@_positive(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {
     UNARY_LOOP_FAST(@type@, @type@, *out = +in);
+}
+
+NPY_NO_EXPORT void
+@TYPE@_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    UNARY_LOOP {
+        *((@type@ *)op1) = 1;
+    }
 }
 
 /**begin repeat1

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -36,6 +36,9 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
 /**end repeat**/
 
 NPY_NO_EXPORT void
+BOOL_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
 BOOL__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
 
 /**begin repeat
@@ -70,6 +73,9 @@ NPY_NO_EXPORT void
 
 NPY_NO_EXPORT void
 @S@@TYPE@_positive(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
+@S@@TYPE@_spacing(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 /**begin repeat2
  * #isa = , _avx2#

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2883,6 +2883,16 @@ def test_spacing():
 def test_spacingf():
     return _test_spacing(np.float32)
 
+def test_spacingi():
+    for dtype in np.typecodes['AllInteger']:
+        one = np.array(1, dtype=dtype)
+        ones = np.ones(5, dtype=dtype)
+        assert_(np.spacing(one) == one)
+        assert_array_equal(np.spacing(ones), ones)
+
+def test_spacingb():
+    assert_raises(TypeError, np.spacing, np.bool_(1))
+    assert_raises(TypeError, np.spacing, np.array([1, 0], dtype=np.bool_))
 
 @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                     reason="long double is same as double")


### PR DESCRIPTION
When the ``dtype`` of the input is ``int`` or ``bool``, the output of ``np.spacing`` function was puzzling. 
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
