### PR TITLE
MAINT: Update pavement.py for towncrier.

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -101,11 +101,13 @@ Building source archives and wheels
 You will need write permission for numpy-wheels in order to trigger wheel
 builds.
 
-* Python(s) from `python.org <https://python.org>`_ or linux distro.
-* cython
-* virtualenv (pip)
-* Paver (pip)
-* numpy-wheels `<https://github.com/MacPython/numpy-wheels>`_ (clone)
+- Python(s) from `python.org <https://python.org>`_ or linux distro.
+- cython (pip)
+- virtualenv (pip)
+- Paver (pip)
+- pandoc `pandoc.org <https://www.pandoc.org>`_ or linux distro.
+- numpy-wheels `<https://github.com/MacPython/numpy-wheels>`_ (clone)
+
 
 Building docs
 -------------
@@ -376,7 +378,7 @@ Make the release
 
 Build the changelog and notes for upload with::
 
-    paver write_release_and_log
+    paver write_release
 
 Build and archive documentation
 -------------------------------

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -366,9 +366,9 @@ Added two new configuration options. During the ``build_src`` subcommand, as
 part of configuring NumPy, the files ``_numpyconfig.h`` and ``config.h`` are
 created by probing support for various runtime functions and routines.
 Previously, the very verbose compiler output during this stage clouded more
-important information. By default the output is silenced. Running ``runtests.py
---debug-info`` will add ``--verbose-cfg`` to the ``build_src`` subcommand,
-which will restore the previous behaviour.
+important information. By default the output is silenced. Running
+``runtests.py --debug-info`` will add ``--verbose-cfg`` to the ``build_src``
+subcommand,which will restore the previous behaviour.
 
 Adding ``CFLAGS=-Werror`` to turn warnings into errors would trigger errors
 during the configuration. Now ``runtests.py --warn-error`` will add


### PR DESCRIPTION
Backport of #15150.

The update is needed so that the links generated by towncrier are
converted in the README.md file generated for the github release
documentation. The code is also simplified.

[skip ci]

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
