### PR TITLE
DOC: add timedelta64 signature

### DIFF
--- a/doc/source/docs/howto_build_docs.rst
+++ b/doc/source/docs/howto_build_docs.rst
@@ -5,7 +5,7 @@ Building the NumPy API and reference docs
 =========================================
 
 We currently use Sphinx_ for generating the API and reference
-documentation for NumPy.  You will need Sphinx 1.8.3 or newer.
+documentation for NumPy.  You will need Sphinx 1.8.3 <= 1.8.5.
 
 If you only want to get the documentation, note that pre-built
 versions can be found at

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -100,7 +100,9 @@ Datetime and Timedelta Arithmetic
 NumPy allows the subtraction of two Datetime values, an operation which
 produces a number with a time unit. Because NumPy doesn't have a physical
 quantities system in its core, the timedelta64 data type was created
-to complement datetime64.
+to complement datetime64. The arguments for timedelta64 are a number, 
+to represent the number of units, and a date/time unit, such as
+(D)ay, (M)onth, (Y)ear, (h)ours, (m)inutes, or (s)econds.
 
 Datetimes and Timedeltas work together to provide ways for
 simple datetime calculations.

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -26,7 +26,9 @@ be either a :ref:`date unit <arrays.dtypes.dateunits>` or a
 :ref:`time unit <arrays.dtypes.timeunits>`. The date units are years ('Y'),
 months ('M'), weeks ('W'), and days ('D'), while the time units are
 hours ('h'), minutes ('m'), seconds ('s'), milliseconds ('ms'), and
-some additional SI-prefix seconds-based units.
+some additional SI-prefix seconds-based units. The datetime64 data type 
+also accepts the string "NAT", in any combination of lowercase/uppercase
+letters, for a "Not A Time" value.
 
 .. admonition:: Example
 
@@ -49,6 +51,11 @@ some additional SI-prefix seconds-based units.
 
     >>> np.datetime64('2005-02-25T03:30')
     numpy.datetime64('2005-02-25T03:30')
+
+    NAT (not a time):
+
+    >>> numpy.datetime64('nat')
+    numpy.datetime64('NaT')
 
 When creating an array of datetimes from a string, it is still possible
 to automatically select the unit from the inputs, by using the
@@ -102,7 +109,19 @@ produces a number with a time unit. Because NumPy doesn't have a physical
 quantities system in its core, the timedelta64 data type was created
 to complement datetime64. The arguments for timedelta64 are a number, 
 to represent the number of units, and a date/time unit, such as
-(D)ay, (M)onth, (Y)ear, (h)ours, (m)inutes, or (s)econds.
+(D)ay, (M)onth, (Y)ear, (h)ours, (m)inutes, or (s)econds. The timedelta64 
+data type also accepts the string "NAT" in place of the number for a "Not A Time" value.
+
+.. admonition:: Example
+
+    >>> numpy.timedelta64(1, 'D')
+    numpy.timedelta64(1,'D')
+
+    >>> numpy.timedelta64(4, 'h')
+    numpy.timedelta64(4,'h')
+
+    >>> numpy.timedelta64('nAt')
+    numpy.timedelta64('NaT')
 
 Datetimes and Timedeltas work together to provide ways for
 simple datetime calculations.
@@ -123,6 +142,12 @@ simple datetime calculations.
 
     >>> np.timedelta64(1,'W') % np.timedelta64(10,'D')
     numpy.timedelta64(7,'D')
+
+    >>> numpy.datetime64('nat') - numpy.datetime64('2009-01-01')
+    numpy.timedelta64('NaT','D')
+
+    >>> numpy.datetime64('2009-01-01') + numpy.timedelta64('nat')
+    numpy.datetime64('NaT')
 
 There are two Timedelta units ('Y', years and 'M', months) which are treated
 specially, because how much time they represent changes depending
@@ -369,131 +394,3 @@ with date units and datetimes with timeunits. With timezone naive datetimes,
 the rule for casting from dates to times is no longer ambiguous.
 
 .. _pandas: http://pandas.pydata.org
-
-
-Differences Between 1.6 and 1.7 Datetimes
-=========================================
-
-The NumPy 1.6 release includes a more primitive datetime data type
-than 1.7. This section documents many of the changes that have taken
-place.
-
-String Parsing
-``````````````
-
-The datetime string parser in NumPy 1.6 is very liberal in what it accepts,
-and silently allows invalid input without raising errors. The parser in
-NumPy 1.7 is quite strict about only accepting ISO 8601 dates, with a few
-convenience extensions. 1.6 always creates microsecond (us) units by
-default, whereas 1.7 detects a unit based on the format of the string.
-Here is a comparison.::
-
-    # NumPy 1.6.1
-    >>> np.datetime64('1979-03-22')
-    1979-03-22 00:00:00
-    # NumPy 1.7.0
-    >>> np.datetime64('1979-03-22')
-    numpy.datetime64('1979-03-22')
-
-    # NumPy 1.6.1, unit default microseconds
-    >>> np.datetime64('1979-03-22').dtype
-    dtype('datetime64[us]')
-    # NumPy 1.7.0, unit of days detected from string
-    >>> np.datetime64('1979-03-22').dtype
-    dtype('<M8[D]')
-
-    # NumPy 1.6.1, ignores invalid part of string
-    >>> np.datetime64('1979-03-2corruptedstring')
-    1979-03-02 00:00:00
-    # NumPy 1.7.0, raises error for invalid input
-    >>> np.datetime64('1979-03-2corruptedstring')
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    ValueError: Error parsing datetime string "1979-03-2corruptedstring" at position 8
-
-    # NumPy 1.6.1, 'nat' produces today's date
-    >>> np.datetime64('nat')
-    2012-04-30 00:00:00
-    # NumPy 1.7.0, 'nat' produces not-a-time
-    >>> np.datetime64('nat')
-    numpy.datetime64('NaT')
-
-    # NumPy 1.6.1, 'garbage' produces today's date
-    >>> np.datetime64('garbage')
-    2012-04-30 00:00:00
-    # NumPy 1.7.0, 'garbage' raises an exception
-    >>> np.datetime64('garbage')
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    ValueError: Error parsing datetime string "garbage" at position 0
-
-    # NumPy 1.6.1, can't specify unit in scalar constructor
-    >>> np.datetime64('1979-03-22T19:00', 'h')
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-    TypeError: function takes at most 1 argument (2 given)
-    # NumPy 1.7.0, unit in scalar constructor
-    >>> np.datetime64('1979-03-22T19:00', 'h')
-    numpy.datetime64('1979-03-22T19:00-0500','h')
-
-    # NumPy 1.6.1, reads ISO 8601 strings w/o TZ as UTC
-    >>> np.array(['1979-03-22T19:00'], dtype='M8[h]')
-    array([1979-03-22 19:00:00], dtype=datetime64[h])
-    # NumPy 1.7.0, reads ISO 8601 strings w/o TZ as local (ISO specifies this)
-    >>> np.array(['1979-03-22T19:00'], dtype='M8[h]')
-    array(['1979-03-22T19-0500'], dtype='datetime64[h]')
-
-    # NumPy 1.6.1, doesn't parse all ISO 8601 strings correctly
-    >>> np.array(['1979-03-22T12'], dtype='M8[h]')
-    array([1979-03-22 00:00:00], dtype=datetime64[h])
-    >>> np.array(['1979-03-22T12:00'], dtype='M8[h]')
-    array([1979-03-22 12:00:00], dtype=datetime64[h])
-    # NumPy 1.7.0, handles this case correctly
-    >>> np.array(['1979-03-22T12'], dtype='M8[h]')
-    array(['1979-03-22T12-0500'], dtype='datetime64[h]')
-    >>> np.array(['1979-03-22T12:00'], dtype='M8[h]')
-    array(['1979-03-22T12-0500'], dtype='datetime64[h]')
-
-Unit Conversion
-```````````````
-
-The 1.6 implementation of datetime does not convert between units correctly.::
-
-    # NumPy 1.6.1, the representation value is untouched
-    >>> np.array(['1979-03-22'], dtype='M8[D]')
-    array([1979-03-22 00:00:00], dtype=datetime64[D])
-    >>> np.array(['1979-03-22'], dtype='M8[D]').astype('M8[M]')
-    array([2250-08-01 00:00:00], dtype=datetime64[M])
-    # NumPy 1.7.0, the representation is scaled accordingly
-    >>> np.array(['1979-03-22'], dtype='M8[D]')
-    array(['1979-03-22'], dtype='datetime64[D]')
-    >>> np.array(['1979-03-22'], dtype='M8[D]').astype('M8[M]')
-    array(['1979-03'], dtype='datetime64[M]')
-
-Datetime Arithmetic
-```````````````````
-
-The 1.6 implementation of datetime only works correctly for a small subset of
-arithmetic operations. Here we show some simple cases.::
-
-    # NumPy 1.6.1, produces invalid results if units are incompatible
-    >>> a = np.array(['1979-03-22T12'], dtype='M8[h]')
-    >>> b = np.array([3*60], dtype='m8[m]')
-    >>> a + b
-    array([1970-01-01 00:00:00.080988], dtype=datetime64[us])
-    # NumPy 1.7.0, promotes to higher-resolution unit
-    >>> a = np.array(['1979-03-22T12'], dtype='M8[h]')
-    >>> b = np.array([3*60], dtype='m8[m]')
-    >>> a + b
-    array(['1979-03-22T15:00-0500'], dtype='datetime64[m]')
-
-    # NumPy 1.6.1, arithmetic works if everything is microseconds
-    >>> a = np.array(['1979-03-22T12:00'], dtype='M8[us]')
-    >>> b = np.array([3*60*60*1000000], dtype='m8[us]')
-    >>> a + b
-    array([1979-03-22 15:00:00], dtype=datetime64[us])
-    # NumPy 1.7.0
-    >>> a = np.array(['1979-03-22T12:00'], dtype='M8[us]')
-    >>> b = np.array([3*60*60*1000000], dtype='m8[us]')
-    >>> a + b
-    array(['1979-03-22T15:00:00.000000-0500'], dtype='datetime64[us]')


### PR DESCRIPTION
fixes #14328 

Added description of the arguments for `np.timedelta64`. I believe I added the correct documentation but any feedback is much appreciated.

Thanks!