### PR TITLE
MAINT: Remove uses of scalar aliases

### DIFF
--- a/doc/neps/roadmap.rst
+++ b/doc/neps/roadmap.rst
@@ -42,7 +42,7 @@ improve the dtype system.
   - One of these should probably be the default for text data. The current
     behavior on Python 3 is neither efficient nor user friendly.
 
-- `np.int` should not be platform dependent
+- ``np.dtype(int)`` should not be platform dependent
 - Better coercion for string + number
 
 Performance

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -57,7 +57,7 @@ cleanup means that legacy and compatibility methods have been removed from
 ``randint``,        ``integers``   Add an ``endpoint`` kwarg
 ``random_integers``
 ------------------- -------------- ------------
-``tomaxint``        removed        Use ``integers(0, np.iinfo(np.int).max,``
+``tomaxint``        removed        Use ``integers(0, np.iinfo(np.int_).max,``
                                                  ``endpoint=False)``
 ------------------- -------------- ------------
 ``seed``            removed        Use `~.SeedSequence.spawn`

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -41,7 +41,7 @@ seed will produce the same outputs.
             self.n = n
             self.executor = concurrent.futures.ThreadPoolExecutor(threads)
             self.values = np.empty(n)
-            self.step = np.ceil(n / threads).astype(np.int)
+            self.step = np.ceil(n / threads).astype(np.int_)
 
         def fill(self):
             def _fill(random_state, out, first, last):

--- a/doc/source/release/1.11.0-notes.rst
+++ b/doc/source/release/1.11.0-notes.rst
@@ -200,7 +200,7 @@ New Features
 * A ``dtype`` parameter has been added to ``np.random.randint``
   Random ndarrays of the following types can now be generated:
 
-  - ``np.bool``,
+  - ``np.bool_``,
   - ``np.int8``, ``np.uint8``,
   - ``np.int16``, ``np.uint16``,
   - ``np.int32``, ``np.uint32``,

--- a/doc/source/release/1.13.0-notes.rst
+++ b/doc/source/release/1.13.0-notes.rst
@@ -275,7 +275,7 @@ In particular ``np.gradient`` can now take:
 
 This means that, e.g., it is now possible to do the following::
 
-    >>> f = np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float)
+    >>> f = np.array([[1, 2, 6], [3, 4, 5]], dtype=np.float_)
     >>> dx = 2.
     >>> y = [1., 1.5, 3.5]
     >>> np.gradient(f, dx, y)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -485,7 +485,7 @@ def sctype2char(sctype):
 
     Examples
     --------
-    >>> for sctype in [np.int32, np.double, np.complex, np.string_, np.ndarray]:
+    >>> for sctype in [np.int32, np.double, np.complex_, np.string_, np.ndarray]:
     ...     print(np.sctype2char(sctype))
     l # may vary
     d

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -296,7 +296,7 @@ def test_array_astype():
 )
 def test_array_astype_warning(t):
     # test ComplexWarning when casting from complex to float or int
-    a = np.array(10, dtype=np.complex)
+    a = np.array(10, dtype=np.complex_)
     assert_warns(np.ComplexWarning, a.astype, t)
 
 def test_copyto_fromscalar():

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -25,7 +25,7 @@ def assert_dtype_not_equal(a, b):
 
 class TestBuiltin(object):
     @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
-                                   np.unicode])
+                                   np.compat.unicode])
     def test_run(self, t):
         """Only test hash runs at all."""
         dt = np.dtype(t)
@@ -986,7 +986,7 @@ class TestPickling(object):
             assert_equal(x[0], y[0])
 
     @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
-                                   np.unicode, bool])
+                                   np.compat.unicode, bool])
     def test_builtin(self, t):
         self.check_pickling(np.dtype(t))
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -964,7 +964,7 @@ class TestCreation(object):
 
     @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Not Python 2")
     def test_sequence_long(self):
-        assert_equal(np.array([long(4), long(4)]).dtype, np.long)
+        assert_equal(np.array([long(4), long(4)]).dtype, long)
         assert_equal(np.array([long(4), 2**80]).dtype, object)
         assert_equal(np.array([long(4), 2**80, long(4)]).dtype, object)
         assert_equal(np.array([2**80, long(4)]).dtype, object)
@@ -1807,7 +1807,7 @@ class TestMethods(object):
 
         # test unicode sorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode)
+        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode_)
         b = a[::-1].copy()
         for kind in self.sort_kinds:
             msg = "unicode sort, kind=%s" % kind
@@ -2059,7 +2059,7 @@ class TestMethods(object):
 
         # test unicode argsorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode)
+        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode_)
         b = a[::-1]
         r = np.arange(101)
         rr = r[::-1]
@@ -2142,7 +2142,7 @@ class TestMethods(object):
         a = np.array(['aaaaaaaaa' for i in range(100)])
         assert_equal(a.argsort(kind='m'), r)
         # unicode
-        a = np.array(['aaaaaaaaa' for i in range(100)], dtype=np.unicode)
+        a = np.array(['aaaaaaaaa' for i in range(100)], dtype=np.unicode_)
         assert_equal(a.argsort(kind='m'), r)
 
     def test_sort_unicode_kind(self):
@@ -2271,7 +2271,7 @@ class TestMethods(object):
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100197_1',
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100198_1',
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100199_1'],
-                     dtype=np.unicode)
+                     dtype=np.unicode_)
         ind = np.arange(len(a))
         assert_equal([a.searchsorted(v, 'left') for v in a], ind)
         assert_equal([a.searchsorted(v, 'right') for v in a], ind + 1)
@@ -7930,20 +7930,20 @@ class TestBytestringArrayNonzero(object):
 class TestUnicodeArrayNonzero(object):
 
     def test_empty_ustring_array_is_falsey(self):
-        assert_(not np.array([''], dtype=np.unicode))
+        assert_(not np.array([''], dtype=np.unicode_))
 
     def test_whitespace_ustring_array_is_falsey(self):
-        a = np.array(['eggs'], dtype=np.unicode)
+        a = np.array(['eggs'], dtype=np.unicode_)
         a[0] = '  \0\0'
         assert_(not a)
 
     def test_all_null_ustring_array_is_falsey(self):
-        a = np.array(['eggs'], dtype=np.unicode)
+        a = np.array(['eggs'], dtype=np.unicode_)
         a[0] = '\0\0\0\0'
         assert_(not a)
 
     def test_null_inside_ustring_array_is_truthy(self):
-        a = np.array(['eggs'], dtype=np.unicode)
+        a = np.array(['eggs'], dtype=np.unicode_)
         a[0] = ' \0 \0'
         assert_(a)
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2104,7 +2104,7 @@ def test_iter_buffering_string():
     assert_equal(i[0], b'abc')
     assert_equal(i[0].dtype, np.dtype('S6'))
 
-    a = np.array(['abc', 'a', 'abcd'], dtype=np.unicode)
+    a = np.array(['abc', 'a', 'abcd'], dtype=np.unicode_)
     assert_equal(a.dtype, np.dtype('U4'))
     assert_raises(TypeError, nditer, a, ['buffered'], ['readonly'],
                     op_dtypes='U2')

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2953,7 +2953,7 @@ class TestIndices(object):
         assert_array_equal(x, np.array([[0], [1], [2], [3]]))
         assert_array_equal(y, np.array([[0, 1, 2]]))
 
-    @pytest.mark.parametrize("dtype", [np.int, np.float32, np.float64])
+    @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
     @pytest.mark.parametrize("dims", [(), (0,), (4, 3)])
     def test_return_type(self, dtype, dims):
         inds = np.indices(dims, dtype=dtype)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1511,7 +1511,7 @@ class TestRegression(object):
             min //= -1
 
         with np.errstate(divide="ignore"):
-            for t in (np.int8, np.int16, np.int32, np.int64, int, np.long):
+            for t in (np.int8, np.int16, np.int32, np.int64, int, np.compat.long):
                 test_type(t)
 
     def test_buffer_hashlib(self):
@@ -2112,7 +2112,7 @@ class TestRegression(object):
         # Ticket #1578, the mismatch only showed up when running
         # python-debug for python versions >= 2.7, and then as
         # a core dump and error message.
-        a = np.array(['abc'], dtype=np.unicode)[0]
+        a = np.array(['abc'], dtype=np.unicode_)[0]
         del a
 
     def test_refcount_error_in_clip(self):

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -68,8 +68,7 @@ class TestCharacter(object):
     def test_char_repeat(self):
         np_s = np.string_('abc')
         np_u = np.unicode_('abc')
-        np_i = np.int(5)
         res_s = b'abc' * 5
         res_u = u'abc' * 5
-        assert_(np_s * np_i == res_s)
-        assert_(np_u * np_i == res_u)
+        assert_(np_s * 5 == res_s)
+        assert_(np_u * 5 == res_u)

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -980,7 +980,7 @@ class TestUfunc(object):
         assert_array_equal(out, mm_row_col_vec.squeeze())
 
     def test_matrix_multiply(self):
-        self.compare_matrix_multiply_results(np.long)
+        self.compare_matrix_multiply_results(np.int64)
         self.compare_matrix_multiply_results(np.double)
 
     def test_matrix_multiply_umath_empty(self):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -792,7 +792,7 @@ class TestAVXFloat32Transcendental(object):
     def test_sincos_float32(self):
         np.random.seed(42)
         N = 1000000
-        M = np.int(N/20)
+        M = np.int_(N/20)
         index = np.random.randint(low=0, high=N, size=M)
         x_f32 = np.float32(np.random.uniform(low=-100.,high=100.,size=N))
         # test coverage for elements > 117435.992f for which glibc is used

--- a/numpy/core/tests/test_umath_accuracy.py
+++ b/numpy/core/tests/test_umath_accuracy.py
@@ -38,7 +38,7 @@ class TestAccuracy(object):
                 with open(filepath) as fid:
                     file_without_comments = (r for r in fid if not r[0] in ('$', '#'))
                 data = np.genfromtxt(file_without_comments,
-                                     dtype=('|S39','|S39','|S39',np.int),
+                                     dtype=('|S39','|S39','|S39',int),
                                      names=('type','input','output','ulperr'),
                                      delimiter=',',
                                      skip_header=1)

--- a/numpy/doc/basics.py
+++ b/numpy/doc/basics.py
@@ -18,7 +18,7 @@ The primitive types supported are tied closely to those in C:
       - C type
       - Description
 
-    * - `np.bool`
+    * - `np.bool_`
       - ``bool``
       - Boolean (True or False) stored as a byte
 
@@ -283,7 +283,7 @@ NumPy provides `numpy.iinfo` and `numpy.finfo` to verify the
 minimum or maximum values of NumPy integer and floating point values
 respectively ::
 
-    >>> np.iinfo(np.int) # Bounds of the default integer on this system.
+    >>> np.iinfo(int) # Bounds of the default integer on this system.
     iinfo(min=-9223372036854775808, max=9223372036854775807, dtype=int64)
     >>> np.iinfo(np.int32) # Bounds of a 32-bit integer
     iinfo(min=-2147483648, max=2147483647, dtype=int32)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1529,9 +1529,9 @@ def fromregex(file, regexp, dtype, encoding=None):
             dtype = np.dtype(dtype)
 
         content = file.read()
-        if isinstance(content, bytes) and isinstance(regexp, np.unicode):
+        if isinstance(content, bytes) and isinstance(regexp, np.compat.unicode):
             regexp = asbytes(regexp)
-        elif isinstance(content, np.unicode) and isinstance(regexp, bytes):
+        elif isinstance(content, np.compat.unicode) and isinstance(regexp, bytes):
             regexp = asstr(regexp)
 
         if not hasattr(regexp, 'match'):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -518,7 +518,7 @@ class TestSaveTxt(object):
 
     def test_unicode(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode)
+        a = np.array([utf8], dtype=np.unicode_)
         with tempdir() as tmpdir:
             # set encoding as on windows it may not be unicode even on py3
             np.savetxt(os.path.join(tmpdir, 'test.csv'), a, fmt=['%s'],
@@ -526,7 +526,7 @@ class TestSaveTxt(object):
 
     def test_unicode_roundtrip(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode)
+        a = np.array([utf8], dtype=np.unicode_)
         # our gz wrapper support encoding
         suffixes = ['', '.gz']
         # stdlib 2 versions do not support encoding
@@ -540,12 +540,12 @@ class TestSaveTxt(object):
                 np.savetxt(os.path.join(tmpdir, 'test.csv' + suffix), a,
                            fmt=['%s'], encoding='UTF-16-LE')
                 b = np.loadtxt(os.path.join(tmpdir, 'test.csv' + suffix),
-                               encoding='UTF-16-LE', dtype=np.unicode)
+                               encoding='UTF-16-LE', dtype=np.unicode_)
                 assert_array_equal(a, b)
 
     def test_unicode_bytestream(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode)
+        a = np.array([utf8], dtype=np.unicode_)
         s = BytesIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
@@ -553,7 +553,7 @@ class TestSaveTxt(object):
 
     def test_unicode_stringstream(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode)
+        a = np.array([utf8], dtype=np.unicode_)
         s = StringIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
@@ -632,12 +632,12 @@ class LoadTxtBase(object):
         with temppath() as path:
             with open(path, "wb") as f:
                 f.write(nonascii.encode("UTF-16"))
-            x = self.loadfunc(path, encoding="UTF-16", dtype=np.unicode)
+            x = self.loadfunc(path, encoding="UTF-16", dtype=np.unicode_)
             assert_array_equal(x, nonascii)
 
     def test_binary_decode(self):
         utf16 = b'\xff\xfeh\x04 \x00i\x04 \x00j\x04'
-        v = self.loadfunc(BytesIO(utf16), dtype=np.unicode, encoding='UTF-16')
+        v = self.loadfunc(BytesIO(utf16), dtype=np.unicode_, encoding='UTF-16')
         assert_array_equal(v, np.array(utf16.decode('UTF-16').split()))
 
     def test_converters_decode(self):
@@ -645,7 +645,7 @@ class LoadTxtBase(object):
         c = TextIO()
         c.write(b'\xcf\x96')
         c.seek(0)
-        x = self.loadfunc(c, dtype=np.unicode,
+        x = self.loadfunc(c, dtype=np.unicode_,
                           converters={0: lambda x: x.decode('UTF-8')})
         a = np.array([b'\xcf\x96'.decode('UTF-8')])
         assert_array_equal(x, a)
@@ -656,7 +656,7 @@ class LoadTxtBase(object):
         with temppath() as path:
             with io.open(path, 'wt', encoding='UTF-8') as f:
                 f.write(utf8)
-            x = self.loadfunc(path, dtype=np.unicode,
+            x = self.loadfunc(path, dtype=np.unicode_,
                               converters={0: lambda x: x + 't'},
                               encoding='UTF-8')
             a = np.array([utf8 + 't'])
@@ -1104,7 +1104,7 @@ class TestLoadTxt(LoadTxtBase):
             with open(path, "wb") as f:
                 f.write(butf8)
             with open(path, "rb") as f:
-                x = np.loadtxt(f, encoding="UTF-8", dtype=np.unicode)
+                x = np.loadtxt(f, encoding="UTF-8", dtype=np.unicode_)
             assert_array_equal(x, sutf8)
             # test broken latin1 conversion people now rely on
             with open(path, "rb") as f:
@@ -1587,7 +1587,7 @@ M   33  21.99
             with open(path, 'wb') as f:
                 f.write(b'skip,skip,2001-01-01' + utf8 + b',1.0,skip')
             test = np.genfromtxt(path, delimiter=",", names=None, dtype=float,
-                                 usecols=(2, 3), converters={2: np.unicode},
+                                 usecols=(2, 3), converters={2: np.compat.unicode},
                                  encoding='UTF-8')
         control = np.array([('2001-01-01' + utf8.decode('UTF-8'), 1.)],
                            dtype=[('', '|U11'), ('', float)])
@@ -2126,7 +2126,7 @@ M   33  21.99
             ctl = np.array([
                      ["test1", "testNonethe" + utf8.decode("UTF-8"), "test3"],
                      ["test1", "testNonethe" + utf8.decode("UTF-8"), "test3"]],
-                     dtype=np.unicode)
+                     dtype=np.unicode_)
             assert_array_equal(test, ctl)
 
             # test a mixed dtype
@@ -2169,7 +2169,7 @@ M   33  21.99
                      ["norm1", "norm2", "norm3"],
                      ["norm1", latin1, "norm3"],
                      ["test1", "testNonethe" + utf8, "test3"]],
-                     dtype=np.unicode)
+                     dtype=np.unicode_)
             assert_array_equal(test, ctl)
 
     def test_recfromtxt(self):

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -21,7 +21,7 @@ class TestUfunclike(object):
         assert_equal(res, tgt)
         assert_equal(out, tgt)
 
-        a = a.astype(np.complex)
+        a = a.astype(np.complex_)
         with assert_raises(TypeError):
             ufl.isposinf(a)
 
@@ -36,7 +36,7 @@ class TestUfunclike(object):
         assert_equal(res, tgt)
         assert_equal(out, tgt)
 
-        a = a.astype(np.complex)
+        a = a.astype(np.complex_)
         with assert_raises(TypeError):
             ufl.isneginf(a)
 

--- a/numpy/random/_bounded_integers.pyx.in
+++ b/numpy/random/_bounded_integers.pyx.in
@@ -191,7 +191,7 @@ cdef object _rand_{{nptype}}_broadcast(object low, object high, object size,
         highm1_arr = <np.ndarray>np.PyArray_FROM_OTF(high_m1, np.{{npctype}}, np.NPY_ALIGNED | np.NPY_FORCECAST)
     else:
         # If input is object or a floating type
-        highm1_arr = <np.ndarray>np.empty_like(high_arr, dtype=np.{{nptype}})
+        highm1_arr = <np.ndarray>np.empty_like(high_arr, dtype=np.{{otype}})
         highm1_data = <{{nptype}}_t *>np.PyArray_DATA(highm1_arr)
         cnt = np.PyArray_SIZE(high_arr)
         flat = high_arr.flat
@@ -213,10 +213,10 @@ cdef object _rand_{{nptype}}_broadcast(object low, object high, object size,
     low_arr = <np.ndarray>np.PyArray_FROM_OTF(low, np.{{npctype}}, np.NPY_ALIGNED | np.NPY_FORCECAST)
 
     if size is not None:
-        out_arr = <np.ndarray>np.empty(size, np.{{nptype}})
+        out_arr = <np.ndarray>np.empty(size, np.{{otype}})
     else:
         it = np.PyArray_MultiIterNew2(low_arr, high_arr)
-        out_arr = <np.ndarray>np.empty(it.shape, np.{{nptype}})
+        out_arr = <np.ndarray>np.empty(it.shape, np.{{otype}})
 
     it = np.PyArray_MultiIterNew3(low_arr, high_arr, out_arr)
     out_data = <uint64_t *>np.PyArray_DATA(out_arr)
@@ -258,12 +258,12 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
     """
     _rand_{{nptype}}(low, high, size, use_masked, *state, lock)
 
-    Return random np.{{nptype}} integers from `low` (inclusive) to `high` (exclusive).
+    Return random `np.{{otype}}` integers from `low` (inclusive) to `high` (exclusive).
 
     Return random integers from the "discrete uniform" distribution in the
     interval [`low`, `high`).  If `high` is None (the default),
     then results are from [0, `low`). On entry the arguments are presumed
-    to have been validated for size and order for the np.{{nptype}} type.
+    to have been validated for size and order for the `np.{{otype}}` type.
 
     Parameters
     ----------
@@ -289,7 +289,7 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
 
     Returns
     -------
-    out : python scalar or ndarray of np.{{nptype}}
+    out : python scalar or ndarray of np.{{otype}}
           `size`-shaped array of random integers from the appropriate
           distribution, or a single such random int if `size` not provided.
 
@@ -308,7 +308,7 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
 
     if size is not None:
         if (np.prod(size) == 0):
-            return np.empty(size, dtype=np.{{nptype}})
+            return np.empty(size, dtype=np.{{otype}})
 
     low_arr = <np.ndarray>np.array(low, copy=False)
     high_arr = <np.ndarray>np.array(high, copy=False)
@@ -337,7 +337,7 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
                 random_bounded_{{utype}}_fill(state, off, rng, 1, use_masked, &out_val)
             return np.{{otype}}(<{{nptype}}_t>out_val)
         else:
-            out_arr = <np.ndarray>np.empty(size, np.{{nptype}})
+            out_arr = <np.ndarray>np.empty(size, np.{{otype}})
             cnt = np.PyArray_SIZE(out_arr)
             out_data = <{{utype}}_t *>np.PyArray_DATA(out_arr)
             with lock, nogil:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -502,7 +502,7 @@ cdef class Generator:
             Desired dtype of the result. All dtypes are determined by their
             name, i.e., 'int64', 'int', etc, so byteorder is not available
             and a specific precision may have different C types depending
-            on the platform. The default value is 'np.int'.
+            on the platform. The default value is `np.int_`.
         endpoint : bool, optional
             If true, sample from the interval [low, high] instead of the
             default [low, high)
@@ -595,7 +595,7 @@ cdef class Generator:
         elif key == 'bool':
             ret = _rand_bool(low, high, size, _masked, endpoint, &self._bitgen, self.lock)
 
-        if size is None and dtype in (np.bool, np.int, np.long):
+        if size is None and dtype in (bool, int, np.compat.long):
             if np.array(ret).shape == ():
                 return dtype(ret)
         return ret

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -555,7 +555,7 @@ cdef class RandomState:
         tomaxint(size=None)
 
         Return a sample of uniformly distributed random integers in the interval
-        [0, ``np.iinfo(np.int).max``]. The np.int type translates to the C long
+        [0, ``np.iinfo(np.int_).max``]. The `np.int_` type translates to the C long
         integer type and its precision is platform dependent.
 
         Parameters
@@ -584,7 +584,7 @@ cdef class RandomState:
                 [ 739731006, 1947757578]],
                [[1871712945,  752307660],
                 [1601631370, 1479324245]]])
-        >>> rs.tomaxint((2,2,2)) < np.iinfo(np.int).max
+        >>> rs.tomaxint((2,2,2)) < np.iinfo(np.int_).max
         array([[[ True,  True],
                 [ True,  True]],
                [[ True,  True],
@@ -636,7 +636,7 @@ cdef class RandomState:
             Desired dtype of the result. All dtypes are determined by their
             name, i.e., 'int64', 'int', etc, so byteorder is not available
             and a specific precision may have different C types depending
-            on the platform. The default value is 'np.int'.
+            on the platform. The default value is `np.int_`.
 
             .. versionadded:: 1.11.0
 
@@ -724,7 +724,7 @@ cdef class RandomState:
         elif key == 'bool':
             ret = _rand_bool(low, high, size, _masked, _endpoint, &self._bitgen, self.lock)
 
-        if size is None and dtype in (np.bool, np.int, np.long):
+        if size is None and dtype in (bool, int, np.compat.long):
             if np.array(ret).shape == ():
                 return dtype(ret)
         return ret
@@ -1165,11 +1165,11 @@ cdef class RandomState:
         """
         random_integers(low, high=None, size=None)
 
-        Random integers of type np.int between `low` and `high`, inclusive.
+        Random integers of type `np.int_` between `low` and `high`, inclusive.
 
-        Return random integers of type np.int from the "discrete uniform"
+        Return random integers of type `np.int_` from the "discrete uniform"
         distribution in the closed interval [`low`, `high`].  If `high` is
-        None (the default), then results are from [1, `low`]. The np.int
+        None (the default), then results are from [1, `low`]. The `np.int_`
         type translates to the C long integer type and its precision
         is platform dependent.
 

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -494,9 +494,8 @@ class TestIntegers(object):
 
     def test_repeatability_broadcasting(self, endpoint):
         for dt in self.itype:
-            lbnd = 0 if dt in (np.bool, bool, np.bool_) else np.iinfo(dt).min
-            ubnd = 2 if dt in (
-                np.bool, bool, np.bool_) else np.iinfo(dt).max + 1
+            lbnd = 0 if dt in (bool, np.bool_) else np.iinfo(dt).min
+            ubnd = 2 if dt in (bool, np.bool_) else np.iinfo(dt).max + 1
             ubnd = ubnd - 1 if endpoint else ubnd
 
             # view as little endian for hash
@@ -535,8 +534,8 @@ class TestIntegers(object):
                 assert_raises(ValueError, random.integers, low_a, high_a,
                               endpoint=endpoint, dtype=dtype)
 
-                low_o = np.array([[low]*10], dtype=np.object)
-                high_o = np.array([high] * 10, dtype=np.object)
+                low_o = np.array([[low]*10], dtype=object)
+                high_o = np.array([high] * 10, dtype=object)
                 assert_raises(ValueError, random.integers, low_o, high,
                               endpoint=endpoint, dtype=dtype)
                 assert_raises(ValueError, random.integers, low, high_o,
@@ -578,7 +577,7 @@ class TestIntegers(object):
             sample = self.rfunc(lbnd, ubnd, endpoint=endpoint, dtype=dt)
             assert_equal(sample.dtype, dt)
 
-        for dt in (bool, int, np.long):
+        for dt in (bool, int, np.compat.long):
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
             ubnd = ubnd - 1 if endpoint else ubnd
@@ -2220,7 +2219,7 @@ class TestSingleEltArrayInput(object):
             assert_equal(out.shape, self.tgtShape)
 
     def test_integers(self, endpoint):
-        itype = [np.bool, np.int8, np.uint8, np.int16, np.uint16,
+        itype = [np.bool_, np.int8, np.uint8, np.int16, np.uint16,
                  np.int32, np.uint32, np.int64, np.uint64]
         func = random.integers
         high = np.array([1])

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -269,7 +269,7 @@ class TestRandint(object):
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
             assert_equal(sample.dtype, np.dtype(dt))
 
-        for dt in (bool, int, np.long):
+        for dt in (bool, int, np.compat.long):
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -229,7 +229,7 @@ class TestSetState(object):
         new_state = ('Unknown', ) + state[1:]
         assert_raises(ValueError, self.random_state.set_state, new_state)
         assert_raises(TypeError, self.random_state.set_state,
-                      np.array(new_state, dtype=np.object))
+                      np.array(new_state, dtype=object))
         state = self.random_state.get_state(legacy=False)
         del state['bit_generator']
         assert_raises(ValueError, self.random_state.set_state, state)
@@ -382,7 +382,7 @@ class TestRandint(object):
             sample = self.rfunc(lbnd, ubnd, dtype=dt)
             assert_equal(sample.dtype, np.dtype(dt))
 
-        for dt in (bool, int, np.long):
+        for dt in (bool, int, np.compat.long):
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
 
@@ -455,7 +455,7 @@ class TestRandomDist(object):
         random.seed(self.seed)
         rs = random.RandomState(self.seed)
         actual = rs.tomaxint(size=(3, 2))
-        if np.iinfo(np.int).max == 2147483647:
+        if np.iinfo(int).max == 2147483647:
             desired = np.array([[1328851649,  731237375],
                                 [1270502067,  320041495],
                                 [1908433478,  499156889]], dtype=np.int64)

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_equal, assert_, assert_array_equal
 from numpy.random import (Generator, MT19937, PCG64, Philox, SFC64)
 
 @pytest.fixture(scope='module',
-                params=(np.bool, np.int8, np.int16, np.int32, np.int64,
+                params=(np.bool_, np.int8, np.int16, np.int32, np.int64,
                         np.uint8, np.uint16, np.uint32, np.uint64))
 def dtype(request):
     return request.param
@@ -655,7 +655,7 @@ class RNG(object):
             rg.standard_gamma(1.0, out=existing[::3])
 
     def test_integers_broadcast(self, dtype):
-        if dtype == np.bool:
+        if dtype == np.bool_:
             upper = 2
             lower = 0
         else:
@@ -672,7 +672,7 @@ class RNG(object):
         assert_equal(a, c)
         self._reset_state()
         d = self.rg.integers(np.array(
-            [lower] * 10), np.array([upper], dtype=np.object), size=10,
+            [lower] * 10), np.array([upper], dtype=object), size=10,
             dtype=dtype)
         assert_equal(a, d)
         self._reset_state()
@@ -701,7 +701,7 @@ class RNG(object):
         assert out.shape == (1,)
 
     def test_integers_broadcast_errors(self, dtype):
-        if dtype == np.bool:
+        if dtype == np.bool_:
             upper = 2
             lower = 0
         else:


### PR DESCRIPTION
Relates to gh-6103

Proof that this is exhaustive as of writing can be found in the CI of gh-14882, hopefully.

Even if it's not exhaustive, it's still good to merge something that gets us closer.

Split from gh-14882 so that cleanup can go in quickly, assuming a long discussion about deprecation.