### PR TITLE
BUG: Do not show Override module in private error classes.

### DIFF
--- a/numpy/core/_exceptions.py
+++ b/numpy/core/_exceptions.py
@@ -27,6 +27,7 @@ def _display_as_base(cls):
     assert issubclass(cls, Exception)
     cls.__name__ = cls.__base__.__name__
     cls.__qualname__ = cls.__base__.__qualname__
+    set_module(cls.__base__.__module__)(cls)
     return cls
 
 


### PR DESCRIPTION
Backport of #14429.  

While IPython seems to not print the module information (or only
prints qualname), python adds the full module, so it needs to be
overridden to not be printed on error.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
