### PR TITLE
MAINT: Revert f2py Python 2.6 workaround

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -169,7 +169,7 @@ Extra options (only effective with -c):
 
 Version:     %s
 numpy Version: %s
-Requires:    Python 2.3 or higher.
+Requires:    Python 3.5 or higher.
 License:     NumPy license (see LICENSE.txt in the NumPy source code)
 Copyright 1999 - 2011 Pearu Peterson all rights reserved.
 http://cens.ioc.ee/projects/f2py2e/""" % (f2py_version, numpy_version)

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -276,7 +276,7 @@ static PyObject *#apiname#(const PyObject *capi_self,
 f2py_start_clock();
 #endif
 \tif (!PyArg_ParseTupleAndKeywords(capi_args,capi_keywds,\\
-\t\t\"#argformat##keyformat##xaformat#:#pyname#\",\\
+\t\t\"#argformat#|#keyformat##xaformat#:#pyname#\",\\
 \t\tcapi_kwlist#args_capi##keys_capi##keys_xa#))\n\t\treturn NULL;
 #frompyobj#
 /*end of frompyobj*/
@@ -1444,16 +1444,6 @@ def buildapi(rout):
             rd['latexdocstrsigns'] = rd['latexdocstrsigns'] + rd[k][0:1] +\
                 ['\\begin{description}'] + rd[k][1:] +\
                 ['\\end{description}']
-
-    # Workaround for Python 2.6, 2.6.1 bug: https://bugs.python.org/issue4720
-    if rd['keyformat'] or rd['xaformat']:
-        argformat = rd['argformat']
-        if isinstance(argformat, list):
-            argformat.append('|')
-        else:
-            assert isinstance(argformat, str), repr(
-                (argformat, type(argformat)))
-            rd['argformat'] += '|'
 
     ar = applyrules(routine_rules, rd)
     if ismoduleroutine(rout):


### PR DESCRIPTION
Revert https://github.com/numpy/numpy/commit/ed916ff07cf2f1fbb6056cdc01fe3ae82a027ed5#diff-c9eccf467e5f6561061d6a5ac4730330 which was needed to workaround http://bugs.python.org/issue4720 which was fixed 12 years ago.