### PR TITLE
MAINT: Use `.identifier = val` to fill type structs

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1781,56 +1781,28 @@ array_free(PyObject * v)
 
 NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.ndarray",                            /* tp_name */
-    NPY_SIZEOF_PYARRAYOBJECT,                   /* tp_basicsize */
-    0,                                          /* tp_itemsize */
+    .tp_name = "numpy.ndarray",
+    .tp_basicsize = NPY_SIZEOF_PYARRAYOBJECT,
     /* methods */
-    (destructor)array_dealloc,                  /* tp_dealloc */
-    (printfunc)NULL,                            /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    (reprfunc)array_repr,                       /* tp_repr */
-    &array_as_number,                           /* tp_as_number */
-    &array_as_sequence,                         /* tp_as_sequence */
-    &array_as_mapping,                          /* tp_as_mapping */
+    .tp_dealloc = (destructor)array_dealloc,
+    .tp_repr = (reprfunc)array_repr,
+    .tp_as_number = &array_as_number,
+    .tp_as_sequence = &array_as_sequence,
+    .tp_as_mapping = &array_as_mapping,
     /*
      * The tp_hash slot will be set PyObject_HashNotImplemented when the
      * module is loaded.
      */
-    (hashfunc)0,                                /* tp_hash */
-    (ternaryfunc)0,                             /* tp_call */
-    (reprfunc)array_str,                        /* tp_str */
-    (getattrofunc)0,                            /* tp_getattro */
-    (setattrofunc)0,                            /* tp_setattro */
-    &array_as_buffer,                           /* tp_as_buffer */
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE), /* tp_flags */
-    0,                                          /* tp_doc */
+    .tp_str = (reprfunc)array_str,
+    .tp_as_buffer = &array_as_buffer,
+    .tp_flags =(Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE),
 
-    (traverseproc)0,                            /* tp_traverse */
-    (inquiry)0,                                 /* tp_clear */
-    (richcmpfunc)array_richcompare,             /* tp_richcompare */
-    offsetof(PyArrayObject_fields, weakreflist), /* tp_weaklistoffset */
-    (getiterfunc)array_iter,                    /* tp_iter */
-    (iternextfunc)0,                            /* tp_iternext */
-    array_methods,                              /* tp_methods */
-    0,                                          /* tp_members */
-    array_getsetlist,                           /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    (initproc)0,                                /* tp_init */
-    (allocfunc)array_alloc,                     /* tp_alloc */
-    (newfunc)array_new,                         /* tp_new */
-    (freefunc)array_free,                       /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_richcompare = (richcmpfunc)array_richcompare,
+    .tp_weaklistoffset = offsetof(PyArrayObject_fields, weakreflist),
+    .tp_iter = (getiterfunc)array_iter,
+    .tp_methods = array_methods,
+    .tp_getset = array_getsetlist,
+    .tp_alloc = (allocfunc)array_alloc,
+    .tp_new = (newfunc)array_new,
+    .tp_free = (freefunc)array_free,
 };

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -494,51 +494,11 @@ static PyGetSetDef busdaycalendar_getsets[] = {
 
 NPY_NO_EXPORT PyTypeObject NpyBusDayCalendar_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.busdaycalendar",                     /* tp_name */
-    sizeof(NpyBusDayCalendar),                  /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)busdaycalendar_dealloc,         /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    busdaycalendar_getsets,                     /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    (initproc)busdaycalendar_init,              /* tp_init */
-    0,                                          /* tp_alloc */
-    busdaycalendar_new,                         /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.busdaycalendar",
+    .tp_basicsize = sizeof(NpyBusDayCalendar),
+    .tp_dealloc = (destructor)busdaycalendar_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_getset = busdaycalendar_getsets,
+    .tp_init = (initproc)busdaycalendar_init,
+    .tp_new = busdaycalendar_new,
 };

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3229,16 +3229,7 @@ descr_nonzero(PyObject *NPY_UNUSED(self))
 }
 
 static PyNumberMethods descr_as_number = {
-    (binaryfunc)0,                          /* nb_add */
-    (binaryfunc)0,                          /* nb_subtract */
-    (binaryfunc)0,                          /* nb_multiply */
-    (binaryfunc)0,                          /* nb_remainder */
-    (binaryfunc)0,                          /* nb_divmod */
-    (ternaryfunc)0,                         /* nb_power */
-    (unaryfunc)0,                           /* nb_negative */
-    (unaryfunc)0,                           /* nb_positive */
-    (unaryfunc)0,                           /* nb_absolute */
-    (inquiry)descr_nonzero,                 /* nb_nonzero */
+    .nb_bool = (inquiry)descr_nonzero,
 };
 
 /*************************************************************************

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -3484,51 +3484,19 @@ static PyMappingMethods descr_as_mapping = {
 
 NPY_NO_EXPORT PyTypeObject PyArrayDescr_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.dtype",                              /* tp_name */
-    sizeof(PyArray_Descr),                      /* tp_basicsize */
-    0,                                          /* tp_itemsize */
+    .tp_name = "numpy.dtype",
+    .tp_basicsize = sizeof(PyArray_Descr),
     /* methods */
-    (destructor)arraydescr_dealloc,             /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    (void *)0,                                  /* tp_reserved */
-    (reprfunc)arraydescr_repr,                  /* tp_repr */
-    &descr_as_number,                           /* tp_as_number */
-    &descr_as_sequence,                         /* tp_as_sequence */
-    &descr_as_mapping,                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    (reprfunc)arraydescr_str,                   /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    (richcmpfunc)arraydescr_richcompare,        /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    arraydescr_methods,                         /* tp_methods */
-    arraydescr_members,                         /* tp_members */
-    arraydescr_getsets,                         /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    arraydescr_new,                             /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_dealloc = (destructor)arraydescr_dealloc,
+    .tp_repr = (reprfunc)arraydescr_repr,
+    .tp_as_number = &descr_as_number,
+    .tp_as_sequence = &descr_as_sequence,
+    .tp_as_mapping = &descr_as_mapping,
+    .tp_str = (reprfunc)arraydescr_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_richcompare = (richcmpfunc)arraydescr_richcompare,
+    .tp_methods = arraydescr_methods,
+    .tp_members = arraydescr_members,
+    .tp_getset = arraydescr_getsets,
+    .tp_new = arraydescr_new,
 };

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -772,51 +772,14 @@ arrayflags_new(PyTypeObject *NPY_UNUSED(self), PyObject *args, PyObject *NPY_UNU
 
 NPY_NO_EXPORT PyTypeObject PyArrayFlags_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.flagsobj",
-    sizeof(PyArrayFlagsObject),
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)arrayflags_dealloc,             /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    (reprfunc)arrayflags_print,                 /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    &arrayflags_as_mapping,                     /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    (reprfunc)arrayflags_print,                 /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    arrayflags_richcompare,                     /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    arrayflags_getsets,                         /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    arrayflags_new,                             /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.flagsobj",
+    .tp_basicsize = sizeof(PyArrayFlagsObject),
+    .tp_dealloc = (destructor)arrayflags_dealloc,
+    .tp_repr = (reprfunc)arrayflags_print,
+    .tp_as_mapping = &arrayflags_as_mapping,
+    .tp_str = (reprfunc)arrayflags_print,
+    .tp_flags =Py_TPFLAGS_DEFAULT,
+    .tp_richcompare = arrayflags_richcompare,
+    .tp_getset = arrayflags_getsets,
+    .tp_new = arrayflags_new,
 };

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1103,53 +1103,16 @@ static PyGetSetDef iter_getsets[] = {
 
 NPY_NO_EXPORT PyTypeObject PyArrayIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.flatiter",                           /* tp_name */
-    sizeof(PyArrayIterObject),                  /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)arrayiter_dealloc,              /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    &iter_as_mapping,                           /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    (richcmpfunc)iter_richcompare,              /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    (iternextfunc)arrayiter_next,               /* tp_iternext */
-    iter_methods,                               /* tp_methods */
-    iter_members,                               /* tp_members */
-    iter_getsets,                               /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.flatiter",
+    .tp_basicsize = sizeof(PyArrayIterObject),
+    .tp_dealloc = (destructor)arrayiter_dealloc,
+    .tp_as_mapping = &iter_as_mapping,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_richcompare = (richcmpfunc)iter_richcompare,
+    .tp_iternext = (iternextfunc)arrayiter_next,
+    .tp_methods = iter_methods,
+    .tp_members = iter_members,
+    .tp_getset = iter_getsets,
 };
 
 /** END of Array Iterator **/
@@ -1552,53 +1515,15 @@ static PyMethodDef arraymultiter_methods[] = {
 
 NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.broadcast",                          /* tp_name */
-    sizeof(PyArrayMultiIterObject),             /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)arraymultiter_dealloc,          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    (iternextfunc)arraymultiter_next,           /* tp_iternext */
-    arraymultiter_methods,                      /* tp_methods */
-    arraymultiter_members,                      /* tp_members */
-    arraymultiter_getsetlist,                   /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    (initproc)0,                                /* tp_init */
-    0,                                          /* tp_alloc */
-    arraymultiter_new,                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.broadcast",
+    .tp_basicsize = sizeof(PyArrayMultiIterObject),
+    .tp_dealloc = (destructor)arraymultiter_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_iternext = (iternextfunc)arraymultiter_next,
+    .tp_methods = arraymultiter_methods,
+    .tp_members = arraymultiter_members,
+    .tp_getset = arraymultiter_getsetlist,
+    .tp_new = arraymultiter_new,
 };
 
 /*========================= Neighborhood iterator ======================*/
@@ -1873,50 +1798,8 @@ static void neighiter_dealloc(PyArrayNeighborhoodIterObject* iter)
 
 NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.neigh_internal_iter",                /* tp_name*/
-    sizeof(PyArrayNeighborhoodIterObject),      /* tp_basicsize*/
-    0,                                          /* tp_itemsize*/
-    (destructor)neighiter_dealloc,              /* tp_dealloc*/
-    0,                                          /* tp_print*/
-    0,                                          /* tp_getattr*/
-    0,                                          /* tp_setattr*/
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr*/
-    0,                                          /* tp_as_number*/
-    0,                                          /* tp_as_sequence*/
-    0,                                          /* tp_as_mapping*/
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call*/
-    0,                                          /* tp_str*/
-    0,                                          /* tp_getattro*/
-    0,                                          /* tp_setattro*/
-    0,                                          /* tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags*/
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    (iternextfunc)0,                            /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    (initproc)0,                                /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.neigh_internal_iter",
+    .tp_basicsize = sizeof(PyArrayNeighborhoodIterObject),
+    .tp_dealloc = (destructor)neighiter_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
 };

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -3336,51 +3336,8 @@ arraymapiter_dealloc(PyArrayMapIterObject *mit)
  */
 NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.mapiter",                            /* tp_name */
-    sizeof(PyArrayMapIterObject),               /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)arraymapiter_dealloc,           /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.mapiter",
+    .tp_basicsize = sizeof(PyArrayMapIterObject),
+    .tp_dealloc = (destructor)arraymapiter_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
 };

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -2491,51 +2491,16 @@ NPY_NO_EXPORT PyMappingMethods npyiter_as_mapping = {
 
 NPY_NO_EXPORT PyTypeObject NpyIter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.nditer",                             /* tp_name */
-    sizeof(NewNpyArrayIterObject),              /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)npyiter_dealloc,                /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    &npyiter_as_sequence,                       /* tp_as_sequence */
-    &npyiter_as_mapping,                        /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    (iternextfunc)npyiter_next,                 /* tp_iternext */
-    npyiter_methods,                            /* tp_methods */
-    npyiter_members,                            /* tp_members */
-    npyiter_getsets,                            /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    (initproc)npyiter_init,                     /* tp_init */
-    0,                                          /* tp_alloc */
-    npyiter_new,                                /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.nditer",
+    .tp_basicsize = sizeof(NewNpyArrayIterObject),
+    .tp_dealloc = (destructor)npyiter_dealloc,
+    .tp_as_sequence = &npyiter_as_sequence,
+    .tp_as_mapping = &npyiter_as_mapping,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_iternext = (iternextfunc)npyiter_next,
+    .tp_methods = npyiter_methods,
+    .tp_members = npyiter_members,
+    .tp_getset = npyiter_getsets,
+    .tp_init = (initproc)npyiter_init,
+    .tp_new = npyiter_new,
 };

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -923,47 +923,43 @@ array_index(PyArrayObject *v)
 
 
 NPY_NO_EXPORT PyNumberMethods array_as_number = {
-    (binaryfunc)array_add,                      /*nb_add*/
-    (binaryfunc)array_subtract,                 /*nb_subtract*/
-    (binaryfunc)array_multiply,                 /*nb_multiply*/
-    (binaryfunc)array_remainder,                /*nb_remainder*/
-    (binaryfunc)array_divmod,                   /*nb_divmod*/
-    (ternaryfunc)array_power,                   /*nb_power*/
-    (unaryfunc)array_negative,                  /*nb_neg*/
-    (unaryfunc)array_positive,                  /*nb_pos*/
-    (unaryfunc)array_absolute,                  /*(unaryfunc)array_abs,*/
-    (inquiry)_array_nonzero,                    /*nb_nonzero*/
-    (unaryfunc)array_invert,                    /*nb_invert*/
-    (binaryfunc)array_left_shift,               /*nb_lshift*/
-    (binaryfunc)array_right_shift,              /*nb_rshift*/
-    (binaryfunc)array_bitwise_and,              /*nb_and*/
-    (binaryfunc)array_bitwise_xor,              /*nb_xor*/
-    (binaryfunc)array_bitwise_or,               /*nb_or*/
-    (unaryfunc)array_int,                       /*nb_int*/
-    0,                                          /*nb_reserved*/
-    (unaryfunc)array_float,                     /*nb_float*/
+    .nb_add = (binaryfunc)array_add,
+    .nb_subtract = (binaryfunc)array_subtract,
+    .nb_multiply = (binaryfunc)array_multiply,
+    .nb_remainder = (binaryfunc)array_remainder,
+    .nb_divmod = (binaryfunc)array_divmod,
+    .nb_power = (ternaryfunc)array_power,
+    .nb_negative = (unaryfunc)array_negative,
+    .nb_positive = (unaryfunc)array_positive,
+    .nb_absolute = (unaryfunc)array_absolute,
+    .nb_bool = (inquiry)_array_nonzero,
+    .nb_invert = (unaryfunc)array_invert,
+    .nb_lshift = (binaryfunc)array_left_shift,
+    .nb_rshift = (binaryfunc)array_right_shift,
+    .nb_and = (binaryfunc)array_bitwise_and,
+    .nb_xor = (binaryfunc)array_bitwise_xor,
+    .nb_or = (binaryfunc)array_bitwise_or,
 
-    /*
-     * This code adds augmented assignment functionality
-     * that was made available in Python 2.0
-     */
-    (binaryfunc)array_inplace_add,              /*nb_inplace_add*/
-    (binaryfunc)array_inplace_subtract,         /*nb_inplace_subtract*/
-    (binaryfunc)array_inplace_multiply,         /*nb_inplace_multiply*/
-    (binaryfunc)array_inplace_remainder,        /*nb_inplace_remainder*/
-    (ternaryfunc)array_inplace_power,           /*nb_inplace_power*/
-    (binaryfunc)array_inplace_left_shift,       /*nb_inplace_lshift*/
-    (binaryfunc)array_inplace_right_shift,      /*nb_inplace_rshift*/
-    (binaryfunc)array_inplace_bitwise_and,      /*nb_inplace_and*/
-    (binaryfunc)array_inplace_bitwise_xor,      /*nb_inplace_xor*/
-    (binaryfunc)array_inplace_bitwise_or,       /*nb_inplace_or*/
+    .nb_int = (unaryfunc)array_int,
+    .nb_float = (unaryfunc)array_float,
+    .nb_index = (unaryfunc)array_index,
 
-    (binaryfunc)array_floor_divide,             /*nb_floor_divide*/
-    (binaryfunc)array_true_divide,              /*nb_true_divide*/
-    (binaryfunc)array_inplace_floor_divide,     /*nb_inplace_floor_divide*/
-    (binaryfunc)array_inplace_true_divide,      /*nb_inplace_true_divide*/
-    (unaryfunc)array_index,                     /*nb_index */
+    .nb_inplace_add = (binaryfunc)array_inplace_add,
+    .nb_inplace_subtract = (binaryfunc)array_inplace_subtract,
+    .nb_inplace_multiply = (binaryfunc)array_inplace_multiply,
+    .nb_inplace_remainder = (binaryfunc)array_inplace_remainder,
+    .nb_inplace_power = (ternaryfunc)array_inplace_power,
+    .nb_inplace_lshift = (binaryfunc)array_inplace_left_shift,
+    .nb_inplace_rshift = (binaryfunc)array_inplace_right_shift,
+    .nb_inplace_and = (binaryfunc)array_inplace_bitwise_and,
+    .nb_inplace_xor = (binaryfunc)array_inplace_bitwise_xor,
+    .nb_inplace_or = (binaryfunc)array_inplace_bitwise_or,
 
-    (binaryfunc)array_matrix_multiply,          /*nb_matrix_multiply*/
-    (binaryfunc)array_inplace_matrix_multiply,  /*nb_inplace_matrix_multiply*/
+    .nb_floor_divide = (binaryfunc)array_floor_divide,
+    .nb_true_divide = (binaryfunc)array_true_divide,
+    .nb_inplace_floor_divide = (binaryfunc)array_inplace_floor_divide,
+    .nb_inplace_true_divide = (binaryfunc)array_inplace_true_divide,
+
+    .nb_matrix_multiply = (binaryfunc)array_matrix_multiply,
+    .nb_inplace_matrix_multiply = (binaryfunc)array_inplace_matrix_multiply,
 };

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -55,53 +55,8 @@ NPY_NO_EXPORT PyTypeObject PyTimeIntegerArrType_Type;
  */
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.@name@",                             /* tp_name*/
-    sizeof(PyObject),                           /* tp_basicsize*/
-    0,                                          /* tp_itemsize */
-    /* methods */
-    0,                                          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    0,                                          /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.@name@",
+    .tp_basicsize = sizeof(PyObject),
 };
 /**end repeat**/
 
@@ -2453,53 +2408,8 @@ static PyBufferProcs gentype_as_buffer = {
 
 NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.generic",                            /* tp_name*/
-    sizeof(PyObject),                           /* tp_basicsize*/
-    0,                                          /* tp_itemsize */
-    /* methods */
-    0,                                          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    0,                                          /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.generic",
+    .tp_basicsize = sizeof(PyObject),
 };
 
 static void
@@ -3266,52 +3176,15 @@ object_arrtype_call(PyObjectScalarObject *obj, PyObject *args, PyObject *kwds)
 
 NPY_NO_EXPORT PyTypeObject PyObjectArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.object_",                            /* tp_name*/
-    sizeof(PyObjectScalarObject),               /* tp_basicsize*/
-    0,                                          /* tp_itemsize */
-    (destructor)object_arrtype_dealloc,         /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    &object_arrtype_as_sequence,                /* tp_as_sequence */
-    &object_arrtype_as_mapping,                 /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    (ternaryfunc)object_arrtype_call,           /* tp_call */
-    0,                                          /* tp_str */
-    (getattrofunc)object_arrtype_getattro,      /* tp_getattro */
-    (setattrofunc)object_arrtype_setattro,      /* tp_setattro */
-    &object_arrtype_as_buffer,                  /* tp_as_buffer */
-    0,                                          /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.object_",
+    .tp_basicsize = sizeof(PyObjectScalarObject),
+    .tp_dealloc = (destructor)object_arrtype_dealloc,
+    .tp_as_sequence = &object_arrtype_as_sequence,
+    .tp_as_mapping = &object_arrtype_as_mapping,
+    .tp_call = (ternaryfunc)object_arrtype_call,
+    .tp_getattro = (getattrofunc)object_arrtype_getattro,
+    .tp_setattro = (setattrofunc)object_arrtype_setattro,
+    .tp_as_buffer = &object_arrtype_as_buffer,
 };
 
 static PyObject *
@@ -3350,52 +3223,8 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
  */
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy." NAME_@name@ "@ex@",                /* tp_name*/
-    sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
-    0,                                          /* tp_itemsize */
-    0,                                          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    0,                                          /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy." NAME_@name@ "@ex@",
+    .tp_basicsize = sizeof(Py@NAME@ScalarObject),
 };
 /**end repeat**/
 
@@ -3430,53 +3259,10 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
 #endif
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.@name@" _THIS_SIZE,                  /* tp_name*/
-    sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
-    0,                                          /* tp_itemsize */
-    0,                                          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    0,                                          /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.@name@" _THIS_SIZE,
+    .tp_basicsize = sizeof(Py@NAME@ScalarObject),
 };
+
 
 #undef _THIS_SIZE
 /**end repeat**/
@@ -3512,52 +3298,9 @@ static PyMappingMethods gentype_as_mapping = {
 
 NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
     PyVarObject_HEAD_INIT(0, 0)
-    "numpy.@name@" _THIS_SIZE,                  /* tp_name*/
-    sizeof(Py@NAME@ScalarObject),               /* tp_basicsize*/
-    0,                                          /* tp_itemsize*/
-    0,                                          /* tp_dealloc*/
-    0,                                          /* tp_print*/
-    0,                                          /* tp_getattr*/
-    0,                                          /* tp_setattr*/
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr*/
-    0,                                          /* tp_as_number*/
-    0,                                          /* tp_as_sequence*/
-    0,                                          /* tp_as_mapping*/
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call*/
-    0,                                          /* tp_str*/
-    0,                                          /* tp_getattro*/
-    0,                                          /* tp_setattro*/
-    0,                                          /* tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,                         /* tp_flags*/
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.@name@" _THIS_SIZE,
+    .tp_basicsize = sizeof(Py@NAME@ScalarObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
 };
 #undef _THIS_SIZE
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -971,42 +971,26 @@ static PyObject *
 /**end repeat**/
 
 static PyNumberMethods gentype_as_number = {
-    (binaryfunc)gentype_add,                     /*nb_add*/
-    (binaryfunc)gentype_subtract,                /*nb_subtract*/
-    (binaryfunc)gentype_multiply,                /*nb_multiply*/
-    (binaryfunc)gentype_remainder,               /*nb_remainder*/
-    (binaryfunc)gentype_divmod,                  /*nb_divmod*/
-    (ternaryfunc)gentype_power,                  /*nb_power*/
-    (unaryfunc)gentype_negative,
-    (unaryfunc)gentype_positive,                 /*nb_pos*/
-    (unaryfunc)gentype_absolute,                 /*(unaryfunc)gentype_abs,*/
-    (inquiry)gentype_nonzero_number,             /*nb_nonzero*/
-    (unaryfunc)gentype_invert,                   /*nb_invert*/
-    (binaryfunc)gentype_lshift,                  /*nb_lshift*/
-    (binaryfunc)gentype_rshift,                  /*nb_rshift*/
-    (binaryfunc)gentype_and,                     /*nb_and*/
-    (binaryfunc)gentype_xor,                     /*nb_xor*/
-    (binaryfunc)gentype_or,                      /*nb_or*/
-    (unaryfunc)gentype_int,                      /*nb_int*/
-    0,                                           /*nb_reserved*/
-    (unaryfunc)gentype_float,                    /*nb_float*/
-    0,                                           /*inplace_add*/
-    0,                                           /*inplace_subtract*/
-    0,                                           /*inplace_multiply*/
-    0,                                           /*inplace_remainder*/
-    0,                                           /*inplace_power*/
-    0,                                           /*inplace_lshift*/
-    0,                                           /*inplace_rshift*/
-    0,                                           /*inplace_and*/
-    0,                                           /*inplace_xor*/
-    0,                                           /*inplace_or*/
-    (binaryfunc)gentype_floor_divide,            /*nb_floor_divide*/
-    (binaryfunc)gentype_true_divide,             /*nb_true_divide*/
-    0,                                           /*nb_inplace_floor_divide*/
-    0,                                           /*nb_inplace_true_divide*/
-    (unaryfunc)NULL,                             /*nb_index*/
-    0,                                           /*np_matmul*/
-    0,                                           /*np_inplace_matmul*/
+    .nb_add = (binaryfunc)gentype_add,
+    .nb_subtract = (binaryfunc)gentype_subtract,
+    .nb_multiply = (binaryfunc)gentype_multiply,
+    .nb_remainder = (binaryfunc)gentype_remainder,
+    .nb_divmod = (binaryfunc)gentype_divmod,
+    .nb_power = (ternaryfunc)gentype_power,
+    .nb_negative = (unaryfunc)gentype_negative,
+    .nb_positive = (unaryfunc)gentype_positive,
+    .nb_absolute = (unaryfunc)gentype_absolute,
+    .nb_bool = (inquiry)gentype_nonzero_number,
+    .nb_invert = (unaryfunc)gentype_invert,
+    .nb_lshift = (binaryfunc)gentype_lshift,
+    .nb_rshift = (binaryfunc)gentype_rshift,
+    .nb_and = (binaryfunc)gentype_and,
+    .nb_xor = (binaryfunc)gentype_xor,
+    .nb_or = (binaryfunc)gentype_or,
+    .nb_int = (unaryfunc)gentype_int,
+    .nb_float = (unaryfunc)gentype_float,
+    .nb_floor_divide = (binaryfunc)gentype_floor_divide,
+    .nb_true_divide = (binaryfunc)gentype_true_divide,
 };
 
 
@@ -2377,29 +2361,22 @@ fail:
 }
 
 static PyMappingMethods voidtype_as_mapping = {
-    (lenfunc)voidtype_length,                    /*mp_length*/
-    (binaryfunc)voidtype_subscript,              /*mp_subscript*/
-    (objobjargproc)voidtype_ass_subscript,       /*mp_ass_subscript*/
+    .mp_length = (lenfunc)voidtype_length,
+    .mp_subscript = (binaryfunc)voidtype_subscript,
+    .mp_ass_subscript = (objobjargproc)voidtype_ass_subscript,
 };
 
 
 static PySequenceMethods voidtype_as_sequence = {
-    (lenfunc)voidtype_length,                    /*sq_length*/
-    0,                                           /*sq_concat*/
-    0,                                           /*sq_repeat*/
-    (ssizeargfunc)voidtype_item,                 /*sq_item*/
-    0,                                           /*sq_slice*/
-    (ssizeobjargproc)voidtype_ass_item,          /*sq_ass_item*/
-    0,                                           /* ssq_ass_slice */
-    0,                                           /* sq_contains */
-    0,                                           /* sq_inplace_concat */
-    0,                                           /* sq_inplace_repeat */
+    .sq_length = (lenfunc)voidtype_length,
+    .sq_item = (ssizeargfunc)voidtype_item,
+    .sq_ass_item = (ssizeobjargproc)voidtype_ass_item,
 };
 
 
 static PyBufferProcs gentype_as_buffer = {
-    gentype_getbuffer,                           /* bf_getbuffer */
-    NULL,                                        /* bf_releasebuffer */
+    .bf_getbuffer = gentype_getbuffer,
+    /* release buffer not defined (see buffer.c) */
 };
 
 
@@ -2745,44 +2722,10 @@ bool_index(PyObject *a)
 
 /* Arithmetic methods -- only so we can override &, |, ^. */
 NPY_NO_EXPORT PyNumberMethods bool_arrtype_as_number = {
-    0,                                           /* nb_add */
-    0,                                           /* nb_subtract */
-    0,                                           /* nb_multiply */
-    0,                                           /* nb_remainder */
-    0,                                           /* nb_divmod */
-    0,                                           /* nb_power */
-    0,                                           /* nb_negative */
-    0,                                           /* nb_positive */
-    0,                                           /* nb_absolute */
-    (inquiry)bool_arrtype_nonzero,               /* nb_nonzero / nb_bool */
-    0,                                           /* nb_invert */
-    0,                                           /* nb_lshift */
-    0,                                           /* nb_rshift */
-    (binaryfunc)bool_arrtype_and,                /* nb_and */
-    (binaryfunc)bool_arrtype_xor,                /* nb_xor */
-    (binaryfunc)bool_arrtype_or,                 /* nb_or */
-    0,                                           /* nb_int */
-    0,                                           /* nb_reserved */
-    0,                                           /* nb_float */
-    /* Added in release 2.0 */
-    0,                                           /* nb_inplace_add */
-    0,                                           /* nb_inplace_subtract */
-    0,                                           /* nb_inplace_multiply */
-    0,                                           /* nb_inplace_remainder */
-    0,                                           /* nb_inplace_power */
-    0,                                           /* nb_inplace_lshift */
-    0,                                           /* nb_inplace_rshift */
-    0,                                           /* nb_inplace_and */
-    0,                                           /* nb_inplace_xor */
-    0,                                           /* nb_inplace_or */
-    /* Added in release 2.2 */
-    /* The following require the Py_TPFLAGS_HAVE_CLASS flag */
-    0,                                           /* nb_floor_divide */
-    0,                                           /* nb_true_divide */
-    0,                                           /* nb_inplace_floor_divide */
-    0,                                           /* nb_inplace_true_divide */
-    /* Added in release 2.5 */
-    0,                                           /* nb_index */
+    .nb_bool = (inquiry)bool_arrtype_nonzero,
+    .nb_and = (binaryfunc)bool_arrtype_and,
+    .nb_xor = (binaryfunc)bool_arrtype_xor,
+    .nb_or = (binaryfunc)bool_arrtype_or,
 };
 
 static PyObject *
@@ -3119,22 +3062,18 @@ object_arrtype_inplace_repeat(PyObjectScalarObject *self, Py_ssize_t count)
 }
 
 static PySequenceMethods object_arrtype_as_sequence = {
-    (lenfunc)object_arrtype_length,              /*sq_length*/
-    (binaryfunc)object_arrtype_concat,           /*sq_concat*/
-    (ssizeargfunc)object_arrtype_repeat,         /*sq_repeat*/
-    0,                                           /*sq_item*/
-    0,                                           /*sq_slice*/
-    0,                                           /* sq_ass_item */
-    0,                                           /* sq_ass_slice */
-    (objobjproc)object_arrtype_contains,         /* sq_contains */
-    (binaryfunc)object_arrtype_inplace_concat,   /* sq_inplace_concat */
-    (ssizeargfunc)object_arrtype_inplace_repeat, /* sq_inplace_repeat */
+    .sq_length = (lenfunc)object_arrtype_length,
+    .sq_concat = (binaryfunc)object_arrtype_concat,
+    .sq_repeat = (ssizeargfunc)object_arrtype_repeat,
+    .sq_contains = (objobjproc)object_arrtype_contains,
+    .sq_inplace_concat = (binaryfunc)object_arrtype_inplace_concat,
+    .sq_inplace_repeat = (ssizeargfunc)object_arrtype_inplace_repeat,
 };
 
 static PyMappingMethods object_arrtype_as_mapping = {
-    (lenfunc)object_arrtype_length,
-    (binaryfunc)object_arrtype_subscript,
-    (objobjargproc)object_arrtype_ass_subscript,
+    .mp_length = (lenfunc)object_arrtype_length,
+    .mp_subscript = (binaryfunc)object_arrtype_subscript,
+    .mp_ass_subscript = (objobjargproc)object_arrtype_ass_subscript,
 };
 
 static int
@@ -3164,8 +3103,8 @@ object_arrtype_releasebuffer(PyObjectScalarObject *self, Py_buffer *view)
 }
 
 static PyBufferProcs object_arrtype_as_buffer = {
-    (getbufferproc)object_arrtype_getbuffer,
-    (releasebufferproc)object_arrtype_releasebuffer,
+    .bf_getbuffer = (getbufferproc)object_arrtype_getbuffer,
+    .bf_releasebuffer = (releasebufferproc)object_arrtype_releasebuffer,
 };
 
 static PyObject *
@@ -3269,9 +3208,7 @@ NPY_NO_EXPORT PyTypeObject Py@NAME@ArrType_Type = {
 
 
 static PyMappingMethods gentype_as_mapping = {
-    NULL,
-    (binaryfunc)gen_arrtype_subscript,
-    NULL
+    .mp_subscript = (binaryfunc)gen_arrtype_subscript,
 };
 
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -1513,44 +1513,28 @@ static PyObject*
  *          cfloat, cdouble, clongdouble#
 **/
 static PyNumberMethods @name@_as_number = {
-    (binaryfunc)@name@_add,                     /*nb_add*/
-    (binaryfunc)@name@_subtract,                /*nb_subtract*/
-    (binaryfunc)@name@_multiply,                /*nb_multiply*/
-    (binaryfunc)@name@_remainder,               /*nb_remainder*/
-    (binaryfunc)@name@_divmod,                  /*nb_divmod*/
-    (ternaryfunc)@name@_power,                  /*nb_power*/
-    (unaryfunc)@name@_negative,
-    (unaryfunc)@name@_positive,                 /*nb_pos*/
-    (unaryfunc)@name@_absolute,                 /*nb_abs*/
-    (inquiry)@name@_bool,                       /*nb_bool*/
-    (unaryfunc)@name@_invert,                   /*nb_invert*/
-    (binaryfunc)@name@_lshift,                  /*nb_lshift*/
-    (binaryfunc)@name@_rshift,                  /*nb_rshift*/
-    (binaryfunc)@name@_and,                     /*nb_and*/
-    (binaryfunc)@name@_xor,                     /*nb_xor*/
-    (binaryfunc)@name@_or,                      /*nb_or*/
-    (unaryfunc)@name@_int,                      /*nb_int*/
-    (unaryfunc)0,                               /*nb_reserved*/
-    (unaryfunc)@name@_float,                    /*nb_float*/
-    0,                                          /*inplace_add*/
-    0,                                          /*inplace_subtract*/
-    0,                                          /*inplace_multiply*/
-    0,                                          /*inplace_remainder*/
-    0,                                          /*inplace_power*/
-    0,                                          /*inplace_lshift*/
-    0,                                          /*inplace_rshift*/
-    0,                                          /*inplace_and*/
-    0,                                          /*inplace_xor*/
-    0,                                          /*inplace_or*/
-    (binaryfunc)@name@_floor_divide,            /*nb_floor_divide*/
-    (binaryfunc)@name@_true_divide,             /*nb_true_divide*/
-    0,                                          /*nb_inplace_floor_divide*/
-    0,                                          /*nb_inplace_true_divide*/
-    (unaryfunc)NULL,                            /*nb_index*/
-#if PY_VERSION_HEX >= 0x03050000
-    0,                                          /*nb_matrix_multiply*/
-    0,                                          /*nb_inplace_matrix_multiply*/
-#endif
+    .nb_add = (binaryfunc)@name@_add,
+    .nb_subtract = (binaryfunc)@name@_subtract,
+    .nb_multiply = (binaryfunc)@name@_multiply,
+    .nb_remainder = (binaryfunc)@name@_remainder,
+    .nb_divmod = (binaryfunc)@name@_divmod,
+    .nb_power = (ternaryfunc)@name@_power,
+    .nb_negative = (unaryfunc)@name@_negative,
+    .nb_positive = (unaryfunc)@name@_positive,
+    .nb_absolute = (unaryfunc)@name@_absolute,
+    .nb_bool = (inquiry)@name@_bool,
+    .nb_invert = (unaryfunc)@name@_invert,
+    .nb_lshift = (binaryfunc)@name@_lshift,
+    .nb_rshift = (binaryfunc)@name@_rshift,
+    .nb_and = (binaryfunc)@name@_and,
+    .nb_xor = (binaryfunc)@name@_xor,
+    .nb_or = (binaryfunc)@name@_or,
+    .nb_int = (unaryfunc)@name@_int,
+    .nb_float = (unaryfunc)@name@_float,
+    .nb_floor_divide = (binaryfunc)@name@_floor_divide,
+    .nb_true_divide = (binaryfunc)@name@_true_divide,
+    /* TODO: This struct/initialization should not be split between files */
+    .nb_index = (unaryfunc)NULL,  /* set in add_scalarmath below */
 };
 /**end repeat**/
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -6040,53 +6040,16 @@ static PyGetSetDef ufunc_getset[] = {
 
 NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "numpy.ufunc",                              /* tp_name */
-    sizeof(PyUFuncObject),                      /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)ufunc_dealloc,                  /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    (reprfunc)ufunc_repr,                       /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    (ternaryfunc)ufunc_generic_call,            /* tp_call */
-    (reprfunc)ufunc_repr,                       /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    0,                                          /* tp_doc */
-    (traverseproc)ufunc_traverse,               /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    ufunc_methods,                              /* tp_methods */
-    0,                                          /* tp_members */
-    ufunc_getset,                               /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
+    .tp_name = "numpy.ufunc",
+    .tp_basicsize = sizeof(PyUFuncObject),
+    .tp_dealloc = (destructor)ufunc_dealloc,
+    .tp_repr = (reprfunc)ufunc_repr,
+    .tp_call = (ternaryfunc)ufunc_generic_call,
+    .tp_str = (reprfunc)ufunc_repr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)ufunc_traverse,
+    .tp_methods = ufunc_methods,
+    .tp_getset = ufunc_getset,
 };
 
 /* End of code for ufunc objects */

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -426,21 +426,13 @@ fortran_repr(PyFortranObject *fp)
 
 PyTypeObject PyFortran_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "fortran",                    /*tp_name*/
-    sizeof(PyFortranObject),      /*tp_basicsize*/
-    0,                            /*tp_itemsize*/
-    /* methods */
-    (destructor)fortran_dealloc,  /*tp_dealloc*/
-    0,                            /*tp_print*/
-    (getattrfunc)fortran_getattr, /*tp_getattr*/
-    (setattrfunc)fortran_setattr, /*tp_setattr*/
-    0,                            /*tp_compare/tp_reserved*/
-    (reprfunc)fortran_repr,       /*tp_repr*/
-    0,                            /*tp_as_number*/
-    0,                            /*tp_as_sequence*/
-    0,                            /*tp_as_mapping*/
-    0,                            /*tp_hash*/
-    (ternaryfunc)fortran_call,    /*tp_call*/
+    .tp_name ="fortran",
+    .tp_basicsize = sizeof(PyFortranObject),
+    .tp_dealloc = (destructor)fortran_dealloc,
+    .tp_getattr = (getattrfunc)fortran_getattr,
+    .tp_setattr = (setattrfunc)fortran_setattr,
+    .tp_repr = (reprfunc)fortran_repr,
+    .tp_call = (ternaryfunc)fortran_call,
 };
 
 /************************* f2py_report_atexit *******************************/


### PR DESCRIPTION
I find the `.tp_name` identifier/designator method *much* easier to read. Python only uses in one or two places where it is explicitly a `static`. So before I go ahead and change it everywhere, are all of these usages: "static storage duration" or is there some reason that the way we create them is considered "dynamic storage duration", in which case initialization would not be defined by the C99 standard.