### PR TITLE
MAINT,API: ignore and NULL fasttake/fastputmask ArrFuncs slots

### DIFF
--- a/doc/release/upcoming_changes/14942.compatibility.rst
+++ b/doc/release/upcoming_changes/14942.compatibility.rst
@@ -1,6 +1,6 @@
 Fasttake and fastputmask slots are deprecated and NULL'ed
 ---------------------------------------------------------
-The fasttake and fastputmask slots are now never used internally.
-They will always set to NULL for builtin dtypes.
-No downstream project should be using these, so no compatibility
-issue are expected.
+The fasttake and fastputmask slots are now never used and
+must always be set to NULL. This will result in no change in behaviour.
+However, if a user dtype should set one of these a DeprecationWarning
+will be given.

--- a/doc/release/upcoming_changes/14942.compatibility.rst
+++ b/doc/release/upcoming_changes/14942.compatibility.rst
@@ -1,5 +1,6 @@
-Fasttake slot is deprecated and now NULL'ed
--------------------------------------------
-The fasttake slot for all dtypes is now never used internally
-and always set to NULL. No downstream project should be using
-this, so no compatibility issue is expected.
+Fasttake and fastputmask slots are deprecated and NULL'ed
+---------------------------------------------------------
+The fasttake and fastputmask slots are now never used internally.
+They will always set to NULL for builtin dtypes.
+No downstream project should be using these, so no compatibility
+issue are expected.

--- a/doc/release/upcoming_changes/14942.compatibility.rst
+++ b/doc/release/upcoming_changes/14942.compatibility.rst
@@ -1,0 +1,5 @@
+Fasttake slot is deprecated and now NULL'ed
+-------------------------------------------
+The fasttake slot for all dtypes is now never used internally
+and always set to NULL. No downstream project should be using
+this, so no compatibility issue is expected.

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -453,8 +453,8 @@ PyArrayDescr_Type and PyArray_Descr
            int **cancastscalarkindto;
            int *cancastto;
            PyArray_FastClipFunc *fastclip;
-           PyArray_FastPutmaskFunc *fastputmask;
-           PyArray_FastTakeFunc *fasttake;
+           PyArray_FastPutmaskFunc *fastputmask;  /* deprecated */
+           PyArray_FastTakeFunc *fasttake;  /* deprecated */
            PyArray_ArgFunc *argmin;
        } PyArray_ArrFuncs;
 
@@ -650,6 +650,10 @@ PyArrayDescr_Type and PyArray_Descr
     .. c:member:: void fastputmask( \
             void *in, void *mask, npy_intp n_in, void *values, npy_intp nv)
 
+        .. deprecated:: 1.19
+            Setting this function is deprecated and should always be ``NULL``,
+            if set, it will be ignored.
+
         A function that takes a pointer ``in`` to an array of ``n_in``
         items, a pointer ``mask`` to an array of ``n_in`` boolean
         values, and a pointer ``vals`` to an array of ``nv`` items.
@@ -661,6 +665,10 @@ PyArrayDescr_Type and PyArray_Descr
             void *dest, void *src, npy_intp *indarray, npy_intp nindarray, \
             npy_intp n_outer, npy_intp m_middle, npy_intp nelem, \
             NPY_CLIPMODE clipmode)
+
+        .. deprecated:: 1.19
+            Setting this function is deprecated and should always be ``NULL``,
+            if set, it will be ignored.
 
         A function that takes a pointer ``src`` to a C contiguous,
         behaved segment, interpreted as a 3-dimensional array of shape

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3973,119 +3973,6 @@ static void
 #define OBJECT_fastputmask NULL
 
 
-/*
- *****************************************************************************
- **                                FASTTAKE                                 **
- *****************************************************************************
- */
-
-
-/**begin repeat
- *
- * #name = BOOL,
- *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
- *         LONG, ULONG, LONGLONG, ULONGLONG,
- *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
- *         CFLOAT, CDOUBLE, CLONGDOUBLE,
- *         DATETIME, TIMEDELTA#
- * #type = npy_bool,
- *         npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_double, npy_longdouble,
- *         npy_cfloat, npy_cdouble, npy_clongdouble,
- *         npy_datetime, npy_timedelta#
-*/
-static int
-@name@_fasttake(@type@ *dest, @type@ *src, npy_intp *indarray,
-                    npy_intp nindarray, npy_intp n_outer,
-                    npy_intp m_middle, npy_intp nelem,
-                    NPY_CLIPMODE clipmode)
-{
-    npy_intp i, j, k, tmp;
-    NPY_BEGIN_THREADS_DEF;
-
-    NPY_BEGIN_THREADS;
-
-    switch(clipmode) {
-    case NPY_RAISE:
-        for (i = 0; i < n_outer; i++) {
-            for (j = 0; j < m_middle; j++) {
-                tmp = indarray[j];
-                /*
-                 * We don't know what axis we're operating on,
-                 * so don't report it in case of an error.
-                 */
-                if (check_and_adjust_index(&tmp, nindarray, -1, _save) < 0) {
-                    return 1;
-                }
-                if (NPY_LIKELY(nelem == 1)) {
-                    *dest++ = *(src + tmp);
-                }
-                else {
-                    for (k = 0; k < nelem; k++) {
-                        *dest++ = *(src + tmp*nelem + k);
-                    }
-                }
-            }
-            src += nelem*nindarray;
-        }
-        break;
-    case NPY_WRAP:
-        for (i = 0; i < n_outer; i++) {
-            for (j = 0; j < m_middle; j++) {
-                tmp = indarray[j];
-                if (tmp < 0) {
-                    while (tmp < 0) {
-                        tmp += nindarray;
-                    }
-                }
-                else if (tmp >= nindarray) {
-                    while (tmp >= nindarray) {
-                        tmp -= nindarray;
-                    }
-                }
-                if (NPY_LIKELY(nelem == 1)) {
-                    *dest++ = *(src+tmp);
-                }
-                else {
-                    for (k = 0; k < nelem; k++) {
-                        *dest++ = *(src+tmp*nelem+k);
-                    }
-                }
-            }
-            src += nelem*nindarray;
-        }
-        break;
-    case NPY_CLIP:
-        for (i = 0; i < n_outer; i++) {
-            for (j = 0; j < m_middle; j++) {
-                tmp = indarray[j];
-                if (tmp < 0) {
-                    tmp = 0;
-                }
-                else if (tmp >= nindarray) {
-                    tmp = nindarray - 1;
-                }
-                if (NPY_LIKELY(nelem == 1)) {
-                    *dest++ = *(src + tmp);
-                }
-                else {
-                    for (k = 0; k < nelem; k++) {
-                        *dest++ = *(src + tmp*nelem + k);
-                    }
-                }
-            }
-            src += nelem*nindarray;
-        }
-        break;
-    }
-
-    NPY_END_THREADS;
-    return 0;
-}
-/**end repeat**/
-
-#define OBJECT_fasttake NULL
 
 /*
  *****************************************************************************
@@ -4446,7 +4333,7 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     NULL,
     (PyArray_FastClipFunc*)NULL,
     (PyArray_FastPutmaskFunc*)@from@_fastputmask,
-    (PyArray_FastTakeFunc*)@from@_fasttake,
+    (PyArray_FastTakeFunc*)NULL,
     (PyArray_ArgFunc*)@from@_argmin
 };
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3923,59 +3923,6 @@ static void
 
 /*
  *****************************************************************************
- **                              FASTPUTMASK                                **
- *****************************************************************************
- */
-
-
-/**begin repeat
- *
- * #name = BOOL,
- *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
- *         LONG, ULONG, LONGLONG, ULONGLONG,
- *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
- *         CFLOAT, CDOUBLE, CLONGDOUBLE,
- *         DATETIME, TIMEDELTA#
- * #type = npy_bool, npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_double, npy_longdouble,
- *         npy_cfloat, npy_cdouble, npy_clongdouble,
- *         npy_datetime, npy_timedelta#
-*/
-static void
-@name@_fastputmask(@type@ *in, npy_bool *mask, npy_intp ni, @type@ *vals,
-        npy_intp nv)
-{
-    npy_intp i, j;
-
-    if (nv == 1) {
-        @type@ s_val = *vals;
-        for (i = 0; i < ni; i++) {
-            if (mask[i]) {
-                in[i] = s_val;
-            }
-        }
-    }
-    else {
-        for (i = 0, j = 0; i < ni; i++, j++) {
-            if (j >= nv) {
-                j = 0;
-            }
-            if (mask[i]) {
-                in[i] = vals[j];
-            }
-        }
-    }
-    return;
-}
-/**end repeat**/
-
-#define OBJECT_fastputmask NULL
-
-
-
-/*
- *****************************************************************************
  **                       small correlate                                   **
  *****************************************************************************
  */
@@ -4332,7 +4279,7 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     NULL,
     NULL,
     (PyArray_FastClipFunc*)NULL,
-    (PyArray_FastPutmaskFunc*)@from@_fastputmask,
+    (PyArray_FastPutmaskFunc*)NULL,
     (PyArray_FastTakeFunc*)NULL,
     (PyArray_ArgFunc*)@from@_argmin
 };

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -490,16 +490,78 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
     return NULL;
 }
 
+
+static NPY_GCC_OPT_3 NPY_INLINE void
+npy_fastputmask_impl(
+        char *dest, char *src, const npy_bool *mask_data,
+        npy_intp ni, npy_intp nv, npy_intp chunk)
+{
+    if (nv == 1) {
+        for (npy_intp i = 0; i < ni; i++) {
+            if (mask_data[i]) {
+                memmove(dest, src, chunk);
+            }
+            dest += chunk;
+        }
+    }
+    else {
+        char *tmp_src = src;
+        for (npy_intp i = 0, j = 0; i < ni; i++, j++) {
+            if (NPY_UNLIKELY(j >= nv)) {
+                j = 0;
+                tmp_src = src;
+            }
+            if (mask_data[i]) {
+                memmove(dest, tmp_src, chunk);
+            }
+            dest += chunk;
+            tmp_src += chunk;
+        }
+    }
+}
+
+
+/*
+ * Helper function instantiating npy_fastput_impl in different branches
+ * to allow the compiler to optimize each to the specific itemsize.
+ */
+static NPY_GCC_OPT_3 void
+npy_fastputmask(
+        char *dest, char *src, npy_bool *mask_data,
+        npy_intp ni, npy_intp nv, npy_intp chunk)
+{
+    if (chunk == 1) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+    if (chunk == 2) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+    if (chunk == 4) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+    if (chunk == 8) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+    if (chunk == 16) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+    if (chunk == 32) {
+        return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+    }
+
+    return npy_fastputmask_impl(dest, src, mask_data, ni, nv, chunk);
+}
+
+
 /*NUMPY_API
  * Put values into an array according to a mask.
  */
 NPY_NO_EXPORT PyObject *
 PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
 {
-    PyArray_FastPutmaskFunc *func;
     PyArrayObject *mask, *values;
     PyArray_Descr *dtype;
-    npy_intp i, j, chunk, ni, nv;
+    npy_intp chunk, ni, nv;
     char *src, *dest;
     npy_bool *mask_data;
     int copied = 0;
@@ -564,7 +626,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     dest = PyArray_DATA(self);
 
     if (PyDataType_REFCHK(PyArray_DESCR(self))) {
-        for (i = 0, j = 0; i < ni; i++, j++) {
+        for (npy_intp i = 0, j = 0; i < ni; i++, j++) {
             if (j >= nv) {
                 j = 0;
             }
@@ -581,20 +643,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     else {
         NPY_BEGIN_THREADS_DEF;
         NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(self));
-        func = PyArray_DESCR(self)->f->fastputmask;
-        if (func == NULL) {
-            for (i = 0, j = 0; i < ni; i++, j++) {
-                if (j >= nv) {
-                    j = 0;
-                }
-                if (mask_data[i]) {
-                    memmove(dest + i*chunk, src + j*chunk, chunk);
-                }
-            }
-        }
-        else {
-            func(dest, mask_data, ni, src, nv);
-        }
+        npy_fastputmask(dest, src, mask_data, ni, nv, chunk);
         NPY_END_THREADS;
     }
 

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -128,6 +128,32 @@ PyArray_InitArrFuncs(PyArray_ArrFuncs *f)
     f->cancastto = NULL;
 }
 
+
+static int
+test_deprecated_arrfuncs_members(PyArray_ArrFuncs *f) {
+    /* NumPy 1.19, 2020-01-15 */
+    if (f->fastputmask != NULL) {
+        if (DEPRECATE(
+                "The ->f->fastputmask member of custom dtypes is ignored; "
+                "setting it may be an error in the future.\n"
+                "The custom dtype you are using must be revised, but "
+                "results will not be affected.") < 0) {
+            return -1;
+        }
+    }
+    /* NumPy 1.19, 2020-01-15 */
+    if (f->fasttake != NULL) {
+        if (DEPRECATE(
+                "The ->f->fastputmask member of custom dtypes is ignored; "
+                "setting it may be an error in the future.\n"
+                "The custom dtype you are using must be revised, but "
+                "results will not be affected.") < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 /*
   returns typenum to associate with this type >=NPY_USERDEF.
   needs the userdecrs table and PyArray_NUMUSER variables
@@ -176,6 +202,11 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
         PyErr_SetString(PyExc_ValueError, "missing typeobject");
         return -1;
     }
+
+    if (test_deprecated_arrfuncs_members(f) < 0) {
+        return -1;
+    }
+
     userdescrs = realloc(userdescrs,
                          (NPY_NUMUSERTYPES+1)*sizeof(void *));
     if (userdescrs == NULL) {

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -20,8 +20,9 @@ class TestTake:
                         'clip': {-1: 0, 4: 1}}
         # Currently all types but object, use the same function generation.
         # So it should not be necessary to test all. However test also a non
-        # refcounted struct on top of object.
-        types = int, object, np.dtype([('', 'i', 2)])
+        # refcounted struct on top of object, which has a size that hits the
+        # default (non-specialized) path.
+        types = int, object, np.dtype([('', 'i2', 3)])
         for t in types:
             # ta works, even if the array may be odd if buffer interface is used
             ta = np.array(a if np.issubdtype(t, np.number) else a_str, dtype=t)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4484,11 +4484,10 @@ class TestCompress:
 class TestPutmask:
     def tst_basic(self, x, T, mask, val):
         np.putmask(x, mask, val)
-        assert_equal(x[mask], T(val))
-        assert_equal(x.dtype, T)
+        assert_equal(x[mask], np.array(val, T))
 
     def test_ip_types(self):
-        unchecked_types = [bytes, unicode, np.void, object]
+        unchecked_types = [bytes, unicode, np.void]
 
         x = np.random.random(1000)*100
         mask = x < 40
@@ -4498,6 +4497,10 @@ class TestPutmask:
                 for T in types:
                     if T not in unchecked_types:
                         self.tst_basic(x.copy().astype(T), T, mask, val)
+
+            # Also test string of a length which uses an untypical length
+            dt = np.dtype("S3")
+            self.tst_basic(x.astype(dt), dt.type, mask, dt.type(val)[:3])
 
     def test_mask_size(self):
         assert_raises(ValueError, np.putmask, np.array([1, 2, 3]), [True], 5)
@@ -4538,7 +4541,7 @@ class TestTake:
         assert_array_equal(x.take(ind, axis=0), x)
 
     def test_ip_types(self):
-        unchecked_types = [bytes, unicode, np.void, object]
+        unchecked_types = [bytes, unicode, np.void]
 
         x = np.random.random(24)*100
         x.shape = 2, 3, 4
@@ -4546,6 +4549,9 @@ class TestTake:
             for T in types:
                 if T not in unchecked_types:
                     self.tst_basic(x.copy().astype(T))
+
+            # Also test string of a length which uses an untypical length
+            self.tst_basic(x.astype("S3"))
 
     def test_raise(self):
         x = np.random.random(24)*100


### PR DESCRIPTION
Always NULL the fasttake slot, and instead move the optimized versions
by doing itemsize specialization in the Take function itself.

---

I still need to check that there is now speed regression.