### PR TITLE
BUG: avoid incorrect broadcasts on non-core outputs

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1645,6 +1645,19 @@ npyiter_fill_axisdata(NpyIter *iter, npy_uint32 flags, npyiter_opitflags *op_itf
                 else if (bshape == 1) {
                     strides[iop] = 0;
                 }
+                else if (i == -2) {
+                    /*
+                     * The signal -2 is meant to indicate that an axis will be
+                     * removed later and should be ignored.  So, we are free
+                     * to just set the strides as 0 here.  Obviously, if
+                     * the caller does not actually remove the axis later,
+                     * there will be problems.
+                     *
+                     * NOTE: this is mostly a rather ugly hack to help
+                     * PyUFunc_GeneralizedFunction.
+                     */
+                    strides[iop] = 0;
+                }
                 else {
                     strides[iop] = 0;
                     /* If it's writeable, this means a reduction */
@@ -2551,7 +2564,7 @@ npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
                     stride *= shape[i];
                 }
             }
-            else {
+            else if (i != -2) {  /* see long comment about -2 above */
                 if (shape == NULL) {
                     /*
                      * If deleting this axis produces a reduction, but

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2713,9 +2713,15 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
             }
         }
 
-        /* Any output core dimensions shape should be ignored */
+        /*
+         * Any output core dimensions shape should be ignored
+         *
+         * Note: here, the special value of -2 signals that the
+         * nditer constructor should not complain if an output is
+         * write-only or reduction is not allowed.
+         */
         for (idim = broadcast_ndim; idim < iter_ndim; ++idim) {
-            op_axes_arrays[i][idim] = -1;
+            op_axes_arrays[i][idim] = -2;
         }
 
         /* Except for when it belongs to this output */
@@ -2787,7 +2793,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
      */
     _ufunc_setup_flags(ufunc, NPY_ITER_COPY | NPY_UFUNC_DEFAULT_INPUT_FLAGS,
                        NPY_ITER_UPDATEIFCOPY |
-                       NPY_ITER_READWRITE |
+                       NPY_ITER_WRITEONLY |
                        NPY_UFUNC_DEFAULT_OUTPUT_FLAGS,
                        op_flags);
     /* For the generalized ufunc, we get the loop right away too */
@@ -2836,7 +2842,6 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
     iter_flags = ufunc->iter_flags |
                  NPY_ITER_MULTI_INDEX |
                  NPY_ITER_REFS_OK |
-                 NPY_ITER_REDUCE_OK |
                  NPY_ITER_ZEROSIZE_OK |
                  NPY_ITER_COPY_IF_OVERLAP;
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -612,7 +612,17 @@ class TestUfunc(object):
             warnings.simplefilter("always")
             u += v
             assert_equal(len(w), 1)
-            assert_(x[0,0]  != u[0, 0])
+            assert_(x[0, 0] != u[0, 0])
+
+        # Output reduction should not be allowed.
+        # See gh-15139
+        a = np.arange(6).reshape(3, 2)
+        b = np.ones(2)
+        out = np.empty(())
+        assert_raises(ValueError, umt.inner1d, a, b, out)
+        out2 = np.empty(3)
+        c = umt.inner1d(a, b, out2)
+        assert_(c is out2)
 
     def test_type_cast(self):
         msg = "type cast"
@@ -944,7 +954,10 @@ class TestUfunc(object):
         assert_array_equal(result, np.vstack((np.zeros(3), a[2], -a[1])))
         assert_raises(ValueError, umt.cross1d, np.eye(4), np.eye(4))
         assert_raises(ValueError, umt.cross1d, a, np.arange(4.))
+        # Wrong output core dimension.
         assert_raises(ValueError, umt.cross1d, a, np.arange(3.), np.zeros((3, 4)))
+        # Wrong output broadcast dimension (see gh-15139).
+        assert_raises(ValueError, umt.cross1d, a, np.arange(3.), np.zeros(3))
 
     def test_can_ignore_signature(self):
         # Comparing the effects of ? in signature:


### PR DESCRIPTION
fixes #15139 

From there, currently:
```
import numpy as np
from numpy.core._umath_tests import inner1d, cross1d

a = np.arange(9.).reshape(3, 3)
inner1d(a, np.array([1., 0., 0.]))
# array([0., 3., 6.])
inner1d(a, np.array([1., 0., 0.]), out=np.empty(()))
# Oops, no error, instead just:
# array(6.)
```

This is because the iterator is set up allowing reduction and with outputs read-write, since otherwise the calculation/allocation for the core dimensions cannot easily be done. However, those dimensions are never iterated over, so should not be considered for reduction in the first place. Here, a special value for `op_axis` is used to indicate that.

Definitely not pretty, but it does work. If it is considered OK, I'll also add line or two to the documentation of the iterator.

A question is whether this behaviour is relied on by anyone - this PR does change the default iterator and operand output flags. (My guess is that explicitly provided outputs are sufficiently rare that this not a problem.)

cc @seberg
