### PR TITLE
BUG: Fix _ctypes class circular reference. (#13808)

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -294,8 +294,7 @@ class _ctypes(object):
         if ctypes:
             self._ctypes = ctypes
             # get a void pointer to the buffer, which keeps the array alive
-            self._data = _get_void_ptr(array)
-            assert self._data.value == ptr
+            self._data = self._ctypes.c_void_p(ptr)
         else:
             # fake a pointer-like object that holds onto the reference
             self._ctypes = _missing_ctypes()
@@ -317,7 +316,9 @@ class _ctypes(object):
 
         The returned pointer will keep a reference to the array.
         """
-        return self._ctypes.cast(self._data, obj)
+        ptr = self._ctypes.cast(self._data, obj)
+        ptr._arr = self._arr
+        return ptr
 
     def shape_as(self, obj):
         """

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -247,30 +247,6 @@ class _missing_ctypes(object):
             self.value = ptr
 
 
-class _unsafe_first_element_pointer(object):
-    """
-    Helper to allow viewing an array as a ctypes pointer to the first element
-
-    This avoids:
-      * dealing with strides
-      * `.view` rejecting object-containing arrays
-      * `memoryview` not supporting overlapping fields
-    """
-    def __init__(self, arr):
-        self.base = arr
-
-    @property
-    def __array_interface__(self):
-        i = dict(
-            shape=(),
-            typestr='|V0',
-            data=(self.base.__array_interface__['data'][0], False),
-            strides=(),
-            version=3,
-        )
-        return i
-
-
 class _ctypes(object):
     def __init__(self, array, ptr=None):
         self._arr = array

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -386,7 +386,7 @@ class _ctypes(object):
 
         Enables `c_func(some_array.ctypes)`
         """
-        return self.data_as(ctpyes.c_void_p)
+        return self.data_as(ctypes.c_void_p)
 
     # kept for compatibility
     get_data = data.fget

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -278,7 +278,8 @@ class _ctypes(object):
         # _ctypes.cast function causes a circular reference of self._data in
         # self._data._objects. Attributes of self._data cannot be released
         # until gc.collect is called. Make a copy of the pointer first then let
-        # it hold the array reference.
+        # it hold the array reference. This is a workaround to circumvent the
+        # CPython bug https://bugs.python.org/issue12836
         ptr = self._ctypes.cast(self._data, obj)
         ptr._arr = self._arr
         return ptr

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -386,7 +386,7 @@ class _ctypes(object):
 
         Enables `c_func(some_array.ctypes)`
         """
-        return self._data
+        return self.data_as(ctpyes.c_void_p)
 
     # kept for compatibility
     get_data = data.fget

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7938,6 +7938,8 @@ class TestFormat(object):
                 dst = object.__format__(a, '30')
                 assert_equal(res, dst)
 
+from numpy.testing import IS_PYPY
+
 class TestCTypes(object):
 
     def test_ctypes_is_available(self):
@@ -8020,6 +8022,11 @@ class TestCTypes(object):
 
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
+        if IS_PYPY:
+            # Pypy does not recycle arr objects immediately. Trigger gc to
+            # release arr. Cpython uses refcounts. An explicit call to gc
+            # should not be needed here.
+            break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8004,7 +8004,6 @@ class TestCTypes(object):
 
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
-        break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
     def test_ctypes_as_parameter_holds_reference(self):
@@ -8021,20 +8020,7 @@ class TestCTypes(object):
 
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
-        break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
-
-    def test_ctypes_data_as_no_circular_reference(self):
-        # check array reference count based on the buffer the array points to
-        data = b'\x00' * 128
-        ref_count = sys.getrefcount(data)
-
-        arr = np.frombuffer(data)
-        ctypes_ptr = arr.ctypes.data_as(ctypes.c_void_p)
-
-        del arr, ctypes_ptr
-        # Do not call gc before checking circular reference
-        assert_(sys.getrefcount(data) == ref_count, "Found ctypes pointer circular reference")
 
 
 class TestWritebackIfCopy(object):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8007,6 +8007,35 @@ class TestCTypes(object):
         break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
+    def test_ctypes_as_parameter_holds_reference(self):
+        arr = np.array([None]).copy()
+
+        arr_ref = weakref.ref(arr)
+
+        ctypes_ptr = arr.ctypes._as_parameter_
+
+        # `ctypes_ptr` should hold onto `arr`
+        del arr
+        break_cycles()
+        assert_(arr_ref() is not None, "ctypes pointer did not hold onto a reference")
+
+        # but when the `ctypes_ptr` object dies, so should `arr`
+        del ctypes_ptr
+        break_cycles()
+        assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
+
+    def test_ctypes_data_as_no_circular_reference(self):
+        # check array reference count based on the buffer the array points to
+        data = b'\x00' * 128
+        ref_count = sys.getrefcount(data)
+
+        arr = np.frombuffer(data)
+        ctypes_ptr = arr.ctypes.data_as(ctypes.c_void_p)
+
+        del arr, ctypes_ptr
+        # Do not call gc before checking circular reference
+        assert_(sys.getrefcount(data) == ref_count, "Found ctypes pointer circular reference")
+
 
 class TestWritebackIfCopy(object):
     # all these tests use the WRITEBACKIFCOPY mechanism

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8006,6 +8006,11 @@ class TestCTypes(object):
 
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
+        if IS_PYPY:
+            # Pypy does not recycle arr objects immediately. Trigger gc to
+            # release arr. Cpython uses refcounts. An explicit call to gc
+            # should not be needed here.
+            break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
     def test_ctypes_as_parameter_holds_reference(self):
@@ -8023,9 +8028,6 @@ class TestCTypes(object):
         # but when the `ctypes_ptr` object dies, so should `arr`
         del ctypes_ptr
         if IS_PYPY:
-            # Pypy does not recycle arr objects immediately. Trigger gc to
-            # release arr. Cpython uses refcounts. An explicit call to gc
-            # should not be needed here.
             break_cycles()
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 


### PR DESCRIPTION
In _ctypes class, ctypes.cast() was called twice. It causes circular reference
for _ctypes._data due to the CPython bug https://bugs.python.org/issue12836.
This bug of ctypes.cast() seems affecting all Python versions.
It can be verified with the code below.
```python
from sys import getrefcount
import ctypes

z = ctypes.c_int(1)
pc = ctypes.cast(ctypes.byref(z), ctypes.c_char_p)
print(getrefcount(pc))  # 2: from getrefcount()
pv = ctypes.cast(pc, ctypes.c_void_p)
print(getrefcount(pc))  # 3: from getrefcount(), pc._objects; circular ref: pc -> pc._objects -> pc!
_objects = pc._objects
print(_objects == pv._objects)
print(getrefcount(_objects))  # 4: from getrefcount(), _objects, pc._objects, pv._objects
pc = pv = None
print(getrefcount(_objects))  # 3: from getrefcount(), _objects; circular ref: _objects -> pc -> pc._objects!
```