### PR TITLE
ENH: add datetime64 support to numpy.linspace. See #14918.

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -124,43 +124,57 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num
 
-    # Convert float/complex array scalars to float, gh-3504
-    # and make sure one can use variables that have an __array_interface__, gh-6634
-    start = asanyarray(start) * 1.0
-    stop  = asanyarray(stop)  * 1.0
+    # make sure one can use variables that have an __array_interface__, gh-6634
+    start = asanyarray(start)
+    stop  = asanyarray(stop)
 
-    dt = result_type(start, stop, float(num))
-    if dtype is None:
-        dtype = dt
-
-    delta = stop - start
-    y = _nx.arange(0, num, dtype=dt).reshape((-1,) + (1,) * ndim(delta))
-    # In-place multiplication y *= delta/div is faster, but prevents the multiplicant
-    # from overriding what class is produced, and thus prevents, e.g. use of Quantities,
-    # see gh-7142. Hence, we multiply in place only for standard scalar types.
-    _mult_inplace = _nx.isscalar(delta)
-    if div > 0:
+    # support datetime64, gh-14918
+    if start.dtype.kind == "M" and stop.dtype.kind == "M":
+        dt = result_type(start, stop)
+        if dtype is None:
+            dtype = dt
+        delta = stop - start
         step = delta / div
-        if _nx.any(step == 0):
-            # Special handling for denormal numbers, gh-5437
-            y /= div
-            if _mult_inplace:
-                y *= delta
-            else:
-                y = y * delta
-        else:
-            if _mult_inplace:
-                y *= step
-            else:
-                y = y * step
+        y = _nx.arange(0, num, dtype=float).reshape((-1,) + (1,) * ndim(delta))
+        y = y * step
+        y = y + start
     else:
-        # sequences with 0 items or 1 item with endpoint=True (i.e. div <= 0)
-        # have an undefined step
-        step = NaN
-        # Multiply with delta to allow possible override of output class.
-        y = y * delta
+        # Convert float/complex array scalars to float, gh-3504
+        start = start * 1.0
+        stop  = stop  * 1.0
 
-    y += start
+        dt = result_type(start, stop, float(num))
+        if dtype is None:
+            dtype = dt
+
+        delta = stop - start
+        y = _nx.arange(0, num, dtype=dt).reshape((-1,) + (1,) * ndim(delta))
+        # In-place multiplication y *= delta/div is faster, but prevents the multiplicant
+        # from overriding what class is produced, and thus prevents, e.g. use of Quantities,
+        # see gh-7142. Hence, we multiply in place only for standard scalar types.
+        _mult_inplace = _nx.isscalar(delta)
+        if div > 0:
+            step = delta / div
+            if _nx.any(step == 0):
+                # Special handling for denormal numbers, gh-5437
+                y /= div
+                if _mult_inplace:
+                    y *= delta
+                else:
+                    y = y * delta
+            else:
+                if _mult_inplace:
+                    y *= step
+                else:
+                    y = y * step
+        else:
+            # sequences with 0 items or 1 item with endpoint=True (i.e. div <= 0)
+            # have an undefined step
+            step = NaN
+            # Multiply with delta to allow possible override of output class.
+            y = y * delta
+
+        y += start
 
     if endpoint and num > 1:
         y[-1] = stop

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 from numpy import (
     logspace, linspace, geomspace, dtype, array, sctypes, arange, isnan,
-    ndarray, sqrt, nextafter, stack
+    ndarray, sqrt, nextafter, stack, datetime64
     )
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal, assert_allclose,
@@ -371,3 +371,11 @@ class TestLinspace(object):
         stop = array(2, dtype='O')
         y = linspace(start, stop, 3)
         assert_array_equal(y, array([1., 1.5, 2.]))
+
+    def test_datetime64(self):
+        start = datetime64('2019-01-01T00:00:00')
+        stop = datetime64('2019-01-01T00:00:04')
+        y = linspace(start, stop, 2, False)
+        expected = array([datetime64('2019-01-01T00:00:00'),
+                          datetime64('2019-01-01T00:00:02')])
+        assert_array_equal(y, expected)


### PR DESCRIPTION
As is, linspace doesn't support datetime64 even though arange does support it. While it is possible to work around the limitation by using arange, it forces the user to calculate the step size when an exact number of samples is desired instead.
