### PR TITLE
NEP: add np.allow_object to the proposal

### DIFF
--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -32,7 +32,7 @@ level have the same length) will force users who actually wish to create
 and ``nd.ndarrays`` are all sequences [0]_. See for instance `issue 5303`_.
 Since this paradigm seems to be in wide use in libraries like pandas, scipy,
 and matplotlib, a work-around via ``np.array([<ragged_nested_sequence>],
-dtype=np.allow_ragged)`` will be added, with the intent that the work-around
+dtype=np.allow_object)`` will be added, with the intent that the work-around
 will be removed at some time in the future.
 
 Usage and Impact
@@ -87,7 +87,7 @@ Implementation
 --------------
 
 The code to be changed is inside ``PyArray_GetArrayParamsFromObject`` and the
-internal ``discover_dimentions`` function. See `PR 14794`_.
+internal ``discover_dimensions`` function. See `PR 14794`_.
 
 Backward compatibility
 ----------------------
@@ -95,7 +95,7 @@ Backward compatibility
 Anyone depending on creating object arrays from ragged nested sequences will
 need to modify their code. There will be a deprecation period during which the
 current behaviour will emit a ``DeprecationWarning``. Additionally, a sentinal
-value ``np.allow_ragged`` will use the pre-NEP-34 behaviour without a warning.
+value ``np.allow_object`` will use the pre-NEP-34 behaviour without a warning.
 Once the implications of the change are well-understood, the sentinal value
 could be removed.
 
@@ -135,14 +135,15 @@ Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 2014. Suggestions to change it have been made in the ensuing years, but none
 have stuck. The implementation in `PR 14794`_ seemed to point to the
 viability of this approach. However this proved very disruptive to downstream
-library authors, so the idea to add a ``np.allow_ragged`` sentinal was added.
+library authors, so the idea to add a ``np.allow_object`` sentinal was added.
 
-The name is specific to ragged nested sequences. In discussion we considered a
-more general ``np.allow_object``. That is over-general and would not
-differentiate between ``np.array([Decimal(10), Decimal(10)])`` and the ragged
-nested sequence ``np.array([Decimal(10), [1, Decimal(10)]])``. Currently the
-NEP does not propose disallowing the latter without an explicit
-``np.allow_ragged``, but a future enhancement could.
+The name is not specific to ragged nested sequences. In discussion we
+considered a more specific ``np.allow_ragged``. However it was felt that there
+is really no difference between an object array with ragged sequences and an
+object array like ``np.array([Decimal(10), Decimal(10)])``. There was some
+discussion of the possibility of a future NEP allowing syntax like
+``np.array([Decimal(10), Decimal(10)], dtype=Decimal)``, but again that is out
+of scope for the current NEP.
 
 References and Footnotes
 ------------------------

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -30,6 +30,10 @@ recursive sequence of sequences, where not all the sequences on the same
 level have the same length) will force users who actually wish to create
 ``object`` arrays to specify that explicitly. Note that ``lists``, ``tuples``,
 and ``nd.ndarrays`` are all sequences [0]_. See for instance `issue 5303`_.
+Since this paradigm seems to be in wide use in libraries like pandas, scipy,
+and matplotlib, a work-around via ``np.array([<ragged_nested_sequence>],
+dtype=np.allow_ragged)`` will be added, with the intent that the work-around
+will be removed at some time in the future.
 
 Usage and Impact
 ----------------
@@ -71,11 +75,13 @@ all of these will be rejected:
 Related Work
 ------------
 
-`PR 14341`_ tried to raise an error when ragged nested sequences were specified
-with a numeric dtype ``np.array, [[1], [2, 3]], dtype=int)`` but failed due to
-false-positives, for instance ``np.array([1, np.array([5])], dtype=int)``.
+`PR 14341`_ tried to change the error reported when ragged nested sequences
+were specified with a numeric dtype ``np.array([[1], [2, 3]], dtype=int)`` but
+failed due to false-positives when assigning a mixed scalar-ndarray list to an
+array (`issue 14138`_)
 
 .. _`PR 14341`: https://github.com/numpy/numpy/pull/14341
+.. _`issue 14138`: https://github.com/numpy/numpy/issue/14138
 
 Implementation
 --------------
@@ -88,7 +94,10 @@ Backward compatibility
 
 Anyone depending on creating object arrays from ragged nested sequences will
 need to modify their code. There will be a deprecation period during which the
-current behaviour will emit a ``DeprecationWarning``. 
+current behaviour will emit a ``DeprecationWarning``. Additionally, a sentinal
+value ``np.allow_ragged`` will use the pre-NEP-34 behaviour without a warning.
+Once the implications of the change are well-understood, the sentinal value
+could be removed.
 
 Alternatives
 ------------
@@ -113,18 +122,26 @@ Alternatives
   the current NEP. Rationale: it's harder to asses the impact of this larger
   change, we're not sure how many users this may impact.
 
+- The issue of ``np.array([0.3, [0.3]])`` (or more commonly ``np.array([0.3,
+  np.array([0.3])])`` creating an object array rather than a ``float64`` array
+  was discussed in `issue 15075`_. This too is out of scope for the current
+  NEP.
+
+
 Discussion
 ----------
 
 Comments to `issue 5303`_ indicate this is unintended behaviour as far back as
 2014. Suggestions to change it have been made in the ensuing years, but none
-have stuck. The WIP implementation in `PR 14794`_ seems to point to the
-viability of this approach.
+have stuck. The implementation in `PR 14794`_ seemed to point to the
+viability of this approach. However this proved very disruptive to downstream
+library authors, so the idea to add a ``np.allow_ragged`` sentinal was added.
 
 References and Footnotes
 ------------------------
 
 .. _`issue 5303`: https://github.com/numpy/numpy/issues/5303
+.. _`issue 15075`: https://github.com/numpy/numpy/issues/15075
 .. _sequences: https://docs.python.org/3.7/glossary.html#term-sequence
 .. _`PR 14794`: https://github.com/numpy/numpy/pull/14794
 .. _`another library`: https://github.com/scikit-hep/awkward-array

--- a/doc/neps/nep-0034.rst
+++ b/doc/neps/nep-0034.rst
@@ -137,6 +137,13 @@ have stuck. The implementation in `PR 14794`_ seemed to point to the
 viability of this approach. However this proved very disruptive to downstream
 library authors, so the idea to add a ``np.allow_ragged`` sentinal was added.
 
+The name is specific to ragged nested sequences. In discussion we considered a
+more general ``np.allow_object``. That is over-general and would not
+differentiate between ``np.array([Decimal(10), Decimal(10)])`` and the ragged
+nested sequence ``np.array([Decimal(10), [1, Decimal(10)]])``. Currently the
+NEP does not propose disallowing the latter without an explicit
+``np.allow_ragged``, but a future enhancement could.
+
 References and Footnotes
 ------------------------
 


### PR DESCRIPTION
xref  gh-15047

I settled on `np.allow_ragged` even though, as @rgommers points out "ragged" is not a concept in the NumPy lexicon. I think it captures the intent. We will need to document the sentinel carefully, and maybe add a section on "automatic conversion" to the [user documents](https://numpy.org/devdocs/user/basics.creation.html#converting-python-array-like-objects-to-numpy-arrays) and [reference documents](https://numpy.org/devdocs/reference/generated/numpy.array.html)