### PR TITLE
DEP: Finish the out kwarg deprecation for ufunc calls

### DIFF
--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -494,31 +494,17 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
             }
             else {
                 /* not a tuple */
-                if (nout > 1 && DEPRECATE("passing a single argument to the "
-                                          "'out' keyword argument of a "
-                                          "ufunc with\n"
-                                          "more than one output will "
-                                          "result in an error in the "
-                                          "future") < 0) {
-                    /*
-                     * If the deprecation is removed, also remove the loop
-                     * below setting tuple items to None (but keep this future
-                     * error message.)
-                     */
+                if (nout > 1) {
                     PyErr_SetString(PyExc_TypeError,
                                     "'out' must be a tuple of arguments");
                     goto fail;
                 }
                 if (out != Py_None) {
                     /* not already a tuple and not None */
-                    PyObject *out_tuple = PyTuple_New(nout);
+                    PyObject *out_tuple = PyTuple_New(1);
 
                     if (out_tuple == NULL) {
                         goto fail;
-                    }
-                    for (i = 1; i < nout; i++) {
-                        Py_INCREF(Py_None);
-                        PyTuple_SET_ITEM(out_tuple, i, Py_None);
                     }
                     /* out was borrowed ref; make it permanent */
                     Py_INCREF(out);

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3602,10 +3602,10 @@ class TestBinop(object):
         assert_equal(np.modf(dummy, out=(None, a)), (1,))
         assert_equal(np.modf(dummy, out=(dummy, a)), (1,))
         assert_equal(np.modf(a, out=(dummy, a)), 0)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_equal(np.modf(dummy, out=a), (0,))
-            assert_(w[0].category is DeprecationWarning)
+        with assert_raises(TypeError):
+            # Out argument must be tuple, since there are multiple outputs
+            np.modf(dummy, out=a)
+
         assert_raises(ValueError, np.modf, dummy, out=(a,))
 
         # 2 inputs, 1 output


### PR DESCRIPTION
This was started in gh-14682 but I missed the path in the override.c
(since we parse these things multiple times currently).

I am not clear why the test seems to be flaky to be honest...

---

I would blame silencing of warnings for the flaky tests, but that does not really make sense here/anymore... Maybe a pytest thing really, since after the DeprecationWarning, there would still be an error raised.