### PR TITLE
DEP: Speed up WarnOnWrite deprecation in buffer interface

### DIFF
--- a/doc/release/1.17.0-notes.rst
+++ b/doc/release/1.17.0-notes.rst
@@ -91,6 +91,12 @@ produce the deprecation warning. To help alleviate confusion, an additional
 `FutureWarning` will be emitted when accessing the ``writeable`` flag state to
 clarify the contradiction.
 
+Note that for the C-side buffer protocol such an array will return a
+readonly buffer immediately unless a writable buffer is requested. If
+a writeable buffer is requested a warning will be given. When using
+cython, the `const` attribute should be used with such arrays to avoid
+the warning.
+
 
 Future Changes
 ==============


### PR DESCRIPTION
When a buffer interface does not request a writeable buffer,
simply pass a read-only one when the warn on write flag is set.

This is to give an easier way forward with avoiding the deprecation
warnings: Simply do not ask for a writeable buffer.

It will break code that expects writeable buffers but does not
ask for them specifically a bit harder than would be nice.
But since such code probably should ask for it specifically, this
is likely fine (an RC release has to find out).

The main reason for this is, that this way it plays very will with
cython, which requests writeable buffers explicitly and if declared
`const` is happy about read-only (so that using `const` is the best
way to avoid the warning and makes code cleaner).

Closes gh-13929, gh-13974

---

There are two things:
 1. [ ] We need to decide that we want to do this, to me this seems like a viable option (i.e. if someone does not *need* a writeable buffer as such, they should be fine, if someone needs a writeable buffer, they should be requesting it specifically.
 2. [ ] We could try to add a more descriptive message that tells someone things about memoryview (and even mentions cython) when this path is hit.