### PR TITLE
MAINT: Remove Python2 workarounds

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -313,9 +313,11 @@ def issubclass_(arg1, arg2):
     Examples
     --------
     >>> np.issubclass_(np.int32, int)
-    False # True on Python 2.7
+    False
     >>> np.issubclass_(np.int32, float)
     False
+    >>> np.issubclass_(np.float64, float)
+    True
 
     """
     try:

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -2,6 +2,7 @@ __all__ = ['atleast_1d', 'atleast_2d', 'atleast_3d', 'block', 'hstack',
            'stack', 'vstack']
 
 import functools
+import itertools
 import operator
 import warnings
 
@@ -530,14 +531,7 @@ def _atleast_nd(a, ndim):
 
 
 def _accumulate(values):
-    # Helper function because Python 2.7 doesn't have
-    # itertools.accumulate
-    value = 0
-    accumulated = []
-    for v in values:
-        value += v
-        accumulated.append(value)
-    return accumulated
+    return list(itertools.accumulate(values))
 
 
 def _concatenate_shapes(shapes, axis):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6273,10 +6273,7 @@ def test_matmul_inplace():
     assert_raises(TypeError, a.__imatmul__, b)
     import operator
     assert_raises(TypeError, operator.imatmul, a, b)
-    # we avoid writing the token `exec` so as not to crash python 2's
-    # parser
-    exec_ = getattr(builtins, "exec")
-    assert_raises(TypeError, exec_, "a @= b", globals(), locals())
+    assert_raises(TypeError, exec, "a @= b", globals(), locals())
 
 def test_matmul_axes():
     a = np.arange(3*4*5).reshape(3, 4, 5)

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -30,12 +30,12 @@ class TestRealScalars:
 
     def test_scalar_cutoffs(self):
         # test that both the str and repr of np.float64 behaves
-        # like python floats in python3. Note that in python2
-        # the str has truncated digits, but we do not do this
+        # like python floats in python3.
         def check(v):
-            # we compare str to repr, to avoid python2 truncation behavior
+            assert_equal(str(np.float64(v)), str(v))
             assert_equal(str(np.float64(v)), repr(v))
             assert_equal(repr(np.float64(v)), repr(v))
+            assert_equal(repr(np.float64(v)), str(v))
 
         # check we use the same number of significant digits
         check(1.12345678901234567890)

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -80,7 +80,6 @@ _ALL_BINARY_OPERATORS = [
     operator.mul,
     operator.truediv,
     operator.floordiv,
-    # TODO: test div on Python 2, only
     operator.mod,
     divmod,
     pow,

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1556,7 +1556,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, True])
         assert_(test.fill_value == True)
 
-        # test = (a[0] == b)  # doesn't work in Python2
+        test = (a[0] == b)
+        assert_equal(test.data, [False, False])
+        assert_equal(test.mask, [True, False])
+        assert_(test.fill_value == True)
+
         test = (b == a[0])
         assert_equal(test.data, [False, False])
         assert_equal(test.mask, [True, False])
@@ -1584,7 +1588,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, True])
         assert_(test.fill_value == True)
 
-        # test = (a[0] != b)  # doesn't work in Python2
+        test = (a[0] != b)
+        assert_equal(test.data, [True, True])
+        assert_equal(test.mask, [True, False])
+        assert_(test.fill_value == True)
+
         test = (b != a[0])
         assert_equal(test.data, [True, True])
         assert_equal(test.mask, [True, False])
@@ -1613,7 +1621,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, True])
         assert_(test.fill_value == True)
 
-        # test = (a[0] == b)  # doesn't work in Python2
+        test = (a[0] == b)
+        assert_equal(test.data, [False, False])
+        assert_equal(test.mask, [True, False])
+        assert_(test.fill_value == True)
+
         test = (b == a[0])
         assert_equal(test.data, [False, False])
         assert_equal(test.mask, [True, False])
@@ -1642,7 +1654,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, [True, True])
         assert_(test.fill_value == True)
 
-        # test = (a[0] != b)  # doesn't work in Python2
+        test = (a[0] != b)
+        assert_equal(test.data, [True, True])
+        assert_equal(test.mask, [True, False])
+        assert_(test.fill_value == True)
+
         test = (b != a[0])
         assert_equal(test.data, [True, True])
         assert_equal(test.mask, [True, False])

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -423,10 +423,6 @@ class ABCPolyBase(abc.ABC):
             return NotImplemented
         return self.__class__(coef, self.domain, self.window)
 
-    def __div__(self, other):
-        # this can be removed when python 2 support is dropped.
-        return self.__floordiv__(other)
-
     def __truediv__(self, other):
         # there is no true divide if the rhs is not a Number, although it
         # could return the first n elements of an infinite series.

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -262,9 +262,6 @@ def detect_runner():
             if module in _test_runners:
                 _test_runner_guess = module
                 break
-            if record[1].endswith("python2.6/unittest.py"):
-                _test_runner_guess = "unittest"
-                break
         else:
             _test_runner_guess = None
     return _test_runner_guess


### PR DESCRIPTION
Remove a handful of Python2 oddity statements