### PR TITLE
DOC: clarify input types in basics.io.genfromtxt.rst

### DIFF
--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -27,13 +27,13 @@ Defining the input
 ==================
 
 The only mandatory argument of :func:`~numpy.genfromtxt` is the source of
-the data. It can be a string, a list of strings, or a generator. If a
-single string is provided, it is assumed to be the name of a local or
-remote file, or an open file-like object with a :meth:`read` method, for
-example, a file or :class:`io.StringIO` object. If a list of strings
-or a generator returning strings is provided, each string is treated as one
-line in a file.  When the URL of a remote file is passed, the file is
-automatically downloaded to the current directory and opened.
+the data. It can be a string, a list of strings, a generator or an open
+file-like object with a :meth:`read` method, for example, a file or 
+:class:`io.StringIO` object. If a single string is provided, it is assumed
+to be the name of a local or remote file, If a list of strings or a generator
+returning strings is provided, each string is treated as one line in a file.
+When the URL of a remote file is passed, the file is automatically downloaded
+to the current directory and opened.
 
 Recognized file types are text files and archives.  Currently, the function
 recognizes :class:`gzip` and :class:`bz2` (`bzip2`) archives.  The type of

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -30,7 +30,7 @@ The only mandatory argument of :func:`~numpy.genfromtxt` is the source of
 the data. It can be a string, a list of strings, a generator or an open
 file-like object with a :meth:`read` method, for example, a file or 
 :class:`io.StringIO` object. If a single string is provided, it is assumed
-to be the name of a local or remote file, If a list of strings or a generator
+to be the name of a local or remote file. If a list of strings or a generator
 returning strings is provided, each string is treated as one line in a file.
 When the URL of a remote file is passed, the file is automatically downloaded
 to the current directory and opened.


### PR DESCRIPTION
The description of the input parameter for genfromtext has become garbled to the extent that it is incorrect. A literal reading of the current text suggests that the function would accept the _name_  of an open file-like object _as a string_ but would not accept a file-like object directly. In reality the function accepts an file-like object directly as would be intuitive for most users and as is described in the docs for genfromtext. This commit simplifies the sentence structure and gives it the correct meaning.
