### PR TITLE
DOC: Add blank line above doctest for intersect1d

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -383,6 +383,7 @@ def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
 
     To return the indices of the values common to the input arrays
     along with the intersected values:
+
     >>> x = np.array([1, 1, 2, 3, 4])
     >>> y = np.array([2, 1, 4, 6])
     >>> xy, x_ind, y_ind = np.intersect1d(x, y, return_indices=True)


### PR DESCRIPTION
Backport of #14085 .

The doctest should have a blank line above and below it.
This fixes the generated documentation.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
