### PR TITLE
MAINT: Improve const-correctness of string arguments

### DIFF
--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -50,14 +50,14 @@ _is_basic_python_type(PyTypeObject *tp)
  * there is no such attribute, and NULL with an exception on failure.
  */
 static NPY_INLINE PyObject *
-maybe_get_attr(PyObject *obj, char *name)
+maybe_get_attr(PyObject *obj, char const *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
     PyObject *res = (PyObject *)NULL;
 
     /* Attribute referenced by (char *)name */
     if (tp->tp_getattr != NULL) {
-        res = (*tp->tp_getattr)(obj, name);
+        res = (*tp->tp_getattr)(obj, (char *)name);
         if (res == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Clear();
         }
@@ -91,7 +91,7 @@ maybe_get_attr(PyObject *obj, char *name)
  * In future, could be made more like _Py_LookupSpecial
  */
 static NPY_INLINE PyObject *
-PyArray_LookupSpecial(PyObject *obj, char *name)
+PyArray_LookupSpecial(PyObject *obj, char const *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
 
@@ -111,7 +111,7 @@ PyArray_LookupSpecial(PyObject *obj, char *name)
  * Kept for backwards compatibility. In future, we should deprecate this.
  */
 static NPY_INLINE PyObject *
-PyArray_LookupSpecial_OnInstance(PyObject *obj, char *name)
+PyArray_LookupSpecial_OnInstance(PyObject *obj, char const *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
 

--- a/numpy/core/src/common/ucsnarrow.c
+++ b/numpy/core/src/common/ucsnarrow.c
@@ -31,7 +31,7 @@
  * Values above 0xffff are converted to surrogate pairs.
  */
 NPY_NO_EXPORT int
-PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs4length)
+PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 const *ucs4, int ucs4length)
 {
     int i;
     int numucs2 = 0;
@@ -63,7 +63,7 @@ PyUCS2Buffer_FromUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs4length)
  * The return value is the actual size of the used part of the ucs4 buffer.
  */
 NPY_NO_EXPORT int
-PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs2len, int ucs4len)
+PyUCS2Buffer_AsUCS4(Py_UNICODE const *ucs2, npy_ucs4 *ucs4, int ucs2len, int ucs4len)
 {
     int i;
     npy_ucs4 chr;
@@ -107,10 +107,11 @@ PyUCS2Buffer_AsUCS4(Py_UNICODE *ucs2, npy_ucs4 *ucs4, int ucs2len, int ucs4len)
  * new_reference: PyUnicodeObject
  */
 NPY_NO_EXPORT PyUnicodeObject *
-PyUnicode_FromUCS4(char *src, Py_ssize_t size, int swap, int align)
+PyUnicode_FromUCS4(char const *src, Py_ssize_t size, int swap, int align)
 {
     Py_ssize_t ucs4len = size / sizeof(npy_ucs4);
-    npy_ucs4 *buf = (npy_ucs4 *)src;
+    /* FIXME: This is safe, but better to rewrite to not cast away const */
+    npy_ucs4 *buf = (npy_ucs4 *)(char *)src;
     int alloc = 0;
     PyUnicodeObject *ret;
 
@@ -136,7 +137,7 @@ PyUnicode_FromUCS4(char *src, Py_ssize_t size, int swap, int align)
     /* produce PyUnicode object */
 #ifdef Py_UNICODE_WIDE
     {
-        ret = (PyUnicodeObject *)PyUnicode_FromUnicode((Py_UNICODE*)buf,
+        ret = (PyUnicodeObject *)PyUnicode_FromUnicode((Py_UNICODE const*)buf,
                                                        (Py_ssize_t) ucs4len);
         if (ret == NULL) {
             goto fail;

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -1,7 +1,7 @@
 #ifndef _NPY_PRIVATE__DATETIME_H_
 #define _NPY_PRIVATE__DATETIME_H_
 
-extern NPY_NO_EXPORT char *_datetime_strings[NPY_DATETIME_NUMUNITS];
+extern NPY_NO_EXPORT char const *_datetime_strings[NPY_DATETIME_NUMUNITS];
 extern NPY_NO_EXPORT int _days_per_month_table[2][12];
 
 NPY_NO_EXPORT void
@@ -68,7 +68,7 @@ days_to_month_number(npy_datetime days);
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-parse_datetime_metadata_from_metastr(char *metastr, Py_ssize_t len,
+parse_datetime_metadata_from_metastr(char const *metastr, Py_ssize_t len,
                                     PyArray_DatetimeMetaData *out_meta);
 
 
@@ -78,7 +78,7 @@ parse_datetime_metadata_from_metastr(char *metastr, Py_ssize_t len,
  * contain its string length.
  */
 NPY_NO_EXPORT PyArray_Descr *
-parse_dtype_from_datetime_typestr(char *typestr, Py_ssize_t len);
+parse_dtype_from_datetime_typestr(char const *typestr, Py_ssize_t len);
 
 /*
  * Converts a substring given by 'str' and 'len' into
@@ -88,7 +88,7 @@ parse_dtype_from_datetime_typestr(char *typestr, Py_ssize_t len);
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT NPY_DATETIMEUNIT
-parse_datetime_unit_from_string(char *str, Py_ssize_t len, char *metastr);
+parse_datetime_unit_from_string(char const *str, Py_ssize_t len, char const *metastr);
 
 /*
  * Translate divisors into multiples of smaller units.
@@ -99,7 +99,7 @@ parse_datetime_unit_from_string(char *str, Py_ssize_t len, char *metastr);
  */
 NPY_NO_EXPORT int
 convert_datetime_divisor_to_multiple(PyArray_DatetimeMetaData *meta,
-                                    int den, char *metastr);
+                                    int den, char const *metastr);
 
 /*
  * Determines whether the 'divisor' metadata divides evenly into

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -388,7 +388,7 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
 /*NUMPY_API
  */
 NPY_NO_EXPORT int
-PyArray_TypeNumFromName(char *str)
+PyArray_TypeNumFromName(char const *str)
 {
     int i;
     PyArray_Descr *descr;
@@ -614,7 +614,7 @@ PyArray_SetDatetimeParseFunction(PyObject *NPY_UNUSED(op))
 /*NUMPY_API
  */
 NPY_NO_EXPORT int
-PyArray_CompareUCS4(npy_ucs4 *s1, npy_ucs4 *s2, size_t len)
+PyArray_CompareUCS4(npy_ucs4 const *s1, npy_ucs4 const *s2, size_t len)
 {
     npy_ucs4 c1, c2;
     while(len-- > 0) {
@@ -703,10 +703,13 @@ PyArray_FailUnlessWriteable(PyArrayObject *obj, const char *name)
    If they are NULL terminated, then stop comparison.
 */
 static int
-_myunincmp(npy_ucs4 *s1, npy_ucs4 *s2, int len1, int len2)
+_myunincmp(npy_ucs4 const *s1, npy_ucs4 const *s2, int len1, int len2)
 {
-    npy_ucs4 *sptr;
-    npy_ucs4 *s1t=s1, *s2t=s2;
+    npy_ucs4 const *sptr;
+    /* FIXME: Casting away const makes the below easier to write, but should
+     * still be safe.
+     */
+    npy_ucs4 *s1t = (npy_ucs4 *)s1, *s2t = (npy_ucs4 *)s2;
     int val;
     npy_intp size;
     int diff;
@@ -763,9 +766,9 @@ _myunincmp(npy_ucs4 *s1, npy_ucs4 *s2, int len1, int len2)
  * If they are NULL terminated, then stop comparison.
  */
 static int
-_mystrncmp(char *s1, char *s2, int len1, int len2)
+_mystrncmp(char const *s1, char const *s2, int len1, int len2)
 {
-    char *sptr;
+    char const *sptr;
     int val;
     int diff;
 
@@ -827,7 +830,7 @@ static void _unistripw(npy_ucs4 *s, int n)
 
 
 static char *
-_char_copy_n_strip(char *original, char *temp, int nc)
+_char_copy_n_strip(char const *original, char *temp, int nc)
 {
     if (nc > SMALL_STRING) {
         temp = malloc(nc);
@@ -850,7 +853,7 @@ _char_release(char *ptr, int nc)
 }
 
 static char *
-_uni_copy_n_strip(char *original, char *temp, int nc)
+_uni_copy_n_strip(char const *original, char *temp, int nc)
 {
     if (nc*sizeof(npy_ucs4) > SMALL_STRING) {
         temp = malloc(nc*sizeof(npy_ucs4));
@@ -919,7 +922,7 @@ _compare_strings(PyArrayObject *result, PyArrayMultiIterObject *multi,
     int N1, N2;
     int (*compfunc)(void *, void *, int, int);
     void (*relfunc)(char *, int);
-    char* (*stripfunc)(char *, char *, int);
+    char* (*stripfunc)(char const *, char *, int);
 
     compfunc = func;
     dptr = (npy_bool *)PyArray_DATA(result);

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -968,13 +968,13 @@ NPY_NO_EXPORT PyBufferProcs array_as_buffer = {
  */
 
 static int
-_descriptor_from_pep3118_format_fast(char *s, PyObject **result);
+_descriptor_from_pep3118_format_fast(char const *s, PyObject **result);
 
 static int
 _pep3118_letter_to_type(char letter, int native, int complex);
 
 NPY_NO_EXPORT PyArray_Descr*
-_descriptor_from_pep3118_format(char *s)
+_descriptor_from_pep3118_format(char const *s)
 {
     char *buf, *p;
     int in_name = 0;
@@ -1059,7 +1059,7 @@ _descriptor_from_pep3118_format(char *s)
  */
 
 static int
-_descriptor_from_pep3118_format_fast(char *s, PyObject **result)
+_descriptor_from_pep3118_format_fast(char const *s, PyObject **result)
 {
     PyArray_Descr *descr;
 

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -554,7 +554,7 @@ fail:
 
 /* new reference */
 NPY_NO_EXPORT PyArray_Descr *
-_array_typedescr_fromstr(char *c_str)
+_array_typedescr_fromstr(char const *c_str)
 {
     PyArray_Descr *descr = NULL;
     PyObject *stringobj = PyString_FromString(c_str);

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -49,7 +49,7 @@ NPY_NO_EXPORT PyArray_Descr *
 _array_find_python_scalar_type(PyObject *op);
 
 NPY_NO_EXPORT PyArray_Descr *
-_array_typedescr_fromstr(char *str);
+_array_typedescr_fromstr(char const *str);
 
 NPY_NO_EXPORT char *
 index2ptr(PyArrayObject *mp, npy_intp i);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3590,7 +3590,7 @@ array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nrea
  */
 #define FROM_BUFFER_SIZE 4096
 static PyArrayObject *
-array_from_text(PyArray_Descr *dtype, npy_intp num, char *sep, size_t *nread,
+array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nread,
                 void *stream, next_element next, skip_separator skip_sep,
                 void *stream_data)
 {

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -218,7 +218,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-parse_iso_8601_datetime(char *str, Py_ssize_t len,
+parse_iso_8601_datetime(char const *str, Py_ssize_t len,
                     NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     npy_datetimestruct *out,
@@ -227,7 +227,7 @@ parse_iso_8601_datetime(char *str, Py_ssize_t len,
 {
     int year_leap = 0;
     int i, numdigits;
-    char *substr;
+    char const *substr;
     Py_ssize_t sublen;
     NPY_DATETIMEUNIT bestunit;
 

--- a/numpy/core/src/multiarray/datetime_strings.h
+++ b/numpy/core/src/multiarray/datetime_strings.h
@@ -33,7 +33,7 @@
  * Returns 0 on success, -1 on failure.
  */
 NPY_NO_EXPORT int
-parse_iso_8601_datetime(char *str, Py_ssize_t len,
+parse_iso_8601_datetime(char const *str, Py_ssize_t len,
                     NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     npy_datetimestruct *out,

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -199,7 +199,7 @@ _check_for_commastring(const char *type, Py_ssize_t len)
 #undef _chk_byteorder
 
 static int
-is_datetime_typestr(char *type, Py_ssize_t len)
+is_datetime_typestr(char const *type, Py_ssize_t len)
 {
     if (len < 2) {
         return 0;

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -26,6 +26,6 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype);
 NPY_NO_EXPORT PyArray_Descr *
 arraydescr_field_subset_view(PyArray_Descr *self, PyObject *ind);
 
-extern NPY_NO_EXPORT char *_datetime_strings[];
+extern NPY_NO_EXPORT char const *_datetime_strings[];
 
 #endif

--- a/numpy/core/src/multiarray/npy_buffer.h
+++ b/numpy/core/src/multiarray/npy_buffer.h
@@ -7,7 +7,7 @@ NPY_NO_EXPORT void
 _dealloc_cached_buffer_info(PyObject *self);
 
 NPY_NO_EXPORT PyArray_Descr*
-_descriptor_from_pep3118_format(char *s);
+_descriptor_from_pep3118_format(char const *s);
 
 NPY_NO_EXPORT int
 gentype_getbuffer(PyObject *obj, Py_buffer *view, int flags);


### PR DESCRIPTION
Using CI to test here because windows compilers aren't strict enough when built by `runtests.py`
