### PR TITLE
DEP: add PendingDeprecation to matlib.py funky namespace

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -153,6 +153,7 @@ class PytestTester:
         # When testing matrices, ignore their PendingDeprecationWarnings
         pytest_args += [
             "-W ignore:the matrix subclass is not",
+            "-W ignore:Importing from numpy.matlib is",
             ]
 
         if doctests:

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -1,3 +1,14 @@
+import warnings
+
+# 2018-05-29, PendingDeprecationWarning added to matrix.__new__
+# 2020-01-23, numpy 1.19.0 PendingDeprecatonWarning
+warnings.warn("Importing from numpy.matlib is deprecated since 1.19.0. "
+              "The matrix subclass is not the recommended way to represent "
+              "matrices or deal with linear algebra (see "
+              "https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). "
+              "Please adjust your code to use regular ndarray. ",
+              PendingDeprecationWarning, stacklevel=2)
+
 import numpy as np
 from numpy.matrixlib.defmatrix import matrix, asmatrix
 # Matlib.py contains all functions in the numpy namespace with a few

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -1,6 +1,8 @@
 import numpy as np
 from numpy.matrixlib.defmatrix import matrix, asmatrix
-# need * as we're copying the numpy namespace (FIXME: this makes little sense)
+# Matlib.py contains all functions in the numpy namespace with a few
+# replacements. See doc/source/reference/routines.matlib.rst for details.
+# Need * as we're copying the numpy namespace.
 from numpy import *  # noqa: F403
 
 __version__ = np.__version__

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -1,11 +1,3 @@
-# As we are testing matrices, we ignore its PendingDeprecationWarnings
-try:
-    import pytest
-    pytestmark = pytest.mark.filterwarnings(
-        'ignore:the matrix subclass is not:PendingDeprecationWarning')
-except ImportError:
-    pass
-
 import numpy as np
 import numpy.matlib
 from numpy.testing import assert_array_equal, assert_

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ filterwarnings =
     ignore::UserWarning:cpuinfo,
 # Matrix PendingDeprecationWarning.
     ignore:the matrix subclass is not
+    ignore:Importing from numpy.matlib is
 
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
[Blame](https://github.com/numpy/numpy/blame/master/numpy/matlib.py), the `(FIXME: this makes little sense)` note was added by @rgommers in 2019. "from numpy import *" has existed since ~2010. Hopefully this better explains why the * import is needed.

doc/source/reference/routines.matlib.rst is also available at https://docs.scipy.org/doc/numpy/reference/routines.matlib.html if that would be a better link

