### PR TITLE
DOC: Change the promotion table checkmark to 'Y'.

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -232,7 +232,7 @@ can generate this table for your system with the code given in the Figure.
     Generally the output depends on the system; your system might result in
     a different table.
 
-    >>> mark = {False: ' -', True: ' ✓'}
+    >>> mark = {False: ' -', True: ' Y'}
     >>> def print_table(ntypes):
     ...     print('X ' + ' '.join(ntypes))
     ...     for row in ntypes:
@@ -243,33 +243,32 @@ can generate this table for your system with the code given in the Figure.
     ...
     >>> print_table(np.typecodes['All'])
     X ? b h i l q p B H I L Q P e f d g F D G S U V O M m
-    ? ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    b - ✓ ✓ ✓ ✓ ✓ ✓ - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    h - - ✓ ✓ ✓ ✓ ✓ - - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    i - - - ✓ ✓ ✓ ✓ - - - - - - - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    l - - - - ✓ ✓ ✓ - - - - - - - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    q - - - - ✓ ✓ ✓ - - - - - - - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    p - - - - ✓ ✓ ✓ - - - - - - - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    B - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    H - - - ✓ ✓ ✓ ✓ - ✓ ✓ ✓ ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    I - - - - ✓ ✓ ✓ - - ✓ ✓ ✓ ✓ - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    L - - - - - - - - - - ✓ ✓ ✓ - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    Q - - - - - - - - - - ✓ ✓ ✓ - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    P - - - - - - - - - - ✓ ✓ ✓ - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - ✓
-    e - - - - - - - - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - -
-    f - - - - - - - - - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ - -
-    d - - - - - - - - - - - - - - - ✓ ✓ - ✓ ✓ ✓ ✓ ✓ ✓ - -
-    g - - - - - - - - - - - - - - - - ✓ - - ✓ ✓ ✓ ✓ ✓ - -
-    F - - - - - - - - - - - - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ ✓ - -
-    D - - - - - - - - - - - - - - - - - - ✓ ✓ ✓ ✓ ✓ ✓ - -
-    G - - - - - - - - - - - - - - - - - - - ✓ ✓ ✓ ✓ ✓ - -
-    S - - - - - - - - - - - - - - - - - - - - ✓ ✓ ✓ ✓ - -
-    U - - - - - - - - - - - - - - - - - - - - - ✓ ✓ ✓ - -
-    V - - - - - - - - - - - - - - - - - - - - - - ✓ ✓ - -
-    O - - - - - - - - - - - - - - - - - - - - - - ✓ ✓ - -
-    M - - - - - - - - - - - - - - - - - - - - - - ✓ ✓ ✓ -
-    m - - - - - - - - - - - - - - - - - - - - - - ✓ ✓ - ✓
-
+    ? Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y - Y
+    b - Y Y Y Y Y Y - - - - - - Y Y Y Y Y Y Y Y Y Y Y - Y
+    h - - Y Y Y Y Y - - - - - - - Y Y Y Y Y Y Y Y Y Y - Y
+    i - - - Y Y Y Y - - - - - - - - Y Y - Y Y Y Y Y Y - Y
+    l - - - - Y Y Y - - - - - - - - Y Y - Y Y Y Y Y Y - Y
+    q - - - - Y Y Y - - - - - - - - Y Y - Y Y Y Y Y Y - Y
+    p - - - - Y Y Y - - - - - - - - Y Y - Y Y Y Y Y Y - Y
+    B - - Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y - Y
+    H - - - Y Y Y Y - Y Y Y Y Y - Y Y Y Y Y Y Y Y Y Y - Y
+    I - - - - Y Y Y - - Y Y Y Y - - Y Y - Y Y Y Y Y Y - Y
+    L - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
+    Q - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
+    P - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
+    e - - - - - - - - - - - - - Y Y Y Y Y Y Y Y Y Y Y - -
+    f - - - - - - - - - - - - - - Y Y Y Y Y Y Y Y Y Y - -
+    d - - - - - - - - - - - - - - - Y Y - Y Y Y Y Y Y - -
+    g - - - - - - - - - - - - - - - - Y - - Y Y Y Y Y - -
+    F - - - - - - - - - - - - - - - - - Y Y Y Y Y Y Y - -
+    D - - - - - - - - - - - - - - - - - - Y Y Y Y Y Y - -
+    G - - - - - - - - - - - - - - - - - - - Y Y Y Y Y - -
+    S - - - - - - - - - - - - - - - - - - - - Y Y Y Y - -
+    U - - - - - - - - - - - - - - - - - - - - - Y Y Y - -
+    V - - - - - - - - - - - - - - - - - - - - - - Y Y - -
+    O - - - - - - - - - - - - - - - - - - - - - - Y Y - -
+    M - - - - - - - - - - - - - - - - - - - - - - Y Y Y -
+    m - - - - - - - - - - - - - - - - - - - - - - Y Y - Y
 
 You should note that, while included in the table for completeness,
 the 'S', 'U', and 'V' types cannot be operated on by ufuncs. Also,


### PR DESCRIPTION
The Unicode checkmark doesn't necessarily have the same width as the
ASCII characters, even when rendered with a fixed-width font, so the
casting table can be misaligned when the checkmark is used.
