### PR TITLE
BUG: Missing warnings import in polyutils

### DIFF
--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -46,6 +46,7 @@ Functions
 from __future__ import division, absolute_import, print_function
 
 import operator
+import warnings
 
 import numpy as np
 

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -13,7 +13,7 @@ import numpy as np
 from numpy.polynomial import (
     Polynomial, Legendre, Chebyshev, Laguerre, Hermite, HermiteE)
 from numpy.testing import (
-    assert_almost_equal, assert_raises, assert_equal, assert_, assert_warns,
+    assert_almost_equal, assert_raises, assert_equal, assert_,
     )
 from numpy.compat import long
 from numpy.polynomial.polyutils import RankWarning
@@ -139,8 +139,9 @@ def test_bad_conditioned_fit(Poly):
     y = [1., 2., 3.]
 
     # check RankWarning is raised
-    with assert_warns(RankWarning):
+    with pytest.warns(RankWarning) as record:
         Poly.fit(x, y, 2)
+    assert record[0].message.args[0] == "The fit may be poorly conditioned"
 
 
 def test_fit(Poly):

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -13,10 +13,10 @@ import numpy as np
 from numpy.polynomial import (
     Polynomial, Legendre, Chebyshev, Laguerre, Hermite, HermiteE)
 from numpy.testing import (
-    assert_almost_equal, assert_raises, assert_equal, assert_,
+    assert_almost_equal, assert_raises, assert_equal, assert_, assert_warns,
     )
 from numpy.compat import long
-
+from numpy.polynomial.polyutils import RankWarning
 
 #
 # fixtures
@@ -131,6 +131,16 @@ def test_fromroots(Poly):
     pwin = Polynomial.window
     p2 = Polynomial.cast(p1, domain=pdom, window=pwin)
     assert_almost_equal(p2.coef[-1], 1)
+
+
+def test_bad_conditioned_fit(Poly):
+
+    x = [0., 0., 1.]
+    y = [1., 2., 3.]
+
+    # check RankWarning is raised
+    with assert_warns(RankWarning):
+        Poly.fit(x, y, 2)
 
 
 def test_fit(Poly):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.polynomial.polynomial as poly
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
-    assert_array_equal)
+    assert_warns, assert_array_equal)
 
 
 def trim(x):
@@ -297,6 +297,8 @@ class TestIntegral(object):
         assert_raises(ValueError, poly.polyint, [0], lbnd=[0])
         assert_raises(ValueError, poly.polyint, [0], scl=[0])
         assert_raises(TypeError, poly.polyint, [0], axis=.5)
+        with assert_warns(DeprecationWarning):
+            poly.polyint([1, 1], 1.)
 
         # test integration of zero polynomial
         for i in range(2, 5):


### PR DESCRIPTION
`warning` module was used but not imported in `numpy.polynomials.polyutils`. Tests were not catching this bug.
- Increase test coverage to trigger and check the RankWarning (including check of error message)
- Add missing import statement
