### PR TITLE
DOC: remove note about Pocketfft license file (non-existing here).

### DIFF
--- a/numpy/fft/README.md
+++ b/numpy/fft/README.md
@@ -10,11 +10,6 @@ advantages:
 - worst case complexity for transform sizes with large prime factors is
   `N*log(N)`, because Bluestein's algorithm [3] is used for these cases.
 
-License
--------
-
-3-clause BSD (see LICENSE.md)
-
 
 Some code details
 -----------------


### PR DESCRIPTION
Closes gh-14552

The Pocketfft author (mreineck) agreed on gh-14552 that Pocketfft can
simply fall under the NumPy license, no separate license file needed.

[ci skip]