### PR TITLE
DOC: Make Py3K docs C code snippets RST literal blocks

### DIFF
--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -812,20 +812,20 @@ Types with tp_as_sequence defined
 
 PySequenceMethods in py3k are binary compatible with py2k, but some of the
 slots have gone away. I suspect this means some functions need redefining so
-the semantics of the slots needs to be checked.
+the semantics of the slots needs to be checked::
 
-PySequenceMethods foo_sequence_methods = {
-    (lenfunc)0,                                 /* sq_length */
-    (binaryfunc)0,                              /* sq_concat */
-    (ssizeargfunc)0,                            /* sq_repeat */
-    (ssizeargfunc)0,                            /* sq_item */
-    (void *)0,                                  /* nee sq_slice */
-    (ssizeobjargproc)0,                         /* sq_ass_item */
-    (void *)0,                                  /* nee sq_ass_slice */
-    (objobjproc)0,                              /* sq_contains */
-    (binaryfunc)0,                              /* sq_inplace_concat */
-    (ssizeargfunc)0                             /* sq_inplace_repeat */
-};
+    PySequenceMethods foo_sequence_methods = {
+        (lenfunc)0,                                 /* sq_length */
+        (binaryfunc)0,                              /* sq_concat */
+        (ssizeargfunc)0,                            /* sq_repeat */
+        (ssizeargfunc)0,                            /* sq_item */
+        (void *)0,                                  /* nee sq_slice */
+        (ssizeobjargproc)0,                         /* sq_ass_item */
+        (void *)0,                                  /* nee sq_ass_slice */
+        (objobjproc)0,                              /* sq_contains */
+        (binaryfunc)0,                              /* sq_inplace_concat */
+        (ssizeargfunc)0                             /* sq_inplace_repeat */
+    };
 
 
 PyMappingMethods
@@ -840,13 +840,13 @@ Types with tp_as_mapping defined
 * multiarray/arrayobject.c
 
 PyMappingMethods in py3k look to be the same as in py2k. The semantics
-of the slots needs to be checked.
+of the slots needs to be checked::
 
-PyMappingMethods foo_mapping_methods = {
-    (lenfunc)0,                             /* mp_length */
-    (binaryfunc)0,                          /* mp_subscript */
-    (objobjargproc)0                        /* mp_ass_subscript */
-};
+    PyMappingMethods foo_mapping_methods = {
+        (lenfunc)0,                             /* mp_length */
+        (binaryfunc)0,                          /* mp_subscript */
+        (objobjargproc)0                        /* mp_ass_subscript */
+    };
 
 
 PyFile


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Unclear where the rendered RST might be used in the HTML website, but the RST rendering of the file directly on GitHub at least, was less than ideal.