### PR TITLE
DEV: update asv.conf.json

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -35,7 +35,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6"],
+    "pythons": ["3.7"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
@@ -43,6 +43,7 @@
     // version.
     "matrix": {
     	"six": [],
+        "Cython": [],
     },
 
     // The directory (relative to the current directory) that benchmarks are
@@ -68,7 +69,7 @@
     // `asv` will cache wheels of the recent builds in each
     // environment, making them faster to install next time.  This is
     // number of builds to keep, per environment.
-    "wheel_cache_size": 2,
+    "build_cache_size": 8,
 
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are


### PR DESCRIPTION
Due to Numpy cythonize changes, Cython is required. Update renamed asv
option + bump default Python version.