### PR TITLE
BUG: Fix memory leak in dtype from dict contructor

### DIFF
--- a/numpy/core/src/common/npy_ctypes.h
+++ b/numpy/core/src/common/npy_ctypes.h
@@ -32,6 +32,7 @@ npy_ctypes_check(PyTypeObject *obj)
     }
 
     ret = PyObject_IsTrue(ret_obj);
+    Py_DECREF(ret_obj);
     if (ret == -1) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1294,6 +1294,12 @@ _convert_from_dict(PyObject *obj, int align)
             goto fail;
         }
     }
+
+    Py_XDECREF(fields);
+    Py_XDECREF(names);
+    Py_XDECREF(descrs);
+    Py_XDECREF(offsets);
+    Py_XDECREF(titles);
     return new;
 
  fail:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -138,6 +138,18 @@ class TestRecord(object):
                       'titles': ['RRed pixel', 'Blue pixel']})
         assert_dtype_not_equal(a, b)
 
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_refcount_dictionary_setting(self):
+        names = ["name1"]
+        formats = ["f8"]
+        titles = ["t1"]
+        offsets = [0]
+        d = dict(names=names, formats=formats, titles=titles, offsets=offsets)
+        refcounts = {k: sys.getrefcount(i) for k, i in d.items()}
+        np.dtype(d)
+        refcounts_new = {k: sys.getrefcount(i) for k, i in d.items()}
+        assert refcounts == refcounts_new
+
     def test_mutate(self):
         # Mutating a dtype should reset the cached hash value
         a = np.dtype([('yo', int)])


### PR DESCRIPTION
Backport of #13855 .

Fixes gh-13853.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
