### PR TITLE
DEP: Finish deprecation of non-integer `num` in linspace

### DIFF
--- a/doc/release/upcoming_changes/14620.expired.rst
+++ b/doc/release/upcoming_changes/14620.expired.rst
@@ -1,0 +1,1 @@
+* np.linspace param num must be an integer. This was deprecated in NumPy 1.12.

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -18,18 +18,6 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-def _index_deprecate(i, stacklevel=2):
-    try:
-        i = operator.index(i)
-    except TypeError:
-        msg = ("object of type {} cannot be safely interpreted as "
-               "an integer.".format(type(i)))
-        i = int(i)
-        stacklevel += 1
-        warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
-    return i
-
-
 def _linspace_dispatcher(start, stop, num=None, endpoint=None, retstep=None,
                          dtype=None, axis=None):
     return (start, stop)
@@ -125,8 +113,13 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     >>> plt.show()
 
     """
-    # 2016-02-25, 1.12
-    num = _index_deprecate(num)
+    try:
+        num = operator.index(num)
+    except TypeError:
+        raise TypeError(
+            "object of type {} cannot be safely interpreted as an integer."
+                .format(type(num)))
+
     if num < 0:
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -323,22 +323,6 @@ class TestArrayDataAttributeAssignmentDeprecation(_DeprecationTestCase):
         self.assert_deprecated(a.__setattr__, args=('data', b.data))
 
 
-class TestLinspaceInvalidNumParameter(_DeprecationTestCase):
-    """Argument to the num parameter in linspace that cannot be
-    safely interpreted as an integer is deprecated in 1.12.0.
-
-    Argument to the num parameter in linspace that cannot be
-    safely interpreted as an integer should not be allowed.
-    In the interest of not breaking code that passes
-    an argument that could still be interpreted as an integer, a
-    DeprecationWarning will be issued for the time being to give
-    developers time to refactor relevant code.
-    """
-    def test_float_arg(self):
-        # 2016-02-25, PR#7328
-        self.assert_deprecated(np.linspace, args=(0, 10, 2.5))
-
-
 class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTestCase):
     """
     If a 'width' parameter is passed into ``binary_repr`` that is insufficient to
@@ -594,7 +578,7 @@ class Test_GetSet_NumericOps(_DeprecationTestCase):
     def test_get_numeric_ops(self):
         from numpy.core._multiarray_tests import getset_numericops
         self.assert_deprecated(getset_numericops, num=2)
-        
+
         # empty kwargs prevents any state actually changing which would break
         # other tests.
         self.assert_deprecated(np.set_numeric_ops, kwargs={})

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -236,10 +236,7 @@ class TestLinspace(object):
     def test_corner(self):
         y = list(linspace(0, 1, 1))
         assert_(y == [0.0], y)
-        with suppress_warnings() as sup:
-            sup.filter(DeprecationWarning, ".*safely interpreted as an integer")
-            y = list(linspace(0, 1, 2.5))
-            assert_(y == [0.0, 1.0])
+        assert_raises(TypeError, linspace, 0, 1, num=2.5)
 
     def test_type(self):
         t1 = linspace(0, 1, 0).dtype


### PR DESCRIPTION
Finishes deprecation started in #7328 and fixes #7289.