### PR TITLE
ENH: f2py: add --f2cmap option for specifying the name of .f2py_f2cmap

### DIFF
--- a/doc/release/upcoming_changes/15106.new_feature.rst
+++ b/doc/release/upcoming_changes/15106.new_feature.rst
@@ -1,0 +1,4 @@
+Add ``--f2cmap`` option to F2PY
+-------------------------------
+Allow specifying a file to load Fortran-to-C type map
+customizations from.

--- a/doc/source/f2py/advanced.rst
+++ b/doc/source/f2py/advanced.rst
@@ -43,3 +43,52 @@ In Python:
 
 .. include:: var_session.dat
   :literal:
+
+
+Dealing with KIND specifiers
+============================
+
+Currently, F2PY can handle only ``<type spec>(kind=<kindselector>)``
+declarations where ``<kindselector>`` is a numeric integer (e.g. 1, 2,
+4,...), but not a function call ``KIND(..)`` or any other
+expression. F2PY needs to know what would be the corresponding C type
+and a general solution for that would be too complicated to implement.
+
+However, F2PY provides a hook to overcome this difficulty, namely,
+users can define their own <Fortran type> to <C type> maps. For
+example, if Fortran 90 code contains::
+
+    REAL(kind=KIND(0.0D0)) ...
+
+then create a file ``.f2py_f2cmap`` (into the working directory)
+containing a Python dictionary::
+
+    {'real': {'KIND(0.0D0)': 'double'}}
+
+for instance.
+
+Or more generally, the file ``.f2py_f2cmap`` must contain a dictionary
+with items::
+
+    <Fortran typespec> : {<selector_expr>:<C type>}
+
+that defines mapping between Fortran type::
+
+    <Fortran typespec>([kind=]<selector_expr>)
+
+and the corresponding <C type>. <C type> can be one of the following::
+
+    char
+    signed_char
+    short
+    int
+    long_long
+    float
+    double
+    long_double
+    complex_float
+    complex_double
+    complex_long_double
+    string
+
+For more information, see F2Py source code ``numpy/f2py/capi_maps.py``.

--- a/doc/source/f2py/advanced.rst
+++ b/doc/source/f2py/advanced.rst
@@ -60,14 +60,17 @@ example, if Fortran 90 code contains::
 
     REAL(kind=KIND(0.0D0)) ...
 
-then create a file ``.f2py_f2cmap`` (into the working directory)
-containing a Python dictionary::
+then create a mapping file containing a Python dictionary::
 
     {'real': {'KIND(0.0D0)': 'double'}}
 
 for instance.
 
-Or more generally, the file ``.f2py_f2cmap`` must contain a dictionary
+Use the ``--f2cmap`` command-line option to pass the file name to F2PY.
+By default, F2PY assumes file name is ``.f2py_f2cmap`` in the current
+working directory.
+
+Or more generally, the f2cmap file must contain a dictionary
 with items::
 
     <Fortran typespec> : {<selector_expr>:<C type>}

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -179,17 +179,29 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
               'character': {'': 'string'}
               }
 
-if os.path.isfile('.f2py_f2cmap'):
+f2cmap_default = copy.deepcopy(f2cmap_all)
+
+
+def load_f2cmap_file(f2cmap_file):
+    global f2cmap_all
+
+    f2cmap_all = copy.deepcopy(f2cmap_default)
+
+    if f2cmap_file is None:
+        # Default value
+        f2cmap_file = '.f2py_f2cmap'
+        if not os.path.isfile(f2cmap_file):
+            return
+
     # User defined additions to f2cmap_all.
-    # .f2py_f2cmap must contain a dictionary of dictionaries, only.  For
+    # f2cmap_file must contain a dictionary of dictionaries, only.  For
     # example, {'real':{'low':'float'}} means that Fortran 'real(low)' is
     # interpreted as C 'float'.  This feature is useful for F90/95 users if
     # they use PARAMETERSs in type specifications.
     try:
-        outmess('Reading .f2py_f2cmap ...\n')
-        f = open('.f2py_f2cmap', 'r')
-        d = eval(f.read(), {}, {})
-        f.close()
+        outmess('Reading f2cmap from {!r} ...\n'.format(f2cmap_file))
+        with open(f2cmap_file, 'r') as f:
+            d = eval(f.read(), {}, {})
         for k, d1 in list(d.items()):
             for k1 in list(d1.keys()):
                 d1[k1.lower()] = d1[k1]
@@ -208,10 +220,10 @@ if os.path.isfile('.f2py_f2cmap'):
                 else:
                     errmess("\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n" % (
                         k, k1, d[k][k1], d[k][k1], list(c2py_map.keys())))
-        outmess('Successfully applied user defined changes from .f2py_f2cmap\n')
+        outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:
         errmess(
-            'Failed to apply user defined changes from .f2py_f2cmap: %s. Skipping.\n' % (msg))
+            'Failed to apply user defined f2cmap changes: %s. Skipping.\n' % (msg))
 
 cformat_map = {'double': '%g',
                'float': '%g',

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import pytest
+import tempfile
 
 from numpy.testing import assert_
 from . import util
@@ -16,6 +17,7 @@ class TestAssumedShapeSumExample(util.F2PyTest):
                _path('src', 'assumed_shape', 'foo_use.f90'),
                _path('src', 'assumed_shape', 'precision.f90'),
                _path('src', 'assumed_shape', 'foo_mod.f90'),
+               _path('src', 'assumed_shape', '.f2py_f2cmap'),
                ]
 
     @pytest.mark.slow
@@ -31,3 +33,23 @@ class TestAssumedShapeSumExample(util.F2PyTest):
         assert_(r == 3, repr(r))
         r = self.module.mod.fsum([1, 2])
         assert_(r == 3, repr(r))
+
+
+class TestF2cmapOption(TestAssumedShapeSumExample):
+    def setup(self):
+        # Use a custom file name for .f2py_f2cmap
+        self.sources = list(self.sources)
+        f2cmap_src = self.sources.pop(-1)
+
+        self.f2cmap_file = tempfile.NamedTemporaryFile(delete=False)
+        with open(f2cmap_src, 'rb') as f:
+            self.f2cmap_file.write(f.read())
+        self.f2cmap_file.close()
+
+        self.sources.append(self.f2cmap_file.name)
+        self.options = ["--f2cmap", self.f2cmap_file.name]
+
+        super(TestF2cmapOption, self).setup()
+
+    def teardown(self):
+        os.unlink(self.f2cmap_file.name)

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -107,6 +107,7 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
 
     # Copy files
     dst_sources = []
+    f2py_sources = []
     for fn in source_files:
         if not os.path.isfile(fn):
             raise RuntimeError("%s is not a file" % fn)
@@ -114,16 +115,14 @@ def build_module(source_files, options=[], skip=[], only=[], module_name=None):
         shutil.copyfile(fn, dst)
         dst_sources.append(dst)
 
-        fn = os.path.join(os.path.dirname(fn), '.f2py_f2cmap')
-        if os.path.isfile(fn):
-            dst = os.path.join(d, os.path.basename(fn))
-            if not os.path.isfile(dst):
-                shutil.copyfile(fn, dst)
+        base, ext = os.path.splitext(dst)
+        if ext in ('.f90', '.f', '.c', '.pyf'):
+            f2py_sources.append(dst)
 
     # Prepare options
     if module_name is None:
         module_name = get_temp_module_name()
-    f2py_opts = ['-c', '-m', module_name] + options + dst_sources
+    f2py_opts = ['-c', '-m', module_name] + options + f2py_sources
     if skip:
         f2py_opts += ['skip:'] + skip
     if only:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -204,14 +204,20 @@ def _get_compiler_status():
         """)
     code = code % dict(syspath=repr(sys.path))
 
-    with temppath(suffix='.py') as script:
+    tmpdir = tempfile.mkdtemp()
+    try:
+        script = os.path.join(tmpdir, 'setup.py')
+
         with open(script, 'w') as f:
             f.write(code)
 
-        cmd = [sys.executable, script, 'config']
+        cmd = [sys.executable, 'setup.py', 'config']
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT)
+                             stderr=subprocess.STDOUT,
+                             cwd=tmpdir)
         out, err = p.communicate()
+    finally:
+        shutil.rmtree(tmpdir)
 
     m = re.search(br'COMPILERS:(\d+),(\d+),(\d+)', out)
     if m:


### PR DESCRIPTION
Backport of #15106. 

Previously, f2py loaded the type mappings from a file `.f2py_f2cmap`
in current directory, at import time.

Make the file name customizable by adding a `--f2cmap` command line
option, and postpone loading the file to f2py.run_main().

Restore the default type mapping in f2py.run_main() before
loading the customizations, so that multiple calls to f2py.run_main() do
not interfere with each other. (For example, numpy.distutils calls f2py
multiple times in the same process.)

Moreover, add documentation for the `.f2py_f2cmap` file (copypasted
from the old f2py FAQ on archive.org), and fix a race condition bug in
the f2py test suite which caused the tests to sometimes not be run
when using pytest-xdist.

cc @pearu

Closes: gh-15096
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
