### PR TITLE
DOC: support and require sphinx>=2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             python3 -m venv venv
             ln -s $(which python3) venv/bin/python3.6
             . venv/bin/activate
-            pip install cython sphinx==1.8.5 matplotlib ipython
+            pip install cython sphinx==2.1.2 matplotlib ipython
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             python3 -m venv venv
             ln -s $(which python3) venv/bin/python3.6
             . venv/bin/activate
-            pip install cython sphinx==2.1.2 matplotlib ipython
+            pip install cython sphinx==2.2.0 matplotlib ipython
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     displayName: 'Install tools'
   - script: |
       python -m pip install -r test_requirements.txt
-      python -m pip install vulture docutils sphinx==1.8.5 numpydoc
+      python -m pip install vulture docutils sphinx==2.1.2 numpydoc
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
     displayName: 'Check for unreachable code paths in Python modules'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
     displayName: 'Install tools'
   - script: |
       python -m pip install -r test_requirements.txt
-      python -m pip install vulture docutils sphinx==2.1.2 numpydoc
+      python -m pip install vulture docutils sphinx==2.2.0 numpydoc
     displayName: 'Install dependencies; some are optional to avoid test skips'
   - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
     displayName: 'Check for unreachable code paths in Python modules'

--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -1,0 +1,14 @@
+{% if objtype == 'property' %}
+:orphan:
+{% endif %}
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+{% if objtype == 'property' %}
+property
+{% endif %}
+
+.. auto{{ objtype }}:: {{ objname }}
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,7 +4,7 @@ from __future__ import division, absolute_import, print_function
 import sys, os, re
 
 # Minimum version, enforced by sphinx
-needs_sphinx = '2.1.2'
+needs_sphinx = '2.2.0'
 
 # -----------------------------------------------------------------------------
 # General configuration

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -3,12 +3,8 @@ from __future__ import division, absolute_import, print_function
 
 import sys, os, re
 
-# Check Sphinx version
-import sphinx
-if sphinx.__version__ < "1.2.1":
-    raise RuntimeError("Sphinx 1.2.1 or newer required")
-
-needs_sphinx = '1.0'
+# Minimum version, enforced by sphinx
+needs_sphinx = '2.1.2'
 
 # -----------------------------------------------------------------------------
 # General configuration
@@ -31,19 +27,18 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
+    'sphinx.ext.imgmath',
 ]
 
-if sphinx.__version__ >= "1.4":
-    extensions.append('sphinx.ext.imgmath')
-    imgmath_image_format = 'svg'
-else:
-    extensions.append('sphinx.ext.pngmath')
+imgmath_image_format = 'svg'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
+
+master_doc = 'contents'
 
 # General substitutions.
 project = 'NumPy'
@@ -93,6 +88,7 @@ pygments_style = 'sphinx'
 def setup(app):
     # add a config value for `ifconfig` directives
     app.add_config_value('python_version_major', str(sys.version_info.major), 'env')
+    app.add_lexer('NumPyC', NumPyLexer(stripnl=False))
 
 # -----------------------------------------------------------------------------
 # HTML output
@@ -176,6 +172,10 @@ latex_documents = [
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
 #latex_use_parts = False
+
+latex_elements = {
+    'fontenc': r'\usepackage[LGR,T1]{fontenc}'
+}
 
 # Additional stuff for the LaTeX preamble.
 latex_preamble = r'''
@@ -368,18 +368,15 @@ def linkcode_resolve(domain, info):
 
 from pygments.lexers import CLexer
 from pygments import token
-from sphinx.highlighting import lexers
 import copy
 
 class NumPyLexer(CLexer):
     name = 'NUMPYLEXER'
 
-    tokens = copy.deepcopy(lexers['c'].tokens)
+    tokens = copy.deepcopy(CLexer.tokens)
     # Extend the regex for valid identifiers with @
     for k, val in tokens.items():
         for i, v in enumerate(val):
             if isinstance(v, tuple):
                 if isinstance(v[0], str):
                     val[i] =  (v[0].replace('a-zA-Z', 'a-zA-Z@'),) + v[1:]
-
-lexers['NumPyC'] = NumPyLexer(stripnl=False)


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/14285

There are a few things happening here, but I have the docs building for `sphinx >= 2.1`. The minimum version is due to a planned deprecation in `3.x` that wasn't supported until `2.1` - this portion can be dropped but there's enough differences between `1.8` and `2.0` that I'm not sure it buys us much.

The changes are:
- `sphinx.highlighting.lexers` is no longer populated, so we can't pull a `CLexer` instance out of it
  - But we're inheriting from `CLexer` already, so just use that
- There's a supported method for adding custom lexers via `.set_lexer()`
  - This will only accept classes starting in `3.x`, but support for classes was only added in `2.1`
  - The use of `partial()` matches how sphinx does it internally: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/highlighting.py#L40
- The `master_doc` parameter is now defaults to `index` when the pre-`2.0` default was `contents`.
  - Explicitly set old default
- Latex recently enabled UTF-8 support and Sphinx makes a number of changes to support that
  - The unicode support is a bit weird, as it translates every code point into a macro. This blows up memory consumption, so latex (at least under some engines) detects what fonts are being used and then loads the relevant macros.
  - This means characters like `γ` (lowercase gamma) now cause latex builds to fail if both of these are false:
    - `\DeclareUnicodeCharacter` is not set for each UTF-8 code point in use or...
    - The font encoding (Greek = `LGR`) is not declared as part of this command:
        - `r'\usepackage[LGR,T1]{fontenc}'`
   - So if someone in the future wants to use Hebrew, Cyrillic, etc. then they need to do one of the two steps above.

I've visually inspected the html and pdf output and it looks good to me. One thing I should note is that the `sphinx` defaults are different for each `latex_engine` setting. It has been defaulting to `pdflatex` for me, but that may not match what is being used for release documentation. It may make sense to configure `latex_engine` explicitly if we see significant variations.

Edit: given the desire to pin sphinx, I've bumped the pinned version to the newest release (`2.2.0`)