### PR TITLE
MAINT: remove internal functions required to handle Python2/3 logic

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -311,32 +311,15 @@ def pyod(filename):
     We only implement enough to get the necessary information for long double
     representation, this is not intended as a compatible replacement for od.
     """
-    def _pyod2():
-        out = []
+    out = []
+    with open(filename, 'rb') as fid:
+        yo2 = [oct(o)[2:] for o in fid.read()]
+    for i in range(0, len(yo2), 16):
+        line = ['%07d' % int(oct(i)[2:])]
+        line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
+        out.append(" ".join(line))
+    return out
 
-        with open(filename, 'rb') as fid:
-            yo = [int(oct(int(binascii.b2a_hex(o), 16))) for o in fid.read()]
-        for i in range(0, len(yo), 16):
-            line = ['%07d' % int(oct(i))]
-            line.extend(['%03d' % c for c in yo[i:i+16]])
-            out.append(" ".join(line))
-        return out
-
-    def _pyod3():
-        out = []
-
-        with open(filename, 'rb') as fid:
-            yo2 = [oct(o)[2:] for o in fid.read()]
-        for i in range(0, len(yo2), 16):
-            line = ['%07d' % int(oct(i)[2:])]
-            line.extend(['%03d' % int(c) for c in yo2[i:i+16]])
-            out.append(" ".join(line))
-        return out
-
-    if sys.version_info[0] < 3:
-        return _pyod2()
-    else:
-        return _pyod3()
 
 _BEFORE_SEQ = ['000', '000', '000', '000', '000', '000', '000', '000',
               '001', '043', '105', '147', '211', '253', '315', '357']

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -923,18 +923,8 @@ class Configuration:
             else:
                 pn = dot_join(*([parent_name] + subpackage_name.split('.')[:-1]))
                 args = (pn,)
-                def fix_args_py2(args):
-                    if setup_module.configuration.__code__.co_argcount > 1:
-                        args = args + (self.top_path,)
-                    return args
-                def fix_args_py3(args):
-                    if setup_module.configuration.__code__.co_argcount > 1:
-                        args = args + (self.top_path,)
-                    return args
-                if sys.version_info[0] < 3:
-                    args = fix_args_py2(args)
-                else:
-                    args = fix_args_py3(args)
+                if setup_module.configuration.__code__.co_argcount > 1:
+                    args = args + (self.top_path,)
                 config = setup_module.configuration(*args)
             if config.name!=dot_join(parent_name, subpackage_name):
                 self.warn('Subpackage %r configuration returned as %r' % \


### PR DESCRIPTION
This PR removes internal functions that were used to handle logic for Python 2 or 3.