### PR TITLE
ENH: datetime unpacker helpers

### DIFF
--- a/doc/release/upcoming_changes/14276.new_function.rst
+++ b/doc/release/upcoming_changes/14276.new_function.rst
@@ -1,0 +1,8 @@
+Datetime unpacking helper functions
+-----------------------------------
+A set of helper functions that help unpack values from datetime64 arrays
+into integer representations is now available: `.datetime_year`,
+`.datetime_month`, `.datetime_day`, `.datetime_hour`, `.datetime_minute`,
+`.datetime_second`, `.datetime_microsecond`, and `.datetime_wday`.  A
+further function computes the yearday as an array of floats:
+`.datetime_yday`.  

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -189,6 +189,23 @@ And here are the time units:
    as      attosecond       +/- 9.2 seconds         [  1969 AD,   1970 AD]
 ======== ================ ======================= ==========================
 
+Datetime Unpacking
+==================
+
+Convenience functions are provided to unpack calendar elements from datetime
+arrays: `.datetime_year`, `.datetime_month`, `.datetime_day`,
+`.datetime_hour`, `.datetime_minute`, `.datetime_second`, and
+`.datetime_microsecond`.
+
+.. admonition:: Example
+
+    >>> d = np.arange('2015-12-20', 31*3, 15, dtype='datetime64[D]')
+    >>> d
+    array(['2015-12-20', '2016-01-04', '2016-01-19', '2016-02-03',
+           '2016-02-18', '2016-03-04', '2016-03-19'], dtype='datetime64[D]')
+    >>> m = np.datetime_month(d); m
+    array([12,  1,  1,  2,  2,  3,  3])
+
 Business Day Functionality
 ==========================
 

--- a/doc/source/reference/routines.datetime.rst
+++ b/doc/source/reference/routines.datetime.rst
@@ -11,6 +11,25 @@ Datetime Support Functions
    datetime_as_string
    datetime_data
 
+Unpacking Functions
+===================
+
+.. currentmodule:: numpy
+
+.. autosummary::
+  :toctree: generated/
+
+   datetime_year
+   datetime_month
+   datetime_day
+   datetime_hour
+   datetime_minute
+   datetime_second
+   datetime_microsecond
+   datetime_yday
+   datetime_wday
+
+
 
 Business Day Functions
 ======================

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -87,6 +87,9 @@ from . import shape_base
 from .shape_base import *
 from . import einsumfunc
 from .einsumfunc import *
+from . import datetimeutils
+from .datetimeutils import *
+
 del nt
 
 from .fromnumeric import amax as max, amin as min, round_ as round

--- a/numpy/core/datetimeutils.py
+++ b/numpy/core/datetimeutils.py
@@ -1,0 +1,244 @@
+"""
+Utilities for extracting datetime64 information.
+"""
+
+import functools
+import sys
+import warnings
+import sys
+
+from . import overrides
+import numpy as np
+
+__all__ = ['datetime_year', 'datetime_month', 'datetime_day', 'datetime_hour',
+           'datetime_minute', 'datetime_second', 'datetime_microsecond',
+           'datetime_yday', 'datetime_wday']
+
+@overrides.set_module('numpy')
+def datetime_year(arr):
+    """
+    Unpack the year from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the year.
+        Note for fine resolutions (i.e. picoseconds, this may return
+        something close to the internal epoch (1970).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-12-31', 12*3, 12, dtype='datetime64[M]')
+    >>> d
+    array(['2015-12', '2016-12', '2017-12'], dtype='datetime64[M]')
+    >>> y = np.datetime_year(d); y
+    array([2015, 2016, 2017])
+    """
+    return arr.astype('datetime64[Y]').astype(int) + 1970
+
+@overrides.set_module('numpy')
+def datetime_month(arr):
+    """
+    Unpack the month from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the month of year (1-12).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-12-20', 31*3, 15, dtype='datetime64[D]')
+    >>> d
+    array(['2015-12-20', '2016-01-04', '2016-01-19', '2016-02-03',
+           '2016-02-18', '2016-03-04', '2016-03-19'], dtype='datetime64[D]')
+    >>> m = np.datetime_month(d); m
+    array([12,  1,  1,  2,  2,  3,  3])
+    """
+    return arr.astype('datetime64[M]').astype(int) % 12 + 1
+
+@overrides.set_module('numpy')
+def datetime_day(arr):
+    """
+    Unpack the day of month from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the day of thee month (1-31).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-12-20', 31*3, 15, dtype='datetime64[D]')
+    >>> d
+    array(['2015-12-20', '2016-01-04', '2016-01-19', '2016-02-03',
+           '2016-02-18', '2016-03-04', '2016-03-19'], dtype='datetime64[D]')
+    >>> day = np.datetime_day(d); day
+    array([20,  4, 19,  3, 18,  4, 19])
+    """
+    return (arr.astype('datetime64[D]') -
+            arr.astype('datetime64[M]')).astype(int) + 1
+
+@overrides.set_module('numpy')
+def datetime_hour(arr):
+    """
+    Unpack the hour of the day from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the hour of the day (0-23).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-10-03T20:10:13', 60*4, 60, dtype='datetime64[m]')
+    >>> d
+    array(['2015-10-03T20:10', '2015-10-03T21:10', '2015-10-03T22:10',
+           '2015-10-03T23:10'], dtype='datetime64[m]')
+    >>> h = np.datetime_hour(d); h
+    array([20, 21, 22, 23])
+    """
+    return arr.astype('datetime64[h]').astype(int) % 24
+
+@overrides.set_module('numpy')
+def datetime_minute(arr):
+    """
+    Unpack the mintes of hour from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the minute of the hour (0-59).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-10-03T20:10:13', 60*4, 60, dtype='datetime64[s]')
+    >>> d
+    array(['2015-10-03T20:10:13', '2015-10-03T20:11:13',
+           '2015-10-03T20:12:13', '2015-10-03T20:13:13'],
+          dtype='datetime64[s]')
+    >>> m = np.datetime_minute(d); m
+    array([10, 11, 12, 13])
+    """
+    return (arr.astype('datetime64[m]') -
+            arr.astype('datetime64[h]')).astype(int)
+
+@overrides.set_module('numpy')
+def datetime_second(arr):
+    """
+    Unpack the seconds from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the second of the minute (0-59).
+
+    Examples
+    --------
+    >>> d = np.arange('2015-10-03T20:10:13.1', 1000*3, 700,
+    ...               dtype='datetime64[ms]')
+    >>> d
+    array(['2015-10-03T20:10:13.100', '2015-10-03T20:10:13.800',
+           '2015-10-03T20:10:14.500', '2015-10-03T20:10:15.200',
+           '2015-10-03T20:10:15.900'], dtype='datetime64[ms]')
+    >>> s = np.datetime_second(d); s
+    array([13, 13, 14, 15, 15])
+    """
+    return (arr.astype('datetime64[s]') -
+            arr.astype('datetime64[m]')).astype(int)
+
+@overrides.set_module('numpy')
+def datetime_microsecond(arr):
+    """
+    Unpack the microseconds from a datetime64 object.
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array-like of integers representing the microseconds of the second.
+        These range from 0 to 999999, so half a second = 500000.
+
+    Examples
+    --------
+    >>> d = np.arange('2015-10-03T20:10:13.125', 1000*3, 700,
+    ...                dtype='datetime64[ns]')
+    >>> d
+    array(['2015-10-03T20:10:13.125000000', '2015-10-03T20:10:13.125000700',
+           '2015-10-03T20:10:13.125001400', '2015-10-03T20:10:13.125002100',
+           '2015-10-03T20:10:13.125002800'], dtype='datetime64[ns]')
+    >>> m = np.datetime_microsecond(d); m
+    array([125000, 125000, 125001, 125002, 125002])
+    """
+    return (arr.astype('datetime64[us]') -
+            arr.astype('datetime64[s]')).astype(int)
+
+@overrides.set_module('numpy')
+def datetime_yday(arr):
+    """
+    Unpack day of year from datetime64 as floating point
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array like of floats in units of days since 1 Jan 00:00. Note
+    1 Jan 12:00 is 0.5 (some yearday conventions will call this 1.5)
+
+    Examples
+    --------
+    >>> d = np.datetime64('2012-01-01T12:00')
+    >>> np.datetime_yday(d)
+    0.5
+    >>> d = np.datetime64('2012-12-31T12:00')
+    >>> np.datetime_yday(d)  # note this is a leap year
+    365.5
+    """
+
+    td = (arr - arr.astype('datetime64[Y]'))
+    return (td).astype('timedelta64[ns]').astype(float) / 1.e9 / 24 / 3600
+
+@overrides.set_module('numpy')
+def datetime_wday(arr):
+    """
+    Unpack days since Sunday from datetime64 as integer
+
+    Parameters
+    ----------
+    arr : array_like of datetime64
+
+    Returns
+    -------
+    array like of ints in units of days since Sunday [0-6].
+
+    Examples
+    --------
+    >>> d = np.datetime64('2012-12-31T23:30')
+    >>> np.datetime_wday(d)  # a Monday
+    1
+    """
+
+    randomsunday = np.datetime64('1969-12-28')  # actually sunday nearest epoch
+    return (arr - randomsunday).astype('timedelta64[D]').astype(int) % 7

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -90,8 +90,8 @@ from numpy.compat import bytes, long
 from numpy.core.multiarray import (
         typeinfo, ndarray, array, empty, dtype, datetime_data,
         datetime_as_string, busday_offset, busday_count, is_busday,
-        busdaycalendar
-        )
+        busdaycalendar)
+from numpy.core.datetimeutils import *
 from numpy.core.overrides import set_module
 
 # we add more at the bottom
@@ -100,7 +100,9 @@ __all__ = ['sctypeDict', 'sctypeNA', 'typeDict', 'typeNA', 'sctypes',
            'maximum_sctype', 'issctype', 'typecodes', 'find_common_type',
            'issubdtype', 'datetime_data', 'datetime_as_string',
            'busday_offset', 'busday_count', 'is_busday', 'busdaycalendar',
-           ]
+           'datetime_year', 'datetime_month', 'datetime_day',
+           'datetime_hour', 'datetime_minute', 'datetime_second',
+           'datetime_microsecond', 'datetime_yday', 'datetime_wday']
 
 # we don't need all these imports, but we need to keep them for compatibility
 # for users using np.core.numerictypes.UPPER_TABLE

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1694,6 +1694,33 @@ class TestDateTime(object):
                            timezone=tz('US/Central'), casting='unsafe'),
                      '2010-02-15')
 
+    def test_datetime_unpack(self):
+        # test that the unpacking functions work...
+        d = np.arange('2012-12-30T13:42', 24*5, 24, dtype='datetime64[h]')
+        assert_equal(np.datetime_year(d), [2012, 2012, 2013, 2013, 2013])
+        assert_equal(np.datetime_month(d), [12, 12, 1, 1, 1])
+        assert_equal(np.datetime_day(d), [30, 31, 1, 2, 3])
+        # double check leap year
+        d = np.arange('2012-02-27T13:42', 24*5, 24, dtype='datetime64[h]')
+        assert_equal(np.datetime_day(d), [27, 28, 29, 1, 2])
+
+        d = np.arange('2012-02-27T21:42:13', 3600*5, 3403,
+                      dtype='datetime64[s]')
+        assert_equal(np.datetime_hour(d), [21, 22, 23,  0,  1, 2])
+        assert_equal(np.datetime_minute(d), [42, 38, 35, 32, 29, 25])
+        assert_equal(np.datetime_second(d), [13, 56, 39, 22, 5, 48])
+        d = np.arange('2012-02-27T21:42:13.00125', 200000, 45032,
+                      dtype='datetime64[ns]')
+        assert_equal(np.datetime_microsecond(d), np.arange(1250, 1433, 45))
+
+        d = np.array(['2012-01-01T12:00', '2012-12-31T16:00'],
+                     dtype='datetime64[s]')
+        assert_equal(np.datetime_yday(d), np.array([0.5, 365 + 16 / 24]))
+
+        d = np.array(['2012-01-01T12:00', '2012-12-31T16:00',
+                      '2012-12-29T16:00'], dtype='datetime64[s]')
+        assert_equal(np.datetime_wday(d), np.array([0, 1, 6]))
+
     def test_datetime_arange(self):
         # With two datetimes provided as strings
         a = np.arange('2010-01-05', '2010-01-10', dtype='M8[D]')


### PR DESCRIPTION
Closes #13779

This implements simple recipes in python for unpacking years, months, days, etc from `datetime64` arrays.  i.e.

```
    >>> d = np.arange('2015-12-20', 31*3, 15, dtype='datetime64[D]')
    >>> d
    array(['2015-12-20', '2016-01-04', '2016-01-19', '2016-02-03',
           '2016-02-18', '2016-03-04', '2016-03-19'], dtype='datetime64[D]')
    >>> m = np.datetime_month(d); m
    array([12,  1,  1,  2,  2,  3,  3])

```

Not sure about the performance of these functions versus going down to the c-level, but I think this is certainly better than many of the workarounds kicking around on stack overflow.  

- [ ] Squash commits 