### PR TITLE
ENH: Add property-based tests using Hypothesis

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -26,8 +26,13 @@ Building NumPy requires the following installed software:
 
    This is required for testing NumPy, but not for using it.
 
+4) Hypothesis__ (optional) 5.3.0 or later
+
+   This is required for testing NumPy, but not for using it.
+
 Python__ http://www.python.org
 pytest__ http://pytest.readthedocs.io
+Hypothesis__ https://hypothesis.readthedocs.io/en/latest/
 
 
 .. note::

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -360,7 +360,17 @@ deterministic by setting the random number seed before generating it.  Use
 either Python's ``random.seed(some_number)`` or NumPy's
 ``numpy.random.seed(some_number)``, depending on the source of random numbers.
 
+Alternatively, you can use `Hypothesis`_ to generate arbitrary data.
+Hypothesis manages both Python's and Numpy's random seeds for you, and
+provides a very concise and powerful way to describe data (including
+``hypothesis.extra.numpy``, e.g. for a set of mutually-broadcastable shapes).
+
+The advantages over random generation include tools to replay and share
+failures without requiring a fixed seed, reporting *minimal* examples for
+each failure, and better-than-naive-random techniques for triggering bugs.
+
 
 .. _nose: https://nose.readthedocs.io/en/latest/
 .. _pytest: https://pytest.readthedocs.io
 .. _parameterization: https://docs.pytest.org/en/latest/parametrize.html
+.. _Hypothesis: https://hypothesis.readthedocs.io/en/latest/

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -3,6 +3,7 @@ Pytest configuration and fixtures for the Numpy test suite.
 """
 import os
 
+import hypothesis
 import pytest
 import numpy
 
@@ -11,6 +12,12 @@ from numpy.core._multiarray_tests import get_fpu_mode
 
 _old_fpu_mode = None
 _collect_results = {}
+
+# See https://hypothesis.readthedocs.io/en/latest/settings.html
+hypothesis.settings.register_profile(
+    name="numpy-profile", deadline=None, print_blob=True,
+)
+hypothesis.settings.load_profile("numpy-profile")
 
 
 def pytest_configure(config):

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 import gc
+from hypothesis import given
+from hypothesis.extra import numpy as hynp
 import pytest
 
 import numpy as np
@@ -392,6 +394,18 @@ class TestArray2String:
             np.array2string(a, max_line_width=5, legacy='1.13'),
             "[ 'xxxxx']"
         )
+
+    @given(hynp.from_dtype(np.dtype("U")))
+    def test_any_text(self, text):
+        # This test checks that, given any value that can be represented in an
+        # array of dtype("U") (i.e. unicode string), ...
+        a = np.array([text, text, text])
+        # casting a list of them to an array does not e.g. truncate the value
+        assert_equal(a[0], text)
+        # and that np.array2string puts a newline in the expected location
+        expected_repr = "[{0!r} {0!r}\n {0!r}]".format(text)
+        result = np.array2string(a, max_line_width=len(repr(text)) * 2 + 3)
+        assert_equal(result, expected_repr)
 
     @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
     def test_refcount(self):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 cython==0.29.14
+hypothesis==5.3.0
 pytest==5.3.5
 pytz==2019.3
 pytest-cov==2.8.1


### PR DESCRIPTION
This property-based testing demo focuses on tricky tests for numeric code - Hypothesis adds most value when the input or configuration space is large, but you can make clear statements about "always" or "never" (even very loose ones!).

@mattip @rgommers, I can spend a few days adding tests to this PR if that would be useful.  Perhaps more importantly I'm happy to help out with code review / debugging / reproducing bugs or whatever else turns up as a result of property-based testing.

The PR currently consists of:

- [x] @kitchoi's test, which closes #14440.  This is a short and simple test which gives you an idea of what Hypothesis tests can look like.
- [x] A more complex test based on @tylerjereddy's [clip tests](https://github.com/tylerjereddy/numpy-property/blob/master/tests/test_clip.py).  I've restricted this so it passes, but allowing clipping by zero-dimensional arrays or varied dtypes turns up inconsistencies with `mininum(maximum(array, clip_low), clip_high)` (contra #12519).
      In the process I found a mishandling of signalling `nan`s: #15127 / #15230!

I would prefer to get this merged before working on further tests, both to allow others to contribute property tests and to ensure that I'm working on something valuable for Numpy.  Proposed follow-up PRs will cover:

- [ ] something based on @rsokl's [`einsum` tests](https://github.com/rsokl/MyGrad/blob/master/tests/linalg/test_einsum.py), which found #10930 (and other tests)
- [ ] Testing `np.dtype()` *ala* #14239 
- [ ] Testing IO that round-trips do in fact round-trip with a wide variety of shapes, dtypes, and IO methods.