### PR TITLE
MAINT: Revise imports from collections.abc module

### DIFF
--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -6,12 +6,8 @@ Show a summary about which NumPy functions are documented and which are not.
 
 """
 import os, glob, re, sys, inspect, optparse
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
+
 sys.path.append(os.path.join(os.path.dirname(__file__), 'sphinxext'))
 from sphinxext.phantom_import import import_phantom_module
 
@@ -139,7 +135,9 @@ def get_undocumented(documented, module, module_name=None, skip=[]):
 
         if full_name in skip: continue
         if full_name.startswith('numpy.') and full_name[6:] in skip: continue
-        if not (inspect.ismodule(obj) or isinstance(obj, collections_abc.Callable) or inspect.isclass(obj)):
+        if not (inspect.ismodule(obj) or
+                isinstance(obj, collections.abc.Callable) or
+                inspect.isclass(obj)):
             continue
 
         if full_name not in documented:

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -3,12 +3,7 @@ Functions for changing global ufunc configuration
 
 This provides helpers which wrap `umath.geterrobj` and `umath.seterrobj`
 """
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 import contextlib
 
 from .overrides import set_module
@@ -307,8 +302,9 @@ def seterrcall(func):
     OrderedDict([('divide', 'log'), ('invalid', 'log'), ('over', 'log'), ('under', 'log')])
 
     """
-    if func is not None and not isinstance(func, collections_abc.Callable):
-        if not hasattr(func, 'write') or not isinstance(func.write, collections_abc.Callable):
+    if func is not None and not isinstance(func, collections.abc.Callable):
+        if (not hasattr(func, 'write') or
+                not isinstance(func.write, collections.abc.Callable)):
             raise ValueError("Only callable can be used as callback")
     pyvals = umath.geterrobj()
     old = geterrcall()

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1,9 +1,4 @@
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 import tempfile
 import sys
 import shutil
@@ -7756,7 +7751,7 @@ class TestHashing:
 
     def test_collections_hashable(self):
         x = np.array([])
-        assert_(not isinstance(x, collections_abc.Hashable))
+        assert_(not isinstance(x, collections.abc.Hashable))
 
 
 class TestArrayPriority:

--- a/numpy/core/tests/test_records.py
+++ b/numpy/core/tests/test_records.py
@@ -1,10 +1,4 @@
-import sys
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 import textwrap
 from os import path
 import pytest
@@ -252,7 +246,7 @@ class TestFromrecords:
         assert_array_equal(ra['shape'], [['A', 'B', 'C']])
         ra.field = 5
         assert_array_equal(ra['field'], [[5, 5, 5]])
-        assert_(isinstance(ra.field, collections_abc.Callable))
+        assert_(isinstance(ra.field, collections.abc.Callable))
 
     def test_fromrecords_with_explicit_dtype(self):
         a = np.rec.fromrecords([(1, 'a'), (2, 'bbb')],

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1,9 +1,4 @@
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 import functools
 import re
 import sys
@@ -613,7 +608,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
     y = zeros(x.shape, x.dtype)
     for k in range(n):
         item = funclist[k]
-        if not isinstance(item, collections_abc.Callable):
+        if not isinstance(item, collections.abc.Callable):
             y[condlist[k]] = item
         else:
             vals = x[condlist[k]]

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -1,9 +1,4 @@
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 
 import numpy as np
 from numpy import matrix, asmatrix, bmat
@@ -297,7 +292,7 @@ class TestMatrixReturn:
             if attrib.startswith('_') or attrib in excluded_methods:
                 continue
             f = getattr(a, attrib)
-            if isinstance(f, collections_abc.Callable):
+            if isinstance(f, collections.abc.Callable):
                 # reset contents of a
                 a.astype('f8')
                 a.fill(1.0)

--- a/numpy/testing/_private/decorators.py
+++ b/numpy/testing/_private/decorators.py
@@ -13,12 +13,7 @@ function name, setup and teardown functions and so on - see
 ``nose.tools`` for more information.
 
 """
-try:
-    # Accessing collections abstract classes from collections
-    # has been deprecated since Python 3.3
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
+import collections.abc
 
 from .utils import SkipTest, assert_warns, HAS_REFCOUNT
 
@@ -129,7 +124,7 @@ def skipif(skip_condition, msg=None):
         import nose
 
         # Allow for both boolean or callable skip conditions.
-        if isinstance(skip_condition, collections_abc.Callable):
+        if isinstance(skip_condition, collections.abc.Callable):
             skip_val = lambda: skip_condition()
         else:
             skip_val = lambda: skip_condition
@@ -205,7 +200,7 @@ def knownfailureif(fail_condition, msg=None):
         msg = 'Test skipped due to known failure'
 
     # Allow for both boolean or callable known failure conditions.
-    if isinstance(fail_condition, collections_abc.Callable):
+    if isinstance(fail_condition, collections.abc.Callable):
         fail_val = lambda: fail_condition()
     else:
         fail_val = lambda: fail_condition
@@ -260,7 +255,7 @@ def deprecated(conditional=True):
             with assert_warns(DeprecationWarning):
                 f(*args, **kwargs)
 
-        if isinstance(conditional, collections_abc.Callable):
+        if isinstance(conditional, collections.abc.Callable):
             cond = conditional()
         else:
             cond = conditional


### PR DESCRIPTION
This PR simplifies importing from the [`collections.abc` module](https://docs.python.org/3/library/collections.abc.html).

This logic was formerly required to support Python 2.7.
