### PR TITLE
DOC: Fix rst rendering in data types

### DIFF
--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -315,7 +315,7 @@ compiler's ``long double`` available as ``np.longdouble`` (and
 numpy provides with ``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C's
-``long double``; in particular, the 128-bit IEEE quad precision
+``long double``\\; in particular, the 128-bit IEEE quad precision
 data type (FORTRAN's ``REAL*16``\\) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -314,8 +314,8 @@ compiler's ``long double`` available as ``np.longdouble`` (and
 ``np.clongdouble`` for the complex numbers). You can find out what your
 numpy provides with ``np.finfo(np.longdouble)``.
 
-NumPy does not provide a dtype with more precision than C
-``long double``\\s; in particular, the 128-bit IEEE quad precision
+NumPy does not provide a dtype with more precision than C's
+``long double``; in particular, the 128-bit IEEE quad precision
 data type (FORTRAN's ``REAL*16``\\) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored


### PR DESCRIPTION
This very small PR tries to fix an issue with the RST rendering in the [Extended Precision section of the Data types page](https://docs.scipy.org/doc/numpy-1.13.0/user/basics.types.html#extended-precision).

> NumPy does not provide a dtype with more precision than C long double``s; in particular, the 128-bit IEEE quad precision data type (FORTRAN's ``REAL*16) is not available.

Unfortunately I was unable to build the documentation locally (several errors were raised), so I hope that it fixes the issue.