### PR TITLE
TST: Remove build job since we now use Dependabot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,19 +219,3 @@ jobs:
       testRunTitle: 'Publish test results for PyPy3'
       failTaskOnFailedTests: true
 
-- job: Check_dependencies
-  pool:
-    vmIMage: 'ubuntu-16.04'
-  steps:
-  - script: |
-        set -e
-        sudo apt-get install python3-venv
-        python3 -mvenv testenv
-        source testenv/bin/activate
-        python -m pip install --upgrade pip setuptools
-        python -m pip list -o > /tmp/current_pkgs
-        python -m pip install -r test_requirements.txt
-        python -m pip list -o > /tmp/test_pkgs
-        # any newer packages should cause the diff to return 1, which fails the job
-        diff /tmp/current_pkgs /tmp/test_pkgs
-    displayName: 'Show any possible updates to packages'


### PR DESCRIPTION
Since we now have a dependabot service, this test run is not needed.

Might be nice to add a `.dependabot/config.yml` file too