### PR TITLE
DOC: fix docstrings so `python tools/refguide-check --rst <file> runs

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -983,8 +983,8 @@ a 2D array if you give them a tuple describing the dimensions of the matrix::
          [0., 0.]])
   >>> rng.random((3, 2))
   array([[0.01652764, 0.81327024],
-           [0.91275558, 0.60663578],
-           [0.72949656, 0.54362499]])  # may vary 
+         [0.91275558, 0.60663578],
+         [0.72949656, 0.54362499]])  # may vary
 
 .. image:: images/np_ones_zeros_matrix.png
 
@@ -1076,13 +1076,13 @@ To get the unique rows, index position, and occurrence count, you can use::
   >>> unique_rows, indices, occurrence_count = np.unique(
   ...      a_2d, axis=0, return_counts=True, return_index=True)
   >>> print(unique_rows)
-    [[ 1  2  3  4]
-     [ 5  6  7  8]
-     [ 9 10 11 12]]
+  [[ 1  2  3  4]
+   [ 5  6  7  8]
+   [ 9 10 11 12]]
   >>> print(indices)
-   [0 1 2]
+  [0 1 2]
   >>> print(occurrence_count)
-   [2 1 1]
+  [2 1 1]
 
 To learn more about finding the unique elements in an array, see `unique`.
 
@@ -1174,9 +1174,9 @@ You can reverse the content in all of the rows and all of the columns with::
 
   >>> reversed_arr = np.flip(arr_2d)
   >>> print(reversed_arr)
-    [[12 11 10  9]
-     [ 8  7  6  5]
-     [ 4  3  2  1]]
+  [[12 11 10  9]
+   [ 8  7  6  5]
+   [ 4  3  2  1]]
 
 You can easily reverse only the *rows* with::
 
@@ -1190,26 +1190,26 @@ Or reverse only the *columns* with::
 
   >>> reversed_arr_columns = np.flip(arr_2d, axis=1)
   >>> print(reversed_arr_columns)
-    [[ 4  3  2  1]
-     [ 8  7  6  5]
-     [12 11 10  9]]
+  [[ 4  3  2  1]
+   [ 8  7  6  5]
+   [12 11 10  9]]
 
 You can also reverse the contents of only one column or row. For example, you
 can reverse the contents of the row at index position 1 (the second row)::
 
   >>> arr_2d[1] = np.flip(arr_2d[1])
   >>> print(arr_2d)
-    [[ 1  2  3  4]
-     [ 8  7  6  5]
-     [ 9 10 11 12]]
+  [[ 1  2  3  4]
+   [ 8  7  6  5]
+   [ 9 10 11 12]]
 
 You can also reverse the column at index position 1 (the second column)::
 
   >>> arr_2d[:,1] = np.flip(arr_2d[:,1])
   >>> print(arr_2d)
-    [[ 1 10  3  4]
-     [ 8  7  6  5]
-     [ 9  2 11 12]]
+  [[ 1 10  3  4]
+   [ 8  7  6  5]
+   [ 9  2 11 12]]
 
 Read more about reversing arrays at `flip`.
 
@@ -1310,15 +1310,14 @@ For example:
 .. code-block:: ipython
 
   In [0]: max?
-  
-  Out[0]: max(iterable, *[, default=obj, key=func]) -> value
-          max(arg1, arg2, *args, *[, key=func]) -> value
+  max(iterable, *[, default=obj, key=func]) -> value
+  max(arg1, arg2, *args, *[, key=func]) -> value
 
-          With a single iterable argument, return its biggest item. The
-          default keyword-only argument specifies an object to return if
-          the provided iterable is empty.
-          With two or more arguments, return the largest argument.
-          Type:      builtin_function_or_method
+  With a single iterable argument, return its biggest item. The
+  default keyword-only argument specifies an object to return if
+  the provided iterable is empty.
+  With two or more arguments, return the largest argument.
+  Type:      builtin_function_or_method
 
 You can even use this notation for object methods and objects themselves.
 
@@ -1332,36 +1331,35 @@ followed by the docstring of ``ndarray`` of which ``a`` is an instance):
 .. code-block:: ipython
 
   In [1]: a?
+  Type:            ndarray
+  String form:     [1 2 3 4 5 6]
+  Length:          6
+  File:            ~/anaconda3/lib/python3.7/site-packages/numpy/__init__.py
+  Docstring:       <no docstring>
+  Class docstring:
+  ndarray(shape, dtype=float, buffer=None, offset=0,
+          strides=None, order=None)
 
-  Out[1]: Type:            ndarray
-          String form:     [1 2 3 4 5 6]
-          Length:          6
-          File:            ~/anaconda3/lib/python3.7/site-packages/numpy/__init__.py
-          Docstring:       <no docstring>
-          Class docstring:
-          ndarray(shape, dtype=float, buffer=None, offset=0,
-                  strides=None, order=None)
+  An array object represents a multidimensional, homogeneous array
+  of fixed-size items.  An associated data-type object describes the
+  format of each element in the array (its byte-order, how many bytes it
+  occupies in memory, whether it is an integer, a floating point number,
+  or something else, etc.)
 
-          An array object represents a multidimensional, homogeneous array
-          of fixed-size items.  An associated data-type object describes the
-          format of each element in the array (its byte-order, how many bytes it
-          occupies in memory, whether it is an integer, a floating point number,
-          or something else, etc.)
+  Arrays should be constructed using `array`, `zeros` or `empty` (refer
+  to the See Also section below).  The parameters given here refer to
+  a low-level method (`ndarray(...)`) for instantiating an array.
 
-          Arrays should be constructed using `array`, `zeros` or `empty` (refer
-          to the See Also section below).  The parameters given here refer to
-          a low-level method (`ndarray(...)`) for instantiating an array.
+  For more information, refer to the `numpy` module and examine the
+  methods and attributes of an array.
 
-          For more information, refer to the `numpy` module and examine the
-          methods and attributes of an array.
+  Parameters
+  ----------
+  (for the __new__ method; see Notes below)
 
-          Parameters
-          ----------
-          (for the __new__ method; see Notes below)
-
-          shape : tuple of ints
-              Shape of created array.
-          ...
+  shape : tuple of ints
+          Shape of created array.
+  ...
 
 This also works for functions and other objects that **you** create. Just
 remember to include a docstring with your function using a string literal
@@ -1378,10 +1376,10 @@ You can obtain information about the function:
 .. code-block:: ipython
 
   In [2]: double?
-  Out[2]: Signature: double(a)
-          Docstring: Return a * 2
-          File:      ~/Desktop/<ipython-input-23-b5adf20be596>
-          Type:      function
+  Signature: double(a)
+  Docstring: Return a * 2
+  File:      ~/Desktop/<ipython-input-23-b5adf20be596>
+  Type:      function
 
 You can reach another level of information by reading the source code of the
 object you're interested in. Using a double question mark (``??``) allows you to
@@ -1392,13 +1390,13 @@ For example:
 .. code-block:: ipython
 
   In [3]: double??
-  Out[3]: Signature: double(a)
-          Source:
-          def double(a):
-              '''Return a * 2'''
-              return a * 2
-          File:      ~/Desktop/<ipython-input-23-b5adf20be596>
-          Type:      function
+  Signature: double(a)
+  Source:
+  def double(a):
+      '''Return a * 2'''
+      return a * 2
+  File:      ~/Desktop/<ipython-input-23-b5adf20be596>
+  Type:      function
 
 If the object in question is compiled in a language other than Python, using
 ``??`` will return the same information as ``?``. You'll find this with a lot of
@@ -1407,18 +1405,18 @@ built-in objects and types, for example:
 .. code-block:: ipython
 
   In [4]: len?
-  Out[4]: Signature: len(obj, /)
-          Docstring: Return the number of items in a container.
-          Type:      builtin_function_or_method
+  Signature: len(obj, /)
+  Docstring: Return the number of items in a container.
+  Type:      builtin_function_or_method
 
 and :
 
 .. code-block:: ipython
 
   In [5]: len??
-  Out[5]: Signature: len(obj, /)
-          Docstring: Return the number of items in a container.
-          Type:      builtin_function_or_method
+  Signature: len(obj, /)
+  Docstring: Return the number of items in a container.
+  Type:      builtin_function_or_method
 
 have the same output because they were compiled in a programming language other
 than Python.

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -966,7 +966,7 @@ All you need to do is pass in the number of elements you want it to generate::
   # the simplest way to generate random numbers
   >>> rng = np.random.default_rng(0)
   >>> rng.random(3)
-  array([0.08419554, 0.01447087, 0.88581866])  # may vary
+  array([0.08419554, 0.01447087, 0.88581866])
 
 .. image:: images/np_ones_zeros_random.png
 
@@ -1686,4 +1686,3 @@ For directions regarding installing Matplotlib, see the official
 -------------------------------------------------------
 
 *Image credits: Jay Alammar http://jalammar.github.io/*
-

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -756,7 +756,7 @@ You can, of course, do more than just addition!
   >>> data * data
   array([1, 4])
   >>> data / data
-  array([1, 1])
+  array([1., 1.])
 
 .. image:: images/np_sub_mult_divide.png
 

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -82,6 +82,7 @@ If you aren't already comfortable with reading tutorials that contain a lot of c
 you might not know how to interpret a code block that looks
 like this::
 
+  >>> a = np.arange(6)
   >>> a2 = a[np.newaxis, :]
   >>> a2.shape
   (1, 6)
@@ -233,6 +234,7 @@ fill every element afterwards! ::
 
   >>> # Create an empty array with 2 elements
   >>> np.empty(2)
+  array([1., 1.])  #may vary
 
 You can create an array with a range of elements::
 
@@ -393,7 +395,8 @@ this array to an array with three rows and two columns::
 
 With ``np.reshape``, you can specify a few optional parameters::
 
-  >>> numpy.reshape(a, newshape, order)
+  >>> numpy.reshape(a, newshape=(1,6), order='C')
+  array([[0, 1, 2, 3, 4, 5]])
 
 ``a`` is the array to be reshaped.
 
@@ -441,7 +444,7 @@ For example, if you start with this array::
 
   >>> a = np.array([1, 2, 3, 4, 5, 6])
   >>> a.shape
- (6,)
+  (6,)
 
 You can use ``np.newaxis`` to add a new axis::
 
@@ -482,7 +485,7 @@ You can add an axis at index position 0 with::
 
   >>> c = np.expand_dims(a, axis=0)
   >>> c.shape
- (1, 6)
+  (1, 6)
 
 Find more information about :ref:`newaxis here <arrays.indexing>` and
 ``expand_dims`` at `expand_dims`.
@@ -620,12 +623,12 @@ Let's say you have this array:
 
 ::
 
-  array([1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
+  >>> a = array([1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
 
 You can create a new array from a section of your array any time by specifying
 where you want to slice your array. ::
 
-  >>> arr1 = np.array[3:8]
+  >>> arr1 = a[3:8]
   >>> arr1
   array([4, 5, 6, 7, 8])
 
@@ -677,7 +680,7 @@ run::
 
 If you wanted to split your array after the third and fourth column, you'd run::
 
-  >>> np.hsplit(array,(3, 4))
+  >>> np.hsplit(x, (3, 4))
   [array([[1, 2, 3],
           [13, 14, 15]]), array([[ 4],
           [16]]), array([[ 5, 6, 7, 8, 9, 10, 11, 12],
@@ -737,7 +740,10 @@ You can add the arrays together with the plus sign.
 
 ::
 
-  data + ones
+  >>> data = np.array([1, 2])
+  >>> ones = np.ones(2)
+  >>> data + ones
+  array([2., 3.])
 
 .. image:: images/np_data_plus_ones.png
 
@@ -745,9 +751,12 @@ You can, of course, do more than just addition!
 
 ::
 
-  data - ones
-  data * data
-  data / data
+  >>> data - ones
+  array([0, 1])
+  >>> data * data
+  array([1, 4])
+  >>> data / data
+  array([1.0, 1.0])
 
 .. image:: images/np_sub_mult_divide.png
 
@@ -788,7 +797,9 @@ or between arrays of two different sizes. For example, your array (we'll call it
 "data") might contain information about distance in miles but you want to
 convert the information to kilometers. You can perform this operation with::
 
+  >>> data = np.array([1.0, 2.0])
   >>> data * 1.6
+  array([1.6, 3.2])
 
 .. image:: images/np_multiply_broadcasting.png
 
@@ -815,8 +826,11 @@ result of multiplying the elements together, ``std`` to get the standard
 deviation, and more. ::
 
   >>> data.max()
+  2.0
   >>> data.min()
+  1.0
   >>> data.sum()
+  3.0
 
 .. image:: images/np_aggregation.png
 
@@ -857,23 +871,32 @@ Creating matrices
 You can pass Python lists of lists to create a 2-D array (or "matrix") to
 represent them in NumPy. ::
 
-  >>> np.array([[1, 2], [3, 4]])
+  >>> data = np.array([[1, 2], [3, 4]])
+  >>> data
+  array([[1, 2],
+           [3, 4]])
 
 .. image:: images/np_create_matrix.png
 
 Indexing and slicing operations are useful when you're manipulating matrices::
 
   >>> data[0, 1]
-  >>> data[1 : 3]
-  >>> data[0 : 2, 0]
+  2
+  >>> data[1:3]
+  array([[3, 4]])
+  >>> data[0:2, 0]
+  array([1, 3])
 
 .. image:: images/np_matrix_indexing.png
 
 You can aggregate matrices the same way you aggregated vectors::
 
   >>> data.max()
+  4
   >>> data.min()
+  1
   >>> data.sum()
+  10
 
 .. image:: images/np_matrix_aggregation.png
 
@@ -881,14 +904,20 @@ You can aggregate all the values in a matrix and you can aggregate them across
 columns or rows using the ``axis`` parameter::
 
   >>> data.max(axis=0)
+  array([3, 4])
   >>> data.max(axis=1)
+  array([2, 4])
 
 .. image:: images/np_matrix_aggregation_row.png
 
 Once you've created your matrices, you can add and multiply them using
 arithmetic operators if you have two matrices that are the same size. ::
 
+  >>> data = np.array([[1, 2], [3, 4]])
+  >>> ones = np.array([[1, 1], [1, 1]])
   >>> data + ones
+  array([[2, 3],
+           [4, 5]])
 
 .. image:: images/np_matrix_arithmetic.png
 
@@ -896,29 +925,31 @@ You can do these arithmetic operations on matrices of different sizes, but only
 if one matrix has only one column or one row. In this case, NumPy will use its
 broadcast rules for the operation. ::
 
+  >>> data = np.array([[1, 2], [3, 4], [5, 6]])
+  >>> ones_row = np.array([[1, 1]])
   >>> data + ones_row
+  array([[2, 3],
+           [4, 5],
+           [6, 7]])
 
 .. image:: images/np_matrix_broadcasting.png
 
 Be aware that when NumPy prints N-dimensional arrays, the last axis is looped
-over the fastest while the first axis is the slowest. That means that::
+over the fastest while the first axis is the slowest. For instance::
 
   >>> np.ones((4, 3, 2))
-
-Will print out like this::
-
   array([[[1., 1.],
           [1., 1.],
           [1., 1.]],
-
+  <BLANKLINE>
          [[1., 1.],
           [1., 1.],
           [1., 1.]],
-
+  <BLANKLINE>
          [[1., 1.],
           [1., 1.],
           [1., 1.]],
-
+  <BLANKLINE>
          [[1., 1.],
           [1., 1.],
           [1., 1.]]])
@@ -929,8 +960,12 @@ array. NumPy offers functions like ``ones()`` and ``zeros()``, and the
 All you need to do is pass in the number of elements you want it to generate::
 
   >>> np.ones(3)
+  array([1., 1., 1.])
   >>> np.zeros(3)
-  >>> np.random.random(3)  # the simplest way to generate random numbers
+  array([0., 0., 0.])
+  # the simplest way to generate random numbers
+  >>> np.random.default_rng().random(3)
+  array([0.08419554, 0.01447087, 0.88581866])  # may vary
 
 .. image:: images/np_ones_zeros_random.png
 
@@ -938,9 +973,17 @@ You can also use ``ones()``, ``zeros()``, and ``random()`` to create
 an array if you give them a tuple describing the dimensions of the matrix::
 
   >>> np.ones((3, 2))
+  array([[1., 1.],
+           [1., 1.],
+           [1., 1.]])
   >>> np.zeros((3, 2))
-  >>> rng = np.random.default_rng()  # the better way to generate random numbers
+  array([[0., 0.],
+           [0., 0.],
+           [0., 0.]])
+  # a way to create repeatable series of random numbers
+  >>> rng = np.random.default_rng(0)
   >>> rng.random()
+  0.6369616873214543
 
 .. image:: images/np_ones_zeros_matrix.png
 
@@ -964,8 +1007,8 @@ that this is inclusive with NumPy) to high (exclusive). You can set
 You can generate a 2 x 4 array of random integers between 0 and 4 with::
 
   >>> rng.integers(5, size=(2, 4))
-  array([[4, 0, 2, 1],
-         [3, 2, 2, 0]])
+  array([[2, 1, 1, 0],
+           [0, 0, 0, 4]])
 
 :ref:`Read more about random number generation here <numpyrandom>`.
 
@@ -994,7 +1037,7 @@ positions of unique values in the array), just pass the ``return_index``
 argument in ``np.unique()`` as well as your array. ::
 
   >>> indices_list = np.unique(a, return_index=True)
-  >>> print(indices_list)
+  >>> print(indices_list[1])
   [ 0  2  3  4  5  6  7 12 13 14]
 
 You can pass the ``return_counts`` argument in ``np.unique()`` along with your
@@ -1029,17 +1072,17 @@ argument. To find the unique rows, specify ``axis=0`` and for columns, specify
 
 To get the unique rows, index position, and occurrence count, you can use::
 
-  >>> unique_rows, indices, occurence_count = np.unique(a_2d, axis=0,
-  >>> return_counts=True, return_index=True)
+  >>> unique_rows, indices, occurrence_count = np.unique(a_2d, axis=0,
+  ...                           return_counts=True, return_index=True)
   >>> print('Unique Rows: ', '\n', unique_rows)
-  >>> print('Indices: ', '\n', indices)
-  >>> print('Occurrence Count:', '\n', occurence_count)
   Unique Rows:
     [[ 1  2  3  4]
      [ 5  6  7  8]
      [ 9 10 11 12]]
+  >>> print('Indices: ', '\n', indices)
   Indices:
     [0 1 2]
+  >>> print('Occurrence Count:', '\n', occurrence_count)
   Occurrence Count:
     [2 1 1]
 
@@ -1064,7 +1107,12 @@ different from your dataset. This is where the ``reshape`` method can be useful.
 You simply need to pass in the new dimensions that you want for the matrix. ::
 
   >>> data.reshape(2, 3)
+  array([[1, 2, 3],
+           [4, 5, 6]])
   >>> data.reshape(3, 2)
+  array([[1, 2],
+           [3, 4],
+           [5, 6]])
 
 .. image:: images/np_reshape.png
 
@@ -1128,8 +1176,7 @@ You can reverse the content in all of the rows and all of the columns with::
 
   >>> reversed_arr = np.flip(arr_2d)
 
-  >>> print('Reversed Array: ')
-  >>> print(reversed_arr)
+  >>> print('Reversed Array: \n', reversed_arr)
   Reversed Array:
     [[12 11 10  9]
      [ 8  7  6  5]
@@ -1139,8 +1186,7 @@ You can easily reverse only the *rows* with::
 
   >>> reversed_arr_rows = np.flip(arr_2d, axis=0)
 
-  >>> print('Reversed Array: ')
-  >>> print(reversed_arr_rows)
+  >>> print('Reversed Array: \n', reversed_arr_rows)
   Reversed Array:
   [[ 9 10 11 12]
    [ 5  6  7  8]
@@ -1150,8 +1196,8 @@ Or reverse only the *columns* with::
 
   >>> reversed_arr_columns = np.flip(arr_2d, axis=1)
 
-  >>> print('Reversed Array columns: ')
-  >>> print(reversed_arr_columns)
+  >>> print('Reversed Array columns: \n', reversed_arr_columns)
+  Reversed Array columns:
     [[ 4  3  2  1]
      [ 8  7  6  5]
      [12 11 10  9]]
@@ -1161,22 +1207,20 @@ can reverse the contents of the row at index position 1 (the second row)::
 
   >>> arr_2d[1] = np.flip(arr_2d[1])
 
-  >>> print('Reversed Array: ')
-  >>> print(arr_2d)
+  >>> print('Reversed Array: \n', arr_2d)
   Reversed Array:
     [[ 1  2  3  4]
-     [ 5  6  7  8]
+     [ 8  7  6  5]
      [ 9 10 11 12]]
 
 You can also reverse the column at index position 1 (the second column)::
 
   >>> arr_2d[:,1] = np.flip(arr_2d[:,1])
 
-  >>> print('Reversed Array: ')
-  >>> print(arr_2d)
+  >>> print('Reversed Array: \n', arr_2d)
   Reversed Array:
     [[ 1 10  3  4]
-     [ 5  6  7  8]
+     [ 8  7  6  5]
      [ 9  2 11 12]]
 
 Read more about reversing arrays at `flip`.
@@ -1251,21 +1295,21 @@ function that can help you access this information. This means that nearly any
 time you need more information, you can use ``help()`` to quickly find the
 information that you need.
 
-For example, ::
+For example::
 
   >>> help(max)
-
-Will return::
-
   Help on built-in function max in module builtins:
+  <BLANKLINE>
+  max(...)
+      max(iterable, *[, default=obj, key=func]) -> value
+      max(arg1, arg2, *args, *[, key=func]) -> value
+  <BLANKLINE>
+      With a single iterable argument, return its biggest item. The
+      default keyword-only argument specifies an object to return if
+      the provided iterable is empty.
+      With two or more arguments, return the largest argument.
+  <BLANKLINE>
 
-  max(...) max(iterable, *[, default=obj, key=func]) -> value max(arg1, arg2,
-  *args, *[, key=func]) -> value
-
-      With a single iterable argument, return its biggest item. The default
-      keyword-only argument specifies an object to return if the provided
-      iterable is empty. With two or more arguments, return the largest
-      argument.
 
 Because access to additional information is so useful, IPython uses the ``?``
 character as a shorthand for accessing this documentation along with other
@@ -1273,21 +1317,20 @@ relevant information. IPython is a command shell for interactive computing in
 multiple languages.
 `You can find more information about IPython here <https://ipython.org/>`_.
 
-For example, ::
+For example:
 
-  >>> max?
+.. code-block:: ipython
 
-Will return::
+  In [0]: max?
+  
+  Out[0]: max(iterable, *[, default=obj, key=func]) -> value
+          max(arg1, arg2, *args, *[, key=func]) -> value
 
-  Docstring:
-  max(iterable, *[, default=obj, key=func]) -> value
-  max(arg1, arg2, *args, *[, key=func]) -> value
-
-  With a single iterable argument, return its biggest item. The
-  default keyword-only argument specifies an object to return if
-  the provided iterable is empty.
-  With two or more arguments, return the largest argument.
-  Type:      builtin_function_or_method
+          With a single iterable argument, return its biggest item. The
+          default keyword-only argument specifies an object to return if
+          the provided iterable is empty.
+          With two or more arguments, return the largest argument.
+          Type:      builtin_function_or_method
 
 You can even use this notation for object methods and objects themselves.
 
@@ -1295,42 +1338,42 @@ Let's say you create this array::
 
   >>> a = np.array([1, 2, 3, 4, 5, 6])
 
-Running ::
+Then you can obtain a lot of useful information (first details about ``a`` itself,
+followed by the docstring of ``ndarray`` of which ``a`` is an instance):
 
-  >>> a?
+.. code-block:: ipython
 
-Will return a lot of useful information (first details about ``a`` itself,
-followed by the docstring of ``ndarray`` of which ``a`` is an instance)::
+  In [1]: a?
 
-  Type:            ndarray
-  String form:     [1 2 3 4 5 6]
-  Length:          6
-  File:            ~/anaconda3/lib/python3.7/site-packages/numpy/__init__.py
-  Docstring:       <no docstring>
-  Class docstring:
-  ndarray(shape, dtype=float, buffer=None, offset=0,
-          strides=None, order=None)
+  Out[1]: Type:            ndarray
+          String form:     [1 2 3 4 5 6]
+          Length:          6
+          File:            ~/anaconda3/lib/python3.7/site-packages/numpy/__init__.py
+          Docstring:       <no docstring>
+          Class docstring:
+          ndarray(shape, dtype=float, buffer=None, offset=0,
+                  strides=None, order=None)
 
-  An array object represents a multidimensional, homogeneous array
-  of fixed-size items.  An associated data-type object describes the
-  format of each element in the array (its byte-order, how many bytes it
-  occupies in memory, whether it is an integer, a floating point number,
-  or something else, etc.)
+          An array object represents a multidimensional, homogeneous array
+          of fixed-size items.  An associated data-type object describes the
+          format of each element in the array (its byte-order, how many bytes it
+          occupies in memory, whether it is an integer, a floating point number,
+          or something else, etc.)
 
-  Arrays should be constructed using `array`, `zeros` or `empty` (refer
-  to the See Also section below).  The parameters given here refer to
-  a low-level method (`ndarray(...)`) for instantiating an array.
+          Arrays should be constructed using `array`, `zeros` or `empty` (refer
+          to the See Also section below).  The parameters given here refer to
+          a low-level method (`ndarray(...)`) for instantiating an array.
 
-  For more information, refer to the `numpy` module and examine the
-  methods and attributes of an array.
+          For more information, refer to the `numpy` module and examine the
+          methods and attributes of an array.
 
-  Parameters
-  ----------
-  (for the __new__ method; see Notes below)
+          Parameters
+          ----------
+          (for the __new__ method; see Notes below)
 
-  shape : tuple of ints
-      Shape of created array.
-  ...
+          shape : tuple of ints
+              Shape of created array.
+          ...
 
 This also works for functions and other objects that **you** create. Just
 remember to include a docstring with your function using a string literal
@@ -1339,52 +1382,54 @@ remember to include a docstring with your function using a string literal
 For example, if you create this function::
 
   >>> def double(a):
-  >>>   '''Return a * 2'''
-  >>>   return a * 2
+  ...   '''Return a * 2'''
+  ...   return a * 2
 
-You can run::
+You can obtain information about the function:
 
-  >>> double?
+.. code-block:: ipython
 
-Which will return::
-
-  Signature: double(a)
-  Docstring: Return a * 2
-  File:      ~/Desktop/<ipython-input-23-b5adf20be596>
-  Type:      function
+  In [2]: double?
+  Out[2]: Signature: double(a)
+          Docstring: Return a * 2
+          File:      ~/Desktop/<ipython-input-23-b5adf20be596>
+          Type:      function
 
 You can reach another level of information by reading the source code of the
 object you're interested in. Using a double question mark (``??``) allows you to
 access the source code.
 
-For example, running::
+For example:
 
-  >>> double??
+.. code-block:: ipython
 
-Will return ::
-
-  Signature: double(a)
-  Source:    def double(a):
-                '''Return a * 2'''
-                return a * 2
-  File:      ~/Desktop/<ipython-input-23-b5adf20be596>
-  Type:      function
+  In [3]: double??
+  Out[3]: Signature: double(a)
+          Source:    def double(a):
+                        '''Return a * 2'''
+                        return a * 2
+          File:      ~/Desktop/<ipython-input-23-b5adf20be596>
+          Type:      function
 
 If the object in question is compiled in a language other than Python, using
 ``??`` will return the same information as ``?``. You'll find this with a lot of
-built-in objects and types, for example::
+built-in objects and types, for example:
 
-  >>> len?
-  Signature: len(obj, /)
-  Docstring: Return the number of items in a container.
-  Type:      builtin_function_or_method
+.. code-block:: ipython
 
-and ::
+  In [4]: len?
+  Out[4]: Signature: len(obj, /)
+          Docstring: Return the number of items in a container.
+          Type:      builtin_function_or_method
 
-  >>> len??
-  Signature: len(obj, /)
-  Docstring: Return the number of items in a container.
-  Type:      builtin_function_or_method
+and :
+
+.. code-block:: ipython
+
+  In [5]: len??
+  Out[5]: Signature: len(obj, /)
+          Docstring: Return the number of items in a container.
+          Type:      builtin_function_or_method
 
 have the same output because they were compiled in a programming language other
 than Python.
@@ -1498,6 +1543,17 @@ Learn more about :ref:`input and output routines here <routines.io>`.
 Importing and exporting a CSV
 -----------------------------
 
+.. save a csv
+   
+   >>> with open('music.csv', 'w') as fid:
+   ...     n = fid.write('Artist,Genre,Listeners,Plays\n')
+   ...     n = fid.write('Billie Holiday,Jazz,1300000,27000000\n')
+   ...     n = fid.write('Jimmie Hendrix,Rock,2700000,70000000\n')
+   ...     n = fid.write('Miles Davis,Jazz,1500000,48000000\n')
+   ...     n = fid.write('SIA,Pop,2000000,74000000\n')
+   
+
+
 It's simple to read in a CSV that contains existing information. The best and
 easiest way to do this is to use
 `Pandas <https://pandas.pydata.org/getpandas.html>`_. ::
@@ -1505,10 +1561,20 @@ easiest way to do this is to use
   >>> import pandas as pd
 
   >>> # If all of your columns are the same type:
-  >>> x = pd.read_csv('music.csv').values
+  >>> x = pd.read_csv('music.csv', header=0).values
+  >>> print(x)
+  [['Billie Holiday' 'Jazz' 1300000 27000000]
+     ['Jimmie Hendrix' 'Rock' 2700000 70000000]
+     ['Miles Davis' 'Jazz' 1500000 48000000]
+     ['SIA' 'Pop' 2000000 74000000]]
 
   >>> # You can also simply select the columns you need:
-  >>> x = pd.read_csv('music.csv', columns=['float_colname_1', ...]).values
+  >>> x = pd.read_csv('music.csv', usecols=['Artist', 'Plays']).values
+  >>> print(x)
+  [['Billie Holiday' 27000000]
+     ['Jimmie Hendrix' 70000000]
+     ['Miles Davis' 48000000]
+     ['SIA' 74000000]]
 
 .. image:: images/np_pandas.png
 
@@ -1518,20 +1584,15 @@ array and then write the data frame to a CSV file with Pandas.
 
 If you created this array "a" ::
 
-  [[-2.58289208,  0.43014843, -1.24082018, 1.59572603],
-   [ 0.99027828, 1.17150989,  0.94125714, -0.14692469],
-   [ 0.76989341,  0.81299683, -0.95068423, 0.11769564],
-   [ 0.20484034,  0.34784527,  1.96979195, 0.51992837]]
+  >>> a = np.array([[-2.58289208,  0.43014843, -1.24082018, 1.59572603],
+  ...               [ 0.99027828, 1.17150989,  0.94125714, -0.14692469],
+  ...               [ 0.76989341,  0.81299683, -0.95068423, 0.11769564],
+  ...               [ 0.20484034,  0.34784527,  1.96979195, 0.51992837]])
 
 You could create a Pandas dataframe ::
 
   >>> df = pd.DataFrame(a)
   >>> print(df)
-
-**Output:**
-
-::
-
             0         1         2         3
   0 -2.582892  0.430148 -1.240820  1.595726
   1  0.990278  1.171510  0.941257 -0.146925
@@ -1544,7 +1605,7 @@ You can easily save your dataframe with::
 
 And read your CSV with::
 
-  >>> pd.read_csv('pd.csv')
+  >>> data = pd.read_csv('pd.csv')
 
 .. image:: images/np_readcsv.png
 
@@ -1555,7 +1616,7 @@ You can also save your array with the NumPy ``savetxt`` method. ::
 If you're using the command line, you can read your saved CSV any time with a
 command such as::
 
-  >>> cat np.csv
+  $cat np.csv
   #  1,  2,  3,  4
   -2.58,0.43,-1.24,1.60
   0.99,1.17,0.94,-0.15
@@ -1584,15 +1645,17 @@ If you already have Matplotlib installed, you can import it with::
 
   >>> import matplotlib.pyplot as plt
 
-  >>> # If you're using Jupyter Notebook, you may also want to run the following
-  >>> line of code to display your code in the notebook:
+  # If you're using Jupyter Notebook, you may also want to run the following
+  # line of code to display your code in the notebook:
 
-  >>> %matplotlib inline
+  %matplotlib inline
 
 All you need to do to plot your values is run::
 
   >>> plt.plot(a)
-  >>> plt.show()
+
+  # If you are running from a command line, you may need to do this:
+  # >>> plt.show()
 
 .. plot:: user/plots/matplotlib1.py
    :align: center

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -234,7 +234,7 @@ fill every element afterwards! ::
 
   >>> # Create an empty array with 2 elements
   >>> np.empty(2)
-  array([1., 1.])  #may vary
+  array([3.14, 42.0])  # may vary
 
 You can create an array with a range of elements::
 
@@ -395,7 +395,7 @@ this array to an array with three rows and two columns::
 
 With ``np.reshape``, you can specify a few optional parameters::
 
-  >>> numpy.reshape(a, newshape=(1,6), order='C')
+  >>> numpy.reshape(a, newshape=(1, 6), order='C')
   array([[0, 1, 2, 3, 4, 5]])
 
 ``a`` is the array to be reshaped.
@@ -623,7 +623,7 @@ Let's say you have this array:
 
 ::
 
-  >>> a = array([1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
+  >>> a = np.array([1,  2,  3,  4,  5,  6,  7,  8,  9, 10])
 
 You can create a new array from a section of your array any time by specifying
 where you want to slice your array. ::
@@ -752,11 +752,11 @@ You can, of course, do more than just addition!
 ::
 
   >>> data - ones
-  array([0, 1])
+  array([0., 1.])
   >>> data * data
   array([1, 4])
   >>> data / data
-  array([1.0, 1.0])
+  array([1., 1.])
 
 .. image:: images/np_sub_mult_divide.png
 
@@ -874,7 +874,7 @@ represent them in NumPy. ::
   >>> data = np.array([[1, 2], [3, 4]])
   >>> data
   array([[1, 2],
-           [3, 4]])
+         [3, 4]])
 
 .. image:: images/np_create_matrix.png
 
@@ -917,7 +917,7 @@ arithmetic operators if you have two matrices that are the same size. ::
   >>> ones = np.array([[1, 1], [1, 1]])
   >>> data + ones
   array([[2, 3],
-           [4, 5]])
+         [4, 5]])
 
 .. image:: images/np_matrix_arithmetic.png
 
@@ -929,8 +929,8 @@ broadcast rules for the operation. ::
   >>> ones_row = np.array([[1, 1]])
   >>> data + ones_row
   array([[2, 3],
-           [4, 5],
-           [6, 7]])
+         [4, 5],
+         [6, 7]])
 
 .. image:: images/np_matrix_broadcasting.png
 
@@ -974,12 +974,12 @@ an array if you give them a tuple describing the dimensions of the matrix::
 
   >>> np.ones((3, 2))
   array([[1., 1.],
-           [1., 1.],
-           [1., 1.]])
+         [1., 1.],
+         [1., 1.]])
   >>> np.zeros((3, 2))
   array([[0., 0.],
-           [0., 0.],
-           [0., 0.]])
+         [0., 0.],
+         [0., 0.]])
   # a way to create repeatable series of random numbers
   >>> rng = np.random.default_rng(0)
   >>> rng.random()
@@ -1008,7 +1008,7 @@ You can generate a 2 x 4 array of random integers between 0 and 4 with::
 
   >>> rng.integers(5, size=(2, 4))
   array([[2, 1, 1, 0],
-           [0, 0, 0, 4]])
+         [0, 0, 0, 4]])
 
 :ref:`Read more about random number generation here <numpyrandom>`.
 
@@ -1036,8 +1036,8 @@ To get the indices of unique values in a NumPy array (an array of first index
 positions of unique values in the array), just pass the ``return_index``
 argument in ``np.unique()`` as well as your array. ::
 
-  >>> indices_list = np.unique(a, return_index=True)
-  >>> print(indices_list[1])
+  >>> unique_values, indices_list = np.unique(a, return_index=True)
+  >>> print(indices_list)
   [ 0  2  3  4  5  6  7 12 13 14]
 
 You can pass the ``return_counts`` argument in ``np.unique()`` along with your
@@ -1081,10 +1081,10 @@ To get the unique rows, index position, and occurrence count, you can use::
      [ 9 10 11 12]]
   >>> print('Indices: ', '\n', indices)
   Indices:
-    [0 1 2]
+   [0 1 2]
   >>> print('Occurrence Count:', '\n', occurrence_count)
   Occurrence Count:
-    [2 1 1]
+   [2 1 1]
 
 To learn more about finding the unique elements in an array, see `unique`.
 
@@ -1108,11 +1108,11 @@ You simply need to pass in the new dimensions that you want for the matrix. ::
 
   >>> data.reshape(2, 3)
   array([[1, 2, 3],
-           [4, 5, 6]])
+         [4, 5, 6]])
   >>> data.reshape(3, 2)
   array([[1, 2],
-           [3, 4],
-           [5, 6]])
+         [3, 4],
+         [5, 6]])
 
 .. image:: images/np_reshape.png
 
@@ -1405,9 +1405,10 @@ For example:
 
   In [3]: double??
   Out[3]: Signature: double(a)
-          Source:    def double(a):
-                        '''Return a * 2'''
-                        return a * 2
+          Source:
+          def double(a):
+              '''Return a * 2'''
+              return a * 2
           File:      ~/Desktop/<ipython-input-23-b5adf20be596>
           Type:      function
 
@@ -1616,7 +1617,7 @@ You can also save your array with the NumPy ``savetxt`` method. ::
 If you're using the command line, you can read your saved CSV any time with a
 command such as::
 
-  $cat np.csv
+  $ cat np.csv
   #  1,  2,  3,  4
   -2.58,0.43,-1.24,1.60
   0.99,1.17,0.94,-0.15

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -234,7 +234,7 @@ fill every element afterwards! ::
 
   >>> # Create an empty array with 2 elements
   >>> np.empty(2)
-  array([3.14, 42.0])  # may vary
+  array([ 3.14, 42.  ])  # may vary
 
 You can create an array with a range of elements::
 

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -741,9 +741,9 @@ You can add the arrays together with the plus sign.
 ::
 
   >>> data = np.array([1, 2])
-  >>> ones = np.ones(2)
+  >>> ones = np.ones(2, dtype=int)
   >>> data + ones
-  array([2., 3.])
+  array([2, 3])
 
 .. image:: images/np_data_plus_ones.png
 
@@ -752,11 +752,11 @@ You can, of course, do more than just addition!
 ::
 
   >>> data - ones
-  array([0., 1.])
+  array([0, 1])
   >>> data * data
   array([1, 4])
   >>> data / data
-  array([1., 1.])
+  array([1, 1])
 
 .. image:: images/np_sub_mult_divide.png
 
@@ -964,13 +964,14 @@ All you need to do is pass in the number of elements you want it to generate::
   >>> np.zeros(3)
   array([0., 0., 0.])
   # the simplest way to generate random numbers
-  >>> np.random.default_rng().random(3)
+  >>> rng = np.random.default_rng(0)
+  >>> rng.random(3)
   array([0.08419554, 0.01447087, 0.88581866])  # may vary
 
 .. image:: images/np_ones_zeros_random.png
 
 You can also use ``ones()``, ``zeros()``, and ``random()`` to create
-an array if you give them a tuple describing the dimensions of the matrix::
+a 2D array if you give them a tuple describing the dimensions of the matrix::
 
   >>> np.ones((3, 2))
   array([[1., 1.],
@@ -980,10 +981,10 @@ an array if you give them a tuple describing the dimensions of the matrix::
   array([[0., 0.],
          [0., 0.],
          [0., 0.]])
-  # a way to create repeatable series of random numbers
-  >>> rng = np.random.default_rng(0)
-  >>> rng.random()
-  0.6369616873214543
+  >>> rng.random((3, 2))
+  array([[0.01652764, 0.81327024],
+           [0.91275558, 0.60663578],
+           [0.72949656, 0.54362499]])  # may vary 
 
 .. image:: images/np_ones_zeros_matrix.png
 
@@ -1008,7 +1009,7 @@ You can generate a 2 x 4 array of random integers between 0 and 4 with::
 
   >>> rng.integers(5, size=(2, 4))
   array([[2, 1, 1, 0],
-         [0, 0, 0, 4]])
+         [0, 0, 0, 4]])  # may vary
 
 :ref:`Read more about random number generation here <numpyrandom>`.
 
@@ -1072,18 +1073,15 @@ argument. To find the unique rows, specify ``axis=0`` and for columns, specify
 
 To get the unique rows, index position, and occurrence count, you can use::
 
-  >>> unique_rows, indices, occurrence_count = np.unique(a_2d, axis=0,
-  ...                           return_counts=True, return_index=True)
-  >>> print('Unique Rows: ', '\n', unique_rows)
-  Unique Rows:
+  >>> unique_rows, indices, occurrence_count = np.unique(
+  ...      a_2d, axis=0, return_counts=True, return_index=True)
+  >>> print(unique_rows)
     [[ 1  2  3  4]
      [ 5  6  7  8]
      [ 9 10 11 12]]
-  >>> print('Indices: ', '\n', indices)
-  Indices:
+  >>> print(indices)
    [0 1 2]
-  >>> print('Occurrence Count:', '\n', occurrence_count)
-  Occurrence Count:
+  >>> print(occurrence_count)
    [2 1 1]
 
 To learn more about finding the unique elements in an array, see `unique`.
@@ -1175,9 +1173,7 @@ If you start with this array::
 You can reverse the content in all of the rows and all of the columns with::
 
   >>> reversed_arr = np.flip(arr_2d)
-
-  >>> print('Reversed Array: \n', reversed_arr)
-  Reversed Array:
+  >>> print(reversed_arr)
     [[12 11 10  9]
      [ 8  7  6  5]
      [ 4  3  2  1]]
@@ -1185,9 +1181,7 @@ You can reverse the content in all of the rows and all of the columns with::
 You can easily reverse only the *rows* with::
 
   >>> reversed_arr_rows = np.flip(arr_2d, axis=0)
-
-  >>> print('Reversed Array: \n', reversed_arr_rows)
-  Reversed Array:
+  >>> print(reversed_arr_rows)
   [[ 9 10 11 12]
    [ 5  6  7  8]
    [ 1  2  3  4]]
@@ -1195,9 +1189,7 @@ You can easily reverse only the *rows* with::
 Or reverse only the *columns* with::
 
   >>> reversed_arr_columns = np.flip(arr_2d, axis=1)
-
-  >>> print('Reversed Array columns: \n', reversed_arr_columns)
-  Reversed Array columns:
+  >>> print(reversed_arr_columns)
     [[ 4  3  2  1]
      [ 8  7  6  5]
      [12 11 10  9]]
@@ -1206,9 +1198,7 @@ You can also reverse the contents of only one column or row. For example, you
 can reverse the contents of the row at index position 1 (the second row)::
 
   >>> arr_2d[1] = np.flip(arr_2d[1])
-
-  >>> print('Reversed Array: \n', arr_2d)
-  Reversed Array:
+  >>> print(arr_2d)
     [[ 1  2  3  4]
      [ 8  7  6  5]
      [ 9 10 11 12]]
@@ -1216,9 +1206,7 @@ can reverse the contents of the row at index position 1 (the second row)::
 You can also reverse the column at index position 1 (the second column)::
 
   >>> arr_2d[:,1] = np.flip(arr_2d[:,1])
-
-  >>> print('Reversed Array: \n', arr_2d)
-  Reversed Array:
+  >>> print(arr_2d)
     [[ 1 10  3  4]
      [ 8  7  6  5]
      [ 9  2 11 12]]
@@ -1565,17 +1553,17 @@ easiest way to do this is to use
   >>> x = pd.read_csv('music.csv', header=0).values
   >>> print(x)
   [['Billie Holiday' 'Jazz' 1300000 27000000]
-     ['Jimmie Hendrix' 'Rock' 2700000 70000000]
-     ['Miles Davis' 'Jazz' 1500000 48000000]
-     ['SIA' 'Pop' 2000000 74000000]]
+   ['Jimmie Hendrix' 'Rock' 2700000 70000000]
+   ['Miles Davis' 'Jazz' 1500000 48000000]
+   ['SIA' 'Pop' 2000000 74000000]]
 
   >>> # You can also simply select the columns you need:
   >>> x = pd.read_csv('music.csv', usecols=['Artist', 'Plays']).values
   >>> print(x)
   [['Billie Holiday' 27000000]
-     ['Jimmie Hendrix' 70000000]
-     ['Miles Davis' 48000000]
-     ['SIA' 74000000]]
+   ['Jimmie Hendrix' 70000000]
+   ['Miles Davis' 48000000]
+   ['SIA' 74000000]]
 
 .. image:: images/np_pandas.png
 

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -6,8 +6,9 @@ Quickstart tutorial
 
 .. testsetup::
 
-   import numpy as np
-   np.random.seed(1)
+   >>> import numpy as np
+   >>> import sys
+   >>> rg = np.random.default_rng(1)
 
 Prerequisites
 =============
@@ -91,12 +92,12 @@ An example
     >>> a.size
     15
     >>> type(a)
-    <type 'numpy.ndarray'>
+    <class 'numpy.ndarray'>
     >>> b = np.array([6, 7, 8])
     >>> b
     array([6, 7, 8])
     >>> type(b)
-    <type 'numpy.ndarray'>
+    <class 'numpy.ndarray'>
 
 .. _quickstart.array-creation:
 
@@ -127,6 +128,9 @@ rather than providing a single sequence as an argument.
 ::
 
     >>> a = np.array(1,2,3,4)    # WRONG
+    Traceback (most recent call last):
+    ...
+    ValueError: only 2 non-keyword arguments accepted
     >>> a = np.array([1,2,3,4])  # RIGHT
 
 ``array`` transforms sequences of sequences into two-dimensional arrays,
@@ -167,18 +171,19 @@ state of the memory. By default, the dtype of the created array is
            [ 0.,  0.,  0.,  0.],
            [ 0.,  0.,  0.,  0.]])
     >>> np.ones( (2,3,4), dtype=np.int16 )                # dtype can also be specified
-    array([[[ 1, 1, 1, 1],
-            [ 1, 1, 1, 1],
-            [ 1, 1, 1, 1]],
-           [[ 1, 1, 1, 1],
-            [ 1, 1, 1, 1],
-            [ 1, 1, 1, 1]]], dtype=int16)
-    >>> np.empty( (2,3) )                                 # uninitialized, output may vary
-    array([[  3.73603959e-262,   6.02658058e-154,   6.55490914e-260],
+    array([[[1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1]],
+    <BLANKLINE>
+           [[1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1]]], dtype=int16)
+    >>> np.empty( (2,3) )                                 # uninitialized
+    array([[  3.73603959e-262,   6.02658058e-154,   6.55490914e-260],  # may vary
            [  5.30498948e-313,   3.14673309e-307,   1.00000000e+000]])
 
 To create sequences of numbers, NumPy provides the ``arange`` function
-which is analogous to the Python built-in ``range``, but returns an 
+which is analogous to the Python built-in ``range``, but returns an
 array.
 
 ::
@@ -210,8 +215,8 @@ of elements that we want, instead of the step::
     `empty_like`,
     `arange`,
     `linspace`,
-    `numpy.random.RandomState.rand`,
-    `numpy.random.RandomState.randn`,
+    `numpy.random.Generator.rand`,
+    `numpy.random.Generator.randn`,
     `fromfunction`,
     `fromfile`
 
@@ -258,16 +263,16 @@ If an array is too large to be printed, NumPy automatically skips the
 central part of the array and only prints the corners::
 
     >>> print(np.arange(10000))
-    [   0    1    2 ..., 9997 9998 9999]
+    [   0    1    2 ... 9997 9998 9999]
     >>>
     >>> print(np.arange(10000).reshape(100,100))
-    [[   0    1    2 ...,   97   98   99]
-     [ 100  101  102 ...,  197  198  199]
-     [ 200  201  202 ...,  297  298  299]
-     ...,
-     [9700 9701 9702 ..., 9797 9798 9799]
-     [9800 9801 9802 ..., 9897 9898 9899]
-     [9900 9901 9902 ..., 9997 9998 9999]]
+    [[   0    1    2 ...   97   98   99]
+     [ 100  101  102 ...  197  198  199]
+     [ 200  201  202 ...  297  298  299]
+     ...
+     [9700 9701 9702 ... 9797 9798 9799]
+     [9800 9801 9802 ... 9897 9898 9899]
+     [9900 9901 9902 ... 9997 9998 9999]]
 
 To disable this behaviour and force NumPy to print the entire array, you
 can change the printing options using ``set_printoptions``.
@@ -325,19 +330,19 @@ existing array rather than create a new one.
 ::
 
     >>> a = np.ones((2,3), dtype=int)
-    >>> b = np.random.random((2,3))
+    >>> b = rg.random((2,3))
     >>> a *= 3
     >>> a
     array([[3, 3, 3],
            [3, 3, 3]])
     >>> b += a
     >>> b
-    array([[ 3.417022  ,  3.72032449,  3.00011437],
-           [ 3.30233257,  3.14675589,  3.09233859]])
+    array([[3.51182162, 3.9504637 , 3.14415961],
+           [3.94864945, 3.31183145, 3.42332645]])
     >>> a += b                  # b is not automatically converted to integer type
     Traceback (most recent call last):
-      ...
-    TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
+        ...
+    numpy.core._exceptions.UFuncTypeError: Cannot cast from dtype('float64') to dtype('int64')  # IGNORE_EXCEPTION_DETAIL
 
 When operating with arrays of different types, the type of the resulting
 array corresponds to the more general or precise one (a behavior known
@@ -366,16 +371,16 @@ the array, are implemented as methods of the ``ndarray`` class.
 
 ::
 
-    >>> a = np.random.random((2,3))
+    >>> a = rg.random((2,3))
     >>> a
-    array([[ 0.18626021,  0.34556073,  0.39676747],
-           [ 0.53881673,  0.41919451,  0.6852195 ]])
+    array([[0.82770259, 0.40919914, 0.54959369],
+           [0.02755911, 0.75351311, 0.53814331]])
     >>> a.sum()
-    2.5718191614547998
+    3.1057109529998157
     >>> a.min()
-    0.1862602113776709
+    0.027559113243068367
     >>> a.max()
-    0.6852195003967595
+    0.8277025938204418
 
 By default, these operations apply to the array as though it were a list
 of numbers, regardless of its shape. However, by specifying the ``axis``
@@ -485,24 +490,27 @@ and other Python sequences.
     8
     >>> a[2:5]
     array([ 8, 27, 64])
-    >>> a[:6:2] = -1000    # equivalent to a[0:6:2] = -1000; from start to position 6, exclusive, set every 2nd element to -1000
+    # equivalent to a[0:6:2] = 1000;
+    # from start to position 6, exclusive, set every 2nd element to 1000
+    >>> a[:6:2] = 1000
     >>> a
-    array([-1000,     1, -1000,    27, -1000,   125,   216,   343,   512,   729])
+    array([1000,    1, 1000,   27, 1000,  125,  216,  343,  512,  729])
     >>> a[ : :-1]                                 # reversed a
-    array([  729,   512,   343,   216,   125, -1000,    27, -1000,     1, -1000])
+    array([  729,  512,  343,  216,  125, 1000,   27, 1000,    1, 1000])
     >>> for i in a:
-    ...     print(i**(1/3.))
+    ...     print(np.abs(i)**(1/3.))
     ...
-    nan
+    9.999999999999998
     1.0
-    nan
+    9.999999999999998
     3.0
-    nan
-    5.0
-    6.0
-    7.0
-    8.0
-    9.0
+    9.999999999999998
+    4.999999999999999
+    5.999999999999999
+    6.999999999999999
+    7.999999999999999
+    8.999999999999998
+
 
 **Multidimensional** arrays can have one index per axis. These indices
 are given in a tuple separated by commas::
@@ -622,11 +630,11 @@ Changing the shape of an array
 
 An array has a shape given by the number of elements along each axis::
 
-    >>> a = np.floor(10*np.random.random((3,4)))
+    >>> a = np.floor(10*rg.random((3,4)))
     >>> a
-    array([[ 2.,  8.,  0.,  6.],
-           [ 4.,  5.,  1.,  1.],
-           [ 8.,  9.,  3.,  6.]])
+    array([[3., 7., 3., 4.],
+           [1., 4., 2., 2.],
+           [7., 2., 4., 9.]])
     >>> a.shape
     (3, 4)
 
@@ -635,19 +643,19 @@ following three commands all return a modified array, but do not change
 the original array::
 
     >>> a.ravel()  # returns the array, flattened
-    array([ 2.,  8.,  0.,  6.,  4.,  5.,  1.,  1.,  8.,  9.,  3.,  6.])
+    array([3., 7., 3., 4., 1., 4., 2., 2., 7., 2., 4., 9.])
     >>> a.reshape(6,2)  # returns the array with a modified shape
-    array([[ 2.,  8.],
-           [ 0.,  6.],
-           [ 4.,  5.],
-           [ 1.,  1.],
-           [ 8.,  9.],
-           [ 3.,  6.]])
+    array([[3., 7.],
+           [3., 4.],
+           [1., 4.],
+           [2., 2.],
+           [7., 2.],
+           [4., 9.]])
     >>> a.T  # returns the array, transposed
-    array([[ 2.,  4.,  8.],
-           [ 8.,  5.,  9.],
-           [ 0.,  1.,  3.],
-           [ 6.,  1.,  6.]])
+    array([[3., 1., 7.],
+           [7., 4., 2.],
+           [3., 2., 4.],
+           [4., 2., 9.]])
     >>> a.T.shape
     (4, 3)
     >>> a.shape
@@ -670,21 +678,21 @@ argument with a modified shape, whereas the
 itself::
 
     >>> a
-    array([[ 2.,  8.,  0.,  6.],
-           [ 4.,  5.,  1.,  1.],
-           [ 8.,  9.,  3.,  6.]])
+    array([[3., 7., 3., 4.],
+           [1., 4., 2., 2.],
+           [7., 2., 4., 9.]])
     >>> a.resize((2,6))
     >>> a
-    array([[ 2.,  8.,  0.,  6.,  4.,  5.],
-           [ 1.,  1.,  8.,  9.,  3.,  6.]])
+    array([[3., 7., 3., 4., 1., 4.],
+           [2., 2., 7., 2., 4., 9.]])
 
 If a dimension is given as -1 in a reshaping operation, the other
 dimensions are automatically calculated::
 
     >>> a.reshape(3,-1)
-    array([[ 2.,  8.,  0.,  6.],
-           [ 4.,  5.,  1.,  1.],
-           [ 8.,  9.,  3.,  6.]])
+    array([[3., 7., 3., 4.],
+           [1., 4., 2., 2.],
+           [7., 2., 4., 9.]])
 
 .. seealso::
 
@@ -701,22 +709,22 @@ Stacking together different arrays
 
 Several arrays can be stacked together along different axes::
 
-    >>> a = np.floor(10*np.random.random((2,2)))
+    >>> a = np.floor(10*rg.random((2,2)))
     >>> a
-    array([[ 8.,  8.],
-           [ 0.,  0.]])
-    >>> b = np.floor(10*np.random.random((2,2)))
+    array([[9., 7.],
+           [5., 2.]])
+    >>> b = np.floor(10*rg.random((2,2)))
     >>> b
-    array([[ 1.,  8.],
-           [ 0.,  4.]])
+    array([[1., 9.],
+           [5., 1.]])
     >>> np.vstack((a,b))
-    array([[ 8.,  8.],
-           [ 0.,  0.],
-           [ 1.,  8.],
-           [ 0.,  4.]])
+    array([[9., 7.],
+           [5., 2.],
+           [1., 9.],
+           [5., 1.]])
     >>> np.hstack((a,b))
-    array([[ 8.,  8.,  1.,  8.],
-           [ 0.,  0.,  0.,  4.]])
+    array([[9., 7., 1., 9.],
+           [5., 2., 5., 1.]])
 
 The function `column_stack`
 stacks 1D arrays as columns into a 2D array. It is equivalent to
@@ -724,8 +732,8 @@ stacks 1D arrays as columns into a 2D array. It is equivalent to
 
     >>> from numpy import newaxis
     >>> np.column_stack((a,b))     # with 2D arrays
-    array([[ 8.,  8.,  1.,  8.],
-           [ 0.,  0.,  0.,  4.]])
+    array([[9., 7., 1., 9.],
+           [5., 2., 5., 1.]])
     >>> a = np.array([4.,2.])
     >>> b = np.array([3.,8.])
     >>> np.column_stack((a,b))     # returns a 2D array
@@ -793,20 +801,22 @@ array along its horizontal axis, either by specifying the number of
 equally shaped arrays to return, or by specifying the columns after
 which the division should occur::
 
-    >>> a = np.floor(10*np.random.random((2,12)))
+    >>> a = np.floor(10*rg.random((2,12)))
     >>> a
-    array([[ 9.,  5.,  6.,  3.,  6.,  8.,  0.,  7.,  9.,  7.,  2.,  7.],
-           [ 1.,  4.,  9.,  2.,  2.,  1.,  0.,  6.,  2.,  2.,  4.,  0.]])
-    >>> np.hsplit(a,3)   # Split a into 3
-    [array([[ 9.,  5.,  6.,  3.],
-           [ 1.,  4.,  9.,  2.]]), array([[ 6.,  8.,  0.,  7.],
-           [ 2.,  1.,  0.,  6.]]), array([[ 9.,  7.,  2.,  7.],
-           [ 2.,  2.,  4.,  0.]])]
-    >>> np.hsplit(a,(3,4))   # Split a after the third and the fourth column
-    [array([[ 9.,  5.,  6.],
-           [ 1.,  4.,  9.]]), array([[ 3.],
-           [ 2.]]), array([[ 6.,  8.,  0.,  7.,  9.,  7.,  2.,  7.],
-           [ 2.,  1.,  0.,  6.,  2.,  2.,  4.,  0.]])]
+    array([[6., 7., 6., 9., 0., 5., 4., 0., 6., 8., 5., 2.],
+           [8., 5., 5., 7., 1., 8., 6., 7., 1., 8., 1., 0.]])
+    # Split a into 3
+    >>> np.hsplit(a,3)
+    [array([[6., 7., 6., 9.],
+           [8., 5., 5., 7.]]), array([[0., 5., 4., 0.],
+           [1., 8., 6., 7.]]), array([[6., 8., 5., 2.],
+           [1., 8., 1., 0.]])]
+    # Split a after the third and the fourth column
+    >>> np.hsplit(a,(3,4))
+    [array([[6., 7., 6.],
+           [8., 5., 5.]]), array([[9.],
+           [7.]]), array([[0., 5., 4., 0., 6., 8., 5., 2.],
+           [1., 8., 6., 7., 1., 8., 1., 0.]])]
 
 `vsplit` splits along the vertical
 axis, and `array_split` allows
@@ -846,9 +856,9 @@ copy.
     ...     print(id(x))
     ...
     >>> id(a)                           # id is a unique identifier of an object
-    148293216
+    148293216  # may vary
     >>> f(a)
-    148293216
+    148293216  # may vary
 
 View or Shallow Copy
 --------------------
@@ -1111,8 +1121,9 @@ then do the indexing with the list.
 
 ::
 
-    >>> l = [i,j]
-    >>> a[l]                                       # equivalent to a[i,j]
+    >>> l = (i, j)
+    # equivalent to a[i,j]
+    >>> a[l]
     array([[ 2,  5],
            [ 7, 11]])
 
@@ -1123,12 +1134,15 @@ of a.
 ::
 
     >>> s = np.array( [i,j] )
-    >>> a[s]                                       # not what we want
+
+    # not what we want
+    >>> a[s]
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
     IndexError: index (3) out of range (0<=index<=2) in dimension 0
-    >>>
-    >>> a[tuple(s)]                                # same as a[i,j]
+
+    # same as a[i,j]
+    >>> a[tuple(s)]
     array([[ 2,  5],
            [ 7, 11]])
 
@@ -1145,20 +1159,22 @@ value of time-dependent series::
            [ 0.98935825,  0.41211849, -0.54402111, -0.99999021],
            [-0.53657292,  0.42016704,  0.99060736,  0.65028784],
            [-0.28790332, -0.96139749, -0.75098725,  0.14987721]])
-    >>>
-    >>> ind = data.argmax(axis=0)                  # index of the maxima for each series
+
+    # index of the maxima for each series
+    >>> ind = data.argmax(axis=0)
     >>> ind
     array([2, 0, 3, 1])
-    >>>
-    >>> time_max = time[ind]                       # times corresponding to the maxima
+
+    # times corresponding to the maxima
+    >>> time_max = time[ind]
     >>>
     >>> data_max = data[ind, range(data.shape[1])] # => data[ind[0],0], data[ind[1],1]...
-    >>>
+
     >>> time_max
     array([  82.5 ,   20.  ,  113.75,   51.25])
     >>> data_max
     array([ 0.98935825,  0.84147098,  0.99060736,  0.6569866 ])
-    >>>
+
     >>> np.all(data_max == data.max(axis=0))
     True
 
@@ -1244,7 +1260,6 @@ set <https://en.wikipedia.org/wiki/Mandelbrot_set>`__:
     ...
     ...     return divtime
     >>> plt.imshow(mandelbrot(400,400))
-    >>> plt.show()
 
 The second way of indexing with booleans is more similar to integer
 indexing; for each dimension of the array we give a 1D boolean array
@@ -1371,8 +1386,8 @@ See linalg.py in numpy folder for more.
     >>> import numpy as np
     >>> a = np.array([[1.0, 2.0], [3.0, 4.0]])
     >>> print(a)
-    [[ 1.  2.]
-     [ 3.  4.]]
+    [[1. 2.]
+     [3. 4.]]
 
     >>> a.transpose()
     array([[ 1.,  3.],
@@ -1481,17 +1496,16 @@ that ``pylab.hist`` plots the histogram automatically, while
 .. plot::
 
     >>> import numpy as np
+    >>> rg = np.random.default_rng(1)
     >>> import matplotlib.pyplot as plt
     >>> # Build a vector of 10000 normal deviates with variance 0.5^2 and mean 2
     >>> mu, sigma = 2, 0.5
-    >>> v = np.random.normal(mu,sigma,10000)
+    >>> v = rg.normal(mu,sigma,10000)
     >>> # Plot a normalized histogram with 50 bins
     >>> plt.hist(v, bins=50, density=1)       # matplotlib version (plot)
-    >>> plt.show()
     >>> # Compute the histogram with numpy and then plot it
     >>> (n, bins) = np.histogram(v, bins=50, density=True)  # NumPy version (no plot)
     >>> plt.plot(.5*(bins[1:]+bins[:-1]), n)
-    >>> plt.show()
 
 
 Further reading

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -498,7 +498,7 @@ and other Python sequences.
     >>> a[ : :-1]                                 # reversed a
     array([  729,  512,  343,  216,  125, 1000,   27, 1000,    1, 1000])
     >>> for i in a:
-    ...     print(np.abs(i)**(1/3.))
+    ...     print(i**(1/3.))
     ...
     9.999999999999998
     1.0


### PR DESCRIPTION
follow on to gh-15435

Now `python tools/refguide-check --rst doc/source/user` passes except for `c-info.python-as-glue.rst`. This will affect the rendering of the html adding more text as a complement to the images. 