### PR TITLE
BUG/TEST: core: Fix an undefined name in a test.

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2015,7 +2015,7 @@ class TestClip:
     def test_NaT_propagation(self, arr, amin, amax):
         # NOTE: the expected function spec doesn't
         # propagate NaT, but clip() now does
-        expected = np.minimum(np.maximum(a, amin), amax)
+        expected = np.minimum(np.maximum(arr, amin), amax)
         actual = np.clip(arr, amin, amax)
         assert_equal(actual, expected)
 


### PR DESCRIPTION
This hasn't generated an error because the test is marked `xfail`.
Code checkers such as pyflakes will flag it, so fixing it is worthwhile.
