### PR TITLE
BLD: remove generated Cython files from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@
 # Avoid using MANIFEST.in for that.
 #
 include MANIFEST.in
+include pyproject.toml
 include pytest.ini
 include *.txt
 include README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "cython"]  # PEP 508 specification
+requires = [
+    "setuptools",
+    "wheel",
+    "Cython>=0.29.13",  # Note: keep in sync with tools/cythonize.py
+]
 
 
 [tool.towncrier]

--- a/setup.py
+++ b/setup.py
@@ -422,8 +422,8 @@ def setup_package():
     if run_build:
         from numpy.distutils.core import setup
         cwd = os.path.abspath(os.path.dirname(__file__))
-        if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
-            # Generate Cython sources, unless building from source release
+        if not 'sdist' in sys.argv:
+            # Generate Cython sources, unless we're generating an sdist
             generate_cython()
 
         metadata['configuration'] = configuration

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -74,6 +74,7 @@ def process_pyx(fromfile, tofile):
         # Cython 0.29.13 is required for Python 3.8 and there are
         # other fixes in the 0.29 series that are needed even for earlier
         # Python versions.
+        # Note: keep in sync with that in pyproject.toml
         required_version = LooseVersion('0.29.13')
 
         if LooseVersion(cython_version) < required_version:


### PR DESCRIPTION
Rationale: it has happened multiple times in the recent past that users
needed to use a more recent Cython than was used to generate the sdist
of the most recent release available on PyPI (e.g. for building with
a not-yet-released version of Python for which a Cython fix just
landed).  The dependency specification and packaging tools have matured
to the point where it should be fine to require Cython to be installed.
Also, we have wheels (and conda-forge packages) for Windows, Linux and
macOS, so this change won't be visible at all to the average user.

Closes gh-13790, closes gh-14403

Also adds `pyproject.toml` to `MANIFEST.in`, it was missing.

Another note: this is not in `setup_requires` on purpose. For one because `generate_cython` runs before `setup(**metadata)` is invoked. For another, because if anyone runs `python setup.py install` they can simply deal with any error if they get it. And using `setup_requires` would invoke `easy_install` in some cases, which isn't nice anyway.