### PR TITLE
DOC: bring the out parameter docstring into line with ufuncs

### DIFF
--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -85,13 +85,20 @@ def fix(x, out=None):
     ----------
     x : array_like
         An array of floats to be rounded
-    y : ndarray, optional
-        Output array
+    out : ndarray, optional
+        A location into which the result is stored. If provided, it must have
+        a shape that the input broadcasts to. If not provided or None, a
+        freshly-allocated array is returned.
 
     Returns
     -------
     out : ndarray of floats
-        The array of rounded numbers
+        A float array with the same dimensions as the input.
+        If second argument is not supplied then a float array is returned
+        with the rounded values.
+
+        If a second argument is supplied the result is stored there.
+        The return value `out` is then a reference to that array.
 
     See Also
     --------
@@ -129,8 +136,10 @@ def isposinf(x, out=None):
     ----------
     x : array_like
         The input array.
-    y : array_like, optional
-        A boolean array with the same shape as `x` to store the result.
+    out : array_like, optional
+        A location into which the result is stored. If provided, it must have a
+        shape that the input broadcasts to. If not provided or None, a
+        freshly-allocated boolean array is returned.
 
     Returns
     -------
@@ -199,8 +208,9 @@ def isneginf(x, out=None):
     x : array_like
         The input array.
     out : array_like, optional
-        A boolean array with the same shape and type as `x` to store the
-        result.
+        A location into which the result is stored. If provided, it must have a
+        shape that the input broadcasts to. If not provided or None, a
+        freshly-allocated boolean array is returned.
 
     Returns
     -------


### PR DESCRIPTION
Closes gh-14760

Document that the `out` parameter can be broadcast to.