### PR TITLE
MAINT: fix typos

### DIFF
--- a/doc/changelog/1.12.0-changelog.rst
+++ b/doc/changelog/1.12.0-changelog.rst
@@ -225,7 +225,7 @@ A total of 418 pull requests were merged for this release.
 * `#7240 <https://github.com/numpy/numpy/pull/7240>`__: Change 'pubic' to 'public'.
 * `#7241 <https://github.com/numpy/numpy/pull/7241>`__: MAINT: update doc/sphinxext to numpydoc 0.6.0, and fix up some...
 * `#7243 <https://github.com/numpy/numpy/pull/7243>`__: ENH: Adding support to the range keyword for estimation of the...
-* `#7246 <https://github.com/numpy/numpy/pull/7246>`__: DOC: metion writeable keyword in as_strided in release notes
+* `#7246 <https://github.com/numpy/numpy/pull/7246>`__: DOC: mention writeable keyword in as_strided in release notes
 * `#7247 <https://github.com/numpy/numpy/pull/7247>`__: TST: Fail quickly on AppVeyor for superseded PR builds
 * `#7248 <https://github.com/numpy/numpy/pull/7248>`__: DOC: remove link to documentation wiki editor from HOWTO_DOCUMENT.
 * `#7250 <https://github.com/numpy/numpy/pull/7250>`__: DOC,REL: Update 1.11.0 notes.
@@ -333,7 +333,7 @@ A total of 418 pull requests were merged for this release.
 * `#7534 <https://github.com/numpy/numpy/pull/7534>`__: MAINT: Update setup.py to reflect supported python versions.
 * `#7536 <https://github.com/numpy/numpy/pull/7536>`__: MAINT: Always use PyCapsule instead of PyCObject in mtrand.pyx
 * `#7539 <https://github.com/numpy/numpy/pull/7539>`__: MAINT: Cleanup of random stuff
-* `#7549 <https://github.com/numpy/numpy/pull/7549>`__: BUG: allow graceful recovery for no Liux compiler
+* `#7549 <https://github.com/numpy/numpy/pull/7549>`__: BUG: allow graceful recovery for no Linux compiler
 * `#7562 <https://github.com/numpy/numpy/pull/7562>`__: BUG: Fix test_from_object_array_unicode (test_defchararray.TestBasic)…
 * `#7565 <https://github.com/numpy/numpy/pull/7565>`__: BUG: Fix test_ctypeslib and test_indexing for debug interpreter
 * `#7566 <https://github.com/numpy/numpy/pull/7566>`__: MAINT: use manylinux1 wheel for cython
@@ -459,7 +459,7 @@ A total of 418 pull requests were merged for this release.
 * `#8016 <https://github.com/numpy/numpy/pull/8016>`__: BUG: Fix numpy.ma.median.
 * `#8018 <https://github.com/numpy/numpy/pull/8018>`__: BUG: Fixes return for np.ma.count if keepdims is True and axis...
 * `#8021 <https://github.com/numpy/numpy/pull/8021>`__: DOC: change all non-code instances of Numpy to NumPy
-* `#8027 <https://github.com/numpy/numpy/pull/8027>`__: ENH: Add platform indepedent lib dir to PYTHONPATH
+* `#8027 <https://github.com/numpy/numpy/pull/8027>`__: ENH: Add platform independent lib dir to PYTHONPATH
 * `#8028 <https://github.com/numpy/numpy/pull/8028>`__: DOC: Update 1.11.2 release notes.
 * `#8030 <https://github.com/numpy/numpy/pull/8030>`__: BUG: fix np.ma.median with only one non-masked value and an axis...
 * `#8038 <https://github.com/numpy/numpy/pull/8038>`__: MAINT: Update error message in rollaxis.

--- a/doc/changelog/1.15.0-changelog.rst
+++ b/doc/changelog/1.15.0-changelog.rst
@@ -316,7 +316,7 @@ A total of 438 pull requests were merged for this release.
 * `#10618 <https://github.com/numpy/numpy/pull/10618>`__: MAINT: Stop using non-tuple indices internally
 * `#10619 <https://github.com/numpy/numpy/pull/10619>`__: BUG: np.ma.flatnotmasked_contiguous behaves differently on mask=nomask...
 * `#10621 <https://github.com/numpy/numpy/pull/10621>`__: BUG: deallocate recursive closure in arrayprint.py
-* `#10623 <https://github.com/numpy/numpy/pull/10623>`__: BUG: Correctly identify comma seperated dtype strings
+* `#10623 <https://github.com/numpy/numpy/pull/10623>`__: BUG: Correctly identify comma separated dtype strings
 * `#10625 <https://github.com/numpy/numpy/pull/10625>`__: BUG: Improve the accuracy of the FFT implementation
 * `#10635 <https://github.com/numpy/numpy/pull/10635>`__: ENH: Implement initial kwarg for ufunc.add.reduce
 * `#10641 <https://github.com/numpy/numpy/pull/10641>`__: MAINT: Post 1.14.1 release updates for master branch
@@ -343,7 +343,7 @@ A total of 438 pull requests were merged for this release.
 * `#10699 <https://github.com/numpy/numpy/pull/10699>`__: DOC: Grammar of np.gradient docstring
 * `#10702 <https://github.com/numpy/numpy/pull/10702>`__: TST, DOC: Upload devdocs and neps after circleci build
 * `#10703 <https://github.com/numpy/numpy/pull/10703>`__: MAINT: NEP process updates
-* `#10708 <https://github.com/numpy/numpy/pull/10708>`__: BUG: fix problem with modifing pyf lines containing ';' in f2py
+* `#10708 <https://github.com/numpy/numpy/pull/10708>`__: BUG: fix problem with modifying pyf lines containing ';' in f2py
 * `#10710 <https://github.com/numpy/numpy/pull/10710>`__: BUG: fix error message in numpy.select
 * `#10711 <https://github.com/numpy/numpy/pull/10711>`__: MAINT: Hard tab and whitespace cleanup.
 * `#10715 <https://github.com/numpy/numpy/pull/10715>`__: MAINT: Fixed C++ guard in f2py test.

--- a/doc/changelog/1.16.5-changelog.rst
+++ b/doc/changelog/1.16.5-changelog.rst
@@ -37,14 +37,14 @@ A total of 23 pull requests were merged for this release.
 * `#13933 <https://github.com/numpy/numpy/pull/13933>`__: MAINT/BUG/DOC: Fix errors in _add_newdocs
 * `#13984 <https://github.com/numpy/numpy/pull/13984>`__: BUG: fix byte order reversal for datetime64[ns]
 * `#13994 <https://github.com/numpy/numpy/pull/13994>`__: MAINT,BUG: Use nbytes to also catch empty descr during allocation
-* `#14042 <https://github.com/numpy/numpy/pull/14042>`__: BUG: np.array cleared errors occured in PyMemoryView_FromObject
+* `#14042 <https://github.com/numpy/numpy/pull/14042>`__: BUG: np.array cleared errors occurred in PyMemoryView_FromObject
 * `#14043 <https://github.com/numpy/numpy/pull/14043>`__: BUG: Fixes for Undefined Behavior Sanitizer (UBSan) errors.
 * `#14044 <https://github.com/numpy/numpy/pull/14044>`__: BUG: ensure that casting to/from structured is properly checked.
 * `#14045 <https://github.com/numpy/numpy/pull/14045>`__: MAINT: fix histogram*d dispatchers
 * `#14046 <https://github.com/numpy/numpy/pull/14046>`__: BUG: further fixup to histogram2d dispatcher.
 * `#14052 <https://github.com/numpy/numpy/pull/14052>`__: BUG: Replace contextlib.suppress for Python 2.7
 * `#14056 <https://github.com/numpy/numpy/pull/14056>`__: BUG: fix compilation of 3rd party modules with Py_LIMITED_API...
-* `#14057 <https://github.com/numpy/numpy/pull/14057>`__: BUG: Fix memory leak in dtype from dict contructor
+* `#14057 <https://github.com/numpy/numpy/pull/14057>`__: BUG: Fix memory leak in dtype from dict constructor
 * `#14058 <https://github.com/numpy/numpy/pull/14058>`__: DOC: Document array_function at a higher level.
 * `#14084 <https://github.com/numpy/numpy/pull/14084>`__: BUG, DOC: add new recfunctions to `__all__`
 * `#14162 <https://github.com/numpy/numpy/pull/14162>`__: BUG: Remove stray print that causes a SystemError on python 3.7

--- a/doc/changelog/1.17.0-changelog.rst
+++ b/doc/changelog/1.17.0-changelog.rst
@@ -276,7 +276,7 @@ A total of 531 pull requests were merged for this release.
 * `#12696 <https://github.com/numpy/numpy/pull/12696>`__: BUG: Fix leak of void scalar buffer info
 * `#12698 <https://github.com/numpy/numpy/pull/12698>`__: DOC: improve comments in copycast_isaligned
 * `#12700 <https://github.com/numpy/numpy/pull/12700>`__: ENH: chain additional exception on ufunc method lookup error
-* `#12702 <https://github.com/numpy/numpy/pull/12702>`__: TST: Check FFT results for C/Fortran ordered and non contigous...
+* `#12702 <https://github.com/numpy/numpy/pull/12702>`__: TST: Check FFT results for C/Fortran ordered and non contiguous...
 * `#12704 <https://github.com/numpy/numpy/pull/12704>`__: TST: pin Azure brew version for stability
 * `#12709 <https://github.com/numpy/numpy/pull/12709>`__: TST: add ppc64le to Travis CI matrix
 * `#12713 <https://github.com/numpy/numpy/pull/12713>`__: BUG: loosen kwargs requirements in ediff1d
@@ -536,7 +536,7 @@ A total of 531 pull requests were merged for this release.
 * `#13503 <https://github.com/numpy/numpy/pull/13503>`__: ENH: Support object arrays in matmul
 * `#13504 <https://github.com/numpy/numpy/pull/13504>`__: DOC: Update links in PULL_REQUEST_TEMPLATE.md
 * `#13506 <https://github.com/numpy/numpy/pull/13506>`__: ENH: Add sparse option to np.core.numeric.indices
-* `#13507 <https://github.com/numpy/numpy/pull/13507>`__: BUG: np.array cleared errors occured in PyMemoryView_FromObject
+* `#13507 <https://github.com/numpy/numpy/pull/13507>`__: BUG: np.array cleared errors occurred in PyMemoryView_FromObject
 * `#13508 <https://github.com/numpy/numpy/pull/13508>`__: BUG: Removes ValueError for empty kwargs in arraymultiter_new
 * `#13518 <https://github.com/numpy/numpy/pull/13518>`__: MAINT: implement assert_array_compare without converting array...
 * `#13520 <https://github.com/numpy/numpy/pull/13520>`__: BUG: exp, log AVX loops do not use steps
@@ -643,7 +643,7 @@ A total of 531 pull requests were merged for this release.
 * `#13815 <https://github.com/numpy/numpy/pull/13815>`__: MAINT: Correct intrinsic use on Windows
 * `#13818 <https://github.com/numpy/numpy/pull/13818>`__: TST: Add tests for ComplexWarning in astype
 * `#13819 <https://github.com/numpy/numpy/pull/13819>`__: DOC: Fix documented default value of ``__array_priority__`` for...
-* `#13820 <https://github.com/numpy/numpy/pull/13820>`__: MAINT, DOC: Fix misspelled words in documetation.
+* `#13820 <https://github.com/numpy/numpy/pull/13820>`__: MAINT, DOC: Fix misspelled words in documentation.
 * `#13821 <https://github.com/numpy/numpy/pull/13821>`__: MAINT: core: Fix a compiler warning.
 * `#13830 <https://github.com/numpy/numpy/pull/13830>`__: MAINT: Update tox for supported Python versions
 * `#13832 <https://github.com/numpy/numpy/pull/13832>`__: MAINT: remove pcg32 BitGenerator
@@ -656,7 +656,7 @@ A total of 531 pull requests were merged for this release.
 * `#13849 <https://github.com/numpy/numpy/pull/13849>`__: DOC: np.random documentation cleanup and expansion.
 * `#13850 <https://github.com/numpy/numpy/pull/13850>`__: DOC: Update performance numbers
 * `#13851 <https://github.com/numpy/numpy/pull/13851>`__: MAINT: Update shippable.yml to remove Python 2 dependency
-* `#13855 <https://github.com/numpy/numpy/pull/13855>`__: BUG: Fix memory leak in dtype from dict contructor
+* `#13855 <https://github.com/numpy/numpy/pull/13855>`__: BUG: Fix memory leak in dtype from dict constructor
 * `#13856 <https://github.com/numpy/numpy/pull/13856>`__: MAINT: move location of bitgen.h
 * `#13858 <https://github.com/numpy/numpy/pull/13858>`__: BUG: do not force emulation of 128-bit arithmetic.
 * `#13859 <https://github.com/numpy/numpy/pull/13859>`__: DOC: Update performance numbers for PCG64

--- a/doc/neps/nep-0000.rst
+++ b/doc/neps/nep-0000.rst
@@ -76,7 +76,7 @@ where ``<n>`` is an appropriately assigned four-digit number (e.g.,
 ``nep-0000.rst``). The draft must use the :doc:`nep-template` file.
 
 Once the PR for the NEP is in place, a post should be made to the
-mailing list containing the sections upto "Backward compatibility",
+mailing list containing the sections up to "Backward compatibility",
 with the purpose of limiting discussion there to usage and impact.
 Discussion on the pull request will have a broader scope, also including
 details of implementation.

--- a/doc/neps/nep-0021-advanced-indexing.rst
+++ b/doc/neps/nep-0021-advanced-indexing.rst
@@ -108,7 +108,7 @@ array ``arr`` with shape ``(X, Y, Z)``:
 3. ``arr[0, :, [0, 1]]`` has shape ``(2, Y)``, not ``(Y, 2)``!
 
 These first two cases are intuitive and consistent with outer indexing, but
-this last case is quite surprising, even to many higly experienced NumPy users.
+this last case is quite surprising, even to many highly experienced NumPy users.
 
 Mixed cases involving multiple array indices are also surprising, and only
 less problematic because the current behavior is so useless that it is rarely
@@ -240,7 +240,7 @@ be deduced:
 7. To ensure that existing subclasses of `ndarray` that override indexing
    do not inadvertently revert to default behavior for indexing attributes,
    these attribute should have explicit checks that disable them if
-   ``__getitem__`` or ``__setitem__`` has been overriden.
+   ``__getitem__`` or ``__setitem__`` has been overridden.
 
 Unlike plain indexing, the new indexing attributes are explicitly aimed
 at higher dimensional indexing, several additional changes should be implemented:
@@ -319,7 +319,7 @@ of ``__getitem__`` on these attributes should test
 subclass has special handling for indexing and ``NotImplementedError``
 should be raised, requiring that the indexing attributes is also explicitly
 overwritten. Likewise, implementations of ``__setitem__`` should check to see
-if ``__setitem__`` is overriden.
+if ``__setitem__`` is overridden.
 
 A further question is how to facilitate implementing the special attributes.
 Also there is the weird functionality where ``__setitem__`` calls

--- a/doc/neps/nep-0030-duck-array-protocol.rst
+++ b/doc/neps/nep-0030-duck-array-protocol.rst
@@ -24,7 +24,7 @@ Detailed description
 NumPy's API, including array definitions, is implemented and mimicked in
 countless other projects. By definition, many of those arrays are fairly
 similar in how they operate to the NumPy standard. The introduction of
-``__array_function__`` allowed dispathing of functions implemented by several
+``__array_function__`` allowed dispatching of functions implemented by several
 of these projects directly via NumPy's API. This introduces a new requirement,
 returning the NumPy-like array itself, rather than forcing a coercion into a
 pure NumPy array.

--- a/doc/neps/nep-0037-array-module.rst
+++ b/doc/neps/nep-0037-array-module.rst
@@ -448,7 +448,7 @@ input arguments:
 This might be useful, but it's not clear if we really need it. Pint seems to
 get along OK without any explicit array creation routines (favoring
 multiplication by units, e.g., ``np.ones(5) * ureg.m``), and for the most part
-Dask is also OK with existing ``__array_function__`` style overides (e.g.,
+Dask is also OK with existing ``__array_function__`` style overrides (e.g.,
 favoring ``np.ones_like`` over ``np.ones``). Choosing whether to place an array
 on the CPU or GPU could be solved by `making array creation lazy
 <https://github.com/google/jax/pull/1668>`_.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1223,7 +1223,7 @@ Converting data types
 
 .. c:function:: int PyArray_ObjectType(PyObject* op, int mintype)
 
-    This function is superceded by :c:func:`PyArray_MinScalarType` and/or
+    This function is superseded by :c:func:`PyArray_MinScalarType` and/or
     :c:func:`PyArray_ResultType`.
 
     This function is useful for determining a common type that two or
@@ -1237,7 +1237,7 @@ Converting data types
 .. c:function:: void PyArray_ArrayType( \
         PyObject* op, PyArray_Descr* mintype, PyArray_Descr* outtype)
 
-    This function is superceded by :c:func:`PyArray_ResultType`.
+    This function is superseded by :c:func:`PyArray_ResultType`.
 
     This function works similarly to :c:func:`PyArray_ObjectType` (...)
     except it handles flexible arrays. The *mintype* argument can have
@@ -1248,7 +1248,7 @@ Converting data types
 .. c:function:: PyArrayObject** PyArray_ConvertToCommonType( \
         PyObject* op, int* n)
 
-    The functionality this provides is largely superceded by iterator
+    The functionality this provides is largely superseded by iterator
     :c:type:`NpyIter` introduced in 1.6, with flag
     :c:data:`NPY_ITER_COMMON_DTYPE` or with the same dtype parameter for
     all operands.
@@ -1439,7 +1439,7 @@ An ndarray can have a data segment that is not a simple contiguous
 chunk of well-behaved memory you can manipulate. It may not be aligned
 with word boundaries (very important on some platforms). It might have
 its data in a different byte-order than the machine recognizes. It
-might not be writeable. It might be in Fortan-contiguous order. The
+might not be writeable. It might be in Fortran-contiguous order. The
 array flags are used to indicate what can be said about data
 associated with an array.
 
@@ -2488,7 +2488,7 @@ an element copier function as a primitive.::
 Array Iterators
 ---------------
 
-As of NumPy 1.6.0, these array iterators are superceded by
+As of NumPy 1.6.0, these array iterators are superseded by
 the new array iterator, :c:type:`NpyIter`.
 
 An array iterator is a simple way to access the elements of an

--- a/doc/source/release/1.13.0-notes.rst
+++ b/doc/source/release/1.13.0-notes.rst
@@ -243,7 +243,7 @@ It is similar to Matlab's square bracket notation for creating block matrices.
 
 ``isin`` function, improving on ``in1d``
 ----------------------------------------
-The new function ``isin`` tests whether each element of an N-dimensonal
+The new function ``isin`` tests whether each element of an N-dimensional
 array is present anywhere within a second array. It is an enhancement
 of ``in1d`` that preserves the shape of the first array.
 

--- a/doc/source/release/1.14.0-notes.rst
+++ b/doc/source/release/1.14.0-notes.rst
@@ -43,7 +43,7 @@ New functions
   floating-point scalars unambiguously with control of rounding and padding.
 
 * ``PyArray_ResolveWritebackIfCopy`` and ``PyArray_SetWritebackIfCopyBase``,
-  new C-API functions useful in achieving PyPy compatibity.
+  new C-API functions useful in achieving PyPy compatibility.
 
 
 Deprecations

--- a/doc/source/release/1.16.5-notes.rst
+++ b/doc/source/release/1.16.5-notes.rst
@@ -51,14 +51,14 @@ A total of 23 pull requests were merged for this release.
 * `#13933 <https://github.com/numpy/numpy/pull/13933>`__: MAINT/BUG/DOC: Fix errors in _add_newdocs
 * `#13984 <https://github.com/numpy/numpy/pull/13984>`__: BUG: fix byte order reversal for datetime64[ns]
 * `#13994 <https://github.com/numpy/numpy/pull/13994>`__: MAINT,BUG: Use nbytes to also catch empty descr during allocation
-* `#14042 <https://github.com/numpy/numpy/pull/14042>`__: BUG: np.array cleared errors occured in PyMemoryView_FromObject
+* `#14042 <https://github.com/numpy/numpy/pull/14042>`__: BUG: np.array cleared errors occurred in PyMemoryView_FromObject
 * `#14043 <https://github.com/numpy/numpy/pull/14043>`__: BUG: Fixes for Undefined Behavior Sanitizer (UBSan) errors.
 * `#14044 <https://github.com/numpy/numpy/pull/14044>`__: BUG: ensure that casting to/from structured is properly checked.
 * `#14045 <https://github.com/numpy/numpy/pull/14045>`__: MAINT: fix histogram*d dispatchers
 * `#14046 <https://github.com/numpy/numpy/pull/14046>`__: BUG: further fixup to histogram2d dispatcher.
 * `#14052 <https://github.com/numpy/numpy/pull/14052>`__: BUG: Replace contextlib.suppress for Python 2.7
 * `#14056 <https://github.com/numpy/numpy/pull/14056>`__: BUG: fix compilation of 3rd party modules with Py_LIMITED_API...
-* `#14057 <https://github.com/numpy/numpy/pull/14057>`__: BUG: Fix memory leak in dtype from dict contructor
+* `#14057 <https://github.com/numpy/numpy/pull/14057>`__: BUG: Fix memory leak in dtype from dict constructor
 * `#14058 <https://github.com/numpy/numpy/pull/14058>`__: DOC: Document array_function at a higher level.
 * `#14084 <https://github.com/numpy/numpy/pull/14084>`__: BUG, DOC: add new recfunctions to `__all__`
 * `#14162 <https://github.com/numpy/numpy/pull/14162>`__: BUG: Remove stray print that causes a SystemError on python 3.7

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -195,7 +195,7 @@ adjustment to user- facing code. Specifically, code that either disallowed the
 calls to ``numpy.isinf`` or ``numpy.isnan`` or checked that they raised an
 exception will require adaptation, and code that mistakenly called
 ``numpy.fmax`` and ``numpy.fmin`` instead of ``numpy.maximum`` or
-``numpy.minimum`` respectively will requre adjustment. This also affects
+``numpy.minimum`` respectively will require adjustment. This also affects
 ``numpy.nanmax`` and ``numpy.nanmin``.
 (`gh-14841 <https://github.com/numpy/numpy/pull/14841>`__)
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -110,7 +110,7 @@ to a small(er) fraction of the total time. Even if the interior of the
 loop is performed without a function call it can be advantageous to
 perform the inner loop over the dimension with the highest number of
 elements to take advantage of speed enhancements available on micro-
-processors that use pipelining to enhance fundmental operations.
+processors that use pipelining to enhance fundamental operations.
 
 The :c:func:`PyArray_IterAllButAxis` ( ``array``, ``&dim`` ) constructs an
 iterator object that is modified so that it will not iterate over the

--- a/numpy/core/src/common/numpyos.c
+++ b/numpy/core/src/common/numpyos.c
@@ -283,7 +283,7 @@ fix_ascii_format(char* buf, size_t buflen, int decimal)
  *      converting.
  *      - value: The value to convert
  *      - decimal: if != 0, always has a decimal, and at leasat one digit after
- *      the decimal. This has the same effect as passing 'Z' in the origianl
+ *      the decimal. This has the same effect as passing 'Z' in the original
  *      PyOS_ascii_formatd
  *
  * This is similar to PyOS_ascii_formatd in python > 2.6, except that it does

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1538,7 +1538,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          *   - If other is not convertible to an array, pass on the error
          *     (MHvK, 2018-06-18: not sure about this, but it's what we have).
          *
-         * However, for backwards compatibilty, we cannot yet return arrays,
+         * However, for backwards compatibility, we cannot yet return arrays,
          * so we raise warnings instead.  Furthermore, we warn on python2
          * for LT, LE, GE, GT, since fall-back behaviour is poorly defined.
          */

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -41,7 +41,7 @@
  */
 
 /*
- * Scanning function for next element parsing and seperator skipping.
+ * Scanning function for next element parsing and separator skipping.
  * These functions return:
  *   - 0 to indicate more data to read
  *   - -1 when reading stopped at the end of the string/file

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -1565,8 +1565,8 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
 /* Options struct for easy passing of Dragon4 options.
  *
  *   scientific - boolean controlling whether scientific notation is used
- *   digit_mode - whether to use unique or fixed fracional output
- *   cutoff_mode - whether 'precision' refers to toal digits, or digits past
+ *   digit_mode - whether to use unique or fixed fractional output
+ *   cutoff_mode - whether 'precision' refers to to all digits, or digits past
  *                 the decimal point.
  *   precision - When negative, prints as many digits as needed for a unique
  *               number. When positive specifies the maximum number of

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -1856,7 +1856,7 @@ static NPY_INLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_@ISA@ void
  * method: x* = x - y*PI/2, where y = rint(x*2/PI). x* \in [-PI/4, PI/4].
  * (3) Map cos(x) to (+/-)sine or (+/-)cosine of x* based on the quadrant k =
  * int(y).
- * (4) For elements outside that range, Cody-Waite reduction peforms poorly
+ * (4) For elements outside that range, Cody-Waite reduction performs poorly
  * leading to catastrophic cancellation. We compute cosine by calling glibc in
  * a scalar fashion.
  * (5) Vectorized implementation has a max ULP of 1.49 and performs at least

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -856,7 +856,7 @@ def test_unicode_object_array():
 
 class TestContextManager:
     def test_ctx_mgr(self):
-        # test that context manager actuall works
+        # test that context manager actually works
         with np.printoptions(precision=2):
             s = str(np.array([2.0]) / 3)
         assert_equal(s, '[0.67]')

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8324,7 +8324,7 @@ def test_npymath_real():
                 assert_allclose(got, expected)
 
 def test_uintalignment_and_alignment():
-    # alignment code needs to satisfy these requrements:
+    # alignment code needs to satisfy these requirements:
     #  1. numpy structs match C struct layout
     #  2. ufuncs/casting is safe wrt to aligned access
     #  3. copy code is safe wrt to "uint alidned" access

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1882,7 +1882,7 @@ class TestClip:
         assert_array_strict_equal(ac, act)
 
     def test_clip_with_out_transposed(self):
-        # Test that the out argument works when tranposed
+        # Test that the out argument works when transposed
         a = np.arange(16).reshape(4, 4)
         out = np.empty_like(a).T
         a.clip(4, 10, out=out)

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -422,7 +422,7 @@ class TestRecord:
         a['obj'] = data
         a['int'] = 42
         ctor, args = a[0].__reduce__()
-        # check the contructor is what we expect before interpreting the arguments
+        # check the constructor is what we expect before interpreting the arguments
         assert ctor is np.core.multiarray.scalar
         dtype, obj = args
         # make sure we did not pickle the address

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1811,7 +1811,7 @@ class TestUfunc:
         assert_raises(TypeError, f, d, 0, keepdims="invalid", dtype="invalid",
                      out=None)
 
-        # invalid keyord
+        # invalid keyword
         assert_raises(TypeError, f, d, axis=0, dtype=None, invalid=0)
         assert_raises(TypeError, f, d, invalid=0)
         assert_raises(TypeError, f, d, 0, keepdims=True, invalid="invalid",

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1624,7 +1624,7 @@ class TestSpecialMethods:
             @property
             def args(self):
                 # We need to ensure these are fetched at the same time, before
-                # any other ufuncs are calld by the assertions
+                # any other ufuncs are called by the assertions
                 return (self._prepare_args, self._wrap_args)
             def __repr__(self):
                 return "a"  # for short test output

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -714,7 +714,7 @@ class system_info:
         return info
 
     def get_info(self, notfound_action=0):
-        """ Return a dictonary with items that are compatible
+        """ Return a dictionary with items that are compatible
             with numpy.distutils.setup keyword arguments.
         """
         flag = 0

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -232,7 +232,7 @@ def _get_linear_ramps(padded, axis, width_pair, end_value_pair):
 
 def _get_stats(padded, axis, width_pair, length_pair, stat_func):
     """
-    Calculate statistic for the empty-padded array in given dimnsion.
+    Calculate statistic for the empty-padded array in given dimension.
 
     Parameters
     ----------
@@ -271,7 +271,7 @@ def _get_stats(padded, axis, width_pair, length_pair, stat_func):
 
     if (left_length == 0 or right_length == 0) \
             and stat_func in {np.amax, np.amin}:
-        # amax and amin can't operate on an emtpy array,
+        # amax and amin can't operate on an empty array,
         # raise a more descriptive warning here instead of the default one
         raise ValueError("stat_length of 0 yields no value for padding")
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -436,7 +436,7 @@ def merge_arrays(seqarrays, fill_value=-1, flatten=False,
         if seqdtype.names is None:
             seqdtype = np.dtype([('', seqdtype)])
         if not flatten or _zip_dtype((seqarrays,), flatten=True) == seqdtype:
-            # Minimal processing needed: just make sure everythng's a-ok
+            # Minimal processing needed: just make sure everything's a-ok
             seqarrays = seqarrays.ravel()
             # Find what type of array we must return
             if usemask:

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -81,7 +81,7 @@ class TestHistogram:
         a, b = histogram(v, bins, density=False)
         assert_array_equal(a, [1, 2, 3, 4])
 
-        # Variale bin widths are especially useful to deal with
+        # Variable bin widths are especially useful to deal with
         # infinities.
         v = np.arange(10)
         bins = [0, 1, 3, 6, np.inf]

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -772,7 +772,7 @@ def cholesky(a):
     return wrap(r.astype(result_t, copy=False))
 
 
-# QR decompostion
+# QR decomposition
 
 def _qr_dispatcher(a, mode=None):
     return (a,)

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -1841,7 +1841,7 @@ typedef struct geev_params_struct {
     void *WR; /* RWORK in complex versions, REAL W buffer for (sd)geev*/
     void *WI;
     void *VLR; /* REAL VL buffers for _geev where _ is s, d */
-    void *VRR; /* REAL VR buffers for _geev hwere _ is s, d */
+    void *VRR; /* REAL VR buffers for _geev where _ is s, d */
     void *WORK;
     void *W;  /* final w */
     void *VL; /* final vl */

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -99,7 +99,7 @@ def _deprecate_argsort_axis(arr):
         The array which argsort was called on
 
     np.ma.argsort has a long-term bug where the default of the axis argument
-    is wrong (gh-8701), which now must be kept for backwards compatibiity.
+    is wrong (gh-8701), which now must be kept for backwards compatibility.
     Thankfully, this only makes a difference when arrays are 2- or more-
     dimensional, so we only need a warning then.
     """

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4017,7 +4017,7 @@ cdef class Generator:
                                         total, num_colors, colors_ptr, nsamp,
                                         num_variates, variates_ptr)
             if result == -1:
-                raise MemoryError("Insufficent memory for multivariate_"
+                raise MemoryError("Insufficient memory for multivariate_"
                                   "hypergeometric with method='count' and "
                                   "sum(colors)=%d" % total)
         else:

--- a/setup.py
+++ b/setup.py
@@ -407,7 +407,7 @@ def setup_package():
     os.chdir(src_path)
     sys.path.insert(0, src_path)
 
-    # Rewrite the version file everytime
+    # Rewrite the version file every time
     write_version_py()
 
     # The f2py scripts that will be installed


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.

Similar to #15129, but uses an updated version of the tool.