### PR TITLE
MAINT: Only copy input array in _replace_nan() if there are nans to replace

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -95,7 +95,7 @@ def _replace_nan(a, val):
         NaNs, otherwise return None.
 
     """
-    a = np.array(a, subok=True, copy=True)
+    a = np.asanyarray(a)
 
     if a.dtype == np.object_:
         # object arrays do not support `isnan` (gh-9009), so make a guess
@@ -106,6 +106,7 @@ def _replace_nan(a, val):
         mask = None
 
     if mask is not None:
+        a = np.array(a, subok=True, copy=True)
         np.copyto(a, val, where=mask)
 
     return a, mask


### PR DESCRIPTION
This PR gets up to a 2x speedup for all `np.nan*` calls with input arrays that do not support NaNs.

While investigating a case where `bottleneck` was unexpectedly significantly faster than `numpy`, I came across a bug where `numpy` always copies the input array in a function called `_replace_nan()`, even if `NaN`s are not possible. Confusingly, the docstring explicitly states the function won't make a copy in this exact case.

So if we simply do what the docstring claims, we go from this:
```
In [1]: import numpy as np                                                                                                                                                                                  

In [2]: a = np.arange(1000000, dtype='int64')                                                                                                                                                               

In [3]: %timeit np.nansum(a)                                                                                                                                                                                
1.34 ms ± 16.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
To this:
```
In [1]: import numpy as np                                                                                                                                                                                  

In [2]: a = np.arange(1000000, dtype='int64')                                                                                                                                                               

In [3]: %timeit np.nansum(a)                                                                                                                                                                                
611 µs ± 1.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
In the event `a` is not a `np.array`, we must keep the copy/cast to support calls like `a.dtype`.

I have also added some regression tests to enforce this behavior.