### PR TITLE
BUG: Remove the broken clip wrapper

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5870,7 +5870,6 @@ class MaskedArray(ndarray):
         return out[()]
 
     # Array methods
-    clip = _arraymethod('clip', onmask=False)
     copy = _arraymethod('copy')
     diagonal = _arraymethod('diagonal')
     flatten = _arraymethod('flatten')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3035,6 +3035,13 @@ class TestMaskedArrayMethods(object):
         assert_equal(clipped._data, x.clip(2, 8))
         assert_equal(clipped._data, mx._data.clip(2, 8))
 
+    def test_clip_out(self):
+        # gh-14140
+        a = np.arange(10)
+        m = np.ma.MaskedArray(a, mask=[0, 1] * 5)
+        m.clip(0, 5, out=m)
+        assert_equal(m.mask, [0, 1] * 5)
+
     def test_compress(self):
         # test compress
         a = masked_array([1., 2., 3., 4., 5.], fill_value=9999)


### PR DESCRIPTION
ndarray.clip is already just a wrapper for the ufunc, so there is no need to do type-specific wrapping here any more

Fixes #14140 

Backportable via the web UI

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
