### PR TITLE
ENH: Chain exception for typed item assignment

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -221,9 +221,7 @@ static int
         if (PySequence_NoString_Check(op)) {
             PyErr_SetString(PyExc_ValueError,
                     "setting an array element with a sequence.");
-            Py_DECREF(type);
-            Py_XDECREF(value);
-            Py_XDECREF(traceback);
+            npy_PyErr_ChainExceptionsCause(type, value, traceback);
         }
         else {
             PyErr_Restore(type, value, traceback);


### PR DESCRIPTION
This was discussed in gh-14000, and slightly improves the situation
at least maybe to the extend of understanding why it happens when
looking more closely.

---

The new output is:
```python
In [1]: class A():
   ...:     def __len__(self):
   ...:         raise ValueError("asdf")
   ...:     def __getitem__(self, i):
   ...:         return i
   ...:     

In [2]: np.array(A(), np.float64)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: float() argument must be a string or a number, not 'A'

The above exception was the direct cause of the following exception:

ValueError                                Traceback (most recent call last)
<ipython-input-2-1a34cbb915be> in <module>()
----> 1 np.array(A(), np.float64)

ValueError: setting an array element with a sequence.
```