### PR TITLE
DOC: Adding instructions for building documentation to developer guide

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -231,6 +231,17 @@ Requirements
 `Sphinx <http://www.sphinx-doc.org/en/stable/>`__ is needed to build
 the documentation. Matplotlib, SciPy, and IPython are also required.
 
+The numpy documentation also depends on the
+`numpydoc <https://numpydoc.readthedocs.io/en/latest/>`__ sphinx extension
+as well as an external sphinx theme.
+These extensions are included as git submodules and must be initialized
+before building the docs.
+From the ``doc/`` directory:
+
+.. code:: sh
+
+    git submodule update --init
+
 Fixing Warnings
 ~~~~~~~~~~~~~~~
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -242,6 +242,11 @@ From the ``doc/`` directory:
 
     git submodule update --init
 
+The documentation includes mathematical formulae with LaTeX formatting.
+A working LaTeX document production system 
+(e.g. `texlive <https://www.tug.org/texlive/>`__) is required for the
+proper rendering of the LaTeX math in the documentation.
+
 Fixing Warnings
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The [Numpy developer guide](https://docs.scipy.org/doc/numpy/dev/) contains a nice subsection on building the documentation from source. When working through the guide, I had a couple of issues:

 1. Initial build failure due to missing sphinx theme and extensions

 2. Sphinx warnings and failure to render LaTeX math due to not having LaTeX installed.

I've added a few sentences to the developer guide to explicitly address each of these issues.

