### PR TITLE
[DOC] Mention behaviour of np.squeeze with one element

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1445,7 +1445,7 @@ def squeeze(a, axis=None):
     squeezed : ndarray
         The input array, but with all or a subset of the
         dimensions of length 1 removed. This is always `a` itself
-        or a view into `a`.Note that if all axes are squeezed,
+        or a view into `a`. Note that if all axes are squeezed,
         the result is a 0d array and not a scalar.
 
     Raises

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1438,7 +1438,9 @@ def squeeze(a, axis=None):
 
         Selects a subset of the single-dimensional entries in the
         shape. If an axis is selected with shape entry greater than
-        one, an error is raised.
+        one, an error is raised. Note that when applied to an array
+        `a` with one element and no axis argument, it returns a
+        wrapped scalar of no shape containing the element in `a`.
 
     Returns
     -------
@@ -1472,6 +1474,17 @@ def squeeze(a, axis=None):
     ValueError: cannot select an axis to squeeze out which has size not equal to one
     >>> np.squeeze(x, axis=2).shape
     (1, 3)
+    >>> x = np.array([[1234]])
+    >>> x.shape
+    (1, 1)
+    >>> np.squeeze(x)
+    array(1234)
+    >>> np.squeeze(x).shape
+    ()
+    >>> np.squeeze(x)[0]
+    Traceback (most recent call last):
+    ...
+    IndexError: too many indices for array
 
     """
     try:

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1438,16 +1438,15 @@ def squeeze(a, axis=None):
 
         Selects a subset of the single-dimensional entries in the
         shape. If an axis is selected with shape entry greater than
-        one, an error is raised. Note that when applied to an array
-        `a` with one element and no axis argument, it returns a
-        wrapped scalar of no shape containing the element in `a`.
+        one, an error is raised.
 
     Returns
     -------
     squeezed : ndarray
         The input array, but with all or a subset of the
         dimensions of length 1 removed. This is always `a` itself
-        or a view into `a`.
+        or a view into `a`.Note that if all axes are squeezed,
+        the result is a 0d array and not a scalar.
 
     Raises
     ------
@@ -1481,10 +1480,8 @@ def squeeze(a, axis=None):
     array(1234)  # 0d array
     >>> np.squeeze(x).shape
     ()
-    >>> np.squeeze(x)[0]
-    Traceback (most recent call last):
-    ...
-    IndexError: too many indices for array
+    >>> np.squeeze(x)[()]
+    1234
 
     """
     try:

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1478,7 +1478,7 @@ def squeeze(a, axis=None):
     >>> x.shape
     (1, 1)
     >>> np.squeeze(x)
-    array(1234)
+    array(1234)  # 0d array
     >>> np.squeeze(x).shape
     ()
     >>> np.squeeze(x)[0]


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Fixes #15313 by mentioning the behaviour of `np.squeeze()` with only one / single element and adds one example