### PR TITLE
BUG: clear only attribute errors in get_attr_string.h::maybe_get_attr

### DIFF
--- a/numpy/core/src/common/binop_override.h
+++ b/numpy/core/src/common/binop_override.h
@@ -134,8 +134,8 @@ binop_should_defer(PyObject *self, PyObject *other, int inplace)
         Py_DECREF(attr);
         return defer;
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
     /*
      * Otherwise, we need to check for the legacy __array_priority__. But if

--- a/numpy/core/src/common/binop_override.h
+++ b/numpy/core/src/common/binop_override.h
@@ -129,10 +129,13 @@ binop_should_defer(PyObject *self, PyObject *other, int inplace)
      * check whether __array_ufunc__ equals None.
      */
     attr = PyArray_LookupSpecial(other, "__array_ufunc__");
-    if (attr) {
+    if (attr != NULL) {
         defer = !inplace && (attr == Py_None);
         Py_DECREF(attr);
         return defer;
+    }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
     }
     /*
      * Otherwise, we need to check for the legacy __array_priority__. But if

--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -39,14 +39,6 @@ _is_basic_python_type(PyTypeObject *tp)
     );
 }
 
-static NPY_INLINE void
-clear_exception(PyObject *exception)
-{
-    if (PyErr_Occurred() && PyErr_ExceptionMatches(exception)) {
-        PyErr_Clear();
-    }
-}
-
 /*
  * Stripped down version of PyObject_GetAttrString,
  * avoids lookups for None, tuple, and List objects,
@@ -70,8 +62,9 @@ maybe_get_attr(PyObject *obj, char *name)
     /* Attribute referenced by (char *)name */
     if (tp->tp_getattr != NULL) {
         res = (*tp->tp_getattr)(obj, name);
-        if (res == NULL) {
-            clear_exception(PyExc_AttributeError);
+        if (res == NULL && PyErr_Occurred() != NULL
+            && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
         }
     }
     /* Attribute referenced by (PyObject *)name */
@@ -86,8 +79,9 @@ maybe_get_attr(PyObject *obj, char *name)
         }
         res = (*tp->tp_getattro)(obj, w);
         Py_DECREF(w);
-        if (res == NULL) {
-            clear_exception(PyExc_AttributeError);
+        if (res == NULL && PyErr_Occurred() != NULL
+            && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
         }
     }
     return res;

--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -62,8 +62,7 @@ maybe_get_attr(PyObject *obj, char *name)
     /* Attribute referenced by (char *)name */
     if (tp->tp_getattr != NULL) {
         res = (*tp->tp_getattr)(obj, name);
-        if (res == NULL && PyErr_Occurred() != NULL
-            && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
         }
     }
@@ -79,8 +78,7 @@ maybe_get_attr(PyObject *obj, char *name)
         }
         res = (*tp->tp_getattro)(obj, w);
         Py_DECREF(w);
-        if (res == NULL && PyErr_Occurred() != NULL
-            && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
         }
     }

--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -39,6 +39,14 @@ _is_basic_python_type(PyTypeObject *tp)
     );
 }
 
+static NPY_INLINE void
+clear_exception(PyObject *exception)
+{
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(exception)) {
+        PyErr_Clear();
+    }
+}
+
 /*
  * Stripped down version of PyObject_GetAttrString,
  * avoids lookups for None, tuple, and List objects,
@@ -63,7 +71,7 @@ maybe_get_attr(PyObject *obj, char *name)
     if (tp->tp_getattr != NULL) {
         res = (*tp->tp_getattr)(obj, name);
         if (res == NULL) {
-            PyErr_Clear();
+            clear_exception(PyExc_AttributeError);
         }
     }
     /* Attribute referenced by (PyObject *)name */
@@ -79,7 +87,7 @@ maybe_get_attr(PyObject *obj, char *name)
         res = (*tp->tp_getattro)(obj, w);
         Py_DECREF(w);
         if (res == NULL) {
-            PyErr_Clear();
+            clear_exception(PyExc_AttributeError);
         }
     }
     return res;

--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -40,18 +40,14 @@ _is_basic_python_type(PyTypeObject *tp)
 }
 
 /*
- * Stripped down version of PyObject_GetAttrString,
- * avoids lookups for None, tuple, and List objects,
- * and doesn't create a PyErr since this code ignores it.
+ * Stripped down version of PyObject_GetAttrString(obj, name) that does not
+ * raise PyExc_AttributeError.
  *
- * This can be much faster then PyObject_GetAttrString where
- * exceptions are not used by caller.
+ * This allows it to avoid creating then discarding exception objects when
+ * performing lookups on objects without any attributes.
  *
- * 'obj' is the object to search for attribute.
- *
- * 'name' is the attribute to search for.
- *
- * Returns attribute value on success, NULL on failure.
+ * Returns attribute value on success, NULL without an exception set if
+ * there is no such attribute, and NULL with an exception on failure.
  */
 static NPY_INLINE PyObject *
 maybe_get_attr(PyObject *obj, char *name)

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -36,6 +36,7 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
      */
     cls_array_ufunc = PyArray_LookupSpecial(obj, "__array_ufunc__");
     if (cls_array_ufunc == NULL) {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
         return NULL;
     }
     /* Ignore if the same as ndarray.__array_ufunc__ */

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -36,7 +36,9 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
      */
     cls_array_ufunc = PyArray_LookupSpecial(obj, "__array_ufunc__");
     if (cls_array_ufunc == NULL) {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+        if (PyErr_Occurred()) {
+            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+        }
         return NULL;
     }
     /* Ignore if the same as ndarray.__array_ufunc__ */

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -26,7 +26,7 @@ static PyObject *
 get_array_function(PyObject *obj)
 {
     static PyObject *ndarray_array_function = NULL;
-    static PyObject *array_function;
+    PyObject *array_function;
 
     if (ndarray_array_function == NULL) {
         ndarray_array_function = get_ndarray_array_function();

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -26,6 +26,7 @@ static PyObject *
 get_array_function(PyObject *obj)
 {
     static PyObject *ndarray_array_function = NULL;
+    static PyObject *array_function;
 
     if (ndarray_array_function == NULL) {
         ndarray_array_function = get_ndarray_array_function();
@@ -37,7 +38,12 @@ get_array_function(PyObject *obj)
         return ndarray_array_function;
     }
 
-    return PyArray_LookupSpecial(obj, "__array_function__");
+    array_function = PyArray_LookupSpecial(obj, "__array_function__");
+    if (array_function == NULL) {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    }
+
+    return array_function;
 }
 
 

--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -39,8 +39,8 @@ get_array_function(PyObject *obj)
     }
 
     array_function = PyArray_LookupSpecial(obj, "__array_function__");
-    if (array_function == NULL) {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    if (array_function == NULL && PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
     return array_function;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -367,8 +367,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
 
@@ -393,8 +393,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
     /* The old buffer interface */
@@ -426,8 +426,8 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
             goto fail;
         }
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
     /*

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -367,6 +367,10 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         }
         Py_DECREF(ip);
     }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    }
+
 
     /* The array struct interface */
     ip = PyArray_LookupSpecial_OnInstance(obj, "__array_struct__");
@@ -388,6 +392,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
             }
         }
         Py_DECREF(ip);
+    }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
     }
 
     /* The old buffer interface */
@@ -418,6 +425,9 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         if (PyErr_Occurred()) {
             goto fail;
         }
+    }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
     }
 
     /*

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2351,7 +2351,11 @@ PyArray_FromStructInterface(PyObject *input)
 
     attr = PyArray_LookupSpecial_OnInstance(input, "__array_struct__");
     if (attr == NULL) {
-        return Py_NotImplemented;
+        if (PyErr_Occurred()) {
+            return NULL;
+        } else {
+            return Py_NotImplemented;
+        }
     }
     if (!NpyCapsule_Check(attr)) {
         goto fail;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -852,8 +852,8 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
             return 0;
         }
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
 
@@ -885,8 +885,8 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
             return 0;
         }
     }
-    else {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    else if (PyErr_Occurred()) {
+        PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
 
     seq = PySequence_Fast(obj, "Could not convert object to sequence");
@@ -2474,7 +2474,9 @@ PyArray_FromInterface(PyObject *origin)
     iface = PyArray_LookupSpecial_OnInstance(origin,
                                                     "__array_interface__");
     if (iface == NULL) {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+        if (PyErr_Occurred()) {
+            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+        }
         return Py_NotImplemented;
     }
     if (!PyDict_Check(iface)) {
@@ -2728,7 +2730,9 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
 
     array_meth = PyArray_LookupSpecial_OnInstance(op, "__array__");
     if (array_meth == NULL) {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+        if (PyErr_Occurred()) {
+            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+        }
         return Py_NotImplemented;
     }
     if (context == NULL) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -852,6 +852,10 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
             return 0;
         }
     }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
+    }
+
 
     /* obj has the __array_interface__ interface */
     e = PyArray_LookupSpecial_OnInstance(obj, "__array_interface__");
@@ -880,6 +884,9 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         if (nd >= 0) {
             return 0;
         }
+    }
+    else {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
     }
 
     seq = PySequence_Fast(obj, "Could not convert object to sequence");
@@ -2467,6 +2474,7 @@ PyArray_FromInterface(PyObject *origin)
     iface = PyArray_LookupSpecial_OnInstance(origin,
                                                     "__array_interface__");
     if (iface == NULL) {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
         return Py_NotImplemented;
     }
     if (!PyDict_Check(iface)) {
@@ -2720,6 +2728,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
 
     array_meth = PyArray_LookupSpecial_OnInstance(op, "__array__");
     if (array_meth == NULL) {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
         return Py_NotImplemented;
     }
     if (context == NULL) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -118,6 +118,7 @@ PyArray_GetPriority(PyObject *obj, double default_)
 
     ret = PyArray_LookupSpecial_OnInstance(obj, "__array_priority__");
     if (ret == NULL) {
+        PyErr_Clear(); // TODO[GH14801]: propagate this?
         return default_;
     }
 
@@ -2063,7 +2064,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     if (file == NULL) {
         return NULL;
     }
-    
+
     if (offset != 0 && strcmp(sep, "") != 0) {
         PyErr_SetString(PyExc_TypeError, "'offset' argument only permitted for binary files");
         Py_XDECREF(type);
@@ -3265,7 +3266,7 @@ array_datetime_data(PyObject *NPY_UNUSED(dummy), PyObject *args)
     }
 
     meta = get_datetime_metadata_from_dtype(dtype);
-    Py_DECREF(dtype);    
+    Py_DECREF(dtype);
     if (meta == NULL) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -118,7 +118,9 @@ PyArray_GetPriority(PyObject *obj, double default_)
 
     ret = PyArray_LookupSpecial_OnInstance(obj, "__array_priority__");
     if (ret == NULL) {
-        PyErr_Clear(); // TODO[GH14801]: propagate this?
+        if (PyErr_Occurred()) {
+            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+        }
         return default_;
     }
 

--- a/numpy/core/tests/test_issue14735.py
+++ b/numpy/core/tests/test_issue14735.py
@@ -1,0 +1,51 @@
+import pytest
+import warnings
+import numpy as np
+
+
+class Wrapper:
+    def __init__(self, array):
+        self.array = array
+
+    def __len__(self):
+        return len(self.array)
+
+    def __getitem__(self, item):
+        return type(self)(self.array[item])
+
+    def __getattr__(self, name):
+        if name.startswith("__array_"):
+            warnings.warn("object got converted", UserWarning)
+
+        return getattr(self.array, name)
+
+    def __repr__(self):
+        return f"<Wrapper({self.array})>"
+
+@pytest.mark.filterwarnings("error")
+def test_pint_replica_warning():
+    array = Wrapper(np.arange(10))
+    with pytest.raises(UserWarning, match="object got converted"):
+        np.asarray(array)
+
+def test_pint_replica():
+    print(np.__version__)
+
+    array = Wrapper(np.arange(10))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        expected = np.asarray(array)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error")
+        try:
+            actual = np.asarray(array)
+        except UserWarning:
+            print("user warning caught")
+            actual = expected
+
+    assert (
+        type(expected) == type(actual)
+        and expected.dtype == actual.dtype
+        and np.allclose(expected, actual)
+    )

--- a/numpy/core/tests/test_issue14735.py
+++ b/numpy/core/tests/test_issue14735.py
@@ -20,7 +20,7 @@ class Wrapper:
         return getattr(self.array, name)
 
     def __repr__(self):
-        return f"<Wrapper({self.array})>"
+        return "<Wrapper({self.array})>".format(self=self)
 
 @pytest.mark.filterwarnings("error")
 def test_pint_replica_warning():

--- a/numpy/core/tests/test_issue14735.py
+++ b/numpy/core/tests/test_issue14735.py
@@ -23,29 +23,7 @@ class Wrapper:
         return "<Wrapper({self.array})>".format(self=self)
 
 @pytest.mark.filterwarnings("error")
-def test_pint_replica_warning():
+def test_getattr_warning():
     array = Wrapper(np.arange(10))
     with pytest.raises(UserWarning, match="object got converted"):
         np.asarray(array)
-
-def test_pint_replica():
-    print(np.__version__)
-
-    array = Wrapper(np.arange(10))
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore")
-        expected = np.asarray(array)
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings("error")
-        try:
-            actual = np.asarray(array)
-        except UserWarning:
-            print("user warning caught")
-            actual = expected
-
-    assert (
-        type(expected) == type(actual)
-        and expected.dtype == actual.dtype
-        and np.allclose(expected, actual)
-    )

--- a/numpy/core/tests/test_issue14735.py
+++ b/numpy/core/tests/test_issue14735.py
@@ -15,7 +15,7 @@ class Wrapper:
 
     def __getattr__(self, name):
         if name.startswith("__array_"):
-            warnings.warn("object got converted", UserWarning)
+            warnings.warn("object got converted", UserWarning, stacklevel=1)
 
         return getattr(self.array, name)
 


### PR DESCRIPTION
fixes #14735.

With this, filtered warnings (and all exceptions other than `AttributeError`) should be passed through. Though now raising `NotImplementedError` will also bubble up.

There are several issues with this fix and I'm not sure how to deal with them:
* I created a new test file named after the issue. This should probably go somewhere else, but I'm not sure where.
* I didn't find something similar, so I added a helper function to clear only a certain exception. Did I miss something?
* I'm also not sure whether the commentary / documentation of `maybe_get_attr` is still accurate (I didn't really understand what it meant).

Also, my knowledge of C is limited, so there may be obvious issues, especially with the signature of the helper.

@seberg, what do you think of this? I can confirm that the original issue can be avoided by explicitly adding `__array__` and warning there, so I don't have to depend on this.