### PR TITLE
BLD: declare support for python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering


### PR DESCRIPTION
The descriptors on [PyPI](https://pypi.org/project/numpy/) are missing Python 3.8