### PR TITLE
BLD, DOC: fix gh-14518, add release note

### DIFF
--- a/doc/release/upcoming_changes/14518.change.rst
+++ b/doc/release/upcoming_changes/14518.change.rst
@@ -1,0 +1,18 @@
+Add options to quiet build configuration and build with ``-Werror``
+-------------------------------------------------------------------
+Added two new configuration options. During the ``build_src`` subcommand, as
+part of configuring NumPy, the files ``_numpyconfig.h`` and ``config.h`` are
+created by probing support for various runtime functions and routines.
+Previously, the very verbose compiler output during this stage clouded more
+important information. By default the output is silenced. Running ``runtests.py
+--debug-configure`` will add ``-v`` to the ``build_src`` subcommand, which
+will restore the previous behaviour.
+
+Adding ``CFLAGS=-Werror`` to turn warnings into errors would trigger errors
+during the configuration. Now ``runtests.py --warn-error`` will add
+``--warn-error`` to the ``build`` subcommand, which will percolate to the
+``build_ext`` and ``build_lib`` subcommands. This will add the compiler flag
+to those stages and turn compiler warnings into errors while actually building
+NumPy itself, avoiding the ``build_src`` subcommand compiler calls.
+
+(`gh-14527 <https://github.com/numpy/numpy/pull/14527>`__)

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -79,7 +79,7 @@ class build_src(build_ext.build_ext):
         self.swig_opts = None
         self.swig_cpp = None
         self.swig = None
-        self.verbose = False
+        self.verbose = None
 
     def finalize_options(self):
         self.set_undefined_options('build',


### PR DESCRIPTION
In gh-14518 we added a `--debug-configure`` option, but it didn't work. In one of the refactoring I made the option default value False when it should have been None.

Also added a release note for both gh-14518 and gh-14527. Manually added the second PR's tag line since towncrier will create the first one. Suggestions to improve the release note text are welcome