### PR TITLE
DOC: Add some missing functions in the list of available ufuncs.

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -569,6 +569,7 @@ Math operations
     add
     subtract
     multiply
+    matmul
     divide
     logaddexp
     logaddexp2
@@ -577,6 +578,7 @@ Math operations
     negative
     positive
     power
+    float_power
     remainder
     mod
     fmod
@@ -635,6 +637,8 @@ The ratio of degrees to radians is :math:`180^{\circ}/\pi.`
     arcsinh
     arccosh
     arctanh
+    degrees
+    radians
     deg2rad
     rad2deg
 


### PR DESCRIPTION
See #15214

It appears that some `ufuncs` instances are not listed in the doc under `available ufuncs`. 
This PR tries to correct this.

The gist https://gist.github.com/hippo91/eed099df061fe399502c05aa99cd9531 details the way missing functions has been detected.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
