### PR TITLE
BUG: Use ``__array__`` during dimension discovery

### DIFF
--- a/doc/release/upcoming_changes/14995.compatibility.rst
+++ b/doc/release/upcoming_changes/14995.compatibility.rst
@@ -1,0 +1,10 @@
+Converting of empty array-like objects to NumPy arrays
+------------------------------------------------------
+Objects with ``len(obj) == 0`` which implement an "array-like" interface,
+meaning an object implementing ``obj.__array__()``,
+``obj.__array_interface__``, ``obj.__array_struct__``, or the python
+buffer interface and which are also sequences (i.e. Pandas objects)
+will now always retain there shape correctly when converted to an array.
+If such an object has a shape of ``(0, 1)`` previously, it could
+be converted into an array of of shape ``(0,)`` (losing all dimensions
+after the first 0).

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2451,6 +2451,27 @@ class TestRegression:
 
         np.array([T()])
 
+    def test_2d__array__shape(self):
+        class T(object):
+            def __array__(self):
+                return np.ndarray(shape=(0,0))
+
+            # Make sure __array__ is used instead of Sequence methods.
+            def __iter__(self):
+                return iter([])
+
+            def __getitem__(self, idx):
+                raise AssertionError("__getitem__ was called")
+
+            def __len__(self):
+                return 0
+
+
+        t = T()
+        # gh-13659, would raise in broadcasting [x=t for x in result]
+        arr = np.array([t])
+        assert arr.shape == (1, 0, 0)
+
     @pytest.mark.skipif(sys.maxsize < 2 ** 31 + 1, reason='overflows 32-bit python')
     @pytest.mark.skipif(sys.platform == 'win32' and sys.version_info[:2] < (3, 8),
                         reason='overflows on windows, fixed in bpo-16865')


### PR DESCRIPTION
``__array__`` was previously not used during dimension discovery,
while bein gused during dtype discovery (if dtype is not given),
as well as during filling of the resulting array.

This would lead to inconsistencies with respect to array likes
that have a shape including a 0 (typically as first dimension).
Thus a shape of ``(0, 1, 1)`` would be found as ``(0,)`` because
a nested list/sequence cannot represent empty shapes, except 1-D.

This uses the `_array_from_array_like` function, which means that
some coercions may be tiny bit slower, at the gain of removing
a lot of complex code.

(this also reverts commit d0d250a3c9d7d90e75701c32d7d435640e6b02eb)

Closes gh-13958

---

I am a bit confused as to why I thought before that just adding `__array__` would not simply solve this. I think it does. I could add the use of `_array_from_array_like` in `common.h` during dtype discovery.

Note that this changes behaviour, so testing against pandas may be in order. And I suppose it needs a release note, I will probably add those tonight.