### PR TITLE
MAINT: Update tox for supported Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,11 +22,11 @@
 #   tox -- -v
 
 # Tox assumes that you have appropriate Python interpreters already
-# installed and that they can be run as 'python2.7', 'python3.3', etc.
+# installed and that they can be run as (e.g.) 'python3.8'
 
 [tox]
 envlist =
-  py35,py36,py37,
+  py36,py37,py38,
   py37-not-relaxed-strides
 
 [testenv]


### PR DESCRIPTION
* Drop Python 3.5, add Python 3.8
* Revise comment to use supported Python bin names