### PR TITLE
BUG: use tmp dir and check version for cython test (#15170)

### DIFF
--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -12,6 +12,7 @@ from setuptools.extension import Extension
 from os.path import join, abspath, dirname
 
 path = abspath(dirname(__file__))
+defs = [('NPY_NO_DEPRECATED_API', 0)]
 
 extending = Extension("extending",
                       sources=[join(path, 'extending.pyx')],
@@ -19,10 +20,13 @@ extending = Extension("extending",
                             np.get_include(),
                             join(path, '..', '..')
                         ],
+                      define_macros=defs,
                       )
 distributions = Extension("extending_distributions",
                           sources=[join(path, 'extending_distributions.pyx')],
-                          include_dirs=[np.get_include()])
+                          include_dirs=[np.get_include()],
+                          define_macros=defs,
+                         )
 
 extensions = [extending, distributions]
 


### PR DESCRIPTION
Backport of #15170.

Fixes gh-15166

- Check the cython version
- Use a subprocess to run the test
- Run the test in a [temporary directory](https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory).
- Clean up a warning


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
