### PR TITLE
ENH: add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "cython"]  # PEP 508 specification
+

--- a/setup.py
+++ b/setup.py
@@ -364,7 +364,7 @@ def parse_setuppy_commands():
 
 
 def setup_package():
-    src_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    src_path = os.path.dirname(os.path.abspath(__file__))
     old_path = os.getcwd()
     os.chdir(src_path)
     sys.path.insert(0, src_path)


### PR DESCRIPTION
xref #13908 

Add a pyproject.toml file. Needed for towncrier. 

This has already hit the mailing list, and met with hesitant approval since it causes `pip install .` to do an "isolated build" which may download a new cython, lengthening the build.

SciPy has added a pyproject.toml, and it doesn't seem to have caused too much pain.