### PR TITLE
ENH: build fallback lapack_lite with 64-bit integers on 64-bit platforms

### DIFF
--- a/doc/release/upcoming_changes/15218.improvement.rst
+++ b/doc/release/upcoming_changes/15218.improvement.rst
@@ -1,0 +1,6 @@
+Use 64-bit integer size on 64-bit platforms in fallback lapack_lite
+-------------------------------------------------------------------
+
+Use 64-bit integer size on 64-bit platforms in the fallback LAPACK library,
+which is used when the system has no LAPACK installed, allowing it to deal with
+linear algebra for large arrays.

--- a/numpy/linalg/lapack_lite/README.rst
+++ b/numpy/linalg/lapack_lite/README.rst
@@ -18,9 +18,9 @@ and is unlikely to ever be ported to python 3.
 The routines that ``lapack_litemodule.c`` wraps are listed in
 ``wrapped_routines``, along with a few exceptions that aren't picked up
 properly. Assuming that you have an unpacked LAPACK source tree in
-``~/LAPACK``, you generate the new routines in a directory ``new-lite/`` with::
+``~/LAPACK``, you generate the new routines in this directory with::
 
-$ python2 ./make_lite.py wrapped_routines ~/LAPACK new-lite/
+$ python2 ./make_lite.py wrapped_routines ~/LAPACK
 
 This will grab the right routines, with dependencies, put them into the
 appropriate ``f2c_*.f`` files, run ``f2c`` over them, then do some scrubbing

--- a/numpy/linalg/lapack_lite/f2c.h
+++ b/numpy/linalg/lapack_lite/f2c.h
@@ -8,15 +8,17 @@
 #define F2C_INCLUDE
 
 #include <math.h>
+#include "numpy/npy_common.h"
+#include "npy_cblas.h"
 
-typedef int integer;
+typedef CBLAS_INT integer;
 typedef char *address;
 typedef short int shortint;
 typedef float real;
 typedef double doublereal;
 typedef struct { real r, i; } complex;
 typedef struct { doublereal r, i; } doublecomplex;
-typedef int logical;
+typedef CBLAS_INT logical;
 typedef short int shortlogical;
 typedef char logical1;
 typedef char integer1;
@@ -37,9 +39,9 @@ typedef short flag;
 typedef short ftnlen;
 typedef short ftnint;
 #else
-typedef int flag;
-typedef int ftnlen;
-typedef int ftnint;
+typedef CBLAS_INT flag;
+typedef CBLAS_INT ftnlen;
+typedef CBLAS_INT ftnint;
 #endif
 
 /*external read, write*/
@@ -352,7 +354,7 @@ extern void s_copy(char *, char *, ftnlen, ftnlen);
 extern int s_paus(char *, ftnlen);
 extern integer s_rdfe(cilist *);
 extern integer s_rdue(cilist *);
-extern integer s_rnge(char *, integer, char *, integer);
+extern int s_rnge(char *, int, char *, int);
 extern integer s_rsfe(cilist *);
 extern integer s_rsfi(icilist *);
 extern integer s_rsle(cilist *);

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -416,5 +416,11 @@ initlapack_lite(void)
     LapackError = PyErr_NewException("lapack_lite.LapackError", NULL, NULL);
     PyDict_SetItemString(d, "LapackError", LapackError);
 
+#ifdef HAVE_BLAS_ILP64
+    PyDict_SetItemString(d, "_ilp64", Py_True);
+#else
+    PyDict_SetItemString(d, "_ilp64", Py_False);
+#endif
+
     return RETVAL(m);
 }

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -31,6 +31,10 @@ def configuration(parent_package='', top_path=None):
     else:
         lapack_info = get_info('lapack_opt', 0)  # and {}
 
+    if not lapack_info and sys.maxsize > 2**32:
+        # Build lapack-lite in 64-bit integer mode
+        config.add_define_macros([('HAVE_BLAS_ILP64', None)])
+
     def get_lapack_lite_sources(ext, build_dir):
         if not lapack_info:
             print("### Warning:  Using unoptimized lapack ###")

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -5,7 +5,7 @@ import sys
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
-    from numpy.distutils.system_info import get_info
+    from numpy.distutils.system_info import get_info, system_info
     config = Configuration('linalg', parent_package, top_path)
 
     config.add_data_dir('tests')
@@ -31,12 +31,23 @@ def configuration(parent_package='', top_path=None):
     else:
         lapack_info = get_info('lapack_opt', 0)  # and {}
 
-    if not lapack_info and sys.maxsize > 2**32:
-        # Build lapack-lite in 64-bit integer mode
-        config.add_define_macros([('HAVE_BLAS_ILP64', None)])
+    use_lapack_lite = not lapack_info
+
+    if use_lapack_lite:
+        # This makes numpy.distutils write the fact that lapack_lite
+        # is being used to numpy.__config__
+        class numpy_linalg_lapack_lite(system_info):
+            def calc_info(self):
+                info = {'language': 'c'}
+                if sys.maxsize > 2**32:
+                    # Build lapack-lite in 64-bit integer mode
+                    info['define_macros'] = [('HAVE_BLAS_ILP64', None)]
+                self.set_info(**info)
+
+        lapack_info = numpy_linalg_lapack_lite().get_info(2)
 
     def get_lapack_lite_sources(ext, build_dir):
-        if not lapack_info:
+        if use_lapack_lite:
             print("### Warning:  Using unoptimized lapack ###")
             return all_sources
         else:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -21,7 +21,7 @@ import pprint
 
 from numpy.core import(
      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
-import numpy.__config__
+import numpy.linalg.lapack_lite
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -54,7 +54,7 @@ verbose = 0
 
 IS_PYPY = platform.python_implementation() == 'PyPy'
 HAS_REFCOUNT = getattr(sys, 'getrefcount', None) is not None
-HAS_LAPACK64 = hasattr(numpy.__config__, 'lapack_ilp64_opt_info')
+HAS_LAPACK64 = numpy.linalg.lapack_lite._ilp64
 
 
 def import_nose():


### PR DESCRIPTION
Build the lapack fallback library (used when no LAPACK installed) with 64-bit integer size when building on a 64-bit platform.

Add an indicator flag in `numpy.linalg.lapack_lite` showing whether it was built with 64-bit integers, and use that in the tests (instead of checking whether numpy was linked with external 64-bit BLAS).

Closes: gh-5906

Note that the 64-bit mode is turned on unconditionally, regardless of the `NPY_USE_BLAS_ILP64` setting. I think this is generally OK --- this stuff is fully internal to Numpy, and the change is not visible outside, and the environment flag is anyway only used as a way for the user to control which BLAS library Numpy links against.

NB. the one `s_rnge` is unused function (error reporting for f2c bounds checking, which is turned off here. Just corrected its prototype here to match `f2c.c`.).