### PR TITLE
DOC: misleading np.sinc() documentation

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3297,13 +3297,6 @@ def sinc(x):
     Text(0.5, 0, 'X')
     >>> plt.show()
 
-    It works in 2-D as well:
-
-    >>> x = np.linspace(-4, 4, 401)
-    >>> xx = np.outer(x, x)
-    >>> plt.imshow(np.sinc(xx))
-    <matplotlib.image.AxesImage object at 0x...>
-
     """
     x = np.asanyarray(x)
     y = pi * where(x == 0, 1.0e-20, x)


### PR DESCRIPTION
The documentation currently states "It works in 2-D as well"
with attached example not correct.

closes #14466

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
