### PR TITLE
BUG: Flags should not contain spaces

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -59,7 +59,7 @@ class IntelFCompiler(BaseIntelFCompiler):
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-fp-model strict -O1 -{}'.format(mpopt)]
+        return ['-fp-model', 'strict', '-O1', '-{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return []
@@ -125,10 +125,10 @@ class IntelEM64TFCompiler(IntelFCompiler):
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-fp-model strict -O1 -{}'.format(mpopt)]
+        return ['-fp-model', 'strict', '-O1', '-{}'.format(mpopt)]
 
     def get_flags_arch(self):
-        return ['']
+        return []
 
 # Is there no difference in the version string between the above compilers
 # and the Visual compilers?
@@ -210,7 +210,7 @@ class IntelEM64VisualFCompiler(IntelVisualFCompiler):
     version_match = simple_version_match(start=r'Intel\(R\).*?64,')
 
     def get_flags_arch(self):
-        return ['']
+        return []
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's very unlikely that `ifort` is supposed to be invoked as `ifort "-fpmodel strict"` instead of `ifort -fpmodel strict` .

Spaces in flag items will end up passed as a single argument.

Don't know if anyone was actually running into this, nor was I able to test it.