### PR TITLE
DEP: Remove Python2 specific C module setup

### DIFF
--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -225,6 +225,8 @@ A #define in config.h, defined when building for Py3.
    Currently, this is generated as a part of the config.
    Is this sensible (we could also use Py_VERSION_HEX)?
 
+   This is being cleaned up in the C code.
+
 
 private/npy_3kcompat.h
 ----------------------

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -976,7 +976,6 @@ The C file is given below.
 
         static void *data[1] = {NULL};
 
-        #if defined(NPY_PY3K)
         static struct PyModuleDef moduledef = {
             PyModuleDef_HEAD_INIT,
             "struct_ufunc_test",
@@ -988,31 +987,18 @@ The C file is given below.
             NULL,
             NULL
         };
-        #endif
 
-        #if defined(NPY_PY3K)
         PyMODINIT_FUNC PyInit_struct_ufunc_test(void)
-        #else
-        PyMODINIT_FUNC initstruct_ufunc_test(void)
-        #endif
         {
             PyObject *m, *add_triplet, *d;
             PyObject *dtype_dict;
             PyArray_Descr *dtype;
             PyArray_Descr *dtypes[3];
 
-        #if defined(NPY_PY3K)
             m = PyModule_Create(&moduledef);
-        #else
-            m = Py_InitModule("struct_ufunc_test", StructUfuncTestMethods);
-        #endif
 
             if (m == NULL) {
-        #if defined(NPY_PY3K)
                 return NULL;
-        #else
-                return;
-        #endif
             }
 
             import_array();
@@ -1043,9 +1029,7 @@ The C file is given below.
 
             PyDict_SetItemString(d, "add_triplet", add_triplet);
             Py_DECREF(add_triplet);
-        #if defined(NPY_PY3K)
             return m;
-        #endif
         }
 
 .. index::

--- a/numpy/core/src/dummymodule.c
+++ b/numpy/core/src/dummymodule.c
@@ -16,7 +16,6 @@ static struct PyMethodDef methods[] = {
 };
 
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "dummy",
@@ -28,10 +27,8 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL
 };
-#endif
 
 /* Initialization function for the module */
-#if defined(NPY_PY3K)
 PyMODINIT_FUNC PyInit__dummy(void) {
     PyObject *m;
     m = PyModule_Create(&moduledef);
@@ -40,9 +37,3 @@ PyMODINIT_FUNC PyInit__dummy(void) {
     }
     return m;
 }
-#else
-PyMODINIT_FUNC
-init_dummy(void) {
-    Py_InitModule("_dummy", methods);
-}
-#endif

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2126,7 +2126,6 @@ static PyMethodDef Multiarray_TestsMethods[] = {
 };
 
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_multiarray_tests",
@@ -2138,24 +2137,13 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL
 };
-#endif
 
-#if defined(NPY_PY3K)
 #define RETVAL m
 PyMODINIT_FUNC PyInit__multiarray_tests(void)
-#else
-#define RETVAL
-PyMODINIT_FUNC
-init_multiarray_tests(void)
-#endif
 {
     PyObject *m;
 
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_multiarray_tests", Multiarray_TestsMethods);
-#endif
     if (m == NULL) {
         return RETVAL;
     }

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -748,7 +748,7 @@ _setup_field(int i, PyArray_Descr *descr, PyArrayObject *arr,
     }
 
     ((PyArrayObject_fields *)(arr))->descr = new;
-    if ((new->alignment > 1) && 
+    if ((new->alignment > 1) &&
                 ((((uintptr_t)dstdata + offset) % new->alignment) != 0)) {
         PyArray_CLEARFLAGS(arr, NPY_ARRAY_ALIGNED);
     }
@@ -836,7 +836,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
             if (names_size != PyTuple_Size(op)) {
                 errmsg = PyUString_FromFormat(
                         "could not assign tuple of length %zd to structure "
-                        "with %" NPY_INTP_FMT " fields.", 
+                        "with %" NPY_INTP_FMT " fields.",
                         PyTuple_Size(op), names_size);
                 PyErr_SetObject(PyExc_ValueError, errmsg);
                 Py_DECREF(errmsg);
@@ -3000,7 +3000,7 @@ OBJECT_compare(PyObject **ip1, PyObject **ip2, PyArrayObject *NPY_UNUSED(ap))
 
     ret = PyObject_RichCompareBool(*ip1, *ip2, Py_LT);
     if (ret < 0) {
-        /* error occurred, avoid the next call to PyObject_RichCompareBool */ 
+        /* error occurred, avoid the next call to PyObject_RichCompareBool */
         return 0;
     }
     if (ret == 1) {
@@ -4429,7 +4429,7 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
         #if @rsort@
             aradixsort_@suff@
         #else
-            atimsort_@suff@            
+            atimsort_@suff@
         #endif
     },
 #else

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1159,7 +1159,7 @@ fail:
 }
 
 
-/* 
+/*
  * Inner loop for unravel_index
  * order must be NPY_CORDER or NPY_FORTRANORDER
  */
@@ -1186,7 +1186,7 @@ unravel_index_loop(int unravel_ndim, npy_intp *unravel_dims,
         }
         idx = idx_start;
         for (i = 0; i < unravel_ndim; ++i) {
-            /* 
+            /*
              * Using a local seems to enable single-divide optimization
              * but only if the / precedes the %
              */

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -241,7 +241,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (!PyArray_DescrConverter(PyTuple_GET_ITEM(obj, 0), &type)) {
             return NULL;
         }
-    }    
+    }
     val = PyTuple_GET_ITEM(obj,1);
     /* try to interpret next item as a type */
     res = _use_inherit(type, val, &errflag);
@@ -455,11 +455,11 @@ _convert_from_array_descr(PyObject *obj, int align)
         Py_INCREF(name);
 
 #if !defined(NPY_PY3K)
-        /* convert unicode name to ascii on Python 2 if possible */ 
+        /* convert unicode name to ascii on Python 2 if possible */
         if (PyUnicode_Check(name)) {
             PyObject *tmp = PyUnicode_AsASCIIString(name);
             Py_DECREF(name);
-            if (tmp == NULL) { 
+            if (tmp == NULL) {
                 goto fail;
             }
             name = tmp;

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2392,7 +2392,7 @@ PyArray_Nonzero(PyArrayObject *self)
             Py_DECREF(ret);
             return NULL;
         }
-        
+
         needs_api = NpyIter_IterationNeedsAPI(iter);
 
         NPY_BEGIN_THREADS_NDITER(iter);
@@ -2436,7 +2436,7 @@ finish:
         Py_DECREF(ret);
         return NULL;
     }
-    
+
     /* if executed `nonzero()` check for miscount due to side-effect */
     if (!is_bool && added_count != nonzero_count) {
         PyErr_SetString(PyExc_RuntimeError,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4551,7 +4551,6 @@ intern_strings(void)
            npy_ma_str_ndmin && npy_ma_str_axis1 && npy_ma_str_axis2;
 }
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_multiarray_umath",
@@ -4563,25 +4562,15 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL
 };
-#endif
 
 /* Initialization function for the module */
-#if defined(NPY_PY3K)
 #define RETVAL(x) x
 PyMODINIT_FUNC PyInit__multiarray_umath(void) {
-#else
-#define RETVAL(x)
-PyMODINIT_FUNC init_multiarray_umath(void) {
-#endif
     PyObject *m, *d, *s;
     PyObject *c_api;
 
     /* Create the module and add the functions */
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_multiarray_umath", array_module_methods);
-#endif
     if (!m) {
         goto err;
     }

--- a/numpy/core/src/umath/_operand_flag_tests.c.src
+++ b/numpy/core/src/umath/_operand_flag_tests.c.src
@@ -39,7 +39,6 @@ static char types[2] = {NPY_LONG, NPY_LONG};
 
 static void *data[1] = {NULL};
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_operand_flag_tests",
@@ -55,19 +54,10 @@ static struct PyModuleDef moduledef = {
 #define RETVAL m
 PyMODINIT_FUNC PyInit__operand_flag_tests(void)
 {
-#else
-#define RETVAL
-PyMODINIT_FUNC init_operand_flag_tests(void)
-{
-#endif
     PyObject *m = NULL;
     PyObject *ufunc;
 
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_operand_flag_tests", TestMethods);
-#endif
     if (m == NULL) {
         goto fail;
     }

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -1126,7 +1126,6 @@ PyMethodDef module_methods[] = {
     {0} /* sentinel */
 };
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_rational_tests",
@@ -1138,16 +1137,9 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
-#if defined(NPY_PY3K)
 #define RETVAL m
 PyMODINIT_FUNC PyInit__rational_tests(void) {
-#else
-#define RETVAL
-PyMODINIT_FUNC init_rational_tests(void) {
-#endif
-
     PyObject *m = NULL;
     PyObject* numpy_str;
     PyObject* numpy;
@@ -1292,11 +1284,7 @@ PyMODINIT_FUNC init_rational_tests(void) {
     REGISTER_UFUNC_UNARY(sign)
 
     /* Create module */
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_rational_tests", module_methods);
-#endif
 
     if (!m) {
         goto fail;
@@ -1399,11 +1387,9 @@ fail:
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot load _rational_tests module.");
     }
-#if defined(NPY_PY3K)
     if (m) {
         Py_DECREF(m);
         m = NULL;
     }
-#endif
     return RETVAL;
 }

--- a/numpy/core/src/umath/_struct_ufunc_tests.c.src
+++ b/numpy/core/src/umath/_struct_ufunc_tests.c.src
@@ -100,7 +100,6 @@ static PyMethodDef StructUfuncTestMethods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_struct_ufunc_tests",
@@ -112,31 +111,18 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
-#if defined(NPY_PY3K)
 PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
-#else
-PyMODINIT_FUNC init_struct_ufunc_tests(void)
-#endif
 {
     PyObject *m, *add_triplet, *d;
     PyObject *dtype_dict;
     PyArray_Descr *dtype;
     PyArray_Descr *dtypes[3];
 
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_struct_ufunc_tests", StructUfuncTestMethods);
-#endif
 
     if (m == NULL) {
-#if defined(NPY_PY3K)
         return NULL;
-#else
-        return;
-#endif
     }
 
     import_array();
@@ -166,7 +152,5 @@ PyMODINIT_FUNC init_struct_ufunc_tests(void)
 
     PyDict_SetItemString(d, "add_triplet", add_triplet);
     Py_DECREF(add_triplet);
-#if defined(NPY_PY3K)
     return m;
-#endif
 }

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -586,7 +586,6 @@ static PyMethodDef UMath_TestsMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "_umath_tests",
@@ -598,25 +597,15 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL
 };
-#endif
 
 /* Initialization function for the module */
-#if defined(NPY_PY3K)
 #define RETVAL(x) x
 PyMODINIT_FUNC PyInit__umath_tests(void) {
-#else
-#define RETVAL(x)
-PyMODINIT_FUNC init_umath_tests(void) {
-#endif
     PyObject *m;
     PyObject *d;
     PyObject *version;
 
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule("_umath_tests", UMath_TestsMethods);
-#endif
     if (m == NULL) {
         return RETVAL(NULL);
     }

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -3626,7 +3626,6 @@ static PyMethodDef UMath_LinAlgMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
-#if defined(NPY_PY3K)
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         UMATH_LINALG_MODULE_NAME,
@@ -3638,27 +3637,16 @@ static struct PyModuleDef moduledef = {
         NULL,
         NULL
 };
-#endif
 
-#if defined(NPY_PY3K)
 #define RETVAL(x) x
 PyObject *PyInit__umath_linalg(void)
-#else
-#define RETVAL(x)
-PyMODINIT_FUNC
-init_umath_linalg(void)
-#endif
 {
     PyObject *m;
     PyObject *d;
     PyObject *version;
 
     init_constants();
-#if defined(NPY_PY3K)
     m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule(UMATH_LINALG_MODULE_NAME, UMath_LinAlgMethods);
-#endif
     if (m == NULL) {
         return RETVAL(NULL);
     }


### PR DESCRIPTION
I'm excited about cleaning up all the Python2 specific code.

I broke out this small change first to make sure this can go in now and is a wanted changed.
If so there are ~700 instances of NPY_PY3K at least 50 of which contain real logic.