### PR TITLE
DOC: clarify that PytestTester is non-public

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -48,10 +48,9 @@ class PytestTester(object):
     """
     Pytest test runner.
 
-    This class is made available in ``numpy.testing``, and a test function
-    is typically added to a package's __init__.py like so::
+    A test function is typically added to a package's __init__.py like so::
 
-      from numpy.testing import PytestTester
+      from numpy._pytesttester import PytestTester
       test = PytestTester(__name__).test
       del PytestTester
 
@@ -67,6 +66,12 @@ class PytestTester(object):
     ----------
     module_name : module name
         The name of the module to test.
+
+    Notes
+    -----
+    Unlike the previous ``nose``-based implementation, this class is not
+    publicly exposed as it performs some ``numpy``-specific warning
+    suppression.
 
     """
     def __init__(self, module_name):


### PR DESCRIPTION
Update `np._pytesttester.PytestTester` docstring based on feedback in https://github.com/numpy/numpy/issues/14354
