### PR TITLE
BLD: MAINT: change default behavior of build flag appending.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,7 +178,6 @@ jobs:
   # vs. manual setup.py and then runtests.py for testing only
   - powershell: |
       If ($(BITS) -eq 32) {
-         $env:NPY_DISTUTILS_APPEND_FLAGS = 1
          $env:CFLAGS = "-m32"
          $env:LDFLAGS = "-m32"
          $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH

--- a/doc/release/upcoming_changes/14248.changes.rst
+++ b/doc/release/upcoming_changes/14248.changes.rst
@@ -1,0 +1,10 @@
+numpy.distutils: append behavior changed for LDFLAGS and similar
+----------------------------------------------------------------
+`numpy.distutils` has always overridden rather than appended to `LDFLAGS` and
+other similar such environment variables for compiling Fortran extensions. Now
+the default behavior changed to appending - which is the expected behavior in
+most situations.  To preserve the old (overwriting) behavior, set the
+`NPY_DISTUTILS_APPEND_FLAGS` environment variable to 0.  This applies to:
+`LDFLAGS`, `F77FLAGS`, `F90FLAGS`, `FREEFLAGS`, `FOPT`, `FDEBUG`, and `FFLAGS`.
+NumPy 1.16 and 1.17 gave build warnings in situations where this change in
+behavior would have affected the compile flags used.

--- a/doc/release/upcoming_changes/14248.changes.rst
+++ b/doc/release/upcoming_changes/14248.changes.rst
@@ -2,8 +2,8 @@ numpy.distutils: append behavior changed for LDFLAGS and similar
 ----------------------------------------------------------------
 `numpy.distutils` has always overridden rather than appended to `LDFLAGS` and
 other similar such environment variables for compiling Fortran extensions. Now
-the default behavior changed to appending - which is the expected behavior in
-most situations.  To preserve the old (overwriting) behavior, set the
+the default behavior has changed to appending - which is the expected behavior
+in most situations.  To preserve the old (overwriting) behavior, set the
 `NPY_DISTUTILS_APPEND_FLAGS` environment variable to 0.  This applies to:
 `LDFLAGS`, `F77FLAGS`, `F90FLAGS`, `FREEFLAGS`, `FOPT`, `FDEBUG`, and `FFLAGS`.
 NumPy 1.16 and 1.17 gave build warnings in situations where this change in

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -59,17 +59,13 @@ class EnvironmentConfig(object):
             if envvar_contents is not None:
                 envvar_contents = convert(envvar_contents)
                 if var and append:
-                    if os.environ.get('NPY_DISTUTILS_APPEND_FLAGS', '0') == '1':
+                    if os.environ.get('NPY_DISTUTILS_APPEND_FLAGS', '1') == '1':
                         var.extend(envvar_contents)
                     else:
+                        # NPY_DISTUTILS_APPEND_FLAGS was explicitly set to 0
+                        # to keep old (overwrite flags rather than append to
+                        # them) behavior
                         var = envvar_contents
-                        if 'NPY_DISTUTILS_APPEND_FLAGS' not in os.environ.keys():
-                            msg = "{} is used as is, not appended ".format(envvar) + \
-                                  "to flags already defined " + \
-                                  "by numpy.distutils! Use NPY_DISTUTILS_APPEND_FLAGS=1 " + \
-                                  "to obtain appending behavior instead (this " + \
-                                  "behavior will become default in a future release)."
-                            warnings.warn(msg, UserWarning, stacklevel=3)
                 else:
                     var = envvar_contents
         if confvar is not None and self._conf:

--- a/numpy/distutils/tests/test_fcompiler.py
+++ b/numpy/distutils/tests/test_fcompiler.py
@@ -45,37 +45,3 @@ def test_fcompiler_flags(monkeypatch):
         else:
             assert_(new_flags == prev_flags + [new_flag])
 
-
-def test_fcompiler_flags_append_warning(monkeypatch):
-    # Test to check that the warning for append behavior changing in future
-    # is triggered.  Need to use a real compiler instance so that we have
-    # non-empty flags to start with (otherwise the "if var and append" check
-    # will always be false).
-    try:
-        with suppress_warnings() as sup:
-            sup.record()
-            fc = numpy.distutils.fcompiler.new_fcompiler(compiler='gnu95')
-            fc.customize()
-    except numpy.distutils.fcompiler.CompilerNotFound:
-        pytest.skip("gfortran not found, so can't execute this test")
-
-    # Ensure NPY_DISTUTILS_APPEND_FLAGS not defined
-    monkeypatch.delenv('NPY_DISTUTILS_APPEND_FLAGS', raising=False)
-
-    for opt, envvar in customizable_flags:
-        new_flag = '-dummy-{}-flag'.format(opt)
-        with suppress_warnings() as sup:
-            sup.record()
-            prev_flags = getattr(fc.flag_vars, opt)
-
-        monkeypatch.setenv(envvar, new_flag)
-        with suppress_warnings() as sup:
-            sup.record()
-            new_flags = getattr(fc.flag_vars, opt)
-            if prev_flags:
-                # Check that warning was issued
-                assert len(sup.log) == 1
-
-        monkeypatch.delenv(envvar)
-        assert_(new_flags == [new_flag])
-


### PR DESCRIPTION
This is a follow-up to gh-12551. This can lead to hard to understand
build failures, and we've warned that this change was coming for two
releases.