### PR TITLE
ENH: add datetime_strftime

### DIFF
--- a/doc/release/upcoming_changes/14264.new_function.rst
+++ b/doc/release/upcoming_changes/14264.new_function.rst
@@ -1,0 +1,5 @@
+`datetime_strftime`
+-------------------
+The ability to format datetime objects beyond ISO-8601 is provided by
+`datetime_strftime`.  Formatting options closely follow those used by
+the standard library's `.datetime.strftime`.  

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -189,6 +189,57 @@ And here are the time units:
    as      attosecond       +/- 9.2 seconds         [  1969 AD,   1970 AD]
 ======== ================ ======================= ==========================
 
+Converting to Strings
+=====================
+
+Two methods are provided for converting datetime64 arrays to strings.  The
+most basic is :func:`datetime_as_string` which yields an array of ISO 8601
+compliant string, with an optional timezone object to convert from the
+internal naive representation to the desired timezone.  Note how for
+the "US/Eastern" timezone example, the change from Daylight Savings Time to
+Standard Time is reflected in the strings.
+
+.. admonition:: Example
+
+    >>> import pytz
+    >>> d = np.arange('2002-10-27T04:30', 4*60, 60, dtype='datetime64[m]')
+    >>> np.datetime_as_string(d)
+    array(['2002-10-27T04:30', '2002-10-27T05:30', '2002-10-27T06:30',
+    '2002-10-27T07:30'], dtype='<U35')
+    >>> np.datetime_as_string(d, timezone='UTC')
+    array(['2002-10-27T04:30Z', '2002-10-27T05:30Z', '2002-10-27T06:30Z',
+           '2002-10-27T07:30Z'], dtype='<U35')
+    >>> np.datetime_as_string(d, timezone=pytz.timezone('US/Eastern'))
+    array(['2002-10-27T00:30-0400', '2002-10-27T01:30-0400',
+       '2002-10-27T01:30-0500', '2002-10-27T02:30-0500'], dtype='<U39')
+
+If more flexibility is desired, then the :func:`datetime_strftime`
+implements the flexible formatting of `datetime.datetime.strftime`, again
+accepting a timezone argument if wanted.  See `datetime.datetime` for a
+description of all the formatting codes.
+
+.. admonition:: Example
+
+    >>> d = np.arange('2002-10-27T04:30', 4*60, 60, dtype='datetime64[m]')
+    >>> np.datetime_strftime(d, "%Y yday=%j %a weekofyear=%W")
+    array(['2002 yday=300 Sun weekofyear=42',
+           '2002 yday=300 Sun weekofyear=42',
+           '2002 yday=300 Sun weekofyear=42',
+           '2002 yday=300 Sun weekofyear=42'], dtype='<U47')
+
+The only different code from `datetime.datetime` is a way to specify the
+number of decimal points in the sub-seconds specified "%f", as in "%10f"
+below.
+
+.. admonition:: Example
+
+    >>> d = np.arange('2000-10-27T04:30:00.00000003', 400, 100,
+                               dtype='datetime64[ns]')
+    >>> np.datetime_strftime(d, "%H:%M:%S.%10f")
+    array(['04:30:00.0000000300', '04:30:00.0000001300',
+           '04:30:00.0000002300', '04:30:00.0000003300'], dtype='<U33')
+
+
 Business Day Functionality
 ==========================
 

--- a/doc/source/reference/routines.datetime.rst
+++ b/doc/source/reference/routines.datetime.rst
@@ -9,6 +9,7 @@ Datetime Support Functions
    :toctree: generated/
 
    datetime_as_string
+   datetime_strftime
    datetime_data
 
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1629,3 +1629,85 @@ def datetime_as_string(arr, unit=None, timezone=None, casting=None):
     datetime with units 'm' according to the rule 'safe'
     """
     return (arr,)
+
+
+@array_function_from_c_func_and_dispatcher(
+    _multiarray_umath.datetime_strftime)
+def datetime_strftime(arr, fmt=None, timezone=None):
+    """
+    datetime_strftime(arr, fmt="%Y-%m-%dT%H%M%s.%f", timezone=None)
+
+    Convert an array of datetimes into an array of strings.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+        The array of UTC timestamps to format.
+    fmt : str
+        A string specifying the desired format of the date.  Accepted
+        formats can be found in `.datetime.datetime` documentation.  The
+        differences here are 1) "%Y" for years can return more than four-digit
+        years and can return negative years. 2) "%f" for sub-second fractions
+        can have a number of digits specified with an optional number "%10f".
+        The default "%f" is the same as "%6f".
+    timezone : tzinfo
+        Timezone information to use when displaying the datetime. If a tzinfo
+        convert the internal naive time to the timezone specified.  To see the
+        timezone in the string specify "%Z" or "%z" in *fmt* kwarg.
+
+    Returns
+    -------
+    str_arr : ndarray
+        An array of strings the same shape as `arr`.
+
+    Examples
+    --------
+    >>> import pytz
+    >>> d = np.arange('2002-10-27T04:30', 4*60, 60, dtype='datetime64[m]')
+    >>> d
+    array(['2002-10-27T04:30', '2002-10-27T05:30', '2002-10-27T06:30',
+           '2002-10-27T07:30'], dtype='datetime64[m]')
+
+    >>> np.datetime_strftime(d, '%Y-%m-%dT%H:%M:%S')
+    array(['2002-10-27T04:30:00', '2002-10-27T05:30:00',
+           '2002-10-27T06:30:00', '2002-10-27T07:30:00'], dtype='<U37')
+
+    Note that we picked datetimes that cross a DST boundary. Passing in a
+    ``pytz`` timezone object will print the appropriate offset, which we
+    specify with "%z".
+
+    >>> np.datetime_strftime(d, '%Y-%m-%dT%H:%M:%S%z',
+    ...                         timezone=pytz.timezone('US/Eastern'))
+    array(['2002-10-27T00:30:00-0400', '2002-10-27T01:30:00-0400',
+           '2002-10-27T01:30:00-0500', '2002-10-27T02:30:00-0500'],
+           dtype='<U39')
+
+    Large years can be used
+
+    >>> d = np.arange('2000002-10-27T04:30', 4*60, 60, dtype='datetime64[m]')
+    >>> np.datetime_strftime(d, '%Y-%m-%dT%H:%M')
+    array(['2000002-10-27T04:30', '2000002-10-27T05:30',
+           '2000002-10-27T06:30', '2000002-10-27T07:30'], dtype='<U34')
+
+    As can negative years (in Julian days, for illustration).
+
+    >>> d = np.arange('-2000-10-27T04:30', 4*60, 60, dtype='datetime64[m]')
+    >>> np.datetime_strftime(d, '%Y jday=%j %H:%M')
+    array(['-2000 jday=301 04:30', '-2000 jday=301 05:30',
+           '-2000 jday=301 06:30', '-2000 jday=301 07:30'], dtype='<U36')
+
+    Fractional seconds can also be specified.
+
+    >>> d = np.arange('2000-10-27T04:30:00.00000003', 400, 100,
+    ...               dtype='datetime64[ns]')
+    >>> d
+    array(['2000-10-27T04:30:00.000000030', '2000-10-27T04:30:00.000000130',
+           '2000-10-27T04:30:00.000000230', '2000-10-27T04:30:00.000000330'],
+          dtype='datetime64[ns]')
+    >>> np.datetime_strftime(d, '%Y-%m-%dT%H:%M:%S.%8f')
+    array(['2000-10-27T04:30:00.00000003', '2000-10-27T04:30:00.00000013',
+           '2000-10-27T04:30:00.00000023', '2000-10-27T04:30:00.00000033'],
+          dtype='<U41')
+
+    """
+    return (arr,)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -89,7 +89,7 @@ import warnings
 from numpy.compat import bytes, long
 from numpy.core.multiarray import (
         typeinfo, ndarray, array, empty, dtype, datetime_data,
-        datetime_as_string, busday_offset, busday_count, is_busday,
+        datetime_as_string, datetime_strftime, busday_offset, busday_count, is_busday,
         busdaycalendar
         )
 from numpy.core.overrides import set_module
@@ -99,6 +99,7 @@ __all__ = ['sctypeDict', 'sctypeNA', 'typeDict', 'typeNA', 'sctypes',
            'ScalarType', 'obj2sctype', 'cast', 'nbytes', 'sctype2char',
            'maximum_sctype', 'issctype', 'typecodes', 'find_common_type',
            'issubdtype', 'datetime_data', 'datetime_as_string',
+           'datetime_strftime',
            'busday_offset', 'busday_count', 'is_busday', 'busdaycalendar',
            ]
 

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -184,6 +184,12 @@ convert_datetime_metadata_tuple_to_datetime_metadata(PyObject *tuple,
  */
 NPY_NO_EXPORT int
 get_tzoffset_from_pytzinfo(PyObject *timezone, npy_datetimestruct *dts);
+NPY_NO_EXPORT int
+get_tzname_from_pytzinfo(PyObject *timezone, npy_datetimestruct *dts,
+                         char *outstr);
+NPY_NO_EXPORT int
+get_formatted_from_datetimestruct(char *ftm, npy_datetimestruct *dts,
+                                  char *outstr, int strsize);
 
 /*
  * Converts an input object into datetime metadata. The input

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1639,17 +1639,24 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
             sscanf(&fmt[count], "%%%df", &ndigits);
             if (ndigits > 0){
                 count += 2;
+                if (count >= strsize){
+                  goto failov;
+                }
                 ch = fmt[count];
                 while ((ch != 'f') && (count < strsize)){
                     ch = fmt[++count];
                 }
-                if (count > strsize){
+                if (count >= strsize){
                   goto failov;
                 }
             }  /* if ndigits > 0 */
             else{
                 /* could be %f  */
                 ch2 = fmt[++count];
+                if (count >= strsize){
+                  goto failov;
+                }
+
                 if (ch2=='f'){
                     ndigits = 6; /* default for microsecond */
                 }
@@ -1798,7 +1805,7 @@ array_datetime_strftime(PyObject *NPY_UNUSED(self), PyObject *args,
     }
 
     /* Claim a reference to timezone for later */
-    /* Py_XINCREF(timezone_obj); */
+    Py_XINCREF(timezone_obj);
 
     op[0] = (PyArrayObject *)PyArray_FROM_O(arr_in);
     if (op[0] == NULL) {

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1617,8 +1617,9 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
     int count, outcount;
     int ndigits, ind0;
     unsigned int ind;
-    int tzoffset;
+    int tzoffset, fmtlen;
 
+    fmtlen = strlen(fmt);
     newfmt = (char *)malloc((strsize + 1) * sizeof(char));
     /* Get the tzoffset from the timezone if provided */
     tzoffset = -1;
@@ -1631,7 +1632,7 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
     }
 
     outcount = 0;
-    for (count=0; (fmt[count]!=0 && count<strsize); ++count){
+    for (count=0; (fmt[count]!=0 && count<fmtlen); ++count){
         ch = fmt[count];
         ndigits = -1;
         if (ch == '%'){
@@ -1639,21 +1640,21 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
             sscanf(&fmt[count], "%%%df", &ndigits);
             if (ndigits > 0){
                 count += 2;
-                if (count >= strsize){
+                if (count >= fmtlen){
                   goto failov;
                 }
                 ch = fmt[count];
-                while ((ch != 'f') && (count < strsize)){
+                while ((ch != 'f') && (count < fmtlen)){
                     ch = fmt[++count];
                 }
-                if (count >= strsize){
+                if (count >= fmtlen){
                   goto failov;
                 }
             }  /* if ndigits > 0 */
             else{
                 /* could be %f  */
                 ch2 = fmt[++count];
-                if (count >= strsize){
+                if (count >= fmtlen){
                   goto failov;
                 }
 
@@ -1667,8 +1668,7 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
                         get_tzname_from_pytzinfo(timezone_obj, &dts, numstr);
                         for (ind=0; ind<strlen(numstr); ++ind){
                             newfmt[outcount] = numstr[ind];
-                            outcount = _inc_countmax(outcount, strsize);
-                            if (outcount < 0){
+                            if (++outcount >= strsize){
                                 goto failov;
                             }
                         }
@@ -1682,8 +1682,7 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
                         sprintf(numstr, "%+03d%02d", output.quot, output.rem);
                         for (ind=0; ind<strlen(numstr); ++ind){
                             newfmt[outcount] = numstr[ind];
-                            outcount = _inc_countmax(outcount, strsize);
-                            if (outcount < 0){
+                            if (++outcount >= strsize){
                                 goto failov;
                             }
                         }
@@ -1702,8 +1701,7 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
                     }
                     for (ind=ind0; ind<strlen(numstr); ++ind){
                         newfmt[outcount] = numstr[ind];
-                        outcount = _inc_countmax(outcount, strsize);
-                        if (outcount < 0){
+                        if (++outcount >= strsize){
                             goto failov;
                         }
                     }
@@ -1711,24 +1709,20 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
                 else {   /* Other formats */
                     ndigits = -1;
                     newfmt[outcount] = ch;
-                    outcount = _inc_countmax(outcount, strsize);
-                    if (outcount < 0){
+                    if (++outcount >= strsize){
                         goto failov;
                     }
                     newfmt[outcount] = ch2;
-                    outcount = _inc_countmax(outcount, strsize);
-                    if (outcount < 0){
+                    if (++outcount >= strsize){
                         goto failov;
                     }
-
                 }
             }
             if (ndigits > 0){
                 sprintf(numstr, "%06d%06d%06d", dts.us, dts.ps, dts.as);
                 for (ind=0; ind<(unsigned int)ndigits;  ++ind){
                     newfmt[outcount] = numstr[ind];
-                    outcount = _inc_countmax(outcount, strsize);
-                    if (outcount < 0){
+                    if (++outcount >= strsize){
                         goto failov;
                     }
                 }
@@ -1736,8 +1730,7 @@ strftime_from_datastruct(npy_datetimestruct dts, PyObject *timezone_obj,
         }  /* ch == % */
         else {
             newfmt[outcount] = fmt[count];
-            outcount = _inc_countmax(outcount, strsize);
-            if (outcount < 0){
+            if (++outcount >= strsize){
                 goto failov;
             }
         }
@@ -1771,7 +1764,6 @@ failov:
         free(newfmt);
     }
     return -1;
-
 }
 
 

--- a/numpy/core/src/multiarray/datetime_strings.h
+++ b/numpy/core/src/multiarray/datetime_strings.h
@@ -81,4 +81,8 @@ NPY_NO_EXPORT PyObject *
 array_datetime_as_string(PyObject *NPY_UNUSED(self), PyObject *args,
                                 PyObject *kwds);
 
+NPY_NO_EXPORT PyObject *
+array_datetime_strftime(PyObject *NPY_UNUSED(self), PyObject *args,
+                                PyObject *kwds);
+
 #endif

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2062,7 +2062,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     if (file == NULL) {
         return NULL;
     }
-    
+
     if (offset != 0 && strcmp(sep, "") != 0) {
         PyErr_SetString(PyExc_TypeError, "'offset' argument only permitted for binary files");
         Py_XDECREF(type);
@@ -3264,7 +3264,7 @@ array_datetime_data(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
 
     meta = get_datetime_metadata_from_dtype(dtype);
-    Py_DECREF(dtype);    
+    Py_DECREF(dtype); 
     if (meta == NULL) {
         return NULL;
     }
@@ -4197,6 +4197,9 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS, NULL},
     {"datetime_as_string",
         (PyCFunction)array_datetime_as_string,
+        METH_VARARGS | METH_KEYWORDS, NULL},
+    {"datetime_strftime",
+        (PyCFunction)array_datetime_strftime,
         METH_VARARGS | METH_KEYWORDS, NULL},
     /* Datetime business-day API */
     {"busday_offset",


### PR DESCRIPTION
Closes: #14243

Numpy currently has a string repr for `datetime64` that conforms to iso 8601 (i.e. `2001-01-01T12:15:00.000000`).   However, it does not allow for pretty printing or flexibility a-la `srtftime` as provided by the `time` and `datetime` modules, which have a much more generous array of formatting options (see https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).  

Don't get me wrong, I *strongly* prefer the ISO standard, but the motivation here is Matplotlib date formatting, and there are many different preferences to how dates get formatted. 

This PR implements `np.datetime_strftime` to allow other time formats supported by `time` and `datetime`.  The list of formats is exactly the one made by `datetime` with three differences.

1. `%f` (subsecond formatting) takes an integer optional argument: `%4f` will make the sub second formatting have 4 digits.  Defaults to 6 (i.e. same as `datetime`), can go as high as 18 (attoseconds)
2. `%z` only supports `HHMM` formatting for the timezone offset, unlike `datetime` which supports seconds and decimal seconds.  We don't display timezone offsets that are non integer minutes, so the offset won't either.  
3. `%Y` is not necessarily a 4-digit integer; it can be larger and negative.

### Examples:

```python
y = np.arange('-2001-02-05T00:00:10.0000', '-2001-02-05T03:00:10.0000', 
                         dtype='datetime64[h]')
print(np.datetime_strftime(y, fmt="%Y-%m-%dT%H:%M:%S.%2f"))
```

```
['-2001-02-05T00:00:00.00' '-2001-02-05T01:00:00.00'
 '-2001-02-05T02:00:00.00']
```

```python
y = np.arange('2001-02-05T00:00:10.0000', '2001-02-05T03:00:10.0000', 
                        dtype='datetime64[h]')
print(np.datetime_strftime(y, fmt="%Y-%m-%dT%H:%M:%S.%2f %Z", 
                                              timezone=pytz.timezone('US/Pacific')))
print(np.datetime_strftime(y, fmt="%Y-%m-%dT%H:%M:%S.%2f%z", 
                                             timezone=pytz.timezone('US/Pacific')))
```

```
['2001-02-04T16:00:00.00 PST' '2001-02-04T17:00:00.00 PST'
 '2001-02-04T18:00:00.00 PST']
['2001-02-04T16:00:00.00-0800' '2001-02-04T17:00:00.00-0800'
 '2001-02-04T18:00:00.00-0800']
```

```python
y = np.array(['2001-02-05T00:00:10.000000008', '2001-02-05T03:00:10.0000'],
             dtype='datetime64[ns]')
print(np.datetime_strftime(y, fmt="%Y-%m-%dT%H:%M:%S.%9f"))
```
```
['2001-02-05T00:00:10.000000008' '2001-02-05T03:00:10.000000000']
```


### Weaknesses

- The size of the strings that get returned is longer than necessary because we cannot tell how long the year arrays are going to be a-priori without formatting all the strings.  
- A *lot* of code is duplicated between `array_datetime_strftime` and `array_datetime_string`.  
- My understanding is that `datetime64` is now always timezone naive, and its up to the user to supply the timezone on access, hence there is no concept of `local` in this implementation. 


[x] Needs docs; not putting the effort in there until folks are OK w/ the basic idea. 



