### PR TITLE
TST, MAINT: include numpy package in .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 branch = True
-source = numpy
+source = .
 disable_warnings = include-ignored

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 branch = True
-include = */numpy/*
+source = numpy
 disable_warnings = include-ignored


### PR DESCRIPTION
* based on coveragepy docs and `.coveragerc` files in
Python projects with more comprehensive codecov reports
available (like scikit-learn), adjust `.coveragerc` to
use the `source` directive to explicitly include the
numpy package / namespace instead of using the
`include` file selection directive

Eric noticed this in https://github.com/numpy/numpy/pull/14310#issuecomment-524424784

Clicking through our codecov badge it looks like pretty much all `numpy.submodule` namespaces are now completely ignored by codecov--the only files and folders I see showing up seem to be those that get fused in from `gcov` report files on compiled files! This simple fix is worth a try... seems to work for `scikit-learn` & seems to be more appropriate directive based on [docs](https://coverage.readthedocs.io/en/v4.5.x/config.html)