### PR TITLE
BUG: properly define PyArray_DescrCheck

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -23,7 +23,7 @@ extern "C" {
 
 /* C-API that requires previous API to be defined */
 
-#define PyArray_DescrCheck(op) (((PyObject*)(op))->ob_type==&PyArrayDescr_Type)
+#define PyArray_DescrCheck(op) PyObject_TypeCheck(op, &PyArrayDescr_Type)
 
 #define PyArray_Check(op) PyObject_TypeCheck(op, &PyArray_Type)
 #define PyArray_CheckExact(op) (((PyObject*)(op))->ob_type == &PyArray_Type)


### PR DESCRIPTION
Backport of #14605. 

`PyArray_DescrCheck` was defined incorrectly. Redefine and add `PyArray_DescrCheckExact`.

This becomes a problem if we allow subclassing `PyArrayDescr_Type`, and should be backported to any version we still support to prevent issues when using a newer NumPy with code compiled with an older NumPy. Searching scipy/pandas/astropy/numba only turned up a use inside numba. Once this is merged we should submit an issue there to work around this for old versions.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
