### PR TITLE
MAINT: concentrate global state in a single struct

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -751,6 +751,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'common', 'ucsnarrow.c'),
             join('src', 'common', 'ufunc_override.c'),
             join('src', 'common', 'numpyos.c'),
+            join('src', 'common', 'npy_global.h.src'),
             ]
 
     if os.environ.get('NPY_USE_BLAS_ILP64', "0") != "0":

--- a/numpy/core/src/common/npy_global.h.src
+++ b/numpy/core/src/common/npy_global.h.src
@@ -1,0 +1,71 @@
+#ifndef NPY_GLOBAL_H
+#define NPY_GLOBAL_H
+
+#include <Python.h>
+#include "numpy/npy_common.h"
+
+static struct _global
+{
+    PyObject * ndarray_array_ufunc;
+    PyObject * ndarray_array_function;
+    PyObject * casting_unsafe_dict;
+    PyObject * errmsg_formatter;
+    PyTypeObject *PyMemberDescr_TypePtr;
+    PyTypeObject *PyGetSetDescr_TypePtr;
+    PyTypeObject *PyMethodDescr_TypePtr;
+    int unpack_init;
+    union {
+        npy_uint8  bytes[8];
+        npy_uint64 uint64;
+    } unpack_lookup_big[256];
+    PyObject * zero_obj;
+    PyObject * one_obj;
+    PyObject *mem_error_exc_type;
+    PyObject *view_is_safe;
+    PyObject *getfield_is_safe;
+/**begin repeat
+ *
+ * #func = amax, amin, ptp, clip, dump, dumps, mean, sum, prod, any, all, std,
+           var #
+ */
+    PyObject *callable_@func@;
+/**end repeat**/
+
+    PyObject *dump_method;
+    PyObject *dumps_method;
+    PyObject *too_hard_cls;
+    PyObject *reprfunc;
+
+    /* temp_elide.c */
+    int elide_init;
+    /*
+     * measured DSO object memory start and end, if an address is located
+     * inside these bounds it is part of that library so we don't need to call
+     * dladdr on it (assuming linear memory)
+     */
+    void * elide_pos_python_start;
+    void * elide_pos_python_end;
+    void * elide_pos_ma_start;
+    void * elide_pos_ma_end;
+
+    /* known address storage to save dladdr calls */
+    void * elide_py_addr[64];
+    void * elide_pyeval_addr[64];
+    npy_intp elide_n_py_addr;
+    npy_intp elide_n_pyeval;
+    npy_bool logical_or_zero[4096];
+    npy_bool logical_and_zero[4096];
+    PyObject *NoValue;
+    PyObject *ComplexWarning;
+    PyObject *ufunc_kwnames[13];
+    PyObject *numpy_matrix;
+    PyObject *sig_formatter;
+    PyObject *UFuncBinaryResolutionError;
+    PyObject *UFuncNoLoopError;
+    PyObject *UFuncInputCastingError;
+    PyObject *UFuncOutputCastingError;
+    PyObject *default_type_tup;
+
+} npy_globals;
+
+#endif

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -5,6 +5,7 @@
 #include "get_attr_string.h"
 #include "npy_import.h"
 #include "ufunc_override.h"
+#include "npy_global.h"
 
 /*
  * Check whether an object has __array_ufunc__ defined on its class and it
@@ -17,12 +18,11 @@
 NPY_NO_EXPORT PyObject *
 PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
 {
-    static PyObject *ndarray_array_ufunc = NULL;
     PyObject *cls_array_ufunc;
 
     /* On first entry, cache ndarray's __array_ufunc__ */
-    if (ndarray_array_ufunc == NULL) {
-        ndarray_array_ufunc = PyObject_GetAttrString((PyObject *)&PyArray_Type,
+    if (npy_globals.ndarray_array_ufunc == NULL) {
+        npy_globals.ndarray_array_ufunc = PyObject_GetAttrString((PyObject *)&PyArray_Type,
                                                      "__array_ufunc__");
     }
 
@@ -42,7 +42,7 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
         return NULL;
     }
     /* Ignore if the same as ndarray.__array_ufunc__ */
-    if (cls_array_ufunc == ndarray_array_ufunc) {
+    if (cls_array_ufunc == npy_globals.ndarray_array_ufunc) {
         Py_DECREF(cls_array_ufunc);
         return NULL;
     }

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -8,6 +8,7 @@
 #include "lowlevel_strided_loops.h"
 
 #include "npy_config.h"
+#include "npy_global.h"
 
 #include "npy_pycompat.h"
 
@@ -834,11 +835,11 @@ _GenericBinaryOutFunction(PyArrayObject *m1, PyObject *m2, PyArrayObject *out,
     }
     else {
         PyObject *args, *ret;
-        static PyObject *kw = NULL;
 
-        if (kw == NULL) {
-            kw = Py_BuildValue("{s:s}", "casting", "unsafe");
-            if (kw == NULL) {
+        if (npy_globals.casting_unsafe_dict == NULL) {
+            npy_globals.casting_unsafe_dict = Py_BuildValue("{s:s}", "casting",
+                                                            "unsafe");
+            if (npy_globals.casting_unsafe_dict == NULL) {
                 return NULL;
             }
         }
@@ -848,7 +849,7 @@ _GenericBinaryOutFunction(PyArrayObject *m1, PyObject *m2, PyArrayObject *out,
             return NULL;
         }
 
-        ret = PyObject_Call(op, args, kw);
+        ret = PyObject_Call(op, args, npy_globals.casting_unsafe_dict);
 
         Py_DECREF(args);
 

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -8,6 +8,7 @@
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
+#include "npy_global.h"
 
 #include "npy_pycompat.h"
 #include "numpy/npy_math.h"
@@ -1998,7 +1999,6 @@ PyArray_Zero(PyArrayObject *arr)
 {
     char *zeroval;
     int ret, storeflags;
-    static PyObject * zero_obj = NULL;
 
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
@@ -2009,9 +2009,9 @@ PyArray_Zero(PyArrayObject *arr)
         return NULL;
     }
 
-    if (zero_obj == NULL) {
-        zero_obj = PyInt_FromLong((long) 0);
-        if (zero_obj == NULL) {
+    if (npy_globals.zero_obj == NULL) {
+        npy_globals.zero_obj = PyInt_FromLong((long) 0);
+        if (npy_globals.zero_obj == NULL) {
             return NULL;
         }
     }
@@ -2022,12 +2022,12 @@ PyArray_Zero(PyArrayObject *arr)
            if they simply memcpy it into a ndarray without using
            setitem(), refcount errors will occur
         */
-        memcpy(zeroval, &zero_obj, sizeof(PyObject *));
+        memcpy(zeroval, &npy_globals.zero_obj, sizeof(PyObject *));
         return zeroval;
     }
     storeflags = PyArray_FLAGS(arr);
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_BEHAVED);
-    ret = PyArray_SETITEM(arr, zeroval, zero_obj);
+    ret = PyArray_SETITEM(arr, zeroval, npy_globals.zero_obj);
     ((PyArrayObject_fields *)arr)->flags = storeflags;
     if (ret < 0) {
         PyDataMem_FREE(zeroval);
@@ -2044,7 +2044,6 @@ PyArray_One(PyArrayObject *arr)
 {
     char *oneval;
     int ret, storeflags;
-    static PyObject * one_obj = NULL;
 
     if (_check_object_rec(PyArray_DESCR(arr)) < 0) {
         return NULL;
@@ -2055,9 +2054,9 @@ PyArray_One(PyArrayObject *arr)
         return NULL;
     }
 
-    if (one_obj == NULL) {
-        one_obj = PyInt_FromLong((long) 1);
-        if (one_obj == NULL) {
+    if (npy_globals.one_obj == NULL) {
+        npy_globals.one_obj = PyInt_FromLong((long) 1);
+        if (npy_globals.one_obj == NULL) {
             return NULL;
         }
     }
@@ -2068,13 +2067,13 @@ PyArray_One(PyArrayObject *arr)
            if they simply memcpy it into a ndarray without using
            setitem(), refcount errors will occur
         */
-        memcpy(oneval, &one_obj, sizeof(PyObject *));
+        memcpy(oneval, &npy_globals.one_obj, sizeof(PyObject *));
         return oneval;
     }
 
     storeflags = PyArray_FLAGS(arr);
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_BEHAVED);
-    ret = PyArray_SETITEM(arr, oneval, one_obj);
+    ret = PyArray_SETITEM(arr, oneval, npy_globals.one_obj);
     ((PyArrayObject_fields *)arr)->flags = storeflags;
     if (ret < 0) {
         PyDataMem_FREE(oneval);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -10,6 +10,7 @@
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"
+#include "npy_global.h"
 
 #include "npy_ctypes.h"
 #include "npy_pycompat.h"
@@ -952,12 +953,10 @@ discover_dimensions(PyObject *obj, int *maxndim, npy_intp *d, int check_it,
 static PyObject *
 raise_memory_error(int nd, npy_intp *dims, PyArray_Descr *descr)
 {
-    static PyObject *exc_type = NULL;
-
     npy_cache_import(
         "numpy.core._exceptions", "_ArrayMemoryError",
-        &exc_type);
-    if (exc_type == NULL) {
+        &npy_globals.mem_error_exc_type);
+    if (npy_globals.mem_error_exc_type == NULL) {
         goto fail;
     }
 
@@ -972,7 +971,7 @@ raise_memory_error(int nd, npy_intp *dims, PyArray_Descr *descr)
     if (exc_value == NULL){
         goto fail;
     }
-    PyErr_SetObject(exc_type, exc_value);
+    PyErr_SetObject(npy_globals.mem_error_exc_type, exc_value);
     Py_DECREF(exc_value);
     return NULL;
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -11,6 +11,7 @@
 #include "npy_config.h"
 #include "npy_pycompat.h"
 #include "npy_import.h"
+#include "npy_global.h"
 
 #include "common.h"
 #include "ctors.h"
@@ -494,15 +495,15 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 
     /* check that we are not reinterpreting memory containing Objects. */
     if (_may_have_objects(PyArray_DESCR(self)) || _may_have_objects(newtype)) {
-        static PyObject *checkfunc = NULL;
         PyObject *safe;
 
-        npy_cache_import("numpy.core._internal", "_view_is_safe", &checkfunc);
-        if (checkfunc == NULL) {
+        npy_cache_import("numpy.core._internal", "_view_is_safe",
+                         &npy_globals.view_is_safe);
+        if (npy_globals.view_is_safe == NULL) {
             goto fail;
         }
 
-        safe = PyObject_CallFunction(checkfunc, "OO",
+        safe = PyObject_CallFunction(npy_globals.view_is_safe, "OO",
                                      PyArray_DESCR(self), newtype);
         if (safe == NULL) {
             goto fail;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -16,6 +16,7 @@
 #include "npy_pycompat.h"
 
 #include "npy_config.h"
+#include "npy_global.h"
 #include "mapping.h"
 #include "ctors.h"
 #include "usertypes.h"
@@ -540,13 +541,12 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
 
 static PyObject *
 _void_scalar_repr(PyObject *obj) {
-    static PyObject *reprfunc = NULL;
     npy_cache_import("numpy.core.arrayprint",
-                     "_void_scalar_repr", &reprfunc);
-    if (reprfunc == NULL) {
+                     "_void_scalar_repr", &npy_globals.reprfunc);
+    if (npy_globals.reprfunc == NULL) {
         return NULL;
     }
-    return PyObject_CallFunction(reprfunc, "O", obj);
+    return PyObject_CallFunction(npy_globals.reprfunc, "O", obj);
 }
 
 static PyObject *

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -7,6 +7,7 @@
 #include "Python.h"
 
 #include "npy_config.h"
+#include "npy_global.h"
 #include "numpy/npy_common.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
@@ -456,11 +457,12 @@ BOOL_@kind@(char **args, npy_intp *dimensions, npy_intp *steps, void *NPY_UNUSED
              * zero blocks, memcmp is faster than memchr on SSE4 machines
              * with glibc >= 2.12 and memchr can only check for equal 1
              */
-            static const npy_bool zero[4096]; /* zero by C standard */
+            npy_bool *zero = npy_globals.@kind@_zero;
+            size_t zero_size = sizeof(npy_globals.@kind@_zero);
             npy_uintp i, n = dimensions[0];
 
-            for (i = 0; !*op && i < n - (n % sizeof(zero)); i += sizeof(zero)) {
-                *op = memcmp(&args[1][i], zero, sizeof(zero)) != 0;
+            for (i = 0; !*op && i < n - (n % zero_size); i += zero_size) {
+                *op = memcmp(&args[1][i], zero, zero_size) != 0;
             }
             if (!*op && n - i > 0) {
                 *op = memcmp(&args[1][i], zero, n - i) != 0;

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -218,7 +218,6 @@ NPY_NO_EXPORT void
                            void *_ip2, npy_intp is2_n, npy_intp is2_p,
                            void *_op, npy_intp os_m, npy_intp os_p,
                            npy_intp dm, npy_intp dn, npy_intp dp)
-                           
 {
     npy_intp m, n, p;
     npy_intp ib1_n, ib2_n, ib2_p, ob_p;
@@ -276,7 +275,6 @@ BOOL_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
                            void *_ip2, npy_intp is2_n, npy_intp is2_p,
                            void *_op, npy_intp os_m, npy_intp os_p,
                            npy_intp dm, npy_intp dn, npy_intp dp)
-                           
 {
     npy_intp m, n, p;
     npy_intp ib2_p, ob_p;
@@ -314,7 +312,7 @@ NPY_NO_EXPORT void
 OBJECT_matmul_inner_noblas(void *_ip1, npy_intp is1_m, npy_intp is1_n,
                            void *_ip2, npy_intp is2_n, npy_intp is2_p,
                            void *_op, npy_intp os_m, npy_intp os_p,
-                           npy_intp dm, npy_intp dn, npy_intp dp)                         
+                           npy_intp dm, npy_intp dn, npy_intp dp)
 {
     char *ip1 = (char *)_ip1, *ip2 = (char *)_ip2, *op = (char *)_op;
 
@@ -439,7 +437,7 @@ NPY_NO_EXPORT void
          * n, m, p and strides.
          */
         if (too_big_for_blas || any_zero_dim) {
-            @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n, 
+            @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
                                        ip2, is2_n, is2_p,
                                        op, os_m, os_p, dm, dn, dp);
         }
@@ -454,7 +452,7 @@ NPY_NO_EXPORT void
                  * could use cblas_Xaxy, but that requires 0ing output
                  * and would not be faster (XXX prove it)
                  */
-                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n, 
+                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
                                            ip2, is2_n, is2_p,
                                            op, os_m, os_p, dm, dn, dp);
             } else if (vector_matrix) {
@@ -468,7 +466,7 @@ NPY_NO_EXPORT void
                             op, os_m, os_p, dm, dn, dp);
             } else {
                 /* column @ row, 2d output, no blas needed or non-blas-able input */
-                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n, 
+                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
                                            ip2, is2_n, is2_p,
                                            op, os_m, os_p, dm, dn, dp);
             }
@@ -494,13 +492,13 @@ NPY_NO_EXPORT void
                  * non-blasable (or non-ccontiguous output)
                  * we could still use BLAS, see gh-12365.
                  */
-                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n, 
+                @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
                                            ip2, is2_n, is2_p,
                                            op, os_m, os_p, dm, dn, dp);
             }
         }
 #else
-        @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n, 
+        @TYPE@_matmul_inner_noblas(ip1, is1_m, is1_n,
                                    ip2, is2_n, is2_p,
                                    op, os_m, os_p, dm, dn, dp);
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -12,6 +12,7 @@
 
 #include "Python.h"
 #include "npy_config.h"
+#include "npy_global.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
@@ -1353,16 +1354,15 @@ NONZERO_NAME(@name@_)(PyObject *a)
 static int
 emit_complexwarning(void)
 {
-    static PyObject *cls = NULL;
-    if (cls == NULL) {
+    if (npy_globals.ComplexWarning == NULL) {
         PyObject *mod;
         mod = PyImport_ImportModule("numpy.core");
         assert(mod != NULL);
-        cls = PyObject_GetAttrString(mod, "ComplexWarning");
-        assert(cls != NULL);
+        npy_globals.ComplexWarning = PyObject_GetAttrString(mod, "ComplexWarning");
+        assert(npy_globals.ComplexWarning != NULL);
         Py_DECREF(mod);
     }
-    return PyErr_WarnEx(cls,
+    return PyErr_WarnEx(npy_globals.ComplexWarning,
             "Casting complex values to real discards the imaginary part", 1);
 }
 

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -147,7 +147,7 @@ PyUFunc_DefaultMaskedInnerLoopSelector(PyUFuncObject *ufunc,
                                       PyArray_Descr *mask_dtypes,
                                       npy_intp *NPY_UNUSED(fixed_strides),
                                       npy_intp NPY_UNUSED(fixed_mask_stride),
-                                      PyUFunc_MaskedStridedInnerLoopFunc 
+                                      PyUFunc_MaskedStridedInnerLoopFunc
                                       **out_innerloop,
                                       NpyAuxData **out_innerloopdata,
                                       int *out_needs_api);


### PR DESCRIPTION
Rather than scatter `static PyObject*` and other static state around the module, concentrate them in one place. Note this does not release the state whe PyFinalize is called.

This would be the a step in moving toward subinterpreters some day.