### PR TITLE
DEP: records: Deprecate treating shape=0 as shape=None

### DIFF
--- a/doc/release/upcoming_changes/15217.deprecation.rst
+++ b/doc/release/upcoming_changes/15217.deprecation.rst
@@ -1,0 +1,11 @@
+Passing ``shape=0`` to factory functions in ``numpy.rec`` is deprecated
+-----------------------------------------------------------------------
+
+``0`` is treated as a special case by these functions, which aliases to
+``None``. In future, ``0`` will not be a special case, and will be treated
+as an array length like any other integer is. The affected functions are:
+
+* `numpy.core.records.fromarrays`
+* `numpy.core.records.fromrecords`
+* `numpy.core.records.fromstring`
+* `numpy.core.records.fromfile`

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -583,6 +583,18 @@ class recarray(ndarray):
             return self.setfield(val, *res)
 
 
+def _deprecate_shape_0_as_None(shape):
+    if shape == 0:
+        warnings.warn(
+            "Passing `shape=0` to have the shape be inferred is deprecated, "
+            "and in future will be equivalent to `shape=(0,)`. To infer "
+            "the shape and suppress this warning, pass `shape=None` instead.",
+            FutureWarning, stacklevel=3)
+        return None
+    else:
+        return shape
+
+
 def fromarrays(arrayList, dtype=None, shape=None, formats=None,
                names=None, titles=None, aligned=False, byteorder=None):
     """ create a record array from a (flat) list of arrays
@@ -600,10 +612,12 @@ def fromarrays(arrayList, dtype=None, shape=None, formats=None,
 
     arrayList = [sb.asarray(x) for x in arrayList]
 
-    if shape is None or shape == 0:
-        shape = arrayList[0].shape
+    # NumPy 1.19.0, 2020-01-01
+    shape = _deprecate_shape_0_as_None(shape)
 
-    if isinstance(shape, int):
+    if shape is None:
+        shape = arrayList[0].shape
+    elif isinstance(shape, int):
         shape = (shape,)
 
     if formats is None and dtype is None:
@@ -689,7 +703,9 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
     try:
         retval = sb.array(recList, dtype=descr)
     except (TypeError, ValueError):
-        if (shape is None or shape == 0):
+        # NumPy 1.19.0, 2020-01-01
+        shape = _deprecate_shape_0_as_None(shape)
+        if shape is None:
             shape = len(recList)
         if isinstance(shape, (int, long)):
             shape = (shape,)
@@ -728,7 +744,11 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
         descr = format_parser(formats, names, titles, aligned, byteorder)._descr
 
     itemsize = descr.itemsize
-    if (shape is None or shape == 0 or shape == -1):
+
+    # NumPy 1.19.0, 2020-01-01
+    shape = _deprecate_shape_0_as_None(shape)
+
+    if shape is None or shape == -1:
         shape = (len(datastring) - offset) // itemsize
 
     _array = recarray(shape, descr, buf=datastring, offset=offset)
@@ -771,7 +791,10 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     if dtype is None and formats is None:
         raise TypeError("fromfile() needs a 'dtype' or 'formats' argument")
 
-    if (shape is None or shape == 0):
+    # NumPy 1.19.0, 2020-01-01
+    shape = _deprecate_shape_0_as_None(shape)
+
+    if shape is None:
         shape = (-1,)
     elif isinstance(shape, (int, long)):
         shape = (shape,)


### PR DESCRIPTION
`shape=n` is a shorthand for `shape=(n,)` except in the case when `n==0`, when it is a shorthand for `shape=None`.

This special case is dangerous, as it makes `fromrecords(..., shape=len(a))` behave surprisingly when a is an empty sequence.

Users impacted by this warning either:
* Have a bug in their code, and will need to either:
  - wait for the deprecation to expire
  - change their code to use `(len(a),)` instead of `len(a)`
* Are using the non-preferred spellling, and will need to replace a literal `0` or `False` with `None`

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
