### PR TITLE
BUG: Fix typeerror in ``rate`` for Decimal

### DIFF
--- a/numpy/lib/financial.py
+++ b/numpy/lib/financial.py
@@ -645,7 +645,7 @@ def rate(nper, pmt, pv, fv, when='end', guess=None, tol=None, maxiter=100):
         rn = rnp1
     if not close:
         # Return nan's in array of the same shape as rn
-        return np.nan + rn
+        return default_type('nan') + rn
     else:
         return rn
 

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -24,6 +24,13 @@ class TestFinancial(object):
         rate = np.rate(Decimal('10'), Decimal('0'), Decimal('-3500'), Decimal('10000'))
         assert_equal(Decimal('0.1106908537142689284704528100'), rate)
 
+    def test_rate_returns_nan_when_infeasible_with_decimal(self):
+        # It is impossible to pay off the existing ammount by making further
+        # withdrawl, therefore no possible ``rate`` exists.
+        # see: https://github.com/numpy/numpy/issues/14638
+        rate = np.rate(Decimal(12), Decimal(400), Decimal(10000), Decimal(0))
+        assert_(isinstance(rate, Decimal) and rate.is_nan())
+
     def test_irr(self):
         v = [-150000, 15000, 25000, 35000, 45000, 60000]
         assert_almost_equal(np.irr(v), 0.0524, 2)


### PR DESCRIPTION
``rate`` should return nan when the solution is infeasible. However
addition between Float and Decimal types (i.e. float + Decimal) is not
defined. This PR explicitly converts the nan to the default_type
required in rate.

This fixes #14638.