### PR TITLE
BUG: fix NameError in clip nan propagation tests

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1991,7 +1991,9 @@ class TestClip:
         actual = np.clip(arr, amin, amax)
         assert_equal(actual, exp)
 
-    @pytest.mark.xfail(reason="no scalar nan propagation yet")
+    @pytest.mark.xfail(reason="no scalar nan propagation yet",
+                       raises=AssertionError,
+                       strict=True)
     @pytest.mark.parametrize("arr, amin, amax", [
         # problematic scalar nan case from hypothesis
         (np.zeros(10, dtype=np.int64),
@@ -2001,10 +2003,10 @@ class TestClip:
     def test_clip_scalar_nan_propagation(self, arr, amin, amax):
         # enforcement of scalar nan propagation for comparisons
         # called through clip()
-        expected = np.minimum(np.maximum(a, amin), amax)
+        expected = np.minimum(np.maximum(arr, amin), amax)
         with assert_warns(DeprecationWarning):
             actual = np.clip(arr, amin, amax)
-            assert_equal(actual, expected)
+        assert_equal(actual, expected)
 
     @pytest.mark.xfail(reason="propagation doesn't match spec")
     @pytest.mark.parametrize("arr, amin, amax", [


### PR DESCRIPTION
The test expects parameters `arr`, `amin` and `amax`. However it then
uses `a`, `amin` and `amax` resulting in a `NameError`. This error was
not caught as the test was marked with xfail.

This commit changes `a` -> `arr` removing the NameError. Further it
adds precautions against similar errors requiring the error to be an
AssertionError and making the test strict.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
