### PR TITLE
BUG: use tmp dir and check version for cython test

### DIFF
--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -12,6 +12,7 @@ from setuptools.extension import Extension
 from os.path import join, abspath, dirname
 
 path = abspath(dirname(__file__))
+defs = [('NPY_NO_DEPRECATED_API', 0)]
 
 extending = Extension("extending",
                       sources=[join(path, 'extending.pyx')],
@@ -19,10 +20,13 @@ extending = Extension("extending",
                             np.get_include(),
                             join(path, '..', '..')
                         ],
+                      define_macros=defs,
                       )
 distributions = Extension("extending_distributions",
                           sources=[join(path, 'extending_distributions.pyx')],
-                          include_dirs=[np.get_include()])
+                          include_dirs=[np.get_include()],
+                          define_macros=defs,
+                         )
 
 extensions = [extending, distributions]
 

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -26,18 +26,16 @@ try:
     import cython
 except ImportError:
     cython = None
-
-cython_ver = cython.__version__.split('.')
-if len(cython_ver) < 3 or cython_ver < ['0', '29', '14']:
-    # too old or wrong cython, skip the test
-    cython = None
+else:
+    cython_ver = cython.__version__.split('.')
+    if len(cython_ver) < 3 or cython_ver < ['0', '29', '14']:
+        # too old or wrong cython, skip the test
+        cython = None
 
 @pytest.mark.skipif(cython is None, reason="requires cython")
 @pytest.mark.slow
 @pytest.mark.skipif(sys.platform == 'win32', reason="cmd too long on CI")
 def test_cython(tmp_path):
-    curdir = os.getcwd()
-    argv = sys.argv
     examples = os.path.join(os.path.dirname(__file__), '..', '_examples')
     base = os.path.dirname(examples)
     shutil.copytree(examples, tmp_path / '_examples')

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -28,6 +28,10 @@ except ImportError:
     cython = None
 else:
     cython_ver = cython.__version__.split('.')
+    # Cython 0.29.14 is required for Python 3.8 and there are
+    # other fixes in the 0.29 series that are needed even for earlier
+    # Python versions.
+    # Note: keep in sync with the one in pyproject.toml
     if len(cython_ver) < 3 or cython_ver < ['0', '29', '14']:
         # too old or wrong cython, skip the test
         cython = None
@@ -39,8 +43,8 @@ def test_cython(tmp_path):
     examples = os.path.join(os.path.dirname(__file__), '..', '_examples')
     base = os.path.dirname(examples)
     shutil.copytree(examples, tmp_path / '_examples')
-    env = os.environ.copy()
-    subprocess.check_call([sys.executable, 'setup.py', 'build'], env=env,
+    subprocess.check_call([sys.executable, 'setup.py', 'build'],
+                          env=os.environ,
                           cwd=str(tmp_path / '_examples' / 'cython'))
 
 @pytest.mark.skipif(numba is None or cffi is None,

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -34,6 +34,7 @@ if len(cython_ver) < 3 or cython_ver < ['0', '29', '14']:
 
 @pytest.mark.skipif(cython is None, reason="requires cython")
 @pytest.mark.slow
+@pytest.mark.skipif(sys.platform == 'win32', reason="cmd too long on CI")
 def test_cython(tmp_path):
     curdir = os.getcwd()
     argv = sys.argv
@@ -47,8 +48,8 @@ def test_cython(tmp_path):
 @pytest.mark.skipif(numba is None or cffi is None,
                     reason="requires numba and cffi")
 def test_numba():
-        from numpy.random._examples.numba import extending
+    from numpy.random._examples.numba import extending
 
 @pytest.mark.skipif(cffi is None, reason="requires cffi")
 def test_cffi():
-        from numpy.random._examples.cffi import extending
+    from numpy.random._examples.cffi import extending

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -24,15 +24,17 @@ except ImportError:
 
 try:
     import cython
+    from Cython.Compiler.Version import version as cython_version
 except ImportError:
     cython = None
 else:
-    cython_ver = cython.__version__.split('.')
+    from distutils.version import LooseVersion
     # Cython 0.29.14 is required for Python 3.8 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    if len(cython_ver) < 3 or cython_ver < ['0', '29', '14']:
+    required_version = LooseVersion('0.29.14')
+    if LooseVersion(cython_version) < required_version:
         # too old or wrong cython, skip the test
         cython = None
 
@@ -44,7 +46,6 @@ def test_cython(tmp_path):
     base = os.path.dirname(examples)
     shutil.copytree(examples, tmp_path / '_examples')
     subprocess.check_call([sys.executable, 'setup.py', 'build'],
-                          env=os.environ,
                           cwd=str(tmp_path / '_examples' / 'cython'))
 
 @pytest.mark.skipif(numba is None or cffi is None,


### PR DESCRIPTION
Fixes gh-15166

- Check the cython version
- Use a subprocess to run the test
- Run the test in a [temporary directory](https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory).
- Clean up a warning