### PR TITLE
DOC: Updating Chararry Buffer datatypes #15360

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1908,7 +1908,7 @@ class chararray(ndarray):
     unicode : bool, optional
         Are the array elements of type unicode (True) or string (False).
         Default is False.
-    buffer : int, optional
+    buffer : int or str or bytes, optional
         Memory address of the start of the array data.  Default is None,
         in which case a new array is created.
     offset : int, optional

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1908,7 +1908,7 @@ class chararray(ndarray):
     unicode : bool, optional
         Are the array elements of type unicode (True) or string (False).
         Default is False.
-    buffer : int or str or bytes, optional
+    buffer : object exposing the buffer interface or str, optional
         Memory address of the start of the array data.  Default is None,
         in which case a new array is created.
     offset : int, optional


### PR DESCRIPTION
This pull request is motivated by the [this](https://github.com/numpy/numpy/issues/15360) documentation issue.
I added the str and bytes datatype, hopefully correct.
