### PR TITLE
TST: Don't construct Fraction instances from numpy scalars

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2523,7 +2523,7 @@ class TestPercentile(object):
         assert_equal(np.percentile(x, 0, interpolation='nearest'), np.nan)
 
     def test_fraction(self):
-        x = [Fraction(i, 2) for i in np.arange(8)]
+        x = [Fraction(i, 2) for i in range(8)]
 
         p = np.percentile(x, Fraction(0))
         assert_equal(p, Fraction(0))
@@ -2943,7 +2943,7 @@ class TestQuantile(object):
 
     def test_fraction(self):
         # fractional input, integral quantile
-        x = [Fraction(i, 2) for i in np.arange(8)]
+        x = [Fraction(i, 2) for i in range(8)]
 
         q = np.quantile(x, 0)
         assert_equal(q, 0)


### PR DESCRIPTION
`Fraction.__float__` gives a DeprecationWarning if the division results in a non-builtin float

```
>>> float(Fraction(1, np.uint8(1)))
DeprecationWarning: Fraction.__float__ returned non-float (type numpy.float64).  The ability to return an instance of a strict subclass of float is deprecated, and may be removed in a future version of Python.
```

This was never intended as part of the test anyway.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Extracted from gh-14802