### PR TITLE
NEP: Only list "Active" NEPs under "Meta-NEPs"

### DIFF
--- a/doc/neps/index.rst.tmpl
+++ b/doc/neps/index.rst.tmpl
@@ -23,7 +23,7 @@ Meta-NEPs (NEPs about NEPs or Processes)
 .. toctree::
    :maxdepth: 1
 
-{% for nep, tags in neps.items() if tags['Type'] == 'Process' %}
+{% for nep, tags in neps.items() if tags['Status'] == 'Active' %}
    {{ tags['Title'] }} <{{ tags['Filename'] }}>
 {% endfor %}
 


### PR DESCRIPTION
In particular, NEP 23 (which is only a draft) is currently listed under both
"Meta-NEPs" *and* "Open NEPs". It should only be in the later.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
