### PR TITLE
ENH: add quoting support to np.genfromtxt

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -258,23 +258,27 @@ class LineSplitter(object):
             return line.split(self.delimiter)
         else:
             out = []
+            index = 0
             isQuoted = False
-            chars = list(line)
             word = ''
 
-            for char in chars:
+            while index < len(line):
+                char = line[index]
                 if char == self.quoter:
-                    isQuoted = not isQuoted
-                else if char == self.delimiter and not isQuoted:
+                    if len(word) == 0 and not isQuoted:
+                        isQuoted = True
+                    else:
+                        isQuoted = False
+                elif char == self.delimiter and not isQuoted:
                     out.append(word)
+                    word = ''
                 else:
                     word += char
-
+                index += 1
             if word:
                 out.append(word)
             
             return out
-    #
 
     def _fixedwidth_splitter(self, line):
         if self.comments is not None:

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1564,7 +1564,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                deletechars=''.join(sorted(NameValidator.defaultdeletechars)),
                replace_space='_', autostrip=False, case_sensitive=True,
                defaultfmt="f%i", unpack=None, usemask=False, loose=True,
-               invalid_raise=True, max_rows=None, encoding='bytes'):
+               invalid_raise=True, max_rows=None, encoding='bytes', quoter=None):
     """
     Load data from a text file, with missing values handled as specified.
 
@@ -1661,6 +1661,13 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         to None the system default is used. The default value is 'bytes'.
 
         .. versionadded:: 1.14.0
+
+    quoter: str, optional
+        The string used as the quoting character. By default, it is assumed
+        that the values are not quoted. If invalid value is provided, quoter
+        defaults to None.
+
+        .. versionadded:: 1.18.0
 
     Returns
     -------
@@ -1780,7 +1787,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
     with fid_ctx:
         split_line = LineSplitter(delimiter=delimiter, comments=comments,
-                                  autostrip=autostrip, encoding=encoding)
+                                  autostrip=autostrip, encoding=encoding,
+                                  quoter=quoter)
         validate_names = NameValidator(excludelist=excludelist,
                                        deletechars=deletechars,
                                        case_sensitive=case_sensitive,

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2420,6 +2420,18 @@ class TestPathUsage(object):
             data = np.genfromtxt(path)
             assert_array_equal(a, data)
 
+    def test_genfromtxt_quoter(self):
+        with temppath(suffix='.txt') as path:
+            path = Path(path)
+            # "This is my text, that has a comma inside","Other value","3"
+            # "Another text, with coma","More text, with comma",5
+            with path.open('w') as f:
+                a = u"\"This is my text, that has a comma inside\",\"Other value\",\"3\"\n\"Another text, with coma\",\"More text, with comma\",5"
+                f.write(a)
+
+            data = np.genfromtxt(path, delimiter=',', quoter='"', encoding=None, dtype=None)
+            assert_equal(data.shape, (2,))
+
     def test_ndfromtxt(self):
         # Test outputting a standard ndarray
         with temppath(suffix='.txt') as path:


### PR DESCRIPTION
Fixes #2211 

Example:
test.txt content:
```
"This is my text, that has a comma inside","Other value","3"
"Another text, with coma","More text, with comma",5
```

Previous behavior:
```
>>> np.genfromtxt('test.txt', delimiter=',', encoding=None, dtype=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/anaconda3/envs/default/lib/python3.7/site-packages/numpy/lib/npyio.py", line 2089, in genfromtxt
    raise ValueError(errmsg)
ValueError: Some errors were detected !
    Line #2 (got 5 columns instead of 4)
```
Expected Behavior:
```
>>> np.genfromtxt('test.txt', delimiter=',', quoter='"', encoding=None, dtype=None)
array([('This is my text, that has a comma inside', 'Other value', 3),
       ('Another text, with coma', 'More text, with comma', 5)],
      dtype=[('f0', '<U40'), ('f1', '<U21'), ('f2', '<i8')])
```
