### PR TITLE
BUG: pickle the content of a scalar containing objects, not the address

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1894,7 +1894,8 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     if (PyDataType_FLAGCHK(typecode, NPY_LIST_PICKLE)) {
         if (!PySequence_Check(obj)) {
             PyErr_SetString(PyExc_TypeError,
-                            "scalar pickle not returning sequence");
+                            "found non-sequence while unpicking scalar with "
+                            "NPY_LIST_PICKLE set");
             return NULL;
         }
         dptr = &obj;

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1894,7 +1894,7 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     if (PyDataType_FLAGCHK(typecode, NPY_LIST_PICKLE)) {
         if (!PySequence_Check(obj)) {
             PyErr_SetString(PyExc_TypeError,
-                            "found non-sequence while unpicking scalar with "
+                            "found non-sequence while unpickling scalar with "
                             "NPY_LIST_PICKLE set");
             return NULL;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1891,8 +1891,16 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                 &PyArrayDescr_Type, &typecode, &obj)) {
         return NULL;
     }
+    if (PyDataType_FLAGCHK(typecode, NPY_LIST_PICKLE)) {
+        if (!PySequence_Check(obj)) {
+            PyErr_SetString(PyExc_TypeError,
+                            "scalar pickle not returning sequence");
+            return NULL;
+        }
+        dptr = &obj;
+    }
 
-    if (PyDataType_FLAGCHK(typecode, NPY_ITEM_IS_POINTER)) {
+    else if (PyDataType_FLAGCHK(typecode, NPY_ITEM_IS_POINTER)) {
         if (obj == NULL) {
             obj = Py_None;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1909,7 +1909,7 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         if (val == NULL) {
             return NULL;
         }
-        PyObject *tup = Py_BuildValue("NO", obj, val);
+        PyObject *tup = Py_BuildValue("NN", obj, val);
         if (tup == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1884,8 +1884,8 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
     PyTuple_SET_ITEM(ret, 0, obj);
     obj = PyObject_GetAttrString((PyObject *)self, "dtype");
     if (PyArray_IsScalar(self, Object)) {
-        PyObject* val = ((PyObjectScalarObject *)self)->obval;
-        PyObject * tup = Py_BuildValue("NO", obj, val);
+        PyObject *val = ((PyObjectScalarObject *)self)->obval;
+        PyObject *tup = Py_BuildValue("NO", obj, val);
         if (tup == NULL) {
             return NULL;
         }
@@ -1899,13 +1899,14 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         }
         PyArrayIterObject *it = (PyArrayIterObject *)PyArray_IterNew(arr);
         if (it == NULL) {
+            Py_DECREF(arr);
             return NULL;
         }
-        /* get arr[0] */
-        PyObject *val = ((PyArray_Descr *)obj)->f->getitem(it->dataptr, arr);
+        /* arr[()] */
+        PyObject *val = PyArray_GETITEM((PyArrayObject *)arr, it->dataptr);
         Py_DECREF(it);
         Py_DECREF(arr);
-        PyObject * tup = Py_BuildValue("NO", obj, val);
+        PyObject *tup = Py_BuildValue("NO", obj, val);
         if (tup == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1906,6 +1906,9 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         PyObject *val = PyArray_GETITEM((PyArrayObject *)arr, it->dataptr);
         Py_DECREF(it);
         Py_DECREF(arr);
+        if (val == NULL) {
+            return NULL;
+        }
         PyObject *tup = Py_BuildValue("NO", obj, val);
         if (tup == NULL) {
             return NULL;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1884,8 +1884,12 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
     PyTuple_SET_ITEM(ret, 0, obj);
     obj = PyObject_GetAttrString((PyObject *)self, "dtype");
     if (PyArray_IsScalar(self, Object)) {
-        mod = ((PyObjectScalarObject *)self)->obval;
-        PyTuple_SET_ITEM(ret, 1, Py_BuildValue("NO", obj, mod));
+        PyObject* val = ((PyObjectScalarObject *)self)->obval;
+        PyObject * tup = Py_BuildValue("NO", obj, val);
+        if (tup == NULL) {
+            return NULL;
+        }
+        PyTuple_SET_ITEM(ret, 1, tup);
     }
     else if (obj && PyDataType_FLAGCHK((PyArray_Descr *)obj, NPY_LIST_PICKLE)) {
         /* a structured dtype with an object in a field */
@@ -1897,11 +1901,15 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         if (it == NULL) {
             return NULL;
         }
-        mod = ((PyArray_Descr *)obj)->f->getitem(it->dataptr, arr);
+        /* get arr[0] */
+        PyObject *val = ((PyArray_Descr *)obj)->f->getitem(it->dataptr, arr);
         Py_DECREF(it);
         Py_DECREF(arr);
-        /* XXX N does not incref, O does. What do we want? */
-        PyTuple_SET_ITEM(ret, 1, Py_BuildValue("NO", obj, mod));
+        PyObject * tup = Py_BuildValue("NO", obj, val);
+        if (tup == NULL) {
+            return NULL;
+        }
+        PyTuple_SET_ITEM(ret, 1, tup);
     }
     else {
 #ifndef Py_UNICODE_WIDE

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1893,18 +1893,12 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
     }
     else if (obj && PyDataType_FLAGCHK((PyArray_Descr *)obj, NPY_LIST_PICKLE)) {
         /* a structured dtype with an object in a field */
-        PyObject *arr = PyArray_FromScalar(self, NULL);
+        PyArrayObject *arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
         if (arr == NULL) {
             return NULL;
         }
-        PyArrayIterObject *it = (PyArrayIterObject *)PyArray_IterNew(arr);
-        if (it == NULL) {
-            Py_DECREF(arr);
-            return NULL;
-        }
         /* arr.item() */
-        PyObject *val = PyArray_GETITEM((PyArrayObject *)arr, it->dataptr);
-        Py_DECREF(it);
+        PyObject *val = PyArray_GETITEM(arr, PyArray_DATA(arr));
         Py_DECREF(arr);
         if (val == NULL) {
             return NULL;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1887,6 +1887,22 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         mod = ((PyObjectScalarObject *)self)->obval;
         PyTuple_SET_ITEM(ret, 1, Py_BuildValue("NO", obj, mod));
     }
+    else if (obj && PyDataType_FLAGCHK((PyArray_Descr *)obj, NPY_LIST_PICKLE)) {
+        /* a structured dtype with an object in a field */
+        PyObject *arr = PyArray_FromScalar(self, NULL);
+        if (arr == NULL) {
+            return NULL;
+        }
+        PyArrayIterObject *it = (PyArrayIterObject *)PyArray_IterNew(arr);
+        if (it == NULL) {
+            return NULL;
+        }
+        mod = ((PyArray_Descr *)obj)->f->getitem(it->dataptr, arr);
+        Py_DECREF(it);
+        Py_DECREF(arr);
+        /* XXX N does not incref, O does. What do we want? */
+        PyTuple_SET_ITEM(ret, 1, Py_BuildValue("NO", obj, mod));
+    }
     else {
 #ifndef Py_UNICODE_WIDE
         /*

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1902,7 +1902,7 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
             Py_DECREF(arr);
             return NULL;
         }
-        /* arr[()] */
+        /* arr.item() */
         PyObject *val = PyArray_GETITEM((PyArrayObject *)arr, it->dataptr);
         Py_DECREF(it);
         Py_DECREF(arr);

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -423,14 +423,12 @@ class TestRecord(object):
         data = (bytearray(b'eman'),)
         a['obj'] = data
         a['int'] = 42
-        state = a[0].__reduce__()
-        # If the data is bytes, it will pickle the address of the content
-        # which cannot be saved/restored
-        assert not isinstance(state[1][1], bytes)
-        b = state[0](*state[1])
-        assert b[0] == (bytearray(b'eman'), 42)
-        # got a fresh version, not the original pointers rebuilt
-        assert b[0][0] is not data
+        ctor, args = a[0].__reduce__()
+        # check the contructor is what we expect before interpreting the arguments
+        assert ctor is np.core.multiarray.scalar
+        dtype, obj = args
+        # make sure we did not pickle the address
+        assert not isinstance(obj, bytes)
 
     def test_objview_record(self):
         # https://github.com/numpy/numpy/issues/2599

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -418,18 +418,19 @@ class TestRecord(object):
 
     def test_pickle_void(self):
         # issue gh-13593
-        dt = np.dtype([('obj', 'O')])
+        dt = np.dtype([('obj', 'O'), ('int', 'i')])
         a = np.empty(1, dtype=dt)
         data = (bytearray(b'eman'),)
         a['obj'] = data
+        a['int'] = 42
         state = a[0].__reduce__()
         # If the data is bytes, it will pickle the address of the content
         # which cannot be saved/restored
         assert not isinstance(state[1][1], bytes)
         b = state[0](*state[1])
-        assert b[0] == (bytearray(b'eman'),)
+        assert b[0] == (bytearray(b'eman'), 42)
         # got a fresh version, not the original pointers rebuilt
-        assert b[0] is not data
+        assert b[0][0] is not data
 
     def test_objview_record(self):
         # https://github.com/numpy/numpy/issues/2599

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -430,6 +430,8 @@ class TestRecord(object):
         # make sure we did not pickle the address
         assert not isinstance(obj, bytes)
 
+        assert_raises(TypeError, ctor, dtype, 13)
+
     def test_objview_record(self):
         # https://github.com/numpy/numpy/issues/2599
         dt = np.dtype([('foo', 'i8'), ('bar', 'O')])


### PR DESCRIPTION
Fixes gh-13593

Scalars with a void dtype that contains objects were not pickled properly. Add a test and fix by checking the `NPY_LIST_PICKLE` flag of the dtype.