### PR TITLE
DOC: fix documentation of i and j for tri.

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -368,7 +368,7 @@ def tri(N, M=None, k=0, dtype=float):
     -------
     tri : ndarray of shape (N, M)
         Array with its lower triangle filled with ones and zero elsewhere;
-        in other words ``T[i,j] == 1`` for ``i <= j + k``, 0 otherwise.
+        in other words ``T[i,j] == 1`` for ``j <= i + k``, 0 otherwise.
 
     Examples
     --------


### PR DESCRIPTION
Fixed the documentation of the return value in `tri` as the rows and columns were seemingly mixed up.