### PR TITLE
BUG: raise ValueError for empty arrays passed to _pyarray_correlate

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1115,6 +1115,14 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
 
     n1 = PyArray_DIMS(ap1)[0];
     n2 = PyArray_DIMS(ap2)[0];
+    if (n1 == 0) {
+      PyErr_SetString(PyExc_ValueError, "first array argument cannot be empty");
+      return NULL;
+    }
+    if (n2 == 0) {
+      PyErr_SetString(PyExc_ValueError, "second array argument cannot be empty");
+      return NULL;
+    }
     if (n1 < n2) {
         ret = ap1;
         ap1 = ap2;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1116,12 +1116,12 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
     n1 = PyArray_DIMS(ap1)[0];
     n2 = PyArray_DIMS(ap2)[0];
     if (n1 == 0) {
-      PyErr_SetString(PyExc_ValueError, "first array argument cannot be empty");
-      return NULL;
+        PyErr_SetString(PyExc_ValueError, "first array argument cannot be empty");
+        return NULL;
     }
     if (n2 == 0) {
-      PyErr_SetString(PyExc_ValueError, "second array argument cannot be empty");
-      return NULL;
+        PyErr_SetString(PyExc_ValueError, "second array argument cannot be empty");
+        return NULL;
     }
     if (n1 < n2) {
         ret = ap1;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2567,6 +2567,11 @@ class TestCorrelate(object):
         z = np.correlate(y, x, mode='full')
         assert_array_almost_equal(z, r_z)
 
+    def test_zero_size(self):
+        with pytest.raises(ValueError):
+            np.correlate(np.array([]), np.ones(1000), mode='full')
+        with pytest.raises(ValueError):
+            np.correlate(np.ones(1000), np.array([]), mode='full')
 
 class TestConvolve(object):
     def test_object(self):


### PR DESCRIPTION
This is related to GitHub issue #14366 (which I found perusing the "good first issue" label) where empty arrays were causing crashes.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
