### PR TITLE
MAINT: umath: Change error message for unsupported bool subtraction.

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -883,7 +883,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* The type resolver would have upcast already */
         if (out_dtypes[0]->type_num == NPY_BOOL) {
             PyErr_Format(PyExc_TypeError,
-                "numpy boolean subtract, the `-` operator, is deprecated, "
+                "numpy boolean subtract, the `-` operator, is not supported, "
                 "use the bitwise_xor, the `^` operator, or the logical_xor "
                 "function instead.");
             return -1;


### PR DESCRIPTION
The error message that results when attempting to subtract bool arrays
is changed to say that the operation is "not supported", rather than
"is deprecated".  This is now consistent with a similar error message
from the negative unary operator.
