### PR TITLE
BUG: initialize variable that is passed by pointer

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1958,7 +1958,8 @@ linear_search_type_resolver(PyUFuncObject *self,
     npy_intp i, j, nin = self->nin, nop = nin + self->nout;
     int types[NPY_MAXARGS];
     const char *ufunc_name;
-    int no_castable_output, use_min_scalar;
+    int no_castable_output = 0;
+    int use_min_scalar;
 
     /* For making a better error message on coercion error */
     char err_dst_typecode = '-', err_src_typecode = '-';


### PR DESCRIPTION
The variable `no_castable_output` is passed by a pointer to the `ufunc_loop_matches` function in which its value is read at https://github.com/numpy/numpy/blob/3251dc2bdd322e7fe3cf80d8337f0d4624922321/numpy/core/src/umath/ufunc_type_resolution.c#L1709

Maybe I am missing something, but it shouldn't hurt.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
