### PR TITLE
BUG: Use PyDict_GetItemWithError() instead of PyDict_GetItem()

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -72,6 +72,22 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
         } while (0)
 #endif
 
+/* introduced in https://github.com/python/cpython/commit/a24107b04c1277e3c1105f98aff5bfa3a98b33a0 */
+#if PY_VERSION_HEX < 0x030800A3
+    static NPY_INLINE PyObject *
+    _PyDict_GetItemStringWithError(PyObject *v, const char *key)
+    {
+        PyObject *kv, *rv;
+        kv = PyUnicode_FromString(key);
+        if (kv == NULL) {
+            return NULL;
+        }
+        rv = PyDict_GetItemWithError(v, kv);
+        Py_DECREF(kv);
+        return rv;
+    }
+#endif
+
 /*
  * PyString -> PyBytes
  */

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -94,8 +94,11 @@ PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject *
         return -1;
     }
     /* borrowed reference */
-    *out_kwd_obj = PyDict_GetItemString(kwds, "out");
+    *out_kwd_obj = _PyDict_GetItemStringWithError(kwds, "out");
     if (*out_kwd_obj == NULL) {
+        if (PyErr_Occurred()) {
+            return -1;
+        }
         Py_INCREF(Py_None);
         *out_kwd_obj = Py_None;
         return 0;

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -317,7 +317,10 @@ PyArray_DTypeFromObjectHelper(PyObject *obj, int maxdims,
         if (PyDict_Check(ip)) {
             PyObject *typestr;
             PyObject *tmp = NULL;
-            typestr = PyDict_GetItemString(ip, "typestr");
+            typestr = _PyDict_GetItemStringWithError(ip, "typestr");
+            if (typestr == NULL && PyErr_Occurred()) {
+                goto fail;
+            }
             /* Allow unicode type strings */
             if (typestr && PyUnicode_Check(typestr)) {
                 tmp = PyUnicode_AsASCIIString(typestr);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1242,8 +1242,14 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
      */
     if (kwds) {
         PyObject *dims_item, *shape_item;
-        dims_item = PyDict_GetItemString(kwds, "dims");
-        shape_item = PyDict_GetItemString(kwds, "shape");
+        dims_item = _PyDict_GetItemStringWithError(kwds, "dims");
+        if (dims_item == NULL && PyErr_Occurred()){
+            return NULL;
+        }
+        shape_item = _PyDict_GetItemStringWithError(kwds, "shape");
+        if (shape_item == NULL && PyErr_Occurred()){
+            return NULL;
+        }
         if (dims_item != NULL && shape_item == NULL) {
             if (DEPRECATE("'shape' argument should be"
                           " used instead of 'dims'") < 0) {
@@ -1429,19 +1435,28 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
 
     if (PyGetSetDescr_TypePtr == NULL) {
         /* Get "subdescr" */
-        myobj = PyDict_GetItemString(tp_dict, "fields");
+        myobj = _PyDict_GetItemStringWithError(tp_dict, "fields");
+        if (myobj == NULL && PyErr_Occurred()) {
+            return NULL;
+        }
         if (myobj != NULL) {
             PyGetSetDescr_TypePtr = Py_TYPE(myobj);
         }
     }
     if (PyMemberDescr_TypePtr == NULL) {
-        myobj = PyDict_GetItemString(tp_dict, "alignment");
+        myobj = _PyDict_GetItemStringWithError(tp_dict, "alignment");
+        if (myobj == NULL && PyErr_Occurred()) {
+            return NULL;
+        }
         if (myobj != NULL) {
             PyMemberDescr_TypePtr = Py_TYPE(myobj);
         }
     }
     if (PyMethodDescr_TypePtr == NULL) {
-        myobj = PyDict_GetItemString(tp_dict, "newbyteorder");
+        myobj = _PyDict_GetItemStringWithError(tp_dict, "newbyteorder");
+        if (myobj == NULL && PyErr_Occurred()) {
+            return NULL;
+        }
         if (myobj != NULL) {
             PyMethodDescr_TypePtr = Py_TYPE(myobj);
         }

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1404,8 +1404,11 @@ _get_field_view(PyArrayObject *arr, PyObject *ind, PyArrayObject **view)
         npy_intp offset;
 
         /* get the field offset and dtype */
-        tup = PyDict_GetItem(PyArray_DESCR(arr)->fields, ind);
-        if (tup == NULL){
+        tup = PyDict_GetItemWithError(PyArray_DESCR(arr)->fields, ind);
+        if (tup == NULL && PyErr_Occurred()) {
+            return 0;
+        }
+        else if (tup == NULL){
             PyObject *errmsg = PyUString_FromString("no field of name ");
             PyUString_Concat(&errmsg, ind);
             PyErr_SetObject(PyExc_ValueError, errmsg);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -64,7 +64,11 @@ get_forwarding_ndarray_method(const char *name)
     if (module_methods == NULL) {
         return NULL;
     }
-    callable = PyDict_GetItemString(PyModule_GetDict(module_methods), name);
+    callable = _PyDict_GetItemStringWithError(PyModule_GetDict(module_methods), name);
+    if (callable == NULL && PyErr_Occurred()) {
+        Py_DECREF(module_methods);
+        return NULL;
+    }
     if (callable == NULL) {
         Py_DECREF(module_methods);
         PyErr_Format(PyExc_RuntimeError,

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -57,8 +57,11 @@ array_inplace_power(PyArrayObject *a1, PyObject *o2, PyObject *NPY_UNUSED(modulo
  */
 
 /* FIXME - macro contains a return */
-#define SET(op)   temp = PyDict_GetItemString(dict, #op); \
-    if (temp != NULL) { \
+#define SET(op)   temp = _PyDict_GetItemStringWithError(dict, #op); \
+    if (temp == NULL && PyErr_Occurred()) { \
+        return -1; \
+    } \
+    else if (temp != NULL) { \
         if (!(PyCallable_Check(temp))) { \
             return -1; \
         } \

--- a/numpy/core/src/umath/extobj.c
+++ b/numpy/core/src/umath/extobj.c
@@ -165,7 +165,7 @@ get_global_ext_obj(void)
         if (thedict == NULL) {
             thedict = PyEval_GetBuiltins();
         }
-        ref = PyDict_GetItem(thedict, npy_um_str_pyvals_name);
+        ref = PyDict_GetItemWithError(thedict, npy_um_str_pyvals_name);
 #if USE_USE_DEFAULTS==1
     }
 #endif
@@ -290,6 +290,9 @@ _check_ufunc_fperr(int errmask, PyObject *extobj, const char *ufunc_name) {
     /* Get error object globals */
     if (extobj == NULL) {
         extobj = get_global_ext_obj();
+        if (extobj == NULL && PyErr_Occurred()) {
+            return -1;
+        }
     }
     if (_extract_pyvals(extobj, ufunc_name,
                         NULL, NULL, &errobj) < 0) {
@@ -311,6 +314,9 @@ _get_bufsize_errmask(PyObject * extobj, const char *ufunc_name,
     /* Get the buffersize and errormask */
     if (extobj == NULL) {
         extobj = get_global_ext_obj();
+        if (extobj == NULL && PyErr_Occurred()) {
+            return -1;
+        }
     }
     if (_extract_pyvals(extobj, ufunc_name,
                         buffersize, errormask, NULL) < 0) {

--- a/numpy/core/src/umath/override.c
+++ b/numpy/core/src/umath/override.c
@@ -112,9 +112,16 @@ fail:
 static int
 normalize_signature_keyword(PyObject *normal_kwds)
 {
-    PyObject* obj = PyDict_GetItemString(normal_kwds, "sig");
+    PyObject *obj = _PyDict_GetItemStringWithError(normal_kwds, "sig");
+    if (obj == NULL && PyErr_Occurred()){
+        return -1;
+    }
     if (obj != NULL) {
-        if (PyDict_GetItemString(normal_kwds, "signature")) {
+        PyObject *sig = _PyDict_GetItemStringWithError(normal_kwds, "signature");
+        if (sig == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        if (sig) {
             PyErr_SetString(PyExc_TypeError,
                             "cannot specify both 'sig' and 'signature'");
             return -1;
@@ -165,11 +172,17 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
 
     /* If we have more args than nin, they must be the output variables.*/
     if (nargs > nin) {
-        if(nkwds > 0 && PyDict_GetItemString(*normal_kwds, "out")) {
-            PyErr_Format(PyExc_TypeError,
-                         "argument given by name ('out') and position "
-                         "(%"NPY_INTP_FMT")", nin);
-            return -1;
+        if (nkwds > 0) {
+            PyObject *out_kwd = _PyDict_GetItemStringWithError(*normal_kwds, "out");
+            if (out_kwd == NULL && PyErr_Occurred()) {
+                return -1;
+            }
+            else if (out_kwd) {
+                PyErr_Format(PyExc_TypeError,
+                             "argument given by name ('out') and position "
+                             "(%"NPY_INTP_FMT")", nin);
+                return -1;
+            }
         }
         for (i = nin; i < nargs; i++) {
             not_all_none = (PyTuple_GET_ITEM(args, i) != Py_None);
@@ -204,11 +217,20 @@ normalize___call___args(PyUFuncObject *ufunc, PyObject *args,
         }
     }
     /* gufuncs accept either 'axes' or 'axis', but not both */
-    if (nkwds >= 2 && (PyDict_GetItemString(*normal_kwds, "axis") &&
-                       PyDict_GetItemString(*normal_kwds, "axes"))) {
-        PyErr_SetString(PyExc_TypeError,
-                        "cannot specify both 'axis' and 'axes'");
-        return -1;
+    if (nkwds >= 2) {
+        PyObject *axis_kwd = _PyDict_GetItemStringWithError(*normal_kwds, "axis");
+        if (axis_kwd == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        PyObject *axes_kwd = _PyDict_GetItemStringWithError(*normal_kwds, "axes");
+        if (axes_kwd == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        if (axis_kwd && axes_kwd) {
+            PyErr_SetString(PyExc_TypeError,
+                            "cannot specify both 'axis' and 'axes'");
+            return -1;
+        }
     }
     /* finally, ufuncs accept 'sig' or 'signature' normalize to 'signature' */
     return nkwds == 0 ? 0 : normalize_signature_keyword(*normal_kwds);
@@ -243,7 +265,11 @@ normalize_reduce_args(PyUFuncObject *ufunc, PyObject *args,
     }
 
     for (i = 1; i < nargs; i++) {
-        if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
+        PyObject *kwd = _PyDict_GetItemStringWithError(*normal_kwds, kwlist[i]);
+        if (kwd == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        else if (kwd) {
             PyErr_Format(PyExc_TypeError,
                          "argument given by name ('%s') and position "
                          "(%"NPY_INTP_FMT")", kwlist[i], i);
@@ -293,7 +319,11 @@ normalize_accumulate_args(PyUFuncObject *ufunc, PyObject *args,
     }
 
     for (i = 1; i < nargs; i++) {
-        if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
+        PyObject *kwd = _PyDict_GetItemStringWithError(*normal_kwds, kwlist[i]);
+        if (kwd == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        else if (kwd) {
             PyErr_Format(PyExc_TypeError,
                          "argument given by name ('%s') and position "
                          "(%"NPY_INTP_FMT")", kwlist[i], i);
@@ -341,7 +371,11 @@ normalize_reduceat_args(PyUFuncObject *ufunc, PyObject *args,
     }
 
     for (i = 2; i < nargs; i++) {
-        if (PyDict_GetItemString(*normal_kwds, kwlist[i])) {
+        PyObject *kwd = _PyDict_GetItemStringWithError(*normal_kwds, kwlist[i]);
+        if (kwd == NULL && PyErr_Occurred()) {
+            return -1;
+        }
+        else if (kwd) {
             PyErr_Format(PyExc_TypeError,
                          "argument given by name ('%s') and position "
                          "(%"NPY_INTP_FMT")", kwlist[i], i);
@@ -469,8 +503,11 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
 
         /* ensure out is always a tuple */
         normal_kwds = PyDict_Copy(kwds);
-        out = PyDict_GetItemString(normal_kwds, "out");
-        if (out != NULL) {
+        out = _PyDict_GetItemStringWithError(normal_kwds, "out");
+        if (out == NULL && PyErr_Occurred()) {
+            goto fail;
+        }
+        else if (out) {
             int nout = ufunc->nout;
 
             if (PyTuple_CheckExact(out)) {

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1379,9 +1379,12 @@ find_userloop(PyUFuncObject *ufunc,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItem(ufunc->userloops, key);
+            obj = PyDict_GetItemWithError(ufunc->userloops, key);
             Py_DECREF(key);
-            if (obj == NULL) {
+            if (obj == NULL && PyErr_Occurred()){
+                return -1;
+            }
+            else if (obj == NULL) {
                 continue;
             }
             for (funcdata = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(obj);
@@ -1784,9 +1787,12 @@ linear_search_userloop_type_resolver(PyUFuncObject *self,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItem(self->userloops, key);
+            obj = PyDict_GetItemWithError(self->userloops, key);
             Py_DECREF(key);
-            if (obj == NULL) {
+            if (obj == NULL && PyErr_Occurred()){
+                return -1;
+            }
+            else if (obj == NULL) {
                 continue;
             }
             for (funcdata = (PyUFunc_Loop1d *)NpyCapsule_AsVoidPtr(obj);
@@ -1848,9 +1854,12 @@ type_tuple_userloop_type_resolver(PyUFuncObject *self,
             if (key == NULL) {
                 return -1;
             }
-            obj = PyDict_GetItem(self->userloops, key);
+            obj = PyDict_GetItemWithError(self->userloops, key);
             Py_DECREF(key);
-            if (obj == NULL) {
+            if (obj == NULL && PyErr_Occurred()){
+                return -1;
+            }
+            else if (obj == NULL) {
                 continue;
             }
 

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -260,8 +260,11 @@ static PyObject *
 fortran_getattr(PyFortranObject *fp, char *name) {
     int i,j,k,flag;
     if (fp->dict != NULL) {
-        PyObject *v = PyDict_GetItemString(fp->dict, name);
-        if (v != NULL) {
+        PyObject *v = _PyDict_GetItemStringWithError(fp->dict, name);
+        if (v == NULL && PyErr_Occurred()) {
+            return NULL;
+        }
+        else if (v != NULL) {
             Py_INCREF(v);
             return v;
         }


### PR DESCRIPTION
This means we no longer interpret `MemoryError` or `KeyboardInterrupt` as `keyword arg not provided`, for instance.

This function is python 3 only, hence this was difficult to do in older versions of numpy.

Inspired by https://bugs.python.org/issue35459.

A few of these calls were places where we would incorrectly assume `PyDict_GetItem` would set an error - so in principle could lead to a `SystemError`. Since these conditions are invariant violations for `PyArray_Descr`, I've made them call `PyErr_BadInternalCall()`.

---

This is a semi-exhaustive conversion - omitted is code that I couldn't work out the error semantics of, ~~such as the mess in `descriptor.c`~~ (this mess was cleaned up by my earlier PRs).

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
