### PR TITLE
BUG: np.load does not handle empty array with an empty descr

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -295,7 +295,11 @@ def descr_to_dtype(descr):
         # subtype, will always have a shape descr[1]
         dt = descr_to_dtype(descr[0])
         return numpy.dtype((dt, descr[1]))
-    fields = []
+
+    titles = []
+    names = []
+    formats = []
+    offsets = []
     offset = 0
     for field in descr:
         if len(field) == 2:
@@ -309,17 +313,13 @@ def descr_to_dtype(descr):
         # Once support for blank names is removed, only "if name == ''" needed)
         is_pad = (name == '' and dt.type is numpy.void and dt.names is None)
         if not is_pad:
-            fields.append((name, dt, offset))
-
+            title, name = name if isinstance(name, tuple) else (None, name)
+            titles.append(title)
+            names.append(name)
+            formats.append(dt)
+            offsets.append(offset)
         offset += dt.itemsize
 
-    if not fields:
-        return numpy.dtype([])
-
-    names, formats, offsets = zip(*fields)
-    # names may be (title, names) tuples
-    nametups = (n  if isinstance(n, tuple) else (None, n) for n in names)
-    titles, names = zip(*nametups)
     return numpy.dtype({'names': names, 'formats': formats, 'titles': titles,
                         'offsets': offsets, 'itemsize': offset})
 

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -313,6 +313,9 @@ def descr_to_dtype(descr):
 
         offset += dt.itemsize
 
+    if not fields:
+        return numpy.dtype([])
+
     names, formats, offsets = zip(*fields)
     # names may be (title, names) tuples
     nametups = (n  if isinstance(n, tuple) else (None, n) for n in names)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -535,8 +535,10 @@ dt4 = np.dtype({'names': ['a', '', 'b'], 'formats': ['i4']*3})
 # titles
 dt5 = np.dtype({'names': ['a', 'b'], 'formats': ['i4', 'i4'],
                 'offsets': [1, 6], 'titles': ['aa', 'bb']})
+# empty
+dt6 = np.dtype({'names': [], 'formats': [], 'itemsize': 8})
 
-@pytest.mark.parametrize("dt", [dt1, dt2, dt3, dt4, dt5])
+@pytest.mark.parametrize("dt", [dt1, dt2, dt3, dt4, dt5, dt6])
 def test_load_padded_dtype(dt):
     arr = np.zeros(3, dt)
     for i in range(3):


### PR DESCRIPTION
The bug occurs since numpy 1.16. Before that empty descr corresponds to
`np.dtype([])`. This fixes the problem by following numpy 1.15's
behavior. #15396 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
