### PR TITLE
MAINT: bump ARMv8 / POWER8 OpenBLAS in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ cache:
 
 env:
   global:
-    - OpenBLAS_version=0.3.5
+    - OpenBLAS_version=0.3.7.dev
     - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
     # The following is generated with the command:
     # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY

--- a/shippable.yml
+++ b/shippable.yml
@@ -48,7 +48,7 @@ build:
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
-    - python tools/openblas_support.py --check_version 0.3.5
+    - python tools/openblas_support.py --check_version 0.3.7.dev
     # run the test suite
     - python runtests.py -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -14,7 +14,7 @@ from tempfile import mkstemp, gettempdir
 import zipfile
 import tarfile
 
-OPENBLAS_V = 'v0.3.5'
+OPENBLAS_V = '6a8b426'
 OPENBLAS_LONG = 'v0.3.5-274-g6a8b4269'
 BASE_LOC = ''
 RACKSPACE = 'https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com'
@@ -47,7 +47,7 @@ def download_openblas(target, arch):
         # https://github.com/tylerjereddy/openblas-static-gcc/tree/master/ARMv8
         # build done on GCC compile farm machine named gcc115
         # tarball uploaded manually to an unshared Dropbox location
-        filename = ('https://www.dropbox.com/s/pbqkxzlmih4cky1/'
+        filename = ('https://www.dropbox.com/s/zsp1wb3tq4n9g0b/'
                     'openblas-{}-armv8.tar.gz?dl=1'.format(OPENBLAS_V))
         typ = 'tar.gz'
     elif arch == 'ppc64':
@@ -55,7 +55,7 @@ def download_openblas(target, arch):
         # https://github.com/tylerjereddy/openblas-static-gcc/blob/master/power8
         # built on GCC compile farm machine named gcc112
         # manually uploaded tarball to an unshared Dropbox location
-        filename = ('https://www.dropbox.com/s/zcwhk7c2zptwy0s/'
+        filename = ('https://www.dropbox.com/s/k9uabwoi8bekjwe/'
                     'openblas-{}-ppc64le-power8.tar.gz?dl=1'.format(OPENBLAS_V))
         typ = 'tar.gz'
     elif arch == 'darwin':


### PR DESCRIPTION
Fixes #14003

* require OpenBLAS `0.3.7.dev` in ARMv8
and POWER8 CI runs to match ecosystem / wheels

Have to use slightly older versions of gcc toolchain to build these OpenBLAS binaries for the usual reason. The links to the build scripts used are already present in the docs visible in the diff.
