### PR TITLE
DOC: Add IPython to dependencies needed to build docs.

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -226,7 +226,7 @@ Requirements
 ~~~~~~~~~~~~
 
 `Sphinx <http://www.sphinx-doc.org/en/stable/>`__ is needed to build
-the documentation. Matplotlib and SciPy are also required.
+the documentation. Matplotlib, SciPy, and IPython are also required.
 
 Fixing Warnings
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
As well as scipy and matplotlib, numpy also needs IPython to build the docs. This PR adds that to the development docs.