### PR TITLE
DOC: Fix a bit of code in 'Beyond the Basics' C API user guide.

### DIFF
--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -300,9 +300,10 @@ An example castfunc is:
 
     static void
     double_to_float(double *from, float* to, npy_intp n,
-           void* ig1, void* ig2);
-    while (n--) {
-          (*to++) = (double) *(from++);
+                    void* ignore1, void* ignore2) {
+        while (n--) {
+              (*to++) = (double) *(from++);
+        }
     }
 
 This could then be registered to convert doubles to floats using the


### PR DESCRIPTION
The example casting function shown in https://numpy.org/devdocs/user/c-info.beyond-basics.html#registering-a-casting-function is not correct C code. 