### PR TITLE
DOC:Add example to clarify "numpy.save" behavior on already open file #10445

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -511,12 +511,14 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     It has similar behavior to append not overwrite since the file is not closed yet.
     Example:
     --------
-    >>>with open('test.npy', 'wb') as f: 
-    np.save(f, np.array([1, 2]))
-    np.save(f, np.array([1, 3]))
+    >>> with open('test.npy', 'wb') as f:
+    ...     np.save(f, np.array([1, 2]))
+    ...     np.save(f, np.array([1, 3]))    
+    
+
     >>> with open('test.npy', 'rb') as f:
-            a = np.load(f)
-            b = np.load(f)
+    ...     a = np.load(f)
+    ...     b = np.load(f)
     >>> print(a, b)
     # [1 2] [1 3]
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -507,8 +507,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
         
-    Any data saved to the file is automatically added to the end if the file is still opened. 
-    It has similar behavior to append not overwrite since the file is not closed yet.
+    Any data saved to the file is appended to the end of the file. 
     Example:
     --------
     >>> with open('test.npy', 'wb') as f:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -510,7 +510,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
 	Example:
-        >>> with open('test.npy', 'wb') as f: # b needed for python 3
+        >>> with open('test.npy', 'wb') as f: 
                 np.save(f, np.array([1, 2]))
                 np.save(f, np.array([1, 3]))
         >>> with open('test.npy', 'rb') as f:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -510,12 +510,12 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
 	Example:
-        >>> with open('test.npy', 'wb') as f:
-        >>>     np.save(f, np.array([1, 2]))
-        >>>     np.save(f, np.array([1, 3]))
+        >>> with open('test.npy', 'wb') as f: # b needed for python 3
+                np.save(f, np.array([1, 2]))
+                np.save(f, np.array([1, 3]))
         >>> with open('test.npy', 'rb') as f:
-        >>>     a = np.load(f)
-        >>>     b = np.load(f)
+                a = np.load(f)
+                b = np.load(f)
         >>> print(a, b)
         [1 2] [1 3]
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -505,11 +505,12 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
     Notes
     -----
-    - For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
+    For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
         
-    - Any data saved to the file is automatically added to the end if the file is still opened. 
+    Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
     Example:
+    --------
     >>> with open('test.npy', 'wb') as f:
     ...     np.save(f, np.array([1, 2]))
     ...     np.save(f, np.array([1, 3]))    

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -510,14 +510,14 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
 	Example:
-	>>> with open('test.npy', 'wb') as f:   # b needed for python 3
-	>>>     np.save(f, np.array([1, 2]))
-	>>>     np.save(f, np.array([1, 3]))
-	>>> with open('test.npy', 'rb') as f:
-	>>>     a = np.load(f)
-	>>>     b = np.load(f)
-	>>> print(a, b)
-	[1 2] [1 3]
+        >>> with open('test.npy', 'wb') as f:   # b needed for python 3
+        >>>     np.save(f, np.array([1, 2]))
+        >>>     np.save(f, np.array([1, 3]))
+        >>> with open('test.npy', 'rb') as f:
+        >>>     a = np.load(f)
+        >>>     b = np.load(f)
+        >>> print(a, b)
+        [1 2] [1 3]
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -505,9 +505,9 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
     Notes
     -----
-    For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
+    - For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
         
-    Any data saved to the file is automatically added to the end if the file is still opened. 
+    - Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
     Example:
     >>> with open('test.npy', 'wb') as f:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -509,15 +509,16 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
-	Example:
-        >>> with open('test.npy', 'wb') as f: 
-                np.save(f, np.array([1, 2]))
-                np.save(f, np.array([1, 3]))
-        >>> with open('test.npy', 'rb') as f:
-                a = np.load(f)
-                b = np.load(f)
-        >>> print(a, b)
-        [1 2] [1 3]
+    Example:
+    --------
+    >>> with open('test.npy', 'wb') as f: 
+            np.save(f, np.array([1, 2]))
+            np.save(f, np.array([1, 3]))
+    >>> with open('test.npy', 'rb') as f:
+            a = np.load(f)
+            b = np.load(f)
+    >>> print(a, b)
+    # [1 2] [1 3]
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -510,7 +510,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
 	Example:
-        >>> with open('test.npy', 'wb') as f:   # b needed for python 3
+        >>> with open('test.npy', 'wb') as f:
         >>>     np.save(f, np.array([1, 2]))
         >>>     np.save(f, np.array([1, 3]))
         >>> with open('test.npy', 'rb') as f:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -508,19 +508,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
         
     Any data saved to the file is appended to the end of the file. 
-    Example:
-    --------
-    >>> with open('test.npy', 'wb') as f:
-    ...     np.save(f, np.array([1, 2]))
-    ...     np.save(f, np.array([1, 3]))    
     
-    >>> with open('test.npy', 'rb') as f:
-    ...     a = np.load(f)
-    ...     b = np.load(f)
-    >>> print(a, b)
-    # [1 2] [1 3]
-    
-
     Examples
     --------
     >>> from tempfile import TemporaryFile
@@ -533,6 +521,15 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     >>> np.load(outfile)
     array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
+
+    >>> with open('test.npy', 'wb') as f:
+    ...     np.save(f, np.array([1, 2]))
+    ...     np.save(f, np.array([1, 3]))    
+    >>> with open('test.npy', 'rb') as f:
+    ...     a = np.load(f)
+    ...     b = np.load(f)
+    >>> print(a, b)
+    # [1 2] [1 3]
     """
     own_fid = False
     if hasattr(file, 'read'):

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -506,6 +506,18 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Notes
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
+    
+    Any data saved to the file is automatically added to the end if the file is still opened. 
+    It has similar behavior to append not overwrite since the file is not closed yet.
+	Example:
+	>>> with open('test.npy', 'wb') as f:   # b needed for python 3
+	>>>     np.save(f, np.array([1, 2]))
+	>>>     np.save(f, np.array([1, 3]))
+	>>> with open('test.npy', 'rb') as f:
+	>>>     a = np.load(f)
+	>>>     b = np.load(f)
+	>>> print(a, b)
+	[1 2] [1 3]
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -507,6 +507,8 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
 
+    
+
     Examples
     --------
     >>> from tempfile import TemporaryFile

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -512,8 +512,8 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Example:
     --------
     >>> with open('test.npy', 'wb') as f: 
-            np.save(f, np.array([1, 2]))
-            np.save(f, np.array([1, 3]))
+        np.save(f, np.array([1, 2]))
+        np.save(f, np.array([1, 3]))
     >>> with open('test.npy', 'rb') as f:
             a = np.load(f)
             b = np.load(f)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -511,9 +511,9 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     It has similar behavior to append not overwrite since the file is not closed yet.
     Example:
     --------
-    >>> with open('test.npy', 'wb') as f: 
-        np.save(f, np.array([1, 2]))
-        np.save(f, np.array([1, 3]))
+    >>>with open('test.npy', 'wb') as f: 
+    np.save(f, np.array([1, 2]))
+    np.save(f, np.array([1, 3]))
     >>> with open('test.npy', 'rb') as f:
             a = np.load(f)
             b = np.load(f)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -506,26 +506,20 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Notes
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
-<<<<<<< HEAD
-    sf
-    
-=======
-    
+        
     Any data saved to the file is automatically added to the end if the file is still opened. 
     It has similar behavior to append not overwrite since the file is not closed yet.
     Example:
-    --------
     >>> with open('test.npy', 'wb') as f:
     ...     np.save(f, np.array([1, 2]))
     ...     np.save(f, np.array([1, 3]))    
     
-
     >>> with open('test.npy', 'rb') as f:
     ...     a = np.load(f)
     ...     b = np.load(f)
     >>> print(a, b)
     # [1 2] [1 3]
->>>>>>> d49b9e57148d2864dc7c2ad1ce25f36b036ea845
+    
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -506,7 +506,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     Notes
     -----
     For a description of the ``.npy`` format, see :py:mod:`numpy.lib.format`.
-
+    sf
     
 
     Examples


### PR DESCRIPTION
DOC:Add example to clarify "numpy.save" behavior on already open file #10445

The docstring of [the](https://numpy.org/devdocs/reference/generated/numpy.save.html?highlight=save#numpy.save) `numpy.save` does not tell what will happen on overwriting the already written and unclosed file, and this might create confusion to the user or produce unwanted output.
So adding illustrative example to show the behavior of re-writing array to already open file 
Closes #10445