### PR TITLE
ENH: Add optional parameter to ignore nan values in np.cov and np.corrcoef

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2453,12 +2453,14 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None):
+def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None,
+                            ignore_nan=None):
     return (x, y)
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
+def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue,
+                ignore_nan=False):
     """
     Return Pearson product-moment correlation coefficients.
 
@@ -2492,6 +2494,9 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
         Has no effect, do not use.
 
         .. deprecated:: 1.10.0
+    ignore_nan: bool, optional
+        If set to True, observations where any variable is equal to np.nan will
+        be ignored.
 
     Returns
     -------
@@ -2520,7 +2525,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
         # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning, stacklevel=3)
-    c = cov(x, y, rowvar)
+    c = cov(x, y, rowvar, ignore_nan=ignore_nan)
     try:
         d = diag(c)
     except ValueError:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2225,13 +2225,13 @@ class vectorize(object):
 
 
 def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
-                    fweights=None, aweights=None):
-    return (m, y, fweights, aweights)
+                    fweights=None, aweights=None, ignore_nan=None):
+    return (m, y, fweights, aweights, ignore_nan)
 
 
 @array_function_dispatch(_cov_dispatcher)
 def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
-        aweights=None):
+        aweights=None, ignore_nan=False):
     """
     Estimate a covariance matrix, given data and weights.
 
@@ -2282,6 +2282,9 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         weights can be used to assign probabilities to observation vectors.
 
         .. versionadded:: 1.10
+    ignore_nan: bool, optional
+        If set to True, observations where any variable is equal to np.nan will
+        be ignored.
 
     Returns
     -------
@@ -2375,6 +2378,13 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         if not rowvar and y.shape[0] != 1:
             y = y.T
         X = np.concatenate((X, y), axis=0)
+
+    # Remove observations with nan values
+    if ignore_nan:
+        for i in range(len(X)):
+            for j in range(len(X[i])-1, -1, -1):
+                if np.isnan(X[i][j]):
+                    X = np.delete(X, j, 1)
 
     if ddof is None:
         if bias == 0:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2385,6 +2385,9 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
             for j in range(len(X[i])-1, -1, -1):
                 if np.isnan(X[i][j]):
                     X = np.delete(X, j, 1)
+        if X.shape[1] <= 1:
+            rows = X.shape[0]
+            return np.full((rows, rows), np.nan)
 
     if ddof is None:
         if bias == 0:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1865,6 +1865,15 @@ class TestCorrCoef(object):
         assert_array_almost_equal(c, np.array([[1., -1.], [-1., 1.]]))
         assert_(np.all(np.abs(c) <= 1.0))
 
+    def test_ignore_nan(self):
+        nan_x1 = np.array([[0, 2], [1,1], [np.nan, np.nan], [2, 0]]).T
+        nan_res1 = np.array([[1., -1.], [-1., 1.]])
+        assert_allclose(np.corrcoef(nan_x1, ignore_nan=True), nan_res1)
+
+        nan_x2 = np.array([[5, np.nan], [0, 2], [1,1], [np.nan, 3], [2, 0]]).T
+        nan_res2 = np.array([[1., -1.], [-1., 1.]])
+        assert_allclose(np.corrcoef(nan_x2, ignore_nan=True), nan_res2)
+
 class TestCov(object):
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T
     res1 = np.array([[1., -1.], [-1., 1.]])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1865,7 +1865,6 @@ class TestCorrCoef(object):
         assert_array_almost_equal(c, np.array([[1., -1.], [-1., 1.]]))
         assert_(np.all(np.abs(c) <= 1.0))
 
-
 class TestCov(object):
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T
     res1 = np.array([[1., -1.], [-1., 1.]])
@@ -1964,6 +1963,15 @@ class TestCov(object):
         assert_allclose(cov(self.x1, fweights=self.unit_frequencies,
                             aweights=self.unit_weights),
                         self.res1)
+
+    def test_ignore_nan(self):
+        nan_x1 = np.array([[0, 2], [1,1], [np.nan, np.nan], [2, 0]]).T
+        nan_res1 = np.array([[1., -1.], [-1., 1.]])
+        assert_allclose(cov(nan_x1, ignore_nan=True), nan_res1)
+
+        nan_x2 = np.array([[5, np.nan], [0, 2], [1,1], [np.nan, 3], [2, 0]]).T
+        nan_res2 = np.array([[1., -1.], [-1., 1.]])
+        assert_allclose(cov(nan_x2, ignore_nan=True), nan_res2)
 
 
 class Test_I0(object):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1982,6 +1982,16 @@ class TestCov(object):
         nan_res2 = np.array([[1., -1.], [-1., 1.]])
         assert_allclose(cov(nan_x2, ignore_nan=True), nan_res2)
 
+        nan_x3 = np.array([
+            [np.nan,      1,      2],
+            [     1, np.nan,      1],
+            [     2,      1, np.nan]])
+        res3 = np.array([
+            [np.nan, np.nan, np.nan],
+            [np.nan, np.nan, np.nan],
+            [np.nan, np.nan, np.nan]])
+        assert_allclose(np.nancov(nan_x3), res3)
+
 
 class Test_I0(object):
 


### PR DESCRIPTION
Addresses one of the features suggesting in issue #14414.

Adds an optional parameter `ignore_nan=False` to `np.cov` and `np.corrcoef` that allows any observations where any variable is `np.nan` to be ignored.

Example case:
```
a = np.array([0, 1, np.nan, 0])
b = np.array([1, 0, 1, 1])
np.corrcoef(a, b, ignore_nan=True)
```

Previous output (without `ignore_nan`):
```
array([[nan, nan],
       [nan,  1.]])
```

Added behavior (with `ignore_nan=True`):
```
array([[ 1., -1.],
       [-1.,  1.]])
```