### PR TITLE
MAINT: Cleanup references to python2

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1329,9 +1329,8 @@ _failed_comparison_workaround(PyArrayObject *self, PyObject *other, int cmp_op)
         /*
          * For LE, LT, GT, GE and a flexible self or other, we return
          * NotImplemented, which is the correct answer since the ufuncs do
-         * not in fact implement loops for those.  On python 3 this will
-         * get us the desired TypeError, but on python 2, one gets strange
-         * ordering, so we emit a warning.
+         * not in fact implement loops for those.  This will get us the
+         * desired TypeError.
          */
         Py_XDECREF(exc);
         Py_XDECREF(val);
@@ -1539,8 +1538,7 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          *     (MHvK, 2018-06-18: not sure about this, but it's what we have).
          *
          * However, for backwards compatibility, we cannot yet return arrays,
-         * so we raise warnings instead.  Furthermore, we warn on python2
-         * for LT, LE, GE, GT, since fall-back behaviour is poorly defined.
+         * so we raise warnings instead.
          */
         result = _failed_comparison_workaround(self, other, cmp_op);
     }

--- a/numpy/core/src/multiarray/typeinfo.c
+++ b/numpy/core/src/multiarray/typeinfo.c
@@ -5,8 +5,10 @@
  */
 #include "typeinfo.h"
 
-/* In python 2, this is not exported from Python.h */
+#if (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM <= 0x07030000))
+/* PyPy issue 3160 */
 #include <structseq.h>
+#endif
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/linalg/lapack_lite/README.rst
+++ b/numpy/linalg/lapack_lite/README.rst
@@ -20,7 +20,7 @@ The routines that ``lapack_litemodule.c`` wraps are listed in
 properly. Assuming that you have an unpacked LAPACK source tree in
 ``~/LAPACK``, you generate the new routines in this directory with::
 
-$ python2 ./make_lite.py wrapped_routines ~/LAPACK
+$ python ./make_lite.py wrapped_routines ~/LAPACK
 
 This will grab the right routines, with dependencies, put them into the
 appropriate ``f2c_*.f`` files, run ``f2c`` over them, then do some scrubbing

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -37,13 +37,6 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy.linalg')
 
 
-# For Python2/3 compatibility
-_N = b'N'
-_V = b'V'
-_A = b'A'
-_S = b'S'
-_L = b'L'
-
 fortran_int = intc
 
 

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -656,7 +656,6 @@ class Checker(doctest.OutputChecker):
     Check the docstrings
     """
     obj_pattern = re.compile('at 0x[0-9a-fA-F]+>')
-    int_pattern = re.compile('^[0-9]+L?$')
     vanilla = doctest.OutputChecker()
     rndm_markers = {'# random', '# Random', '#random', '#Random', "# may vary",
                     "# uninitialized", "#uninitialized"}
@@ -694,11 +693,6 @@ class Checker(doctest.OutputChecker):
         # ignore comments (e.g. signal.freqresp)
         if want.lstrip().startswith("#"):
             return True
-
-        # python 2 long integers are equal to python 3 integers
-        if self.int_pattern.match(want) and self.int_pattern.match(got):
-            if want.rstrip("L\r\n") == got.rstrip("L\r\n"):
-                return True
 
         # try the standard doctest
         try:


### PR DESCRIPTION
These were found with `grep [pP]ython\s*2` and should probably be cleaned up.