### PR TITLE
MAINT: cleanup unused imports; avoid redefinition of imports

### DIFF
--- a/benchmarks/benchmarks/bench_random.py
+++ b/benchmarks/benchmarks/bench_random.py
@@ -2,8 +2,6 @@ from .common import Benchmark
 
 import numpy as np
 
-from numpy.random import RandomState
-
 try:
     from numpy.random import Generator
 except ImportError:

--- a/benchmarks/benchmarks/bench_records.py
+++ b/benchmarks/benchmarks/bench_records.py
@@ -1,5 +1,3 @@
-import os
-
 from .common import Benchmark
 
 import numpy as np

--- a/doc/neps/tools/build_index.py
+++ b/doc/neps/tools/build_index.py
@@ -4,7 +4,6 @@ metadata is passed to Jinja for filling out `index.rst.tmpl`.
 """
 
 import os
-import sys
 import jinja2
 import glob
 import re

--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -6,7 +6,6 @@ Post-processes HTML and Latex files output by Sphinx.
 MODE is either 'html' or 'tex'.
 
 """
-import re
 import optparse
 import io
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -257,7 +257,6 @@ numpydoc_use_plots = True
 # Autosummary
 # -----------------------------------------------------------------------------
 
-import glob
 autosummary_generate = True
 
 # -----------------------------------------------------------------------------
@@ -381,7 +380,6 @@ def linkcode_resolve(domain, info):
            numpy.__version__, fn, linespec)
 
 from pygments.lexers import CLexer
-from pygments import token
 import copy
 
 class NumPyLexer(CLexer):

--- a/doc/source/user/plots/matplotlib3.py
+++ b/doc/source/user/plots/matplotlib3.py
@@ -1,6 +1,5 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib import cm
 from mpl_toolkits.mplot3d import Axes3D
 
 fig = plt.figure()

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -23,7 +23,6 @@ and sometimes other mappings too.
 
 """
 import warnings
-import sys
 
 from numpy.compat import unicode
 from numpy._globals import VisibleDeprecationWarning

--- a/numpy/core/code_generators/generate_ufunc_api.py
+++ b/numpy/core/code_generators/generate_ufunc_api.py
@@ -3,8 +3,7 @@ import genapi
 
 import numpy_api
 
-from genapi import \
-        TypeApi, GlobalVarApi, FunctionApi, BoolValuesApi
+from genapi import TypeApi, FunctionApi
 
 h_template = r"""
 #ifdef _UMATHMODULE

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -4,8 +4,7 @@ import operator
 import types
 
 from . import numeric as _nx
-from .numeric import (result_type, NaN, shares_memory, MAY_SHARE_BOUNDS,
-                      TooHardError, asanyarray, ndim)
+from .numeric import result_type, NaN, asanyarray, ndim
 from numpy.core.multiarray import add_docstring
 from numpy.core import overrides
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -392,7 +392,7 @@ def visibility_define(config):
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration, dot_join
-    from numpy.distutils.system_info import get_info, dict_append
+    from numpy.distutils.system_info import get_info
 
     config = Configuration('core', parent_package, top_path)
     local_dir = config.local_path

--- a/numpy/core/umath.py
+++ b/numpy/core/umath.py
@@ -8,9 +8,7 @@ by importing from the extension module.
 
 from . import _multiarray_umath
 from ._multiarray_umath import *  # noqa: F403
-from ._multiarray_umath import (
-    _UFUNC_API, _add_newdoc_ufunc, _ones_like
-    )
+from ._multiarray_umath import _UFUNC_API, _add_newdoc_ufunc
 
 __all__ = [
     '_UFUNC_API', 'ERR_CALL', 'ERR_DEFAULT', 'ERR_IGNORE', 'ERR_LOG',

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -9,9 +9,10 @@ from distutils.errors import DistutilsSetupError, DistutilsError, \
 
 from numpy.distutils import log
 from distutils.dep_util import newer_group
-from numpy.distutils.misc_util import filter_sources, has_f_sources,\
-     has_cxx_sources, all_strings, get_lib_source_files, is_sequence, \
-     get_numpy_include_dirs
+from numpy.distutils.misc_util import (
+    filter_sources, get_lib_source_files, get_numpy_include_dirs,
+    has_cxx_sources, has_f_sources, is_sequence
+)
 
 # Fix Python distutils bug sf #1718574:
 _l = old_build_clib.user_options

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -13,11 +13,11 @@ from distutils.file_util import copy_file
 
 from numpy.distutils import log
 from numpy.distutils.exec_command import filepath_from_subprocess_output
-from numpy.distutils.system_info import combine_paths, system_info
-from numpy.distutils.misc_util import filter_sources, has_f_sources, \
-    has_cxx_sources, get_ext_source_files, \
-    get_numpy_include_dirs, is_sequence, get_build_architecture, \
-    msvc_version
+from numpy.distutils.system_info import combine_paths
+from numpy.distutils.misc_util import (
+    filter_sources, get_ext_source_files, get_numpy_include_dirs,
+    has_cxx_sources, has_f_sources, is_sequence
+)
 from numpy.distutils.command.config_compiler import show_fortran_compilers
 
 

--- a/numpy/distutils/core.py
+++ b/numpy/distutils/core.py
@@ -1,5 +1,5 @@
 import sys
-from distutils.core import Distribution, setup
+from distutils.core import Distribution
 
 if 'setuptools' in sys.modules:
     have_setuptools = True
@@ -25,7 +25,7 @@ from numpy.distutils.command import config, config_compiler, \
      build, build_py, build_ext, build_clib, build_src, build_scripts, \
      sdist, install_data, install_headers, install, bdist_rpm, \
      install_clib
-from numpy.distutils.misc_util import get_data_files, is_sequence, is_string
+from numpy.distutils.misc_util import is_sequence, is_string
 
 numpy_cmdclass = {'build':            build.build,
                   'build_src':        build_src.build_src,

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -6,7 +6,6 @@ modules in setup scripts.
 Overridden to support f2py.
 
 """
-import sys
 import re
 from distutils.extension import Extension as old_Extension
 

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -19,7 +19,6 @@ __all__ = ['FCompiler', 'new_fcompiler', 'show_fcompilers',
 import os
 import sys
 import re
-import types
 
 from numpy.compat import open_latin1
 

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from distutils.dist import Distribution
 
 __metaclass__ = type

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -10,7 +10,6 @@ import subprocess
 from subprocess import Popen, PIPE, STDOUT
 from numpy.distutils.exec_command import filepath_from_subprocess_output
 from numpy.distutils.fcompiler import FCompiler
-from numpy.distutils.system_info import system_info
 
 compilers = ['GnuFCompiler', 'Gnu95FCompiler']
 

--- a/numpy/distutils/fcompiler/pg.py
+++ b/numpy/distutils/fcompiler/pg.py
@@ -1,7 +1,7 @@
 # http://www.pgroup.com
 import sys
 
-from numpy.distutils.fcompiler import FCompiler, dummy_fortran_file
+from numpy.distutils.fcompiler import FCompiler
 from sys import platform
 from os.path import join, dirname, normpath
 

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -14,7 +14,7 @@ import re
 import textwrap
 
 # Overwrite certain distutils.ccompiler functions:
-import numpy.distutils.ccompiler
+import numpy.distutils.ccompiler  # noqa: F401
 from numpy.distutils import log
 # NT stuff
 # 1. Make sure libpython<version>.a exists for gcc.  If not, build it.
@@ -26,8 +26,7 @@ import distutils.cygwinccompiler
 from distutils.version import StrictVersion
 from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import get_build_version as get_build_msvc_version
-from distutils.errors import (DistutilsExecError, CompileError,
-                              UnknownFileError)
+from distutils.errors import UnknownFileError
 from numpy.distutils.misc_util import (msvc_runtime_library,
                                        msvc_runtime_version,
                                        msvc_runtime_major,

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -375,7 +375,6 @@ def read_config(pkgname, dirs=None):
 # pkg-config simple emulator - useful for debugging, and maybe later to query
 # the system
 if __name__ == '__main__':
-    import sys
     from optparse import OptionParser
     import glob
 

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -177,7 +177,7 @@ from distutils.util import get_platform
 
 from numpy.distutils.exec_command import (
     find_executable, filepath_from_subprocess_output,
-    get_pythonexe)
+    )
 from numpy.distutils.misc_util import (is_sequence, is_string,
                                        get_shared_lib_extension)
 from numpy.distutils.command.config import config as cmd_config

--- a/numpy/distutils/tests/test_fcompiler.py
+++ b/numpy/distutils/tests/test_fcompiler.py
@@ -1,6 +1,4 @@
-import pytest
-
-from numpy.testing import assert_, suppress_warnings
+from numpy.testing import assert_
 import numpy.distutils.fcompiler
 
 customizable_flags = [

--- a/numpy/distutils/tests/test_shell_utils.py
+++ b/numpy/distutils/tests/test_shell_utils.py
@@ -1,6 +1,5 @@
 import pytest
 import subprocess
-import os
 import json
 import sys
 

--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -8,8 +8,6 @@ import sys
 import subprocess
 import os
 
-import numpy as np
-
 from . import f2py2e
 from . import f2py_testing
 from . import diagnose

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -19,7 +19,6 @@ f2py_version = __version__.version
 import copy
 import re
 import os
-import sys
 from .crackfortran import markoutercomma
 from . import cb_rules
 

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
 from . import util

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -2,7 +2,6 @@
 
 """
 import sys
-from importlib import import_module
 import pytest
 
 from numpy.testing import assert_equal

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -4,7 +4,7 @@ Copied from fftpack.helper by Pearu Peterson, October 2005
 
 """
 import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_equal
+from numpy.testing import assert_array_almost_equal
 from numpy import fft, pi
 
 

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -5,7 +5,6 @@ from numpy.testing import (
         assert_array_equal, assert_raises, assert_allclose
         )
 import threading
-import sys
 import queue
 
 

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -35,7 +35,6 @@ Example::
 
 """
 import os
-import sys
 import shutil
 import io
 from contextlib import closing

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -13,7 +13,6 @@ and the masking of individual fields.
 #  first place, and then rename the invalid fields with a trailing
 #  underscore. Maybe we could just overload the parser function ?
 
-import sys
 import warnings
 
 import numpy as np

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -50,8 +50,8 @@ def test_cython(tmp_path):
 @pytest.mark.skipif(numba is None or cffi is None,
                     reason="requires numba and cffi")
 def test_numba():
-    from numpy.random._examples.numba import extending
+    from numpy.random._examples.numba import extending  # noqa: F401
 
 @pytest.mark.skipif(cffi is None, reason="requires cffi")
 def test_cffi():
-    from numpy.random._examples.cffi import extending
+    from numpy.random._examples.cffi import extending  # noqa: F401

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -31,7 +31,6 @@ either expressed or implied, of David Wolever.
 
 """
 import re
-import sys
 import inspect
 import warnings
 from functools import wraps

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -2,7 +2,6 @@ import warnings
 import sys
 import os
 import itertools
-import textwrap
 import pytest
 import weakref
 

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -1,5 +1,3 @@
-import sys
-
 from numpy.testing import assert_raises, assert_, assert_equal
 from numpy.compat import pickle
 

--- a/numpy/tests/test_scripts.py
+++ b/numpy/tests/test_scripts.py
@@ -9,7 +9,7 @@ from os.path import join as pathjoin, isfile, dirname
 import subprocess
 
 import numpy as np
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_equal
 
 is_inplace = isfile(pathjoin(dirname(np.__file__),  '..', 'setup.py'))
 

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -2,7 +2,6 @@
 Tests which scan for certain occurrences in the code, they may not find
 all of these occurrences but should catch almost all.
 """
-import sys
 import pytest
 
 from pathlib import Path

--- a/pavement.py
+++ b/pavement.py
@@ -25,8 +25,6 @@ TODO
 import os
 import sys
 import shutil
-import subprocess
-import re
 import hashlib
 
 # The paver package needs to be installed to run tasks

--- a/runtests.py
+++ b/runtests.py
@@ -53,7 +53,6 @@ else:
 
 import sys
 import os
-import builtins
 
 # In case we are run from the source directory, we don't want to import the
 # project from there:

--- a/setup.py
+++ b/setup.py
@@ -458,8 +458,9 @@ def setup_package():
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = parse_setuppy_commands()
 
-    from setuptools import setup
     if run_build:
+        # patches distutils, even though we don't use it
+        import setuptools  # noqa: F401
         from numpy.distutils.core import setup
         cwd = os.path.abspath(os.path.dirname(__file__))
         if not 'sdist' in sys.argv:
@@ -470,6 +471,7 @@ def setup_package():
         # Customize extension building
         cmdclass['build_clib'], cmdclass['build_ext'] = get_build_overrides()
     else:
+        from setuptools import setup
         # Version number is added to metadata inside configuration() if build
         # is run.
         metadata['version'] = get_version_info()[0]

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -103,7 +103,6 @@ def setup_openblas(arch=get_arch(), ilp64=get_ilp64()):
         return unpack_targz(tmp)
 
 def unpack_windows_zip(fname):
-    import sysconfig
     with zipfile.ZipFile(fname, 'r') as zf:
         # Get the openblas.a file, but not openblas.dll.a nor openblas.dev.a
         lib = [x for x in zf.namelist() if OPENBLAS_LONG in x and

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -27,7 +27,6 @@ or in RST-based documentations::
 """
 import copy
 import doctest
-import glob
 import inspect
 import io
 import os

--- a/tools/swig/test/setup.py
+++ b/tools/swig/test/setup.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 # System imports
 from distutils.core import Extension, setup
-from distutils      import sysconfig
 
 # Third-party modules - we depend on numpy for everything
 import numpy

--- a/tools/swig/test/testArray.py
+++ b/tools/swig/test/testArray.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testFlat.py
+++ b/tools/swig/test/testFlat.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testFortran.py
+++ b/tools/swig/test/testFortran.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testMatrix.py
+++ b/tools/swig/test/testMatrix.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testSuperTensor.py
+++ b/tools/swig/test/testSuperTensor.py
@@ -1,8 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-from   math           import sqrt
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testTensor.py
+++ b/tools/swig/test/testTensor.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
 from   math           import sqrt
-import os
 import sys
 import unittest
 

--- a/tools/swig/test/testVector.py
+++ b/tools/swig/test/testVector.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 # System imports
-from   distutils.util import get_platform
-import os
 import sys
 import unittest
 


### PR DESCRIPTION
* Cleanup unused import of mostly standard Python modules, or some internal but unlikely referenced modules  ([F401](https://flake8.pycqa.org/en/latest/user/error-codes.html))
* Where not-obvious internal imports are potentially used, <s>either add to `__all__`, or use them in some way</s> mark with `noqa`
* Avoid redefinition of imports (F811)

These were found using something like: `flake8 --select=F401,F811`

Most internal imports to `__init__.py` or other well-exposed files are left alone for obvious reasons. Let me know if any other imports should remain, as to avoid any surprises downstream.

And yes, this my last import-related cleanup PR.