### PR TITLE
BUG: Fix nonrandom first uint32 in MT19937 state initialization.

### DIFF
--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -129,9 +129,9 @@ cdef class MT19937(BitGenerator):
         BitGenerator.__init__(self, seed)
         val = self._seed_seq.generate_state(RK_STATE_LEN, np.uint32)
         # MSB is 1; assuring non-zero initial array
-        self.rng_state.key[0] = 0x80000000UL
-        for i in range(1, RK_STATE_LEN):
+        for i in range(RK_STATE_LEN):
             self.rng_state.key[i] = val[i]
+        self.rng_state.key[0] |= 0x80000000UL
         self.rng_state.pos = i
 
         self._bitgen.state = &self.rng_state
@@ -169,9 +169,9 @@ cdef class MT19937(BitGenerator):
                     seed = SeedSequence()
                     val = seed.generate_state(RK_STATE_LEN)
                     # MSB is 1; assuring non-zero initial array
-                    self.rng_state.key[0] = 0x80000000UL
-                    for i in range(1, RK_STATE_LEN):
+                    for i in range(RK_STATE_LEN):
                         self.rng_state.key[i] = val[i]
+                    self.rng_state.key[0] |= 0x80000000UL
                 else:
                     if hasattr(seed, 'squeeze'):
                         seed = seed.squeeze()

--- a/numpy/random/src/mt19937/mt19937.c
+++ b/numpy/random/src/mt19937/mt19937.c
@@ -77,7 +77,7 @@ void mt19937_init_by_array(mt19937_state *state, uint32_t *init_key,
     }
   }
 
-  mt[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
+  mt[0] |= 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
 }
 
 void mt19937_gen(mt19937_state *state) {


### PR DESCRIPTION
Fixes gh-14844. As noted in the comments there by @rkern, the bug was to set the first byte to a value rather than to OR it with that value.