### PR TITLE
BUG: distutils: fix msvc+gfortran openblas handling corner case

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2102,16 +2102,17 @@ class openblas_info(blas_info):
                 return None
 
         # Generate numpy.distutils virtual static library file
-        tmpdir = os.path.join(os.getcwd(), 'build', 'openblas')
+        basename = self.__class__.__name__
+        tmpdir = os.path.join(os.getcwd(), 'build', basename)
         if not os.path.isdir(tmpdir):
             os.makedirs(tmpdir)
 
         info = {'library_dirs': [tmpdir],
-                'libraries': ['openblas'],
+                'libraries': [basename],
                 'language': 'f77'}
 
-        fake_lib_file = os.path.join(tmpdir, 'openblas.fobjects')
-        fake_clib_file = os.path.join(tmpdir, 'openblas.cobjects')
+        fake_lib_file = os.path.join(tmpdir, basename + '.fobjects')
+        fake_clib_file = os.path.join(tmpdir, basename + '.cobjects')
         with open(fake_lib_file, 'w') as f:
             f.write("\n".join(library_paths))
         with open(fake_clib_file, 'w') as f:


### PR DESCRIPTION
Backport of #15211. 

Ensure the openblas MSVC+gfortran temporary library names are unique
for the different openblas_* system_info classes.

If multiple openblas libraries (e.g. both a 32-bit and a 64-bit one) are
used in the same project, when compiling in the msvc+gfortran mode, this
previously resulted to only the last one being used.

This is mainly relevant for the above case (32+64bit openblas in same project) for which it seems to work [as seen here](https://dev.azure.com/scipy-org/SciPy/_build/results?buildId=4459&view=logs&j=da2f0622-108b-5827-a4af-f8cb335e1cfa) ([build log](https://dev.azure.com/scipy-org/df8ffb44-7275-43bc-90f9-aa5c93ef5c51/_apis/build/builds/4459/logs/41)); there's no problem with the single-library case which does not require this PR (this case is tested on the CI by gh-15107).

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
