### PR TITLE
DOC: clarify the effect of None parameters passed to ndarray.view

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4126,6 +4126,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
 
     New view of array with the same data.
 
+    .. note::
+        Passing None for ``dtype`` is different from omitting the parameter,
+        since the former invokes ``dtype(None)`` which is an alias for
+        ``dtype('float_')``.
+
     Parameters
     ----------
     dtype : data-type or ndarray sub-class, optional

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4122,7 +4122,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('var',
 
 add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     """
-    a.view(dtype=None, type=None)
+    a.view([dtype][, type])
 
     New view of array with the same data.
 
@@ -4159,11 +4159,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
     defined as a slice or transpose, etc., the view may give different
     results.
-
-    Passing None explicitly for ``dtype`` is different from omitting the
-    parameter, since the former invokes ``dtype(None)`` which is an alias for
-    ``dtype('float_')``. Similarly, explicitly passing None for ``type``
-    is an error.
 
 
     Examples

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4129,14 +4129,14 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     Parameters
     ----------
     dtype : data-type or ndarray sub-class, optional
-        Data-type descriptor of the returned view, e.g., float32 or int16. The
-        default, None, results in the view having the same data-type as `a`.
+        Data-type descriptor of the returned view, e.g., float32 or int16.
+        Omitting it results in the view having the same data-type as `a`.
         This argument can also be specified as an ndarray sub-class, which
         then specifies the type of the returned object (this is equivalent to
         setting the ``type`` parameter).
     type : Python type, optional
-        Type of the returned view, e.g., ndarray or matrix.  Again, the
-        default None results in type preservation.
+        Type of the returned view, e.g., ndarray or matrix.  Again, omission
+        of the parameter results in type preservation.
 
     Notes
     -----
@@ -4159,6 +4159,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
     defined as a slice or transpose, etc., the view may give different
     results.
+
+    Passing None explicitly for ``dtype`` is different from omitting the
+    parameter, since the former invokes ``dtype(None)`` which is an alias for
+    ``dtype('float_')``. Similarly, explicitly passing None for ``type``
+    is an error.
 
 
     Examples


### PR DESCRIPTION
Issue https://github.com/numpy/numpy/issues/14875 suggests that passing explicit `None`s to `ndarray.view` will lead to surprising (non-default) behaviour. Although the behaviour is due to an implementation detail (i.e. that `view` is written in C), it might be helpful to make this quirk explicit in the documentation.

Related things that might need tackling:

1. There's a reference to core/defmatrix.py at the top of core/_add_newdocs.py, but I can't seem to find this file. Perhaps this reference should be removed or fixed while we're at it.
2. Masked arrays have a similar API for `.view`, yet there passing `None` works as expected, since it's all written in Python. Perhaps this should be mentioned in those docs? I'm leaning towards "no".
3. The description of the `dtype` parameter references a hypothetical `a` array, which makes sense in the interactive help but seems undefined in [the online docs](https://numpy.org/devdocs/reference/generated/numpy.ndarray.view.html#numpy.ndarray.view) where the header says `ndarray.view` rather than `a.view`. This is probably a more ubiquitous feature in the docs, but I figured I'd note it in case this needs fixing too.
4. I rephrased the parameter descriptions to emphasize the _omission_ of these parameters, but I also added a paragraph to the notes explaining the behaviour when explicit `None`s are passed. If this  latter addition ends up staying, would it make sense to have a test for `dtype(None) is dtype('float_')` (assuming there isn't one already, I haven't looked yet)? In case this ever gets changed, [though not very likely](https://github.com/numpy/numpy/issues/14875#issuecomment-552280923), we'd want to update these notes as well.