### PR TITLE
MAINT: Cleaned up mintypecode for Py3

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -68,16 +68,14 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
     'G'
 
     """
-    typecodes = [(isinstance(t, str) and t) or asarray(t).dtype.char
-                 for t in typechars]
-    intersection = [t for t in typecodes if t in typeset]
+    typecodes = ((isinstance(t, str) and t) or asarray(t).dtype.char
+                 for t in typechars)
+    intersection = set(t for t in typecodes if t in typeset)
     if not intersection:
         return default
     if 'F' in intersection and 'd' in intersection:
         return 'D'
-    l = [(_typecodes_by_elsize.index(t), t) for t in intersection]
-    l.sort()
-    return l[0][1]
+    return min((_typecodes_by_elsize.index(t), t) for t in intersection)[1]
 
 
 def _asfarray_dispatcher(a, dtype=None):


### PR DESCRIPTION
This is a small cleanup PR for `mintypecode`.

- Using generators instead of full-blown lists
- Using set for search instead of list
- Using min to get single element instead of sorting full list

All changes are internal, and should be relatively uncontroversial. As such no tests were modified in this PR.