### PR TITLE
Fixing failure on Python 2.7 on Windows 7

### DIFF
--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -95,7 +95,7 @@ class CompaqVisualFCompiler(FCompiler):
                 raise e
         except ValueError:
             e = get_exception()
-            if not "path']" in str(e):
+            if not "'path'" in str(e):
                 print("Unexpected ValueError in", __file__)
                 raise e
 


### PR DESCRIPTION
When executing ``pytest --pyargs numpy.distuils.tests.test_fcompiler``
the ``test_fcompiler_flags`` fails with

```
>                   raise e
E                   ValueError: [u'path', u'include', u'lib']

lib\site-packages\numpy\distutils\fcompiler\compaq.py:100: ValueError
---------------------------- Captured stdout call -----------------------------
Unexpected ValueError in C:\TCAgent1\work\7cc6992266387eba\distribution\lib\site
-packages\numpy\distutils\fcompiler\compaq.py
```

It appears that the list argument of ValueError contains 'path' not at the
end of the list like the current test expects, but at the beginning.

After this fix, 9 test failures of `pytest --pyargs numpy.distutils` go away.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

@dmitrii-zagornyi 