### PR TITLE
BUG: fix unexpected zero division warning in np.nper()

### DIFF
--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -302,12 +302,13 @@ def nper(rate, pmt, pv, fv=0, when='end'):
         except FloatingPointError:
             use_zero_rate = True
 
-    if use_zero_rate:
-        return (-fv + pv) / pmt
-    else:
-        A = -(fv + pv)/(pmt+0)
-        B = np.log((-fv+z) / (pv+z))/np.log(1+rate)
-        return np.where(rate == 0, A, B)
+    with np.errstate(divide="ignore"):
+        if use_zero_rate:
+            return (-fv + pv) / pmt
+        else:
+            A = -(fv + pv)/(pmt+0)
+            B = np.log((-fv+z) / (pv+z))/np.log(1+rate)
+            return np.where(rate == 0, A, B)
 
 
 def _ipmt_dispatcher(rate, per, nper, pv, fv=None, when=None):


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Closes #13941. Suppresses zero division warnings when calculating payment terms since ```inf``` is as expected when indicating payment terms cannot be met.