### PR TITLE
MAINT: travis-ci: Update CI scripts.

### DIFF
--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Exit the script immediately if a command exits with a non-zero status,
+# and print commands and their arguments as they are executed.
+set -ex
+
 uname -a
 free -m
 df -h
@@ -32,6 +36,18 @@ python -V
 
 popd
 
-pip install --upgrade pip setuptools
-pip install -r test_requirements.txt
+pip install --upgrade pip
+
+# 'setuptools', 'wheel' and 'cython' are build dependencies.  This information
+# is stored in pyproject.toml, but there is not yet a standard way to install
+# those dependencies with, say, a pip command, so we'll just hard-code their
+# installation here.  We only need to install them separately for the cases
+# where numpy is installed with setup.py, which is the case for the Travis jobs
+# where the environment variables USE_DEBUG or USE_WHEEL are set. When pip is
+# used to install numpy, pip gets the build dependencies from pyproject.toml.
+# A specific version of cython is required, so we read the cython package
+# requirement using `grep cython test_requirements.txt` instead of simply
+# writing 'pip install setuptools wheel cython'.
+pip install setuptools wheel `grep cython test_requirements.txt`
+
 if [ -n "$USE_ASV" ]; then pip install asv; fi


### PR DESCRIPTION
MAINT: travis-ci: Update CI scripts.

* Use `set -ex` in tools/travis-before-install.sh.
* Install build dependencies in tools/travis-before-install.sh.
* Update a comment about an additional option in CFLAGS when USE_DEBUG=1.
* Clear PYTHONOPTIMIZE when running `pip install -r test_requirements.txt`
  because version 2.19 of pycparser (a dependency of one of the packages
  in test_requirements.txt) does not provide a wheel, and the source tar
  file does not install correctly when Python's optimization level is set
  to strip docstrings (see https://github.com/eliben/pycparser/issues/291).
* Remove unnecessary calls of `pip install` in tools/travis-test.sh.

Closes gh-15108.
