### PR TITLE
MAINT: import time: avoid repeated textwrap function dispatch instantiation

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -2,6 +2,7 @@
 import collections
 import functools
 import os
+import textwrap
 
 from numpy.core._multiarray_umath import (
     add_docstring, implement_array_function, _get_implementing_args)
@@ -162,13 +163,13 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         # more interpettable name. Otherwise, the original function does not
         # show up at all in many cases, e.g., if it's written in C or if the
         # dispatcher gets an invalid keyword argument.
-        source = """
-@functools.wraps(implementation)
-def {name}(*args, **kwargs):
-    relevant_args = dispatcher(*args, **kwargs)
-    return implement_array_function(
-        implementation, {name}, relevant_args, args, kwargs)
-""".format(name=implementation.__name__)
+        source = textwrap.dedent("""
+        @functools.wraps(implementation)
+        def {name}(*args, **kwargs):
+            relevant_args = dispatcher(*args, **kwargs)
+            return implement_array_function(
+                implementation, {name}, relevant_args, args, kwargs)
+        """).format(name=implementation.__name__)
 
         source_object = compile(
             source, filename='<__array_function__ internals>', mode='exec')

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -2,7 +2,6 @@
 import collections
 import functools
 import os
-import textwrap
 
 from numpy.core._multiarray_umath import (
     add_docstring, implement_array_function, _get_implementing_args)
@@ -163,13 +162,13 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         # more interpettable name. Otherwise, the original function does not
         # show up at all in many cases, e.g., if it's written in C or if the
         # dispatcher gets an invalid keyword argument.
-        source = textwrap.dedent("""
-        @functools.wraps(implementation)
-        def {name}(*args, **kwargs):
-            relevant_args = dispatcher(*args, **kwargs)
-            return implement_array_function(
-                implementation, {name}, relevant_args, args, kwargs)
-        """).format(name=implementation.__name__)
+        source = """
+@functools.wraps(implementation)
+def {name}(*args, **kwargs):
+    relevant_args = dispatcher(*args, **kwargs)
+    return implement_array_function(
+        implementation, {name}, relevant_args, args, kwargs)
+""".format(name=implementation.__name__)
 
         source_object = compile(
             source, filename='<__array_function__ internals>', mode='exec')

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -25,7 +25,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 import operator
 import warnings
-import textwrap
 import re
 from functools import reduce
 
@@ -2445,32 +2444,32 @@ def _recursive_printoption(result, mask, printopt):
 
 # For better or worse, these end in a newline
 _legacy_print_templates = dict(
-    long_std=textwrap.dedent("""\
-        masked_%(name)s(data =
-         %(data)s,
-        %(nlen)s        mask =
-         %(mask)s,
-        %(nlen)s  fill_value = %(fill)s)
-        """),
-    long_flx=textwrap.dedent("""\
-        masked_%(name)s(data =
-         %(data)s,
-        %(nlen)s        mask =
-         %(mask)s,
-        %(nlen)s  fill_value = %(fill)s,
-        %(nlen)s       dtype = %(dtype)s)
-        """),
-    short_std=textwrap.dedent("""\
-        masked_%(name)s(data = %(data)s,
-        %(nlen)s        mask = %(mask)s,
-        %(nlen)s  fill_value = %(fill)s)
-        """),
-    short_flx=textwrap.dedent("""\
-        masked_%(name)s(data = %(data)s,
-        %(nlen)s        mask = %(mask)s,
-        %(nlen)s  fill_value = %(fill)s,
-        %(nlen)s       dtype = %(dtype)s)
-        """)
+    long_std="""\
+masked_%(name)s(data =
+ %(data)s,
+%(nlen)s        mask =
+ %(mask)s,
+%(nlen)s  fill_value = %(fill)s)
+""",
+    long_flx="""\
+masked_%(name)s(data =
+ %(data)s,
+%(nlen)s        mask =
+ %(mask)s,
+%(nlen)s  fill_value = %(fill)s,
+%(nlen)s       dtype = %(dtype)s)
+""",
+    short_std="""\
+masked_%(name)s(data = %(data)s,
+%(nlen)s        mask = %(mask)s,
+%(nlen)s  fill_value = %(fill)s)
+""",
+    short_flx="""\
+masked_%(name)s(data = %(data)s,
+%(nlen)s        mask = %(mask)s,
+%(nlen)s  fill_value = %(fill)s,
+%(nlen)s       dtype = %(dtype)s)
+"""
 )
 
 ###############################################################################

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -25,6 +25,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import operator
 import warnings
+import textwrap
 import re
 from functools import reduce
 
@@ -2444,32 +2445,32 @@ def _recursive_printoption(result, mask, printopt):
 
 # For better or worse, these end in a newline
 _legacy_print_templates = dict(
-    long_std="""\
-masked_%(name)s(data =
- %(data)s,
-%(nlen)s        mask =
- %(mask)s,
-%(nlen)s  fill_value = %(fill)s)
-""",
-    long_flx="""\
-masked_%(name)s(data =
- %(data)s,
-%(nlen)s        mask =
- %(mask)s,
-%(nlen)s  fill_value = %(fill)s,
-%(nlen)s       dtype = %(dtype)s)
-""",
-    short_std="""\
-masked_%(name)s(data = %(data)s,
-%(nlen)s        mask = %(mask)s,
-%(nlen)s  fill_value = %(fill)s)
-""",
-    short_flx="""\
-masked_%(name)s(data = %(data)s,
-%(nlen)s        mask = %(mask)s,
-%(nlen)s  fill_value = %(fill)s,
-%(nlen)s       dtype = %(dtype)s)
-"""
+    long_std=textwrap.dedent("""\
+        masked_%(name)s(data =
+         %(data)s,
+        %(nlen)s        mask =
+         %(mask)s,
+        %(nlen)s  fill_value = %(fill)s)
+        """),
+    long_flx=textwrap.dedent("""\
+        masked_%(name)s(data =
+         %(data)s,
+        %(nlen)s        mask =
+         %(mask)s,
+        %(nlen)s  fill_value = %(fill)s,
+        %(nlen)s       dtype = %(dtype)s)
+        """),
+    short_std=textwrap.dedent("""\
+        masked_%(name)s(data = %(data)s,
+        %(nlen)s        mask = %(mask)s,
+        %(nlen)s  fill_value = %(fill)s)
+        """),
+    short_flx=textwrap.dedent("""\
+        masked_%(name)s(data = %(data)s,
+        %(nlen)s        mask = %(mask)s,
+        %(nlen)s  fill_value = %(fill)s,
+        %(nlen)s       dtype = %(dtype)s)
+        """)
 )
 
 ###############################################################################


### PR DESCRIPTION
Avoid the use of textwrap to deindent static code. This shaves about 6-8ms ms of import time (at the expense of slightly less readable code depending on who you ask -- but definitely if you ask @eric-wieser)

After: 99.1±2ms
Before: 106±2ms (master)

