### PR TITLE
TEST: re-enable durations for RUN_FULL_TESTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
             - python3-dbg
             - python3-dev
             - python3-setuptools
-    - python: 3.6
+    - python: 3.7
       env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1 INSTALL_PICKLE5=1
     - python: 3.6
       env: USE_SDIST=1

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -90,9 +90,7 @@ run_test()
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
     $PYTHON ../runtests.py -n -v --durations 10 --mode=full $COVERAGE_FLAG
   else
-    # disable --durations temporarily, pytest currently aborts
-    # when that is used with python3.6-dbg
-    $PYTHON ../runtests.py -n -v  # --durations 10
+    $PYTHON ../runtests.py -n -v  --durations 10
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then


### PR DESCRIPTION
Duration reporting was disabled in #14291 since it caused a segfault in debug versions of Cpython. As stated there, this was fixed but only for CPython 3.7. This PR re-enables duration for `RUN_FULL_TESTS` and moves the `RUN_FULL_TESTS` flag to 3.7.

Closes #14293.