### PR TITLE
MAINT: Remove python2 array_{get,set}slice

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -164,8 +164,6 @@ class PytestTester:
 
         # Ignore python2.7 -3 warnings
         pytest_args += [
-            r"-W ignore:in 3\.x, __setslice__:DeprecationWarning",
-            r"-W ignore:in 3\.x, __getslice__:DeprecationWarning",
             r"-W ignore:buffer\(\) not supported in 3\.x:DeprecationWarning",
             r"-W ignore:CObject type is not supported in 3\.x:DeprecationWarning",
             r"-W ignore:comparing unequal types not supported in 3\.x:DeprecationWarning",

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2641,51 +2641,6 @@ array_complex(PyArrayObject *self, PyObject *NPY_UNUSED(args))
     return c;
 }
 
-#ifndef NPY_PY3K
-
-static PyObject *
-array_getslice(PyArrayObject *self, PyObject *args)
-{
-    PyObject *start, *stop, *slice, *result;
-    if (!PyArg_ParseTuple(args, "OO:__getslice__", &start, &stop)) {
-        return NULL;
-    }
-
-    slice = PySlice_New(start, stop, NULL);
-    if (slice == NULL) {
-        return NULL;
-    }
-
-    /* Deliberately delegate to subclasses */
-    result = PyObject_GetItem((PyObject *)self, slice);
-    Py_DECREF(slice);
-    return result;
-}
-
-static PyObject *
-array_setslice(PyArrayObject *self, PyObject *args)
-{
-    PyObject *start, *stop, *value, *slice;
-    if (!PyArg_ParseTuple(args, "OOO:__setslice__", &start, &stop, &value)) {
-        return NULL;
-    }
-
-    slice = PySlice_New(start, stop, NULL);
-    if (slice == NULL) {
-        return NULL;
-    }
-
-    /* Deliberately delegate to subclasses */
-    if (PyObject_SetItem((PyObject *)self, slice, value) < 0) {
-        Py_DECREF(slice);
-        return NULL;
-    }
-    Py_DECREF(slice);
-    Py_RETURN_NONE;
-}
-
-#endif
-
 NPY_NO_EXPORT PyMethodDef array_methods[] = {
 
     /* for subtypes */
@@ -2748,23 +2703,6 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
     {"__format__",
         (PyCFunction) array_format,
         METH_VARARGS, NULL},
-
-#ifndef NPY_PY3K
-    /*
-     * While we could put these in `tp_sequence`, its' easier to define them
-     * in terms of PyObject* arguments.
-     *
-     * We must provide these for compatibility with code that calls them
-     * directly. They are already deprecated at a language level in python 2.7,
-     * but are removed outright in python 3.
-     */
-    {"__getslice__",
-        (PyCFunction) array_getslice,
-        METH_VARARGS, NULL},
-    {"__setslice__",
-        (PyCFunction) array_setslice,
-        METH_VARARGS, NULL},
-#endif
 
     /* Original and Extended methods added 2005 */
     {"all",

--- a/numpy/core/tests/test_indexing.py
+++ b/numpy/core/tests/test_indexing.py
@@ -648,40 +648,6 @@ class TestSubclasses:
         assert_array_equal(new_s.finalize_status, new_s)
         assert_array_equal(new_s.old, s)
 
-    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
-    def test_slice_decref_getsetslice(self):
-        # See gh-10066, a temporary slice object should be discarted.
-        # This test is only really interesting on Python 2 since
-        # it goes through `__set/getslice__` here and can probably be
-        # removed. Use 0:7 to make sure it is never None:7.
-        class KeepIndexObject(np.ndarray):
-            def __getitem__(self, indx):
-                self.indx = indx
-                if indx == slice(0, 7):
-                    raise ValueError
-
-            def __setitem__(self, indx, val):
-                self.indx = indx
-                if indx == slice(0, 4):
-                    raise ValueError
-
-        k = np.array([1]).view(KeepIndexObject)
-        k[0:5]
-        assert_equal(k.indx, slice(0, 5))
-        assert_equal(sys.getrefcount(k.indx), 2)
-        with assert_raises(ValueError):
-            k[0:7]
-        assert_equal(k.indx, slice(0, 7))
-        assert_equal(sys.getrefcount(k.indx), 2)
-
-        k[0:3] = 6
-        assert_equal(k.indx, slice(0, 3))
-        assert_equal(sys.getrefcount(k.indx), 2)
-        with assert_raises(ValueError):
-            k[0:4] = 2
-        assert_equal(k.indx, slice(0, 4))
-        assert_equal(sys.getrefcount(k.indx), 2)
-
 
 class TestFancyIndexingCast:
     def test_boolean_index_cast_assign(self):

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -454,8 +454,6 @@ class NoseTester:
                 # This is very specific, so using the fragile module filter
                 # is fine
                 import threading
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __setslice__")
-                sup.filter(DeprecationWarning, message=r"in 3\.x, __getslice__")
                 sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"CObject type is not supported in 3\.x")
                 sup.filter(DeprecationWarning, message=r"comparing unequal types not supported in 3\.x")

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,8 +14,6 @@ filterwarnings =
 # Matrix PendingDeprecationWarning.
     ignore:the matrix subclass is not
 # Ignore python2.7 -3 warnings
-    ignore:in 3\.x, __setslice__:DeprecationWarning
-    ignore:in 3\.x, __getslice__:DeprecationWarning
     ignore:buffer\(\) not supported in 3\.x:DeprecationWarning
     ignore:CObject type is not supported in 3\.x:DeprecationWarning
     ignore:comparing unequal types not supported in 3\.x:DeprecationWarning


### PR DESCRIPTION
More Py3K work.

I don't think it needs a release doc but I prepared this version (cribbing from gh-15229) if people want.

```txt
Removed ``ndarray.__getslice__`` and ``ndarray.__setslice__``
-------------------------------------------------------------

As part of the continued removal of Python 2 compatibility,
``ndarray.__[gs]etslice__`` was removed. They are already deprecated at a 
language level in python 2.7.
```