### PR TITLE
DOC: Document the NPY_SCALARKIND values as C variables.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2797,10 +2797,7 @@ Array Scalars
     *arr* is not ``NULL`` and the first element is negative then
     :c:data:`NPY_INTNEG_SCALAR` is returned, otherwise
     :c:data:`NPY_INTPOS_SCALAR` is returned. The possible return values
-    are :c:data:`NPY_{kind}_SCALAR` where ``{kind}`` can be **INTPOS**,
-    **INTNEG**, **FLOAT**, **COMPLEX**, **BOOL**, or **OBJECT**.
-    :c:data:`NPY_NOSCALAR` is also an enumerated value
-    :c:type:`NPY_SCALARKIND` variables can take on.
+    are the enumerated values in :c:type:`NPY_SCALARKIND`.
 
 .. c:function:: int PyArray_CanCoerceScalar( \
         char thistype, char neededtype, NPY_SCALARKIND scalar)
@@ -3596,11 +3593,21 @@ Enumerated Types
 
     A special variable type indicating the number of "kinds" of
     scalars distinguished in determining scalar-coercion rules. This
-    variable can take on the values :c:data:`NPY_{KIND}` where ``{KIND}`` can be
+    variable can take on the values:
 
-        **NOSCALAR**, **BOOL_SCALAR**, **INTPOS_SCALAR**,
-        **INTNEG_SCALAR**, **FLOAT_SCALAR**, **COMPLEX_SCALAR**,
-        **OBJECT_SCALAR**
+    .. c:var:: NPY_NOSCALAR
+
+    .. c:var:: NPY_BOOL_SCALAR
+
+    .. c:var:: NPY_INTPOS_SCALAR
+
+    .. c:var:: NPY_INTNEG_SCALAR
+
+    .. c:var:: NPY_FLOAT_SCALAR
+
+    .. c:var:: NPY_COMPLEX_SCALAR
+
+    .. c:var:: NPY_OBJECT_SCALAR
 
     .. c:var:: NPY_NSCALARKINDS
 


### PR DESCRIPTION
Currently the ":c:data:" links could not resolve these because the values were not explicitly documented.

Also removes some duplication with the doc of `PyArray_ScalarKind`.

Current documentation: https://numpy.org/devdocs/reference/c-api/array.html#c.NPY_SCALARKIND