### PR TITLE
ENH: Additions to np.farray API

### DIFF
--- a/doc/release/upcoming_changes/14966.new_feature.rst
+++ b/doc/release/upcoming_changes/14966.new_feature.rst
@@ -1,0 +1,5 @@
+`numpy.asfarray` accepts `copy` argument
+----------------------------------------
+It is now possible to force `asfarray` to make a copy using `copy=True`.
+`dtype` also accepts an argument of `None`, to attempt to preserve the type of
+any array-like.

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -469,14 +469,49 @@ class TestRealIfClose(object):
         assert_all(isrealobj(b))
 
 
-class TestArrayConversion(object):
+class TestAsfarray(object):
 
-    def test_asfarray(self):
-        a = asfarray(np.array([1, 2, 3]))
+    def test_basic(self):
+        a = asfarray([1, 2, 3])
         assert_equal(a.__class__, np.ndarray)
         assert_(np.issubdtype(a.dtype, np.floating))
 
+        b = asfarray(np.array([1, 2, 3]))
+        assert_equal(b.__class__, np.ndarray)
+        assert_(np.issubdtype(b.dtype, np.floating))
+
+    def test_dtype(self):
+        a = asfarray(np.array([1, 2, 3]), dtype=np.int32)
+        assert_(np.issubdtype(a.dtype, np.floating))
+
+        a = asfarray(np.array([1, 2, 3]), dtype=np.float16)
+        assert_(np.issubdtype(a.dtype, np.floating))
+
+        a = asfarray(np.array([1, 2, 3]), dtype=np.complex128)
+        assert_(np.issubdtype(a.dtype, np.complexfloating))
+
+    def test_dtype_none(self):
+        a = asfarray(np.array([1, 2, 3]), dtype=None)
+        assert_(np.issubdtype(a.dtype, np.floating))
+
+        b = asfarray(np.array([1.0, 2.0, 3.0]), dtype=None)
+        assert_(np.issubdtype(b.dtype, np.inexact))
+
+        c = asfarray(np.array([1.0+1j, 2.0+2j, 3.0+3j]), dtype=None)
+        assert_(np.issubdtype(c.dtype, np.complexfloating))
+
+    def test_dtype_array(self):
         # previously this would infer dtypes from arrays, unlike every single
         # other numpy function
-        assert_raises(TypeError,
-            asfarray, np.array([1, 2, 3]), dtype=np.array(1.0))
+        assert_raises(TypeError, asfarray,
+                      np.array([1, 2, 3]), dtype=np.array(1.0))
+
+    def test_copy(self):
+        a = np.array([1, 2, 3])
+        assert_(asfarray(a, copy=False) is not a)
+        assert_(asfarray(a, copy=True) is not a)
+
+        b = np.array([1.0, 2.0, 3.0])
+        assert_(asfarray(b, copy=False) is b)
+        assert_(asfarray(b, copy=True) is not b)
+

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -10,6 +10,7 @@ __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'typename', 'asfarray', 'mintypecode', 'asscalar',
            'common_type']
 
+from numpy.core.multiarray import array
 import numpy.core.numeric as _nx
 from numpy.core.numeric import asarray, asanyarray, isnan, zeros
 from numpy.core.overrides import set_module
@@ -80,12 +81,12 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
     return l[0][1]
 
 
-def _asfarray_dispatcher(a, dtype=None):
+def _asfarray_dispatcher(a, dtype=None, copy=None):
     return (a,)
 
 
 @array_function_dispatch(_asfarray_dispatcher)
-def asfarray(a, dtype=_nx.float_):
+def asfarray(a, dtype=_nx.float_, copy=False):
     """
     Return an array converted to a float type.
 
@@ -93,9 +94,13 @@ def asfarray(a, dtype=_nx.float_):
     ----------
     a : array_like
         The input array.
-    dtype : str or dtype object, optional
+    dtype : str or dtype object or None, optional
         Float type code to coerce input array `a`.  If `dtype` is one of the
-        'int' dtypes, it is replaced with float64.
+        'int' dtypes, it is replaced with float64. If `None`, use the dtype of
+        the array itself in the same way.
+    copy : bool
+        If `True`, a copy will be returned even if the input array meets the
+        type criteria.
 
     Returns
     -------
@@ -112,9 +117,17 @@ def asfarray(a, dtype=_nx.float_):
     array([2.,  3.])
 
     """
+    if dtype is None:
+        orig = a
+        a = array(orig, copy=False, subok=False, order=None)
+        dtype = a.dtype
+        if a is not orig:
+            copy = False
+
     if not _nx.issubdtype(dtype, _nx.inexact):
         dtype = _nx.float_
-    return asarray(a, dtype=dtype)
+
+    return array(a, dtype=dtype, copy=copy, subok=False, order=None)
 
 
 def _real_dispatcher(val):


### PR DESCRIPTION
1. Added `copy` parameter which defaults to `False`.
2. Added `None` option to the `dtype` parameter.

Item #1 is inspired by situations like the one in Stack Overflow question https://stackoverflow.com/q/58998475/2988730. Sometimes, you just need to ensure a copy, and it's nice not to have to check things like `if asfarray(x) is x: x = x.copy()`.

Item #2 solves the problem of trying to do `asfarray(x, dtype=x.dtype)` for `x` that don't have a `dtype` attribute, like lists or tuples.

API Change, so mailing list: https://mail.python.org/pipermail/numpy-discussion/2019-November/080251.html