### PR TITLE
DOC: Remove duplicated code in true_divide docstring

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3840,9 +3840,6 @@ add_newdoc('numpy.core.umath', 'true_divide',
 
     >>> x/4
     array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])
-    >>> x//4
-    array([0, 0, 0, 0, 1])
-
     """)
 
 add_newdoc('numpy.core.umath', 'frexp',

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3835,11 +3835,11 @@ add_newdoc('numpy.core.umath', 'true_divide',
     >>> np.true_divide(x, 4)
     array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])
 
-    >>> x//4
-    array([0, 0, 0, 0, 1])
-
     >>> x/4
     array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])
+
+    >>> x//4
+    array([0, 0, 0, 0, 1])
     """)
 
 add_newdoc('numpy.core.umath', 'frexp',


### PR DESCRIPTION
I believe this line comes from an older version of the docstring which was importing `__future__`.