### PR TITLE
ENH: untangle circular import: core imports compat

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -139,9 +139,9 @@ else:
     # Allow distributors to run custom init code
     from . import _distributor_init
 
+    from . import compat
     from . import core
     from .core import *
-    from . import compat
     from . import lib
     # FIXME: why have numpy.lib if everything is imported here??
     from .lib import *


### PR DESCRIPTION
SciPy [reported](https://github.com/MacPython/scipy-wheels/pull/55#issuecomment-547767779) a problem importing 1.17.3 on CPython3.8. I think it is a circular import problem. 