### PR TITLE
MAINT: simd: Avoid signed comparison warning

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -1134,7 +1134,7 @@ sse2_@kind@_@TYPE@(@type@ * ip, @type@ * op, const npy_intp n)
         /* Order of operations important for MSVC 2015 */
         *op = (*op @OP@ ip[i] || npy_isnan(*op)) ? *op : ip[i];
     }
-    assert((npy_uintp)n < (stride) || npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES));
+    assert(n < stride || npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES));
     if (i + 3 * stride <= n) {
         /* load the first elements */
         @vtype@ c1 = @vpre@_load_@vsuf@((@type@*)&ip[i]);


### PR DESCRIPTION
We do not need to cast the dimensions (`n`) to ``npy_uintp`` when
comparing it to the stride length (of type ``npy_intp``). The cast is
kept from similar checks where the cast is required

    (npy_uintp)n < (VECTOR_SIZE_BYTES / sizeof(@type@))

In this case `strides` is precalcuated as

    VECTOR_SIZE_BYTES / (npy_intp)sizeof(@type@))

therefore `n` is already of the correct type when the check is
performed.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
