### PR TITLE
BUG: Fix uint-overflow if padding with linear_ramp and negative gain (backport)

### DIFF
--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -679,6 +679,30 @@ class TestLinearRamp(object):
         ])
         assert_equal(actual, expected)
 
+    @pytest.mark.parametrize("dtype", (
+        np.sctypes["uint"]
+        + np.sctypes["int"]
+        + np.sctypes["float"]
+        + np.sctypes["complex"]
+    ))
+    def test_negative_difference(self, dtype):
+        """
+        Check correct behavior of unsigned dtypes if there is a negative
+        difference between the edge to pad and `end_values`. Check both cases
+        to be independent of implementation. Test behavior for all other dtypes
+        in case dtype casting interferes with complex dtypes. See gh-14191.
+        """
+        x = np.array([3], dtype=dtype)
+        result = np.pad(x, 3, mode="linear_ramp", end_values=0)
+        expected = np.array([0, 1, 2, 3, 2, 1, 0], dtype=dtype)
+        assert_equal(result, expected)
+
+        x = np.array([0], dtype=dtype)
+        result = np.pad(x, 3, mode="linear_ramp", end_values=3)
+        expected = np.array([3, 2, 1, 0, 1, 2, 3], dtype=dtype)
+        assert_equal(result, expected)
+
+
 
 class TestReflect(object):
     def test_check_simple(self):


### PR DESCRIPTION
Manual backport (see gh-14191 and gh-14209).

In case end_value was greater than the edge values of the array to pad,
the resulting difference was negative and caused overflows in case the
input array used unsigned types. The new behavior will cast to a
compatible signed dtype that is as small as possible (float16 because of
the division).
Note: Simply casting to float64 doesn't work for complex inputs.

Protect against this regression with a new test for all numeric dtypes.

cc @seberg @charris 
