### PR TITLE
ENH: Calculate mean sequentially along different axis

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -150,7 +150,7 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False):
             is_float16_result = True
 
     if axis is None: 
-        sorted_axis = range(len(arr.shape))
+        sorted_axis = range(arr.ndim)
     elif isinstance(axis, tuple): 
         sorted_axis = np.sort(np.unique(axis))
     else: 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5570,6 +5570,11 @@ class TestStats(object):
         # of float32.
         assert_(_mean(np.ones(100000, dtype='float16')) == 1)
 
+    def test_mean_accuracy(self):
+        # This fail if the sum inside mean is done in float16 instead
+        # of float32.
+        assert_(_mean(np.ones((1000000, 4, 15), dtype = 'float32')) == 1)
+
     def test_var_values(self):
         for mat in [self.rmat, self.cmat, self.omat]:
             for axis in [0, 1, None]:


### PR DESCRIPTION
See #8869 
Instead of calculating sum of all elements and dividing that by number of elements, we calculate mean along one axis, then another one etc., which increases precision.
```
>>> import numpy as np
>>> test_array = np.ones((10000000, 4, 15), dtype = np.float32)
>>> test_array.mean(axis=(0,1))
```
would return result of `test_array.mean(axis=0).mean(axis=0)`.