### PR TITLE
TST: add value to pytest.ini for pytest6 compatibility

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 addopts = -l
 norecursedirs = doc tools numpy/linalg/lapack_lite numpy/core/code_generators
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS ALLOW_UNICODE ALLOW_BYTES
+junit_family=xunit2
 
 filterwarnings =
     error


### PR DESCRIPTION
This warning is showing up on the azure test runs, due to the azurepipelines plugin:
```
site-packages/_pytest/junitxml.py:436: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.
```

I think this change is what is needed to silence the warning