### PR TITLE
MAINT: Update pavement.py for towncrier.

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -106,9 +106,10 @@ You will need write permission for numpy-wheels in order to trigger wheel
 builds.
 
 - Python(s) from `python.org <https://python.org>`_ or linux distro.
-- cython
+- cython (pip)
 - virtualenv (pip)
 - Paver (pip)
+- pandoc `pandoc.org <https://www.pandoc.org>`_ or linux distro.
 - numpy-wheels `<https://github.com/MacPython/numpy-wheels>`_ (clone)
 
 
@@ -379,7 +380,7 @@ Make the release
 ----------------
 Build the changelog and notes for upload with::
 
-    paver write_release_and_log
+    paver write_release
 
 
 Build and archive documentation

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -366,9 +366,9 @@ Added two new configuration options. During the ``build_src`` subcommand, as
 part of configuring NumPy, the files ``_numpyconfig.h`` and ``config.h`` are
 created by probing support for various runtime functions and routines.
 Previously, the very verbose compiler output during this stage clouded more
-important information. By default the output is silenced. Running ``runtests.py
---debug-info`` will add ``--verbose-cfg`` to the ``build_src`` subcommand,
-which will restore the previous behaviour.
+important information. By default the output is silenced. Running
+``runtests.py --debug-info`` will add ``--verbose-cfg`` to the ``build_src``
+subcommand,which will restore the previous behaviour.
 
 Adding ``CFLAGS=-Werror`` to turn warnings into errors would trigger errors
 during the configuration. Now ``runtests.py --warn-error`` will add


### PR DESCRIPTION
The update is needed so that the links generated by towncrier are
converted in the README.md file generated for the github release
documentation. The code is also simplified.

[skip ci]

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
