### PR TITLE
MAINT: Cleaning up PY_MAJOR_VERSION/PY_VERSION_HEX

### DIFF
--- a/doc/Py3K.rst.txt
+++ b/doc/Py3K.rst.txt
@@ -357,9 +357,7 @@ The Py2/Py3 compatible structure definition looks like::
 	(binaryfunc)0,               /*nb_true_divide*/
 	0,                           /*nb_inplace_floor_divide*/
 	0,                           /*nb_inplace_true_divide*/
-    #if PY_VERSION_HEX >= 0x02050000
 	(unaryfunc)NULL,             /*nb_index*/
-    #endif
     };
 
 

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -137,7 +137,6 @@ the module.
 
 
         /* This initiates the module using the above definitions. */
-        #if PY_VERSION_HEX >= 0x03000000
         static struct PyModuleDef moduledef = {
             PyModuleDef_HEAD_INIT,
             "spam",
@@ -159,17 +158,6 @@ the module.
             }
             return m;
         }
-        #else
-        PyMODINIT_FUNC initspam(void)
-        {
-            PyObject *m;
-
-            m = Py_InitModule("spam", SpamMethods);
-            if (m == NULL) {
-                return;
-            }
-        }
-        #endif
 
 To use the setup.py file, place setup.py and spammodule.c in the same
 folder. Then python setup.py build will build the module to import,
@@ -322,7 +310,6 @@ the primary thing that must be changed to create your own ufunc.
 
         static void *data[1] = {NULL};
 
-        #if PY_VERSION_HEX >= 0x03000000
         static struct PyModuleDef moduledef = {
             PyModuleDef_HEAD_INIT,
             "npufunc",
@@ -357,30 +344,6 @@ the primary thing that must be changed to create your own ufunc.
 
             return m;
         }
-        #else
-        PyMODINIT_FUNC initnpufunc(void)
-        {
-            PyObject *m, *logit, *d;
-
-
-            m = Py_InitModule("npufunc", LogitMethods);
-            if (m == NULL) {
-                return;
-            }
-
-            import_array();
-            import_umath();
-
-            logit = PyUFunc_FromFuncAndData(funcs, data, types, 1, 1, 1,
-                                            PyUFunc_None, "logit",
-                                            "logit_docstring", 0);
-
-            d = PyModule_GetDict(m);
-
-            PyDict_SetItemString(d, "logit", logit);
-            Py_DECREF(logit);
-        }
-        #endif
 
 This is a setup.py file for the above code. As before, the module
 can be build via calling python setup.py build at the command prompt,
@@ -601,7 +564,6 @@ the primary thing that must be changed to create your own ufunc.
                         NPY_LONGDOUBLE, NPY_LONGDOUBLE};
         static void *data[4] = {NULL, NULL, NULL, NULL};
 
-        #if PY_VERSION_HEX >= 0x03000000
         static struct PyModuleDef moduledef = {
             PyModuleDef_HEAD_INIT,
             "npufunc",
@@ -636,30 +598,6 @@ the primary thing that must be changed to create your own ufunc.
 
             return m;
         }
-        #else
-        PyMODINIT_FUNC initnpufunc(void)
-        {
-            PyObject *m, *logit, *d;
-
-
-            m = Py_InitModule("npufunc", LogitMethods);
-            if (m == NULL) {
-                return;
-            }
-
-            import_array();
-            import_umath();
-
-            logit = PyUFunc_FromFuncAndData(funcs, data, types, 4, 1, 1,
-                                            PyUFunc_None, "logit",
-                                            "logit_docstring", 0);
-
-            d = PyModule_GetDict(m);
-
-            PyDict_SetItemString(d, "logit", logit);
-            Py_DECREF(logit);
-        }
-        #endif
 
 This is a setup.py file for the above code. As before, the module
 can be build via calling python setup.py build at the command prompt,
@@ -824,7 +762,6 @@ as well as all other properties of a ufunc.
 
         static void *data[1] = {NULL};
 
-        #if PY_VERSION_HEX >= 0x03000000
         static struct PyModuleDef moduledef = {
             PyModuleDef_HEAD_INIT,
             "npufunc",
@@ -859,30 +796,6 @@ as well as all other properties of a ufunc.
 
             return m;
         }
-        #else
-        PyMODINIT_FUNC initnpufunc(void)
-        {
-            PyObject *m, *logit, *d;
-
-
-            m = Py_InitModule("npufunc", LogitMethods);
-            if (m == NULL) {
-                return;
-            }
-
-            import_array();
-            import_umath();
-
-            logit = PyUFunc_FromFuncAndData(funcs, data, types, 1, 2, 2,
-                                            PyUFunc_None, "logit",
-                                            "logit_docstring", 0);
-
-            d = PyModule_GetDict(m);
-
-            PyDict_SetItemString(d, "logit", logit);
-            Py_DECREF(logit);
-        }
-        #endif
 
 
 .. _`sec:NumPy-struct-dtype`:

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -59,21 +59,12 @@ _import_array(void)
       return -1;
   }
 
-#if PY_VERSION_HEX >= 0x03000000
   if (!PyCapsule_CheckExact(c_api)) {
       PyErr_SetString(PyExc_RuntimeError, "_ARRAY_API is not PyCapsule object");
       Py_DECREF(c_api);
       return -1;
   }
   PyArray_API = (void **)PyCapsule_GetPointer(c_api, NULL);
-#else
-  if (!PyCObject_Check(c_api)) {
-      PyErr_SetString(PyExc_RuntimeError, "_ARRAY_API is not PyCObject object");
-      Py_DECREF(c_api);
-      return -1;
-  }
-  PyArray_API = (void **)PyCObject_AsVoidPtr(c_api);
-#endif
   Py_DECREF(c_api);
   if (PyArray_API == NULL) {
       PyErr_SetString(PyExc_RuntimeError, "_ARRAY_API is NULL pointer");

--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -51,21 +51,12 @@ _import_umath(void)
       return -1;
   }
 
-#if PY_VERSION_HEX >= 0x03000000
   if (!PyCapsule_CheckExact(c_api)) {
       PyErr_SetString(PyExc_RuntimeError, "_UFUNC_API is not PyCapsule object");
       Py_DECREF(c_api);
       return -1;
   }
   PyUFunc_API = (void **)PyCapsule_GetPointer(c_api, NULL);
-#else
-  if (!PyCObject_Check(c_api)) {
-      PyErr_SetString(PyExc_RuntimeError, "_UFUNC_API is not PyCObject object");
-      Py_DECREF(c_api);
-      return -1;
-  }
-  PyUFunc_API = (void **)PyCObject_AsVoidPtr(c_api);
-#endif
   Py_DECREF(c_api);
   if (PyUFunc_API == NULL) {
       PyErr_SetString(PyExc_RuntimeError, "_UFUNC_API is NULL pointer");

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -45,7 +45,6 @@ extern "C" {
 
 #define PyArray_CheckScalar(m) (PyArray_IsScalar(m, Generic) ||               \
                                 PyArray_IsZeroDim(m))
-#if PY_MAJOR_VERSION >= 3
 #define PyArray_IsPythonNumber(obj)                                           \
         (PyFloat_Check(obj) || PyComplex_Check(obj) ||                        \
          PyLong_Check(obj) || PyBool_Check(obj))
@@ -54,17 +53,6 @@ extern "C" {
 #define PyArray_IsPythonScalar(obj)                                           \
         (PyArray_IsPythonNumber(obj) || PyBytes_Check(obj) ||                 \
          PyUnicode_Check(obj))
-#else
-#define PyArray_IsPythonNumber(obj)                                           \
-        (PyInt_Check(obj) || PyFloat_Check(obj) || PyComplex_Check(obj) ||    \
-         PyLong_Check(obj) || PyBool_Check(obj))
-#define PyArray_IsIntegerScalar(obj) (PyInt_Check(obj)                        \
-              || PyLong_Check(obj)                                            \
-              || PyArray_IsScalar((obj), Integer))
-#define PyArray_IsPythonScalar(obj)                                           \
-        (PyArray_IsPythonNumber(obj) || PyString_Check(obj) ||                \
-         PyUnicode_Check(obj))
-#endif
 
 #define PyArray_IsAnyScalar(obj)                                              \
         (PyArray_IsScalar(obj, Generic) || PyArray_IsPythonScalar(obj))
@@ -248,11 +236,6 @@ NPY_TITLE_KEY_check(PyObject *key, PyObject *value)
     if (PyUnicode_Check(title) && PyUnicode_Check(key)) {
         return PyUnicode_Compare(title, key) == 0 ? 1 : 0;
     }
-#if PY_VERSION_HEX < 0x03000000
-    if (PyString_Check(title) && PyString_Check(key)) {
-        return PyObject_Compare(title, key) == 0 ? 1 : 0;
-    }
-#endif
 #endif
     return 0;
 }

--- a/numpy/core/include/numpy/npy_1_7_deprecated_api.h
+++ b/numpy/core/include/numpy/npy_1_7_deprecated_api.h
@@ -69,18 +69,11 @@
 #define PyArray_DEFAULT NPY_DEFAULT_TYPE
 
 /* These DATETIME bits aren't used internally */
-#if PY_VERSION_HEX >= 0x03000000
 #define PyDataType_GetDatetimeMetaData(descr)                                 \
     ((descr->metadata == NULL) ? NULL :                                       \
         ((PyArray_DatetimeMetaData *)(PyCapsule_GetPointer(                   \
                 PyDict_GetItemString(                                         \
                     descr->metadata, NPY_METADATA_DTSTR), NULL))))
-#else
-#define PyDataType_GetDatetimeMetaData(descr)                                 \
-    ((descr->metadata == NULL) ? NULL :                                       \
-        ((PyArray_DatetimeMetaData *)(PyCObject_AsVoidPtr(                    \
-                PyDict_GetItemString(descr->metadata, NPY_METADATA_DTSTR)))))
-#endif
 
 /*
  * Deprecated as of NumPy 1.7, this kind of shortcut doesn't

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -13,10 +13,8 @@
 #include <Python.h>
 #include <stdio.h>
 
-#if PY_VERSION_HEX >= 0x03000000
 #ifndef NPY_PY3K
 #define NPY_PY3K 1
-#endif
 #endif
 
 #include "numpy/npy_common.h"

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1293,7 +1293,6 @@ gentype_sizeof(PyObject *self)
     return PyLong_FromSsize_t(nbytes);
 }
 
-#if PY_VERSION_HEX >= 0x03000000
 NPY_NO_EXPORT void
 gentype_struct_free(PyObject *ptr)
 {
@@ -1307,17 +1306,6 @@ gentype_struct_free(PyObject *ptr)
     PyArray_free(arrif->shape);
     PyArray_free(arrif);
 }
-#else
-NPY_NO_EXPORT void
-gentype_struct_free(void *ptr, void *arg)
-{
-    PyArrayInterface *arrif = (PyArrayInterface *)ptr;
-    Py_DECREF((PyObject *)arg);
-    Py_XDECREF(arrif->descr);
-    PyArray_free(arrif->shape);
-    PyArray_free(arrif);
-}
-#endif
 
 static PyObject *
 gentype_struct_get(PyObject *self)

--- a/numpy/core/src/multiarray/scalartypes.h
+++ b/numpy/core/src/multiarray/scalartypes.h
@@ -19,13 +19,8 @@ initialize_casting_tables(void);
 NPY_NO_EXPORT void
 initialize_numeric_types(void);
 
-#if PY_VERSION_HEX >= 0x03000000
 NPY_NO_EXPORT void
 gentype_struct_free(PyObject *ptr);
-#else
-NPY_NO_EXPORT void
-gentype_struct_free(void *ptr, void *arg);
-#endif
 
 NPY_NO_EXPORT int
 is_anyscalar_exact(PyObject *obj);

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -609,9 +609,6 @@ static PyNumberMethods pyrational_as_number = {
     pyrational_add,          /* nb_add */
     pyrational_subtract,     /* nb_subtract */
     pyrational_multiply,     /* nb_multiply */
-#if PY_MAJOR_VERSION < 3
-    pyrational_divide,       /* nb_divide */
-#endif
     pyrational_remainder,    /* nb_remainder */
     0,                       /* nb_divmod */
     0,                       /* nb_power */
@@ -625,27 +622,13 @@ static PyNumberMethods pyrational_as_number = {
     0,                       /* nb_and */
     0,                       /* nb_xor */
     0,                       /* nb_or */
-#if PY_MAJOR_VERSION < 3
-    0,                       /* nb_coerce */
-#endif
     pyrational_int,          /* nb_int */
-#if PY_MAJOR_VERSION < 3
-    pyrational_int,          /* nb_long */
-#else
     0,                       /* reserved */
-#endif
     pyrational_float,        /* nb_float */
-#if PY_MAJOR_VERSION < 3
-    0,                       /* nb_oct */
-    0,                       /* nb_hex */
-#endif
 
     0,                       /* nb_inplace_add */
     0,                       /* nb_inplace_subtract */
     0,                       /* nb_inplace_multiply */
-#if PY_MAJOR_VERSION < 3
-    0,                       /* nb_inplace_divide */
-#endif
     0,                       /* nb_inplace_remainder */
     0,                       /* nb_inplace_power */
     0,                       /* nb_inplace_lshift */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -929,22 +929,9 @@ parse_ufunc_keywords(PyUFuncObject *ufunc, PyObject *kwds, PyObject **kwnames, .
             }
         }
         else {
-#if PY_VERSION_HEX >= 0x03000000
             PyErr_Format(PyExc_TypeError,
                          "'%S' is an invalid keyword to ufunc '%s'",
                          key, ufunc_get_name_cstr(ufunc));
-#else
-            char *str = PyString_AsString(key);
-            if (str == NULL) {
-                PyErr_Clear();
-                PyErr_SetString(PyExc_TypeError, "invalid keyword argument");
-            }
-            else {
-                PyErr_Format(PyExc_TypeError,
-                             "'%s' is an invalid keyword to ufunc '%s'",
-                             str, ufunc_get_name_cstr(ufunc));
-            }
-#endif
             return -1;
         }
     }
@@ -5068,21 +5055,12 @@ _free_loop1d_list(PyUFunc_Loop1d *data)
     }
 }
 
-#if PY_VERSION_HEX >= 0x03000000
 static void
 _loop1d_list_free(PyObject *ptr)
 {
     PyUFunc_Loop1d *data = (PyUFunc_Loop1d *)PyCapsule_GetPointer(ptr, NULL);
     _free_loop1d_list(data);
 }
-#else
-static void
-_loop1d_list_free(void *ptr)
-{
-    PyUFunc_Loop1d *data = (PyUFunc_Loop1d *)ptr;
-    _free_loop1d_list(data);
-}
-#endif
 
 
 /*

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -646,7 +646,6 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(cha
         tmp = obj;
         Py_INCREF(tmp);
     }
-#if PY_VERSION_HEX >= 0x03000000
     else if (PyUnicode_Check(obj)) {
         tmp = PyUnicode_AsASCIIString(obj);
     }
@@ -661,11 +660,6 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(cha
             tmp = NULL;
         }
     }
-#else
-    else {
-        tmp = PyObject_Str(obj);
-    }
-#endif
     if (tmp == NULL) goto capi_fail;
     if (*len == -1)
         *len = PyString_GET_SIZE(tmp);
@@ -1094,13 +1088,8 @@ if (tmp_fun==NULL) {
 fprintf(stderr,\"Call-back argument must be function|instance|instance.__call__|f2py-function but got %s.\\n\",(fun==NULL?\"NULL\":Py_TYPE(fun)->tp_name));
 goto capi_fail;
 }
-#if PY_VERSION_HEX >= 0x03000000
     if (PyObject_HasAttrString(tmp_fun,\"__code__\")) {
         if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"__code__\"),\"co_argcount\")) {
-#else
-    if (PyObject_HasAttrString(tmp_fun,\"func_code\")) {
-        if (PyObject_HasAttrString(tmp = PyObject_GetAttrString(tmp_fun,\"func_code\"),\"co_argcount\")) {
-#endif
             PyObject *tmp_argcount = PyObject_GetAttrString(tmp,\"co_argcount\");
             Py_DECREF(tmp);
             if (tmp_argcount == NULL) {
@@ -1111,13 +1100,8 @@ goto capi_fail;
         }
     }
     /* Get the number of optional arguments */
-#if PY_VERSION_HEX >= 0x03000000
     if (PyObject_HasAttrString(tmp_fun,\"__defaults__\")) {
         if (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"__defaults__\")))
-#else
-    if (PyObject_HasAttrString(tmp_fun,\"func_defaults\")) {
-        if (PyTuple_Check(tmp = PyObject_GetAttrString(tmp_fun,\"func_defaults\")))
-#endif
             opt = PyTuple_Size(tmp);
         Py_XDECREF(tmp);
     }

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -180,7 +180,6 @@ static PyMethodDef f2py_module_methods[] = {
 \t{NULL,NULL}
 };
 
-#if PY_VERSION_HEX >= 0x03000000
 static struct PyModuleDef moduledef = {
 \tPyModuleDef_HEAD_INIT,
 \t"#modulename#",
@@ -192,16 +191,11 @@ static struct PyModuleDef moduledef = {
 \tNULL,
 \tNULL
 };
-#endif
 
 PyMODINIT_FUNC PyInit_#modulename#(void) {
 \tint i;
 \tPyObject *m,*d, *s, *tmp;
-#if PY_VERSION_HEX >= 0x03000000
 \tm = #modulename#_module = PyModule_Create(&moduledef);
-#else
-\tm = #modulename#_module = Py_InitModule(\"#modulename#\", f2py_module_methods);
-#endif
 \tPy_TYPE(&PyFortran_Type) = &PyType_Type;
 \timport_array();
 \tif (PyErr_Occurred())
@@ -210,11 +204,7 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 \ts = PyString_FromString(\"$R""" + """evision: $\");
 \tPyDict_SetItemString(d, \"__version__\", s);
 \tPy_DECREF(s);
-#if PY_VERSION_HEX >= 0x03000000
 \ts = PyUnicode_FromString(
-#else
-\ts = PyString_FromString(
-#endif
 \t\t\"This module '#modulename#' is auto-generated with f2py (version:#f2py_version#).\\nFunctions:\\n\"\n#docs#\".\");
 \tPyDict_SetItemString(d, \"__doc__\", s);
 \tPy_DECREF(s);
@@ -442,11 +432,7 @@ rout_rules = [
       tmp = F2PyCapsule_FromVoidPtr((void*)#F_FUNC#(#name_lower#,#NAME#),NULL);
       PyObject_SetAttrString(o,"_cpointer", tmp);
       Py_DECREF(tmp);
-#if PY_VERSION_HEX >= 0x03000000
       s = PyUnicode_FromString("#name#");
-#else
-      s = PyString_FromString("#name#");
-#endif
       PyObject_SetAttrString(o,"__name__", s);
       Py_DECREF(s);
     }
@@ -484,11 +470,7 @@ rout_rules = [
       tmp = F2PyCapsule_FromVoidPtr((void*)#F_FUNC#(#name_lower#,#NAME#),NULL);
       PyObject_SetAttrString(o,"_cpointer", tmp);
       Py_DECREF(tmp);
-#if PY_VERSION_HEX >= 0x03000000
       s = PyUnicode_FromString("#name#");
-#else
-      s = PyString_FromString("#name#");
-#endif
       PyObject_SetAttrString(o,"__name__", s);
       Py_DECREF(s);
     }

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -115,14 +115,6 @@ fortran_dealloc(PyFortranObject *fp) {
 }
 
 
-#if PY_VERSION_HEX >= 0x03000000
-#else
-static PyMethodDef fortran_methods[] = {
-    {NULL,          NULL}           /* sentinel */
-};
-#endif
-
-
 /* Returns number of bytes consumed from buf, or -1 on error. */
 static Py_ssize_t
 format_def(char *buf, Py_ssize_t size, FortranDataDef def)
@@ -242,11 +234,7 @@ fortran_doc(FortranDataDef def)
     size--;
 
     /* p now points one beyond the last character of the string in buf */
-#if PY_VERSION_HEX >= 0x03000000
     s = PyUnicode_FromStringAndSize(buf, p - buf);
-#else
-    s = PyString_FromStringAndSize(buf, p - buf);
-#endif
 
     PyMem_Free(buf);
     return s;
@@ -306,7 +294,6 @@ fortran_getattr(PyFortranObject *fp, char *name) {
         return fp->dict;
     }
     if (strcmp(name,"__doc__")==0) {
-#if PY_VERSION_HEX >= 0x03000000
         PyObject *s = PyUnicode_FromString(""), *s2, *s3;
         for (i=0;i<fp->len;i++) {
             s2 = fortran_doc(fp->defs[i]);
@@ -315,11 +302,6 @@ fortran_getattr(PyFortranObject *fp, char *name) {
             Py_DECREF(s);
             s = s3;
         }
-#else
-        PyObject *s = PyString_FromString("");
-        for (i=0;i<fp->len;i++)
-            PyString_ConcatAndDel(&s,fortran_doc(fp->defs[i]));
-#endif
         if (PyDict_SetItemString(fp->dict, name, s))
             return NULL;
         return s;
@@ -330,7 +312,6 @@ fortran_getattr(PyFortranObject *fp, char *name) {
             return NULL;
         return cobj;
     }
-#if PY_VERSION_HEX >= 0x03000000
     if (1) {
         PyObject *str, *ret;
         str = PyUnicode_FromString(name);
@@ -338,9 +319,6 @@ fortran_getattr(PyFortranObject *fp, char *name) {
         Py_DECREF(str);
         return ret;
     }
-#else
-    return Py_FindMethod(fortran_methods, (PyObject *)fp, name);
-#endif
 }
 
 static int
@@ -434,33 +412,19 @@ fortran_repr(PyFortranObject *fp)
     PyObject *name = NULL, *repr = NULL;
     name = PyObject_GetAttrString((PyObject *)fp, "__name__");
     PyErr_Clear();
-#if PY_VERSION_HEX >= 0x03000000
     if (name != NULL && PyUnicode_Check(name)) {
         repr = PyUnicode_FromFormat("<fortran %U>", name);
     }
     else {
         repr = PyUnicode_FromString("<fortran object>");
     }
-#else
-    if (name != NULL && PyString_Check(name)) {
-        repr = PyString_FromFormat("<fortran %s>", PyString_AsString(name));
-    }
-    else {
-        repr = PyString_FromString("<fortran object>");
-    }
-#endif
     Py_XDECREF(name);
     return repr;
 }
 
 
 PyTypeObject PyFortran_Type = {
-#if PY_VERSION_HEX >= 0x03000000
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(0)
-    0,                            /*ob_size*/
-#endif
     "fortran",                    /*tp_name*/
     sizeof(PyFortranObject),      /*tp_basicsize*/
     0,                            /*tp_itemsize*/

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -82,19 +82,9 @@ typedef struct {
   extern PyObject * PyFortranObject_New(FortranDataDef* defs, f2py_void_func init);
   extern PyObject * PyFortranObject_NewAsAttr(FortranDataDef* defs);
 
-#if PY_VERSION_HEX >= 0x03000000
-
 PyObject * F2PyCapsule_FromVoidPtr(void *ptr, void (*dtor)(PyObject *));
 void * F2PyCapsule_AsVoidPtr(PyObject *obj);
 int F2PyCapsule_Check(PyObject *ptr);
-
-#else
-
-PyObject * F2PyCapsule_FromVoidPtr(void *ptr, void (*dtor)(void *));
-void * F2PyCapsule_AsVoidPtr(PyObject *ptr);
-int F2PyCapsule_Check(PyObject *ptr);
-
-#endif
 
 #define ISCONTIGUOUS(m) (PyArray_FLAGS(m) & NPY_ARRAY_C_CONTIGUOUS)
 #define F2PY_INTENT_IN 1

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -129,7 +129,6 @@ static PyMethodDef f2py_module_methods[] = {
   {NULL,NULL}
 };
 
-#if PY_VERSION_HEX >= 0x03000000
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "test_array_from_pyobj_ext",
@@ -141,7 +140,6 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
 PyMODINIT_FUNC PyInit_test_array_from_pyobj_ext(void) {
   PyObject *m,*d, *s;

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -120,11 +120,6 @@
     if (PyDict_Check(    py_obj)) return "dict"        ;
     if (PyList_Check(    py_obj)) return "list"        ;
     if (PyTuple_Check(   py_obj)) return "tuple"       ;
-%#if PY_MAJOR_VERSION < 3
-    if (PyFile_Check(    py_obj)) return "file"        ;
-    if (PyModule_Check(  py_obj)) return "module"      ;
-    if (PyInstance_Check(py_obj)) return "instance"    ;
-%#endif
 
     return "unknown type";
   }
@@ -545,7 +540,7 @@
     const npy_intp *dims = array_dimensions(ary);
     for (i=0; i < nd; ++i)
       n_non_one += (dims[i] != 1) ? 1 : 0;
-    if (n_non_one > 1)    
+    if (n_non_one > 1)
       array_clearflags(ary,NPY_ARRAY_CARRAY);
     array_enableflags(ary,NPY_ARRAY_FARRAY);
     /* Recompute the strides */

--- a/tools/swig/pyfragments.swg
+++ b/tools/swig/pyfragments.swg
@@ -75,21 +75,6 @@
   SWIGINTERN int
   SWIG_AsVal_dec(unsigned long)(PyObject *obj, unsigned long *val)
   {
-    %#if PY_VERSION_HEX < 0x03000000
-    if (PyInt_Check(obj)) 
-    {
-      long v = PyInt_AsLong(obj);
-      if (v >= 0) 
-      {
-        if (val) *val = v;
-	    return SWIG_OK;
-      } 
-      else 
-      {
-	    return SWIG_OverflowError;
-      }
-    } else 
-    %#endif
     if (PyLong_Check(obj)) {
       unsigned long v = PyLong_AsUnsignedLong(obj);
       if (!PyErr_Occurred()) {


### PR DESCRIPTION
Remove most of PY_MAJOR_VERSION guards that are no longer needed (after Python2 support is dropped)

There are a handful more of these that are more difficult (e.g. [this](https://github.com/numpy/numpy/blob/f91b033aa35b929610c0db12f16b1b0c1ddc08e6/numpy/core/src/multiarray/typeinfo.c#L108) or [this](https://github.com/numpy/numpy/blob/96708210309be41cb7bba85155416fc0fc3f86a3/numpy/core/src/multiarray/common.c#L169)) that will be handled in a 2nd pass