### PR TITLE
DOC: Add backslashes so PyUFunc_FromFuncAndDataAndSignatureAndIdentity renders correctly with sphinx.

### DIFF
--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -198,10 +198,10 @@ Functions
         to calling PyUFunc_FromFuncAndData. A copy of the string is made,
         so the passed in buffer can be freed.
 
-.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignatureAndIdentity(
+.. c:function:: PyObject* PyUFunc_FromFuncAndDataAndSignatureAndIdentity( \
         PyUFuncGenericFunction *func, void **data, char *types, int ntypes, \
-        int nin, int nout, int identity, char *name, char *doc, int unused, char *signature,
-        PyObject *identity_value)
+        int nin, int nout, int identity, char *name, char *doc, int unused, \
+        char *signature, PyObject *identity_value)
 
    This function is very similar to `PyUFunc_FromFuncAndDataAndSignature` above,
    but has an extra *identity_value* argument, to define an arbitrary identity


### PR DESCRIPTION
Currently the function is not properly rendered in the sphinx documentation (the function after https://docs.scipy.org/doc/numpy/reference/c-api.ufunc.html#c.PyUFunc_FromFuncAndDataAndSignature). By adding the backslashes sphinx will realize that the signature extends over multiple lines.