### PR TITLE
BUILD: change to build_src --verbose-cfg, runtests.py --debug-info

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
            python3 -m pip install --user -r test_requirements.txt && \
            python3 -m pip install . && \
            F77=gfortran-5 F90=gfortran-5 \
-           CFLAGS='-UNDEBUG -std=c99' python3 runtests.py -n --debug-configure --mode=full -- -rsx --junitxml=junit/test-results.xml && \
+           CFLAGS='-UNDEBUG -std=c99' python3 runtests.py -n --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml && \
            python3 tools/openblas_support.py --check_version $(OpenBLAS_version)"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
@@ -94,7 +94,7 @@ jobs:
     displayName: 'Check for unreachable code paths in Python modules'
   # prefer usage of clang over gcc proper
   # to match likely scenario on many user mac machines
-  - script: python setup.py build -j 4 build_src -v install
+  - script: python setup.py build -j 4 build_src --verbose-cfg install
     displayName: 'Build NumPy'
     env:
       BLAS: None

--- a/doc/release/upcoming_changes/14518.change.rst
+++ b/doc/release/upcoming_changes/14518.change.rst
@@ -5,8 +5,8 @@ part of configuring NumPy, the files ``_numpyconfig.h`` and ``config.h`` are
 created by probing support for various runtime functions and routines.
 Previously, the very verbose compiler output during this stage clouded more
 important information. By default the output is silenced. Running ``runtests.py
---debug-configure`` will add ``-v`` to the ``build_src`` subcommand, which
-will restore the previous behaviour.
+--debug-info`` will add ``--verbose-cfg`` to the ``build_src`` subcommand,
+which will restore the previous behaviour.
 
 Adding ``CFLAGS=-Werror`` to turn warnings into errors would trigger errors
 during the configuration. Now ``runtests.py --warn-error`` will add

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -53,12 +53,12 @@ class build_src(build_ext.build_ext):
         ('inplace', 'i',
          "ignore build-lib and put compiled extensions into the source " +
          "directory alongside your pure Python modules"),
-        ('verbose', 'v',
+        ('verbose-cfg', None,
          "change logging level from WARN to INFO which will show all " +
          "compiler output")
         ]
 
-    boolean_options = ['force', 'inplace', 'verbose']
+    boolean_options = ['force', 'inplace', 'verbose-cfg']
 
     help_options = []
 
@@ -79,7 +79,7 @@ class build_src(build_ext.build_ext):
         self.swig_opts = None
         self.swig_cpp = None
         self.swig = None
-        self.verbose = None
+        self.verbose_cfg = None
 
     def finalize_options(self):
         self.set_undefined_options('build',
@@ -370,7 +370,7 @@ class build_src(build_ext.build_ext):
                                        +name.split('.')[:-1]))
         self.mkpath(build_dir)
 
-        if self.verbose:
+        if self.verbose_cfg:
             new_level = log.INFO
         else:
             new_level = log.WARN

--- a/runtests.py
+++ b/runtests.py
@@ -71,8 +71,8 @@ def main(argv):
     parser = ArgumentParser(usage=__doc__.lstrip())
     parser.add_argument("--verbose", "-v", action="count", default=1,
                         help="more verbosity")
-    parser.add_argument("--debug-configure", action="store_true",
-                        help=("add -v to build_src to show compiler "
+    parser.add_argument("--debug-info", action="store_true",
+                        help=("add --verbose-cfg to build_src to show compiler "
                               "configuration output while creating "
                               "_numpyconfig.h and config.h"))
     parser.add_argument("--no-build", "-n", action="store_true", default=False,
@@ -376,8 +376,8 @@ def build_project(args):
     cmd += ["build"]
     if args.parallel > 1:
         cmd += ["-j", str(args.parallel)]
-    if args.debug_configure:
-        cmd += ["build_src", "--verbose"]
+    if args.debug_info:
+        cmd += ["build_src", "--verbose-cfg"]
     if args.warn_error:
         cmd += ["--warn-error"]
     # Install; avoid producing eggs so numpy can be imported from dst_dir.

--- a/shippable.yml
+++ b/shippable.yml
@@ -48,7 +48,7 @@ build:
     # check OpenBLAS version
     - python tools/openblas_support.py --check_version 0.3.7
     # run the test suite
-    - python runtests.py --debug-configure --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
+    - python runtests.py --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 
     cache: true
     cache_dir_list:

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -39,7 +39,7 @@ echo pypy3 version
 pypy3/bin/pypy3 -c "import sys; print(sys.version)"
 echo
 
-pypy3/bin/pypy3 runtests.py --debug-configure --show-build-log -v -- -rsx \
+pypy3/bin/pypy3 runtests.py --debug-info --show-build-log -v -- -rsx \
       --junitxml=junit/test-results.xml --durations 10
 
 echo Make sure the correct openblas has been linked in

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -52,7 +52,7 @@ setup_base()
   else
     # Python3.5-dbg on travis seems to need this
     export CFLAGS=$CFLAGS" -Wno-maybe-uninitialized"
-    $PYTHON setup.py build build_src -v build_ext --inplace 2>&1 | tee log
+    $PYTHON setup.py build build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \
     | grep -vE "ld returned 1|no previously-included files matching|manifest_maker: standard file '-c'" \
@@ -151,7 +151,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
      export F90='gfortran --coverage'
      export LDFLAGS='--coverage'
   fi
-  $PYTHON setup.py build build_src -v bdist_wheel
+  $PYTHON setup.py build build_src --verbose-cfg bdist_wheel
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel
   . venv-for-wheel/bin/activate


### PR DESCRIPTION
In gh-14518 we repurposed the `verbose` option to `build_src` in order to quiet the configuration compiler output. Unfortunately it is [reset by distutils](https://github.com/python/cpython/blob/v3.6.9/Lib/distutils/cmd.py#L76) to the value of `dist.verbose`. Change the name to `--verbose-cfg` and remove the short `-v` option.

Also changed the `runtests.py` option to `debug-info` as per [this comment](https://github.com/numpy/numpy/pull/14568#issuecomment-533887229)