### PR TITLE
BLD: add warn-error option,  adds -Werror to  compiler

### DIFF
--- a/numpy/distutils/command/build.py
+++ b/numpy/distutils/command/build.py
@@ -16,6 +16,8 @@ class build(old_build):
     user_options = old_build.user_options + [
         ('fcompiler=', None,
          "specify the Fortran compiler type"),
+        ('warn-error', None,
+         "turn all warnings into errors (-Werror)"),
         ]
 
     help_options = old_build.help_options + [
@@ -26,6 +28,7 @@ class build(old_build):
     def initialize_options(self):
         old_build.initialize_options(self)
         self.fcompiler = None
+        self.warn_error = False
 
     def finalize_options(self):
         build_scripts = self.build_scripts

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -33,15 +33,18 @@ class build_clib(old_build_clib):
         ('inplace', 'i', 'Build in-place'),
         ('parallel=', 'j',
          "number of parallel jobs"),
+        ('warn-error', None,
+         "turn all warnings into errors (-Werror)"),
     ]
 
-    boolean_options = old_build_clib.boolean_options + ['inplace']
+    boolean_options = old_build_clib.boolean_options + ['inplace', 'warn-error']
 
     def initialize_options(self):
         old_build_clib.initialize_options(self)
         self.fcompiler = None
         self.inplace = 0
         self.parallel = None
+        self.warn_error = None
 
     def finalize_options(self):
         if self.parallel:
@@ -50,7 +53,10 @@ class build_clib(old_build_clib):
             except ValueError:
                 raise ValueError("--parallel/-j argument must be an integer")
         old_build_clib.finalize_options(self)
-        self.set_undefined_options('build', ('parallel', 'parallel'))
+        self.set_undefined_options('build',
+                                        ('parallel', 'parallel'),
+                                        ('warn_error', 'warn_error'),
+                                  )
 
     def have_f_sources(self):
         for (lib_name, build_info) in self.libraries:
@@ -85,6 +91,10 @@ class build_clib(old_build_clib):
                                      force=self.force)
         self.compiler.customize(self.distribution,
                                 need_cxx=self.have_cxx_sources())
+
+        if self.warn_error:
+            self.compiler.compiler.append('-Werror')
+            self.compiler.compiler_so.append('-Werror')
 
         libraries = self.libraries
         self.libraries = None

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -33,6 +33,8 @@ class build_ext (old_build_ext):
          "specify the Fortran compiler type"),
         ('parallel=', 'j',
          "number of parallel jobs"),
+        ('warn-error', None,
+         "turn all warnings into errors (-Werror)"),
     ]
 
     help_options = old_build_ext.help_options + [
@@ -40,10 +42,13 @@ class build_ext (old_build_ext):
          show_fortran_compilers),
     ]
 
+    boolean_options = old_build_ext.boolean_options + ['warn-error']
+
     def initialize_options(self):
         old_build_ext.initialize_options(self)
         self.fcompiler = None
         self.parallel = None
+        self.warn_error = None
 
     def finalize_options(self):
         if self.parallel:
@@ -69,7 +74,10 @@ class build_ext (old_build_ext):
         self.include_dirs.extend(incl_dirs)
 
         old_build_ext.finalize_options(self)
-        self.set_undefined_options('build', ('parallel', 'parallel'))
+        self.set_undefined_options('build',
+                                        ('parallel', 'parallel'),
+                                        ('warn_error', 'warn_error'),
+                                  )
 
     def run(self):
         if not self.extensions:
@@ -116,6 +124,11 @@ class build_ext (old_build_ext):
                                      force=self.force)
         self.compiler.customize(self.distribution)
         self.compiler.customize_cmd(self)
+
+        if self.warn_error:
+            self.compiler.compiler.append('-Werror')
+            self.compiler.compiler_so.append('-Werror')
+
         self.compiler.show_customization()
 
         # Setup directory for storing generated extra DLL files on Windows

--- a/runtests.py
+++ b/runtests.py
@@ -110,6 +110,8 @@ def main(argv):
                         help="Debug build")
     parser.add_argument("--parallel", "-j", type=int, default=0,
                         help="Number of parallel jobs during build")
+    parser.add_argument("--warn-error", action="store_true",
+                        help="Set -Werror to convert all compiler warnings to errors")
     parser.add_argument("--show-build-log", action="store_true",
                         help="Show build output rather than using a log file")
     parser.add_argument("--bench", action="store_true",
@@ -372,6 +374,8 @@ def build_project(args):
         cmd += ["-j", str(args.parallel)]
     if args.debug_configure:
         cmd += ["build_src", "--verbose"]
+    if args.warn_error:
+        cmd += ["--warn-error"]
     # Install; avoid producing eggs so numpy can be imported from dst_dir.
     cmd += ['install', '--prefix=' + dst_dir,
             '--single-version-externally-managed',


### PR DESCRIPTION
Adds the -Werror compiler option to build, build_clib and build_ext sub-commands. Can be used with `CC=clang` to try out the clang compiler and see the errors