### PR TITLE
DEP: ufunc `out` argument must be a tuple for multiple outputs

### DIFF
--- a/doc/release/upcoming_changes/14682.expired.rst
+++ b/doc/release/upcoming_changes/14682.expired.rst
@@ -1,0 +1,2 @@
+* UFuncs with multiple outputs must use a tuple for the `out` kwarg. This
+  finishes a deprecation started in NumPy 1.10.

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1193,34 +1193,11 @@ get_ufunc_arguments(PyUFuncObject *ufunc,
                 }
             }
             else {
-                /*
-                 * If the deprecated behavior is ever removed,
-                 * keep only the else branch of this if-else
-                 */
-                if (PyArray_Check(out_kwd) || out_kwd == Py_None) {
-                    if (DEPRECATE("passing a single array to the "
-                                  "'out' keyword argument of a "
-                                  "ufunc with\n"
-                                  "more than one output will "
-                                  "result in an error in the "
-                                  "future") < 0) {
-                        /* The future error message */
-                        PyErr_SetString(PyExc_TypeError,
-                                        "'out' must be a tuple of arrays");
-                        goto fail;
-                    }
-                    if (_set_out_array(out_kwd, out_op+nin) < 0) {
-                        goto fail;
-                    }
-                }
-                else {
-                    PyErr_SetString(PyExc_TypeError,
-                                    nout > 1 ? "'out' must be a tuple "
-                                    "of arrays" :
-                                    "'out' must be an array or a "
-                                    "tuple of a single array");
-                    goto fail;
-                }
+                PyErr_SetString(PyExc_TypeError,
+                        nout > 1 ? "'out' must be a tuple of arrays" :
+                                   "'out' must be an array or a tuple with "
+                                   "a single array");
+                goto fail;
             }
         }
         /*

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -75,11 +75,9 @@ class TestOut(object):
             assert_(r1 is o1)
             assert_(r2 is o2)
 
-            with warnings.catch_warnings(record=True) as w:
-                warnings.filterwarnings('always', '', DeprecationWarning)
+            with assert_raises(TypeError):
+                # Out argument must be tuple, since there are multiple outputs.
                 r1, r2 = np.frexp(d, out=o1, subok=subok)
-                assert_(r1 is o1)
-                assert_(w[0].category is DeprecationWarning)
 
             assert_raises(ValueError, np.add, a, 2, o, o, subok=subok)
             assert_raises(ValueError, np.add, a, 2, o, out=o, subok=subok)
@@ -165,14 +163,9 @@ class TestOut(object):
             else:
                 assert_(type(r1) == np.ndarray)
 
-            with warnings.catch_warnings(record=True) as w:
-                warnings.filterwarnings('always', '', DeprecationWarning)
+            with assert_raises(TypeError):
+                # Out argument must be tuple, since there are multiple outputs.
                 r1, r2 = np.frexp(d, out=o1, subok=subok)
-                if subok:
-                    assert_(isinstance(r2, ArrayWrap))
-                else:
-                    assert_(type(r2) == np.ndarray)
-                assert_(w[0].category is DeprecationWarning)
 
 
 class TestComparisons(object):
@@ -2161,10 +2154,9 @@ class TestSpecialMethods(object):
         assert_(np.modf(a, None) == {})
         assert_(np.modf(a, None, None) == {})
         assert_(np.modf(a, out=(None, None)) == {})
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_(np.modf(a, out=None) == {})
-            assert_(w[0].category is DeprecationWarning)
+        with assert_raises(TypeError):
+            # Out argument must be tuple, since there are multiple outputs.
+            np.modf(a, out=None)
 
         # don't give positional and output argument, or too many arguments.
         # wrong number of arguments in the tuple is an error too.


### PR DESCRIPTION
This finishes a deprecation started in NumPy 1.10. when the support
for providing multiple output arguments was added.