### PR TITLE
MAINT: Silence integer comparison build warnings in assert statements

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -1017,7 +1017,7 @@ sse2_sqrt_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
         op[i] = @scalarf@(ip[i]);
     }
-    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
+    assert((npy_uintp)n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
            npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
     if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
@@ -1069,7 +1069,7 @@ sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
         op[i] = @scalar@_@type@(ip[i]);
     }
-    assert(n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
+    assert((npy_uintp)n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
            npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
     if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
@@ -1104,7 +1104,7 @@ sse2_@kind@_@TYPE@(@type@ * ip, @type@ * op, const npy_intp n)
         /* Order of operations important for MSVC 2015 */
         *op = (*op @OP@ ip[i] || npy_isnan(*op)) ? *op : ip[i];
     }
-    assert(n < (stride) || npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES));
+    assert((npy_uintp)n < (stride) || npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES));
     if (i + 3 * stride <= n) {
         /* load the first elements */
         @vtype@ c1 = @vpre@_load_@vsuf@((@type@*)&ip[i]);


### PR DESCRIPTION
Just a few warnings less on my gcc (debug) build at leas (was annoying me while writing larger amounts of new code and trying to find the relevant actual warnings)