### PR TITLE
BUG: remove -std=c99 for c++ compilation (#15194)

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -532,7 +532,7 @@ def CCompiler_customize(self, dist, need_cxx=0):
                                       'g++' in self.compiler[0] or
                                       'clang' in self.compiler[0]):
         self._auto_depends = True
-        if 'gcc' in self.compiler[0]:
+        if 'gcc' in self.compiler[0] and not need_cxx:
             # add std=c99 flag for gcc
             # TODO: does this need to be more specific?
             self.compiler.append('-std=c99')

--- a/numpy/distutils/tests/test_ccompiler.py
+++ b/numpy/distutils/tests/test_ccompiler.py
@@ -1,0 +1,24 @@
+from __future__ import division, absolute_import, print_function
+
+from distutils.ccompiler import new_compiler
+
+from numpy.distutils.numpy_distribution import NumpyDistribution
+
+def test_ccompiler():
+    '''
+    scikit-image/scikit-image issue 4369
+    We unconditionally add ``-std-c99`` to the gcc compiler in order
+    to support c99 with very old gcc compilers. However the same call
+    is used to get the flags for the c++ compiler, just with a kwarg.
+    Make sure in this case, where it would not be legal, the option is **not** added
+    '''
+    dist = NumpyDistribution()
+    compiler = new_compiler()
+    compiler.customize(dist)
+    if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
+        assert 'c99' in ' '.join(compiler.compiler)
+
+    compiler = new_compiler()
+    compiler.customize(dist, need_cxx=True)
+    if hasattr(compiler, 'compiler') and 'gcc' in compiler.compiler[0]:
+        assert 'c99' not in ' '.join(compiler.compiler)


### PR DESCRIPTION
Backport of #15194. 

xref scikit-image/scikit-image#4369

The blanket addition of `-std=c99` to the compiler flags broke compilation for `c++` compilers. Now tested and fixed.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
