### PR TITLE
REV: "ENH: Improved performance of PyArray_FromAny for sequences of array-like"

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -969,29 +969,6 @@ class TestCreation(object):
         assert_equal(np.array([long(4), 2**80, long(4)]).dtype, object)
         assert_equal(np.array([2**80, long(4)]).dtype, object)
 
-    def test_sequence_of_array_like(self):
-        class ArrayLike:
-            def __init__(self):
-                self.__array_interface__ = {
-                    "shape": (42,),
-                    "typestr": "<i1",
-                    "data": bytes(42)
-                }
-
-            # Make sure __array_*__ is used instead of Sequence methods.
-            def __iter__(self):
-                raise AssertionError("__iter__ was called")
-
-            def __getitem__(self, idx):
-                raise AssertionError("__getitem__ was called")
-
-            def __len__(self):
-                return 42
-
-        assert_equal(
-            np.array([ArrayLike()]),
-            np.zeros((1, 42), dtype=np.byte))
-
     def test_non_sequence_sequence(self):
         """Should not segfault.
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2454,23 +2454,3 @@ class TestRegression(object):
             __array_interface__ = {}
 
         np.array([T()])
-
-    def test_2d__array__shape(self):
-        class T(object):
-            def __array__(self):
-                return np.ndarray(shape=(0,0))
-
-            # Make sure __array__ is used instead of Sequence methods.
-            def __iter__(self):
-                return iter([])
-
-            def __getitem__(self, idx):
-                raise AssertionError("__getitem__ was called")
-
-            def __len__(self):
-                return 0
-
-
-        t = T()
-        #gh-13659, would raise in broadcasting [x=t for x in result]
-        np.array([t])


### PR DESCRIPTION
This reverts commit 71fc59d587016d6f36007ba06e074d4d4a6b483d
which was part of gh-13399 and the followup commit
ba53a63ee9be7a7bad7685b051a0ef984caa321e from gh-13663.

The issue is that we mix Sequence protocol and `__array__` usage
when coercing arrays. It seems easiest to revert this for the 1.17.x release
and make a larger breaking change in the 1.18.x release cycle.
Since this only occurs for stranger array-likes. This revert is limited
to the 1.17.x branch for now.

---

@charris do you think such a revert is feasible? I have removed the benchmark and test changes from the revert. The PR was a bit of nice maintenance as well, but it seems to me that full revert is "simpler".