### PR TITLE
DOC: added sys.floatinfo to see also for np.finfo

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -350,6 +350,7 @@ class finfo(object):
     --------
     MachAr : The implementation of the tests that produce this information.
     iinfo : The equivalent for integer data types.
+    sys.float_info : Python's definitions of these values for
 
     Notes
     -----


### PR DESCRIPTION
Help clarify the English language definitions by pointing at Python's
definition which in turn points at an ISO C Standard.

~Fixes #6940~,

Feel free to close, just trying to propose patches for easy old issues.