### PR TITLE
BLD: add 'apt update' to shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -23,6 +23,7 @@ runtime:
 build:
     ci:
     # install dependencies
+    - sudo apt-get update
     - sudo apt-get install gcc gfortran libblas-dev liblapack-dev
     # add pathlib for Python 2, otherwise many tests are skipped
     - pip install --upgrade pip


### PR DESCRIPTION
Backport of #14842. 

gh-14841 failed to pass shippable tests, the CI could not install
gfortran. We may need to add apt update before apt install.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
