### PR TITLE
Changing ImportWarning to DeprecationWarning

### DIFF
--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -10,7 +10,7 @@ import warnings
 # 2018-04-04, numpy 1.15.0
 warnings.warn("Importing from numpy.testing.utils is deprecated "
               "since 1.15.0, import from numpy.testing instead.",
-              ImportWarning, stacklevel=2)
+              DeprecationWarning, stacklevel=2)
 
 from ._private.utils import *
 

--- a/numpy/testing/utils.py
+++ b/numpy/testing/utils.py
@@ -7,7 +7,8 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 
-# 2018-04-04, numpy 1.15.0
+# 2018-04-04, numpy 1.15.0 ImportWarning
+# 2019-09-18, numpy 1.18.0 DeprecatonWarning (changed)
 warnings.warn("Importing from numpy.testing.utils is deprecated "
               "since 1.15.0, import from numpy.testing instead.",
               DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
Fixing typo from #10850 

I would guess the comment about 1.15 can be updated as well and say it was deprecated in 1.18 as downstream users might not noticed the ImportWarning.