### PR TITLE
BUG: warn when saving dtype with metadata

### DIFF
--- a/doc/release/upcoming_changes/14142.change.rst
+++ b/doc/release/upcoming_changes/14142.change.rst
@@ -1,6 +1,6 @@
-Warn when saving a dtype that cannot be loaded
-----------------------------------------------
+Warn when saving a dtype with metadata
+--------------------------------------
 A ``UserWarning`` will be raised when saving an array via `numpy.save` with
-``metadata``, since loading such an array will cause a ``ValueError``. This
-shorcoming in the NPY format will be addressed in a future release, in the
-mean time use pickle instead.
+``metadata``, since saving such an array may not preserve metadata and loading
+if metadata is preserved, loading it will cause a ``ValueError``. This
+shorcoming in the NPY format will be addressed in a future release.

--- a/doc/release/upcoming_changes/14142.change.rst
+++ b/doc/release/upcoming_changes/14142.change.rst
@@ -1,0 +1,6 @@
+Warn when saving a dtype that cannot be loaded
+----------------------------------------------
+A ``UserWarning`` will be raised when saving an array via `numpy.save` with
+``metadata``, since loading such an array will cause a ``ValueError``. This
+shorcoming in the NPY format will be addressed in a future release, in the
+mean time use pickle instead.

--- a/doc/release/upcoming_changes/14142.change.rst
+++ b/doc/release/upcoming_changes/14142.change.rst
@@ -1,6 +1,6 @@
 Warn when saving a dtype with metadata
 --------------------------------------
-A ``UserWarning`` will be raised when saving an array via `numpy.save` with
-``metadata``, since saving such an array may not preserve metadata and loading
-if metadata is preserved, loading it will cause a ``ValueError``. This
-shorcoming in the NPY format will be addressed in a future release.
+A ``UserWarning`` will be emitted when saving an array via `numpy.save` with
+``metadata``. Saving such an array may not preserve metadata, and if metadata
+is preserved, loading it will cause a ``ValueError``. This shortcoming in save
+and load will be addressed in a future release.

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -265,13 +265,20 @@ def dtype_to_descr(dtype):
         replicate the input dtype.
 
     """
+    warn_msg = ("metadata on a dtype can be saved but cannot be read. Use "
+               "another form of storage for the array")
     if dtype.names is not None:
         # This is a record array. The .descr is fine.  XXX: parts of the
         # record array with an empty name, like padding bytes, still get
         # fiddled with. This needs to be fixed in the C implementation of
         # dtype().
+        for k in dtype.names:
+            if dtype[k].metadata:
+                warnings.warn (warn_msg, UserWarning, stacklevel=2)
         return dtype.descr
     else:
+        if dtype.metadata:
+            warnings.warn (warn_msg, UserWarning, stacklevel=2)
         return dtype.str
 
 def descr_to_dtype(descr):

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -279,8 +279,8 @@ def dtype_to_descr(dtype):
 
     """
     if _has_metadata(dtype):
-        warnings.warn("metadata on a dtype can be saved but will be ignored "
-                      "or raise when read. Use another form of storage.",
+        warnings.warn("metadata on a dtype may be saved or ignored, but will "
+                      "raise if saved when read. Use another form of storage.",
                       MetadataWarning, stacklevel=2)
     if dtype.names is not None:
         # This is a record array. The .descr is fine.  XXX: parts of the

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -242,9 +242,6 @@ def read_magic(fp):
         major, minor = magic_str[-2:]
     return major, minor
 
-class MetadataWarning(UserWarning):
-    pass
-
 def _has_metadata(dt):
     if dt.metadata is not None:
         return True
@@ -281,7 +278,7 @@ def dtype_to_descr(dtype):
     if _has_metadata(dtype):
         warnings.warn("metadata on a dtype may be saved or ignored, but will "
                       "raise if saved when read. Use another form of storage.",
-                      MetadataWarning, stacklevel=2)
+                      UserWarning, stacklevel=2)
     if dtype.names is not None:
         # This is a record array. The .descr is fine.  XXX: parts of the
         # record array with an empty name, like padding bytes, still get

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -964,13 +964,33 @@ def test_unicode_field_names():
         with assert_warns(UserWarning):
             format.write_array(f, arr, version=None)
 
-def test_metadata_dtype():
+
+@pytest.mark.parametrize('dt, fail', [
+    (np.dtype({'names': ['a', 'b'], 'formats':  [float, np.dtype('S3',
+                 metadata={'some': 'stuff'})]}), True),
+    (np.dtype(int, metadata={'some': 'stuff'}), False),
+    (np.dtype(int, (2,), metadata={'some': 'stuff'}), False),
+    # recursive: metadata on the field of a dtype
+    (np.dtype({'names': ['a', 'b'], 'formats': [float,
+        np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})],
+        }),
+     False)
+    ])
+def test_metadata_dtype(dt, fail):
     # gh-14142
-    dt = np.dtype({'names': ['a', 'b'], 'formats':  [float, np.dtype('S3', metadata={'some': 'stuff'})]})
-    arr = np.array([(1, 'abc'), (2, 'def')], dtype=dt)
+    arr = np.ones(10, dtype=dt)
     buf = BytesIO()
     with assert_warns(UserWarning):
         np.save(buf, arr)
     buf.seek(0)
-    with assert_raises(ValueError):
-        np.load(buf)
+    if fail:
+        with assert_raises(ValueError):
+            np.load(buf)
+    else:
+        arr2 = np.load(buf)
+        # BUG: assert_array_equal does not check metadata
+        from numpy.lib.format import _has_metadata
+        assert_array_equal(arr, arr2)
+        assert _has_metadata(arr.dtype)
+        assert not _has_metadata(arr2.dtype)
+

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -963,3 +963,14 @@ def test_unicode_field_names():
     with open(fname, 'wb') as f:
         with assert_warns(UserWarning):
             format.write_array(f, arr, version=None)
+
+def test_metadata_dtype():
+    # gh-14142
+    dt = np.dtype({'names': ['a', 'b'], 'formats':  [float, np.dtype('S3', metadata={'some': 'stuff'})]})
+    arr = np.array([(1, 'abc'), (2, 'def')], dtype=dt)
+    buf = BytesIO()
+    with assert_warns(UserWarning):
+        np.save(buf, arr)
+    buf.seek(0)
+    with assert_raises(ValueError):
+        np.load(buf)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -970,11 +970,11 @@ def test_unicode_field_names():
                  metadata={'some': 'stuff'})]}), True),
     (np.dtype(int, metadata={'some': 'stuff'}), False),
     (np.dtype(int, (2,), metadata={'some': 'stuff'}), False),
+    (np.dtype((int, 3), metadata={'some': 'stuff'}), True),
     # recursive: metadata on the field of a dtype
-    (np.dtype({'names': ['a', 'b'], 'formats': [float,
-        np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})],
-        }),
-     False)
+    (np.dtype({'names': ['a', 'b'], 'formats': [
+        float, np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})
+    ]}), False)
     ])
 def test_metadata_dtype(dt, fail):
     # gh-14142

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -969,7 +969,7 @@ def test_unicode_field_names():
     (np.dtype({'names': ['a', 'b'], 'formats':  [float, np.dtype('S3',
                  metadata={'some': 'stuff'})]}), True),
     (np.dtype(int, metadata={'some': 'stuff'}), False),
-    (np.dtype(int, (2,), metadata={'some': 'stuff'}), False),
+    (np.dtype([('subarray', (int, (2,)))], metadata={'some': 'stuff'}), False),
     # recursive: metadata on the field of a dtype
     (np.dtype({'names': ['a', 'b'], 'formats': [
         float, np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -970,7 +970,6 @@ def test_unicode_field_names():
                  metadata={'some': 'stuff'})]}), True),
     (np.dtype(int, metadata={'some': 'stuff'}), False),
     (np.dtype(int, (2,), metadata={'some': 'stuff'}), False),
-    (np.dtype((int, 3), metadata={'some': 'stuff'}), True),
     # recursive: metadata on the field of a dtype
     (np.dtype({'names': ['a', 'b'], 'formats': [
         float, np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})


### PR DESCRIPTION
Address gh-14142 for the 1.18 release: warn when saving a dtype with metadata that cannot be loaded.