### PR TITLE
BUG: Replace contextlib.suppress for Python 2.7

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -3,7 +3,6 @@ Histogram-related functions
 """
 from __future__ import division, absolute_import, print_function
 
-import contextlib
 import functools
 import operator
 import warnings
@@ -924,9 +923,11 @@ def _histogramdd_dispatcher(sample, bins=None, range=None, normed=None,
     else:
         for s in sample:
             yield s
-    with contextlib.suppress(TypeError):
+    try:
         for b in bins:
             yield b
+    except TypeError:
+        pass
     yield weights
 
 


### PR DESCRIPTION
The contextlib.suppress context manager is not available in Python 2.7.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
