### PR TITLE
BUG: Fix formatting error in exception message

### DIFF
--- a/numpy/random/common.pyx
+++ b/numpy/random/common.pyx
@@ -227,7 +227,7 @@ cdef check_output(object out, object dtype, object size):
         raise ValueError('Supplied output array is not contiguous, writable or aligned.')
     if out_array.dtype != dtype:
         raise TypeError('Supplied output array has the wrong type. '
-                        'Expected {0}, got {0}'.format(dtype, out_array.dtype))
+                        'Expected {0}, got {1}'.format(dtype, out_array.dtype))
     if size is not None:
         try:
             tup_size = tuple(size)

--- a/numpy/random/common.pyx
+++ b/numpy/random/common.pyx
@@ -227,7 +227,7 @@ cdef check_output(object out, object dtype, object size):
         raise ValueError('Supplied output array is not contiguous, writable or aligned.')
     if out_array.dtype != dtype:
         raise TypeError('Supplied output array has the wrong type. '
-                        'Expected {0}, got {1}'.format(dtype, out_array.dtype))
+                        'Expected {0}, got {1}'.format(np.dtype(dtype), out_array.dtype))
     if size is not None:
         try:
             tup_size = tuple(size)


### PR DESCRIPTION
This fixes a simple formatting error in an exception message in `random/common.pyx`. The message is supposed to contain the expected vs. the actually received dtype, but instead contained two times the expected dtype. This would lead to confusing error messages such as `Supplied output array has the wrong type. Expected <class 'numpy.float64'>, got <class 'numpy.float64'>`.

Example code to enforce the error message:
```python
import numpy as np
arr = np.zeros((1,), dtype="float32")
gen = np.random.Generator(np.random.SFC64(0))
gen.random(size=(1,), dtype="float64", out=arr)
```
Output after the fix:
```
TypeError: Supplied output array has the wrong type. Expected <class 'numpy.float64'>, got float32
```