### PR TITLE
MAINT: Cleanup python2 references

### DIFF
--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -42,9 +42,7 @@ def _indices_for_axis():
     res = []
     for nelems in (0, 2, 3):
         ind = _indices_for_nelems(nelems)
-
-        # no itertools.product available in Py2.4
-        res.extend([(a, b) for a in ind for b in ind])  # all assignments of size "nelems"
+        res.extend(itertools.product(ind, ind))  # all assignments of size "nelems"
 
     return res
 
@@ -53,18 +51,7 @@ def _indices(ndims):
     """Returns ((axis0_src, axis0_dst), (axis1_src, axis1_dst), ... ) index pairs."""
 
     ind = _indices_for_axis()
-
-    # no itertools.product available in Py2.4
-
-    res = [[]]
-    for i in range(ndims):
-        newres = []
-        for elem in ind:
-            for others in res:
-                newres.append([elem] + others)
-        res = newres
-
-    return res
+    return itertools.product(ind, repeat=ndims)
 
 
 def _check_assignment(srcidx, dstidx):

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -82,10 +82,7 @@ class TestRealScalars:
             orig_stdout, orig_stderr = sys.stdout, sys.stderr
             sys.stdout, sys.stderr = fo, fe
 
-            # py2 code.interact sends irrelevant internal DeprecationWarnings
-            with suppress_warnings() as sup:
-                sup.filter(DeprecationWarning)
-                code.interact(local={'np': np}, readfunc=input_func, banner='')
+            code.interact(local={'np': np}, readfunc=input_func, banner='')
 
             sys.stdout, sys.stderr = orig_stdout, orig_stderr
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1319,7 +1319,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
     delimiter = asstr(delimiter)
 
     class WriteWrap:
-        """Convert to unicode in py2 or to bytes on bytestream inputs.
+        """Convert to bytes on bytestream inputs.
 
         """
         def __init__(self, fh, encoding):


### PR DESCRIPTION
This comes from `grep '\bpy[23]'`.

There is still some use in `tools/npy_tempita.py` and `tools/npy_tempita/compat3.py`. Can `npy_tempita/compat3.py` be cleanedup and deleted? I'm happy to do it, but I'm not sure if it's only for internal tool use or the cleanup needs to be staged...