### PR TITLE
ENH: Merge empty hist bins

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -274,7 +274,7 @@ def _report_auto_method(x, range):
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    either 'fd' or 'sturges' - whichever has the smaller bin width
 
     See Also
     --------
@@ -282,7 +282,6 @@ def _report_auto_method(x, range):
     """
     fd_bw = _hist_bin_fd(x, range)
     sturges_bw = _hist_bin_sturges(x, range)
-    del range  # unused
     if fd_bw:
         if fd_bw < sturges_bw:
             return 'fd'
@@ -389,8 +388,9 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
         Ravelled data array
     first_edge, last_edge
         Forwarded arguments from `_get_outer_edges`.
-    n_equal_bins : ndarray, optional
-        Ravelled weights array, or None
+    n_equal_bins : 
+        Forwarded arugment from _get_bin_edges,
+        this function only called when n_equal_bins > 2
 
     Returns
     =======

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -505,7 +505,7 @@ def _get_bin_edges(a, bins, range, weights):
             bin_type = np.result_type(bin_type, float)
 
         # bin edges must be computed
-        if all([bins is 'auto', auto_method is 'fd', n_equal_bins>2]):
+        if bins == 'auto' and auto_method == 'fd' and n_equal_bins > 2:
             bin_edges = _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge)
             return bin_edges, None
         

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -262,6 +262,36 @@ def _hist_bin_auto(x, range):
         # limited variance, so we return a len dependent bw estimator
         return sturges_bw
 
+def _report_auto_method(x, range):
+    """
+    return the auto method used given an array
+
+    Parameters
+    ----------
+    x : array_like
+        Input data that is to be histogrammed, trimmed to range. May not
+        be empty.
+
+    Returns
+    -------
+    h : An estimate of the optimal bin width for the given data.
+
+    See Also
+    --------
+    _hist_bin_fd, _hist_bin_sturges
+    """
+    fd_bw = _hist_bin_fd(x, range)
+    sturges_bw = _hist_bin_sturges(x, range)
+    del range  # unused
+    if fd_bw:
+        if fd_bw < sturges_bw:
+            return 'fd'
+        else:
+            return 'sturges'
+    else:
+        # limited variance, so we return a len dependent bw estimator
+        return 'sturges'
+
 # Private dict initialized at module load time
 _hist_bin_selectors = {'stone': _hist_bin_stone,
                        'auto': _hist_bin_auto,
@@ -349,6 +379,41 @@ def _unsigned_subtract(a, b):
         # signed to unsigned
         return np.subtract(a, b, casting='unsafe', dtype=dt)
 
+def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
+    """
+    Computes the bins used internally by `np.histogram(bins='auto')`.
+
+    Parameters
+    ==========
+    a : ndarray
+        Ravelled data array
+    first_edge, last_edge
+        Forwarded arguments from `_get_outer_edges`.
+    n_equal_bins : ndarray, optional
+        Ravelled weights array, or None
+
+    Returns
+    =======
+    bin_edges : ndarray
+        Array of bin edges
+    """
+    keep = (a >= first_edge)
+    keep &= (a <= last_edge)
+    if not np.logical_and.reduce(keep):
+        a = a[keep]
+
+    if a.size == 0:
+        return np.array([0,1])
+
+    width = np.ptp((first_edge,last_edge))/(n_equal_bins)
+    left_edges = np.floor_divide((a - first_edge), width) * width
+    right_edges = left_edges + width
+    inner_edges = np.unique((left_edges, right_edges)) + first_edge
+    edges = np.append(np.append(first_edge, inner_edges), last_edge)
+
+    TOL = width/2
+    widths = np.append(width, np.diff(edges)) #remove bins produced by float errors
+    return edges[(widths>TOL) & (edges <= last_edge)]
 
 def _get_bin_edges(a, bins, range, weights):
     """
@@ -374,6 +439,8 @@ def _get_bin_edges(a, bins, range, weights):
     # parse the overloaded bins argument
     n_equal_bins = None
     bin_edges = None
+    width = None
+    auto_method = None
 
     if isinstance(bins, basestring):
         bin_name = bins
@@ -400,6 +467,8 @@ def _get_bin_edges(a, bins, range, weights):
         else:
             # Do not call selectors on empty arrays
             width = _hist_bin_selectors[bin_name](a, (first_edge, last_edge))
+            if bin_name == 'auto':
+                auto_method = _report_auto_method(a,range)
             if width:
                 n_equal_bins = int(np.ceil(_unsigned_subtract(last_edge, first_edge) / width))
             else:
@@ -436,6 +505,10 @@ def _get_bin_edges(a, bins, range, weights):
             bin_type = np.result_type(bin_type, float)
 
         # bin edges must be computed
+        if all([bins is 'auto', auto_method is 'fd', n_equal_bins>2]):
+            bin_edges = _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge)
+            return bin_edges, None
+        
         bin_edges = np.linspace(
             first_edge, last_edge, n_equal_bins + 1,
             endpoint=True, dtype=bin_type)

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -406,10 +406,12 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
         return np.array([0,1])
 
     width = np.ptp((first_edge,last_edge))/(n_equal_bins)
-    left_edges = np.floor_divide((a - first_edge), width) * width
+    zeroed_min = a - first_edge
+    quantized = np.floor_divide(zeroed_min, width) * width
+    left_edges = np.unique(quantized)
     right_edges = left_edges + width
-    inner_edges = np.unique((left_edges, right_edges)) + first_edge
-    edges = np.append(np.append(first_edge, inner_edges), last_edge)
+    unzeroed_edges = np.unique((left_edges, right_edges)) + first_edge
+    edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
 
     TOL = width/2
     widths = np.append(width, np.diff(edges)) #remove bins produced by float errors

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -421,8 +421,9 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     # edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
 
     TOL = width/2
-    widths = np.concatenate(([width], np.diff(edges)))  # remove bins produced by float errors
-    return bins = edges[widths>TOL][:-1] # remove last extra right edge
+    widths = np.concatenate(([width], np.diff(edges)))
+    bins = edges[widths>TOL][:-1] # remove fp artifacts, remove last extra right edge
+    return bins
 
 def _get_bin_edges(a, bins, range, weights):
     """

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -416,12 +416,13 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     quantized = np.floor_divide(zeroed_min, width) * width
     left_edges = np.unique(quantized) # TODO: consider np.unique(a, return_counts=True)
     right_edges = left_edges + width
-    unzeroed_edges = np.unique((left_edges, right_edges)) + first_edge
-    edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
+    extra_right_edges = right_edges + width # otherwise fp rounding can fill empty bins
+    edges = np.unique((left_edges, right_edges, extra_right_edges)) + first_edge
+    # edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
 
     TOL = width/2
     widths = np.concatenate(([width], np.diff(edges)))  # remove bins produced by float errors
-    return edges[(widths>TOL) & (edges <= last_edge)]
+    return bins = edges[widths>TOL][:-1] # remove last extra right edge
 
 def _get_bin_edges(a, bins, range, weights):
     """

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -405,7 +405,7 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     if a.size == 0:
         return np.array([0,1])
 
-    width = np.ptp((first_edge,last_edge))/(n_equal_bins)
+    width = _unsigned_subtract(last_edge, first_edge) / n_equal_bins
     zeroed_min = a - first_edge
     quantized = np.floor_divide(zeroed_min, width) * width
     left_edges = np.unique(quantized)

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -382,6 +382,11 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     """
     Computes the bins used internally by `np.histogram(bins='auto')`.
 
+    TODO: consider leveraging np.unique(a, return_counts=True)
+    Immediately return the resulting edges and counts, which
+    avoids re-computing bin counts.
+    Significant speed up, but bypasses existing bin counting code.
+
     Parameters
     ==========
     a : ndarray
@@ -408,7 +413,7 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     width = np.ptp((first_edge,last_edge))/(n_equal_bins)
     zeroed_min = a - first_edge
     quantized = np.floor_divide(zeroed_min, width) * width
-    left_edges = np.unique(quantized)
+    left_edges = np.unique(quantized) # TODO: consider np.unique(a, return_counts=True)
     right_edges = left_edges + width
     unzeroed_edges = np.unique((left_edges, right_edges)) + first_edge
     edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -418,7 +418,6 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     right_edges = left_edges + width
     extra_right_edges = right_edges + width # otherwise fp rounding can fill empty bins
     edges = np.unique((left_edges, right_edges, extra_right_edges)) + first_edge
-    # edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
 
     TOL = width/2
     widths = np.concatenate(([width], np.diff(edges)))

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -410,7 +410,8 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     if a.size == 0:
         return np.array([0,1])
 
-    width = _unsigned_subtract(last_edge, first_edge) / n_equal_bins
+    fd_width = _unsigned_subtract(last_edge, first_edge) / n_equal_bins
+    width = fd_width if (last_edge/fd_width <= 1e+16) else last_edge/1e+16 # fp resolution
     zeroed_min = a - first_edge
     quantized = np.floor_divide(zeroed_min, width) * width
     left_edges = np.unique(quantized) # TODO: consider np.unique(a, return_counts=True)

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -414,7 +414,7 @@ def _get_auto_bin_edges(a, n_equal_bins, first_edge, last_edge):
     edges = np.concatenate(([first_edge], unzeroed_edges, [last_edge]))
 
     TOL = width/2
-    widths = np.append(width, np.diff(edges)) #remove bins produced by float errors
+    widths = np.concatenate(([width], np.diff(edges)))  # remove bins produced by float errors
     return edges[(widths>TOL) & (edges <= last_edge)]
 
 def _get_bin_edges(a, bins, range, weights):

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -600,6 +600,16 @@ class TestHistogramOptimBinNums(object):
             assert_raises(TypeError, histogram, [1, 2, 3],
                           estimator, weights=[1, 2, 3])
 
+    def test_no_memory_error(self):
+        """
+        Check that large ranges and small IQRs do not raise MemoryError
+        when the bins method is set to 'auto'
+        """
+        x = np.array([ 2, 2, 2 - 1e-15, 2 - 1e-15, 1], dtype=np.float64)
+        assert_raises(MemoryError, histogram, x, 'fd')
+        a, b = histogram(x, bins='auto')
+        assert_equal(sum(a), 5)
+        assert_equal(len(b), 4)
 
 class TestHistogramdd(object):
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -575,7 +575,7 @@ class TestHistogramOptimBinNums(object):
                       500:  {'fd': 15, 'scott': 16, 'rice': 32,
                              'sturges': 20, 'auto': 20, 'stone': 80},
                       5000: {'fd': 33, 'scott': 33, 'rice': 69,
-                             'sturges': 27, 'auto': 33, 'stone': 80}
+                             'sturges': 27, 'auto': 19, 'stone': 80}
                      }
 
         for testlen, expectedResults in basic_test.items():

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -606,7 +606,6 @@ class TestHistogramOptimBinNums(object):
         when the bins method is set to 'auto'
         """
         x = np.array([ 2, 2, 2 - 1e-15, 2 - 1e-15, 1], dtype=np.float64)
-        assert_raises(MemoryError, histogram, x, 'fd')
         a, b = histogram(x, bins='auto')
         assert_equal(sum(a), 5)
         assert_equal(len(b), 4)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -613,7 +613,9 @@ class TestHistogramOptimBinNums(object):
     def test_merged_bins_empty(self):
         """
         Check that merged histogram bins are empty
-        merges happen when 'auto' defaults to 'fd'
+        Bin merges can happen when bin type is set to 'auto' and defaults to 'fd'
+
+        All test values have been precomputed and shouldn't change
         """
         bin_merge_test = {
               5000:   {'auto': (10000, 12, True)},

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -610,6 +610,33 @@ class TestHistogramOptimBinNums(object):
         assert_equal(sum(a), 5)
         assert_equal(len(b), 5)
 
+    def test_merged_bins_empty(self):
+        """
+        Check that merged histogram bins are empty
+        merges happen when 'auto' defaults to 'fd'
+        """
+        bin_merge_test = {
+              5000:   {'auto': (10000, 12, True)},
+              50_000:  {'auto': (100000, 16, True)},
+              100_000: {'auto': (200000, 16, True)}
+             }
+
+        for testlen, expectedResults in bin_merge_test.items():
+            x1 = np.linspace(-1000, -900, testlen // 5 * 2)
+            x2 = np.linspace(1, 100, testlen // 5 * 3)
+            x3 = np.linspace(1000, 1100, testlen)
+            x = np.hstack((x1, x2, x3))
+            for estimator, test_values in expectedResults.items():
+                hist_counts, hist_bin_edges = np.histogram(x, estimator, range = None)
+                vals, counts = np.unique(np.diff(hist_bin_edges), return_counts=True)
+                mode = vals[np.argmax(counts)]
+                merged_bins = np.where(np.diff(hist_bin_edges)>(mode*1.5))[0]
+                is_merged_bins_zero = np.count_nonzero(hist_counts[merged_bins]) == 0
+                total_counts, total_bins, merged_bins_zero = test_values
+                assert_equal(sum(hist_counts), total_counts)
+                assert_equal(len(hist_bin_edges), total_bins)
+                assert_equal(is_merged_bins_zero, merged_bins_zero)
+
 class TestHistogramdd(object):
 
     def test_simple(self):

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -575,7 +575,7 @@ class TestHistogramOptimBinNums(object):
                       500:  {'fd': 15, 'scott': 16, 'rice': 32,
                              'sturges': 20, 'auto': 20, 'stone': 80},
                       5000: {'fd': 33, 'scott': 33, 'rice': 69,
-                             'sturges': 27, 'auto': 19, 'stone': 80}
+                             'sturges': 27, 'auto': 17, 'stone': 80}
                      }
 
         for testlen, expectedResults in basic_test.items():
@@ -608,7 +608,7 @@ class TestHistogramOptimBinNums(object):
         x = np.array([ 2, 2, 2 - 1e-15, 2 - 1e-15, 1], dtype=np.float64)
         a, b = histogram(x, bins='auto')
         assert_equal(sum(a), 5)
-        assert_equal(len(b), 4)
+        assert_equal(len(b), 5)
 
 class TestHistogramdd(object):
 


### PR DESCRIPTION
ENH/BUG: merge empty bins when np.histogram(bin='auto') to avoid raising MemoryErrors

See #11879 , #10297, #8203 

histogram(bins='auto') will sometimes raise a memory error if the number of automatically-generated bin edges is too large. In all documented cases, the conditions producing outsized bin numbers are when the auto-binning defaults to the 'fd' method.

Based on suggestions from @eric-wieser , this approach merges empty bins. In order to minimize the impact of this enhancement, I only invoke the new method when 'auto' defaults to 'fd'. A direct call to the 'fd' method produces the same results as before.

Note that this approach gives us back unequal bin widths. The non-empty bins all have the same width, but the zero bins will vary in their width depending on how many empty bins there are. 

All tests are passing. I did have to change the expected number of bins for one test to account for the merged empty bins. You can see this in `test_histograms.simple_range`. I also added a new test that expects a direct call to the 'fd' method to raise a MemoryError, and a call to bins='auto' to produce a small number of bins.

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
