### PR TITLE
MAINT: Fix expm1 instability for small complex numbers.

### DIFF
--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -360,9 +360,9 @@ nc_exp2@c@(@ctype@ *x, @ctype@ *r)
 static void
 nc_expm1@c@(@ctype@ *x, @ctype@ *r)
 {
-    @ftype@ a = npy_exp@c@(x->real);
-    r->real = a*npy_cos@c@(x->imag) - 1.0@c@;
-    r->imag = a*npy_sin@c@(x->imag);
+    @ftype@ a = npy_cos@c@(x->imag);
+    r->real = npy_expm1@c@(x->real) * a + (a - 1);
+    r->imag = npy_exp@c@(x->real) * npy_sin@c@(x->imag);
     return;
 }
 

--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -360,8 +360,8 @@ nc_exp2@c@(@ctype@ *x, @ctype@ *r)
 static void
 nc_expm1@c@(@ctype@ *x, @ctype@ *r)
 {
-    @ftype@ a = npy_cos@c@(x->imag);
-    r->real = npy_expm1@c@(x->real) * a + (a - 1);
+    @ftype@ a = npy_sin@c@(x->imag / 2);
+    r->real = npy_expm1@c@(x->real) * npy_cos@c@(x->imag) - 2 * a * a;
     r->imag = npy_exp@c@(x->real) * npy_sin@c@(x->imag);
     return;
 }

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -888,6 +888,12 @@ class TestExpm1(object):
         assert_equal(ncu.expm1(np.inf), np.inf)
         assert_equal(ncu.expm1(-np.inf), -1.)
 
+    def test_complex(self):
+        x = np.asarray(1e-12)
+        assert_allclose(x, ncu.expm1(x))
+        x = x.astype(np.complex128)
+        assert_allclose(x, ncu.expm1(x))
+
 
 class TestHypot(object):
     def test_simple(self):


### PR DESCRIPTION
Fixes #14019 based on the [scipy evaluation](https://github.com/scipy/scipy/blob/557ab7e/scipy/special/_cunity.pxd#L86-L115) by reordering terms.