### PR TITLE
BLD: Add a best-effort build.log parser that looks for warnings

### DIFF
--- a/numpy/distutils/numpy_distribution.py
+++ b/numpy/distutils/numpy_distribution.py
@@ -13,6 +13,7 @@ class NumpyDistribution(Distribution):
         self.installed_libraries = []
         # A dict of pkg_config files to generate/install
         self.installed_pkg_config = {}
+        self.define_macros = attrs.pop('define_macros', None)
         Distribution.__init__(self, attrs)
 
     def has_scons_scripts(self):


### PR DESCRIPTION
Add a parser that under "normal development" workflow (on linux, using gcc, without `--show-build`) will raise an error if warnings are emitted during `run_tests.py`

I have been bitten by this many times, where I miss the warnings since I do not by default look at the `build.log`. This works for me (I caused a warning to be emitted and indeed `runtests.py` fails.

How much further should I pursue this: adding support for clang, windows, using `--show-build` ?