### PR TITLE
DOC: Effect of type promotion on endianness

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -275,6 +275,13 @@ the 'S', 'U', and 'V' types cannot be operated on by ufuncs. Also,
 note that on a 32-bit system the integer types may have different
 sizes, resulting in a slightly altered table.
 
+.. note::
+
+    The byte order (endianness) of data types is not necessarily
+    preserved during casting. The casting process automatically
+    converts the endianness of the resultant data type to match
+    that of the host system.
+
 Mixed scalar-array operations use a different set of casting rules
 that ensure that a scalar cannot "upcast" an array unless the scalar is
 of a fundamentally different kind of data (*i.e.*, under a different

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -652,6 +652,10 @@ def result_type(*arrays_and_dtypes):
     By examining the value of the constant, '3', we see that it fits in
     an 8-bit integer, which can be cast losslessly into the 32-bit float.
 
+    The type promotion process results in a data type with the same byte
+    order as the host system, regardless of the byte order of the
+    original data type(s).
+
     Parameters
     ----------
     arrays_and_dtypes : list of arrays and dtypes
@@ -671,6 +675,9 @@ def result_type(*arrays_and_dtypes):
     .. versionadded:: 1.6.0
 
     The specific algorithm used is as follows.
+
+    If there is only one input parameter, the data type of the
+    input is returned unmodified.
 
     Categories are determined by first checking which of boolean,
     integer (int/uint), or floating point (float/complex) the maximum
@@ -699,6 +706,11 @@ def result_type(*arrays_and_dtypes):
 
     >>> np.result_type(3.0, -2)
     dtype('float64')
+
+    Byte order of result of type promotion on a little-endian system
+
+    >>> np.result_type('>i4', '>i4')
+    dtype('int32')
 
     """
     return arrays_and_dtypes


### PR DESCRIPTION
I added to the documentation in two places to provide additional information about how the casting process effects endianness. The additional documentation is intended to provide some additional context for issues like #15088.

Please pay careful attention to my word choice when reviewing - there are some terms ("type coercion", "type promotion", "casting") that I may have erroneously used interchangeably.