### PR TITLE
MAINT: Try to use the fast histogram algorithm with provided bins.

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -449,7 +449,13 @@ def _get_bin_edges(a, bins, range, weights, fast):
         return bin_edges, None
 
 def _bins_are_equally_spaced(bin_edges, fast):
-    equally_spaced_bins = np.linspace(bin_edges[0], bin_edges[-1], num=len(bin_edges))
+    # Some valid bin types can't be generated using linspace (e.g. datetime, timedelta)
+    # Bins are also not equally spaced if a RuntimeWarning is thrown because of nans/inf
+    try:
+        equally_spaced_bins = np.linspace(bin_edges[0], bin_edges[-1], num=len(bin_edges))
+    except (TypeError, DeprecationWarning, RuntimeWarning):
+        return False
+
     try:
         resolution = np.finfo(bin_edges.dtype).eps
     except ValueError:

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -429,7 +429,7 @@ def _get_bin_edges(a, bins, range, weights):
         except ValueError:
             resolution = np.finfo(np.float64).resolution
         widths = np.diff(bin_edges)
-        if np.allclose(widths / widths[0] - 1, 0, rtol=2 * resolution):
+        if np.allclose(widths / widths[0] - 1, 0, rtol=0, atol=2 * resolution):
             n_equal_bins = len(bin_edges) - 1
             first_edge, last_edge = bin_edges[0], bin_edges[-1]
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -350,7 +350,7 @@ def _unsigned_subtract(a, b):
         return np.subtract(a, b, casting='unsafe', dtype=dt)
 
 
-def _get_bin_edges(a, bins, range, weights):
+def _get_bin_edges(a, bins, range, weights, fast):
     """
     Computes the bins used internally by `histogram`.
 
@@ -423,13 +423,9 @@ def _get_bin_edges(a, bins, range, weights):
         if np.any(bin_edges[:-1] > bin_edges[1:]):
             raise ValueError(
                 '`bins` must increase monotonically, when an array')
-        # Use the fast algorithm if the given bins are equally spaced
-        try:
-            resolution = np.finfo(bin_edges.dtype).resolution
-        except ValueError:
-            resolution = np.finfo(np.float64).resolution
-        widths = np.diff(bin_edges)
-        if np.allclose(widths / widths[0] - 1, 0, rtol=0, atol=2 * resolution):
+        # Use the fast algorithm if the given bins are equally spaced or within
+        # numerical precision of being equally spaced and fast is True.
+        if _bins_are_equally_spaced(bin_edges, fast):
             n_equal_bins = len(bin_edges) - 1
             first_edge, last_edge = bin_edges[0], bin_edges[-1]
 
@@ -452,6 +448,14 @@ def _get_bin_edges(a, bins, range, weights):
     else:
         return bin_edges, None
 
+def _bins_are_equally_spaced(bin_edges, fast):
+    equally_spaced_bins = np.linspace(bin_edges[0], bin_edges[-1], num=len(bin_edges))
+    try:
+        resolution = np.finfo(bin_edges.dtype).eps
+    except ValueError:
+        resolution = 0
+    return np.all(bin_edges == equally_spaced_bins) or (fast and np.allclose(
+            bin_edges, equally_spaced_bins, rtol=resolution, atol=0))
 
 def _search_sorted_inclusive(a, v):
     """
@@ -667,18 +671,18 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     """
     a, weights = _ravel_and_check_weights(a, weights)
-    bin_edges, _ = _get_bin_edges(a, bins, range, weights)
+    bin_edges, _ = _get_bin_edges(a, bins, range, weights, fast=False)
     return bin_edges
 
 
-def _histogram_dispatcher(
-        a, bins=None, range=None, normed=None, weights=None, density=None):
+def _histogram_dispatcher(a, bins=None, range=None, normed=None,
+                          weights=None, density=None, fast=None):
     return (a, bins, weights)
 
 
 @array_function_dispatch(_histogram_dispatcher)
 def histogram(a, bins=10, range=None, normed=None, weights=None,
-              density=None):
+              density=None, fast=False):
     r"""
     Compute the histogram of a set of data.
 
@@ -730,6 +734,10 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
         width are chosen; it is not a probability *mass* function.
 
         Overrides the ``normed`` keyword if given.
+    fast : bool, optional
+        If ``True`` and bins is a sequence that is within numerical precision
+        of being equal width, the fast histogram algorithm is used on the
+        equal width bins. This has no effect if bins is not a sequence.
 
     Returns
     -------
@@ -791,7 +799,7 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
     """
     a, weights = _ravel_and_check_weights(a, weights)
 
-    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
+    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights, fast)
 
     # Histogram is an integer or a float array depending on the weights.
     if weights is None:

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -423,6 +423,15 @@ def _get_bin_edges(a, bins, range, weights):
         if np.any(bin_edges[:-1] > bin_edges[1:]):
             raise ValueError(
                 '`bins` must increase monotonically, when an array')
+        # Use the fast algorithm if the given bins are equally spaced
+        try:
+            resolution = np.finfo(bin_edges.dtype).resolution
+        except ValueError:
+            resolution = np.finfo(np.float64).resolution
+        widths = np.diff(bin_edges)
+        if np.allclose(widths / widths[0] - 1, 0, rtol=2 * resolution):
+            n_equal_bins = len(bin_edges) - 1
+            first_edge, last_edge = bin_edges[0], bin_edges[-1]
 
     else:
         raise ValueError('`bins` must be 1d, when an array')

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -424,7 +424,6 @@ class TestHistogram(object):
         assert_array_equal(edges, e)
 
     def test_obeys_fast_kwarg(self):
-        np.set_printoptions(precision=100)
         inp_edges = np.linspace(1, 2, num=11)
         # Peturb all of the bins, except for the endpoints by eps
         inp_edges[1:-1] += np.finfo(inp_edges.dtype).eps


### PR DESCRIPTION
ENH: Use the fast histogram algorithm when provided bins are exactly equal width. Provide a kwarg that lets the user use the fast histogram algorithm when the provided bins are within numerical precision of being equal with. In the `fast=True` and bins within numerical precision of equal width case, the returned bins differ slightly from the provided bins.


----------------- Original comment now out of date (afce765) -----------------------
There is a fast histogram algorithm that can be used when the bins are of equal width. However, if bins are provided as an array, this is never used, even when those bins are an equal width. This change checks the provided bins and sends the histogram down that path if possible.

There is a downside though. I assume that if the bins are within numerical precision of being the same width, they are. I think that this mostly fine? But it might not always be... This also results in the `bin_edges` returned not necessarily being the same as the `bins` that were provided (possibly different by the precision).

I'll leave it up to someone who knows more than I do to make the call of whether the performance improvement is worth this. Else, let me know if you want me to make any other changes.

Thanks!