### PR TITLE
BUILD: use standard build of OpenBLAS for aarch64, ppc64le, s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ stages:
 
 env:
   global:
-    - OpenBLAS_version=0.3.7
+    - OpenBLAS_version=0.3.8
     - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
     # The following is generated with the command:
     # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 group: travis_latest
 os: linux
-dist: xenial
+dist: bionic
 
 # Travis whitelists the installable packages, additions can be requested
 #   https://github.com/travis-ci/apt-package-whitelist
@@ -11,6 +11,8 @@ addons:
   apt:
     packages: &common_packages
       - gfortran
+      - libgfortran5
+      - libgfortran3
       - libatlas-base-dev
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
@@ -47,7 +49,6 @@ jobs:
     - python: 3.7
 
     - python: 3.6
-      dist: bionic
       env: USE_DEBUG=1
       addons:
         apt:
@@ -112,7 +113,17 @@ jobs:
       arch: s390x
       env:
        # use s390x OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
+
+    - python: 3.7
+      os: linux
+      arch: aarch64
+      env:
+       # use ppc64le OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
+       - ATLAS=None
+
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,8 @@ jobs:
           packages:
             - gfortran
             - eatmydata
+            - libgfortran5
+            - libgfortran3
 
     - python: 3.7
       env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 variables:
   # OpenBLAS_version should be updated
   # to match numpy-wheels repo
-  OpenBLAS_version: 0.3.7
+  OpenBLAS_version: 0.3.8
 
 stages:
 - stage: InitialTests

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -2152,6 +2152,11 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
         }
         /* A repeated label, find the original one and merge them. */
         else {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
             int i = icombinemap[idim + label];
 
             icombinemap[idim] = -1;
@@ -2164,6 +2169,9 @@ get_combined_dims_view(PyArrayObject *op, int iop, char *labels)
                 return NULL;
             }
             new_strides[i] += stride;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
         }
     }
 

--- a/numpy/fft/_pocketfft.c
+++ b/numpy/fft/_pocketfft.c
@@ -10,6 +10,11 @@
  *  \author Martin Reinecke
  */
 
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include "Python.h"
+#include "numpy/arrayobject.h"
+
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
@@ -2183,11 +2188,6 @@ WARN_UNUSED_RESULT static int rfft_forward(rfft_plan plan, double c[], double fc
   else // if (plan->blueplan)
     return rfftblue_forward(plan->blueplan,c,fct);
   }
-
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
-#include "numpy/arrayobject.h"
 
 static PyObject *
 execute_complex(PyObject *a1, int is_forward, double fct)

--- a/numpy/random/src/distributions/random_mvhg_count.c
+++ b/numpy/random/src/distributions/random_mvhg_count.c
@@ -1,8 +1,8 @@
+#include "numpy/random/distributions.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
 
-#include "numpy/random/distributions.h"
 
 /*
  *  random_multivariate_hypergeometric_count

--- a/numpy/random/src/distributions/random_mvhg_marginals.c
+++ b/numpy/random/src/distributions/random_mvhg_marginals.c
@@ -1,9 +1,9 @@
+#include "numpy/random/distributions.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <math.h>
 
-#include "numpy/random/distributions.h"
 #include "logfactorial.h"
 
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,9 +21,10 @@ runtime:
 
 build:
     ci:
-    # install dependencies
+    # install dependencies and newer toolchain for gfortran5
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
-    - sudo apt-get install gcc gfortran
+    - sudo apt-get install gcc gfortran libgfortran5
     - target=$(python tools/openblas_support.py)
     - ls -lR "${target}"
     - sudo cp -r "${target}"/lib/* /usr/lib

--- a/shippable.yml
+++ b/shippable.yml
@@ -49,7 +49,7 @@ build:
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
-    - python tools/openblas_support.py --check_version 0.3.7
+    - python tools/openblas_support.py --check_version 0.3.8
     # run the test suite
     - python runtests.py -n --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -16,7 +16,7 @@ import zipfile
 import tarfile
 
 OPENBLAS_V = 'v0.3.7'
-OPENBLAS_LONG = 'v0.3.5-605-gc815b8fb' 
+OPENBLAS_LONG = 'v0.3.7' 
 BASE_LOC = ''
 RACKSPACE = 'https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -15,8 +15,8 @@ from tempfile import mkstemp, gettempdir
 import zipfile
 import tarfile
 
-OPENBLAS_V = 'v0.3.7'
-OPENBLAS_LONG = 'v0.3.7' 
+OPENBLAS_V = 'v0.3.8'
+OPENBLAS_LONG = 'v0.3.5-605-gc815b8fb'  # the 0.3.5 is misleading
 BASE_LOC = ''
 RACKSPACE = 'https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -33,6 +33,7 @@ fi
 
 source venv/bin/activate
 python -V
+gcc --version
 
 popd
 


### PR DESCRIPTION
In MacPython/openblas-libs#9 we added aarch64, ppc64le, s390x to the standard builds of the OpenBLAS libs. On those architectures we use the multilinux2014 docker image, x86 still uses multilinux1. This PR now uses those CI builds (instead of manual builds) for numpy.

This simplifies `tools/openblas_support.py` and gets us one step closer to wheels for other architectures (gh-14886)