### PR TITLE
WIP, MAINT: Improve import time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             python3 -m venv venv
             ln -s $(which python3) venv/bin/python3.6
             . venv/bin/activate
-            pip install cython sphinx==1.8.5 matplotlib ipython
+            pip install cython sphinx==1.8.5 matplotlib ipython fastrlock
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
@@ -30,7 +30,7 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --upgrade pip setuptools
-            pip install cython
+            pip install cython fastrlock
             pip install .
             pip install scipy
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
            apt-get -y update && \
            apt-get -y install python3.6-dev python3-pip locales python3-certifi && \
            locale-gen fr_FR && update-locale && \
-           pip3 install setuptools nose cython==0.29.0 pytest pytz pickle5 && \
+           pip3 install setuptools nose cython==0.29.0 pytest pytz pickle5 fastrlock && \
            apt-get -y install gfortran-5 wget && \
            target=\$(python3 tools/openblas_support.py) && \
            cp -r \$target/usr/local/lib/* /usr/lib && \
@@ -85,7 +85,7 @@ jobs:
     displayName: 'install pre-built openblas'
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install cython nose pytz pytest pickle5 vulture docutils sphinx==1.8.5 numpydoc
+  - script: python -m pip install cython fastrlock nose pytz pytest pickle5 vulture docutils sphinx==1.8.5 numpydoc
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
     displayName: 'Check for unreachable code paths in Python modules'
@@ -156,13 +156,13 @@ jobs:
       architecture: $(PYTHON_ARCH)
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
-  - script: python -m pip install cython nose pytz pytest
+  - script: python -m pip install cython fastrlock nose pytz pytest
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: if [%INSTALL_PICKLE5%]==[1] python -m pip install pickle5
     displayName: 'Install optional pickle5 backport (only for python3.6 and 3.7)'
 
   - powershell: |
-      $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
+      $pyversion = python -c "
       Write-Host "Python Version: $pyversion"
       $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
       Write-Host "target path: $target"

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -182,10 +182,6 @@ else:
     oldnumeric = 'removed'
     numarray = 'removed'
 
-    # We don't actually use this ourselves anymore, but I'm not 100% sure that
-    # no-one else in the world is using it (though I hope not)
-    from .testing import Tester
-
     # Pytest testing
     from numpy._pytesttester import PytestTester
     test = PytestTester(__name__)

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -8,7 +8,7 @@ __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
            'integer_types', 'is_pathlib_path', 'npy_load_module', 'Path',
-           'pickle', 'contextlib_nullcontext', 'os_fspath', 'os_PathLike']
+           'get_pickle', 'contextlib_nullcontext', 'os_fspath', 'os_PathLike']
 
 import sys
 import os
@@ -20,10 +20,12 @@ except ImportError:
 if sys.version_info[0] >= 3:
     import io
 
-    try:
-        import pickle5 as pickle
-    except ImportError:
-        import pickle
+    def get_pickle():
+        try:
+            import pickle5 as pickle
+        except ImportError:
+            import pickle
+        return pickle
 
     long = int
     integer_types = (int,)
@@ -58,7 +60,9 @@ if sys.version_info[0] >= 3:
     strchar = 'U'
 
 else:
-    import cpickle as pickle
+    def get_pickle():
+        import cpickle as pickle
+        return pickle
 
     bytes = str
     long = long

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -7,15 +7,11 @@ from __future__ import division, absolute_import, print_function
 __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
            'unicode', 'asunicode', 'asbytes_nested', 'asunicode_nested',
            'asstr', 'open_latin1', 'long', 'basestring', 'sixu',
-           'integer_types', 'is_pathlib_path', 'npy_load_module', 'Path',
+           'integer_types', 'is_pathlib_path', 'npy_load_module',
            'get_pickle', 'contextlib_nullcontext', 'os_fspath', 'os_PathLike']
 
 import sys
 import os
-try:
-    from pathlib import Path, PurePath
-except ImportError:
-    Path = PurePath = None
 
 if sys.version_info[0] >= 3:
     import io
@@ -108,6 +104,7 @@ def is_pathlib_path(obj):
 
     Prefer using `isinstance(obj, os_PathLike)` instead of this function.
     """
+    from pathlib import Path
     return Path is not None and isinstance(obj, Path)
 
 # from Python 3.7
@@ -204,6 +201,10 @@ if sys.version_info[:2] >= (3, 6):
 else:
     def _PurePath__fspath__(self):
         return str(self)
+
+    # Pathlib isn't exactly a cheap import. Lazy import it here in case
+    # users are running python older 3.6
+    from pathlib import Pathlike
 
     class os_PathLike(abc_ABC):
         """Abstract base class for implementing the file system path protocol."""

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -909,4 +909,3 @@ class recursive(object):
         self.func = func
     def __call__(self, *args, **kwargs):
         return self.func(self, *args, **kwargs)
-

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -8,7 +8,6 @@ from __future__ import division, absolute_import, print_function
 
 import re
 import sys
-import platform
 
 from numpy.compat import unicode
 from .multiarray import dtype, array, ndarray
@@ -17,7 +16,10 @@ try:
 except ImportError:
     ctypes = None
 
-IS_PYPY = platform.python_implementation() == 'PyPy'
+# While one could use platform.python_implementation
+# importing platform is quite slow
+IS_PYPY = "PyPy" in sys.version
+
 
 if (sys.byteorder == 'little'):
     _nbo = b'<'

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -13,7 +13,7 @@ from numpy.core._asarray import asanyarray
 from numpy.core import numerictypes as nt
 from numpy.core import _exceptions
 from numpy._globals import _NoValue
-from numpy.compat import pickle, os_fspath, contextlib_nullcontext
+from numpy.compat import os_fspath, contextlib_nullcontext, get_pickle
 
 # save those O(100) nanoseconds!
 umr_maximum = um.maximum.reduce
@@ -233,6 +233,7 @@ def _ptp(a, axis=None, out=None, keepdims=False):
     )
 
 def _dump(self, file, protocol=2):
+    pickle = get_pickle()
     if hasattr(file, 'write'):
         ctx = contextlib_nullcontext(file)
     else:
@@ -241,4 +242,5 @@ def _dump(self, file, protocol=2):
         pickle.dump(self, f, protocol=protocol)
 
 def _dumps(self, protocol=2):
+    pickle = get_pickle()
     return pickle.dumps(self, protocol=protocol)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -9,7 +9,7 @@ import numbers
 import contextlib
 
 import numpy as np
-from numpy.compat import pickle, basestring
+from numpy.compat import get_pickle, basestring
 from . import multiarray
 from .multiarray import (
     _fastCopyAndTranspose as fastCopyAndTranspose, ALLOW_THREADS,
@@ -49,6 +49,7 @@ array_function_dispatch = functools.partial(
 
 
 def loads(*args, **kwargs):
+    pickle = get_pickle()
     # NumPy 1.15.0, 2017-12-10
     warnings.warn(
         "np.core.numeric.loads is deprecated, use pickle.loads instead",
@@ -937,7 +938,7 @@ def tensordot(a, b, axes=2):
     Returns
     -------
     output : ndarray
-        The tensor dot product of the input.  
+        The tensor dot product of the input.
 
     See Also
     --------
@@ -2038,6 +2039,7 @@ def load(file):
     load, save
 
     """
+    pickle = get_pickle()
     # NumPy 1.15.0, 2017-12-10
     warnings.warn(
         "np.core.numeric.load is deprecated, use pickle.load instead",

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -2,7 +2,6 @@
 import collections
 import functools
 import os
-import textwrap
 
 from numpy.core._multiarray_umath import (
     add_docstring, implement_array_function, _get_implementing_args)
@@ -163,13 +162,13 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         # more interpettable name. Otherwise, the original function does not
         # show up at all in many cases, e.g., if it's written in C or if the
         # dispatcher gets an invalid keyword argument.
-        source = textwrap.dedent("""
-        @functools.wraps(implementation)
-        def {name}(*args, **kwargs):
-            relevant_args = dispatcher(*args, **kwargs)
-            return implement_array_function(
-                implementation, {name}, relevant_args, args, kwargs)
-        """).format(name=implementation.__name__)
+        source = """
+@functools.wraps(implementation)
+def {name}(*args, **kwargs):
+    relevant_args = dispatcher(*args, **kwargs)
+    return implement_array_function(
+        implementation, {name}, relevant_args, args, kwargs)
+        """.format(name=implementation.__name__)
 
         source_object = compile(
             source, filename='<__array_function__ internals>', mode='exec')

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -9,7 +9,8 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_warns, suppress_warnings,
     assert_raises_regex,
     )
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 # Use pytz to test out various time zones if available
 try:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -10,7 +10,8 @@ import numpy as np
 from numpy.core._rational_tests import rational
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, HAS_REFCOUNT)
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 from itertools import permutations
 
 def assert_dtype_equal(a, b):
@@ -138,11 +139,11 @@ class TestBuiltin(object):
                          'offsets':[0, 2]}, align=True)
 
     def test_field_order_equality(self):
-        x = np.dtype({'names': ['A', 'B'], 
-                      'formats': ['i4', 'f4'], 
+        x = np.dtype({'names': ['A', 'B'],
+                      'formats': ['i4', 'f4'],
                       'offsets': [0, 4]})
-        y = np.dtype({'names': ['B', 'A'], 
-                      'formats': ['f4', 'i4'], 
+        y = np.dtype({'names': ['B', 'A'],
+                      'formats': ['f4', 'i4'],
                       'offsets': [4, 0]})
         assert_equal(x == y, False)
 
@@ -1279,4 +1280,3 @@ class TestFromCTypes(object):
         pair_type = np.dtype('{},{}'.format(*pair))
         expected = np.dtype([('f0', pair[0]), ('f1', pair[1])])
         assert_equal(pair_type, expected)
-

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -9,7 +9,7 @@ from tempfile import NamedTemporaryFile, TemporaryFile, mktemp, mkdtemp
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
-from numpy.compat import Path
+from pathlib import Path
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -21,7 +21,8 @@ import weakref
 import pytest
 from contextlib import contextmanager
 
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 try:
     import pathlib
@@ -114,7 +115,7 @@ class TestFlags(object):
         # Ensure that any base being writeable is sufficient to change flag;
         # this is especially interesting for arrays from an array interface.
         arr = np.arange(10)
-        
+
         class subclass(np.ndarray):
             pass
 
@@ -3967,13 +3968,13 @@ class TestPickling(object):
 
     def test_datetime64_byteorder(self):
         original = np.array([['2015-02-24T00:00:00.000000000']], dtype='datetime64[ns]')
-    
+
         original_byte_reversed = original.copy(order='K')
         original_byte_reversed.dtype = original_byte_reversed.dtype.newbyteorder('S')
         original_byte_reversed.byteswap(inplace=True)
 
         new = pickle.loads(pickle.dumps(original_byte_reversed))
-    
+
         assert_equal(original.dtype, new.dtype)
 
 
@@ -4868,7 +4869,7 @@ class TestIO(object):
             offset_bytes = self.dtype.itemsize
             z = np.fromfile(f, dtype=self.dtype, offset=offset_bytes)
             assert_array_equal(z, self.x.flat[offset_items+count_items+1:])
-        
+
         with open(self.filename, 'wb') as f:
             self.x.tofile(f, sep=",")
 
@@ -6225,14 +6226,14 @@ class TestMatmul(MatmulCommon):
 
         r3 = np.matmul(args[0].copy(), args[1].copy())
         assert_equal(r1, r3)
-    
+
     def test_matmul_object(self):
         import fractions
 
         f = np.vectorize(fractions.Fraction)
         def random_ints():
             return np.random.randint(1, 1000, size=(10, 3, 3))
-        M1 = f(random_ints(), random_ints()) 
+        M1 = f(random_ints(), random_ints())
         M2 = f(random_ints(), random_ints())
 
         M3 = self.matmul(M1, M2)

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -10,7 +10,8 @@ from numpy.testing import (
 from numpy.core.overrides import (
     _get_implementing_args, array_function_dispatch,
     verify_matching_signatures, ARRAY_FUNCTION_ENABLED)
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 import pytest
 
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -17,8 +17,8 @@ from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, temppath
     )
-from numpy.compat import pickle
-
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 class TestFromrecords(object):
     def test_fromrecords(self):

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -12,7 +12,7 @@ from os import path
 import pytest
 
 import numpy as np
-from numpy.compat import Path
+from pathlib import Path
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, temppath

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -16,7 +16,8 @@ from numpy.testing import (
         assert_raises_regex, assert_warns, suppress_warnings,
         _assert_valid_refcount, HAS_REFCOUNT,
         )
-from numpy.compat import asbytes, asunicode, long, pickle
+from numpy.compat import asbytes, asunicode, long, get_pickle
+pickle = get_pickle()
 
 try:
     RecursionError

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -15,8 +15,8 @@ from numpy.testing import (
     assert_almost_equal, assert_array_almost_equal, assert_no_warnings,
     assert_allclose,
     )
-from numpy.compat import pickle
-
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 class TestUfuncKwargs(object):
     def test_kwarg_exact(self):

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -92,11 +92,11 @@ else:
     # Adapted from Albert Strasheim
     def load_library(libname, loader_path):
         """
-        It is possible to load a library using 
+        It is possible to load a library using
         >>> lib = ctypes.cdll[<full_path_name>] # doctest: +SKIP
 
         But there are cross-platform considerations, such as library file extensions,
-        plus the fact Windows will just load the first library it finds with that name.  
+        plus the fact Windows will just load the first library it finds with that name.
         NumPy supplies the load_library function as a convenience.
 
         Parameters
@@ -110,12 +110,12 @@ else:
         Returns
         -------
         ctypes.cdll[libpath] : library object
-           A ctypes library object 
+           A ctypes library object
 
         Raises
         ------
         OSError
-            If there is no library with the expected extension, or the 
+            If there is no library with the expected extension, or the
             library is defective and cannot be loaded.
         """
         if ctypes.__version__ < '1.0.1':
@@ -354,7 +354,6 @@ if ctypes is not None:
             # prevent the type name include np.ctypeslib
             element_type.__module__ = None
         return element_type
-
 
     def _get_scalar_type_map():
         """

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -39,7 +39,6 @@ from __future__ import division, absolute_import, print_function
 import os
 import sys
 import warnings
-import shutil
 import io
 from contextlib import closing
 
@@ -330,6 +329,7 @@ class DataSource(object):
             self._istmpdest = True
 
     def __del__(self):
+        import shutil
         # Remove temp directories
         if hasattr(self, '_istmpdest') and self._istmpdest:
             shutil.rmtree(self._destpath)
@@ -413,6 +413,7 @@ class DataSource(object):
             os.makedirs(os.path.dirname(upath))
 
         # TODO: Doesn't handle compressed files!
+        import shutil
         if self._isurl(path):
             try:
                 with closing(urlopen(path)) as openedurl:

--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -12,7 +12,6 @@ otherwise stated.
 """
 from __future__ import division, absolute_import, print_function
 
-from decimal import Decimal
 import functools
 
 import numpy as np
@@ -621,6 +620,8 @@ def rate(nper, pmt, pv, fv, when='end', guess=None, tol=None, maxiter=100):
     OpenDocument-formula-20090508.odt
 
     """
+    from decimal import Decimal
+
     when = _convert_when(when)
     default_type = Decimal if isinstance(pmt, Decimal) else float
 
@@ -812,6 +813,8 @@ def mirr(values, finance_rate, reinvest_rate):
         Modified internal rate of return
 
     """
+    from decimal import Decimal
+
     values = np.asarray(values)
     n = values.size
 

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -169,7 +169,7 @@ import io
 import warnings
 from numpy.lib.utils import safe_eval
 from numpy.compat import (
-    isfileobj, long, os_fspath, pickle
+    isfileobj, long, os_fspath, get_pickle
     )
 
 
@@ -656,6 +656,7 @@ def write_array(fp, array, version=None, allow_pickle=True, pickle_kwargs=None):
                              "allow_pickle=False")
         if pickle_kwargs is None:
             pickle_kwargs = {}
+        pickle = get_pickle()
         pickle.dump(array, fp, protocol=3, **pickle_kwargs)
     elif array.flags.f_contiguous and not array.flags.c_contiguous:
         if isfileobj(fp):
@@ -724,6 +725,7 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None):
         if pickle_kwargs is None:
             pickle_kwargs = {}
         try:
+            pickle = get_pickle()
             array = pickle.load(fp, **pickle_kwargs)
         except UnicodeError as err:
             if sys.version_info[0] >= 3:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -25,7 +25,7 @@ from ._iotools import (
 
 from numpy.compat import (
     asbytes, asstr, asunicode, bytes, basestring, os_fspath, os_PathLike,
-    pickle, contextlib_nullcontext
+    get_pickle, contextlib_nullcontext
     )
 
 if sys.version_info[0] >= 3:
@@ -37,6 +37,7 @@ else:
 
 @set_module('numpy')
 def loads(*args, **kwargs):
+    pickle = get_pickle()
     # NumPy 1.15.0, 2017-12-10
     warnings.warn(
         "np.loads is deprecated, use pickle.loads instead",
@@ -457,6 +458,7 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
                 raise ValueError("Cannot load file containing pickled data "
                                  "when allow_pickle=False")
             try:
+                pickle = get_pickle()
                 return pickle.load(fid, **pickle_kwargs)
             except Exception:
                 raise IOError(
@@ -680,7 +682,7 @@ def savez_compressed(file, *args, **kwds):
     The ``.npz`` file format is a zipped archive of files named after the
     variables they contain.  The archive is compressed with
     ``zipfile.ZIP_DEFLATED`` and each file in the archive contains one variable
-    in ``.npy`` format. For a description of the ``.npy`` format, see 
+    in ``.npy`` format. For a description of the ``.npy`` format, see
     :py:mod:`numpy.lib.format`.
 
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -6,7 +6,6 @@ import re
 import functools
 import itertools
 import warnings
-import weakref
 import contextlib
 from operator import itemgetter, index as opindex
 
@@ -87,6 +86,7 @@ class BagObj(object):
     """
 
     def __init__(self, obj):
+        import weakref
         # Use weakref to make NpzFile objects collectable by refcount
         self._obj = weakref.proxy(obj)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -17,7 +17,8 @@ import locale
 import numpy as np
 import numpy.ma as ma
 from numpy.lib._iotools import ConverterError, ConversionWarning
-from numpy.compat import asbytes, bytes, Path
+from numpy.compat import asbytes, bytes
+from pathlib import Path
 from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     assert_warns, assert_, assert_raises_regex, assert_raises,

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -46,7 +46,7 @@ from numpy.compat import (
 from numpy import expand_dims
 from numpy.core.numeric import normalize_axis_tuple
 from numpy.core._internal import recursive
-from numpy.compat import pickle
+from numpy.compat import get_pickle
 
 
 __all__ = [
@@ -7919,6 +7919,7 @@ def dump(a, F):
 
     """
     _pickle_warn('dump')
+    pickle = get_pickle()
     if not hasattr(F, 'readline'):
         with open(F, 'w') as F:
             pickle.dump(a, F)
@@ -7940,6 +7941,7 @@ def dumps(a):
 
     """
     _pickle_warn('dumps')
+    pickle = get_pickle()
     return pickle.dumps(a)
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -25,7 +25,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 import operator
 import warnings
-import textwrap
 import re
 from functools import reduce
 
@@ -2445,32 +2444,32 @@ def _recursive_printoption(result, mask, printopt):
 
 # For better or worse, these end in a newline
 _legacy_print_templates = dict(
-    long_std=textwrap.dedent("""\
-        masked_%(name)s(data =
-         %(data)s,
-        %(nlen)s        mask =
-         %(mask)s,
-        %(nlen)s  fill_value = %(fill)s)
-        """),
-    long_flx=textwrap.dedent("""\
-        masked_%(name)s(data =
-         %(data)s,
-        %(nlen)s        mask =
-         %(mask)s,
-        %(nlen)s  fill_value = %(fill)s,
-        %(nlen)s       dtype = %(dtype)s)
-        """),
-    short_std=textwrap.dedent("""\
-        masked_%(name)s(data = %(data)s,
-        %(nlen)s        mask = %(mask)s,
-        %(nlen)s  fill_value = %(fill)s)
-        """),
-    short_flx=textwrap.dedent("""\
-        masked_%(name)s(data = %(data)s,
-        %(nlen)s        mask = %(mask)s,
-        %(nlen)s  fill_value = %(fill)s,
-        %(nlen)s       dtype = %(dtype)s)
-        """)
+    long_std="""\
+masked_%(name)s(data =
+ %(data)s,
+%(nlen)s        mask =
+ %(mask)s,
+%(nlen)s  fill_value = %(fill)s)
+""",
+    long_flx="""\
+masked_%(name)s(data =
+ %(data)s,
+%(nlen)s        mask =
+ %(mask)s,
+%(nlen)s  fill_value = %(fill)s,
+%(nlen)s       dtype = %(dtype)s)
+""",
+    short_std="""\
+masked_%(name)s(data = %(data)s,
+%(nlen)s        mask = %(mask)s,
+%(nlen)s  fill_value = %(fill)s)
+""",
+    short_flx="""\
+masked_%(name)s(data = %(data)s,
+%(nlen)s        mask = %(mask)s,
+%(nlen)s  fill_value = %(fill)s,
+%(nlen)s       dtype = %(dtype)s)
+"""
 )
 
 ###############################################################################

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -49,8 +49,8 @@ from numpy.ma.core import (
     ravel, repeat, reshape, resize, shape, sin, sinh, sometrue, sort, sqrt,
     subtract, sum, take, tan, tanh, transpose, where, zeros,
     )
-from numpy.compat import pickle
-
+from numpy.compat import get_pickle
+pickle = get_pickle()
 pi = np.pi
 
 

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -23,7 +23,8 @@ from numpy.ma.testutils import (
     assert_, assert_equal,
     assert_equal_records,
     )
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 
 class TestMRecords(object):

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -21,7 +21,8 @@ from numpy.ma import (
     repeat, resize, shape, sin, sinh, sometrue, sort, sqrt, subtract, sum,
     take, tan, tanh, transpose, where, zeros,
     )
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 pi = np.pi
 

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -7,7 +7,8 @@ from numpy.ma.core import (masked_array, masked_values, masked, allequal,
                            MaskType, getmask, MaskedArray, nomask,
                            log, add, hypot, divide)
 from numpy.ma.extras import mr_
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
 
 
 class MMatrix(MaskedArray, np.matrix,):

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -249,6 +249,11 @@ cdef class SeedlessSeedSequence():
 # we must register it after the fact.
 ISpawnableSeedSequence.register(SeedlessSeedSequence)
 
+# Taken from https://github.com/python/cpython/blob/3.7/Lib/secrets.py#L24
+# secret imports many things we don't need
+from random import SystemRandom
+_sysrand = SystemRandom()
+randbits = _sysrand.getrandbits
 
 cdef class SeedSequence():
     """

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -43,12 +43,8 @@ except ImportError:
     from random import SystemRandom
     randbits = SystemRandom().getrandbits
 
-try:
-    from threading import Lock
-except ImportError:
-    from dummy_threading import Lock
-
 from cpython.pycapsule cimport PyCapsule_New
+from fastrlock.rlock cimport create_fastrlock as Lock
 
 import numpy as np
 cimport numpy as np

--- a/numpy/random/philox.pyx
+++ b/numpy/random/philox.pyx
@@ -1,10 +1,5 @@
 from cpython.pycapsule cimport PyCapsule_New
 
-try:
-    from threading import Lock
-except ImportError:
-    from dummy_threading import Lock
-
 import numpy as np
 
 from .common cimport *

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -28,7 +28,6 @@ def check_dir(module, module_name=None):
 def test_numpy_namespace():
     # None of these objects are publicly documented.
     undocumented = {
-        'Tester': 'numpy.testing._private.nosetester.NoseTester',
         '_add_newdoc_ufunc': 'numpy.core._multiarray_umath._add_newdoc_ufunc',
         'add_docstring': 'numpy.core._multiarray_umath.add_docstring',
         'add_newdoc': 'numpy.core.function_base.add_newdoc',

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -3,7 +3,9 @@ from __future__ import division, absolute_import, print_function
 import sys
 
 from numpy.testing import assert_raises, assert_, assert_equal
-from numpy.compat import pickle
+from numpy.compat import get_pickle
+pickle = get_pickle()
+
 
 if sys.version_info[:2] >= (3, 4):
     from importlib import reload

--- a/shippable.yml
+++ b/shippable.yml
@@ -32,6 +32,8 @@ build:
     # version is scraped in by pip; otherwise, use the cached
     # wheel shippable places on Amazon S3 after we build it once
     - pip install cython --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    # Install fastrlock for locks in random
+    - pip install fastrlock
     # install pytz for datetime testing
     - pip install pytz
     # install pytest-xdist to leverage a second core

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -32,7 +32,7 @@ mkdir -p pypy3
 (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
 pypy3/bin/pypy3 -mensurepip
 pypy3/bin/pypy3 -m pip install --upgrade pip setuptools
-pypy3/bin/pypy3 -m pip install --user cython==0.29.0 pytest pytz --no-warn-script-location
+pypy3/bin/pypy3 -m pip install --user fastrlock cython==0.29.0 pytest pytz --no-warn-script-location
 
 echo
 echo pypy3 version 

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -36,6 +36,6 @@ fi
 
 
 pip install --upgrade pip setuptools
-pip install nose pytz cython pytest
+pip install nose pytz cython pytest fastrlock
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd


### PR DESCRIPTION
This was not meant to be posted here with no note. I think i missed which fork I was targetting. I wanted to create a summary of the changes for discussion.

Going to repost my original comments here for discussion. xref: https://github.com/numpy/numpy/issues/11457#issuecomment-514030619

As stated, I think blaming numpy.testing alone is probably misleading.

There are quite a few other modules that take time.

One of those "innocent" looking ones is:
* `platform`. The only location where it is truely necessary is to create the variable `IS_PYPY`. That said, it seems to import all of `Threading`, which accounts for a large chunk of the import time. If detecting `PyPy` was hard and inconvenient, it might be justified, but in fact, it is as easy as `"PyPy" in sys.version`.
* `Threading` is also imported for a `Lock` in the random module, which is a Cython module. I made a proof of concept where I imported `fastrlock` (ok, I know that we don't need reentrant locks, but I wanted something that look API compatible easily). The random modules are already cython, and thus this is a "small micro optimization" that doesn't add any cost. We can use the same `locking` primitives that fastrlock uses to speed up the whole module.
* `secrets` is quite slow to import. Since we only need it for a few random bits, we can import what we need ourselves. https://github.com/numpy/numpy/pull/14083/files#diff-89944aec176617da993c6de4d9529348R251
* As stated, by other `UnitTest` does take quite a bit of time. The warning in the comments indicates that it is likely only used by packages, that can find the relevant documentation to test numpy as needed.
* `pickle` is quite slow too. `pickle` is a strange one, since many other libraries will import it, but from what I found by removing it, almost everywhere it was used except for `numpy.core._methods`, it is associated with a warning. Not sure if the omission of the warning there was an honest mistake or an API decision. But avoiding the import of pickle can speed things up for those that don't need it. 
https://github.com/numpy/numpy/blob/master/numpy/core/_methods.py#L241
* `textwrap` is not a trivial import. It is only used in 2 location where it makes the code "indented to according to a certain style". It doesn't seem worthwhile to use it to sanitize static strings. https://github.com/numpy/numpy/blob/master/numpy/core/overrides.py#L166 https://github.com/numpy/numpy/blob/master/numpy/ma/core.py#L2448
* `Decimal` takes time, but there isn't much you can do other than ruining code style.
* `pathlib` is also not a trivial import. In fact the one location where it is imported directly has a comment stating that it should not be the prefered method. https://github.com/numpy/numpy/blob/master/numpy/compat/py3k.py#L105
* `shutils` can be lazy imported in the two locations where it is used.

While some of these might be `micro optimizations`, I think many might be well justified to help improve numpy's import time in the near term especially seeing as these optimizations hit code that is considered `soft deprecated` or `convenient for compatibility reasons that no longer exist (i.e. python 2 has been dropped)`.

I'm going to refer to numpy's own benchmarks regarding the amount of time it takes for numpy to import:
https://pv.github.io/numpy-bench/#bench_import.Import.time_numpy

According to those, on some computer somewhere, it might take about 900 ms to import numpy up from 700 ms in recent versions. While the benchmarks running on my laptop are not that slow, it also isn't the cheapest laptop around.

Here is a PR made to my own branch showing the changes in case anybody wanted to glance at them: https://github.com/numpy/numpy/pull/14083

And an image of the improvements as I made the changes.
![image](https://user-images.githubusercontent.com/90008/61677077-355b6a00-accc-11e9-95c1-5d2c9efd9986.png)

I'm happy to cleanup the changes as required.
Other relevant discussion here:
https://news.ycombinator.com/item?id=16978932 linking to a post where python core devs are worried about import time as well.

I get that in many application the caller will likely import `Threading`, or `pathlib` or `platform` themselves, and thus their application will not see the overall benefit or removing all 3 imports, but they might see the slight improvement in removing one of the many dependencies that aren't critical, or, at the very least, they might have a nice way of lazy importing them themselves.


# Summary

The commits here are kinda my only reference. I really want to keep them until a consensus is reached on what should be kept and what shouldn't be:


| Library                          | Performance cost | proposed "fix"           | eric-wieser       |
| -------------------------------- | ---------------- | ------------------------ | ----------------- |
| total master                     | 100 ms  on a good laptop, 1s according to official benchmarks         |                          |                   |
| python core libraries      | 10%              |                          |                   |
| platform https://github.com/numpy/numpy/pull/14098                        | 6%               | avoid (1 line vendor)      |                   |
| np.testing https://github.com/numpy/numpy/pull/14097                      | 9.5%             | remove                   |                   |
| textwrap https://github.com/numpy/numpy/pull/14095                        | 3.4%             | avoid                    | vendor `deindent` |
| pickle                           | 2%               | avoid (deprecated)       |                   |
| pathlib  https://github.com/numpy/numpy/pull/14093                        | 2%               | avoid (remove after 3.6) |                   |
| datetime                         | 1%               | don't know               |                   |
| secrets https://github.com/numpy/numpy/pull/14094                         | 3%               | 1 line vendor              |                   |
| threading (imported by platform) https://github.com/numpy/numpy/pull/14098 | 2%               | avoid                    |                   |


