### PR TITLE
MAINT: Propagate UnicodeDecodeError from PyArray_DescrConverter()

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1669,10 +1669,11 @@ finish:
             if (!item && PyBytes_Check(obj)) {
                 PyObject *tmp;
                 tmp = PyUnicode_FromEncodedObject(obj, "ascii", "strict");
-                if (tmp != NULL) {
-                    item = PyDict_GetItem(typeDict, tmp);
-                    Py_DECREF(tmp);
+                if (tmp == NULL) {
+                    goto error;
                 }
+                item = PyDict_GetItem(typeDict, tmp);
+                Py_DECREF(tmp);
             }
 #endif
             if (item) {

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -115,8 +115,8 @@ class TestBuiltin(object):
         assert_dtype_equal(np.dtype(b'f'), np.dtype('float32'))
 
         # Bytes with non-ascii values raise errors
-        assert_raises(TypeError, np.dtype, b'\xff')
-        assert_raises(TypeError, np.dtype, b's\xff')
+        assert_raises(UnicodeDecodeError, np.dtype, b'\xff')
+        assert_raises(UnicodeDecodeError, np.dtype, b's\xff')
 
     def test_bad_param(self):
         # Can't give a size that's too small


### PR DESCRIPTION
Callers are now presented with a more informative and accurate exception
if PyUnicode_FromEncodedObject() fails deep inside
PyArray_DescrConverter() due to a text decoding issue.

---

This change was suggested in #14368.
