### PR TITLE
BUG: Add missing check for 0-sized array in ravel_multi_index

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -950,7 +950,7 @@ ravel_multi_index_loop(int ravel_ndim, npy_intp *ravel_dims,
         for (i = 0; i < ravel_ndim; ++i) {
             if (ravel_dims[i] == 0) {
                 PyErr_SetString(PyExc_ValueError,
-                        "cannot unravel if shape has zero entry (is empty).");
+                        "cannot unravel if shape has zero entries (is empty).");
                 return NPY_FAIL;
             }
         }

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -942,6 +942,20 @@ ravel_multi_index_loop(int ravel_ndim, npy_intp *ravel_dims,
     char invalid;
     npy_intp j, m;
 
+    /*
+     * Check for 0-dimensional axes unless there is nothing to do.
+     * An empty array/shape cannot be indexed at all.
+     */
+    if (count != 0) {
+        for (i = 0; i < ravel_ndim; ++i) {
+            if (ravel_dims[i] == 0) {
+                PyErr_SetString(PyExc_ValueError,
+                        "cannot unravel if shape has zero entry (is empty).");
+                return NPY_FAIL;
+            }
+        }
+    }
+
     NPY_BEGIN_ALLOW_THREADS;
     invalid = 0;
     while (count--) {

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -175,6 +175,24 @@ class TestRavelUnravelIndex(object):
         assert_raises_regex(
             ValueError, "out of bounds", np.unravel_index, [1], ())
 
+    @pytest.mark.parametrize("mode", ["clip", "wrap", "raise"])
+    def test_empty_array_ravel(self, mode):
+        res = np.ravel_multi_index(
+                    np.zeros((3, 0), dtype=np.intp), (2, 1, 0), mode=mode)
+        assert(res.shape == (0,))
+
+        with assert_raises(ValueError):
+            np.ravel_multi_index(
+                    np.zeros((3, 1), dtype=np.intp), (2, 1, 0), mode=mode)
+
+    def test_empty_array_unravel(self):
+        res = np.unravel_index(np.zeros(0, dtype=np.intp), (2, 1, 0))
+        # res is a tuple of three empty arrays
+        assert(len(res) == 3)
+        assert(all(a.shape == (0,) for a in res))
+
+        with assert_raises(ValueError):
+            np.unravel_index([1], (2, 1, 0))
 
 class TestGrid(object):
     def test_basic(self):


### PR DESCRIPTION
In wrap and clip modes ravel_multi_index crashes or gave
invalid results if input arrays were empty but the shape not.


---

A small silly fix from 7 years ago I found while trying to clean up my branches a bit.