### PR TITLE
TST: Fix missing output in refguide-check

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -826,6 +826,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
                 success = False
             ns = t.globs
 
+    output.seek(0)
     return success, output.read()
 
 


### PR DESCRIPTION
A roll forward fix instead of the revert in #15515,

tested with 
```bash
(numpy-dev) eights:~/Projects/numpy$ python tools/refguide_check.py --rst doc/source/user/c-info.python-as-glue.rst > before.txt 2> before.stderr

(applied fix)

(numpy-dev) eights:~/Projects/numpy$ python tools/refguide_check.py --rst doc/source/user/c-info.python-as-glue.rst > after.txt 2> after.stderr
(numpy-dev) eights:~/Projects/numpy$ diff before.txt after.txt 
11c11
< File "/tmp/tmp_r2n8h5n/doc/source/user/c-info.python-as-glue.rst", line 172, in doc/source/user/c-info.python-as-glue.rst
---
> File "/tmp/tmpaz__izh_/doc/source/user/c-info.python-as-glue.rst", line 172, in doc/source/user/c-info.python-as-glue.rst
23c23
< File "/tmp/tmp_r2n8h5n/doc/source/user/c-info.python-as-glue.rst", line 173, in doc/source/user/c-info.python-as-glue.rst
---
> File "/tmp/tmpaz__izh_/doc/source/user/c-info.python-as-glue.rst", line 173, in doc/source/user/c-info.python-as-glue.rst
36c36
...

(numpy-dev) eights:~/Projects/numpy$ diff before.stderr after.stderr 
(numpy-dev) eights:~/Projects/numpy$ wc before.* after.*
   2    2   45 before.stderr
  85  267 3381 before.txt
   2    2   45 after.stderr
  85  267 3381 after.txt
 174  538 6852 total
```