### PR TITLE
TST: mark the top 3 slowest tests to save ~10 seconds

### DIFF
--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -725,6 +725,7 @@ class TestUFunc:
         a = np.arange(10000, dtype=np.int16)
         check(np.add, a, a[::-1], a)
 
+    @pytest.mark.slow
     def test_unary_gufunc_fuzz(self):
         shapes = [7, 13, 8, 21, 29, 32]
         gufunc = _umath_tests.euclidean_pdist

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7161,6 +7161,7 @@ class TestNewBufferProtocol:
         a = np.empty((1,) * 32)
         self._check_roundtrip(a)
 
+    @pytest.mark.slow
     def test_error_too_many_dims(self):
         def make_ctype(shape, scalar_type):
             t = scalar_type

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1827,6 +1827,7 @@ def test_xerbla_override():
             pytest.skip('Numpy xerbla not linked in.')
 
 
+@pytest.mark.slow
 def test_sdot_bug_8577():
     # Regression test that loading certain other libraries does not
     # result to wrong results in float32 linear algebra.


### PR DESCRIPTION
Locally this saves 10 out of 76 seconds from the test run.

On the [shippable](https://app.shippable.com/github/numpy/numpy/runs/8798/1/console) arm64 build this save 30 secs out of 272 seconds. These will still run on all the `-mfull` runs, which are 
- travis linux64 python3.7, 
- azure linux32 python3.6
- azure macos python3.6 (with both OpenBLAS32 and OpenBLAS64)
- azure windows python 3.6, 3.7, 3.8

I wonder how long it will take to recoup the carbon costs of merging this PR :)