### PR TITLE
ENH: add c-imported modules for freeze analysis in np.random

### DIFF
--- a/numpy/random/__init__.py
+++ b/numpy/random/__init__.py
@@ -177,7 +177,12 @@ __all__ = [
     'zipf',
 ]
 
-from . import mtrand
+# add these for module-freeze analysis (like PyInstaller)
+from . import _pickle
+from . import common
+from . import bounded_integers
+from . import entropy
+
 from .mtrand import *
 from .generator import Generator, default_rng
 from .bit_generator import SeedSequence


### PR DESCRIPTION
Backport of #14141 .

New module `numpy.random` in `1.17.0` caused `ModuleNotFoundError` for module-freeze analysis project like PyInstaller.

```bash
  File "c:\python37-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages\numpy\__init__.py", line 150, in <module>
  File "c:\python37-x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 627, in exec_module
    exec(bytecode, module.__dict__)
  File "site-packages\numpy\random\__init__.py", line 180, in <module>
  File "mtrand.pyx", line 1, in init numpy.random.mtrand
ModuleNotFoundError: No module named 'numpy.random.common'
```

So I added some "hooks" for that.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
