### PR TITLE
MAINT: Better error message for norm

### DIFF
--- a/numpy/fft/pocketfft.py
+++ b/numpy/fft/pocketfft.py
@@ -271,9 +271,10 @@ def ifft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    fct = 1/n
     if norm is not None and _unitary(norm):
-        fct = 1/sqrt(n)
+        fct = 1/sqrt(max(n, 1))
+    else:
+        fct = 1/max(n, 1)
     output = _raw_fft(a, n, axis, False, False, fct)
     return output
 

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -45,12 +45,16 @@ class TestFFT1D(object):
         assert_allclose(fft1(x) / np.sqrt(30),
                         np.fft.fft(x, norm="ortho"), atol=1e-6)
 
-    def test_ifft(self):
+    @pytest.mark.parametrize('norm', (None, 'ortho'))
+    def test_ifft(self, norm):
         x = random(30) + 1j*random(30)
-        assert_allclose(x, np.fft.ifft(np.fft.fft(x)), atol=1e-6)
         assert_allclose(
-            x, np.fft.ifft(np.fft.fft(x, norm="ortho"), norm="ortho"),
+            x, np.fft.ifft(np.fft.fft(x, norm=norm), norm=norm),
             atol=1e-6)
+        # Ensure we get the correct error message
+        with pytest.raises(ValueError,
+                           match='Invalid number of FFT data points'):
+            np.fft.ifft([], norm=norm)
 
     def test_fft2(self):
         x = random((30, 20)) + 1j*random((30, 20))


### PR DESCRIPTION
While testing https://github.com/cupy/cupy/pull/2355 I found I was getting this error:
```
E     File "/home/larsoner/python/cupy/tests/cupyx_tests/scipy_tests/fft_tests/test_fft.py", line 76, in test_ifft_overwrite
E       **overwrite_kw)
E     File "<__array_function__ internals>", line 6, in ifft
E     File "/home/larsoner/python/numpy/numpy/fft/pocketfft.py", line 274, in ifft
E       fct = 1/n
E   ZeroDivisionError: division by zero
```
This fixes it by ensuring the correct, more informative error message is emitted.