### PR TITLE
MAINT: Ragged cleanup

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2256,21 +2256,19 @@ class TestMethods(object):
         assert_equal([a.searchsorted(a[i], 'left') for i in ind], ind)
         assert_equal([a.searchsorted(a[i], 'right') for i in ind], ind + 1)
 
-    @pytest.mark.parametrize('index, sorter, error',
-                        (
-                            (0, np.array([1, (2, 3)], dtype=object), TypeError),
-                            (0, [1.1], TypeError),
-                            (0, [1, 2, 3, 4], ValueError),
-                            (0, [1, 2, 3, 4, 5, 6], ValueError),
-                            # bounds check
-                            (4, [0, 1, 2, 3, 5], ValueError),
-                            (0, [-1, 0, 1, 2, 3], ValueError),
-                            (0, [4, 0, -1, 2, 3], ValueError),
-                        ))
-    def test_searchsorted_with_invalid_sorter(self, index, sorter, error):
+    def test_searchsorted_with_invalid_sorter(self):
         a = np.array([5, 2, 1, 3, 4])
         s = np.argsort(a)
-        assert_raises(error, np.searchsorted, a, index, sorter=sorter)
+        assert_raises(TypeError, np.searchsorted, a, 0,
+                      sorter=np.array((1, (2, 3)), dtype=object))
+        assert_raises(TypeError, np.searchsorted, a, 0, sorter=[1.1])
+        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4])
+        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4, 5, 6])
+
+        # bounds check
+        assert_raises(ValueError, np.searchsorted, a, 4, sorter=[0, 1, 2, 3, 5])
+        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[-1, 0, 1, 2, 3])
+        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[4, 0, -1, 2, 3])
 
     def test_searchsorted_with_sorter(self):
         a = np.random.rand(300)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2256,19 +2256,23 @@ class TestMethods(object):
         assert_equal([a.searchsorted(a[i], 'left') for i in ind], ind)
         assert_equal([a.searchsorted(a[i], 'right') for i in ind], ind + 1)
 
-    def test_searchsorted_with_sorter(self):
+    @pytest.mark.parametrize('index, sorter, error',
+                        (
+                            (0, np.array([1, (2, 3)], dtype=object), TypeError),
+                            (0, [1.1], TypeError),
+                            (0, [1, 2, 3, 4], ValueError),
+                            (0, [1, 2, 3, 4, 5, 6], ValueError),
+                            # bounds check
+                            (4, [0, 1, 2, 3, 5], ValueError),
+                            (0, [-1, 0, 1, 2, 3], ValueError),
+                            (0, [4, 0, -1, 2, 3], ValueError),
+                        ))
+    def test_searchsorted_with_invalid_sorter(self, index, sorter, error):
         a = np.array([5, 2, 1, 3, 4])
         s = np.argsort(a)
-        assert_raises(TypeError, np.searchsorted, a, 0, sorter=(1, (2, 3)))
-        assert_raises(TypeError, np.searchsorted, a, 0, sorter=[1.1])
-        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4])
-        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[1, 2, 3, 4, 5, 6])
+        assert_raises(error, np.searchsorted, a, index, sorter=sorter)
 
-        # bounds check
-        assert_raises(ValueError, np.searchsorted, a, 4, sorter=[0, 1, 2, 3, 5])
-        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[-1, 0, 1, 2, 3])
-        assert_raises(ValueError, np.searchsorted, a, 0, sorter=[4, 0, -1, 2, 3])
-
+    def test_searchsorted_with_sorter(self):
         a = np.random.rand(300)
         s = a.argsort()
         b = np.sort(a)

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -542,12 +542,15 @@ def _valnd(val_f, c, *args):
     c, args :
         See the ``<type>val<n>d`` functions for more detail
     """
-    if len(args) > 2:
-        if len(args[0]) != len(args[1]) or len(args[1]) != len(args[2]):
+    args = [np.asanyarray(a) for a in args]
+    shape0 = args[0].shape
+    if not all((a.shape == shape0 for a in args)):
+        if len(args) ==3:
             raise ValueError('x, y, z are incompatible')
-    elif len(args) > 1:
-        if len(args[0]) != len(args[1]):
+        elif len(args) ==2:
             raise ValueError('x, y are incompatible')
+        else:
+            raise ValueError('ordinates are incompatible')
     it = iter(args)
     x0 = next(it)
 

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -542,17 +542,12 @@ def _valnd(val_f, c, *args):
     c, args :
         See the ``<type>val<n>d`` functions for more detail
     """
-    try:
-        args = tuple(np.array(args, copy=False))
-    except Exception:
-        # preserve the old error message
-        if len(args) == 2:
+    if len(args) > 2:
+        if len(args[0]) != len(args[1]) or len(args[1]) != len(args[2]):
             raise ValueError('x, y, z are incompatible')
-        elif len(args) == 3:
+    elif len(args) > 1:
+        if len(args[0]) != len(args[1]):
             raise ValueError('x, y are incompatible')
-        else:
-            raise ValueError('ordinates are incompatible')
-
     it = iter(args)
     x0 = next(it)
 

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -545,7 +545,7 @@ def _valnd(val_f, c, *args):
     args = [np.asanyarray(a) for a in args]
     shape0 = args[0].shape
     if not all((a.shape == shape0 for a in args[1:])):
-        if len(args) ==3:
+        if len(args) == 3:
             raise ValueError('x, y, z are incompatible')
         elif len(args) == 2:
             raise ValueError('x, y are incompatible')

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -544,10 +544,10 @@ def _valnd(val_f, c, *args):
     """
     args = [np.asanyarray(a) for a in args]
     shape0 = args[0].shape
-    if not all((a.shape == shape0 for a in args)):
+    if not all((a.shape == shape0 for a in args[1:])):
         if len(args) ==3:
             raise ValueError('x, y, z are incompatible')
-        elif len(args) ==2:
+        elif len(args) == 2:
             raise ValueError('x, y are incompatible')
         else:
             raise ValueError('ordinates are incompatible')

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -9,7 +9,7 @@ import numpy as np
 import numpy.polynomial.polynomial as poly
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
-    assert_warns, assert_array_equal)
+    assert_warns, assert_array_equal, assert_raises_regex)
 
 
 def trim(x):
@@ -229,7 +229,8 @@ class TestEvaluation(object):
         y1, y2, y3 = self.y
 
         #test exceptions
-        assert_raises(ValueError, poly.polyval2d, x1, x2[:2], self.c2d)
+        assert_raises_regex(ValueError, 'incompatible',
+                            poly.polyval2d, x1, x2[:2], self.c2d)
 
         #test values
         tgt = y1*y2
@@ -246,7 +247,8 @@ class TestEvaluation(object):
         y1, y2, y3 = self.y
 
         #test exceptions
-        assert_raises(ValueError, poly.polyval3d, x1, x2, x3[:2], self.c3d)
+        assert_raises_regex(ValueError, 'incompatible',
+                      poly.polyval3d, x1, x2, x3[:2], self.c3d)
 
         #test values
         tgt = y1*y2*y3


### PR DESCRIPTION
Redo gh-15048.

- `sorter=val` tests created a ragged array, which would raise due to ["sorter is an array of integer indices"](https://numpy.org/devdocs/reference/generated/numpy.searchsorted.html). The test now creates the object array in the test, rather than passing in `[1, [2, 3]]` and relying on internal conversion.
- polynomial has a helper function `_valnd` which tested for an exception that was never raised. The `assert_raises` tests succeeded since a broadcast error was raised in calling `val_f()`