### PR TITLE
BUG: Fixes StopIteration error from 'np.genfromtext' for empty file with skip_header > 0

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1776,12 +1776,13 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                                        replace_space=replace_space)
 
         # Skip the first `skip_header` rows
-        for i in range(skip_header):
-            next(fhd)
-
-        # Keep on until we find the first valid values
-        first_values = None
         try:
+            for i in range(skip_header):
+                next(fhd)
+
+            # Keep on until we find the first valid values
+            first_values = None
+
             while not first_values:
                 first_line = _decode_line(next(fhd), encoding)
                 if (names is True) and (comments is not None):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1681,6 +1681,10 @@ M   33  21.99
             test = np.genfromtxt(data)
             assert_equal(test, np.array([]))
 
+            # when skip_header > 0
+            test = np.genfromtxt(data, skip_header=1)
+            assert_equal(test, np.array([]))
+
     def test_fancy_dtype_alt(self):
         # Check that a nested dtype isn't MIA
         data = TextIO('1,2,3.0\n4,5,6.0\n')


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

[#14225](https://github.com/numpy/numpy/issues/14225)

Instead of throwing a `StopIteration` error when `skip_header > 0` for an empty file, it returns a `UserWarning` and an empty list. This behaviour is consistent with `skip_header=0`,` max_rows > 0` and `skip_rows > 0`. 