### PR TITLE
DOC: add moved modules to 1.18 release note

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -199,6 +199,14 @@ exception will require adaptation, and code that mistakenly called
 ``numpy.nanmax`` and ``numpy.nanmin``.
 (`gh-14841 <https://github.com/numpy/numpy/pull/14841>`__)
 
+Moved modules in ``numpy.random``
+---------------------------------
+As part of the API cleanup, the submodules in ``numpy.random``
+``bit_generator``, ``philox``, ``pcg64``, ``sfc64, ``common``, ``generator``,
+and ``bounded_integers`` were moved to ``_bit_generator``, ``_philox``,
+``_pcg64``, ``_sfc64, ``_common``, ``_generator``, and ``_bounded_integers``
+respectively to indicate that they are not part of the public interface.
+
 
 C API changes
 =============

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -206,6 +206,7 @@ As part of the API cleanup, the submodules in ``numpy.random``
 and ``bounded_integers`` were moved to ``_bit_generator``, ``_philox``,
 ``_pcg64``, ``_sfc64, ``_common``, ``_generator``, and ``_bounded_integers``
 respectively to indicate that they are not part of the public interface.
+(`gh-14608 <https://github.com/numpy/numpy/pull/14608>`__)
 
 
 C API changes


### PR DESCRIPTION
Backport of #15156. 

Closes #15152. Document that some numpy.random submodules moved to indicate they are not part of the public interface.

[ci-skip]
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
