### PR TITLE
MAINT: Remove references to non-existent sys.exc_clear()

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -164,7 +164,6 @@ class PytestTester:
 
         # Ignore python2.7 -3 warnings
         pytest_args += [
-            r"-W ignore:sys\.exc_clear\(\) not supported in 3\.x:DeprecationWarning",
             r"-W ignore:in 3\.x, __setslice__:DeprecationWarning",
             r"-W ignore:in 3\.x, __getslice__:DeprecationWarning",
             r"-W ignore:buffer\(\) not supported in 3\.x:DeprecationWarning",

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -9,7 +9,7 @@ from numpy.core._multiarray_tests import array_indexing
 from itertools import product
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal, assert_warns,
-    HAS_REFCOUNT, suppress_warnings,
+    HAS_REFCOUNT,
     )
 
 
@@ -669,30 +669,16 @@ class TestSubclasses:
         k[0:5]
         assert_equal(k.indx, slice(0, 5))
         assert_equal(sys.getrefcount(k.indx), 2)
-        try:
+        with assert_raises(ValueError):
             k[0:7]
-            raise AssertionError
-        except ValueError:
-            # The exception holds a reference to the slice so clear on Py2
-            if hasattr(sys, 'exc_clear'):
-                with suppress_warnings() as sup:
-                    sup.filter(DeprecationWarning)
-                    sys.exc_clear()
         assert_equal(k.indx, slice(0, 7))
         assert_equal(sys.getrefcount(k.indx), 2)
 
         k[0:3] = 6
         assert_equal(k.indx, slice(0, 3))
         assert_equal(sys.getrefcount(k.indx), 2)
-        try:
+        with assert_raises(ValueError):
             k[0:4] = 2
-            raise AssertionError
-        except ValueError:
-            # The exception holds a reference to the slice so clear on Py2
-            if hasattr(sys, 'exc_clear'):
-                with suppress_warnings() as sup:
-                    sup.filter(DeprecationWarning)
-                    sys.exc_clear()
         assert_equal(k.indx, slice(0, 4))
         assert_equal(sys.getrefcount(k.indx), 2)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8221,9 +8221,6 @@ class TestArrayFinalize:
         # get an array that crashed in __array_finalize__
         with assert_raises(Exception) as e:
             obj_arr.view(RaisesInFinalize)
-        if sys.version_info.major == 2:
-            # prevent an extra reference being kept
-            sys.exc_clear()
 
         obj_subarray = e.exception.args[0]
         del e

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -454,9 +454,6 @@ class NoseTester:
                 # This is very specific, so using the fragile module filter
                 # is fine
                 import threading
-                sup.filter(DeprecationWarning,
-                           r"sys\.exc_clear\(\) not supported in 3\.x",
-                           module=threading)
                 sup.filter(DeprecationWarning, message=r"in 3\.x, __setslice__")
                 sup.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
                 sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ filterwarnings =
 # Matrix PendingDeprecationWarning.
     ignore:the matrix subclass is not
 # Ignore python2.7 -3 warnings
-    ignore:sys\.exc_clear\(\) not supported in 3\.x:DeprecationWarning
     ignore:in 3\.x, __setslice__:DeprecationWarning
     ignore:in 3\.x, __getslice__:DeprecationWarning
     ignore:buffer\(\) not supported in 3\.x:DeprecationWarning


### PR DESCRIPTION
sys.exc_clear() was removed in [Python 3.0](https://docs.python.org/3.8/whatsnew/3.0.html?highlight=exc_clear). All internal uses can be
removed.

Edit: added link to python release note