### PR TITLE
BUG: core: Fix the str function of the rational dtype.

### DIFF
--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -539,11 +539,11 @@ static PyObject*
 pyrational_str(PyObject* self) {
     rational x = ((PyRational*)self)->r;
     if (d(x)!=1) {
-        return PyString_FromFormat(
+        return PyUString_FromFormat(
                 "%ld/%ld",(long)x.n,(long)d(x));
     }
     else {
-        return PyString_FromFormat(
+        return PyUString_FromFormat(
                 "%ld",(long)x.n);
     }
 }


### PR DESCRIPTION
Fix the function pyrational_str to return a Unicode string.

Before this change:

    >>> r = _rational_tests.rational(17, 5)
    >>> r
    rational(17,5)
    >>> str(r)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: __str__ returned non-string (type bytes)

After this change:

    >>> r = _rational_tests.rational(17, 5)
    >>> r
    rational(17,5)
    >>> str(r)
    '17/5'

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
