### PR TITLE
TST: Pin pytest version to 5.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages: &common_packages
       - gfortran
-      - libatlas-dev
       - libatlas-base-dev
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -36,6 +36,6 @@ fi
 
 
 pip install --upgrade pip setuptools
-pip install pytz cython pytest
+pip install pytz cython pytest==5.0.1
 if [ -n "$USE_ASV" ]; then pip install asv; fi
 popd


### PR DESCRIPTION
Pytest 5.1.0 segfaults when run with python3.5-dbg. Should be backported to 1.16.x.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
