### PR TITLE
ENH: add isinf, isnan, fmin, fmax loops for datetime64, timedelta64

### DIFF
--- a/doc/release/upcoming_changes/14841.compatibility.rst
+++ b/doc/release/upcoming_changes/14841.compatibility.rst
@@ -3,9 +3,9 @@ Add more ufunc loops for ``datetime64``, ``timedelta64``
 ``np.datetime('NaT')`` should behave more like ``float('Nan')``. Add needed
 infrastructure so ``np.isinf(a)`` and ``np.isnan(a)`` will run on
 ``datetime64`` and ``timedelta64`` dtypes. Also added specific loops for
-``fmin`` and ``fmax`` that mask ``NaT``. This may require adjustment to user-
-facing code. Specifically, code that either disallowed the calls to `isinf`` or
-``isnan`` or checked that they raised an exception will require adaptation, and
-code that mistakenly called ``fmax`` and ``fmin`` instead of ``maximum`` or
-``minimum`` respectively will requre adjustment. This also affects ``nanmax``
-and ``nanmin``.
+`numpy.fmin` and `numpy.fmax` that mask ``NaT``. This may require adjustment to user-
+facing code. Specifically, code that either disallowed the calls to
+`numpy.isinf` or `numpy.isnan` or checked that they raised an exception will
+require adaptation, and code that mistakenly called `numpy.fmax` and
+`numpy.fmin` instead of `numpy.maximum` or `numpy.minimum` respectively will
+requre adjustment. This also affects `numpy.nanmax` and `numpy.nanmin`.

--- a/doc/release/upcoming_changes/14841.compatibility.rst
+++ b/doc/release/upcoming_changes/14841.compatibility.rst
@@ -1,0 +1,6 @@
+Add ufunc loops to ``isinf`` and ``isnan`` for ``datetime64``, ``timedelta64``
+------------------------------------------------------------------------------
+Add needed infrastructure so ``np.isinf(a)`` and ``np.isnan(a)`` will run on
+``datetime64`` and ``timedelta64`` dtypes. This may require adjustment to user-
+facing code that either disallowed the calls or checked that they raised an
+exception.

--- a/doc/release/upcoming_changes/14841.compatibility.rst
+++ b/doc/release/upcoming_changes/14841.compatibility.rst
@@ -8,4 +8,4 @@ facing code. Specifically, code that either disallowed the calls to `isinf`` or
 ``isnan`` or checked that they raised an exception will require adaptation, and
 code that mistakenly called ``fmax`` and ``fmin`` instead of ``maximum`` or
 ``minimum`` respectively will requre adjustment. This also affects ``nanmax``
-and ``nanmin`` which may no longer return ``NaT``.
+and ``nanmin``.

--- a/doc/release/upcoming_changes/14841.compatibility.rst
+++ b/doc/release/upcoming_changes/14841.compatibility.rst
@@ -1,6 +1,11 @@
-Add ufunc loops to ``isinf`` and ``isnan`` for ``datetime64``, ``timedelta64``
-------------------------------------------------------------------------------
-Add needed infrastructure so ``np.isinf(a)`` and ``np.isnan(a)`` will run on
-``datetime64`` and ``timedelta64`` dtypes. This may require adjustment to user-
-facing code that either disallowed the calls or checked that they raised an
-exception.
+Add more ufunc loops for ``datetime64``, ``timedelta64``
+--------------------------------------------------------
+``np.datetime('NaT')`` should behave more like ``float('Nan')``. Add needed
+infrastructure so ``np.isinf(a)`` and ``np.isnan(a)`` will run on
+``datetime64`` and ``timedelta64`` dtypes. Also added specific loops for
+``fmin`` and ``fmax`` that mask ``NaT``. This may require adjustment to user-
+facing code. Specifically, code that either disallowed the calls to `isinf`` or
+``isnan`` or checked that they raised an exception will require adaptation, and
+code that mistakenly called ``fmax`` and ``fmin`` instead of ``maximum`` or
+``minimum`` respectively will requre adjustment. This also affects ``nanmax``
+and ``nanmin`` which may no longer return ``NaT``.

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -858,8 +858,8 @@ defdict = {
 'isnan':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isnan'),
-          None,
-          TD(nodatetime_or_obj, out='?'),
+          'PyUFunc_IsFiniteTypeResolver',
+          TD(noobj, out='?'),
           ),
 'isnat':
     Ufunc(1, 1, None,
@@ -870,8 +870,8 @@ defdict = {
 'isinf':
     Ufunc(1, 1, None,
           docstrings.get('numpy.core.umath.isinf'),
-          None,
-          TD(nodatetime_or_obj, out='?'),
+          'PyUFunc_IsFiniteTypeResolver',
+          TD(noobj, out='?'),
           ),
 'isfinite':
     Ufunc(1, 1, None,

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1245,16 +1245,6 @@ NPY_NO_EXPORT void
     }
 }
 
-
-NPY_NO_EXPORT void
-@TYPE@_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
-{
-    UNARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        *((npy_bool *)op1) = (in1 == NPY_DATETIME_NAT);
-    }
-}
-
 NPY_NO_EXPORT void
 @TYPE@_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
 {

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1312,6 +1312,29 @@ NPY_NO_EXPORT void
 }
 /**end repeat1**/
 
+/**begin repeat1
+ * #kind = fmax, fmin#
+ * #OP =  >=, <=#
+ **/
+NPY_NO_EXPORT void
+@TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    BINARY_LOOP {
+        const @type@ in1 = *(@type@ *)ip1;
+        const @type@ in2 = *(@type@ *)ip2;
+        if (in1 == NPY_DATETIME_NAT) {
+            *((@type@ *)op1) = in2;
+        }
+        else if (in2 == NPY_DATETIME_NAT) {
+            *((@type@ *)op1) = in1;
+        }
+        else {
+            *((@type@ *)op1) = in1 @OP@ in2 ? in1 : in2;
+        }
+    }
+}
+/**end repeat1**/
+
 /**end repeat**/
 
 NPY_NO_EXPORT void

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1245,6 +1245,22 @@ NPY_NO_EXPORT void
     }
 }
 
+
+NPY_NO_EXPORT void
+@TYPE@_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    UNARY_LOOP {
+        const @type@ in1 = *(@type@ *)ip1;
+        *((npy_bool *)op1) = (in1 == NPY_DATETIME_NAT);
+    }
+}
+
+NPY_NO_EXPORT void
+@TYPE@_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func))
+{
+    UNARY_LOOP_FAST(npy_bool, npy_bool, (void)in; *out = NPY_FALSE);
+}
+
 NPY_NO_EXPORT void
 @TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data))
 {

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -494,8 +494,7 @@ NPY_NO_EXPORT void
 /**end repeat1**/
 
 /**begin repeat1
- * #kind = maximum, minimum#
- * #OP =  >, <#
+ * #kind = maximum, minimum, fmin, fmax#
  **/
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
@@ -559,10 +558,6 @@ TIMEDELTA_mm_qm_divmod(char **args, npy_intp *dimensions, npy_intp *steps, void 
 #define TIMEDELTA_mq_m_floor_divide TIMEDELTA_mq_m_divide
 #define TIMEDELTA_md_m_floor_divide TIMEDELTA_md_m_divide
 /* #define TIMEDELTA_mm_d_floor_divide TIMEDELTA_mm_d_divide */
-#define TIMEDELTA_fmin TIMEDELTA_minimum
-#define TIMEDELTA_fmax TIMEDELTA_maximum
-#define DATETIME_fmin DATETIME_minimum
-#define DATETIME_fmax DATETIME_maximum
 
 /*
  *****************************************************************************

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -480,8 +480,7 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
-NPY_NO_EXPORT void
-@TYPE@_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+#define @TYPE@_isnan @TYPE@_isnat
 
 NPY_NO_EXPORT void
 @TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -478,6 +478,12 @@ NPY_NO_EXPORT void
 @TYPE@_isfinite(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
+@TYPE@_isinf(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
+@TYPE@_isnan(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
 @TYPE@__ones_like(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED(data));
 
 /**begin repeat1

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2260,6 +2260,10 @@ class TestDateTime(object):
         assert_equal(np.isinf(arr), false)
         assert_equal(np.isnan(arr), neg)
 
+    def test_assert_equal(self):
+        assert_raises(AssertionError, assert_equal,
+                np.datetime64('nat'), np.timedelta64('nat'))
+
     def test_corecursive_input(self):
         # construct a co-recursive list
         a, b = [], []

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2242,19 +2242,19 @@ class TestDateTime(object):
 
     @pytest.mark.parametrize('unit', ['Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms',
                                       'us', 'ns', 'ps', 'fs', 'as'])
-    def test_isxx_units(self, unit):
+    @pytest.mark.parametrize('dstr', ['<datetime64[%s]', '>datetime64[%s]',
+                                      '<timedelta64[%s]', '>timedelta64[%s]'])
+    def test_isfinite_isinf_isnan_units(self, unit, dstr):
         '''check isfinite, isinf, isnan for all units of <M, >M, <m, >m dtypes
         '''
         arr_val = [123, -321, "NaT"]
-        dstr = ['<datetime64[%s]', '>datetime64[%s]',
-                '<timedelta64[%s]', '>timedelta64[%s]']
-        for arr in [np.array(arr_val,  dtype= s % unit) for s in dstr]:
-            pos = np.array([True, True,  False])
-            neg = np.array([False, False,  True])
-            false = np.array([False, False,  False])
-            assert_equal(np.isfinite(arr), pos)
-            assert_equal(np.isinf(arr), false)
-            assert_equal(np.isnan(arr), neg)
+        arr = np.array(arr_val,  dtype= dstr % unit)
+        pos = np.array([True, True,  False])
+        neg = np.array([False, False,  True])
+        false = np.array([False, False,  False])
+        assert_equal(np.isfinite(arr), pos)
+        assert_equal(np.isinf(arr), false)
+        assert_equal(np.isnan(arr), neg)
 
     def test_corecursive_input(self):
         # construct a co-recursive list

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2232,7 +2232,7 @@ class TestDateTime(object):
                 continue
             assert_raises(TypeError, np.isnat, np.zeros(10, t))
 
-    def test_isfinite(self):
+    def test_isfinite_scalar(self):
         assert_(not np.isfinite(np.datetime64('NaT', 'ms')))
         assert_(not np.isfinite(np.datetime64('NaT', 'ns')))
         assert_(np.isfinite(np.datetime64('2038-01-19T03:14:07')))
@@ -2240,18 +2240,21 @@ class TestDateTime(object):
         assert_(not np.isfinite(np.timedelta64('NaT', "ms")))
         assert_(np.isfinite(np.timedelta64(34, "ms")))
 
-        res = np.array([True, True,  False])
-        for unit in ['Y', 'M', 'W', 'D',
-                     'h', 'm', 's', 'ms', 'us',
-                     'ns', 'ps', 'fs', 'as']:
-            arr = np.array([123, -321, "NaT"], dtype='<datetime64[%s]' % unit)
-            assert_equal(np.isfinite(arr), res)
-            arr = np.array([123, -321, "NaT"], dtype='>datetime64[%s]' % unit)
-            assert_equal(np.isfinite(arr), res)
-            arr = np.array([123, -321, "NaT"], dtype='<timedelta64[%s]' % unit)
-            assert_equal(np.isfinite(arr), res)
-            arr = np.array([123, -321, "NaT"], dtype='>timedelta64[%s]' % unit)
-            assert_equal(np.isfinite(arr), res)
+    @pytest.mark.parametrize('unit', ['Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms',
+                                      'us', 'ns', 'ps', 'fs', 'as'])
+    def test_isxx_units(self, unit):
+        '''check isfinite, isinf, isnan for all units of <M, >M, <m, >m dtypes
+        '''
+        arr_val = [123, -321, "NaT"]
+        dstr = ['<datetime64[%s]', '>datetime64[%s]',
+                '<timedelta64[%s]', '>timedelta64[%s]']
+        for arr in [np.array(arr_val,  dtype= s % unit) for s in dstr]:
+            pos = np.array([True, True,  False])
+            neg = np.array([False, False,  True])
+            false = np.array([False, False,  False])
+            assert_equal(np.isfinite(arr), pos)
+            assert_equal(np.isinf(arr), false)
+            assert_equal(np.isnan(arr), neg)
 
     def test_corecursive_input(self):
         # construct a co-recursive list

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1361,6 +1361,10 @@ class TestDateTime(object):
         assert_equal(np.minimum(dtnat, a), dtnat)
         assert_equal(np.maximum(a, dtnat), dtnat)
         assert_equal(np.maximum(dtnat, a), dtnat)
+        assert_equal(np.fmin(dtnat, a), a)
+        assert_equal(np.fmin(a, dtnat), a)
+        assert_equal(np.fmax(dtnat, a), a)
+        assert_equal(np.fmax(a, dtnat), a)
 
         # Also do timedelta
         a = np.array(3, dtype='m8[h]')

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -386,7 +386,7 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
             if not signbit(desired) == signbit(actual):
                 raise AssertionError(msg)
 
-    except (TypeError, ValueError, NotImplementedError):
+    except (TypeError, ValueError, NotImplementedError, DeprecationWarning):
         pass
 
     try:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -406,7 +406,8 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
             # Now it succeeds but comparison to scalar with a different type
             # emits a DeprecationWarning.
             # Avoid that by skipping the next check
-            raise NotImplementedError('cannot compare datetime64 to 0')
+            raise NotImplementedError('cannot compare to a scalar '
+                                      'with a different type')
 
         if desired == 0 and actual == 0:
             if not signbit(desired) == signbit(actual):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -402,8 +402,8 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
         if (array_actual.dtype.char in 'Mm' or
                 array_desired.dtype.char in 'Mm'):
             # version 1.18
-            # until this version, gisnan failed for datetime64. Now
-            # it succeeds but comparison to 0 emits a DeprecationWarning
+            # until this version, gisnan failed for datetime64 and timedelta64.
+            # Now it succeeds but comparison to 0 emits a DeprecationWarning
             # Avoid that by skipping the next check
             raise NotImplementedError('cannot compare datetime64 to 0')
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -403,7 +403,8 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
                 array_desired.dtype.char in 'Mm'):
             # version 1.18
             # until this version, gisnan failed for datetime64 and timedelta64.
-            # Now it succeeds but comparison to 0 emits a DeprecationWarning
+            # Now it succeeds but comparison to scalar with a different type
+            # emits a DeprecationWarning.
             # Avoid that by skipping the next check
             raise NotImplementedError('cannot compare datetime64 to 0')
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -387,6 +387,11 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
                 raise AssertionError(msg)
 
     except (TypeError, ValueError, NotImplementedError, DeprecationWarning):
+        # version 1.18:
+        # datetime64/timedelta64 used to raise since they had no isnan
+        # implementation. Now they do, but raise a DeprecationWarning when
+        # compared to 0. When that restriction is removed, they will still
+        # raise an error when signbit is called.
         pass
 
     try:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -386,12 +386,13 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
             if not signbit(desired) == signbit(actual):
                 raise AssertionError(msg)
 
-    except (TypeError, ValueError, NotImplementedError, DeprecationWarning):
-        # version 1.18:
-        # datetime64/timedelta64 used to raise since they had no isnan
-        # implementation. Now they do, but raise a DeprecationWarning when
-        # compared to 0. When that restriction is removed, they will still
-        # raise an error when signbit is called.
+    except (TypeError, ValueError, NotImplementedError):
+        pass
+    except DeprecationWarning:
+        # version 1.18
+        # gisnan used to raise for datetime64/timedelta64 (dt64) since they had
+        # no isnan implementation. That call no longer raises. However, a
+        # DeprecationWarning is raised when comparing dt64 to 0.
         pass
 
     try:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -300,9 +300,9 @@ class TestEqual(TestArrayEqual):
             self._test_not_equal([a], b)
 
         for a, b in itertools.product(tds, dts):
-            self._assert_func(a, b)
+            self._test_not_equal(a, b)
             self._test_not_equal(a, [b])
-            self._assert_func([a], [b])
+            self._test_not_equal([a], [b])
             self._test_not_equal([a], np.datetime64("2017-01-01", "s"))
             self._test_not_equal([b], np.datetime64("2017-01-01", "s"))
             self._test_not_equal([a], np.timedelta64(123, "s"))

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -300,9 +300,9 @@ class TestEqual(TestArrayEqual):
             self._test_not_equal([a], b)
 
         for a, b in itertools.product(tds, dts):
-            self._test_not_equal(a, b)
+            self._assert_func(a, b)
             self._test_not_equal(a, [b])
-            self._test_not_equal([a], [b])
+            self._assert_func([a], [b])
             self._test_not_equal([a], np.datetime64("2017-01-01", "s"))
             self._test_not_equal([b], np.datetime64("2017-01-01", "s"))
             self._test_not_equal([a], np.timedelta64(123, "s"))


### PR DESCRIPTION
Fixes gh-14831.

Changes behavior. Previously `isnan`, `isinf` were unavailable for `datetime64` dtypes. Now `assert_equal` behaves slightly differently. Previously `assert_equal(a, b)` would raise if `a` and `b` contained `NaT` in the same position. Now `NaT` is equivalent to `float('nan')` and the call passes. I think this is consistent with the function docstring:

> This function handles NaN comparisons as if NaN was a "normal" number.
    That is, no assertion is raised if both objects have NaNs in the same
    positions.  This is in contrast to the IEEE standard on NaNs, which says
    that NaN compared to anything must return False.