### PR TITLE
MAINT: handle case where GIT_VERSION is empty string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
+        assert GIT_REVISION, "Empty GIT_REVISION see gh-8512"
         FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 
     return FULLVERSION, GIT_REVISION

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,10 @@ def git_version():
     except (subprocess.SubprocessError, OSError):
         GIT_REVISION = "Unknown"
 
+    if not GIT_REVISION:
+        # this shouldn't happen but apparently can (see gh-8512)
+        GIT_REVISION = "Unknown"
+
     return GIT_REVISION
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
@@ -116,7 +120,6 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        assert GIT_REVISION, "Empty GIT_REVISION see gh-8512"
         FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 
     return FULLVERSION, GIT_REVISION


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Assert that git revision is not missing (as happened in #8512).
Parsing the bug (which is old) I don't believe this should ever assert unless in weird situations. 

I'm also happy if people want to close the bug as obsolete 