### PR TITLE
DOC: add the reference to 'printoptions'

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -194,7 +194,7 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
 
     See Also
     --------
-    get_printoptions, set_string_function, array2string
+    get_printoptions, printoptions, set_string_function, array2string
 
     Notes
     -----
@@ -285,7 +285,7 @@ def get_printoptions():
 
     See Also
     --------
-    set_printoptions, set_string_function
+    set_printoptions, printoptions, set_string_function
 
     """
     return _format_options.copy()


### PR DESCRIPTION
We add the reference to `printoptions` context manager in "See Also" section in `set_printoptions` and `get_printoptions` functions. These changes improve the documentation and make it easy to search.
