### PR TITLE
WIP, ENH: Buffer Support for DateTime Array

### DIFF
--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -378,7 +378,7 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
         case NPY_CFLOAT:       if (_append_str(str, "Zf") < 0) return -1; break;
         case NPY_CDOUBLE:      if (_append_str(str, "Zd") < 0) return -1; break;
         case NPY_CLONGDOUBLE:  if (_append_str(str, "Zg") < 0) return -1; break;
-        /* XXX NPY_DATETIME */
+        case NPY_DATETIME:     if (_append_char(str, 'i') < 0) return -1; break;
         /* XXX NPY_TIMEDELTA */
         case NPY_OBJECT:       if (_append_char(str, 'O') < 0) return -1; break;
         case NPY_STRING: {

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2365,6 +2365,13 @@ class TestDateTime:
         limit_via_str = np.datetime64(str(limit), time_unit)
         assert limit_via_str == limit
 
+    def test_memview_buffer(self):
+        arr = np.array([np.datetime64('2000-01-01'), np.datetime64('2020-01-01')])
+        expected = arr.astype(np.int64)
+        memview = memoryview(arr)
+        assert memview[0] == expected[0]
+        assert memview[1] == expected[1]
+
 
 class TestDateTimeData:
 


### PR DESCRIPTION
closes #4983

I don't believe this is mergeable in current state but hoping that this is moving in the right direction.

Currently this allows writing of datetime arrays as their integer values but round-tripping is not really possible. I think what we might want to do instead is add a format for a struct that contains the value and information around the precision, so something like `i:val:2c:unit` (untested)