### PR TITLE
MAINT: remove unused functions, rearrange headers (from CC=clang)

### DIFF
--- a/numpy/core/src/common/npy_partition.h.src
+++ b/numpy/core/src/common/npy_partition.h.src
@@ -113,9 +113,6 @@ get_argpartition_func(int type, NPY_SELECTKIND which)
     npy_intp i;
     npy_intp ntypes = ARRAY_SIZE(_part_map);
 
-    if (which >= NPY_NSELECTS) {
-        return NULL;
-    }
     for (i = 0; i < ntypes; i++) {
         if (type == _part_map[i].typenum) {
             return _part_map[i].argpart[which];

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1336,7 +1336,11 @@ PyArray_ArgPartition(PyArrayObject *op, PyArrayObject *ktharray, int axis,
     PyArray_ArgSortFunc *argsort;
     PyObject *ret;
 
-    if (which < 0 || which >= NPY_NSELECTS) {
+    /*
+     * As a C-exported function, enum NPY_SELECTKIND loses its enum property
+     * Check the values to make sure they are in range
+     */
+    if ((int)which < 0 || (int)which >= NPY_NSELECTS) {
         PyErr_SetString(PyExc_ValueError,
                         "not a valid partition kind");
         return NULL;

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -40,13 +40,14 @@
  * flag in an efficient way. The flag is IEEE specific. See
  * https://github.com/freebsd/freebsd/blob/4c6378299/lib/msun/src/catrig.c#L42
  */
+#if !defined(HAVE_CACOSF) || !defined(HAVE_CACOSL) || !defined(HAVE_CASINHF) || !defined(HAVE_CASINHL)
 #define raise_inexact() do {                        \
     volatile npy_float NPY_UNUSED(junk) = 1 + tiny; \
 } while (0)
 
 
 static const volatile npy_float tiny = 3.9443045e-31f;
-
+#endif
 
 /**begin repeat
  * #type = npy_float, npy_double, npy_longdouble#
@@ -64,9 +65,6 @@ static const volatile npy_float tiny = 3.9443045e-31f;
  * Constants
  *=========================================================*/
 static const @ctype@ c_1@c@ = {1.0@C@, 0.0};
-static const @ctype@ c_half@c@ = {0.5@C@, 0.0};
-static const @ctype@ c_i@c@ = {0.0, 1.0@C@};
-static const @ctype@ c_ihalf@c@ = {0.0, 0.5@C@};
 
 /*==========================================================
  * Helper functions
@@ -74,22 +72,6 @@ static const @ctype@ c_ihalf@c@ = {0.0, 0.5@C@};
  * These are necessary because we do not count on using a
  * C99 compiler.
  *=========================================================*/
-static NPY_INLINE
-@ctype@
-cadd@c@(@ctype@ a, @ctype@ b)
-{
-    return npy_cpack@c@(npy_creal@c@(a) + npy_creal@c@(b),
-                        npy_cimag@c@(a) + npy_cimag@c@(b));
-}
-
-static NPY_INLINE
-@ctype@
-csub@c@(@ctype@ a, @ctype@ b)
-{
-    return npy_cpack@c@(npy_creal@c@(a) - npy_creal@c@(b),
-                        npy_cimag@c@(a) - npy_cimag@c@(b));
-}
-
 static NPY_INLINE
 @ctype@
 cmul@c@(@ctype@ a, @ctype@ b)
@@ -130,20 +112,6 @@ cdiv@c@(@ctype@ a, @ctype@ b)
         @type@ scl = 1.0@C@/(bi + br*rat);
         return npy_cpack@c@((ar*rat + ai)*scl, (ai*rat - ar)*scl);
     }
-}
-
-static NPY_INLINE
-@ctype@
-cneg@c@(@ctype@ a)
-{
-    return npy_cpack@c@(-npy_creal@c@(a), -npy_cimag@c@(a));
-}
-
-static NPY_INLINE
-@ctype@
-cmuli@c@(@ctype@ a)
-{
-    return npy_cpack@c@(-npy_cimag@c@(a), npy_creal@c@(a));
 }
 
 /*==========================================================

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1430,21 +1430,18 @@ static PyObject *
 
 /**begin repeat
  *
- * #name = (byte, ubyte, short, ushort, int, uint,
+ * #name = byte, ubyte, short, ushort, int, uint,
  *             long, ulong, longlong, ulonglong,
  *             half, float, double, longdouble,
- *             cfloat, cdouble, clongdouble)*2#
- * #Name = (Byte, UByte, Short, UShort, Int, UInt,
+ *             cfloat, cdouble, clongdouble#
+ * #Name = Byte, UByte, Short, UShort, Int, UInt,
  *             Long, ULong, LongLong, ULongLong,
  *             Half, Float, Double, LongDouble,
- *             CFloat, CDouble, CLongDouble)*2#
- * #cmplx = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1)*2#
- * #to_ctype = (, , , , , , , , , , npy_half_to_double, , , , , , )*2#
- * #which = long*17, float*17#
- * #func = (PyLong_FromLongLong,  PyLong_FromUnsignedLongLong)*5,
- *         PyLong_FromDouble*3, npy_longdouble_to_PyLong,
- *         PyLong_FromDouble*2, npy_longdouble_to_PyLong,
- *         PyFloat_FromDouble*17#
+ *             CFloat, CDouble, CLongDouble#
+ * #cmplx = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1#
+ * #to_ctype = , , , , , , , , , , npy_half_to_double, , , , , , #
+ * #which = float*17#
+ * #func = PyFloat_FromDouble*17#
  */
 static NPY_INLINE PyObject *
 @name@_@which@(PyObject *obj)
@@ -1460,7 +1457,39 @@ static NPY_INLINE PyObject *
 }
 /**end repeat**/
 
+
 #if !defined(NPY_PY3K)
+
+/**begin repeat
+ *
+ * #name = (byte, ubyte, short, ushort, int, uint,
+ *             long, ulong, longlong, ulonglong,
+ *             half, float, double, longdouble,
+ *             cfloat, cdouble, clongdouble)#
+ * #Name = (Byte, UByte, Short, UShort, Int, UInt,
+ *             Long, ULong, LongLong, ULongLong,
+ *             Half, Float, Double, LongDouble,
+ *             CFloat, CDouble, CLongDouble)#
+ * #cmplx = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1)#
+ * #to_ctype = (, , , , , , , , , , npy_half_to_double, , , , , , )#
+ * #which = long*17#
+ * #func = (PyLong_FromLongLong,  PyLong_FromUnsignedLongLong)*5,
+ *         PyLong_FromDouble*3, npy_longdouble_to_PyLong,
+ *         PyLong_FromDouble*2, npy_longdouble_to_PyLong#
+ */
+static NPY_INLINE PyObject *
+@name@_@which@(PyObject *obj)
+{
+#if @cmplx@
+    if (emit_complexwarning() < 0) {
+        return NULL;
+    }
+    return @func@(@to_ctype@(PyArrayScalar_VAL(obj, @Name@).real));
+#else
+    return @func@(@to_ctype@(PyArrayScalar_VAL(obj, @Name@)));
+#endif
+}
+/**end repeat**/
 
 /**begin repeat
  *

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1440,11 +1440,10 @@ static PyObject *
  *             CFloat, CDouble, CLongDouble#
  * #cmplx = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1#
  * #to_ctype = , , , , , , , , , , npy_half_to_double, , , , , , #
- * #which = float*17#
  * #func = PyFloat_FromDouble*17#
  */
 static NPY_INLINE PyObject *
-@name@_@which@(PyObject *obj)
+@name@_float(PyObject *obj)
 {
 #if @cmplx@
     if (emit_complexwarning() < 0) {
@@ -1472,13 +1471,12 @@ static NPY_INLINE PyObject *
  *             CFloat, CDouble, CLongDouble)#
  * #cmplx = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1)#
  * #to_ctype = (, , , , , , , , , , npy_half_to_double, , , , , , )#
- * #which = long*17#
  * #func = (PyLong_FromLongLong,  PyLong_FromUnsignedLongLong)*5,
  *         PyLong_FromDouble*3, npy_longdouble_to_PyLong,
  *         PyLong_FromDouble*2, npy_longdouble_to_PyLong#
  */
 static NPY_INLINE PyObject *
-@name@_@which@(PyObject *obj)
+@name@_long(PyObject *obj)
 {
 #if @cmplx@
     if (emit_complexwarning() < 0) {

--- a/numpy/random/src/distributions/distributions.h
+++ b/numpy/random/src/distributions/distributions.h
@@ -1,13 +1,12 @@
 #ifndef _RANDOMDGEN__DISTRIBUTIONS_H_
 #define _RANDOMDGEN__DISTRIBUTIONS_H_
 
-#pragma once
+#include "Python.h"
+#include "numpy/npy_common.h"
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "Python.h"
-#include "numpy/npy_common.h"
 #include "numpy/npy_math.h"
 #include "numpy/random/bitgen.h"
 

--- a/numpy/random/src/distributions/random_hypergeometric.c
+++ b/numpy/random/src/distributions/random_hypergeometric.c
@@ -1,6 +1,6 @@
-#include <stdint.h>
 #include "distributions.h"
 #include "logfactorial.h"
+#include <stdint.h>
 
 /*
  *  Generate a sample from the hypergeometric distribution.

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -1,8 +1,8 @@
 #ifndef _RANDOMDGEN__PHILOX_H_
 #define _RANDOMDGEN__PHILOX_H_
 
-#include <inttypes.h>
 #include "numpy/npy_common.h"
+#include <inttypes.h>
 
 #define PHILOX_BUFFER_SIZE 4L
 

--- a/numpy/random/src/sfc64/sfc64.h
+++ b/numpy/random/src/sfc64/sfc64.h
@@ -1,11 +1,11 @@
 #ifndef _RANDOMDGEN__SFC64_H_
 #define _RANDOMDGEN__SFC64_H_
 
+#include "numpy/npy_common.h"
 #include <inttypes.h>
 #ifdef _WIN32
 #include <stdlib.h>
 #endif
-#include "numpy/npy_common.h"
 
 typedef struct s_sfc64_state {
   uint64_t s[4];


### PR DESCRIPTION
Cleanup unused function and tweak order of header include to get a clean build on clang (at least on my machine). I built this on top of #14527 to turn all warnings into errors after the `build_src` configuration step.