### PR TITLE
MAINT: Improve import time: Avoid importing secrets

### DIFF
--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -36,12 +36,10 @@ import sys
 from itertools import cycle
 import re
 
-try:
-    from secrets import randbits
-except ImportError:
-    # secrets unavailable on python 3.5 and before
-    from random import SystemRandom
-    randbits = SystemRandom().getrandbits
+# The secrets librayr does exist in Python>=3.5, but it is rather slow to load
+# use this instead since it is every so slightly faster to load.
+from random import SystemRandom
+randbits = SystemRandom().getrandbits
 
 try:
     from threading import Lock


### PR DESCRIPTION
This is admittedly a really small gain.
I think it only avoid the import of hashlib.

Feel free to just shut this one down if it isn't worth your keystrokes.

I think the gain here is on the order of 1ms. Hard to measure.

It avoid the import of `hashlib` and `hmac`

![image](https://user-images.githubusercontent.com/90008/61760294-18409d00-ad99-11e9-8589-42be3ce2a027.png)
