### PR TITLE
MAINT: Cleanup most PY3K #ifdef guards

### DIFF
--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -7,9 +7,6 @@ _is_basic_python_type(PyTypeObject *tp)
     return (
         /* Basic number types */
         tp == &PyBool_Type ||
-#if !defined(NPY_PY3K)
-        tp == &PyInt_Type ||
-#endif
         tp == &PyLong_Type ||
         tp == &PyFloat_Type ||
         tp == &PyComplex_Type ||
@@ -22,9 +19,6 @@ _is_basic_python_type(PyTypeObject *tp)
         tp == &PyFrozenSet_Type ||
         tp == &PyUnicode_Type ||
         tp == &PyBytes_Type ||
-#if !defined(NPY_PY3K)
-        tp == &PyString_Type ||
-#endif
 
         /* other builtins */
         tp == &PySlice_Type ||
@@ -64,11 +58,7 @@ maybe_get_attr(PyObject *obj, char const *name)
     }
     /* Attribute referenced by (PyObject *)name */
     else if (tp->tp_getattro != NULL) {
-#if defined(NPY_PY3K)
         PyObject *w = PyUnicode_InternFromString(name);
-#else
-        PyObject *w = PyString_InternFromString(name);
-#endif
         if (w == NULL) {
             return (PyObject *)NULL;
         }

--- a/numpy/core/src/common/npy_longdouble.c
+++ b/numpy/core/src/common/npy_longdouble.c
@@ -100,16 +100,12 @@ done:
 static PyObject *
 _PyLong_Bytes(PyObject *long_obj) {
     PyObject *bytes;
-#if defined(NPY_PY3K)
     PyObject *unicode = PyObject_Str(long_obj);
     if (unicode == NULL) {
         return NULL;
     }
     bytes = PyUnicode_AsUTF8String(unicode);
     Py_DECREF(unicode);
-#else
-    bytes = PyObject_Str(long_obj);
-#endif
     return bytes;
 }
 

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -771,30 +771,6 @@ npy_discard(PyObject* NPY_UNUSED(self), PyObject* args)
     Py_RETURN_NONE;
 }
 
-#if !defined(NPY_PY3K)
-static PyObject *
-int_subclass(PyObject *dummy, PyObject *args)
-{
-
-  PyObject *result = NULL;
-  PyObject *scalar_object = NULL;
-
-  if (!PyArg_UnpackTuple(args, "test_int_subclass", 1, 1, &scalar_object))
-    return NULL;
-
-  if (PyInt_Check(scalar_object))
-    result = Py_True;
-  else
-    result = Py_False;
-
-  Py_INCREF(result);
-
-  return result;
-
-}
-#endif
-
-
 /*
  * Create python string from a FLAG and or the corresponding PyBuf flag
  * for the use in get_buffer_info.
@@ -1210,11 +1186,7 @@ array_solve_diophantine(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject 
 
         for (j = 0; j < nterms; ++j) {
             PyObject *obj;
-#if defined(NPY_PY3K)
             obj = PyLong_FromSsize_t(x[j]);
-#else
-            obj = PyInt_FromSsize_t(x[j]);
-#endif
             if (obj == NULL) {
                 goto fail;
             }
@@ -2018,11 +1990,6 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"npy_discard",
         npy_discard,
         METH_O, NULL},
-#if !defined(NPY_PY3K)
-    {"test_int_subclass",
-        int_subclass,
-        METH_VARARGS, NULL},
-#endif
     {"get_buffer_info",
         get_buffer_info,
         METH_VARARGS, NULL},

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1333,14 +1333,6 @@ _failed_comparison_workaround(PyArrayObject *self, PyObject *other, int cmp_op)
          * get us the desired TypeError, but on python 2, one gets strange
          * ordering, so we emit a warning.
          */
-#if !defined(NPY_PY3K)
-        /* 2015-05-14, 1.10 */
-        if (DEPRECATE(
-                "unorderable dtypes; returning scalar but in "
-                "the future this will be an error") < 0) {
-            goto fail;
-        }
-#endif
         Py_XDECREF(exc);
         Py_XDECREF(val);
         Py_XDECREF(tb);
@@ -1790,12 +1782,7 @@ array_free(PyObject * v)
 
 
 NPY_NO_EXPORT PyTypeObject PyArray_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.ndarray",                            /* tp_name */
     NPY_SIZEOF_PYARRAYOBJECT,                   /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -1804,11 +1791,7 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     (printfunc)NULL,                            /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     (reprfunc)array_repr,                       /* tp_repr */
     &array_as_number,                           /* tp_as_number */
     &array_as_sequence,                         /* tp_as_sequence */
@@ -1823,12 +1806,7 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     (getattrofunc)0,                            /* tp_getattro */
     (setattrofunc)0,                            /* tp_setattro */
     &array_as_buffer,                           /* tp_as_buffer */
-    (Py_TPFLAGS_DEFAULT
-#if !defined(NPY_PY3K)
-     | Py_TPFLAGS_CHECKTYPES
-     | Py_TPFLAGS_HAVE_NEWBUFFER
-#endif
-     | Py_TPFLAGS_BASETYPE),                    /* tp_flags */
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE), /* tp_flags */
     0,                                          /* tp_doc */
 
     (traverseproc)0,                            /* tp_traverse */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -330,11 +330,7 @@ string_to_long_double(PyObject*op)
     /* Convert python long objects to a longdouble, without precision or range
      * loss via a double.
      */
-    if ((PyLong_Check(op) && !PyBool_Check(op))
-#if !defined(NPY_PY3K)
-        || (PyInt_Check(op) && !PyBool_Check(op))
-#endif
-    ) {
+    if ((PyLong_Check(op) && !PyBool_Check(op))) {
         return npy_longdouble_from_PyLong(op);
     }
 
@@ -470,7 +466,6 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
                 "setting an array element with a sequence");
         return -1;
     }
-#if defined(NPY_PY3K)
     if (PyBytes_Check(op)) {
         /* Try to decode from ASCII */
         temp = PyUnicode_FromEncodedObject(op, "ASCII", "strict");
@@ -479,9 +474,6 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
         }
     }
     else if ((temp=PyObject_Str(op)) == NULL) {
-#else
-    if ((temp=PyObject_Unicode(op)) == NULL) {
-#endif
         return -1;
     }
     ptr = PyUnicode_AS_UNICODE(temp);
@@ -561,7 +553,6 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
                 "setting an array element with a sequence");
         return -1;
     }
-#if defined(NPY_PY3K)
     if (PyUnicode_Check(op)) {
         /* Assume ASCII codec -- function similarly as Python 2 */
         temp = PyUnicode_AsASCIIString(op);
@@ -588,11 +579,6 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
             return -1;
         }
     }
-#else
-    if ((temp = PyObject_Str(op)) == NULL) {
-        return -1;
-    }
-#endif
     if (PyBytes_AsStringAndSize(temp, &ptr, &len) < 0) {
         Py_DECREF(temp);
         return -1;
@@ -919,7 +905,6 @@ VOID_setitem(PyObject *op, void *input, void *vap)
      * undiscerning case: It interprets any object as a buffer
      * and reads as many bytes as possible, padding with 0.
      */
-#if defined(NPY_PY3K)
     {
         Py_buffer view;
 
@@ -933,20 +918,6 @@ VOID_setitem(PyObject *op, void *input, void *vap)
         PyBuffer_Release(&view);
         _dealloc_cached_buffer_info(op);
     }
-#else
-    {
-        const void *buffer;
-        Py_ssize_t buflen;
-
-        if (PyObject_AsReadBuffer(op, &buffer, &buflen) < 0) {
-            return -1;
-        }
-        memcpy(ip, buffer, PyArray_MIN(buflen, itemsize));
-        if (itemsize > buflen) {
-            memset(ip + buflen, 0, itemsize - buflen);
-        }
-    }
-#endif
     return 0;
 }
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -98,13 +98,8 @@ _append_field_name(_tmp_string_t *str, PyObject *name)
     char *p;
     Py_ssize_t len;
     PyObject *tmp;
-#if defined(NPY_PY3K)
     /* FIXME: XXX -- should it use UTF-8 here? */
     tmp = PyUnicode_AsUTF8String(name);
-#else
-    tmp = name;
-    Py_INCREF(tmp);
-#endif
     if (tmp == NULL || PyBytes_AsStringAndSize(tmp, &p, &len) < 0) {
         PyErr_Clear();
         PyErr_SetString(PyExc_ValueError, "invalid field name");

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -772,11 +772,7 @@ PyArray_Mean(PyArrayObject *self, int axis, int rtype, PyArrayObject *out)
         return NULL;
     }
     if (!out) {
-#if defined(NPY_PY3K)
         ret = PyNumber_TrueDivide(obj1, obj2);
-#else
-        ret = PyNumber_Divide(obj1, obj2);
-#endif
     }
     else {
         ret = PyObject_CallFunction(n_ops.divide, "OOO", out, obj2, out);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1447,7 +1447,6 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
         }
     }
 
-#if defined(NPY_PY3K)
     if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyUnicode_Type, &str)) {
         return NULL;
     }
@@ -1456,13 +1455,6 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
     if (docstr == NULL) {
         return NULL;
     }
-#else
-    if (!PyArg_ParseTuple(args, "OO!:add_docstring", &obj, &PyString_Type, &str)) {
-        return NULL;
-    }
-
-    docstr = PyString_AS_STRING(str);
-#endif
 
 #define _TESTDOC1(typebase) (Py_TYPE(obj) == &Py##typebase##_Type)
 #define _TESTDOC2(typebase) (Py_TYPE(obj) == Py##typebase##_TypePtr)

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -152,11 +152,7 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
 NPY_NO_EXPORT int
 PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
 {
-#if defined(NPY_PY3K)
     Py_buffer view;
-#else
-    Py_ssize_t buflen;
-#endif
 
     buf->ptr = NULL;
     buf->flags = NPY_ARRAY_BEHAVED;
@@ -165,7 +161,6 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
         return NPY_SUCCEED;
     }
 
-#if defined(NPY_PY3K)
     if (PyObject_GetBuffer(obj, &view,
                 PyBUF_ANY_CONTIGUOUS|PyBUF_WRITABLE|PyBUF_SIMPLE) != 0) {
         PyErr_Clear();
@@ -192,22 +187,6 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
     if (PyMemoryView_Check(obj)) {
         buf->base = PyMemoryView_GET_BASE(obj);
     }
-#else
-    if (PyObject_AsWriteBuffer(obj, &(buf->ptr), &buflen) < 0) {
-        PyErr_Clear();
-        buf->flags &= ~NPY_ARRAY_WRITEABLE;
-        if (PyObject_AsReadBuffer(obj, (const void **)&(buf->ptr),
-                                  &buflen) < 0) {
-            return NPY_FAIL;
-        }
-    }
-    buf->len = (npy_intp) buflen;
-
-    /* Point to the base of the buffer object if present */
-    if (PyBuffer_Check(obj)) {
-        buf->base = ((PyArray_Chunk *)obj)->base;
-    }
-#endif
     if (buf->base == NULL) {
         buf->base = obj;
     }

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -262,18 +262,12 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                     return -1;
                 }
             }
-#if defined(NPY_PY3K)
             byteobj = PyUnicode_AsASCIIString(strobj);
-#else
-            byteobj = strobj;
-#endif
             NPY_BEGIN_ALLOW_THREADS;
             n2 = PyBytes_GET_SIZE(byteobj);
             n = fwrite(PyBytes_AS_STRING(byteobj), 1, n2, fp);
             NPY_END_ALLOW_THREADS;
-#if defined(NPY_PY3K)
             Py_DECREF(byteobj);
-#endif
             if (n < n2) {
                 PyErr_Format(PyExc_IOError,
                         "problem writing element %" NPY_INTP_FMT

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -493,12 +493,7 @@ static PyGetSetDef busdaycalendar_getsets[] = {
 };
 
 NPY_NO_EXPORT PyTypeObject NpyBusDayCalendar_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.busdaycalendar",                     /* tp_name */
     sizeof(NpyBusDayCalendar),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -507,11 +502,7 @@ NPY_NO_EXPORT PyTypeObject NpyBusDayCalendar_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1487,7 +1487,6 @@ array_datetime_as_string(PyObject *NPY_UNUSED(self), PyObject *args,
 
     /* Get a string size long enough for any datetimes we're given */
     strsize = get_datetime_iso_8601_strlen(local, unit);
-#if defined(NPY_PY3K)
     /*
      * For Python3, allocate the output array as a UNICODE array, so
      * that it will behave as strings properly
@@ -1504,7 +1503,6 @@ array_datetime_as_string(PyObject *NPY_UNUSED(self), PyObject *args,
         op_dtypes[1] = NULL;
         goto fail;
     }
-#endif
     /* Create the iteration string data type (always ASCII string) */
     op_dtypes[1] = PyArray_DescrNewFromType(NPY_STRING);
     if (op_dtypes[1] == NULL) {

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -793,12 +793,7 @@ arrayflags_new(PyTypeObject *NPY_UNUSED(self), PyObject *args, PyObject *NPY_UNU
 }
 
 NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.flagsobj",
     sizeof(PyArrayFlagsObject),
     0,                                          /* tp_itemsize */
@@ -807,11 +802,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    (cmpfunc)arrayflags_compare,                /* tp_compare */
-#endif
     (reprfunc)arrayflags_print,                 /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -110,12 +110,7 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
     npy_intp offset = 0;
     npy_intp lower_offset = 0;
     npy_intp upper_offset = 0;
-#if defined(NPY_PY3K)
     Py_buffer view;
-#else
-    Py_ssize_t buf_len;
-    char *buf;
-#endif
 
     if (obj == NULL) {
         PyErr_SetString(PyExc_AttributeError,
@@ -140,7 +135,6 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
      * Get the available memory through the buffer interface on
      * PyArray_BASE(new) or if that fails from the current new
      */
-#if defined(NPY_PY3K)
     if (PyArray_BASE(new) &&
             PyObject_GetBuffer(PyArray_BASE(new), &view, PyBUF_SIMPLE) >= 0) {
         offset = PyArray_BYTES(self) - (char *)view.buf;
@@ -148,14 +142,6 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
         PyBuffer_Release(&view);
         _dealloc_cached_buffer_info((PyObject*)new);
     }
-#else
-    if (PyArray_BASE(new) &&
-            PyObject_AsReadBuffer(PyArray_BASE(new), (const void **)&buf,
-                                  &buf_len) >= 0) {
-        offset = PyArray_BYTES(self) - buf;
-        numbytes = buf_len + offset;
-    }
-#endif
     else {
         PyErr_Clear();
         offset_bounds_from_strides(PyArray_ITEMSIZE(new), PyArray_NDIM(new),
@@ -318,23 +304,7 @@ array_interface_get(PyArrayObject *self)
 static PyObject *
 array_data_get(PyArrayObject *self)
 {
-#if defined(NPY_PY3K)
     return PyMemoryView_FromObject((PyObject *)self);
-#else
-    npy_intp nbytes;
-    if (!(PyArray_ISONESEGMENT(self))) {
-        PyErr_SetString(PyExc_AttributeError, "cannot get single-"\
-                        "segment buffer for discontiguous array");
-        return NULL;
-    }
-    nbytes = PyArray_NBYTES(self);
-    if (PyArray_ISWRITEABLE(self)) {
-        return PyBuffer_FromReadWriteObject((PyObject *)self, 0, (Py_ssize_t) nbytes);
-    }
-    else {
-        return PyBuffer_FromObject((PyObject *)self, 0, (Py_ssize_t) nbytes);
-    }
-#endif
 }
 
 static int
@@ -343,9 +313,7 @@ array_data_set(PyArrayObject *self, PyObject *op)
     void *buf;
     Py_ssize_t buf_len;
     int writeable=1;
-#if defined(NPY_PY3K)
     Py_buffer view;
-#endif
 
     /* 2016-19-02, 1.12 */
     int ret = DEPRECATE("Assigning the 'data' attribute is an "
@@ -360,7 +328,6 @@ array_data_set(PyArrayObject *self, PyObject *op)
                 "Cannot delete array data");
         return -1;
     }
-#if defined(NPY_PY3K)
     if (PyObject_GetBuffer(op, &view, PyBUF_WRITABLE|PyBUF_SIMPLE) < 0) {
         writeable = 0;
         PyErr_Clear();
@@ -378,18 +345,7 @@ array_data_set(PyArrayObject *self, PyObject *op)
      */
     PyBuffer_Release(&view);
     _dealloc_cached_buffer_info(op);
-#else
-    if (PyObject_AsWriteBuffer(op, &buf, &buf_len) < 0) {
-        PyErr_Clear();
-        writeable = 0;
-        if (PyObject_AsReadBuffer(op, (const void **)&buf, &buf_len) < 0) {
-            PyErr_Clear();
-            PyErr_SetString(PyExc_AttributeError,
-                    "object does not have single-segment buffer interface");
-            return -1;
-        }
-    }
-#endif
+
     if (!PyArray_ISONESEGMENT(self)) {
         PyErr_SetString(PyExc_AttributeError,
                 "cannot set single-segment buffer for discontiguous array");

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1059,12 +1059,10 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
         if (argpart == NULL) {
             ret = argsort(valptr, idxptr, N, op);
-#if defined(NPY_PY3K)
             /* Object comparisons may raise an exception in Python 3 */
             if (hasrefs && PyErr_Occurred()) {
                 ret = -1;
             }
-#endif
             if (ret < 0) {
                 goto fail;
             }
@@ -1075,12 +1073,10 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
             for (i = 0; i < nkth; ++i) {
                 ret = argpart(valptr, idxptr, N, kth[i], pivots, &npiv, op);
-#if defined(NPY_PY3K)
                 /* Object comparisons may raise an exception in Python 3 */
                 if (hasrefs && PyErr_Occurred()) {
                     ret = -1;
                 }
-#endif
                 if (ret < 0) {
                     goto fail;
                 }
@@ -1566,12 +1562,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                     _strided_byte_swap(valbuffer, (npy_intp) elsize, N, elsize);
                 }
                 rcode = argsort(valbuffer, (npy_intp *)indbuffer, N, mps[j]);
-#if defined(NPY_PY3K)
                 if (rcode < 0 || (PyDataType_REFCHK(PyArray_DESCR(mps[j]))
                             && PyErr_Occurred())) {
-#else
-                if (rcode < 0) {
-#endif
                     PyDataMem_FREE(valbuffer);
                     PyDataMem_FREE(indbuffer);
                     free(swaps);
@@ -1601,12 +1593,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                 }
                 rcode = argsort(its[j]->dataptr,
                         (npy_intp *)rit->dataptr, N, mps[j]);
-#if defined(NPY_PY3K)
                 if (rcode < 0 || (PyDataType_REFCHK(PyArray_DESCR(mps[j]))
                             && PyErr_Occurred())) {
-#else
-                if (rcode < 0) {
-#endif
                     goto fail;
                 }
                 PyArray_ITER_NEXT(its[j]);

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1102,12 +1102,7 @@ static PyGetSetDef iter_getsets[] = {
 };
 
 NPY_NO_EXPORT PyTypeObject PyArrayIter_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.flatiter",                           /* tp_name */
     sizeof(PyArrayIterObject),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -1116,11 +1111,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayIter_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -1560,12 +1551,7 @@ static PyMethodDef arraymultiter_methods[] = {
 };
 
 NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.broadcast",                          /* tp_name */
     sizeof(PyArrayMultiIterObject),             /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -1574,11 +1560,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -1890,12 +1872,7 @@ static void neighiter_dealloc(PyArrayNeighborhoodIterObject* iter)
 }
 
 NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.neigh_internal_iter",                /* tp_name*/
     sizeof(PyArrayNeighborhoodIterObject),      /* tp_basicsize*/
     0,                                          /* tp_itemsize*/
@@ -1903,11 +1880,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
     0,                                          /* tp_print*/
     0,                                          /* tp_getattr*/
     0,                                          /* tp_setattr*/
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr*/
     0,                                          /* tp_as_number*/
     0,                                          /* tp_as_sequence*/

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -227,11 +227,7 @@ unpack_indices(PyObject *index, PyObject **result, npy_intp result_n)
 
     /* Obvious single-entry cases */
     if (0  /* to aid macros below */
-#if !defined(NPY_PY3K)
-            || PyInt_CheckExact(index)
-#else
             || PyLong_CheckExact(index)
-#endif
             || index == Py_None
             || PySlice_Check(index)
             || PyArray_Check(index)
@@ -481,11 +477,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
              *
              * Check for integers first, purely for performance
              */
-#if !defined(NPY_PY3K)
-            if (PyInt_CheckExact(obj) || !PyArray_Check(obj)) {
-#else
             if (PyLong_CheckExact(obj) || !PyArray_Check(obj)) {
-#endif
                 npy_intp ind = PyArray_PyIntAsIntp(obj);
 
                 if (error_converting(ind)) {
@@ -3340,12 +3332,7 @@ arraymapiter_dealloc(PyArrayMapIterObject *mit)
  * to a[indexobj].flat but the latter gets to use slice syntax.
  */
 NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.mapiter",                            /* tp_name */
     sizeof(PyArrayMapIterObject),               /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -3354,11 +3341,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1954,7 +1954,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
     else {
         Py_INCREF(rawdata);
 
-#if defined(NPY_PY3K)
         /* Backward compatibility with Python 2 NumPy pickles */
         if (PyUnicode_Check(rawdata)) {
             PyObject *tmp;
@@ -1969,7 +1968,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 return NULL;
             }
         }
-#endif
 
         if (!PyBytes_Check(rawdata)) {
             PyErr_SetString(PyExc_TypeError,
@@ -2030,14 +2028,9 @@ array_setstate(PyArrayObject *self, PyObject *args)
     if (!PyDataType_FLAGCHK(typecode, NPY_LIST_PICKLE)) {
         int swap = PyArray_ISBYTESWAPPED(self);
         fa->data = datastr;
-#ifndef NPY_PY3K
-        /* Check that the string is not interned */
-        if (!IsAligned(self) || swap || PyString_CHECK_INTERNED(rawdata)) {
-#else
         /* Bytes should always be considered immutable, but we just grab the
          * pointer if they are large, to save memory. */
         if (!IsAligned(self) || swap || (len <= 1000)) {
-#endif
             npy_intp num = PyArray_NBYTES(self);
             if (num == 0) {
                 Py_DECREF(rawdata);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1920,7 +1920,6 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
             alloc = 1;
         }
         else {
-#if defined(NPY_PY3K)
             /* Backward compatibility with Python 2 NumPy pickles */
             if (PyUnicode_Check(obj)) {
                 tmpobj = PyUnicode_AsLatin1String(obj);
@@ -1934,8 +1933,6 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
                     return NULL;
                 }
             }
-#endif
-
             if (!PyString_Check(obj)) {
                 PyErr_SetString(PyExc_TypeError,
                         "initializing object must be a string");
@@ -2020,11 +2017,7 @@ array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     if (count == -1) {
         return NULL;
     }
-#if defined(NPY_PY3K)
     return PyLong_FromSsize_t(count);
-#else
-    return PyInt_FromSsize_t(count);
-#endif
 }
 
 static PyObject *
@@ -2639,13 +2632,11 @@ array_einsum(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
         while (PyDict_Next(kwds, &pos, &key, &value)) {
             char *str = NULL;
 
-#if defined(NPY_PY3K)
             Py_XDECREF(str_key_obj);
             str_key_obj = PyUnicode_AsASCIIString(key);
             if (str_key_obj != NULL) {
                 key = str_key_obj;
             }
-#endif
 
             str = PyBytes_AsString(key);
 
@@ -3873,11 +3864,6 @@ array_shares_memory_impl(PyObject *args, PyObject *kwds, Py_ssize_t default_max_
             goto fail;
         }
     }
-#if !defined(NPY_PY3K)
-    else if (PyInt_Check(max_work_obj)) {
-        max_work = PyInt_AsSsize_t(max_work_obj);
-    }
-#endif
     else {
         PyErr_SetString(PyExc_ValueError, "max_work must be an integer");
         goto fail;
@@ -4180,11 +4166,6 @@ setup_scalartypes(PyObject *NPY_UNUSED(dict))
     if (PyType_Ready(&PyBool_Type) < 0) {
         return -1;
     }
-#if !defined(NPY_PY3K)
-    if (PyType_Ready(&PyInt_Type) < 0) {
-        return -1;
-    }
-#endif
     if (PyType_Ready(&PyFloat_Type) < 0) {
         return -1;
     }
@@ -4239,22 +4220,10 @@ setup_scalartypes(PyObject *NPY_UNUSED(dict))
  * In Py3K, int is no longer a fixed-width integer type, so don't
  * inherit numpy.int_ from it.
  */
-#if defined(NPY_PY3K)
 #define INHERIT_INT(child, parent2)                                     \
     SINGLE_INHERIT(child, parent2);
-#else
-#define INHERIT_INT(child, parent2)                                     \
-    Py##child##ArrType_Type.tp_flags |= Py_TPFLAGS_INT_SUBCLASS;        \
-    DUAL_INHERIT(child, Int, parent2);
-#endif
 
-#if defined(NPY_PY3K)
 #define DUAL_INHERIT_COMPARE(child, parent1, parent2)
-#else
-#define DUAL_INHERIT_COMPARE(child, parent1, parent2)                   \
-    Py##child##ArrType_Type.tp_compare =                                \
-        Py##parent1##_Type.tp_compare;
-#endif
 
 #define DUAL_INHERIT2(child, parent1, parent2)                          \
     Py##child##ArrType_Type.tp_base = &Py##parent1##_Type;              \

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2490,12 +2490,7 @@ NPY_NO_EXPORT PyMappingMethods npyiter_as_mapping = {
 };
 
 NPY_NO_EXPORT PyTypeObject NpyIter_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.nditer",                             /* tp_name */
     sizeof(NewNpyArrayIterObject),              /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -2504,11 +2499,7 @@ NPY_NO_EXPORT PyTypeObject NpyIter_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     &npyiter_as_sequence,                       /* tp_as_sequence */

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -901,66 +901,11 @@ array_float(PyArrayObject *v)
     return array_scalar_forward(v, &PyNumber_Float, " in ndarray.__float__");
 }
 
-#if defined(NPY_PY3K)
-
 NPY_NO_EXPORT PyObject *
 array_int(PyArrayObject *v)
 {
     return array_scalar_forward(v, &PyNumber_Long, " in ndarray.__int__");
 }
-
-#else
-
-NPY_NO_EXPORT PyObject *
-array_int(PyArrayObject *v)
-{
-    return array_scalar_forward(v, &PyNumber_Int, " in ndarray.__int__");
-}
-
-NPY_NO_EXPORT PyObject *
-array_long(PyArrayObject *v)
-{
-    return array_scalar_forward(v, &PyNumber_Long, " in ndarray.__long__");
-}
-
-/* hex and oct aren't exposed to the C api, but we need a function pointer */
-static PyObject *
-_PyNumber_Oct(PyObject *o) {
-    PyObject *res;
-    PyObject *mod = PyImport_ImportModule("__builtin__");
-    if (mod == NULL) {
-        return NULL;
-    }
-    res = PyObject_CallMethod(mod, "oct", "(O)", o);
-    Py_DECREF(mod);
-    return res;
-}
-
-static PyObject *
-_PyNumber_Hex(PyObject *o) {
-    PyObject *res;
-    PyObject *mod = PyImport_ImportModule("__builtin__");
-    if (mod == NULL) {
-        return NULL;
-    }
-    res = PyObject_CallMethod(mod, "hex", "(O)", o);
-    Py_DECREF(mod);
-    return res;
-}
-
-NPY_NO_EXPORT PyObject *
-array_oct(PyArrayObject *v)
-{
-    return array_scalar_forward(v, &_PyNumber_Oct, " in ndarray.__oct__");
-}
-
-NPY_NO_EXPORT PyObject *
-array_hex(PyArrayObject *v)
-{
-    return array_scalar_forward(v, &_PyNumber_Hex, " in ndarray.__hex__");
-}
-
-#endif
 
 static PyObject *
 array_index(PyArrayObject *v)
@@ -991,20 +936,9 @@ NPY_NO_EXPORT PyNumberMethods array_as_number = {
     (binaryfunc)array_bitwise_and,              /*nb_and*/
     (binaryfunc)array_bitwise_xor,              /*nb_xor*/
     (binaryfunc)array_bitwise_or,               /*nb_or*/
-#if !defined(NPY_PY3K)
-    0,                                          /*nb_coerce*/
-#endif
     (unaryfunc)array_int,                       /*nb_int*/
-#if defined(NPY_PY3K)
     0,                                          /*nb_reserved*/
-#else
-    (unaryfunc)array_long,                      /*nb_long*/
-#endif
     (unaryfunc)array_float,                     /*nb_float*/
-#if !defined(NPY_PY3K)
-    (unaryfunc)array_oct,                       /*nb_oct*/
-    (unaryfunc)array_hex,                       /*nb_hex*/
-#endif
 
     /*
      * This code adds augmented assignment functionality

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -708,9 +708,6 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
         if (type_num == NPY_STRING) {
             destptr = PyString_AS_STRING(obj);
             ((PyStringObject *)obj)->ob_shash = -1;
-#if !defined(NPY_PY3K)
-            ((PyStringObject *)obj)->ob_sstate = SSTATE_NOT_INTERNED;
-#endif
             memcpy(destptr, data, itemsize);
             return obj;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -54,12 +54,7 @@ NPY_NO_EXPORT PyTypeObject PyTimeIntegerArrType_Type;
  *         Floating, ComplexFloating, Flexible, Character#
  */
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.@name@",                             /* tp_name*/
     sizeof(PyObject),                           /* tp_basicsize*/
     0,                                          /* tp_itemsize */
@@ -68,11 +63,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -279,27 +270,6 @@ gentype_@name@(PyObject *m1)
 }
 /**end repeat**/
 
-#if !defined(NPY_PY3K)
-/**begin repeat
- *
- * #name = long, oct, hex#
- */
-static PyObject *
-gentype_@name@(PyObject *m1)
-{
-    PyObject *arr, *ret;
-
-    arr = PyArray_FromScalar(m1, NULL);
-    if (arr == NULL) {
-        return NULL;
-    }
-    ret = Py_TYPE(arr)->tp_as_number->nb_@name@(arr);
-    Py_DECREF(arr);
-    return ret;
-}
-/**end repeat**/
-#endif
-
 static int
 gentype_nonzero_number(PyObject *m1)
 {
@@ -310,11 +280,7 @@ gentype_nonzero_number(PyObject *m1)
     if (arr == NULL) {
         return -1;
     }
-#if defined(NPY_PY3K)
     ret = Py_TYPE(arr)->tp_as_number->nb_bool(arr);
-#else
-    ret = Py_TYPE(arr)->tp_as_number->nb_nonzero(arr);
-#endif
     Py_DECREF(arr);
     return ret;
 }
@@ -342,21 +308,9 @@ gentype_format(PyObject *self, PyObject *args)
     PyObject *format_spec;
     PyObject *obj, *ret;
 
-#if defined(NPY_PY3K)
     if (!PyArg_ParseTuple(args, "U:__format__", &format_spec)) {
         return NULL;
     }
-#else
-    if (!PyArg_ParseTuple(args, "O:__format__", &format_spec)) {
-        return NULL;
-    }
-
-    if (!PyUnicode_Check(format_spec) && !PyString_Check(format_spec)) {
-        PyErr_SetString(PyExc_TypeError,
-                "format must be a string");
-        return NULL;
-    }
-#endif
 
     /*
      * Convert to an appropriate Python type and call its format.
@@ -367,11 +321,7 @@ gentype_format(PyObject *self, PyObject *args)
         obj = PyBool_FromLong(((PyBoolScalarObject *)self)->obval);
     }
     else if (PyArray_IsScalar(self, Integer)) {
-#if defined(NPY_PY3K)
         obj = Py_TYPE(self)->tp_as_number->nb_int(self);
-#else
-        obj = Py_TYPE(self)->tp_as_number->nb_long(self);
-#endif
     }
     else if (PyArray_IsScalar(self, Floating)) {
         obj = Py_TYPE(self)->tp_as_number->nb_float(self);
@@ -1063,27 +1013,6 @@ static PyObject *
     return npy_longdouble_to_PyLong(val);
 }
 
-#if !defined(NPY_PY3K)
-
-/**begin repeat1
- * #name = int, hex, oct#
- */
-static PyObject *
-@char@longdoubletype_@name@(PyObject *self)
-{
-    PyObject *ret;
-    PyObject *obj = @char@longdoubletype_long(self);
-    if (obj == NULL) {
-        return NULL;
-    }
-    ret = Py_TYPE(obj)->tp_as_number->nb_@name@(obj);
-    Py_DECREF(obj);
-    return ret;
-}
-/**end repeat1**/
-
-#endif /* !defined(NPY_PY3K) */
-
 /**end repeat**/
 
 static PyNumberMethods gentype_as_number = {
@@ -1103,20 +1032,9 @@ static PyNumberMethods gentype_as_number = {
     (binaryfunc)gentype_and,                     /*nb_and*/
     (binaryfunc)gentype_xor,                     /*nb_xor*/
     (binaryfunc)gentype_or,                      /*nb_or*/
-#if !defined(NPY_PY3K)
-    0,                                           /*nb_coerce*/
-#endif
     (unaryfunc)gentype_int,                      /*nb_int*/
-#if defined(NPY_PY3K)
     0,                                           /*nb_reserved*/
-#else
-    (unaryfunc)gentype_long,                     /*nb_long*/
-#endif
     (unaryfunc)gentype_float,                    /*nb_float*/
-#if !defined(NPY_PY3K)
-    (unaryfunc)gentype_oct,                      /*nb_oct*/
-    (unaryfunc)gentype_hex,                      /*nb_hex*/
-#endif
     0,                                           /*inplace_add*/
     0,                                           /*inplace_subtract*/
     0,                                           /*inplace_multiply*/
@@ -1224,11 +1142,7 @@ inttype_denominator_get(PyObject *self)
 static PyObject *
 gentype_data_get(PyObject *self)
 {
-#if defined(NPY_PY3K)
     return PyMemoryView_FromObject(self);
-#else
-    return PyBuffer_FromObject(self, 0, Py_END_OF_BUFFER);
-#endif
 }
 
 
@@ -1802,9 +1716,7 @@ static PyObject *
 gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
 {
     PyObject *ret = NULL, *obj = NULL, *mod = NULL;
-#if defined(NPY_PY3K)
     Py_buffer view;
-#endif
     const char *buffer;
     Py_ssize_t buflen;
 
@@ -1814,7 +1726,6 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         return NULL;
     }
 
-#if defined(NPY_PY3K)
     if (PyArray_IsScalar(self, Unicode)) {
         /* Unicode on Python 3 does not expose the buffer interface */
         buffer = PyUnicode_AS_DATA(self);
@@ -1836,12 +1747,6 @@ gentype_reduce(PyObject *self, PyObject *NPY_UNUSED(args))
         Py_DECREF(ret);
         return NULL;
     }
-#else
-    if (PyObject_AsReadBuffer(self, (const void **)&buffer, &buflen)<0) {
-        Py_DECREF(ret);
-        return NULL;
-    }
-#endif
 
     mod = PyImport_ImportModule("numpy.core._multiarray_umath");
     if (mod == NULL) {
@@ -2260,12 +2165,10 @@ static PyMethodDef gentype_methods[] = {
     {"round",
         (PyCFunction)gentype_round,
         METH_VARARGS | METH_KEYWORDS, NULL},
-#if defined(NPY_PY3K)
     /* Hook for the round() builtin */
     {"__round__",
         (PyCFunction)gentype_round,
         METH_VARARGS | METH_KEYWORDS, NULL},
-#endif
     /* For the format function */
     {"__format__",
         gentype_format,
@@ -2577,21 +2480,11 @@ static PyBufferProcs gentype_as_buffer = {
 };
 
 
-#if defined(NPY_PY3K)
 #define BASEFLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE
 #define LEAFFLAGS  Py_TPFLAGS_DEFAULT
-#else
-#define BASEFLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_CHECKTYPES
-#define LEAFFLAGS  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES
-#endif
 
 NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.generic",                            /* tp_name*/
     sizeof(PyObject),                           /* tp_basicsize*/
     0,                                          /* tp_itemsize */
@@ -2600,11 +2493,7 @@ NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -3021,22 +2910,9 @@ NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
     (binaryfunc)bool_arrtype_and,                /* nb_and */
     (binaryfunc)bool_arrtype_xor,                /* nb_xor */
     (binaryfunc)bool_arrtype_or,                 /* nb_or */
-#if defined(NPY_PY3K)
-#else
-    0,                                           /* nb_coerce */
-#endif
     0,                                           /* nb_int */
-#if defined(NPY_PY3K)
     0,                                           /* nb_reserved */
-#else
-    0,                                           /* nb_long */
-#endif
     0,                                           /* nb_float */
-#if defined(NPY_PY3K)
-#else
-    0,                                           /* nb_oct */
-    0,                                           /* nb_hex */
-#endif
     /* Added in release 2.0 */
     0,                                           /* nb_inplace_add */
     0,                                           /* nb_inplace_subtract */
@@ -3076,11 +2952,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *NPY_UNUSED(kwds))
             (PyArray_Check(obj) &&
                      PyArray_NDIM((PyArrayObject *)obj)==0 &&
                      PyArray_ISINTEGER((PyArrayObject *)obj))) {
-#if defined(NPY_PY3K)
         new = Py_TYPE(obj)->tp_as_number->nb_int(obj);
-#else
-        new = Py_TYPE(obj)->tp_as_number->nb_long(obj);
-#endif
     }
     if (new && PyLong_Check(new)) {
         PyObject *ret;
@@ -3166,7 +3038,6 @@ int_arrtype_hash(PyObject *obj)
     return x;
 }
 
-#if defined(NPY_PY3K)
 static npy_hash_t
 long_arrtype_hash(PyObject *obj)
 {
@@ -3175,7 +3046,6 @@ long_arrtype_hash(PyObject *obj)
     Py_DECREF(l);
     return x;
 }
-#endif
 
 /**begin repeat
  * #char = ,u#
@@ -3415,72 +3285,6 @@ static PyMappingMethods object_arrtype_as_mapping = {
     (objobjargproc)object_arrtype_ass_subscript,
 };
 
-#if !defined(NPY_PY3K)
-static Py_ssize_t
-object_arrtype_getsegcount(PyObjectScalarObject *self, Py_ssize_t *lenp)
-{
-    Py_ssize_t newlen;
-    int cnt;
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
-
-    if (pb == NULL ||
-            pb->bf_getsegcount == NULL ||
-            (cnt = (*pb->bf_getsegcount)(self->obval, &newlen)) != 1) {
-        return 0;
-    }
-    if (lenp) {
-        *lenp = newlen;
-    }
-    return cnt;
-}
-
-static Py_ssize_t
-object_arrtype_getreadbuf(PyObjectScalarObject *self, Py_ssize_t segment, void **ptrptr)
-{
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
-
-    if (pb == NULL ||
-            pb->bf_getreadbuffer == NULL ||
-            pb->bf_getsegcount == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                "expected a readable buffer object");
-        return -1;
-    }
-    return (*pb->bf_getreadbuffer)(self->obval, segment, ptrptr);
-}
-
-static Py_ssize_t
-object_arrtype_getwritebuf(PyObjectScalarObject *self, Py_ssize_t segment, void **ptrptr)
-{
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
-
-    if (pb == NULL ||
-            pb->bf_getwritebuffer == NULL ||
-            pb->bf_getsegcount == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                "expected a writeable buffer object");
-        return -1;
-    }
-    return (*pb->bf_getwritebuffer)(self->obval, segment, ptrptr);
-}
-
-static Py_ssize_t
-object_arrtype_getcharbuf(PyObjectScalarObject *self, Py_ssize_t segment,
-                          constchar **ptrptr)
-{
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
-
-    if (pb == NULL ||
-            pb->bf_getcharbuffer == NULL ||
-            pb->bf_getsegcount == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                "expected a character buffer object");
-        return -1;
-    }
-    return (*pb->bf_getcharbuffer)(self->obval, segment, ptrptr);
-}
-#endif
-
 static int
 object_arrtype_getbuffer(PyObjectScalarObject *self, Py_buffer *view, int flags)
 {
@@ -3508,12 +3312,6 @@ object_arrtype_releasebuffer(PyObjectScalarObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs object_arrtype_as_buffer = {
-#if !defined(NPY_PY3K)
-    (readbufferproc)object_arrtype_getreadbuf,
-    (writebufferproc)object_arrtype_getwritebuf,
-    (segcountproc)object_arrtype_getsegcount,
-    (charbufferproc)object_arrtype_getcharbuf,
-#endif
     (getbufferproc)object_arrtype_getbuffer,
     (releasebufferproc)object_arrtype_releasebuffer,
 };
@@ -3525,12 +3323,7 @@ object_arrtype_call(PyObjectScalarObject *obj, PyObject *args, PyObject *kwds)
 }
 
 NPY_NO_EXPORT PyTypeObject PyObjectArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.object_",                            /* tp_name*/
     sizeof(PyObjectScalarObject),               /* tp_basicsize*/
     0,                                          /* tp_itemsize */
@@ -3538,11 +3331,7 @@ NPY_NO_EXPORT PyTypeObject PyObjectArrType_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     &object_arrtype_as_sequence,                /* tp_as_sequence */
@@ -3609,13 +3398,8 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
 
 #define NAME_bool "bool"
 #define NAME_void "void"
-#if defined(NPY_PY3K)
 #define NAME_string "bytes"
 #define NAME_unicode "str"
-#else
-#define NAME_string "string"
-#define NAME_unicode "unicode"
-#endif
 
 /**begin repeat
  * #name = bool, string, unicode, void#
@@ -3623,12 +3407,7 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
  * #ex = _,_,_,#
  */
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy." NAME_@name@ "@ex@",                /* tp_name*/
     sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
     0,                                          /* tp_itemsize */
@@ -3636,11 +3415,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -3712,12 +3487,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
 #define _THIS_SIZE "256"
 #endif
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.@name@" _THIS_SIZE,                  /* tp_name*/
     sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
     0,                                          /* tp_itemsize */
@@ -3725,11 +3495,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -3803,12 +3569,7 @@ static PyMappingMethods gentype_as_mapping = {
 #endif
 
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(0, 0)
-#else
-    PyObject_HEAD_INIT(0)
-    0,                                          /* ob_size */
-#endif
     "numpy.@name@" _THIS_SIZE,                  /* tp_name*/
     sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
     0,                                          /* tp_itemsize*/
@@ -3816,11 +3577,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     0,                                          /* tp_print*/
     0,                                          /* tp_getattr*/
     0,                                          /* tp_setattr*/
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     0,                                          /* tp_repr*/
     0,                                          /* tp_as_number*/
     0,                                          /* tp_as_sequence*/
@@ -4191,38 +3948,6 @@ initialize_casting_tables(void)
     }
 }
 
-#ifndef NPY_PY3K
-/*
- * In python2, the `float` and `complex` types still implement the obsolete
- * "tp_print" method, which uses CPython's float-printing routines to print the
- * float.  Numpy's float_/cfloat inherit from Python float/complex, but
- * override its tp_repr and tp_str methods. In order to avoid an inconsistency
- * with the inherited tp_print, we need to override it too.
- *
- * In python3 the tp_print method is reserved/unused.
- */
-static int
-doubletype_print(PyObject *o, FILE *fp, int flags)
-{
-    int ret;
-    PyObject *to_print;
-    if (flags & Py_PRINT_RAW) {
-        to_print = PyObject_Str(o);
-    }
-    else {
-        to_print = PyObject_Repr(o);
-    }
-
-    if (to_print == NULL) {
-        return -1;
-    }
-
-    ret = PyObject_Print(to_print, fp, Py_PRINT_RAW);
-    Py_DECREF(to_print);
-    return ret;
-}
-#endif
-
 static PyNumberMethods longdoubletype_as_number;
 static PyNumberMethods clongdoubletype_as_number;
 static void init_basetypes(void);
@@ -4273,12 +3998,6 @@ initialize_numeric_types(void)
     Py@NAME@ArrType_Type.tp_as_number = &@name@_arrtype_as_number;
 
     /**end repeat**/
-
-#ifndef NPY_PY3K
-    PyDoubleArrType_Type.tp_print = &doubletype_print;
-    PyCDoubleArrType_Type.tp_print = &doubletype_print;
-#endif
-
 
     PyBoolArrType_Type.tp_as_number->nb_index = (unaryfunc)bool_index;
 
@@ -4360,10 +4079,8 @@ initialize_numeric_types(void)
     /* We won't be inheriting from Python Int type. */
     PyIntArrType_Type.tp_hash = int_arrtype_hash;
 
-#if defined(NPY_PY3K)
     /* We won't be inheriting from Python Int type. */
     PyLongArrType_Type.tp_hash = long_arrtype_hash;
-#endif
 
     /* We won't be inheriting from Python Int type. */
     PyLongLongArrType_Type.tp_hash = longlong_arrtype_hash;
@@ -4409,14 +4126,7 @@ initialize_numeric_types(void)
      * does not return a normal Python type
      */
     @char@longdoubletype_as_number.nb_float = @char@longdoubletype_float;
-#if defined(NPY_PY3K)
     @char@longdoubletype_as_number.nb_int  = @char@longdoubletype_long;
-#else
-    @char@longdoubletype_as_number.nb_int  = @char@longdoubletype_int;
-    @char@longdoubletype_as_number.nb_long = @char@longdoubletype_long;
-    @char@longdoubletype_as_number.nb_hex  = @char@longdoubletype_hex;
-    @char@longdoubletype_as_number.nb_oct  = @char@longdoubletype_oct;
-#endif
 
     Py@CHAR@LongDoubleArrType_Type.tp_as_number = &@char@longdoubletype_as_number;
     Py@CHAR@LongDoubleArrType_Type.tp_repr = @char@longdoubletype_repr;

--- a/numpy/core/src/multiarray/typeinfo.c
+++ b/numpy/core/src/multiarray/typeinfo.c
@@ -58,11 +58,7 @@ PyArray_typeinfo(
     PyObject *entry = PyStructSequence_New(&PyArray_typeinfoType);
     if (entry == NULL)
         return NULL;
-#if defined(NPY_PY3K)
     PyStructSequence_SET_ITEM(entry, 0, Py_BuildValue("C", typechar));
-#else
-    PyStructSequence_SET_ITEM(entry, 0, Py_BuildValue("c", typechar));
-#endif
     PyStructSequence_SET_ITEM(entry, 1, Py_BuildValue("i", typenum));
     PyStructSequence_SET_ITEM(entry, 2, Py_BuildValue("i", nbits));
     PyStructSequence_SET_ITEM(entry, 3, Py_BuildValue("i", align));
@@ -84,11 +80,7 @@ PyArray_typeinforanged(
     PyObject *entry = PyStructSequence_New(&PyArray_typeinforangedType);
     if (entry == NULL)
         return NULL;
-#if defined(NPY_PY3K)
     PyStructSequence_SET_ITEM(entry, 0, Py_BuildValue("C", typechar));
-#else
-    PyStructSequence_SET_ITEM(entry, 0, Py_BuildValue("c", typechar));
-#endif
     PyStructSequence_SET_ITEM(entry, 1, Py_BuildValue("i", typenum));
     PyStructSequence_SET_ITEM(entry, 2, Py_BuildValue("i", nbits));
     PyStructSequence_SET_ITEM(entry, 3, Py_BuildValue("i", align));

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -661,12 +661,7 @@ static PyGetSetDef pyrational_getset[] = {
 };
 
 static PyTypeObject PyRational_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                        /* ob_size */
-#endif
     "rational",                               /* tp_name */
     sizeof(PyRational),                       /* tp_basicsize */
     0,                                        /* tp_itemsize */
@@ -674,11 +669,7 @@ static PyTypeObject PyRational_Type = {
     0,                                        /* tp_print */
     0,                                        /* tp_getattr */
     0,                                        /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                        /* tp_reserved */
-#else
-    0,                                        /* tp_compare */
-#endif
     pyrational_repr,                          /* tp_repr */
     &pyrational_as_number,                    /* tp_as_number */
     0,                                        /* tp_as_sequence */

--- a/numpy/core/src/umath/funcs.inc.src
+++ b/numpy/core/src/umath/funcs.inc.src
@@ -38,11 +38,7 @@ Py_reciprocal(PyObject *o)
     if (!one) {
         return NULL;
     }
-#if defined(NPY_PY3K)
     result = PyNumber_TrueDivide(one, o);
-#else
-    result = PyNumber_Divide(one, o);
-#endif
     Py_DECREF(one);
     return result;
 }

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1291,11 +1291,7 @@ static PyObject *
 
 /**end repeat**/
 
-#if defined(NPY_PY3K)
 #define NONZERO_NAME(prefix) prefix##bool
-#else
-#define NONZERO_NAME(prefix) prefix##nonzero
-#endif
 
 #define _IS_NONZERO(x) (x != 0)
 /**begin repeat
@@ -1401,15 +1397,6 @@ static PyObject *
         return NULL;
     }
 
-#ifndef NPY_PY3K
-    /* Invoke long.__int__ to try to downcast */
-    {
-        PyObject *before_downcast = long_result;
-        long_result = Py_TYPE(long_result)->tp_as_number->nb_int(long_result);
-        Py_DECREF(before_downcast);
-    }
-#endif
-
     return long_result;
 }
 /**end repeat**/
@@ -1441,63 +1428,6 @@ static NPY_INLINE PyObject *
 #endif
 }
 /**end repeat**/
-
-
-#if !defined(NPY_PY3K)
-
-/**begin repeat
- *
- * #name = (byte, ubyte, short, ushort, int, uint,
- *             long, ulong, longlong, ulonglong,
- *             half, float, double, longdouble,
- *             cfloat, cdouble, clongdouble)#
- * #Name = (Byte, UByte, Short, UShort, Int, UInt,
- *             Long, ULong, LongLong, ULongLong,
- *             Half, Float, Double, LongDouble,
- *             CFloat, CDouble, CLongDouble)#
- * #cmplx = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1)#
- * #to_ctype = (, , , , , , , , , , npy_half_to_double, , , , , , )#
- * #func = (PyLong_FromLongLong,  PyLong_FromUnsignedLongLong)*5,
- *         PyLong_FromDouble*3, npy_longdouble_to_PyLong,
- *         PyLong_FromDouble*2, npy_longdouble_to_PyLong#
- */
-static NPY_INLINE PyObject *
-@name@_long(PyObject *obj)
-{
-#if @cmplx@
-    if (emit_complexwarning() < 0) {
-        return NULL;
-    }
-    return @func@(@to_ctype@(PyArrayScalar_VAL(obj, @Name@).real));
-#else
-    return @func@(@to_ctype@(PyArrayScalar_VAL(obj, @Name@)));
-#endif
-}
-/**end repeat**/
-
-/**begin repeat
- *
- * #name = (byte, ubyte, short, ushort, int, uint,
- *             long, ulong, longlong, ulonglong,
- *             half, float, double, longdouble,
- *             cfloat, cdouble, clongdouble)*2#
- * #oper = oct*17,  hex*17#
- * #kind = (int*5,  long*5,  int*2,  long*2,  int,  long*2)*2#
- * #cap = (Int*5,  Long*5,  Int*2,  Long*2,  Int,  Long*2)*2#
- */
-static PyObject *
-@name@_@oper@(PyObject *obj)
-{
-    PyObject *pyint;
-    pyint = @name@_@kind@(obj);
-    if (pyint == NULL) {
-        return NULL;
-    }
-    return Py@cap@_Type.tp_as_number->nb_@oper@(pyint);
-}
-/**end repeat**/
-
-#endif
 
 /**begin repeat
  * #oper = le, ge, lt, gt, eq, ne#
@@ -1594,31 +1524,16 @@ static PyNumberMethods @name@_as_number = {
     (unaryfunc)@name@_negative,
     (unaryfunc)@name@_positive,                 /*nb_pos*/
     (unaryfunc)@name@_absolute,                 /*nb_abs*/
-#if defined(NPY_PY3K)
     (inquiry)@name@_bool,                       /*nb_bool*/
-#else
-    (inquiry)@name@_nonzero,                    /*nb_nonzero*/
-#endif
     (unaryfunc)@name@_invert,                   /*nb_invert*/
     (binaryfunc)@name@_lshift,                  /*nb_lshift*/
     (binaryfunc)@name@_rshift,                  /*nb_rshift*/
     (binaryfunc)@name@_and,                     /*nb_and*/
     (binaryfunc)@name@_xor,                     /*nb_xor*/
     (binaryfunc)@name@_or,                      /*nb_or*/
-#if !defined(NPY_PY3K)
-    0,                                          /*nb_coerce*/
-#endif
     (unaryfunc)@name@_int,                      /*nb_int*/
-#if defined(NPY_PY3K)
     (unaryfunc)0,                               /*nb_reserved*/
-#else
-    (unaryfunc)@name@_long,                     /*nb_long*/
-#endif
     (unaryfunc)@name@_float,                    /*nb_float*/
-#if !defined(NPY_PY3K)
-    (unaryfunc)@name@_oct,                      /*nb_oct*/
-    (unaryfunc)@name@_hex,                      /*nb_hex*/
-#endif
     0,                                          /*inplace_add*/
     0,                                          /*inplace_subtract*/
     0,                                          /*inplace_multiply*/

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -6038,12 +6038,7 @@ static PyGetSetDef ufunc_getset[] = {
  *****************************************************************************/
 
 NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
-#if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
-#endif
     "numpy.ufunc",                              /* tp_name */
     sizeof(PyUFuncObject),                      /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -6052,11 +6047,7 @@ NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
     0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
     (reprfunc)ufunc_repr,                       /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1361,20 +1361,6 @@ PyUFunc_MixedDivisionTypeResolver(PyUFuncObject *ufunc,
                                   PyObject *type_tup,
                                   PyArray_Descr **out_dtypes)
 {
- /* Deprecation checks needed only on python 2 */
-#if !defined(NPY_PY3K)
-    int type_num1, type_num2;
-
-    type_num1 = PyArray_DESCR(operands[0])->type_num;
-    type_num2 = PyArray_DESCR(operands[1])->type_num;
-
-    /* If both types are integer, warn the user, same as python does */
-    if (Py_DivisionWarningFlag &&
-            (PyTypeNum_ISINTEGER(type_num1) || PyTypeNum_ISBOOL(type_num1)) &&
-            (PyTypeNum_ISINTEGER(type_num2) || PyTypeNum_ISBOOL(type_num2))) {
-        PyErr_Warn(PyExc_DeprecationWarning, "numpy: classic int division");
-    }
-#endif
     return PyUFunc_DivisionTypeResolver(ufunc, casting, operands,
                                         type_tup, out_dtypes);
 }

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -174,7 +174,6 @@ add_newdoc_ufunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
     PyObject *str, *tmp;
     char *docstr, *newdocstr;
 
-#if defined(NPY_PY3K)
     if (!PyArg_ParseTuple(args, "O!O!:_add_newdoc_ufunc", &PyUFunc_Type, &ufunc,
                                         &PyUnicode_Type, &str)) {
         return NULL;
@@ -184,20 +183,11 @@ add_newdoc_ufunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
         return NULL;
     }
     docstr = PyBytes_AS_STRING(tmp);
-#else
-    if (!PyArg_ParseTuple(args, "O!O!:_add_newdoc_ufunc", &PyUFunc_Type, &ufunc,
-                                         &PyString_Type, &str)) {
-        return NULL;
-    }
-    docstr = PyString_AS_STRING(str);
-#endif
 
     if (NULL != ufunc->doc) {
         PyErr_SetString(PyExc_ValueError,
                 "Cannot change docstring of ufunc with non-NULL docstring");
-#if defined(NPY_PY3K)
         Py_DECREF(tmp);
-#endif
         return NULL;
     }
 
@@ -211,9 +201,7 @@ add_newdoc_ufunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
     strcpy(newdocstr, docstr);
     ufunc->doc = newdocstr;
 
-#if defined(NPY_PY3K)
     Py_DECREF(tmp);
-#endif
     Py_RETURN_NONE;
 }
 
@@ -324,10 +312,8 @@ int initumath(PyObject *m)
     PyModule_AddObject(m, "NZERO", PyFloat_FromDouble(NPY_NZERO));
     PyModule_AddObject(m, "NAN", PyFloat_FromDouble(NPY_NAN));
 
-#if defined(NPY_PY3K)
     s = PyDict_GetItemString(d, "true_divide");
     PyDict_SetItemString(d, "divide", s);
-#endif
 
     s = PyDict_GetItemString(d, "conjugate");
     s2 = PyDict_GetItemString(d, "remainder");

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -346,17 +346,8 @@ class TestAttributes:
 
         numpy_int = np.int_(0)
 
-        if sys.version_info[0] >= 3:
-            # On Py3k int_ should not inherit from int, because it's not
-            # fixed-width anymore
-            assert_equal(isinstance(numpy_int, int), False)
-        else:
-            # Otherwise, it should inherit from int...
-            assert_equal(isinstance(numpy_int, int), True)
-
-            # ... and fast-path checks on C-API level should also work
-            from numpy.core._multiarray_tests import test_int_subclass
-            assert_equal(test_int_subclass(numpy_int), True)
+        # int_ doesn't inherit from Python int, because it is not fixed width
+        assert_equal(isinstance(numpy_int, int), False)
 
     def test_stridesattr(self):
         x = self.one


### PR DESCRIPTION
I tested with runtest and by grep'ing each function I removed to make sure I didn't leave uses in dead code.  

One major changes is changing `PyObject_HEAD_INIT(NULL)` to `PyVarObject_HEAD_INIT(NULL, 0)`

Smaller changes include
* using `PyUnicode_GetLength(...);`
* removing `PyInt_Type`
* `PyObject_Str` vs `PyObject_Unicode`

---

I have previously broke out all the easy logical groupings but if this is to large I'm happy to try and break this into a couple of PRs
