### PR TITLE
DOC: Remove additional blank line from towncrier

### DIFF
--- a/doc/release/upcoming_changes/template.rst
+++ b/doc/release/upcoming_changes/template.rst
@@ -17,7 +17,6 @@
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 {{ text }}
-
 {{ get_indent(text) }}({{values|join(', ') }})
 
 {% endfor %}


### PR DESCRIPTION
The additional blank line creates a problem for indented items
(but without the blank line, manual bullets are an issue).

Another solution would be to add a blank line only when there is
a bullet point before. This would make the template somewhat
more unweildy though, so lets see how often we actually run into
an issue.

---

Try to see if this is the issue, but if CI passes, maybe this is OK, really. A bit too bad about not being able to end fragments in bullet points...