### PR TITLE
DOC: Fix reference NPY_ARRAY_OWNDATA instead of NPY_OWNDATA.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -226,7 +226,7 @@ From scratch
 
     If *data* is not ``NULL``, then it is assumed to point to the memory
     to be used for the array and the *flags* argument is used as the
-    new flags for the array (except the state of :c:data:`NPY_OWNDATA`,
+    new flags for the array (except the state of :c:data:`NPY_ARRAY_OWNDATA`,
     :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` and :c:data:`NPY_ARRAY_UPDATEIFCOPY`
     flags of the new array will be reset).
 


### PR DESCRIPTION
The documentation isn't creating a link (https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.PyArray_NewFromDescr) because the documented member is called `NPY_ARRAY_OWNDATA` (https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.NPY_ARRAY_OWNDATA)