### PR TITLE
BUG: core: Handle large negative np.int64 args in binary_repr.

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1935,6 +1935,10 @@ def binary_repr(num, width=None):
                 "will raise an error in the future.", DeprecationWarning,
                 stacklevel=3)
 
+    # Ensure that num is a Python integer to avoid overflow or unwanted
+    # casts to floating point.
+    num = operator.index(num)
+
     if num == 0:
         return '0' * (width or 1)
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1341,6 +1341,11 @@ class TestBinaryRepr(object):
             exp = '1' + (width - 1) * '0'
             assert_equal(np.binary_repr(num, width=width), exp)
 
+    def test_large_neg_int64(self):
+        # See gh-14289.
+        assert_equal(np.binary_repr(np.int64(-2**62), width=64),
+                     '11' + '0'*62)
+
 
 class TestBaseRepr(object):
     def test_base3(self):


### PR DESCRIPTION
To avoid the cast to floating point that can occur when the first
argument to binary_repr is a NumPy integer, the argument is converted
to a Python integer at the beginning of the function.

Closes gh-14289.
