### PR TITLE
BLD: Update RELEASE_WALKTHROUGH and cythonize.

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -56,7 +56,7 @@ repository::
     $ git checkout maintenance/1.14.x
     $ git pull upstream maintenance/1.14.x
     $ git submodule update
-    $ git clean -xdf > /dev/null
+    $ git clean -xdfq
 
 Edit pavement.py and setup.py as detailed in HOWTO_RELEASE::
 
@@ -83,7 +83,7 @@ Paver is used to build the source releases. It will create the ``release`` and
 ``release/installers`` directories and put the ``*.zip`` and ``*.tar.gz``
 source releases in the latter. ::
 
-    $ cython --version  # check that you have the correct cython version
+    $ python3 -m cython --version  # check for correct cython version
     $ paver sdist  # sdist will do a git clean -xdf, so we omit that
 
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ cythonize
 
 Cythonize pyx files into C files as needed.
@@ -54,7 +54,7 @@ except NameError:
 def process_pyx(fromfile, tofile):
     flags = ['-3', '--fast-fail']
     if tofile.endswith('.cxx'):
-        flags += ['--cplus']
+        flags.append('--cplus')
 
     try:
         # try the cython in the installed python first (somewhat related to scipy/scipy#2397)
@@ -71,13 +71,10 @@ def process_pyx(fromfile, tofile):
         # check the version, and invoke through python
         from distutils.version import LooseVersion
 
-        # requiring the newest version on all pythons doesn't work, since
-        # we're relying on the version of the distribution cython. Add new
-        # versions as they become required for new python versions.
-        if sys.version_info[:2] < (3, 7):
-            required_version = LooseVersion('0.19')
-        else:
-            required_version = LooseVersion('0.28')
+        # Cython 0.29.13 is required for Python 3.8 and there are
+        # other fixes in the 0.29 series that are needed even for earlier
+        # Python versions.
+        required_version = LooseVersion('0.29.13')
 
         if LooseVersion(cython_version) < required_version:
             raise RuntimeError('Building {} requires Cython >= {}'.format(


### PR DESCRIPTION
Make it less likely that the wrong cython version is used for
building or cythonizing NumPy. This is motivated by the upcoming
Python 3.8 release that requires the cython 0.29.13 as of 3.8.0b4.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
