### PR TITLE
ENH: Propose standard policy for dropping support of old Python versions

### DIFF
--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -2,7 +2,7 @@
 NEP 28 - A standard community policy for dropping support of old Python and Numpy versions
 ==========================================================================================
 
-:Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland, Mattias Bussonier, Stefan van der Walt
+:Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
 :Status: Draft
 :Type: Informational Track
 :Created: 2019-07-13

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -24,34 +24,35 @@ Detailed description
 --------------------
 
 When making a new major or minor release, projects should support all
-minor versions of ``CPython`` initially released in the prior 40
+minor versions of ``CPython`` initially released in the prior 42
 months from their anticipated release date and all minor version of
-``numpy`` released in the prior 24 months.
+NumPy released in the prior 24 months.
 
 
 The diagram::
 
-       Jan 16       Jan 17       Jan 18       Jan 19       Jan 20
-       |            |            |            |            |
-  +++++|++++++++++++|++++++++++++|++++++++++++|++++++++++++|++++++++++++
-   |               |                   |                |
-   py 3.5.0        py 3.6.0            py 3.7.0         py 3.8.0
-        |---------------------------------------> Feb19
-                 |----------------------------------------> Dec19
-                        |----------------------------------------> Jul20
+       Jan 16      Jan 17      Jan 18      Jan 19      Jan 20
+       |           |           |           |           |
+  +++++|+++++++++++|+++++++++++|+++++++++++|+++++++++++|++++++++++++
+   |              |                  |               |
+   py 3.5.0       py 3.6.0           py 3.7.0        py 3.8.0
+  |-----------------------------------------> Feb19
+            |-----------------------------------------> Dec19
+                      |-----------------------------------------> Nov20
 
 shows the support windows for ``CPython``.  A project with a minor
-release in Feb19 or Dec19 should support py36 and newer whereas a
-project released in Jul20 should support py37 and newer.
+release in Feb19 should support py35 and newer, a project with a minor
+release in Dec19 should support py36 and newer, and a project
+with a minor release in Nov20 should support py37 and newer.
 
-The current CPython release cadence is 18 months so a 40 month window
+The current CPython release cadence is 18 months so a 42 month window
 ensures that there will always be at least two versions of ``CPython``
-in the window.  By padding the window by 4 months from the anticipated
+in the window.  By padding the window by 6 months from the anticipated
 ``CPython`` cadence we avoid the edge cases where a project releases
 the month after ``CPython`` and would effectively only support one
-version of ``CPython`` that has an install base.  This buffer
-also makes us resilient to minor fluctuations / delays in the
-``CPython`` release schedule.
+version of ``CPython`` that has an install base (and then the window
+is 42).  This buffer also makes us resilient to minor fluctuations /
+delays in the ``CPython`` release schedule.
 
 Because the threshold for dropping a version of ``CPython`` is based
 on historical release dates and a project's plans, the decision to drop
@@ -75,7 +76,7 @@ development guidelines:
 
 
    - support minor versions of ``CPython`` initially released
-     40 months prior to our planned release date
+     42 months prior to our planned release date
    - always support at least the 2 latest versions of ``CPython``
    - support minor versions of ``numpy`` initially released in the 24
      months prior to our planned release date or oldest that supports the
@@ -142,7 +143,7 @@ N minor versions of Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given the current release cadence of the CPython, the proposed time
-(40 months) is roughly equivalent to "the last two" CPython minor
+(42 months) is roughly equivalent to "the last two" CPython minor
 versions.  However, if CPython changes their release cadence, any rule
 based on the number of minor releases will need to be changed.
 

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -50,10 +50,11 @@ The diagram::
             |-----------------------------------------> Dec19
                       |-----------------------------------------> Nov20
 
-shows the support windows for ``CPython``.  A project with a minor
-release in Feb19 should support py35 and newer, a project with a minor
-release in Dec19 should support py36 and newer, and a project
-with a minor release in Nov20 should support py37 and newer.
+shows the support windows for ``CPython``.  A project with a major or
+minor release in Feb19 should support py35 and newer, a project with a
+major or minor release in Dec19 should support py36 and newer, and a
+project with a major or minor release in Nov20 should support py37 and
+newer.
 
 The current CPython release cadence is 18 months so a 42 month window
 ensures that there will always be at least two versions of ``CPython``

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -1,6 +1,6 @@
-===========================================================================================
-NEP 28 — A standard community policy for dropping support of old CPython and NumPy versions
-===========================================================================================
+==========================================================================================
+NEP 28 — A standard community policy for dropping support of old Python and NumPy versions
+==========================================================================================
 
 
 :Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland <mhaberla@calpoly.edu>, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
@@ -13,7 +13,7 @@ Abstract
 --------
 
 All projects across the ecosystem should adopt a common time window
-based policy for increasing the minimum version of CPython and NumPy
+based policy for increasing the minimum version of Python and NumPy
 that downstream projects support.  By standardizing this policy
 across the community we will make it easier for downstream projects to
 plan.
@@ -34,7 +34,7 @@ Detailed description
 --------------------
 
 When making a new major or minor release, projects should support all
-minor versions of ``CPython`` initially released in the prior 42
+minor versions of ``Python`` initially released in the prior 42
 months from their anticipated release date and all minor version of
 NumPy released in the prior 24 months.
 
@@ -50,33 +50,33 @@ The diagram::
             |-----------------------------------------> Dec19
                       |-----------------------------------------> Nov20
 
-shows the support windows for ``CPython``.  A project with a major or
+shows the support windows for ``Python``.  A project with a major or
 minor release in Feb19 should support py35 and newer, a project with a
 major or minor release in Dec19 should support py36 and newer, and a
 project with a major or minor release in Nov20 should support py37 and
 newer.
 
-The current CPython release cadence is 18 months so a 42 month window
-ensures that there will always be at least two versions of ``CPython``
+The current Python release cadence is 18 months so a 42 month window
+ensures that there will always be at least two versions of ``Python``
 in the window.  By padding the window by 6 months from the anticipated
-``CPython`` cadence we avoid the edge cases where a project releases
-the month after ``CPython`` and would effectively only support one
-version of ``CPython`` that has an install base (and then the window
+``Python`` cadence we avoid the edge cases where a project releases
+the month after ``Python`` and would effectively only support one
+version of ``Python`` that has an install base (and then the window
 is 42).  This buffer also makes us resilient to minor fluctuations /
-delays in the ``CPython`` release schedule.
+delays in the ``Python`` release schedule.
 
-Because the threshold for dropping a version of ``CPython`` is based
+Because the threshold for dropping a version of ``Python`` is based
 on historical release dates and a project's plans, the decision to drop
-support for a given version of ``CPython`` can be made very early in
+support for a given version of ``Python`` can be made very early in
 the release process.
 
 There will be some unavoidable mismatch in supported version of
-``CPython`` between packages immediately after a version of
-``CPython`` ages out.  However this should not last longer than one
+``Python`` between packages immediately after a version of
+``Python`` ages out.  However this should not last longer than one
 release cycle of each of the projects, and when a given project
 does a minor or major release, it is guaranteed that there will be a
 stable release of all other projects that support the set of
-``CPython`` the new release will support.
+``Python`` the new release will support.
 
 
 Implementation
@@ -86,19 +86,19 @@ We suggest that all projects adopt the following language into their
 development guidelines:
 
 
-   - support minor versions of ``CPython`` initially released
+   - support minor versions of ``Python`` initially released
      42 months prior to our planned release date
-   - always support at least the 2 latest versions of ``CPython``
+   - always support at least the 2 latest versions of ``Python``
    - support minor versions of ``numpy`` initially released in the 24
      months prior to our planned release date or oldest that supports the
      minimum Python version (whichever is higher)
 
-   The minimum supported version of ``CPython`` will be set to
+   The minimum supported version of ``Python`` will be set to
    ``python_requires`` in ``setup`` and all supported versions of
-   CPython will be in the test matrix and have binary artifacts built
+   Python will be in the test matrix and have binary artifacts built
    for releases.
 
-   We will bump the minimum CPython and NumPy versions as we can on
+   We will bump the minimum Python and NumPy versions as we can on
    every minor and major release, but never on a patch release.
 
 For other dependencies, adopt similar time windows of 24 months or
@@ -109,7 +109,7 @@ Backward compatibility
 ----------------------
 
 No issues other than the intentional dropping of old version of
-``CPython`` and dependencies.
+``Python`` and dependencies.
 
 
 Alternatives
@@ -119,7 +119,7 @@ Ad-Hoc
 ~~~~~~
 
 Projects could on every release evaluate if they want to increase
-the minimum version of CPython supported.  While this is a notionally
+the minimum version of Python supported.  While this is a notionally
 simple policy, it makes it hard for downstream users to predict what
 the future minimum versions will be.  As there is no objective threshold
 to when the minimum version should be dropped, it is easy for these
@@ -145,7 +145,7 @@ packages to carry fewer version-specific patches.
 Default version on Linux distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The policy could be support the version of CPython that ships by
+The policy could be support the version of Python that ships by
 default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
 would still have to standardize across the community which
 distribution we are following.
@@ -155,17 +155,17 @@ are giving up technical control of our projects to external
 organizations that may have different motivations and concerns than we
 do.
 
-N minor versions of CPython
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+N minor versions of Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Given the current release cadence of the CPython, the proposed time
-(42 months) is roughly equivalent to "the last two" CPython minor
-versions.  However, if CPython changes their release cadence, any rule
+Given the current release cadence of the Python, the proposed time
+(42 months) is roughly equivalent to "the last two" Python minor
+versions.  However, if Python changes their release cadence, any rule
 based on the number of minor releases will need to be changed.
 
 
-Time window on the X.Y.1 CPython release
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Time window on the X.Y.1 Python release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As the first bug fix release is typically a few months after the
 initial release, you can achieve the same effect by using a large delay

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -1,6 +1,6 @@
-==========================================================================================
-NEP 28 — A standard community policy for dropping support of old Python and NumPy versions
-==========================================================================================
+===========================================================================================
+NEP 28 — A standard community policy for dropping support of old CPython and NumPy versions
+===========================================================================================
 
 
 :Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland <mhaberla@calpoly.edu>, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
@@ -13,7 +13,7 @@ Abstract
 --------
 
 All projects across the ecosystem should adopt a common time window
-based policy for increasing the minimum version of Python and NumPy
+based policy for increasing the minimum version of CPython and NumPy
 that downstream projects support.  By standardizing this policy
 across community we will make it easier for down stream projects to
 plan.
@@ -94,10 +94,10 @@ development guidelines:
 
    The minimum supported version of ``CPython`` will be set to
    ``python_requires`` in ``setup`` and all supported versions of
-   Python will be in the test matrix and have binary artifacts built
+   CPython will be in the test matrix and have binary artifacts built
    for releases.
 
-   We will bump the minimum Python and NumPy versions as we can on
+   We will bump the minimum CPython and NumPy versions as we can on
    every minor and major release, but never on a patch release.
 
 For other dependencies, adopt similar time windows 24 months shorter.
@@ -117,7 +117,7 @@ Ad-Hoc
 ~~~~~~
 
 Projects could on every release evaluate if they want to increase
-the minimum version of Python supported.  While this is a notionally
+the minimum version of CPython supported.  While this is a notionally
 simple policy, it makes it hard for downstream users to predict what
 the future minimum versions will be.  As there is no objective threshold
 to when the minimum version should be dropped, it is easy for these
@@ -143,7 +143,7 @@ packages to carry fewer version-specific patches.
 Default version on Linux distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The policy could be support the version of Python that ships by
+The policy could be support the version of CPython that ships by
 default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
 would still have to standardize across the community which
 distribution we are following.
@@ -153,8 +153,8 @@ are giving up technical control of our projects to external
 organizations that may have different motivations and concerns than we
 do.
 
-N minor versions of Python
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+N minor versions of CPython
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given the current release cadence of the CPython, the proposed time
 (42 months) is roughly equivalent to "the last two" CPython minor

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -2,7 +2,8 @@
 NEP 28 - A standard community policy for dropping support of old Python and Numpy versions
 ==========================================================================================
 
-:Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
+
+:Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland <mhaberla@calpoly.edu>, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
 :Status: Draft
 :Type: Informational Track
 :Created: 2019-07-13
@@ -13,7 +14,7 @@ Abstract
 
 All projects across the ecosystem should adopt a common time window
 based policy for increasing the minimum version of Python and numpy
-that down stream projects support.  By standardizing this policy
+that downstream projects support.  By standardizing this policy
 across community we will make it easier for down stream projects to
 plan.
 
@@ -25,7 +26,7 @@ Detailed description
 When making a new major or minor release, projects should support all
 minor versions of ``CPython`` initially released in the prior 40
 months from their anticipated release date and all minor version of
-``numpy`` release in the prior 24 months.
+``numpy`` released in the prior 24 months.
 
 
 The diagram::
@@ -40,10 +41,10 @@ The diagram::
                         |----------------------------------------> Jul20
 
 shows the support windows for ``CPython``.  A project with a minor
-release in Feb19 or Dec19 should support py36 or newer whereas a
+release in Feb19 or Dec19 should support py36 and newer whereas a
 project released in Jul20 should support py37 and newer.
 
-The current CPython release cadence is 18mo so a 40 month window
+The current CPython release cadence is 18 months so a 40 month window
 ensures that there will always be at least two versions of ``CPython``
 in the window.  By padding the window by 4 months from the anticipated
 ``CPython`` cadence we avoid the edge cases where a project releases
@@ -57,10 +58,10 @@ on historical release dates and a project's plans, the decision to drop
 support for a given version of ``CPython`` can be made very early in
 the release process.
 
-There will be some unavoidable miss match in supported version of
+There will be some unavoidable mismatch in supported version of
 ``CPython`` between packages immediately after a version of
-``CPython`` ages out.  However this should not last longer that one
-release cycle of each of the projects and when a given project
+``CPython`` ages out.  However this should not last longer than one
+release cycle of each of the projects, and when a given project
 does a minor or major release, it is guaranteed that there will be a
 stable release of all other projects that support the set of
 ``CPython`` the new release will support.
@@ -69,21 +70,21 @@ stable release of all other projects that support the set of
 Implementation
 --------------
 
-We suggest that all project adopt the following language into their
+We suggest that all projects adopt the following language into their
 development guidelines:
 
 
    - support minor versions of ``CPython`` initially released
-     40 months prior to our planned release date.
-   - always support at least the 2 latest versions of ``CPython``.
+     40 months prior to our planned release date
+   - always support at least the 2 latest versions of ``CPython``
    - support minor versions of ``numpy`` initially released in the 24
      months prior to our planned release date or oldest that supports the
-     minimum python version (which ever is higher)
+     minimum Python version (whichever is higher)
 
-   We will bump the minimum python and numpy versions as we can on
-   every minor and major release, but never on a patch release
+   We will bump the minimum Python and numpy versions as we can on
+   every minor and major release, but never on a patch release.
 
-For other dependencies adopt similar time windows of the same length
+For other dependencies, adopt similar time windows of the same length
 or shorter than 24 months.
 
 
@@ -100,26 +101,26 @@ Alternatives
 Ad-Hoc
 ~~~~~~
 
-Projects could on a every release evaluate if they want to increase
-the minimum version of python supported.  While this is a notionally
-simple policy, it makes it hard for down-stream users to predict what
-the future minimum versions will be.  There is no objective threshold
+Projects could on every release evaluate if they want to increase
+the minimum version of Python supported.  While this is a notionally
+simple policy, it makes it hard for downstream users to predict what
+the future minimum versions will be.  As there is no objective threshold
 to when the minimum version should be dropped, it is easy for these
 discussions to devolve into bike shedding and acrimony.
 
 
-All PSF supported versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+All Python Software Foundation supported versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a very clear and conservative approach.  However it means that
+This is a very clear and conservative approach.  However, it means that
 there is 4 year lag between when new language features come into the
 language and when the projects are able to use them.  Additionally,
 for projects that have a significant component of compiled extensions
 this requires building many binary artifacts for each release.
 
-For the case of numpy, many projects carry work-arounds to bugs that
+For the case of numpy, many projects carry workarounds to bugs that
 are fixed in subsequent versions of numpy.  Being proactive about
-increasing the minimum version of numpy will allow down-stream
+increasing the minimum version of numpy will allow downstream
 packages to carry fewer version-specific patches.
 
 
@@ -127,12 +128,12 @@ packages to carry fewer version-specific patches.
 Default version on Linux distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The policy could be support the version of python that ships by
+The policy could be to support the version of Python that ships by
 default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
 would still have to standardize across the community which
 distribution we are following.
 
-By following the versions supported by major linux distributions we
+By following the versions supported by major Linux distributions, we
 are giving up technical control of our projects to external
 organizations that may have different motivations and concerns than we
 do.
@@ -142,7 +143,7 @@ N minor versions of Python
 
 Given the current release cadence of the CPython, the proposed time
 (40 months) is roughly equivalent to "the last two" CPython minor
-versions.  However, if CPython changes their release cadence any rule
+versions.  However, if CPython changes their release cadence, any rule
 based on the number of minor releases will need to be changed.
 
 

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -1,5 +1,5 @@
 ==========================================================================================
-NEP 28 - A standard community policy for dropping support of old Python and Numpy versions
+NEP 28 - A standard community policy for dropping support of old Python and NumPy versions
 ==========================================================================================
 
 
@@ -13,7 +13,7 @@ Abstract
 --------
 
 All projects across the ecosystem should adopt a common time window
-based policy for increasing the minimum version of Python and numpy
+based policy for increasing the minimum version of Python and NumPy
 that downstream projects support.  By standardizing this policy
 across community we will make it easier for down stream projects to
 plan.
@@ -82,11 +82,15 @@ development guidelines:
      months prior to our planned release date or oldest that supports the
      minimum Python version (whichever is higher)
 
-   We will bump the minimum Python and numpy versions as we can on
+   The minimum supported version of ``CPython`` will be set to
+   ``python_requires`` in ``setup`` and all supported versions of
+   Python will be in the test matrix and have binary artifacts built
+   for releases.
+
+   We will bump the minimum Python and NumPy versions as we can on
    every minor and major release, but never on a patch release.
 
-For other dependencies, adopt similar time windows of the same length
-or shorter than 24 months.
+For other dependencies, adopt similar time windows 24 months shorter.
 
 
 Backward compatibility
@@ -119,9 +123,9 @@ language and when the projects are able to use them.  Additionally,
 for projects that have a significant component of compiled extensions
 this requires building many binary artifacts for each release.
 
-For the case of numpy, many projects carry workarounds to bugs that
-are fixed in subsequent versions of numpy.  Being proactive about
-increasing the minimum version of numpy will allow downstream
+For the case of NumPy, many projects carry workarounds to bugs that
+are fixed in subsequent versions of NumPy.  Being proactive about
+increasing the minimum version of NumPy will allow downstream
 packages to carry fewer version-specific patches.
 
 
@@ -129,7 +133,7 @@ packages to carry fewer version-specific patches.
 Default version on Linux distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The policy could be to support the version of Python that ships by
+The policy could be support the version of Python that ships by
 default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
 would still have to standardize across the community which
 distribution we are following.
@@ -151,8 +155,9 @@ based on the number of minor releases will need to be changed.
 Time window on the X.Y.1 CPython release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can achieve the same name effect by making the window longer which is
-easier to explain.
+As the first bug fix release is typically a few months after the
+initial release, you can achieve the same name effect by making the
+window longer which is easier to explain.
 
 
 Discussion

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -15,11 +15,11 @@ Abstract
 All projects across the ecosystem should adopt a common time window
 based policy for increasing the minimum version of CPython and NumPy
 that downstream projects support.  By standardizing this policy
-across community we will make it easier for down stream projects to
+across the community we will make it easier for downstream projects to
 plan.
 
-This is an unusual NEP in that it is recommendations for community
-wide policy and not for changes to NumPy itself.  However, we do not
+This is an unusual NEP in that it is recommendations for community-wide
+policy and not for changes to NumPy itself.  However, we do not
 currently have a place for SPEEPs (Scientific Python Ecosystem
 Enhancement Proposals) and given NumPy's central role in our community
 this seems like the proper place to document this.

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -100,7 +100,8 @@ development guidelines:
    We will bump the minimum CPython and NumPy versions as we can on
    every minor and major release, but never on a patch release.
 
-For other dependencies, adopt similar time windows 24 months shorter.
+For other dependencies, adopt similar time windows of 24 months or
+shorter.
 
 
 Backward compatibility

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -168,8 +168,8 @@ Time window on the X.Y.1 CPython release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As the first bug fix release is typically a few months after the
-initial release, you can achieve the same name effect by making the
-window longer which is easier to explain.
+initial release, you can achieve the same effect by using a large delay
+from the X.Y.0 release which seems simpler to explain.
 
 
 Discussion

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -18,6 +18,16 @@ that downstream projects support.  By standardizing this policy
 across community we will make it easier for down stream projects to
 plan.
 
+This is an unusual NEP in that it is recommendations for community
+wide policy and not for changes to NumPy itself.  However, we do not
+currently have a place for SPEEPs (Scientific Python Ecosystem
+Enhancement Proposals) and given NumPy's central roll in our community
+this seems like the proper place to document this.
+
+
+This is being put forward by maintainers of Matplotlib, scikit-learn,
+IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.
+
 
 
 Detailed description

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -1,0 +1,167 @@
+==========================================================================================
+NEP 28 - A standard community policy for dropping support of old Python and Numpy versions
+==========================================================================================
+
+:Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland, Mattias Bussonier, Stefan van der Walt
+:Status: Draft
+:Type: Informational Track
+:Created: 2019-07-13
+
+
+Abstract
+--------
+
+All projects across the ecosystem should adopt a common time window
+based policy for increasing the minimum version of Python and numpy
+that down stream projects support.  By standardizing this policy
+across community we will make it easier for down stream projects to
+plan.
+
+
+
+Detailed description
+--------------------
+
+When making a new major or minor release, projects should support all
+minor versions of ``CPython`` initially released in the prior 40
+months from their anticipated release date and all minor version of
+``numpy`` release in the prior 24 months.
+
+
+The diagram::
+
+       Jan 16       Jan 17       Jan 18       Jan 19       Jan 20
+       |            |            |            |            |
+  +++++|++++++++++++|++++++++++++|++++++++++++|++++++++++++|++++++++++++
+   |               |                   |                |
+   py 3.5.0        py 3.6.0            py 3.7.0         py 3.8.0
+        |---------------------------------------> Feb19
+                 |----------------------------------------> Dec19
+                        |----------------------------------------> Jul20
+
+shows the support windows for ``CPython``.  A project with a minor
+release in Feb19 or Dec19 should support py36 or newer whereas a
+project released in Jul20 should support py37 and newer.
+
+The current CPython release cadence is 18mo so a 40 month window
+ensures that there will always be at least two versions of ``CPython``
+in the window.  By padding the window by 4 months from the anticipated
+``CPython`` cadence we avoid the edge cases where a project releases
+the month after ``CPython`` and would effectively only support one
+version of ``CPython`` that has an install base.  This buffer
+also makes us resilient to minor fluctuations / delays in the
+``CPython`` release schedule.
+
+Because the threshold for dropping a version of ``CPython`` is based
+on historical release dates and a project's plans, the decision to drop
+support for a given version of ``CPython`` can be made very early in
+the release process.
+
+There will be some unavoidable miss match in supported version of
+``CPython`` between packages immediately after a version of
+``CPython`` ages out.  However this should not last longer that one
+release cycle of each of the projects and when a given project
+does a minor or major release, it is guaranteed that there will be a
+stable release of all other projects that support the set of
+``CPython`` the new release will support.
+
+
+Implementation
+--------------
+
+We suggest that all project adopt the following language into their
+development guidelines:
+
+
+   - support minor versions of ``CPython`` initially released
+     40 months prior to our planned release date.
+   - always support at least the 2 latest versions of ``CPython``.
+   - support minor versions of ``numpy`` initially released in the 24
+     months prior to our planned release date or oldest that supports the
+     minimum python version (which ever is higher)
+
+   We will bump the minimum python and numpy versions as we can on
+   every minor and major release, but never on a patch release
+
+For other dependencies adopt similar time windows of the same length
+or shorter than 24 months.
+
+
+Backward compatibility
+----------------------
+
+No issues other than the intentional dropping of old version of
+``CPython`` and dependencies.
+
+
+Alternatives
+------------
+
+Ad-Hoc
+~~~~~~
+
+Projects could on a every release evaluate if they want to increase
+the minimum version of python supported.  While this is a notionally
+simple policy, it makes it hard for down-stream users to predict what
+the future minimum versions will be.  There is no objective threshold
+to when the minimum version should be dropped, it is easy for these
+discussions to devolve into bike shedding and acrimony.
+
+
+All PSF supported versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is a very clear and conservative approach.  However it means that
+there is 4 year lag between when new language features come into the
+language and when the projects are able to use them.  Additionally,
+for projects that have a significant component of compiled extensions
+this requires building many binary artifacts for each release.
+
+For the case of numpy, many projects carry work-arounds to bugs that
+are fixed in subsequent versions of numpy.  Being proactive about
+increasing the minimum version of numpy will allow down-stream
+packages to carry fewer version-specific patches.
+
+
+
+Default version on Linux distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The policy could be support the version of python that ships by
+default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
+would still have to standardize across the community which
+distribution we are following.
+
+By following the versions supported by major linux distributions we
+are giving up technical control of our projects to external
+organizations that may have different motivations and concerns than we
+do.
+
+N minor versions of Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given the current release cadence of the CPython, the proposed time
+(40 months) is roughly equivalent to "the last two" CPython minor
+versions.  However, if CPython changes their release cadence any rule
+based on the number of minor releases will need to be changed.
+
+
+Time window on the X.Y.1 CPython release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can achieve the same name effect by making the window longer which is
+easier to explain.
+
+
+Discussion
+----------
+
+
+References and Footnotes
+------------------------
+
+
+Copyright
+---------
+
+This document has been placed in the public domain.

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -21,7 +21,7 @@ plan.
 This is an unusual NEP in that it is recommendations for community
 wide policy and not for changes to NumPy itself.  However, we do not
 currently have a place for SPEEPs (Scientific Python Ecosystem
-Enhancement Proposals) and given NumPy's central roll in our community
+Enhancement Proposals) and given NumPy's central role in our community
 this seems like the proper place to document this.
 
 

--- a/doc/neps/nep-0028-deprecation_policy.rst
+++ b/doc/neps/nep-0028-deprecation_policy.rst
@@ -1,5 +1,5 @@
 ==========================================================================================
-NEP 28 - A standard community policy for dropping support of old Python and NumPy versions
+NEP 28 — A standard community policy for dropping support of old Python and NumPy versions
 ==========================================================================================
 
 

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -132,8 +132,8 @@ No backward compatibility issues.
 Alternatives
 ------------
 
-Ad-Hoc
-~~~~~~
+Ad-Hoc version support
+~~~~~~~~~~~~~~~~~~~~~~
 
 A project could on every release evaluate whether to increase
 the minimum version of Python supported.

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -123,7 +123,7 @@ the minimum version of Python supported.  While this is a notionally
 simple policy, it makes it hard for downstream users to predict what
 the future minimum versions will be.  As there is no objective threshold
 to when the minimum version should be dropped, it is easy for these
-discussions to devolve into bike shedding and acrimony.
+discussions to devolve into [bike shedding](https://en.wikipedia.org/wiki/Wikipedia:Avoid_Parkinson%27s_bicycle-shed_effect) and acrimony.
 
 
 All Python Software Foundation supported versions
@@ -145,7 +145,7 @@ packages to carry fewer version-specific patches.
 Default version on Linux distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The policy could be support the version of Python that ships by
+The policy could be to support the version of Python that ships by
 default in the latest Ubuntu LTS or CentOS/RHEL release.  However, we
 would still have to standardize across the community which
 distribution we are following.

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -78,21 +78,21 @@ version of ``Python`` that has an installed base.
 This six month buffer provides resilience to minor fluctuations /
 delays in the ``Python`` release schedule.
 
-Because ``Python`` version support is based
-on historical release dates, a 42 month time window, and a project's plans, a project can decide to drop
-a given version of ``Python`` very early in
-the release process.
+Because ``Python`` version support is based on historical release
+dates, a 42 month time window, and a project's plans, a project can
+decide to drop a given version of ``Python`` very early in the release
+process.
 
 While there will be some unavoidable mismatch in supported version of
-``Python`` between if a project release occurs immediately after a version of
-``Python`` ages out.  This should not last longer than one
-release cycle of each of the projects, and when a given project
-does a minor or major release, it is guaranteed that there will be a
-stable release of all other projects that support the set of
-``Python`` the new release will support.
+``Python`` between if a project release occurs immediately after a
+version of ``Python`` ages out.  This should not last longer than one
+release cycle of each of the projects, and when a given project does a
+minor or major release, it is guaranteed that there will be a stable
+release of all other projects that support the set of ``Python`` the
+new release will support.
 
-If there is a Python 4 this policy will have to be reviewed in light
-of the community's and projects' best interests.
+If there is a ``Python`` 4 or a NumPy 2 this policy will have to be
+reviewed in light of the community's and projects' best interests.
 
 
 Implementation
@@ -104,18 +104,21 @@ development guidelines:
 
    - This project supports minor versions of ``Python`` initially released
      42 months prior to a planned project release date.
-   - The project will always support at least the 2 latest minor versions of ``Python``
+   - The project will always support at least the 2 latest minor
+     versions of ``Python``
    - support minor versions of ``numpy`` initially released in the 24
-     months prior to a planned project release date or the oldest version that supports the
-     minimum Python version (whichever is higher)
+     months prior to a planned project release date or the oldest
+     version that supports the minimum Python version (whichever is
+     higher)
 
    The minimum supported version of ``Python`` will be set to
    ``python_requires`` in ``setup``.  All supported versions of
    Python will be in the test matrix and have binary artifacts built
    for releases.
 
-   The project will bump (adjust upward) the minimum Python and NumPy version support on
-   every minor and major release, but never on a patch release.
+   The project will bump (adjust upward) the minimum Python and NumPy
+   version support on every minor and major release, but never on a
+   patch release.
 
 For other dependencies, adopt similar time windows of 24 months or
 shorter.

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -211,8 +211,8 @@ N minor versions of Python
 
 Given the current release cadence of the Python, the proposed time
 (42 months) is roughly equivalent to "the last two" Python minor
-versions.  However, if Python changes their release cadence, any rule
-based on the number of minor releases will need to be changed.
+versions.  However, if Python changes their release cadence substantially, any rule
+based solely on the number of minor releases may need to be changed to remain sensible.
 
 
 Time window on the X.Y.1 Python release

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -33,10 +33,23 @@ IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.
 Detailed description
 --------------------
 
-When a project creates a new major or minor release, we recommend that the project should support all
-minor versions of ``Python`` introduced and released in the prior 42
-months ~~from their anticipated release date~~ and all minor versions of
-NumPy released in the prior 24 months.
+For the purposes of this NEP we assume semantic versioning and define:
+
+*major version*
+   A release that change the first number (e.g. X.0.0)
+
+*minor version*
+   A release that changes the second number (e.g x.Y.0)
+
+*patch version*
+   A release that changes the third number (e.g. x.y.Z)
+
+
+When a project creates a new major or minor version, we recommend that
+the project should support all minor versions of ``Python`` introduced
+and released in the prior 42 months ~~from their anticipated release
+date~~ and all minor versions of NumPy released in the prior 24
+months.
 
 
 The diagram::
@@ -50,11 +63,11 @@ The diagram::
             |-----------------------------------------> Dec19
                       |-----------------------------------------> Nov20
 
-shows the 42 month support windows for ``Python``.  A project with a major or
-minor release in Feb19 should support py35 and newer, a project with a
-major or minor release in Dec19 should support py36 and newer, and a
-project with a major or minor release in Nov20 should support py37 and
-newer.
+shows the 42 month support windows for ``Python``.  A project with a
+major or minor version release in Feb19 should support py35 and newer,
+a project with a major or minor version release in Dec19 should
+support py36 and newer, and a project with a major or minor version
+release in Nov20 should support py37 and newer.
 
 The current Python release cadence is 18 months so a 42 month window
 ensures that there will always be at least two versions of ``Python``

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -1,6 +1,6 @@
-==========================================================================================
-NEP 29 — A standard community policy for dropping support of old Python and NumPy versions
-==========================================================================================
+==================================================================================
+NEP 29 — Recommend Python and Numpy version support as a community policy standard
+==================================================================================
 
 
 :Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland <mhaberla@calpoly.edu>, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt
@@ -18,12 +18,12 @@ that downstream projects support.  By standardizing this policy
 across the community we will make it easier for downstream projects to
 plan.
 
-This is an unusual NEP in that it offers recommendations for community-wide
-policy and not for changes to NumPy itself.  However, we do not
-currently have a place for SPEEPs (Scientific Python Ecosystem
-Enhancement Proposals) and given NumPy's central role in our community
-this seems like the proper place to document this.
-
+This is an unusual NEP in that it offers recommendations for
+community-wide policy and not for changes to NumPy itself.  Since a
+common place for SPEEPs (Scientific Python Ecosystem Enhancement
+Proposals) does not exist and given NumPy's central role in the
+ecosystem, a NEP provides a visible place to document the proposed
+policy.
 
 This NEP is being put forward by maintainers of Matplotlib, scikit-learn,
 IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.
@@ -112,9 +112,7 @@ shorter.
 Backward compatibility
 ----------------------
 
-No issues other than the intentional dropping of old version of
-``Python`` and dependencies.
-
+No backward compatibility issues.
 
 Alternatives
 ------------
@@ -131,13 +129,15 @@ version support discussions to devolve into [bike shedding](https://en.wikipedia
 
 
 All CPython supported versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a very clear and conservative approach.  However, it means that
-there is 4 year lag between when new language features come into the
-language and when the projects are able to use them.  Additionally,
-for projects that have a significant component of compiled extensions
-this requires building many binary artifacts for each release.
+The CPython supported versions of Python are listed in the Python
+Developers Guide and the Python PEPs. Supporting these are a very
+clear and conservative approach.  However, it means that there is 4
+year lag between when new language features come into the language and
+when the projects are able to use them.  Additionally, for projects
+that have a significant component of compiled extensions this requires
+building many binary artifacts for each release.
 
 For the case of NumPy, many projects carry workarounds to bugs that
 are fixed in subsequent versions of NumPy.  Being proactive about

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -1,5 +1,5 @@
 ==========================================================================================
-NEP 28 — A standard community policy for dropping support of old Python and NumPy versions
+NEP 29 — A standard community policy for dropping support of old Python and NumPy versions
 ==========================================================================================
 
 

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -78,6 +78,10 @@ does a minor or major release, it is guaranteed that there will be a
 stable release of all other projects that support the set of
 ``Python`` the new release will support.
 
+If there is a major version bump in Python this policy will have to be
+re-addressed as we can not predict how drastic the changes will be and
+how the community will react.
+
 
 Implementation
 --------------

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -221,8 +221,11 @@ predicting the release schedule of Python for the next 3-4 years.  A
 time-based rule is only depends on things that have already happened
 and the length of the support window.
 
-Time window on the X.Y.1 Python release
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+Time window from the X.Y.1 Python release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is equivalent to a few month longer support window from the X.Y.0
 release.  This is because X.Y.1 bug-fix release is typically a few

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -46,7 +46,7 @@ For the purposes of this NEP we assume semantic versioning and define:
 
 
 When a project creates a new major or minor version, we recommend that
-the project should support all minor versions of ``Python`` introduced
+the project should support all minor versions of Python introduced
 and released in the prior 42 months ~~from their anticipated release
 date~~ and all minor versions of NumPy released in the prior 24
 months.
@@ -63,35 +63,35 @@ The diagram::
             |-----------------------------------------> Dec19
                       |-----------------------------------------> Nov20
 
-shows the 42 month support windows for ``Python``.  A project with a
+shows the 42 month support windows for Python.  A project with a
 major or minor version release in Feb19 should support py35 and newer,
 a project with a major or minor version release in Dec19 should
 support py36 and newer, and a project with a major or minor version
 release in Nov20 should support py37 and newer.
 
 The current Python release cadence is 18 months so a 42 month window
-ensures that there will always be at least two versions of ``Python``
+ensures that there will always be at least two versions of Python
 in the window.  By padding the window by 6 months from the anticipated
-``Python`` cadence we avoid the edge cases where a project releases
-the month after ``Python`` and would effectively only support one
-version of ``Python`` that has an installed base.
+Python cadence we avoid the edge cases where a project releases
+the month after Python and would effectively only support one
+version of Python that has an installed base.
 This six month buffer provides resilience to minor fluctuations /
-delays in the ``Python`` release schedule.
+delays in the Python release schedule.
 
-Because ``Python`` version support is based on historical release
+Because Python version support is based on historical release
 dates, a 42 month time window, and a project's plans, a project can
-decide to drop a given version of ``Python`` very early in the release
+decide to drop a given version of Python very early in the release
 process.
 
 While there will be some unavoidable mismatch in supported version of
-``Python`` between if a project release occurs immediately after a
-version of ``Python`` ages out.  This should not last longer than one
+Python between if a project release occurs immediately after a
+version of Python ages out.  This should not last longer than one
 release cycle of each of the projects, and when a given project does a
 minor or major release, it is guaranteed that there will be a stable
-release of all other projects that support the set of ``Python`` the
+release of all other projects that support the set of Python the
 new release will support.
 
-If there is a ``Python`` 4 or a NumPy 2 this policy will have to be
+If there is a Python 4 or a NumPy 2 this policy will have to be
 reviewed in light of the community's and projects' best interests.
 
 
@@ -134,16 +134,16 @@ We suggest that all projects adopt the following language into their
 development guidelines:
 
 
-   - This project supports minor versions of ``Python`` initially released
+   - This project supports minor versions of Python initially released
      42 months prior to a planned project release date.
    - The project will always support at least the 2 latest minor
-     versions of ``Python``
+     versions of Python
    - support minor versions of ``numpy`` initially released in the 24
      months prior to a planned project release date or the oldest
      version that supports the minimum Python version (whichever is
      higher)
 
-   The minimum supported version of ``Python`` will be set to
+   The minimum supported version of Python will be set to
    ``python_requires`` in ``setup``.  All supported versions of
    Python will be in the test matrix and have binary artifacts built
    for releases.

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -84,7 +84,7 @@ decide to drop a given version of Python very early in the release
 process.
 
 While there will be some unavoidable mismatch in supported version of
-Python between if a project release occurs immediately after a
+Python between projects if releases occurs immediately after a
 version of Python ages out.  This should not last longer than one
 release cycle of each of the projects, and when a given project does a
 minor or major release, it is guaranteed that there will be a stable

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -208,11 +208,18 @@ do.
 N minor versions of Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Given the current release cadence of the Python, the proposed time
-(42 months) is roughly equivalent to "the last two" Python minor
-versions.  However, if Python changes their release cadence substantially, any rule
-based solely on the number of minor releases may need to be changed to remain sensible.
+Given the current release cadence of the Python, the proposed time (42
+months) is roughly equivalent to "the last two" Python minor versions.
+However, if Python changes their release cadence substantially, any
+rule based solely on the number of minor releases may need to be
+changed to remain sensible.
 
+A more fundamental problem with a policy based on number of Python
+releases is that it is hard to predict when support for a given minor
+version of Python will be dropped as that requires correctly
+predicting the release schedule of Python for the next 3-4 years.  A
+time-based rule is only depends on things that have already happened
+and the length of the support window.
 
 Time window on the X.Y.1 Python release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -154,9 +154,6 @@ development guidelines:
    version support on every minor and major release, but never on a
    patch release.
 
-For other dependencies, adopt similar time windows of 24 months or
-shorter.
-
 
 Backward compatibility
 ----------------------

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -78,9 +78,8 @@ does a minor or major release, it is guaranteed that there will be a
 stable release of all other projects that support the set of
 ``Python`` the new release will support.
 
-If there is a major version bump in Python this policy will have to be
-re-addressed as we can not predict how drastic the changes will be and
-how the community will react.
+If there is a Python 4 this policy will have to be reviewed in light
+of the community's and projects' best interests.
 
 
 Implementation

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -46,10 +46,12 @@ For the purposes of this NEP we assume semantic versioning and define:
 
 
 When a project creates a new major or minor version, we recommend that
-the project should support all minor versions of Python introduced
-and released in the prior 42 months ~~from their anticipated release
-date~~ and all minor versions of NumPy released in the prior 24
-months.
+the project should support at least all minor versions of Python
+introduced and released in the prior 42 months ~~from their
+anticipated release date~~ with a minimum of 2 minor versions of
+Python, and all minor versions of NumPy released in the prior 24
+months ~~from their anticipated release date~~ with a minimum of 3
+minor versions of NumPy.
 
 
 The diagram::
@@ -79,7 +81,7 @@ This six month buffer provides resilience to minor fluctuations /
 delays in the Python release schedule.
 
 Because Python minor version support is based on historical release
-dates, a 42 month time window, and a project's plans, a project can
+dates, a 36 month time window, and a project's plans, a project can
 decide to drop a given minor version of Python very early in the release
 process.
 
@@ -136,21 +138,24 @@ We suggest that all projects adopt the following language into their
 development guidelines:
 
 
-   - This project supports minor versions of Python initially released
-     42 months prior to a planned project release date.
+   - This project supports at least the minor versions of Python
+     initially released 42 months prior to a planned project release
+     date.
    - The project will always support at least the 2 latest minor
-     versions of Python
+     versions of Python.
    - support minor versions of ``numpy`` initially released in the 24
      months prior to a planned project release date or the oldest
      version that supports the minimum Python version (whichever is
-     higher)
+     higher).
+   - The project will always support at least the 3 latest minor
+     versions of NumPy.
 
    The minimum supported version of Python will be set to
    ``python_requires`` in ``setup``.  All supported minor versions of
    Python will be in the test matrix and have binary artifacts built
    for releases.
 
-   The project will bump (adjust upward) the minimum Python and NumPy
+   The project should adjust upward the minimum Python and NumPy
    version support on every minor and major release, but never on a
    patch release.
 

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -12,20 +12,20 @@ NEP 29 — A standard community policy for dropping support of old Python and Nu
 Abstract
 --------
 
-All projects across the ecosystem should adopt a common time window
+This NEP recommends and encourages all projects across the Scientific Python ecosystem to adopt a common "time window-based" policy for support of Python and NumPy versions. Standardizing a recommendation for project support of minimum Python and NumPy versions will improve downstream project planning.
 based policy for increasing the minimum version of Python and NumPy
 that downstream projects support.  By standardizing this policy
 across the community we will make it easier for downstream projects to
 plan.
 
-This is an unusual NEP in that it is recommendations for community-wide
+This is an unusual NEP in that it offers recommendations for community-wide
 policy and not for changes to NumPy itself.  However, we do not
 currently have a place for SPEEPs (Scientific Python Ecosystem
 Enhancement Proposals) and given NumPy's central role in our community
 this seems like the proper place to document this.
 
 
-This is being put forward by maintainers of Matplotlib, scikit-learn,
+This NEP is being put forward by maintainers of Matplotlib, scikit-learn,
 IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.
 
 
@@ -33,9 +33,9 @@ IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.
 Detailed description
 --------------------
 
-When making a new major or minor release, projects should support all
-minor versions of ``Python`` initially released in the prior 42
-months from their anticipated release date and all minor version of
+When a project creates a new major or minor release, we recommend that the project should support all
+minor versions of ``Python`` introduced and released in the prior 42
+months ~~from their anticipated release date~~ and all minor versions of
 NumPy released in the prior 24 months.
 
 
@@ -50,7 +50,7 @@ The diagram::
             |-----------------------------------------> Dec19
                       |-----------------------------------------> Nov20
 
-shows the support windows for ``Python``.  A project with a major or
+shows the 42 month support windows for ``Python``.  A project with a major or
 minor release in Feb19 should support py35 and newer, a project with a
 major or minor release in Dec19 should support py36 and newer, and a
 project with a major or minor release in Nov20 should support py37 and
@@ -61,18 +61,18 @@ ensures that there will always be at least two versions of ``Python``
 in the window.  By padding the window by 6 months from the anticipated
 ``Python`` cadence we avoid the edge cases where a project releases
 the month after ``Python`` and would effectively only support one
-version of ``Python`` that has an install base (and then the window
-is 42).  This buffer also makes us resilient to minor fluctuations /
+version of ``Python`` that has an installed base.
+This six month buffer provides resilience to minor fluctuations /
 delays in the ``Python`` release schedule.
 
-Because the threshold for dropping a version of ``Python`` is based
-on historical release dates and a project's plans, the decision to drop
-support for a given version of ``Python`` can be made very early in
+Because ``Python`` version support is based
+on historical release dates, a 42 month time window, and a project's plans, a project can decide to drop
+a given version of ``Python`` very early in
 the release process.
 
-There will be some unavoidable mismatch in supported version of
-``Python`` between packages immediately after a version of
-``Python`` ages out.  However this should not last longer than one
+While there will be some unavoidable mismatch in supported version of
+``Python`` between if a project release occurs immediately after a version of
+``Python`` ages out.  This should not last longer than one
 release cycle of each of the projects, and when a given project
 does a minor or major release, it is guaranteed that there will be a
 stable release of all other projects that support the set of
@@ -90,19 +90,19 @@ We suggest that all projects adopt the following language into their
 development guidelines:
 
 
-   - support minor versions of ``Python`` initially released
-     42 months prior to our planned release date
-   - always support at least the 2 latest minor versions of ``Python``
+   - This project supports minor versions of ``Python`` initially released
+     42 months prior to a planned project release date.
+   - The project will always support at least the 2 latest minor versions of ``Python``
    - support minor versions of ``numpy`` initially released in the 24
-     months prior to our planned release date or oldest that supports the
+     months prior to a planned project release date or the oldest version that supports the
      minimum Python version (whichever is higher)
 
    The minimum supported version of ``Python`` will be set to
-   ``python_requires`` in ``setup`` and all supported versions of
+   ``python_requires`` in ``setup``.  All supported versions of
    Python will be in the test matrix and have binary artifacts built
    for releases.
 
-   We will bump the minimum Python and NumPy versions as we can on
+   The project will bump (adjust upward) the minimum Python and NumPy version support on
    every minor and major release, but never on a patch release.
 
 For other dependencies, adopt similar time windows of 24 months or
@@ -122,15 +122,15 @@ Alternatives
 Ad-Hoc
 ~~~~~~
 
-Projects could on every release evaluate if they want to increase
-the minimum version of Python supported.  While this is a notionally
-simple policy, it makes it hard for downstream users to predict what
+A project could on every release evaluate whether to increase
+the minimum version of Python supported.
+As a major downside, an ad-hoc approach makes it hard for downstream users to predict what
 the future minimum versions will be.  As there is no objective threshold
 to when the minimum version should be dropped, it is easy for these
-discussions to devolve into [bike shedding](https://en.wikipedia.org/wiki/Wikipedia:Avoid_Parkinson%27s_bicycle-shed_effect) and acrimony.
+version support discussions to devolve into [bike shedding](https://en.wikipedia.org/wiki/Wikipedia:Avoid_Parkinson%27s_bicycle-shed_effect) and acrimony.
 
 
-All Python Software Foundation supported versions
+All CPython supported versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is a very clear and conservative approach.  However, it means that

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -108,7 +108,8 @@ Jan 07, 2020 3.6+   1.15+
 Jun 23, 2020 3.7+   1.15+
 Jul 23, 2020 3.7+   1.16+
 Jan 13, 2021 3.7+   1.17+
-Dec 26, 2021 3.8+   1.17+
+Jul 26, 2021 3.7+   1.18+
+Dec 26, 2021 3.8+   1.18+
 ============ ====== =====
 
 
@@ -124,6 +125,7 @@ Drop Schedule
   On Jun 23, 2020 drop support for Python 3.6 (initially released on Dec 23, 2016)
   On Jul 23, 2020 drop support for Numpy 1.15 (initially released on Jul 23, 2018)
   On Jan 13, 2021 drop support for Numpy 1.16 (initially released on Jan 13, 2019)
+  On Jul 26, 2021 drop support for Numpy 1.17 (initially released on Jul 26, 2019)
   On Dec 26, 2021 drop support for Python 3.7 (initially released on Jun 27, 2018)
 
 
@@ -247,6 +249,7 @@ Code to generate support and drop schedule tables ::
   Jan 06, 2018: Numpy 1.14
   Jul 23, 2018: Numpy 1.15
   Jan 13, 2019: Numpy 1.16
+  Jul 26, 2019: Numpy 1.17
   """
 
   releases = []
@@ -267,7 +270,7 @@ Code to generate support and drop schedule tables ::
   releases = sorted(releases, key=lambda x: x[0])
 
   minpy = '3.8+'
-  minnum = '1.17+'
+  minnum = '1.18+'
 
   toprint_drop_dates = ['']
   toprint_support_table = []

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -12,11 +12,11 @@ NEP 29 — Recommend Python and Numpy version support as a community policy stan
 Abstract
 --------
 
-This NEP recommends and encourages all projects across the Scientific Python ecosystem to adopt a common "time window-based" policy for support of Python and NumPy versions. Standardizing a recommendation for project support of minimum Python and NumPy versions will improve downstream project planning.
-based policy for increasing the minimum version of Python and NumPy
-that downstream projects support.  By standardizing this policy
-across the community we will make it easier for downstream projects to
-plan.
+This NEP recommends and encourages all projects across the Scientific
+Python ecosystem to adopt a common "time window-based" policy for
+support of Python and NumPy versions. Standardizing a recommendation
+for project support of minimum Python and NumPy versions will improve
+downstream project planning.
 
 This is an unusual NEP in that it offers recommendations for
 community-wide policy and not for changes to NumPy itself.  Since a

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -88,7 +88,7 @@ development guidelines:
 
    - support minor versions of ``Python`` initially released
      42 months prior to our planned release date
-   - always support at least the 2 latest versions of ``Python``
+   - always support at least the 2 latest minor versions of ``Python``
    - support minor versions of ``numpy`` initially released in the 24
      months prior to our planned release date or oldest that supports the
      minimum Python version (whichever is higher)

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -95,6 +95,38 @@ If there is a ``Python`` 4 or a NumPy 2 this policy will have to be
 reviewed in light of the community's and projects' best interests.
 
 
+Support Table
+~~~~~~~~~~~~~
+
+============ ====== =====
+Date         Python NumPy
+------------ ------ -----
+Jan 16, 2019 3.5+   1.13+
+Mar 14, 2019 3.6+   1.13+
+Jun 08, 2019 3.6+   1.14+
+Jan 07, 2020 3.6+   1.15+
+Jun 23, 2020 3.7+   1.15+
+Jul 23, 2020 3.7+   1.16+
+Jan 13, 2021 3.7+   1.17+
+Dec 26, 2021 3.8+   1.17+
+============ ====== =====
+
+
+Drop Schedule
+~~~~~~~~~~~~~
+
+::
+
+  On Jan 16, 2019 drop support for Numpy 1.12 (initially released on Jan 15, 2017)
+  On Mar 14, 2019 drop support for Python 3.5 (initially released on Sep 13, 2015)
+  On Jun 08, 2019 drop support for Numpy 1.13 (initially released on Jun 07, 2017)
+  On Jan 07, 2020 drop support for Numpy 1.14 (initially released on Jan 06, 2018)
+  On Jun 23, 2020 drop support for Python 3.6 (initially released on Dec 23, 2016)
+  On Jul 23, 2020 drop support for Numpy 1.15 (initially released on Jul 23, 2018)
+  On Jan 13, 2021 drop support for Numpy 1.16 (initially released on Jan 13, 2019)
+  On Dec 26, 2021 drop support for Python 3.7 (initially released on Jun 27, 2018)
+
+
 Implementation
 --------------
 
@@ -197,6 +229,63 @@ Discussion
 
 References and Footnotes
 ------------------------
+
+Code to generate support and drop schedule tables ::
+
+  from datetime import datetime, timedelta
+
+  data = """Jan 15, 2017: Numpy 1.12
+  Sep 13, 2015: Python 3.5
+  Jun 27, 2018: Python 3.7
+  Dec 23, 2016: Python 3.6
+  Jun 07, 2017: Numpy 1.13
+  Jan 06, 2018: Numpy 1.14
+  Jul 23, 2018: Numpy 1.15
+  Jan 13, 2019: Numpy 1.16
+  """
+
+  releases = []
+
+  plus42 = timedelta(days=int(365*3.5 + 1))
+  plus24 = timedelta(days=int(365*2 + 1))
+
+  for line in data.splitlines():
+      date, project_version = line.split(':')
+      project, version = project_version.strip().split(' ')
+      release = datetime.strptime(date, '%b %d, %Y')
+      if project.lower() == 'numpy':
+          drop = release + plus24
+      else:
+          drop = release + plus42
+      releases.append((drop, project, version, release))
+
+  releases = sorted(releases, key=lambda x: x[0])
+
+  minpy = '3.8+'
+  minnum = '1.17+'
+
+  toprint_drop_dates = ['']
+  toprint_support_table = []
+  for d, p, v, r in releases[::-1]:
+      df = d.strftime('%b %d, %Y')
+      toprint_drop_dates.append(
+          f'On {df} drop support for {p} {v} '
+          f'(initially released on {r.strftime("%b %d, %Y")})')
+      toprint_support_table.append(f'{df} {minpy:<6} {minnum:<5}')
+      if p.lower() == 'numpy':
+          minnum = v+'+'
+      else:
+          minpy = v+'+'
+
+  for e in toprint_drop_dates[::-1]:
+      print(e)
+
+  print('============ ====== =====')
+  print('Date         Python NumPy')
+  print('------------ ------ -----')
+  for e in toprint_support_table[::-1]:
+      print(e)
+  print('============ ====== =====')
 
 
 Copyright

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -218,9 +218,14 @@ based solely on the number of minor releases may need to be changed to remain se
 Time window on the X.Y.1 Python release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As the first bug fix release is typically a few months after the
-initial release, you can achieve the same effect by using a large delay
-from the X.Y.0 release which seems simpler to explain.
+This is equivalent to a few month longer support window from the X.Y.0
+release.  This is because X.Y.1 bug-fix release is typically a few
+months after the X.Y.0 release, thus a N month window from X.Y.1 is
+roughly equivalent to a N+3 month from X.Y.0.
+
+The X.Y.0 release is naturally a special release.  If we were to
+anchor the window on X.Y.1 we would then have the discussion of why
+not X.Y.M?
 
 
 Discussion

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -70,22 +70,22 @@ support py36 and newer, and a project with a major or minor version
 release in Nov20 should support py37 and newer.
 
 The current Python release cadence is 18 months so a 42 month window
-ensures that there will always be at least two versions of Python
+ensures that there will always be at least two minor versions of Python
 in the window.  By padding the window by 6 months from the anticipated
 Python cadence we avoid the edge cases where a project releases
 the month after Python and would effectively only support one
-version of Python that has an installed base.
+minor version of Python that has an installed base.
 This six month buffer provides resilience to minor fluctuations /
 delays in the Python release schedule.
 
-Because Python version support is based on historical release
+Because Python minor version support is based on historical release
 dates, a 42 month time window, and a project's plans, a project can
-decide to drop a given version of Python very early in the release
+decide to drop a given minor version of Python very early in the release
 process.
 
-While there will be some unavoidable mismatch in supported version of
+While there will be some unavoidable mismatch in supported versions of
 Python between projects if releases occurs immediately after a
-version of Python ages out.  This should not last longer than one
+minor version of Python ages out.  This should not last longer than one
 release cycle of each of the projects, and when a given project does a
 minor or major release, it is guaranteed that there will be a stable
 release of all other projects that support the set of Python the
@@ -146,7 +146,7 @@ development guidelines:
      higher)
 
    The minimum supported version of Python will be set to
-   ``python_requires`` in ``setup``.  All supported versions of
+   ``python_requires`` in ``setup``.  All supported minor versions of
    Python will be in the test matrix and have binary artifacts built
    for releases.
 
@@ -181,7 +181,7 @@ All CPython supported versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The CPython supported versions of Python are listed in the Python
-Developers Guide and the Python PEPs. Supporting these are a very
+Developers Guide and the Python PEPs. Supporting these is a very
 clear and conservative approach.  However, it means that there is 4
 year lag between when new language features come into the language and
 when the projects are able to use them.  Additionally, for projects


### PR DESCRIPTION
This NEP is a proposing a standard policy for the community to determine when we age-out support for old versions of Python.  This came out of in-person discussions at SciPy earlier in July and scattered discussion across github.  This is being proposed by maintainers from Matplotlib, scikit-learn,
IPython, Jupyter, yt, SciPy, NumPy, and scikit-image.

TL;DR:

We propose only supporting versions of Python initially released in the preceding 42 months of a major or minor release of any of our projects.