### PR TITLE
DOC: Add to doc that interp cannot contain NaN

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1338,7 +1338,8 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
         np.all(np.diff(xp) > 0)
 
-    The value of `xp` cannot be `NaN` because its input is required to be sorted. 
+    Note that since `NaN` is unsortable, this also means that `xp` cannot
+    contain `NaN`, which the check above will detect.
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1332,14 +1332,15 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
     Notes
     -----
-    Does not check that the x-coordinate sequence `xp` is increasing.
-    If `xp` is not increasing, the results are nonsense.
-    A simple check for increasing is::
+    The x-coordinate sequence is expected to be increasing, but this is not
+    explicitly enforced.  However, if the sequence `xp` is non-increasing,
+    interpolation results are meaningless.
 
-        np.all(np.diff(xp) > 0)
+    Note that, since `NaN` is unsortable, `xp` then also cannot contain `NaN`s.
 
-    Note that since `NaN` is unsortable, this also means that `xp` cannot
-    contain `NaN`, which the check above will detect.
+    A simple check for `xp` being strictly increasing is::
+
+        np.all(np.diff(xp) > 0
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1336,7 +1336,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     explicitly enforced.  However, if the sequence `xp` is non-increasing,
     interpolation results are meaningless.
 
-    Note that, since `NaN` is unsortable, `xp` then also cannot contain `NaN`s.
+    Note that, since NaN is unsortable, `xp` also cannot contain NaNs.
 
     A simple check for `xp` being strictly increasing is::
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1338,6 +1338,8 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
         np.all(np.diff(xp) > 0)
 
+    The value of `xp` cannot be `NaN` because its input is required to be sorted. 
+
     Examples
     --------
     >>> xp = [1, 2, 3]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1340,7 +1340,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
     A simple check for `xp` being strictly increasing is::
 
-        np.all(np.diff(xp) > 0
+        np.all(np.diff(xp) > 0)
 
     Examples
     --------


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Address #13919 by adding to documentation that `xp` cannot contain `NaN` because its input is required to be sorted.