### PR TITLE
DOC: remove scipy.org from the breadcrumb formattiong

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -123,7 +123,6 @@ else:
         "scipy_org_logo": False,
         "rootlinks": [("https://numpy.org/", "NumPy.org"),
                       ("https://numpy.org/doc", "Docs"),
-                      ("https://scipy.org/", "Scipy.org"),
                      ]
     }
     html_sidebars = {'index': ['indexsidebar.html', 'searchbox.html']}


### PR DESCRIPTION
Continuation of the formatting of documentation on numpy.org from #14235, this removes the link to scipy.org from the breadcrumbs of links across the top of the documentation pages.