### PR TITLE
DOC: Improve quickstart documentation of new random Generator

### DIFF
--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -32,8 +32,9 @@ instance's methods are imported into the numpy.random namespace, see
 Quick Start
 -----------
 
-By default, `~Generator` uses sequences provided by `~pcg64.PCG64` which will be
-statistically more reliable than the legacy methods in `~.RandomState`
+By default, `~Generator` uses bits provided by `~pcg64.PCG64` which
+has better statistical properties than the legacy mt19937 random
+number generator in `~.RandomState`
 
 .. code-block:: python
 

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -32,7 +32,7 @@ instance's methods are imported into the numpy.random namespace, see
 Quick Start
 -----------
 
-By default, `~Generator` uses normals provided by `~pcg64.PCG64` which will be
+By default, `~Generator` uses sequences provided by `~pcg64.PCG64` which will be
 statistically more reliable than the legacy methods in `~.RandomState`
 
 .. code-block:: python


### PR DESCRIPTION
The [reference document](http://www.numpy.org/devdocs/reference/random/index.html?highlight=random#module-numpy.random) on numpy.random stated in the opening sentence of the quick start section

> By default, `~Generator` uses normals provided by `~pcg64.PCG64` which will be	By default, `~Generator` uses sequences provided by `~pcg64.PCG64` which will be statistically more reliable than the legacy methods in `~.RandomState`

which is misleading, as `PCG64` does not provide routine to generate normals. 

So I assume it meant "uses sequences provided by PCG64" instead. 

While at the topic, I would like to also suggest to reword "statistically more reliable" into more specific "of better statistical quality". 

If no objection arise to the latter change, I will push a commit. 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

@mattip @bashtage 