### PR TITLE
DOC, MAINT: Clarify error message of random.randint.

### DIFF
--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -473,7 +473,7 @@ cdef class Generator:
                     ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
         except ValueError as e:
             if high_and_low_swapped and 'low >= high' == str(e):
-                e.args = ("low must be greater than 0 when high is not given.",)
+                raise ValueError("low must be greater than 0 when high is not given.") from None
             raise
 
         if size is None and dtype in (np.bool, np.int, np.long):

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -438,9 +438,6 @@ cdef class Generator:
             high = low
             low = 0
 
-        if high_and_low_swapped and np.any(np.array(high) <= 0):
-            raise ValueError("low must be greater than 0 when high is not given.")
-
         dt = np.dtype(dtype)
         key = dt.name
         if key not in _integers_types:
@@ -455,26 +452,29 @@ cdef class Generator:
         # bounded uniform integers. Lemire's method is preferable since it is
         # faster. randomgen allows a choice, we will always use the faster one.
         cdef bint _masked = False
-
-        if key == 'int32':
-                ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int64':
-                ret = _rand_int64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int16':
-                ret = _rand_int16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int8':
-                ret = _rand_int8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint64':
-                ret = _rand_uint64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint32':
-                ret = _rand_uint32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint16':
-                ret = _rand_uint16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint8':
-                ret = _rand_uint8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'bool':
-                ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-
+        try:
+            if key == 'int32':
+                    ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int64':
+                    ret = _rand_int64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int16':
+                    ret = _rand_int16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int8':
+                    ret = _rand_int8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint64':
+                    ret = _rand_uint64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint32':
+                    ret = _rand_uint32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint16':
+                    ret = _rand_uint16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint8':
+                    ret = _rand_uint8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'bool':
+                    ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+        except ValueError as e:
+            if high_and_low_swapped and 'low >= high' == str(e):
+                e.args = ("low must be greater than 0 when high is not given.",)
+            raise
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -434,6 +434,8 @@ cdef class Generator:
 
         """
         if high is None:
+            if low <= 0:
+                raise ValueError("low must be greater than 0 when high is not given.")
             high = low
             low = 0
 

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -438,6 +438,9 @@ cdef class Generator:
             high = low
             low = 0
 
+        if high_and_low_swapped and np.any(np.array(high) <= 0):
+            raise ValueError("low must be greater than 0 when high is not given.")
+
         dt = np.dtype(dtype)
         key = dt.name
         if key not in _integers_types:
@@ -452,29 +455,26 @@ cdef class Generator:
         # bounded uniform integers. Lemire's method is preferable since it is
         # faster. randomgen allows a choice, we will always use the faster one.
         cdef bint _masked = False
-        try:
-            if key == 'int32':
+
+        if key == 'int32':
                 ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'int64':
+        elif key == 'int64':
                 ret = _rand_int64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'int16':
+        elif key == 'int16':
                 ret = _rand_int16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'int8':
+        elif key == 'int8':
                 ret = _rand_int8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'uint64':
+        elif key == 'uint64':
                 ret = _rand_uint64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'uint32':
+        elif key == 'uint32':
                 ret = _rand_uint32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'uint16':
+        elif key == 'uint16':
                 ret = _rand_uint16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'uint8':
+        elif key == 'uint8':
                 ret = _rand_uint8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-            elif key == 'bool':
+        elif key == 'bool':
                 ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        except ValueError as e:
-            if high_and_low_swapped and 'low >= high' == str(e):
-                e.args = ("low must be greater than 0 when high is not given.", )
-            raise
+
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -434,7 +434,7 @@ cdef class Generator:
 
         """
         if high is None:
-            if low <= 0:
+            if isinstance(low, (int, np.integer)) and low <= 0:
                 raise ValueError("low must be greater than 0 when high is not given.")
             high = low
             low = 0

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -433,9 +433,8 @@ cdef class Generator:
                http://arxiv.org/abs/1805.10941.
 
         """
-        if high is None:
-            if isinstance(low, (int, np.integer)) and low <= 0:
-                raise ValueError("low must be greater than 0 when high is not given.")
+        high_and_low_swapped = high is None
+        if high_and_low_swapped:
             high = low
             low = 0
 
@@ -453,25 +452,29 @@ cdef class Generator:
         # bounded uniform integers. Lemire's method is preferable since it is
         # faster. randomgen allows a choice, we will always use the faster one.
         cdef bint _masked = False
-
-        if key == 'int32':
-            ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int64':
-            ret = _rand_int64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int16':
-            ret = _rand_int16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'int8':
-            ret = _rand_int8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint64':
-            ret = _rand_uint64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint32':
-            ret = _rand_uint32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint16':
-            ret = _rand_uint16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'uint8':
-            ret = _rand_uint8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
-        elif key == 'bool':
-            ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+        try:
+            if key == 'int32':
+                ret = _rand_int32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int64':
+                ret = _rand_int64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int16':
+                ret = _rand_int16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'int8':
+                ret = _rand_int8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint64':
+                ret = _rand_uint64(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint32':
+                ret = _rand_uint32(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint16':
+                ret = _rand_uint16(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'uint8':
+                ret = _rand_uint8(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+            elif key == 'bool':
+                ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
+        except ValueError as e:
+            if high_and_low_swapped and 'low >= high' == str(e):
+                e.args = ("low must be greater than 0 when high is not given.", )
+            raise
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -600,10 +600,8 @@ cdef class RandomState:
         array([[ 8,  6,  9,  7], # random
                [ 1, 16,  9, 12]], dtype=uint8)
         """
-
-        if high is None:
-            if isinstance(low, (int, np.integer)) and low <= 0:
-                raise ValueError("low must be greater than 0 when high is not given.")
+        high_and_low_swapped = high is None
+        if high_and_low_swapped:
             high = low
             low = 0
 
@@ -626,24 +624,29 @@ cdef class RandomState:
         cdef bint _masked = True
         cdef bint _endpoint = False
 
-        if key == 'int32':
-            ret = _rand_int32(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'int64':
-            ret = _rand_int64(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'int16':
-            ret = _rand_int16(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'int8':
-            ret = _rand_int8(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'uint64':
-            ret = _rand_uint64(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'uint32':
-            ret = _rand_uint32(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'uint16':
-            ret = _rand_uint16(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'uint8':
-            ret = _rand_uint8(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
-        elif key == 'bool':
-            ret = _rand_bool(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+        try:
+            if key == 'int32':
+                ret = _rand_int32(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'int64':
+                ret = _rand_int64(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'int16':
+                ret = _rand_int16(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'int8':
+                ret = _rand_int8(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'uint64':
+                ret = _rand_uint64(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'uint32':
+                ret = _rand_uint32(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'uint16':
+                ret = _rand_uint16(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'uint8':
+                ret = _rand_uint8(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+            elif key == 'bool':
+                ret = _rand_bool(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
+        except ValueError as e:
+            if high_and_low_swapped and 'low >= high' == str(e):
+                e.args = ("low must be greater than 0 when high is not given.", )
+            raise
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -602,7 +602,7 @@ cdef class RandomState:
         """
 
         if high is None:
-            if low <= 0:
+            if isinstance(low, (int, np.integer)) and low <= 0:
                 raise ValueError("low must be greater than 0 when high is not given.")
             high = low
             low = 0

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -602,6 +602,8 @@ cdef class RandomState:
         """
 
         if high is None:
+            if low <= 0:
+                raise ValueError("low must be greater than 0 when high is not given.")
             high = low
             low = 0
 

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -497,6 +497,7 @@ class TestRandomDist(object):
         actual = random.integers(-99, 99, size=(3, 2))
         desired = np.array([[-80, -56], [41, 37], [-83, -16]])
         assert_array_equal(actual, desired)
+        assert_raises(ValueError, random.integers, 0)
 
     def test_integers_masked(self):
         # Test masked rejection sampling algorithm to generate array of

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -4,7 +4,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import (
-    assert_, assert_raises, assert_equal,
+    assert_, assert_raises, assert_equal, assert_raises_regex,
     assert_warns, assert_no_warnings, assert_array_equal,
     assert_array_almost_equal, suppress_warnings)
 
@@ -497,7 +497,9 @@ class TestRandomDist(object):
         actual = random.integers(-99, 99, size=(3, 2))
         desired = np.array([[-80, -56], [41, 37], [-83, -16]])
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, random.integers, 0)
+        assert_raises_regex(ValueError,
+                            "low must be greater than 0 when high is not given.",
+                            random.integers, 0)
 
     def test_integers_masked(self):
         # Test masked rejection sampling algorithm to generate array of

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -431,6 +431,7 @@ class TestRandomDist(object):
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
+        assert_raises(ValueError, random.randint, 0)
 
     def test_random_integers(self):
         random.seed(self.seed)

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 import pytest
 from numpy.testing import (
-        assert_, assert_raises, assert_equal, assert_warns,
+        assert_, assert_raises, assert_equal, assert_warns, assert_raises_regex,
         assert_no_warnings, assert_array_equal, assert_array_almost_equal,
         suppress_warnings
         )
@@ -431,7 +431,9 @@ class TestRandomDist(object):
                             [-52, 41],
                             [-48, -66]])
         assert_array_equal(actual, desired)
-        assert_raises(ValueError, random.randint, 0)
+        assert_raises_regex(ValueError,
+                            "low must be greater than 0 when high is not given.",
+                            random.randint, 0)
 
     def test_random_integers(self):
         random.seed(self.seed)


### PR DESCRIPTION
Improve the error raised by `random.randint` when `low <= 0` and `high` is not given.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

The previous behaviour to throw `ValueError: ValueError: low >= high` which is correct but confusing unless you read the source code. I don't think adding that extra check early on will degrade performance. 