### PR TITLE
BUILD: adapt "make version-check" to "make dist"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: install dependencies
           command: |
             python3 -m venv venv
+            ln -s $(which python3) venv/bin/python3.6
             . venv/bin/activate
             pip install cython sphinx==1.8.5 matplotlib ipython
             sudo apt-get update

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,10 +10,6 @@
 PYVER:=$(shell python3 -c 'from sys import version_info as v; print("{0}.{1}".format(v[0], v[1]))')
 PYTHON = python$(PYVER)
 
-NUMPYVER:=$(shell python3 -c "import numpy; print(numpy.version.git_revision[:10])")
-GITVER ?= $(shell cd ..; python3 -c "from setup import git_version; \
-				print(git_version()[:10])")
-
 # You can set these variables from the command line.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= LANG=C sphinx-build
@@ -49,18 +45,6 @@ clean:
 	-rm -rf build/* 
 	find . -name generated -type d -prune -exec rm -rf "{}" ";"
 
-version-check:
-ifeq "$(GITVER)" "Unknown"
-	# @echo sdist build with unlabeled sources
-else ifneq ($(NUMPYVER),$(GITVER))
-	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
-	@echo use '"make dist"' or '"GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
-	@exit 1
-else
-	# for testing
-	# @echo installed numpy $(NUMPYVER) matches git version $(GITVER); exit 1
-endif
-
 gitwash-update:
 	rm -rf source/dev/gitwash
 	install -d source/dev/gitwash
@@ -86,7 +70,24 @@ INSTALL_DIR = $(CURDIR)/build/inst-dist
 INSTALL_PPH = $(INSTALL_DIR)/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/site-packages:$(INSTALL_DIR)/lib/python$(PYVER)/dist-packages:$(INSTALL_DIR)/local/lib/python$(PYVER)/dist-packages
 UPLOAD_DIR=/srv/docs_scipy_org/doc/numpy-$(RELEASE)
 
-DIST_VARS=SPHINXBUILD="LANG=C PYTHONPATH=$(INSTALL_PPH) python$(PYVER) `which sphinx-build`" PYTHON="PYTHONPATH=$(INSTALL_PPH) python$(PYVER)" SPHINXOPTS="$(SPHINXOPTS)"
+DIST_VARS=SPHINXBUILD="LANG=C PYTHONPATH=$(INSTALL_PPH) python$(PYVER) `which sphinx-build`" PYTHON="PYTHONPATH=$(INSTALL_PPH) python$(PYVER)" 
+
+NUMPYVER:=$(shell $(PYTHON) -c "import numpy; print(numpy.version.git_revision[:10])")
+GITVER ?= $(shell cd ..; $(PYTHON) -c "from setup import git_version; \
+				print(git_version()[:10])")
+
+version-check:
+ifeq "$(GITVER)" "Unknown"
+	# @echo sdist build with unlabeled sources
+else ifneq ($(NUMPYVER),$(GITVER))
+	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
+	@echo use '"make dist"' or '"GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
+	@exit 1
+else
+	# for testing
+	# @echo installed numpy $(NUMPYVER) matches git version $(GITVER); exit 1
+endif
+
 
 dist:
 	make $(DIST_VARS) real-dist


### PR DESCRIPTION
In gh-13336 a check was added when building the documentation to ensure the numpy docstrings would match the documentation version by comparing the git version of the documentation to the git version of the numpy installed in python. This check ignored `PYTHONPATH` when checking the numpy version, which broke `make dist`

This PR fixes it by rearranging the Makefile and using the `PYTHON` macro in `version-check`