### PR TITLE
ENH: random: Add the method `permuted` to Generator.

### DIFF
--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -36,11 +36,82 @@ Simple random data
 
 Permutations
 ============
+
+The methods `Generator.shuffle`, `Generator.permutation` and
+`Generator.permuted` are used for randomly permuting an input array.
+The following describes the important differences among these methods.
+
+Handling the ``axis`` parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+An important distinction for these methods is how they handle the ``axis``
+parameter.  Both `Generator.shuffle` and `Generator.permutation` treat the
+input as a one-dimensional sequence, and the ``axis`` parameter determines
+which dimension of the input array to use as the sequence. In the case of a
+two-dimensional array, ``axis=0`` will, in effect, rearrange the rows of the
+array, and  ``axis=1`` will rearrange the columns.  For example
+
+    >>> rg = np.random.default_rng()
+    >>> x = np.arange(0, 15).reshape(3, 5)
+    >>> x
+    array([[ 0,  1,  2,  3,  4],
+           [ 5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14]])
+    >>> rg.permutation(x, axis=1)
+    array([[ 0,  1,  4,  3,  2],  # random
+           [ 5,  6,  9,  8,  7],
+           [10, 11, 14, 13, 12]])
+
+Note that the columns have been rearranged "in bulk": the values within
+each column have not changed.
+
+The method `Generator.permuted` treats the ``axis`` parameter similar to
+how `numpy.sort` treats it.  Each slice along the given axis is shuffled
+independently of the others.  Compare the following example of the use of
+`Generator.permuted` to the above example of `Generator.permutation`:
+
+    >>> rg.permuted(x, axis=1)
+    array([[ 1,  0,  2,  4,  3],  # random
+           [ 5,  7,  6,  9,  8],
+           [10, 14, 12, 13, 11]])
+
+In this example, the values within each row (i.e. the values along
+``axis=1``) have been shuffled independently.  This is not a "bulk"
+shuffle of the columns.
+
+In-place vs. copy
+~~~~~~~~~~~~~~~~~
+The main difference between `Generator.shuffle` and `Generator.permutation`
+is that `Generator.shuffle` operates in-place, while `Generator.permutation`
+returns a copy.
+
+By default, `Generator.permuted` returns a copy.  To operate in-place with
+`Generator.permuted`, pass the same array as the first argument *and* as
+the value of the ``out`` parameter.  For example,
+
+    >>> x
+    array([[ 0,  1,  2,  3,  4],
+           [ 5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14]])
+    >>> y = rg.permuted(x, axis=1, out=x)
+    >>> x
+    array([[ 1,  0,  2,  4,  3],  # random
+           [ 6,  7,  8,  9,  5],
+           [10, 14, 11, 13, 12]])
+
+Note that when ``out`` is given, the return value is ``out``:
+
+    >>> y is x
+    True
+
+Permutation methods
+~~~~~~~~~~~~~~~~~~~
+
 .. autosummary::
    :toctree: generated/
 
    ~numpy.random.Generator.shuffle
    ~numpy.random.Generator.permutation
+   ~numpy.random.Generator.permuted
 
 Distributions
 =============

--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -36,10 +36,29 @@ Simple random data
 
 Permutations
 ============
+The methods for randomly permuting a sequence are
 
-The methods `Generator.shuffle`, `Generator.permutation` and
-`Generator.permuted` are used for randomly permuting an input array.
-The following describes the important differences among these methods.
+.. autosummary::
+   :toctree: generated/
+
+   ~numpy.random.Generator.shuffle
+   ~numpy.random.Generator.permutation
+   ~numpy.random.Generator.permuted
+
+The following table summarizes the behaviors of the methods.
+
++--------------+-------------------+------------------+
+| method       | copy/in-place     | axis handling    |
++==============+===================+==================+
+| shuffle      | in-place          | as if 1d         |
++--------------+-------------------+------------------+
+| permutation  | copy              | as if 1d         |
++--------------+-------------------+------------------+
+| permuted     | either (use 'out' | axis independent |
+|              | for in-place)     |                  |
++--------------+-------------------+------------------+
+
+The following subsections provide more details about the differences.
 
 In-place vs. copy
 ~~~~~~~~~~~~~~~~~
@@ -51,6 +70,8 @@ By default, `Generator.permuted` returns a copy.  To operate in-place with
 `Generator.permuted`, pass the same array as the first argument *and* as
 the value of the ``out`` parameter.  For example,
 
+    >>> rg = np.random.default_rng()
+    >>> x = np.arange(0, 15).reshape(3, 5)
     >>> x
     array([[ 0,  1,  2,  3,  4],
            [ 5,  6,  7,  8,  9],
@@ -82,9 +103,9 @@ array, and  ``axis=1`` will rearrange the columns.  For example
            [ 5,  6,  7,  8,  9],
            [10, 11, 12, 13, 14]])
     >>> rg.permutation(x, axis=1)
-    array([[ 0,  1,  4,  3,  2],  # random
-           [ 5,  6,  9,  8,  7],
-           [10, 11, 14, 13, 12]])
+    array([[ 1,  3,  2,  0,  4],  # random
+           [ 6,  8,  7,  5,  9],
+           [11, 13, 12, 10, 14]])
 
 Note that the columns have been rearranged "in bulk": the values within
 each column have not changed.
@@ -114,31 +135,6 @@ For example,
     >>> rg.shuffle(a)  # shuffle the list in-place
     >>> a
     ['B', 'D', 'A', 'E', 'C']  # random
-
-
-Permutation methods summary
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The methods for randomly permuting a sequence are
-
-.. autosummary::
-   :toctree: generated/
-
-   ~numpy.random.Generator.shuffle
-   ~numpy.random.Generator.permutation
-   ~numpy.random.Generator.permuted
-
-The following table summarizes the behaviors of the methods.
-
-+--------------+-------------------+------------------+
-| method       | copy/in-place     | axis handling    |
-+==============+===================+==================+
-| shuffle      | in-place          | as if 1d         |
-+--------------+-------------------+------------------+
-| permutation  | copy              | as if 1d         |
-+--------------+-------------------+------------------+
-| permuted     | either (use 'out' | axis independent |
-|              | for in-place)     |                  |
-+--------------+-------------------+------------------+
 
 Distributions
 =============

--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -41,6 +41,31 @@ The methods `Generator.shuffle`, `Generator.permutation` and
 `Generator.permuted` are used for randomly permuting an input array.
 The following describes the important differences among these methods.
 
+In-place vs. copy
+~~~~~~~~~~~~~~~~~
+The main difference between `Generator.shuffle` and `Generator.permutation`
+is that `Generator.shuffle` operates in-place, while `Generator.permutation`
+returns a copy.
+
+By default, `Generator.permuted` returns a copy.  To operate in-place with
+`Generator.permuted`, pass the same array as the first argument *and* as
+the value of the ``out`` parameter.  For example,
+
+    >>> x
+    array([[ 0,  1,  2,  3,  4],
+           [ 5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14]])
+    >>> y = rg.permuted(x, axis=1, out=x)
+    >>> x
+    array([[ 1,  0,  2,  4,  3],  # random
+           [ 6,  7,  8,  9,  5],
+           [10, 14, 11, 13, 12]])
+
+Note that when ``out`` is given, the return value is ``out``:
+
+    >>> y is x
+    True
+
 Handling the ``axis`` parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 An important distinction for these methods is how they handle the ``axis``
@@ -78,33 +103,22 @@ In this example, the values within each row (i.e. the values along
 ``axis=1``) have been shuffled independently.  This is not a "bulk"
 shuffle of the columns.
 
-In-place vs. copy
-~~~~~~~~~~~~~~~~~
-The main difference between `Generator.shuffle` and `Generator.permutation`
-is that `Generator.shuffle` operates in-place, while `Generator.permutation`
-returns a copy.
+Shuffling non-NumPy sequences
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Generator.shuffle` works on non-NumPy sequences.  That is, if it is given
+a sequence that is not a NumPy array, it shuffles that sequence in-place.
+For example,
 
-By default, `Generator.permuted` returns a copy.  To operate in-place with
-`Generator.permuted`, pass the same array as the first argument *and* as
-the value of the ``out`` parameter.  For example,
+    >>> rg = np.random.default_rng()
+    >>> a = ['A', 'B', 'C', 'D', 'E']
+    >>> rg.shuffle(a)  # shuffle the list in-place
+    >>> a
+    ['B', 'D', 'A', 'E', 'C']  # random
 
-    >>> x
-    array([[ 0,  1,  2,  3,  4],
-           [ 5,  6,  7,  8,  9],
-           [10, 11, 12, 13, 14]])
-    >>> y = rg.permuted(x, axis=1, out=x)
-    >>> x
-    array([[ 1,  0,  2,  4,  3],  # random
-           [ 6,  7,  8,  9,  5],
-           [10, 14, 11, 13, 12]])
 
-Note that when ``out`` is given, the return value is ``out``:
-
-    >>> y is x
-    True
-
-Permutation methods
-~~~~~~~~~~~~~~~~~~~
+Permutation methods summary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The methods for randomly permuting a sequence are
 
 .. autosummary::
    :toctree: generated/
@@ -112,6 +126,19 @@ Permutation methods
    ~numpy.random.Generator.shuffle
    ~numpy.random.Generator.permutation
    ~numpy.random.Generator.permuted
+
+The following table summarizes the behaviors of the methods.
+
++--------------+-------------------+------------------+
+| method       | copy/in-place     | axis handling    |
++==============+===================+==================+
+| shuffle      | in-place          | as if 1d         |
++--------------+-------------------+------------------+
+| permutation  | copy              | as if 1d         |
++--------------+-------------------+------------------+
+| permuted     | either (use 'out' | axis independent |
+|              | for in-place)     |                  |
++--------------+-------------------+------------------+
 
 Distributions
 =============

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -13,7 +13,6 @@ cimport numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from .c_distributions cimport *
-from libc.stdlib cimport malloc, free
 from libc cimport string
 from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
                           int32_t, int64_t, INT64_MAX, SIZE_MAX)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -31,9 +31,8 @@ from ._common cimport (POISSON_LAM_MAX, CONS_POSITIVE, CONS_NONE,
         )
 
 cdef extern from "numpy/arrayobject.h":
-    #int PyArray_SetWritebackIfCopyBase(np.ndarray, np.ndarray)
     int PyArray_ResolveWritebackIfCopy(np.ndarray)
-    object PyArray_FromArray(object, object, int)
+    object PyArray_FromArray(np.PyArrayObject *, object, int)
 
     enum:
         NPY_ARRAY_WRITEBACKIFCOPY
@@ -4298,7 +4297,7 @@ cdef class Generator:
                                                  np.NPY_ARRAY_F_CONTIGUOUS)): 
                     flags = (np.NPY_ARRAY_C_CONTIGUOUS |
                              NPY_ARRAY_WRITEBACKIFCOPY)
-                    to_shuffle = PyArray_FromArray(out, <object>NULL, flags)
+                    to_shuffle = PyArray_FromArray(<np.PyArrayObject *>out, <object>NULL, flags)
                     self.shuffle(to_shuffle.ravel(order='K'))
                     # Because we only execute this block if out is not
                     # contiguous, we know this call will always result in a

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -32,7 +32,7 @@ from ._common cimport (POISSON_LAM_MAX, CONS_POSITIVE, CONS_NONE,
 
 cdef extern from "numpy/arrayobject.h":
     int PyArray_ResolveWritebackIfCopy(np.ndarray)
-    object PyArray_FromArray(np.PyArrayObject *, object, int)
+    object PyArray_FromArray(np.PyArrayObject *, np.PyArray_Descr *, int)
 
     enum:
         NPY_ARRAY_WRITEBACKIFCOPY
@@ -4297,7 +4297,8 @@ cdef class Generator:
                                                  np.NPY_ARRAY_F_CONTIGUOUS)): 
                     flags = (np.NPY_ARRAY_C_CONTIGUOUS |
                              NPY_ARRAY_WRITEBACKIFCOPY)
-                    to_shuffle = PyArray_FromArray(<np.PyArrayObject *>out, <object>NULL, flags)
+                    to_shuffle = PyArray_FromArray(<np.PyArrayObject *>out,
+                                                   <np.PyArray_Descr *>NULL, flags)
                     self.shuffle(to_shuffle.ravel(order='K'))
                     # Because we only execute this block if out is not
                     # contiguous, we know this call will always result in a

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4263,6 +4263,8 @@ cdef class Generator:
         else:
             if type(out) is not np.ndarray:
                 raise TypeError('out must be a numpy array')
+            if out.shape != x.shape:
+                raise ValueError('out must have the same shape as x')
             out[...] = x
 
         if axis is None:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -5,6 +5,7 @@ import warnings
 
 from cpython.pycapsule cimport PyCapsule_IsValid, PyCapsule_GetPointer
 from cpython cimport (Py_INCREF, PyFloat_AsDouble)
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
 
 cimport cython
 import numpy as np
@@ -4275,7 +4276,7 @@ cdef class Generator:
 
         it = np.PyArray_IterAllButAxis(out, &ax)
 
-        buf = malloc(itemsize)
+        buf = PyMem_Malloc(itemsize)
         if buf == NULL:
             raise MemoryError('memory allocation failed in permuted')
 
@@ -4285,7 +4286,7 @@ cdef class Generator:
                              <char *>np.PyArray_ITER_DATA(it), <char *>buf)
                 np.PyArray_ITER_NEXT(it)
 
-        free(buf)
+        PyMem_Free(buf)
         return out
 
     def shuffle(self, object x, axis=0):

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4259,7 +4259,7 @@ cdef class Generator:
         x = np.asarray(x)
 
         if out is None:
-            out = x.copy()
+            out = x.copy(order='K')
         else:
             if type(out) is not np.ndarray:
                 raise TypeError('out must be a numpy array')

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4262,7 +4262,7 @@ cdef class Generator:
             out = x.copy()
         else:
             if type(out) is not np.ndarray:
-                raise ValueError('out must be a numpy array')
+                raise TypeError('out must be a numpy array')
             out[...] = x
 
         if axis is None:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4276,7 +4276,7 @@ cdef class Generator:
                 raise TypeError('out must be a numpy array')
             if out.shape != x.shape:
                 raise ValueError('out must have the same shape as x')
-            out[...] = x
+            np.copyto(out, x, casting='safe')
 
         if axis is None:
             if x.ndim > 1:

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1081,6 +1081,12 @@ class TestRandomDist:
         with pytest.raises(ValueError, match='same shape'):
             random.permuted(a, out=out)
 
+    def test_permuted_out_with_wrong_type(self):
+        out = np.zeros((3, 5), dtype=np.int32)
+        x = np.ones((3, 5))
+        with pytest.raises(TypeError, match='Cannot cast'):
+            random.permuted(x, axis=1, out=out)
+
     def test_beta(self):
         random = Generator(MT19937(self.seed))
         actual = random.beta(.1, .9, size=(3, 2))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1039,6 +1039,41 @@ class TestRandomDist:
         assert_raises(np.AxisError, random.permutation, arr, 3)
         assert_raises(TypeError, random.permutation, arr, slice(1, 2, None))
 
+    @pytest.mark.parametrize("axis, expected",
+                             [(None, np.array([[3, 7, 0, 9, 10, 11],
+                                               [8, 4, 2, 5,  1,  6]])),
+                              (0, np.array([[6, 1, 2, 9, 10, 11],
+                                            [0, 7, 8, 3,  4,  5]])),
+                              (1, np.array([[ 5, 3,  4, 0, 2, 1],
+                                            [11, 9, 10, 6, 8, 7]]))])
+    def test_permuted(self, axis, expected):
+        random = Generator(MT19937(self.seed))
+        x = np.arange(12).reshape(2, 6)
+        random.permuted(x, axis=axis, out=x)
+        assert_array_equal(x, expected)
+
+        random = Generator(MT19937(self.seed))
+        x = np.arange(12).reshape(2, 6)
+        y = random.permuted(x, axis=axis)
+        assert_array_equal(y, expected)
+
+    def test_permuted_with_strides(self):
+        random = Generator(MT19937(self.seed))
+        x0 = np.arange(22).reshape(2, 11)
+        x1 = x0.copy()
+        x = x0[:, ::3]
+        y = random.permuted(x, axis=1, out=x)
+        expected = np.array([[0, 9, 3, 6],
+                             [14, 20, 11, 17]])
+        assert_array_equal(y, expected)
+        x1[:, ::3] = expected
+        # Verify that the original x0 was modified in-place as expected.
+        assert_array_equal(x1, x0)
+
+    def test_permuted_empty(self):
+        y = random.permuted([])
+        assert_array_equal(y, [])
+
     def test_beta(self):
         random = Generator(MT19937(self.seed))
         actual = random.beta(.1, .9, size=(3, 2))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1074,6 +1074,13 @@ class TestRandomDist:
         y = random.permuted([])
         assert_array_equal(y, [])
 
+    @pytest.mark.parametrize('outshape', [(2, 3), 5])
+    def test_permuted_out_with_wrong_shape(self, outshape):
+        a = np.array([1, 2, 3])
+        out = np.zeros(outshape, dtype=a.dtype)
+        with pytest.raises(ValueError, match='same shape'):
+            random.permuted(a, out=out)
+
     def test_beta(self):
         random = Generator(MT19937(self.seed))
         actual = random.beta(.1, .9, size=(3, 2))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1039,6 +1039,7 @@ class TestRandomDist:
         assert_raises(np.AxisError, random.permutation, arr, 3)
         assert_raises(TypeError, random.permutation, arr, slice(1, 2, None))
 
+    @pytest.mark.parametrize("dtype", [int, object])
     @pytest.mark.parametrize("axis, expected",
                              [(None, np.array([[3, 7, 0, 9, 10, 11],
                                                [8, 4, 2, 5,  1,  6]])),
@@ -1046,15 +1047,16 @@ class TestRandomDist:
                                             [0, 7, 8, 3,  4,  5]])),
                               (1, np.array([[ 5, 3,  4, 0, 2, 1],
                                             [11, 9, 10, 6, 8, 7]]))])
-    def test_permuted(self, axis, expected):
+    def test_permuted(self, dtype, axis, expected):
         random = Generator(MT19937(self.seed))
-        x = np.arange(12).reshape(2, 6)
+        x = np.arange(12).reshape(2, 6).astype(dtype)
         random.permuted(x, axis=axis, out=x)
         assert_array_equal(x, expected)
 
         random = Generator(MT19937(self.seed))
-        x = np.arange(12).reshape(2, 6)
+        x = np.arange(12).reshape(2, 6).astype(dtype)
         y = random.permuted(x, axis=axis)
+        assert y.dtype == dtype
         assert_array_equal(y, expected)
 
     def test_permuted_with_strides(self):


### PR DESCRIPTION
*Note*: updated on 15-July-2020.

In 2014, I created a github issue [1]_ and started a mailing list
discussion [2]_ about a limitation of the functions `shuffle` and
`permutation` in `numpy.random`.  The problem is that those functions
treat the input as 1-d sequence, and only apply the shuffle or
permutation to that 1-d input.  There is no function to, say, shuffle
each row of a 2-d array, with the permutation of each row being
independent of the others.

At the time, most folks were in favor of adding new functions, although
there was still some debate about the names.  This PR is an implementation
of the Generator method `permuted` with an `out` parameter as proposed
by @eric-wieser below, and as favored by @seberg in gh-5173.  The full
signature is

    def permuted(self, object x, *, axis=None, out=None):

When axis=None, the operation applies to the flattened array.
(The return value of `permuted` in that case still has the
same shape as `x`.)  Otherwise, random permutations are applied
independently along the given axis.

Currently `permuted` is the only new function that is implemented.
For a consistent API, we would might eventually deprecate `shuffle`
and `permutation` (as proposed in gh=5173), and replace them with

    def shuffled(self, object x, *, axis=None, out=None):

This would handle `axis` like `shuffle` and permutation currently
handle it.  I can add that to this PR if we want to make that change now.

Closes gh-5173.

[1] https://github.com/numpy/numpy/issues/5173
[2] https://mail.python.org/pipermail/numpy-discussion/2014-October/071340.html
