### PR TITLE
TST: move _no_tracing to testing._private, remove testing.support

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -44,6 +44,7 @@ from numpy.testing import (
     assert_allclose, IS_PYPY, HAS_REFCOUNT, assert_array_less, runstring,
     temppath, suppress_warnings, break_cycles,
     )
+from numpy.testing._private.utils import _no_tracing
 from numpy.core.tests._locales import CommaDecimalPointLocale
 
 # Need to test an object that does not fully implement math interface
@@ -93,26 +94,6 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
     data = np.ndarray(shape, dtype, buf, order=order)
     data.fill(0)
     return data
-
-def _no_tracing(func):
-    """
-    Decorator to temporarily turn off tracing for the duration of a test.
-    Needed in tests that check refcounting, otherwise the tracing itself
-    influences the refcounts
-    """
-    if not hasattr(sys, 'gettrace'):
-        return func
-    else:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            original_trace = sys.gettrace()
-            try:
-                sys.settrace(None)
-                return func(*args, **kwargs)
-            finally:
-                sys.settrace(original_trace)
-        return wrapper
-
 
 
 class TestFlags:

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -14,8 +14,8 @@ from numpy.testing import (
         assert_raises_regex, assert_warns, suppress_warnings,
         _assert_valid_refcount, HAS_REFCOUNT,
         )
+from numpy.testing._private.utils import _no_tracing
 from numpy.compat import asbytes, asunicode, long, pickle
-from test.support import no_tracing
 
 try:
     RecursionError
@@ -1315,7 +1315,7 @@ class TestRegression:
             assert_(pickle.loads(
                 pickle.dumps(test_record, protocol=proto)) == test_record)
 
-    @no_tracing
+    @_no_tracing
     def test_blasdot_uninitialized_memory(self):
         # Ticket #950
         for m in [0, 1, 2]:

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2474,3 +2474,24 @@ def _get_mem_available():
             return info['memfree'] + info['cached']
 
     return None
+
+
+def _no_tracing(func):
+    """
+    Decorator to temporarily turn off tracing for the duration of a test.
+    Needed in tests that check refcounting, otherwise the tracing itself
+    influences the refcounts
+    """
+    if not hasattr(sys, 'gettrace'):
+        return func
+    else:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            original_trace = sys.gettrace()
+            try:
+                sys.settrace(None)
+                return func(*args, **kwargs)
+            finally:
+                sys.settrace(original_trace)
+        return wrapper
+


### PR DESCRIPTION
Move `_no_tracing` to `numpy.testing._private.utils` and use it in `test_regressions.py`

xref gh-15203, gh-15202