### PR TITLE
DOC: Fix statement about norms

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2355,7 +2355,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
     Notes
     -----
-    For values of ``ord <= 1``, the result is, strictly speaking, not a
+    For values of ``ord < 1``, the result is, strictly speaking, not a
     mathematical 'norm', but it may still be useful for various numerical
     purposes.
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2355,7 +2355,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
     Notes
     -----
-    For values of ``ord <= 0``, the result is, strictly speaking, not a
+    For values of ``ord <= 1``, the result is, strictly speaking, not a
     mathematical 'norm', but it may still be useful for various numerical
     purposes.
 


### PR DESCRIPTION
The "0.5-norm" violates the triangle inequality because its unit ball is nonconvex.