### PR TITLE
ENH: Add object loops to isnan, isinf, and isfinite

### DIFF
--- a/doc/release/upcoming_changes/14802.improvement.rst
+++ b/doc/release/upcoming_changes/14802.improvement.rst
@@ -1,0 +1,3 @@
+``isfinite``, ``isinf``, and ``isnan`` support object arrays
+------------------------------------------------------------
+These fall back on the functions from the `math` module with the same names.

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -851,6 +851,7 @@ defdict = {
           docstrings.get('numpy.core.umath.isnan'),
           None,
           TD(nodatetime_or_obj, out='?'),
+          TD(O, f='npy_ObjectIsNaN'),
           ),
 'isnat':
     Ufunc(1, 1, None,
@@ -863,12 +864,14 @@ defdict = {
           docstrings.get('numpy.core.umath.isinf'),
           None,
           TD(nodatetime_or_obj, out='?'),
+          TD(O, f='npy_ObjectIsInf'),
           ),
 'isfinite':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isfinite'),
           'PyUFunc_IsFiniteTypeResolver',
           TD(noobj, out='?'),
+          TD(O, f='npy_ObjectIsFinite'),
           ),
 'signbit':
     Ufunc(1, 1, None,

--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -234,6 +234,39 @@ npy_ObjectGCD(PyObject *i1, PyObject *i2)
 }
 
 static PyObject *
+npy_ObjectIsFinite(PyObject *obj) {
+    static PyObject *math_isfinite_func = NULL;
+
+    npy_cache_import("math", "isfinite", &math_isfinite_func);
+    if (math_isfinite_func == NULL) {
+        return NULL;
+    }
+    return PyObject_CallFunction(math_isfinite_func, "O", obj);
+}
+
+static PyObject *
+npy_ObjectIsInf(PyObject *obj) {
+    static PyObject *math_isinf_func = NULL;
+
+    npy_cache_import("math", "isinf", &math_isinf_func);
+    if (math_isinf_func == NULL) {
+        return NULL;
+    }
+    return PyObject_CallFunction(math_isinf_func, "O", obj);
+}
+
+static PyObject *
+npy_ObjectIsNaN(PyObject *obj) {
+    static PyObject *math_isnan_func = NULL;
+
+    npy_cache_import("math", "isnan", &math_isnan_func);
+    if (math_isnan_func == NULL) {
+        return NULL;
+    }
+    return PyObject_CallFunction(math_isnan_func, "O", obj);
+}
+
+static PyObject *
 npy_ObjectLCM(PyObject *i1, PyObject *i2)
 {
     /* lcm(a, b) = abs(a // gcd(a, b) * b) */

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2661,6 +2661,31 @@ class TestRoundingFunctions(object):
         assert_equal(np.trunc(f), -1)
 
 
+class TestWrappedMathModuleFunctions(object):
+    """ Tests of ufuncs which just wrap the math module on object arrays """
+    def test_float_coercible(self):
+        class C:
+            def __init__(self, val):
+                self.val = val
+            def __float__(self):
+                return float(self.val)
+
+        # this test is trying to test object arrays
+        assert np.array(C(1)).dtype == object
+
+        assert_equal(np.isfinite(C(0)), True)
+        assert_equal(np.isfinite(C(np.nan)), False)
+        assert_equal(np.isfinite(C(np.inf)), False)
+
+        assert_equal(np.isinf(C(0)), False)
+        assert_equal(np.isinf(C(np.nan)), False)
+        assert_equal(np.isinf(C(np.inf)), True)
+
+        assert_equal(np.isnan(C(0)), False)
+        assert_equal(np.isnan(C(np.nan)), True)
+        assert_equal(np.isnan(C(np.inf)), False)
+
+
 class TestComplexFunctions(object):
     funcs = [np.arcsin,  np.arccos,  np.arctan, np.arcsinh, np.arccosh,
              np.arctanh, np.sin,     np.cos,    np.tan,     np.exp,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2523,7 +2523,7 @@ class TestPercentile(object):
         assert_equal(np.percentile(x, 0, interpolation='nearest'), np.nan)
 
     def test_fraction(self):
-        x = [Fraction(i, 2) for i in np.arange(8)]
+        x = [Fraction(i, 2) for i in range(8)]
 
         p = np.percentile(x, Fraction(0))
         assert_equal(p, Fraction(0))
@@ -2943,7 +2943,7 @@ class TestQuantile(object):
 
     def test_fraction(self):
         # fractional input, integral quantile
-        x = [Fraction(i, 2) for i in np.arange(8)]
+        x = [Fraction(i, 2) for i in range(8)]
 
         q = np.quantile(x, 0)
         assert_equal(q, 0)


### PR DESCRIPTION
These just fall back on the corresponding function from the `math` module, which in practice coerces to float

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
