### PR TITLE
ENH: Adding offset functionality to fill_diagonal in index_tricks.py. Associated with issue #14402

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -770,6 +770,9 @@ def fill_diagonal(a, val, wrap=False, offset=0):
       diagonal "wrapped" after N columns. You can have this behavior
       with this option. This affects only tall matrices.
 
+    offset: int
+      Fills array along non-primary diagonal specified by offset.
+
     See also
     --------
     diag_indices, diag_indices_from

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -359,9 +359,61 @@ def test_c_():
 
 
 class TestFillDiagonal(object):
+    def test_offset_tall(self):
+        a = np.zeros((10, 4), int)
+        fill_diagonal(a, 5, wrap=True)
+        assert_array_equal(
+            a, np.array([[5, 0, 0, 0],
+                         [0, 5, 0, 0],
+                         [0, 0, 5, 0],
+                         [0, 0, 0, 5],
+                         [0, 0, 0, 0],
+                         [5, 0, 0, 0],
+                         [0, 5, 0, 0],
+                         [0, 0, 5, 0],
+                         [0, 0, 0, 5],
+                         [0, 0, 0, 0]])
+            )
+
+    def test_offset_tall2(self):
+        a = np.zeros((10,7), int)
+        fill_diagonal(a, 5, wrap=True)
+        assert_array_equal(
+            a, np.array([[5, 0, 0, 0, 0, 0, 0],
+                         [0, 5, 0, 0, 0, 0, 0],
+                         [0, 0, 5, 0, 0, 0, 0],
+                         [0, 0, 0, 5, 0, 0, 0],
+                         [0, 0, 0, 0, 5, 0, 0],
+                         [0, 0, 0, 0, 0, 5, 0],
+                         [0, 0, 0, 0, 0, 0, 5],
+                         [0, 0, 0, 0, 0, 0, 0],
+                         [5, 0, 0, 0, 0, 0, 0],
+                         [0, 5, 0, 0, 0, 0, 0]])
+            )
+
+
+    def test_offset_nowrap(self):
+        a = np.zeros((3,3), int)
+        fill_diagonal(a, 5, offset=2)
+        assert_array_equal(
+            a, np.array([[0, 0, 5],
+                         [0, 0, 0],
+                         [0, 0, 0]])
+            )
+
+    def test_offset_square_wrap(self):
+        a = np.zeros((3,3), int)
+        fill_diagonal(a, 5, wrap=True, offset=2)
+        assert_array_equal(
+            a, np.array([[0, 0, 5],
+                         [5, 0, 0],
+                         [0, 5, 0]])
+            )
+
     def test_basic(self):
         a = np.zeros((3, 3), int)
         fill_diagonal(a, 5)
+        print(a)
         assert_array_equal(
             a, np.array([[5, 0, 0],
                          [0, 5, 0],


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

ENH: Adding offset functionality to fill_diagonal in index_tricks.py. Associated with [issue 14402](https://github.com/numpy/numpy/issues/14402)

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
