### PR TITLE
MAINT: Fix typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["setuptools", "wheel", "cython"]  # PEP 508 specification
       showcontent = true
 
     [[tool.towncrier.type]]
-      directory = "coompatibility"
+      directory = "compatibility"
       name = "Compatibility notes"
       showcontent = true
 


### PR DESCRIPTION
In response to the lowest bullet point of Issue #14112. 
A typing error of "directory = "coompatibility"" changed to "directory = "compatibility"". Present at Line 37.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
