### PR TITLE
REV: "ENH: Improved performance of PyArray_FromAny for sequences of array-like

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2484,26 +2484,6 @@ class TestRegression(object):
 
         np.array([T()])
 
-    def test_2d__array__shape(self):
-        class T(object):
-            def __array__(self):
-                return np.ndarray(shape=(0,0))
-
-            # Make sure __array__ is used instead of Sequence methods.
-            def __iter__(self):
-                return iter([])
-
-            def __getitem__(self, idx):
-                raise AssertionError("__getitem__ was called")
-
-            def __len__(self):
-                return 0
-
-
-        t = T()
-        #gh-13659, would raise in broadcasting [x=t for x in result]
-        np.array([t])
-
     @pytest.mark.skipif(sys.maxsize < 2 ** 31 + 1, reason='overflows 32-bit python')
     @pytest.mark.skipif(sys.platform == 'win32' and sys.version_info[:2] < (3, 8),
                         reason='overflows on windows, fixed in bpo-16865')


### PR DESCRIPTION
See #13958. 

 
This reverts commit 71fc59d587016d6f36007ba06e074d4d4a6b483d
which was part of gh-13399 and the followup commit
ba53a63ee9be7a7bad7685b051a0ef984caa321e from gh-13663.

The issue is that we mix Sequence protocol and `__array__` usage
when coercing arrays.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
