### PR TITLE
DEP: Deprecate `->f->fastclip` at registration time

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -452,7 +452,7 @@ PyArrayDescr_Type and PyArray_Descr
            PyArray_ScalarKindFunc *scalarkind;
            int **cancastscalarkindto;
            int *cancastto;
-           PyArray_FastClipFunc *fastclip;
+           PyArray_FastClipFunc *fastclip;  /* deprecated */
            PyArray_FastPutmaskFunc *fastputmask;  /* deprecated */
            PyArray_FastTakeFunc *fasttake;  /* deprecated */
            PyArray_ArgFunc *argmin;
@@ -640,6 +640,16 @@ PyArrayDescr_Type and PyArray_Descr
 
     .. c:member:: void fastclip( \
             void *in, npy_intp n_in, void *min, void *max, void *out)
+
+        .. deprecated:: 1.17
+            The use of this function will give a deprecation warning when
+            ``np.clip``. Instead of this function, the datatype must
+            instead use ``PyUFunc_RegisterLoopForDescr`` to attach a custom
+            loop to ``np.core.umath.clip``, ``np.minimum``, and ``np.maximum``.
+
+        .. deprecated:: 1.19
+            Setting this function is deprecated and should always be ``NULL``,
+            if set, it will be ignored.
 
         A function that reads ``n_in`` items from ``in``, and writes to
         ``out`` the read value if it is within the limits pointed to by

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -926,14 +926,15 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
         }
     }
 
-    /* NumPy 1.17.0, 2019-02-24 */
-    if (DEPRECATE(
-            "->f->fastclip is deprecated. Use PyUFunc_RegisterLoopForDescr to "
-            "attach a custom loop to np.core.umath.clip, np.minimum, and "
-            "np.maximum") < 0) {
-        return NULL;
-    }
-    /* everything below can be removed once this deprecation completes */
+    /*
+     * NumPy 1.17.0, 2019-02-24
+     * NumPy 1.19.0, 2020-01-15
+     *
+     * Setting `->f->fastclip to anything but NULL has been deprecated in 1.19
+     * the code path below was previously deprecated since 1.17.
+     * (the deprecation moved to registration time instead of execution time)
+     * everything below can be removed once this deprecation completes
+     */
 
     if (func == NULL
         || (min != NULL && !PyArray_CheckAnyScalar(min))

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -151,6 +151,18 @@ test_deprecated_arrfuncs_members(PyArray_ArrFuncs *f) {
             return -1;
         }
     }
+    /* NumPy 1.19, 2020-01-15 */
+    if (f->fastclip != NULL) {
+        /* fastclip was already deprecated at execution time in 1.17. */
+        if (DEPRECATE(
+                "The ->f->fastclip member of custom dtypes is deprecated; "
+                "setting it will be an error in the future.\n"
+                "The custom dtype you are using must be changed to use "
+                "PyUFunc_RegisterLoopForDescr to attach a custom loop to "
+                "np.core.umath.clip, np.minimum, and np.maximum") < 0) {
+            return -1;
+        }
+    }
     return 0;
 }
 


### PR DESCRIPTION
This adds the additional deprecation of fastclip if it is set at
registration time instead of only testing that it is never used.

---

Add a further step in deprecating the slot completely (and document the deprecation). Tested manually by changing the rational tests only. Can add a release note, although it was already deprecated in 1.17.
