### PR TITLE
MAINT: Cleanup duplicate line in refguide_check

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -1200,8 +1200,6 @@ def main(argv):
                 sys.stderr.write('\n')
                 sys.stderr.flush()
 
-            all_dict, deprecated, others = get_all_dict(module)
-
     if args.rst:
         base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
         rst_path = os.path.relpath(os.path.join(base_dir, args.rst))


### PR DESCRIPTION
I believe (strongly) this accidentally left in during https://github.com/numpy/numpy/pull/14732.

`$ python runtests.py --refguide-check` passes without this line.