### PR TITLE
TST: Allow fuss in testing strided/non-strided exp/log loops

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -14,7 +14,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_raises_regex,
     assert_array_equal, assert_almost_equal, assert_array_almost_equal,
     assert_array_max_ulp, assert_allclose, assert_no_warnings, suppress_warnings,
-    _gen_alignment_data
+    _gen_alignment_data, assert_array_almost_equal_nulp
     )
 
 def on_powerpc():
@@ -700,8 +700,8 @@ class TestExpLogFloat32(object):
             exp_true = np.exp(x_f32)
             log_true = np.log(x_f32)
             for jj in strides:
-                assert_equal(np.exp(x_f32[::jj]), exp_true[::jj])
-                assert_equal(np.log(x_f32[::jj]), log_true[::jj])
+                assert_array_almost_equal_nulp(np.exp(x_f32[::jj]), exp_true[::jj], nulp=2)
+                assert_array_almost_equal_nulp(np.log(x_f32[::jj]), log_true[::jj], nulp=2)
 
 class TestLogAddExp(_FilterInvalids):
     def test_logaddexp_values(self):


### PR DESCRIPTION
This is related to:

https://github.com/numpy/numpy/issues/14087
https://github.com/numpy/numpy/pull/14091

Allows for `nulp` fuss when comparing results of `np.exp`/`np.log` on strided vs. unit-strided float32 arrays.