### PR TITLE
ENH: change object-array comparisons to prefer OO->O unfuncs

### DIFF
--- a/doc/release/upcoming_changes/14800.improvement.rst
+++ b/doc/release/upcoming_changes/14800.improvement.rst
@@ -1,0 +1,14 @@
+Comparison on ``object`` dtypes will prefer ``object`` output
+-------------------------------------------------------------
+Comparison ufuncs (``np.equal`` and friends) would return boolean arrays when
+the input array dtype was ``object``. This led to inconsistent behaviour for
+ragged arrays ``a = np.array([1, np.array([1, 2, 3])], dtype=object)``. This
+will now return an object array::
+
+    >>> a = np.array([1, np.array([1, 2, 3])], dtype=object)
+    >>> np.equal(a, a)
+    array([True, array([ True,  True,  True])], dtype=object)
+
+The old behaviour, which will raise a ``ValueError`` in this case, is still
+available by specifying a dtype as ``np.equal(a, a, dtype=bool)``.
+

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -431,6 +431,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'greater_equal':
     Ufunc(2, 1, None,
@@ -438,6 +439,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'less':
     Ufunc(2, 1, None,
@@ -445,6 +447,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'less_equal':
     Ufunc(2, 1, None,
@@ -452,6 +455,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'equal':
     Ufunc(2, 1, None,
@@ -459,6 +463,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'not_equal':
     Ufunc(2, 1, None,
@@ -466,6 +471,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
+          TD('O', out='?'),
           ),
 'logical_and':
     Ufunc(2, 1, True_,
@@ -473,6 +479,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(nodatetime_or_obj, out='?', simd=[('avx2', ints)]),
           TD(O, f='npy_ObjectLogicalAnd'),
+          TD(O, f='npy_ObjectLogicalAnd', out='?'),
           ),
 'logical_not':
     Ufunc(1, 1, None,
@@ -480,6 +487,7 @@ defdict = {
           None,
           TD(nodatetime_or_obj, out='?', simd=[('avx2', ints)]),
           TD(O, f='npy_ObjectLogicalNot'),
+          TD(O, f='npy_ObjectLogicalNot', out='?'),
           ),
 'logical_or':
     Ufunc(2, 1, False_,
@@ -487,6 +495,7 @@ defdict = {
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
           TD(nodatetime_or_obj, out='?', simd=[('avx2', ints)]),
           TD(O, f='npy_ObjectLogicalOr'),
+          TD(O, f='npy_ObjectLogicalOr', out='?'),
           ),
 'logical_xor':
     Ufunc(2, 1, False_,

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -226,7 +226,7 @@ chartoname = {
     'P': 'OBJECT',
 }
 
-all = '?bBhHiIlLqQefdgFDGOMm'
+noobj = '?bBhHiIlLqQefdgFDGmM'
 O = 'O'
 P = 'P'
 ints = 'bBhHiIlLqQ'
@@ -246,10 +246,8 @@ inexactvec = 'fd'
 noint = inexact+O
 nointP = inexact+P
 allP = bints+times+flts+cmplxP
-nobool = all[1:]
-noobj = all[:-3]+all[-2:]
-nobool_or_obj = all[1:-3]+all[-2:]
-nobool_or_datetime = all[1:-2]+all[-1:]
+nobool_or_obj = noobj[1:]
+nobool_or_datetime = noobj[1:-1] + O # includes m - timedelta64
 intflt = ints+flts
 intfltcmplx = ints+flts+cmplx
 nocmplx = bints+times+flts
@@ -431,42 +429,42 @@ defdict = {
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.greater'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'greater_equal':
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.greater_equal'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'less':
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.less'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'less_equal':
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.less_equal'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'equal':
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.equal'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'not_equal':
     Ufunc(2, 1, None,
           docstrings.get('numpy.core.umath.not_equal'),
           'PyUFunc_SimpleBinaryComparisonTypeResolver',
-          TD(all, out='?', simd=[('avx2', ints)]),
+          TD(noobj, out='?', simd=[('avx2', ints)]),
           [TypeDescription('O', FullTypeDescr, 'OO', 'O')],
           ),
 'logical_and':

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -172,10 +172,11 @@ class TestComparisonDeprecations(_DeprecationTestCase):
             # (warning is issued a couple of times here)
             self.assert_deprecated(op, args=(a, a[:-1]), num=None)
 
-            # Element comparison error (numpy array can't be compared).
+            # ragged array comparison returns True/False
             a = np.array([1, np.array([1,2,3])], dtype=object)
             b = np.array([1, np.array([1,2,3])], dtype=object)
-            self.assert_deprecated(op, args=(a, b), num=None)
+            res = op(a, b)
+            assert res.dtype == 'object'
 
     def test_string(self):
         # For two string arrays, strings always raised the broadcasting error:

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1090,14 +1090,18 @@ class TestUfunc(object):
                 return '=='
 
         arr0d = np.array(HasComparisons())
-        assert_equal(arr0d == arr0d, True)
-        assert_equal(np.equal(arr0d, arr0d), True)  # normal behavior is a cast
+        assert_equal(arr0d == arr0d, '==')
+        assert_equal(np.equal(arr0d, arr0d), '==')
+        assert_equal(np.equal(arr0d, arr0d, dtype=bool), True)
         assert_equal(np.equal(arr0d, arr0d, dtype=object), '==')
 
         arr1d = np.array([HasComparisons()])
-        assert_equal(arr1d == arr1d, np.array([True]))
-        assert_equal(np.equal(arr1d, arr1d), np.array([True]))  # normal behavior is a cast
-        assert_equal(np.equal(arr1d, arr1d, dtype=object), np.array(['==']))
+        ret_obj = np.array(['=='], dtype=object)
+        ret_bool = np.array([True])
+        assert_equal(arr1d == arr1d, ret_obj)
+        assert_equal(np.equal(arr1d, arr1d), ret_obj)
+        assert_equal(np.equal(arr1d, arr1d, dtype=object), ret_obj)
+        assert_equal(np.equal(arr1d, arr1d, dtype=bool), ret_bool)
 
     def test_object_array_reduction(self):
         # Reductions on object arrays

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -170,10 +170,11 @@ class TestOut(object):
 
 class TestComparisons(object):
     def test_ignore_object_identity_in_equal(self):
-        # Check error raised when comparing identical objects whose comparison
+        # Check comparing identical objects whose comparison
         # is not a simple boolean, e.g., arrays that are compared elementwise.
         a = np.array([np.array([1, 2, 3]), None], dtype=object)
-        assert_raises(ValueError, np.equal, a, a)
+        b = np.equal(a, a.copy())
+        assert b.shape == a.shape
 
         # Check error raised when comparing identical non-comparable objects.
         class FunkyType(object):
@@ -188,10 +189,11 @@ class TestComparisons(object):
         assert_equal(np.equal(a, a), [False])
 
     def test_ignore_object_identity_in_not_equal(self):
-        # Check error raised when comparing identical objects whose comparison
+        # Check comparing identical objects whose comparison
         # is not a simple boolean, e.g., arrays that are compared elementwise.
         a = np.array([np.array([1, 2, 3]), None], dtype=object)
-        assert_raises(ValueError, np.not_equal, a, a)
+        b = np.not_equal(a, a.copy())
+        assert b.shape == a.shape
 
         # Check error raised when comparing identical non-comparable objects.
         class FunkyType(object):

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -562,11 +562,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:
-                mask &= (ar1 != a)
+                mask &= (ar1 != a).astype(bool)
         else:
             mask = np.zeros(len(ar1), dtype=bool)
             for a in ar2:
-                mask |= (ar1 == a)
+                mask |= (ar1 == a).astype(bool)
         return mask
 
     # Otherwise use sorting

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -562,10 +562,14 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
             for a in ar2:
+                # convert object arrays to bool
+                # cannot use np.not_equal until 'S' and 'U' have loops
                 mask &= (ar1 != a).astype(bool)
         else:
             mask = np.zeros(len(ar1), dtype=bool)
             for a in ar2:
+                # convert object arrays to bool
+                # cannot use np.equal until 'S' and 'U' have loops
                 mask |= (ar1 == a).astype(bool)
         return mask
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -99,7 +99,7 @@ def _replace_nan(a, val):
 
     if a.dtype == np.object_:
         # object arrays do not support `isnan` (gh-9009), so make a guess
-        mask = a != a
+        mask = (a != a).astype(bool)
     elif issubclass(a.dtype.type, np.inexact):
         mask = np.isnan(a)
     else:

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -99,7 +99,7 @@ def _replace_nan(a, val):
 
     if a.dtype == np.object_:
         # object arrays do not support `isnan` (gh-9009), so make a guess
-        mask = (a != a).astype(bool)
+        mask = np.not_equal(a, a, dtype=bool)
     elif issubclass(a.dtype.type, np.inexact):
         mask = np.isnan(a)
     else:

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -109,9 +109,9 @@ class TestRegression(object):
         assert_raises(ValueError, linalg.norm, testvector, ord='nuc')
         assert_raises(ValueError, linalg.norm, testvector, ord=np.inf)
         assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
-        # Succeeds, but returns boolean?
+        # Succeeds, equivalent to "sum(x != 0)"
         r = linalg.norm(testvector, ord=0)
-        assert_(r.dtype == np.type('float64'))
+        assert_(r.dtype == 'bool')
         assert_raises(ValueError, linalg.norm, testvector, ord=-1)
         assert_raises(ValueError, linalg.norm, testvector, ord=-2)
 

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -109,10 +109,9 @@ class TestRegression(object):
         assert_raises(ValueError, linalg.norm, testvector, ord='nuc')
         assert_raises(ValueError, linalg.norm, testvector, ord=np.inf)
         assert_raises(ValueError, linalg.norm, testvector, ord=-np.inf)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            assert_raises((AttributeError, DeprecationWarning),
-                              linalg.norm, testvector, ord=0)
+        # Succeeds, but returns boolean?
+        r = linalg.norm(testvector, ord=0)
+        assert_(r.dtype == np.type('float64'))
         assert_raises(ValueError, linalg.norm, testvector, ord=-1)
         assert_raises(ValueError, linalg.norm, testvector, ord=-2)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4791,6 +4791,7 @@ class MaskedArray(ndarray):
         mask = _check_mask_axis(self._mask, axis, **kwargs)
         if out is None:
             r = self.filled(True).all(axis=axis, **kwargs)
+            # object dtypes with axis=None return a scalar
             if isinstance(r, bool):
                 d = type(self)(r)
             else:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4790,7 +4790,11 @@ class MaskedArray(ndarray):
 
         mask = _check_mask_axis(self._mask, axis, **kwargs)
         if out is None:
-            d = self.filled(True).all(axis=axis, **kwargs).view(type(self))
+            r = self.filled(True).all(axis=axis, **kwargs)
+            if isinstance(r, bool):
+                d = type(self)(r)
+            else:
+                d = r.view(type(self))
             if d.ndim:
                 d.__setmask__(mask)
             elif mask:


### PR DESCRIPTION
We have many FutureDeprecationWarnings, DeprecationWarnings, and inconsistent behaviour in `array_richcompare` functions. xref gh-577. In discussion there, it was suggested to prioritize `OO->O` over `OO->?` for object array richcompare, then to work through the rest of the warnings in `array_richcompare` and `_failed_comparison_workaround`. For now I ~completely removed `OO->?` and~ only needed to add `result.astype(bool)` in a few code paths.

The change did not adversely affect the sympy test suite.