### PR TITLE
DEP: Schedule unused C-API functions for removal/disabling

### DIFF
--- a/doc/release/upcoming_changes/15427.deprecation.rst
+++ b/doc/release/upcoming_changes/15427.deprecation.rst
@@ -1,0 +1,12 @@
+Deprecation of probably unused C-API functions
+----------------------------------------------
+The following C-API functions are probably unused and have been
+deprecated:
+
+* ``PyArray_GetArrayParamsFromObject``
+* ``PyUFunc_GenericFunction``
+* ``PyUFunc_SetUsesArraysAsData``
+
+In most cases ``PyArray_GetArrayParamsFromObject`` should be replaced
+by converting to an array, while ``PyUFunc_GenericFunction`` can be
+replaced with ``PyObject_Call`` (see documentation for details).

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -550,73 +550,16 @@ From other objects
         PyArray_Descr** out_dtype, int* out_ndim, npy_intp* out_dims, \
         PyArrayObject** out_arr, PyObject* context)
 
+    .. deprecated:: NumPy 1.19
+
+        Unless NumPy is made aware of an issue with this, this function
+        is scheduled for rapid removal without replacement.
+
+    .. versionchanged:: NumPy 1.19
+
+        `context` is never used. Its use results in an error.
+
     .. versionadded:: 1.6
-
-    Retrieves the array parameters for viewing/converting an arbitrary
-    PyObject* to a NumPy array. This allows the "innate type and shape"
-    of Python list-of-lists to be discovered without
-    actually converting to an array. PyArray_FromAny calls this function
-    to analyze its input.
-
-    In some cases, such as structured arrays and the :obj:`~numpy.class.__array__` interface,
-    a data type needs to be used to make sense of the object.  When
-    this is needed, provide a Descr for 'requested_dtype', otherwise
-    provide NULL. This reference is not stolen. Also, if the requested
-    dtype doesn't modify the interpretation of the input, out_dtype will
-    still get the "innate" dtype of the object, not the dtype passed
-    in 'requested_dtype'.
-
-    If writing to the value in 'op' is desired, set the boolean
-    'writeable' to 1.  This raises an error when 'op' is a scalar, list
-    of lists, or other non-writeable 'op'. This differs from passing
-    :c:data:`NPY_ARRAY_WRITEABLE` to PyArray_FromAny, where the writeable array may
-    be a copy of the input.
-
-    `context` is not used.
-
-    When success (0 return value) is returned, either out_arr
-    is filled with a non-NULL PyArrayObject and
-    the rest of the parameters are untouched, or out_arr is
-    filled with NULL, and the rest of the parameters are filled.
-
-    Typical usage:
-
-    .. code-block:: c
-
-        PyArrayObject *arr = NULL;
-        PyArray_Descr *dtype = NULL;
-        int ndim = 0;
-        npy_intp dims[NPY_MAXDIMS];
-
-        if (PyArray_GetArrayParamsFromObject(op, NULL, 1, &dtype,
-                                            &ndim, &dims, &arr, NULL) < 0) {
-            return NULL;
-        }
-        if (arr == NULL) {
-            /*
-            ... validate/change dtype, validate flags, ndim, etc ...
-             Could make custom strides here too */
-            arr = PyArray_NewFromDescr(&PyArray_Type, dtype, ndim,
-                                        dims, NULL,
-                                        fortran ? NPY_ARRAY_F_CONTIGUOUS : 0,
-                                        NULL);
-            if (arr == NULL) {
-                return NULL;
-            }
-            if (PyArray_CopyObject(arr, op) < 0) {
-                Py_DECREF(arr);
-                return NULL;
-            }
-        }
-        else {
-            /*
-            ... in this case the other parameters weren't filled, just
-                validate and possibly copy arr itself ...
-            */
-        }
-        /*
-        ... use arr ...
-        */
 
 .. c:function:: PyObject* PyArray_CheckFromAny( \
         PyObject* op, PyArray_Descr* dtype, int min_depth, int max_depth, \

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -253,15 +253,16 @@ Functions
 .. c:function:: int PyUFunc_GenericFunction( \
         PyUFuncObject* self, PyObject* args, PyObject* kwds, PyArrayObject** mps)
 
-    A generic ufunc call. The ufunc is passed in as *self*, the arguments
-    to the ufunc as *args* and *kwds*. The *mps* argument is an array of
-    :c:type:`PyArrayObject` pointers whose values are discarded and which
-    receive the converted input arguments as well as the ufunc outputs
-    when success is returned. The user is responsible for managing this
-    array and receives a new reference for each array in *mps*. The total
-    number of arrays in *mps* is given by *self* ->nin + *self* ->nout.
+    .. deprecated:: NumPy 1.19
 
-    Returns 0 on success, -1 on error.
+        Unless NumPy is made aware of an issue with this, this function
+        is scheduled for rapid removal without replacement.
+
+    Instead of this function ``PyObject_Call(ufunc, args, kwds)`` should be
+    used. The above function differs from this because it ignores support
+    for non-array, or array subclasses as inputs.
+    To ensure identical behaviour, it may be necessary to convert all inputs
+    using ``PyArray_FromAny(obj, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL)``.
 
 .. c:function:: int PyUFunc_checkfperr(int errmask, PyObject* errobj)
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -278,8 +278,8 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      * Get either an array object we can copy from, or its parameters
      * if there isn't a convenient array available.
      */
-    if (PyArray_GetArrayParamsFromObject(src_object, PyArray_DESCR(dest),
-                0, &dtype, &ndim, dims, &src, NULL) < 0) {
+    if (PyArray_GetArrayParamsFromObject_int(src_object,
+                PyArray_DESCR(dest), 0, &dtype, &ndim, dims, &src) < 0) {
         Py_DECREF(src_object);
         return -1;
     }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -255,11 +255,11 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                             int ndim = 0;
                             npy_intp dims[NPY_MAXDIMS];
                             list = PyArray_ToList((PyArrayObject *)data_obj);
-                            result = PyArray_GetArrayParamsFromObject(
+                            result = PyArray_GetArrayParamsFromObject_int(
                                     list,
                                     retval,
                                     0, &dtype,
-                                    &ndim, dims, &arr, NULL);
+                                    &ndim, dims, &arr);
                             Py_DECREF(list);
                             Py_XDECREF(arr);
                             if (result < 0) {

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -13,6 +13,7 @@
 #include "numpy/npy_math.h"
 
 #include "common.h"
+#include "ctors.h"
 #include "scalartypes.h"
 #include "mapping.h"
 

--- a/numpy/core/src/multiarray/ctors.h
+++ b/numpy/core/src/multiarray/ctors.h
@@ -30,6 +30,14 @@ PyArray_New(
         PyTypeObject *, int nd, npy_intp const *,
         int, npy_intp const*, void *, int, int, PyObject *);
 
+NPY_NO_EXPORT int
+PyArray_GetArrayParamsFromObject_int(PyObject *op,
+         PyArray_Descr *requested_dtype,
+         npy_bool writeable,
+         PyArray_Descr **out_dtype,
+         int *out_ndim, npy_intp *out_dims,
+         PyArrayObject **out_arr);
+
 NPY_NO_EXPORT PyObject *
 PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
                 int max_depth, int flags, PyObject *context);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4996,6 +4996,16 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
 NPY_NO_EXPORT int
 PyUFunc_SetUsesArraysAsData(void **data, size_t i)
 {
+    /* NumPy 1.19, 2020-01-24 */
+    if (DEPRECATE(
+            "PyUFunc_SetUsesArraysAsData() C-API function is deprecated "
+            "and expected to be removed rapidly. If you are using it (i.e. see "
+            "this warning/error), please notify the NumPy developers. "
+            "It is currently assumed that this function is simply unused and "
+            "its removal will facilitate the implementation of better "
+            "approaches.") < 0) {
+        return -1;
+    }
     data[i] = (void*)PyUFunc_SetUsesArraysAsData;
     return 0;
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3052,17 +3052,15 @@ fail:
     return retval;
 }
 
-/*UFUNC_API
- *
+/*
  * This generic function is called with the ufunc object, the arguments to it,
  * and an array of (pointers to) PyArrayObjects which are NULL.
  *
  * 'op' is an array of at least NPY_MAXARGS PyArrayObject *.
  */
-NPY_NO_EXPORT int
-PyUFunc_GenericFunction(PyUFuncObject *ufunc,
-                        PyObject *args, PyObject *kwds,
-                        PyArrayObject **op)
+static int
+PyUFunc_GenericFunction_int(PyUFuncObject *ufunc,
+        PyObject *args, PyObject *kwds, PyArrayObject **op)
 {
     int nin, nout;
     int i, nop;
@@ -3267,6 +3265,27 @@ fail:
 
     return retval;
 }
+
+
+/*UFUNC_API*/
+NPY_NO_EXPORT int
+PyUFunc_GenericFunction(PyUFuncObject *ufunc,
+        PyObject *args, PyObject *kwds, PyArrayObject **op)
+{
+    /* NumPy 1.19, 2020-01-24 */
+    if (DEPRECATE(
+            "PyUFunc_GenericFunction() C-API function is deprecated "
+            "and expected to be removed rapidly. If you are using it (i.e. see "
+            "this warning/error), please notify the NumPy developers. "
+            "As of now it is expected that any use case is served better by "
+            "the direct use of `PyObject_Call(ufunc, args, kwargs)`. "
+            "PyUFunc_GenericFunction function has slightly different "
+            "untested behaviour.") < 0) {
+        return -1;
+    }
+    return PyUFunc_GenericFunction_int(ufunc, args, kwds, op);
+}
+
 
 /*
  * Given the output type, finds the specified binary op.  The
@@ -4683,7 +4702,7 @@ ufunc_generic_call(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         return override;
     }
 
-    errval = PyUFunc_GenericFunction(ufunc, args, kwds, mps);
+    errval = PyUFunc_GenericFunction_int(ufunc, args, kwds, mps);
     if (errval < 0) {
         return NULL;
     }


### PR DESCRIPTION
This deprecates three functions which I believe are unlikely to have any use case outside NumPy. My current hope is that we can remove these (and plausibly more) immediately after a 1.19 release and manage to put in a large hunk of dtype changes than.

The last function was not even documented, and is pretty much useless, unless _possibly_ for someone writing `datetime` ufuncs outside of NumPy.

---

I probably need to add tests for this ;), and will ping the mailing list. I will admit that none of the functions are completely unreasonable to expose, but their implementation details seem to expose unnecessary complexity at this time.