### PR TITLE
BUG: Remove builtins from __all__

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -158,6 +158,7 @@ else:
 
     # Make these accessible from numpy name-space
     # but not imported in from numpy import *
+    # TODO[gh-6103]: Deprecate these
     if sys.version_info[0] >= 3:
         from builtins import bool, int, float, complex, object, str
         unicode = str
@@ -168,13 +169,16 @@ else:
     # now that numpy modules are imported, can initialize limits
     core.getlimits._register_known_types()
 
-    __all__.extend(['bool', 'int', 'float', 'complex', 'object', 'unicode',
-                    'str'])
     __all__.extend(['__version__', 'show_config'])
     __all__.extend(core.__all__)
     __all__.extend(_mat.__all__)
     __all__.extend(lib.__all__)
     __all__.extend(['linalg', 'fft', 'random', 'ctypeslib', 'ma'])
+
+    # These are added by `from .core import *` and `core.__all__`, but we
+    # overwrite them above with builtins we do _not_ want to export.
+    __all__.remove('long')
+    __all__.remove('unicode')
 
     # Remove things that are in the numpy.lib but not in the numpy namespace
     # Note that there is a test (numpy/tests/test_public_api.py:test_numpy_namespace)

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -216,7 +216,7 @@ else:
                                      "{!r}".format(__name__, attr))
 
         def __dir__():
-            return __all__ + ['Tester', 'testing']
+            return list(globals().keys()) + ['Tester', 'testing']
 
     else:
         # We don't actually use this ourselves anymore, but I'm not 100% sure that


### PR DESCRIPTION
This was introduced in 3ca0eb1136102ff01bcc171f53c106326fa4445b, due to an incorrect implementation of `__dir__` (fixed in the first commit of this patch). Looks like I never finished reviewing [this part](https://github.com/numpy/numpy/pull/14097#discussion_r309506000) of the original PR.

It was never released, so this is not a breaking change.

In that commit, `from numpy import *` would reset all the builtins to their defaults, and set `unicode = str`, `long = int`.
