### PR TITLE
BUG: Exceptions tracebacks are dropped

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -496,8 +496,7 @@ class recarray(ndarray):
         except Exception:
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             if attr not in fielddict:
-                exctype, value = sys.exc_info()[:2]
-                raise exctype(value)
+                raise
         else:
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             if attr not in fielddict:

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -260,8 +260,7 @@ class MaskedRecords(MaskedArray, object):
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             optinfo = ndarray.__getattribute__(self, '_optinfo') or {}
             if not (attr in fielddict or attr in optinfo):
-                exctype, value = sys.exc_info()[:2]
-                raise exctype(value)
+                raise
         else:
             # Get the list of names
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}


### PR DESCRIPTION
Backport of #15039. 

For some reason this code reconstructed brand new exception objects with
no traceback, rather than just re-raising

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
