### PR TITLE
DEP: issue deprecation warning when creating ragged array (NEP 34)

### DIFF
--- a/doc/release/upcoming_changes/14794.deprecation.rst
+++ b/doc/release/upcoming_changes/14794.deprecation.rst
@@ -1,0 +1,7 @@
+Deprecate automatic ``dtype=object`` for ragged input
+-----------------------------------------------------
+Calling ``np.array([[1, [1, 2, 3]])`` will issue a ``DeprecationWarning`` as
+per `NEP 34`_. Users should explicitly use ``dtype=object`` to avoid the
+warning.
+
+.. _`NEP 34`: http://www.numpy.org/neps

--- a/doc/release/upcoming_changes/14794.deprecation.rst
+++ b/doc/release/upcoming_changes/14794.deprecation.rst
@@ -4,4 +4,4 @@ Calling ``np.array([[1, [1, 2, 3]])`` will issue a ``DeprecationWarning`` as
 per `NEP 34`_. Users should explicitly use ``dtype=object`` to avoid the
 warning.
 
-.. _`NEP 34`: http://www.numpy.org/neps
+.. _`NEP 34`: https://numpy.org/neps/nep-0034.html

--- a/doc/release/upcoming_changes/template.rst
+++ b/doc/release/upcoming_changes/template.rst
@@ -17,6 +17,7 @@
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 {{ text }}
+
 {{ get_indent(text) }}({{values|join(', ') }})
 
 {% endfor %}

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -713,11 +713,11 @@ discover_itemsize(PyObject *s, int nd, int *itemsize, int string_type)
     return 0;
 }
 
-enum NDISOVER_RET {
+typedef enum {
     DISCOVERED_OK = 0,
     DISCOVERED_RAGGED = 1,
-    DISCOVERED_DICT = 2
-};
+    DISCOVERED_OBJECT = 2
+} discovered_t;
 
 /*
  * Take an arbitrary object and discover how many dimensions it
@@ -726,7 +726,7 @@ enum NDISOVER_RET {
 static int
 discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
                                     int stop_at_string, int stop_at_tuple,
-                                    enum NDISOVER_RET *out_is_object)
+                                    discovered_t *out_is_object)
 {
     PyObject *e;
     npy_intp n, i;
@@ -912,7 +912,7 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
         if (PyErr_ExceptionMatches(PyExc_KeyError)) {
             PyErr_Clear();
             *maxndim = 0;
-            *out_is_object = DISCOVERED_DICT;
+            *out_is_object = DISCOVERED_OBJECT;
             return 0;
         }
         else {
@@ -1817,7 +1817,7 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
     if (!writeable && PySequence_Check(op)) {
         int check_it, stop_at_string, stop_at_tuple;
         int type_num, type;
-        enum NDISOVER_RET is_object = DISCOVERED_OK;
+        discovered_t is_object = DISCOVERED_OK;
 
         /*
          * Determine the type, using the requested data type if
@@ -1893,6 +1893,7 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
                     return -1;
                 }
             }
+            /* either DISCOVERED_OBJECT or there is a requested_dtype */
             Py_DECREF(*out_dtype);
             *out_dtype = PyArray_DescrFromType(NPY_OBJECT);
             if (*out_dtype == NULL) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1817,7 +1817,6 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
     if (!writeable && PySequence_Check(op)) {
         int check_it, stop_at_string, stop_at_tuple;
         int type_num, type;
-        discovered_t is_object = DISCOVERED_OK;
 
         /*
          * Determine the type, using the requested data type if
@@ -1866,6 +1865,7 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
                          ((*out_dtype)->names || (*out_dtype)->subarray));
 
         *out_ndim = NPY_MAXDIMS;
+        discovered_t is_object = DISCOVERED_OK;
         if (discover_dimensions(
                 op, out_ndim, out_dims, check_it,
                 stop_at_string, stop_at_tuple, &is_object) < 0) {
@@ -1883,9 +1883,8 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
         }
         /* If object arrays are forced */
         if (is_object != DISCOVERED_OK) {
-            if (is_object == DISCOVERED_RAGGED && requested_dtype == NULL)
-            {
-                /* 2019-Nov-1 1.18 */
+            if (is_object == DISCOVERED_RAGGED && requested_dtype == NULL) {
+                /* NumPy 1.18, 2019-11-01 */
                 if (DEPRECATE("Creating an ndarray with automatic object "
                     "dtype is deprecated, use dtype=object if you intended "
                     "it, otherwise specify an exact dtype") < 0)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -542,7 +542,6 @@ class TestFromStringAndFileInvalidData(_DeprecationTestCase):
             res = np.fromstring(x_str, sep=",", count=4)
             assert_array_equal(res, x)
 
-
 class Test_GetSet_NumericOps(_DeprecationTestCase):
     # 2018-09-20, 1.16.0
     def test_get_numeric_ops(self):
@@ -568,3 +567,12 @@ class TestNonZero(_DeprecationTestCase):
     def test_zerod(self):
         self.assert_deprecated(lambda: np.nonzero(np.array(0)))
         self.assert_deprecated(lambda: np.nonzero(np.array(1)))
+
+
+class TestRaggedArary(_DeprecationTestCase):
+    # 2019-11-29 1.18.0
+    def test_deprecate_ragged_arrays(self):
+        # NEP 34 deprecated automatic object dtype when creating ragged
+        # arrays. Also see the "ragged" tests in `test_multiarray`
+        self.assert_deprecated(np.array, args=([1, [2, 3]],)) 
+

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -542,6 +542,7 @@ class TestFromStringAndFileInvalidData(_DeprecationTestCase):
             res = np.fromstring(x_str, sep=",", count=4)
             assert_array_equal(res, x)
 
+
 class Test_GetSet_NumericOps(_DeprecationTestCase):
     # 2018-09-20, 1.16.0
     def test_get_numeric_ops(self):
@@ -569,10 +570,11 @@ class TestNonZero(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.nonzero(np.array(1)))
 
 
-class TestRaggedArary(_DeprecationTestCase):
+class TestRaggedArray(_DeprecationTestCase):
     # 2019-11-29 1.18.0
     def test_deprecate_ragged_arrays(self):
         # NEP 34 deprecated automatic object dtype when creating ragged
         # arrays. Also see the "ragged" tests in `test_multiarray`
-        self.assert_deprecated(np.array, args=([1, [2, 3]],)) 
+        arg = [1, [2, 3]]
+        self.assert_deprecated(np.array, args=(arg,))
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -447,7 +447,7 @@ class TestArrayConstruction(object):
         assert_equal(r, np.ones((2, 6, 6)))
 
         d = np.ones((6, ))
-        r = np.array([[d, d + 1], d + 2])
+        r = np.array([[d, d + 1], d + 2], dtype=object)
         assert_equal(len(r), 2)
         assert_equal(r[0], [d, d + 1])
         assert_equal(r[1], d + 2)
@@ -1073,34 +1073,60 @@ class TestCreation(object):
             assert_raises(ValueError, np.ndarray, buffer=buf, strides=(0,),
                           shape=(max_bytes//itemsize + 1,), dtype=dtype)
 
-    def test_jagged_ndim_object(self):
+    def _ragged_creation(self, seq):
+        # without dtype=object, the ragged object should raise
+        with assert_warns(DeprecationWarning):
+            a = np.array(seq)
+        b = np.array(seq, dtype=object)
+        assert_equal(a, b)
+        return b
+
+    def test_ragged_ndim_object(self):
         # Lists of mismatching depths are treated as object arrays
-        a = np.array([[1], 2, 3])
+        a = self._ragged_creation([[1], 2, 3])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
 
-        a = np.array([1, [2], 3])
+        a = self._ragged_creation([1, [2], 3])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
 
-        a = np.array([1, 2, [3]])
+        a = self._ragged_creation([1, 2, [3]])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
 
-    def test_jagged_shape_object(self):
+    def test_ragged_shape_object(self):
         # The jagged dimension of a list is turned into an object array
-        a = np.array([[1, 1], [2], [3]])
+        a = self._ragged_creation([[1, 1], [2], [3]])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
 
-        a = np.array([[1], [2, 2], [3]])
+        a = self._ragged_creation([[1], [2, 2], [3]])
         assert_equal(a.shape, (3,))
         assert_equal(a.dtype, object)
 
-        a = np.array([[1], [2], [3, 3]])
-        assert_equal(a.shape, (3,))
-        assert_equal(a.dtype, object)
+        a = self._ragged_creation([[1], [2], [3, 3]])
+        assert a.shape == (3,)
+        assert a.dtype == object
 
+    def test_array_of_ragged_array(self):
+        outer = np.array([None, None])
+        outer[0] = outer[1] = np.array([1, 2, 3])
+        assert np.array(outer).shape == (2,)
+        assert np.array([outer]).shape == (1, 2)
+
+        outer_ragged = np.array([None, None])
+        outer_ragged[0] = np.array([1, 2, 3])
+        outer_ragged[1] = np.array([1, 2, 3, 4])
+        # should both of these emit deprecation warnings?
+        assert np.array(outer_ragged).shape == (2,)
+        assert np.array([outer_ragged]).shape == (1, 2,)
+
+    def test_deep_nonragged_object(self):
+        # None of these should raise, even though they are missing dtype=object
+        a = np.array([[[Decimal(1)]]])
+        a = np.array([1, Decimal(1)])
+        a = np.array([[1], [Decimal(1)]])
 
 class TestStructured(object):
     def test_subarray_field_access(self):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1211,7 +1211,7 @@ class TestNonzero(object):
 
     def test_nonzero_invalid_object(self):
         # gh-9295
-        a = np.array([np.array([1, 2]), 3])
+        a = np.array([np.array([1, 2]), 3], dtype=object)
         assert_raises(ValueError, np.nonzero, a)
 
         class BoolErrors:

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1365,13 +1365,13 @@ class TestRegression(object):
     def test_array_from_sequence_scalar_array(self):
         # Ticket #1078: segfaults when creating an array with a sequence of
         # 0d arrays.
-        a = np.array((np.ones(2), np.array(2)))
+        a = np.array((np.ones(2), np.array(2)), dtype=object)
         assert_equal(a.shape, (2,))
         assert_equal(a.dtype, np.dtype(object))
         assert_equal(a[0], np.ones(2))
         assert_equal(a[1], np.array(2))
 
-        a = np.array(((1,), np.array(1)))
+        a = np.array(((1,), np.array(1)), dtype=object)
         assert_equal(a.shape, (2,))
         assert_equal(a.dtype, np.dtype(object))
         assert_equal(a[0], (1,))
@@ -1379,7 +1379,7 @@ class TestRegression(object):
 
     def test_array_from_sequence_scalar_array2(self):
         # Ticket #1081: weird array with strange input...
-        t = np.array([np.array([]), np.array(0, object)])
+        t = np.array([np.array([]), np.array(0, object)], dtype=object)
         assert_equal(t.shape, (2,))
         assert_equal(t.dtype, np.dtype(object))
 
@@ -2288,7 +2288,7 @@ class TestRegression(object):
             x[0], x[-1] = x[-1], x[0]
 
         uf = np.frompyfunc(f, 1, 0)
-        a = np.array([[1, 2, 3], [4, 5], [6, 7, 8, 9]])
+        a = np.array([[1, 2, 3], [4, 5], [6, 7, 8, 9]], dtype=object)
         assert_equal(uf(a), ())
         assert_array_equal(a, [[3, 2, 1], [5, 4], [9, 7, 8, 6]])
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2290,7 +2290,8 @@ class TestRegression(object):
         uf = np.frompyfunc(f, 1, 0)
         a = np.array([[1, 2, 3], [4, 5], [6, 7, 8, 9]], dtype=object)
         assert_equal(uf(a), ())
-        assert_array_equal(a, [[3, 2, 1], [5, 4], [9, 7, 8, 6]])
+        expected = np.array([[3, 2, 1], [5, 4], [9, 7, 8, 6]], dtype=object)
+        assert_array_equal(a, expected)
 
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test_leak_in_structured_dtype_comparison(self):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1125,14 +1125,18 @@ class TestUfunc(object):
         # Twice reproduced also for tuples:
         np.add.accumulate(arr, out=arr)
         np.add.accumulate(arr, out=arr)
-        assert_array_equal(arr, np.array([[1]*i for i in [1, 3, 6, 10]]))
+        assert_array_equal(arr,
+                           np.array([[1]*i for i in [1, 3, 6, 10]], dtype=object),
+                          )
 
         # And the same if the axis argument is used
         arr = np.ones((2, 4), dtype=object)
         arr[0, :] = [[2] for i in range(4)]
         np.add.accumulate(arr, out=arr, axis=-1)
         np.add.accumulate(arr, out=arr, axis=-1)
-        assert_array_equal(arr[0, :], np.array([[2]*i for i in [1, 3, 6, 10]]))
+        assert_array_equal(arr[0, :],
+                           np.array([[2]*i for i in [1, 3, 6, 10]], dtype=object),
+                          )
 
     def test_object_array_reduceat_inplace(self):
         # Checks that in-place reduceats work, see also gh-7465

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1262,24 +1262,29 @@ class TestPadWidth(object):
         with pytest.raises(ValueError, match=match):
             np.pad(arr, pad_width, mode)
 
-    @pytest.mark.parametrize("pad_width", [
-        "3",
-        "word",
-        None,
-        object(),
-        3.4,
-        ((2, 3, 4), (3, 2)),  # dtype=object (tuple)
-        complex(1, -1),
-        ((-2.1, 3), (3, 2)),
+    @pytest.mark.parametrize("pad_width, dtype", [
+        ("3", None),
+        ("word", None),
+        (None, None),
+        (object(), None),
+        (3.4, None),
+        (((2, 3, 4), (3, 2)), object),
+        (complex(1, -1), None),
+        (((-2.1, 3), (3, 2)), None),
     ])
     @pytest.mark.parametrize("mode", _all_modes.keys())
-    def test_bad_type(self, pad_width, mode):
+    def test_bad_type(self, pad_width, dtype, mode):
         arr = np.arange(30).reshape((6, 5))
         match = "`pad_width` must be of integral type."
-        with pytest.raises(TypeError, match=match):
-            np.pad(arr, pad_width, mode)
-        with pytest.raises(TypeError, match=match):
-            np.pad(arr, np.array(pad_width), mode)
+        if dtype is not None:
+            # avoid DeprecationWarning when not specifying dtype
+            with pytest.raises(TypeError, match=match):
+                np.pad(arr, np.array(pad_width, dtype=dtype), mode)
+        else:
+            with pytest.raises(TypeError, match=match):
+                np.pad(arr, pad_width, mode)
+            with pytest.raises(TypeError, match=match):
+                np.pad(arr, np.array(pad_width), mode)
 
     def test_pad_width_as_ndarray(self):
         a = np.arange(12)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -583,7 +583,7 @@ class TestSaveTxt(object):
         except (MemoryError, OverflowError):
             pytest.skip("Cannot allocate enough memory for test")
         test_data = np.asarray([np.random.rand(np.random.randint(50,100),4)
-                               for i in range(800000)])
+                               for i in range(800000)], dtype=object)
         with tempdir() as tmpdir:
             np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2817,8 +2817,8 @@ class MaskedArray(ndarray):
             elif isinstance(data, (tuple, list)):
                 try:
                     # If data is a sequence of masked array
-                    mask = np.array([getmaskarray(m) for m in data],
-                                    dtype=mdtype)
+                    mask = np.array([getmaskarray(np.asanyarray(m, dtype=mdtype))
+                                                    for m in data], dtype=mdtype)
                 except ValueError:
                     # If data is nested
                     mask = nomask

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -936,7 +936,7 @@ class TestMaskedArray(object):
     def test_object_with_array(self):
         mx1 = masked_array([1.], mask=[True])
         mx2 = masked_array([1., 2.])
-        mx = masked_array([mx1, mx2], mask=[False, True])
+        mx = masked_array([mx1, mx2], mask=[False, True], dtype=object)
         assert_(mx[0] is mx1)
         assert_(mx[1] is not mx2)
         assert_(np.all(mx[1].data == mx2.data))

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -56,7 +56,7 @@ class TestRegression(object):
                   [1, (2, 2), (3, 3), None],
                   [(1, 1), 2, 3, None]]:
             mt19937 = Generator(MT19937(12345))
-            shuffled = list(t)
+            shuffled = np.array(t, dtype=object)
             mt19937.shuffle(shuffled)
             assert_array_equal(shuffled, [t[2], t[0], t[3], t[1]])
 
@@ -118,7 +118,7 @@ class TestRegression(object):
         # a segfault on garbage collection.
         # See gh-7719
         mt19937 = Generator(MT19937(1234))
-        a = np.array([np.arange(1), np.arange(4)])
+        a = np.array([np.arange(1), np.arange(4)], dtype=object)
 
         for _ in range(1000):
             mt19937.shuffle(a)

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -58,7 +58,8 @@ class TestRegression(object):
             mt19937 = Generator(MT19937(12345))
             shuffled = np.array(t, dtype=object)
             mt19937.shuffle(shuffled)
-            assert_array_equal(shuffled, [t[2], t[0], t[3], t[1]])
+            expected = np.array([t[2], t[0], t[3], t[1]], dtype=object)
+            assert_array_equal(np.array(shuffled, dtype=object), expected)
 
     def test_call_within_randomstate(self):
         # Check that custom BitGenerator does not call into global state

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -68,7 +68,8 @@ class TestRegression(object):
             random.seed(12345)
             shuffled = list(t)
             random.shuffle(shuffled)
-            assert_array_equal(shuffled, [t[0], t[3], t[1], t[2]])
+            expected = np.array([t[0], t[3], t[1], t[2]], dtype=object)
+            assert_array_equal(np.array(shuffled, dtype=object), expected)
 
     def test_call_within_randomstate(self):
         # Check that custom RandomState does not call into global state

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -128,7 +128,7 @@ class TestRegression(object):
         # a segfault on garbage collection.
         # See gh-7719
         random.seed(1234)
-        a = np.array([np.arange(1), np.arange(4)])
+        a = np.array([np.arange(1), np.arange(4)], dtype=object)
 
         for _ in range(1000):
             random.shuffle(a)

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -66,7 +66,8 @@ class TestRegression(object):
             np.random.seed(12345)
             shuffled = list(t)
             random.shuffle(shuffled)
-            assert_array_equal(shuffled, [t[0], t[3], t[1], t[2]])
+            expected = np.array([t[0], t[3], t[1], t[2]], dtype=object)
+            assert_array_equal(np.array(shuffled, dtype=object), expected)
 
     def test_call_within_randomstate(self):
         # Check that custom RandomState does not call into global state

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -126,7 +126,7 @@ class TestRegression(object):
         # a segfault on garbage collection.
         # See gh-7719
         np.random.seed(1234)
-        a = np.array([np.arange(1), np.arange(4)])
+        a = np.array([np.arange(1), np.arange(4)], dtype=object)
 
         for _ in range(1000):
             np.random.shuffle(a)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -688,8 +688,10 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate, all, max, object_
 
-    x = array(x, copy=False, subok=True)
-    y = array(y, copy=False, subok=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', '', DeprecationWarning)
+        x = array(x, copy=False, subok=True)
+        y = array(y, copy=False, subok=True)
 
     # original array for output formatting
     ox, oy = x, y

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -688,10 +688,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate, all, max, object_
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', '', DeprecationWarning)
-        x = array(x, copy=False, subok=True)
-        y = array(y, copy=False, subok=True)
+    x = array(x, copy=False, subok=True)
+    y = array(y, copy=False, subok=True)
 
     # original array for output formatting
     ox, oy = x, y


### PR DESCRIPTION
~A demo of the direction of~ Implement NEP 34 (deprecating automatic object detection of ragged arrays). It seems to work ~except for~ including record arrays
```
>>> descr = [('v', int, 3), ('x', [('y', float)])]
>>> x = np.array([
...             [([1, 2, 3], (1.0,)),  ([1, 2, 3], (2.0,))],
...             [([1, 2, 3], (3.0,)),  ([1, 2, 3], (4.0,))]], dtype=descr)
```
I needed to filter the DeprecationWarning in `assert_equal(x, y) since they could be ragged lists.