### PR TITLE
MAINT: random: Match type of SeedSequence.pool_size to DEFAULT_POOL_SIZE.

### DIFF
--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -16,7 +16,7 @@ cdef class SeedSequence():
     cdef readonly tuple spawn_key
     cdef readonly uint32_t pool_size
     cdef readonly object pool
-    cdef readonly int n_children_spawned
+    cdef readonly uint32_t n_children_spawned
 
     cdef mix_entropy(self, np.ndarray[np.npy_uint32, ndim=1] mixer,
                      np.ndarray[np.npy_uint32, ndim=1] entropy_array)

--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -1,5 +1,5 @@
 
-from .common cimport bitgen_t
+from .common cimport bitgen_t, uint32_t
 cimport numpy as np
 
 cdef class BitGenerator():
@@ -14,7 +14,7 @@ cdef class BitGenerator():
 cdef class SeedSequence():
     cdef readonly object entropy
     cdef readonly tuple spawn_key
-    cdef readonly int pool_size
+    cdef readonly uint32_t pool_size
     cdef readonly object pool
     cdef readonly int n_children_spawned
 

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -116,7 +116,7 @@ def _coerce_to_uint32_array(x):
     Examples
     --------
     >>> import numpy as np
-    >>> from np.random.bit_generator import _coerce_to_uint32_array
+    >>> from numpy.random.bit_generator import _coerce_to_uint32_array
     >>> _coerce_to_uint32_array(12345)
     array([12345], dtype=uint32)
     >>> _coerce_to_uint32_array('12345')

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -458,6 +458,8 @@ cdef class SeedSequence():
         -------
         seqs : list of `SeedSequence` s
         """
+        cdef uint32_t i
+
         seqs = []
         for i in range(self.n_children_spawned,
                        self.n_children_spawned + n_children):


### PR DESCRIPTION
Fixes this compiler warning:

gcc: numpy/random/bit_generator.c
numpy/random/bit_generator.c:4889:41: warning: comparison of integers of different signs: 'int' and 'uint32_t' (aka 'unsigned int') [-Wsign-compare]
  __pyx_t_6 = ((__pyx_v_self->pool_size != __pyx_v_5numpy_6random_13bit_generator_DEFAULT_POOL_SIZE) != 0);
                ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
