### PR TITLE
MAINT: Remove Python 2 divide

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3293,10 +3293,6 @@ static PyNumberMethods descr_as_number = {
     (binaryfunc)0,                          /* nb_add */
     (binaryfunc)0,                          /* nb_subtract */
     (binaryfunc)0,                          /* nb_multiply */
-    #if defined(NPY_PY3K)
-    #else
-    (binaryfunc)0,                          /* nb_divide */
-    #endif
     (binaryfunc)0,                          /* nb_remainder */
     (binaryfunc)0,                          /* nb_divmod */
     (ternaryfunc)0,                         /* nb_power */

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -32,10 +32,6 @@ static PyObject *
 array_inplace_subtract(PyArrayObject *m1, PyObject *m2);
 static PyObject *
 array_inplace_multiply(PyArrayObject *m1, PyObject *m2);
-#if !defined(NPY_PY3K)
-static PyObject *
-array_inplace_divide(PyArrayObject *m1, PyObject *m2);
-#endif
 static PyObject *
 array_inplace_true_divide(PyArrayObject *m1, PyObject *m2);
 static PyObject *
@@ -352,20 +348,6 @@ array_multiply(PyArrayObject *m1, PyObject *m2)
     }
     return PyArray_GenericBinaryFunction(m1, m2, n_ops.multiply);
 }
-
-#if !defined(NPY_PY3K)
-static PyObject *
-array_divide(PyArrayObject *m1, PyObject *m2)
-{
-    PyObject *res;
-
-    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_divide, array_divide);
-    if (try_binary_elide(m1, m2, &array_inplace_divide, &res, 0)) {
-        return res;
-    }
-    return PyArray_GenericBinaryFunction(m1, m2, n_ops.divide);
-}
-#endif
 
 static PyObject *
 array_remainder(PyArrayObject *m1, PyObject *m2)
@@ -728,16 +710,6 @@ array_inplace_multiply(PyArrayObject *m1, PyObject *m2)
     return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.multiply);
 }
 
-#if !defined(NPY_PY3K)
-static PyObject *
-array_inplace_divide(PyArrayObject *m1, PyObject *m2)
-{
-    INPLACE_GIVE_UP_IF_NEEDED(
-            m1, m2, nb_inplace_divide, array_inplace_divide);
-    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.divide);
-}
-#endif
-
 static PyObject *
 array_inplace_remainder(PyArrayObject *m1, PyObject *m2)
 {
@@ -1008,9 +980,6 @@ NPY_NO_EXPORT PyNumberMethods array_as_number = {
     (binaryfunc)array_add,                      /*nb_add*/
     (binaryfunc)array_subtract,                 /*nb_subtract*/
     (binaryfunc)array_multiply,                 /*nb_multiply*/
-#if !defined(NPY_PY3K)
-    (binaryfunc)array_divide,                   /*nb_divide*/
-#endif
     (binaryfunc)array_remainder,                /*nb_remainder*/
     (binaryfunc)array_divmod,                   /*nb_divmod*/
     (ternaryfunc)array_power,                   /*nb_power*/
@@ -1046,9 +1015,6 @@ NPY_NO_EXPORT PyNumberMethods array_as_number = {
     (binaryfunc)array_inplace_add,              /*nb_inplace_add*/
     (binaryfunc)array_inplace_subtract,         /*nb_inplace_subtract*/
     (binaryfunc)array_inplace_multiply,         /*nb_inplace_multiply*/
-#if !defined(NPY_PY3K)
-    (binaryfunc)array_inplace_divide,           /*nb_inplace_divide*/
-#endif
     (binaryfunc)array_inplace_remainder,        /*nb_inplace_remainder*/
     (ternaryfunc)array_inplace_power,           /*nb_inplace_power*/
     (binaryfunc)array_inplace_left_shift,       /*nb_inplace_lshift*/

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -226,20 +226,6 @@ gentype_@name@(PyObject *m1, PyObject *m2)
 
 /**end repeat**/
 
-#if !defined(NPY_PY3K)
-/**begin repeat
- *
- * #name = divide#
- */
-static PyObject *
-gentype_@name@(PyObject *m1, PyObject *m2)
-{
-    BINOP_GIVE_UP_IF_NEEDED(m1, m2, nb_@name@, gentype_@name@);
-    return PyArray_Type.tp_as_number->nb_@name@(m1, m2);
-}
-/**end repeat**/
-#endif
-
 /* Get a nested slot, or NULL if absent */
 #define GET_NESTED_SLOT(type, group, slot) \
     ((type)->group == NULL ? NULL : (type)->group->slot)
@@ -1104,9 +1090,6 @@ static PyNumberMethods gentype_as_number = {
     (binaryfunc)gentype_add,                     /*nb_add*/
     (binaryfunc)gentype_subtract,                /*nb_subtract*/
     (binaryfunc)gentype_multiply,                /*nb_multiply*/
-#if !defined(NPY_PY3K)
-    (binaryfunc)gentype_divide,                  /*nb_divide*/
-#endif
     (binaryfunc)gentype_remainder,               /*nb_remainder*/
     (binaryfunc)gentype_divmod,                  /*nb_divmod*/
     (ternaryfunc)gentype_power,                  /*nb_power*/
@@ -1137,9 +1120,6 @@ static PyNumberMethods gentype_as_number = {
     0,                                           /*inplace_add*/
     0,                                           /*inplace_subtract*/
     0,                                           /*inplace_multiply*/
-#if !defined(NPY_PY3K)
-    0,                                           /*inplace_divide*/
-#endif
     0,                                           /*inplace_remainder*/
     0,                                           /*inplace_power*/
     0,                                           /*inplace_lshift*/
@@ -3034,10 +3014,6 @@ NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
     0,                                           /* nb_add */
     0,                                           /* nb_subtract */
     0,                                           /* nb_multiply */
-#if defined(NPY_PY3K)
-#else
-    0,                                           /* nb_divide */
-#endif
     0,                                           /* nb_remainder */
     0,                                           /* nb_divmod */
     0,                                           /* nb_power */
@@ -3071,10 +3047,6 @@ NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
     0,                                           /* nb_inplace_add */
     0,                                           /* nb_inplace_subtract */
     0,                                           /* nb_inplace_multiply */
-#if defined(NPY_PY3K)
-#else
-    0,                                           /* nb_inplace_divide */
-#endif
     0,                                           /* nb_inplace_remainder */
     0,                                           /* nb_inplace_power */
     0,                                           /* nb_inplace_lshift */

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -744,55 +744,49 @@ _@name@_convert2_to_ctypes(PyObject *a, @type@ *arg1,
 /**end repeat**/
 
 
-#if defined(NPY_PY3K)
-#define CODEGEN_SKIP_divide_FLAG
-#endif
-
 /**begin repeat
  *
  * #name = (byte, ubyte, short, ushort, int, uint,
- *             long, ulong, longlong, ulonglong)*13,
+ *             long, ulong, longlong, ulonglong)*12,
  *         (half, float, double, longdouble,
- *             cfloat, cdouble, clongdouble)*6,
+ *             cfloat, cdouble, clongdouble)*5,
  *         (half, float, double, longdouble)*2#
  * #Name = (Byte, UByte, Short, UShort, Int, UInt,
- *             Long, ULong,LongLong,ULongLong)*13,
+ *             Long, ULong,LongLong,ULongLong)*12,
  *         (Half, Float, Double, LongDouble,
- *             CFloat, CDouble, CLongDouble)*6,
+ *             CFloat, CDouble, CLongDouble)*5,
  *         (Half, Float, Double, LongDouble)*2#
  * #type = (npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *             npy_long, npy_ulong, npy_longlong, npy_ulonglong)*13,
+ *             npy_long, npy_ulong, npy_longlong, npy_ulonglong)*12,
  *         (npy_half, npy_float, npy_double, npy_longdouble,
- *             npy_cfloat, npy_cdouble, npy_clongdouble)*6,
+ *             npy_cfloat, npy_cdouble, npy_clongdouble)*5,
  *         (npy_half, npy_float, npy_double, npy_longdouble)*2#
  *
- * #oper = add*10, subtract*10, multiply*10, divide*10, remainder*10,
+ * #oper = add*10, subtract*10, multiply*10, remainder*10,
  *         divmod*10, floor_divide*10, lshift*10, rshift*10, and*10,
  *         or*10, xor*10, true_divide*10,
- *         add*7, subtract*7, multiply*7, divide*7, floor_divide*7, true_divide*7,
+ *         add*7, subtract*7, multiply*7, floor_divide*7, true_divide*7,
  *         divmod*4, remainder*4#
  *
- * #fperr = 1*70,0*50,1*10,
- *          1*42,
+ * #fperr = 1*60,0*50,1*10,
+ *          1*35,
  *          1*8#
- * #twoout = 0*50,1*10,0*70,
- *           0*42,
+ * #twoout = 0*40,1*10,0*70,
+ *           0*35,
  *           1*4,0*4#
  * #otype = (npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *             npy_long, npy_ulong, npy_longlong, npy_ulonglong)*12,
+ *             npy_long, npy_ulong, npy_longlong, npy_ulonglong)*11,
  *         npy_float*4, npy_double*6,
  *         (npy_half, npy_float, npy_double, npy_longdouble,
- *             npy_cfloat, npy_cdouble, npy_clongdouble)*6,
+ *             npy_cfloat, npy_cdouble, npy_clongdouble)*5,
  *         (npy_half, npy_float, npy_double, npy_longdouble)*2#
  * #OName = (Byte, UByte, Short, UShort, Int, UInt,
- *              Long, ULong, LongLong, ULongLong)*12,
+ *              Long, ULong, LongLong, ULongLong)*11,
  *          Float*4, Double*6,
  *          (Half, Float, Double, LongDouble,
- *              CFloat, CDouble, CLongDouble)*6,
+ *              CFloat, CDouble, CLongDouble)*5,
  *          (Half, Float, Double, LongDouble)*2#
  */
-
-#if !defined(CODEGEN_SKIP_@oper@_FLAG)
 
 static PyObject *
 @name@_@oper@(PyObject *a, PyObject *b)
@@ -904,11 +898,8 @@ static PyObject *
 #endif
     return ret;
 }
-#endif
 
 /**end repeat**/
-
-#undef CODEGEN_SKIP_divide_FLAG
 
 #define _IS_ZERO(x) (x == 0)
 
@@ -1597,9 +1588,6 @@ static PyNumberMethods @name@_as_number = {
     (binaryfunc)@name@_add,                     /*nb_add*/
     (binaryfunc)@name@_subtract,                /*nb_subtract*/
     (binaryfunc)@name@_multiply,                /*nb_multiply*/
-#if !defined(NPY_PY3K)
-    (binaryfunc)@name@_divide,                  /*nb_divide*/
-#endif
     (binaryfunc)@name@_remainder,               /*nb_remainder*/
     (binaryfunc)@name@_divmod,                  /*nb_divmod*/
     (ternaryfunc)@name@_power,                  /*nb_power*/
@@ -1634,9 +1622,6 @@ static PyNumberMethods @name@_as_number = {
     0,                                          /*inplace_add*/
     0,                                          /*inplace_subtract*/
     0,                                          /*inplace_multiply*/
-#if !defined(NPY_PY3K)
-    0,                                          /*inplace_divide*/
-#endif
     0,                                          /*inplace_remainder*/
     0,                                          /*inplace_power*/
     0,                                          /*inplace_lshift*/


### PR DESCRIPTION
Cleaned up some of the special handling in numpy of python2 divide

NOTE: I'm leaving these for a follow up PR
```c
#if defined(NPY_PY3K)
    result = PyNumber_TrueDivide(one, o); 
#else
    result = PyNumber_Divide(one, o); 
#endif
```

I search for all the names I removed and did several general searches (e.g. `grep -riP '(?<!floor|true)_divide'`) as due diligence BUT I'm less confident than normal that I caught 100% of related code with this PR. It's very possible that there are some tests now testing nothing, warnings that don't need to be suppressed... If I did miss things I have some confidence that my "Remove all python2 reference in c/python code" will catch some of them.

