### PR TITLE
MAINT: Remove NPY_PY3K constant

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -467,10 +467,6 @@ def configuration(parent_package='',top_path=None):
                 moredefs.append('NPY_DO_NOT_OPTIMIZE_LONGLONG_right_shift')
                 moredefs.append('NPY_DO_NOT_OPTIMIZE_ULONGLONG_right_shift')
 
-            # Py3K check
-            if sys.version_info[0] >= 3:
-                moredefs.append(('NPY_PY3K', 1))
-
             # Generate the config.h file from moredefs
             with open(target, 'w') as target_f:
                 for d in moredefs:

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1309,18 +1309,9 @@ _convert_from_type(PyObject *obj) {
     if (PyType_IsSubtype(typ, &PyGenericArrType_Type)) {
         return PyArray_DescrFromTypeObject(obj);
     }
-#if !defined(NPY_PY3K)
-    else if (typ == &PyInt_Type) {
-        return PyArray_DescrFromType(NPY_LONG);
-    }
-    else if (typ == &PyLong_Type) {
-        return PyArray_DescrFromType(NPY_LONGLONG);
-    }
-#else
     else if (typ == &PyLong_Type) {
         return PyArray_DescrFromType(NPY_LONG);
     }
-#endif
     else if (typ == &PyFloat_Type) {
         return PyArray_DescrFromType(NPY_DOUBLE);
     }
@@ -1336,11 +1327,7 @@ _convert_from_type(PyObject *obj) {
     else if (typ == &PyUnicode_Type) {
         return PyArray_DescrFromType(NPY_UNICODE);
     }
-#if defined(NPY_PY3K)
     else if (typ == &PyMemoryView_Type) {
-#else
-    else if (typ == &PyBuffer_Type) {
-#endif
         return PyArray_DescrFromType(NPY_VOID);
     }
     else {


### PR DESCRIPTION
After this PR NPY_PY3K should only appear in 'npy_3kcompat.h' and
'doc/Py3K.rst.txt'

I've had a lot of fun removing python2 code and wanted to say thanks to all of the wonderful maintainers who have answered my questions, promptly commented on my pulls, and provided advice along the way. numpy is amazing!
![numpy_thanks](https://user-images.githubusercontent.com/10172976/72114511-a2a19c80-32f8-11ea-8668-810f16008d64.jpg)
