### PR TITLE
ENH: Update return value of ma.average and allow weights to be masked.

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -494,7 +494,7 @@ def average(a, axis=None, weights=None, returned=False, *,
         if `a` is integral. Otherwise, if `weights` is not None and `a` is non-
         integral, the result type will be the type of lowest precision capable of
         representing values of both `a` and `weights`. If `a` happens to be
-        integral, the previous rules still applies but the result dtype will
+        integral, the previous rule still applies but the result dtype will
         at least be ``float64``.
 
     Raises

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4329,6 +4329,87 @@ class TestMaskedArrayMathMethods:
         assert_equal(test.filled(0), [0, 0, 0])
         assert_equal(test.mask, [1, 1, 1])
 
+    def test_mean_masked_result(self):
+        a = array(np.ones((3, 3, 3)), mask=np.ones((3, 3, 3)))
+        m = a.mean()
+        assert_equal(m, masked)
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+    def test_mean_dtypes_are_preserved(self, dtype):
+        a = array(np.ones((3, 3, 3), dtype=dtype),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, dtype)
+
+        a = array(np.ones((3, 3, 3), dtype=dtype))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, dtype)
+
+    @pytest.mark.parametrize("dtype", [np.int8, np.uint8, np.uint32, np.int64])
+    def test_mean_integral_dtypes_become_float64(self, dtype):
+        a = array(np.ones((3, 3, 3), dtype=dtype),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, np.float64)
+
+        a = array(np.ones((3, 3, 3), dtype=dtype))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, np.float64)
+
+    def test_mean_complex_dtypes_are_kept(self):
+        a = array(np.ones((3, 3, 3), dtype=np.complex64),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, np.complex64)
+
+        a = array(np.ones((3, 3, 3), dtype=np.complex64))
+        v = a.mean(axis=0)
+        assert_equal(v.dtype, np.complex64)
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.int32, np.uint8])
+    def test_mean_explicit_dtypes_apply(self, dtype):
+        a = array(np.ones((3, 3, 3)))
+        v = a.mean(axis=0, dtype=dtype)
+        assert_equal(v.dtype, dtype)
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+    def test_var_dtypes_are_preserved(self, dtype):
+        a = array(np.ones((3, 3, 3), dtype=dtype),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, dtype)
+
+        a = array(np.ones((3, 3, 3), dtype=dtype))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, dtype)
+
+    @pytest.mark.parametrize("dtype", [np.int8, np.uint8, np.uint32, np.int64])
+    def test_var_integral_dtypes_become_float64(self, dtype):
+        a = array(np.ones((3, 3, 3), dtype=dtype),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, np.float64)
+
+        a = array(np.ones((3, 3, 3), dtype=dtype))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, np.float64)
+
+    def test_var_complex_dtypes_are_kept(self):
+        a = array(np.ones((3, 3, 3), dtype=np.complex64),
+                  mask=np.zeros((3, 3, 3)))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, np.complex64)
+
+        a = array(np.ones((3, 3, 3), dtype=np.complex64))
+        v = a.var(axis=0)
+        assert_equal(v.dtype, np.complex64)
+
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.int32, np.uint8])
+    def test_var_explicit_dtypes_apply(self, dtype):
+        a = array(np.ones((3, 3, 3)))
+        v = a.var(axis=0, dtype=dtype)
+        assert_equal(v.dtype, dtype)
+
     def test_diag(self):
         # Test diag
         x = arange(9).reshape((3, 3))
@@ -4371,6 +4452,28 @@ class TestMaskedArrayMathMethods:
         a = masked_array(np.full((10000, 10000), 65535, dtype=np.uint16),
                          mask=np.zeros((10000, 10000)))
         assert_equal(a.mean(), 65535.0)
+
+    @pytest.mark.parametrize("dtype",
+                             [np.float16, np.float32, np.double, np.longdouble])
+    def test_ma_mean_behaves_like_ndarray(self, dtype):
+        x = np.arange(-30, 30).astype(dtype)
+        mx = array(x, mask=np.zeros(x.shape, dtype=bool))
+        assert_equal(x.mean(), mx.mean())
+
+        x = np.arange(0, 30).astype(dtype)
+        mx = array(x, mask=np.zeros(x.shape, dtype=bool))
+        assert_equal(x.mean(), mx.mean())
+
+    @pytest.mark.parametrize("dtype",
+                             [np.float16, np.float32, np.double, np.longdouble])
+    def test_ma_var_behaves_like_ndarray(self, dtype):
+        x = np.arange(-30, 30).astype(dtype)
+        mx = array(x, mask=np.zeros(x.shape, dtype=bool))
+        assert_equal(x.var(), mx.var())
+
+        x = np.arange(0, 30).astype(dtype)
+        mx = array(x, mask=np.zeros(x.shape, dtype=bool))
+        assert_equal(x.var(), mx.var())
 
     def test_diff_with_prepend(self):
         # GH 22465

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -334,6 +334,12 @@ class TestAverage:
                       "shape of a along specified axis"):
             average(yma, axis=(0, 1), weights=subw1)
 
+        with pytest.raises(
+                TypeError,
+                match="Axis must be specified when shapes of a and weights "
+                      "differ."):
+            average(yma, weights=subw1)
+
         # swapping the axes should be same as transposing weights
         actual = average(yma, axis=(1, 0), weights=subw0)
         desired = average(yma, axis=(0, 1), weights=subw0.T)
@@ -412,6 +418,137 @@ class TestAverage:
         assert_array_equal(wavg, expected_wavg)
         assert wsum.shape == np.shape(expected_wsum)
         assert_array_equal(wsum, expected_wsum)
+
+    def test_average_float_dtype(self):
+        """Tests that float types are preserved for masked and unmasked inputs."""
+        data = np.ones((3, 3, 3), dtype=np.float32)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float32)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.float32),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float32)
+
+        data = np.ones((3, 3, 3), dtype=np.float64)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float64)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.float64),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float64)
+
+        data = np.ones((3, 3, 3), dtype=np.float16)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float16)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.float16),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float16)
+
+    def test_average_integral_dtype(self):
+        """Tests the integral rules, that is integral values become float64"""
+        data = np.ones((3, 3, 3), dtype=np.int8)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float64)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.int8),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float64)
+
+        data = np.ones((3, 3, 3), dtype=np.uint8)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float64)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.uint8),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float64)
+
+        data = np.ones((3, 3, 3), dtype=np.int32)
+        unmasked_average = average(data, axis=0)
+        assert_equal(unmasked_average.dtype, np.float64)
+
+        data_masked = masked_array(np.ones((3, 3, 3), dtype=np.int32),
+                                   np.ones((3, 3, 3), dtype=bool))
+        masked_average = average(data_masked, axis=0)
+        assert_equal(masked_average.dtype, np.float64)
+
+    @pytest.mark.skipif(not hasattr(np, 'float128') or not hasattr(np, 'complex256'),
+                        reason='Does not work on systems without float128 or complex256'
+                               'dtypes.')
+    def test_average_minimal_dtype(self):
+        """Tests rules for type mangling: choose minimal type to represent
+        result properly."""
+        a = masked_array(np.ones(5, dtype=np.float128))
+        w = masked_array(np.ones(5, dtype=np.complex64))
+        assert_equal(average(a, weights=w).dtype, np.complex256)
+
+        a = masked_array(np.ones(5, dtype=np.float128),
+                         np.zeros(5, dtype=bool))
+        w = masked_array(np.ones(5, dtype=np.complex64),
+                         np.zeros(5, dtype=bool))
+        assert_equal(average(a, weights=w), 1)
+        assert_equal(average(a, weights=w).dtype, np.complex256)
+
+    def test_average_masked_weights(self):
+        # weighted average of unmasked values
+        a = masked_array(np.arange(5),
+                         [False, False, True, False, False])
+        w = masked_array(np.arange(5),
+                         [False, True, False, False, False])
+        assert_equal(average(a, weights=w), 25 / 7)
+
+        # along different dimensions
+        a = masked_array(np.ones((1, 5)),
+                         [[False, False, True, False, False]])
+        w = masked_array(np.ones((1, 5)),
+                         [[False, True, False, False, False]])
+        assert_equal(average(a, weights=w), 1)
+        assert_equal(average(a, axis=0, weights=w), [1, 99., 99., 1, 1])
+        assert_equal(average(a, axis=1, weights=w), [1])
+
+        # different shapes for a and weights
+        a = masked_array([np.arange(5), np.arange(1, 6)],
+                         [[False, True, False, False, False]] * 2)
+        w = masked_array(np.arange(1, 6),
+                         [False, True, False, False, False])
+        assert_equal(average(a, axis=1, weights=w), [38 / 13, 51 / 13])
+
+        # no mask for a, but mask for weights; same shapes
+        a = masked_array(np.arange(5))
+        w = masked_array(np.arange(5),
+                         [False, True, False, True, False])
+        assert_equal(average(a, weights=w), 20 / 6)
+
+        # no mask for a, but mask for weights; different shapes
+        a = masked_array([np.arange(5), np.arange(1, 6)])
+        w = masked_array([1, 0],
+                         [False, True])
+        assert_equal(average(a, axis=0, weights=w).mask,
+                     [False, False, False, False, False])
+
+        # more complex new masks per axis
+        a = masked_array([np.arange(1, 6), np.arange(1, 6)])
+        w = masked_array([np.arange(1, 6), np.arange(1, 6)],
+                         [[True, True, True, True, True],
+                          [False, True, False, False, False]])
+        assert_equal(average(a, weights=w), 51 / 13)
+        assert_equal(average(a, axis=0, weights=w).mask,
+                     [False, True, False, False, False])
+        assert_equal(average(a, axis=1, weights=w).mask, [True, False])
+
+    def test_div0_masking(self):
+        # Division by 0 should mask a value to retain backwards compatibility
+        # (See also https://github.com/numpy/numpy/pull/14668 for a discussion)
+        x = masked_array([[1, 2]], mask=[[0, 1]])
+        w = masked_array([[0, 0]], mask=[[0, 0]])
+        avg = average(x, weights=w, axis=1)
+        exp = masked_array([9], mask=[True])
+        assert_equal(avg, exp)
 
     def test_masked_weights(self):
         # Test with masked weights.


### PR DESCRIPTION
This pull request makes changes to the np.ma.average function, and with it to the MaskedArray.mean and MaskedArray.var methods.
They behave more predictable and in line with their np. counterparts with regards to dtype handling.
Additionally, np.ma.average can now handle masked arrays as weights. Please see the commit messages below for more details. 

As this is my first numpy contribution, any feedback is highly appreciated! :-)

---

DOC: typos in np.average

---

ENH: ma.average like np.average; allow weight mask 

This commit makes ma.average to behave more like np.average regarding
dtypes and result handling.

The change required code similar to the code in np.mean, as suggested by
Sebastian Berg, but also some handling in np.ma.average. As a result,
ma.mean handles dtypes like to np.mean. Similar changes have been done
to ma.var, so that it also keeps proper dtypes and uses np.float64 for
integral types.

While getting my head around the code, I inevitably introduced a change
in weights handling: np.ma.average now handles masked weights such that
only values which are not masked in either the data or the weights are
taken into account.

Additional tests and updated documentation are included.

Resolves #14462.