### PR TITLE
DOC: Use `pip install .` where possible instead of calling setup.py

### DIFF
--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -90,9 +90,6 @@ Other build options
 It's possible to do a parallel build with ``numpy.distutils`` with the ``-j`` option;
 see :ref:`parallel-builds` for more details.
 
-In order to install the development version of NumPy in ``site-packages``, use
-``pip install . --user``.
-
 A similar approach to in-place builds and use of ``PYTHONPATH`` but outside the
 source tree is to use::
 

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -91,12 +91,12 @@ It's possible to do a parallel build with ``numpy.distutils`` with the ``-j`` op
 see :ref:`parallel-builds` for more details.
 
 In order to install the development version of NumPy in ``site-packages``, use
-``python setup.py install --user``.
+``pip install . --user``.
 
 A similar approach to in-place builds and use of ``PYTHONPATH`` but outside the
 source tree is to use::
 
-    $ python setup.py install --prefix /some/owned/folder
+    $ pip install . --prefix /some/owned/folder
     $ export PYTHONPATH=/some/owned/folder/lib/python3.4/site-packages
 
 

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -56,7 +56,7 @@ Basic Installation
 
 To install NumPy run::
 
-    python setup.py install
+    pip install .
 
 To perform an in-place build that can be run from the source folder run::
 

--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -387,7 +387,7 @@ distribution of the ``add.f`` module (as part of the package
 
 Installation of the new package is easy using::
 
-    python setup.py install
+    pip install .
 
 assuming you have the proper permissions to write to the main site-
 packages directory for the version of Python you are using. For the

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -3,7 +3,7 @@
 setup.py for installing F2PY
 
 Usage:
-   python setup.py install
+   pip install .
 
 Copyright 2001-2005 Pearu Peterson all rights reserved,
 Pearu Peterson <pearu@cens.ioc.ee>

--- a/shippable.yml
+++ b/shippable.yml
@@ -43,7 +43,7 @@ build:
     # build first and adjust PATH so f2py is found in scripts dir
     # use > 1 core for build sometimes slows down a fair bit,
     # other times modestly speeds up, so avoid for now
-    - python setup.py install
+    - pip install .
     - extra_directories=($SHIPPABLE_REPO_DIR/build/*scripts*)
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"


### PR DESCRIPTION
pip will itself call setup.py install with the rights options.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
