### PR TITLE
BUG: Fix to ma.core for issue #15077 to correctly set min and max values for all float/complex dtypes

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -198,14 +198,14 @@ for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
     default_filler["M8[" + v + "]"] = np.datetime64("NaT", v)
     default_filler["m8[" + v + "]"] = np.timedelta64("NaT", v)
 
-float_types_list = [np.float16, np.float32, np.float64, np.float128,
-                    np.complex64, np.complex128, np.complex256]
+float_types_list = ['float16', 'float32', 'float64', 'float128',
+                    'complex64', 'complex128', 'complex256']
 max_filler = ntypes._minvals
-max_filler.update([(k, -np.inf) for k in float_types_list
-                    if k in ntypes.typeDict.values()])
+max_filler.update([(ntypes.typeDict[k], -np.inf) for k in float_types_list
+                    if k in ntypes.typeDict])
 min_filler = ntypes._maxvals
-min_filler.update([(k, +np.inf) for k in float_types_list
-                    if k in ntypes.typeDict.values()])
+min_filler.update([(ntypes.typeDict[k], +np.inf) for k in float_types_list
+                    if k in ntypes.typeDict])
 del float_types_list
 
 def _recursive_fill_value(dtype, f):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -198,12 +198,12 @@ for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
     default_filler["M8[" + v + "]"] = np.datetime64("NaT", v)
     default_filler["m8[" + v + "]"] = np.timedelta64("NaT", v)
 
-float_types_list = ['half', 'single', 'double', 'longdouble',
-                    'csingle', 'cdouble', 'clongdouble']
+float_types_list = [np.half, np.single, np.double, np.longdouble,
+                    np.csingle, np.cdouble, np.clongdouble]
 max_filler = ntypes._minvals
-max_filler.update([(ntypes.typeDict[k], -np.inf) for k in float_types_list])
+max_filler.update([(k, -np.inf) for k in float_types_list])
 min_filler = ntypes._maxvals
-min_filler.update([(ntypes.typeDict[k], +np.inf) for k in float_types_list])
+min_filler.update([(k, +np.inf) for k in float_types_list])
 del float_types_list
 
 def _recursive_fill_value(dtype, f):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -198,14 +198,14 @@ for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
     default_filler["M8[" + v + "]"] = np.datetime64("NaT", v)
     default_filler["m8[" + v + "]"] = np.timedelta64("NaT", v)
 
+float_types_list = [np.float16, np.float32, np.float64, np.float128,
+                    np.complex64, np.complex128, np.complex256]
 max_filler = ntypes._minvals
-max_filler.update([(k, -np.inf) for k in [np.float32, np.float64]])
+max_filler.update([(k, -np.inf) for k in float_types_list
+                    if k in ntypes.typeDict.values()])
 min_filler = ntypes._maxvals
-min_filler.update([(k, +np.inf) for k in [np.float32, np.float64]])
-if 'float128' in ntypes.typeDict:
-    max_filler.update([(np.float128, -np.inf)])
-    min_filler.update([(np.float128, +np.inf)])
-
+min_filler.update([(k, +np.inf) for k in float_types_list
+                    if k in ntypes.typeDict.values()])
 
 def _recursive_fill_value(dtype, f):
     """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -206,6 +206,7 @@ max_filler.update([(k, -np.inf) for k in float_types_list
 min_filler = ntypes._maxvals
 min_filler.update([(k, +np.inf) for k in float_types_list
                     if k in ntypes.typeDict.values()])
+del float_types_list
 
 def _recursive_fill_value(dtype, f):
     """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -198,14 +198,12 @@ for v in ["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", "ps",
     default_filler["M8[" + v + "]"] = np.datetime64("NaT", v)
     default_filler["m8[" + v + "]"] = np.timedelta64("NaT", v)
 
-float_types_list = ['float16', 'float32', 'float64', 'float128',
-                    'complex64', 'complex128', 'complex256']
+float_types_list = ['half', 'single', 'double', 'longdouble',
+                    'csingle', 'cdouble', 'clongdouble']
 max_filler = ntypes._minvals
-max_filler.update([(ntypes.typeDict[k], -np.inf) for k in float_types_list
-                    if k in ntypes.typeDict])
+max_filler.update([(ntypes.typeDict[k], -np.inf) for k in float_types_list])
 min_filler = ntypes._maxvals
-min_filler.update([(ntypes.typeDict[k], +np.inf) for k in float_types_list
-                    if k in ntypes.typeDict])
+min_filler.update([(ntypes.typeDict[k], +np.inf) for k in float_types_list])
 del float_types_list
 
 def _recursive_fill_value(dtype, f):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1232,6 +1232,32 @@ class TestMaskedArrayArithmetic(object):
         assert_(x.max() is masked)
         assert_(x.ptp() is masked)
 
+    def test_minmax_dtypes(self):
+        # Additonal tests on max/min for non-standard float and complex dtypes
+        (x, _, a10, m1, _, xm, _, _, _, _) = self.d
+        assert_equal(xm.max(), a10)
+        assert_equal(masked_array(x, mask=m1, dtype=np.half).max(), np.half(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.single).max(), np.single(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.double).max(), np.double(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.longdouble).max(), np.longdouble(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.cfloat).max(), np.cfloat(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.cdouble).max(), np.cdouble(a10))
+        assert_equal(masked_array(x, mask=m1, dtype=np.clongdouble).max(), np.clongdouble(a10))
+        ym = masked_array([1e20, 2e20], mask=[1,0])
+        assert_equal(ym.min(), 2e20)
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.single)
+        assert_equal(ym.min(), np.single(2e20))
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.double)
+        assert_equal(ym.min(), np.double(2e20))
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.longdouble)
+        assert_equal(ym.min(), np.longdouble(2e20))
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.cfloat)
+        assert_equal(ym.min(), np.cfloat(2e20))
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.cdouble)
+        assert_equal(ym.min(), np.cdouble(2e20))
+        ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.clongdouble)
+        assert_equal(ym.min(), np.clongdouble(2e20))
+
     def test_addsumprod(self):
         # Tests add, sum, product.
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1233,7 +1233,7 @@ class TestMaskedArrayArithmetic(object):
         assert_(x.ptp() is masked)
 
     def test_minmax_dtypes(self):
-        # Additonal tests on max/min for non-standard float and complex dtypes
+        # Additional tests on max/min for non-standard float and complex dtypes
         (x, _, a10, m1, _, xm, _, _, _, _) = self.d
         assert_equal(xm.max(), a10)
         assert_equal(masked_array(x, mask=m1, dtype=np.half).max(), np.half(a10))
@@ -1243,8 +1243,6 @@ class TestMaskedArrayArithmetic(object):
         assert_equal(masked_array(x, mask=m1, dtype=np.cfloat).max(), np.cfloat(a10))
         assert_equal(masked_array(x, mask=m1, dtype=np.cdouble).max(), np.cdouble(a10))
         assert_equal(masked_array(x, mask=m1, dtype=np.clongdouble).max(), np.clongdouble(a10))
-        ym = masked_array([1e20, 2e20], mask=[1,0])
-        assert_equal(ym.min(), 2e20)
         ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.single)
         assert_equal(ym.min(), np.single(2e20))
         ym = masked_array([1e20, 2e20], mask=[1,0], dtype=np.double)


### PR DESCRIPTION
Finding the max of a masked array with float16 or complex dtype returned inf due to the min and max values for these dtypes not being defined. These values are now set to +/- inf, the same as for float32, float64 and float128 dtypes.

Fixes #15077 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
