### PR TITLE
MAINT: Fix spelling error in npy_tempita  kwarg

### DIFF
--- a/tools/npy_tempita/__init__.py
+++ b/tools/npy_tempita/__init__.py
@@ -105,21 +105,21 @@ class Template(object):
 
     def __init__(self, content, name=None, namespace=None, stacklevel=None,
                  get_template=None, default_inherit=None, line_offset=0,
-                 delimeters=None):
+                 delimiters=None):
         self.content = content
 
-        # set delimeters
-        if delimeters is None:
-            delimeters = (self.default_namespace['start_braces'],
+        # set delimiters
+        if delimiters is None:
+            delimiters = (self.default_namespace['start_braces'],
                           self.default_namespace['end_braces'])
         else:
-            assert len(delimeters) == 2 and all(
-                [isinstance(delimeter, basestring_)
-                    for delimeter in delimeters])
+            assert len(delimiters) == 2 and all(
+                [isinstance(delimiter, basestring_)
+                    for delimiter in delimiters])
             self.default_namespace = self.__class__.default_namespace.copy()
-            self.default_namespace['start_braces'] = delimeters[0]
-            self.default_namespace['end_braces'] = delimeters[1]
-        self.delimeters = delimeters
+            self.default_namespace['start_braces'] = delimiters[0]
+            self.default_namespace['end_braces'] = delimiters[1]
+        self.delimiters = delimiters
 
         self._unicode = is_unicode(content)
         if name is None and stacklevel is not None:
@@ -143,7 +143,7 @@ class Template(object):
         self.name = name
         self._parsed = parse(
             content, name=name, line_offset=line_offset,
-            delimeters=self.delimeters)
+            delimiters=self.delimiters)
         if namespace is None:
             namespace = {}
         self.namespace = namespace
@@ -392,9 +392,9 @@ class Template(object):
         return msg
 
 
-def sub(content, delimeters=None, **kw):
+def sub(content, delimiters=None, **kw):
     name = kw.get('__name')
-    tmpl = Template(content, name=name, delimeters=delimeters)
+    tmpl = Template(content, name=name, delimiters=delimiters)
     return tmpl.substitute(kw)
 
 
@@ -652,28 +652,28 @@ del _Empty
 ############################################################
 
 
-def lex(s, name=None, trim_whitespace=True, line_offset=0, delimeters=None):
-    if delimeters is None:
-        delimeters = (Template.default_namespace['start_braces'],
+def lex(s, name=None, trim_whitespace=True, line_offset=0, delimiters=None):
+    if delimiters is None:
+        delimiters = (Template.default_namespace['start_braces'],
                       Template.default_namespace['end_braces'])
     in_expr = False
     chunks = []
     last = 0
     last_pos = (line_offset + 1, 1)
-    token_re = re.compile(r'%s|%s' % (re.escape(delimeters[0]),
-                                      re.escape(delimeters[1])))
+    token_re = re.compile(r'%s|%s' % (re.escape(delimiters[0]),
+                                      re.escape(delimiters[1])))
     for match in token_re.finditer(s):
         expr = match.group(0)
         pos = find_position(s, match.end(), last, last_pos)
-        if expr == delimeters[0] and in_expr:
-            raise TemplateError('%s inside expression' % delimeters[0],
+        if expr == delimiters[0] and in_expr:
+            raise TemplateError('%s inside expression' % delimiters[0],
                                 position=pos,
                                 name=name)
-        elif expr == delimeters[1] and not in_expr:
-            raise TemplateError('%s outside expression' % delimeters[1],
+        elif expr == delimiters[1] and not in_expr:
+            raise TemplateError('%s outside expression' % delimiters[1],
                                 position=pos,
                                 name=name)
-        if expr == delimeters[0]:
+        if expr == delimiters[0]:
             part = s[last:match.start()]
             if part:
                 chunks.append(part)
@@ -684,7 +684,7 @@ def lex(s, name=None, trim_whitespace=True, line_offset=0, delimeters=None):
         last = match.end()
         last_pos = pos
     if in_expr:
-        raise TemplateError('No %s to finish last expression' % delimeters[1],
+        raise TemplateError('No %s to finish last expression' % delimiters[1],
                             name=name, position=last_pos)
     part = s[last:]
     if part:
@@ -822,12 +822,12 @@ def find_position(string, index, last_index, last_pos):
     return (last_pos[0] + lines, column)
 
 
-def parse(s, name=None, line_offset=0, delimeters=None):
+def parse(s, name=None, line_offset=0, delimiters=None):
 
-    if delimeters is None:
-        delimeters = (Template.default_namespace['start_braces'],
+    if delimiters is None:
+        delimiters = (Template.default_namespace['start_braces'],
                       Template.default_namespace['end_braces'])
-    tokens = lex(s, name=name, line_offset=line_offset, delimeters=delimeters)
+    tokens = lex(s, name=name, line_offset=line_offset, delimiters=delimiters)
     result = []
     while tokens:
         next_chunk, tokens = parse_expr(tokens, name)


### PR DESCRIPTION
This commit fixes the spelling of the ``delimeter`` kwarg to
``delimiter`` (note the second e -> i) in the npy_tempita module. This

npy_tempita vendorises Tempita a minimal templating language.
The spelling has been fixed in the official documentation [1] and source
code [2]. This commit fixes that fix by aligning npy_tempita with the
reference documentation.

Although the vendored version is used in NumPy the delimeter kwarg is
not. This raised the consideration of reverting to either the original
version or Cython's non-vendored version [3]. Both were decided against
because:

1. The original is not actively maintained and required some fixes.
2. Cython's Tempita is an internal Cython tool and Cython may not
guarantee that it will be present.

[1] https://pyrocore.readthedocs.io/en/latest/tempita.html
[2] https://bitbucket.org/ianb/tempita/src/default/tempita/__init__.py
[3] https://github.com/cython/cython/blob/master/Cython/Tempita/_tempita.py