### PR TITLE
WIP, BUILD: update mingw32 from gcc5.3 to 7.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,7 +188,7 @@ jobs:
       cp $tmpdir\$(BITS)\lib\libopenblas_v0.3.5-274-g6a8b4269-gcc_7_1_0.a $target
     displayName: 'Download / Install OpenBLAS'
   - powershell: |
-      choco install -y mingw --forcex86 --force --version=5.3.0
+      choco install -y mingw --forcex86 --force --version=7.3.0
     displayName: 'Install 32-bit mingw for 32-bit builds'
     condition: eq(variables['BITS'], 32)
   # NOTE: for Windows builds it seems much more tractable to use runtests.py


### PR DESCRIPTION
mingw32 version 5.3 is no longer provided on [Sourceforge](https://sourceforge.net/projects/mingw-w64/files/), try 7.3 instead.