### PR TITLE
ENH: linspace works with datetime64 and timedelta64.

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -135,8 +135,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         # Warning: dtype must have high enough precision so
         # that it is at all possible to draw num equispaced
         # samples.
-        assert dtype is not None, "linspace with {} objects cannot be called "\
-            "with dtype=None".format(start.dtype)
+        if dtype is None:
+            raise ValueError("linspace with {} objects cannot be called with"
+                    "dtype=None".format(start.dtype))
         start = start.astype(dtype)
         stop = stop.astype(dtype)
         # y cannot be cast to datetime64/timedelta64, but left

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -138,6 +138,10 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         if dtype is None:
             raise ValueError("linspace with {} objects cannot be called with"
                     "dtype=None".format(start.dtype))
+        if np.isnat(start):
+            raise ValueError("start is NaT, linspace won't work.")
+        if np.isnat(stop):
+            raise ValueError("stop is NaT, linspace won't work.")
         start = start.astype(dtype).view(_nx.int64)
         stop = stop.astype(dtype).view(_nx.int64)
     else:

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -130,18 +130,18 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     # check if dealing with datetime64 or timedelta64
     is_datelike = start.dtype.kind in 'Mm'
     if is_datelike:
-        # For datetime/timedelta, dtype must be specified:
-        # start and stop will first be cast to this dtype.
-        # Warning: dtype must have high enough precision so
-        # that it is at all possible to draw num equispaced
-        # samples.
+        # For datetime/timedelta, dtype must be specified.
+        # Warning: dtype must have high enough precision so that it is at all possible
+        # to draw num equispaced samples.
         if dtype is None:
-            raise ValueError("linspace with {} objects cannot be called with"
-                    "dtype=None".format(start.dtype))
-        if np.isnat(start):
-            raise ValueError("start is NaT, linspace won't work.")
-        if np.isnat(stop):
-            raise ValueError("stop is NaT, linspace won't work.")
+            raise ValueError("linspace() with {} objects requires the `dtype` argument "
+                    "to be set to the desired output dtype".format(start.dtype))
+        if _nx.isnat(start):
+            raise ValueError("linspace() cannot be called with start=NaT")
+        if _nx.isnat(stop):
+            raise ValueError("linspace() cannot be called with end=NaT")
+        # for datetime/timedelta, we convert start and stop to their internal int
+        # representation.
         start = start.astype(dtype).view(_nx.int64)
         stop = stop.astype(dtype).view(_nx.int64)
     else:
@@ -158,20 +158,18 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     # In-place multiplication y *= delta/div is faster, but prevents the multiplicant
     # from overriding what class is produced, and thus prevents, e.g. use of Quantities,
-    # see gh-7142. Hence, we multiply in place only for standard scalar types,
-    # excepting datetime64 and timedelta64
-    _mult_inplace = _nx.isscalar(delta)
+    # see gh-7142. Hence, we multiply in place only for standard scalar types.
     if num > 1:
         step = delta / div
         if _nx.any(step == 0):
             # Special handling for denormal numbers, gh-5437
             y /= div
-            if _mult_inplace:
+            if _nx.isscalar(delta):
                 y *= delta
             else:
                 y = y * delta
         else:
-            if _mult_inplace:
+            if _nx.isscalar(delta):
                 y *= step
             else:
                 y = y * step

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -365,3 +365,16 @@ class TestLinspace(object):
         stop = array(2, dtype='O')
         y = linspace(start, stop, 3)
         assert_array_equal(y, array([1., 1.5, 2.]))
+
+    def test_datetime(self):
+        dt1 = array('2018-12-12 06:00:00', dtype='M8[s]')
+        dt2 = array('2018-12-12 07:00:00', dtype='M8[s]')
+        quarters = array([0, 15*60, 30*60, 45*60, 60*60], dtype='m8[s]')
+        assert_((linspace(dt1, dt2, 5, dtype='M8[s]') == dt1 + quarters).all())
+
+    def test_timedelta(self):
+        td1 = array(0, dtype='m8[s]')
+        td2 = array(3600, dtype='m8[s]')
+        quarters = array([0, 15*60, 30*60, 45*60, 60*60], dtype='m8[s]')
+        assert_((linspace(td1, td2, 5, dtype='m8[s]') == td1 + quarters).all())
+


### PR DESCRIPTION
This pull request is intended to partially fix the issue #10514. 

The changes introduced in `np.linspace` does the following:

1. Calling `linspace(start_datetime, stop_datetime, num, dtype=<dt>)` with `datetime64` and `timedelta64` objects with a supplied `dtype` returns
without raising any exception. 

2. However, if the `dtype` supplied has so low precision that `num` equispaced samples of that dtype cannot be drawn, then the array returned are not equispaced (just like the result of ` np.linspace(1, 10, 7, dtype=np.int64)`) are not equispaced.
```python
In [6]: d1 = np.datetime64(100, 'D')                                                                                                                          

In [7]: d2 = np.datetime64(200, 'D')                                                                                                                          

In [8]: np.linspace(d1, d2, 4, dtype='<M8[s]')                                                                                                                
Out[8]: 
array(['1970-04-11T00:00:00', '1970-05-14T08:00:00',
       '1970-06-16T16:00:00', '1970-07-20T00:00:00'],
      dtype='datetime64[s]')

In [9]: np.linspace(d1, d2, 4)                                                                                                                                
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-9-d64154514c2d> in <module>
----> 1 np.linspace(d1, d2, 4)

<__array_function__ internals> in linspace(*args, **kwargs)

~/src/numpy/build/testenv/lib/python3.5/site-packages/numpy/core/function_base.py in linspace(start, stop, num, endpoint, retstep, dtype, axis)
    137         # samples.
    138         assert dtype is not None, "linspace with {} objects cannot be called"\
--> 139             "with dtype=None".format(type(start))
    140         start = start.astype(dtype)
    141         stop = stop.astype(dtype)

AssertionError: linspace with datetime64[D]  objects cannot be called with dtype=None
```