### PR TITLE
ENH: Enable huge pages in all Linux builds

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -27,6 +27,13 @@
 
 #ifdef NPY_OS_LINUX
 #include <sys/mman.h>
+#ifndef MADV_HUGEPAGE
+/*
+ * Use code 14 (MADV_HUGEPAGE) if it isn't defined. This gives a chance of
+ * enabling huge pages even if built with linux kernel < 2.6.38
+ */
+#define MADV_HUGEPAGE 14
+#endif
 #endif
 
 #define NBUCKETS 1024 /* number of buckets for data*/
@@ -76,14 +83,7 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
         if (NPY_UNLIKELY(nelem * esz >= ((1u<<22u)))) {
             npy_uintp offset = 4096u - (npy_uintp)p % (4096u);
             npy_uintp length = nelem * esz - offset;
-#ifdef MADV_HUGEPAGE
             madvise((void*)((npy_uintp)p + offset), length, MADV_HUGEPAGE);
-#else
-            // Use code 14 (MADV_HUGEPAGE) if it isn't defined. This gives
-            // a chance of enabling huge pages even if build with linux
-            // kernel < 2.6.38
-            madvise((void*)((npy_uintp)p + offset), length, 14);
-#endif
         }
 #endif
     }

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -83,6 +83,10 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
         if (NPY_UNLIKELY(nelem * esz >= ((1u<<22u)))) {
             npy_uintp offset = 4096u - (npy_uintp)p % (4096u);
             npy_uintp length = nelem * esz - offset;
+            /**
+             * Intentionally not checking for errors that may be returned by
+             * older kernel versions; optimistically tries enabling huge pages.
+             */
             madvise((void*)((npy_uintp)p + offset), length, MADV_HUGEPAGE);
         }
 #endif


### PR DESCRIPTION
This PR modifies memory allocation in such a way that huge pages for large arrays is enabled in all Linux builds (even if `MADV_HUGEPAGE` is not defined). As per discussion in #14177, this isn't the case currently, which means huge pages may never be available depending on the NumPy build, even if the runtime system supports it. Both conda-forge and pip builds for 1.17.0 seem to not include support for huge pages.

The `madvise()`  [man-pages](http://man7.org/linux/man-pages/man2/madvise.2.html) indicates that it will return `EINVAL` if the `advice` is invalid. At runtime, that means that it will be enabled if available, otherwise for the use case in NumPy it's enough to simply ignore the error to fallback to default behavior.

Fixes #14177 .

cc @hmaarrfk @jakirkham @charris @seberg @mrocklin 