### PR TITLE
DOC: BLD: add empty release notes for 1.19.0 to fix doc build error

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -1,8 +1,8 @@
 .. currentmodule:: numpy
 
-================================
-NumPy NumPy 1.18.0 Release Notes
-================================
+==========================
+NumPy 1.18.0 Release Notes
+==========================
 
 In addition to the usual bug fixes, this NumPy release cleans up and documents
 the new random C-API, expires a large number of old deprecations, and improves

--- a/doc/source/release/1.19.0-notes.rst
+++ b/doc/source/release/1.19.0-notes.rst
@@ -1,0 +1,6 @@
+.. currentmodule:: numpy
+
+==========================
+NumPy 1.19.0 Release Notes
+==========================
+


### PR DESCRIPTION
Was discussed before in gh-15042 but forgotten about. Sphinx now complains about this missing file, and warnings get turned into errors in some cases in our build setup.

[ci skip]