### PR TITLE
DOC: Add warn if numpy.split() arguments are not sorted.

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -770,6 +770,18 @@ def array_split(ary, indices_or_sections, axis=0):
     for i in range(Nsections):
         st = div_points[i]
         end = div_points[i + 1]
+
+        # normalize negative indexes
+        # st = normalize_axis_index(st, Ntotal+1)
+        if st < 0:
+            st += Ntotal
+        # end = normalize_axis_index(end, Ntotal+1)
+        if end < 0:
+            end += Ntotal
+
+        if end < st:
+            warnings.warn("split had negative range", stacklevel=3)
+
         sub_arys.append(_nx.swapaxes(sary[st:end], axis, 0))
 
     return sub_arys

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -436,10 +436,18 @@ class TestArraySplit(object):
     def test_index_split_high_bound(self):
         a = np.arange(10)
         indices = [0, 5, 7, 10, 12]
-        res = array_split(a, indices, axis=-1)
+        with assert_warns(UserWarning):
+            res = array_split(a, indices, axis=-1)
         desired = [np.array([]), np.arange(0, 5), np.arange(5, 7),
                    np.arange(7, 10), np.array([]), np.array([])]
         compare_results(res, desired)
+
+    def test_index_empty_range(self):
+        a = np.arange(10)
+        with assert_warns(UserWarning):
+            res = array_split(a, [6, -7])
+            desired = [np.arange(0,6), np.array([]), np.arange(3, 10)]
+            compare_results(res, desired)
 
 
 class TestSplit(object):


### PR DESCRIPTION
Opening this to see if people are still interested in addressing #8683,

Currently the implementation warns if [indices_or_sections](https://docs.scipy.org/doc/numpy/reference/generated/numpy.split.html#numpy-split) is greater than the length of the array
e.g. `np.split(np.arange(10), [2, 18])` instead of just validating that the arguments are sorted