### PR TITLE
TST: move pypy CI to ubuntu 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ stages:
     - template: azure-steps-windows.yml
   - job: Linux_PyPy3
     pool:
-      vmIMage: 'ubuntu-16.04'
+      vmIMage: 'ubuntu-18.04'
     steps:
     - script: source tools/pypy-test.sh
       displayName: 'Run PyPy3 Build / Tests'

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -6,7 +6,6 @@ set -o pipefail
 # Print expanded commands
 set -x
 
-sudo apt-get -yq update
 sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5
 F77=gfortran-5 F90=gfortran-5 \
 


### PR DESCRIPTION
CI is randomly failing for Ubuntu 16.04, maybe moving to 18.04 will help?