### PR TITLE
TST, BUILD: add a gcc 4.8 run on ubuntu 18.04

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -28,7 +28,7 @@ Building NumPy requires the following installed software:
 
 2) Cython >= 0.29.2 (for development versions of numpy, not for released
                      versions)
-                     
+
 3) pytest__ (optional) 1.15 or later
 
    This is required for testing numpy, but not for using it.
@@ -37,7 +37,7 @@ Python__ http://www.python.org
 pytest__ http://pytest.readthedocs.io
 
 
-.. note:: 
+.. note::
 
    If you want to build NumPy in order to work on NumPy itself, use
    ``runtests.py``.  For more details, see
@@ -77,11 +77,7 @@ skipped when running the test suite if no Fortran compiler is available.  For
 building Scipy a Fortran compiler is needed though, so we include some details
 on Fortran compilers in the rest of this section.
 
-On OS X and Linux, all common compilers will work.  Note that C99 support is
-required.  For compilers that don't support the C99 language standard by
-default (such as ``gcc`` versions < 5.0), it should be enabled.  For ``gcc``::
-
-    export CFLAGS='-std=c99'
+On OS X and Linux, all common compilers will work.
 
 For Fortran, ``gfortran`` works, ``g77`` does not.  In case ``g77`` is
 installed then ``g77`` will be detected and used first.  To explicitly select
@@ -117,9 +113,9 @@ details.
 Windows
 -------
 
-The Intel compilers work with Intel MKL, see the application note linked above. 
+The Intel compilers work with Intel MKL, see the application note linked above.
 MingwPy__ works with OpenBLAS.
-For an overview of the state of BLAS/LAPACK libraries on Windows, see 
+For an overview of the state of BLAS/LAPACK libraries on Windows, see
 `here <https://mingwpy.github.io/blas_lapack.html>`_.
 
 OS X

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
             python3 -m pip install --user -r test_requirements.txt && \
             python3 -m pip install . && \
             F77=gfortran-5 F90=gfortran-5 \
-            CFLAGS='-UNDEBUG -std=c99' python3 runtests.py -n --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml && \
+            CFLAGS=-UNDEBUG python3 runtests.py -n --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml && \
             python3 tools/openblas_support.py --check_version $(OpenBLAS_version)"
       displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
     - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
       # the docs even though i.e., numba uses another in their
       # azure config for mac os -- Microsoft has indicated
       # they will patch this issue
-      vmImage: macOS-10.13
+      vmImage: macOS-10.14
     steps:
     # the @0 refers to the (major) version of the *task* on Microsoft's
     # end, not the order in the build matrix nor anything to do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,3 +180,25 @@ stages:
         testResultsFiles: '**/test-*.xml'
         testRunTitle: 'Publish test results for PyPy3'
         failTaskOnFailedTests: true
+  - job: Linux_gcc48
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - script: |
+            if ! `gcc-4.8 2>/dev/null`; then
+                sudo apt install gcc-4.8
+            fi
+      displayName: 'add gcc 4.8'
+    - script: |
+            python3 -m pip install --user --upgrade pip setuptools
+            python3 -m pip install --user -r test_requirements.txt
+            CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
+            python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
+      displayName: 'Run gcc4.8 Build / Tests'
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '**/test-*.xml'
+        failTaskOnFailedTests: true
+        testRunTitle: 'Publish test results for gcc 4.8'
+

--- a/doc/release/upcoming_changes/14771.improvement.rst
+++ b/doc/release/upcoming_changes/14771.improvement.rst
@@ -1,6 +1,5 @@
 ``std=c99`` added if compiler is named ``gcc``
 ----------------------------------------------
-
 GCC before version 5 requies the ``-std=c99`` command line argument. Newer
 compilers automatically turn on C99 mode. The compiler setup code will
 automatically add the code if the compiler name has ``gcc`` in it.

--- a/doc/release/upcoming_changes/14771.improvement.rst
+++ b/doc/release/upcoming_changes/14771.improvement.rst
@@ -1,0 +1,6 @@
+``std=c99`` added if compiler is named ``gcc``
+----------------------------------------------
+
+GCC before version 5 requies the ``-std=c99`` command line argument. Newer
+compilers automatically turn on C99 mode. The compiler setup code will
+automatically add the code if the compiler name has ``gcc`` in it.

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -11,8 +11,7 @@ Recommended development setup
 Since NumPy contains parts written in C and Cython that need to be
 compiled before use, make sure you have the necessary compilers and Python
 development headers installed - see :ref:`building-from-source`. Building
-NumPy as of version ``1.17`` requires a C99 compliant compiler. For
-some older compilers this may require ``export CFLAGS='-std=c99'``.
+NumPy as of version ``1.17`` requires a C99 compliant compiler.
 
 Having compiled code also means that importing NumPy from the development
 sources needs some additional steps, which are explained below.  For the rest

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -655,11 +655,10 @@ def configuration(parent_package='',top_path=None):
         # compiler does not work).
         st = config_cmd.try_link('int main(void) { return 0;}')
         if not st:
+            # rerun the failing command in verbose mode
             config_cmd.compiler.verbose = True
-            st = config_cmd.try_link('int main(void) { return 0;}')
-            raise RuntimeError("Broken toolchain: cannot link a simple C program "
-                               "when using these flags:\n"
-                                )
+            config_cmd.try_link('int main(void) { return 0;}')
+            raise RuntimeError("Broken toolchain: cannot link a simple C program")
         mlibs = check_mathlib(config_cmd)
 
         posix_mlib = ' '.join(['-l%s' % l for l in mlibs])

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -655,7 +655,11 @@ def configuration(parent_package='',top_path=None):
         # compiler does not work).
         st = config_cmd.try_link('int main(void) { return 0;}')
         if not st:
-            raise RuntimeError("Broken toolchain: cannot link a simple C program")
+            config_cmd.compiler.verbose = True
+            st = config_cmd.try_link('int main(void) { return 0;}')
+            raise RuntimeError("Broken toolchain: cannot link a simple C program "
+                               "when using these flags:\n"
+                                )
         mlibs = check_mathlib(config_cmd)
 
         posix_mlib = ' '.join(['-l%s' % l for l in mlibs])

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -532,6 +532,11 @@ def CCompiler_customize(self, dist, need_cxx=0):
                                       'g++' in self.compiler[0] or
                                       'clang' in self.compiler[0]):
         self._auto_depends = True
+        if 'gcc' in self.compiler[0]:
+            # add std=c99 flag for gcc < 5
+            # TODO: does this need to be more specific?
+            self.compiler.append('-std=c99')
+            self.compiler_so.append('-std=c99')
     elif os.name == 'posix':
         import tempfile
         import shutil

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -533,7 +533,7 @@ def CCompiler_customize(self, dist, need_cxx=0):
                                       'clang' in self.compiler[0]):
         self._auto_depends = True
         if 'gcc' in self.compiler[0]:
-            # add std=c99 flag for gcc < 5
+            # add std=c99 flag for gcc
             # TODO: does this need to be more specific?
             self.compiler.append('-std=c99')
             self.compiler_so.append('-std=c99')

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -156,7 +156,7 @@ from numpy.distutils.misc_util import (is_sequence, is_string,
                                        get_shared_lib_extension)
 from numpy.distutils.command.config import config as cmd_config
 from numpy.distutils.compat import get_exception
-from numpy.distutils import customized_ccompiler
+from numpy.distutils import customized_ccompiler as _customized_ccompiler
 from numpy.distutils import _shell_utils
 import distutils.ccompiler
 import tempfile
@@ -167,6 +167,15 @@ import shutil
 import platform
 _bits = {'32bit': 32, '64bit': 64}
 platform_bits = _bits[platform.architecture()[0]]
+
+
+global_compiler = None
+
+def customized_ccompiler():
+    global global_compiler
+    if not global_compiler:
+        global_compiler = _customized_ccompiler()
+    return global_compiler
 
 
 def _c_string_literal(s):

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1580,7 +1580,7 @@ def get_atlas_version(**config):
             log.info('Status: %d', s)
             log.info('Output: %s', o)
 
-    if atlas_version == '3.2.1_pre3.3.6':
+    elif atlas_version == '3.2.1_pre3.3.6':
         dict_append(info, define_macros=[('NO_ATLAS_INFO', -2)])
     else:
         dict_append(info, define_macros=[(

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -36,8 +36,6 @@ setup_base()
   sysflags="$($PYTHON -c "from distutils import sysconfig; \
     print (sysconfig.get_config_var('CFLAGS'))")"
   export CFLAGS="$sysflags $werrors -Wlogical-op -Wno-sign-compare"
-  # use c99
-  export CFLAGS=$CFLAGS" -std=c99"
   # We used to use 'setup.py install' here, but that has the terrible
   # behaviour that if a copy of the package is already installed in the
   # install location, then the new copy just gets dropped on top of it.
@@ -141,8 +139,6 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   $PIP install -U virtualenv
   # ensure some warnings are not issued
   export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
-  # use c99
-  export CFLAGS=$CFLAGS" -std=c99"
   # adjust gcc flags if C coverage requested
   if [ -n "$RUN_COVERAGE" ]; then
      export NPY_DISTUTILS_APPEND_FLAGS=1
@@ -169,8 +165,6 @@ elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
   $PYTHON -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   # ensure some warnings are not issued
   export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
-  # use c99
-  export CFLAGS=$CFLAGS" -std=c99"
   $PYTHON setup.py sdist
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel


### PR DESCRIPTION

Add a gcc 4.8 build to Azure, with the goal of properly adding a std=c99 flag