### PR TITLE
DOC:  Create `class Extension` docstring and add it to documentation.

### DIFF
--- a/doc/source/f2py/distutils.rst
+++ b/doc/source/f2py/distutils.rst
@@ -26,7 +26,7 @@ sources, call F2PY to construct extension modules, etc.
 
 :mod:`numpy.distutils` extends ``distutils`` with the following features:
 
-* ``Extension`` class argument ``sources`` may contain Fortran source
+* :class:`Extension` class argument ``sources`` may contain Fortran source
   files. In addition, the list ``sources`` may contain at most one
   F2PY signature file, and then the name of an Extension module must
   match with the ``<modulename>`` used in signature file.  It is
@@ -37,7 +37,7 @@ sources, call F2PY to construct extension modules, etc.
   to scan Fortran source files for routine signatures to construct the
   wrappers to Fortran codes.
 
-  Additional options to F2PY process can be given using ``Extension``
+  Additional options to F2PY process can be given using :class:`Extension`
   class argument ``f2py_options``.
 
 * The following new ``distutils`` commands are defined:

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -26,6 +26,11 @@ Modules in :mod:`numpy.distutils`
 .. currentmodule:: numpy.distutils
 
 .. autosummary::
+   :toctree: distutils/
+
+   misc_util
+
+.. autosummary::
    :toctree: generated/
 
    ccompiler
@@ -33,7 +38,6 @@ Modules in :mod:`numpy.distutils`
    core.Extension
    exec_command
    log.set_verbosity
-   misc_util
    system_info.get_info
    system_info.get_standard_file
 
@@ -41,7 +45,7 @@ Modules in :mod:`numpy.distutils`
 Configuration class
 ===================
 
-.. currentmodule:: numpy.distutils
+.. currentmodule:: numpy.distutils.misc_util
 
 .. class:: Configuration(package_name=None, parent_name=None, top_path=None, package_path=None, **attrs)
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -23,37 +23,25 @@ information is available in the :ref:`distutils-user-guide`.
 Modules in :mod:`numpy.distutils`
 =================================
 
-misc_util
----------
-
-.. module:: numpy.distutils.misc_util
+.. currentmodule:: numpy.distutils
 
 .. autosummary::
    :toctree: generated/
 
-   get_numpy_include_dirs
-   dict_append
-   appendpath
-   allpath
-   dot_join
-   generate_config_py
-   get_cmd
-   terminal_has_colors
-   red_text
-   green_text
-   yellow_text
-   blue_text
-   cyan_text
-   cyg2win32
-   all_strings
-   has_f_sources
-   has_cxx_sources
-   filter_sources
-   get_dependencies
-   is_local_src_dir
-   get_ext_source_files
-   get_script_files
+   ccompiler
+   cpuinfo.cpu
+   core.Extension
+   exec_command
+   log.set_verbosity
+   misc_util
+   system_info.get_info
+   system_info.get_standard_file
 
+
+Configuration class
+===================
+
+.. currentmodule:: numpy.distutils
 
 .. class:: Configuration(package_name=None, parent_name=None, top_path=None, package_path=None, **attrs)
 
@@ -108,20 +96,6 @@ misc_util
     .. automethod:: make_config_py
 
     .. automethod:: get_info
-
-Other modules
--------------
-
-.. currentmodule:: numpy.distutils
-
-.. autosummary::
-   :toctree: generated/
-
-   system_info.get_info
-   system_info.get_standard_file
-   cpuinfo.cpu
-   log.set_verbosity
-   exec_command
 
 Building Installable C libraries
 ================================

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -22,13 +22,13 @@ information is available in the :ref:`distutils-user-guide`.
 
 Modules in :mod:`numpy.distutils`
 =================================
+.. toctree::
+   :maxdepth: 2
+
+   distutils/misc_util
+
 
 .. currentmodule:: numpy.distutils
-
-.. autosummary::
-   :toctree: distutils/
-
-   misc_util
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reference/distutils/misc_util.rst
+++ b/doc/source/reference/distutils/misc_util.rst
@@ -1,0 +1,2 @@
+.. automodule:: numpy.distutils.misc_util
+   :members:

--- a/doc/source/reference/distutils/misc_util.rst
+++ b/doc/source/reference/distutils/misc_util.rst
@@ -1,2 +1,7 @@
+distutils.misc_util
+===================
+
 .. automodule:: numpy.distutils.misc_util
    :members:
+   :undoc-members:
+   :exclude-members: Configuration

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -19,8 +19,24 @@ if sys.version_info[0] >= 3:
 cxx_ext_re = re.compile(r'.*[.](cpp|cxx|cc)\Z', re.I).match
 fortran_pyf_ext_re = re.compile(r'.*[.](f90|f95|f77|for|ftn|f|pyf)\Z', re.I).match
 
+
 class Extension(old_Extension):
-    def __init__ (
+    """
+    Parameters
+    ----------
+    name : str
+        Extension name.
+    sources : list of str
+        List of source file locations relative to the top directory of
+        the package.
+    extra_compile_args : list of str
+        Extra command line arguments to pass to the compiler.
+    extra_f77_compile_args : list of str
+        Extra command line arguments to pass to the fortran77 compiler.
+    extra_f90_compile_args : list of str
+        Extra command line arguments to pass to the fortran90 compiler.
+    """
+    def __init__(
             self, name, sources,
             include_dirs=None,
             define_macros=None,


### PR DESCRIPTION
Fixes #14633. I have also

- Removed individual entries for everything in `misc_util` from the main page.
- Moved the `ConfigurationClass` doc down a section