### PR TITLE
BUG: reference count leaks in _ctypes

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -294,8 +294,7 @@ class _ctypes(object):
         if ctypes:
             self._ctypes = ctypes
             # get a void pointer to the buffer, which keeps the array alive
-            self._data = _get_void_ptr(array)
-            assert self._data.value == ptr
+            self._data = self._ctypes.c_void_p(ptr)
         else:
             # fake a pointer-like object that holds onto the reference
             self._ctypes = _missing_ctypes()
@@ -317,7 +316,9 @@ class _ctypes(object):
 
         The returned pointer will keep a reference to the array.
         """
-        return self._ctypes.cast(self._data, obj)
+        ptr = self._ctypes.cast(self._data, obj)
+        ptr._arr = self._arr
+        return ptr
 
     def shape_as(self, obj):
         """


### PR DESCRIPTION
ctypes.POINTER function caches the C pointer types created by core._internal._ctypes class

https://github.com/python/cpython/blob/master/Modules/_ctypes/callproc.c#L1783

This leads to an extra reference count to the array object in function _get_void_ptr. Changing the call to ctypes.pointer to ctypes.byref should fix the problem in #13808