### PR TITLE
MAINT,CI: fix signed-unsigned comparison warning

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -280,11 +280,11 @@ run_binary_simd_@kind@_@TYPE@(char **args, npy_intp *dimensions, npy_intp *steps
     @type@ * op = (@type@ *)args[2];
     npy_intp n = dimensions[0];
 #if defined __AVX512F__
-    const npy_intp vector_size_bytes = 64;
+    const npy_uintp vector_size_bytes = 64;
 #elif defined __AVX2__
-    const npy_intp vector_size_bytes = 32;
+    const npy_uintp vector_size_bytes = 32;
 #else
-    const npy_intp vector_size_bytes = 32;
+    const npy_uintp vector_size_bytes = 32;
 #endif
     /* argument one scalar */
     if (IS_BLOCKABLE_BINARY_SCALAR1(sizeof(@type@), vector_size_bytes)) {

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -155,7 +155,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
      export F90='gfortran --coverage'
      export LDFLAGS='--coverage'
   fi
-  $PYTHON setup.py build build_src --verbose-cfg bdist_wheel
+  $PYTHON setup.py build --warn-error build_src --verbose-cfg bdist_wheel
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel
   . venv-for-wheel/bin/activate


### PR DESCRIPTION
fixes gh-14655

Also always build on linux with `-Werror` to catch warnings earlier