### PR TITLE
BUG: searchsorted: passing the keys as a keyword argument

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1469,7 +1469,7 @@ array_argpartition(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_searchsorted(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"keys", "side", "sorter", NULL};
+    static char *kwlist[] = {"v", "side", "sorter", NULL};
     PyObject *keys;
     PyObject *sorter;
     NPY_SEARCHSIDE side = NPY_SEARCHLEFT;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2144,6 +2144,8 @@ class TestMethods(object):
         msg = "Test real searchsorted with nans, side='r'"
         b = a.searchsorted(a, side='r')
         assert_equal(b, np.arange(1, 4), msg)
+        # check keyword arguments
+        a.searchsorted(v=1)
         # check double complex
         a = np.zeros(9, dtype=np.complex128)
         a.real += [0, 0, 1, 1, 0, 1, np.nan, np.nan, np.nan]


### PR DESCRIPTION
```python
import numpy as np
a = np.arange(5)
```

The docstring of `ndarray.searchsorted` claims it has a signature of
```python
a.searchsorted(v, side='left', sorter=None)
```
However, trying to pass `v` as a keyword argument (`a.searchsorted(v=3)`) fails with a `TypeError`. The docstring also claims that `np.searchsorted` works the same as `ndarray.searchsorted` but `np.searchsorted(a, v=3)` works as expected.

This changes the name of the parameter from `keys` to `v`.