### PR TITLE
DOC, BUILD: cleanups and fix (again) 'make dist'

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,7 +24,7 @@ ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
   $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
-        dist dist-build gitwash-update version-check
+        dist dist-build gitwash-update version-check html-build latex-build
 
 #------------------------------------------------------------------------------
 
@@ -72,13 +72,16 @@ UPLOAD_DIR=/srv/docs_scipy_org/doc/numpy-$(RELEASE)
 
 DIST_VARS=SPHINXBUILD="LANG=C PYTHONPATH=$(INSTALL_PPH) python$(PYVER) `which sphinx-build`" PYTHON="PYTHONPATH=$(INSTALL_PPH) python$(PYVER)" 
 
-NUMPYVER:=$(shell $(PYTHON) -c "import numpy; print(numpy.version.git_revision[:10])")
+NUMPYVER:=$(shell $(PYTHON) -c "import numpy; print(numpy.version.git_revision[:10])" 2>/dev/null)
 GITVER ?= $(shell cd ..; $(PYTHON) -c "from setup import git_version; \
 				print(git_version()[:10])")
 
 version-check:
 ifeq "$(GITVER)" "Unknown"
 	# @echo sdist build with unlabeled sources
+else ifeq ("", "$(NUMPYVER)")
+	@echo numpy not found, cannot build documentation without successful \"import numpy\"
+	@exit 1
 else ifneq ($(NUMPYVER),$(GITVER))
 	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
 	@echo use '"make dist"' or '"GITVER=$(NUMPYVER) make $(MAKECMDGOALS) ..."'
@@ -92,10 +95,9 @@ endif
 dist:
 	make $(DIST_VARS) real-dist
 
-real-dist: dist-build html html-scipyorg
-	test -d build/latex || make latex
+real-dist: dist-build html-build html-scipyorg
+	test -d build/latex || make latex-build
 	make -C build/latex all-pdf
-	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
 	cp -r build/html-scipyorg build/dist
 	cd build/html && zip -9r ../dist/numpy-html.zip .
@@ -137,7 +139,8 @@ build/generate-stamp: $(wildcard source/reference/*.rst)
 	mkdir -p build
 	touch build/generate-stamp
 
-html: generate version-check
+html: version-check html-build
+html-build: generate
 	mkdir -p build/html build/doctrees
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) build/html $(FILES)
 	$(PYTHON) postprocess.py html build/html/*.html
@@ -175,7 +178,8 @@ qthelp: generate version-check
 	mkdir -p build/qthelp build/doctrees
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) build/qthelp $(FILES)
 
-latex: generate version-check
+latex: version-check latex-build
+latex-build: generate
 	mkdir -p build/latex build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex $(FILES)
 	$(PYTHON) postprocess.py tex build/latex/*.tex

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -34,7 +34,7 @@ Quick Start
 
 By default, `~Generator` uses bits provided by `~pcg64.PCG64` which
 has better statistical properties than the legacy mt19937 random
-number generator in `~.RandomState`
+number generator in `~.RandomState`.
 
 .. code-block:: python
 


### PR DESCRIPTION
xref #13990 

- Add "." missing from #14028
- Documentation build: `make dist` had to be called twice to succeed. Fixed by using `latex-build` and  `html-build` targets that avoid `version-check`, and use them in the `dist` target. See below for more info

<details>

`$NUMPYVER` was evaluated globally when Makefile was first read. On a clean build, before numpy is built and installed, the variable would be empty. The `dist` target would call the `dist-build` target, which would install numpy, then the `html` target which checks `version-check` and uses the stale value for `$NUMPYVER`. Upon a second call to `make dist`, `$NUMPYVER` would evaluate to the version of numpy produced in the previous call. 

Rather than mess with getting the stale value updated, it is easier to avoid the check altogether when calling `make dist`