### PR TITLE
MAINT: Implement keyword-only arguments as syntax

### DIFF
--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -430,8 +430,8 @@ class errstate(contextlib.ContextDecorator):
 
     """
 
-    def __init__(self, **kwargs):
-        self.call = kwargs.pop('call', _Unspecified)
+    def __init__(self, *, call=_Unspecified, **kwargs):
+        self.call = call
         self.kwargs = kwargs
 
     def __enter__(self):

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -130,7 +130,7 @@ class Ufunc:
     type_descriptions : list of TypeDescription objects
     """
     def __init__(self, nin, nout, identity, docstring, typereso,
-                 *type_descriptions, **kwargs):
+                 *type_descriptions, signature=None):
         self.nin = nin
         self.nout = nout
         if identity is None:
@@ -139,13 +139,11 @@ class Ufunc:
         self.docstring = docstring
         self.typereso = typereso
         self.type_descriptions = []
-        self.signature = kwargs.pop('signature', None)
+        self.signature = signature
         for td in type_descriptions:
             self.type_descriptions.extend(td)
         for td in self.type_descriptions:
             td.finish_signature(self.nin, self.nout)
-        if kwargs:
-            raise ValueError('unknown kwargs %r' % str(kwargs))
 
 # String-handling utilities to avoid locale-dependence.
 

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -34,7 +34,7 @@ class MachArLike:
 
     def __init__(self,
                  ftype,
-                 **kwargs):
+                 *, eps, epsneg, huge, tiny, ibeta, **kwargs):
         params = _MACHAR_PARAMS[ftype]
         float_conv = lambda v: array([v], ftype)
         float_to_float = lambda v : _fr1(float_conv(v))
@@ -42,11 +42,11 @@ class MachArLike:
 
         self.title = params['title']
         # Parameter types same as for discovered MachAr object.
-        self.epsilon = self.eps = float_to_float(kwargs.pop('eps'))
-        self.epsneg = float_to_float(kwargs.pop('epsneg'))
-        self.xmax = self.huge = float_to_float(kwargs.pop('huge'))
-        self.xmin = self.tiny = float_to_float(kwargs.pop('tiny'))
-        self.ibeta = params['itype'](kwargs.pop('ibeta'))
+        self.epsilon = self.eps = float_to_float(eps)
+        self.epsneg = float_to_float(epsneg)
+        self.xmax = self.huge = float_to_float(huge)
+        self.xmin = self.tiny = float_to_float(tiny)
+        self.ibeta = params['itype'](ibeta)
         self.__dict__.update(kwargs)
         self.precision = int(-log10(self.eps))
         self.resolution = float_to_float(float_conv(10) ** (-self.precision))

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1721,7 +1721,7 @@ def indices(dimensions, dtype=int, sparse=False):
 
 
 @set_module('numpy')
-def fromfunction(function, shape, **kwargs):
+def fromfunction(function, shape, *, dtype=float, **kwargs):
     """
     Construct an array by executing a function over each coordinate.
 
@@ -1772,7 +1772,6 @@ def fromfunction(function, shape, **kwargs):
            [2, 3, 4]])
 
     """
-    dtype = kwargs.pop('dtype', float)
     args = indices(shape, dtype=dtype)
     return function(*args, **kwargs)
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2353,7 +2353,7 @@ class TestSpecialMethods:
         # NOTE: this class is given as an example in doc/subclassing.py;
         # if you make any changes here, do update it there too.
         class A(np.ndarray):
-            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+            def __array_ufunc__(self, ufunc, method, *inputs, out=None, **kwargs):
                 args = []
                 in_no = []
                 for i, input_ in enumerate(inputs):
@@ -2363,7 +2363,7 @@ class TestSpecialMethods:
                     else:
                         args.append(input_)
 
-                outputs = kwargs.pop('out', None)
+                outputs = out
                 out_no = []
                 if outputs:
                     out_args = []

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -454,7 +454,7 @@ following.
     input numpy as np
 
     class A(np.ndarray):
-        def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        def __array_ufunc__(self, ufunc, method, *inputs, out=None, **kwargs):
             args = []
             in_no = []
             for i, input_ in enumerate(inputs):
@@ -464,7 +464,7 @@ following.
                 else:
                     args.append(input_)
 
-            outputs = kwargs.pop('out', None)
+            outputs = out
             out_no = []
             if outputs:
                 out_args = []

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -770,14 +770,14 @@ def copy(a, order='K'):
 # Basic operations
 
 
-def _gradient_dispatcher(f, *varargs, **kwargs):
+def _gradient_dispatcher(f, *varargs, axis=None, edge_order=None):
     yield f
     for v in varargs:
         yield v
 
 
 @array_function_dispatch(_gradient_dispatcher)
-def gradient(f, *varargs, **kwargs):
+def gradient(f, *varargs, axis=None, edge_order=1):
     """
     Return the gradient of an N-dimensional array.
 
@@ -954,11 +954,10 @@ def gradient(f, *varargs, **kwargs):
     f = np.asanyarray(f)
     N = f.ndim  # number of dimensions
 
-    axes = kwargs.pop('axis', None)
-    if axes is None:
+    if axis is None:
         axes = tuple(range(N))
     else:
-        axes = _nx.normalize_axis_tuple(axes, N)
+        axes = _nx.normalize_axis_tuple(axis, N)
 
     len_axes = len(axes)
     n = len(varargs)
@@ -993,10 +992,6 @@ def gradient(f, *varargs, **kwargs):
     else:
         raise TypeError("invalid number of arguments")
 
-    edge_order = kwargs.pop('edge_order', 1)
-    if kwargs:
-        raise TypeError('"{}" are not valid keyword arguments.'.format(
-                                                  '", "'.join(kwargs.keys())))
     if edge_order > 2:
         raise ValueError("'edge_order' greater than 2 not supported")
 
@@ -4063,13 +4058,13 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     return ret
 
 
-def _meshgrid_dispatcher(*xi, **kwargs):
+def _meshgrid_dispatcher(*xi, copy=None, sparse=None, indexing=None):
     return xi
 
 
 # Based on scitools meshgrid
 @array_function_dispatch(_meshgrid_dispatcher)
-def meshgrid(*xi, **kwargs):
+def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     """
     Return coordinate matrices from coordinate vectors.
 
@@ -4175,14 +4170,6 @@ def meshgrid(*xi, **kwargs):
     """
     ndim = len(xi)
 
-    copy_ = kwargs.pop('copy', True)
-    sparse = kwargs.pop('sparse', False)
-    indexing = kwargs.pop('indexing', 'xy')
-
-    if kwargs:
-        raise TypeError("meshgrid() got an unexpected keyword argument '%s'"
-                        % (list(kwargs)[0],))
-
     if indexing not in ['xy', 'ij']:
         raise ValueError(
             "Valid values for `indexing` are 'xy' and 'ij'.")
@@ -4200,7 +4187,7 @@ def meshgrid(*xi, **kwargs):
         # Return the full N-D matrix (not only the 1-D vector)
         output = np.broadcast_arrays(*output, subok=True)
 
-    if copy_:
+    if copy:
         output = [x.copy() for x in output]
 
     return output

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -197,12 +197,12 @@ def _broadcast_shape(*args):
     return b.shape
 
 
-def _broadcast_arrays_dispatcher(*args, **kwargs):
+def _broadcast_arrays_dispatcher(*args, subok=None):
     return args
 
 
 @array_function_dispatch(_broadcast_arrays_dispatcher, module='numpy')
-def broadcast_arrays(*args, **kwargs):
+def broadcast_arrays(*args, subok=False):
     """
     Broadcast any number of arrays against each other.
 
@@ -253,10 +253,6 @@ def broadcast_arrays(*args, **kwargs):
     # return np.nditer(args, flags=['multi_index', 'zerosize_ok'],
     #                  order='C').itviews
 
-    subok = kwargs.pop('subok', False)
-    if kwargs:
-        raise TypeError('broadcast_arrays() got an unexpected keyword '
-                        'argument {!r}'.format(list(kwargs.keys())[0]))
     args = [np.array(_m, copy=False, subok=subok) for _m in args]
 
     shape = _broadcast_shape(*args)

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -63,8 +63,7 @@ def test_broadcast_kwargs():
     x = np.arange(10)
     y = np.arange(10)
 
-    with assert_raises_regex(TypeError,
-                             r'broadcast_arrays\(\) got an unexpected keyword*'):
+    with assert_raises_regex(TypeError, 'got an unexpected keyword'):
         broadcast_arrays(x, y, dtype='float64')
 
 
@@ -354,14 +353,12 @@ def as_strided_writeable():
 
 class VerySimpleSubClass(np.ndarray):
     def __new__(cls, *args, **kwargs):
-        kwargs['subok'] = True
-        return np.array(*args, **kwargs).view(cls)
+        return np.array(*args, subok=True, **kwargs).view(cls)
 
 
 class SimpleSubClass(VerySimpleSubClass):
     def __new__(cls, *args, **kwargs):
-        kwargs['subok'] = True
-        self = np.array(*args, **kwargs).view(cls)
+        self = np.array(*args, subok=True, **kwargs).view(cls)
         self.info = 'simple'
         return self
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2216,8 +2216,7 @@ class suppress_warnings:
         del self._filters
 
     def _showwarning(self, message, category, filename, lineno,
-                     *args, **kwargs):
-        use_warnmsg = kwargs.pop("use_warnmsg", None)
+                     *args, use_warnmsg=None, **kwargs):
         for cat, _, pattern, mod, rec in (
                 self._suppressions + self._tmp_suppressions)[::-1]:
             if (issubclass(category, cat) and


### PR DESCRIPTION
Now that 2.7 is gone, there is no need to pop manually from kwarg dictionaries.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
