### PR TITLE
BUG: ensure reduction output matches input along non-reduction axes.

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1888,6 +1888,23 @@ class TestUfunc(object):
         assert_equal(y_base[1,:], y_base_copy[1,:])
         assert_equal(y_base[3,:], y_base_copy[3,:])
 
+    @pytest.mark.parametrize('output_shape',
+                             [(), (1,), (1, 1), (1, 3), (4, 3)])
+    @pytest.mark.parametrize('f_reduce', [np.add.reduce, np.minimum.reduce])
+    def test_reduce_wrong_dimension_output(self, f_reduce, output_shape):
+        # Test that we're not incorrectly broadcasting dimensions.
+        # See gh-15144 (failed for np.add.reduce previously).
+        a = np.arange(12.).reshape(4, 3)
+        out = np.empty(output_shape, a.dtype)
+        assert_raises(ValueError, f_reduce, a, axis=0, out=out)
+        if output_shape != (1, 3):
+            assert_raises(ValueError, f_reduce, a, axis=0, out=out,
+                          keepdims=True)
+        else:
+            check = f_reduce(a, axis=0, out=out, keepdims=True)
+            assert_(check is out)
+            assert_array_equal(check, f_reduce(a, axis=0, keepdims=True))
+
     def test_no_doc_string(self):
         # gh-9337
         assert_('\n' not in umt.inner1d_no_doc.__doc__)


### PR DESCRIPTION
As noticed by @seberg while discussing a similar problem for gufuncs in https://github.com/numpy/numpy/pull/15142#issuecomment-568104286, in current master, things like `np.add.reduce(np.ones((3, 3)), axis=0, out=np.empty(1))` work, even though the output should have shape (3,). This PR strengthens the existing conformation of the output to include checks on the non-reduction axes.
