### PR TITLE
TST: Add tests for deprecated C functions (PyArray_As1D, PyArray_As1D)

### DIFF
--- a/doc/release/upcoming_changes/14036.deprecation.rst
+++ b/doc/release/upcoming_changes/14036.deprecation.rst
@@ -1,0 +1,4 @@
+Deprecate `PyArray_As1D`, `PyArray_As2D`
+----------------------------------------
+`PyArray_As1D`, `PyArray_As2D` are deprecated, use
+`PyArray_AsCArray` instead

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -656,6 +656,35 @@ npy_updateifcopy_deprecation(PyObject* NPY_UNUSED(self), PyObject* args)
     Py_RETURN_NONE;
 }
 
+/* used to test PyArray_As1D usage emits not implemented error */
+static PyObject*
+npy_pyarrayas1d_deprecation(PyObject* NPY_UNUSED(self), PyObject* NPY_UNUSED(args))
+{
+    PyObject **result = Py_BuildValue("i", 42);
+    int dim = 4;
+    double arg[2] = {1, 2};
+    int temp = PyArray_As1D(result, (char **)&arg, &dim, NPY_DOUBLE);
+    if (temp < 0) {
+        return NULL;
+    }
+    return *result;
+}
+
+/* used to test PyArray_As2D usage emits not implemented error */
+static PyObject*
+npy_pyarrayas2d_deprecation(PyObject* NPY_UNUSED(self), PyObject* NPY_UNUSED(args))
+{
+    PyObject **result = Py_BuildValue("i", 42);
+    int dim1 = 4;
+    int dim2 = 6;
+    double arg[2][2] = {{1, 2}, {3, 4}};
+    int temp = PyArray_As2D(result, (char ***)&arg, &dim1, &dim2, NPY_DOUBLE);
+    if (temp < 0) {
+        return NULL;
+    }
+    return *result;
+}
+
 /* used to create array with WRITEBACKIFCOPY flag */
 static PyObject*
 npy_create_writebackifcopy(PyObject* NPY_UNUSED(self), PyObject* args)
@@ -1939,6 +1968,12 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"npy_updateifcopy_deprecation",
         npy_updateifcopy_deprecation,
         METH_O, NULL},
+    {"npy_pyarrayas1d_deprecation",
+        npy_pyarrayas1d_deprecation,
+        METH_NOARGS, NULL},
+    {"npy_pyarrayas2d_deprecation",
+        npy_pyarrayas2d_deprecation,
+        METH_NOARGS, NULL},
     {"npy_create_writebackifcopy",
         npy_create_writebackifcopy,
         METH_O, NULL},

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -660,29 +660,37 @@ npy_updateifcopy_deprecation(PyObject* NPY_UNUSED(self), PyObject* args)
 static PyObject*
 npy_pyarrayas1d_deprecation(PyObject* NPY_UNUSED(self), PyObject* NPY_UNUSED(args))
 {
-    PyObject **result = Py_BuildValue("i", 42);
+    PyObject *op = Py_BuildValue("i", 42);
+    PyObject *result = op;
     int dim = 4;
     double arg[2] = {1, 2};
-    int temp = PyArray_As1D(result, (char **)&arg, &dim, NPY_DOUBLE);
+    int temp = PyArray_As1D(&result, (char **)&arg, &dim, NPY_DOUBLE);
     if (temp < 0) {
+        Py_DECREF(op);
         return NULL;
     }
-    return *result;
+    /* op != result */
+    Py_DECREF(op);
+    return result;
 }
 
 /* used to test PyArray_As2D usage emits not implemented error */
 static PyObject*
 npy_pyarrayas2d_deprecation(PyObject* NPY_UNUSED(self), PyObject* NPY_UNUSED(args))
 {
-    PyObject **result = Py_BuildValue("i", 42);
+    PyObject *op = Py_BuildValue("i", 42);
+    PyObject *result = op;
     int dim1 = 4;
     int dim2 = 6;
     double arg[2][2] = {{1, 2}, {3, 4}};
-    int temp = PyArray_As2D(result, (char ***)&arg, &dim1, &dim2, NPY_DOUBLE);
+    int temp = PyArray_As2D(&result, (char ***)&arg, &dim1, &dim2, NPY_DOUBLE);
     if (temp < 0) {
+        Py_DECREF(op);
         return NULL;
     }
-    return *result;
+    /* op != result */
+    Py_DECREF(op);
+    return result;
 }
 
 /* used to create array with WRITEBACKIFCOPY flag */

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -442,6 +442,18 @@ class TestNPY_CHAR(_DeprecationTestCase):
         assert_(npy_char_deprecation() == 'S1')
 
 
+class TestPyArray_AS1D(_DeprecationTestCase):
+    def test_npy_pyarrayas1d_deprecation(self):
+        from numpy.core._multiarray_tests import npy_pyarrayas1d_deprecation
+        assert_raises(NotImplementedError, npy_pyarrayas1d_deprecation)
+
+
+class TestPyArray_AS2D(_DeprecationTestCase):
+    def test_npy_pyarrayas2d_deprecation(self):
+        from numpy.core._multiarray_tests import npy_pyarrayas2d_deprecation
+        assert_raises(NotImplementedError, npy_pyarrayas2d_deprecation)
+
+
 class Test_UPDATEIFCOPY(_DeprecationTestCase):
     """
     v1.14 deprecates creating an array with the UPDATEIFCOPY flag, use


### PR DESCRIPTION
Followup to #14036 , related to #11521 