### PR TITLE
DOC: Note runtests.py `-- -s` method to use pytests `-s`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -18,6 +18,10 @@ Run a debugger:
 
     $ gdb --args python runtests.py [...other args...]
 
+Disable pytest capturing of output by using its '-s' option:
+
+    $ python runtests.py -- -s
+
 Generate C code coverage listing under build/lcov/:
 (requires http://ltp.sourceforge.net/coverage/lcov.php)
 


### PR DESCRIPTION
The `-s` option allows disabling the printing capture, which can
be useful during debugging, and thus should be a bit more
discoverable.

Replaces/closes gh-12829

---

Do not want to snipe it, but thought it was quickest to just open a PR myself and finish it @madphysicist, what do you think?