### PR TITLE
DOC: Fix Multithreaded Generation example docs

### DIFF
--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -88,7 +88,7 @@ The single threaded call directly uses the BitGenerator.
 .. code-block:: ipython
 
     In [5]: values = np.empty(10000000)
-       ...: rg = default_rng(PCG64())
+       ...: rg = default_rng()
        ...: %timeit rg.standard_normal(out=values)
 
     Out[5]: 99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
@@ -99,7 +99,7 @@ that does not use an existing array due to array creation overhead.
 
 .. code-block:: ipython
 
-    In [6]: rg = default_rng(PCG64())
+    In [6]: rg = default_rng()
        ...: %timeit rg.standard_normal(10000000)
 
     Out[6]: 125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -19,24 +19,26 @@ seed will produce the same outputs.
 
 .. code-block:: ipython
 
-    from numpy.random import Generator, PCG64
+    from numpy.random import default_rng, PCG64
     import multiprocessing
     import concurrent.futures
     import numpy as np
 
     class MultithreadedRNG:
         def __init__(self, n, seed=None, threads=None):
-            rg = PCG64(seed)
+            bg = PCG64(seed)
             if threads is None:
                 threads = multiprocessing.cpu_count()
             self.threads = threads
 
-            self._random_generators = [rg]
-            last_rg = rg
+            self._random_generators = [bg]
+            last_bg = bg
             for _ in range(0, threads-1):
-                new_rg = last_rg.jumped()
-                self._random_generators.append(new_rg)
-                last_rg = new_rg
+                new_bg = last_bg.jumped()
+                self._random_generators.append(new_bg)
+                last_bg = new_bg
+            self._random_generators = [default_rng(bg) for bg in
+                                       self._random_generators]
 
             self.n = n
             self.executor = concurrent.futures.ThreadPoolExecutor(threads)
@@ -61,6 +63,7 @@ seed will produce the same outputs.
             self.executor.shutdown(False)
 
 
+
 The multithreaded random number generator can be used to fill an array.
 The ``values`` attributes shows the zero-value before the fill and the
 random value after.
@@ -73,7 +76,7 @@ random value after.
 
     In [3]: mrng.fill()
         ...: print(mrng.values[-1])
-    3.296046120254392
+    -0.40807406258535955
 
 The time required to produce using multiple threads can be compared to
 the time required to generate using a single thread.
@@ -91,7 +94,7 @@ The single threaded call directly uses the BitGenerator.
 .. code-block:: ipython
 
     In [5]: values = np.empty(10000000)
-        ...: rg = Generator(PCG64())
+        ...: rg = default_rng(PCG64())
         ...: %timeit rg.standard_normal(out=values)
 
     99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
@@ -102,7 +105,7 @@ that does not use an existing array due to array creation overhead.
 
 .. code-block:: ipython
 
-    In [6]: rg = Generator(PCG64())
+    In [6]: rg = default_rng(PCG64())
         ...: %timeit rg.standard_normal(10000000)
 
     125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -19,7 +19,7 @@ change.
 
 .. code-block:: ipython
 
-    from numpy.random import default_rng, PCG64, SeedSequence
+    from numpy.random import default_rng, SeedSequence
     import multiprocessing
     import concurrent.futures
     import numpy as np

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -69,12 +69,12 @@ random value after.
 .. code-block:: ipython
 
     In [2]: mrng = MultithreadedRNG(10000000, seed=0)
-    ...: print(mrng.values[-1])
-    0.0
+       ...: print(mrng.values[-1])
+    Out[2]: 0.0
 
     In [3]: mrng.fill()
-        ...: print(mrng.values[-1])
-    -0.40807406258535955
+       ...: print(mrng.values[-1])
+    Out[3]: -0.40807406258535955
 
 The time required to produce using multiple threads can be compared to
 the time required to generate using a single thread.
@@ -82,20 +82,20 @@ the time required to generate using a single thread.
 .. code-block:: ipython
 
     In [4]: print(mrng.threads)
-        ...: %timeit mrng.fill()
+       ...: %timeit mrng.fill()
 
-    4
-    32.8 ms ± 2.71 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+    Out[4]: 4
+       ...: 32.8 ms ± 2.71 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
 The single threaded call directly uses the BitGenerator.
 
 .. code-block:: ipython
 
     In [5]: values = np.empty(10000000)
-        ...: rg = Generator(PCG64())
-        ...: %timeit rg.standard_normal(out=values)
+       ...: rg = Generator(PCG64())
+       ...: %timeit rg.standard_normal(out=values)
 
-    99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+    Out[5]: 99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
 The gains are substantial and the scaling is reasonable even for large that
 are only moderately large.  The gains are even larger when compared to a call
@@ -104,6 +104,6 @@ that does not use an existing array due to array creation overhead.
 .. code-block:: ipython
 
     In [6]: rg = Generator(PCG64())
-        ...: %timeit rg.standard_normal(10000000)
+       ...: %timeit rg.standard_normal(10000000)
 
-    125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+    Out[6]: 125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -108,6 +108,7 @@ Note that if `threads` is not set by the user, it will be determined by
 `multiprocessing.cpu_count()`.
 
 .. code-block:: ipython
+
     In [7]: # simulate the behavior for `threads=None`, if the machine had only one thread
        ...: mrng = MultithreadedRNG(10000000, seed=12345, threads=1)
        ...: print(mrng.values[-1])

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -11,16 +11,15 @@ these requirements.
 
 This example makes use of Python 3 :mod:`concurrent.futures` to fill an array
 using multiple threads.  Threads are long-lived so that repeated calls do not
-require any additional overheads from thread creation. The underlying
-BitGenerator is `PCG64` is fast, has a long period and is seeded by quasi-independent
-seeds of a `~SeedSequence`.
+require any additional overheads from thread creation.
 
 The random numbers generated are reproducible in the sense that the same
-seed will produce the same outputs, given that the number of threads does not change.
+seed will produce the same outputs, given that the number of threads does not
+change.
 
 .. code-block:: ipython
 
-    from numpy.random import Generator, PCG64, SeedSequence
+    from numpy.random import default_rng, PCG64, SeedSequence
     import multiprocessing
     import concurrent.futures
     import numpy as np
@@ -32,7 +31,8 @@ seed will produce the same outputs, given that the number of threads does not ch
             self.threads = threads
 
             seq = SeedSequence(seed)
-            self._random_generators = [Generator(PCG64(s)) for s in seq.spawn(threads)]
+            self._random_generators = [default_rng(s)
+                                       for s in seq.spawn(threads)]
 
             self.n = n
             self.executor = concurrent.futures.ThreadPoolExecutor(threads)
@@ -88,7 +88,7 @@ The single threaded call directly uses the BitGenerator.
 .. code-block:: ipython
 
     In [5]: values = np.empty(10000000)
-       ...: rg = Generator(PCG64())
+       ...: rg = default_rng(PCG64())
        ...: %timeit rg.standard_normal(out=values)
 
     Out[5]: 99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
@@ -99,12 +99,13 @@ that does not use an existing array due to array creation overhead.
 
 .. code-block:: ipython
 
-    In [6]: rg = Generator(PCG64())
+    In [6]: rg = default_rng(PCG64())
        ...: %timeit rg.standard_normal(10000000)
 
     Out[6]: 125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
-Note that if `threads` is not set by the user, it will be determined by the architecture
+Note that if `threads` is not set by the user, it will be determined by
+`multiprocessing.cpu_count()`.
 
 .. code-block:: ipython
     In [7]: # simulate the behavior for `threads=None`, if the machine had only one thread

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -19,7 +19,7 @@ seed will produce the same outputs.
 
 .. code-block:: ipython
 
-    from numpy.random import default_rng, PCG64
+    from numpy.random import Generator, PCG64
     import multiprocessing
     import concurrent.futures
     import numpy as np
@@ -31,14 +31,12 @@ seed will produce the same outputs.
                 threads = multiprocessing.cpu_count()
             self.threads = threads
 
-            self._random_generators = [bg]
+            self._random_generators = [Generator(bg)]
             last_bg = bg
             for _ in range(0, threads-1):
                 new_bg = last_bg.jumped()
-                self._random_generators.append(new_bg)
+                self._random_generators.append(Generator(new_bg))
                 last_bg = new_bg
-            self._random_generators = [default_rng(bg) for bg in
-                                       self._random_generators]
 
             self.n = n
             self.executor = concurrent.futures.ThreadPoolExecutor(threads)
@@ -94,7 +92,7 @@ The single threaded call directly uses the BitGenerator.
 .. code-block:: ipython
 
     In [5]: values = np.empty(10000000)
-        ...: rg = default_rng(PCG64())
+        ...: rg = Generator(PCG64())
         ...: %timeit rg.standard_normal(out=values)
 
     99.6 ms ± 222 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
@@ -105,7 +103,7 @@ that does not use an existing array due to array creation overhead.
 
 .. code-block:: ipython
 
-    In [6]: rg = default_rng(PCG64())
+    In [6]: rg = Generator(PCG64())
         ...: %timeit rg.standard_normal(10000000)
 
     125 ms ± 309 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)


### PR DESCRIPTION
Working on #15365
The code runs now, but I get quite different runtimes than in the example. Thus it may need some more work.

Timing tests are also from the original documentation (but rerun here)

1. using multiple threads
``` python
print(mrng.threads)
%timeit mrng.fill()
# 4
# 52.6 ms ± 508 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

2. single threaded directly
``` python
values = np.empty(10000000)
rg = default_rng(PCG64())
%timeit rg.standard_normal(out=values)
# 143 ms ± 1.14 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

3. single threaded directly, but do not use an existing array.
``` python
rg = default_rng(PCG64())
%timeit rg.standard_normal(10000000)
# 148 ms ± 590 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

So following quote would not make sense on my machine.
> 
> The gains are substantial and the scaling is reasonable even for large that
> are only moderately large.  The gains are even larger when compared to a call
> that does not use an existing array due to array creation overhead.

Can someone confirm this? Or did I implement something wrong?