### PR TITLE
MAINT, TST: cleanup ragged array test and code

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1826,8 +1826,9 @@ PyArray_GetArrayParamsFromObject(PyObject *op,
             if (is_object == DISCOVERED_RAGGED && requested_dtype == NULL) {
                 /* NumPy 1.18, 2019-11-01 */
                 if (DEPRECATE("Creating an ndarray with automatic object "
-                    "dtype is deprecated, use dtype=object if you intended "
-                    "it, otherwise specify an exact dtype") < 0)
+                              "dtype is deprecated, use dtype=object if you "
+                              "intended it, otherwise specify an exact "
+                              "dtype") < 0)
                 {
                     return -1;
                 }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2285,7 +2285,9 @@ class TestMethods(object):
     def test_searchsorted_with_sorter(self):
         a = np.array([5, 2, 1, 3, 4])
         s = np.argsort(a)
-        assert_raises(TypeError, np.searchsorted, a, 0, sorter=(1, (2, 3)))
+        with assert_raises(TypeError):
+            with assert_warns(DeprecationWarning):
+                np.searchsorted(a, 0, sorter=(1, (2, 3)))
         assert_raises(TypeError, np.searchsorted, a, 0, sorter=[1.1])
         assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4])
         assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4, 5, 6])

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -543,13 +543,18 @@ def _valnd(val_f, c, *args):
         See the ``<type>val<n>d`` functions for more detail
     """
     try:
-        args = tuple(np.array(args, copy=False))
-    except Exception:
+        # Automatic object array creation from ragged lists deprecated in 1.18,
+        # so pre-emptively raise. Change to correct exception when deprecation is removed
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', 'Creating an ndarray with automatic',
+                                    DeprecationWarning)
+            args = tuple(np.array(args, copy=False))
+    except DeprecationWarning:
         # preserve the old error message
         if len(args) == 2:
-            raise ValueError('x, y, z are incompatible')
-        elif len(args) == 3:
             raise ValueError('x, y are incompatible')
+        elif len(args) == 3:
+            raise ValueError('x, y, z are incompatible')
         else:
             raise ValueError('ordinates are incompatible')
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,8 @@ filterwarnings =
     ignore:comparing unequal types not supported in 3\.x:DeprecationWarning
     ignore:the commands module has been removed in Python 3\.0:DeprecationWarning
     ignore:The 'new' module has been removed in Python 3\.0:DeprecationWarning
+# Do not mask this warning behind an error gh-15048
+    always:Creating an ndarray with automatic object dtype:DeprecationWarning
 
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
Fixes gh-15044
xref issue gh-15045 and [comment](https://github.com/numpy/numpy/pull/14794#discussion_r352811781) on gh-14794

For some reason pytest did not report the warning emitted in an `assert_raise`, except when run in the `numpy-wheels` repo by CPython3.8