### PR TITLE
MAINT: Do not use private Python function in testing

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -20,7 +20,6 @@ import gc
 import weakref
 import pytest
 from contextlib import contextmanager
-from test.support import no_tracing
 
 from numpy.compat import pickle
 
@@ -96,6 +95,26 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
     data = np.ndarray(shape, dtype, buf, order=order)
     data.fill(0)
     return data
+
+def _no_tracing(func):
+    """
+    Decorator to temporarily turn off tracing for the duration of a test.
+    Needed in tests that check refcounting, otherwise the tracing itself
+    influences the refcounts
+    """
+    if not hasattr(sys, 'gettrace'):
+        return func
+    else:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            original_trace = sys.gettrace()
+            try:
+                sys.settrace(None)
+                return func(*args, **kwargs)
+            finally:
+                sys.settrace(original_trace)
+        return wrapper
+
 
 
 class TestFlags(object):
@@ -5098,7 +5117,7 @@ class TestFlat(object):
 
 class TestResize(object):
 
-    @no_tracing
+    @_no_tracing
     def test_basic(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         if IS_PYPY:
@@ -5115,7 +5134,7 @@ class TestResize(object):
         assert_raises(ValueError, x.resize, (5, 1))
         del y  # avoid pyflakes unused variable warning.
 
-    @no_tracing
+    @_no_tracing
     def test_int_shape(self):
         x = np.eye(3)
         if IS_PYPY:
@@ -5149,7 +5168,7 @@ class TestResize(object):
         assert_raises(TypeError, np.eye(3).resize, order=1)
         assert_raises(TypeError, np.eye(3).resize, refcheck='hi')
 
-    @no_tracing
+    @_no_tracing
     def test_freeform_shape(self):
         x = np.eye(3)
         if IS_PYPY:
@@ -5158,7 +5177,7 @@ class TestResize(object):
             x.resize(3, 2, 1)
         assert_(x.shape == (3, 2, 1))
 
-    @no_tracing
+    @_no_tracing
     def test_zeros_appended(self):
         x = np.eye(3)
         if IS_PYPY:
@@ -5168,7 +5187,7 @@ class TestResize(object):
         assert_array_equal(x[0], np.eye(3))
         assert_array_equal(x[1], np.zeros((3, 3)))
 
-    @no_tracing
+    @_no_tracing
     def test_obj_obj(self):
         # check memory is initialized on resize, gh-4857
         a = np.ones(10, dtype=[('k', object, 2)])
@@ -7789,7 +7808,7 @@ if not IS_PYPY:
             d = np.ones(100)
             assert_(sys.getsizeof(d) < sys.getsizeof(d.reshape(100, 1, 1).copy()))
 
-        @no_tracing
+        @_no_tracing
         def test_resize(self):
             d = np.ones(100)
             old = sys.getsizeof(d)


### PR DESCRIPTION
Fixes #15202 

As @pv pointed out, the `test` module is not to be used outside `stdlib` tests. Copy-pasting seems the best idea to resolve this.