### PR TITLE
MAINT: Remove implicit inheritance from object class

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -104,7 +104,7 @@ def memoize(f):
     return f
 
 
-class SortGenerator(object):
+class SortGenerator:
     # The size of the unsorted area in the "random unsorted area"
     # benchmarks
     AREA_SIZE = 100

--- a/benchmarks/benchmarks/bench_overrides.py
+++ b/benchmarks/benchmarks/bench_overrides.py
@@ -33,7 +33,7 @@ def mock_concatenate(arrays, axis=0, out=None):
     pass
 
 
-class DuckArray(object):
+class DuckArray:
     def __array_function__(self, func, types, args, kwargs):
         pass
 

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -150,7 +150,7 @@ class Scalar(Benchmark):
         (self.y + self.z)
 
 
-class ArgPack(object):
+class ArgPack:
     __slots__ = ['args', 'kwargs']
     def __init__(self, *args, **kwargs):
         self.args = args

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -110,5 +110,5 @@ def get_indexes_rand_():
     return indexes_rand_
 
 
-class Benchmark(object):
+class Benchmark:
     goal_time = 0.25

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -119,7 +119,7 @@ that makes it hard to identify the test from the output of running the test
 suite with ``verbose=2`` (or similar verbosity setting).  Use plain comments
 (``#``) if necessary.
 
-Labeling tests 
+Labeling tests
 --------------
 
 As an alternative to ``pytest.mark.<label>``, there are a number of labels you
@@ -174,7 +174,7 @@ name; thus::
       print 'doing teardown'
 
 
-  class TestMe(object):
+  class TestMe:
       def setup():
           """Class-level setup"""
           print 'doing setup'

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -24,7 +24,7 @@ seed will produce the same outputs.
     import concurrent.futures
     import numpy as np
 
-    class MultithreadedRNG(object):
+    class MultithreadedRNG:
         def __init__(self, n, seed=None, threads=None):
             rg = PCG64(seed)
             if threads is None:

--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -54,7 +54,7 @@ class VisibleDeprecationWarning(UserWarning):
 VisibleDeprecationWarning.__module__ = 'numpy'
 
 
-class _NoValueType(object):
+class _NoValueType:
     """Special keyword value.
 
     The instance of this class may be used as the default value assigned to a

--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -42,7 +42,7 @@ def _show_numpy_info():
     print("NumPy relaxed strides checking option:", relaxed_strides)
 
 
-class PytestTester(object):
+class PytestTester:
     """
     Pytest test runner.
 

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -113,7 +113,7 @@ def is_pathlib_path(obj):
     return Path is not None and isinstance(obj, Path)
 
 # from Python 3.7
-class contextlib_nullcontext(object):
+class contextlib_nullcontext:
     """Context manager that does no additional processing.
 
     Used as a stand-in for a normal context manager, when a particular

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -201,7 +201,7 @@ def _commastring(astr):
 
     return result
 
-class dummy_ctype(object):
+class dummy_ctype:
     def __init__(self, cls):
         self._cls = cls
     def __mul__(self, other):
@@ -236,16 +236,16 @@ _getintp_ctype.cache = None
 
 # Used for .ctypes attribute of ndarray
 
-class _missing_ctypes(object):
+class _missing_ctypes:
     def cast(self, num, obj):
         return num.value
 
-    class c_void_p(object):
+    class c_void_p:
         def __init__(self, ptr):
             self.value = ptr
 
 
-class _ctypes(object):
+class _ctypes:
     def __init__(self, array, ptr=None):
         self._arr = array
 
@@ -521,7 +521,7 @@ _pep3118_unsupported_map = {
     'X': 'function pointers',
 }
 
-class _Stream(object):
+class _Stream:
     def __init__(self, s):
         self.s = s
         self.byteorder = '@'
@@ -843,7 +843,7 @@ def npy_ctypes_check(cls):
         return False
 
 
-class recursive(object):
+class recursive:
     '''
     A decorator class for recursive nested functions.
     Naive recursive nested functions hold a reference to themselves:

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -288,7 +288,7 @@ def seterrcall(func):
 
     Log error message:
 
-    >>> class Log(object):
+    >>> class Log:
     ...     def write(self, msg):
     ...         print("LOG: %s" % msg)
     ...
@@ -363,7 +363,7 @@ def geterrcall():
     return umath.geterrobj()[2]
 
 
-class _unspecified(object):
+class _unspecified:
     pass
 
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -849,7 +849,7 @@ def _none_or_positive_arg(x, name):
         raise ValueError("{} must be >= 0".format(name))
     return x
 
-class FloatingFormat(object):
+class FloatingFormat:
     """ Formatter for subtypes of np.floating """
     def __init__(self, data, precision, floatmode, suppress_small, sign=False,
                  **kwarg):
@@ -1138,7 +1138,7 @@ def format_float_positional(x, precision=None, unique=True,
                               pad_right=pad_right)
 
 
-class IntegerFormat(object):
+class IntegerFormat:
     def __init__(self, data):
         if data.size > 0:
             max_str_len = max(len(str(np.max(data))),
@@ -1151,7 +1151,7 @@ class IntegerFormat(object):
         return self.format % x
 
 
-class BoolFormat(object):
+class BoolFormat:
     def __init__(self, data, **kwargs):
         # add an extra space so " True" and "False" have the same length and
         # array elements align nicely when printed, except in 0d arrays
@@ -1161,7 +1161,7 @@ class BoolFormat(object):
         return self.truestr if x else "False"
 
 
-class ComplexFloatingFormat(object):
+class ComplexFloatingFormat:
     """ Formatter for subtypes of np.complexfloating """
     def __init__(self, x, precision, floatmode, suppress_small,
                  sign=False, **kwarg):
@@ -1190,7 +1190,7 @@ class ComplexFloatingFormat(object):
         return r + i
 
 
-class _TimelikeFormat(object):
+class _TimelikeFormat:
     def __init__(self, data):
         non_nat = data[~isnat(data)]
         if len(non_nat) > 0:
@@ -1253,7 +1253,7 @@ class TimedeltaFormat(_TimelikeFormat):
         return str(x.astype('i8'))
 
 
-class SubArrayFormat(object):
+class SubArrayFormat:
     def __init__(self, format_function):
         self.format_function = format_function
 
@@ -1263,7 +1263,7 @@ class SubArrayFormat(object):
         return "[" + ", ".join(self.__call__(a) for a in arr) + "]"
 
 
-class StructuredVoidFormat(object):
+class StructuredVoidFormat:
     """
     Formatter for structured np.void objects.
 

--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -74,7 +74,7 @@ def _repl(str):
     return str.replace('Bool', 'npy_bool')
 
 
-class StealRef(object):
+class StealRef:
     def __init__(self, arg):
         self.arg = arg # counting from 1
 
@@ -85,7 +85,7 @@ class StealRef(object):
             return 'NPY_STEALS_REF_TO_ARG(%d)' % self.arg
 
 
-class NonNull(object):
+class NonNull:
     def __init__(self, arg):
         self.arg = arg # counting from 1
 
@@ -96,7 +96,7 @@ class NonNull(object):
             return 'NPY_GCC_NONNULL(%d)' % self.arg
 
 
-class Function(object):
+class Function:
     def __init__(self, name, return_type, args, doc=''):
         self.name = name
         self.return_type = _repl(return_type)
@@ -307,7 +307,7 @@ def write_file(filename, data):
 
 
 # Those *Api classes instances know how to output strings for the generated code
-class TypeApi(object):
+class TypeApi:
     def __init__(self, name, index, ptr_cast, api_name):
         self.index = index
         self.name = name
@@ -329,7 +329,7 @@ extern NPY_NO_EXPORT PyTypeObject %(type)s;
 """ % {'type': self.name}
         return astr
 
-class GlobalVarApi(object):
+class GlobalVarApi:
     def __init__(self, name, index, type, api_name):
         self.name = name
         self.index = index
@@ -353,7 +353,7 @@ extern NPY_NO_EXPORT %(type)s %(name)s;
 
 # Dummy to be able to consistently use *Api instances for all items in the
 # array api
-class BoolValuesApi(object):
+class BoolValuesApi:
     def __init__(self, name, index, api_name):
         self.name = name
         self.index = index
@@ -375,7 +375,7 @@ extern NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[2];
 """
         return astr
 
-class FunctionApi(object):
+class FunctionApi:
     def __init__(self, name, index, annotations, return_type, args, api_name):
         self.name = name
         self.index = index

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -19,16 +19,16 @@ ReorderableNone = "(Py_INCREF(Py_None), Py_None)"
 
 # Sentinel value to specify using the full type description in the
 # function name
-class FullTypeDescr(object):
+class FullTypeDescr:
     pass
 
-class FuncNameSuffix(object):
+class FuncNameSuffix:
     """Stores the suffix to append when generating functions names.
     """
     def __init__(self, suffix):
         self.suffix = suffix
 
-class TypeDescription(object):
+class TypeDescription:
     """Type signature for a ufunc.
 
     Attributes
@@ -118,7 +118,7 @@ def TD(types, f=None, astype=None, in_=None, out=None, simd=None):
         tds.append(TypeDescription(t, f=fd, in_=i, out=o, astype=astype, simd=simdt))
     return tds
 
-class Ufunc(object):
+class Ufunc:
     """Description of a ufunc.
 
     Attributes

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -29,7 +29,7 @@ def _fr1(a):
         a.shape = ()
     return a
 
-class MachArLike(object):
+class MachArLike:
     """ Object to simulate MachAr instance """
 
     def __init__(self,
@@ -289,7 +289,7 @@ def _discovered_machar(ftype):
 
 
 @set_module('numpy')
-class finfo(object):
+class finfo:
     """
     finfo(dtype)
 
@@ -440,7 +440,7 @@ class finfo(object):
 
 
 @set_module('numpy')
-class iinfo(object):
+class iinfo:
     """
     iinfo(type)
 

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -14,7 +14,7 @@ from numpy.core.overrides import set_module
 # Need to speed this up...especially for longfloat
 
 @set_module('numpy')
-class MachAr(object):
+class MachAr:
     """
     Diagnosing machine parameters.
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -96,7 +96,7 @@ def find_duplicate(list):
 
 
 @set_module('numpy')
-class format_parser(object):
+class format_parser:
     """
     Class to convert formats, names, titles description to a dtype.
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -36,7 +36,7 @@ NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CH
 # Use pickle in all cases, as cPickle is gone in python3 and the difference
 # in time is only in build. -- Charles Harris, 2013-03-30
 
-class CallOnceOnly(object):
+class CallOnceOnly:
     def __init__(self):
         self._check_types = None
         self._check_ieee_macros = None

--- a/numpy/core/tests/_locales.py
+++ b/numpy/core/tests/_locales.py
@@ -43,7 +43,7 @@ def find_comma_decimal_point_locale():
     return old_locale, new_locale
 
 
-class CommaDecimalPointLocale(object):
+class CommaDecimalPointLocale:
     """Sets LC_NUMERIC to a locale with comma as decimal point.
 
     Classes derived from this class have setup and teardown methods that run

--- a/numpy/core/tests/test_abc.py
+++ b/numpy/core/tests/test_abc.py
@@ -5,7 +5,7 @@ import numbers
 import numpy as np
 from numpy.core.numerictypes import sctypes
 
-class TestABC(object):
+class TestABC:
     def test_abstract(self):
         assert_(issubclass(np.number, numbers.Number))
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -10,7 +10,7 @@ from numpy.testing import (
     )
 import textwrap
 
-class TestArrayRepr(object):
+class TestArrayRepr:
     def test_nan_inf(self):
         x = np.array([np.nan, np.inf])
         assert_equal(repr(x), 'array([nan, inf])')
@@ -158,7 +158,7 @@ class TestArrayRepr(object):
         assert_equal(repr(arr_no_fields), 'array([(), (), (), ()], dtype=[])')
 
 
-class TestComplexArray(object):
+class TestComplexArray:
     def test_str(self):
         rvals = [0, 1, -1, np.inf, -np.inf, np.nan]
         cvals = [complex(rp, ip) for rp in rvals for ip in rvals]
@@ -205,7 +205,7 @@ class TestComplexArray(object):
         for res, val in zip(actual, wanted):
             assert_equal(res, val)
 
-class TestArray2String(object):
+class TestArray2String:
     def test_basic(self):
         """Basic test of array2string."""
         a = np.arange(3)
@@ -411,7 +411,7 @@ class TestArray2String(object):
         gc.enable()
         assert_(r1 == r2)
 
-class TestPrintOptions(object):
+class TestPrintOptions:
     """Test getting and setting global print options."""
 
     def setup(self):
@@ -854,7 +854,7 @@ def test_unicode_object_array():
     assert_equal(repr(x), expected)
 
 
-class TestContextManager(object):
+class TestContextManager:
     def test_ctx_mgr(self):
         # test that context manager actuall works
         with np.printoptions(precision=2):

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -22,7 +22,7 @@ except NameError:
     RecursionError = RuntimeError  # python < 3.5
 
 
-class TestDateTime(object):
+class TestDateTime:
     def test_datetime_dtype_creation(self):
         for unit in ['Y', 'M', 'W', 'D',
                      'h', 'm', 's', 'ms', 'us',
@@ -2366,7 +2366,7 @@ class TestDateTime(object):
         assert limit_via_str == limit
 
 
-class TestDateTimeData(object):
+class TestDateTimeData:
 
     def test_basic(self):
         a = np.array(['1980-03-23'], dtype=np.datetime64)

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -10,7 +10,7 @@ from numpy.testing import (
 kw_unicode_true = {'unicode': True}  # make 2to3 work properly
 kw_unicode_false = {'unicode': False}
 
-class TestBasic(object):
+class TestBasic:
     def test_from_object_array(self):
         A = np.array([['abc', 2],
                       ['long   ', '0123456789']], dtype='O')
@@ -81,7 +81,7 @@ class TestBasic(object):
         assert_equal(A.itemsize, 4)
         assert_(issubclass(A.dtype.type, np.unicode_))
 
-class TestVecString(object):
+class TestVecString:
     def test_non_existent_method(self):
 
         def fail():
@@ -132,7 +132,7 @@ class TestVecString(object):
         assert_raises(ValueError, fail)
 
 
-class TestWhitespace(object):
+class TestWhitespace:
     def setup(self):
         self.A = np.array([['abc ', '123  '],
                            ['789 ', 'xyz ']]).view(np.chararray)
@@ -147,7 +147,7 @@ class TestWhitespace(object):
         assert_(not np.any(self.A < self.B))
         assert_(not np.any(self.A != self.B))
 
-class TestChar(object):
+class TestChar:
     def setup(self):
         self.A = np.array('abc1', dtype='c').view(np.chararray)
 
@@ -155,7 +155,7 @@ class TestChar(object):
         assert_equal(self.A.shape, (4,))
         assert_equal(self.A.upper()[:2].tobytes(), b'AB')
 
-class TestComparisons(object):
+class TestComparisons:
     def setup(self):
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']]).view(np.chararray)
@@ -196,7 +196,7 @@ class TestComparisonsMixed2(TestComparisons):
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']], np.unicode_).view(np.chararray)
 
-class TestInformation(object):
+class TestInformation:
     def setup(self):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
@@ -302,7 +302,7 @@ class TestInformation(object):
         assert_raises(TypeError, fail)
 
 
-class TestMethods(object):
+class TestMethods:
     def setup(self):
         self.A = np.array([[' abc ', ''],
                            ['12345', 'MixedCase'],
@@ -597,7 +597,7 @@ class TestMethods(object):
                 [False, False], [True, False], [False, False]])
 
 
-class TestOperations(object):
+class TestOperations:
     def setup(self):
         self.A = np.array([['abc', '123'],
                            ['789', 'xyz']]).view(np.chararray)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -25,7 +25,7 @@ except ImportError:
     _has_pytz = False
 
 
-class _DeprecationTestCase(object):
+class _DeprecationTestCase:
     # Just as warning: warnings uses re.match, so the start of this message
     # must match.
     message = ''
@@ -135,7 +135,7 @@ class _VisibleDeprecationTestCase(_DeprecationTestCase):
     warning_cls = np.VisibleDeprecationWarning
 
 
-class TestNonTupleNDIndexDeprecation(object):
+class TestNonTupleNDIndexDeprecation:
     def test_basic(self):
         a = np.zeros((5, 5))
         with warnings.catch_warnings():
@@ -187,7 +187,7 @@ class TestComparisonDeprecations(_DeprecationTestCase):
         assert_warns(FutureWarning, lambda: a == [])
 
     def test_void_dtype_equality_failures(self):
-        class NotArray(object):
+        class NotArray:
             def __array__(self):
                 raise TypeError
 
@@ -340,7 +340,7 @@ class TestNumericStyleTypecodes(_DeprecationTestCase):
                                    args=(dt,))
 
 
-class TestTestDeprecated(object):
+class TestTestDeprecated:
     def test_assert_deprecated(self):
         test_case_instance = _DeprecationTestCase()
         test_case_instance.setup()

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -21,7 +21,7 @@ def assert_dtype_not_equal(a, b):
     assert_(hash(a) != hash(b),
             "two different types hash to the same value !")
 
-class TestBuiltin(object):
+class TestBuiltin:
     @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
                                    np.compat.unicode])
     def test_run(self, t):
@@ -144,7 +144,7 @@ class TestBuiltin(object):
                       'offsets': [4, 0]})
         assert_equal(x == y, False)
 
-class TestRecord(object):
+class TestRecord:
     def test_equivalent_record(self):
         """Test whether equivalent record dtypes hash the same."""
         a = np.dtype([('yo', int)])
@@ -443,7 +443,7 @@ class TestRecord(object):
                      np.ones((1, 2), dtype=bool))
 
 
-class TestSubarray(object):
+class TestSubarray:
     def test_single_subarray(self):
         a = np.dtype((int, (2)))
         b = np.dtype((int, (2,)))
@@ -519,7 +519,7 @@ class TestSubarray(object):
         assert_(isinstance(dt['a'].shape, tuple))
         #
 
-        class IntLike(object):
+        class IntLike:
             def __index__(self):
                 return 3
 
@@ -709,7 +709,7 @@ class TestStructuredObjectRefcounting:
         assert after_repeat - after == count * 2 * 10
 
 
-class TestStructuredDtypeSparseFields(object):
+class TestStructuredDtypeSparseFields:
     """Tests subarray fields which contain sparse dtypes so that
     not all memory is used by the dtype work. Such dtype's should
     leave the underlying memory unchanged.
@@ -739,7 +739,7 @@ class TestStructuredDtypeSparseFields(object):
         assert_array_equal(arr["a"]["aa"], np.zeros((3, 2, 3)))
 
 
-class TestMonsterType(object):
+class TestMonsterType:
     """Test deeply nested subtypes."""
 
     def test1(self):
@@ -757,7 +757,7 @@ class TestMonsterType(object):
             ('yi', np.dtype((a, (3, 2))))])
         assert_dtype_equal(c, d)
 
-class TestMetadata(object):
+class TestMetadata:
     def test_no_metadata(self):
         d = np.dtype(int)
         assert_(d.metadata is None)
@@ -779,7 +779,7 @@ class TestMetadata(object):
         d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
         assert_(d.metadata == {'datum': 1})
 
-class TestString(object):
+class TestString:
     def test_complex_dtype_str(self):
         dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),
                                 ('rtile', '>f4', (64, 36))], (3,)),
@@ -932,7 +932,7 @@ class TestString(object):
         assert_equal(dt.name, 'record16')
 
 
-class TestDtypeAttributeDeletion(object):
+class TestDtypeAttributeDeletion:
 
     def test_dtype_non_writable_attributes_deletion(self):
         dt = np.dtype(np.double)
@@ -950,7 +950,7 @@ class TestDtypeAttributeDeletion(object):
             assert_raises(AttributeError, delattr, dt, s)
 
 
-class TestDtypeAttributes(object):
+class TestDtypeAttributes:
     def test_descr_has_trailing_void(self):
         # see gh-6359
         dtype = np.dtype({
@@ -968,7 +968,7 @@ class TestDtypeAttributes(object):
         assert_equal(np.dtype(user_def_subcls).name, 'user_def_subcls')
 
 
-class TestPickling(object):
+class TestPickling:
 
     def check_pickling(self, dtype):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1052,7 +1052,7 @@ def test_invalid_dtype_string():
     assert_raises(TypeError, np.dtype, u'Fl\xfcgel')
 
 
-class TestFromDTypeAttribute(object):
+class TestFromDTypeAttribute:
     def test_simple(self):
         class dt:
             dtype = "f8"
@@ -1096,7 +1096,7 @@ class TestFromDTypeAttribute(object):
         with pytest.raises(RecursionError):
             np.dtype(dt(1))
 
-class TestFromCTypes(object):
+class TestFromCTypes:
 
     @staticmethod
     def check(ctype, dtype):

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -12,7 +12,7 @@ sizes = np.array([2, 3, 4, 5, 4, 3, 2, 6, 5, 4, 3])
 global_size_dict = dict(zip(chars, sizes))
 
 
-class TestEinsum(object):
+class TestEinsum:
     def test_einsum_errors(self):
         for do_opt in [True, False]:
             # Need enough arguments
@@ -866,7 +866,7 @@ class TestEinsum(object):
         self.optimize_compare('obk,ijk->ioj', operands=[g, g])
 
 
-class TestEinsumPath(object):
+class TestEinsumPath:
     def build_operands(self, string, size_dict=global_size_dict):
 
         # Builds views based off initial operands

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_, assert_raises
 
 
-class TestErrstate(object):
+class TestErrstate:
     @pytest.mark.skipif(platform.machine() == "armv5tel", reason="See gh-413.")
     def test_invalid(self):
         with np.errstate(all='raise', under='ignore'):

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -40,7 +40,7 @@ class PhysicalQuantity2(ndarray):
     __array_priority__ = 10
 
 
-class TestLogspace(object):
+class TestLogspace:
 
     def test_basic(self):
         y = logspace(0, 6)
@@ -90,7 +90,7 @@ class TestLogspace(object):
         assert_equal(ls, logspace(1.0, 7.0, 1))
 
 
-class TestGeomspace(object):
+class TestGeomspace:
 
     def test_basic(self):
         y = geomspace(1, 1e6)
@@ -220,7 +220,7 @@ class TestGeomspace(object):
         assert_raises(ValueError, geomspace, 0, 0)
 
 
-class TestLinspace(object):
+class TestLinspace:
 
     def test_basic(self):
         y = linspace(0, 10)
@@ -307,7 +307,7 @@ class TestLinspace(object):
         # Ensure that start/stop can be objects that implement
         # __array_interface__ and are convertible to numeric scalars
 
-        class Arrayish(object):
+        class Arrayish:
             """
             A generic object that supports the __array_interface__ and hence
             can in principle be converted to a numeric scalar, but is not

--- a/numpy/core/tests/test_getlimits.py
+++ b/numpy/core/tests/test_getlimits.py
@@ -9,37 +9,37 @@ from numpy.core.getlimits import _discovered_machar, _float_ma
 
 ##################################################
 
-class TestPythonFloat(object):
+class TestPythonFloat:
     def test_singleton(self):
         ftype = finfo(float)
         ftype2 = finfo(float)
         assert_equal(id(ftype), id(ftype2))
 
-class TestHalf(object):
+class TestHalf:
     def test_singleton(self):
         ftype = finfo(half)
         ftype2 = finfo(half)
         assert_equal(id(ftype), id(ftype2))
 
-class TestSingle(object):
+class TestSingle:
     def test_singleton(self):
         ftype = finfo(single)
         ftype2 = finfo(single)
         assert_equal(id(ftype), id(ftype2))
 
-class TestDouble(object):
+class TestDouble:
     def test_singleton(self):
         ftype = finfo(double)
         ftype2 = finfo(double)
         assert_equal(id(ftype), id(ftype2))
 
-class TestLongdouble(object):
+class TestLongdouble:
     def test_singleton(self):
         ftype = finfo(longdouble)
         ftype2 = finfo(longdouble)
         assert_equal(id(ftype), id(ftype2))
 
-class TestFinfo(object):
+class TestFinfo:
     def test_basic(self):
         dts = list(zip(['f2', 'f4', 'f8', 'c8', 'c16'],
                        [np.float16, np.float32, np.float64, np.complex64,
@@ -52,7 +52,7 @@ class TestFinfo(object):
                              getattr(finfo(dt2), attr), attr)
         assert_raises(ValueError, finfo, 'i4')
 
-class TestIinfo(object):
+class TestIinfo:
     def test_basic(self):
         dts = list(zip(['i1', 'i2', 'i4', 'i8',
                    'u1', 'u2', 'u4', 'u8'],
@@ -69,7 +69,7 @@ class TestIinfo(object):
         for T in types:
             assert_equal(iinfo(T).max, T(-1))
 
-class TestRepr(object):
+class TestRepr:
     def test_iinfo_repr(self):
         expected = "iinfo(min=-32768, max=32767, dtype=int16)"
         assert_equal(repr(np.iinfo(np.int16)), expected)

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -16,7 +16,7 @@ def assert_raises_fpe(strmatch, callable, *args, **kwargs):
         assert_(False,
                 "Did not raise floating point %s error" % strmatch)
 
-class TestHalf(object):
+class TestHalf:
     def setup(self):
         # An array of all possible float16 values
         self.all_f16 = np.arange(0x10000, dtype=uint16)

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_raises
 
-class TestIndexErrors(object):
+class TestIndexErrors:
     '''Tests to exercise indexerrors not covered by other tests.'''
 
     def test_arraytypes_fasttake(self):

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -13,7 +13,7 @@ from numpy.testing import (
     )
 
 
-class TestIndexing(object):
+class TestIndexing:
     def test_index_no_floats(self):
         a = np.array([[[5]]])
 
@@ -395,14 +395,14 @@ class TestIndexing(object):
     def test_scalar_return_type(self):
         # Full scalar indices should return scalars and object
         # arrays should not call PyArray_Return on their items
-        class Zero(object):
+        class Zero:
             # The most basic valid indexing
             def __index__(self):
                 return 0
 
         z = Zero()
 
-        class ArrayLike(object):
+        class ArrayLike:
             # Simple array, should behave like the array
             def __array__(self):
                 return np.array(0)
@@ -482,7 +482,7 @@ class TestIndexing(object):
         # on item getting, this should not be converted to an nd-index (tuple)
         # If this object happens to be a valid index otherwise, it should work
         # This object here is very dubious and probably bad though:
-        class SequenceLike(object):
+        class SequenceLike:
             def __index__(self):
                 return 0
 
@@ -525,7 +525,7 @@ class TestIndexing(object):
         arr[slices] = 10
         assert_array_equal(arr, 10.)
 
-class TestFieldIndexing(object):
+class TestFieldIndexing:
     def test_scalar_return_type(self):
         # Field access on an array should return an array, even if it
         # is 0-d.
@@ -534,7 +534,7 @@ class TestFieldIndexing(object):
         assert_(isinstance(a[['a']], np.ndarray))
 
 
-class TestBroadcastedAssignments(object):
+class TestBroadcastedAssignments:
     def assign(self, a, ind, val):
         a[ind] = val
         return a
@@ -585,7 +585,7 @@ class TestBroadcastedAssignments(object):
         assert_((a[::-1] == v).all())
 
 
-class TestSubclasses(object):
+class TestSubclasses:
     def test_basic(self):
         # Test that indexing in various ways produces SubClass instances,
         # and that the base is set up correctly: the original subclass
@@ -697,7 +697,7 @@ class TestSubclasses(object):
         assert_equal(sys.getrefcount(k.indx), 2)
 
 
-class TestFancyIndexingCast(object):
+class TestFancyIndexingCast:
     def test_boolean_index_cast_assign(self):
         # Setup the boolean index and float arrays.
         shape = (8, 63)
@@ -719,7 +719,7 @@ class TestFancyIndexingCast(object):
                      zero_array.__setitem__, bool_index, np.array([1j]))
         assert_equal(zero_array[0, 1], 0)
 
-class TestFancyIndexingEquivalence(object):
+class TestFancyIndexingEquivalence:
     def test_object_assign(self):
         # Check that the field and object special case using copyto is active.
         # The right hand side cannot be converted to an array here.
@@ -767,7 +767,7 @@ class TestFancyIndexingEquivalence(object):
         assert_array_equal(a, b[0])
 
 
-class TestMultiIndexingAutomated(object):
+class TestMultiIndexingAutomated:
     """
     These tests use code to mimic the C-Code indexing for selection.
 
@@ -1189,7 +1189,7 @@ class TestMultiIndexingAutomated(object):
         for index in self.complex_indices:
             self._check_single_index(a, index)
 
-class TestFloatNonIntegerArgument(object):
+class TestFloatNonIntegerArgument:
     """
     These test that ``TypeError`` is raised when you try to use
     non-integers as arguments to for indexing and slicing e.g. ``a[0.0:5]``
@@ -1244,7 +1244,7 @@ class TestFloatNonIntegerArgument(object):
         assert_raises(TypeError, np.min, d, (.2, 1.2))
 
 
-class TestBooleanIndexing(object):
+class TestBooleanIndexing:
     # Using a boolean as integer argument/indexing is an error.
     def test_bool_as_int_argument_errors(self):
         a = np.array([[[1]]])
@@ -1265,7 +1265,7 @@ class TestBooleanIndexing(object):
         assert_raises(IndexError, lambda: a[False, [0, 1], ...])
 
 
-class TestArrayToIndexDeprecation(object):
+class TestArrayToIndexDeprecation:
     """Creating an an index from array not 0-D is an error.
 
     """
@@ -1278,7 +1278,7 @@ class TestArrayToIndexDeprecation(object):
         assert_raises(TypeError, np.take, a, [0], a)
 
 
-class TestNonIntegerArrayLike(object):
+class TestNonIntegerArrayLike:
     """Tests that array_likes only valid if can safely cast to integer.
 
     For instance, lists give IndexError when they cannot be safely cast to
@@ -1295,7 +1295,7 @@ class TestNonIntegerArrayLike(object):
         a.__getitem__([])
 
 
-class TestMultipleEllipsisError(object):
+class TestMultipleEllipsisError:
     """An index can only have a single ellipsis.
 
     """
@@ -1306,7 +1306,7 @@ class TestMultipleEllipsisError(object):
         assert_raises(IndexError, a.__getitem__, ((Ellipsis,) * 3,))
 
 
-class TestCApiAccess(object):
+class TestCApiAccess:
     def test_getitem(self):
         subscript = functools.partial(array_indexing, 0)
 

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -6,7 +6,7 @@ from numpy.testing import (
     )
 
 
-class TestTake(object):
+class TestTake:
     def test_simple(self):
         a = [[1, 2], [3, 4]]
         a_str = [[b'1', b'2'], [b'3', b'4']]

--- a/numpy/core/tests/test_longdouble.py
+++ b/numpy/core/tests/test_longdouble.py
@@ -119,7 +119,7 @@ def test_fromstring_missing():
                      np.array([1]))
 
 
-class TestFileBased(object):
+class TestFileBased:
 
     ldbl = 1 + LD_INFO.eps
     tgt = np.array([ldbl]*5)

--- a/numpy/core/tests/test_machar.py
+++ b/numpy/core/tests/test_machar.py
@@ -8,7 +8,7 @@ import numpy.core.numerictypes as ntypes
 from numpy import errstate, array
 
 
-class TestMachAr(object):
+class TestMachAr:
     def _run_machar_highprec(self):
         # Instantiate MachAr instance with high enough precision to cause
         # underflow

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -562,7 +562,7 @@ def test_internal_overlap_fuzz():
 def test_non_ndarray_inputs():
     # Regression check for gh-5604
 
-    class MyArray(object):
+    class MyArray:
         def __init__(self, data):
             self.data = data
 
@@ -570,7 +570,7 @@ def test_non_ndarray_inputs():
         def __array_interface__(self):
             return self.data.__array_interface__
 
-    class MyArray2(object):
+    class MyArray2:
         def __init__(self, data):
             self.data = data
 
@@ -617,7 +617,7 @@ def assert_copy_equivalent(operation, args, out, **kwargs):
         assert_equal(got, expected)
 
 
-class TestUFunc(object):
+class TestUFunc:
     """
     Test ufunc call memory overlap handling
     """

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -14,7 +14,7 @@ from numpy.testing import (
     assert_, assert_equal, assert_array_equal, suppress_warnings
     )
 
-class TestMemmap(object):
+class TestMemmap:
     def setup(self):
         self.tmpfp = NamedTemporaryFile(prefix='mmap')
         self.tempdir = mkdtemp()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -96,7 +96,7 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
     return data
 
 
-class TestFlags(object):
+class TestFlags:
     def setup(self):
         self.a = np.arange(10)
 
@@ -264,7 +264,7 @@ class TestFlags(object):
         assert_(a.flags.aligned)
 
 
-class TestHash(object):
+class TestHash:
     # see #3793
     def test_int(self):
         for st, ut, s in [(np.int8, np.uint8, 8),
@@ -286,7 +286,7 @@ class TestHash(object):
                              err_msg="%r: 2**%d - 1" % (ut, i))
 
 
-class TestAttributes(object):
+class TestAttributes:
     def setup(self):
         self.one = np.arange(10)
         self.two = np.arange(20).reshape(4, 5)
@@ -419,7 +419,7 @@ class TestAttributes(object):
         assert_array_equal(x['b'], [-2, -2])
 
 
-class TestArrayConstruction(object):
+class TestArrayConstruction:
     def test_array(self):
         d = np.ones(6)
         r = np.array([d, d])
@@ -497,7 +497,7 @@ class TestArrayConstruction(object):
         assert_(np.asfortranarray(d).flags.f_contiguous)
 
 
-class TestAssignment(object):
+class TestAssignment:
     def test_assignment_broadcasting(self):
         a = np.arange(6).reshape(2, 3)
 
@@ -563,7 +563,7 @@ class TestAssignment(object):
         u = np.array([u'done'])
         b = np.array([b'done'])
 
-        class bad_sequence(object):
+        class bad_sequence:
             def __getitem__(self): pass
             def __len__(self): raise RuntimeError
 
@@ -614,7 +614,7 @@ class TestAssignment(object):
         assert_equal(a[0], b"1.1234567890123457")
 
 
-class TestDtypedescr(object):
+class TestDtypedescr:
     def test_construction(self):
         d1 = np.dtype('i4')
         assert_equal(d1, np.dtype(np.int32))
@@ -636,7 +636,7 @@ class TestDtypedescr(object):
             "array([0, 0, 0, 0], dtype=(numpy.int32, [('a', '<i2'), ('b', '<i2')]))")
 
 
-class TestZeroRank(object):
+class TestZeroRank:
     def setup(self):
         self.d = np.array(0), np.array('x', object)
 
@@ -734,7 +734,7 @@ class TestZeroRank(object):
         assert_equal(xi.flags.f_contiguous, True)
 
 
-class TestScalarIndexing(object):
+class TestScalarIndexing:
     def setup(self):
         self.d = np.array([0, 1])[0]
 
@@ -830,12 +830,12 @@ class TestScalarIndexing(object):
         assert_equal(a, [0, 1, 0, 1, 2])
 
 
-class TestCreation(object):
+class TestCreation:
     """
     Test the np.array constructor
     """
     def test_from_attribute(self):
-        class x(object):
+        class x:
             def __array__(self, dtype=None):
                 pass
 
@@ -977,14 +977,14 @@ class TestCreation(object):
         of an error in the Fail case.
 
         """
-        class Fail(object):
+        class Fail:
             def __len__(self):
                 return 1
 
             def __getitem__(self, index):
                 raise ValueError()
 
-        class Map(object):
+        class Map:
             def __len__(self):
                 return 1
 
@@ -1022,7 +1022,7 @@ class TestCreation(object):
 
     def test_failed_len_sequence(self):
         # gh-7393
-        class A(object):
+        class A:
             def __init__(self, data):
                 self._data = data
             def __getitem__(self, item):
@@ -1078,7 +1078,7 @@ class TestCreation(object):
         assert_equal(a.dtype, object)
 
 
-class TestStructured(object):
+class TestStructured:
     def test_subarray_field_access(self):
         a = np.zeros((3, 5), dtype=[('a', ('i4', (2, 2)))])
         a['a'] = np.arange(60).reshape(3, 5, 2, 2)
@@ -1366,7 +1366,7 @@ class TestStructured(object):
         a[['b','c']]  # no exception
 
 
-class TestBool(object):
+class TestBool:
     def test_test_interning(self):
         a0 = np.bool_(0)
         b0 = np.bool_(False)
@@ -1456,7 +1456,7 @@ class TestBool(object):
         self._test_cast_from_flexible(np.bytes_)
 
 
-class TestZeroSizeFlexible(object):
+class TestZeroSizeFlexible:
     @staticmethod
     def _zeros(shape, dtype=str):
         dtype = np.dtype(dtype)
@@ -1543,7 +1543,7 @@ class TestZeroSizeFlexible(object):
         assert array_from_buffer[0] == -1, array_from_buffer[0]
 
 
-class TestMethods(object):
+class TestMethods:
 
     sort_kinds = ['quicksort', 'heapsort', 'stable']
 
@@ -1870,7 +1870,7 @@ class TestMethods(object):
 
         # test generic class with bogus ordering,
         # should not segfault.
-        class Boom(object):
+        class Boom:
             def __lt__(self, other):
                 return True
 
@@ -1898,7 +1898,7 @@ class TestMethods(object):
         for kind in self.sort_kinds:
             assert_raises(TypeError, arr.sort, kind=kind)
         #gh-3879
-        class Raiser(object):
+        class Raiser:
             def raises_anything(*args, **kwargs):
                 raise TypeError("SOMETHING ERRORED")
             __eq__ = __ne__ = __lt__ = __gt__ = __ge__ = __le__ = raises_anything
@@ -2940,7 +2940,7 @@ class TestMethods(object):
 
     def test_dot_matmul_inner_array_casting_fails(self):
 
-        class A(object):
+        class A:
             def __array__(self, *args, **kwargs):
                 raise NotImplementedError
 
@@ -3301,12 +3301,12 @@ class TestMethods(object):
         e = np.array(['1+1j'], 'U')
         assert_raises(TypeError, complex, e)
 
-class TestCequenceMethods(object):
+class TestCequenceMethods:
     def test_array_contains(self):
         assert_(4.0 in np.arange(16.).reshape(4,4))
         assert_(20.0 not in np.arange(16.).reshape(4,4))
 
-class TestBinop(object):
+class TestBinop:
     def test_inplace(self):
         # test refcount 1 inplace conversion
         assert_array_almost_equal(np.array([0.5]) * np.array([1.0, 2.0]),
@@ -3531,7 +3531,7 @@ class TestBinop(object):
 
     def test_ufunc_override_normalize_signature(self):
         # gh-5674
-        class SomeClass(object):
+        class SomeClass:
             def __array_ufunc__(self, ufunc, method, *inputs, **kw):
                 return kw
 
@@ -3549,7 +3549,7 @@ class TestBinop(object):
         # Check that index is set appropriately, also if only an output
         # is passed on (latter is another regression tests for github bug 4753)
         # This also checks implicitly that 'out' is always a tuple.
-        class CheckIndex(object):
+        class CheckIndex:
             def __array_ufunc__(self, ufunc, method, *inputs, **kw):
                 for i, a in enumerate(inputs):
                     if a is self:
@@ -3637,7 +3637,7 @@ class TestBinop(object):
 
     def test_pow_array_object_dtype(self):
         # test pow on arrays of object dtype
-        class SomeClass(object):
+        class SomeClass:
             def __init__(self, num=None):
                 self.num = num
 
@@ -3678,7 +3678,7 @@ class TestBinop(object):
             +tst
 
 
-class TestTemporaryElide(object):
+class TestTemporaryElide:
     # elision is only triggered on relatively large arrays
 
     def test_extension_incref_elide(self):
@@ -3780,7 +3780,7 @@ class TestTemporaryElide(object):
         assert_equal(a, 1)
 
 
-class TestCAPI(object):
+class TestCAPI:
     def test_IsPythonScalar(self):
         from numpy.core._multiarray_tests import IsPythonScalar
         assert_(IsPythonScalar(b'foobar'))
@@ -3790,7 +3790,7 @@ class TestCAPI(object):
         assert_(IsPythonScalar("a"))
 
 
-class TestSubscripting(object):
+class TestSubscripting:
     def test_test_zero_rank(self):
         x = np.array([1, 2, 3])
         assert_(isinstance(x[0], np.int_))
@@ -3799,7 +3799,7 @@ class TestSubscripting(object):
         assert_(type(x[0, ...]) is np.ndarray)
 
 
-class TestPickling(object):
+class TestPickling:
     @pytest.mark.skipif(pickle.HIGHEST_PROTOCOL >= 5,
                         reason=('this tests the error messages when trying to'
                                 'protocol 5 although it is not available'))
@@ -3956,7 +3956,7 @@ class TestPickling(object):
         assert_equal(original.dtype, new.dtype)
 
 
-class TestFancyIndexing(object):
+class TestFancyIndexing:
     def test_list(self):
         x = np.ones((1, 1))
         x[:, [0]] = 2.0
@@ -4010,7 +4010,7 @@ class TestFancyIndexing(object):
         assert_array_equal(x, np.array([[1, 10, 3, 4], [5, 6, 7, 8]]))
 
 
-class TestStringCompare(object):
+class TestStringCompare:
     def test_string(self):
         g1 = np.array(["This", "is", "example"])
         g2 = np.array(["This", "was", "example"])
@@ -4042,7 +4042,7 @@ class TestStringCompare(object):
         assert_array_equal(g1 > g2,  [g1[i] > g2[i] for i in [0, 1, 2]])
 
 
-class TestArgmax(object):
+class TestArgmax:
 
     nan_arr = [
         ([0, 1, 2, 3, np.nan], 4),
@@ -4177,7 +4177,7 @@ class TestArgmax(object):
         assert_equal(a.argmax(), 1)
 
 
-class TestArgmin(object):
+class TestArgmin:
 
     nan_arr = [
         ([0, 1, 2, 3, np.nan], 4),
@@ -4326,7 +4326,7 @@ class TestArgmin(object):
         assert_equal(a.argmin(), 1)
 
 
-class TestMinMax(object):
+class TestMinMax:
 
     def test_scalar(self):
         assert_raises(np.AxisError, np.amax, 1, 1)
@@ -4352,14 +4352,14 @@ class TestMinMax(object):
             assert_equal(np.amax(a), a[3])
 
 
-class TestNewaxis(object):
+class TestNewaxis:
     def test_basic(self):
         sk = np.array([0, -0.1, 0.1])
         res = 250*sk[:, np.newaxis]
         assert_almost_equal(res.ravel(), 250*sk)
 
 
-class TestClip(object):
+class TestClip:
     def _check_range(self, x, cmin, cmax):
         assert_(np.all(x >= cmin))
         assert_(np.all(x <= cmax))
@@ -4437,7 +4437,7 @@ class TestClip(object):
         assert_array_equal(result, expected)
 
 
-class TestCompress(object):
+class TestCompress:
     def test_axis(self):
         tgt = [[5, 6, 7, 8, 9]]
         arr = np.arange(10).reshape(2, 5)
@@ -4460,7 +4460,7 @@ class TestCompress(object):
         assert_equal(out, 1)
 
 
-class TestPutmask(object):
+class TestPutmask:
     def tst_basic(self, x, T, mask, val):
         np.putmask(x, mask, val)
         assert_equal(x[mask], T(val))
@@ -4511,7 +4511,7 @@ class TestPutmask(object):
         assert_equal(x, np.array([True, True, True, True]))
 
 
-class TestTake(object):
+class TestTake:
     def tst_basic(self, x):
         ind = list(range(x.shape[0]))
         assert_array_equal(x.take(ind, axis=0), x)
@@ -4564,7 +4564,7 @@ class TestTake(object):
         y = np.take(x, [1, 2, 3], out=x[2:5], mode='wrap')
         assert_equal(y, np.array([1, 2, 3]))
 
-class TestLexsort(object):
+class TestLexsort:
     @pytest.mark.parametrize('dtype',[
         np.uint8, np.uint16, np.uint32, np.uint64,
         np.int8, np.int16, np.int32, np.int64,
@@ -4619,7 +4619,7 @@ class TestLexsort(object):
         x = np.linspace(0., 1., 42*3).reshape(42, 3)
         assert_raises(np.AxisError, np.lexsort, x, axis=2)
 
-class TestIO(object):
+class TestIO:
     """Test tofile, fromfile, tobytes, and fromstring"""
 
     def setup(self):
@@ -5009,7 +5009,7 @@ class TestIO(object):
             assert_array_equal(x, res)
 
 
-class TestFromBuffer(object):
+class TestFromBuffer:
     @pytest.mark.parametrize('byteorder', ['<', '>'])
     @pytest.mark.parametrize('dtype', [float, int, complex])
     def test_basic(self, byteorder, dtype):
@@ -5022,7 +5022,7 @@ class TestFromBuffer(object):
         assert_array_equal(np.frombuffer(b''), np.array([]))
 
 
-class TestFlat(object):
+class TestFlat:
     def setup(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)
@@ -5094,7 +5094,7 @@ class TestFlat(object):
             assert_(abs(sys.getrefcount(indtype) - rc_indtype) < 50)
 
 
-class TestResize(object):
+class TestResize:
 
     @no_tracing
     def test_basic(self):
@@ -5193,7 +5193,7 @@ class TestResize(object):
         del xref  # avoid pyflakes unused variable warning.
 
 
-class TestRecord(object):
+class TestRecord:
     def test_field_rename(self):
         dt = np.dtype([('f', float), ('i', int)])
         dt.names = ['p', 'q']
@@ -5355,7 +5355,7 @@ class TestRecord(object):
         v[:] = (4,5)
         assert_equal(a[0].item(), (4, 1, 5))
 
-class TestView(object):
+class TestView:
     def test_basic(self):
         x = np.array([(1, 2, 3, 4), (5, 6, 7, 8)],
                      dtype=[('r', np.int8), ('g', np.int8),
@@ -5380,7 +5380,7 @@ def _std(a, **args):
     return a.std(**args)
 
 
-class TestStats(object):
+class TestStats:
 
     funcs = [_mean, _var, _std]
 
@@ -5587,7 +5587,7 @@ class TestStats(object):
         res = dat.var(1)
         assert_(res.info == dat.info)
 
-class TestVdot(object):
+class TestVdot:
     def test_basic(self):
         dt_numeric = np.typecodes['AllFloat'] + np.typecodes['AllInteger']
         dt_complex = np.typecodes['Complex']
@@ -5647,7 +5647,7 @@ class TestVdot(object):
                          np.vdot(a.flatten(), b.flatten()))
 
 
-class TestDot(object):
+class TestDot:
     def setup(self):
         np.random.seed(128)
         self.A = np.random.rand(4, 2)
@@ -5749,7 +5749,7 @@ class TestDot(object):
             assert_almost_equal(res, tgt, decimal=self.N)
 
     def test_vecobject(self):
-        class Vec(object):
+        class Vec:
             def __init__(self, sequence=None):
                 if sequence is None:
                     sequence = []
@@ -5918,7 +5918,7 @@ class TestDot(object):
             assert_dot_close(A_f_12, X_f_2, desired)
 
 
-class MatmulCommon(object):
+class MatmulCommon:
     """Common tests for '@' operator and numpy.matmul.
 
     """
@@ -6300,7 +6300,7 @@ if sys.version_info[:2] >= (3, 5):
 
         def test_array_priority_override(self):
 
-            class A(object):
+            class A:
                 __array_priority__ = 1000
 
                 def __matmul__(self, other):
@@ -6345,7 +6345,7 @@ if sys.version_info[:2] >= (3, 5):
         assert f.shape == (4, 5)
 
 
-class TestInner(object):
+class TestInner:
 
     def test_inner_type_mismatch(self):
         c = 1.
@@ -6423,7 +6423,7 @@ class TestInner(object):
             assert_equal(np.inner(b, a).transpose(2,3,0,1), desired)
 
 
-class TestAlen(object):
+class TestAlen:
     def test_basic(self):
         with pytest.warns(DeprecationWarning):
             m = np.array([1, 2, 3])
@@ -6443,7 +6443,7 @@ class TestAlen(object):
             assert_equal(np.alen(5), 1)
 
 
-class TestChoose(object):
+class TestChoose:
     def setup(self):
         self.x = 2*np.ones((3,), dtype=int)
         self.y = 3*np.ones((3,), dtype=int)
@@ -6473,7 +6473,7 @@ class TestChoose(object):
         assert(np.choose([0], ops).dtype == expected_dt)
 
 
-class TestRepeat(object):
+class TestRepeat:
     def setup(self):
         self.m = np.array([1, 2, 3, 4, 5, 6])
         self.m_rect = self.m.reshape((2, 3))
@@ -6515,7 +6515,7 @@ NEIGH_MODE = {'zero': 0, 'one': 1, 'constant': 2, 'circular': 3, 'mirror': 4}
 
 
 @pytest.mark.parametrize('dt', [float, Decimal], ids=['float', 'object'])
-class TestNeighborhoodIter(object):
+class TestNeighborhoodIter:
     # Simple, 2d tests
     def test_simple2d(self, dt):
         # Test zero and one padding for simple data type
@@ -6594,7 +6594,7 @@ class TestNeighborhoodIter(object):
 
 
 # Test stacking neighborhood iterators
-class TestStackedNeighborhoodIter(object):
+class TestStackedNeighborhoodIter:
     # Simple, 1d test: stacking 2 constant-padded neigh iterators
     def test_simple_const(self):
         dt = np.float64
@@ -6744,7 +6744,7 @@ class TestStackedNeighborhoodIter(object):
                 x, [1, 1], NEIGH_MODE['zero'], [-1, 2], NEIGH_MODE['circular'])
         assert_array_equal(l, r)
 
-class TestWarnings(object):
+class TestWarnings:
 
     def test_complex_warning(self):
         x = np.array([1, 2])
@@ -6756,7 +6756,7 @@ class TestWarnings(object):
             assert_equal(x, [1, 2])
 
 
-class TestMinScalarType(object):
+class TestMinScalarType:
 
     def test_usigned_shortshort(self):
         dt = np.min_scalar_type(2**8-1)
@@ -6787,7 +6787,7 @@ class TestMinScalarType(object):
 from numpy.core._internal import _dtype_from_pep3118
 
 
-class TestPEP3118Dtype(object):
+class TestPEP3118Dtype:
     def _check(self, spec, wanted):
         dt = np.dtype(wanted)
         actual = _dtype_from_pep3118(spec)
@@ -6894,7 +6894,7 @@ class TestPEP3118Dtype(object):
         self._check('i:f0:', [('f0', 'i')])
 
 
-class TestNewBufferProtocol(object):
+class TestNewBufferProtocol:
     """ Test PEP3118 buffers """
 
     def _check_roundtrip(self, obj):
@@ -7291,7 +7291,7 @@ class TestNewBufferProtocol(object):
         assert_equal(arr['a'], 3)
 
 
-class TestArrayAttributeDeletion(object):
+class TestArrayAttributeDeletion:
 
     def test_multiarray_writable_attributes_deletion(self):
         # ticket #2046, should not seqfault, raise AttributeError
@@ -7326,7 +7326,7 @@ class TestArrayAttributeDeletion(object):
 
 
 class TestArrayInterface():
-    class Foo(object):
+    class Foo:
         def __init__(self, value):
             self.value = value
             self.iface = {'typestr': 'f8'}
@@ -7371,7 +7371,7 @@ class TestArrayInterface():
             assert_equal(pre_cnt, post_cnt)
 
 def test_interface_no_shape():
-    class ArrayLike(object):
+    class ArrayLike:
         array = np.array(1)
         __array_interface__ = array.__array_interface__
     assert_equal(np.array(ArrayLike()), 1)
@@ -7393,7 +7393,7 @@ def test_array_interface_empty_shape():
     interface1 = dict(arr.__array_interface__)
     interface1['shape'] = ()
 
-    class DummyArray1(object):
+    class DummyArray1:
         __array_interface__ = interface1
 
     # NOTE: Because Py2 str/Py3 bytes supports the buffer interface, setting
@@ -7403,7 +7403,7 @@ def test_array_interface_empty_shape():
     interface2 = dict(interface1)
     interface2['data'] = arr[0].tobytes()
 
-    class DummyArray2(object):
+    class DummyArray2:
         __array_interface__ = interface2
 
     arr1 = np.asarray(DummyArray1())
@@ -7420,7 +7420,7 @@ def test_array_interface_offset():
     interface['offset'] = 4
 
 
-    class DummyArray(object):
+    class DummyArray:
         __array_interface__ = interface
 
     arr1 = np.asarray(DummyArray())
@@ -7442,7 +7442,7 @@ def test_scalar_element_deletion():
     assert_raises(ValueError, a[0].__delitem__, 'x')
 
 
-class TestMemEventHook(object):
+class TestMemEventHook:
     def test_mem_seteventhook(self):
         # The actual tests are within the C code in
         # multiarray/_multiarray_tests.c.src
@@ -7454,7 +7454,7 @@ class TestMemEventHook(object):
         break_cycles()
         _multiarray_tests.test_pydatamem_seteventhook_end()
 
-class TestMapIter(object):
+class TestMapIter:
     def test_mapiter(self):
         # The actual tests are within the C code in
         # multiarray/_multiarray_tests.c.src
@@ -7476,7 +7476,7 @@ class TestMapIter(object):
         assert_equal(b, [100.1,  51.,   6.,   3.,   4.,   5.])
 
 
-class TestAsCArray(object):
+class TestAsCArray:
     def test_1darray(self):
         array = np.arange(24, dtype=np.double)
         from_c = _multiarray_tests.test_as_c_array(array, 3)
@@ -7493,7 +7493,7 @@ class TestAsCArray(object):
         assert_equal(array[1, 2, 3], from_c)
 
 
-class TestConversion(object):
+class TestConversion:
     def test_array_scalar_relational_operation(self):
         # All integer
         for dt1 in np.typecodes['AllInteger']:
@@ -7541,7 +7541,7 @@ class TestConversion(object):
         assert_equal(bool(np.array([[42]])), True)
         assert_raises(ValueError, bool, np.array([1, 2]))
 
-        class NotConvertible(object):
+        class NotConvertible:
             def __bool__(self):
                 raise NotImplementedError
             __nonzero__ = __bool__  # python 2
@@ -7578,7 +7578,7 @@ class TestConversion(object):
             assert_equal(3, int_func(np.array(HasTrunc())))
             assert_equal(3, int_func(np.array([HasTrunc()])))
 
-            class NotConvertible(object):
+            class NotConvertible:
                 def __int__(self):
                     raise NotImplementedError
             assert_raises(NotImplementedError,
@@ -7587,7 +7587,7 @@ class TestConversion(object):
                 int_func, np.array([NotConvertible()]))
 
 
-class TestWhere(object):
+class TestWhere:
     def test_basic(self):
         dts = [bool, np.int16, np.int32, np.int64, np.double, np.complex128,
                np.longdouble, np.clongdouble]
@@ -7754,7 +7754,7 @@ class TestWhere(object):
 
 if not IS_PYPY:
     # sys.getsizeof() is not valid on PyPy
-    class TestSizeOf(object):
+    class TestSizeOf:
 
         def test_empty_array(self):
             x = np.array([])
@@ -7801,7 +7801,7 @@ if not IS_PYPY:
             assert_raises(TypeError, d.__sizeof__, "a")
 
 
-class TestHashing(object):
+class TestHashing:
 
     def test_arrays_not_hashable(self):
         x = np.ones(3)
@@ -7812,7 +7812,7 @@ class TestHashing(object):
         assert_(not isinstance(x, collections_abc.Hashable))
 
 
-class TestArrayPriority(object):
+class TestArrayPriority:
     # This will go away when __array_priority__ is settled, meanwhile
     # it serves to check unintended changes.
     op = operator
@@ -7839,7 +7839,7 @@ class TestArrayPriority(object):
         def __new__(cls, *args, **kwargs):
             return np.array(*args, **kwargs).view(cls)
 
-    class Other(object):
+    class Other:
         __array_priority__ = 1000.
 
         def _all(self, other):
@@ -7898,7 +7898,7 @@ class TestArrayPriority(object):
             assert_(isinstance(f(b, a), self.Other), msg)
 
 
-class TestBytestringArrayNonzero(object):
+class TestBytestringArrayNonzero:
 
     def test_empty_bstring_array_is_falsey(self):
         assert_(not np.array([''], dtype=str))
@@ -7919,7 +7919,7 @@ class TestBytestringArrayNonzero(object):
         assert_(a)
 
 
-class TestUnicodeArrayNonzero(object):
+class TestUnicodeArrayNonzero:
 
     def test_empty_ustring_array_is_falsey(self):
         assert_(not np.array([''], dtype=np.unicode_))
@@ -7940,7 +7940,7 @@ class TestUnicodeArrayNonzero(object):
         assert_(a)
 
 
-class TestFormat(object):
+class TestFormat:
 
     def test_0d(self):
         a = np.array(np.pi)
@@ -7965,7 +7965,7 @@ class TestFormat(object):
 
 from numpy.testing import IS_PYPY
 
-class TestCTypes(object):
+class TestCTypes:
 
     def test_ctypes_is_available(self):
         test_arr = np.array([[1, 2, 3], [4, 5, 6]])
@@ -8057,7 +8057,7 @@ class TestCTypes(object):
         assert_(arr_ref() is None, "unknowable whether ctypes pointer holds a reference")
 
 
-class TestWritebackIfCopy(object):
+class TestWritebackIfCopy:
     # all these tests use the WRITEBACKIFCOPY mechanism
     def test_argmax_with_out(self):
         mat = np.eye(5)
@@ -8170,7 +8170,7 @@ class TestWritebackIfCopy(object):
         assert_equal(arr, orig)
 
 
-class TestArange(object):
+class TestArange:
     def test_infinite(self):
         assert_raises_regex(
             ValueError, "size exceeded",
@@ -8192,7 +8192,7 @@ class TestArange(object):
         assert_raises(ZeroDivisionError, np.arange, 0.0, 0.0, 0.0)
 
 
-class TestArrayFinalize(object):
+class TestArrayFinalize:
     """ Tests __array_finalize__ """
 
     def test_receives_base(self):
@@ -8212,7 +8212,7 @@ class TestArrayFinalize(object):
                 raise Exception(self)
 
         # a plain object can't be weakref'd
-        class Dummy(object): pass
+        class Dummy: pass
 
         # get a weak reference to an object within an array
         obj_arr = np.array(Dummy())
@@ -8252,7 +8252,7 @@ def test_equal_override():
     # gh-9153: ndarray.__eq__ uses special logic for structured arrays, which
     # did not respect overrides with __array_priority__ or __array_ufunc__.
     # The PR fixed this for __array_priority__ and __array_ufunc__ = None.
-    class MyAlwaysEqual(object):
+    class MyAlwaysEqual:
         def __eq__(self, other):
             return "eq"
 
@@ -8350,7 +8350,7 @@ def test_uintalignment_and_alignment():
     dst = np.zeros((2,2), dtype='c8')
     dst[:,1] = src[:,1]  # assert in lowlevel_strided_loops fails?
 
-class TestAlignment(object):
+class TestAlignment:
     # adapted from scipy._lib.tests.test__util.test__aligned_zeros
     # Checks that unusual memory alignments don't trip up numpy.
     # In particular, check RELAXED_STRIDES don't trip alignment assertions in

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2186,7 +2186,7 @@ def test_iter_no_broadcast():
                   [['readonly'], ['readonly'], ['readonly', 'no_broadcast']])
 
 
-class TestIterNested(object):
+class TestIterNested:
 
     def test_basic(self):
         # Test nested iteration basic usage

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -15,7 +15,7 @@ from numpy.testing import (
     )
 
 
-class TestResize(object):
+class TestResize:
     def test_copies(self):
         A = np.array([[1, 2], [3, 4]])
         Ar1 = np.array([[1, 2, 3, 4], [1, 2, 3, 4]])
@@ -47,7 +47,7 @@ class TestResize(object):
         assert_equal(A.dtype, Ar.dtype)
 
 
-class TestNonarrayArgs(object):
+class TestNonarrayArgs:
     # check that non-array arguments to functions wrap them in arrays
     def test_choose(self):
         choices = [[0, 1, 2],
@@ -218,7 +218,7 @@ class TestNonarrayArgs(object):
         B[0] = 1j
         assert_almost_equal(np.var(B), 0.25)
 
-class TestIsscalar(object):
+class TestIsscalar:
     def test_isscalar(self):
         assert_(np.isscalar(3.1))
         assert_(np.isscalar(np.int16(12345)))
@@ -234,7 +234,7 @@ class TestIsscalar(object):
         assert_(np.isscalar(Number()))
 
 
-class TestBoolScalar(object):
+class TestBoolScalar:
     def test_logical(self):
         f = np.False_
         t = np.True_
@@ -267,7 +267,7 @@ class TestBoolScalar(object):
         assert_((f ^ f) is f)
 
 
-class TestBoolArray(object):
+class TestBoolArray:
     def setup(self):
         # offset for simd tests
         self.t = np.array([True] * 41, dtype=bool)[1::]
@@ -354,7 +354,7 @@ class TestBoolArray(object):
         assert_array_equal(self.im ^ False, self.im)
 
 
-class TestBoolCmp(object):
+class TestBoolCmp:
     def setup(self):
         self.f = np.ones(256, dtype=np.float32)
         self.ef = np.ones(self.f.size, dtype=bool)
@@ -454,7 +454,7 @@ class TestBoolCmp(object):
             assert_array_equal(np.signbit(self.signd[i:]), self.ed[i:])
 
 
-class TestSeterr(object):
+class TestSeterr:
     def test_default(self):
         err = np.geterr()
         assert_equal(err,
@@ -535,7 +535,7 @@ class TestSeterr(object):
             np.seterrobj(olderrobj)
 
 
-class TestFloatExceptions(object):
+class TestFloatExceptions:
     def assert_raises_fpe(self, fpeerr, flop, x, y):
         ftype = type(x)
         try:
@@ -631,7 +631,7 @@ class TestFloatExceptions(object):
                 assert_("underflow" in str(w[-1].message))
 
 
-class TestTypes(object):
+class TestTypes:
     def check_promotion_cases(self, promote_func):
         # tests that the scalars get coerced correctly.
         b = np.bool_(0)
@@ -952,7 +952,7 @@ class NIterError(Exception):
     pass
 
 
-class TestFromiter(object):
+class TestFromiter:
     def makegen(self):
         for x in range(24):
             yield x**2
@@ -1003,7 +1003,7 @@ class TestFromiter(object):
                           self.load_data(count, eindex), dtype=int, count=count)
 
 
-class TestNonzero(object):
+class TestNonzero:
     def test_nonzero_trivial(self):
         assert_equal(np.count_nonzero(np.array([])), 0)
         assert_equal(np.count_nonzero(np.array([], dtype='?')), 0)
@@ -1286,7 +1286,7 @@ class TestNonzero(object):
         assert_raises(ValueError, np.nonzero, a)
 
 
-class TestIndex(object):
+class TestIndex:
     def test_boolean(self):
         a = rand(3, 5, 8)
         V = rand(5, 8)
@@ -1303,7 +1303,7 @@ class TestIndex(object):
         assert_equal(c.dtype, np.dtype('int32'))
 
 
-class TestBinaryRepr(object):
+class TestBinaryRepr:
     def test_zero(self):
         assert_equal(np.binary_repr(0), '0')
 
@@ -1345,7 +1345,7 @@ class TestBinaryRepr(object):
                      '11' + '0'*62)
 
 
-class TestBaseRepr(object):
+class TestBaseRepr:
     def test_base3(self):
         assert_equal(np.base_repr(3**5, 3), '100000')
 
@@ -1367,7 +1367,7 @@ class TestBaseRepr(object):
             np.base_repr(1, 37)
 
 
-class TestArrayComparisons(object):
+class TestArrayComparisons:
     def test_array_equal(self):
         res = np.array_equal(np.array([1, 2]), np.array([1, 2]))
         assert_(res)
@@ -1446,7 +1446,7 @@ def assert_array_strict_equal(x, y):
     assert_(x.dtype.isnative == y.dtype.isnative)
 
 
-class TestClip(object):
+class TestClip:
     def setup(self):
         self.nr = 5
         self.nc = 3
@@ -2020,7 +2020,7 @@ class TestClip(object):
         assert_equal(actual, expected)
 
 
-class TestAllclose(object):
+class TestAllclose:
     rtol = 1e-5
     atol = 1e-8
 
@@ -2105,7 +2105,7 @@ class TestAllclose(object):
         assert_(type(np.allclose(a, a)) is bool)
 
 
-class TestIsclose(object):
+class TestIsclose:
     rtol = 1e-5
     atol = 1e-8
 
@@ -2243,7 +2243,7 @@ class TestIsclose(object):
         assert_(type(np.isclose(0, np.inf)) is np.bool_)
 
 
-class TestStdVar(object):
+class TestStdVar:
     def setup(self):
         self.A = np.array([1, -1, 1, -1])
         self.real_var = 1
@@ -2282,7 +2282,7 @@ class TestStdVar(object):
         assert_array_equal(r, out)
 
 
-class TestStdVarComplex(object):
+class TestStdVarComplex:
     def test_basic(self):
         A = np.array([1, 1.j, -1, -1.j])
         real_var = 1
@@ -2294,7 +2294,7 @@ class TestStdVarComplex(object):
         assert_equal(np.std(1j), 0)
 
 
-class TestCreationFuncs(object):
+class TestCreationFuncs:
     # Test ones, zeros, empty and full.
 
     def setup(self):
@@ -2365,7 +2365,7 @@ class TestCreationFuncs(object):
         assert_(sys.getrefcount(dim) == beg)
 
 
-class TestLikeFuncs(object):
+class TestLikeFuncs:
     '''Test ones_like, zeros_like, empty_like and full_like'''
 
     def setup(self):
@@ -2515,7 +2515,7 @@ class TestLikeFuncs(object):
         self.check_like_function(np.full_like, np.inf, True)
 
 
-class TestCorrelate(object):
+class TestCorrelate:
     def _setup(self, dt):
         self.x = np.array([1, 2, 3, 4, 5], dtype=dt)
         self.xs = np.arange(1, 20)[::3]
@@ -2571,7 +2571,7 @@ class TestCorrelate(object):
         with pytest.raises(ValueError):
             np.correlate(np.ones(1000), np.array([]), mode='full')
 
-class TestConvolve(object):
+class TestConvolve:
     def test_object(self):
         d = [1.] * 100
         k = [1.] * 3
@@ -2585,7 +2585,7 @@ class TestConvolve(object):
         assert_array_equal(k, np.ones(3))
 
 
-class TestArgwhere(object):
+class TestArgwhere:
 
     @pytest.mark.parametrize('nd', [0, 1, 2])
     def test_nd(self, nd):
@@ -2622,7 +2622,7 @@ class TestArgwhere(object):
         assert_equal(np.argwhere([4, 0, 2, 1, 3]), [[0], [2], [3], [4]])
 
 
-class TestStringFunction(object):
+class TestStringFunction:
 
     def test_set_string_function(self):
         a = np.array([1])
@@ -2637,7 +2637,7 @@ class TestStringFunction(object):
         assert_equal(str(a), "[1]")
 
 
-class TestRoll(object):
+class TestRoll:
     def test_roll1d(self):
         x = np.arange(10)
         xr = np.roll(x, 2)
@@ -2695,7 +2695,7 @@ class TestRoll(object):
         assert_equal(np.roll(x, 1), np.array([]))
 
 
-class TestRollaxis(object):
+class TestRollaxis:
 
     # expected shape indexed by (axis, start) for array of
     # shape (1, 2, 3, 4)
@@ -2757,7 +2757,7 @@ class TestRollaxis(object):
             assert_(not res.flags['OWNDATA'])
 
 
-class TestMoveaxis(object):
+class TestMoveaxis:
     def test_move_to_end(self):
         x = np.random.randn(5, 6, 7)
         for source, expected in [(0, (6, 7, 5)),
@@ -2831,7 +2831,7 @@ class TestMoveaxis(object):
         assert_(isinstance(result, np.ndarray))
 
 
-class TestCross(object):
+class TestCross:
     def test_2x2(self):
         u = [1, 2]
         v = [3, 4]
@@ -2920,7 +2920,7 @@ def test_outer_out_param():
     assert_equal(np.outer(arr2, arr3, out2), out2)
 
 
-class TestIndices(object):
+class TestIndices:
 
     def test_simple(self):
         [x, y] = np.indices((4, 3))
@@ -2961,7 +2961,7 @@ class TestIndices(object):
             assert_(arr.dtype == dtype)
 
 
-class TestRequire(object):
+class TestRequire:
     flag_names = ['C', 'C_CONTIGUOUS', 'CONTIGUOUS',
                   'F', 'F_CONTIGUOUS', 'FORTRAN',
                   'A', 'ALIGNED',
@@ -3035,7 +3035,7 @@ class TestRequire(object):
             self.set_and_check_flag(flag, None, a)
 
 
-class TestBroadcast(object):
+class TestBroadcast:
     def test_broadcast_in_args(self):
         # gh-5881
         arrs = [np.empty((6, 7)), np.empty((5, 6, 1)), np.empty((7,)),
@@ -3086,7 +3086,7 @@ class TestBroadcast(object):
 
         assert_raises(ValueError, np.broadcast, 1, **{'x': 1})
 
-class TestKeepdims(object):
+class TestKeepdims:
 
     class sub_array(np.ndarray):
         def sum(self, axis=None, dtype=None, out=None):
@@ -3098,7 +3098,7 @@ class TestKeepdims(object):
         assert_raises(TypeError, np.sum, x, keepdims=True)
 
 
-class TestTensordot(object):
+class TestTensordot:
 
     def test_zero_dimension(self):
         # Test resolution to issue #5663

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -98,7 +98,7 @@ def normalize_descr(descr):
 #    Creation tests
 ############################################################
 
-class CreateZeros(object):
+class CreateZeros:
     """Check the creation of heterogeneous arrays zero-valued"""
 
     def test_zeros0D(self):
@@ -141,7 +141,7 @@ class TestCreateZerosNested(CreateZeros):
     _descr = Ndescr
 
 
-class CreateValues(object):
+class CreateValues:
     """Check the creation of heterogeneous arrays with values"""
 
     def test_tuple(self):
@@ -201,7 +201,7 @@ class TestCreateValuesNestedMultiple(CreateValues):
 #    Reading tests
 ############################################################
 
-class ReadValuesPlain(object):
+class ReadValuesPlain:
     """Check the reading of values in heterogeneous arrays (plain)"""
 
     def test_access_fields(self):
@@ -233,7 +233,7 @@ class TestReadValuesPlainMultiple(ReadValuesPlain):
     multiple_rows = 1
     _buffer = PbufferT
 
-class ReadValuesNested(object):
+class ReadValuesNested:
     """Check the reading of values in heterogeneous arrays (nested)"""
 
     def test_access_top_fields(self):
@@ -331,14 +331,14 @@ class TestReadValuesNestedMultiple(ReadValuesNested):
     multiple_rows = True
     _buffer = NbufferT
 
-class TestEmptyField(object):
+class TestEmptyField:
     def test_assign(self):
         a = np.arange(10, dtype=np.float32)
         a.dtype = [("int",   "<0i4"), ("float", "<2f4")]
         assert_(a['int'].shape == (5, 0))
         assert_(a['float'].shape == (5, 2))
 
-class TestCommonType(object):
+class TestCommonType:
     def test_scalar_loses1(self):
         res = np.find_common_type(['f4', 'f4', 'i2'], ['f8'])
         assert_(res == 'f4')
@@ -359,7 +359,7 @@ class TestCommonType(object):
         res = np.find_common_type(['u8', 'i8', 'i8'], ['f8'])
         assert_(res == 'f8')
 
-class TestMultipleFields(object):
+class TestMultipleFields:
     def setup(self):
         self.ary = np.array([(1, 2, 3, 4), (5, 6, 7, 8)], dtype='i4,f4,i2,c8')
 
@@ -374,7 +374,7 @@ class TestMultipleFields(object):
         assert_(res == [(1, 3), (5, 7)])
 
 
-class TestIsSubDType(object):
+class TestIsSubDType:
     # scalar types can be promoted into dtypes
     wrappers = [np.dtype, lambda x: x]
 
@@ -405,18 +405,18 @@ class TestIsSubDType(object):
             assert_(not np.issubdtype(w1(np.float64), w2(np.float32)))
 
 
-class TestSctypeDict(object):
+class TestSctypeDict:
     def test_longdouble(self):
         assert_(np.sctypeDict['f8'] is not np.longdouble)
         assert_(np.sctypeDict['c16'] is not np.clongdouble)
 
 
-class TestBitName(object):
+class TestBitName:
     def test_abstract(self):
         assert_raises(ValueError, np.core.numerictypes.bitname, np.floating)
 
 
-class TestMaximumSctype(object):
+class TestMaximumSctype:
 
     # note that parametrizing with sctype['int'] and similar would skip types
     # with the same size (gh-11923)
@@ -442,7 +442,7 @@ class TestMaximumSctype(object):
         assert_equal(np.maximum_sctype(t), t)
 
 
-class Test_sctype2char(object):
+class Test_sctype2char:
     # This function is old enough that we're really just documenting the quirks
     # at this point.
 
@@ -490,7 +490,7 @@ def test_issctype(rep, expected):
 @pytest.mark.skipif(sys.flags.optimize > 1,
                     reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")
 @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
-class TestDocStrings(object):
+class TestDocStrings:
     def test_platform_dependent_aliases(self):
         if np.int64 is np.int_:
             assert_('int64' in np.int_.__doc__)

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -34,7 +34,7 @@ def dispatched_two_arg(array1, array2):
     return 'original'
 
 
-class TestGetImplementingArgs(object):
+class TestGetImplementingArgs:
 
     def test_ndarray(self):
         array = np.array(1)
@@ -75,7 +75,7 @@ class TestGetImplementingArgs(object):
 
     def test_ndarray_and_duck_array(self):
 
-        class Other(object):
+        class Other:
             __array_function__ = _return_not_implemented
 
         array = np.array(1)
@@ -92,7 +92,7 @@ class TestGetImplementingArgs(object):
         class OverrideSub(np.ndarray):
             __array_function__ = _return_not_implemented
 
-        class Other(object):
+        class Other:
             __array_function__ = _return_not_implemented
 
         array = np.array(1)
@@ -106,7 +106,7 @@ class TestGetImplementingArgs(object):
 
     def test_many_duck_arrays(self):
 
-        class A(object):
+        class A:
             __array_function__ = _return_not_implemented
 
         class B(A):
@@ -115,7 +115,7 @@ class TestGetImplementingArgs(object):
         class C(A):
             __array_function__ = _return_not_implemented
 
-        class D(object):
+        class D:
             __array_function__ = _return_not_implemented
 
         a = A()
@@ -145,12 +145,12 @@ class TestGetImplementingArgs(object):
             _get_implementing_args(relevant_args)
 
 
-class TestNDArrayArrayFunction(object):
+class TestNDArrayArrayFunction:
 
     @requires_array_function
     def test_method(self):
 
-        class Other(object):
+        class Other:
             __array_function__ = _return_not_implemented
 
         class NoOverrideSub(np.ndarray):
@@ -207,7 +207,7 @@ class TestNDArrayArrayFunction(object):
 
 
 @requires_array_function
-class TestArrayFunctionDispatch(object):
+class TestArrayFunctionDispatch:
 
     def test_pickle(self):
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
@@ -222,7 +222,7 @@ class TestArrayFunctionDispatch(object):
 
     def test_interface(self):
 
-        class MyArray(object):
+        class MyArray:
             def __array_function__(self, func, types, args, kwargs):
                 return (self, func, types, args, kwargs)
 
@@ -237,7 +237,7 @@ class TestArrayFunctionDispatch(object):
 
     def test_not_implemented(self):
 
-        class MyArray(object):
+        class MyArray:
             def __array_function__(self, func, types, args, kwargs):
                 return NotImplemented
 
@@ -247,7 +247,7 @@ class TestArrayFunctionDispatch(object):
 
 
 @requires_array_function
-class TestVerifyMatchingSignatures(object):
+class TestVerifyMatchingSignatures:
 
     def test_verify_matching_signatures(self):
 
@@ -281,7 +281,7 @@ def _new_duck_type_and_implements():
     """Create a duck array type and implements functions."""
     HANDLED_FUNCTIONS = {}
 
-    class MyArray(object):
+    class MyArray:
         def __array_function__(self, func, types, args, kwargs):
             if func not in HANDLED_FUNCTIONS:
                 return NotImplemented
@@ -300,7 +300,7 @@ def _new_duck_type_and_implements():
 
 
 @requires_array_function
-class TestArrayFunctionImplementation(object):
+class TestArrayFunctionImplementation:
 
     def test_one_arg(self):
         MyArray, implements = _new_duck_type_and_implements()
@@ -353,7 +353,7 @@ class TestArrayFunctionImplementation(object):
             func(MyArray())
 
 
-class TestNDArrayMethods(object):
+class TestNDArrayMethods:
 
     def test_repr(self):
         # gh-12162: should still be defined even if __array_function__ doesn't
@@ -368,7 +368,7 @@ class TestNDArrayMethods(object):
         assert_equal(str(array), '1')
 
 
-class TestNumPyFunctions(object):
+class TestNumPyFunctions:
 
     def test_set_module(self):
         assert_equal(np.sum.__module__, 'numpy')

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -18,7 +18,7 @@ from numpy.testing import (
 from numpy.compat import pickle
 
 
-class TestFromrecords(object):
+class TestFromrecords:
     def test_fromrecords(self):
         r = np.rec.fromrecords([[456, 'dbe', 1.2], [2, 'de', 1.3]],
                             names='col1,col2,col3')
@@ -324,7 +324,7 @@ class TestFromrecords(object):
 
 
 @pytest.mark.skipif(Path is None, reason="No pathlib.Path")
-class TestPathUsage(object):
+class TestPathUsage:
     # Test that pathlib.Path can be used
     def test_tofile_fromfile(self):
         with temppath(suffix='.bin') as path:
@@ -340,7 +340,7 @@ class TestPathUsage(object):
             assert_array_equal(x, a)
 
 
-class TestRecord(object):
+class TestRecord:
     def setup(self):
         self.data = np.rec.fromrecords([(1, 2, 3), (4, 5, 6)],
                             dtype=[("col1", "<i4"),

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -22,7 +22,7 @@ try:
 except NameError:
     RecursionError = RuntimeError  # python < 3.5
 
-class TestRegression(object):
+class TestRegression:
     def test_invalid_round(self):
         # Ticket #3
         v = 4.7599999999999998
@@ -426,7 +426,7 @@ class TestRegression(object):
 
     def test_lexsort_invalid_sequence(self):
         # Issue gh-4123
-        class BuggySequence(object):
+        class BuggySequence:
             def __len__(self):
                 return 4
 
@@ -1039,7 +1039,7 @@ class TestRegression(object):
 
     def test_mem_custom_float_to_array(self):
         # Ticket 702
-        class MyFloat(object):
+        class MyFloat:
             def __float__(self):
                 return 1.0
 
@@ -1048,7 +1048,7 @@ class TestRegression(object):
 
     def test_object_array_refcount_self_assign(self):
         # Ticket #711
-        class VictimObject(object):
+        class VictimObject:
             deleted = False
 
             def __del__(self):
@@ -2231,7 +2231,7 @@ class TestRegression(object):
         import operator as op
 
         # dummy class where __array__ throws exception
-        class Foo(object):
+        class Foo:
             __array_priority__ = 1002
 
             def __array__(self, *args, **kwargs):
@@ -2480,7 +2480,7 @@ class TestRegression(object):
             assert_equal(pickle.loads(dumped), arr)
 
     def test_bad_array_interface(self):
-        class T(object):
+        class T:
             __array_interface__ = {}
 
         np.array([T()])

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -10,7 +10,7 @@ from numpy.testing import (
     assert_equal, assert_almost_equal, assert_raises, assert_warns,
     )
 
-class TestFromString(object):
+class TestFromString:
     def test_floating(self):
         # Ticket #640, floats from string
         fsingle = np.single('1.234')
@@ -54,7 +54,7 @@ class TestFromString(object):
         assert_equal(255, np.intp('0xFF', 16))
 
 
-class TestFromInt(object):
+class TestFromInt:
     def test_intp(self):
         # Ticket #99
         assert_equal(1024, np.intp(1024))

--- a/numpy/core/tests/test_scalar_methods.py
+++ b/numpy/core/tests/test_scalar_methods.py
@@ -14,7 +14,7 @@ from numpy.testing import (
     dec
 )
 
-class TestAsIntegerRatio(object):
+class TestAsIntegerRatio:
     # derived in part from the cpython test "test_floatasratio"
 
     @pytest.mark.parametrize("ftype", [

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -33,7 +33,7 @@ scalars_only, codes_only = zip(*scalars_and_codes)
 
 @pytest.mark.skipif(sys.version_info.major < 3,
                     reason="Python 2 scalars lack a buffer interface")
-class TestScalarPEP3118(object):
+class TestScalarPEP3118:
 
     @pytest.mark.parametrize('scalar', scalars_only, ids=codes_only)
     def test_scalar_match_array(self, scalar):

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_
 
 
-class A(object):
+class A:
     pass
 class B(A, np.float64):
     pass
@@ -21,7 +21,7 @@ class B0(np.float64, A):
 class C0(B0):
     pass
 
-class TestInherit(object):
+class TestInherit:
     def test_init(self):
         x = B(1.0)
         assert_(str(x) == '1.0')
@@ -37,7 +37,7 @@ class TestInherit(object):
         assert_(str(y) == '2.0')
 
 
-class TestCharacter(object):
+class TestCharacter:
     def test_char_radd(self):
         # GH issue 9620, reached gentype_add and raise TypeError
         np_s = np.string_('abc')

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -23,7 +23,7 @@ complex_floating_types = np.complexfloating.__subclasses__()
 
 # This compares scalarmath against ufuncs.
 
-class TestTypes(object):
+class TestTypes:
     def test_types(self):
         for atype in types:
             a = atype(1)
@@ -62,7 +62,7 @@ class TestTypes(object):
             np.add(1, 1)
 
 
-class TestBaseMath(object):
+class TestBaseMath:
     def test_blocked(self):
         # test alignments offsets for simd instructions
         # alignments for vz + 2 * (vs - 1) + 1
@@ -108,7 +108,7 @@ class TestBaseMath(object):
         np.add(d, np.ones_like(d))
 
 
-class TestPower(object):
+class TestPower:
     def test_small_types(self):
         for t in [np.int8, np.int16, np.float16]:
             a = t(3)
@@ -200,7 +200,7 @@ def _signs(dt):
         return (+1, -1)
 
 
-class TestModulus(object):
+class TestModulus:
 
     def test_modulus_basic(self):
         dt = np.typecodes['AllInteger'] + np.typecodes['Float']
@@ -302,7 +302,7 @@ class TestModulus(object):
             a //= b
 
 
-class TestComplexDivision(object):
+class TestComplexDivision:
     def test_zero_division(self):
         with np.errstate(all="ignore"):
             for t in [np.complex64, np.complex128]:
@@ -374,7 +374,7 @@ class TestComplexDivision(object):
                     assert_equal(result.imag, ex[1])
 
 
-class TestConversion(object):
+class TestConversion:
     def test_int_from_long(self):
         l = [1e6, 1e12, 1e18, -1e6, -1e12, -1e18]
         li = [10**6, 10**12, 10**18, -10**6, -10**12, -10**18]
@@ -510,7 +510,7 @@ class TestConversion(object):
         assert_(np.equal(np.datetime64('NaT'), None))
 
 
-#class TestRepr(object):
+#class TestRepr:
 #    def test_repr(self):
 #        for t in types:
 #            val = t(1197346475.0137341)
@@ -519,7 +519,7 @@ class TestConversion(object):
 #            assert_equal( val, val2 )
 
 
-class TestRepr(object):
+class TestRepr:
     def _test_type_repr(self, t):
         finfo = np.finfo(t)
         last_fraction_bit_idx = finfo.nexp + finfo.nmant
@@ -554,7 +554,7 @@ class TestRepr(object):
 
 if not IS_PYPY:
     # sys.getsizeof() is not valid on PyPy
-    class TestSizeOf(object):
+    class TestSizeOf:
 
         def test_equal_nbytes(self):
             for type in types:
@@ -566,7 +566,7 @@ if not IS_PYPY:
             assert_raises(TypeError, d.__sizeof__, "a")
 
 
-class TestMultiply(object):
+class TestMultiply:
     def test_seq_repeat(self):
         # Test that basic sequences get repeated when multiplied with
         # numpy integers. And errors are raised when multiplied with others.
@@ -603,7 +603,7 @@ class TestMultiply(object):
         # Test that an array-like which does not know how to be multiplied
         # does not attempt sequence repeat (raise TypeError).
         # See also gh-7428.
-        class ArrayLike(object):
+        class ArrayLike:
             def __init__(self, arr):
                 self.arr = arr
             def __array__(self):
@@ -617,7 +617,7 @@ class TestMultiply(object):
             assert_array_equal(np.int_(3) * arr_like, np.full(3, 3))
 
 
-class TestNegative(object):
+class TestNegative:
     def test_exceptions(self):
         a = np.ones((), dtype=np.bool_)[()]
         assert_raises(TypeError, operator.neg, a)
@@ -631,7 +631,7 @@ class TestNegative(object):
                 assert_equal(operator.neg(a) + a, 0)
 
 
-class TestSubtract(object):
+class TestSubtract:
     def test_exceptions(self):
         a = np.ones((), dtype=np.bool_)[()]
         assert_raises(TypeError, operator.sub, a, a)
@@ -645,7 +645,7 @@ class TestSubtract(object):
                 assert_equal(operator.sub(a, a), 0)
 
 
-class TestAbs(object):
+class TestAbs:
     def _test_abs_func(self, absfunc):
         for tp in floating_types + complex_floating_types:
             x = tp(-1.5)
@@ -674,7 +674,7 @@ class TestAbs(object):
         self._test_abs_func(np.abs)
 
 
-class TestBitShifts(object):
+class TestBitShifts:
 
     @pytest.mark.parametrize('type_code', np.typecodes['AllInteger'])
     @pytest.mark.parametrize('op',

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryFile
 import numpy as np
 from numpy.testing import assert_, assert_equal, suppress_warnings
 
-class TestRealScalars(object):
+class TestRealScalars:
     def test_str(self):
         svals = [0.0, -0.0, 1, -1, np.inf, -np.inf, np.nan]
         styps = [np.float16, np.float32, np.float64, np.longdouble]

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -14,7 +14,7 @@ from numpy.testing import (
 
 from numpy.compat import long
 
-class TestAtleast1d(object):
+class TestAtleast1d:
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -55,7 +55,7 @@ class TestAtleast1d(object):
         assert_(atleast_1d([[2, 3], [4, 5]]).shape == (2, 2))
 
 
-class TestAtleast2d(object):
+class TestAtleast2d:
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -94,7 +94,7 @@ class TestAtleast2d(object):
         assert_(atleast_2d([[[3, 1], [4, 5]], [[3, 5], [1, 2]]]).shape == (2, 2, 2))
 
 
-class TestAtleast3d(object):
+class TestAtleast3d:
     def test_0D_array(self):
         a = array(1)
         b = array(2)
@@ -126,7 +126,7 @@ class TestAtleast3d(object):
         assert_array_equal(res, desired)
 
 
-class TestHstack(object):
+class TestHstack:
     def test_non_iterable(self):
         assert_raises(TypeError, hstack, 1)
 
@@ -163,7 +163,7 @@ class TestHstack(object):
                 hstack(map(lambda x: x, np.ones((3, 2))))
 
 
-class TestVstack(object):
+class TestVstack:
     def test_non_iterable(self):
         assert_raises(TypeError, vstack, 1)
 
@@ -203,7 +203,7 @@ class TestVstack(object):
             vstack((np.arange(3) for _ in range(2)))
 
 
-class TestConcatenate(object):
+class TestConcatenate:
     def test_returns_copy(self):
         a = np.eye(3)
         b = np.concatenate([a])
@@ -407,7 +407,7 @@ def test_stack():
     assert_array_equal(result, np.array([0, 1, 2]))
 
 
-class TestBlock(object):
+class TestBlock:
     @pytest.fixture(params=['block', 'force_concatenate', 'force_slicing'])
     def block(self, request):
         # blocking small arrays and large arrays go through different paths.
@@ -705,7 +705,7 @@ class TestBlock(object):
 
 
 def test_block_dispatcher():
-    class ArrayLike(object):
+    class ArrayLike:
         pass
     a = ArrayLike()
     b = ArrayLike()

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -21,7 +21,7 @@ UNARY_UFUNCS = [obj for obj in np.core.umath.__dict__.values()
 UNARY_OBJECT_UFUNCS = [uf for uf in UNARY_UFUNCS if "O->O" in uf.types]
 
 
-class TestUfuncKwargs(object):
+class TestUfuncKwargs:
     def test_kwarg_exact(self):
         assert_raises(TypeError, np.add, 1, 2, castingx='safe')
         assert_raises(TypeError, np.add, 1, 2, dtypex=int)
@@ -47,7 +47,7 @@ class TestUfuncKwargs(object):
         assert_raises(TypeError, np.add, 1, 2, extobj=[4096], parrot=True)
 
 
-class TestUfuncGenericLoops(object):
+class TestUfuncGenericLoops:
     """Test generic loops.
 
     The loops to be tested are:
@@ -116,7 +116,7 @@ class TestUfuncGenericLoops(object):
         assert_equal(ys.dtype, output_dtype)
 
     # class to use in testing object method loops
-    class foo(object):
+    class foo:
         def conjugate(self):
             return np.bool_(1)
 
@@ -177,7 +177,7 @@ class TestUfuncGenericLoops(object):
                 assert_array_equal(res_num.astype("O"), res_obj)
 
 
-class TestUfunc(object):
+class TestUfunc:
     def test_pickle(self):
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
             assert_(pickle.loads(pickle.dumps(np.sin,
@@ -1121,7 +1121,7 @@ class TestUfunc(object):
         assert_equal(np.logical_and.reduce(a), None)
 
     def test_object_comparison(self):
-        class HasComparisons(object):
+        class HasComparisons:
             def __eq__(self, other):
                 return '=='
 
@@ -1590,7 +1590,7 @@ class TestUfunc(object):
 
     def test_custom_array_like(self):
 
-        class MyThing(object):
+        class MyThing:
             __array_priority__ = 1000
 
             rmul_count = 0

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -21,7 +21,7 @@ def on_powerpc():
            platform.machine().startswith('ppc')
 
 
-class _FilterInvalids(object):
+class _FilterInvalids:
     def setup(self):
         self.olderr = np.seterr(invalid='ignore')
 
@@ -29,7 +29,7 @@ class _FilterInvalids(object):
         np.seterr(**self.olderr)
 
 
-class TestConstants(object):
+class TestConstants:
     def test_pi(self):
         assert_allclose(ncu.pi, 3.141592653589793, 1e-15)
 
@@ -40,7 +40,7 @@ class TestConstants(object):
         assert_allclose(ncu.euler_gamma, 0.5772156649015329, 1e-15)
 
 
-class TestOut(object):
+class TestOut:
     def test_out_subok(self):
         for subok in (True, False):
             a = np.array(0.5)
@@ -166,7 +166,7 @@ class TestOut(object):
                 r1, r2 = np.frexp(d, out=o1, subok=subok)
 
 
-class TestComparisons(object):
+class TestComparisons:
     def test_ignore_object_identity_in_equal(self):
         # Check comparing identical objects whose comparison
         # is not a simple boolean, e.g., arrays that are compared elementwise.
@@ -174,7 +174,7 @@ class TestComparisons(object):
         assert_raises(ValueError, np.equal, a, a)
 
         # Check error raised when comparing identical non-comparable objects.
-        class FunkyType(object):
+        class FunkyType:
             def __eq__(self, other):
                 raise TypeError("I won't compare")
 
@@ -192,7 +192,7 @@ class TestComparisons(object):
         assert_raises(ValueError, np.not_equal, a, a)
 
         # Check error raised when comparing identical non-comparable objects.
-        class FunkyType(object):
+        class FunkyType:
             def __ne__(self, other):
                 raise TypeError("I won't compare")
 
@@ -204,7 +204,7 @@ class TestComparisons(object):
         assert_equal(np.not_equal(a, a), [True])
 
 
-class TestAdd(object):
+class TestAdd:
     def test_reduce_alignment(self):
         # gh-9876
         # make sure arrays with weird strides work with the optimizations in
@@ -215,7 +215,7 @@ class TestAdd(object):
         assert_equal(a['b'].sum(), 0)
 
 
-class TestDivision(object):
+class TestDivision:
     def test_division_int(self):
         # int division should follow Python
         x = np.array([5, 10, 90, 100, -5, -10, -90, -100, -120])
@@ -282,7 +282,7 @@ def _signs(dt):
         return (+1, -1)
 
 
-class TestRemainder(object):
+class TestRemainder:
 
     def test_remainder_basic(self):
         dt = np.typecodes['AllInteger'] + np.typecodes['Float']
@@ -373,7 +373,7 @@ class TestRemainder(object):
                 assert_(np.isnan(rem), 'dt: %s, rem: %s' % (dt, rem))
 
 
-class TestCbrt(object):
+class TestCbrt:
     def test_cbrt_scalar(self):
         assert_almost_equal((np.cbrt(np.float32(-2.5)**3)), -2.5)
 
@@ -386,7 +386,7 @@ class TestCbrt(object):
         assert_equal(np.cbrt(-np.inf), -np.inf)
 
 
-class TestPower(object):
+class TestPower:
     def test_power_float(self):
         x = np.array([1., 2., 3.])
         assert_equal(x**0, [1., 1., 1.])
@@ -525,7 +525,7 @@ class TestPower(object):
             assert_raises(ValueError, np.power, one, minusone)
 
 
-class TestFloat_power(object):
+class TestFloat_power:
     def test_type_conversion(self):
         arg_type = '?bhilBHILefdgFDG'
         res_type = 'ddddddddddddgDDG'
@@ -536,7 +536,7 @@ class TestFloat_power(object):
             assert_(res.dtype.name == np.dtype(dtout).name, msg)
 
 
-class TestLog2(object):
+class TestLog2:
     def test_log2_values(self):
         x = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
         y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -567,7 +567,7 @@ class TestLog2(object):
             assert_(w[2].category is RuntimeWarning)
 
 
-class TestExp2(object):
+class TestExp2:
     def test_exp2_values(self):
         x = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
         y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -619,7 +619,7 @@ class TestLogAddExp2(_FilterInvalids):
         assert_(np.isnan(np.logaddexp2(np.nan, np.nan)))
 
 
-class TestLog(object):
+class TestLog:
     def test_log_values(self):
         x = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
         y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -630,7 +630,7 @@ class TestLog(object):
             assert_almost_equal(np.log(xf), yf)
 
 
-class TestExp(object):
+class TestExp:
     def test_exp_values(self):
         x = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
         y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -640,7 +640,7 @@ class TestExp(object):
             yf = np.array(y, dtype=dt)*log2_
             assert_almost_equal(np.exp(yf), xf)
 
-class TestSpecialFloats(object):
+class TestSpecialFloats:
     def test_exp_values(self):
         x = [np.nan,  np.nan, np.inf, 0.]
         y = [np.nan, -np.nan, np.inf, -np.inf]
@@ -742,7 +742,7 @@ avx_ufuncs = {'sqrt'        :[1,  0.,   100.],
               'ceil'        :[0, -100., 100.],
               'trunc'       :[0, -100., 100.]}
 
-class TestAVXUfuncs(object):
+class TestAVXUfuncs:
     def test_avx_based_ufunc(self):
         strides = np.array([-4,-3,-2,-1,1,2,3,4])
         np.random.seed(42)
@@ -774,7 +774,7 @@ class TestAVXUfuncs(object):
                         assert_equal(myfunc(x_f64[::jj]), y_true64[::jj])
                         assert_equal(myfunc(x_f32[::jj]), y_true32[::jj])
 
-class TestAVXFloat32Transcendental(object):
+class TestAVXFloat32Transcendental:
     def test_exp_float32(self):
         np.random.seed(42)
         x_f32 = np.float32(np.random.uniform(low=0.0,high=88.1,size=1000000))
@@ -860,7 +860,7 @@ class TestLogAddExp(_FilterInvalids):
         assert_equal(np.logaddexp.reduce([]), -np.inf)
 
 
-class TestLog1p(object):
+class TestLog1p:
     def test_log1p(self):
         assert_almost_equal(ncu.log1p(0.2), ncu.log(1.2))
         assert_almost_equal(ncu.log1p(1e-6), ncu.log(1+1e-6))
@@ -874,7 +874,7 @@ class TestLog1p(object):
             assert_equal(ncu.log1p(-np.inf), np.nan)
 
 
-class TestExpm1(object):
+class TestExpm1:
     def test_expm1(self):
         assert_almost_equal(ncu.expm1(0.2), ncu.exp(0.2)-1)
         assert_almost_equal(ncu.expm1(1e-6), ncu.exp(1e-6)-1)
@@ -893,7 +893,7 @@ class TestExpm1(object):
         assert_allclose(x, ncu.expm1(x))
 
 
-class TestHypot(object):
+class TestHypot:
     def test_simple(self):
         assert_almost_equal(ncu.hypot(1, 1), ncu.sqrt(2))
         assert_almost_equal(ncu.hypot(0, 0), 0)
@@ -917,7 +917,7 @@ def assert_hypot_isinf(x, y):
                 "hypot(%s, %s) is %s, not inf" % (x, y, ncu.hypot(x, y)))
 
 
-class TestHypotSpecialValues(object):
+class TestHypotSpecialValues:
     def test_nan_outputs(self):
         assert_hypot_isnan(np.nan, np.nan)
         assert_hypot_isnan(np.nan, 1)
@@ -954,7 +954,7 @@ def assert_arctan2_isnzero(x, y):
     assert_((ncu.arctan2(x, y) == 0 and np.signbit(ncu.arctan2(x, y))), "arctan(%s, %s) is %s, not -0" % (x, y, ncu.arctan2(x, y)))
 
 
-class TestArctan2SpecialValues(object):
+class TestArctan2SpecialValues:
     def test_one_one(self):
         # atan2(1, 1) returns pi/4.
         assert_almost_equal(ncu.arctan2(1, 1), 0.25 * np.pi)
@@ -1023,7 +1023,7 @@ class TestArctan2SpecialValues(object):
         assert_arctan2_isnan(np.nan, np.nan)
 
 
-class TestLdexp(object):
+class TestLdexp:
     def _check_ldexp(self, tp):
         assert_almost_equal(ncu.ldexp(np.array(2., np.float32),
                                       np.array(3, tp)), 16.)
@@ -1251,7 +1251,7 @@ class TestFmin(_FilterInvalids):
             assert_equal(np.fmin(arg1, arg2), out)
 
 
-class TestBool(object):
+class TestBool:
     def test_exceptions(self):
         a = np.ones(1, dtype=np.bool_)
         assert_raises(TypeError, np.negative, a)
@@ -1314,7 +1314,7 @@ class TestBool(object):
             assert_equal(np.logical_xor.reduce(arr), arr.sum() % 2 == 1)
 
 
-class TestBitwiseUFuncs(object):
+class TestBitwiseUFuncs:
 
     bitwise_types = [np.dtype(c) for c in '?' + 'bBhHiIlLqQ' + 'O']
 
@@ -1398,7 +1398,7 @@ class TestBitwiseUFuncs(object):
             assert_(type(f.reduce(btype)) is bool, msg)
 
 
-class TestInt(object):
+class TestInt:
     def test_logical_not(self):
         x = np.ones(10, dtype=np.int16)
         o = np.ones(10 * 2, dtype=bool)
@@ -1409,24 +1409,24 @@ class TestInt(object):
         assert_array_equal(o, tgt)
 
 
-class TestFloatingPoint(object):
+class TestFloatingPoint:
     def test_floating_point(self):
         assert_equal(ncu.FLOATING_POINT_SUPPORT, 1)
 
 
-class TestDegrees(object):
+class TestDegrees:
     def test_degrees(self):
         assert_almost_equal(ncu.degrees(np.pi), 180.0)
         assert_almost_equal(ncu.degrees(-0.5*np.pi), -90.0)
 
 
-class TestRadians(object):
+class TestRadians:
     def test_radians(self):
         assert_almost_equal(ncu.radians(180.0), np.pi)
         assert_almost_equal(ncu.radians(-90.0), -0.5*np.pi)
 
 
-class TestHeavside(object):
+class TestHeavside:
     def test_heaviside(self):
         x = np.array([[-30.0, -0.1, 0.0, 0.2], [7.5, np.nan, np.inf, -np.inf]])
         expectedhalf = np.array([[0.0, 0.0, 0.5, 1.0], [1.0, np.nan, 1.0, 0.0]])
@@ -1448,7 +1448,7 @@ class TestHeavside(object):
         assert_equal(h, expected1.astype(np.float32))
 
 
-class TestSign(object):
+class TestSign:
     def test_sign(self):
         a = np.array([np.inf, -np.inf, np.nan, 0.0, 3.0, -3.0])
         out = np.zeros(a.shape)
@@ -1479,7 +1479,7 @@ class TestSign(object):
 
         assert_raises(TypeError, test_nan)
 
-class TestMinMax(object):
+class TestMinMax:
     def test_minmax_blocked(self):
         # simd tests on max/min, test all alignments, slow but important
         # for 2 * vz + 2 * (vs - 1) + 1 (unrolled once)
@@ -1522,7 +1522,7 @@ class TestMinMax(object):
         assert_equal(a, np.nan)
 
 
-class TestAbsoluteNegative(object):
+class TestAbsoluteNegative:
     def test_abs_neg_blocked(self):
         # simd tests on abs, test all alignments for vz + 2 * (vs - 1) + 1
         for dt, sz in [(np.float32, 11), (np.float64, 5)]:
@@ -1564,7 +1564,7 @@ class TestAbsoluteNegative(object):
         np.abs(np.ones_like(d), out=d)
 
 
-class TestPositive(object):
+class TestPositive:
     def test_valid(self):
         valid_dtypes = [int, float, complex, object]
         for dtype in valid_dtypes:
@@ -1583,10 +1583,10 @@ class TestPositive(object):
             np.positive(np.array(['bar'], dtype=object))
 
 
-class TestSpecialMethods(object):
+class TestSpecialMethods:
     def test_wrap(self):
 
-        class with_wrap(object):
+        class with_wrap:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1690,7 +1690,7 @@ class TestSpecialMethods(object):
 
     def test_old_wrap(self):
 
-        class with_wrap(object):
+        class with_wrap:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1705,7 +1705,7 @@ class TestSpecialMethods(object):
 
     def test_priority(self):
 
-        class A(object):
+        class A:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1748,7 +1748,7 @@ class TestSpecialMethods(object):
 
     def test_failing_wrap(self):
 
-        class A(object):
+        class A:
             def __array__(self):
                 return np.zeros(2)
 
@@ -1780,7 +1780,7 @@ class TestSpecialMethods(object):
     def test_none_wrap(self):
         # Tests that issue #8507 is resolved. Previously, this would segfault
 
-        class A(object):
+        class A:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1792,7 +1792,7 @@ class TestSpecialMethods(object):
 
     def test_default_prepare(self):
 
-        class with_wrap(object):
+        class with_wrap:
             __array_priority__ = 10
 
             def __array__(self):
@@ -1838,7 +1838,7 @@ class TestSpecialMethods(object):
 
     def test_failing_prepare(self):
 
-        class A(object):
+        class A:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1850,7 +1850,7 @@ class TestSpecialMethods(object):
 
     def test_array_with_context(self):
 
-        class A(object):
+        class A:
             def __array__(self, dtype=None, context=None):
                 func, args, i = context
                 self.func = func
@@ -1858,11 +1858,11 @@ class TestSpecialMethods(object):
                 self.i = i
                 return np.zeros(1)
 
-        class B(object):
+        class B:
             def __array__(self, dtype=None):
                 return np.zeros(1, dtype)
 
-        class C(object):
+        class C:
             def __array__(self):
                 return np.zeros(1)
 
@@ -1877,7 +1877,7 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override(self):
         # check override works even with instance with high priority.
-        class A(object):
+        class A:
             def __array_ufunc__(self, func, method, *inputs, **kwargs):
                 return self, func, method, inputs, kwargs
 
@@ -1914,7 +1914,7 @@ class TestSpecialMethods(object):
         three_mul_ufunc = np.frompyfunc(tres_mul, 3, 1)
         four_mul_ufunc = np.frompyfunc(quatro_mul, 4, 1)
 
-        class A(object):
+        class A:
             def __array_ufunc__(self, func, method, *inputs, **kwargs):
                 return "A"
 
@@ -1922,11 +1922,11 @@ class TestSpecialMethods(object):
             def __array_ufunc__(self, func, method, *inputs, **kwargs):
                 return "ASub"
 
-        class B(object):
+        class B:
             def __array_ufunc__(self, func, method, *inputs, **kwargs):
                 return "B"
 
-        class C(object):
+        class C:
             def __init__(self):
                 self.count = 0
 
@@ -2038,7 +2038,7 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override_methods(self):
 
-        class A(object):
+        class A:
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 return self, ufunc, method, inputs, kwargs
 
@@ -2207,11 +2207,11 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override_out(self):
 
-        class A(object):
+        class A:
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 return kwargs
 
-        class B(object):
+        class B:
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 return kwargs
 
@@ -2263,7 +2263,7 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override_exception(self):
 
-        class A(object):
+        class A:
             def __array_ufunc__(self, *a, **kwargs):
                 raise ValueError("oops")
 
@@ -2274,7 +2274,7 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override_not_implemented(self):
 
-        class A(object):
+        class A:
             def __array_ufunc__(self, *args, **kwargs):
                 return NotImplemented
 
@@ -2291,7 +2291,7 @@ class TestSpecialMethods(object):
 
     def test_ufunc_override_disabled(self):
 
-        class OptOut(object):
+        class OptOut:
             __array_ufunc__ = None
 
         opt_out = OptOut()
@@ -2308,7 +2308,7 @@ class TestSpecialMethods(object):
         # opt-outs still hold even when other arguments have pathological
         # __array_ufunc__ implementations
 
-        class GreedyArray(object):
+        class GreedyArray:
             def __array_ufunc__(self, *args, **kwargs):
                 return self
 
@@ -2322,7 +2322,7 @@ class TestSpecialMethods(object):
     def test_gufunc_override(self):
         # gufunc are just ufunc instances, but follow a different path,
         # so check __array_ufunc__ overrides them properly.
-        class A(object):
+        class A:
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 return self, ufunc, method, inputs, kwargs
 
@@ -2404,7 +2404,7 @@ class TestSpecialMethods(object):
 
                 return results[0] if len(results) == 1 else results
 
-        class B(object):
+        class B:
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
                 if any(isinstance(input_, A) for input_ in inputs):
                     return "A!"
@@ -2523,14 +2523,14 @@ class TestSpecialMethods(object):
         assert_(a.info, {'inputs': [0, 2]})
 
 
-class TestChoose(object):
+class TestChoose:
     def test_mixed(self):
         c = np.array([True, True])
         a = np.array([True, True])
         assert_equal(np.choose(c, (a, 1)), np.array([1, 1]))
 
 
-class TestRationalFunctions(object):
+class TestRationalFunctions:
     def test_lcm(self):
         self._test_lcm_inner(np.int16)
         self._test_lcm_inner(np.uint16)
@@ -2629,7 +2629,7 @@ class TestRationalFunctions(object):
         assert_equal(np.gcd(2**100, 3**100), 1)
 
 
-class TestRoundingFunctions(object):
+class TestRoundingFunctions:
 
     def test_object_direct(self):
         """ test direct implementation of these magic methods """
@@ -2665,7 +2665,7 @@ class TestRoundingFunctions(object):
         assert_equal(np.trunc(f), -1)
 
 
-class TestComplexFunctions(object):
+class TestComplexFunctions:
     funcs = [np.arcsin,  np.arccos,  np.arctan, np.arcsinh, np.arccosh,
              np.arctanh, np.sin,     np.cos,    np.tan,     np.exp,
              np.exp2,    np.log,     np.sqrt,   np.log10,   np.log2,
@@ -2848,7 +2848,7 @@ class TestComplexFunctions(object):
             check(func, pts, 1+1j)
 
 
-class TestAttributes(object):
+class TestAttributes:
     def test_attributes(self):
         add = ncu.add
         assert_equal(add.__name__, 'add')
@@ -2867,7 +2867,7 @@ class TestAttributes(object):
             "frexp(x[, out1, out2], / [, out=(None, None)], *, where=True"))
 
 
-class TestSubclass(object):
+class TestSubclass:
 
     def test_subclass_op(self):
 

--- a/numpy/core/tests/test_umath_accuracy.py
+++ b/numpy/core/tests/test_umath_accuracy.py
@@ -28,7 +28,7 @@ files = ['umath-validation-set-exp',
          'umath-validation-set-sin',
          'umath-validation-set-cos']
 
-class TestAccuracy(object):
+class TestAccuracy:
     @pytest.mark.xfail(reason="Fails for MacPython/numpy-wheels builds")
     def test_validate_transcendentals(self):
         with np.errstate(all='ignore'):

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -29,7 +29,7 @@ platform_skip = pytest.mark.skipif(xfail_complex_tests,
 
 
 
-class TestCexp(object):
+class TestCexp:
     def test_simple(self):
         check = check_complex_value
         f = np.exp
@@ -129,7 +129,7 @@ class TestCexp(object):
 
         check(f, np.nan, 0, np.nan, 0)
 
-class TestClog(object):
+class TestClog:
     def test_simple(self):
         x = np.array([1+0j, 1+2j])
         y_r = np.log(np.abs(x)) + 1j * np.angle(x)
@@ -274,7 +274,7 @@ class TestClog(object):
                 assert_almost_equal(np.log(xa[i].conj()), ya[i].conj())
 
 
-class TestCsqrt(object):
+class TestCsqrt:
 
     def test_simple(self):
         # sqrt(1)
@@ -354,7 +354,7 @@ class TestCsqrt(object):
         # XXX: check for conj(csqrt(z)) == csqrt(conj(z)) (need to fix branch
         # cuts first)
 
-class TestCpow(object):
+class TestCpow:
     def setup(self):
         self.olderr = np.seterr(invalid='ignore')
 
@@ -394,7 +394,7 @@ class TestCpow(object):
         for i in lx:
             assert_almost_equal(n_r[i], p_r[i], err_msg='Loop %d\n' % i)
 
-class TestCabs(object):
+class TestCabs:
     def setup(self):
         self.olderr = np.seterr(invalid='ignore')
 
@@ -456,7 +456,7 @@ class TestCabs(object):
             ref = g(x[i], y[i])
             check_real_value(f, x[i], y[i], ref)
 
-class TestCarg(object):
+class TestCarg:
     def test_simple(self):
         check_real_value(ncu._arg, 1, 0, 0, False)
         check_real_value(ncu._arg, 0, 1, 0.5*np.pi, False)

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -65,7 +65,7 @@ def test_string_cast():
 #    Creation tests
 ############################################################
 
-class CreateZeros(object):
+class CreateZeros:
     """Check the creation of zero-valued arrays"""
 
     def content_check(self, ua, ua_scalar, nbytes):
@@ -117,7 +117,7 @@ class TestCreateZeros_1009(CreateZeros):
     ulen = 1009
 
 
-class CreateValues(object):
+class CreateValues:
     """Check the creation of unicode arrays with values"""
 
     def content_check(self, ua, ua_scalar, nbytes):
@@ -202,7 +202,7 @@ class TestCreateValues_1009_UCS4(CreateValues):
 #    Assignment tests
 ############################################################
 
-class AssignValues(object):
+class AssignValues:
     """Check the assignment of unicode arrays with values"""
 
     def content_check(self, ua, ua_scalar, nbytes):
@@ -292,7 +292,7 @@ class TestAssignValues_1009_UCS4(AssignValues):
 #    Byteorder tests
 ############################################################
 
-class ByteorderValues(object):
+class ByteorderValues:
     """Check the byteorder of unicode arrays in round-trip conversions"""
 
     def test_values0D(self):

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -493,7 +493,7 @@ class config(old_config):
         self._clean()
         return exitcode, output
 
-class GrabStdout(object):
+class GrabStdout:
 
     def __init__(self):
         self.sys_stdout = sys.stdout

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -65,7 +65,7 @@ def key_value_from_command(cmd, sep, successful_status=(0,),
             d[l[0]] = l[1]
     return d
 
-class CPUInfoBase(object):
+class CPUInfoBase:
     """Holds CPU information and provides methods for requiring
     the availability of various CPU features.
     """

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -4,7 +4,7 @@ from distutils.dist import Distribution
 
 __metaclass__ = type
 
-class EnvironmentConfig(object):
+class EnvironmentConfig:
     def __init__(self, distutils_section='ALL', **kw):
         self._distutils_section = distutils_section
         self._conf_keys = kw

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -49,7 +49,7 @@ __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'quote_args', 'get_build_architecture', 'get_info', 'get_pkg_info',
            'get_num_build_jobs']
 
-class InstallableLib(object):
+class InstallableLib:
     """
     Container to hold information on an installable library.
 
@@ -726,7 +726,7 @@ def get_frame(level=0):
 
 ######################
 
-class Configuration(object):
+class Configuration:
 
     _list_keys = ['packages', 'ext_modules', 'data_files', 'include_dirs',
                   'libraries', 'headers', 'scripts', 'py_modules',

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -76,7 +76,7 @@ def parse_flags(line):
 def _escape_backslash(val):
     return val.replace('\\', '\\\\')
 
-class LibraryInfo(object):
+class LibraryInfo:
     """
     Object containing build information about a library.
 
@@ -148,7 +148,7 @@ class LibraryInfo(object):
 
         return "\n".join(m)
 
-class VariableSet(object):
+class VariableSet:
     """
     Container object for the variables defined in a config file.
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -580,7 +580,7 @@ class UmfpackNotFoundError(NotFoundError):
     the UMFPACK environment variable."""
 
 
-class system_info(object):
+class system_info:
 
     """ get_info() is the only public method. Don't use others.
     """

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -13,7 +13,7 @@ if sys.version_info[0] >= 3:
 else:
     from StringIO import StringIO
 
-class redirect_stdout(object):
+class redirect_stdout:
     """Context manager to redirect stdout for exec_command test."""
     def __init__(self, stdout=None):
         self._stdout = stdout or sys.stdout
@@ -28,7 +28,7 @@ class redirect_stdout(object):
         # note: closing sys.stdout won't close it.
         self._stdout.close()
 
-class redirect_stderr(object):
+class redirect_stderr:
     """Context manager to redirect stderr for exec_command test."""
     def __init__(self, stderr=None):
         self._stderr = stderr or sys.stderr
@@ -43,7 +43,7 @@ class redirect_stderr(object):
         # note: closing sys.stderr won't close it.
         self._stderr.close()
 
-class emulate_nonposix(object):
+class emulate_nonposix:
     """Context manager to emulate os.name != 'posix' """
     def __init__(self, osname='non-posix'):
         self._new_name = osname
@@ -96,7 +96,7 @@ def test_exec_command_stderr():
                         exec_command.exec_command("cd '.'")
 
 
-class TestExecCommand(object):
+class TestExecCommand:
     def setup(self):
         self.pyexe = get_pythonexe()
 

--- a/numpy/distutils/tests/test_fcompiler_gnu.py
+++ b/numpy/distutils/tests/test_fcompiler_gnu.py
@@ -28,7 +28,7 @@ gfortran_version_strings = [
     ('GNU Fortran (crosstool-NG 8a21ab48) 7.2.0', '7.2.0')
 ]
 
-class TestG77Versions(object):
+class TestG77Versions:
     def test_g77_version(self):
         fc = numpy.distutils.fcompiler.new_fcompiler(compiler='gnu')
         for vs, version in g77_version_strings:
@@ -41,7 +41,7 @@ class TestG77Versions(object):
             v = fc.version_match(vs)
             assert_(v is None, (vs, v))
 
-class TestGFortranVersions(object):
+class TestGFortranVersions:
     def test_gfortran_version(self):
         fc = numpy.distutils.fcompiler.new_fcompiler(compiler='gnu95')
         for vs, version in gfortran_version_strings:

--- a/numpy/distutils/tests/test_fcompiler_intel.py
+++ b/numpy/distutils/tests/test_fcompiler_intel.py
@@ -14,7 +14,7 @@ intel_64bit_version_strings = [
      "running on Intel(R) 64, Version 11.1", '11.1')
 ]
 
-class TestIntelFCompilerVersions(object):
+class TestIntelFCompilerVersions:
     def test_32bit_version(self):
         fc = numpy.distutils.fcompiler.new_fcompiler(compiler='intel')
         for vs, version in intel_32bit_version_strings:
@@ -22,7 +22,7 @@ class TestIntelFCompilerVersions(object):
             assert_(v == version)
 
 
-class TestIntelEM64TFCompilerVersions(object):
+class TestIntelEM64TFCompilerVersions:
     def test_64bit_version(self):
         fc = numpy.distutils.fcompiler.new_fcompiler(compiler='intelem')
         for vs, version in intel_64bit_version_strings:

--- a/numpy/distutils/tests/test_fcompiler_nagfor.py
+++ b/numpy/distutils/tests/test_fcompiler_nagfor.py
@@ -14,7 +14,7 @@ nag_version_strings = [('nagfor', 'NAG Fortran Compiler Release '
                         '431,435,437,446,459-460,463,472,494,496,503,508,'
                         '511,517,529,555,557,565)', '5.1')]
 
-class TestNagFCompilerVersions(object):
+class TestNagFCompilerVersions:
     def test_version_match(self):
         for comp, vs, version in nag_version_strings:
             fc = numpy.distutils.fcompiler.new_fcompiler(compiler=comp)

--- a/numpy/distutils/tests/test_misc_util.py
+++ b/numpy/distutils/tests/test_misc_util.py
@@ -9,7 +9,7 @@ from numpy.testing import (
 
 ajoin = lambda *paths: join(*((sep,)+paths))
 
-class TestAppendpath(object):
+class TestAppendpath:
 
     def test_1(self):
         assert_equal(appendpath('prefix', 'name'), join('prefix', 'name'))
@@ -33,7 +33,7 @@ class TestAppendpath(object):
         assert_equal(appendpath('/prefix/sub/sub2', '/prefix/sub/sup/name'),
                      ajoin('prefix', 'sub', 'sub2', 'sup', 'name'))
 
-class TestMinrelpath(object):
+class TestMinrelpath:
 
     def test_1(self):
         n = lambda path: path.replace('/', sep)
@@ -47,7 +47,7 @@ class TestMinrelpath(object):
         assert_equal(minrelpath(n('.././..')), n('../..'))
         assert_equal(minrelpath(n('aa/bb/.././../dd')), n('dd'))
 
-class TestGpaths(object):
+class TestGpaths:
 
     def test_gpaths(self):
         local_path = minrelpath(join(dirname(__file__), '..'))
@@ -56,7 +56,7 @@ class TestGpaths(object):
         f = gpaths('system_info.py', local_path)
         assert_(join(local_path, 'system_info.py') == f[0], repr(f))
 
-class TestSharedExtension(object):
+class TestSharedExtension:
 
     def test_get_shared_lib_extension(self):
         import sys

--- a/numpy/distutils/tests/test_npy_pkg_config.py
+++ b/numpy/distutils/tests/test_npy_pkg_config.py
@@ -34,7 +34,7 @@ libs = -L${libdir}
 simple_variable_d = {'cflags': '-I/foo/bar/include', 'libflags': '-L/foo/bar/lib',
         'version': '0.1', 'name': 'foo'}
 
-class TestLibraryInfo(object):
+class TestLibraryInfo:
     def test_simple(self):
         with temppath('foo.ini') as path:
             with open(path,  'w') as f:
@@ -61,7 +61,7 @@ class TestLibraryInfo(object):
         out.vars['prefix'] = '/Users/david'
         assert_(out.cflags() == '-I/Users/david/include')
 
-class TestParseFlags(object):
+class TestParseFlags:
     def test_simple_cflags(self):
         d = parse_flags("-I/usr/include")
         assert_(d['include_dirs'] == ['/usr/include'])

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -128,7 +128,7 @@ class DuplicateOptionInfo(_system_info):
     section = 'duplicate_options'
 
 
-class TestSystemInfoReading(object):
+class TestSystemInfoReading:
 
     def setup(self):
         """ Create the libraries """

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -182,7 +182,7 @@ Glossary
    instance
        A class definition gives the blueprint for constructing an object::
 
-         >>> class House(object):
+         >>> class House:
          ...     wall_colour = 'white'
 
        Yet, we have to *build* a house before it exists::
@@ -336,7 +336,7 @@ Glossary
        Often seen in method signatures, ``self`` refers to the instance
        of the associated class.  For example:
 
-         >>> class Paintbrush(object):
+         >>> class Paintbrush:
          ...     color = 'blue'
          ...
          ...     def paint(self):

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -114,7 +114,7 @@ For example, consider the following Python code:
 
 .. testcode::
 
-  class C(object):
+  class C:
       def __new__(cls, *args):
           print('Cls in __new__:', cls)
           print('Args in __new__:', args)

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -550,7 +550,7 @@ class F2PYError(Exception):
     pass
 
 
-class throw_error(object):
+class throw_error:
 
     def __init__(self, mess):
         self.mess = mess

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -55,7 +55,7 @@ def flags2names(flags):
     return info
 
 
-class Intent(object):
+class Intent:
 
     def __init__(self, intent_list=[]):
         self.intent_list = intent_list[:]
@@ -129,7 +129,7 @@ if ((intp().dtype.itemsize != 4 or clongdouble().dtype.alignment <= 8) and
     _cast_dict['CDOUBLE'] = _cast_dict['DOUBLE'] + ['CFLOAT', 'CDOUBLE']
 
 
-class Type(object):
+class Type:
     _type_cache = {}
 
     def __new__(cls, name):
@@ -190,7 +190,7 @@ class Type(object):
         return types
 
 
-class Array(object):
+class Array:
 
     def __init__(self, typ, dims, intent, obj):
         self.type = typ
@@ -291,7 +291,7 @@ class Array(object):
         return obj_attr[0] == self.arr_attr[0]
 
 
-class TestIntent(object):
+class TestIntent:
 
     def test_in_out(self):
         assert_equal(str(intent.in_.out), 'intent(in,out)')
@@ -302,7 +302,7 @@ class TestIntent(object):
         assert_(not intent.in_.is_intent('c'))
 
 
-class TestSharedMemory(object):
+class TestSharedMemory:
     num2seq = [1, 2]
     num23seq = [[1, 2, 3], [4, 5, 6]]
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -116,7 +116,7 @@ cf2py  intent(out) a
         r = t(self.module.func0._cpointer)
         assert_(r == 11, repr(r))
 
-        class A(object):
+        class A:
 
             def __call__(self):
                 return 7

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -313,7 +313,7 @@ def build_module_distutils(source_files, config_code, module_name, **kw):
 #
 
 
-class F2PyTest(object):
+class F2PyTest:
     code = None
     sources = None
     options = []

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_almost_equal, assert_equal
 from numpy import fft, pi
 
 
-class TestFFTShift(object):
+class TestFFTShift:
 
     def test_definition(self):
         x = [0, 1, 2, 3, 4, -4, -3, -2, -1]
@@ -134,7 +134,7 @@ class TestFFTShift(object):
                                               original_ifftshift(inp, axes_keyword))
 
 
-class TestFFTFreq(object):
+class TestFFTFreq:
 
     def test_definition(self):
         x = [0, 1, 2, 3, 4, -4, -3, -2, -1]
@@ -145,7 +145,7 @@ class TestFFTFreq(object):
         assert_array_almost_equal(10*pi*fft.fftfreq(10, pi), x)
 
 
-class TestRFFTFreq(object):
+class TestRFFTFreq:
 
     def test_definition(self):
         x = [0, 1, 2, 3, 4]
@@ -156,7 +156,7 @@ class TestRFFTFreq(object):
         assert_array_almost_equal(10*pi*fft.rfftfreq(10, pi), x)
 
 
-class TestIRFFTN(object):
+class TestIRFFTN:
 
     def test_not_last_axis_success(self):
         ar, ai = np.random.random((2, 16, 8, 32))

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -19,13 +19,13 @@ def fft1(x):
     return np.sum(x*np.exp(phase), axis=1)
 
 
-class TestFFTShift(object):
+class TestFFTShift:
 
     def test_fft_n(self):
         assert_raises(ValueError, np.fft.fft, [1, 2, 3], 0)
 
 
-class TestFFT1D(object):
+class TestFFT1D:
 
     def test_identity(self):
         maxlen = 512
@@ -220,7 +220,7 @@ def test_fft_with_order(dtype, order, fft):
         raise ValueError()
 
 
-class TestFFTThreadSafe(object):
+class TestFFTThreadSafe:
     threads = 16
     input_shape = (800, 200)
 

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -139,7 +139,7 @@ def _python2_gzipopen(fn, mode, encoding, newline):
 # deferring the import of lzma, bz2 and gzip until needed
 
 # TODO: .zip support, .tar support?
-class _FileOpeners(object):
+class _FileOpeners:
     """
     Container for different methods to open (un-)compressed files.
 
@@ -268,7 +268,7 @@ def open(path, mode='r', destpath=os.curdir, encoding=None, newline=None):
 
 
 @set_module('numpy')
-class DataSource(object):
+class DataSource:
     """
     DataSource(destpath='.')
 

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -130,7 +130,7 @@ def flatten_dtype(ndtype, flatten_base=False):
         return types
 
 
-class LineSplitter(object):
+class LineSplitter:
     """
     Object to split a string at a given delimiter or at given places.
 
@@ -231,7 +231,7 @@ class LineSplitter(object):
         return self._handyman(_decode_line(line, self.encoding))
 
 
-class NameValidator(object):
+class NameValidator:
     """
     Object to validate a list of strings to use as field names.
 
@@ -454,7 +454,7 @@ class ConversionWarning(UserWarning):
     pass
 
 
-class StringConverter(object):
+class StringConverter:
     """
     Factory class for function transforming a string into another object
     (int, float).

--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -15,7 +15,7 @@ from numpy.compat import long
 __all__ = ['Arrayterator']
 
 
-class Arrayterator(object):
+class Arrayterator:
     """
     Buffered iterator for big arrays.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1870,7 +1870,7 @@ def _create_arrays(broadcast_shape, dim_sizes, list_of_core_dims, dtypes):
 
 
 @set_module('numpy')
-class vectorize(object):
+class vectorize:
     """
     vectorize(pyfunc, otypes=None, doc=None, excluded=None, cache=False,
               signature=None)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -105,7 +105,7 @@ def ix_(*args):
         out.append(new)
     return tuple(out)
 
-class nd_grid(object):
+class nd_grid:
     """
     Construct a multi-dimensional "meshgrid".
 
@@ -297,7 +297,7 @@ class OGridClass(nd_grid):
 ogrid = OGridClass()
 
 
-class AxisConcatenator(object):
+class AxisConcatenator:
     """
     Translates slice objects to concatenation along an axis.
 
@@ -550,7 +550,7 @@ c_ = CClass()
 
 
 @set_module('numpy')
-class ndenumerate(object):
+class ndenumerate:
     """
     Multidimensional index iterator.
 
@@ -601,7 +601,7 @@ class ndenumerate(object):
 
 
 @set_module('numpy')
-class ndindex(object):
+class ndindex:
     """
     An N-dimensional iterator object to index arrays.
 
@@ -679,7 +679,7 @@ class ndindex(object):
 #
 #
 
-class IndexExpression(object):
+class IndexExpression:
     """
     A nicer way to build up index tuples for arrays.
 

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -58,7 +58,7 @@ def _unary_method(ufunc, name):
     return func
 
 
-class NDArrayOperatorsMixin(object):
+class NDArrayOperatorsMixin:
     """Mixin defining all operator special methods using __array_ufunc__.
 
     This class implements the special methods for almost all of Python's

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -53,7 +53,7 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-class BagObj(object):
+class BagObj:
     """
     BagObj(obj)
 
@@ -67,7 +67,7 @@ class BagObj(object):
     Examples
     --------
     >>> from numpy.lib.npyio import BagObj as BO
-    >>> class BagDemo(object):
+    >>> class BagDemo:
     ...     def __getitem__(self, key): # An instance of BagObj(BagDemo)
     ...                                 # will call this method when any
     ...                                 # attribute look-up is required
@@ -1334,7 +1334,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         fmt = asstr(fmt)
     delimiter = asstr(delimiter)
 
-    class WriteWrap(object):
+    class WriteWrap:
         """Convert to unicode in py2 or to bytes on bytestream inputs.
 
         """

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1005,7 +1005,7 @@ def _raise_power(astr, wrap=70):
 
 
 @set_module('numpy')
-class poly1d(object):
+class poly1d:
     """
     A one-dimensional polynomial class.
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -11,7 +11,7 @@ from numpy.core.overrides import array_function_dispatch
 __all__ = ['broadcast_to', 'broadcast_arrays']
 
 
-class DummyArray(object):
+class DummyArray:
     """Dummy object that just exists to hang __array_interface__ dictionaries
     and possibly keep alive a reference to a base array.
     """

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -94,7 +94,7 @@ def invalid_httpfile():
     return http_fakefile
 
 
-class TestDataSourceOpen(object):
+class TestDataSourceOpen:
     def setup(self):
         self.tmpdir = mkdtemp()
         self.ds = datasource.DataSource(self.tmpdir)
@@ -181,7 +181,7 @@ class TestDataSourceOpen(object):
         assert_equal(magic_line, result)
 
 
-class TestDataSourceExists(object):
+class TestDataSourceExists:
     def setup(self):
         self.tmpdir = mkdtemp()
         self.ds = datasource.DataSource(self.tmpdir)
@@ -211,7 +211,7 @@ class TestDataSourceExists(object):
         assert_equal(self.ds.exists(tmpfile), False)
 
 
-class TestDataSourceAbspath(object):
+class TestDataSourceAbspath:
     def setup(self):
         self.tmpdir = os.path.abspath(mkdtemp())
         self.ds = datasource.DataSource(self.tmpdir)
@@ -276,7 +276,7 @@ class TestDataSourceAbspath(object):
             os.sep = orig_os_sep
 
 
-class TestRepositoryAbspath(object):
+class TestRepositoryAbspath:
     def setup(self):
         self.tmpdir = os.path.abspath(mkdtemp())
         self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
@@ -309,7 +309,7 @@ class TestRepositoryAbspath(object):
             os.sep = orig_os_sep
 
 
-class TestRepositoryExists(object):
+class TestRepositoryExists:
     def setup(self):
         self.tmpdir = mkdtemp()
         self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
@@ -342,7 +342,7 @@ class TestRepositoryExists(object):
         assert_(self.repos.exists(tmpfile))
 
 
-class TestOpenFunc(object):
+class TestOpenFunc:
     def setup(self):
         self.tmpdir = mkdtemp()
 

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -12,7 +12,7 @@ from numpy.lib._iotools import (
 from numpy.compat import unicode
 
 
-class TestLineSplitter(object):
+class TestLineSplitter:
     "Tests the LineSplitter class."
 
     def test_no_delimiter(self):
@@ -81,7 +81,7 @@ class TestLineSplitter(object):
 # -----------------------------------------------------------------------------
 
 
-class TestNameValidator(object):
+class TestNameValidator:
 
     def test_case_sensitivity(self):
         "Test case sensitivity"
@@ -139,7 +139,7 @@ def _bytes_to_date(s):
     return date(*time.strptime(s, "%Y-%m-%d")[:3])
 
 
-class TestStringConverter(object):
+class TestStringConverter:
     "Test StringConverter"
 
     def test_creation(self):
@@ -264,7 +264,7 @@ class TestStringConverter(object):
         assert_(converter(val) == 9223372043271415339)
 
 
-class TestMiscFunctions(object):
+class TestMiscFunctions:
 
     def test_has_nested_dtype(self):
         "Test has_nested_dtype"

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -29,7 +29,7 @@ _all_modes = {
 }
 
 
-class TestAsPairs(object):
+class TestAsPairs:
     def test_single_value(self):
         """Test casting for a single value."""
         expected = np.array([[3, 3]] * 10)
@@ -112,7 +112,7 @@ class TestAsPairs(object):
             _as_pairs(np.ones((2, 3)), 3)
 
 
-class TestConditionalShortcuts(object):
+class TestConditionalShortcuts:
     @pytest.mark.parametrize("mode", _all_modes.keys())
     def test_zero_padding_shortcuts(self, mode):
         test = np.arange(120).reshape(4, 5, 6)
@@ -134,7 +134,7 @@ class TestConditionalShortcuts(object):
                            np.pad(test, pad_amt, mode=mode, stat_length=30))
 
 
-class TestStatistic(object):
+class TestStatistic:
     def test_check_mean_stat_length(self):
         a = np.arange(100).astype('f')
         a = np.pad(a, ((25, 20), ), 'mean', stat_length=((2, 3), ))
@@ -496,7 +496,7 @@ class TestStatistic(object):
             np.pad([1., 2.], 1, mode, stat_length=(1, 0))
 
 
-class TestConstant(object):
+class TestConstant:
     def test_check_constant(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), 'constant', constant_values=(10, 20))
@@ -675,7 +675,7 @@ class TestConstant(object):
         assert result.shape == (3, 4, 4)
 
 
-class TestLinearRamp(object):
+class TestLinearRamp:
     def test_check_simple(self):
         a = np.arange(100).astype('f')
         a = np.pad(a, (25, 20), 'linear_ramp', end_values=(4, 5))
@@ -760,7 +760,7 @@ class TestLinearRamp(object):
         assert_equal(result, expected)
 
 
-class TestReflect(object):
+class TestReflect:
     def test_check_simple(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), 'reflect')
@@ -870,7 +870,7 @@ class TestReflect(object):
         assert_array_equal(a, b)
 
 
-class TestEmptyArray(object):
+class TestEmptyArray:
     """Check how padding behaves on arrays with an empty dimension."""
 
     @pytest.mark.parametrize(
@@ -894,7 +894,7 @@ class TestEmptyArray(object):
         assert result.shape == (8, 0, 4)
 
 
-class TestSymmetric(object):
+class TestSymmetric:
     def test_check_simple(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), 'symmetric')
@@ -1028,7 +1028,7 @@ class TestSymmetric(object):
         assert_array_equal(a, b)
 
 
-class TestWrap(object):
+class TestWrap:
     def test_check_simple(self):
         a = np.arange(100)
         a = np.pad(a, (25, 20), 'wrap')
@@ -1142,7 +1142,7 @@ class TestWrap(object):
         assert_array_equal(np.r_[a, a, a, a][:-3], b)
 
 
-class TestEdge(object):
+class TestEdge:
     def test_check_simple(self):
         a = np.arange(12)
         a = np.reshape(a, (4, 3))
@@ -1181,7 +1181,7 @@ class TestEdge(object):
         assert_array_equal(padded, expected)
 
 
-class TestEmpty(object):
+class TestEmpty:
     def test_simple(self):
         arr = np.arange(24).reshape(4, 6)
         result = np.pad(arr, [(2, 3), (3, 1)], mode="empty")
@@ -1229,7 +1229,7 @@ def test_object_input(mode):
     assert_array_equal(np.pad(a, pad_amt, mode=mode), b)
 
 
-class TestPadWidth(object):
+class TestPadWidth:
     @pytest.mark.parametrize("pad_width", [
         (4, 5, 6, 7),
         ((1,), (2,), (3,)),

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -12,7 +12,7 @@ import pytest
 
 
 
-class TestSetOps(object):
+class TestSetOps:
 
     def test_intersect1d(self):
         # unique inputs
@@ -34,7 +34,7 @@ class TestSetOps(object):
 
     def test_intersect1d_array_like(self):
         # See gh-11772
-        class Test(object):
+        class Test:
             def __array__(self):
                 return np.arange(3)
 
@@ -413,7 +413,7 @@ class TestSetOps(object):
         assert_array_equal(c1, c2)
 
 
-class TestUnique(object):
+class TestUnique:
 
     def test_unique_1d(self):
 

--- a/numpy/lib/tests/test_financial.py
+++ b/numpy/lib/tests/test_financial.py
@@ -16,7 +16,7 @@ def filter_deprecation(func):
     return newfunc
 
 
-class TestFinancial(object):
+class TestFinancial:
     @filter_deprecation
     def test_npv_irr_congruence(self):
         # IRR is defined as the rate required for the present value of a

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -42,7 +42,7 @@ def _make_complex(real, imag):
     return ret
 
 
-class TestRot90(object):
+class TestRot90:
     def test_basic(self):
         assert_raises(ValueError, rot90, np.ones(4))
         assert_raises(ValueError, rot90, np.ones((2,2,2)), axes=(0,1,2))
@@ -110,7 +110,7 @@ class TestRot90(object):
                          rot90(a_rot90_20, k=k-1, axes=(2, 0)))
 
 
-class TestFlip(object):
+class TestFlip:
 
     def test_axes(self):
         assert_raises(np.AxisError, np.flip, np.ones(4), axis=1)
@@ -213,7 +213,7 @@ class TestFlip(object):
         assert_equal(np.flip(a, axis=(1, 2)), c)
 
 
-class TestAny(object):
+class TestAny:
 
     def test_basic(self):
         y1 = [0, 0, 1, 0]
@@ -230,7 +230,7 @@ class TestAny(object):
         assert_array_equal(np.sometrue(y1, axis=1), [0, 1, 1])
 
 
-class TestAll(object):
+class TestAll:
 
     def test_basic(self):
         y1 = [0, 1, 1, 0]
@@ -248,7 +248,7 @@ class TestAll(object):
         assert_array_equal(np.alltrue(y1, axis=1), [0, 0, 1])
 
 
-class TestCopy(object):
+class TestCopy:
 
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
@@ -276,7 +276,7 @@ class TestCopy(object):
         assert_(a_fort_copy.flags.f_contiguous)
 
 
-class TestAverage(object):
+class TestAverage:
 
     def test_basic(self):
         y1 = np.array([1, 2, 3])
@@ -377,7 +377,7 @@ class TestAverage(object):
         w /= w.sum()
         assert_almost_equal(a.mean(0), average(a, weights=w))
 
-class TestSelect(object):
+class TestSelect:
     choices = [np.array([1, 2, 3]),
                np.array([4, 5, 6]),
                np.array([7, 8, 9])]
@@ -439,7 +439,7 @@ class TestSelect(object):
         select(conditions, choices)
 
 
-class TestInsert(object):
+class TestInsert:
 
     def test_basic(self):
         a = [1, 2, 3]
@@ -540,7 +540,7 @@ class TestInsert(object):
         assert_array_equal(b[[0, 3]], np.array(val, dtype=b.dtype))
 
 
-class TestAmax(object):
+class TestAmax:
 
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
@@ -552,7 +552,7 @@ class TestAmax(object):
         assert_equal(np.amax(b, axis=1), [9.0, 10.0, 8.0])
 
 
-class TestAmin(object):
+class TestAmin:
 
     def test_basic(self):
         a = [3, 4, 5, 10, -3, -5, 6.0]
@@ -564,7 +564,7 @@ class TestAmin(object):
         assert_equal(np.amin(b, axis=1), [3.0, 4.0, 2.0])
 
 
-class TestPtp(object):
+class TestPtp:
 
     def test_basic(self):
         a = np.array([3, 4, 5, 10, -3, -5, 6.0])
@@ -579,7 +579,7 @@ class TestPtp(object):
         assert_equal(b.ptp(axis=(0,1), keepdims=True), [[8.0]])
 
 
-class TestCumsum(object):
+class TestCumsum:
 
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
@@ -602,7 +602,7 @@ class TestCumsum(object):
             assert_array_equal(np.cumsum(a2, axis=1), tgt)
 
 
-class TestProd(object):
+class TestProd:
 
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
@@ -622,7 +622,7 @@ class TestProd(object):
                                    np.array([24, 1890, 600], ctype))
 
 
-class TestCumprod(object):
+class TestCumprod:
 
     def test_basic(self):
         ba = [1, 2, 10, 11, 6, 5, 4]
@@ -649,7 +649,7 @@ class TestCumprod(object):
                                              [10, 30, 120, 600]], ctype))
 
 
-class TestDiff(object):
+class TestDiff:
 
     def test_basic(self):
         x = [1, 4, 6, 7, 12]
@@ -789,7 +789,7 @@ class TestDiff(object):
         assert_raises(np.AxisError, diff, x, append=0, axis=3)
 
 
-class TestDelete(object):
+class TestDelete:
 
     def setup(self):
         self.a = np.arange(5)
@@ -864,7 +864,7 @@ class TestDelete(object):
         assert_equal(m.flags.f_contiguous, k.flags.f_contiguous)
 
 
-class TestGradient(object):
+class TestGradient:
 
     def test_basic(self):
         v = [[1, 1], [3, 4]]
@@ -1116,7 +1116,7 @@ class TestGradient(object):
         assert_array_equal(dfdx, [0.5, 0.5])
 
 
-class TestAngle(object):
+class TestAngle:
 
     def test_basic(self):
         x = [1 + 3j, np.sqrt(2) / 2.0 + 1j * np.sqrt(2) / 2,
@@ -1142,7 +1142,7 @@ class TestAngle(object):
         assert_equal(actual, expected)
 
 
-class TestTrimZeros(object):
+class TestTrimZeros:
 
     """
     Only testing for integer splits.
@@ -1165,7 +1165,7 @@ class TestTrimZeros(object):
         assert_array_equal(res, np.array([1, 0, 2, 3, 0, 4]))
 
 
-class TestExtins(object):
+class TestExtins:
 
     def test_basic(self):
         a = np.array([1, 3, 2, 1, 2, 3, 3])
@@ -1204,7 +1204,7 @@ class TestExtins(object):
         assert_array_equal(a, ac)
 
 
-class TestVectorize(object):
+class TestVectorize:
 
     def test_simple(self):
         def addsubtract(a, b):
@@ -1536,8 +1536,8 @@ class TestVectorize(object):
             f(x)
 
 
-class TestLeaks(object):
-    class A(object):
+class TestLeaks:
+    class A:
         iters = 20
 
         def bound(self, *args):
@@ -1579,7 +1579,7 @@ class TestLeaks(object):
         finally:
             gc.enable()
 
-class TestDigitize(object):
+class TestDigitize:
 
     def test_forward(self):
         x = np.arange(-6, 5)
@@ -1664,7 +1664,7 @@ class TestDigitize(object):
         assert_equal(np.digitize(x, [x + 1, x - 1]), 1)
 
 
-class TestUnwrap(object):
+class TestUnwrap:
 
     def test_simple(self):
         # check that unwrap removes jumps greater that 2*pi
@@ -1673,7 +1673,7 @@ class TestUnwrap(object):
         assert_(np.all(diff(unwrap(rand(10) * 100)) < np.pi))
 
 
-class TestFilterwindows(object):
+class TestFilterwindows:
 
     def test_hanning(self):
         # check symmetry
@@ -1704,7 +1704,7 @@ class TestFilterwindows(object):
         assert_almost_equal(np.sum(w, axis=0), 3.7800, 4)
 
 
-class TestTrapz(object):
+class TestTrapz:
 
     def test_simple(self):
         x = np.arange(-10, 10, .1)
@@ -1766,7 +1766,7 @@ class TestTrapz(object):
         assert_almost_equal(trapz(y, xm), r)
 
 
-class TestSinc(object):
+class TestSinc:
 
     def test_simple(self):
         assert_(sinc(0) == 1)
@@ -1783,7 +1783,7 @@ class TestSinc(object):
         assert_array_equal(y1, y3)
 
 
-class TestUnique(object):
+class TestUnique:
 
     def test_simple(self):
         x = np.array([4, 3, 2, 1, 1, 2, 3, 4, 0])
@@ -1795,7 +1795,7 @@ class TestUnique(object):
         assert_(np.all(unique(x) == [1 + 1j, 1 + 10j, 5 + 6j, 10]))
 
 
-class TestCheckFinite(object):
+class TestCheckFinite:
 
     def test_simple(self):
         a = [1, 2, 3]
@@ -1812,7 +1812,7 @@ class TestCheckFinite(object):
         assert_(a.dtype == np.float64)
 
 
-class TestCorrCoef(object):
+class TestCorrCoef:
     A = np.array(
         [[0.15391142, 0.18045767, 0.14197213],
          [0.70461506, 0.96474128, 0.27906989],
@@ -1897,7 +1897,7 @@ class TestCorrCoef(object):
         assert_(np.all(np.abs(c) <= 1.0))
 
 
-class TestCov(object):
+class TestCov:
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T
     res1 = np.array([[1., -1.], [-1., 1.]])
     x2 = np.array([0.0, 1.0, 2.0], ndmin=2)
@@ -1997,7 +1997,7 @@ class TestCov(object):
                         self.res1)
 
 
-class Test_I0(object):
+class Test_I0:
 
     def test_simple(self):
         assert_almost_equal(
@@ -2043,7 +2043,7 @@ class Test_I0(object):
         assert_array_equal(exp, res)
 
 
-class TestKaiser(object):
+class TestKaiser:
 
     def test_simple(self):
         assert_(np.isfinite(kaiser(1, 1.0)))
@@ -2062,7 +2062,7 @@ class TestKaiser(object):
         kaiser(3, 4)
 
 
-class TestMsort(object):
+class TestMsort:
 
     def test_simple(self):
         A = np.array([[0.44567325, 0.79115165, 0.54900530],
@@ -2075,7 +2075,7 @@ class TestMsort(object):
                       [0.64864341, 0.79115165, 0.96098397]]))
 
 
-class TestMeshgrid(object):
+class TestMeshgrid:
 
     def test_simple(self):
         [X, Y] = meshgrid([1, 2, 3], [4, 5, 6, 7])
@@ -2164,7 +2164,7 @@ class TestMeshgrid(object):
         assert_equal(x[1, :], X)
 
 
-class TestPiecewise(object):
+class TestPiecewise:
 
     def test_simple(self):
         # Condition is single bool list
@@ -2256,7 +2256,7 @@ class TestPiecewise(object):
                                         [3., 3., 1.]]))
 
 
-class TestBincount(object):
+class TestBincount:
 
     def test_simple(self):
         y = np.bincount(np.arange(4))
@@ -2343,7 +2343,7 @@ class TestBincount(object):
         assert_equal(sys.getrefcount(np.dtype(np.double)), double_refcount)
 
 
-class TestInterp(object):
+class TestInterp:
 
     def test_exceptions(self):
         assert_raises(ValueError, interp, 0, [], [])
@@ -2542,7 +2542,7 @@ def compare_results(res, desired):
         assert_array_equal(res[i], desired[i])
 
 
-class TestPercentile(object):
+class TestPercentile:
 
     def test_basic(self):
         x = np.arange(8) * 0.5
@@ -2963,7 +2963,7 @@ class TestPercentile(object):
             a, [0.3, 0.6], (0, 2), interpolation='nearest'), b)
 
 
-class TestQuantile(object):
+class TestQuantile:
     # most of this is already tested by TestPercentile
 
     def test_basic(self):
@@ -3005,7 +3005,7 @@ class TestQuantile(object):
         assert_array_equal(p, p0)
 
 
-class TestMedian(object):
+class TestMedian:
 
     def test_basic(self):
         a0 = np.array(1)
@@ -3244,7 +3244,7 @@ class TestMedian(object):
                      (1, 1, 7, 1))
 
 
-class TestAdd_newdoc_ufunc(object):
+class TestAdd_newdoc_ufunc:
 
     def test_ufunc_arg(self):
         assert_raises(TypeError, add_newdoc_ufunc, 2, "blah")
@@ -3254,7 +3254,7 @@ class TestAdd_newdoc_ufunc(object):
         assert_raises(TypeError, add_newdoc_ufunc, np.add, 3)
 
 
-class TestAdd_newdoc(object):
+class TestAdd_newdoc:
 
     @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")
     @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
@@ -3265,7 +3265,7 @@ class TestAdd_newdoc(object):
         assert_(len(np.core.ufunc.identity.__doc__) > 300)
         assert_(len(np.lib.index_tricks.mgrid.__doc__) > 300)
 
-class TestSortComplex(object):
+class TestSortComplex:
 
     @pytest.mark.parametrize("type_in, type_out", [
         ('l', 'D'),

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -9,7 +9,7 @@ from numpy.testing import (
 import pytest
 
 
-class TestHistogram(object):
+class TestHistogram:
 
     def setup(self):
         pass
@@ -422,7 +422,7 @@ class TestHistogram(object):
         assert_array_equal(edges, e)
 
 
-class TestHistogramOptimBinNums(object):
+class TestHistogramOptimBinNums:
     """
     Provide test coverage when using provided estimators for optimal number of
     bins
@@ -610,7 +610,7 @@ class TestHistogramOptimBinNums(object):
                           estimator, weights=[1, 2, 3])
 
 
-class TestHistogramdd(object):
+class TestHistogramdd:
 
     def test_simple(self):
         x = np.array([[-.5, .5, 1.5], [-.5, 1.5, 2.5], [-.5, 2.5, .5],

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -12,7 +12,7 @@ from numpy.lib.index_tricks import (
     )
 
 
-class TestRavelUnravelIndex(object):
+class TestRavelUnravelIndex:
     def test_basic(self):
         assert_equal(np.unravel_index(2, (2, 2)), (1, 0))
 
@@ -192,7 +192,7 @@ class TestRavelUnravelIndex(object):
         with assert_raises(ValueError):
             np.unravel_index([1], (2, 1, 0))
 
-class TestGrid(object):
+class TestGrid:
     def test_basic(self):
         a = mgrid[-1:1:10j]
         b = mgrid[-1:1:0.1]
@@ -250,7 +250,7 @@ class TestGrid(object):
         assert_equal(grid_small.size, expected[1])
 
 
-class TestConcatenator(object):
+class TestConcatenator:
     def test_1d(self):
         assert_array_equal(r_[1, 2, 3, 4, 5, 6], np.array([1, 2, 3, 4, 5, 6]))
         b = np.ones(5)
@@ -288,14 +288,14 @@ class TestConcatenator(object):
         assert_equal(r_[np.array(0), [1, 2, 3]], [0, 1, 2, 3])
 
 
-class TestNdenumerate(object):
+class TestNdenumerate:
     def test_basic(self):
         a = np.array([[1, 2], [3, 4]])
         assert_equal(list(ndenumerate(a)),
                      [((0, 0), 1), ((0, 1), 2), ((1, 0), 3), ((1, 1), 4)])
 
 
-class TestIndexExpression(object):
+class TestIndexExpression:
     def test_regression_1(self):
         # ticket #1196
         a = np.arange(2)
@@ -309,7 +309,7 @@ class TestIndexExpression(object):
         assert_equal(a[:, :3, [1, 2]], a[s_[:, :3, [1, 2]]])
 
 
-class TestIx_(object):
+class TestIx_:
     def test_regression_1(self):
         # Test empty untyped inputs create outputs of indexing type, gh-5804
         a, = np.ix_(range(0))
@@ -356,7 +356,7 @@ def test_c_():
     assert_equal(a, [[1, 2, 3, 0, 0, 4, 5, 6]])
 
 
-class TestFillDiagonal(object):
+class TestFillDiagonal:
     def test_basic(self):
         a = np.zeros((3, 3), int)
         fill_diagonal(a, 5)
@@ -455,7 +455,7 @@ def test_diag_indices():
         )
 
 
-class TestDiagIndicesFrom(object):
+class TestDiagIndicesFrom:
 
     def test_diag_indices_from(self):
         x = np.random.random((4, 4))

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -69,7 +69,7 @@ def strptime(s, fmt=None):
     return datetime(*time.strptime(s, fmt)[:3])
 
 
-class RoundtripTest(object):
+class RoundtripTest:
     def roundtrip(self, save_func, *args, **kwargs):
         """
         save_func : callable
@@ -316,7 +316,7 @@ class TestSavezLoad(RoundtripTest):
             assert_(fp.closed)
 
 
-class TestSaveTxt(object):
+class TestSaveTxt:
     def test_array(self):
         a = np.array([[1, 2], [3, 4]], float)
         fmt = "%.18e"
@@ -582,7 +582,7 @@ class TestSaveTxt(object):
         with tempdir() as tmpdir:
             np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
 
-class LoadTxtBase(object):
+class LoadTxtBase:
     def check_compressed(self, fopen, suffixes):
         # Test that we can load data from a compressed file
         wanted = np.arange(6).reshape((2, 3))
@@ -824,7 +824,7 @@ class TestLoadTxt(LoadTxtBase):
             assert_array_equal(x, a[:, 1])
 
         # Testing with some crazy custom integer type
-        class CrazyInt(object):
+        class CrazyInt:
             def __index__(self):
                 return 1
 
@@ -1156,7 +1156,7 @@ class TestLoadTxt(LoadTxtBase):
         a = np.array([[1, 2, 3, 5], [4, 5, 7, 8], [2, 1, 4, 5]], int)
         assert_array_equal(x, a)
 
-class Testfromregex(object):
+class Testfromregex:
     def test_record(self):
         c = TextIO()
         c.write('1.312 foo\n1.534 bar\n4.444 qux')
@@ -2347,7 +2347,7 @@ M   33  21.99
 
 
 @pytest.mark.skipif(Path is None, reason="No pathlib.Path")
-class TestPathUsage(object):
+class TestPathUsage:
     # Test that pathlib.Path can be used
     def test_loadtxt(self):
         with temppath(suffix='.txt') as path:
@@ -2480,7 +2480,7 @@ def test_gzip_load():
 
 # These next two classes encode the minimal API needed to save()/load() arrays.
 # The `test_ducktyping` ensures they work correctly
-class JustWriter(object):
+class JustWriter:
     def __init__(self, base):
         self.base = base
 
@@ -2490,7 +2490,7 @@ class JustWriter(object):
     def flush(self):
         return self.base.flush()
 
-class JustReader(object):
+class JustReader:
     def __init__(self, base):
         self.base = base
 

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -96,7 +96,7 @@ _ALL_BINARY_OPERATORS = [
 ]
 
 
-class TestNDArrayOperatorsMixin(object):
+class TestNDArrayOperatorsMixin:
 
     def test_array_like_add(self):
 
@@ -126,7 +126,7 @@ class TestNDArrayOperatorsMixin(object):
 
     def test_opt_out(self):
 
-        class OptOut(object):
+        class OptOut:
             """Object that opts out of __array_ufunc__."""
             __array_ufunc__ = None
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -35,7 +35,7 @@ _ndat_zeros = np.array([[0.6244, 0.0, 0.2692, 0.0116, 0.0, 0.1170],
                         [0.1610, 0.0, 0.0, 0.1859, 0.3146, 0.0]])
 
 
-class TestNanFunctions_MinMax(object):
+class TestNanFunctions_MinMax:
 
     nanfuncs = [np.nanmin, np.nanmax]
     stdfuncs = [np.min, np.max]
@@ -169,7 +169,7 @@ class TestNanFunctions_MinMax(object):
             assert_(issubclass(w[0].category, RuntimeWarning))
 
 
-class TestNanFunctions_ArgminArgmax(object):
+class TestNanFunctions_ArgminArgmax:
 
     nanfuncs = [np.nanargmin, np.nanargmax]
 
@@ -231,7 +231,7 @@ class TestNanFunctions_ArgminArgmax(object):
             assert_(res.shape == ())
 
 
-class TestNanFunctions_IntTypes(object):
+class TestNanFunctions_IntTypes:
 
     int_types = (np.int8, np.int16, np.int32, np.int64, np.uint8,
                  np.uint16, np.uint32, np.uint64)
@@ -306,7 +306,7 @@ class TestNanFunctions_IntTypes(object):
             assert_equal(np.nanstd(mat, ddof=1), tgt)
 
 
-class SharedNanFunctionsTestsMixin(object):
+class SharedNanFunctionsTestsMixin:
     def test_mutation(self):
         # Check that passed array is not modified.
         ndat = _ndat.copy()
@@ -588,7 +588,7 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
                     assert_(len(w) == 0)
 
 
-class TestNanFunctions_Median(object):
+class TestNanFunctions_Median:
 
     def test_mutation(self):
         # Check that passed array is not modified.
@@ -752,7 +752,7 @@ class TestNanFunctions_Median(object):
                                      ([np.nan] * i) + [-inf] * j)
 
 
-class TestNanFunctions_Percentile(object):
+class TestNanFunctions_Percentile:
 
     def test_mutation(self):
         # Check that passed array is not modified.
@@ -891,7 +891,7 @@ class TestNanFunctions_Percentile(object):
         assert_equal(np.nanpercentile(megamat, perc, axis=(1, 2)).shape, (2, 3, 6))
 
 
-class TestNanFunctions_Quantile(object):
+class TestNanFunctions_Quantile:
     # most of this is already tested by TestPercentile
 
     def test_regression(self):

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -5,7 +5,7 @@ from numpy.testing import (
     )
 
 
-class TestPolynomial(object):
+class TestPolynomial:
     def test_poly1d_str_and_repr(self):
         p = np.poly1d([1., 2, 3])
         assert_equal(repr(p), 'poly1d([1., 2., 3.])')

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -17,7 +17,7 @@ zip_descr = np.lib.recfunctions._zip_descr
 zip_dtype = np.lib.recfunctions._zip_dtype
 
 
-class TestRecFunctions(object):
+class TestRecFunctions:
     # Misc tests
 
     def setup(self):
@@ -346,7 +346,7 @@ class TestRecFunctions(object):
         assert_equal(b[()], 3)
 
 
-class TestRecursiveFillFields(object):
+class TestRecursiveFillFields:
     # Test recursive_fill_fields.
     def test_simple_flexible(self):
         # Test recursive_fill_fields on flexible-array
@@ -369,7 +369,7 @@ class TestRecursiveFillFields(object):
         assert_equal(test, control)
 
 
-class TestMergeArrays(object):
+class TestMergeArrays:
     # Test merge_arrays
 
     def setup(self):
@@ -502,7 +502,7 @@ class TestMergeArrays(object):
         assert_equal(test, control)
 
 
-class TestAppendFields(object):
+class TestAppendFields:
     # Test append_fields
 
     def setup(self):
@@ -556,7 +556,7 @@ class TestAppendFields(object):
         assert_equal(test, control)
 
 
-class TestStackArrays(object):
+class TestStackArrays:
     # Test stack_arrays
     def setup(self):
         x = np.array([1, 2, ])
@@ -727,7 +727,7 @@ class TestStackArrays(object):
         assert_equal(res.mask, expected.mask)
 
 
-class TestJoinBy(object):
+class TestJoinBy:
     def setup(self):
         self.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
                                    np.arange(100, 110))),
@@ -892,7 +892,7 @@ class TestJoinBy(object):
         assert_equal(res.dtype, expected_dtype)
 
 
-class TestJoinBy2(object):
+class TestJoinBy2:
     @classmethod
     def setup(cls):
         cls.a = np.array(list(zip(np.arange(10), np.arange(50, 60),
@@ -957,7 +957,7 @@ class TestJoinBy2(object):
         assert_equal(test.dtype, control.dtype)
         assert_equal(test, control)
 
-class TestAppendFieldsObj(object):
+class TestAppendFieldsObj:
     """
     Test append_fields with arrays containing objects
     """

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -9,7 +9,7 @@ from numpy.testing import (
 from numpy.compat import unicode
 
 
-class TestRegression(object):
+class TestRegression:
     def test_poly1d(self):
         # Ticket #28
         assert_equal(np.poly1d([1]) - np.poly1d([1, 0]),

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -27,7 +27,7 @@ def _add_keepdims(func):
     return wrapped
 
 
-class TestTakeAlongAxis(object):
+class TestTakeAlongAxis:
     def test_argequivalent(self):
         """ Test it translates from arg<func> to <func> """
         from numpy.random import rand
@@ -79,7 +79,7 @@ class TestTakeAlongAxis(object):
         assert_equal(actual.shape, (3, 2, 5))
 
 
-class TestPutAlongAxis(object):
+class TestPutAlongAxis:
     def test_replace_max(self):
         a_base = np.array([[10, 30, 20], [60, 40, 50]])
 
@@ -104,7 +104,7 @@ class TestPutAlongAxis(object):
         assert_equal(take_along_axis(a, ai, axis=1), 20)
 
 
-class TestApplyAlongAxis(object):
+class TestApplyAlongAxis:
     def test_simple(self):
         a = np.ones((20, 10), 'd')
         assert_array_equal(
@@ -270,14 +270,14 @@ class TestApplyAlongAxis(object):
             assert_equal(type(actual[i]), type(expected[i]))
 
 
-class TestApplyOverAxes(object):
+class TestApplyOverAxes:
     def test_simple(self):
         a = np.arange(24).reshape(2, 3, 4)
         aoa_a = apply_over_axes(np.sum, a, [0, 2])
         assert_array_equal(aoa_a, np.array([[[60], [92], [124]]]))
 
 
-class TestExpandDims(object):
+class TestExpandDims:
     def test_functionality(self):
         s = (2, 3, 4, 5)
         a = np.empty(s)
@@ -317,7 +317,7 @@ class TestExpandDims(object):
         assert_equal(expanded.mask.shape, (2, 1, 5))
 
 
-class TestArraySplit(object):
+class TestArraySplit:
     def test_integer_0_split(self):
         a = np.arange(10)
         assert_raises(ValueError, array_split, a, 0)
@@ -451,7 +451,7 @@ class TestArraySplit(object):
         compare_results(res, desired)
 
 
-class TestSplit(object):
+class TestSplit:
     # The split function is essentially the same as array_split,
     # except that it test if splitting will result in an
     # equal split.  Only test for this case.
@@ -467,7 +467,7 @@ class TestSplit(object):
         assert_raises(ValueError, split, a, 3)
 
 
-class TestColumnStack(object):
+class TestColumnStack:
     def test_non_iterable(self):
         assert_raises(TypeError, column_stack, 1)
 
@@ -496,7 +496,7 @@ class TestColumnStack(object):
             column_stack((np.arange(3) for _ in range(2)))
 
 
-class TestDstack(object):
+class TestDstack:
     def test_non_iterable(self):
         assert_raises(TypeError, dstack, 1)
 
@@ -535,7 +535,7 @@ class TestDstack(object):
 
 # array_split has more comprehensive test of splitting.
 # only do simple test on hsplit, vsplit, and dsplit
-class TestHsplit(object):
+class TestHsplit:
     """Only testing for integer splits.
 
     """
@@ -564,7 +564,7 @@ class TestHsplit(object):
         compare_results(res, desired)
 
 
-class TestVsplit(object):
+class TestVsplit:
     """Only testing for integer splits.
 
     """
@@ -591,7 +591,7 @@ class TestVsplit(object):
         compare_results(res, desired)
 
 
-class TestDsplit(object):
+class TestDsplit:
     # Only testing for integer splits.
     def test_non_iterable(self):
         assert_raises(ValueError, dsplit, 1, 1)
@@ -624,7 +624,7 @@ class TestDsplit(object):
         compare_results(res, desired)
 
 
-class TestSqueeze(object):
+class TestSqueeze:
     def test_basic(self):
         from numpy.random import rand
 
@@ -643,7 +643,7 @@ class TestSqueeze(object):
         assert_equal(type(res), np.ndarray)
 
 
-class TestKron(object):
+class TestKron:
     def test_return_type(self):
         class myarray(np.ndarray):
             __array_priority__ = 0.0
@@ -656,7 +656,7 @@ class TestKron(object):
         assert_equal(type(kron(ma, a)), myarray)
 
 
-class TestTile(object):
+class TestTile:
     def test_basic(self):
         a = np.array([0, 1, 2])
         b = [[1, 2], [3, 4]]
@@ -696,7 +696,7 @@ class TestTile(object):
                 assert_equal(large, klarge)
 
 
-class TestMayShareMemory(object):
+class TestMayShareMemory:
     def test_basic(self):
         d = np.ones((50, 60))
         d2 = np.ones((30, 60, 6))

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -24,7 +24,7 @@ def get_mat(n):
     return data
 
 
-class TestEye(object):
+class TestEye:
     def test_basic(self):
         assert_equal(eye(4),
                      array([[1, 0, 0, 0],
@@ -106,7 +106,7 @@ class TestEye(object):
         assert mat_f.flags.f_contiguous
 
 
-class TestDiag(object):
+class TestDiag:
     def test_vector(self):
         vals = (100 * arange(5)).astype('l')
         b = zeros((5, 5))
@@ -153,7 +153,7 @@ class TestDiag(object):
         assert_raises(ValueError, diag, [[[1]]])
 
 
-class TestFliplr(object):
+class TestFliplr:
     def test_basic(self):
         assert_raises(ValueError, fliplr, ones(4))
         a = get_mat(4)
@@ -166,7 +166,7 @@ class TestFliplr(object):
         assert_equal(fliplr(a), b)
 
 
-class TestFlipud(object):
+class TestFlipud:
     def test_basic(self):
         a = get_mat(4)
         b = a[::-1, :]
@@ -178,7 +178,7 @@ class TestFlipud(object):
         assert_equal(flipud(a), b)
 
 
-class TestHistogram2d(object):
+class TestHistogram2d:
     def test_simple(self):
         x = array(
             [0.41702200, 0.72032449, 1.1437481e-4, 0.302332573, 0.146755891])
@@ -296,7 +296,7 @@ class TestHistogram2d(object):
         assert_(r, ((ShouldDispatch,), (xy, xy), dict(weights=s_d)))
 
 
-class TestTri(object):
+class TestTri:
     def test_dtype(self):
         out = array([[1, 0, 0],
                      [1, 1, 0],
@@ -434,7 +434,7 @@ def test_tril_indices():
                               [-10, -10, -10, -10, -10]]))
 
 
-class TestTriuIndices(object):
+class TestTriuIndices:
     def test_triu_indices(self):
         iu1 = triu_indices(4)
         iu2 = triu_indices(4, k=2)
@@ -484,21 +484,21 @@ class TestTriuIndices(object):
                                   [16, 17, 18, -1, -1]]))
 
 
-class TestTrilIndicesFrom(object):
+class TestTrilIndicesFrom:
     def test_exceptions(self):
         assert_raises(ValueError, tril_indices_from, np.ones((2,)))
         assert_raises(ValueError, tril_indices_from, np.ones((2, 2, 2)))
         # assert_raises(ValueError, tril_indices_from, np.ones((2, 3)))
 
 
-class TestTriuIndicesFrom(object):
+class TestTriuIndicesFrom:
     def test_exceptions(self):
         assert_raises(ValueError, triu_indices_from, np.ones((2,)))
         assert_raises(ValueError, triu_indices_from, np.ones((2, 2, 2)))
         # assert_raises(ValueError, triu_indices_from, np.ones((2, 3)))
 
 
-class TestVander(object):
+class TestVander:
     def test_basic(self):
         c = np.array([0, 1, -2, 3])
         v = vander(c)

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -13,7 +13,7 @@ def assert_all(x):
     assert_(np.all(x), x)
 
 
-class TestCommonType(object):
+class TestCommonType:
     def test_basic(self):
         ai32 = np.array([[1, 2], [3, 4]], dtype=np.int32)
         af16 = np.array([[1, 2], [3, 4]], dtype=np.float16)
@@ -29,7 +29,7 @@ class TestCommonType(object):
         assert_(common_type(acd) == np.cdouble)
 
 
-class TestMintypecode(object):
+class TestMintypecode:
 
     def test_default_1(self):
         for itype in '1bcsuwil':
@@ -79,7 +79,7 @@ class TestMintypecode(object):
         assert_equal(mintypecode('idD'), 'D')
 
 
-class TestIsscalar(object):
+class TestIsscalar:
 
     def test_basic(self):
         assert_(np.isscalar(3))
@@ -90,7 +90,7 @@ class TestIsscalar(object):
         assert_(np.isscalar(4.0))
 
 
-class TestReal(object):
+class TestReal:
 
     def test_real(self):
         y = np.random.rand(10,)
@@ -121,7 +121,7 @@ class TestReal(object):
         assert_(not isinstance(out, np.ndarray))
 
 
-class TestImag(object):
+class TestImag:
 
     def test_real(self):
         y = np.random.rand(10,)
@@ -152,7 +152,7 @@ class TestImag(object):
         assert_(not isinstance(out, np.ndarray))
 
 
-class TestIscomplex(object):
+class TestIscomplex:
 
     def test_fail(self):
         z = np.array([-1, 0, 1])
@@ -165,7 +165,7 @@ class TestIscomplex(object):
         assert_array_equal(res, [1, 0, 0])
 
 
-class TestIsreal(object):
+class TestIsreal:
 
     def test_pass(self):
         z = np.array([-1, 0, 1j])
@@ -178,7 +178,7 @@ class TestIsreal(object):
         assert_array_equal(res, [0, 1, 1])
 
 
-class TestIscomplexobj(object):
+class TestIscomplexobj:
 
     def test_basic(self):
         z = np.array([-1, 0, 1])
@@ -207,7 +207,7 @@ class TestIscomplexobj(object):
         # (pandas.core.dtypes)
         class PdComplex(np.complex128):
             pass
-        class PdDtype(object):
+        class PdDtype:
             name = 'category'
             names = None
             type = PdComplex
@@ -231,7 +231,7 @@ class TestIscomplexobj(object):
         assert_(iscomplexobj(a))
 
 
-class TestIsrealobj(object):
+class TestIsrealobj:
     def test_basic(self):
         z = np.array([-1, 0, 1])
         assert_(isrealobj(z))
@@ -239,7 +239,7 @@ class TestIsrealobj(object):
         assert_(not isrealobj(z))
 
 
-class TestIsnan(object):
+class TestIsnan:
 
     def test_goodvalues(self):
         z = np.array((-1., 0., 1.))
@@ -269,7 +269,7 @@ class TestIsnan(object):
             assert_all(np.isnan(np.array(0+0j)/0.) == 1)
 
 
-class TestIsfinite(object):
+class TestIsfinite:
     # Fixme, wrong place, isfinite now ufunc
 
     def test_goodvalues(self):
@@ -300,7 +300,7 @@ class TestIsfinite(object):
             assert_all(np.isfinite(np.array(1+1j)/0.) == 0)
 
 
-class TestIsinf(object):
+class TestIsinf:
     # Fixme, wrong place, isinf now ufunc
 
     def test_goodvalues(self):
@@ -329,7 +329,7 @@ class TestIsinf(object):
             assert_all(np.isinf(np.array((0.,))/0.) == 0)
 
 
-class TestIsposinf(object):
+class TestIsposinf:
 
     def test_generic(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -339,7 +339,7 @@ class TestIsposinf(object):
         assert_(vals[2] == 1)
 
 
-class TestIsneginf(object):
+class TestIsneginf:
 
     def test_generic(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -349,7 +349,7 @@ class TestIsneginf(object):
         assert_(vals[2] == 0)
 
 
-class TestNanToNum(object):
+class TestNanToNum:
 
     def test_generic(self):
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -454,7 +454,7 @@ class TestNanToNum(object):
         assert_equal(type(vals), np.ndarray)
 
 
-class TestRealIfClose(object):
+class TestRealIfClose:
 
     def test_basic(self):
         a = np.random.rand(10)
@@ -467,7 +467,7 @@ class TestRealIfClose(object):
         assert_all(isrealobj(b))
 
 
-class TestArrayConversion(object):
+class TestArrayConversion:
 
     def test_asfarray(self):
         a = asfarray(np.array([1, 2, 3]))

--- a/numpy/lib/tests/test_ufunclike.py
+++ b/numpy/lib/tests/test_ufunclike.py
@@ -6,7 +6,7 @@ from numpy.testing import (
 )
 
 
-class TestUfunclike(object):
+class TestUfunclike:
 
     def test_isposinf(self):
         a = nx.array([nx.inf, -nx.inf, nx.nan, 0.0, 3.0, -3.0])

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -100,7 +100,7 @@ def test_safe_eval_nameconstant():
     utils.safe_eval('None')
 
 
-class TestByteBounds(object):
+class TestByteBounds:
 
     def test_byte_bounds(self):
         # pointer difference matches size * itemsize

--- a/numpy/lib/user_array.py
+++ b/numpy/lib/user_array.py
@@ -14,7 +14,7 @@ from numpy.core import (
 from numpy.compat import long
 
 
-class container(object):
+class container:
     """
     container(data, dtype=None, copy=True)
 

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -53,7 +53,7 @@ def _set_function_name(func, name):
     return func
 
 
-class _Deprecate(object):
+class _Deprecate:
     """
     Decorator class to deprecate old functions.
 

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -104,7 +104,7 @@ def cleanSource(source):
     source = re.sub(r'\n\n\n\n+', r'\n\n\n', source)
     return source
 
-class LineQueue(object):
+class LineQueue:
     def __init__(self):
         object.__init__(self)
         self._queue = []

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -24,7 +24,7 @@ def lineType(line):
     else:
         return STATEMENT
 
-class LineIterator(object):
+class LineIterator:
     """LineIterator(iterable)
 
     Return rstrip()'d lines from iterable, while keeping a count of the
@@ -47,7 +47,7 @@ class LineIterator(object):
     next = __next__
 
 
-class PushbackIterator(object):
+class PushbackIterator:
     """PushbackIterator(iterable)
 
     Return an iterator for which items can be pushed back into.

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -63,7 +63,7 @@ them.
 #endif
 '''
 
-class FortranRoutine(object):
+class FortranRoutine:
     """Wrapper for a Fortran routine in a file.
     """
     type = 'generic'
@@ -95,7 +95,7 @@ class UnknownFortranRoutine(FortranRoutine):
     def dependencies(self):
         return []
 
-class FortranLibrary(object):
+class FortranLibrary:
     """Container for a bunch of Fortran routines.
     """
     def __init__(self, src_dirs):

--- a/numpy/linalg/tests/test_build.py
+++ b/numpy/linalg/tests/test_build.py
@@ -7,7 +7,7 @@ from numpy.linalg import lapack_lite
 from numpy.testing import assert_
 
 
-class FindDependenciesLdd(object):
+class FindDependenciesLdd:
 
     def __init__(self):
         self.cmd = ['ldd']
@@ -39,7 +39,7 @@ class FindDependenciesLdd(object):
         return founds
 
 
-class TestF77Mismatch(object):
+class TestF77Mismatch:
 
     @pytest.mark.skipif(not(sys.platform[:5] == 'linux'),
                         reason="no fortran compiler on non-Linux platform")

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -66,7 +66,7 @@ all_tags = {
 }
 
 
-class LinalgCase(object):
+class LinalgCase:
     def __init__(self, name, a, b, tags=set()):
         """
         A bundle of arguments to be passed to a test case, with an identifying
@@ -331,7 +331,7 @@ CASES += _make_strided_cases()
 #
 # Test different routines against the above cases
 #
-class LinalgTestCase(object):
+class LinalgTestCase:
     TEST_CASES = CASES
 
     def check_cases(self, require=set(), exclude=set()):
@@ -632,7 +632,7 @@ class TestEig(EigCases):
         assert_(isinstance(a, np.ndarray))
 
 
-class SVDBaseTests(object):
+class SVDBaseTests:
     hermitian = False
 
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
@@ -974,7 +974,7 @@ class TestLstsq(LstsqCases):
 
 
 @pytest.mark.parametrize('dt', [np.dtype(c) for c in '?bBhHiIqQefdgFDGO']) 
-class TestMatrixPower(object):
+class TestMatrixPower:
 
     rshft_0 = np.eye(4)
     rshft_1 = rshft_0[[3, 0, 1, 2]]
@@ -1074,7 +1074,7 @@ class TestEigvalshCases(HermitianTestCase, HermitianGeneralizedTestCase):
         assert_allclose(ev2, evalues, rtol=get_rtol(ev.dtype))
 
 
-class TestEigvalsh(object):
+class TestEigvalsh:
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
@@ -1150,7 +1150,7 @@ class TestEighCases(HermitianTestCase, HermitianGeneralizedTestCase):
                         rtol=get_rtol(ev.dtype), err_msg=repr(a))
 
 
-class TestEigh(object):
+class TestEigh:
     @pytest.mark.parametrize('dtype', [single, double, csingle, cdouble])
     def test_types(self, dtype):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
@@ -1209,7 +1209,7 @@ class TestEigh(object):
         assert_(isinstance(a, np.ndarray))
 
 
-class _TestNormBase(object):
+class _TestNormBase:
     dt = None
     dec = None
 
@@ -1495,7 +1495,7 @@ class _TestNorm(_TestNorm2D, _TestNormGeneral):
     pass
 
 
-class TestNorm_NonSystematic(object):
+class TestNorm_NonSystematic:
 
     def test_longdouble_norm(self):
         # Non-regression test: p-norm of longdouble would previously raise
@@ -1550,7 +1550,7 @@ class TestNormInt64(_TestNorm, _TestNormInt64Base):
     pass
 
 
-class TestMatrixRank(object):
+class TestMatrixRank:
 
     def test_matrix_rank(self):
         # Full rank matrix
@@ -1599,7 +1599,7 @@ def test_reduced_rank():
         assert_equal(matrix_rank(X), 8)
 
 
-class TestQR(object):
+class TestQR:
     # Define the array class here, so run this on matrices elsewhere.
     array = np.array
 
@@ -1699,7 +1699,7 @@ class TestQR(object):
             self.check_qr(m2.T)
 
 
-class TestCholesky(object):
+class TestCholesky:
     # TODO: are there no other tests for cholesky?
 
     def test_basic_property(self):
@@ -1861,7 +1861,7 @@ def test_sdot_bug_8577():
         subprocess.check_call([sys.executable, "-c", code])
 
 
-class TestMultiDot(object):
+class TestMultiDot:
 
     def test_basic_function_with_three_arguments(self):
         # multi_dot with three arguments uses a fast hand coded algorithm to
@@ -1955,7 +1955,7 @@ class TestMultiDot(object):
         assert_raises(ValueError, multi_dot, [np.random.random((3, 3))])
 
 
-class TestTensorinv(object):
+class TestTensorinv:
 
     @pytest.mark.parametrize("arr, ind", [
         (np.ones((4, 6, 8, 2)), 2),

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -10,7 +10,7 @@ from numpy.testing import (
 )
 
 
-class TestRegression(object):
+class TestRegression:
 
     def test_eig_build(self):
         # Ticket #652

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -798,7 +798,7 @@ ufunc_domain = {}
 ufunc_fills = {}
 
 
-class _DomainCheckInterval(object):
+class _DomainCheckInterval:
     """
     Define a valid interval, so that :
 
@@ -823,7 +823,7 @@ class _DomainCheckInterval(object):
                                     umath.less(x, self.a))
 
 
-class _DomainTan(object):
+class _DomainTan:
     """
     Define a valid interval for the `tan` function, so that:
 
@@ -841,7 +841,7 @@ class _DomainTan(object):
             return umath.less(umath.absolute(umath.cos(x)), self.eps)
 
 
-class _DomainSafeDivide(object):
+class _DomainSafeDivide:
     """
     Define a domain for safe division.
 
@@ -862,7 +862,7 @@ class _DomainSafeDivide(object):
             return umath.absolute(a) * self.tolerance >= umath.absolute(b)
 
 
-class _DomainGreater(object):
+class _DomainGreater:
     """
     DomainGreater(v)(x) is True where x <= v.
 
@@ -878,7 +878,7 @@ class _DomainGreater(object):
             return umath.less_equal(x, self.critical_value)
 
 
-class _DomainGreaterEqual(object):
+class _DomainGreaterEqual:
     """
     DomainGreaterEqual(v)(x) is True where x < v.
 
@@ -894,7 +894,7 @@ class _DomainGreaterEqual(object):
             return umath.less(x, self.critical_value)
 
 
-class _MaskedUFunc(object):
+class _MaskedUFunc:
     def __init__(self, ufunc):
         self.f = ufunc
         self.__doc__ = ufunc.__doc__
@@ -2384,7 +2384,7 @@ def masked_invalid(a, copy=True):
 ###############################################################################
 
 
-class _MaskedPrintOption(object):
+class _MaskedPrintOption:
     """
     Handle the string used to represent missing data in a masked array.
 
@@ -2602,7 +2602,7 @@ def _arraymethod(funcname, onmask=True):
     return wrapped_method
 
 
-class MaskedIterator(object):
+class MaskedIterator:
     """
     Flat iterator object to iterate over masked arrays.
 
@@ -6644,7 +6644,7 @@ ptp.__doc__ = MaskedArray.ptp.__doc__
 ##############################################################################
 
 
-class _frommethod(object):
+class _frommethod:
     """
     Define functions from existing MaskedArray methods.
 
@@ -7978,7 +7978,7 @@ def fromflex(fxarray):
     return masked_array(fxarray['_data'], mask=fxarray['_mask'])
 
 
-class _convert2ma(object):
+class _convert2ma:
 
     """
     Convert functions from numpy to numpy.ma.

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -212,7 +212,7 @@ def masked_all_like(arr):
 #####--------------------------------------------------------------------------
 #---- --- Standard functions ---
 #####--------------------------------------------------------------------------
-class _fromnxfunction(object):
+class _fromnxfunction:
     """
     Defines a wrapper to adapt NumPy functions to masked arrays.
 

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -85,7 +85,7 @@ def _get_fieldmask(self):
     return fdmask
 
 
-class MaskedRecords(MaskedArray, object):
+class MaskedRecords(MaskedArray):
     """
 
     Attributes

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -63,7 +63,7 @@ num_dts = [np.dtype(dt_) for dt_ in '?bhilqBHILQefdgFD']
 num_ids = [dt_.char for dt_ in num_dts]
 
 
-class TestMaskedArray(object):
+class TestMaskedArray:
     # Base test class for MaskedArrays.
 
     def setup(self):
@@ -944,7 +944,7 @@ class TestMaskedArray(object):
         assert_(mx2[0] == 0.)
 
 
-class TestMaskedArrayArithmetic(object):
+class TestMaskedArrayArithmetic:
     # Base test class for MaskedArrays.
 
     def setup(self):
@@ -1713,7 +1713,7 @@ class TestMaskedArrayArithmetic(object):
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
 
-class TestMaskedArrayAttributes(object):
+class TestMaskedArrayAttributes:
 
     def test_keepmask(self):
         # Tests the keep mask flag
@@ -1889,7 +1889,7 @@ class TestMaskedArrayAttributes(object):
         assert_equal(m._mask, np.ma.nomask)
 
 
-class TestFillingValues(object):
+class TestFillingValues:
 
     def test_check_on_scalar(self):
         # Test _check_fill_value set to valid and invalid values
@@ -2227,7 +2227,7 @@ class TestFillingValues(object):
         assert_equal(a["f1"].fill_value, default_fill_value("eggs"))
 
 
-class TestUfuncs(object):
+class TestUfuncs:
     # Test class for the application of ufuncs on MaskedArrays.
 
     def setup(self):
@@ -2307,7 +2307,7 @@ class TestUfuncs(object):
         assert_raises(TypeError, operator.mul, a, "abc")
         assert_raises(TypeError, operator.truediv, a, "abc")
 
-        class MyClass(object):
+        class MyClass:
             __array_priority__ = a.__array_priority__ + 1
 
             def __mul__(self, other):
@@ -2321,7 +2321,7 @@ class TestUfuncs(object):
         assert_(a * me == "My rmul")
 
         # and that __array_priority__ is respected
-        class MyClass2(object):
+        class MyClass2:
             __array_priority__ = 100
 
             def __mul__(self, other):
@@ -2371,7 +2371,7 @@ class TestUfuncs(object):
             # also check that allclose uses ma ufuncs, to avoid warning
             allclose(m, 0.5)
 
-class TestMaskedArrayInPlaceArithmetics(object):
+class TestMaskedArrayInPlaceArithmetics:
     # Test MaskedArray Arithmetics
 
     def setup(self):
@@ -2873,7 +2873,7 @@ class TestMaskedArrayInPlaceArithmetics(object):
                 assert_equal(len(w), 0, "Failed on type=%s." % t)
 
 
-class TestMaskedArrayMethods(object):
+class TestMaskedArrayMethods:
     # Test class for miscellaneous MaskedArrays methods.
     def setup(self):
         # Base data definition.
@@ -3580,7 +3580,7 @@ class TestMaskedArrayMethods(object):
         assert_equal(xd.data, x.diagonal().data)
 
 
-class TestMaskedArrayMathMethods(object):
+class TestMaskedArrayMathMethods:
 
     def setup(self):
         # Base data definition.
@@ -3858,7 +3858,7 @@ class TestMaskedArrayMathMethods(object):
         assert_equal(a.max(1), [3, 6])
 
 
-class TestMaskedArrayMathMethodsComplex(object):
+class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
     def setup(self):
         # Base data definition.
@@ -3911,7 +3911,7 @@ class TestMaskedArrayMathMethodsComplex(object):
                                 mX[:, k].compressed().std())
 
 
-class TestMaskedArrayFunctions(object):
+class TestMaskedArrayFunctions:
     # Test class for miscellaneous functions.
 
     def setup(self):
@@ -4550,7 +4550,7 @@ class TestMaskedArrayFunctions(object):
         assert_equal(test, masked_equal([-1, -1, -1, -1, -1], -1))
 
 
-class TestMaskedFields(object):
+class TestMaskedFields:
 
     def setup(self):
         ilist = [1, 2, 3, 4, 5]
@@ -4712,7 +4712,7 @@ class TestMaskedFields(object):
             assert_equal(len(rec), len(self.data['ddtype']))
 
 
-class TestMaskedObjectArray(object):
+class TestMaskedObjectArray:
 
     def test_getitem(self):
         arr = np.ma.array([None, None])
@@ -4760,7 +4760,7 @@ class TestMaskedObjectArray(object):
         assert_(arr[0] is np.ma.masked)
 
 
-class TestMaskedView(object):
+class TestMaskedView:
 
     def setup(self):
         iterator = list(zip(np.arange(10), np.random.rand(10)))
@@ -4838,7 +4838,7 @@ class TestMaskedView(object):
         assert_(not isinstance(test, MaskedArray))
 
 
-class TestOptionalArgs(object):
+class TestOptionalArgs:
     def test_ndarrayfuncs(self):
         # test axis arg behaves the same as ndarray (including multiple axes)
 
@@ -4925,7 +4925,7 @@ class TestOptionalArgs(object):
         assert_raises(np.AxisError, count, np.ma.array(1), axis=1)
 
 
-class TestMaskedConstant(object):
+class TestMaskedConstant:
     def _do_add_test(self, add):
         # sanity check
         assert_(add(np.ma.masked, 1) is np.ma.masked)
@@ -5042,7 +5042,7 @@ class TestMaskedConstant(object):
         assert_raises(AttributeError, setattr, np.ma.masked, 'dtype', np.int64)
 
 
-class TestMaskedWhereAliases(object):
+class TestMaskedWhereAliases:
 
     # TODO: Test masked_object, masked_equal, ...
 

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_warns
 from numpy.ma.testutils import assert_equal
 from numpy.ma.core import MaskedArrayFutureWarning
 
-class TestArgsort(object):
+class TestArgsort:
     """ gh-8701 """
     def _test_base(self, argsort, cls):
         arr_0d = np.array(1).view(cls)
@@ -35,7 +35,7 @@ class TestArgsort(object):
         return self._test_base(np.ma.MaskedArray.argsort, np.ma.MaskedArray)
 
 
-class TestMinimumMaximum(object):
+class TestMinimumMaximum:
     def test_minimum(self):
         assert_warns(DeprecationWarning, np.ma.minimum, np.ma.array([1, 2]))
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -32,7 +32,7 @@ from numpy.ma.extras import (
     )
 
 
-class TestGeneric(object):
+class TestGeneric:
     #
     def test_masked_all(self):
         # Tests masked_all
@@ -140,7 +140,7 @@ class TestGeneric(object):
         assert_equal(test, [])
 
 
-class TestAverage(object):
+class TestAverage:
     # Several tests of average. Why so many ? Good point...
     def test_testAverage1(self):
         # Test of average.
@@ -271,7 +271,7 @@ class TestAverage(object):
         assert_almost_equal(wav1.imag, expected1.imag)
 
 
-class TestConcatenator(object):
+class TestConcatenator:
     # Tests for mr_, the equivalent of r_ for masked arrays.
 
     def test_1d(self):
@@ -315,7 +315,7 @@ class TestConcatenator(object):
         assert_equal(actual.data[:2], [1, 2])
 
 
-class TestNotMasked(object):
+class TestNotMasked:
     # Tests notmasked_edges and notmasked_contiguous.
 
     def test_edges(self):
@@ -385,7 +385,7 @@ class TestNotMasked(object):
         ])
 
 
-class TestCompressFunctions(object):
+class TestCompressFunctions:
 
     def test_compress_nd(self):
         # Tests compress_nd
@@ -650,7 +650,7 @@ class TestCompressFunctions(object):
         assert_equal(a, res)
 
 
-class TestApplyAlongAxis(object):
+class TestApplyAlongAxis:
     # Tests 2D functions
     def test_3d(self):
         a = arange(12.).reshape(2, 2, 3)
@@ -672,7 +672,7 @@ class TestApplyAlongAxis(object):
         assert_equal(xa, [[2, 5], [8, 11]])
 
 
-class TestApplyOverAxes(object):
+class TestApplyOverAxes:
     # Tests apply_over_axes
     def test_basic(self):
         a = arange(24).reshape(2, 3, 4)
@@ -685,7 +685,7 @@ class TestApplyOverAxes(object):
         assert_equal(test, ctrl)
 
 
-class TestMedian(object):
+class TestMedian:
     def test_pytype(self):
         r = np.ma.median([[np.inf, np.inf], [np.inf, np.inf]], axis=-1)
         assert_equal(r, np.inf)
@@ -1064,7 +1064,7 @@ class TestMedian(object):
         assert_(type(np.ma.median(o.astype(object))), float)
 
 
-class TestCov(object):
+class TestCov:
 
     def setup(self):
         self.data = array(np.random.rand(12))
@@ -1131,7 +1131,7 @@ class TestCov(object):
                              x.shape[0] / frac))
 
 
-class TestCorrcoef(object):
+class TestCorrcoef:
 
     def setup(self):
         self.data = array(np.random.rand(12))
@@ -1238,7 +1238,7 @@ class TestCorrcoef(object):
                                 control[:-1, :-1])
 
 
-class TestPolynomial(object):
+class TestPolynomial:
     #
     def test_polyfit(self):
         # Tests polyfit
@@ -1296,7 +1296,7 @@ class TestPolynomial(object):
             assert_almost_equal(a, a_)
 
 
-class TestArraySetOps(object):
+class TestArraySetOps:
 
     def test_unique_onlist(self):
         # Test unique on list
@@ -1528,7 +1528,7 @@ class TestArraySetOps(object):
         assert_array_equal(setdiff1d(a, b), np.array(['c']))
 
 
-class TestShapeBase(object):
+class TestShapeBase:
 
     def test_atleast_2d(self):
         # Test atleast_2d
@@ -1584,7 +1584,7 @@ class TestShapeBase(object):
         assert_equal(b.mask.shape, b.data.shape)
 
 
-class TestStack(object):
+class TestStack:
 
     def test_stack_1d(self):
         a = masked_array([0, 1, 2], mask=[0, 1, 0])

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -24,7 +24,7 @@ from numpy.ma.testutils import (
 from numpy.compat import pickle
 
 
-class TestMRecords(object):
+class TestMRecords:
 
     ilist = [1, 2, 3, 4, 5]
     flist = [1.1, 2.2, 3.3, 4.4, 5.5]
@@ -346,7 +346,7 @@ class TestMRecords(object):
                                       dtype=mult.dtype))
 
 
-class TestView(object):
+class TestView:
 
     def setup(self):
         (a, b) = (np.arange(10), np.random.rand(10))
@@ -384,7 +384,7 @@ class TestView(object):
 
 
 ##############################################################################
-class TestMRecordsImport(object):
+class TestMRecordsImport:
 
     _a = ma.array([1, 2, 3], mask=[0, 0, 1], dtype=int)
     _b = ma.array([1.1, 2.2, 3.3], mask=[0, 0, 1], dtype=float)

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -31,7 +31,7 @@ def eq(v, w, msg=''):
     return result
 
 
-class TestMa(object):
+class TestMa:
 
     def setup(self):
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
@@ -698,7 +698,7 @@ class TestMa(object):
         assert_equal(b[1].shape, ())
 
 
-class TestUfuncs(object):
+class TestUfuncs:
     def setup(self):
         self.d = (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
@@ -763,7 +763,7 @@ class TestUfuncs(object):
             assert_(eq(nonzero(x), [0]))
 
 
-class TestArrayMethods(object):
+class TestArrayMethods:
 
     def setup(self):
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -4,7 +4,7 @@ from numpy.testing import (
     )
 
 
-class TestRegression(object):
+class TestRegression:
     def test_masked_array_create(self):
         # Ticket #17
         x = np.ma.masked_array([0, 1, 2, 3, 0, 4, 5, 6],

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -78,7 +78,7 @@ msubarray = MSubArray
 # and overrides __array_wrap__, updating the info dict, to check that this
 # doesn't get destroyed by MaskedArray._update_from.  But this one also needs
 # its own iterator...
-class CSAIterator(object):
+class CSAIterator:
     """
     Flat iterator object that uses its own setter/getter
     (works around ndarray.flat not propagating subclass setters/getters
@@ -152,7 +152,7 @@ class ComplicatedSubArray(SubArray):
         return obj
 
 
-class TestSubclassing(object):
+class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
 
     def setup(self):

--- a/numpy/ma/timer_comparison.py
+++ b/numpy/ma/timer_comparison.py
@@ -13,7 +13,7 @@ np.seterr(all='ignore')
 pi = np.pi
 
 
-class ModuleTester(object):
+class ModuleTester:
     def __init__(self, module):
         self.module = module
         self.allequal = module.allequal

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -14,7 +14,7 @@ from numpy.testing import (
 from numpy.linalg import matrix_power
 from numpy.matrixlib import mat
 
-class TestCtor(object):
+class TestCtor:
     def test_basic(self):
         A = np.array([[1, 2], [3, 4]])
         mA = matrix(A)
@@ -61,7 +61,7 @@ class TestCtor(object):
         assert_(np.all(b2 == mixresult))
 
 
-class TestProperties(object):
+class TestProperties:
     def test_sum(self):
         """Test whether matrix.sum(axis=1) preserves orientation.
         Fails in NumPy <= 0.9.6.2127.
@@ -194,7 +194,7 @@ class TestProperties(object):
         B = matrix([[True], [True], [False]])
         assert_array_equal(A, B)
 
-class TestCasting(object):
+class TestCasting:
     def test_basic(self):
         A = np.arange(100).reshape(10, 10)
         mA = matrix(A)
@@ -213,7 +213,7 @@ class TestCasting(object):
         assert_(np.all(mA != mB))
 
 
-class TestAlgebra(object):
+class TestAlgebra:
     def test_basic(self):
         import numpy.linalg as linalg
 
@@ -272,7 +272,7 @@ class TestAlgebra(object):
             A*object()
 
 
-class TestMatrixReturn(object):
+class TestMatrixReturn:
     def test_instance_methods(self):
         a = matrix([1.0], dtype='f8')
         methodargs = {
@@ -314,7 +314,7 @@ class TestMatrixReturn(object):
         assert_(type(d) is np.ndarray)
 
 
-class TestIndexing(object):
+class TestIndexing:
     def test_basic(self):
         x = asmatrix(np.zeros((3, 2), float))
         y = np.zeros((3, 1), float)
@@ -323,7 +323,7 @@ class TestIndexing(object):
         assert_equal(x, [[0, 1], [0, 0], [0, 0]])
 
 
-class TestNewScalarIndexing(object):
+class TestNewScalarIndexing:
     a = matrix([[1, 2], [3, 4]])
 
     def test_dimesions(self):
@@ -390,7 +390,7 @@ class TestNewScalarIndexing(object):
         assert_array_equal(x[[2, 1, 0],:], x[::-1,:])
 
 
-class TestPower(object):
+class TestPower:
     def test_returntype(self):
         a = np.array([[0, 1], [0, 0]])
         assert_(type(matrix_power(a, 2)) is np.ndarray)
@@ -401,7 +401,7 @@ class TestPower(object):
         assert_array_equal(matrix_power([[0, 1], [0, 0]], 2), [[0, 0], [0, 0]])
 
 
-class TestShape(object):
+class TestShape:
 
     a = np.array([[1], [2]])
     m = matrix([[1], [2]])

--- a/numpy/matrixlib/tests/test_interaction.py
+++ b/numpy/matrixlib/tests/test_interaction.py
@@ -288,7 +288,7 @@ def test_kron_matrix():
     assert_equal(type(np.kron(m, a)), np.matrix)
 
 
-class TestConcatenatorMatrix(object):
+class TestConcatenatorMatrix:
     # 2018-04-29: moved here from core.tests.test_index_tricks.
     def test_matrix(self):
         a = [1, 2]

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -27,7 +27,7 @@ class MMatrix(MaskedArray, np.matrix,):
         return _view
 
 
-class TestMaskedMatrix(object):
+class TestMaskedMatrix:
     def test_matrix_indexing(self):
         # Tests conversions and indexing
         x1 = np.matrix([[1, 2, 3], [4, 3, 2]])
@@ -169,7 +169,7 @@ class TestMaskedMatrix(object):
         assert_(not isinstance(test, MaskedArray))
 
 
-class TestSubclassing(object):
+class TestSubclassing:
     # Test suite for masked subclasses of ndarray.
 
     def setup(self):
@@ -210,7 +210,7 @@ class TestSubclassing(object):
         assert_(isinstance(divide(mx, x), MMatrix))
         assert_equal(divide(mx, mx), divide(xmx, xmx))
 
-class TestConcatenator(object):
+class TestConcatenator:
     # Tests for mr_, the equivalent of r_ for masked arrays.
 
     def test_matrix_builder(self):

--- a/numpy/matrixlib/tests/test_multiarray.py
+++ b/numpy/matrixlib/tests/test_multiarray.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_, assert_equal, assert_array_equal
 
-class TestView(object):
+class TestView:
     def test_type(self):
         x = np.array([1, 2, 3])
         assert_(isinstance(x.view(np.matrix), np.matrix))

--- a/numpy/matrixlib/tests/test_numeric.py
+++ b/numpy/matrixlib/tests/test_numeric.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal
 
-class TestDot(object):
+class TestDot:
     def test_matscalar(self):
         b1 = np.matrix(np.ones((3, 3), dtype=complex))
         assert_equal(b1*1.0, b1)

--- a/numpy/matrixlib/tests/test_regression.py
+++ b/numpy/matrixlib/tests/test_regression.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises
 
 
-class TestRegression(object):
+class TestRegression:
     def test_kron_matrix(self):
         # Ticket #71
         x = np.matrix('[1 0; 1 0]')

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -78,7 +78,7 @@ class PolyDomainError(PolyError):
 # Base class for all polynomial types
 #
 
-class PolyBase(object):
+class PolyBase:
     """
     Base class for all polynomial types.
 

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -28,7 +28,7 @@ T9 = [0, 9, 0, -120, 0, 432, 0, -576, 0, 256]
 Tlist = [T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]
 
 
-class TestPrivate(object):
+class TestPrivate:
 
     def test__cseries_to_zseries(self):
         for i in range(5):
@@ -45,7 +45,7 @@ class TestPrivate(object):
             assert_equal(res, tgt)
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_chebdomain(self):
         assert_equal(cheb.chebdomain, [-1, 1])
@@ -60,7 +60,7 @@ class TestConstants(object):
         assert_equal(cheb.chebx, [0, 1])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
 
     def test_chebadd(self):
         for i in range(5):
@@ -121,7 +121,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([2.5, 2., 1.5])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -215,7 +215,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_chebint(self):
         # check exceptions
@@ -317,7 +317,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_chebder(self):
         # check exceptions
@@ -357,7 +357,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -405,7 +405,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestFitting(object):
+class TestFitting:
 
     def test_chebfit(self):
         def f(x):
@@ -482,7 +482,7 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
-class TestInterpolate(object):
+class TestInterpolate:
 
     def f(self, x):
         return x * (x - 1) * (x - 2)
@@ -507,7 +507,7 @@ class TestInterpolate(object):
                 assert_almost_equal(cheb.chebval(x, c), powx(x, p), decimal=12)
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, cheb.chebcompanion, [])
@@ -522,7 +522,7 @@ class TestCompanion(object):
         assert_(cheb.chebcompanion([1, 2])[0, 0] == -.5)
 
 
-class TestGauss(object):
+class TestGauss:
 
     def test_100(self):
         x, w = cheb.chebgauss(100)
@@ -541,7 +541,7 @@ class TestGauss(object):
         assert_almost_equal(w.sum(), tgt)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_chebfromroots(self):
         res = cheb.chebfromroots([])

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -572,7 +572,7 @@ def test_ufunc_override(Poly):
 
 
 
-class TestLatexRepr(object):
+class TestLatexRepr:
     """Test the latex repr used by ipython """
 
     def as_latex(self, obj):
@@ -626,7 +626,7 @@ class TestLatexRepr(object):
 #
 
 
-class TestInterpolate(object):
+class TestInterpolate:
 
     def f(self, x):
         return x * (x - 1) * (x - 2)

--- a/numpy/polynomial/tests/test_hermite.py
+++ b/numpy/polynomial/tests/test_hermite.py
@@ -28,7 +28,7 @@ def trim(x):
     return herm.hermtrim(x, tol=1e-6)
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_hermdomain(self):
         assert_equal(herm.hermdomain, [-1, 1])
@@ -43,7 +43,7 @@ class TestConstants(object):
         assert_equal(herm.hermx, [0, .5])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
     x = np.linspace(-3, 3, 100)
 
     def test_hermadd(self):
@@ -109,7 +109,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([2.5, 1., .75])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -203,7 +203,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_hermint(self):
         # check exceptions
@@ -305,7 +305,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_hermder(self):
         # check exceptions
@@ -345,7 +345,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -393,7 +393,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestFitting(object):
+class TestFitting:
 
     def test_hermfit(self):
         def f(x):
@@ -470,7 +470,7 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, herm.hermcompanion, [])
@@ -485,7 +485,7 @@ class TestCompanion(object):
         assert_(herm.hermcompanion([1, 2])[0, 0] == -.25)
 
 
-class TestGauss(object):
+class TestGauss:
 
     def test_100(self):
         x, w = herm.hermgauss(100)
@@ -504,7 +504,7 @@ class TestGauss(object):
         assert_almost_equal(w.sum(), tgt)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_hermfromroots(self):
         res = herm.hermfromroots([])

--- a/numpy/polynomial/tests/test_hermite_e.py
+++ b/numpy/polynomial/tests/test_hermite_e.py
@@ -28,7 +28,7 @@ def trim(x):
     return herme.hermetrim(x, tol=1e-6)
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_hermedomain(self):
         assert_equal(herme.hermedomain, [-1, 1])
@@ -43,7 +43,7 @@ class TestConstants(object):
         assert_equal(herme.hermex, [0, 1])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
     x = np.linspace(-3, 3, 100)
 
     def test_hermeadd(self):
@@ -109,7 +109,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([4., 2., 3.])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -203,7 +203,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_hermeint(self):
         # check exceptions
@@ -305,7 +305,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_hermeder(self):
         # check exceptions
@@ -346,7 +346,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -394,7 +394,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestFitting(object):
+class TestFitting:
 
     def test_hermefit(self):
         def f(x):
@@ -471,7 +471,7 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, herme.hermecompanion, [])
@@ -486,7 +486,7 @@ class TestCompanion(object):
         assert_(herme.hermecompanion([1, 2])[0, 0] == -.5)
 
 
-class TestGauss(object):
+class TestGauss:
 
     def test_100(self):
         x, w = herme.hermegauss(100)
@@ -505,7 +505,7 @@ class TestGauss(object):
         assert_almost_equal(w.sum(), tgt)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_hermefromroots(self):
         res = herme.hermefromroots([])

--- a/numpy/polynomial/tests/test_laguerre.py
+++ b/numpy/polynomial/tests/test_laguerre.py
@@ -25,7 +25,7 @@ def trim(x):
     return lag.lagtrim(x, tol=1e-6)
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_lagdomain(self):
         assert_equal(lag.lagdomain, [0, 1])
@@ -40,7 +40,7 @@ class TestConstants(object):
         assert_equal(lag.lagx, [1, -1])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
     x = np.linspace(-3, 3, 100)
 
     def test_lagadd(self):
@@ -106,7 +106,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([9., -14., 6.])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -200,7 +200,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_lagint(self):
         # check exceptions
@@ -302,7 +302,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_lagder(self):
         # check exceptions
@@ -342,7 +342,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -390,7 +390,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestFitting(object):
+class TestFitting:
 
     def test_lagfit(self):
         def f(x):
@@ -452,7 +452,7 @@ class TestFitting(object):
         assert_almost_equal(lag.lagfit(x, x, [0, 1]), [1, -1])
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, lag.lagcompanion, [])
@@ -467,7 +467,7 @@ class TestCompanion(object):
         assert_(lag.lagcompanion([1, 2])[0, 0] == 1.5)
 
 
-class TestGauss(object):
+class TestGauss:
 
     def test_100(self):
         x, w = lag.laggauss(100)
@@ -486,7 +486,7 @@ class TestGauss(object):
         assert_almost_equal(w.sum(), tgt)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_lagfromroots(self):
         res = lag.lagfromroots([])

--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -28,7 +28,7 @@ def trim(x):
     return leg.legtrim(x, tol=1e-6)
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_legdomain(self):
         assert_equal(leg.legdomain, [-1, 1])
@@ -43,7 +43,7 @@ class TestConstants(object):
         assert_equal(leg.legx, [0, 1])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
     x = np.linspace(-1, 1, 100)
 
     def test_legadd(self):
@@ -110,7 +110,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([2., 2., 2.])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -204,7 +204,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_legint(self):
         # check exceptions
@@ -306,7 +306,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_legder(self):
         # check exceptions
@@ -346,7 +346,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -394,7 +394,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestFitting(object):
+class TestFitting:
 
     def test_legfit(self):
         def f(x):
@@ -471,7 +471,7 @@ class TestFitting(object):
         assert_almost_equal(coef1, coef2)
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, leg.legcompanion, [])
@@ -486,7 +486,7 @@ class TestCompanion(object):
         assert_(leg.legcompanion([1, 2])[0, 0] == -.5)
 
 
-class TestGauss(object):
+class TestGauss:
 
     def test_100(self):
         x, w = leg.leggauss(100)
@@ -505,7 +505,7 @@ class TestGauss(object):
         assert_almost_equal(w.sum(), tgt)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_legfromroots(self):
         res = leg.legfromroots([])

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -27,7 +27,7 @@ T9 = [0, 9, 0, -120, 0, 432, 0, -576, 0, 256]
 Tlist = [T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]
 
 
-class TestConstants(object):
+class TestConstants:
 
     def test_polydomain(self):
         assert_equal(poly.polydomain, [-1, 1])
@@ -42,7 +42,7 @@ class TestConstants(object):
         assert_equal(poly.polyx, [0, 1])
 
 
-class TestArithmetic(object):
+class TestArithmetic:
 
     def test_polyadd(self):
         for i in range(5):
@@ -112,7 +112,7 @@ class TestArithmetic(object):
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
 
-class TestEvaluation(object):
+class TestEvaluation:
     # coefficients of 1 + 2*x + 3*x**2
     c1d = np.array([1., 2., 3.])
     c2d = np.einsum('i,j->ij', c1d, c1d)
@@ -285,7 +285,7 @@ class TestEvaluation(object):
         assert_(res.shape == (2, 3)*3)
 
 
-class TestIntegral(object):
+class TestIntegral:
 
     def test_polyint(self):
         # check exceptions
@@ -384,7 +384,7 @@ class TestIntegral(object):
         assert_almost_equal(res, tgt)
 
 
-class TestDerivative(object):
+class TestDerivative:
 
     def test_polyder(self):
         # check exceptions
@@ -424,7 +424,7 @@ class TestDerivative(object):
         assert_almost_equal(res, tgt)
 
 
-class TestVander(object):
+class TestVander:
     # some random values in [-1, 1)
     x = np.random.random((3, 5))*2 - 1
 
@@ -472,7 +472,7 @@ class TestVander(object):
         assert_(van.shape == (1, 5, 24))
 
 
-class TestCompanion(object):
+class TestCompanion:
 
     def test_raises(self):
         assert_raises(ValueError, poly.polycompanion, [])
@@ -487,7 +487,7 @@ class TestCompanion(object):
         assert_(poly.polycompanion([1, 2])[0, 0] == -.5)
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_polyfromroots(self):
         res = poly.polyfromroots([])

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -8,7 +8,7 @@ from numpy.testing import (
     )
 
 
-class TestMisc(object):
+class TestMisc:
 
     def test_trimseq(self):
         for i in range(5):
@@ -41,7 +41,7 @@ class TestMisc(object):
         assert_equal(pu.trimcoef(coef, 2), [0])
 
 
-class TestDomain(object):
+class TestDomain:
 
     def test_getdomain(self):
         # test for real values

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -2,7 +2,7 @@ import numpy.polynomial as poly
 from numpy.testing import assert_equal
 
 
-class TestStr(object):
+class TestStr:
     def test_polynomial_str(self):
         res = str(poly.Polynomial([0, 1]))
         tgt = 'poly([0. 1.])'
@@ -34,7 +34,7 @@ class TestStr(object):
         assert_equal(res, tgt)
 
 
-class TestRepr(object):
+class TestRepr:
     def test_polynomial_str(self):
         res = repr(poly.Polynomial([0, 1]))
         tgt = 'Polynomial([0., 1.], domain=[-1,  1], window=[-1,  1])'

--- a/numpy/random/tests/test_direct.py
+++ b/numpy/random/tests/test_direct.py
@@ -145,7 +145,7 @@ def test_seedsequence():
     assert len(dummy.spawn(10)) == 10
 
 
-class Base(object):
+class Base:
     dtype = np.uint64
     data2 = data1 = {}
 
@@ -410,7 +410,7 @@ class TestSFC64(Base):
         cls.invalid_init_values = [(-1,)]
 
 
-class TestDefaultRNG(object):
+class TestDefaultRNG:
     def test_seed(self):
         for args in [(), (None,), (1234,), ([1234, 5678],)]:
             rg = default_rng(*args)

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -19,7 +19,7 @@ def endpoint(request):
     return request.param
 
 
-class TestSeed(object):
+class TestSeed:
     def test_scalar(self):
         s = Generator(MT19937(0))
         assert_equal(s.integers(1000), 479)
@@ -55,7 +55,7 @@ class TestSeed(object):
         assert_raises(ValueError, Generator, MT19937)
 
 
-class TestBinomial(object):
+class TestBinomial:
     def test_n_zero(self):
         # Tests the corner case of n == 0 for the binomial distribution.
         # binomial(0, p) should be zero for any p in [0, 1].
@@ -70,7 +70,7 @@ class TestBinomial(object):
         assert_raises(ValueError, random.binomial, 1, np.nan)
 
 
-class TestMultinomial(object):
+class TestMultinomial:
     def test_basic(self):
         random.multinomial(100, [0.2, 0.8])
 
@@ -116,7 +116,7 @@ class TestMultinomial(object):
         assert_array_equal(non_contig, contig)
 
 
-class TestMultivariateHypergeometric(object):
+class TestMultivariateHypergeometric:
 
     def setup(self):
         self.seed = 8675309
@@ -250,7 +250,7 @@ class TestMultivariateHypergeometric(object):
         assert_array_equal(sample, expected)
 
 
-class TestSetState(object):
+class TestSetState:
     def setup(self):
         self.seed = 1234567890
         self.rg = Generator(MT19937(self.seed))
@@ -284,7 +284,7 @@ class TestSetState(object):
         self.rg.negative_binomial(0.5, 0.5)
 
 
-class TestIntegers(object):
+class TestIntegers:
     rfunc = random.integers
 
     # valid integer/boolean types
@@ -637,7 +637,7 @@ class TestIntegers(object):
         assert chi2 < chi2max
 
 
-class TestRandomDist(object):
+class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
@@ -1565,7 +1565,7 @@ class TestRandomDist(object):
         assert_array_equal(actual, desired)
 
 
-class TestBroadcast(object):
+class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
     def setup(self):
@@ -2117,7 +2117,7 @@ class TestBroadcast(object):
         assert_array_equal(actual, desired)
 
 
-class TestThread(object):
+class TestThread:
     # make sure each state produces the same sequence even in threads
     def setup(self):
         self.seeds = range(4)
@@ -2164,7 +2164,7 @@ class TestThread(object):
 
 
 # See Issue #4263
-class TestSingleEltArrayInput(object):
+class TestSingleEltArrayInput:
     def setup(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -7,7 +7,7 @@ from numpy.random import Generator, MT19937
 mt19937 = Generator(MT19937())
 
 
-class TestRegression(object):
+class TestRegression:
 
     def test_VonMises_range(self):
         # Make sure generated random variables are in [-pi, pi].
@@ -136,7 +136,7 @@ class TestRegression(object):
         assert_array_equal(perm, np.array([2, 0, 1]))
         assert_array_equal(orig, np.arange(3).view(N))
 
-        class M(object):
+        class M:
             a = np.arange(5)
 
             def __array__(self):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -10,7 +10,7 @@ from numpy import random
 import sys
 
 
-class TestSeed(object):
+class TestSeed:
     def test_scalar(self):
         s = np.random.RandomState(0)
         assert_equal(s.randint(1000), 684)
@@ -49,7 +49,7 @@ class TestSeed(object):
                                                           [4, 5, 6]])
 
 
-class TestBinomial(object):
+class TestBinomial:
     def test_n_zero(self):
         # Tests the corner case of n == 0 for the binomial distribution.
         # binomial(0, p) should be zero for any p in [0, 1].
@@ -64,7 +64,7 @@ class TestBinomial(object):
         assert_raises(ValueError, random.binomial, 1, np.nan)
 
 
-class TestMultinomial(object):
+class TestMultinomial:
     def test_basic(self):
         random.multinomial(100, [0.2, 0.8])
 
@@ -92,7 +92,7 @@ class TestMultinomial(object):
                       float(1))
 
 
-class TestSetState(object):
+class TestSetState:
     def setup(self):
         self.seed = 1234567890
         self.prng = random.RandomState(self.seed)
@@ -140,7 +140,7 @@ class TestSetState(object):
         self.prng.negative_binomial(0.5, 0.5)
 
 
-class TestRandint(object):
+class TestRandint:
 
     rfunc = np.random.randint
 
@@ -278,7 +278,7 @@ class TestRandint(object):
             assert_equal(type(sample), dt)
 
 
-class TestRandomDist(object):
+class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
@@ -973,7 +973,7 @@ class TestRandomDist(object):
         assert_array_equal(actual, desired)
 
 
-class TestBroadcast(object):
+class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
     def setup(self):
@@ -1543,7 +1543,7 @@ class TestBroadcast(object):
         assert_raises(ValueError, logseries, bad_p_two * 3)
 
 
-class TestThread(object):
+class TestThread:
     # make sure each state produces the same sequence even in threads
     def setup(self):
         self.seeds = range(4)
@@ -1587,7 +1587,7 @@ class TestThread(object):
 
 
 # See Issue #4263
-class TestSingleEltArrayInput(object):
+class TestSingleEltArrayInput:
     def setup(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -61,7 +61,7 @@ def assert_mt19937_state_equal(a, b):
     assert_equal(a['gauss'], b['gauss'])
 
 
-class TestSeed(object):
+class TestSeed:
     def test_scalar(self):
         s = random.RandomState(0)
         assert_equal(s.randint(1000), 684)
@@ -108,7 +108,7 @@ class TestSeed(object):
         assert_raises(ValueError, random.RandomState, MT19937)
 
 
-class TestBinomial(object):
+class TestBinomial:
     def test_n_zero(self):
         # Tests the corner case of n == 0 for the binomial distribution.
         # binomial(0, p) should be zero for any p in [0, 1].
@@ -123,7 +123,7 @@ class TestBinomial(object):
         assert_raises(ValueError, random.binomial, 1, np.nan)
 
 
-class TestMultinomial(object):
+class TestMultinomial:
     def test_basic(self):
         random.multinomial(100, [0.2, 0.8])
 
@@ -168,7 +168,7 @@ class TestMultinomial(object):
         assert_array_equal(non_contig, contig)
 
 
-class TestSetState(object):
+class TestSetState:
     def setup(self):
         self.seed = 1234567890
         self.random_state = random.RandomState(self.seed)
@@ -255,7 +255,7 @@ class TestSetState(object):
         assert repr(self.random_state).startswith('RandomState(MT19937)')
 
 
-class TestRandint(object):
+class TestRandint:
 
     rfunc = random.randint
 
@@ -392,7 +392,7 @@ class TestRandint(object):
             assert_equal(type(sample), dt)
 
 
-class TestRandomDist(object):
+class TestRandomDist:
     # Make sure the random distribution returns the correct value for a
     # given seed
 
@@ -1245,7 +1245,7 @@ class TestRandomDist(object):
         assert_array_equal(actual, desired)
 
 
-class TestBroadcast(object):
+class TestBroadcast:
     # tests that functions that broadcast behave
     # correctly when presented with non-scalar arguments
     def setup(self):
@@ -1832,7 +1832,7 @@ class TestBroadcast(object):
         assert_raises(ValueError, logseries, bad_p_two * 3)
 
 
-class TestThread(object):
+class TestThread:
     # make sure each state produces the same sequence even in threads
     def setup(self):
         self.seeds = range(4)
@@ -1879,7 +1879,7 @@ class TestThread(object):
 
 
 # See Issue #4263
-class TestSingleEltArrayInput(object):
+class TestSingleEltArrayInput:
     def setup(self):
         self.argOne = np.array([2])
         self.argTwo = np.array([3])

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy import random
 
 
-class TestRegression(object):
+class TestRegression:
 
     def test_VonMises_range(self):
         # Make sure generated random variables are in [-pi, pi].
@@ -147,7 +147,7 @@ class TestRegression(object):
         assert_array_equal(perm, np.array([0, 2, 1]))
         assert_array_equal(orig, np.arange(3).view(N))
 
-        class M(object):
+        class M:
             a = np.arange(5)
 
             def __array__(self):

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -7,7 +7,7 @@ from numpy.compat import long
 import numpy as np
 
 
-class TestRegression(object):
+class TestRegression:
 
     def test_VonMises_range(self):
         # Make sure generated random variables are in [-pi, pi].
@@ -143,7 +143,7 @@ class TestRegression(object):
         assert_array_equal(perm, np.array([0, 2, 1]))
         assert_array_equal(orig, np.arange(3).view(N))
 
-        class M(object):
+        class M:
             a = np.arange(5)
 
             def __array__(self):

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -91,7 +91,7 @@ def warmup(rg, n=None):
     rg.random(n, dtype=np.float32)
 
 
-class RNG(object):
+class RNG:
     @classmethod
     def setup_class(cls):
         # Overridden in test classes. Place holder to silence IDE noise

--- a/numpy/testing/_private/noseclasses.py
+++ b/numpy/testing/_private/noseclasses.py
@@ -266,7 +266,7 @@ class NumpyDoctest(npd.Doctest):
         return npd.Doctest.wantFile(self, file)
 
 
-class Unplugger(object):
+class Unplugger:
     """ Nose plugin to remove named plugin late in loading
 
     By default it removes the "doctest" plugin.

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -110,7 +110,7 @@ def run_module_suite(file_to_run=None, argv=None):
     nose.run(argv=argv, addplugins=[KnownFailurePlugin()])
 
 
-class NoseTester(object):
+class NoseTester:
     """
     Nose test runner.
 

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -293,10 +293,10 @@ def detect_runner():
             _test_runner_guess = None
     return _test_runner_guess
 
-class parameterized(object):
+class parameterized:
     """ Parameterize a test case::
 
-            class TestInt(object):
+            class TestInt:
                 @parameterized([
                     ("A", 10),
                     ("F", 15),

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2001,7 +2001,7 @@ class clear_and_catch_warnings(warnings.catch_warnings):
                 mod.__warningregistry__.update(self._warnreg_copies[mod])
 
 
-class suppress_warnings(object):
+class suppress_warnings:
     """
     Context manager and decorator doing much the same as
     ``warnings.catch_warnings``.

--- a/numpy/testing/print_coercion_tables.py
+++ b/numpy/testing/print_coercion_tables.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 # Generic object that can be added, but doesn't do anything else
-class GenericObject(object):
+class GenericObject:
     def __init__(self, v):
         self.v = v
 

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -21,7 +21,7 @@ else:
 
 
 @pytest.mark.skipif(not HAVE_NOSE, reason="Needs nose")
-class TestNoseDecorators(object):
+class TestNoseDecorators:
     # These tests are run in a class for simplicity while still
     # getting a report on each, skipped or success.
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -18,7 +18,7 @@ from numpy.testing import (
 from numpy.core.overrides import ARRAY_FUNCTION_ENABLED
 
 
-class _GenericTest(object):
+class _GenericTest:
 
     def _test_equal(self, a, b):
         self._assert_func(a, b)
@@ -209,7 +209,7 @@ class TestArrayEqual(_GenericTest):
         self._test_not_equal(b, a)
 
 
-class TestBuildErrorMessage(object):
+class TestBuildErrorMessage:
 
     def test_build_err_msg_defaults(self):
         x = np.array([1.00001, 2.00002, 3.00003])
@@ -616,7 +616,7 @@ class TestAlmostEqual(_GenericTest):
         self._assert_func(a, a)
 
 
-class TestApproxEqual(object):
+class TestApproxEqual:
 
     def setup(self):
         self._assert_func = assert_approx_equal
@@ -659,7 +659,7 @@ class TestApproxEqual(object):
         assert_raises(AssertionError, lambda: self._assert_func(ainf, anan))
 
 
-class TestArrayAssertLess(object):
+class TestArrayAssertLess:
 
     def setup(self):
         self._assert_func = assert_array_less
@@ -769,7 +769,7 @@ class TestArrayAssertLess(object):
 
 
 @pytest.mark.skip(reason="The raises decorator depends on Nose")
-class TestRaises(object):
+class TestRaises:
 
     def setup(self):
         class MyException(Exception):
@@ -803,7 +803,7 @@ class TestRaises(object):
             raise AssertionError("should have raised an AssertionError")
 
 
-class TestWarns(object):
+class TestWarns:
 
     def test_warn(self):
         def f():
@@ -854,7 +854,7 @@ class TestWarns(object):
             raise AssertionError("wrong warning caught by assert_warn")
 
 
-class TestAssertAllclose(object):
+class TestAssertAllclose:
 
     def test_simple(self):
         x = 1e-3
@@ -924,7 +924,7 @@ class TestAssertAllclose(object):
         assert_('Max relative difference: 0.5' in msg)
 
 
-class TestArrayAlmostEqualNulp(object):
+class TestArrayAlmostEqualNulp:
 
     def test_float64_pass(self):
         # The number of units of least precision
@@ -1121,7 +1121,7 @@ class TestArrayAlmostEqualNulp(object):
                       xi, y + y*1j, nulp)
 
 
-class TestULP(object):
+class TestULP:
 
     def test_equal(self):
         x = np.random.randn(10)
@@ -1177,7 +1177,7 @@ class TestULP(object):
                           maxulp=maxulp))
 
 
-class TestStringEqual(object):
+class TestStringEqual:
     def test_simple(self):
         assert_string_equal("hello", "hello")
         assert_string_equal("hello\nmultiline", "hello\nmultiline")
@@ -1239,7 +1239,7 @@ def test_warn_len_equal_call_scenarios():
     # check that no assertion is uncaught
 
     # parallel scenario -- no warning issued yet
-    class mod(object):
+    class mod:
         pass
 
     mod_inst = mod()
@@ -1249,7 +1249,7 @@ def test_warn_len_equal_call_scenarios():
 
     # serial test scenario -- the __warningregistry__
     # attribute should be present
-    class mod(object):
+    class mod:
         def __init__(self):
             self.__warningregistry__ = {'warning1':1,
                                         'warning2':2}
@@ -1524,7 +1524,7 @@ def test_clear_and_catch_warnings_inherit():
 
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-class TestAssertNoGcCycles(object):
+class TestAssertNoGcCycles:
     """ Test assert_no_gc_cycles """
     def test_passes(self):
         def no_cycle():
@@ -1558,7 +1558,7 @@ class TestAssertNoGcCycles(object):
         error, instead of hanging forever trying to clear it.
         """
 
-        class ReferenceCycleInDel(object):
+        class ReferenceCycleInDel:
             """
             An object that not only contains a reference cycle, but creates new
             cycles whenever it's garbage-collected and its __del__ runs

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -35,7 +35,7 @@ else:
                     reason="ctypes not available in this python")
 @pytest.mark.skipif(sys.platform == 'cygwin',
                     reason="Known to fail on cygwin")
-class TestLoadLibrary(object):
+class TestLoadLibrary:
     def test_basic(self):
         try:
             # Should succeed
@@ -61,7 +61,7 @@ class TestLoadLibrary(object):
             print(msg)
 
 
-class TestNdpointer(object):
+class TestNdpointer:
     def test_dtype(self):
         dt = np.intc
         p = ndpointer(dtype=dt)
@@ -128,7 +128,7 @@ class TestNdpointer(object):
 
 @pytest.mark.skipif(ctypes is None,
                     reason="ctypes not available on this python installation")
-class TestNdpointerCFunc(object):
+class TestNdpointerCFunc:
     def test_arguments(self):
         """ Test that arguments are coerced from arrays """
         c_forward_pointer.restype = ctypes.c_void_p
@@ -184,7 +184,7 @@ class TestNdpointerCFunc(object):
 
 @pytest.mark.skipif(ctypes is None,
                     reason="ctypes not available on this python installation")
-class TestAsArray(object):
+class TestAsArray:
     def test_array(self):
         from ctypes import c_int
 
@@ -275,7 +275,7 @@ class TestAsArray(object):
 
 @pytest.mark.skipif(ctypes is None,
                     reason="ctypes not available on this python installation")
-class TestAsCtypesType(object):
+class TestAsCtypesType:
     """ Test conversion from dtypes to ctypes types """
     def test_scalar(self):
         dt = np.dtype('<u2')

--- a/tools/allocation_tracking/alloc_hook.pyx
+++ b/tools/allocation_tracking/alloc_hook.pyx
@@ -22,7 +22,7 @@ cdef void pyhook(void *old, void *new, size_t size, void *user_data):
            PyLong_FromVoidPtr(new),
            size)
 
-class NumpyAllocHook(object):
+class NumpyAllocHook:
     def __init__(self, callback):
         self.callback = callback
 

--- a/tools/allocation_tracking/track_allocations.py
+++ b/tools/allocation_tracking/track_allocations.py
@@ -3,7 +3,7 @@ import gc
 import inspect
 from alloc_hook import NumpyAllocHook
 
-class AllocationTracker(object):
+class AllocationTracker:
     def __init__(self, threshold=0):
         '''track numpy allocations of size threshold bytes or more.'''
 

--- a/tools/npy_tempita/__init__.py
+++ b/tools/npy_tempita/__init__.py
@@ -90,7 +90,7 @@ def get_file_template(name, from_template):
         get_template=from_template.get_template)
 
 
-class Template(object):
+class Template:
 
     default_namespace = {
         'start_braces': '{{',
@@ -438,7 +438,7 @@ class bunch(dict):
 ############################################################
 
 
-class html(object):
+class html:
 
     def __init__(self, value):
         self.value = value
@@ -520,7 +520,7 @@ def sub_html(content, **kw):
     return tmpl.substitute(kw)
 
 
-class TemplateDef(object):
+class TemplateDef:
     def __init__(self, template, func_name, func_signature,
                  body, ns, pos, bound_self=None):
         self._template = template
@@ -597,7 +597,7 @@ class TemplateDef(object):
         return values
 
 
-class TemplateObject(object):
+class TemplateObject:
 
     def __init__(self, name):
         self.__name = name
@@ -607,7 +607,7 @@ class TemplateObject(object):
         return '<%s %s>' % (self.__class__.__name__, self.__name)
 
 
-class TemplateObjectGetter(object):
+class TemplateObjectGetter:
 
     def __init__(self, template_obj):
         self.__template_obj = template_obj
@@ -620,7 +620,7 @@ class TemplateObjectGetter(object):
             self.__class__.__name__, self.__template_obj)
 
 
-class _Empty(object):
+class _Empty:
     def __call__(self, *args, **kw):
         return self
 

--- a/tools/npy_tempita/_looper.py
+++ b/tools/npy_tempita/_looper.py
@@ -23,7 +23,7 @@ from .compat3 import basestring_
 __all__ = ['looper']
 
 
-class looper(object):
+class looper:
     """
     Helper for looping (particularly in templates)
 
@@ -45,7 +45,7 @@ class looper(object):
             self.__class__.__name__, self.seq)
 
 
-class looper_iter(object):
+class looper_iter:
 
     def __init__(self, seq):
         self.seq = list(seq)
@@ -65,7 +65,7 @@ class looper_iter(object):
         next = __next__
 
 
-class loop_pos(object):
+class loop_pos:
 
     def __init__(self, seq, pos):
         self.seq = seq

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -795,7 +795,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
     def out(msg):
         output.append(msg)
 
-    class MyStderr(object):
+    class MyStderr:
         """
         Redirect stderr to the current stdout
         """


### PR DESCRIPTION
Inheriting from object was necessary for Python 2 compatibility to use
new-style classes. In Python 3, this is unnecessary as there are no
old-style classes.

Dropping the object is more idiomatic Python.