### PR TITLE
BUG: `nanquantile`/`percentile` result shape on empty input

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1365,9 +1365,8 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # so deal them upfront
     if a.size == 0:
         #to return a nan for all quantiles
-        ans=[np.nanmean(a, axis, out=out, keepdims=keepdims) for _ in range(q.size)]
+        ans = [np.nanmean(a, axis, out=out, keepdims=keepdims) for _ in range(q.size)]
         return np.array(ans)
-
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,
         overwrite_input=overwrite_input, interpolation=interpolation

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1365,7 +1365,11 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # so deal them upfront
     if a.size == 0:
         #to return a nan for all quantiles
-        return np.full(q.size,np.nanmean(a, axis, out=out, keepdims=keepdims))
+        ans=[]
+        for i in range(q.size):
+            ans.append(np.nanmean(a, axis, out=out, keepdims=keepdims))
+        
+        return np.array(ans)
 
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1366,7 +1366,7 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     if a.size == 0:
         #to return a nan for all quantiles
         ans=[]
-        for i in range(q.size):
+        for _ in range(q.size):
             ans.append(np.nanmean(a, axis, out=out, keepdims=keepdims))
         
         return np.array(ans)

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1365,10 +1365,7 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # so deal them upfront
     if a.size == 0:
         #to return a nan for all quantiles
-        ans=[]
-        for _ in range(q.size):
-            ans.append(np.nanmean(a, axis, out=out, keepdims=keepdims))
-        
+        ans=[np.nanmean(a, axis, out=out, keepdims=keepdims) for _ in range(q.size)]
         return np.array(ans)
 
     r, k = function_base._ureduce(

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1364,7 +1364,8 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # apply_along_axis in _nanpercentile doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
-        return np.nanmean(a, axis, out=out, keepdims=keepdims)
+        #to return a nan for all quantiles
+        return np.full(q.size,np.nanmean(a, axis, out=out, keepdims=keepdims))
 
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
I have modified the nanquantile_unchecked function in /numpy/lib/nanfunctions.py so that it returns nan value for all quantiles asked for an empty array. "see Issue #14599"

This is my first commit, apologies is something went wrong and would love any feedback- mail: disha.97.agarwal@gmail.com.