### PR TITLE
BUG: importing build_src breaks setuptools monkeypatch for msvc14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,6 @@ class concat_license_files():
 
 
 from distutils.command.sdist import sdist
-from numpy.distutils.command.build_src import build_src
 class sdist_checked(sdist):
     """ check submodules on sdist to prevent incomplete tarballs """
     def run(self):
@@ -405,7 +404,6 @@ def setup_package():
         platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
         test_suite='nose.collector',
         cmdclass={"sdist": sdist_checked,
-                  "build_src": build_src,
                  },
         python_requires='>=3.5',
         zip_safe=False,


### PR DESCRIPTION
It turns out importing `build_src` in the `setup.py` breaks a numpy-specific monkey patch of setuptools for msvc14. Not sure why this only shows up in the wheel builds. The reason for the import was to improve the help message output for `python setup.py --help-commands`.  `build_src`, a numpy-specific addition, is not listed in the `Extra commands` section.

xref MacPython/numpy-wheels#61

At some point we could revisit this, but this PR should un-break the wheel builds.