### PR TITLE
BUG: add endfunction, endsubroutine to valid fortran end words

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -542,7 +542,7 @@ cppmacros[
     'ARRSIZE'] = '#define ARRSIZE(dims,rank) (_PyArray_multiply_list(dims,rank))'
 cppmacros['OLDPYNUM'] = """\
 #ifdef OLDPYNUM
-#error You need to install NumPy version 13 or higher. See https://scipy.org/install.html
+#error You need to install NumPy version 0.13 or higher. See https://scipy.org/install.html
 #endif
 """
 ################# C functions ###############

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -558,7 +558,8 @@ groupbegins90 = groupbegins77 + \
     r'|module(?!\s*procedure)|python\s*module|interface|type(?!\s*\()'
 beginpattern90 = re.compile(
     beforethisafter % ('', groupbegins90, groupbegins90, '.*'), re.I), 'begin'
-groupends = r'end|endprogram|endblockdata|endmodule|endpythonmodule|endinterface'
+groupends = (r'end|endprogram|endblockdata|endmodule|endpythonmodule|'
+             r'endinterface|endsubroutine|endfunction')
 endpattern = re.compile(
     beforethisafter % ('', groupends, groupends, r'[\w\s]*'), re.I), 'end'
 # endifs='end\s*(if|do|where|select|while|forall)'

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -8,6 +8,8 @@ from . import util
 
 
 class TestNoSpace(util.F2PyTest):
+    # issue gh-15035: add handling for endsubroutine, endfunction with no space
+    # between "end" and the block name
     code = """
         subroutine subb(k)
           real(8), intent(inout) :: k(:)
@@ -25,12 +27,11 @@ class TestNoSpace(util.F2PyTest):
           character t0
           t0 = value
         endfunction
- 
     """
 
     def test_module(self):
-        k = np.array([1, 2, 3], dtype = np.float)
-        w = np.array([1, 2, 3], dtype = np.float)
+        k = np.array([1, 2, 3], dtype=np.float64)
+        w = np.array([1, 2, 3], dtype=np.float64)
         self.module.subb(k)
         assert_array_equal(k, w + 1)
         self.module.subc([w, k])

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,0 +1,39 @@
+from __future__ import division, absolute_import, print_function
+
+import pytest
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from . import util
+
+
+class TestNoSpace(util.F2PyTest):
+    code = """
+        subroutine subb(k)
+          real(8), intent(inout) :: k(:)
+          k=k+1
+        endsubroutine
+
+        subroutine subc(w,k)
+          real(8), intent(in) :: w(:)
+          real(8), intent(out) :: k(size(w))
+          k=w+1
+        endsubroutine
+
+        function t0(value)
+          character value
+          character t0
+          t0 = value
+        endfunction
+ 
+    """
+
+    def test_module(self):
+        k = np.array([1, 2, 3], dtype = np.float)
+        w = np.array([1, 2, 3], dtype = np.float)
+        self.module.subb(k)
+        assert_array_equal(k, w + 1)
+        self.module.subc([w, k])
+        assert_array_equal(k, w + 1)
+        assert self.module.t0(23) == b'2'
+


### PR DESCRIPTION
Test, fix for missing end words in fortran subroutines and functions.
Fixes gh-14625