### PR TITLE
NEP: Accept NEP 29 as final

### DIFF
--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -4,9 +4,10 @@ NEP 29 — Recommend Python and Numpy version support as a community policy stan
 
 
 :Author: Thomas A Caswell <tcaswell@gmail.com>, Andreas Mueller, Brian Granger, Madicken Munk, Ralf Gommers, Matt Haberland <mhaberla@calpoly.edu>, Matthias Bussonnier <bussonniermatthias@gmail.com>, Stefan van der Walt <stefanv@berkeley.edu>
-:Status: Draft
-:Type: Informational Track
+:Status: Final
+:Type: Informational
 :Created: 2019-07-13
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2019-October/080128.html
 
 
 Abstract


### PR DESCRIPTION
This has been on the Not-Done list for a while. We can accept NEP 29 (phasing out old python/numpy version support) and thus marking it as Final.