### PR TITLE
MAINT: Remove sys.version checks in tests

### DIFF
--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -233,12 +233,8 @@ class TestArray2String:
                 return 'O'
 
         x = np.arange(3)
-        if sys.version_info[0] >= 3:
-            x_hex = "[0x0 0x1 0x2]"
-            x_oct = "[0o0 0o1 0o2]"
-        else:
-            x_hex = "[0x0L 0x1L 0x2L]"
-            x_oct = "[0L 01L 02L]"
+        x_hex = "[0x0 0x1 0x2]"
+        x_oct = "[0o0 0o1 0o2]"
         assert_(np.array2string(x, formatter={'all':_format_function}) ==
                 "[. o O]")
         assert_(np.array2string(x, formatter={'int_kind':_format_function}) ==
@@ -469,12 +465,8 @@ class TestPrintOptions:
 
         assert_equal(unicode(np.array(u'café', '<U4')), u'café')
 
-        if sys.version_info[0] >= 3:
-            assert_equal(repr(np.array('café', '<U4')),
-                         "array('café', dtype='<U4')")
-        else:
-            assert_equal(repr(np.array(u'café', '<U4')),
-                         "array(u'caf\\xe9', dtype='<U4')")
+        assert_equal(repr(np.array('café', '<U4')),
+                     "array('café', dtype='<U4')")
         assert_equal(str(np.array('test', np.str_)), 'test')
 
         a = np.zeros(1, dtype=[('a', '<i4', (3,))])
@@ -707,7 +699,7 @@ class TestPrintOptions:
             array([10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22.],
                   dtype=float32)"""))
 
-        styp = '<U4' if sys.version_info[0] >= 3 else '|S4'
+        styp = '<U4'
         assert_equal(repr(np.ones(3, dtype=styp)),
             "array(['1', '1', '1'], dtype='{}')".format(styp))
         assert_equal(repr(np.ones(12, dtype=styp)), textwrap.dedent("""\
@@ -846,10 +838,7 @@ class TestPrintOptions:
 
 def test_unicode_object_array():
     import sys
-    if sys.version_info[0] >= 3:
-        expected = "array(['é'], dtype=object)"
-    else:
-        expected = "array([u'\\xe9'], dtype=object)"
+    expected = "array(['é'], dtype=object)"
     x = np.array([u'\xe9'], dtype=object)
     assert_equal(repr(x), expected)
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -341,15 +341,8 @@ class TestMethods:
         assert_array_equal(C, tgt)
 
     def test_decode(self):
-        if sys.version_info[0] >= 3:
-            A = np.char.array([b'\\u03a3'])
-            assert_(A.decode('unicode-escape')[0] == '\u03a3')
-        else:
-            with suppress_warnings() as sup:
-                if sys.py3kwarning:
-                    sup.filter(DeprecationWarning, "'hex_codec'")
-                A = np.char.array(['736563726574206d657373616765'])
-                assert_(A.decode('hex_codec')[0] == 'secret message')
+        A = np.char.array([b'\\u03a3'])
+        assert_(A.decode('unicode-escape')[0] == '\u03a3')
 
     def test_encode(self):
         B = self.B.encode('unicode_escape')
@@ -360,18 +353,12 @@ class TestMethods:
         assert_(T[2, 0] == b'123      345 \0')
 
     def test_join(self):
-        if sys.version_info[0] >= 3:
-            # NOTE: list(b'123') == [49, 50, 51]
-            #       so that b','.join(b'123') results to an error on Py3
-            A0 = self.A.decode('ascii')
-        else:
-            A0 = self.A
+        # NOTE: list(b'123') == [49, 50, 51]
+        #       so that b','.join(b'123') results to an error on Py3
+        A0 = self.A.decode('ascii')
 
         A = np.char.join([',', '#'], A0)
-        if sys.version_info[0] >= 3:
-            assert_(issubclass(A.dtype.type, np.unicode_))
-        else:
-            assert_(issubclass(A.dtype.type, np.string_))
+        assert_(issubclass(A.dtype.type, np.unicode_))
         tgt = np.array([[' ,a,b,c, ', ''],
                         ['1,2,3,4,5', 'M#i#x#e#d#C#a#s#e'],
                         ['1,2,3, ,\t, ,3,4,5, ,\x00, ', 'U#P#P#E#R']])
@@ -441,15 +428,6 @@ class TestMethods:
                [b'12########## \t ##########45 \x00', b'UPPER']]
         assert_(issubclass(R.dtype.type, np.string_))
         assert_array_equal(R, tgt)
-
-        if sys.version_info[0] < 3:
-            # NOTE: b'abc'.replace(b'a', 'b') is not allowed on Py3
-            R = self.A.replace(b'a', u'\u03a3')
-            tgt = [[u' \u03a3bc ', ''],
-                   ['12345', u'MixedC\u03a3se'],
-                   ['123 \t 345 \x00', 'UPPER']]
-            assert_(issubclass(R.dtype.type, np.unicode_))
-            assert_array_equal(R, tgt)
 
     def test_rjust(self):
         assert_(issubclass(self.A.rjust(10).dtype.type, np.string_))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -227,15 +227,10 @@ class TestComparisonDeprecations(_DeprecationTestCase):
             struct = np.zeros(2, dtype="i4,i4")
             for arg2 in [struct, "a"]:
                 for f in [operator.lt, operator.le, operator.gt, operator.ge]:
-                    if sys.version_info[0] >= 3:
-                        # py3
-                        with warnings.catch_warnings() as l:
-                            warnings.filterwarnings("always")
-                            assert_raises(TypeError, f, arg1, arg2)
-                            assert_(not l)
-                    else:
-                        # py2
-                        assert_warns(DeprecationWarning, f, arg1, arg2)
+                    with warnings.catch_warnings() as l:
+                        warnings.filterwarnings("always")
+                        assert_raises(TypeError, f, arg1, arg2)
+                        assert_(not l)
 
 
 class TestDatetime64Timezone(_DeprecationTestCase):
@@ -332,9 +327,6 @@ class TestNumericStyleTypecodes(_DeprecationTestCase):
             'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
             'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0'
             ]
-        if sys.version_info[0] < 3:
-            deprecated_types.extend(['Unicode0', 'String0'])
-
         for dt in deprecated_types:
             self.assert_deprecated(np.dtype, exceptions=(TypeError,),
                                    args=(dt,))
@@ -353,28 +345,6 @@ class TestTestDeprecated:
 
         test_case_instance.assert_deprecated(foo)
         test_case_instance.teardown()
-
-
-class TestClassicIntDivision(_DeprecationTestCase):
-    """
-    See #7949. Deprecate the numeric-style dtypes with -3 flag in python 2
-    if used for division
-    List of data types: https://docs.scipy.org/doc/numpy/user/basics.types.html
-    """
-    def test_int_dtypes(self):
-        #scramble types and do some mix and match testing
-        deprecated_types = [
-           'bool_', 'int_', 'intc', 'uint8', 'int8', 'uint64', 'int32', 'uint16',
-           'intp', 'int64', 'uint32', 'int16'
-            ]
-        if sys.version_info[0] < 3 and sys.py3kwarning:
-            import operator as op
-            dt2 = 'bool_'
-            for dt1 in deprecated_types:
-                a = np.array([1,2,3], dtype=dt1)
-                b = np.array([1,2,3], dtype=dt2)
-                self.assert_deprecated(op.div, args=(a,b))
-                dt2 = dt1
 
 
 class TestNonNumericConjugate(_DeprecationTestCase):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -136,11 +136,11 @@ class TestBuiltin:
                          'offsets':[0, 2]}, align=True)
 
     def test_field_order_equality(self):
-        x = np.dtype({'names': ['A', 'B'], 
-                      'formats': ['i4', 'f4'], 
+        x = np.dtype({'names': ['A', 'B'],
+                      'formats': ['i4', 'f4'],
                       'offsets': [0, 4]})
-        y = np.dtype({'names': ['B', 'A'], 
-                      'formats': ['f4', 'i4'], 
+        y = np.dtype({'names': ['B', 'A'],
+                      'formats': ['f4', 'i4'],
                       'offsets': [4, 0]})
         assert_equal(x == y, False)
 
@@ -418,7 +418,7 @@ class TestRecord:
                 {'formats': ['i4', 'i4'], 'f0': ('i4', 0), 'f1':('i4', 4)})
 
     def test_fieldless_views(self):
-        a = np.zeros(2, dtype={'names':[], 'formats':[], 'offsets':[], 
+        a = np.zeros(2, dtype={'names':[], 'formats':[], 'offsets':[],
                                'itemsize':8})
         assert_raises(ValueError, a.view, np.dtype([]))
 
@@ -899,11 +899,6 @@ class TestString:
         dt = np.dtype(('<i2', (1,)))
         assert_equal(repr(dt), "dtype(('<i2', (1,)))")
         assert_equal(str(dt), "('<i2', (1,))")
-
-    @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Python 2 only")
-    def test_dtype_str_with_long_in_shape(self):
-        # Pull request #376, should not error
-        np.dtype('(1L,)i4')
 
     def test_base_dtype_with_object_type(self):
         # Issue gh-2798, should not error.

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -11,9 +11,6 @@ from numpy.testing import (
     assert_, assert_raises, assert_equal, assert_array_equal
     )
 
-if sys.version_info[0] >= 3:
-    xrange = range
-
 
 ndims = 2
 size = 10
@@ -138,11 +135,7 @@ def test_diophantine_fuzz():
                 # Check no solution exists (provided the problem is
                 # small enough so that brute force checking doesn't
                 # take too long)
-                try:
-                    ranges = tuple(xrange(0, a*ub+1, a) for a, ub in zip(A, U))
-                except OverflowError:
-                    # xrange on 32-bit Python 2 may overflow
-                    continue
+                ranges = tuple(range(0, a*ub+1, a) for a, ub in zip(A, U))
 
                 size = 1
                 for r in ranges:
@@ -475,7 +468,7 @@ def check_internal_overlap(a, manual_expected=None):
 
     # Brute-force check
     m = set()
-    ranges = tuple(xrange(n) for n in a.shape)
+    ranges = tuple(range(n) for n in a.shape)
     for v in itertools.product(*ranges):
         offset = sum(s*w for s, w in zip(a.strides, v))
         if offset in m:

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -306,10 +306,7 @@ class ReadValuesNested:
         h = np.array(self._buffer, dtype=self._descr)
         assert_(h.dtype['Info']['value'].name == 'complex128')
         assert_(h.dtype['Info']['y2'].name == 'float64')
-        if sys.version_info[0] >= 3:
-            assert_(h.dtype['info']['Name'].name == 'str256')
-        else:
-            assert_(h.dtype['info']['Name'].name == 'unicode256')
+        assert_(h.dtype['info']['Name'].name == 'str256')
         assert_(h.dtype['info']['Value'].name == 'complex128')
 
     def test_nested2_descriptor(self):

--- a/numpy/core/tests/test_print.py
+++ b/numpy/core/tests/test_print.py
@@ -7,10 +7,7 @@ from numpy.testing import assert_, assert_equal
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 _REF = {np.inf: 'inf', -np.inf: '-inf', np.nan: 'nan'}
 

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -24,12 +24,8 @@ class TestFromrecords:
                             names='col1,col2,col3')
         assert_equal(r[0].item(), (456, 'dbe', 1.2))
         assert_equal(r['col1'].dtype.kind, 'i')
-        if sys.version_info[0] >= 3:
-            assert_equal(r['col2'].dtype.kind, 'U')
-            assert_equal(r['col2'].dtype.itemsize, 12)
-        else:
-            assert_equal(r['col2'].dtype.kind, 'S')
-            assert_equal(r['col2'].dtype.itemsize, 3)
+        assert_equal(r['col2'].dtype.kind, 'U')
+        assert_equal(r['col2'].dtype.itemsize, 12)
         assert_equal(r['col3'].dtype.kind, 'f')
 
     def test_fromrecords_0len(self):

--- a/numpy/core/tests/test_scalar_ctors.py
+++ b/numpy/core/tests/test_scalar_ctors.py
@@ -40,19 +40,6 @@ class TestFromString:
         flongdouble = assert_warns(RuntimeWarning, np.longdouble, '-1e10000')
         assert_equal(flongdouble, -np.inf)
 
-    @pytest.mark.skipif((sys.version_info[0] >= 3)
-                        or (sys.platform == "win32"
-                            and platform.architecture()[0] == "64bit"),
-                        reason="numpy.intp('0xff', 16) not supported on Py3 "
-                               "or 64 bit Windows")
-    def test_intp(self):
-        # Ticket #99
-        i_width = np.int_(0).nbytes*2 - 1
-        np.intp('0x' + 'f'*i_width, 16)
-        assert_raises(OverflowError, np.intp, '0x' + 'f'*(i_width+1), 16)
-        assert_raises(ValueError, np.intp, '0x1', 32)
-        assert_equal(255, np.intp('0xFF', 16))
-
 
 class TestFromInt:
     def test_intp(self):

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -31,8 +31,6 @@ scalars_and_codes = [
 scalars_only, codes_only = zip(*scalars_and_codes)
 
 
-@pytest.mark.skipif(sys.version_info.major < 3,
-                    reason="Python 2 scalars lack a buffer interface")
 class TestScalarPEP3118:
 
     @pytest.mark.parametrize('scalar', scalars_only, ids=codes_only)
@@ -91,7 +89,7 @@ class TestScalarPEP3118:
         expected = {'strides': (1,), 'itemsize': 1, 'ndim': 1,
                     'shape': (8,), 'format': 'B'}
         v = memoryview(dt1)
-        res = as_dict(v) 
+        res = as_dict(v)
         assert_equal(res, expected)
 
         v = memoryview(dt2 - dt1)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -84,7 +84,7 @@ class TestBaseMath:
                 assert_almost_equal(np.square(inp2),
                                     np.multiply(inp2, inp2),  err_msg=msg)
                 # skip true divide for ints
-                if dt != np.int32 or (sys.version_info.major < 3 and not sys.py3kwarning):
+                if dt != np.int32:
                     assert_almost_equal(np.reciprocal(inp2),
                                         np.divide(1, inp2),  err_msg=msg)
 

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -157,10 +157,8 @@ class TestHstack:
     def test_generator(self):
         with assert_warns(FutureWarning):
             hstack((np.arange(3) for _ in range(2)))
-        if sys.version_info.major > 2:
-            # map returns a list on Python 2
-            with assert_warns(FutureWarning):
-                hstack(map(lambda x: x, np.ones((3, 2))))
+        with assert_warns(FutureWarning):
+            hstack(map(lambda x: x, np.ones((3, 2))))
 
 
 class TestVstack:

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -4,40 +4,28 @@ import numpy as np
 from numpy.compat import unicode
 from numpy.testing import assert_, assert_equal, assert_array_equal
 
-# Guess the UCS length for this python interpreter
-if sys.version_info[:2] >= (3, 3):
-    # Python 3.3 uses a flexible string representation
-    ucs4 = False
+# Python 3.3+ uses a flexible string representation
+ucs4 = False
 
-    def buffer_length(arr):
-        if isinstance(arr, unicode):
-            arr = str(arr)
-            if not arr:
-                charmax = 0
-            else:
-                charmax = max([ord(c) for c in arr])
-            if charmax < 256:
-                size = 1
-            elif charmax < 65536:
-                size = 2
-            else:
-                size = 4
-            return size * len(arr)
-        v = memoryview(arr)
-        if v.shape is None:
-            return len(v) * v.itemsize
+def buffer_length(arr):
+    if isinstance(arr, unicode):
+        arr = str(arr)
+        if not arr:
+            charmax = 0
         else:
-            return np.prod(v.shape) * v.itemsize
-else:
-    if len(buffer(u'u')) == 4:
-        ucs4 = True
+            charmax = max([ord(c) for c in arr])
+        if charmax < 256:
+            size = 1
+        elif charmax < 65536:
+            size = 2
+        else:
+            size = 4
+        return size * len(arr)
+    v = memoryview(arr)
+    if v.shape is None:
+        return len(v) * v.itemsize
     else:
-        ucs4 = False
-
-    def buffer_length(arr):
-        if isinstance(arr, np.ndarray):
-            return len(arr.data)
-        return len(buffer(arr))
+        return np.prod(v.shape) * v.itemsize
 
 # In both cases below we need to make sure that the byte swapped value (as
 # UCS4) is still a valid unicode:
@@ -52,12 +40,8 @@ def test_string_cast():
     uni_arr1 = str_arr.astype('>U')
     uni_arr2 = str_arr.astype('<U')
 
-    if sys.version_info[0] < 3:
-        assert_array_equal(str_arr, uni_arr1)
-        assert_array_equal(str_arr, uni_arr2)
-    else:
-        assert_(str_arr != uni_arr1)
-        assert_(str_arr != uni_arr2)
+    assert_(str_arr != uni_arr1)
+    assert_(str_arr != uni_arr2)
     assert_array_equal(uni_arr1, uni_arr2)
 
 

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -8,10 +8,7 @@ from numpy.testing import tempdir, assert_, assert_warns
 
 # In python 3 stdout, stderr are text (unicode compliant) devices, so to
 # emulate them import StringIO from the io module.
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 class redirect_stdout:
     """Context manager to redirect stdout for exec_command test."""

--- a/numpy/f2py/tests/test_compile_function.py
+++ b/numpy/f2py/tests/test_compile_function.py
@@ -14,8 +14,6 @@ from . import util
 
 
 def setup_module():
-    if sys.platform == 'win32' and sys.version_info[0] < 3:
-        pytest.skip('Fails with MinGW64 Gfortran (Issue #9673)')
     if not util.has_c_compiler():
         pytest.skip("Needs C compiler")
     if not util.has_f77_compiler():

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -6,10 +6,7 @@ from numpy.testing import (
         )
 import threading
 import sys
-if sys.version_info[0] >= 3:
-    import queue
-else:
-    import Queue as queue
+import queue
 
 
 def fft1(x):

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -9,14 +9,9 @@ from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_warns
     )
 
-if sys.version_info[0] >= 3:
-    import urllib.request as urllib_request
-    from urllib.parse import urlparse
-    from urllib.error import URLError
-else:
-    import urllib2 as urllib_request
-    from urlparse import urlparse
-    from urllib2 import URLError
+import urllib.request as urllib_request
+from urllib.parse import urlparse
+from urllib.error import URLError
 
 
 def urlopen_stub(url, data=None):
@@ -160,24 +155,6 @@ class TestDataSourceOpen:
         fp = self.ds.open(filepath)
         result = fp.readline()
         fp.close()
-        assert_equal(magic_line, result)
-
-    @pytest.mark.skipif(sys.version_info[0] >= 3, reason="Python 2 only")
-    def test_Bz2File_text_mode_warning(self):
-        try:
-            import bz2
-        except ImportError:
-            # We don't have the bz2 capabilities to test.
-            pytest.skip()
-        # Test datasource's internal file_opener for BZip2 files.
-        filepath = os.path.join(self.tmpdir, 'foobar.txt.bz2')
-        fp = bz2.BZ2File(filepath, 'w')
-        fp.write(magic_line)
-        fp.close()
-        with assert_warns(RuntimeWarning):
-            fp = self.ds.open(filepath, 'rt')
-            result = fp.readline()
-            fp.close()
         assert_equal(magic_line, result)
 
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -548,10 +548,7 @@ def test_load_padded_dtype(dt):
 
 
 def test_python2_python3_interoperability():
-    if sys.version_info[0] >= 3:
-        fname = 'win64python2.npy'
-    else:
-        fname = 'python3.npy'
+    fname = 'win64python2.npy'
     path = os.path.join(os.path.dirname(__file__), 'data', fname)
     data = np.load(path)
     assert_array_equal(data, np.ones(2))
@@ -561,13 +558,7 @@ def test_pickle_python2_python3():
     # Python 2 and Python 3 and vice versa
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
-    if sys.version_info[0] >= 3:
-        xrange = range
-    else:
-        import __builtin__
-        xrange = __builtin__.xrange
-
-    expected = np.array([None, xrange, u'\u512a\u826f',
+    expected = np.array([None, range, u'\u512a\u826f',
                          b'\xe4\xb8\x8d\xe8\x89\xaf'],
                         dtype=object)
 
@@ -583,34 +574,30 @@ def test_pickle_python2_python3():
             else:
                 data = data_f
 
-            if sys.version_info[0] >= 3:
-                if encoding == 'latin1' and fname.startswith('py2'):
-                    assert_(isinstance(data[3], str))
-                    assert_array_equal(data[:-1], expected[:-1])
-                    # mojibake occurs
-                    assert_array_equal(data[-1].encode(encoding), expected[-1])
-                else:
-                    assert_(isinstance(data[3], bytes))
-                    assert_array_equal(data, expected)
+            if encoding == 'latin1' and fname.startswith('py2'):
+                assert_(isinstance(data[3], str))
+                assert_array_equal(data[:-1], expected[:-1])
+                # mojibake occurs
+                assert_array_equal(data[-1].encode(encoding), expected[-1])
             else:
+                assert_(isinstance(data[3], bytes))
                 assert_array_equal(data, expected)
 
-        if sys.version_info[0] >= 3:
-            if fname.startswith('py2'):
-                if fname.endswith('.npz'):
-                    data = np.load(path, allow_pickle=True)
-                    assert_raises(UnicodeError, data.__getitem__, 'x')
-                    data.close()
-                    data = np.load(path, allow_pickle=True, fix_imports=False,
-                                   encoding='latin1')
-                    assert_raises(ImportError, data.__getitem__, 'x')
-                    data.close()
-                else:
-                    assert_raises(UnicodeError, np.load, path,
-                                  allow_pickle=True)
-                    assert_raises(ImportError, np.load, path,
-                                  allow_pickle=True, fix_imports=False,
-                                  encoding='latin1')
+        if fname.startswith('py2'):
+            if fname.endswith('.npz'):
+                data = np.load(path, allow_pickle=True)
+                assert_raises(UnicodeError, data.__getitem__, 'x')
+                data.close()
+                data = np.load(path, allow_pickle=True, fix_imports=False,
+                               encoding='latin1')
+                assert_raises(ImportError, data.__getitem__, 'x')
+                data.close()
+            else:
+                assert_raises(UnicodeError, np.load, path,
+                              allow_pickle=True)
+                assert_raises(ImportError, np.load, path,
+                              allow_pickle=True, fix_imports=False,
+                              encoding='latin1')
 
 
 def test_pickle_disallow():

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -23,8 +23,6 @@ from numpy.lib import (
 
 from numpy.compat import long
 
-PY2 = sys.version_info[0] == 2
-
 def get_mat(n):
     data = np.arange(n)
     data = np.add.outer(data, data)
@@ -1568,11 +1566,8 @@ class TestLeaks:
                 a.f = np.frompyfunc(getattr(a, name), 1, 1)
                 out = a.f(np.arange(10))
             a = None
-            if PY2:
-                assert_equal(sys.getrefcount(A_func), refcount)
-            else:
-                # A.func is part of a reference cycle if incr is non-zero
-                assert_equal(sys.getrefcount(A_func), refcount + incr)
+            # A.func is part of a reference cycle if incr is non-zero
+            assert_equal(sys.getrefcount(A_func), refcount + incr)
             for i in range(5):
                 gc.collect()
             assert_equal(sys.getrefcount(A_func), refcount)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -44,7 +44,6 @@ class TextIO(BytesIO):
         BytesIO.writelines(self, [asbytes(s) for s in lines])
 
 
-MAJVER, MINVER = sys.version_info[:2]
 IS_64BIT = sys.maxsize > 2**32
 try:
     import bz2
@@ -528,12 +527,10 @@ class TestSaveTxt:
         a = np.array([utf8], dtype=np.unicode_)
         # our gz wrapper support encoding
         suffixes = ['', '.gz']
-        # stdlib 2 versions do not support encoding
-        if MAJVER > 2:
-            if HAS_BZ2:
-                suffixes.append('.bz2')
-            if HAS_LZMA:
-                suffixes.extend(['.xz', '.lzma'])
+        if HAS_BZ2:
+            suffixes.append('.bz2')
+        if HAS_LZMA:
+            suffixes.extend(['.xz', '.lzma'])
         with tempdir() as tmpdir:
             for suffix in suffixes:
                 np.savetxt(os.path.join(tmpdir, 'test.csv' + suffix), a,
@@ -599,18 +596,14 @@ class LoadTxtBase:
                         res = self.loadfunc(f)
                     assert_array_equal(res, wanted)
 
-    # Python2 .open does not support encoding
-    @pytest.mark.skipif(MAJVER == 2, reason="Needs Python version >= 3")
     def test_compressed_gzip(self):
         self.check_compressed(gzip.open, ('.gz',))
 
     @pytest.mark.skipif(not HAS_BZ2, reason="Needs bz2")
-    @pytest.mark.skipif(MAJVER == 2, reason="Needs Python version >= 3")
     def test_compressed_bz2(self):
         self.check_compressed(bz2.open, ('.bz2',))
 
     @pytest.mark.skipif(not HAS_LZMA, reason="Needs lzma")
-    @pytest.mark.skipif(MAJVER == 2, reason="Needs Python version >= 3")
     def test_compressed_lzma(self):
         self.check_compressed(lzma.open, ('.xz', '.lzma'))
 

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -6,9 +6,6 @@ import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises
 
 
-PY2 = sys.version_info.major < 3
-
-
 # NOTE: This class should be kept as an exact copy of the example from the
 # docstring for NDArrayOperatorsMixin.
 
@@ -202,11 +199,10 @@ class TestNDArrayOperatorsMixin:
         array_like = ArrayLike(array)
         expected = ArrayLike(np.float64(5))
         _assert_equal_type_and_value(expected, np.matmul(array_like, array))
-        if not PY2:
-            _assert_equal_type_and_value(
-                expected, operator.matmul(array_like, array))
-            _assert_equal_type_and_value(
-                expected, operator.matmul(array, array_like))
+        _assert_equal_type_and_value(
+            expected, operator.matmul(array_like, array))
+        _assert_equal_type_and_value(
+            expected, operator.matmul(array, array_like))
 
     def test_ufunc_at(self):
         array = ArrayLike(np.array([1, 2, 3, 4]))

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -206,10 +206,7 @@ class TestRegression:
 
     def test_loadtxt_fields_subarrays(self):
         # For ticket #1936
-        if sys.version_info[0] >= 3:
-            from io import StringIO
-        else:
-            from StringIO import StringIO
+        from io import StringIO
 
         dt = [("a", 'u1', 2), ("b", 'u1', 2)]
         x = np.loadtxt(StringIO("0 1 2 3"), dtype=dt)

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -7,10 +7,7 @@ from numpy.testing import assert_, assert_equal, assert_raises_regex
 from numpy.lib import deprecate
 import numpy.lib.utils as utils
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5006,11 +5006,6 @@ class TestMaskedConstant:
         assert_raises(MaskError, operator.setitem, a_i, (), np.ma.masked)
         assert_raises(MaskError, int, np.ma.masked)
 
-    @pytest.mark.skipif(sys.version_info.major == 3,
-                        reason="long doesn't exist in Python 3")
-    def test_coercion_long(self):
-        assert_raises(MaskError, long, np.ma.masked)
-
     def test_coercion_float(self):
         a_f = np.zeros((), float)
         assert_warns(UserWarning, operator.setitem, a_f, (), np.ma.masked)

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -448,15 +448,6 @@ class NoseTester:
                 warnings.simplefilter("always")
                 from ...distutils import cpuinfo
             sup.filter(category=UserWarning, module=cpuinfo)
-            # See #7949: Filter out deprecation warnings due to the -3 flag to
-            # python 2
-            if sys.version_info.major == 2 and sys.py3kwarning:
-                # This is very specific, so using the fragile module filter
-                # is fine
-                import threading
-                sup.filter(DeprecationWarning, message=r"buffer\(\) not supported in 3\.x")
-                sup.filter(DeprecationWarning, message=r"CObject type is not supported in 3\.x")
-                sup.filter(DeprecationWarning, message=r"comparing unequal types not supported in 3\.x")
             # Filter out some deprecation warnings inside nose 1.3.7 when run
             # on python 3.5b2. See
             #     https://github.com/nose-devs/nose/issues/929

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -21,10 +21,7 @@ from numpy.core import(
      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
 import numpy.linalg.lapack_lite
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 __all__ = [
         'assert_equal', 'assert_almost_equal', 'assert_approx_equal',
@@ -1344,14 +1341,7 @@ def assert_raises_regex(exception_class, expected_regexp, *args, **kwargs):
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test
-
-    if sys.version_info.major >= 3:
-        funcname = _d.assertRaisesRegex
-    else:
-        # Only present in Python 2.7, missing from unittest in 2.6
-        funcname = _d.assertRaisesRegexp
-
-    return funcname(exception_class, expected_regexp, *args, **kwargs)
+    return _d.assertRaisesRegex(exception_class, expected_regexp, *args, **kwargs)
 
 
 def decorate_methods(cls, decorator, testmatch=None):

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -28,9 +28,6 @@ def check_dir(module, module_name=None):
     return results
 
 
-@pytest.mark.skipif(
-    sys.version_info[0] < 3,
-    reason="NumPy exposes slightly different functions on Python 2")
 def test_numpy_namespace():
     # None of these objects are publicly documented to be part of the main
     # NumPy namespace (some are useful though, others need to be cleaned up)

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -3,10 +3,7 @@ import sys
 from numpy.testing import assert_raises, assert_, assert_equal
 from numpy.compat import pickle
 
-if sys.version_info[:2] >= (3, 4):
-    from importlib import reload
-else:
-    from imp import reload
+from importlib import reload
 
 def test_numpy_reloading():
     # gh-7844. Also check that relevant globals retain their identity.

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -5,72 +5,71 @@ all of these occurrences but should catch almost all.
 import sys
 import pytest
 
-if sys.version_info >= (3, 4):
-    from pathlib import Path
-    import ast
-    import tokenize
-    import numpy
+from pathlib import Path
+import ast
+import tokenize
+import numpy
 
-    class ParseCall(ast.NodeVisitor):
-        def __init__(self):
-            self.ls = []
+class ParseCall(ast.NodeVisitor):
+    def __init__(self):
+        self.ls = []
 
-        def visit_Attribute(self, node):
-            ast.NodeVisitor.generic_visit(self, node)
-            self.ls.append(node.attr)
+    def visit_Attribute(self, node):
+        ast.NodeVisitor.generic_visit(self, node)
+        self.ls.append(node.attr)
 
-        def visit_Name(self, node):
-            self.ls.append(node.id)
+    def visit_Name(self, node):
+        self.ls.append(node.id)
 
 
-    class FindFuncs(ast.NodeVisitor):
-        def __init__(self, filename):
-            super().__init__()
-            self.__filename = filename
+class FindFuncs(ast.NodeVisitor):
+    def __init__(self, filename):
+        super().__init__()
+        self.__filename = filename
 
-        def visit_Call(self, node):
-            p = ParseCall()
-            p.visit(node.func)
-            ast.NodeVisitor.generic_visit(self, node)
+    def visit_Call(self, node):
+        p = ParseCall()
+        p.visit(node.func)
+        ast.NodeVisitor.generic_visit(self, node)
 
-            if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
-                if node.args[0].s == "ignore":
-                    raise AssertionError(
-                        "ignore filter should not be used; found in "
-                        "{} on line {}".format(self.__filename, node.lineno))
-
-            if p.ls[-1] == 'warn' and (
-                    len(p.ls) == 1 or p.ls[-2] == 'warnings'):
-
-                if "testing/tests/test_warnings.py" == self.__filename:
-                    # This file
-                    return
-
-                # See if stacklevel exists:
-                if len(node.args) == 3:
-                    return
-                args = {kw.arg for kw in node.keywords}
-                if "stacklevel" in args:
-                    return
+        if p.ls[-1] == 'simplefilter' or p.ls[-1] == 'filterwarnings':
+            if node.args[0].s == "ignore":
                 raise AssertionError(
-                    "warnings should have an appropriate stacklevel; found in "
+                    "ignore filter should not be used; found in "
                     "{} on line {}".format(self.__filename, node.lineno))
 
+        if p.ls[-1] == 'warn' and (
+                len(p.ls) == 1 or p.ls[-2] == 'warnings'):
 
-    @pytest.mark.slow
-    def test_warning_calls():
-        # combined "ignore" and stacklevel error
-        base = Path(numpy.__file__).parent
+            if "testing/tests/test_warnings.py" == self.__filename:
+                # This file
+                return
 
-        for path in base.rglob("*.py"):
-            if base / "testing" in path.parents:
-                continue
-            if path == base / "__init__.py":
-                continue
-            if path == base / "random" / "__init__.py":
-                continue
-            # use tokenize to auto-detect encoding on systems where no
-            # default encoding is defined (e.g. LANG='C')
-            with tokenize.open(str(path)) as file:
-                tree = ast.parse(file.read())
-                FindFuncs(path).visit(tree)
+            # See if stacklevel exists:
+            if len(node.args) == 3:
+                return
+            args = {kw.arg for kw in node.keywords}
+            if "stacklevel" in args:
+                return
+            raise AssertionError(
+                "warnings should have an appropriate stacklevel; found in "
+                "{} on line {}".format(self.__filename, node.lineno))
+
+
+@pytest.mark.slow
+def test_warning_calls():
+    # combined "ignore" and stacklevel error
+    base = Path(numpy.__file__).parent
+
+    for path in base.rglob("*.py"):
+        if base / "testing" in path.parents:
+            continue
+        if path == base / "__init__.py":
+            continue
+        if path == base / "random" / "__init__.py":
+            continue
+        # use tokenize to auto-detect encoding on systems where no
+        # default encoding is defined (e.g. LANG='C')
+        with tokenize.open(str(path)) as file:
+            tree = ast.parse(file.read())
+            FindFuncs(path).visit(tree)


### PR DESCRIPTION
Cleanup checks for python2 (via sys.version) in test files.