### PR TITLE
MAINT: Cleaned up mintypecode for Py3 (pt. 2)

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -75,7 +75,7 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
         return default
     if 'F' in intersection and 'd' in intersection:
         return 'D'
-    return min((_typecodes_by_elsize.index(t), t) for t in intersection)[1]
+    return min(intersection, key=_typecodes_by_elsize.index)
 
 
 def _asfarray_dispatcher(a, dtype=None):


### PR DESCRIPTION
Followup to #14967. Cleaned up to use `min` with proper `key` instead of workaround. 