### PR TITLE
BUG: added negative checks to reshape #15030

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -298,6 +298,9 @@ def reshape(a, newshape, order='C'):
            [3, 4],
            [5, 6]])
     """
+    for dim in newshape:
+        if dim < 0:
+            raise ValueError('negative dimensions not allowed')
     return _wrapfunc(a, 'reshape', newshape, order=order)
 
 


### PR DESCRIPTION
Address reshape/resize allowing negative numbers. See #15030 
Checks each dimension in newshape to make sure its not negative.
If there is a negative dimension, ValueError is raised. 


