### PR TITLE
Update system_info.py

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1905,8 +1905,6 @@ class blas_info(system_info):
                                       library_dirs=info['library_dirs'],
                                       extra_postargs=info.get('extra_link_args', []))
                     return libs
-                    # This breaks the for loop
-                    break
                 except distutils.ccompiler.LinkError:
                     pass
         finally:


### PR DESCRIPTION
Removes redundant/unreachable `break` from `get_cblas_libs`.

The `libs` is returned beforehand, so `break` is not needed.

Found with LGTM: https://lgtm.com/projects/g/numpy/numpy/snapshot/3acf5e0d956ec72b5cebe43b281e0bac095e7db3/files/numpy/distutils/system_info.py?sort=name&dir=ASC&mode=heatmap

EDIT: Oh there is LGTM analysis already, nice ;).