### PR TITLE
[MAINT] backport proper `__all__` lists to 1.13

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -34,7 +34,7 @@ __all__ = [
         'assert_array_max_ulp', 'assert_warns', 'assert_no_warnings',
         'assert_allclose', 'IgnoreException', 'clear_and_catch_warnings',
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
-        'HAS_REFCOUNT', 'suppress_warnings'
+        'HAS_REFCOUNT', 'suppress_warnings', 'assert_array_compare'
         ]
 
 


### PR DESCRIPTION
This blocks replacing all "import numpy.testing.utils" with "import numpy.testing" in 1.13

This was fixed in 1.14:
https://github.com/numpy/numpy/commit/ae84af3b6e6d96e4be408e8a56408290ee1879db#diff-d2424d7d23f870114dd2368c68d4a964R16

