### PR TITLE
MAINT: Remove duplicate files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,10 +146,6 @@ numpy/core/src/npysort/radixsort.c
 numpy/core/src/npysort/selection.c
 numpy/core/src/npysort/timsort.c
 numpy/core/src/npysort/sort.c
-numpy/core/src/common/npy_binsearch.h
-numpy/core/src/common/npy_partition.h
-numpy/core/src/common/npy_sort.h
-numpy/core/src/common/templ_common.h
 numpy/core/src/private/npy_binsearch.h
 numpy/core/src/private/npy_partition.h
 numpy/core/src/private/templ_common.h


### PR DESCRIPTION
This commit removes lines 149-152 as they are duplicates of lines 127-130.
These correspond to the files:

    * numpy/core/src/common/npy_binsearch.h
    * numpy/core/src/common/npy_partition.h
    * numpy/core/src/common/npy_sort.h
    * numpy/core/src/common/templ_common.h