### PR TITLE
DOC: Fix typos, via a Levenshtein-style corrector

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -158,7 +158,7 @@ endif
 	@# the instructions in doc/HOWTO_RELEASE.rst.txt
 	@echo " "
 	@echo New documentation archive added to ./build/merge.
-	@echo Now add/modify the appropiate section after
+	@echo Now add/modify the appropriate section after
 	@echo "    <!-- insert here -->"
 	@echo in build/merge/index.html,
 	@echo then \"git commit\", \"git push\"

--- a/doc/neps/nep-0023-backwards-compatibility.rst
+++ b/doc/neps/nep-0023-backwards-compatibility.rst
@@ -198,7 +198,7 @@ Policy
    can be made, *provided the benefit is worth the cost* and suitable deprecation
    warnings have been raised first.
 3. Deprecation warnings are in all cases warnings that functionality will be removed.
-   If there is no intent to remove functionlity, then deprecation in documentation
+   If there is no intent to remove functionality, then deprecation in documentation
    only or other types of warnings shall be used.
 4. Deprecations for stylistic reasons (e.g. consistency between functions) are
    strongly discouraged.

--- a/doc/neps/nep-0028-website-redesign.rst
+++ b/doc/neps/nep-0028-website-redesign.rst
@@ -166,7 +166,7 @@ have a similar deployment to GitHub Pages or Netlify.
 Analytics
 ~~~~~~~~~
 
-It's benefical to maintainers to know how many visitors are coming to
+It's beneficial to maintainers to know how many visitors are coming to
 numpy.org. Google Analytics offers visitor counts and locations. This will
 help to support and deploy more strategically, and help maintainers
 understand where traffic is coming from.

--- a/doc/release/upcoming_changes/14933.compatibility.rst
+++ b/doc/release/upcoming_changes/14933.compatibility.rst
@@ -5,6 +5,6 @@ The promotion of mixed scalars and arrays in ``PyArray_ConvertToCommonType``
 has been changed to adhere to those used by ``np.result_type``.
 This means that input such as ``(1000, np.array([1], dtype=np.uint8)))``
 will now return ``uint16`` dtypes. In most cases the behaviour is unchanged.
-Note that the use of this C-API function is generally discouarged.
+Note that the use of this C-API function is generally discouraged.
 This also fixes ``np.choose`` to behave the same way as the rest of NumPy
 in this respect.

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -303,7 +303,7 @@ Suppose that the commit history looks like this::
     2dec1ac Fix a few bugs + disable
     13d7934 First implementation
     6ad92e5 * masked is now an instance of a new object, MaskedConstant
-    29001ed Add pre-nep for a copule of structured_array_extensions.
+    29001ed Add pre-nep for a couple of structured_array_extensions.
     ...
 
 and ``6ad92e5`` is the last commit in the ``master`` branch. Suppose we

--- a/doc/source/dev/governance/governance.rst
+++ b/doc/source/dev/governance/governance.rst
@@ -301,7 +301,7 @@ its interactions with NumFOCUS.
    or technical direction of the Project.
 -  This Subcommittee will have 5 members, 4 of whom will be current
    Council Members and 1 of whom will be external to the Steering
-   Council. No more than 2 Subcommitee Members can report to one person
+   Council. No more than 2 Subcommittee Members can report to one person
    through employment or contracting work (including the reportee, i.e.
    the reportee + 1 is the max). This avoids effective majorities
    resting on one person.

--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -193,7 +193,7 @@ Those can be useful for precise floating point comparison.
 .. c:function:: int npy_get_floatstatus_barrier(char*)
 
     Get floating point status. A pointer to a local variable is passed in to
-    prevent aggressive compiler optimizations from reodering this function call
+    prevent aggressive compiler optimizations from reordering this function call
     relative to the code setting the status, which could lead to incorrect
     results.
 
@@ -219,7 +219,7 @@ Those can be useful for precise floating point comparison.
 .. c:function:: int npy_clear_floatstatus_barrier(char*)
 
     Clears the floating point status. A pointer to a local variable is passed in to
-    prevent aggressive compiler optimizations from reodering this function call.
+    prevent aggressive compiler optimizations from reordering this function call.
     Returns the previous status mask.
 
     .. versionadded:: 1.15.0

--- a/doc/source/reference/random/legacy.rst
+++ b/doc/source/reference/random/legacy.rst
@@ -125,7 +125,7 @@ Distributions
 Functions in `numpy.random`
 ===========================
 Many of the RandomState methods above are exported as functions in
-`numpy.random` This usage is discouraged, as it is implemented via a gloabl
+`numpy.random` This usage is discouraged, as it is implemented via a global
 `RandomState` instance which is not advised on two counts:
 
 - It uses global state, which means results will change as the code changes

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -297,7 +297,7 @@ mergesort. Due to the need to maintain backward compatibility, the sorting
 ``kind`` options ``"stable"`` and ``"mergesort"`` have been made aliases of
 each other with the actual sort implementation depending on the array type.
 Radix sort is used for small integer types of 16 bits or less and timsort for
-the remaining types.  Timsort features improved performace on data containing
+the remaining types.  Timsort features improved performance on data containing
 already or nearly sorted data and performs like mergesort on random data and
 requires :math:`O(n/2)` working space.  Details of the timsort algorithm can be
 found at `CPython listsort.txt

--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -15,7 +15,7 @@ Warnings filtering and other runtime settings should be dealt with in the
 whether or not that file is found as follows:
 
 * ``pytest.ini`` is present (develop mode)
-    All warnings except those explicily filtered out are raised as error.
+    All warnings except those explicitly filtered out are raised as error.
 * ``pytest.ini`` is absent (release mode)
     DeprecationWarnings and PendingDeprecationWarnings are ignored, other
     warnings are passed through.

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -1,7 +1,7 @@
 """
 Python 3.X compatibility tools.
 
-While this file was originally intented for Python 2 -> 3 transition,
+While this file was originally intended for Python 2 -> 3 transition,
 it is now used to create a compatibility layer between different
 minor versions of Python 3.
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -358,7 +358,7 @@ def _mod_dispatcher(a, values):
 def mod(a, values):
     """
     Return (a % i), that is pre-Python 2.6 string formatting
-    (iterpolation), element-wise for a pair of array_likes of str
+    (interpolation), element-wise for a pair of array_likes of str
     or unicode.
 
     Parameters
@@ -2112,7 +2112,7 @@ class chararray(ndarray):
     def __mod__(self, i):
         """
         Return (self % i), that is pre-Python 2.6 string formatting
-        (iterpolation), element-wise for a pair of array_likes of `string_`
+        (interpolation), element-wise for a pair of array_likes of `string_`
         or `unicode_`.
 
         See also

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4193,7 +4193,7 @@ _datetime_dtype_metadata_clone(NpyAuxData *data)
 }
 
 /*
- * Allcoate and initialize a PyArray_DatetimeDTypeMetaData object
+ * Allocate and initialize a PyArray_DatetimeDTypeMetaData object
  */
 static NpyAuxData*
 _create_datetime_metadata(NPY_DATETIMEUNIT base, int num)

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -523,7 +523,7 @@ _buffer_info_new(PyObject *obj)
         /*
          * Special case datetime64 scalars to remain backward compatible.
          * This will change in a future version.
-         * Note arrays of datetime64 and strutured arrays with datetime64
+         * Note arrays of datetime64 and structured arrays with datetime64
          * fields will not hit this code path and are currently unsupported
          * in _buffer_format_string.
          */

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -172,7 +172,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_IterNew(PyObject *obj)
 {
     /*
-     * Note that internall PyArray_RawIterBaseInit may be called directly on a
+     * Note that internally PyArray_RawIterBaseInit may be called directly on a
      * statically allocated PyArrayIterObject.
      */
     PyArrayIterObject *it;

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -732,7 +732,7 @@ class TestStructuredDtypeSparseFields(object):
         assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
 
     def test_sparse_field_assignment_fancy(self):
-        # Fancy assignment goes to the copyswap function for comlex types:
+        # Fancy assignment goes to the copyswap function for complex types:
         arr = np.zeros(3, self.dtype)
         sparse_arr = arr.view(self.sparse_dtype)
 

--- a/numpy/doc/dispatch.py
+++ b/numpy/doc/dispatch.py
@@ -58,7 +58,7 @@ numpy.ndarray
 
 How can we pass our custom array type through this function? Numpy allows a
 class to indicate that it would like to handle computations in a custom-defined
-way through the interaces ``__array_ufunc__`` and ``__array_function__``. Let's
+way through the interfaces ``__array_ufunc__`` and ``__array_function__``. Let's
 take one at a time, starting with ``_array_ufunc__``. This method covers
 :ref:`ufuncs`, a class of functions that includes, for example,
 :func:`numpy.multiply` and :func:`numpy.sin`.

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -79,7 +79,7 @@ c2capi_map = {'double': 'NPY_DOUBLE',
               'complex_long_double': 'NPY_CDOUBLE',   # forced casting
               'string': 'NPY_STRING'}
 
-# These new maps aren't used anyhere yet, but should be by default
+# These new maps aren't used anywhere yet, but should be by default
 #  unless building numeric or numarray extensions.
 if using_newcore:
     c2capi_map = {'double': 'NPY_DOUBLE',

--- a/numpy/linalg/lapack_lite/f2c.c
+++ b/numpy/linalg/lapack_lite/f2c.c
@@ -567,7 +567,7 @@ if( (abi = b->i) < 0.f)
 	abi = - abi;
 if( abr <= abi )
 	{
-	  /*Let IEEE Infinties handle this ;( */
+	  /*Let IEEE Infinities handle this ;( */
 	  /*if(abi == 0)
 		sig_die("complex division by zero", 1);*/
 	ratio = b->r / b->i ;
@@ -603,7 +603,7 @@ if( (abi = b->i) < 0.)
 	abi = - abi;
 if( abr <= abi )
 	{
-	  /*Let IEEE Infinties handle this ;( */
+	  /*Let IEEE Infinities handle this ;( */
 	  /*if(abi == 0)
 		sig_die("complex division by zero", 1);*/
 	ratio = b->r / b->i ;

--- a/numpy/linalg/lapack_lite/f2c_blas.c
+++ b/numpy/linalg/lapack_lite/f2c_blas.c
@@ -4912,7 +4912,7 @@ L20:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -9807,7 +9807,7 @@ L40:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -14410,7 +14410,7 @@ L40:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of
@@ -19998,7 +19998,7 @@ L20:
              ( 1 + ( n - 1 )*abs( INCX ) ).
              Before entry, the incremented array X must contain the n
              element vector x. On exit, X is overwritten with the
-             tranformed vector x.
+             transformed vector x.
 
     INCX   - INTEGER.
              On entry, INCX specifies the increment for the elements of

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -14,7 +14,7 @@ def isContinuation(line):
 
 COMMENT, STATEMENT, CONTINUATION = 0, 1, 2
 def lineType(line):
-    """Return the type of a line of Fortan code."""
+    """Return the type of a line of Fortran code."""
     if isBlank(line):
         return COMMENT
     elif isLabel(line):

--- a/numpy/random/src/philox/philox-benchmark.c
+++ b/numpy/random/src/philox/philox-benchmark.c
@@ -1,5 +1,5 @@
 /*
- * Simple benchamrk command
+ * Simple benchmark command
  *
  *  cl philox-benchmark.c /Ox
  *

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -271,7 +271,7 @@ def set_test_runner(name):
 def detect_runner():
     """ Guess which test runner we're using by traversing the stack and looking
         for the first matching module. This *should* be reasonably safe, as
-        it's done during test disocvery where the test runner should be the
+        it's done during test discovery where the test runner should be the
         stack frame immediately outside. """
     if _test_runner_override is not None:
         return _test_runner_override


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.