### PR TITLE
DOC:Link between the two indexing documentation pages

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -3,6 +3,10 @@
 Indexing
 ========
 
+.. seealso::
+
+   :doc:`/source/user/basics.indexing`
+
 .. sectionauthor:: adapted from "Guide to NumPy" by Travis E. Oliphant
 
 .. currentmodule:: numpy

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -5,7 +5,7 @@ Indexing
 
 .. seealso::
 
-   :doc:`/source/user/basics.indexing`
+   :ref:`<basics.indexing>`
 
 .. sectionauthor:: adapted from "Guide to NumPy" by Travis E. Oliphant
 

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -5,7 +5,7 @@ Indexing
 
 .. seealso::
 
-   :ref:`<basics.indexing>`
+   :ref:`Indexing basics <basics.indexing>`
 
 .. sectionauthor:: adapted from "Guide to NumPy" by Travis E. Oliphant
 

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -6,7 +6,7 @@ Indexing
 
 .. seealso::
 
+   :ref:`Indexing <arrays.indexing>`
    :ref:`Indexing routines <routines.indexing>`
-   :ref:`<arrays.indexing>`
 
 .. automodule:: numpy.doc.indexing

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -7,6 +7,6 @@ Indexing
 .. seealso::
 
    :ref:`Indexing routines <routines.indexing>`
-   :doc:`/source/reference/arrays.indexing`
+   :ref:`<arrays.indexing>`
 
 .. automodule:: numpy.doc.indexing

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -7,6 +7,7 @@ Indexing
 .. seealso::
 
    :ref:`Indexing <arrays.indexing>`
+
    :ref:`Indexing routines <routines.indexing>`
 
 .. automodule:: numpy.doc.indexing

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -4,6 +4,9 @@
 Indexing
 ********
 
-.. seealso:: :ref:`Indexing routines <routines.indexing>`
+.. seealso::
+
+   :ref:`Indexing routines <routines.indexing>`
+   :doc:`/source/reference/arrays.indexing`
 
 .. automodule:: numpy.doc.indexing


### PR DESCRIPTION
Made references to each other for the following two indexing docs

    https://docs.scipy.org/doc/numpy-1.15.0/user/basics.indexing.html
    https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.indexing.html

closes #12195

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
