### PR TITLE
BUG: Fix flatten_dtype so that nested 0-field structs are flattened correctly

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -200,7 +200,7 @@ def flatten_descr(ndtype):
         descr = []
         for field in names:
             (typ, _) = ndtype.fields[field]
-            if typ.names:
+            if typ.names is not None:
                 descr.extend(flatten_descr(typ))
             else:
                 descr.append((field, typ))

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -378,8 +378,8 @@ class TestMergeArrays(object):
         z = np.array(
             [('A', 1.), ('B', 2.)], dtype=[('A', '|S3'), ('B', float)])
         w = np.array(
-            [(1, (2, 3.0)), (4, (5, 6.0))],
-            dtype=[('a', int), ('b', [('ba', float), ('bb', int)])])
+            [(1, (2, 3.0, ())), (4, (5, 6.0, ()))],
+            dtype=[('a', int), ('b', [('ba', float), ('bb', int), ('bc', [])])])
         self.data = (w, x, y, z)
 
     def test_solo(self):
@@ -450,8 +450,8 @@ class TestMergeArrays(object):
         test = merge_arrays((x, w), flatten=False)
         controldtype = [('f0', int),
                                 ('f1', [('a', int),
-                                        ('b', [('ba', float), ('bb', int)])])]
-        control = np.array([(1., (1, (2, 3.0))), (2, (4, (5, 6.0)))],
+                                        ('b', [('ba', float), ('bb', int), ('bc', [])])])]
+        control = np.array([(1., (1, (2, 3.0, ()))), (2, (4, (5, 6.0, ())))],
                            dtype=controldtype)
         assert_equal(test, control)
 


### PR DESCRIPTION
This affects the behavior of merge_arrays.

Revived from my stash thanks to @ahaldane fixing structured equality

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
