### PR TITLE
TST: shippable build efficiency

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -27,29 +27,29 @@ build:
     - target=$(python tools/openblas_support.py)
     - sudo cp -r "${target}"/64/lib/* /usr/lib
     - sudo cp "${target}"/64/include/* /usr/include
-    - pip install --upgrade pip
+    - python -m pip install --upgrade pip
 
     # we will pay the ~13 minute cost of compiling Cython only when a new
     # version is scraped in by pip; otherwise, use the cached
     # wheel shippable places on Amazon S3 after we build it once
-    - pip install -r test_requirements.txt --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - python -m pip install -r test_requirements.txt --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
     # install pytest-xdist to leverage a second core
     # for unit tests
-    - pip install pytest-xdist
+    - python -m pip install pytest-xdist
 
     # build and test numpy
     - export PATH=$PATH:$SHIPPABLE_REPO_DIR
     # build first and adjust PATH so f2py is found in scripts dir
     # use > 1 core for build sometimes slows down a fair bit,
     # other times modestly speeds up, so avoid for now
-    - pip install .
+    - python -m pip install .
     - extra_directories=($SHIPPABLE_REPO_DIR/build/*scripts*)
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
     - python tools/openblas_support.py --check_version 0.3.7
     # run the test suite
-    - python runtests.py --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
+    - python runtests.py -n --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 
     cache: true
     cache_dir_list:


### PR DESCRIPTION
Fixes #15137, but check the CI log to make sure it actually does help.

* try to avoid a redundant build of NumPy
by Shippable CI; use "-n" flag to runtests.py
to encourage use of installed NumPy instead of
trying to rebuild

* prefix pip installs with "python" to avoid
common issues using pip installs

This may not have been done initially because of the `f2py` issues noted in the comments---hopefully that is not a problem anymore.