### PR TITLE
MAINT: adjustments to test_ufunc_noncontigous

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1933,4 +1933,13 @@ def test_ufunc_noncontiguous(ufunc):
             warnings.filterwarnings("always")
             res_c = ufunc(*args_c)
             res_n = ufunc(*args_n)
-        assert_equal(res_c, res_n)
+        dt = np.find_common_type([np.dtype(c) for c in out], [])
+        if np.issubdtype(dt, np.floating):
+            # for floating point results allow a small fuss in comparisons
+            # since different algorithms (libm vs. intrinsics) can be used
+            # for different input strides
+            res_eps = np.finfo(dt).eps
+            tol = 4*res_eps
+            assert_allclose(res_c, res_n, atol=tol, rtol=tol)
+        else:
+            assert_equal(res_c, res_n)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -13,7 +13,7 @@ import numpy.core._rational_tests as _rational_tests
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal,
     assert_almost_equal, assert_array_almost_equal, assert_no_warnings,
-    assert_allclose, assert_array_almost_equal_nulp
+    assert_allclose,
     )
 from numpy.compat import pickle
 


### PR DESCRIPTION
Fixes #14087.

For ufunc where results are floating point arrays allow for some fuss (currently 4*machine epsilon, up for debates) in comparing results evaluated on contiguous and non-contiguous arrays of the same values. 

@charris 