### PR TITLE
DOC: Update NumFOCUS subcommittee replacing Nathaniel with Sebastian

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -48,7 +48,7 @@ NumFOCUS Subcommittee
 
 * Jaime Fernández del Río
 
-* Nathaniel Smith
+* Sebastian Berg
 
 * External member: Thomas Caswell
 


### PR DESCRIPTION
I believe that we pretty much decided on this and @njsmith wished
to not be the NumFOCUS liason, so this suggests to replace me and him
for the subcommittee as well. This is up for discussion, if anyone
else is interested I would be happy to exchange it and if Nathaniel
wants to remain on the subcommittee we can go another route.

---

@rgommers can you pass on my contact information to NumFOCUS? I assume it is unlikely that we go a different route (and we can easily ask them to change it again). Lets keep this open for a few days to give everyone time to discuss here or elsewhere.
