### PR TITLE
ENH: Add support to sort timedelta64 `NaT` to end of the array

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -318,6 +318,7 @@ Changes
 purposes, so that it sorts to the end of arrays. This change is for consistency
 with ``NaN`` sorting behavior.
 (`gh-12658 <https://github.com/numpy/numpy/pull/12658>`__)
+(`gh-15068 <https://github.com/numpy/numpy/pull/15068>`__)
 
 Incorrect ``threshold`` in ``np.set_printoptions`` raises ``TypeError`` or ``ValueError``
 -----------------------------------------------------------------------------------------

--- a/numpy/core/src/npysort/npysort_common.h
+++ b/numpy/core/src/npysort/npysort_common.h
@@ -344,6 +344,14 @@ DATETIME_LT(npy_datetime a, npy_datetime b)
 NPY_INLINE static int
 TIMEDELTA_LT(npy_timedelta a, npy_timedelta b)
 {
+    if (a == NPY_DATETIME_NAT) {
+        return 0;
+    }
+
+    if (b == NPY_DATETIME_NAT) {
+        return 1;
+    }
+
     return a < b;
 }
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -145,35 +145,47 @@ class TestDateTime(object):
         assert_(np.datetime64('NaT') != np.datetime64('NaT', 'us'))
         assert_(np.datetime64('NaT', 'us') != np.datetime64('NaT'))
 
-
-
     @pytest.mark.parametrize("size", [
         3, 21, 217, 1000])
-    def test_nat_argsort_stability(self, size):
+    def test_datetime_nat_argsort_stability(self, size):
         # NaT < NaT should be False internally for
         # sort stability
         expected = np.arange(size)
         arr = np.tile(np.datetime64('NaT'), size)
         assert_equal(np.argsort(arr, kind='mergesort'), expected)
+    
+    @pytest.mark.parametrize("size", [
+        3, 21, 217, 1000])
+    def test_timedelta_nat_argsort_stability(self, size):
+        # NaT < NaT should be False internally for
+        # sort stability
+        expected = np.arange(size)
+        arr = np.tile(np.timedelta64('NaT'), size)
+        assert_equal(np.argsort(arr, kind='mergesort'), expected)
 
     @pytest.mark.parametrize("arr, expected", [
         # the example provided in gh-12629
-        (np.array(['NaT', 1, 2, 3], dtype='M8[ns]'),
-         np.array([1, 2, 3, 'NaT'], dtype='M8[ns]')),
+        (['NaT', 1, 2, 3],
+         [1, 2, 3, 'NaT']),
         # multiple NaTs
-        (np.array(['NaT', 9, 'NaT', -707], dtype='M8[s]'),
-         np.array([-707, 9, 'NaT', 'NaT'], dtype='M8[s]')),
+        (['NaT', 9, 'NaT', -707],
+         [-707, 9, 'NaT', 'NaT']),
         # this sort explores another code path for NaT
-        (np.array([1, -2, 3, 'NaT'], dtype='M8[ns]'),
-         np.array([-2, 1, 3, 'NaT'], dtype='M8[ns]')),
+        ([1, -2, 3, 'NaT'],
+         [-2, 1, 3, 'NaT']),
         # 2-D array
-        (np.array([[51, -220, 'NaT'],
-                   [-17, 'NaT', -90]], dtype='M8[us]'),
-         np.array([[-220, 51, 'NaT'],
-                   [-90, -17, 'NaT']], dtype='M8[us]')),
+        ([[51, -220, 'NaT'],
+          [-17, 'NaT', -90]],
+         [[-220, 51, 'NaT'],
+          [-90, -17, 'NaT']]),
         ])
-    def test_sort_nat(self, arr, expected):
-        # fix for gh-12629; NaT sorting to end of array
+    @pytest.mark.parametrize("dtype", [
+        'M8[ns]', 'M8[us]',
+        'm8[ns]', 'm8[us]'])
+    def test_datetime_timedelta_sort_nat(self, arr, expected, dtype):
+        # fix for gh-12629 and gh-15063; NaT sorting to end of array
+        arr = np.array(arr, dtype=dtype)
+        expected = np.array(expected, dtype=dtype)
         arr.sort()
         assert_equal(arr, expected)
 


### PR DESCRIPTION
Backport of #15068. 

This work is a follow up of gh-12658.
As requested in gh-15063, add NaT sort support for timedelta64 datatypes also.

Fixes gh-15063

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
