### PR TITLE
MAINT: Fix long name of PCG64

### DIFF
--- a/doc/source/reference/random/bit_generators/pcg64.rst
+++ b/doc/source/reference/random/bit_generators/pcg64.rst
@@ -1,4 +1,4 @@
-Parallel Congruent Generator (64-bit, PCG64)
+Permuted Congruent Generator (64-bit, PCG64)
 --------------------------------------------
 
 .. currentmodule:: numpy.random

--- a/doc/source/reference/random/bit_generators/pcg64.rst
+++ b/doc/source/reference/random/bit_generators/pcg64.rst
@@ -1,5 +1,5 @@
-Permuted Congruent Generator (64-bit, PCG64)
---------------------------------------------
+Permuted Congruential Generator (64-bit, PCG64)
+-----------------------------------------------
 
 .. currentmodule:: numpy.random
 


### PR DESCRIPTION
See publication by O'Neill (reference 2):

"The name for the family, PCG, stands for permuted congruential
generator [...]"
