### PR TITLE
MAINT: Disallow complex covariances in multivariate_normal

### DIFF
--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -3438,6 +3438,10 @@ cdef class Generator:
         # Check preconditions on arguments
         mean = np.array(mean)
         cov = np.array(cov)
+
+        if np.issubdtype(cov.dtype, np.complexfloating):
+            raise NotImplementedError("Complex gaussians are not supported.")
+
         if size is None:
             shape = []
         elif isinstance(size, (int, long, np.integer)):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1094,6 +1094,8 @@ class TestRandomDist(object):
                       mu, np.empty((3, 2)))
         assert_raises(ValueError, random.multivariate_normal,
                       mu, np.eye(3))
+        
+        assert_raises(NotImplementedError, np.random.multivariate_normal, [0], [[1+1j]])
 
     def test_negative_binomial(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
This commit disallows complex covariances in multivariate_normal
as passing them can silently lead to incorrect results.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
