### PR TITLE
MAINT: use test_requirements.txt in tox and shippable, ship it too

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,10 @@ include pytest.ini
 include *.txt
 include README.md
 include site.cfg.example
+include runtests.py
+include tox.ini
+include .coveragerc
+include test_requirements.txt
 recursive-include numpy/random *.pyx *.pxd *.pyx.in *.pxd.in
 include numpy/__init__.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
@@ -18,8 +22,6 @@ include numpy/__init__.pxd
 recursive-include numpy *
 recursive-include numpy/_build_utils *
 recursive-include numpy/linalg/lapack_lite *
-include runtests.py
-include tox.ini pytest.ini .coveragerc
 recursive-include tools *
 # Add sdist files whose use depends on local configuration.
 include numpy/core/src/common/cblasfuncs.c

--- a/shippable.yml
+++ b/shippable.yml
@@ -31,9 +31,7 @@ build:
     # we will pay the ~13 minute cost of compiling Cython only when a new
     # version is scraped in by pip; otherwise, use the cached
     # wheel shippable places on Amazon S3 after we build it once
-    - pip install cython --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
-    # install pytz for datetime testing
-    - pip install pytz
+    - pip install -r test_requirements.txt --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
     # install pytest-xdist to leverage a second core
     # for unit tests
     - pip install pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,7 @@ envlist =
   py37-not-relaxed-strides
 
 [testenv]
-deps=
-  pytest
+deps= -Ur{toxinidir}/test_requirements.txt
 changedir={envdir}
 commands={envpython} {toxinidir}/runtests.py --mode=full {posargs:}
 


### PR DESCRIPTION
In #14378 we added a test_requirements.txt file, but as shown in #14440 I missed using it in the shippable CI configuration and for the tox configuration. In order for tox to use it, we must ship it (put it in `MANIFEST.in`), which is a good idea anyway.

Also refactored the `includes` in the `MANIFEST.in`