### PR TITLE
BUG: fix build issue on icc 2016

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -138,6 +138,8 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                        # broken on OSX 10.11, make sure its not optimized away
                        ("volatile int r = __builtin_cpu_supports", '"sse"',
                         "stdio.h", "__BUILTIN_CPU_SUPPORTS"),
+                       ("volatile int r = __builtin_cpu_supports", '"avx512f"',
+                        "stdio.h", "__BUILTIN_CPU_SUPPORTS_AVX512F"),
                        # MMX only needed for icc, but some clangs don't have it
                        ("_m_from_int64", '0', "emmintrin.h"),
                        ("_mm_load_ps", '(float*)0', "xmmintrin.h"),  # SSE

--- a/numpy/core/src/umath/cpuid.c
+++ b/numpy/core/src/umath/cpuid.c
@@ -57,10 +57,10 @@ npy_cpu_supports(const char * feature)
 {
 #ifdef HAVE___BUILTIN_CPU_SUPPORTS
     if (strcmp(feature, "avx512f") == 0) {
-#if defined(__GNUC__) && (__GNUC__ < 5)
-        return 0;
-#else
+#ifdef HAVE___BUILTIN_CPU_SUPPORTS_AVX512F
         return __builtin_cpu_supports("avx512f") && os_avx512_support();
+#else
+        return 0;
 #endif
     }
     else if (strcmp(feature, "avx2") == 0) {


### PR DESCRIPTION
Backport of #14074 .

Test if compiler supports _builtin_supports("avx512f") before calling it
Fixes #14059: Test if compiler supports _builtin_supports("avx512f") before calling it
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
