### PR TITLE
BUG: Make advanced indexing result on read-only subclass writeable

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1699,7 +1699,7 @@ array_subscript(PyArrayObject *self, PyObject *op)
                 PyArray_SHAPE(tmp_arr),
                 PyArray_STRIDES(tmp_arr),
                 PyArray_BYTES(tmp_arr),
-                PyArray_FLAGS(self),
+                PyArray_FLAGS(tmp_arr),
                 (PyObject *)self, (PyObject *)tmp_arr);
         Py_DECREF(tmp_arr);
         if (result == NULL) {

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -625,7 +625,7 @@ class TestSubclasses(object):
 
         a = np.arange(5)
         s = a.view(SubClass)
-        s.setflags(write=False)
+        s.flags.writeable = False
         s_fancy = s[[0, 1, 2]]
         assert_(s_fancy.flags.writeable)
 

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -627,7 +627,7 @@ class TestSubclasses(object):
         s = a.view(SubClass)
         s.setflags(write=False)
         s_fancy = s[[0, 1, 2]]
-        assert_(s_fancy.flags['WRITEABLE'])
+        assert_(s_fancy.flags.writeable)
 
 
     def test_finalize_gets_full_info(self):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -617,6 +617,19 @@ class TestSubclasses(object):
         assert_array_equal(s_bool, a[a > 0])
         assert_array_equal(s_bool.base, a[a > 0])
 
+    def test_fancy_on_read_only(self):
+        # Test that fancy indexing on read-only SubClass does not make a
+        # read-only copy (gh-14132)
+        class SubClass(np.ndarray):
+            pass
+
+        a = np.arange(5)
+        s = a.view(SubClass)
+        s.setflags(write=False)
+        s_fancy = s[[0, 1, 2]]
+        assert_(s_fancy.flags['WRITEABLE'])
+
+
     def test_finalize_gets_full_info(self):
         # Array finalize should be called on the filled array.
         class SubClass(np.ndarray):


### PR DESCRIPTION
Fixes #14132 

Fancy indexing on read-only subclass makes a read-only copy. This PR avoids using the flags of the original array.