### PR TITLE
BUG: Do not show Override module in private error classes.

### DIFF
--- a/numpy/core/_exceptions.py
+++ b/numpy/core/_exceptions.py
@@ -27,6 +27,7 @@ def _display_as_base(cls):
     assert issubclass(cls, Exception)
     cls.__name__ = cls.__base__.__name__
     cls.__qualname__ = cls.__base__.__qualname__
+    set_module(cls.__base__.__module__)(cls)
     return cls
 
 


### PR DESCRIPTION
While IPython seems to not print the module information (or only
prints qualname), python adds the full module, so it needs to be
overridden to not be printed on error.

---

Followup to gh-13306.