### PR TITLE
MAINT: Improve performance of isscalar

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1851,8 +1851,8 @@ def isscalar(num):
     True
 
     """
-    return (isinstance(num, generic)
-            or type(num) in ScalarType
+    return (type(num) in ScalarType
+            or isinstance(num, generic)
             or isinstance(num, numbers.Number))
 
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -523,7 +523,7 @@ except AttributeError:
     ScalarType = [int, float, complex, int, bool, bytes, str, memoryview]
 
 ScalarType.extend(_concrete_types)
-ScalarType = tuple(ScalarType)
+ScalarType = frozenset(ScalarType)
 
 
 # Now add the types we've determined to this module


### PR DESCRIPTION
Before:

```
>>> o = object()
>>> %timeit np.isscalar(42.0)
249 ns ± 0.424 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
>>> %timeit np.isscalar([])
1.45 µs ± 23.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
>>> %timeit np.isscalar(o)
1.5 µs ± 36.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

After:

```
>>> %timeit np.isscalar(42.0)
153 ns ± 0.371 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
>>> %timeit np.isscalar([])
1.13 µs ± 11.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
>>> %timeit np.isscalar(o)
1.15 µs ± 1.59 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

The speedup comes from changing np.core.numerictypes.ScalarType to be a set,
and reordering the checks inside isscalar: set lookup is faster than
an isinstance check.
