### PR TITLE
NEP: add default-dtype-object-deprecation nep 34

### DIFF
--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -11,9 +11,9 @@ NEP 34 — Disallow inferring ``dtype=object`` from sequences
 Abstract
 --------
 
-``np.array([<sequence>, <sequence>])`` with no ``dtype`` keyword argument will
-sometimes default to an ``object``-dtype array. Change the behaviour to raise a
-`ValueError` instead.
+``np.array([<ragged_nested_sequence>])`` with no ``dtype`` keyword argument
+will sometimes default to an ``object``-dtype array. Change the behaviour to
+raise a `ValueError` instead.
 
 Motivation and Scope
 --------------------
@@ -31,10 +31,10 @@ Usage and Impact
 
 After this change, ragged array creation must explicitly define a dtype:
 
-    np.array([[1, 2], [1]])
+    >>> np.array([[1, 2], [1]])
     ValueError: cannot guess the desired dtype from the input
 
-    np.array([[1, 2], [1]], dtype=object)
+    >>> np.array([[1, 2], [1]], dtype=object)
     # succeeds, with no change from current behaviour
 
 Detailed description
@@ -43,8 +43,8 @@ Detailed description
 To explicitly set the shape of the object array, since it is sometimes hard to
 determine what shape is desired, one could use:
 
-    arr = np.empty(correct_shape, dtype=object)
-    arr[...] = values
+    >>> arr = np.empty(correct_shape, dtype=object)
+    >>> arr[...] = values
 
 Related Work
 ------------
@@ -68,7 +68,7 @@ Backward compatibility
 
 Anyone depending on ragged lists-of-lists creating object arrays will need to
 modify their code. There will be a deprecation period during which the current
-behaviour will emit a ``DeprecationWarning``
+behaviour will emit a ``DeprecationWarning``.
 
 
 Alternatives

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -70,18 +70,27 @@ false-positives, for instance ``np.array([1, np.array([5])], dtype=int)``.
 Implementation
 --------------
 
-The code to be changed is inside ``PyArray_DTypeFromObject``, specifically in
-``PyArray_DTypeFromObjectHelper``. Since ``PyArray_DTypeFromObject`` is part of
-the NumPy C-API, its interface cannot be changed, but it can return ``-1`` to
-indicate failure.
+The code to be changed is inside ``PyArray_GetArrayParamsFromObject`` and the
+internal ``discover_dimentions`` function. See `PR 14794`_.
 
 Backward compatibility
 ----------------------
 
 Anyone depending on ragged nested sequences creating object arrays will need to
 modify their code. There will be a deprecation period during which the current
-behaviour will emit a ``DeprecationWarning``.
+behaviour will emit a ``DeprecationWarning``. There is an open question whether
+the ``assert_equal`` family of functions should be changed or users be forced
+to change code like
 
+```
+np.assert_equal(a, [[1, 2], 3])
+```
+
+to 
+
+```
+np.assert_equal(a, np.array([[1, 2], 3], dtype=object)
+```
 
 Alternatives
 ------------
@@ -99,22 +108,22 @@ Alternatives
 
 - It was also suggested to deprecate all automatic creation of ``object``-dtype
   arrays, which would require a dtype for something like ``np.array([Decimal(10),
-  Decimal(10)])``. This too is out of scope for the current NEP: only if all
-  the top-level elements are `sequences`_ will we require an explicit
-  ``dtype=object``.
+  Decimal(10)])``. This too is out of scope for the current NEP.
 
 Discussion
 ----------
 
 Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 2014. Suggestions to change it have been made in the ensuing years, but none
-have stuck. 
+have stuck. The WIP implementation in `PR 14794`_ seems to point to the
+viability of this approach.
 
 References and Footnotes
 ------------------------
 
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
 .. _sequences: https://docs.python.org/3.7/glossary.html#term-sequence
+.. _`PR 14794`: https://github.com/numpy/numpy/pull/14794
 
 Copyright
 ---------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -51,7 +51,7 @@ users will have to change code like::
 
 to::
 
-    np.assert_equal(a, np.array([[1, 2], 3], dtype=object)
+    np.assert_equal(a, np.array([[1, 2], 3], dtype=object))
 
 Detailed description
 --------------------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -1,6 +1,6 @@
-==========================================
-NEP 34 — Disallow default ``dtype=object``
-==========================================
+===========================================================
+NEP 34 — Disallow inferring ``dtype=object`` from sequences
+===========================================================
 
 :Author: Matti Picus
 :Status: Draft
@@ -11,8 +11,8 @@ NEP 34 — Disallow default ``dtype=object``
 Abstract
 --------
 
-``np.array([<value])`` with no ``dtype`` keyword argument will sometimes
-default to an ``object``-dtype array. Change the behaviour to raise a
+``np.array([<sequence>, <sequence>])`` with no ``dtype`` keyword argument will
+sometimes default to an ``object``-dtype array. Change the behaviour to raise a
 `ValueError` instead.
 
 Motivation and Scope
@@ -31,19 +31,31 @@ Detailed description
 
 After this change, ragged array creation must explicitly define a dtype:
 
-    a = np.array([1, 2], [1])
+    np.array([[1, 2], [1]])
     ValueError: cannot guess the desired dtype from the input
 
-    a = np.array([1, 2], [1], dtype=object)
-    print(a.dtype)
-    object
+    np.array([[1, 2], [1]], dtype=object)
+    ValueError: cannot guess the desired object type, use \
+    ``ragged_object_array`` instead
+
+    np.ragged_array_object([[1, 2], [1]], depth=0)
+    array([list([[1, 2], [1]])], dtype=object)
+
+    np.ragged_array_object([[1, 2], [1]], depth=1)
+    array([list([1, 2]), list([1])], dtype=object)
+
+    np.ragged_array_object([[1, 2], [1]], depth=2)
+    ValueError: cannot interpret input as depth-2 sequences
+    
+    np.ragged_array_object([[[1, 2], [1]], [['a']]], depth = 2)
+    array([[list([1, 2]), list([1])], [list(['a'])]], dtype=object)
 
 Related Work
 ------------
 
 `PR 14341`_ tried to raise an error when ragged arrays were specified with
 a numeric dtype ``np.array, [[1], [2, 3]], dtype=int)`` but failed due to
-false-postives, for instance ``np.array([1, np.array([5])], dtype=int)``.
+false-positives, for instance ``np.array([1, np.array([5])], dtype=int)``.
 
 .. _`PR 14341`: https://github.com/numpy/numpy/pull/14341
 

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -24,9 +24,11 @@ Users who specify lists-of-lists when creating a `numpy.ndarray` via
 ``np.array`` may mistakenly pass in lists of different lengths. Currently we
 accept this input and create a ragged array with ``dtype=object``. This can be
 confusing, since it is rarely what is desired. Changing the automatic dtype
-detection to never return ``object`` for ragged arrays will force users who
-actually wish to create ``object`` arrays to specify that explicitly, see for
-instance `issue 5303`_.
+detection to never return ``object`` for ragged arrays (defined as a recursive
+`sequence`_ of sequences, where not all the sequences on the same level have
+the same length) will force users who actually wish to create ``object`` arrays
+to specify that explicitly. Note that lists, tuples, and nd.arrays are all
+sequences. See for instance `issue 5303`_.
 
 Usage and Impact
 ----------------
@@ -47,6 +49,12 @@ determine what shape is desired, one could use:
 
     >>> arr = np.empty(correct_shape, dtype=object)
     >>> arr[...] = values
+
+We will also reject mixed seqeunces of ``non-sequence and sequence``, for instance
+all of these will be rejected:
+
+    >>> arr = np.array([np.arange(10), [10]])
+    >>> arr = np.array([[range(3), range(3), range(3)], [range(3), 0, 0]])
 
 Related Work
 ------------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -11,9 +11,11 @@ NEP 34 — Disallow inferring ``dtype=object`` from sequences
 Abstract
 --------
 
-``np.array([<ragged_nested_sequence>])`` with no ``dtype`` keyword argument
-will sometimes default to an ``object``-dtype array. Change the behaviour to
-raise a `ValueError` instead.
+When users create arrays with lists-of-lists, they sometimes err in matching
+the lengths of the nested lists, commonly called "ragged arrays". Creating such
+arrays via ``np.array([<ragged_nested_sequence>])`` with no ``dtype`` keyword
+argument will today default to an ``object``-dtype array. Change the behaviour to
+raise a ``ValueError`` instead.
 
 Motivation and Scope
 --------------------
@@ -80,8 +82,14 @@ It was also suggested to add a kwarg `depth` to array creation, or perhaps to
 add another array creation API function `ragged_array_object`. The goal was
 to eliminate the ambiguity in creating an object array from `array([[1, 2],
 [1]], dtype=object)`: should the returned array have a shape of `(1,)`, or
-`(2,)`? This PR does not deal with that issue, and only deprecates the use of
+`(2,)`? This NEP does not deal with that issue, and only deprecates the use of
 `array` with no `dtype=object` for ragged arrays.
+
+It was also suggested to deprecate all automatic creation of ``object``-dtype
+arrays, which would require a dtype for something like ``np.array([Decimal(10),
+Decimal(10)])``. This too is out of scope for the current NEP: only if all the
+top-level elements are `sequences`_ will we require an explicit
+``dtype=object``.
 
 Discussion
 ----------
@@ -94,7 +102,7 @@ References and Footnotes
 ------------------------
 
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
-
+.. _`sequences`: https://docs.python.org/3.7/glossary.html#term-sequence
 
 Copyright
 ---------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -43,6 +43,16 @@ define a dtype:
     >>> np.array([[1, 2], [1]], dtype=object)
     # succeeds, with no change from current behaviour
 
+The deprecation will affect any call that internally calls ``np.asarray``.  For
+instance, the ``assert_equal`` family of functions calls ``np.asarray``, so
+users will have to change code like::
+
+    np.assert_equal(a, [[1, 2], 3])
+
+to::
+
+    np.assert_equal(a, np.array([[1, 2], 3], dtype=object)
+
 Detailed description
 --------------------
 
@@ -76,21 +86,9 @@ internal ``discover_dimentions`` function. See `PR 14794`_.
 Backward compatibility
 ----------------------
 
-Anyone depending on ragged nested sequences creating object arrays will need to
-modify their code. There will be a deprecation period during which the current
-behaviour will emit a ``DeprecationWarning``. There is an open question whether
-the ``assert_equal`` family of functions should be changed or users be forced
-to change code like
-
-```
-np.assert_equal(a, [[1, 2], 3])
-```
-
-to 
-
-```
-np.assert_equal(a, np.array([[1, 2], 3], dtype=object)
-```
+Anyone depending on creating object arrays from ragged nested sequences will
+need to modify their code. There will be a deprecation period during which the
+current behaviour will emit a ``DeprecationWarning``. 
 
 Alternatives
 ------------
@@ -104,11 +102,16 @@ Alternatives
   ``(1,)``, or ``(2,)``? This NEP does not deal with that issue, and only
   deprecates the use of ``array`` with no ``dtype=object`` for ragged nested
   sequences. Users of ragged nested sequences may face another deprecation
-  cycle in the future.
+  cycle in the future. Rationale: we expect that there are very few users who
+  intend to use ragged arrays like that, this was never intended as a use case
+  of NumPy arrays. Users are likely better off with `another library`_ or just
+  using list of lists.
 
 - It was also suggested to deprecate all automatic creation of ``object``-dtype
-  arrays, which would require a dtype for something like ``np.array([Decimal(10),
-  Decimal(10)])``. This too is out of scope for the current NEP.
+  arrays, which would require adding an explicit ``dtype=object`` for something
+  like ``np.array([Decimal(10), Decimal(10)])``. This too is out of scope for
+  the current NEP. Rationale: it's harder to asses the impact of this larger
+  change, we're not sure how many users this may impact.
 
 Discussion
 ----------
@@ -124,6 +127,7 @@ References and Footnotes
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
 .. _sequences: https://docs.python.org/3.7/glossary.html#term-sequence
 .. _`PR 14794`: https://github.com/numpy/numpy/pull/14794
+.. _`another library`: https://github.com/scikit-hep/awkward-array
 
 Copyright
 ---------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -1,0 +1,87 @@
+==========================================
+NEP 34 — Disallow default ``dtype=object``
+==========================================
+
+:Author: Matti Picus
+:Status: Draft
+:Type: Standards Track
+:Created: 2019-10-10
+
+
+Abstract
+--------
+
+``np.array([<value])`` with no ``dtype`` keyword argument will sometimes
+default to an ``object``-dtype array. Change the behaviour to raise a
+`ValueError` instead.
+
+Motivation and Scope
+--------------------
+
+Users who specify lists-of-lists when creating a `numpy.ndarray` via
+``np.array`` may mistakenly pass in lists of different lengths. Currently we
+accept this input and create a ragged array with ``dtype=object``. This can be
+confusing, since it is rarely what is desired. Changing the default dtype
+detection to never return ``object`` will force users who actually wish to
+create ``object`` arrays to specify that explicitly, see for instance `issue
+5303`_.
+
+Detailed description
+--------------------
+
+After this change, ragged array creation must explicitly define a dtype:
+
+    a = np.array([1, 2], [1])
+    ValueError: cannot guess the desired dtype from the input
+
+    a = np.array([1, 2], [1], dtype=object)
+    print(a.dtype)
+    object
+
+Related Work
+------------
+
+`PR 14341`_ tried to raise an error when ragged arrays were specified with
+a numeric dtype ``np.array, [[1], [2, 3]], dtype=int)`` but failed due to
+false-postives, for instance ``np.array([1, np.array([5])], dtype=int)``.
+
+.. _`PR 14341`: https://github.com/numpy/numpy/pull/14341
+
+Implementation
+--------------
+
+The code to be changed is inside ``PyArray_DTypeFromObject``, specifically in
+``PyArray_DTypeFromObjectHelper``. Since ``PyArray_DTypeFromObject`` is part of
+the NumPy C-API, its interface cannot be changed, but it can return ``-1`` to
+indicate failure.
+
+Backward compatibility
+----------------------
+
+Anyone depending on ragged lists-of-lists creating object arrays will need to
+modify their code. There will be a deprecation period during which the current
+behaviour will emit a ``DeprecationWarning``
+
+
+Alternatives
+------------
+
+We could continue with the current situation.
+
+Discussion
+----------
+
+Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
+2014. Suggestions to change it have been made in the ensuing years, but none
+have stuck.
+
+References and Footnotes
+------------------------
+
+.. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
+
+
+Copyright
+---------
+
+This document has been placed in the public domain.

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -21,13 +21,13 @@ Motivation and Scope
 Users who specify lists-of-lists when creating a `numpy.ndarray` via
 ``np.array`` may mistakenly pass in lists of different lengths. Currently we
 accept this input and create a ragged array with ``dtype=object``. This can be
-confusing, since it is rarely what is desired. Changing the default dtype
-detection to never return ``object`` will force users who actually wish to
-create ``object`` arrays to specify that explicitly, see for instance `issue
-5303`_.
+confusing, since it is rarely what is desired. Changing the automatic dtype
+detection to never return ``object`` for ragged arrays will force users who
+actually wish to create ``object`` arrays to specify that explicitly, see for
+instance `issue 5303`_.
 
-Detailed description
---------------------
+Usage and Impact
+----------------
 
 After this change, ragged array creation must explicitly define a dtype:
 
@@ -35,20 +35,16 @@ After this change, ragged array creation must explicitly define a dtype:
     ValueError: cannot guess the desired dtype from the input
 
     np.array([[1, 2], [1]], dtype=object)
-    ValueError: cannot guess the desired object type, use \
-    ``ragged_object_array`` instead
+    # succeeds, with no change from current behaviour
 
-    np.ragged_array_object([[1, 2], [1]], depth=0)
-    array([list([[1, 2], [1]])], dtype=object)
+Detailed description
+--------------------
 
-    np.ragged_array_object([[1, 2], [1]], depth=1)
-    array([list([1, 2]), list([1])], dtype=object)
+To explicitly set the shape of the object array, since it is sometimes hard to
+determine what shape is desired, one could use:
 
-    np.ragged_array_object([[1, 2], [1]], depth=2)
-    ValueError: cannot interpret input as depth-2 sequences
-    
-    np.ragged_array_object([[[1, 2], [1]], [['a']]], depth = 2)
-    array([[list([1, 2]), list([1])], [list(['a'])]], dtype=object)
+    arr = np.empty(correct_shape, dtype=object)
+    arr[...] = values
 
 Related Work
 ------------
@@ -80,12 +76,19 @@ Alternatives
 
 We could continue with the current situation.
 
+It was also suggested to add a kwarg `depth` to array creation, or perhaps to
+add another array creation API function `ragged_array_object`. The goal was
+to eliminate the ambiguity in creating an object array from `array([[1, 2],
+[1]], dtype=object)`: should the returned array have a shape of `(1,)`, or
+`(2,)`? This PR does not deal with that issue, and only deprecates the use of
+`array` with no `dtype=object` for ragged arrays.
+
 Discussion
 ----------
 
 Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 2014. Suggestions to change it have been made in the ensuing years, but none
-have stuck.
+have stuck. The mailing list 
 
 References and Footnotes
 ------------------------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -11,8 +11,9 @@ NEP 34 — Disallow inferring ``dtype=object`` from sequences
 Abstract
 --------
 
-When users create arrays with lists-of-lists, they sometimes err in matching
-the lengths of the nested lists, commonly called "ragged arrays". Creating such
+When users create arrays with sequences-of-sequences, they sometimes err in
+matching the lengths of the nested sequences_, commonly called "ragged
+arrays".  Here we will refer to them as ragged nested sequences. Creating such
 arrays via ``np.array([<ragged_nested_sequence>])`` with no ``dtype`` keyword
 argument will today default to an ``object``-dtype array. Change the behaviour to
 raise a ``ValueError`` instead.
@@ -22,18 +23,19 @@ Motivation and Scope
 
 Users who specify lists-of-lists when creating a `numpy.ndarray` via
 ``np.array`` may mistakenly pass in lists of different lengths. Currently we
-accept this input and create a ragged array with ``dtype=object``. This can be
+accept this input and create an array with ``dtype=object``. This can be
 confusing, since it is rarely what is desired. Changing the automatic dtype
-detection to never return ``object`` for ragged arrays (defined as a recursive
-`sequence`_ of sequences, where not all the sequences on the same level have
-the same length) will force users who actually wish to create ``object`` arrays
-to specify that explicitly. Note that lists, tuples, and nd.arrays are all
-sequences. See for instance `issue 5303`_.
+detection to never return ``object`` for ragged nested sequences (defined as a
+recursive sequence of sequences, where not all the sequences on the same
+level have the same length) will force users who actually wish to create
+``object`` arrays to specify that explicitly. Note that lists, tuples, and
+nd.arrays are all sequences. See for instance `issue 5303`_.
 
 Usage and Impact
 ----------------
 
-After this change, ragged array creation must explicitly define a dtype:
+After this change, array creation with ragged nested sequences must explicitly
+define a dtype:
 
     >>> np.array([[1, 2], [1]])
     ValueError: cannot guess the desired dtype from the input
@@ -50,7 +52,7 @@ determine what shape is desired, one could use:
     >>> arr = np.empty(correct_shape, dtype=object)
     >>> arr[...] = values
 
-We will also reject mixed seqeunces of ``non-sequence and sequence``, for instance
+We will also reject mixed sequences of non-sequence and sequence, for instance
 all of these will be rejected:
 
     >>> arr = np.array([np.arange(10), [10]])
@@ -59,8 +61,8 @@ all of these will be rejected:
 Related Work
 ------------
 
-`PR 14341`_ tried to raise an error when ragged arrays were specified with
-a numeric dtype ``np.array, [[1], [2, 3]], dtype=int)`` but failed due to
+`PR 14341`_ tried to raise an error when ragged nested sequences were specified
+with a numeric dtype ``np.array, [[1], [2, 3]], dtype=int)`` but failed due to
 false-positives, for instance ``np.array([1, np.array([5])], dtype=int)``.
 
 .. _`PR 14341`: https://github.com/numpy/numpy/pull/14341
@@ -76,7 +78,7 @@ indicate failure.
 Backward compatibility
 ----------------------
 
-Anyone depending on ragged lists-of-lists creating object arrays will need to
+Anyone depending on ragged nested sequences creating object arrays will need to
 modify their code. There will be a deprecation period during which the current
 behaviour will emit a ``DeprecationWarning``.
 
@@ -84,33 +86,35 @@ behaviour will emit a ``DeprecationWarning``.
 Alternatives
 ------------
 
-We could continue with the current situation.
+- We could continue with the current situation.
 
-It was also suggested to add a kwarg `depth` to array creation, or perhaps to
-add another array creation API function `ragged_array_object`. The goal was
-to eliminate the ambiguity in creating an object array from `array([[1, 2],
-[1]], dtype=object)`: should the returned array have a shape of `(1,)`, or
-`(2,)`? This NEP does not deal with that issue, and only deprecates the use of
-`array` with no `dtype=object` for ragged arrays.
+- It was also suggested to add a kwarg ``depth`` to array creation, or perhaps
+  to add another array creation API function ``ragged_array_object``. The goal
+  was to eliminate the ambiguity in creating an object array from ``array([[1,
+  2], [1]], dtype=object)``: should the returned array have a shape of
+  ``(1,)``, or ``(2,)``? This NEP does not deal with that issue, and only
+  deprecates the use of ``array`` with no ``dtype=object`` for ragged nested
+  sequences. Users of ragged nested sequences may face another deprecation
+  cycle in the future.
 
-It was also suggested to deprecate all automatic creation of ``object``-dtype
-arrays, which would require a dtype for something like ``np.array([Decimal(10),
-Decimal(10)])``. This too is out of scope for the current NEP: only if all the
-top-level elements are `sequences`_ will we require an explicit
-``dtype=object``.
+- It was also suggested to deprecate all automatic creation of ``object``-dtype
+  arrays, which would require a dtype for something like ``np.array([Decimal(10),
+  Decimal(10)])``. This too is out of scope for the current NEP: only if all
+  the top-level elements are `sequences`_ will we require an explicit
+  ``dtype=object``.
 
 Discussion
 ----------
 
 Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 2014. Suggestions to change it have been made in the ensuing years, but none
-have stuck. The mailing list 
+have stuck. 
 
 References and Footnotes
 ------------------------
 
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
-.. _`sequences`: https://docs.python.org/3.7/glossary.html#term-sequence
+.. _sequences: https://docs.python.org/3.7/glossary.html#term-sequence
 
 Copyright
 ---------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -23,13 +23,13 @@ Motivation and Scope
 
 Users who specify lists-of-lists when creating a `numpy.ndarray` via
 ``np.array`` may mistakenly pass in lists of different lengths. Currently we
-accept this input and create an array with ``dtype=object``. This can be
-confusing, since it is rarely what is desired. Changing the automatic dtype
-detection to never return ``object`` for ragged nested sequences (defined as a
+accept this input and automatically create an array with ``dtype=object``. This
+can be confusing, since it is rarely what is desired. Changing the automatic
+dtype detection to never return ``object`` for ragged nested sequences (defined as a
 recursive sequence of sequences, where not all the sequences on the same
 level have the same length) will force users who actually wish to create
-``object`` arrays to specify that explicitly. Note that lists, tuples, and
-nd.arrays are all sequences. See for instance `issue 5303`_.
+``object`` arrays to specify that explicitly. Note that ``lists``, ``tuples``,
+and ``nd.ndarrays`` are all sequences [0]_. See for instance `issue 5303`_.
 
 Usage and Impact
 ----------------
@@ -128,6 +128,12 @@ References and Footnotes
 .. _sequences: https://docs.python.org/3.7/glossary.html#term-sequence
 .. _`PR 14794`: https://github.com/numpy/numpy/pull/14794
 .. _`another library`: https://github.com/scikit-hep/awkward-array
+
+.. [0] ``np.ndarrays`` are not recursed into, rather their shape is used
+   directly. This will not emit warnings::
+
+      ragged = np.array([[1], [1, 2, 3]], dtype=object)
+      np.array([ragged, ragged]) # no dtype needed
 
 Copyright
 ---------


### PR DESCRIPTION
NEP to deprecate `a = np.array([1, 2], [1])` without explicitly stating `dtype=object`.

xref gh-5303, related to gh-13913, gh-14341.

