### PR TITLE
BUG: Fix format statement associated with AttributeError.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -202,9 +202,8 @@ else:
                 from .testing import Tester
                 return Tester
             else:
-                raise AttributeError(
-                    "module %s has no attribute $s".format(__name__, attr))
-
+                raise AttributeError("module {!r} has no attribute "
+                                     "{!r}".format(__name__, attr))
 
         def __dir__():
             return __all__ + ['Tester', 'testing']


### PR DESCRIPTION
Before this fix, a reference such as `numpy.wxyz` produced an
incorrect error message because of the invalid format specifiers
in the error message string:

	>>> import numpy
	>>> numpy.wxyz
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/.../numpy/__init__.py", line 206, in __getattr__
	    "module %s has no attribute $s".format(__name__, attr))
	AttributeError: module %s has no attribute $s

After the fix:

	>>> import numpy
	>>> numpy.wxyz
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/.../numpy/__init__.py", line 206, in __getattr__
	    "{!r}".format(__name__, attr))
	AttributeError: module 'numpy' has no attribute 'wxyz'
