### PR TITLE
DOC: fix markup of news fragment readme

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -26,12 +26,11 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 
 So for example: ``123.new_features.rst`` would have the content:
 
-```
 my_new_feature option for `my_favorite_function`
 ------------------------------------------------
 The ``my_new_feature`` option is now available for `my_favorite_function`.
 To use it, write ``np.my_favorite_function(..., my_new_feature=True)``.
-```
+
 
 Note the use of single-backticks to get an internal link (assuming
 ``my_favorite_function`` is exported from the ``numpy`` namespace), and double-

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -24,12 +24,12 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``improvements``: Performance and edge-case changes
 * ``changes``: Other changes
 
-So for example: ``123.new_features.rst`` would have the content:
+So for example: ``123.new_features.rst`` would have the content::
 
-my_new_feature option for `my_favorite_function`
-------------------------------------------------
-The ``my_new_feature`` option is now available for `my_favorite_function`.
-To use it, write ``np.my_favorite_function(..., my_new_feature=True)``.
+    my_new_feature option for `my_favorite_function`
+    ------------------------------------------------
+    The ``my_new_feature`` option is now available for `my_favorite_function`.
+    To use it, write ``np.my_favorite_function(..., my_new_feature=True)``.
 
 
 Note the use of single-backticks to get an internal link (assuming


### PR DESCRIPTION
fixed reST formatting typo in changelog/README.md. 
Looked like there was an extra pair of    ` ``` `

Before:
![before](https://user-images.githubusercontent.com/43701530/61873911-adac7000-af04-11e9-8d68-f7297b11ea68.png)

After:
![after](https://user-images.githubusercontent.com/43701530/61873926-b604ab00-af04-11e9-8201-6325649a13e1.png)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
