### PR TITLE
MAINT: Improve C level error messages for np.ones, zeros etc.

### DIFF
--- a/mytest.py
+++ b/mytest.py
@@ -1,3 +1,0 @@
-import numpy as np
-np.empty_like(1, 1)
-

--- a/mytest.py
+++ b/mytest.py
@@ -1,0 +1,3 @@
+import numpy as np
+np.empty_like(1, 1)
+

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -351,6 +351,7 @@ multiarray_funcs_api = {
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
     'PyArray_DescrConverterDetectIntegerArgument': (304,),
+    # End 1.18 API
 }
 
 ufunc_types_api = {

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -350,6 +350,7 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
+    'PyArray_DescrConverterDetectIntegerArgument': (304,),
 }
 
 ufunc_types_api = {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1744,14 +1744,13 @@ error:
 }
 
 /*NUMPY_API
- * Get typenum from an object.
- * This function takes a Python object representing a type and converts it
- * to a the correct PyArray_Descr * structure to describe the type.
+ * Get typenum from an object -- None goes to NPY_DEFAULT_TYPE
+ * This function takes a Python object representing a type and converts it to
+ * the correct PyArray_Descr * structure to describe the type. Many objects
+ * can be used to represent a data-type which in NumPy is quite a flexible
+ * concept.
  *
- * Many objects can be used to represent a data-type which in NumPy is
- * quite a flexible concept.
- *
- * Raises a BadArgument error if obj is an Integral type and returns NULL
+ * Raises MisplacedShapeArgumentError if obj is an Integer and returns NULL
  * in *at. Otherwise returns a new reference in *at. The returned should not
  * be modified as it may be one of the canonical immutable objects or a
  * reference to the input obj.
@@ -1761,15 +1760,15 @@ PyArray_DescrConverterDetectIntegerArgument(PyObject *obj, PyArray_Descr **at)
 {
     if (PyArray_IsIntegerScalar(obj)) {
         *at = NULL;
-
-        PyErr_Clear();
-        PyErr_BadArgument();
+        PyErr_SetString(PyArray_MisplacedShapeArgumentError,
+                        "Descriptor converter detected an integer type");
         return NPY_FAIL;
     }
     else {
         return PyArray_DescrConverter(obj, at);
     };
 }
+
 /** Array Descr Objects for dynamic types **/
 
 /*

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1743,6 +1743,33 @@ error:
     return NPY_FAIL;
 }
 
+/*NUMPY_API
+ * Get typenum from an object.
+ * This function takes a Python object representing a type and converts it
+ * to a the correct PyArray_Descr * structure to describe the type.
+ *
+ * Many objects can be used to represent a data-type which in NumPy is
+ * quite a flexible concept.
+ *
+ * Raises a BadArgument error if obj is an Integral type and returns NULL
+ * in *at. Otherwise returns a new reference in *at. The returned should not
+ * be modified as it may be one of the canonical immutable objects or a
+ * reference to the input obj.
+ */
+NPY_NO_EXPORT int
+PyArray_DescrConverterDetectIntegerArgument(PyObject *obj, PyArray_Descr **at)
+{
+    if (PyArray_IsIntegerScalar(obj)) {
+        *at = NULL;
+
+        PyErr_Clear();
+        PyErr_BadArgument();
+        return NPY_FAIL;
+    }
+    else {
+        return PyArray_DescrConverter(obj, at);
+    };
+}
 /** Array Descr Objects for dynamic types **/
 
 /*

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -26,6 +26,9 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype);
 NPY_NO_EXPORT PyArray_Descr *
 arraydescr_field_subset_view(PyArray_Descr *self, PyObject *ind);
 
+NPY_NO_EXPORT PyObject *
+PyArray_MisplacedShapeArgumentError;
+
 extern NPY_NO_EXPORT char *_datetime_strings[];
 
 #endif

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1840,6 +1840,7 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
 fail:
     if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_Clear();
         PyErr_SetString(PyExc_TypeError,
                 "data type not understood, "
                 "did you mean to use a tuple for size?");
@@ -1881,6 +1882,7 @@ array_empty_like(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
 fail:
     if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_Clear();
         PyErr_SetString(PyExc_TypeError,
                 "data type not understood, "
                 "did you mean to use a tuple for size?");
@@ -2009,6 +2011,7 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
 fail:
     if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_Clear();
         PyErr_SetString(PyExc_TypeError,
                 "data type not understood, "
                 "did you mean to use a tuple for size?");

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1816,6 +1816,12 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                 PyArray_IntpConverter, &shape,
                 PyArray_DescrConverterDetectIntegerArgument, &typecode,
                 PyArray_OrderConverter, &order)) {
+        if (PyErr_ExceptionMatches(PyArray_MisplacedShapeArgumentError)) {
+            PyErr_Clear();
+            PyErr_SetString(PyExc_TypeError,
+                            "data type not understood, "
+                            "did you mean to use a tuple for size?");
+        }
         goto fail;
     }
 
@@ -1839,12 +1845,6 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
-        PyErr_Clear();
-        PyErr_SetString(PyExc_TypeError,
-                "data type not understood, "
-                "did you mean to use a tuple for size?");
-    }
     Py_XDECREF(typecode);
     npy_free_cache_dim_obj(shape);
     return NULL;
@@ -1987,6 +1987,12 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                 PyArray_IntpConverter, &shape,
                 PyArray_DescrConverterDetectIntegerArgument, &typecode,
                 PyArray_OrderConverter, &order)) {
+        if (PyErr_ExceptionMatches(PyArray_MisplacedShapeArgumentError)) {
+            PyErr_Clear();
+            PyErr_SetString(PyExc_TypeError,
+                            "data type not understood, "
+                            "did you mean to use a tuple for size?");
+        }
         goto fail;
     }
 
@@ -2010,12 +2016,6 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
-        PyErr_Clear();
-        PyErr_SetString(PyExc_TypeError,
-                "data type not understood, "
-                "did you mean to use a tuple for size?");
-    }
     Py_XDECREF(typecode);
     npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;
@@ -4714,6 +4714,12 @@ PyMODINIT_FUNC init_multiarray_umath(void) {
      * This is for backward compatibility with existing code.
      */
     PyDict_SetItemString (d, "error", PyExc_Exception);
+
+    PyArray_MisplacedShapeArgumentError = PyErr_NewException(
+            "multiarray.PyArray_MisplacedShapeArgumentError", NULL, NULL);
+    PyDict_SetItemString(d,
+                         "PyArray_MisplacedShapeArgumentError",
+                         PyArray_MisplacedShapeArgumentError);
 
     s = PyInt_FromLong(NPY_TRACE_DOMAIN);
     PyDict_SetItemString(d, "tracemalloc_domain", s);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1881,12 +1881,6 @@ array_empty_like(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
-        PyErr_Clear();
-        PyErr_SetString(PyExc_TypeError,
-                "data type not understood, "
-                "did you mean to use a tuple for size?");
-    }
     Py_XDECREF(prototype);
     Py_XDECREF(dtype);
     return NULL;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1839,6 +1839,11 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_SetString(PyExc_TypeError,
+                "data type not understood, "
+                "did you mean to use a tuple for size?");
+    }
     Py_XDECREF(typecode);
     npy_free_cache_dim_obj(shape);
     return NULL;
@@ -1875,6 +1880,11 @@ array_empty_like(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_SetString(PyExc_TypeError,
+                "data type not understood, "
+                "did you mean to use a tuple for size?");
+    }
     Py_XDECREF(prototype);
     Py_XDECREF(dtype);
     return NULL;
@@ -1998,6 +2008,11 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     return (PyObject *)ret;
 
 fail:
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_TypeError)) {
+        PyErr_SetString(PyExc_TypeError,
+                "data type not understood, "
+                "did you mean to use a tuple for size?");
+    }
     Py_XDECREF(typecode);
     npy_free_cache_dim_obj(shape);
     return (PyObject *)ret;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1814,7 +1814,7 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&:empty", kwlist,
                 PyArray_IntpConverter, &shape,
-                PyArray_DescrConverter, &typecode,
+                PyArray_DescrConverterDetectIntegerArgument, &typecode,
                 PyArray_OrderConverter, &order)) {
         goto fail;
     }
@@ -1985,7 +1985,7 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&:zeros", kwlist,
                 PyArray_IntpConverter, &shape,
-                PyArray_DescrConverter, &typecode,
+                PyArray_DescrConverterDetectIntegerArgument, &typecode,
                 PyArray_OrderConverter, &order)) {
         goto fail;
     }

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -524,3 +524,18 @@ def test_broadcast_arrays():
     result = np.broadcast_arrays(a, b)
     assert_equal(result[0], np.array([(1, 2, 3), (1, 2, 3), (1, 2, 3)], dtype='u4,u4,u4'))
     assert_equal(result[1], np.array([(1, 2, 3), (4, 5, 6), (7, 8, 9)], dtype='u4,u4,u4'))
+
+@pytest.mark.parametrize('fn', [np.ones, np.ones_like, np.zeros, np.empty, np.empty_like])
+def test_homogenous_array_creation_returns_descriptive_errror(fn):
+    # These functions have signatures fn(shape, dtype=None, order='C')
+    # where `shape` may be either an integer or a tuple. For higher
+    # dimensional shapes this is often confused e.g. np.ones(5, 5) when
+    # np.ones((5, 5)) is desired.
+    # e.g.: https://twitter.com/karpathy/status/1099793055853375489
+    message = (
+        "data type not understood,"
+        " did you mean to use a tuple for size?")
+    with pytest.raises(TypeError) as e:
+        fn(1, 1)
+    assert_equal(str(e.value), message)
+

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -525,8 +525,8 @@ def test_broadcast_arrays():
     assert_equal(result[0], np.array([(1, 2, 3), (1, 2, 3), (1, 2, 3)], dtype='u4,u4,u4'))
     assert_equal(result[1], np.array([(1, 2, 3), (4, 5, 6), (7, 8, 9)], dtype='u4,u4,u4'))
 
-@pytest.mark.parametrize('fn', [np.ones, np.ones_like, np.zeros, np.empty, np.empty_like])
-def test_homogenous_array_creation_returns_descriptive_errror(fn):
+@pytest.mark.parametrize('fn', [np.ones, np.zeros, np.empty])
+def test_homogenous_array_creation_returns_descriptive_error(fn):
     # These functions have signatures fn(shape, dtype=None, order='C')
     # where `shape` may be either an integer or a tuple. For higher
     # dimensional shapes this is often confused e.g. np.ones(5, 5) when


### PR DESCRIPTION
This PR improves the error messages for TypeErrors in np.ones, np.ones_like, np.zeros, np.empty and np.empty_like by changing the error message of the corresponding C level functions array_zeros,  array_empty and array_empty_like.

```python
>>> import numpy as np
>>> np.zeros(1, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: data type not understood, did you mean to use a tuple for size?
```
The issue comes from the dtype argument (in this case an integer value) not corresponding to a valid datatype. In which case the C function PyArray_DescrConverter cannot will raise register a TypeError. 

This issue was original raised on [Twitter](https://twitter.com/karpathy/status/1099793055853375489). Multiple PRs have been submitted [#13048, #13040], these have not been accepted as their focus  was on the matrixlib and that they worked at the Python level.