### PR TITLE
BUG: Add basic __format__ for masked element to fix incorrect print

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6398,7 +6398,10 @@ class MaskedConstant(MaskedArray):
             return object.__repr__(self)
 
     def __format__(self, format_spec):
-        return format(str(masked_print_option._display), format_spec)
+        # Replace ndarray.__format__ with the default, which supports no format characters.
+        # Supporting format characters is unwise here, because we do not know what type
+        # the user was expecting - better to not guess.
+        return object.__format__(self, format_spec)
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6401,7 +6401,15 @@ class MaskedConstant(MaskedArray):
         # Replace ndarray.__format__ with the default, which supports no format characters.
         # Supporting format characters is unwise here, because we do not know what type
         # the user was expecting - better to not guess.
-        return object.__format__(self, format_spec)
+        try:
+            return object.__format__(self, format_spec)
+        except Exception:
+            warnings.warn(
+                "Format strings passed to MaskedConstant are ignored, but in future may "
+                "error or produce different behavior",
+                FutureWarning, stacklevel=2
+            )
+            return object.__format__(self, "")
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6397,6 +6397,9 @@ class MaskedConstant(MaskedArray):
             # it's a subclass, or something is wrong, make it obvious
             return object.__repr__(self)
 
+    def __format__(self, format_spec):
+        return str(masked_print_option._display)
+
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.
         """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6398,7 +6398,7 @@ class MaskedConstant(MaskedArray):
             return object.__repr__(self)
 
     def __format__(self, format_spec):
-        return str(masked_print_option._display)
+        return format(str(masked_print_option._display), format_spec)
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -448,14 +448,14 @@ class TestMaskedArray:
         assert_equal(a.mask, [0, 1, 0])
 
     def test_format(self):
-        # Note: Python 3.6 and above fstring uses __format__, see PEP 498.
-        # Testing with underlying primitive.
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(format(a), "[0 -- 2]")
         assert_equal(format(masked), "--")
         assert_equal(format(masked, ""), "--")
-        assert_equal(format(masked, " >5"), "   --")
-        assert_equal(format(masked, " <5"), "--   ")
+
+        # Postponed from PR #15410, perhaps address in the future.
+        # assert_equal(format(masked, " >5"), "   --")
+        # assert_equal(format(masked, " <5"), "--   ")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -457,11 +457,9 @@ class TestMaskedArray:
         # assert_equal(format(masked, " >5"), "   --")
         # assert_equal(format(masked, " <5"), "--   ")
 
-        # instead we have....
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings("always")
-            assert_equal(format(masked, " >5"), "--")
-            assert_equal(len(w), 1, "Expected a FutureWarning for using format_spec with MaskedElement")
+        # Expect a FutureWarning for using format_spec with MaskedElement
+        with_format_string = assert_warns(FutureWarning, format, masked, " >5")
+        assert_equal(with_format_string, "--")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -457,6 +457,12 @@ class TestMaskedArray:
         # assert_equal(format(masked, " >5"), "   --")
         # assert_equal(format(masked, " <5"), "--   ")
 
+        # instead we have....
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
+            assert_equal(format(masked, " >5"), "--")
+            assert_equal(len(w), 1, "Expected a FutureWarning for using format_spec with MaskedElement")
+
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(str(a), '[0 -- 2]')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -447,12 +447,15 @@ class TestMaskedArray:
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
-    def test_fstring(self):
-        # fstrings (PEP 498) are a SyntaxError in versions under Py 3.6.
-        # Seeing that as of 20200123, the atravis do not target versions under 3.6, so this is ok.
+    def test_format(self):
+        # Note: Python 3.6 and above fstring uses __format__, see PEP 498.
+        # Testing with underlying primitive.
         a = array([0, 1, 2], mask=[False, True, False])
-        assert_equal(f"{a}", "[0 -- 2]")
-        assert_equal(f"{masked}", "--")
+        assert_equal(format(a), "[0 -- 2]")
+        assert_equal(format(masked), "--")
+        assert_equal(format(masked, ""), "--")
+        assert_equal(format(masked, " >5"), "   --")
+        assert_equal(format(masked, " <5"), "--   ")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -447,6 +447,13 @@ class TestMaskedArray:
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
+    def test_fstring(self):
+        # fstrings (PEP 498) are a SyntaxError in versions under Py 3.6.
+        # Seeing that as of 20200123, the atravis do not target versions under 3.6, so this is ok.
+        a = array([0, 1, 2], mask=[False, True, False])
+        assert_equal(f"{a}", "[0 -- 2]")
+        assert_equal(f"{masked}", "--")
+
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(str(a), '[0 -- 2]')


### PR DESCRIPTION
Fix and test conversion of masked element to string in fstring / string interpolation. See PEP 498 for string interpolation (aka fstrings) in Python 3.6 and above.

Fixes #15409.