### PR TITLE
MAINT: Added Python3.8 branch to dll lib discovery

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2281,8 +2281,11 @@ def generate_config_py(target):
             extra_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
 
             if sys.platform == 'win32' and os.path.isdir(extra_dll_dir):
-                os.environ.setdefault('PATH', '')
-                os.environ['PATH'] += os.pathsep + extra_dll_dir
+                if sys.version_info >= (3, 8):
+                    os.add_dll_directory(extra_dll_dir)
+                else:
+                    os.environ.setdefault('PATH', '')
+                    os.environ['PATH'] += os.pathsep + extra_dll_dir
 
             """))
 


### PR DESCRIPTION
Backport of #14974. 

Closes #14923

Not sure if I've did the right fix regarding the issue linked above, however it does indeed fix the NumPy/SciPy related dll import errors on Windows/Python3.8.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
