### PR TITLE
MAINT: remove python 3.5 from builds for 1.19, as per NEP 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
                ahp7Qnm0rWRmA0z9SomuRUQOJQ6s684vU="
 
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8-dev
@@ -62,7 +61,7 @@ matrix:
        - NPY_BLAS_ORDER=mkl,blis,openblas,atlas,accelerate,blas
        - NPY_LAPACK_ORDER=MKL,OPENBLAS,ATLAS,ACCELERATE,LAPACK
        - USE_ASV=1
-    - python: 3.5
+    - python: 3.6
       env: NPY_RELAXED_STRIDES_CHECKING=0
     - python: 3.6
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,11 +134,6 @@ jobs:
           PYTHON_ARCH: 'x86'
           TEST_MODE: fast
           BITS: 32
-        Python35-64bit-full:
-          PYTHON_VERSION: '3.5'
-          PYTHON_ARCH: 'x64'
-          TEST_MODE: full
-          BITS: 64
         Python36-64bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'

--- a/doc/release/upcoming_changes/14673.expired.rst
+++ b/doc/release/upcoming_changes/14673.expired.rst
@@ -1,0 +1,1 @@
+* Remove builds of Python 3.5, as per NEP 29

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ License :: OSI Approved
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3 :: Only


### PR DESCRIPTION
remove python 3.5 as a supported platform, as per NEP 29