### PR TITLE
MAINT: Workaround for Intel compiler bug leading to failing test

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -367,6 +367,18 @@ arr_insert(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
 #define LIKELY_IN_CACHE_SIZE 8
 
+#ifdef __INTEL_COMPILER
+#pragma intel optimization_level 0
+#endif
+static NPY_INLINE npy_intp
+_linear_search(const npy_double key, const npy_double *arr, const npy_intp len, const npy_intp i0)
+{
+    npy_intp i;
+
+    for (i = i0; i < len && key >= arr[i]; i++);
+    return i - 1;
+}
+
 /** @brief find index of a sorted array such that arr[i] <= key < arr[i + 1].
  *
  * If an starting index guess is in-range, the array values around this
@@ -406,10 +418,7 @@ binary_search_with_guess(const npy_double key, const npy_double *arr,
      * From above we know key >= arr[0] when we start.
      */
     if (len <= 4) {
-        npy_intp i;
-
-        for (i = 1; i < len && key >= arr[i]; ++i);
-        return i - 1;
+        return _linear_search(key, arr, len, 1);
     }
 
     if (guess > len - 3) {


### PR DESCRIPTION
Backport of #14185 .

A work-around for Intel C Compiler erroneously incrementing the iterator one extra time when comparing with FP exceptions, such as NAN, leading to failure of the test [test_function_base.py::TestInterp::test_non_finite_any_none](https://github.com/numpy/numpy/blob/master/numpy/lib/tests/test_function_base.py#L2418).

Function `binary_search_with_guess` in `numpy/core/src/multiarray/compiled_base.c` uses linear search when the number of points is small. 

Default compiler optimization level generates machine code that increments the iteration variable one time too many, which does not happen with optimization level 0. 

The fix is to separate line-search into a separate short inline routine and use pragma to suggest Intel C Compiler to compile it with `-O0`. 


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
