### PR TITLE
MAINT: Use True/False instead of 1/0 in np.dtype.__reduce__

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2420,7 +2420,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         }
         obj = PyUString_FromFormat("%c%d",self->kind, elsize);
     }
-    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(Nii)", obj, 0, 1));
+    PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(NOO)", obj, Py_False, Py_True));
 
     /*
      * Now return the state which is at least byteorder,


### PR DESCRIPTION
This doesn't really make much difference, but is a little more correct, a little faster, and produces two fewer bytes of pickle data.