### PR TITLE
MAINT: Remove unnecessary call to NpyIter_IterationNeedsAPI

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3861,8 +3861,6 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         stride_copy[1] = stride1;
         stride_copy[2] = stride0;
 
-        needs_api = NpyIter_IterationNeedsAPI(iter);
-
         NPY_BEGIN_THREADS_NDITER(iter);
 
         do {


### PR DESCRIPTION
Commit 390497831094034ad4d0e27d7a0f8ffc6d743542 removed some checks for needs_api from PyUFunc_Accumulate, but it neglected to remove the call to NpyIter_IterationNeedsAPI(iter) that set needs_api. This function call is now unnecessary and can be safely removed.