### PR TITLE
BUG: Fix PyArray_DescrAlignConverter2 on tuples

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2969,32 +2969,13 @@ PyArray_DescrAlignConverter(PyObject *obj, PyArray_Descr **at)
 NPY_NO_EXPORT int
 PyArray_DescrAlignConverter2(PyObject *obj, PyArray_Descr **at)
 {
-    if (PyDict_Check(obj) || PyDictProxy_Check(obj)) {
-        *at =  _convert_from_dict(obj, 1);
-    }
-    else if (PyBytes_Check(obj)) {
-        *at = _convert_from_commastring(obj, 1);
-    }
-    else if (PyUnicode_Check(obj)) {
-        PyObject *tmp;
-        tmp = PyUnicode_AsASCIIString(obj);
-        *at = _convert_from_commastring(tmp, 1);
-        Py_DECREF(tmp);
-    }
-    else if (PyList_Check(obj)) {
-        *at = _convert_from_array_descr(obj, 1);
+    if (obj == Py_None) {
+        *at = NULL;
+        return NPY_SUCCEED;
     }
     else {
-        return PyArray_DescrConverter2(obj, at);
+        return PyArray_DescrAlignConverter(obj, at);
     }
-    if (*at == NULL) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_ValueError,
-                    "data-type-descriptor not understood");
-        }
-        return NPY_FAIL;
-    }
-    return NPY_SUCCEED;
 }
 
 


### PR DESCRIPTION
The previous implementation of `PyArray_DescrAlignConverter2` did not match `PyArray_DescrAlignConverter`, and only the latter would actually apply the alignment flag to ~~union~~ subarray types.

What happened here is that ab9953baf29ace44ef1f014f3713f1ee919f79bb (#10923) fixed union types for `PyArray_DescrAlignConverter` but forgot to apply the same fix for `PyArray_DescrAlignConverter2` .

Expressing one in terms of the other makes this problem go away.

Numpy has no internal callers of PyArray_DescrAlignConverter2.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

---

Split from #15265, since that failed in a peculiar way in only non-windows CI, and submitting this commit separately will allow me to bisect.