### PR TITLE
TST, BUG: Use python3.6-dbg.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages: &common_packages
       - gfortran
-      - libatlas-dev
       - libatlas-base-dev
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
@@ -33,12 +32,14 @@ env:
 python:
   - 3.5
   - 3.6
+  - 3.7
   - 3.8-dev
 matrix:
   include:
     - python: 3.7
       env: INSTALL_PICKLE5=1
-    - python: 3.5
+    - python: 3.6
+      dist: bionic
       env: USE_DEBUG=1
       addons:
         apt:

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -36,6 +36,6 @@ fi
 
 
 pip install --upgrade pip setuptools
-pip install pytz cython pytest
+pip install pytz cython pytest==5.0.1
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -36,6 +36,6 @@ fi
 
 
 pip install --upgrade pip setuptools
-pip install pytz cython pytest==5.0.1
+pip install pytz cython pytest
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -90,7 +90,9 @@ run_test()
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
     $PYTHON ../runtests.py -n -v --durations 10 --mode=full $COVERAGE_FLAG
   else
-    $PYTHON ../runtests.py -n -v --durations 10
+    # disable --durations temporarily, pytest currently aborts
+    # when that is used with python3.6-dbg
+    $PYTHON ../runtests.py -n -v  # --durations 10
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then


### PR DESCRIPTION
Pytest-5.1.0 is segfaults on python3.5-dbg. Because we will be dropping 3.5 for NumPy 1.18 we might as well use a later Python version for the debug testing instead of pinning the pytest version. That way there will be no need to unpin pytest when it gets fixed.

EDIT:

Both pytest-5.0.1 and pytest-5.1.0 abort when passed the `--durations` flag on python3.6-dbg, so temporarily disable that flag pending a fix and leave the pytest version unpinned until then.    

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
