### PR TITLE
ENH: Provide functions to convert the axes of object arrays to and from lists

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -20,7 +20,7 @@ __all__ = [
     'column_stack', 'row_stack', 'dstack', 'array_split', 'split',
     'hsplit', 'vsplit', 'dsplit', 'apply_over_axes', 'expand_dims',
     'apply_along_axis', 'kron', 'tile', 'get_array_wrap', 'take_along_axis',
-    'put_along_axis'
+    'put_along_axis', 'array_of_lists_to_array'
     ]
 
 
@@ -1241,3 +1241,51 @@ def tile(A, reps):
                 c = c.reshape(-1, n).repeat(nrep, 0)
             n //= dim_in
     return c.reshape(shape_out)
+
+def _safe_list_conversion(l):
+    if not isinstance(l, list):
+        raise TypeError('the values of the array must be lists')
+    return array(l)
+
+def _array_of_lists_to_array_dispatcher(a):
+    return (a)
+
+@array_function_dispatch(_array_of_lists_to_array_dispatcher)
+def array_of_lists_to_array(a):
+    """
+    Converts an array of lists into an array with those lists converted into arrays.
+
+    Parameters
+    ----------
+    a : array_like
+        The input array of lists.
+
+    Returns
+    -------
+    c : ndarray
+        The converted output array.
+
+    Raises
+    ------
+    TypeError
+        If the input array's values aren't lists.
+    ValueError
+        If the lists in the array aren't of the same length.
+
+    See Also
+    --------
+    array_to_array_of_lists : The inverse of this function.
+
+    Examples
+    --------
+    >>> a = np.char.split(np.array([['1 2'], ['3 4']]))
+    >>> a
+    >>> array([[list(['1', '2'])],
+               [list(['3', '4'])]], dtype=object)
+    >>> np.array_of_lists_to_array(a)
+    >>> array([[['1' '2']],
+               [['3' '4']]], dtype=np.str_)
+    """
+    
+    axis = -1
+    return apply_along_axis(lambda r: _safe_list_conversion(r[0]), axis, a[..., None])

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -9,7 +9,7 @@ import pytest
 from numpy.lib.shape_base import (
     apply_along_axis, apply_over_axes, array_split, split, hsplit, dsplit,
     vsplit, dstack, column_stack, kron, tile, expand_dims, take_along_axis,
-    put_along_axis
+    put_along_axis, array_of_lists_to_array
     )
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, assert_warns
@@ -700,6 +700,30 @@ class TestMayShareMemory(object):
         assert_(not np.may_share_memory(d[::2], d2))
         assert_(not np.may_share_memory(d[1:, ::-1], d2))
         assert_(np.may_share_memory(d2[1:, ::-1], d2))
+
+class TestArrayOfListsToArray(object):
+    def test_basic(self):
+        a = np.empty(2, dtype=object)
+        a[0] = list([1, 2])
+        a[1] = list([3, 4])
+        b = np.array([[1, 2], [3, 4]])
+        c = array_of_lists_to_array(a)
+
+        assert_equal(b, c)
+
+    def test_incompatible_lengths(self):
+        a = np.empty(2, dtype=object)
+        a[0] = list([1, 2, 3])
+        a[1] = list([4, 5])
+
+        with assert_raises(ValueError):
+            b = array_of_lists_to_array(a)
+
+    def test_not_list(self):
+        a = np.array([[1, 2], [3, 4]])
+        
+        with assert_raises(TypeError):
+            b = array_of_lists_to_array(a)
 
 
 # Utility

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -9,7 +9,7 @@ import pytest
 from numpy.lib.shape_base import (
     apply_along_axis, apply_over_axes, array_split, split, hsplit, dsplit,
     vsplit, dstack, column_stack, kron, tile, expand_dims, take_along_axis,
-    put_along_axis, array_of_lists_to_array
+    put_along_axis, array_of_lists_to_array, array_to_array_of_lists
     )
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises, assert_warns
@@ -724,6 +724,33 @@ class TestArrayOfListsToArray(object):
         
         with assert_raises(TypeError):
             b = array_of_lists_to_array(a)
+
+
+class TestArrayToArrayOfLists(object):
+    def test_basic(self):
+        a = np.array([[[1, 2], [3, 4]]])
+        b = np.empty((1, 2), dtype=object)
+        b[0][0] = list([1, 2])
+        b[0][1] = list([3, 4])
+        c = array_to_array_of_lists(a, -2)
+
+        assert_equal(b, c)
+
+    def test_default(self):
+        a = np.array([[[1, 2], [3, 4]]])
+        b = np.empty(1, dtype=object)
+        b[0] = list([[1, 2], [3, 4]])
+        c = array_to_array_of_lists(a)
+
+        assert_equal(b, c)
+
+    def test_axis_error(self):
+        a = np.array([[1, 2], [3, 4]])
+
+        with assert_raises(ValueError):
+            array_to_array_of_lists(a, -1)
+        with assert_raises(ValueError):
+            array_to_array_of_lists(a, 1)
 
 
 # Utility


### PR DESCRIPTION
Closes #14478.
This pull request implements functionalities asked for in #14478.
I decided to implement the function converting arrays to arrays of lists in a way that allows choosing the axis to convert, as if we always converted the last (or next-to-last, depending how we look at it) axis, then those functions wouldn't be inverses of eachother; for example, converting
`array([list([[1, 2], 
                  [3, 4]])])`
with array_of_lists_to_array results in
`array([[[1, 2], 
             [3, 4]]])`
but converting the last axis of the above array into lists would yield
`array([[list([1, 2]), 
            list([3, 4])]])`
which is different to what we started with.
I would greatly appreciate opinions on the above change and regarding the names of the functions and their placement in the project structure (currently placed in lib/shape_base.py).