### PR TITLE
MAINT: resolve pyflake F403	'from module import *' used

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -14,8 +14,8 @@ import sys
 from . import overrides
 from . import _multiarray_umath
 import numpy as np
-from numpy.core._multiarray_umath import *
-from numpy.core._multiarray_umath import (
+from ._multiarray_umath import *  # noqa: F403
+from ._multiarray_umath import (
     _fastCopyAndTranspose, _flagdict, _insert, _reconstruct, _vec_string,
     _ARRAY_API, _monotonicity, _get_ndarray_c_version
     )

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -14,7 +14,7 @@ from numpy._build_utils.apple_accelerate import (
     uses_accelerate_framework, get_sgemv_fix
     )
 from numpy.compat import npy_load_module
-from setup_common import *
+from setup_common import *  # noqa: F403
 
 # Set to True to enable relaxed strides checking. This (mostly) means
 # that `strides[dim]` is ignored if `shape[dim] == 1` when setting flags.

--- a/numpy/core/tests/test_umath_accuracy.py
+++ b/numpy/core/tests/test_umath_accuracy.py
@@ -3,7 +3,7 @@ import platform
 from os import path
 import sys
 import pytest
-from ctypes import *
+from ctypes import c_float, c_int, cast, pointer, POINTER
 from numpy.testing import assert_array_max_ulp
 
 runtest = sys.platform.startswith('linux') and (platform.machine() == 'x86_64')

--- a/numpy/core/umath.py
+++ b/numpy/core/umath.py
@@ -7,8 +7,8 @@ by importing from the extension module.
 """
 
 from . import _multiarray_umath
-from numpy.core._multiarray_umath import *
-from numpy.core._multiarray_umath import (
+from ._multiarray_umath import *  # noqa: F403
+from ._multiarray_umath import (
     _UFUNC_API, _add_newdoc_ufunc, _ones_like
     )
 

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -7,9 +7,14 @@ import time
 import subprocess
 from copy import copy
 from distutils import ccompiler
-from distutils.ccompiler import *
-from distutils.errors import DistutilsExecError, DistutilsModuleError, \
-                             DistutilsPlatformError, CompileError
+from distutils.ccompiler import (
+    compiler_class, gen_lib_options, get_default_compiler, new_compiler,
+    CCompiler
+)
+from distutils.errors import (
+    DistutilsExecError, DistutilsModuleError, DistutilsPlatformError,
+    CompileError, UnknownFileError
+)
 from distutils.sysconfig import customize_compiler
 from distutils.version import LooseVersion
 

--- a/numpy/distutils/core.py
+++ b/numpy/distutils/core.py
@@ -1,5 +1,5 @@
 import sys
-from distutils.core import *
+from distutils.core import Distribution, setup
 
 if 'setuptools' in sys.modules:
     have_setuptools = True

--- a/numpy/distutils/log.py
+++ b/numpy/distutils/log.py
@@ -1,6 +1,6 @@
 # Colored log, requires Python 2.3 or up.
 import sys
-from distutils.log import *
+from distutils.log import *  # noqa: F403
 from distutils.log import Log as old_Log
 from distutils.log import _global_log
 

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -4,8 +4,8 @@ unixccompiler - can handle very long argument lists for ar.
 """
 import os
 
-from distutils.errors import DistutilsExecError, CompileError
-from distutils.unixccompiler import *
+from distutils.errors import CompileError, DistutilsExecError, LibError
+from distutils.unixccompiler import UnixCCompiler
 from numpy.distutils.ccompiler import replace_method
 from numpy.distutils.misc_util import _commandline_dep_string
 from numpy.distutils import log

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.matrixlib.defmatrix import matrix, asmatrix
 # need * as we're copying the numpy namespace (FIXME: this makes little sense)
-from numpy import *
+from numpy import *  # noqa: F403
 
 __version__ = np.__version__
 

--- a/tools/swig/test/setup.py
+++ b/tools/swig/test/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # System imports
-from distutils.core import *
+from distutils.core import Extension, setup
 from distutils      import sysconfig
 
 # Third-party modules - we depend on numpy for everything


### PR DESCRIPTION
* For external modules, resolve imported members
* Most internal relative modules were ignored or marked `noqa: F403`
* Convert a few internal absolute imports to relative imports

Found using:
```
flake8 --select=F403 | grep -v "'from \." | sort
```
the regular expression ignores internal relative imports