### PR TITLE
DOC: random: fix doc linking, was referencing private submodules.

### DIFF
--- a/doc/source/reference/random/bit_generators/mt19937.rst
+++ b/doc/source/reference/random/bit_generators/mt19937.rst
@@ -1,9 +1,7 @@
-Mersenne Twister (MT19937) 
+Mersenne Twister (MT19937)
 --------------------------
 
-.. module:: numpy.random.mt19937
-
-.. currentmodule:: numpy.random.mt19937
+.. currentmodule:: numpy.random
 
 .. autoclass:: MT19937
 	:exclude-members:

--- a/doc/source/reference/random/bit_generators/pcg64.rst
+++ b/doc/source/reference/random/bit_generators/pcg64.rst
@@ -1,9 +1,7 @@
 Parallel Congruent Generator (64-bit, PCG64)
 --------------------------------------------
 
-.. module:: numpy.random.pcg64
-
-.. currentmodule:: numpy.random.pcg64
+.. currentmodule:: numpy.random
 
 .. autoclass:: PCG64
 	:exclude-members:

--- a/doc/source/reference/random/bit_generators/philox.rst
+++ b/doc/source/reference/random/bit_generators/philox.rst
@@ -1,9 +1,7 @@
 Philox Counter-based RNG
 ------------------------
 
-.. module:: numpy.random.philox
-
-.. currentmodule:: numpy.random.philox
+.. currentmodule:: numpy.random
 
 .. autoclass:: Philox
 	:exclude-members:

--- a/doc/source/reference/random/bit_generators/sfc64.rst
+++ b/doc/source/reference/random/bit_generators/sfc64.rst
@@ -1,9 +1,7 @@
 SFC64 Small Fast Chaotic PRNG
 -----------------------------
 
-.. module:: numpy.random.sfc64
-
-.. currentmodule:: numpy.random.sfc64
+.. currentmodule:: numpy.random
 
 .. autoclass:: SFC64
         :exclude-members:

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -190,7 +190,7 @@ Concepts
    :maxdepth: 1
 
    generator
-   Legacy generator and functions <legacy>
+   Legacy Generator (RandomState) <legacy>
    BitGenerators, SeedSequences <bit_generators/index>
 
 Features

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -190,7 +190,7 @@ Concepts
    :maxdepth: 1
 
    generator
-   legacy mtrand <legacy>
+   Legacy generator and functions <legacy>
    BitGenerators, SeedSequences <bit_generators/index>
 
 Features

--- a/doc/source/reference/random/legacy.rst
+++ b/doc/source/reference/random/legacy.rst
@@ -4,7 +4,7 @@
 
 Legacy Random Generation
 ------------------------
-The `~mtrand.RandomState` provides access to
+The `RandomState` provides access to
 legacy generators. This generator is considered frozen and will have
 no further improvements.  It is guaranteed to produce the same values
 as the final point release of NumPy v1.16. These all depend on Box-Muller
@@ -12,19 +12,19 @@ normals or inverse CDF exponentials or gammas. This class should only be used
 if it is essential to have randoms that are identical to what
 would have been produced by previous versions of NumPy.
 
-`~mtrand.RandomState` adds additional information
+`RandomState` adds additional information
 to the state which is required when using Box-Muller normals since these
 are produced in pairs. It is important to use
-`~mtrand.RandomState.get_state`, and not the underlying bit generators
+`RandomState.get_state`, and not the underlying bit generators
 `state`, when accessing the state so that these extra values are saved.
 
-Although we provide the `~mt19937.MT19937` BitGenerator for use independent of
-`~mtrand.RandomState`, note that its default seeding uses `~SeedSequence`
-rather than the legacy seeding algorithm. `~mtrand.RandomState` will use the
+Although we provide the `MT19937` BitGenerator for use independent of
+`RandomState`, note that its default seeding uses `SeedSequence`
+rather than the legacy seeding algorithm. `RandomState` will use the
 legacy seeding algorithm. The methods to use the legacy seeding algorithm are
 currently private as the main reason to use them is just to implement
-`~mtrand.RandomState`. However, one can reset the state of `~mt19937.MT19937`
-using the state of the `~mtrand.RandomState`:
+`RandomState`. However, one can reset the state of `MT19937`
+using the state of the `RandomState`:
 
 .. code-block:: python
 
@@ -46,8 +46,6 @@ using the state of the `~mtrand.RandomState`:
    rs.standard_exponential()
    rs2.standard_exponential()
 
-
-.. currentmodule:: numpy.random.mtrand
 
 .. autoclass:: RandomState
 	:exclude-members:

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -83,8 +83,8 @@ cdef class RandomState:
     See Also
     --------
     Generator
-    mt19937.MT19937
-    Bit_Generators
+    MT19937
+    :ref:`bit_generator`
 
     """
     cdef public object _bit_generator


### PR DESCRIPTION
Backport of #14360. 

Addresses part of gh-14359

**TODO / to decide**: there's still two namespaces left that look private:

- numpy.random.entropy (contains `random_entropy` and `seed_by_array`, unclear if those need to be public)
- numpy.random.bit_generator (contains only `BitGenerator` as a public object I think)
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
