### PR TITLE
TST: Check requires_memory immediately before the test

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -288,7 +288,7 @@ to 0 or 1 (``NPY_TRUE`` or ``NPY_FALSE``).
 (`gh-14464 <https://github.com/numpy/numpy/pull/14464>`__)
 
 ``numpy.random.randint`` produced incorrect value when the range was ``2**32``
-----------------------------------------------------------------------------
+------------------------------------------------------------------------------
 The implementation introduced in 1.17.0 had an incorrect check when
 determining whether to use the 32-bit path or the full 64-bit
 path that incorrectly redirected random integer generation with a high - low


### PR DESCRIPTION
Backport #15072. 

Perform the available-memory check immediately before the test, not at
import time, and catch MemoryError.

Possibly helps with #15071



<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
