### PR TITLE
[DOC] LaTeX: fix preamble (closes #15026)

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -217,7 +217,7 @@ latex-build: generate
 	mkdir -p build/latex build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) build/latex $(FILES)
 	$(PYTHON) postprocess.py tex build/latex/*.tex
-	perl -pi -e 's/\t(latex.*|pdflatex) (.*)/\t-$$1 -interaction batchmode $$2/' build/latex/Makefile
+	perl -pi -e 's/LATEXOPTS =/LATEXOPTS ?= --halt-on-error/' build/latex/Makefile
 	@echo
 	@echo "Build finished; the LaTeX files are in build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -178,15 +178,28 @@ latex_elements = {
 }
 
 # Additional stuff for the LaTeX preamble.
-latex_preamble = r'''
-\usepackage{amsmath}
-\DeclareUnicodeCharacter{00A0}{\nobreakspace}
-
+latex_elements['preamble'] = r'''
 % In the parameters section, place a newline after the Parameters
 % header
 \usepackage{expdlist}
 \let\latexdescription=\description
 \def\description{\latexdescription{}{} \breaklabel}
+% but expdlist old LaTeX package requires fixes:
+% 1) remove extra space
+\usepackage{etoolbox}
+\makeatletter
+\patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+\makeatother
+% 2) fix bug in expdlist's way of breaking the line after long item label
+\makeatletter
+\def\breaklabel{%
+    \def\@breaklabel{%
+        \leavevmode\par
+        % now a hack because Sphinx inserts \leavevmode after term node
+        \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+    }%
+}
+\makeatother
 
 % Make Examples/etc section headers smaller and more compact
 \makeatletter

--- a/doc/source/docs/howto_build_docs.rst
+++ b/doc/source/docs/howto_build_docs.rst
@@ -5,7 +5,7 @@ Building the NumPy API and reference docs
 =========================================
 
 We currently use Sphinx_ for generating the API and reference
-documentation for NumPy.  You will need Sphinx 1.8.3 <= 1.8.5.
+documentation for NumPy.  You will need Sphinx >= 2.0.0.
 
 If you only want to get the documentation, note that pre-built
 versions can be found at
@@ -57,7 +57,9 @@ To build the PDF documentation, do instead::
    make latex
    make -C build/latex all-pdf
 
-You will need to have Latex installed for this.
+You will need to have Latex installed for this, inclusive of support for
+Greek letters.  For example, on Ubuntu xenial ``texlive-lang-greek`` and
+``cm-super`` are needed.  Also ``latexmk`` is needed on non-Windows systems.
 
 Instead of the above, you can also do::
 


### PR DESCRIPTION
I tried it out only with Python 3.7.5 (CPython), Sphinx 2.2.1.

I feel `--halt-on-error` is better than `-interaction = batchmode` (anyhow this was not applied because Sphinx LaTeX Makefile changed at 1.6). In both cases latexmk exists with an error, but the former will have the error crashing the build be the last thing in the LaTeX log file.

But I separated this as a second commit so the two commits can be considered separately.
