### PR TITLE
BUG: fix inconsistent axes ordering for axis in function `unique`

### DIFF
--- a/doc/release/upcoming_changes/14255.improvement.rst
+++ b/doc/release/upcoming_changes/14255.improvement.rst
@@ -1,0 +1,4 @@
+`unique` has consistent axes order (except the chosen one) when `axis` is not None
+----------------------------------------------------------------------------------
+Using `moveaxis` instead of `swapaxes` when implementation, so that the ordering
+of axes except the axis in arguments will not be broken.

--- a/doc/release/upcoming_changes/14255.improvement.rst
+++ b/doc/release/upcoming_changes/14255.improvement.rst
@@ -1,4 +1,4 @@
-`unique` has consistent axes order (except the chosen one) when `axis` is not None
-----------------------------------------------------------------------------------
-Using `moveaxis` instead of `swapaxes` when implementation, so that the ordering
-of axes except the axis in arguments will not be broken.
+`numpy.unique` has consistent axes order (except the chosen one) when ``axis`` is not None
+------------------------------------------------------------------------------------------
+Using ``moveaxis`` instead of ``swapaxes`` in `numpy.unique`, so that the ordering of axes
+except the axis in arguments will not be broken.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -213,6 +213,7 @@ def unique(ar, return_index=False, return_inverse=False,
     -----
     When an axis is specified the subarrays indexed by the axis are sorted.
     This is done by making the specified axis the first dimension of the array
+    (move the axis to the first dimension to keep the order of the other axes)
     and then flattening the subarrays in C order. The flattened subarrays are
     then viewed as a structured type with each element given a label, with the
     effect that we end up with a 1-D array of structured types that can be

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -264,7 +264,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
     # axis was specified and not None
     try:
-        ar = np.swapaxes(ar, axis, 0)
+        ar = np.moveaxis(ar, axis, 0)
     except np.AxisError:
         # this removes the "axis1" or "axis2" prefix from the error message
         raise np.AxisError(axis, ar.ndim)
@@ -285,7 +285,7 @@ def unique(ar, return_index=False, return_inverse=False,
     def reshape_uniq(uniq):
         uniq = uniq.view(orig_dtype)
         uniq = uniq.reshape(-1, *orig_shape[1:])
-        uniq = np.swapaxes(uniq, 0, axis)
+        uniq = np.moveaxis(uniq, 0, axis)
         return uniq
 
     output = _unique1d(consolidated, return_index,

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -600,8 +600,11 @@ class TestUnique(object):
         assert_array_equal(unique(data, axis=1), result.astype(dtype), msg)
 
         msg = 'Unique with 3d array and axis=2 failed'
-        data3d = np.dstack([data] * 3)
-        result = data3d[..., :1]
+        data3d = np.array([[[1, 1],
+                            [1, 0]],
+                           [[0, 1],
+                            [0, 0]]]).astype(dtype)
+        result = np.take(data3d, [1, 0], axis=2)
         assert_array_equal(unique(data3d, axis=2), result, msg)
 
         uniq, idx, inv, cnt = unique(data, axis=0, return_index=True,


### PR DESCRIPTION
`unique` has is consistent axes order (except the chosen one) when `axis` is not `None` now.
Details in https://github.com/numpy/numpy/issues/14244.

### Change
Using `moveaxis` instead of `swapaxes` when implementation, so that the ordering
of axes except the axis in arguments will not be broken.
