### PR TITLE
TST: skip if cython is not available

### DIFF
--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -11,6 +11,12 @@ try:
 except ImportError:
     numba = None
 
+try:
+    import cython
+except ImportError:
+    cython = None
+
+@pytest.mark.skipif(cython is None, reason="requires cython")
 def test_cython():
     curdir = os.getcwd()
     argv = sys.argv


### PR DESCRIPTION
Fixes gh-14955 by skipping the test that requires cython