### PR TITLE
BUG: Do not crash on recursive `.dtype` attribute lookup.

### DIFF
--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -7,8 +7,8 @@ NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(PyArray_Descr *self);
 NPY_NO_EXPORT PyObject *
 array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 
-NPY_NO_EXPORT PyArray_Descr *
-_arraydescr_from_dtype_attr(PyObject *obj);
+int
+_arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **newdescr);
 
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -471,12 +471,18 @@ PyArray_DescrFromTypeObject(PyObject *type)
     /* Do special thing for VOID sub-types */
     if (PyType_IsSubtype((PyTypeObject *)type, &PyVoidArrType_Type)) {
         new = PyArray_DescrNewFromType(NPY_VOID);
-        conv = _arraydescr_from_dtype_attr(type);
-        if (conv) {
+        if (new == NULL) {
+            return NULL;
+        }
+        if (_arraydescr_from_dtype_attr(type, &conv)) {
+            if (conv == NULL) {
+                Py_DECREF(new);
+                return NULL;
+            }
             new->fields = conv->fields;
-            Py_INCREF(new->fields);
+            Py_XINCREF(new->fields);
             new->names = conv->names;
-            Py_INCREF(new->names);
+            Py_XINCREF(new->names);
             new->elsize = conv->elsize;
             new->subarray = conv->subarray;
             conv->subarray = NULL;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1006,6 +1006,50 @@ def test_invalid_dtype_string():
     assert_raises(TypeError, np.dtype, u'Fl\xfcgel')
 
 
+class TestFromDTypeAttribute(object):
+    def test_simple(self):
+        class dt:
+            dtype = "f8"
+
+        assert np.dtype(dt) == np.float64
+        assert np.dtype(dt()) == np.float64
+
+    def test_recursion(self):
+        class dt:
+            pass
+
+        dt.dtype = dt
+        with pytest.raises(RecursionError):
+            np.dtype(dt)
+
+        dt_instance = dt()
+        dt_instance.dtype = dt
+        with pytest.raises(RecursionError):
+            np.dtype(dt_instance)
+
+    def test_void_subtype(self):
+        class dt(np.void):
+            # This code path is fully untested before, so it is unclear
+            # what this should be useful for. Note that if np.void is used
+            # numpy will think we are deallocating a base type [1.17, 2019-02].
+            dtype = np.dtype("f,f")
+            pass
+
+        np.dtype(dt)
+        np.dtype(dt(1))
+
+    def test_void_subtype_recursion(self):
+        class dt(np.void):
+            pass
+
+        dt.dtype = dt
+
+        with pytest.raises(RecursionError):
+            np.dtype(dt)
+
+        with pytest.raises(RecursionError):
+            np.dtype(dt(1))
+
 class TestFromCTypes(object):
 
     @staticmethod


### PR DESCRIPTION
Backport of #13003.

The code path in scalarapi.c which checks dtype on one inheriting
from np.void is especially awkward and was completely untested
previously. So I am not sure we should even support it at all

Closes gh-12982, gh-3614, and gh-12751

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
