### PR TITLE
TST, MAINT: bump to OpenBLAS 0.3.7 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 env:
   global:
-    - OpenBLAS_version=0.3.7.dev
+    - OpenBLAS_version=0.3.7
     - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
     # The following is generated with the command:
     # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 variables:
   # OpenBLAS_version should be updated
   # to match numpy-wheels repo
-  OpenBLAS_version: 0.3.7.dev
+  OpenBLAS_version: 0.3.7
 
 jobs:
 - job: Linux_Python_36_32bit_full_with_asserts

--- a/shippable.yml
+++ b/shippable.yml
@@ -48,7 +48,7 @@ build:
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
-    - python tools/openblas_support.py --check_version 0.3.7.dev
+    - python tools/openblas_support.py --check_version 0.3.7
     # run the test suite
     - python runtests.py -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -14,8 +14,8 @@ from tempfile import mkstemp, gettempdir
 import zipfile
 import tarfile
 
-OPENBLAS_V = '6a8b426'
-OPENBLAS_LONG = 'v0.3.5-274-g6a8b4269'
+OPENBLAS_V = 'v0.3.7'
+OPENBLAS_LONG = 'v0.3.7'
 BASE_LOC = ''
 RACKSPACE = 'https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com'
 ARCHITECTURES = ['', 'windows', 'darwin', 'arm', 'x86', 'ppc64']
@@ -47,7 +47,7 @@ def download_openblas(target, arch):
         # https://github.com/tylerjereddy/openblas-static-gcc/tree/master/ARMv8
         # build done on GCC compile farm machine named gcc115
         # tarball uploaded manually to an unshared Dropbox location
-        filename = ('https://www.dropbox.com/s/zsp1wb3tq4n9g0b/'
+        filename = ('https://www.dropbox.com/s/vdeckao4omss187/'
                     'openblas-{}-armv8.tar.gz?dl=1'.format(OPENBLAS_V))
         typ = 'tar.gz'
     elif arch == 'ppc64':
@@ -55,7 +55,7 @@ def download_openblas(target, arch):
         # https://github.com/tylerjereddy/openblas-static-gcc/blob/master/power8
         # built on GCC compile farm machine named gcc112
         # manually uploaded tarball to an unshared Dropbox location
-        filename = ('https://www.dropbox.com/s/k9uabwoi8bekjwe/'
+        filename = ('https://www.dropbox.com/s/yt0d2j86x1j8nh1/'
                     'openblas-{}-ppc64le-power8.tar.gz?dl=1'.format(OPENBLAS_V))
         typ = 'tar.gz'
     elif arch == 'darwin':


### PR DESCRIPTION
* for those cases where our CI uses an OpenBLAS backend
for testing it has now been updated to use `v0.3.7` stable release
instead of a commit hash on the development branch preceding that
release

* the pre-built OpenBLAS binaries are pulled in from either the
MacPython ecosystem (most architectures) or from a custom build
script for ARMv8 and ppc64le architectures used on gcc compile farm machines
(documented in `openblas_support` module)

Note that `OPENBLAS_LONG` and `OPENBLAS_V` converge when using stable releases.
