### PR TITLE
MAINT: Remove other uses of six module

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -42,7 +42,6 @@
     // list indicates to just test against the default (latest)
     // version.
     "matrix": {
-    	"six": [],
         "Cython": [],
     },
 

--- a/benchmarks/benchmarks/bench_app.py
+++ b/benchmarks/benchmarks/bench_app.py
@@ -2,8 +2,6 @@ from .common import Benchmark
 
 import numpy as np
 
-from six.moves import xrange
-
 
 class LaplaceInplace(Benchmark):
     params = ['inplace', 'normal']
@@ -59,7 +57,7 @@ class MaxesOfDots(Benchmark):
         ntime = 200
 
         self.arrays = [np.random.normal(size=(ntime, nfeat))
-                       for i in xrange(nsubj)]
+                       for i in range(nsubj)]
 
     def maxes_of_dots(self, arrays):
         """


### PR DESCRIPTION
Continue edits from #15358 to remove use of the `six` module, which is no longer needed.