### PR TITLE
DOC: Note FFT type promotion

### DIFF
--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -121,9 +121,9 @@ argument and the default normalization by :math:`1/n`.
 Type Promotion
 --------------
 
-`numpy.fft` is inconsistent with other NumPy functions as it promotes
-`float32` and `complex64` arrays to `float64` and `complex128` arrays.
-For an FFT implementation that does not promote input arrays, see `scipy.fftpack`.
+`numpy.fft` promotes ``float32`` and ``complex64`` arrays to ``float64`` and
+``complex128`` arrays respectively. For an FFT implementation that does not
+promote input arrays, see `scipy.fftpack`.
 
 Normalization
 -------------

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -118,8 +118,16 @@ The inverse DFT is defined as
 It differs from the forward transform by the sign of the exponential
 argument and the default normalization by :math:`1/n`.
 
+Type Promotion
+--------------
+
+`numpy.fft` is inconsistent with other NumPy functions as it promotes
+`float32` and `complex64` arrays to `float64` and `complex128` arrays.
+For an FFT implementation that does not promote input arrays, see `scipy.fftpack`.
+
 Normalization
 -------------
+
 The default normalization has the direct transforms unscaled and the inverse
 transforms are scaled by :math:`1/n`. It is possible to obtain unitary
 transforms by setting the keyword argument ``norm`` to ``"ortho"`` (default is


### PR DESCRIPTION
The NumPy FFT implementation will promote `float32` types to `float64` types. This may not be desired for some applications, but the SciPy implementation supports more data types.

Closes #14892

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
