### PR TITLE
MAINT: Extract raising of MemoryError to a helper function

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -936,6 +936,39 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
     return 0;
 }
 
+static PyObject *
+raise_memory_error(int nd, npy_intp *dims, PyArray_Descr *descr)
+{
+    static PyObject *exc_type = NULL;
+
+    npy_cache_import(
+        "numpy.core._exceptions", "_ArrayMemoryError",
+        &exc_type);
+    if (exc_type == NULL) {
+        goto fail;
+    }
+
+    PyObject *shape = PyArray_IntTupleFromIntp(nd, dims);
+    if (shape == NULL) {
+        goto fail;
+    }
+
+    /* produce an error object */
+    PyObject *exc_value = PyTuple_Pack(2, shape, (PyObject *)descr);
+    Py_DECREF(shape);
+    if (exc_value == NULL){
+        goto fail;
+    }
+    PyErr_SetObject(exc_type, exc_value);
+    Py_DECREF(exc_value);
+    return NULL;
+
+fail:
+    /* we couldn't raise the formatted exception for some reason */
+    PyErr_WriteUnraisable(NULL);
+    return PyErr_NoMemory();
+}
+
 /*
  * Generic new array creation routine.
  * Internal variant with calloc argument for PyArray_Zeros.
@@ -1113,30 +1146,7 @@ PyArray_NewFromDescr_int(
             data = npy_alloc_cache(nbytes);
         }
         if (data == NULL) {
-            static PyObject *exc_type = NULL;
-            
-            npy_cache_import(
-                "numpy.core._exceptions", "_ArrayMemoryError",
-                &exc_type);
-            if (exc_type == NULL) {
-                return NULL;
-            }
-            
-            PyObject *shape = PyArray_IntTupleFromIntp(fa->nd,fa->dimensions);
-            if (shape == NULL) {
-                return NULL;
-            }
-            
-            /* produce an error object */
-            PyObject *exc_value = PyTuple_Pack(2, shape, descr);
-            Py_DECREF(shape);
-            if (exc_value == NULL){
-                return NULL;
-            }
-            PyErr_SetObject(exc_type, exc_value);
-            Py_DECREF(exc_value);
-            return NULL;
-
+            return raise_memory_error(fa->nd, fa->dimensions, descr);
         }
         fa->flags |= NPY_ARRAY_OWNDATA;
 


### PR DESCRIPTION
Some minor cleanup that makes the error handling path take up less space in the main flow.

This also fails in a slightly more sensible way if somehow other stuff goes wrong while trying to produce the error message.