### PR TITLE
ENH: Adding parameters to unwrap

### DIFF
--- a/doc/release/upcoming_changes/14877. new_feature.rst
+++ b/doc/release/upcoming_changes/14877. new_feature.rst
@@ -1,4 +1,4 @@
-`numpy.unwrap` has new `min_val` and `max_val` arguments for handling non-radian wrapping
+`numpy.unwrap` has new ``min_val`` and ``max_val`` arguments for handling non-radian wrapping
 -----------------------------------------------------------------------------------------
 The `unwrap` function has been improved to support other wrapping cases like overflow 
 with integers when these keyword-only arguments are given. The default behavior is unchanged.

--- a/doc/release/upcoming_changes/14877. new_feature.rst
+++ b/doc/release/upcoming_changes/14877. new_feature.rst
@@ -1,4 +1,4 @@
 `numpy.unwrap` has new `min_val` and `max_val` arguments for handling non-radian wrapping
 -----------------------------------------------------------------------------------------
 The `unwrap` function has been improved to support other wrapping cases like overflow 
-with integers when these keyword-only arguments are given (old behavior is unchanged)
+with integers when these keyword-only arguments are given. The default behavior is unchanged.

--- a/doc/release/upcoming_changes/14877. new_feature.rst
+++ b/doc/release/upcoming_changes/14877. new_feature.rst
@@ -1,0 +1,4 @@
+`numpy.unwrap` has new `min_val` and `max_val` arguments for handling non-radian wrapping
+-----------------------------------------------------------------------------------------
+The `unwrap` function has been improved to support other wrapping cases like overflow 
+with integers when these keyword-only arguments are given (old behavior is unchanged)

--- a/doc/release/upcoming_changes/14877. new_feature.rst
+++ b/doc/release/upcoming_changes/14877. new_feature.rst
@@ -1,4 +1,4 @@
 `numpy.unwrap` has new ``min_val`` and ``max_val`` arguments for handling non-radian wrapping
------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------
 The `unwrap` function has been improved to support other wrapping cases like overflow 
 with integers when these keyword-only arguments are given. The default behavior is unchanged.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1514,7 +1514,7 @@ def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
     slice1 = [slice(None, None)]*nd     # full slices
     slice1[axis] = slice(1, None)
     slice1 = tuple(slice1)
-    ddmod = mod(dd - min_val, max_val-min_val) + min_val
+    ddmod = mod(dd - min_val, max_val - min_val) + min_val
     _nx.copyto(ddmod, max_val, where=(ddmod == min_val) & (dd > 0))
     ph_correct = ddmod - dd
     _nx.copyto(ph_correct, 0, where=abs(dd) < discont)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1460,7 +1460,7 @@ def _unwrap_dispatcher(p, discont=None, axis=None, min_val=None, max_val=None):
 
 
 @array_function_dispatch(_unwrap_dispatcher)
-def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
+def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
     """
     Unwrap by changing deltas between values to complement.
     

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1495,7 +1495,7 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
 
     Notes
     -----
-    If the discontinuity in `p` is smaller than ``max_val-min_val/2``, 
+    If the discontinuity in `p` is smaller than ``(max_val-min_val)/2``, 
     but larger than `discont`, no unwrapping is done because taking 
     the complement would only make the discontinuity larger.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1507,7 +1507,8 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
     array([ 0.        ,  0.78539816,  1.57079633,  5.49778714,  6.28318531]) # may vary
     >>> np.unwrap(phase)
     array([ 0.        ,  0.78539816,  1.57079633, -0.78539816,  0.        ]) # may vary
-
+    >>> unwrap([0, 1, 2, -1, 0], min_val=-1, max_val=3)
+    array([0., 1., 2., 3., 4.])
     """
     if discont is None:
         discont = (max_val - min_val)/2

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1464,9 +1464,12 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
     """
     Unwrap by changing deltas between values to complement.
     
-    For `min_val=-pi` and `max_val=pi`, unwraps radian phase `p` by 
-    changing absolute jumps greater than `discont` to their 2*pi 
-    complement along the given axis.
+    For the default case where `min_val=-pi`, `max_val=pi`, `discont=pi`
+    It unwraps radian phase `p` by changing absolute jumps greater 
+    than `pi` to their 2*pi complement along the given axis.
+    
+    In general it unwrapps a signal `p` by changing absolute jumps 
+    greater than `discont` to their complementary values.
 
     Parameters
     ----------
@@ -1492,8 +1495,8 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
 
     Notes
     -----
-    If the discontinuity in `p` is smaller than ``pi``, but larger than
-    `discont`, no unwrapping is done because taking the 2*pi complement
+    If the discontinuity in `p` is smaller than ``max_val``, but larger than
+    `discont`, no unwrapping is done because taking the complement
     would only make the discontinuity larger.
 
     Examples

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1473,7 +1473,7 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
     p : array_like
         Input array.
     discont : float, optional
-        Maximum discontinuity between values, default is ``pi``.
+        Maximum discontinuity between values, default is ``(max_val - min_val)/2``.
     axis : int, optional
         Axis along which unwrap will operate, default is the last axis.
     min_val : float, optional

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1460,7 +1460,7 @@ def _unwrap_dispatcher(p, discont=None, axis=None):
 
 
 @array_function_dispatch(_unwrap_dispatcher)
-def unwrap(p, discont=None, axis=-1, min_val=None, max_val=None):
+def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
     """
     Unwrap by changing deltas between values to 2*pi complement.
 
@@ -1505,10 +1505,6 @@ def unwrap(p, discont=None, axis=-1, min_val=None, max_val=None):
     array([ 0.        ,  0.78539816,  1.57079633, -0.78539816,  0.        ]) # may vary
 
     """
-    if min_val is None:
-        min_val = -pi
-    if max_val is None:
-        max_val = pi
     if discont is None:
         discont = (max_val-min_val)/2
     p = asarray(p)
@@ -1518,7 +1514,7 @@ def unwrap(p, discont=None, axis=-1, min_val=None, max_val=None):
     slice1[axis] = slice(1, None)
     slice1 = tuple(slice1)
     ddmod = mod(dd - min_val, max_val-min_val) + min_val
-    _nx.copyto(ddmod, pi, where=(ddmod == min_val) & (dd > 0))
+    _nx.copyto(ddmod, max_val, where=(ddmod == min_val) & (dd > 0))
     ph_correct = ddmod - dd
     _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
     up = array(p, copy=True, dtype='d')

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1495,9 +1495,9 @@ def unwrap(p, discont=None, axis=-1, *, min_val=-pi, max_val=pi):
 
     Notes
     -----
-    If the discontinuity in `p` is smaller than ``max_val``, but larger than
-    `discont`, no unwrapping is done because taking the complement
-    would only make the discontinuity larger.
+    If the discontinuity in `p` is smaller than ``max_val-min_val/2``, 
+    but larger than `discont`, no unwrapping is done because taking 
+    the complement would only make the discontinuity larger.
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1455,7 +1455,7 @@ def angle(z, deg=False):
     return a
 
 
-def _unwrap_dispatcher(p, discont=None, axis=None, min_val=None, max_val=None):
+def _unwrap_dispatcher(p, discont=None, axis=None, *, min_val=None, max_val=None):
     return (p,)
 
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1455,17 +1455,18 @@ def angle(z, deg=False):
     return a
 
 
-def _unwrap_dispatcher(p, discont=None, axis=None):
+def _unwrap_dispatcher(p, discont=None, axis=None, min_val=None, max_val=None):
     return (p,)
 
 
 @array_function_dispatch(_unwrap_dispatcher)
 def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
     """
-    Unwrap by changing deltas between values to 2*pi complement.
-
-    Unwrap radian phase `p` by changing absolute jumps greater than
-    `discont` to their 2*pi complement along the given axis.
+    Unwrap by changing deltas between values to complement.
+    
+    For `min_val=-pi` and `max_val=pi`, unwraps radian phase `p` by 
+    changing absolute jumps greater than `discont` to their 2*pi 
+    complement along the given axis.
 
     Parameters
     ----------
@@ -1476,9 +1477,9 @@ def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
     axis : int, optional
         Axis along which unwrap will operate, default is the last axis.
     min_val : float, optional
-        Minimum value when sequence underflows, default is ``-pi``
+        Minimum value when sequence overflows, default is ``-pi``
     max_val : float, optional
-        Maximum value when sequence overflows, default is ``pi``
+        Maximum value when sequence underflows, default is ``pi``
 
     Returns
     -------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1507,7 +1507,7 @@ def unwrap(p, discont=None, axis=-1, min_val=-pi, max_val=pi):
 
     """
     if discont is None:
-        discont = (max_val-min_val)/2
+        discont = (max_val - min_val)/2
     p = asarray(p)
     nd = p.ndim
     dd = diff(p, axis=axis)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1643,10 +1643,20 @@ class TestUnwrap(object):
 
     def test_minmax(self):
         # check that unwrap removes jumps greater that 255
-        assert_array_equal(unwrap([1, 1 + 256], min_val=0, max_val=255), [1, ])
+        assert_array_equal(unwrap([1, 1 + 256], min_val=0, max_val=255), [1, 2])
         # check that unwrap maintains continuity
         assert_(np.all(diff(unwrap(rand(10) * 1000, min_val=0, max_val=255)) < 255))
-
+        # check simple case
+        simple_seq = linspace(0, 512, 6)
+        wrap_seq = mod(simple_seq, 255)
+        assert_array_equal(unwrap(wrap_seq, min_val=0, max_val=255), simple_seq)
+        # check custom discont value
+        uneven_seq = np.array(simple_seq.tolist()+[765])
+        wrap_uneven = mod(uneven_seq, 255)
+        no_discont = unwrap(wrap_uneven, min_val=0, max_val=255)
+        assert_array_equal(no_discont[:-1], uneven_seq[:-1])
+        sm_discont = unwrap(wrap_uneven, min_val=0, max_val=255, discont=2)
+        assert_array_equal(sm_discont, uneven_seq)
 
 
 class TestFilterwindows(object):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1641,6 +1641,13 @@ class TestUnwrap(object):
         # check that unwrap maintains continuity
         assert_(np.all(diff(unwrap(rand(10) * 100)) < np.pi))
 
+    def test_minmax(self):
+        # check that unwrap removes jumps greater that 255
+        assert_array_equal(unwrap([1, 1 + 256], min_val=0, max_val=255), [1, ])
+        # check that unwrap maintains continuity
+        assert_(np.all(diff(unwrap(rand(10) * 1000, min_val=0, max_val=255)) < 255))
+
+
 
 class TestFilterwindows(object):
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1647,17 +1647,16 @@ class TestUnwrap(object):
         # check that unwrap maintains continuity
         assert_(np.all(diff(unwrap(rand(10) * 1000, min_val=0, max_val=255)) < 255))
         # check simple case
-        simple_seq = np.linspace(0, 512, 6)
+        simple_seq = np.array([0, 75, 150, 225, 300])
         wrap_seq = np.mod(simple_seq, 255)
         assert_array_equal(unwrap(wrap_seq, min_val=0, max_val=255), simple_seq)
         # check custom discont value
-        uneven_seq = np.array(simple_seq.tolist()+[765])
+        uneven_seq = np.array([0, 75, 150, 225, 300, 553])
         wrap_uneven = np.mod(uneven_seq, 255)
         no_discont = unwrap(wrap_uneven, min_val=0, max_val=255)
-        assert_array_equal(no_discont[:-1], uneven_seq[:-1])
+        assert_array_equal(no_discont, [0, 75, 150, 225, 300, 298])
         sm_discont = unwrap(wrap_uneven, min_val=0, max_val=255, discont=2)
-        assert_array_equal(sm_discont, uneven_seq)
-
+        assert_array_equal(sm_discont, [0, 75, 150, 225, 300, 553])
 
 class TestFilterwindows(object):
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1647,12 +1647,12 @@ class TestUnwrap(object):
         # check that unwrap maintains continuity
         assert_(np.all(diff(unwrap(rand(10) * 1000, min_val=0, max_val=255)) < 255))
         # check simple case
-        simple_seq = linspace(0, 512, 6)
-        wrap_seq = mod(simple_seq, 255)
+        simple_seq = np.linspace(0, 512, 6)
+        wrap_seq = np.mod(simple_seq, 255)
         assert_array_equal(unwrap(wrap_seq, min_val=0, max_val=255), simple_seq)
         # check custom discont value
         uneven_seq = np.array(simple_seq.tolist()+[765])
-        wrap_uneven = mod(uneven_seq, 255)
+        wrap_uneven = np.mod(uneven_seq, 255)
         no_discont = unwrap(wrap_uneven, min_val=0, max_val=255)
         assert_array_equal(no_discont[:-1], uneven_seq[:-1])
         sm_discont = unwrap(wrap_uneven, min_val=0, max_val=255, discont=2)


### PR DESCRIPTION
Adding optional min_val and max_val to unwrap without changing normal behavior (discont is overwritten unless it is explicitly specified). 

I unfortunately not yet followed any of the guidelines and did the PR more to provide a simple reference implementation, I'll try to clean it up

- closes #14876 