### PR TITLE
MAINT: distutils: Add newline at the end of printed warnings.

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -859,7 +859,7 @@ class Configuration(object):
             print(message)
 
     def warn(self, message):
-        sys.stderr.write('Warning: %s' % (message,))
+        sys.stderr.write('Warning: %s\n' % (message,))
 
     def set_options(self, **options):
         """


### PR DESCRIPTION
I noticed this when I got a warning while using numpy.distutils.  The printed output was not terminated with a newline, so after running setup.py, the shell prompt ended up at the end of the printed warning instead of in a new line.  For example, the following shows the last few lines of output when I ran setup.py in the directory `~/repos/git/sources/numtypes`.  Note that the shell prompt `~/repos/git/sources/numtypes$` ends up tacked on to the warning instead of in a new line:

```
[...]
running install_clib
customize UnixCCompiler
Warning: Assuming default configuration (numtypes/{setup_numtypes,setup}.py was not found)~/repos/git/sources/numtypes$
```
