### PR TITLE
MAINT, DOC: Remove use of old Python __builtin__, now known as builtins

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -157,11 +157,8 @@ else:
     # Make these accessible from numpy name-space
     # but not imported in from numpy import *
     # TODO[gh-6103]: Deprecate these
-    if sys.version_info[0] >= 3:
-        from builtins import bool, int, float, complex, object, str
-        unicode = str
-    else:
-        from __builtin__ import bool, int, float, complex, object, unicode, str
+    from builtins import bool, int, float, complex, object, str
+    unicode = str
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -274,7 +274,7 @@ def str_len(a):
 
     See also
     --------
-    __builtin__.len
+    builtins.len
     """
     return _vec_string(a, integer, '__len__')
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -164,7 +164,6 @@ def get_path_from_frame(frame, parent_path=None):
             # we're probably running setup.py as execfile("setup.py")
             # (likely we're building an egg)
             d = os.path.abspath('.')
-            # hmm, should we use sys.argv[0] like in __builtin__ case?
 
     if parent_path is not None:
         d = rel_path(d, parent_path)


### PR DESCRIPTION
Python 2's [`__builtin__` module](https://docs.python.org/2/library/__builtin__.html) is replaced with the [`builtins` module](https://docs.python.org/3/library/builtins.html).

A few notes:
- See [gh-6103](https://github.com/numpy/numpy/pull/6103) for planned DEP to `numpy/__init__.py`, which are not touched here, just re-arranged to remove Python 2 logic
- Not sure if "See also" link in `numpy/core/defchararray.py` will work in Sphinx outputs (the [current `__builtin__.len`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.char.str_len.html) does not link)
- Removed a 14-year-old "hmm," comment (44f0e40eed3cc04292f1295ae524a1d5aedb382c) that does not make sense for the current form of `numpy/distutils/misc_util.py`.