### PR TITLE
MAINT: Added Python3.8 branch to dll lib discovery on Windows

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2329,8 +2329,11 @@ def generate_config_py(target):
             extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
 
             if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
-                os.environ.setdefault('PATH', '')
-                os.environ['PATH'] += os.pathsep + extra_dll_dir
+                if sys.version_info >= (3, 8):
+                    os.add_dll_directory(extra_dll_dir)
+                else:
+                    os.environ.setdefault('PATH', '')
+                    os.environ['PATH'] += os.pathsep + extra_dll_dir
 
             """))
 


### PR DESCRIPTION
Closes #14923 

Not sure if I've did the right fix regarding the issue linked above, however it does indeed fix the NumPy/SciPy related dll import errors on Windows/Python3.8.

This is actually a blocker for SciPy Python 3.8 release wheels hence I'd appreciate all feedback.


