### PR TITLE
DOC: Doc release

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -197,17 +197,6 @@ best to read the pavement.py script.
 .. note:: The following steps are repeated for the beta(s), release
    candidates(s) and the final release.
 
-Check that docs can be built
-----------------------------
-Do::
-
-    cd doc/
-    make dist
-
-to check that the documentation is in a buildable state.  See
-doc/HOWTO_BUILD_DOCS.rst.txt for more details and for how to update
-https://docs.scipy.org.
-
 Check deprecations
 ------------------
 Before the release branch is made, it should be checked that all deprecated
@@ -389,6 +378,25 @@ Build the changelog and notes for upload with::
 
     paver write_release_and_log
 
+Build and archive documentation
+-------------------------------
+Do::
+
+    cd doc/
+    make dist
+
+to check that the documentation is in a buildable state. Then, after tagging,
+create an archive of the documentation in the numpy/doc repo::
+
+    # This checks out github.com/numpy/doc and adds (``git add``) the
+    # documentation to the checked out repo.
+    make merge-doc
+    # Now edit the ``index.html`` file in the repo to reflect the new content,
+    # and commit the changes
+    git -C dist/merge commit -a "Add documentation for <version>"
+    # Push to numpy/doc repo
+    git -C push
+
 Update PyPI
 -----------
 
@@ -439,28 +447,6 @@ you released you can push the tag and release commit up to github::
 
 where ``upstream`` points to the main https://github.com/numpy/numpy.git
 repository.
-
-Update docs.scipy.org
----------------------
-
-All documentation for a release can be updated on https://docs.scipy.org/ with:
-
-    make dist
-    make upload USERNAME=<yourname> RELEASE=1.11.0
-
-Note that ``<username>`` must have SSH credentials on the server.  If you don't
-have those, ask someone who does (the list currently includes @rgommers,
-@juliantaylor and @pv).
-
-Also rebuild and upload ``docs.scipy.org`` front page, if the release
-series is a new one. The front page sources have their own repo:
-https://github.com/scipy/docs.scipy.org.  Do the following:
-
-- Update ``index.rst`` for the new version.
-- ``make dist``
-- Check that the built documentation is OK.
-- ``touch output-is-fine``
-- ``make upload USERNAME=<username> RELEASE=1.x.y``
 
 Update scipy.org
 ----------------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,10 @@ PYTHON = python$(PYVER)
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= LANG=C sphinx-build
 PAPER         ?=
+# For merging a documentation archive into a git checkout of numpy/doc
+# Turn a tag like v1.18.0 into 1.18
+# Use sed -n -e 's/patttern/match/p' to return a blank value if no match
+TAG ?= $(shell git describe --tag | sed -n -e's,v\([1-9]\.[0-9]*\)\.[0-9].*,\1,p')
 
 FILES=
 
@@ -24,7 +28,8 @@ ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
   $(SPHINXOPTS) source
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
-        dist dist-build gitwash-update version-check html-build latex-build
+		dist dist-build gitwash-update version-check html-build latex-build \
+		merge-doc
 
 #------------------------------------------------------------------------------
 
@@ -40,6 +45,7 @@ help:
 	@echo "  dist PYVER=... to make a distribution-ready tree"
 	@echo "  gitwash-update GITWASH=path/to/gitwash  update gitwash developer docs"
 	@echo "  upload USERNAME=... RELEASE=... to upload built docs to docs.scipy.org"
+	@echo "  merge-doc TAG=... to clone numpy/doc and archive documentation into it"
 
 clean:
 	-rm -rf build/* 
@@ -92,7 +98,9 @@ else
 endif
 
 
-dist:
+dist: build/dist.tar.gz
+
+build/dist.tar.gz:
 	make $(DIST_VARS) real-dist
 
 real-dist: dist-build html-build html-scipyorg
@@ -113,7 +121,7 @@ dist-build:
 	install -d $(subst :, ,$(INSTALL_PPH))
 	$(PYTHON) `which easy_install` --prefix=$(INSTALL_DIR) ../dist/*.egg
 
-upload:
+upload: build/dist.tar.gz
 	# SSH must be correctly configured for this to work.
 	# Assumes that ``make dist`` was already run
 	# Example usage: ``make upload USERNAME=rgommers RELEASE=1.10.1``
@@ -129,6 +137,32 @@ upload:
 	    $(UPLOAD_DIR)/numpy-html-$(RELEASE).zip
 	ssh $(USERNAME)@docs.scipy.org rm $(UPLOAD_DIR)/dist.tar.gz
 	ssh $(USERNAME)@docs.scipy.org ln -snf numpy-$(RELEASE) /srv/docs_scipy_org/doc/numpy
+
+
+merge-doc: build/dist.tar.gz
+ifeq "$(TAG)" ""
+	echo tag "$(TAG)" not of the form 1.18;
+	exit 1;
+endif
+	@# Only clone if the directory does not exist
+	@if ! test -d build/merge; then \
+		git clone https://github.com/numpy/doc build/merge; \
+	fi;
+	@# Remove any old content and copy in the new, add it to git
+	-rm -rf build/merge/$(TAG)/*
+	-mkdir -p build/merge/$(TAG)
+	@# -C changes working directory
+	tar -C build/merge/$(TAG) -xf build/dist.tar.gz
+	git -C build/merge add $(TAG)
+	@# For now, the user must do this. If it is onerous, automate it and change
+	@# the instructions in doc/HOWTO_RELEASE.rst.txt
+	@echo " "
+	@echo New documentation archive added to ./build/merge.
+	@echo Now add/modify the appropiate section after
+	@echo "    <!-- insert here -->"
+	@echo in build/merge/index.html,
+	@echo then \"git commit\", \"git push\"
+	
 
 #------------------------------------------------------------------------------
 # Basic Sphinx generation rules for different formats


### PR DESCRIPTION
Builds upon gh-14062 to use the output of `make dist` and update the numpy/doc documentation archive repo when on a tagged release. Will require rebase after gh-14062 is merged

The idea is that, as part of the release process, we tag a repo checkout, build the docs, and commit that version of the documentation to the numpy/doc repo which is visible as https://numpy.org/doc. That means there is no delay between release and achive documentation availablility.

~Also needs numpy/numpy.org#25 to drive traffic from https://numpy.org to https:/numpy.org/doc~

Edit: numpy.org PR was merged