### PR TITLE
BLD: catch link error.

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1742,7 +1742,7 @@ class blas_info(system_info):
                                       library_dirs=info['library_dirs'],
                                       extra_postargs=info.get('extra_link_args', []))
                     res = "blas"
-            except distutils.ccompiler.CompileError:
+            except (distutils.ccompiler.CompileError, distutils.ccompiler.LinkError):
                 res = None
         finally:
             shutil.rmtree(tmpdir)


### PR DESCRIPTION
When system_info.py is trying to find cblas as libblas, there can be a
different library called libblas that doesn't contain the referenced
function cblas_ddot. This raises a distutils.errors.LinkError, which
is currently not caught.

This patch fixes #15389.

The system_info in master was reworked for 1.17, and doesn't have this
issue.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
