### PR TITLE
DEP: Add deprecation for NaN in xp in np.interp

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -594,9 +594,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             }
 
             j = binary_search_with_guess(x_val, dx, lenxp, j);
-            if (npy_isnan(dx[j]) || (j < lenxp && npy_isnan(dx[j+1]) )) {
-                found_nan = NPY_TRUE;
-            }
+
             if (j == -1) {
                 dres[i] = lval;
             }
@@ -622,6 +620,10 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                     if (NPY_UNLIKELY(npy_isnan(dres[i])) && dy[j] == dy[j+1]) {
                         dres[i] = dy[j];
                     }
+                }
+
+                if (npy_isnan(dx[j]) || npy_isnan(dx[j+1])) {
+                    found_nan = NPY_TRUE;
                 }
             }
         }
@@ -793,9 +795,6 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             }
 
             j = binary_search_with_guess(x_val, dx, lenxp, j);
-            if (npy_isnan(dx[j]) || (j < lenxp && npy_isnan(dx[j+1]) )) {
-                found_nan = NPY_TRUE;
-            }
             if (j == -1) {
                 dres[i] = lval;
             }
@@ -837,7 +836,11 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                         dres[i].imag = dy[j].imag;
                     }
                 }
+                if (npy_isnan(dx[j]) || npy_isnan(dx[j+1])) {
+                    found_nan = NPY_TRUE;
+                }
             }
+
         }
 
         NPY_END_THREADS;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -552,10 +552,29 @@ class TestNonZero(_DeprecationTestCase):
 
 class TestInterpNaN(_DeprecationTestCase):
     # 2019-07-13, 1.17.0
-    def test_xp_nan(self):
+
+    @pytest.fixture(params=[
+        lambda x: np.float_(x),
+        lambda x: np.complex_(x),
+    ], ids=[
+        'real',
+        'complex'
+    ])
+    def sc(self, request):
+        """ scale function used by the below tests """
+        return request.param
+
+    def test_xp_nan(self, sc):
+        self.assert_deprecated(lambda: np.interp([1], [np.nan], sc([10])))
         self.assert_deprecated(lambda: np.interp(
-            [1,3,1], [0, 2, np.nan, np.nan], [10, 20, 30, 40]
+            [2], [1, np.nan], sc([10, 20])
             ))
         self.assert_deprecated(lambda: np.interp(
-            [1,3,1], [0, 2, np.nan, np.nan, np.nan], [10, 20, 30, 40, 50]
+            [1,3,1], [0, 2, np.nan, np.nan], sc([10, 20, 30, 40])
+            ))
+        self.assert_deprecated(lambda: np.interp(
+            [1,3,1], [0, 2, np.nan, np.nan, np.nan], sc([10, 20, 30, 40, 50])
+            ))
+        self.assert_deprecated(lambda: np.interp(
+            [1,3,1], [0, 2, np.nan, np.nan, np.nan], sc([10, 20, 30, 40, 50])
             ))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -548,3 +548,14 @@ class TestNonZero(_DeprecationTestCase):
     def test_zerod(self):
         self.assert_deprecated(lambda: np.nonzero(np.array(0)))
         self.assert_deprecated(lambda: np.nonzero(np.array(1)))
+
+
+class TestInterpNaN(_DeprecationTestCase):
+    # 2019-07-13, 1.17.0
+    def test_xp_nan(self):
+        self.assert_deprecated(lambda: np.interp(
+            [1,3,1], [0, 2, np.nan, np.nan], [10, 20, 30, 40]
+            ))
+        self.assert_deprecated(lambda: np.interp(
+            [1,3,1], [0, 2, np.nan, np.nan, np.nan], [10, 20, 30, 40, 50]
+            ))

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1287,6 +1287,10 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     Returns the one-dimensional piecewise linear interpolant to a function
     with given discrete data points (`xp`, `fp`), evaluated at `x`.
 
+    .. deprecated:: 1.18.0
+        `np.interp` found NaN in xp. This will raise an error starting in 
+        NumPy 1.19.0.
+
     Parameters
     ----------
     x : array_like

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2414,8 +2414,9 @@ class TestInterp(object):
 
     def test_non_finite_any_nan(self, sc):
         """ test that nans are propagated """
-        assert_equal(np.interp(0.5, [np.nan,      1], sc([     0,     10])), sc(np.nan))
-        assert_equal(np.interp(0.5, [     0, np.nan], sc([     0,     10])), sc(np.nan))
+        with pytest.warns(DeprecationWarning):
+            assert_equal(np.interp(0.5, [np.nan,      1], sc([     0,     10])), sc(np.nan))
+            assert_equal(np.interp(0.5, [     0, np.nan], sc([     0,     10])), sc(np.nan))
         assert_equal(np.interp(0.5, [     0,      1], sc([np.nan,     10])), sc(np.nan))
         assert_equal(np.interp(0.5, [     0,      1], sc([     0, np.nan])), sc(np.nan))
 


### PR DESCRIPTION
Adding deprecation for NaN in `xp` in `np.interp`.

After some discussions with @seberg, we think the best way to address #13919 is to add a deprecation message with the end goal of raising an error if we found NaN in `xp`.

We are open to suggestions and discussions on other ideas to handle this problem.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
