### PR TITLE
BUG: always free clean_sep

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3709,6 +3709,8 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
     }
     NPY_END_ALLOW_THREADS;
 
+    free(clean_sep);
+
     if (stop_reading_flag == -2) {
         if (PyErr_Occurred()) {
             /* If an error is already set (unlikely), do not create new one */
@@ -3722,8 +3724,6 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
             goto fail;
         }
     }
-
-    free(clean_sep);
 
 fail:
     Py_DECREF(dtype);


### PR DESCRIPTION
in the case of `stop_reading_flag == -2`  this code will return before the malloc from `swab_separator(sep)` (line 3659) is freed