### PR TITLE
BUILD: remove SSE2 flag from numpy.random builds

### DIFF
--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -47,11 +47,6 @@ def configuration(parent_package='', top_path=None):
     elif not is_msvc:
         # Some bit generators require c99
         EXTRA_COMPILE_ARGS += ['-std=c99']
-        INTEL_LIKE = any(arch in platform.machine() 
-                         for arch in ('x86', 'i686', 'i386', 'amd64'))
-        if INTEL_LIKE:
-            # Assumes GCC or GCC-like compiler
-            EXTRA_COMPILE_ARGS += ['-msse2']
 
     # Use legacy integer variable sizes
     LEGACY_DEFS = [('NP_RANDOM_LEGACY', '1')]


### PR DESCRIPTION
Backport of #14878. 

fixes gh-14861

We used to have code in the BitGenerators that benefitted from compilation with SSE2. Those BitGenerators were removed, and it turns out setting this flag breaks cross-compilation builds
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
