### PR TITLE
BUG: revert detecting and raising error on ragged arrays

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1849,13 +1849,6 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
             *out_arr = NULL;
             return 0;
         }
-        if (is_object && (requested_dtype != NULL) && 
-                (requested_dtype->type_num != NPY_OBJECT)) {
-            PyErr_SetString(PyExc_ValueError,
-               "cannot create an array from unequal-length (ragged) sequences");
-            Py_DECREF(*out_dtype);
-            return -1;
-        }
         /* If object arrays are forced */
         if (is_object) {
             Py_DECREF(*out_dtype);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -44,7 +44,7 @@ from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
     assert_array_equal, assert_raises_regex, assert_array_almost_equal,
     assert_allclose, IS_PYPY, HAS_REFCOUNT, assert_array_less, runstring,
-    temppath, suppress_warnings, break_cycles, assert_raises_regex,
+    temppath, suppress_warnings, break_cycles,
     )
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
@@ -497,9 +497,6 @@ class TestArrayConstruction(object):
         assert_(np.ascontiguousarray(d).flags.c_contiguous)
         assert_(np.asfortranarray(d).flags.f_contiguous)
 
-    def test_ragged(self):
-        assert_raises_regex(ValueError, 'ragged',
-                             np.array, [[1], [2, 3]], dtype=int)
 
 class TestAssignment(object):
     def test_assignment_broadcasting(self):


### PR DESCRIPTION
Reverts gh-13913 since it has false-positives in detection of ragged arrays (for instance `np.array([1, np.array([5])], dtype=int)`

Fixes gh-14138, reopens gh-5303 and gh-6584.

The correct fix is to add this corner case and make sure `discover_dimensions` does not set `is_object` when it does not need to.