### PR TITLE
API: Forbid Q<->m safe casting

### DIFF
--- a/doc/release/upcoming_changes/14718.compatibility.rst
+++ b/doc/release/upcoming_changes/14718.compatibility.rst
@@ -1,0 +1,7 @@
+``np.can_cast(np.uint64, np.timedelta64, casting='safe')`` is now ``False``
+---------------------------------------------------------------------------
+Previously this was ``True`` - however, this was inconsistent with ``uint64``
+not being safely castable to ``int64``, and resulting in strange type
+resolution.
+
+If this impacts your code, cast ``uint64`` to ``int64`` first.

--- a/doc/release/upcoming_changes/14718.compatibility.rst
+++ b/doc/release/upcoming_changes/14718.compatibility.rst
@@ -1,5 +1,6 @@
 ``np.can_cast(np.uint64, np.timedelta64, casting='safe')`` is now ``False``
 ---------------------------------------------------------------------------
+
 Previously this was ``True`` - however, this was inconsistent with ``uint64``
 not being safely castable to ``int64``, and resulting in strange type
 resolution.

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -253,9 +253,9 @@ can generate this table for your system with the code given in the Figure.
     B - - Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y Y - Y
     H - - - Y Y Y Y - Y Y Y Y Y - Y Y Y Y Y Y Y Y Y Y - Y
     I - - - - Y Y Y - - Y Y Y Y - - Y Y - Y Y Y Y Y Y - Y
-    L - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
-    Q - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
-    P - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - Y
+    L - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - -
+    Q - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - -
+    P - - - - - - - - - - Y Y Y - - Y Y - Y Y Y Y Y Y - -
     e - - - - - - - - - - - - - Y Y Y Y Y Y Y Y Y Y Y - -
     f - - - - - - - - - - - - - - Y Y Y Y Y Y Y Y Y Y - -
     d - - - - - - - - - - - - - - - Y Y - Y Y Y Y Y Y - -

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -877,7 +877,13 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
             from_order = dtype_kind_to_ordering(from->kind);
             to_order = dtype_kind_to_ordering(to->kind);
 
-            return from_order != -1 && from_order <= to_order;
+            if (to->kind == 'm') {
+                /* both types being timedelta is already handled before. */
+                int integer_order = dtype_kind_to_ordering('i');
+                return (from_order != -1) && (from_order <= integer_order);
+            }
+
+            return (from_order != -1) && (from_order <= to_order);
         }
         else {
             return 0;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4060,8 +4060,11 @@ initialize_casting_tables(void)
     _npy_can_cast_safely_table[_FROM_NUM][NPY_STRING] = 1;
     _npy_can_cast_safely_table[_FROM_NUM][NPY_UNICODE] = 1;
 
-    /* Allow casts from any integer to the TIMEDELTA type */
-#if @from_isint@ || @from_isuint@
+#if @from_isint@ && NPY_SIZEOF_TIMEDELTA >= _FROM_BSIZE
+    /* Allow casts from smaller or equal signed integers to the TIMEDELTA type */
+    _npy_can_cast_safely_table[_FROM_NUM][NPY_TIMEDELTA] = 1;
+#elif @from_isuint@ && NPY_SIZEOF_TIMEDELTA > _FROM_BSIZE
+    /* Allow casts from smaller unsigned integers to the TIMEDELTA type */
     _npy_can_cast_safely_table[_FROM_NUM][NPY_TIMEDELTA] = 1;
 #endif
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -82,7 +82,7 @@ class TestDateTime(object):
 
         # Cannot cast safely from unsigned integer of the same size, which
         # could overflow
-        assert_(not np.can_cast('u8', 'm8', casting='same_kind'))
+        assert_(np.can_cast('u8', 'm8', casting='same_kind'))
         assert_(not np.can_cast('u8', 'm8', casting='safe'))
 
         # Cannot cast safely/same_kind from float to timedelta

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -75,6 +75,15 @@ class TestDateTime(object):
         # Can cast safely/same_kind from integer to timedelta
         assert_(np.can_cast('i8', 'm8', casting='same_kind'))
         assert_(np.can_cast('i8', 'm8', casting='safe'))
+        assert_(np.can_cast('i4', 'm8', casting='same_kind'))
+        assert_(np.can_cast('i4', 'm8', casting='safe'))
+        assert_(np.can_cast('u4', 'm8', casting='same_kind'))
+        assert_(np.can_cast('u4', 'm8', casting='safe'))
+
+        # Cannot cast safely from unsigned integer of the same size, which
+        # could overflow
+        assert_(not np.can_cast('u8', 'm8', casting='same_kind'))
+        assert_(not np.can_cast('u8', 'm8', casting='safe'))
 
         # Cannot cast safely/same_kind from float to timedelta
         assert_(not np.can_cast('f4', 'm8', casting='same_kind'))

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_almost_equal,
     assert_array_equal, IS_PYPY, suppress_warnings, _gen_alignment_data,
-    assert_warns
+    assert_warns, assert_raises_regex,
     )
 
 types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
@@ -292,6 +292,16 @@ class TestModulus(object):
                 assert_(np.isnan(rem), 'dt: %s' % dt)
                 rem = operator.mod(finf, fone)
                 assert_(np.isnan(rem), 'dt: %s' % dt)
+
+    def test_inplace_floordiv_handling(self):
+        # issue gh-12927
+        # this only applies to in-place floordiv //=, because the output type
+        # promotes to float which does not fit
+        a = np.array([1, 2], np.int64)
+        b = np.array([1, 2], np.uint64)
+        pattern = 'could not be coerced to provided output parameter'
+        with assert_raises_regex(TypeError, pattern):
+            a //= b
 
 
 class TestComplexDivision(object):


### PR DESCRIPTION
A lighter-weight alternative to gh-13061, fixes #12927