### PR TITLE
BUILD: ignore more build.log warnings

### DIFF
--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -53,7 +53,7 @@ setup_base()
     $PYTHON setup.py build build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \
-    | grep -vE "ld returned 1|no previously-included files matching|manifest_maker: standard file '-c'" \
+    | grep -vE "ld returned 1|no files found matching|no previously-included files matching|manifest_maker: standard file '-c'" \
     | grep -E "warning\>" \
     | tee warnings
   if [ "$LAPACK" != "None" ]; then

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -53,9 +53,9 @@ setup_base()
     $PYTHON setup.py build build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \
-    | grep -vE "ld returned 1|no files found matching"
-    | grep -vE "no previously-included files matching"
-    | grep -vE "manifest_maker: standard file '-c'"
+    | grep -vE "ld returned 1|no files found matching" \
+    | grep -vE "no previously-included files matching" \
+    | grep -vE "manifest_maker: standard file '-c'" \
     | grep -E "warning\>" \
     | tee warnings
   if [ "$LAPACK" != "None" ]; then

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -53,7 +53,9 @@ setup_base()
     $PYTHON setup.py build build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \
-    | grep -vE "ld returned 1|no files found matching|no previously-included files matching|manifest_maker: standard file '-c'" \
+    | grep -vE "ld returned 1|no files found matching"
+    | grep -vE "no previously-included files matching"
+    | grep -vE "manifest_maker: standard file '-c'"
     | grep -E "warning\>" \
     | tee warnings
   if [ "$LAPACK" != "None" ]; then


### PR DESCRIPTION
Since the release of cython 0.29.14, there are new warning messages when building the package for PowerPC. We build since there is no binary wheel available, and there are now messages with the message "warning: no files found matching ...". Add that to the filtered output when building on travis.
```
    running install_egg_info
    running egg_info
    creating Cython.egg-info
    writing Cython.egg-info/PKG-INFO
    writing dependency_links to Cython.egg-info/dependency_links.txt
    writing entry points to Cython.egg-info/entry_points.txt
    writing top-level names to Cython.egg-info/top_level.txt
    writing manifest file 'Cython.egg-info/SOURCES.txt'
    reading manifest file 'Cython.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no files found matching 'Doc/*'
    warning: no files found matching '*.pyx' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Utility'
    warning: no files found matching 'pyximport/README'
    writing manifest file 'Cython.egg-info/SOURCES.txt'
    Copying Cython.egg-info to build/bdist.linux-ppc64le/wheel/Cython-0.29.14-py3.6.egg-info
```