### PR TITLE
BUG: dtype refcount cleanups

### DIFF
--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -601,7 +601,6 @@ static PyObject *
 fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
 {
     char *string;
-    PyObject  *ret;
     PyArray_Descr *descr;
 
     string = PyBytes_AsString(byte_obj);
@@ -609,8 +608,7 @@ fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
         return NULL;
     }
     descr = PyArray_DescrNewFromType(NPY_FLOAT64);
-    ret = PyArray_FromString( string, -1, descr, -1, " ");
-    return ret;
+    return PyArray_FromString( string, -1, descr, -1, " ");
 }
 
 
@@ -916,7 +914,6 @@ get_c_wrapping_array(PyObject* NPY_UNUSED(self), PyObject* arg)
 {
     int writeable, flags;
     PyArray_Descr *descr;
-    PyObject *ret;
     npy_intp zero = 0;
 
     writeable = PyObject_IsTrue(arg);
@@ -927,9 +924,8 @@ get_c_wrapping_array(PyObject* NPY_UNUSED(self), PyObject* arg)
     flags = writeable ? NPY_ARRAY_WRITEABLE : 0;
     /* Create an empty array (which points to a random place) */
     descr =  PyArray_DescrNewFromType(NPY_INTP);
-    ret = PyArray_NewFromDescr(&PyArray_Type, descr,
+    return PyArray_NewFromDescr(&PyArray_Type, descr,
                                 1, &zero, NULL, &zero, flags, NULL);
-    return ret;
 }
 
 

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -608,7 +608,7 @@ fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
         return NULL;
     }
     descr = PyArray_DescrNewFromType(NPY_FLOAT64);
-    return PyArray_FromString( string, -1, descr, -1, " ");
+    return PyArray_FromString(string, -1, descr, -1, " ");
 }
 
 

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -601,14 +601,21 @@ static PyObject *
 fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
 {
     char *string;
+    PyObject  *ret;
+    PyArray_Descr *descr;
 
     string = PyBytes_AsString(byte_obj);
     if (string == NULL) {
         return NULL;
     }
-
-    return PyArray_FromString(
-                    string, -1, PyArray_DescrFromType(NPY_FLOAT64), -1, " ");
+    descr = PyArray_DescrFromType(NPY_FLOAT64);
+    Py_INCREF(descr);
+    ret = PyArray_FromString( string, -1, descr, -1, " ");
+    if (ret == NULL)
+    {
+        Py_DECREF(descr);
+    }
+    return ret;
 }
 
 
@@ -913,6 +920,8 @@ static PyObject*
 get_c_wrapping_array(PyObject* NPY_UNUSED(self), PyObject* arg)
 {
     int writeable, flags;
+    PyArray_Descr *descr;
+    PyObject *ret;
     npy_intp zero = 0;
 
     writeable = PyObject_IsTrue(arg);
@@ -922,8 +931,15 @@ get_c_wrapping_array(PyObject* NPY_UNUSED(self), PyObject* arg)
 
     flags = writeable ? NPY_ARRAY_WRITEABLE : 0;
     /* Create an empty array (which points to a random place) */
-    return PyArray_NewFromDescr(&PyArray_Type, PyArray_DescrFromType(NPY_INTP),
+    descr =  PyArray_DescrFromType(NPY_INTP);
+    Py_INCREF(descr);
+    ret = PyArray_NewFromDescr(&PyArray_Type, descr,
                                 1, &zero, NULL, &zero, flags, NULL);
+    if (ret == NULL)
+    {
+        Py_DECREF(descr);
+    }
+    return ret;
 }
 
 

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -608,13 +608,8 @@ fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
     if (string == NULL) {
         return NULL;
     }
-    descr = PyArray_DescrFromType(NPY_FLOAT64);
-    Py_INCREF(descr);
+    descr = PyArray_DescrNewFromType(NPY_FLOAT64);
     ret = PyArray_FromString( string, -1, descr, -1, " ");
-    if (ret == NULL)
-    {
-        Py_DECREF(descr);
-    }
     return ret;
 }
 
@@ -931,14 +926,9 @@ get_c_wrapping_array(PyObject* NPY_UNUSED(self), PyObject* arg)
 
     flags = writeable ? NPY_ARRAY_WRITEABLE : 0;
     /* Create an empty array (which points to a random place) */
-    descr =  PyArray_DescrFromType(NPY_INTP);
-    Py_INCREF(descr);
+    descr =  PyArray_DescrNewFromType(NPY_INTP);
     ret = PyArray_NewFromDescr(&PyArray_Type, descr,
                                 1, &zero, NULL, &zero, flags, NULL);
-    if (ret == NULL)
-    {
-        Py_DECREF(descr);
-    }
     return ret;
 }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3726,9 +3726,6 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
     free(clean_sep);
 
 fail:
-    if (r == NULL) {
-        Py_DECREF(dtype);
-    }
     if (err == 1) {
         PyErr_NoMemory();
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3574,6 +3574,7 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     return NULL;
 }
 
+/* This array creation function steals the reference to dtype. */
 static PyArrayObject *
 array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nread)
 {
@@ -3605,27 +3606,24 @@ array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nrea
         }
         num = numbytes / dtype->elsize;
     }
-    /*
-     * When dtype->subarray is true, PyArray_NewFromDescr will decref dtype
-     * even on success, so make sure it stays around until exit.
-     */
-    Py_INCREF(dtype);
     r = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype, 1, &num,
                                               NULL, NULL, 0, NULL);
     if (r == NULL) {
-        Py_DECREF(dtype);
         return NULL;
     }
+    /* In some cases NewFromDescr can replace the dtype, so fetch new one */
+    dtype = PyArray_DESCR(r);
+
     NPY_BEGIN_ALLOW_THREADS;
     *nread = fread(PyArray_DATA(r), dtype->elsize, num, fp);
     NPY_END_ALLOW_THREADS;
-    Py_DECREF(dtype);
     return r;
 }
 
 /*
  * Create an array by reading from the given stream, using the passed
  * next_element and skip_separator functions.
+ * As typical for array creation functions, it steals the reference to dtype.
  */
 #define FROM_BUFFER_SIZE 4096
 static PyArrayObject *
@@ -3644,18 +3642,15 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
 
     size = (num >= 0) ? num : FROM_BUFFER_SIZE;
 
-    /*
-     * When dtype->subarray is true, PyArray_NewFromDescr will decref dtype
-     * even on success, so make sure it stays around until exit.
-     */
-    Py_INCREF(dtype);
     r = (PyArrayObject *)
         PyArray_NewFromDescr(&PyArray_Type, dtype, 1, &size,
                              NULL, NULL, 0, NULL);
     if (r == NULL) {
-        Py_DECREF(dtype);
         return NULL;
     }
+    /* In some cases NewFromDescr can replace the dtype, so fetch new one */
+    dtype = PyArray_DESCR(r);
+
     clean_sep = swab_separator(sep);
     if (clean_sep == NULL) {
         err = 1;
@@ -3742,9 +3737,8 @@ fail:
  * Given a ``FILE *`` pointer ``fp``, and a ``PyArray_Descr``, return an
  * array corresponding to the data encoded in that file.
  *
- * If the dtype is NULL, the default array type is used (double).
- * If non-null, the reference is stolen and if dtype->subarray is true dtype
- * will be decrefed even on success.
+ * The reference to `dtype` is stolen (it is possible that the passed in
+ * dtype is not held on to).
  *
  * The number of elements to read is given as ``num``; if it is < 0, then
  * then as many as possible are read.
@@ -3792,7 +3786,6 @@ PyArray_FromFile(FILE *fp, PyArray_Descr *dtype, npy_intp num, char *sep)
                 (skip_separator) fromfile_skip_separator, NULL);
     }
     if (ret == NULL) {
-        Py_DECREF(dtype);
         return NULL;
     }
     if (((npy_intp) nread) < num) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3726,7 +3726,9 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
     free(clean_sep);
 
 fail:
-    Py_DECREF(dtype);
+    if (r == NULL) {
+        Py_DECREF(dtype);
+    }
     if (err == 1) {
         PyErr_NoMemory();
     }


### PR DESCRIPTION
gh-13605 did not handle refcounts of dtype instances. I discovered this by running
```
python runtests.py -t numpy/core/tests/test_deprecations.py
```
which printed the following twice at the end
```
*** Reference count error detected: 
an attempt was made to deallocate 12 (d) ***
```

The lack of those reference count errors when running all the tests (before this PR) would suggest we have places in the code that leak references by incref-ing without decref-ing.