### PR TITLE
BUG: Fix refcounting in ufunc object loops

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -575,7 +575,11 @@ PyUFunc_O_O_method(char **args, npy_intp *dimensions, npy_intp *steps, void *fun
         PyObject **out = (PyObject **)op1;
         PyObject *ret, *func;
         func = PyObject_GetAttrString(in1 ? in1 : Py_None, meth);
-        if (func == NULL || !PyCallable_Check(func)) {
+        if (func != NULL && !PyCallable_Check(func)) {
+            Py_DECREF(func);
+            func = NULL;
+        }
+        if (func == NULL) {
             PyObject *exc, *val, *tb;
             PyTypeObject *type = in1 ? Py_TYPE(in1) : Py_TYPE(Py_None);
             PyErr_Fetch(&exc, &val, &tb);
@@ -588,6 +592,7 @@ PyUFunc_O_O_method(char **args, npy_intp *dimensions, npy_intp *steps, void *fun
             return;
         }
         ret = PyObject_Call(func, tup, NULL);
+        Py_DECREF(func);
         if (ret == NULL) {
             Py_DECREF(tup);
             return;


### PR DESCRIPTION
Previously `func` was leaked on both success and failure paths.

Backport of #15036 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
