### PR TITLE
MAINT: Fixes for prospective Python 3.10 and 4.0

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -464,7 +464,7 @@ def configuration(parent_package='',top_path=None):
             moredefs.append(('HAVE_LDOUBLE_%s' % rep, 1))
 
             # Py3K check
-            if sys.version_info[0] == 3:
+            if sys.version_info[0] >= 3:
                 moredefs.append(('NPY_PY3K', 1))
 
             # Generate the config.h file from moredefs

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -38,7 +38,7 @@ class build(old_build):
                 raise ValueError("--parallel/-j argument must be an integer")
         build_scripts = self.build_scripts
         old_build.finalize_options(self)
-        plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info)
+        plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info[:2])
         if build_scripts is None:
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts' + plat_specifier)

--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -38,7 +38,7 @@ class build(old_build):
                 raise ValueError("--parallel/-j argument must be an integer")
         build_scripts = self.build_scripts
         old_build.finalize_options(self)
-        plat_specifier = ".%s-%s" % (get_platform(), sys.version[0:3])
+        plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info)
         if build_scripts is None:
             self.build_scripts = os.path.join(self.build_base,
                                               'scripts' + plat_specifier)

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -90,7 +90,7 @@ class build_src(build_ext.build_ext):
         self.data_files = self.distribution.data_files or []
 
         if self.build_src is None:
-            plat_specifier = ".%s-%s" % (get_platform(), sys.version[0:3])
+            plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info)
             self.build_src = os.path.join(self.build_base, 'src'+plat_specifier)
 
         # py_modules_dict is used in build_py.find_package_modules

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -90,7 +90,7 @@ class build_src(build_ext.build_ext):
         self.data_files = self.distribution.data_files or []
 
         if self.build_src is None:
-            plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info)
+            plat_specifier = ".{}-{}.{}".format(get_platform(), *sys.version_info[:2])
             self.build_src = os.path.join(self.build_base, 'src'+plat_specifier)
 
         # py_modules_dict is used in build_py.find_package_modules

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -45,11 +45,18 @@ except ImportError:
 
 from unittest import TestCase
 
-PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
 
 
-if PY3:
+if PY2:
+    from types import InstanceType
+    lzip = zip
+    text_type = unicode
+    bytes_type = str
+    string_types = basestring,
+    def make_method(func, instance, type):
+        return MethodType(func, instance, type)
+else:
     # Python 3 doesn't have an InstanceType, so just use a dummy type.
     class InstanceType():
         pass
@@ -61,14 +68,6 @@ if PY3:
         if instance is None:
             return func
         return MethodType(func, instance)
-else:
-    from types import InstanceType
-    lzip = zip
-    text_type = unicode
-    bytes_type = str
-    string_types = basestring,
-    def make_method(func, instance, type):
-        return MethodType(func, instance, type)
 
 _param = namedtuple("param", "args kwargs")
 

--- a/tools/npy_tempita/compat3.py
+++ b/tools/npy_tempita/compat3.py
@@ -5,7 +5,7 @@ import sys
 __all__ = ['PY3', 'b', 'basestring_', 'bytes', 'next', 'is_unicode',
            'iteritems']
 
-PY3 = True if sys.version_info[0] == 3 else False
+PY3 = True if sys.version_info[0] >= 3 else False
 
 if sys.version_info[0] < 3:
 

--- a/tools/swig/test/testFarray.py
+++ b/tools/swig/test/testFarray.py
@@ -15,7 +15,7 @@ else:          BadListError = ValueError
 
 # Add the distutils-generated build directory to the python search path and then
 # import the extension module
-libDir = "lib.{}-{}.{}".format(get_platform(), *sys.version_info)
+libDir = "lib.{}-{}.{}".format(get_platform(), *sys.version_info[:2])
 sys.path.insert(0, os.path.join("build", libDir))
 import Farray
 

--- a/tools/swig/test/testFarray.py
+++ b/tools/swig/test/testFarray.py
@@ -15,7 +15,7 @@ else:          BadListError = ValueError
 
 # Add the distutils-generated build directory to the python search path and then
 # import the extension module
-libDir = "lib.%s-%s" % (get_platform(), sys.version[:3])
+libDir = "lib.{}-{}.{}".format(get_platform(), *sys.version_info)
 sys.path.insert(0, os.path.join("build", libDir))
 import Farray
 


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 (when Python 3.9 reaches beta)](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some places in the codebase that slice the `sys.version` string, assuming the string is 3 characters long. This sort of thing will break on Python 3.10:

```python
# in python3.10 this will report as '3.1' (should be '3.10')
python_version = sys.version[0:3]

# correct way to do this
python_version = '{}.{}'.format(*sys.version_info)
```

And also some places that would run Python 2 code on Python 4, such as:

```python
# in python4 this will report as `False` (and suddenly run python2 code!)
is_py3 = sys.version_info[0] == 3

# correct way to do this
is_py3 = sys.version_info[0] >= 3
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./tools/swig/test/testFarray.py:18:41: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./tools/npy_tempita/compat3.py:8:15: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./numpy/distutils/command/build.py:41:54: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./numpy/distutils/command/build_src.py:93:58: YTT101: `sys.version[:...]` referenced (python3.10), use `sys.version_info`
./numpy/core/setup.py:467:16: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./numpy/testing/_private/parameterized.py:48:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
```
