### PR TITLE
BUG: Fix numpy.random bug in platform detection

### DIFF
--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -49,8 +49,8 @@ def configuration(parent_package='', top_path=None):
     elif not is_msvc:
         # Some bit generators require c99
         EXTRA_COMPILE_ARGS += ['-std=c99']
-        INTEL_LIKE = any([val in k.lower() for k in platform.uname()
-                          for val in ('x86', 'i686', 'i386', 'amd64')])
+        INTEL_LIKE = any(arch in platform.machine() 
+                         for arch in ('x86', 'i686', 'i386', 'amd64'))
         if INTEL_LIKE:
             # Assumes GCC or GCC-like compiler
             EXTRA_COMPILE_ARGS += ['-msse2']


### PR DESCRIPTION
Backport of #14298. 

BUG: fix platform detection
Wrong platfrom detection

Enviroment: 
Linux host:  Linux debian-cross 4.19.0-5-amd64 #1 SMP Debian 4.19.37-5+deb10u2 (2019-08-08) x86_64 GNU/Linux
Python3 version: Python 3.7.3
Pip3 version:  18.1
Debian version: 10 
Numpy cross-compile on debian 10 failed because numpy detects arm platform as amd64 and add msse2 flag.

For reproduce:
Install proot and qemu
`apt install proot qemu qemu-user`
Download raspbian from official mirror:
`wget https://downloads.raspberrypi.org/raspbian/images/raspbian-2019-07-12/2019-07-10-raspbian-buster.zip`
`unzip 2019-07-10-raspbian-buster.zip`
Mount partion:
`fdisk -l 2019-07-10-raspbian-buster.img `
Need these string from output
2019-07-10-raspbian-buster.img2      540672 7380991 6840320  3.3G 83 Linux
`mount -o loop,offset=$((512*540672))  2019-07-10-raspbian-buster.img /mnt`
Chroot into raspbian:
`proot -R /mnt -q qemu-arm`
After that:
`bash`
`pip3 install --log=/tmp/numpy git+https://github.com/numpy/numpy.git`
Chroot enviroment: Linux debian-cross 4.19.0-5-amd64 #1 SMP Debian 4.19.37-5+deb10u2 (2019-08-08) armv7l GNU/Linux

Also If you have not Intel like hardwate (e.g. raspberry pi)
You can set hostname e.g. `hostname leafx86` and try to compile numpy.
Compile log in attachment:
[numpy_failed.log](https://github.com/numpy/numpy/files/3513997/numpy_failed.log)


 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
