### PR TITLE
MAINT: Refactor dtype conversion functions to be more similar

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -156,17 +156,11 @@ _try_convert_from_dtype_attr(PyObject *obj)
     return NULL;
 }
 
-/* This is used from another file */
-NPY_NO_EXPORT int
-_arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **out)
+/* Expose to another file with a prefixed name */
+NPY_NO_EXPORT PyArray_Descr *
+arraydescr_try_convert_from_dtype_attr(PyObject *obj)
 {
-    PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
-    if ((PyObject *)ret == Py_NotImplemented) {
-        Py_DECREF(ret);
-        return 0;
-    }
-    *out = ret;
-    return 1;
+    return _try_convert_from_dtype_attr(obj);
 }
 
 /*

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -158,7 +158,7 @@ _try_convert_from_dtype_attr(PyObject *obj)
 
 /* Expose to another file with a prefixed name */
 NPY_NO_EXPORT PyArray_Descr *
-arraydescr_try_convert_from_dtype_attr(PyObject *obj)
+_arraydescr_try_convert_from_dtype_attr(PyObject *obj)
 {
     return _try_convert_from_dtype_attr(obj);
 }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -40,16 +40,6 @@
 static PyObject *typeDict = NULL;   /* Must be explicitly loaded */
 
 /*
- * Returned as a singleton address by the `_try_convert` methods, for cases
- * when conversion was not possible, but there is no error to be reported.
- *
- * This object does not actually exist, it's just a reserved memory location.
- * So don't touch any of its members or try to incref it - treat it like you
- * would a NULL.
- */
-static PyArray_Descr _try_convert_attempt_failed;
-
-/*
  * Generate a vague error message when a function returned NULL but forgot
  * to set an exception. We should aim to remove this eventually.
  */
@@ -78,7 +68,7 @@ _arraydescr_run_converter(PyObject *arg, int align)
 /*
  * This function creates a dtype object when the object is a ctypes subclass.
  *
- * Returns `&_try_convert_attempt_failed` if the type is not a ctypes subclass.
+ * Returns `Py_NotImplemented` if the type is not a ctypes subclass.
  */
 static PyArray_Descr *
 _try_convert_from_ctypes_type(PyTypeObject *type)
@@ -87,7 +77,8 @@ _try_convert_from_ctypes_type(PyTypeObject *type)
     PyObject *res;
 
     if (!npy_ctypes_check(type)) {
-        return &_try_convert_attempt_failed;
+        Py_INCREF(Py_NotImplemented);
+        return (PyArray_Descr *)Py_NotImplemented;
     }
 
     /* Call the python function of the same name. */
@@ -121,7 +112,7 @@ _convert_from_any(PyObject *obj, int align);
  * This function creates a dtype object when the object has a "dtype" attribute,
  * and it can be converted to a dtype object.
  *
- * Returns `&_try_convert_attempt_failed` if this is not possible.
+ * Returns `Py_NotImplemented` if this is not possible.
  * Currently the only failure mode for a NULL return is a RecursionError.
  */
 static PyArray_Descr *
@@ -159,7 +150,8 @@ _try_convert_from_dtype_attr(PyObject *obj)
     /* Ignore all but recursion errors, to give ctypes a full try. */
     if (!PyErr_ExceptionMatches(PyExc_RecursionError)) {
         PyErr_Clear();
-        return &_try_convert_attempt_failed;
+        Py_INCREF(Py_NotImplemented);
+        return (PyArray_Descr *)Py_NotImplemented;
     }
     return NULL;
 }
@@ -169,7 +161,8 @@ NPY_NO_EXPORT int
 _arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **out)
 {
     PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
-    if (ret == &_try_convert_attempt_failed) {
+    if ((PyObject *)ret == Py_NotImplemented) {
+        Py_DECREF(ret);
         return 0;
     }
     *out = ret;
@@ -286,10 +279,11 @@ _convert_from_tuple(PyObject *obj, int align)
     PyObject *val = PyTuple_GET_ITEM(obj,1);
     /* try to interpret next item as a type */
     PyArray_Descr *res = _try_convert_from_inherit_tuple(type, val);
-    if (res != &_try_convert_attempt_failed) {
+    if ((PyObject *)res != Py_NotImplemented) {
         Py_DECREF(type);
         return res;
     }
+    Py_DECREF(res);
     /*
      * We get here if _try_convert_from_inherit_tuple failed without crashing
      */
@@ -816,7 +810,7 @@ fail:
  *
  * leave type reference alone
  *
- * Returns `&_try_convert_attempt_failed` if the second tuple item is not
+ * Returns `Py_NotImplemented` if the second tuple item is not
  * appropriate.
  */
 static PyArray_Descr *
@@ -830,7 +824,8 @@ _try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj)
             || !PyArray_DescrConverter(newobj, &conv)) {
         /* PyArray_DescrConverter may have set an exception, which we ignore */
         PyErr_Clear();
-        return &_try_convert_attempt_failed;
+        Py_INCREF(Py_NotImplemented);
+        return (PyArray_Descr *)Py_NotImplemented;
     }
     new = PyArray_DescrNew(type);
     if (new == NULL) {
@@ -1377,9 +1372,10 @@ _convert_from_type(PyObject *obj) {
     }
     else {
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
-        if (ret != &_try_convert_attempt_failed) {
+        if ((PyObject *)ret != Py_NotImplemented) {
             return ret;
         }
+        Py_DECREF(ret);
 
         /*
          * Note: this comes after _try_convert_from_dtype_attr because the ctypes
@@ -1387,9 +1383,10 @@ _convert_from_type(PyObject *obj) {
          * support it.
          */
         ret = _try_convert_from_ctypes_type(typ);
-        if (ret != &_try_convert_attempt_failed) {
+        if ((PyObject *)ret != Py_NotImplemented) {
             return ret;
         }
+        Py_DECREF(ret);
 
         /* All other classes are treated as object */
         return PyArray_DescrFromType(NPY_OBJECT);
@@ -1453,18 +1450,20 @@ _convert_from_any(PyObject *obj, int align)
     }
     else {
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
-        if (ret != &_try_convert_attempt_failed) {
+        if ((PyObject *)ret != Py_NotImplemented) {
             return ret;
         }
+        Py_DECREF(ret);
         /*
          * Note: this comes after _try_convert_from_dtype_attr because the ctypes
          * type might override the dtype if numpy does not otherwise
          * support it.
          */
         ret = _try_convert_from_ctypes_type(Py_TYPE(obj));
-        if (ret != &_try_convert_attempt_failed) {
+        if ((PyObject *)ret != Py_NotImplemented) {
             return ret;
         }
+        Py_DECREF(ret);
         _report_generic_error();
         return NULL;
     }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -40,6 +40,16 @@
 static PyObject *typeDict = NULL;   /* Must be explicitly loaded */
 
 /*
+ * Returned as a singleton address by the `_try_convert` methods, for cases
+ * when conversion was not possible, but there is no error to be reported.
+ *
+ * This object does not actually exist, it's just a reserved memory location.
+ * So don't touch any of its members or try to incref it - treat it like you
+ * would a NULL.
+ */
+static PyArray_Descr _try_convert_attempt_failed;
+
+/*
  * Generate a vague error message when a function returned NULL but forgot
  * to set an exception. We should aim to remove this eventually.
  */
@@ -49,7 +59,7 @@ _report_generic_error(void) {
 }
 
 static PyArray_Descr *
-_use_inherit(PyArray_Descr *type, PyObject *newobj, int *errflag);
+_try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj);
 
 static PyArray_Descr *
 _convert_from_any(PyObject *obj, int align);
@@ -65,11 +75,20 @@ _arraydescr_run_converter(PyObject *arg, int align)
     return type;
 }
 
+/*
+ * This function creates a dtype object when the object is a ctypes subclass.
+ *
+ * Returns `&_try_convert_attempt_failed` if the type is not a ctypes subclass.
+ */
 static PyArray_Descr *
-_arraydescr_from_ctypes_type(PyTypeObject *type)
+_try_convert_from_ctypes_type(PyTypeObject *type)
 {
     PyObject *_numpy_dtype_ctypes;
     PyObject *res;
+
+    if (!npy_ctypes_check(type)) {
+        return &_try_convert_attempt_failed;
+    }
 
     /* Call the python function of the same name. */
     _numpy_dtype_ctypes = PyImport_ImportModule("numpy.core._dtype_ctypes");
@@ -95,25 +114,21 @@ _arraydescr_from_ctypes_type(PyTypeObject *type)
     return (PyArray_Descr *)res;
 }
 
+static PyArray_Descr *
+_convert_from_any(PyObject *obj, int align);
+
 /*
  * This function creates a dtype object when the object has a "dtype" attribute,
  * and it can be converted to a dtype object.
  *
- * Returns a new reference to a dtype object, or NULL
- * if this is not possible.
- * When the return value is true, the dtype attribute should have been used
- * and parsed. Currently the only failure mode for a 1 return is a
- * RecursionError and the descriptor is set to NULL.
- * When the return value is false, no error will be set.
+ * Returns `&_try_convert_attempt_failed` if this is not possible.
+ * Currently the only failure mode for a NULL return is a RecursionError.
  */
-int
-_arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **newdescr)
+static PyArray_Descr *
+_try_convert_from_dtype_attr(PyObject *obj)
 {
-    PyObject *dtypedescr;
-    int ret;
-
     /* For arbitrary objects that have a "dtype" attribute */
-    dtypedescr = PyObject_GetAttrString(obj, "dtype");
+    PyObject *dtypedescr = PyObject_GetAttrString(obj, "dtype");
     if (dtypedescr == NULL) {
         /*
          * This can be reached due to recursion limit being hit while fetching
@@ -126,10 +141,11 @@ _arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **newdescr)
             " while trying to convert the given data type from its "
             "`.dtype` attribute.") != 0) {
         Py_DECREF(dtypedescr);
-        return 1;
+        return NULL;
     }
 
-    ret = PyArray_DescrConverter(dtypedescr, newdescr);
+    PyArray_Descr *newdescr;
+    int ret = PyArray_DescrConverter(dtypedescr, &newdescr);
 
     Py_DECREF(dtypedescr);
     Py_LeaveRecursiveCall();
@@ -137,14 +153,26 @@ _arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **newdescr)
         goto fail;
     }
 
-    return 1;
+    return newdescr;
 
   fail:
     /* Ignore all but recursion errors, to give ctypes a full try. */
     if (!PyErr_ExceptionMatches(PyExc_RecursionError)) {
         PyErr_Clear();
+        return &_try_convert_attempt_failed;
+    }
+    return NULL;
+}
+
+/* This is used from another file */
+NPY_NO_EXPORT int
+_arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **out)
+{
+    PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
+    if (ret == &_try_convert_attempt_failed) {
         return 0;
     }
+    *out = ret;
     return 1;
 }
 
@@ -257,16 +285,13 @@ _convert_from_tuple(PyObject *obj, int align)
     }
     PyObject *val = PyTuple_GET_ITEM(obj,1);
     /* try to interpret next item as a type */
-    int errflag;
-    PyArray_Descr *res = _use_inherit(type, val, &errflag);
-    if (res || errflag) {
+    PyArray_Descr *res = _try_convert_from_inherit_tuple(type, val);
+    if (res != &_try_convert_attempt_failed) {
         Py_DECREF(type);
         return res;
     }
-    PyErr_Clear();
     /*
-     * We get here if res was NULL but errflag wasn't set
-     * --- i.e. the conversion to a data-descr failed in _use_inherit
+     * We get here if _try_convert_from_inherit_tuple failed without crashing
      */
     if (PyDataType_ISUNSIZED(type)) {
         /* interpret next item as a typesize */
@@ -729,7 +754,7 @@ _is_tuple_of_integers(PyObject *obj)
 }
 
 /*
- * helper function for _use_inherit to disallow dtypes of the form
+ * helper function for _try_convert_from_inherit_tuple to disallow dtypes of the form
  * (old_dtype, new_dtype) where either of the dtypes contains python
  * objects - these dtypes are not useful and can be a source of segfaults,
  * when an attempt is made to interpret a python object as a different dtype
@@ -790,20 +815,23 @@ fail:
  * a['real'] and a['imag'] to an int32 array.
  *
  * leave type reference alone
+ *
+ * Returns `&_try_convert_attempt_failed` if the second tuple item is not
+ * appropriate.
  */
 static PyArray_Descr *
-_use_inherit(PyArray_Descr *type, PyObject *newobj, int *errflag)
+_try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj)
 {
     PyArray_Descr *new;
     PyArray_Descr *conv;
 
-    *errflag = 0;
     if (PyArray_IsScalar(newobj, Integer)
             || _is_tuple_of_integers(newobj)
             || !PyArray_DescrConverter(newobj, &conv)) {
-        return NULL;
+        /* PyArray_DescrConverter may have set an exception, which we ignore */
+        PyErr_Clear();
+        return &_try_convert_attempt_failed;
     }
-    *errflag = 1;
     new = PyArray_DescrNew(type);
     if (new == NULL) {
         goto fail;
@@ -838,7 +866,6 @@ _use_inherit(PyArray_Descr *type, PyObject *newobj, int *errflag)
     }
     new->flags = conv->flags;
     Py_DECREF(conv);
-    *errflag = 0;
     return new;
 
  fail:
@@ -954,7 +981,7 @@ validate_object_field_overlap(PyArray_Descr *dtype)
  * then it will be checked for conformity and used directly.
  */
 static PyArray_Descr *
-_use_fields_dict(PyObject *obj, int align)
+_convert_from_field_dict(PyObject *obj, int align)
 {
     PyObject *_numpy_internal;
     PyArray_Descr *res;
@@ -987,7 +1014,7 @@ _convert_from_dict(PyObject *obj, int align)
         Py_DECREF(fields);
         /* XXX should check this is a KeyError */
         PyErr_Clear();
-        return _use_fields_dict(obj, align);
+        return _convert_from_field_dict(obj, align);
     }
     PyObject *descrs = PyMapping_GetItemString(obj, "formats");
     if (descrs == NULL) {
@@ -995,7 +1022,7 @@ _convert_from_dict(PyObject *obj, int align)
         /* XXX should check this is a KeyError */
         PyErr_Clear();
         Py_DECREF(names);
-        return _use_fields_dict(obj, align);
+        return _convert_from_field_dict(obj, align);
     }
     int n = PyObject_Length(names);
     PyObject *offsets = PyMapping_GetItemString(obj, "offsets");
@@ -1349,24 +1376,19 @@ _convert_from_type(PyObject *obj) {
         return PyArray_DescrFromType(NPY_VOID);
     }
     else {
-        PyArray_Descr *at = NULL;
-        if (_arraydescr_from_dtype_attr(obj, &at)) {
-            /*
-             * Using dtype attribute, *at may be NULL if a
-             * RecursionError occurred.
-             */
-            if (at == NULL) {
-                return NULL;
-            }
-            return at;
+        PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
+        if (ret != &_try_convert_attempt_failed) {
+            return ret;
         }
+
         /*
-         * Note: this comes after _arraydescr_from_dtype_attr because the ctypes
+         * Note: this comes after _try_convert_from_dtype_attr because the ctypes
          * type might override the dtype if numpy does not otherwise
          * support it.
          */
-        if (npy_ctypes_check(typ)) {
-            return _arraydescr_from_ctypes_type(typ);
+        ret = _try_convert_from_ctypes_type(typ);
+        if (ret != &_try_convert_attempt_failed) {
+            return ret;
         }
 
         /* All other classes are treated as object */
@@ -1430,21 +1452,18 @@ _convert_from_any(PyObject *obj, int align)
         return NULL;
     }
     else {
-        PyArray_Descr *ret;
-        if (_arraydescr_from_dtype_attr(obj, &ret)) {
-            /*
-             * Using dtype attribute, ret may be NULL if a
-             * RecursionError occurred.
-             */
+        PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
+        if (ret != &_try_convert_attempt_failed) {
             return ret;
         }
         /*
-         * Note: this comes after _arraydescr_from_dtype_attr because the ctypes
+         * Note: this comes after _try_convert_from_dtype_attr because the ctypes
          * type might override the dtype if numpy does not otherwise
          * support it.
          */
-        if (npy_ctypes_check(Py_TYPE(obj))) {
-            return _arraydescr_from_ctypes_type(Py_TYPE(obj));
+        ret = _try_convert_from_ctypes_type(Py_TYPE(obj));
+        if (ret != &_try_convert_attempt_failed) {
+            return ret;
         }
         _report_generic_error();
         return NULL;

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -7,8 +7,8 @@ NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(PyArray_Descr *self);
 NPY_NO_EXPORT PyObject *
 array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 
-int
-_arraydescr_from_dtype_attr(PyObject *obj, PyArray_Descr **newdescr);
+PyArray_Descr *
+_arraydescr_try_convert_from_dtype_attr(PyObject *obj);
 
 
 NPY_NO_EXPORT int

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -7,7 +7,7 @@ NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(PyArray_Descr *self);
 NPY_NO_EXPORT PyObject *
 array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 
-PyArray_Descr *
+NPY_NO_EXPORT PyArray_Descr *
 _arraydescr_try_convert_from_dtype_attr(PyObject *obj);
 
 


### PR DESCRIPTION
Before there were three signatures:

* `PyArray_Descr*(...)`
* `PyArray_Descr*(..., int* err_flag)`
* `int(..., PyArray_Descr** ret)`

This unifies them all into `PyArray_Descr*(...)`, and introduces a special singeton to distinguish "error" from "gave up" cases.

Also changes function names for consistency.

---

The goal here is to make it very easy to spot returns that forgot to set an error.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
