### PR TITLE
MAINT: Eliminate some calls to `eval`

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -4,6 +4,7 @@ A place for internal code
 Some things are more easily handled Python.
 
 """
+import ast
 import re
 import sys
 import platform
@@ -196,7 +197,7 @@ def _commastring(astr):
         if (repeats == ''):
             newitem = dtype
         else:
-            newitem = (dtype, eval(repeats))
+            newitem = (dtype, ast.literal_eval(repeats))
         result.append(newitem)
 
     return result

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3113,11 +3113,12 @@ def true_intent_list(var):
     ret = []
     for intent in lst:
         try:
-            c = eval('isintent_%s(var)' % intent)
-        except NameError:
-            c = 0
-        if c:
-            ret.append(intent)
+            f = globals()['isintent_%s' % intent]
+        except KeyError:
+            c = False
+        else:
+            if f(var):
+                ret.append(intent)
     return ret
 
 

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3115,7 +3115,7 @@ def true_intent_list(var):
         try:
             f = globals()['isintent_%s' % intent]
         except KeyError:
-            c = False
+            pass
         else:
             if f(var):
                 ret.append(intent)

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -178,7 +178,7 @@ def buildhooks(pymod):
                      (m['name'], undo_rmbadname1(n)))
                 fadd('integer flag\n')
                 fhooks[0] = fhooks[0] + fgetdims1
-                dms = eval('range(1,%s+1)' % (dm['rank']))
+                dms = range(1, int(dm['rank']) + 1)
                 fadd(' allocate(d(%s))\n' %
                      (','.join(['s(%s)' % i for i in dms])))
                 fhooks[0] = fhooks[0] + use_fgetdims2


### PR DESCRIPTION
* The instance in `_internal` is parsing tuples and integers, so `ast.literal_eval` is just fine
* The instance in `crack_fortran` is just trying to lookup a function name dynamically
* The instance in `f90mod_rules` is looking at the result of `capi_maps.getarrdims(...)['rank']`, which is always a string representation of an integer

The f2py code is still littered with `eval`, but the remaining cases were harder to reason about.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
