### PR TITLE
BUG: Disallow type-promotion of dtypes with different field names

### DIFF
--- a/doc/release/upcoming_changes/15509.compatibility.rst
+++ b/doc/release/upcoming_changes/15509.compatibility.rst
@@ -1,0 +1,12 @@
+Disallow type-promotion of structured dtypes with different field names
+-----------------------------------------------------------------------
+Operations such as ``np.concatenate([a, b])`` and
+``np.promote_types(a.dtype, b.dtype)``  will now raise a ``TypeError`` if
+``a`` and ``b`` are structured arrays whose dtypes have different field names,
+orders, or offsets, even if the field types are castable. Such code should be
+modified to rename or re-order the fields, using ``.astype``,
+``numpy.lib.recfunctions.rename_fields`` or
+``numpy.lib.recfunctions.repack_fields`` depending on the desired behavior.
+Furthermore, ``np.can_cast`` now more consistently reports that structured
+dtypes with different field-names but castable field dtypes are castable.
+Previously some cases were overlooked.

--- a/doc/release/upcoming_changes/15509.compatibility.rst
+++ b/doc/release/upcoming_changes/15509.compatibility.rst
@@ -3,10 +3,10 @@ Disallow type-promotion of structured dtypes with different field names
 Operations such as ``np.concatenate([a, b])`` and
 ``np.promote_types(a.dtype, b.dtype)``  will now raise a ``TypeError`` if
 ``a`` and ``b`` are structured arrays whose dtypes have different field names,
-orders, or offsets, even if the field types are castable. Such code should be
-modified to rename or re-order the fields, using ``.astype``,
-``numpy.lib.recfunctions.rename_fields`` or
-``numpy.lib.recfunctions.repack_fields`` depending on the desired behavior.
+even if the field types are castable, and if the field names are the same it will
+promote to a "packed" memory layout with native endianness. Code which now
+fails should be modified to rename the fields, using ``.astype`` or
+``numpy.lib.recfunctions.rename_fields`` depending on the desired behavior.
 Furthermore, ``np.can_cast`` now more consistently reports that structured
 dtypes with different field-names but castable field dtypes are castable.
 Previously some cases were overlooked.

--- a/doc/release/upcoming_changes/15509.compatibility.rst
+++ b/doc/release/upcoming_changes/15509.compatibility.rst
@@ -1,12 +1,15 @@
-Disallow type-promotion of structured dtypes with different field names
------------------------------------------------------------------------
-Operations such as ``np.concatenate([a, b])`` and
-``np.promote_types(a.dtype, b.dtype)``  will now raise a ``TypeError`` if
-``a`` and ``b`` are structured arrays whose dtypes have different field names,
-even if the field types are castable, and if the field names are the same it will
-promote to a "packed" memory layout with native endianness. Code which now
-fails should be modified to rename the fields, using ``.astype`` or
-``numpy.lib.recfunctions.rename_fields`` depending on the desired behavior.
-Furthermore, ``np.can_cast`` now more consistently reports that structured
-dtypes with different field-names but castable field dtypes are castable.
-Previously some cases were overlooked.
+Changes to type-promotion and casting of structured dtypes
+----------------------------------------------------------
+Type-promotion of structured dtypes, such as in operations such as
+``np.concatenate([a, b])`` and ``np.promote_types(a.dtype, b.dtype)``, now
+requires that the field names and orders of the two dtypes are the same, and
+that the respective fields are promotable. This will promote to a "packed"
+memory layout with native endianness with each respective field promoted.  A
+``TypeError`` will now be raised if the dtypes have different field names.
+Code which now fails should be modified to rename the fields, using ``.astype``
+or ``numpy.lib.recfunctions.rename_fields`` depending on the desired behavior.
+
+Casting between structured dtypes, and methods like ``np.can_cast`` and
+``.astype``,  now more consistently require that the two dtypes have the same
+number of fields and that the respective fields can be cast, and act without
+regard to the field names.  Previously some cases were overlooked.

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -9,7 +9,7 @@ import re
 import sys
 import platform
 
-from .multiarray import dtype, array, ndarray
+from .multiarray import dtype, array, ndarray, promote_types
 try:
     import ctypes
 except ImportError:
@@ -397,6 +397,27 @@ def _copy_fields(ary):
     copy_dtype = {'names': dt.names,
                   'formats': [dt.fields[name][0] for name in dt.names]}
     return array(ary, dtype=copy_dtype, copy=True)
+
+def _promote_fields(dt1, dt2):
+    """ Perform type promotion for two structured dtypes.
+
+    Parameters
+    ----------
+    dt1 : structured dtype
+        First dtype.
+    dt2 : structured dtype
+        Second dtype.
+
+    Returns
+    -------
+    out : dtype
+        The promoted dtype
+    """
+    if (dt1.names is None or dt2.names is None) or dt1.names != dt2.names:
+        raise TypeError("invalid type promotion")
+
+    return dtype([(name, promote_types(dt1[name], dt2[name]))
+                  for name in dt1.names])
 
 def _getfield_is_safe(oldtype, newtype, offset):
     """ Checks safety of getfield for object arrays.

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -631,44 +631,52 @@ type_num_unsigned_to_signed(int type_num)
 }
 
 /*
- * Compare two field dictionaries for castability.
+ * Compare two structured datatypes for castability.
  *
- * Return 1 if 'field1' can be cast to 'field2' according to the rule
+ * Return 1 if 'from' can be cast to 'to' according to the rule
  * 'casting', 0 if not.
  *
- * Castabiliy of field dictionaries is defined recursively: 'field1' and
- * 'field2' must have the same field names (possibly in different
- * orders), and the corresponding field types must be castable according
- * to the given casting rule.
+ * Castability of structured types is defined recursively: the corresponding
+ * field types of 'from' and 'to' must be castable according to the given
+ * casting rule. The field names are ignored.
  */
 static int
-can_cast_fields(PyObject *field1, PyObject *field2, NPY_CASTING casting)
+can_cast_fields(PyArray_Descr *from, PyArray_Descr *to, NPY_CASTING casting)
 {
-    Py_ssize_t ppos;
-    PyObject *key;
-    PyObject *tuple1, *tuple2;
-
-    if (field1 == field2) {
-        return 1;
-    }
-    if (field1 == NULL || field2 == NULL) {
-        return 0;
-    }
-    if (PyDict_Size(field1) != PyDict_Size(field2)) {
+    if (from->names == NULL || to->names == NULL) {
         return 0;
     }
 
-    /* Iterate over all the fields and compare for castability */
-    ppos = 0;
-    while (PyDict_Next(field1, &ppos, &key, &tuple1)) {
-        if ((tuple2 = PyDict_GetItem(field2, key)) == NULL) {
+    int field_count = PyTuple_GET_SIZE(to->names);
+    if (field_count != PyTuple_GET_SIZE(from->names)) {
+        return 0;
+    }
+
+    for (int i = 0; i < field_count; ++i) {
+        PyArray_Descr *to_fld_dtype, *from_fld_dtype;
+
+        PyObject *to_key = PyTuple_GET_ITEM(to->names, i);
+        PyObject *to_tup = PyDict_GetItemWithError(to->fields, to_key);
+        if (to_tup == NULL) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_RuntimeError, "bug, should not happen");
+            }
             return 0;
         }
+        to_fld_dtype = (PyArray_Descr*)PyTuple_GET_ITEM(to_tup, 0);
+
+        PyObject *from_key = PyTuple_GET_ITEM(from->names, i);
+        PyObject *from_tup = PyDict_GetItemWithError(from->fields, from_key);
+        if (from_tup == NULL) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_RuntimeError, "bug, should not happen");
+            }
+            return 0;
+        }
+        from_fld_dtype = (PyArray_Descr*)PyTuple_GET_ITEM(from_tup, 0);
+
         /* Compare the dtype of the field for castability */
-        if (!PyArray_CanCastTypeTo(
-                        (PyArray_Descr *)PyTuple_GET_ITEM(tuple1, 0),
-                        (PyArray_Descr *)PyTuple_GET_ITEM(tuple2, 0),
-                        casting)) {
+        if (!PyArray_CanCastTypeTo(from_fld_dtype, to_fld_dtype, casting)) {
             return 0;
         }
     }
@@ -798,7 +806,7 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
                      * `from' and `to' must have the same fields, and
                      * corresponding fields must be (recursively) castable.
                      */
-                    return can_cast_fields(from->fields, to->fields, casting);
+                    return can_cast_fields(from, to, casting);
 
                 case NPY_NO_CASTING:
                 default:
@@ -1424,6 +1432,15 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
                 return ensure_dtype_nbo(type2);
             }
             break;
+    }
+
+    if (PyDataType_HASFIELDS(type1) || PyDataType_HASFIELDS(type2)) {
+        if (!PyArray_EquivTypes(type1, type2)) {
+            PyErr_SetString(PyExc_TypeError,
+                    "cannot promote structured types with non-equivalent fields");
+            return NULL;
+        }
+        return ensure_dtype_nbo(type1);
     }
 
     /* For types equivalent up to endianness, can return either */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1390,6 +1390,25 @@ class TestStructured:
 
         ab[:] = ba  # make sure assignment still works
 
+        # tests of type-promotion of corresponding fields
+        dt1 = np.dtype([("", "i4")])
+        dt2 = np.dtype([("", "i8")])
+        assert_equal(np.promote_types(dt1, dt2), np.dtype([('f0', 'i8')]))
+        assert_equal(np.promote_types(dt2, dt1), np.dtype([('f0', 'i8')]))
+        assert_raises(TypeError, np.promote_types, dt1, np.dtype([("", "V3")]))
+        assert_equal(np.promote_types('i4,f8', 'i8,f4'),
+                     np.dtype([('f0', 'i8'), ('f1', 'f8')]))
+        # test nested case
+        dt1nest = np.dtype([("", dt1)])
+        dt2nest = np.dtype([("", dt2)])
+        assert_equal(np.promote_types(dt1nest, dt2nest),
+                     np.dtype([('f0', np.dtype([('f0', 'i8')]))]))
+
+        # note that offsets are lost when promoting:
+        dt = np.dtype({'names': ['x'], 'formats': ['i4'], 'offsets': [8]})
+        a = np.ones(3, dtype=dt)
+        assert_equal(np.concatenate([a, a]).dtype, np.dtype([('x', 'i4')]))
+
 
 class TestBool:
     def test_test_interning(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -31,6 +31,7 @@ from numpy.testing import (
     )
 from numpy.testing._private.utils import _no_tracing
 from numpy.core.tests._locales import CommaDecimalPointLocale
+from numpy.lib.recfunctions import repack_fields
 
 # Need to test an object that does not fully implement math interface
 from datetime import timedelta, datetime
@@ -1365,7 +1366,7 @@ class TestStructured:
         # gh-15494
         # dtypes with different field names are not promotable
         A = ("a", "<i8")
-        B = ("b", "<i8")
+        B = ("b", ">i8")
         ab = np.array([(1, 2)], dtype=[A, B])
         ba = np.array([(1, 2)], dtype=[B, A])
         assert_raises(TypeError, np.concatenate, ab, ba)
@@ -1373,9 +1374,9 @@ class TestStructured:
         assert_raises(TypeError, np.promote_types, ab.dtype, ba.dtype)
 
         # dtypes with same field names/order but different memory offsets
-        # are not promotable either.
-        assert_raises(TypeError, np.promote_types,
-                                 ab.dtype, ba[['a', 'b']].dtype)
+        # and byte-order are promotable to packed nbo.
+        assert_equal(np.promote_types(ab.dtype, ba[['a', 'b']].dtype),
+                     repack_fields(ab.dtype.newbyteorder('N')))
 
         # gh-13667
         # dtypes with different fieldnames but castable field types are castable

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -540,6 +540,22 @@ calling :func:`ndarray.item`::
  >>> scalar.item(), type(scalar.item())
  ((1, 4.0, 3.0), <class 'tuple'>)
 
+Casting and Type-Promotion of Structured Datatypes
+--------------------------------------------------
+
+A structured datatype can be cast to another structured datatype as long as the
+number of fields is the same and the fields of the source datatype can be cast
+to the field in the same respective position in the target datatype, for
+instance when using ``ndarray.astype`` or as tested by ``np.can_cast``.
+
+However, numpy is unable to perform type-promotion of a group of structured
+datatypes to a common structured datatype unless their field names, orders, and
+offsets match, even if they can be cast to each other. For instance, this
+applies when using ``np.promote_type``, ``np.result_type`` or functions which
+depend on these such as ``np.concatenate``, as it is ambiguous which field
+names or offsets to use in the promoted type. These functions will raise an
+error if there is no unambiguous promotion type.
+
 Viewing Structured Arrays Containing Objects
 --------------------------------------------
 

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -546,15 +546,18 @@ Casting and Type-Promotion of Structured Datatypes
 A structured datatype can be cast to another structured datatype as long as the
 number of fields is the same and the fields of the source datatype can be cast
 to the field in the same respective position in the target datatype, for
-instance when using ``ndarray.astype`` or as tested by ``np.can_cast``.
+instance when using ``ndarray.astype`` or as tested by ``np.can_cast``. The
+field names do not affect casting.
 
 A pair of structured datatypes can be promoted to a common type as long as their
-field names and order match exactly, but their field offsets may differ. The
-promoted type will be a structured datatype with packed fields with the same
-names and order converted to native endianness.  For instance, this applies
-when using ``np.promote_type``, ``np.result_type`` or functions which depend on
-these such as ``np.concatenate``. These functions will raise an error if the
-field names differ.
+field names and order match exactly, though their field offsets may differ, and
+as long as the field datatypes at the same field-positions are promotable. The
+promoted type will be a structured datatype with packed native-endianness
+fields with the same names and order and whose datatype are the respective
+promoted types. For instance, this applies when using ``np.promote_type``,
+``np.result_type`` or functions which depend on these such as
+``np.concatenate``. These functions will raise an error if the field names
+differ.
 
 Viewing Structured Arrays Containing Objects
 --------------------------------------------

--- a/numpy/doc/structured_arrays.py
+++ b/numpy/doc/structured_arrays.py
@@ -548,13 +548,13 @@ number of fields is the same and the fields of the source datatype can be cast
 to the field in the same respective position in the target datatype, for
 instance when using ``ndarray.astype`` or as tested by ``np.can_cast``.
 
-However, numpy is unable to perform type-promotion of a group of structured
-datatypes to a common structured datatype unless their field names, orders, and
-offsets match, even if they can be cast to each other. For instance, this
-applies when using ``np.promote_type``, ``np.result_type`` or functions which
-depend on these such as ``np.concatenate``, as it is ambiguous which field
-names or offsets to use in the promoted type. These functions will raise an
-error if there is no unambiguous promotion type.
+A pair of structured datatypes can be promoted to a common type as long as their
+field names and order match exactly, but their field offsets may differ. The
+promoted type will be a structured datatype with packed fields with the same
+names and order converted to native endianness.  For instance, this applies
+when using ``np.promote_type``, ``np.result_type`` or functions which depend on
+these such as ``np.concatenate``. These functions will raise an error if the
+field names differ.
 
 Viewing Structured Arrays Containing Objects
 --------------------------------------------

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -151,7 +151,8 @@ class TestArrayEqual(_GenericTest):
 
         self._test_equal(a, b)
 
-        c = np.empty(2, [('floupipi', float), ('floupa', float)])
+        c = np.empty(2, [('floupipi', float),
+                         ('floupi', float), ('floupa', float)])
         c['floupipi'] = a['floupi'].copy()
         c['floupa'] = a['floupa'].copy()
 


### PR DESCRIPTION
Fixes #15494


The fix seems fairly painless. 



I also considered if we should restrict things even more, but didn't do so. For instance, what about if the field names and order are the same, but the byte-offsets of the fields are different. Which dtype "wins"?

Eg:

```python
>>> A = ("a", "<i8") 
>>> B = ("b", "<i8") 
>>> ab = np.rec.array(obj=np.array([]), dtype=[A, B]) 
>>> ba = np.rec.array(obj=np.array([]), dtype=[B, A])                                       
>>> np.concatenate([a_b_, b_a_[['a', 'b']]])                                                  
array([],
      dtype=(numpy.record, {'names':['a','b'], 'formats':['<i8','<i8'], 'offsets':[8,0], 'itemsize':16}))
```
The behavior shown here is actually the same as the behavior from 1.13 and before (with assign-by-fieldname), where the last dtype would be used in such cases, just like here. Since that is old behavior, I opted to leave it alone.