### PR TITLE
MAINT: align random double_fill to float_fill, simplify distributions.c

### DIFF
--- a/numpy/random/common.pxd
+++ b/numpy/random/common.pxd
@@ -50,7 +50,6 @@ cdef extern from "src/aligned_malloc/aligned_malloc.h":
     cdef void *PyArray_calloc_aligned(size_t n, size_t s)
     cdef void PyArray_free_aligned(void *p)
 
-ctypedef double (*random_double_fill)(bitgen_t *state, np.npy_intp count, double* out) nogil
 ctypedef double (*random_double_0)(void *state) nogil
 ctypedef double (*random_double_1)(void *state, double a) nogil
 ctypedef double (*random_double_2)(void *state, double a, double b) nogil

--- a/numpy/random/common.pyx
+++ b/numpy/random/common.pyx
@@ -238,7 +238,7 @@ cdef check_output(object out, object dtype, object size):
 
 
 cdef object double_fill(void *func, bitgen_t *state, object size, object lock, object out):
-    cdef random_double_fill random_func = (<random_double_fill>func)
+    cdef random_double_0 random_func = (<random_double_0>func)
     cdef double out_val
     cdef double *out_array_data
     cdef np.ndarray out_array
@@ -246,8 +246,7 @@ cdef object double_fill(void *func, bitgen_t *state, object size, object lock, o
 
     if size is None and out is None:
         with lock:
-            random_func(state, 1, &out_val)
-            return out_val
+            return random_func(state)
 
     if out is not None:
         check_output(out, np.float64, size)
@@ -258,7 +257,8 @@ cdef object double_fill(void *func, bitgen_t *state, object size, object lock, o
     n = np.PyArray_SIZE(out_array)
     out_array_data = <double *>np.PyArray_DATA(out_array)
     with lock, nogil:
-        random_func(state, n, out_array_data)
+        for i in range(n):
+            out_array_data[i] = random_func(state)
     return out_array
 
 cdef object float_fill(void *func, bitgen_t *state, object size, object lock, object out):

--- a/numpy/random/distributions.pxd
+++ b/numpy/random/distributions.pxd
@@ -29,13 +29,9 @@ cdef extern from "src/distributions/distributions.h":
     ctypedef s_binomial_t binomial_t
 
     double random_double(bitgen_t *bitgen_state) nogil
-    void random_double_fill(bitgen_t* bitgen_state, np.npy_intp cnt, double *out) nogil
     double random_standard_exponential(bitgen_t *bitgen_state) nogil
-    void random_standard_exponential_fill(bitgen_t *bitgen_state, np.npy_intp cnt, double *out) nogil
     double random_standard_exponential_zig(bitgen_t *bitgen_state) nogil
-    void random_standard_exponential_zig_fill(bitgen_t *bitgen_state, np.npy_intp cnt, double *out) nogil
     double random_gauss_zig(bitgen_t* bitgen_state) nogil
-    void random_gauss_zig_fill(bitgen_t *bitgen_state, np.npy_intp count, double *out) nogil
     double random_standard_gamma_zig(bitgen_t *bitgen_state, double shape) nogil
 
     float random_float(bitgen_t *bitgen_state) nogil

--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -193,7 +193,7 @@ cdef class Generator:
         cdef double temp
         key = np.dtype(dtype).name
         if key == 'float64':
-            return double_fill(&random_double_fill, &self._bitgen, size, self.lock, out)
+            return double_fill(&random_double, &self._bitgen, size, self.lock, out)
         elif key == 'float32':
             return float_fill(&random_float, &self._bitgen, size, self.lock, out)
         else:
@@ -336,9 +336,9 @@ cdef class Generator:
         key = np.dtype(dtype).name
         if key == 'float64':
             if method == u'zig':
-                return double_fill(&random_standard_exponential_zig_fill, &self._bitgen, size, self.lock, out)
+                return double_fill(&random_standard_exponential_zig, &self._bitgen, size, self.lock, out)
             else:
-                return double_fill(&random_standard_exponential_fill, &self._bitgen, size, self.lock, out)
+                return double_fill(&random_standard_exponential, &self._bitgen, size, self.lock, out)
         elif key == 'float32':
             if method == u'zig':
                 return float_fill(&random_standard_exponential_zig_f, &self._bitgen, size, self.lock, out)
@@ -920,7 +920,7 @@ cdef class Generator:
         """
         key = np.dtype(dtype).name
         if key == 'float64':
-            return double_fill(&random_gauss_zig_fill, &self._bitgen, size, self.lock, out)
+            return double_fill(&random_gauss_zig, &self._bitgen, size, self.lock, out)
         elif key == 'float32':
             return float_fill(&random_gauss_zig_f, &self._bitgen, size, self.lock, out)
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -329,7 +329,7 @@ cdef class RandomState:
 
         """
         cdef double temp
-        return double_fill(&random_double_fill, &self._bitgen, size, self.lock, None)
+        return double_fill(&random_double, &self._bitgen, size, self.lock, None)
 
     def random(self, size=None):
         """

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -21,24 +21,10 @@ double random_standard_exponential(bitgen_t *bitgen_state) {
   return next_standard_exponential(bitgen_state);
 }
 
-void random_standard_exponential_fill(bitgen_t *bitgen_state, npy_intp cnt,
-                                      double *out) {
-  npy_intp i;
-  for (i = 0; i < cnt; i++) {
-    out[i] = next_standard_exponential(bitgen_state);
-  }
-}
-
 float random_standard_exponential_f(bitgen_t *bitgen_state) {
   return -logf(1.0f - next_float(bitgen_state));
 }
 
-void random_double_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out) {
-  npy_intp i;
-  for (i = 0; i < cnt; i++) {
-    out[i] = next_double(bitgen_state);
-  }
-}
 #if 0
 double random_gauss(bitgen_t *bitgen_state) {
   if (bitgen_state->has_gauss) {
@@ -124,14 +110,6 @@ double random_standard_exponential_zig(bitgen_t *bitgen_state) {
   return standard_exponential_zig(bitgen_state);
 }
 
-void random_standard_exponential_zig_fill(bitgen_t *bitgen_state, npy_intp cnt,
-                                          double *out) {
-  npy_intp i;
-  for (i = 0; i < cnt; i++) {
-    out[i] = standard_exponential_zig(bitgen_state);
-  }
-}
-
 static NPY_INLINE float standard_exponential_zig_f(bitgen_t *bitgen_state);
 
 static float standard_exponential_zig_unlikely_f(bitgen_t *bitgen_state,
@@ -204,13 +182,6 @@ static NPY_INLINE double next_gauss_zig(bitgen_t *bitgen_state) {
 
 double random_gauss_zig(bitgen_t *bitgen_state) {
   return next_gauss_zig(bitgen_state);
-}
-
-void random_gauss_zig_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out) {
-  npy_intp i;
-  for (i = 0; i < cnt; i++) {
-    out[i] = next_gauss_zig(bitgen_state);
-  }
 }
 
 float random_gauss_zig_f(bitgen_t *bitgen_state) {

--- a/numpy/random/src/distributions/distributions.h
+++ b/numpy/random/src/distributions/distributions.h
@@ -80,7 +80,6 @@ DECLDIR double loggam(double x);
 
 DECLDIR float random_float(bitgen_t *bitgen_state);
 DECLDIR double random_double(bitgen_t *bitgen_state);
-DECLDIR void random_double_fill(bitgen_t *bitgen_state, npy_intp cnt, double *out);
 
 DECLDIR int64_t random_positive_int64(bitgen_t *bitgen_state);
 DECLDIR int32_t random_positive_int32(bitgen_t *bitgen_state);
@@ -88,12 +87,8 @@ DECLDIR int64_t random_positive_int(bitgen_t *bitgen_state);
 DECLDIR uint64_t random_uint(bitgen_t *bitgen_state);
 
 DECLDIR double random_standard_exponential(bitgen_t *bitgen_state);
-DECLDIR void random_standard_exponential_fill(bitgen_t *bitgen_state, npy_intp cnt,
-                                              double *out);
 DECLDIR float random_standard_exponential_f(bitgen_t *bitgen_state);
 DECLDIR double random_standard_exponential_zig(bitgen_t *bitgen_state);
-DECLDIR void random_standard_exponential_zig_fill(bitgen_t *bitgen_state,
-                                                  npy_intp cnt, double *out);
 DECLDIR float random_standard_exponential_zig_f(bitgen_t *bitgen_state);
 
 /*
@@ -102,8 +97,6 @@ DECLDIR float random_gauss_f(bitgen_t *bitgen_state);
 */
 DECLDIR double random_gauss_zig(bitgen_t *bitgen_state);
 DECLDIR float random_gauss_zig_f(bitgen_t *bitgen_state);
-DECLDIR void random_gauss_zig_fill(bitgen_t *bitgen_state, npy_intp cnt,
-                                   double *out);
 
 /*
 DECLDIR double random_standard_gamma(bitgen_t *bitgen_state, double shape);


### PR DESCRIPTION
Part of the C-API overhaul in gh-14608 and gh-14604, and should be merged first to simplify the distribution function renaming.

`double_fill` had an interface that required a `fill` variant of the sampling function, while `float_fill` and `float_fill_from_double` were different. Align the interfaces and remove the `fill variants in `distributions.c` and `distributions.h`.