### PR TITLE
MAINT: random: Follow-up to PR 14458.

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3492,7 +3492,6 @@ cdef class RandomState:
         cdef np.ndarray ongood, onbad, onsample
         cdef int64_t lngood, lnbad, lnsample
 
-        # This cast to long is required to ensure that the values are inbounds
         ongood = <np.ndarray>np.PyArray_FROM_OTF(ngood, np.NPY_INT64, np.NPY_ALIGNED)
         onbad = <np.ndarray>np.PyArray_FROM_OTF(nbad, np.NPY_INT64, np.NPY_ALIGNED)
         onsample = <np.ndarray>np.PyArray_FROM_OTF(nsample, np.NPY_INT64, np.NPY_ALIGNED)
@@ -3514,10 +3513,7 @@ cdef class RandomState:
 
         if np.any(np.less(np.add(ongood, onbad), onsample)):
             raise ValueError("ngood + nbad < nsample")
-        # Convert to int64, if necessary, to use int64 infrastructure
-        ongood = ongood.astype(np.int64)
-        onbad = onbad.astype(np.int64)
-        onbad = onbad.astype(np.int64)
+
         out = discrete_broadcast_iii(&legacy_random_hypergeometric,&self._bitgen, size, self.lock,
                                      ongood, 'ngood', CONS_NON_NEGATIVE,
                                      onbad, 'nbad', CONS_NON_NEGATIVE,


### PR DESCRIPTION
* The comment about casting to long is no longer relevant.
* The conversion of the arrays to int64 immediately before calling
  `discrete_broadcast_iii` is no longer necessary, because they are
  created as int64 arrays.
