### PR TITLE
BUG: test, fix for c++ compilation

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -532,7 +532,7 @@ def CCompiler_customize(self, dist, need_cxx=0):
                                       'g++' in self.compiler[0] or
                                       'clang' in self.compiler[0]):
         self._auto_depends = True
-        if 'gcc' in self.compiler[0]:
+        if 'gcc' in self.compiler[0] and not need_cxx:
             # add std=c99 flag for gcc
             # TODO: does this need to be more specific?
             self.compiler.append('-std=c99')

--- a/numpy/distutils/tests/test_ccompiler.py
+++ b/numpy/distutils/tests/test_ccompiler.py
@@ -1,0 +1,18 @@
+from __future__ import division, absolute_import, print_function
+
+from distutils.ccompiler import new_compiler
+
+from numpy.distutils.numpy_distribution import NumpyDistribution
+
+def test_ccompiler():
+    dist = NumpyDistribution()
+    compiler = new_compiler()
+    compiler.customize(dist, need_cxx=False)
+    if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
+        assert 'c99' in ' '.join(compiler.compiler)
+
+    compiler = new_compiler()
+    compiler.customize(dist, need_cxx=True)
+    if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
+        assert 'c99' not in ' '.join(compiler.compiler)
+

--- a/numpy/distutils/tests/test_ccompiler.py
+++ b/numpy/distutils/tests/test_ccompiler.py
@@ -5,9 +5,16 @@ from distutils.ccompiler import new_compiler
 from numpy.distutils.numpy_distribution import NumpyDistribution
 
 def test_ccompiler():
+    '''
+    scikit-image/scikit-image issue 4369
+    We unconditionally add ``-std-c99`` to the gcc compiler in order
+    to support c99 with very old gcc compilers. However the same call
+    is used to get the flags for the c++ compiler, just with a kwarg.
+    Make sure in this case the option is **not** added.
+    '''
     dist = NumpyDistribution()
     compiler = new_compiler()
-    compiler.customize(dist, need_cxx=False)
+    compiler.customize(dist)
     if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
         assert 'c99' in ' '.join(compiler.compiler)
 

--- a/numpy/distutils/tests/test_ccompiler.py
+++ b/numpy/distutils/tests/test_ccompiler.py
@@ -10,7 +10,7 @@ def test_ccompiler():
     We unconditionally add ``-std-c99`` to the gcc compiler in order
     to support c99 with very old gcc compilers. However the same call
     is used to get the flags for the c++ compiler, just with a kwarg.
-    Make sure in this case the option is **not** added.
+    Make sure in this case, where it would not be legal, the option is **not** added
     '''
     dist = NumpyDistribution()
     compiler = new_compiler()
@@ -22,4 +22,3 @@ def test_ccompiler():
     compiler.customize(dist, need_cxx=True)
     if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
         assert 'c99' not in ' '.join(compiler.compiler)
-


### PR DESCRIPTION
xref scikit-image/scikit-image#4369

The blanket addition of `-std=c99` to the compiler flags broke compilation for `c++` compilers. Now tested and fixed.