### PR TITLE
DEP: Deprecate the axis argument to masked_rows and masked_cols

### DIFF
--- a/doc/release/upcoming_changes/14996.deprecation.rst
+++ b/doc/release/upcoming_changes/14996.deprecation.rst
@@ -1,0 +1,3 @@
+The ``axis`` argument to `numpy.ma.mask_cols` and `numpy.ma.mask_row` is deprecated
+-----------------------------------------------------------------------------------
+This argument was always ignored.

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -937,7 +937,7 @@ def compress_cols(a):
         raise NotImplementedError("compress_cols works for 2D arrays only.")
     return compress_rowcols(a, 1)
 
-def mask_rows(a, axis=None):
+def mask_rows(a, axis=np._NoValue):
     """
     Mask rows of a 2D array that contain masked values.
 
@@ -979,9 +979,15 @@ def mask_rows(a, axis=None):
       fill_value=1)
 
     """
+    if axis is not np._NoValue:
+        # remove the axis argument when this deprecation expires
+        # NumPy 1.18.0, 2019-11-28
+        warnings.warn(
+            "The axis argument has always been ignored, in future passing it "
+            "will raise TypeError", DeprecationWarning, stacklevel=2)
     return mask_rowcols(a, 0)
 
-def mask_cols(a, axis=None):
+def mask_cols(a, axis=np._NoValue):
     """
     Mask columns of a 2D array that contain masked values.
 
@@ -1022,6 +1028,12 @@ def mask_cols(a, axis=None):
       fill_value=1)
 
     """
+    if axis is not np._NoValue:
+        # remove the axis argument when this deprecation expires
+        # NumPy 1.18.0, 2019-11-28
+        warnings.warn(
+            "The axis argument has always been ignored, in future passing it "
+            "will raise TypeError", DeprecationWarning, stacklevel=2)
     return mask_rowcols(a, 1)
 
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -11,6 +11,7 @@ from __future__ import division, absolute_import, print_function
 
 import warnings
 import itertools
+import pytest
 
 import numpy as np
 from numpy.testing import (
@@ -551,6 +552,18 @@ class TestCompressFunctions(object):
         assert_(mask_rowcols(x).mask.all())
         assert_(mask_rowcols(x, 0).mask.all())
         assert_(mask_rowcols(x, 1).mask.all())
+
+    @pytest.mark.parametrize("axis", [None, 0, 1])
+    @pytest.mark.parametrize(["func", "rowcols_axis"],
+                             [(np.ma.mask_rows, 0), (np.ma.mask_cols, 1)])
+    def test_mask_row_cols_axis_deprecation(self, axis, func, rowcols_axis):
+        # Test deprecation of the axis argument to `mask_rows` and `mask_cols`
+        x = array(np.arange(9).reshape(3, 3),
+                  mask=[[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+        with assert_warns(DeprecationWarning):
+            res = func(x, axis=axis)
+            assert_equal(res, mask_rowcols(x, rowcols_axis))
 
     def test_dot(self):
         # Tests dot product


### PR DESCRIPTION
This argument isn't used, and is confusing.

Is this worth a deprecation, or should I just outright remove it as I do here?