### PR TITLE
BUILD, MAINT: run tests with verbose for PyPY, also do not leak resource

### DIFF
--- a/numpy/core/tests/test_umath_accuracy.py
+++ b/numpy/core/tests/test_umath_accuracy.py
@@ -35,7 +35,8 @@ class TestAccuracy(object):
             for filename in files:
                 data_dir = path.join(path.dirname(__file__), 'data')
                 filepath = path.join(data_dir, filename)
-                file_without_comments = (r for r in open(filepath) if not r[0] in ('$', '#'))
+                with open(filepath) as fid:
+                    file_without_comments = (r for r in fid if not r[0] in ('$', '#'))
                 data = np.genfromtxt(file_without_comments,
                                      dtype=('|S39','|S39','|S39',np.int),
                                      names=('type','input','output','ulperr'),

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -39,7 +39,7 @@ echo pypy3 version
 pypy3/bin/pypy3 -c "import sys; print(sys.version)"
 echo
 
-pypy3/bin/pypy3 runtests.py --show-build-log -- -rsx \
+pypy3/bin/pypy3 runtests.py --show-build-log -v -- -rsx \
       --junitxml=junit/test-results.xml --durations 10
 
 echo Make sure the correct openblas has been linked in


### PR DESCRIPTION
There are occasional hangs on the CI runs with PyPy. Adding `-v` to try to pinpoint which test sequences hang. Also noticed a resource leak.