### PR TITLE
DOC: Fix a minor typo in dispatch documentation.

### DIFF
--- a/numpy/doc/dispatch.py
+++ b/numpy/doc/dispatch.py
@@ -223,7 +223,7 @@ calls ``numpy.sum(self)``, and the same for ``mean``.
 ...     return arr._i * arr._N
 ...
 >>> @implements(np.mean)
-... def sum(arr):
+... def mean(arr):
 ...     "Implementation of np.mean for DiagonalArray objects"
 ...     return arr._i / arr._N
 ...


### PR DESCRIPTION
This fixes my own typo in #13979. The current exampple code is
_runnable_ but potentially confusing to read.