### PR TITLE
API: Do not return None from recfunctions.drop_fields

### DIFF
--- a/doc/release/upcoming_changes/14510.compatibility.rst
+++ b/doc/release/upcoming_changes/14510.compatibility.rst
@@ -1,0 +1,10 @@
+`numpy.lib.recfunctions.drop_fields` can no longer return ``None``
+------------------------------------------------------------------
+If ``drop_fields`` is used to drop all fields, previously the array would
+be completely discarded and ``None`` returned. Now it returns an array of the
+same shape as the input, but with no fields. The old behavior can be retained
+with::
+
+    dropped_arr = drop_fields(arr, ['a', 'b'])
+    if dropped_arr.dtype.names == ():
+        dropped_arr = None

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -527,6 +527,10 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
 
     Nested fields are supported.
 
+    ..versionchanged: 1.18.0
+        `drop_fields` returns an array with 0 fields if all fields are dropped,
+        rather than returning ``None`` as it did previously.
+
     Parameters
     ----------
     base : array
@@ -566,7 +570,7 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
             current = ndtype[name]
             if name in drop_names:
                 continue
-            if current.names:
+            if current.names is not None:
                 descr = _drop_descr(current, drop_names)
                 if descr:
                     newdtype.append((name, descr))
@@ -575,8 +579,6 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
         return newdtype
 
     newdtype = _drop_descr(base.dtype, drop_names)
-    if not newdtype:
-        return None
 
     output = np.empty(base.shape, dtype=newdtype)
     output = recursive_fill_fields(base, output)

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -91,8 +91,10 @@ class TestRecFunctions(object):
         control = np.array([(1,), (4,)], dtype=[('a', int)])
         assert_equal(test, control)
 
+        # dropping all fields results in an array with no fields
         test = drop_fields(a, ['a', 'b'])
-        assert_(test is None)
+        control = np.array([(), ()], dtype=[])
+        assert_equal(test, control)
 
     def test_rename_fields(self):
         # Test rename fields


### PR DESCRIPTION
This return value was not documented and did not make any sense. There's no reason to have a special case here.