### PR TITLE
ENH: Copy ndarray subclasses to ndarray before formatting.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -46,7 +46,7 @@ from .multiarray import (array, dragon4_positional, dragon4_scientific,
                          datetime_as_string, datetime_data, ndarray,
                          set_legacy_print_mode)
 from .fromnumeric import ravel, any
-from .numeric import concatenate, asarray, errstate
+from .numeric import concatenate, asarray, asanyarray, errstate
 from .numerictypes import (longlong, intc, int_, float_, complex_, bool_,
                            flexible)
 from .overrides import array_function_dispatch, set_module
@@ -496,8 +496,7 @@ def _array2string(a, options, separator=' ', prefix=""):
     # Note we use the copied array instead of the input array here (since for
     # subclasses gathering from the array to format it may be expensive, e.g. if
     # the buffer is on an accelerator).
-    if type(arr) is not ndarray:
-        a = asarray(a)
+    a = asanyarray(a)
 
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -493,6 +493,12 @@ def _recursive_guard(fillvalue='...'):
 # gracefully handle recursive calls, when object arrays contain themselves
 @_recursive_guard()
 def _array2string(a, options, separator=' ', prefix=""):
+    # Note we use the copied array instead of the input array here (since for
+    # subclasses gathering from the array to format it may be expensive, e.g. if
+    # the buffer is on an accelerator).
+    if type(arr) is not ndarray:
+        a = asarray(a)
+
     # The formatter __init__s in _get_format_function cannot deal with
     # subclasses yet, and we also need to avoid recursion issues in
     # _formatArray with subclasses which return 0d arrays in place of scalars


### PR DESCRIPTION
Operations (e.g. slicing) on `ndarray` subclasses might be more expensive than those on `ndarray` itself. Since we have already copied the input `ndarray` we should slice into that instead.

For [JAX](https://github.com/google/jax) (a library implementing the `Numpy` API backed by accelerators)  this results in significantly faster printing for their `DeviceArray` subclass:

Preamble:

    In [1]: import jax
    In [2]: import jax.numpy as jnp
    In [3]: x = jax.random.normal(jax.random.PRNGKey(42), [100, 100])
    In [4]: x.device_buffer.device()
    Out[4]: GpuDevice(id=0)

Before:

    In [5]: %timeit -n 100 repr(x)
    100 loops, best of 3: 62.6 ms per loop

After:

    In [5]: %timeit -n 1000 repr(x)
    1000 loops, best of 3: 373 µs per loop

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
