### PR TITLE
MAINT: cleanup use of sys.exc_info

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -16,7 +16,6 @@ from distutils.sysconfig import customize_compiler
 from distutils.version import LooseVersion
 
 from numpy.distutils import log
-from numpy.distutils.compat import get_exception
 from numpy.distutils.exec_command import (
     filepath_from_subprocess_output, forward_bytes_to_stdout
 )
@@ -756,15 +755,15 @@ def new_compiler (plat=None,
     module_name = "numpy.distutils." + module_name
     try:
         __import__ (module_name)
-    except ImportError:
-        msg = str(get_exception())
+    except ImportError as e:
+        msg = str(e)
         log.info('%s in numpy.distutils; trying from distutils',
                  str(msg))
         module_name = module_name[6:]
         try:
             __import__(module_name)
-        except ImportError:
-            msg = str(get_exception())
+        except ImportError as e:
+            msg = str(e)
             raise DistutilsModuleError("can't compile C/C++ code: unable to load module '%s'" % \
                   module_name)
     try:

--- a/numpy/distutils/command/config.py
+++ b/numpy/distutils/command/config.py
@@ -24,7 +24,6 @@ from numpy.distutils.command.autodist import (check_gcc_function_attribute,
                                               check_inline,
                                               check_restrict,
                                               check_compiler_gcc4)
-from numpy.distutils.compat import get_exception
 
 LANG_EXT['f77'] = '.f'
 LANG_EXT['f90'] = '.f90'
@@ -52,8 +51,7 @@ class config(old_config):
             if not self.compiler.initialized:
                 try:
                     self.compiler.initialize()
-                except IOError:
-                    e = get_exception()
+                except IOError as e:
                     msg = textwrap.dedent("""\
                         Could not initialize compiler instance: do you have Visual Studio
                         installed?  If you are trying to build with MinGW, please use "python setup.py
@@ -96,8 +94,8 @@ class config(old_config):
             self.compiler = self.fcompiler
         try:
             ret = mth(*((self,)+args))
-        except (DistutilsExecError, CompileError):
-            str(get_exception())
+        except (DistutilsExecError, CompileError) as e:
+            str(e)
             self.compiler = save_compiler
             raise CompileError
         self.compiler = save_compiler

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -87,8 +87,6 @@ import os
 import sys
 import re
 
-from numpy.distutils.compat import get_exception
-
 # names for replacement that are already global.
 global_names = {}
 
@@ -240,8 +238,7 @@ def parse_string(astr, env, level, line) :
             code.append(replace_re.sub(replace, pref))
             try :
                 envlist = parse_loop_header(head)
-            except ValueError:
-                e = get_exception()
+            except ValueError as e:
                 msg = "line %d: %s" % (newline, e)
                 raise ValueError(msg)
             for newenv in envlist :
@@ -289,8 +286,7 @@ def process_file(source):
     sourcefile = os.path.normcase(source).replace("\\", "\\\\")
     try:
         code = process_str(''.join(lines))
-    except ValueError:
-        e = get_exception()
+    except ValueError as e:
         raise ValueError('In "%s" loop at %s' % (sourcefile, e))
     return '#line 1 "%s"\n%s' % (sourcefile, code)
 
@@ -327,8 +323,7 @@ def main():
     allstr = fid.read()
     try:
         writestr = process_str(allstr)
-    except ValueError:
-        e = get_exception()
+    except ValueError as e:
         raise ValueError("In %s loop at %s" % (file, e))
 
     outfile.write(writestr)

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -27,13 +27,10 @@ else:
 import warnings
 import platform
 
-from numpy.distutils.compat import get_exception
-
 def getoutput(cmd, successful_status=(0,), stacklevel=1):
     try:
         status, output = getstatusoutput(cmd)
-    except EnvironmentError:
-        e = get_exception()
+    except EnvironmentError as e:
         warnings.warn(str(e), UserWarning, stacklevel=stacklevel)
         return False, ""
     if os.WIFEXITED(status) and os.WEXITSTATUS(status) in successful_status:
@@ -115,8 +112,7 @@ class LinuxCPUInfo(CPUInfoBase):
             info[0]['uname_m'] = output.strip()
         try:
             fo = open('/proc/cpuinfo')
-        except EnvironmentError:
-            e = get_exception()
+        except EnvironmentError as e:
             warnings.warn(str(e), UserWarning, stacklevel=2)
         else:
             for line in fo:
@@ -523,8 +519,8 @@ class Win32CPUInfo(CPUInfoBase):
                                     info[-1]["Family"]=int(srch.group("FML"))
                                     info[-1]["Model"]=int(srch.group("MDL"))
                                     info[-1]["Stepping"]=int(srch.group("STP"))
-        except Exception:
-            print(sys.exc_info()[1], '(ignoring)')
+        except Exception as e:
+            print(e, '(ignoring)')
         self.__class__.info = info
 
     def _not_impl(self): pass

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -36,7 +36,6 @@ from numpy.distutils import log
 from numpy.distutils.misc_util import is_string, all_strings, is_sequence, \
     make_temp_file, get_shared_lib_extension
 from numpy.distutils.exec_command import find_executable
-from numpy.distutils.compat import get_exception
 from numpy.distutils import _shell_utils
 
 from .environment import EnvironmentConfig
@@ -614,8 +613,8 @@ class FCompiler(CCompiler):
                               src)
         try:
             self.spawn(command, display=display)
-        except DistutilsExecError:
-            msg = str(get_exception())
+        except DistutilsExecError as e:
+            msg = str(e)
             raise CompileError(msg)
 
     def module_options(self, module_dirs, module_build_dir):
@@ -682,8 +681,8 @@ class FCompiler(CCompiler):
             command = linker + ld_args
             try:
                 self.spawn(command)
-            except DistutilsExecError:
-                msg = str(get_exception())
+            except DistutilsExecError as e:
+                msg = str(e)
                 raise LinkError(msg)
         else:
             log.debug("skipping %s (up-to-date)", output_filename)
@@ -931,8 +930,7 @@ def show_fcompilers(dist=None):
             c = new_fcompiler(compiler=compiler, verbose=dist.verbose)
             c.customize(dist)
             v = c.get_version()
-        except (DistutilsModuleError, CompilerNotFound):
-            e = get_exception()
+        except (DistutilsModuleError, CompilerNotFound) as e:
             log.debug("show_fcompilers: %s not found" % (compiler,))
             log.debug(repr(e))
 

--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 from numpy.distutils.fcompiler import FCompiler
-from numpy.distutils.compat import get_exception
 from distutils.errors import DistutilsPlatformError
 
 compilers = ['CompaqFCompiler']
@@ -82,19 +81,16 @@ class CompaqVisualFCompiler(FCompiler):
             ar_exe = m.lib
         except DistutilsPlatformError:
             pass
-        except AttributeError:
-            msg = get_exception()
+        except AttributeError as e:
             if '_MSVCCompiler__root' in str(msg):
                 print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (msg))
             else:
                 raise
-        except IOError:
-            e = get_exception()
+        except IOError as e:
             if not "vcvarsall.bat" in str(e):
                 print("Unexpected IOError in", __file__)
                 raise e
-        except ValueError:
-            e = get_exception()
+        except ValueError as e:
             if not "'path'" in str(e):
                 print("Unexpected ValueError in", __file__)
                 raise e

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -12,7 +12,6 @@ import subprocess
 from subprocess import Popen, PIPE, STDOUT
 from numpy.distutils.exec_command import filepath_from_subprocess_output
 from numpy.distutils.fcompiler import FCompiler
-from numpy.distutils.compat import get_exception
 from numpy.distutils.system_info import system_info
 
 compilers = ['GnuFCompiler', 'Gnu95FCompiler']
@@ -560,5 +559,5 @@ if __name__ == '__main__':
     print(customized_fcompiler('gnu').get_version())
     try:
         print(customized_fcompiler('g95').get_version())
-    except Exception:
-        print(get_exception())
+    except Exception as e:
+        print(e)

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -34,7 +34,6 @@ def clean_up_temporary_directory():
 
 atexit.register(clean_up_temporary_directory)
 
-from numpy.distutils.compat import get_exception
 from numpy.compat import basestring
 from numpy.compat import npy_load_module
 
@@ -1972,9 +1971,8 @@ class Configuration(object):
                 try:
                     version_module = npy_load_module('_'.join(n.split('.')),
                                                      fn, info)
-                except ImportError:
-                    msg = get_exception()
-                    self.warn(str(msg))
+                except ImportError as e:
+                    self.warn(str(e))
                     version_module = None
                 if version_module is None:
                     continue

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -163,7 +163,6 @@ from numpy.distutils.exec_command import (
 from numpy.distutils.misc_util import (is_sequence, is_string,
                                        get_shared_lib_extension)
 from numpy.distutils.command.config import config as cmd_config
-from numpy.distutils.compat import get_exception
 from numpy.distutils import customized_ccompiler as _customized_ccompiler
 from numpy.distutils import _shell_utils
 import distutils.ccompiler
@@ -2541,18 +2540,18 @@ class numerix_info(system_info):
             try:
                 import numpy  # noqa: F401
                 which = "numpy", "defaulted"
-            except ImportError:
-                msg1 = str(get_exception())
+            except ImportError as e:
+                msg1 = str(e)
                 try:
                     import Numeric  # noqa: F401
                     which = "numeric", "defaulted"
-                except ImportError:
-                    msg2 = str(get_exception())
+                except ImportError as e:
+                    msg2 = str(e)
                     try:
                         import numarray  # noqa: F401
                         which = "numarray", "defaulted"
-                    except ImportError:
-                        msg3 = str(get_exception())
+                    except ImportError as e:
+                        msg3 = str(e)
                         log.info(msg1)
                         log.info(msg2)
                         log.info(msg3)

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -9,7 +9,6 @@ import os
 from distutils.errors import DistutilsExecError, CompileError
 from distutils.unixccompiler import *
 from numpy.distutils.ccompiler import replace_method
-from numpy.distutils.compat import get_exception
 from numpy.distutils.misc_util import _commandline_dep_string
 
 if sys.version_info[0] < 3:
@@ -56,8 +55,8 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
     try:
         self.spawn(self.compiler_so + cc_args + [src, '-o', obj] + deps +
                    extra_postargs, display = display)
-    except DistutilsExecError:
-        msg = str(get_exception())
+    except DistutilsExecError as e:
+        msg = str(e)
         raise CompileError(msg)
 
     # add commandline flags to dependency file
@@ -128,8 +127,8 @@ def UnixCCompiler_create_static_lib(self, objects, output_libname,
             try:
                 self.spawn(self.ranlib + [output_filename],
                            display = display)
-            except DistutilsExecError:
-                msg = str(get_exception())
+            except DistutilsExecError as e:
+                msg = str(e)
                 raise LibError(msg)
     else:
         log.debug("skipping %s (up-to-date)", output_filename)


### PR DESCRIPTION
This code originates from python 2.6, before there was an `as` clause in `except`.

This removes all callers of `numpy.distutils.compat.get_exception`.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
