### PR TITLE
MAINT: use 'yield from <expr>' for simple cases

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -984,8 +984,7 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
 def _einsum_dispatcher(*operands, out=None, optimize=None, **kwargs):
     # Arguably we dispatch on more arguments that we really should; see note in
     # _einsum_path_dispatcher for why.
-    for op in operands:
-        yield op
+    yield from operands
     yield out
 
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -300,8 +300,7 @@ def reshape(a, newshape, order='C'):
 
 def _choose_dispatcher(a, choices, out=None, mode=None):
     yield a
-    for c in choices:
-        yield c
+    yield from choices
     yield out
 
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -670,8 +670,7 @@ def _block_dispatcher(arrays):
     # tuple. Also, we know that list.__array_function__ will never exist.
     if type(arrays) is list:
         for subarrays in arrays:
-            for subarray in _block_dispatcher(subarrays):
-                yield subarray
+            yield from _block_dispatcher(subarrays)
     else:
         yield arrays
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -954,8 +954,7 @@ class NIterError(Exception):
 
 class TestFromiter:
     def makegen(self):
-        for x in range(24):
-            yield x**2
+        return (x**2 for x in range(24))
 
     def test_types(self):
         ai32 = np.fromiter(self.makegen(), np.int32)

--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -161,8 +161,7 @@ class Arrayterator:
 
         """
         for block in self:
-            for value in block.flat:
-                yield value
+            yield from block.flat
 
     @property
     def shape(self):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -492,8 +492,7 @@ def _piecewise_dispatcher(x, condlist, funclist, *args, **kw):
     yield x
     # support the undocumented behavior of allowing scalars
     if np.iterable(condlist):
-        for c in condlist:
-            yield c
+        yield from condlist
 
 
 @array_function_dispatch(_piecewise_dispatcher)
@@ -619,10 +618,8 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
 
 def _select_dispatcher(condlist, choicelist, default=None):
-    for c in condlist:
-        yield c
-    for c in choicelist:
-        yield c
+    yield from condlist
+    yield from choicelist
 
 
 @array_function_dispatch(_select_dispatcher)
@@ -767,8 +764,7 @@ def copy(a, order='K'):
 
 def _gradient_dispatcher(f, *varargs, axis=None, edge_order=None):
     yield f
-    for v in varargs:
-        yield v
+    yield from varargs
 
 
 @array_function_dispatch(_gradient_dispatcher)

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -539,10 +539,8 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
 
 
 def _savez_dispatcher(file, *args, **kwds):
-    for a in args:
-        yield a
-    for v in kwds.values():
-        yield v
+    yield from args
+    yield from kwds.values()
 
 
 @array_function_dispatch(_savez_dispatcher)
@@ -628,10 +626,8 @@ def savez(file, *args, **kwds):
 
 
 def _savez_compressed_dispatcher(file, *args, **kwds):
-    for a in args:
-        yield a
-    for v in kwds.values():
-        yield v
+    yield from args
+    yield from kwds.values()
 
 
 @array_function_dispatch(_savez_compressed_dispatcher)

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -285,8 +285,7 @@ def _izip_fields_flat(iterable):
     """
     for element in iterable:
         if isinstance(element, np.void):
-            for f in _izip_fields_flat(tuple(element)):
-                yield f
+            yield from _izip_fields_flat(tuple(element))
         else:
             yield element
 
@@ -299,11 +298,10 @@ def _izip_fields(iterable):
     for element in iterable:
         if (hasattr(element, '__iter__') and
                 not isinstance(element, str)):
-            for f in _izip_fields(element):
-                yield f
+            yield from _izip_fields(element)
         elif isinstance(element, np.void) and len(tuple(element)) == 1:
-            for f in _izip_fields(element):
-                yield f
+            # this statement is the same from the previous expression
+            yield from _izip_fields(element)
         else:
             yield element
 
@@ -657,8 +655,7 @@ def rename_fields(base, namemapper):
 def _append_fields_dispatcher(base, names, data, dtypes=None,
                               fill_value=None, usemask=None, asrecarray=None):
     yield base
-    for d in data:
-        yield d
+    yield from data
 
 
 @array_function_dispatch(_append_fields_dispatcher)
@@ -734,8 +731,7 @@ def append_fields(base, names, data, dtypes=None,
 
 def _rec_append_fields_dispatcher(base, names, data, dtypes=None):
     yield base
-    for d in data:
-        yield d
+    yield from data
 
 
 @array_function_dispatch(_rec_append_fields_dispatcher)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1800,8 +1800,7 @@ def flatten_mask(mask):
         try:
             for element in sequence:
                 if hasattr(element, '__iter__'):
-                    for f in _flatsequence(element):
-                        yield f
+                    yield from _flatsequence(element)
                 else:
                     yield element
         except TypeError:
@@ -2528,8 +2527,7 @@ def flatten_structured_array(a):
         """
         for elm in iter(iterable):
             if hasattr(elm, '__iter__'):
-                for f in flatten_sequence(elm):
-                    yield f
+                yield from flatten_sequence(elm)
             else:
                 yield elm
 
@@ -6215,8 +6213,7 @@ class mvoid(MaskedArray):
         "Defines an iterator for mvoid"
         (_data, _mask) = (self._data, self._mask)
         if _mask is nomask:
-            for d in _data:
-                yield d
+            yield from _data
         else:
             for (d, m) in zip(_data, _mask):
                 if m:

--- a/numpy/testing/_private/decorators.py
+++ b/numpy/testing/_private/decorators.py
@@ -152,8 +152,7 @@ def skipif(skip_condition, msg=None):
             if skip_val():
                 raise SkipTest(get_msg(f, msg))
             else:
-                for x in f(*args, **kwargs):
-                    yield x
+                yield from f(*args, **kwargs)
 
         # Choose the right skipper to use when building the actual decorator.
         if nose.util.isgenerator(f):

--- a/numpy/testing/tests/test_decorators.py
+++ b/numpy/testing/tests/test_decorators.py
@@ -106,8 +106,7 @@ class TestNoseDecorators:
     def test_skip_generators_hardcoded(self):
         @dec.knownfailureif(True, "This test is known to fail")
         def g1(x):
-            for i in range(x):
-                yield i
+            yield from range(x)
 
         try:
             for j in g1(10):
@@ -119,8 +118,7 @@ class TestNoseDecorators:
 
         @dec.knownfailureif(False, "This test is NOT known to fail")
         def g2(x):
-            for i in range(x):
-                yield i
+            yield from range(x)
             raise self.DidntSkipException('FAIL')
 
         try:
@@ -137,8 +135,7 @@ class TestNoseDecorators:
 
         @dec.knownfailureif(skip_tester, "This test is known to fail")
         def g1(x):
-            for i in range(x):
-                yield i
+            yield from range(x)
 
         try:
             skip_flag = 'skip me!'
@@ -151,8 +148,7 @@ class TestNoseDecorators:
 
         @dec.knownfailureif(skip_tester, "This test is NOT known to fail")
         def g2(x):
-            for i in range(x):
-                yield i
+            yield from range(x)
             raise self.DidntSkipException('FAIL')
 
         try:


### PR DESCRIPTION
This PR uses simple cases of [PEP 380](https://www.python.org/dev/peps/pep-0380/) to rewrite:
```python
for v in g:
    yield v
```
into:
```python
yield from <expr>
```
which was a new feature in [Python 3.3](https://docs.python.org/3/whatsnew/3.3.html#pep-380), but raised a `SyntaxError` in prior releases.

See [further discussion on SO](https://stackoverflow.com/q/9708902/), which discusses more advanced uses of PEP 380 not attempted here.