### PR TITLE
DEP: Deprecate aliases of builtin types in python 3.7+ 

### DIFF
--- a/doc/release/upcoming_changes/14882.deprecation.rst
+++ b/doc/release/upcoming_changes/14882.deprecation.rst
@@ -1,0 +1,30 @@
+Using the aliases of builtin types like ``np.int`` is deprecated
+----------------------------------------------------------------
+
+For a long time, ``np.int`` has been an alias of the builtin ``int``. This is
+repeatedly a cause of confusion for newcomers, and is also simply not useful.
+
+These aliases have been deprecated. The table below shows the full list of
+deprecated aliases, along with their exact meaning. Replacing uses of items in
+the first column with the contents of the second column will work identically
+and silence the deprecation warning.
+
+In many cases, it may have been intended to use the types from the third column.
+Be aware that use of these types may result in subtle but desirable behavior
+changes.
+
+==================  =================================  ==================================================================
+Deprecated name     Identical to                       Possibly intended numpy type
+==================  =================================  ==================================================================
+``numpy.bool``      ``bool``                           `numpy.bool_`
+``numpy.int``       ``int``                            `numpy.int_` (default int dtype), `numpy.cint` (C ``int``)
+``numpy.float``     ``float``                          `numpy.float_`, `numpy.double` (equivalent)
+``numpy.complex``   ``complex``                        `numpy.complex_`, `numpy.cdouble` (equivalent)
+``numpy.object``    ``object``                         `numpy.object_`
+``numpy.str``       ``str``                            `numpy.str_`
+``numpy.long``      ``int`` (``long`` on Python 2)     `numpy.int_` (C ``long``), `numpy.longlong` (largest integer type)
+``numpy.unicode``   ``str`` (``unicode`` on Python 2)  `numpy.unicode_`
+==================  =================================  ==================================================================
+
+Note that for technical reasons these deprecation warnings will only be emitted
+on Python 3.7 and above.

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -291,7 +291,7 @@ def test_array_astype_warning(t):
 
 @pytest.mark.parametrize(["dtype", "out_dtype"],
         [(np.bytes_, np.bool_),
-         (np.unicode, np.bool_),
+         (np.unicode_, np.bool_),
          (np.dtype("S10,S9"), np.dtype("?,?"))])
 def test_string_to_boolean_cast(dtype, out_dtype):
     """
@@ -305,7 +305,7 @@ def test_string_to_boolean_cast(dtype, out_dtype):
 
 @pytest.mark.parametrize(["dtype", "out_dtype"],
         [(np.bytes_, np.bool_),
-         (np.unicode, np.bool_),
+         (np.unicode_, np.bool_),
          (np.dtype("S10,S9"), np.dtype("?,?"))])
 def test_string_to_boolean_cast_errors(dtype, out_dtype):
     """

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -9,6 +9,7 @@ import warnings
 import pytest
 import tempfile
 import re
+import sys
 
 import numpy as np
 from numpy.testing import (
@@ -655,3 +656,22 @@ class TestNonExactMatchDeprecation(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.ravel_multi_index(arr, (7, 6), mode='Cilp'))
         # using completely different word with first character as R
         self.assert_deprecated(lambda: np.searchsorted(arr[0], 4, side='Random'))
+
+
+class TestDeprecatedGlobals(_DeprecationTestCase):
+    # 2020-06-06
+    @pytest.mark.skipif(
+        sys.version_info < (3, 7),
+        reason='module-level __getattr__ not supported')
+    def test_type_aliases(self):
+        # from builtins
+        self.assert_deprecated(lambda: np.bool)
+        self.assert_deprecated(lambda: np.int)
+        self.assert_deprecated(lambda: np.float)
+        self.assert_deprecated(lambda: np.complex)
+        self.assert_deprecated(lambda: np.object)
+        self.assert_deprecated(lambda: np.str)
+
+        # from np.compat
+        self.assert_deprecated(lambda: np.long)
+        self.assert_deprecated(lambda: np.unicode)

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -65,7 +65,7 @@ class TestExtraArgs:
 
     def test_bool(self):
         with pytest.raises(TypeError):
-            np.bool(False, garbage=True)
+            np.bool_(False, garbage=True)
 
     def test_void(self):
         with pytest.raises(TypeError):

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -545,25 +545,25 @@ class TestSpecialComplexAVX(object):
     @pytest.mark.parametrize("stride", [-4,-2,-1,1,2,4])
     @pytest.mark.parametrize("astype", [np.complex64, np.complex128])
     def test_array(self, stride, astype):
-        arr = np.array([np.complex(np.nan , np.nan),
-                        np.complex(np.nan , np.inf),
-                        np.complex(np.inf , np.nan),
-                        np.complex(np.inf , np.inf),
-                        np.complex(0.     , np.inf),
-                        np.complex(np.inf , 0.),
-                        np.complex(0.     , 0.),
-                        np.complex(0.     , np.nan),
-                        np.complex(np.nan , 0.)], dtype=astype)
+        arr = np.array([complex(np.nan , np.nan),
+                        complex(np.nan , np.inf),
+                        complex(np.inf , np.nan),
+                        complex(np.inf , np.inf),
+                        complex(0.     , np.inf),
+                        complex(np.inf , 0.),
+                        complex(0.     , 0.),
+                        complex(0.     , np.nan),
+                        complex(np.nan , 0.)], dtype=astype)
         abs_true = np.array([np.nan, np.inf, np.inf, np.inf, np.inf, np.inf, 0., np.nan, np.nan], dtype=arr.real.dtype)
-        sq_true = np.array([np.complex(np.nan,  np.nan),
-                            np.complex(np.nan,  np.nan),
-                            np.complex(np.nan,  np.nan),
-                            np.complex(np.nan,  np.inf),
-                            np.complex(-np.inf, np.nan),
-                            np.complex(np.inf,  np.nan),
-                            np.complex(0.,     0.),
-                            np.complex(np.nan, np.nan),
-                            np.complex(np.nan, np.nan)], dtype=astype)
+        sq_true = np.array([complex(np.nan,  np.nan),
+                            complex(np.nan,  np.nan),
+                            complex(np.nan,  np.nan),
+                            complex(np.nan,  np.inf),
+                            complex(-np.inf, np.nan),
+                            complex(np.inf,  np.nan),
+                            complex(0.,     0.),
+                            complex(np.nan, np.nan),
+                            complex(np.nan, np.nan)], dtype=astype)
         assert_equal(np.abs(arr[::stride]), abs_true[::stride])
         with np.errstate(invalid='ignore'):
             assert_equal(np.square(arr[::stride]), sq_true[::stride])

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -957,7 +957,7 @@ def test__replace_nan():
     """ Test that _replace_nan returns the original array if there are no
     NaNs, not a copy.
     """
-    for dtype in [np.bool, np.int32, np.int64]:
+    for dtype in [np.bool_, np.int32, np.int64]:
         arr = np.array([0, 1], dtype=dtype)
         result, mask = _replace_nan(arr, 0)
         assert mask is None

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -54,18 +54,22 @@ def test_numpy_namespace():
         'show_config': 'numpy.__config__.show',
         'who': 'numpy.lib.utils.who',
     }
-    # These built-in types are re-exported by numpy.
-    builtins = {
-        'bool': 'builtins.bool',
-        'complex': 'builtins.complex',
-        'float': 'builtins.float',
-        'int': 'builtins.int',
-        'long': 'builtins.int',
-        'object': 'builtins.object',
-        'str': 'builtins.str',
-        'unicode': 'builtins.str',
-    }
-    whitelist = dict(undocumented, **builtins)
+    if sys.version_info < (3, 7):
+        # These built-in types are re-exported by numpy.
+        builtins = {
+            'bool': 'builtins.bool',
+            'complex': 'builtins.complex',
+            'float': 'builtins.float',
+            'int': 'builtins.int',
+            'long': 'builtins.int',
+            'object': 'builtins.object',
+            'str': 'builtins.str',
+            'unicode': 'builtins.str',
+        }
+        whitelist = dict(undocumented, **builtins)
+    else:
+        # after 3.7, we override dir to not show these members
+        whitelist = undocumented
     bad_results = check_dir(np)
     # pytest gives better error messages with the builtin assert than with
     # assert_equal


### PR DESCRIPTION
This:
* Makes accessing these attributes emit a deprecation warning, such as:
  > `np.float` is a deprecated alias for the builtin `float`. Use `float` by itself, which is identical in behavior, to silence this warning. If you specifically wanted the numpy scalar type, use `np.float_` here.
* Removes them from `dir(numpy)`, so as not to emit warnings for user of `inspect.getmembers`

Fixes #6103

---


~~Marking as draft until #14881 is merged~~

~~Marking as WIP until gh-14901 is merged~~