### PR TITLE
TST: add BLAS ILP64 run in Travis & Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ matrix:
       arch: ppc64le
       env:
        # use ppc64le OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
 
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,17 @@ matrix:
        - USE_ASV=1
 
     - python: 3.7
-      env: NPY_RELAXED_STRIDES_CHECKING=0
+      env:
+        - NPY_RELAXED_STRIDES_CHECKING=0
+        # use custom symbol-suffixed openblas build, not system ATLAS
+        - DOWNLOAD_OPENBLAS=1
+        - CHECK_BLAS=1
+        - NPY_USE_BLAS_ILP64=1
+      addons:
+        apt:
+          packages:
+            - gfortran
+            - eatmydata
 
     - python: 3.7
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,13 +65,21 @@ stages:
       # azure config for mac os -- Microsoft has indicated
       # they will patch this issue
       vmImage: macOS-10.14
+    strategy:
+      maxParallel: 2
+      matrix:
+          Python36:
+            PYTHON_VERSION: '3.6'
+          Python36-ILP64:
+            PYTHON_VERSION: '3.6'
+            NPY_USE_BLAS_ILP64: '1'
     steps:
     # the @0 refers to the (major) version of the *task* on Microsoft's
     # end, not the order in the build matrix nor anything to do
     # with version of Python selected
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.6'
+        versionSpec: $(PYTHON_VERSION)
         addToPath: true
         architecture: 'x64'
     # NOTE: do we have a compelling reason to use older / newer

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,9 @@ stages:
             locale-gen fr_FR && update-locale && \
             apt-get -y install gfortran-5 wget && \
             target=\$(python3 tools/openblas_support.py) && \
-            cp -r \$target/usr/local/lib/* /usr/lib && \
-            cp \$target/usr/local/include/* /usr/include && \
+            ls -lR \$target && \
+            cp -r \$target/lib/* /usr/lib && \
+            cp \$target/include/* /usr/include && \
             python3 -m pip install --user --upgrade pip setuptools && \
             python3 -m pip install --user -r test_requirements.txt && \
             python3 -m pip install . && \
@@ -105,9 +106,10 @@ stages:
     # primarily on file size / name details
     - script: |
         target=$(python tools/openblas_support.py)
+        ls -lR $target
         # manually link to appropriate system paths
-        cp $target/usr/local/lib/* /usr/local/lib/
-        cp $target/usr/local/include/* /usr/local/include/
+        cp $target/lib/* /usr/local/lib/
+        cp $target/include/* /usr/local/include/
       displayName: 'install pre-built openblas'
     - script: python -m pip install --upgrade pip setuptools wheel
       displayName: 'Install tools'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,8 @@ stages:
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64
+            NPY_USE_BLAS_ILP64: '1'
+            OPENBLAS_SUFFIX: '64_'
     steps:
     - template: azure-steps-windows.yml
   - job: Linux_PyPy3

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -11,7 +11,7 @@ steps:
 - powershell: |
     $pyversion = python -c "from __future__ import print_function; import sys; print(sys.version.split()[0])"
     Write-Host "Python Version: $pyversion"
-    $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas.a"
+    $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas$env:OPENBLAS_SUFFIX.a"
     Write-Host "target path: $target"
     $openblas = python tools/openblas_support.py
     cp $openblas $target

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,9 +25,10 @@ build:
     - sudo apt-get update
     - sudo apt-get install gcc gfortran
     - target=$(python tools/openblas_support.py)
-    - sudo cp -r "${target}"/64/lib/* /usr/lib
-    - sudo cp "${target}"/64/include/* /usr/include
-    - pip install --upgrade pip
+    - ls -lR "${target}"
+    - sudo cp -r "${target}"/lib/* /usr/lib
+    - sudo cp "${target}"/include/* /usr/include
+    - python -m pip install --upgrade pip
 
     # we will pay the ~13 minute cost of compiling Cython only when a new
     # version is scraped in by pip; otherwise, use the cached

--- a/shippable.yml
+++ b/shippable.yml
@@ -33,24 +33,24 @@ build:
     # we will pay the ~13 minute cost of compiling Cython only when a new
     # version is scraped in by pip; otherwise, use the cached
     # wheel shippable places on Amazon S3 after we build it once
-    - pip install -r test_requirements.txt --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
+    - python -m pip install -r test_requirements.txt --cache-dir=/root/.cache/pip/wheels/$SHIPPABLE_PYTHON_VERSION
     # install pytest-xdist to leverage a second core
     # for unit tests
-    - pip install pytest-xdist
+    - python -m pip install pytest-xdist
 
     # build and test numpy
     - export PATH=$PATH:$SHIPPABLE_REPO_DIR
     # build first and adjust PATH so f2py is found in scripts dir
     # use > 1 core for build sometimes slows down a fair bit,
     # other times modestly speeds up, so avoid for now
-    - pip install .
+    - python -m pip install .
     - extra_directories=($SHIPPABLE_REPO_DIR/build/*scripts*)
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
     - python tools/openblas_support.py --check_version 0.3.7
     # run the test suite
-    - python runtests.py --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
+    - python runtests.py -n --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 
     cache: true
     cache_dir_list:

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -11,19 +11,20 @@ sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5
 F77=gfortran-5 F90=gfortran-5 \
 
 # Download the proper OpenBLAS x64 precompiled library
-target=$(python tools/openblas_support.py)
+target=$(python3 tools/openblas_support.py)
+ls -lR "$target"
 echo getting OpenBLAS into $target
-export LD_LIBRARY_PATH=$target/usr/local/lib
-export LIB=$target/usr/local/lib
-export INCLUDE=$target/usr/local/include
+export LD_LIBRARY_PATH=$target/lib
+export LIB=$target/lib
+export INCLUDE=$target/include
 
 # Use a site.cfg to build with local openblas
 cat << EOF > site.cfg
 [openblas]
 libraries = openblas
-library_dirs = $target/usr/local/lib:$LIB
-include_dirs = $target/usr/local/lib:$LIB
-runtime_library_dirs = $target/usr/local/lib
+library_dirs = $target/lib:$LIB
+include_dirs = $target/lib:$LIB
+runtime_library_dirs = $target/lib
 EOF
 
 echo getting PyPy 3.6 nightly

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -5,12 +5,17 @@ free -m
 df -h
 ulimit -a
 
-if [ -n "$PPC64_LE" ]; then
+if [ -n "$PPC64_LE" -o -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd
   ls -ltrh
   target=$(python tools/openblas_support.py)
-  sudo cp -r $target/64/lib/* /usr/lib
-  sudo cp $target/64/include/* /usr/include
+  if [ -d "$target/usr/local" ]; then
+      sudo cp -r $target/usr/local/lib/* /usr/lib
+      sudo cp $target/usr/local/include/* /usr/include
+  else
+      sudo cp -r $target/64/lib/* /usr/lib
+      sudo cp $target/64/include/* /usr/include
+  fi
 fi
 
 mkdir builds

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -9,13 +9,8 @@ if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd
   ls -ltrh
   target=$(python tools/openblas_support.py)
-  if [ -d "$target/usr/local" ]; then
-      sudo cp -r $target/usr/local/lib/* /usr/lib
-      sudo cp $target/usr/local/include/* /usr/include
-  else
-      sudo cp -r $target/64/lib/* /usr/lib
-      sudo cp $target/64/include/* /usr/include
-  fi
+  sudo cp -r $target/lib/* /usr/lib
+  sudo cp $target/include/* /usr/include
 fi
 
 mkdir builds

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -5,7 +5,7 @@ free -m
 df -h
 ulimit -a
 
-if [ -n "$PPC64_LE" -o -n "$DOWNLOAD_OPENBLAS" ]; then
+if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd
   ls -ltrh
   target=$(python tools/openblas_support.py)


### PR DESCRIPTION
### Backport of #15107. 

Add Travis CI run for OpenBLAS ILP64 on Linux, and Windows & MacOS runs on Azure.

For Windows & Linux, I added the ILP64 build flags to an existing jobs. As there was only one MacOS job, I added a new job for that platform.

<s>The download location is currently temporary, possibly could make sense to move it to rackspace.</s> The openblas64_ builds are now on rackspace, together with the usual openblas ones.
### Backport of #15143. 

Fixes #15137, but check the CI log to make sure it actually does help.

* try to avoid a redundant build of NumPy
by Shippable CI; use "-n" flag to runtests.py
to encourage use of installed NumPy instead of
trying to rebuild

* prefix pip installs with "python" to avoid
common issues using pip installs


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
