### PR TITLE
BUG: Fix file-like object check when saving arrays

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -521,7 +521,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
     """
     own_fid = False
-    if hasattr(file, 'read'):
+    if hasattr(file, 'write'):
         fid = file
     else:
         file = os_fspath(file)
@@ -709,7 +709,7 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
     # component of the so-called standard library.
     import zipfile
 
-    if not hasattr(file, 'read'):
+    if not hasattr(file, 'write'):
         file = os_fspath(file)
         if not file.endswith('.npz'):
             file = file + '.npz'

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2472,6 +2472,44 @@ def test_gzip_load():
     assert_array_equal(np.load(f), a)
 
 
+# These next two classes encode the minimal API needed to save()/load() arrays.
+# The `test_ducktyping` ensures they work correctly
+class JustWriter(object):
+    def __init__(self, base):
+        self.base = base
+
+    def write(self, s):
+        return self.base.write(s)
+
+    def flush(self):
+        return self.base.flush()
+
+class JustReader(object):
+    def __init__(self, base):
+        self.base = base
+
+    def read(self, n):
+        return self.base.read(n)
+
+    def seek(self, off, whence=0):
+        return self.base.seek(off, whence)
+
+
+def test_ducktyping():
+    a = np.random.random((5, 5))
+
+    s = BytesIO()
+    f = JustWriter(s)
+
+    np.save(f, a)
+    f.flush()
+    s.seek(0)
+
+    f = JustReader(s)
+    assert_array_equal(np.load(f), a)
+
+
+
 def test_gzip_loadtxt():
     # Thanks to another windows brokenness, we can't use
     # NamedTemporaryFile: a file created from this function cannot be


### PR DESCRIPTION
Backport of #14063 .

For writing arrays, only the write method is necessary.

I had code that was broken by this check and had to introduce a fake read method for it to work: https://github.com/luispedro/jug/blob/b32f4389acd1c3edf1a6a593799e853ded7849a2/jug/backends/encode.py#L88


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
