### PR TITLE
TST: Add s390x to the TravisCI test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,13 +82,19 @@ matrix:
        - BLAS=None
        - LAPACK=None
        - ATLAS=None
-    - os: linux-ppc64le
-      python: 3.6
+    - python: 3.6
+      os: linux
+      arch: ppc64le
       env:
-       # for matrix annotation only
-       - PPC64_LE=1
-       # use POWER8 OpenBLAS build, not system ATLAS
+       # use ppc64le OpenBLAS build, not system ATLAS
        - ATLAS=None
+    - python: 3.6
+      os: linux
+      arch: s390x
+      env:
+       # use s390x OpenBLAS build, not system ATLAS
+       - ATLAS=None
+
 
 before_install:
   - ./tools/travis-before-install.sh


### PR DESCRIPTION
This gives us a big endian architecture for testing.

The entry for ppc64le is also updated from the development version. IBM provides arm64 as well, but that seems to hang at the moment.

Closes #14904.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
