### PR TITLE
MAINT: unskip test on win32

### DIFF
--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -9,9 +9,9 @@ import numpy as np
 from distutils.core import setup
 from Cython.Build import cythonize
 from setuptools.extension import Extension
-from os.path import join, abspath, dirname
+from os.path import join, dirname
 
-path = abspath(dirname(__file__))
+path = dirname(__file__)
 defs = [('NPY_NO_DEPRECATED_API', 0)]
 
 extending = Extension("extending",

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -42,7 +42,6 @@ else:
 @pytest.mark.slow
 def test_cython(tmp_path):
     examples = os.path.join(os.path.dirname(__file__), '..', '_examples')
-    base = os.path.dirname(examples)
     shutil.copytree(examples, tmp_path / '_examples')
     subprocess.check_call([sys.executable, 'setup.py', 'build'],
                           cwd=str(tmp_path / '_examples' / 'cython'))

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -40,7 +40,6 @@ else:
 
 @pytest.mark.skipif(cython is None, reason="requires cython")
 @pytest.mark.slow
-@pytest.mark.skipif(sys.platform == 'win32', reason="cmd too long on CI")
 def test_cython(tmp_path):
     examples = os.path.join(os.path.dirname(__file__), '..', '_examples')
     base = os.path.dirname(examples)


### PR DESCRIPTION
continuation of gh-15170; following the suggestion of @eric-wieser 

Remove `abspath()`, enable tests on win32