### PR TITLE
BUG: Fix inline assembly that detects cpu features on x86(32bit)

### DIFF
--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -94,15 +94,21 @@ npy__cpu_cpuid(int reg[4], int func_id)
     __cpuid(reg, func_id);
 #elif defined(__GNUC__) || defined(__clang__)
     #if defined(NPY_CPU_X86) && defined(__PIC__)
-    // %ebx may be the PIC register
-        #define NPY__CPUID_ASM \
-            "xchg{l}\t{%%}ebx, %1\n\t" \
-            "cpuid\n\t"                \
-            "xchg{l}\t{%%}ebx, %1\n\t"
+        // %ebx may be the PIC register
+        __asm__("xchg{l}\t{%%}ebx, %1\n\t"
+                "cpuid\n\t"
+                "xchg{l}\t{%%}ebx, %1\n\t"
+                : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),
+                  "=d" (reg[3])
+                : "a" (func_id), "c" (0)
+        );
     #else
-        #define NPY__CPUID_ASM "cpuid"
+        __asm__("cpuid\n\t"
+                : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),
+                  "=d" (reg[3])
+                : "a" (func_id), "c" (0)
+        );
     #endif
-    __asm__(NPY__CPUID_ASM : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]), "=d" (reg[3]) : "a" (func_id), "c" (0) : );
 #else
     // TODO: handle other x86 compilers
     reg[0] = 0;


### PR DESCRIPTION
resolves #15525
tested on [godbolt](https://godbolt.org/e#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAM1QDsCBlZAQwBtMQBGAFlICsupVs1qgA%2BhOSkAzpnbICeOpUy10AYVSsArgFtaXAOylV6ADJ5amAHJ6ARpmIgAzAE5SAB1TTCS2pp19I09vXzoLK1tdByc3GTlMBT8GAmZiAgC9A05jWXlFOhS0ggibe0cXd2lU9MygnJkakssy6Iq3AEoZVG1iZA4AcgBSACZnPCoAaiwqFvQISYk8ZwAOADYJSY7JocN1XfVpzFmreeX17YODo5PMebEAWTEASQANC6GABgBBSb%2BdsYzFqTawABQAmmJ1KCAKpid5rL7fUbOUwTJFI6rMRTISYAN1QeHQSNoHgAnpIPNoxMgqUSIJYCJNiJhgEMAKwAIW4HIAIqRJozJlRtLRkGIiR0MYZORixhMbnMII8GOoxAA1bAAJSlP3%2BixpdKwAA8ICzgAKRWKJegBZ8pc5ZT8UXIFUDTsqXtYACrYMxQgDyD1BzzM2t1v3%2BlO09PNltF4slQ0dctRrDdxyVEgA4tYYWqxJc9td3XdPchhKIJBH9SiM7d5mDIdC4QjLiNER3FR6JCGCzX9f8APRDgHszB2Y2TXTMMmTByTAgITCTPvM1l4aqOJGDqNiZjSXQSCCjEbG5AINky1i7Xkc9QEXaykbs0avwy8ifGgVvzj32j3o%2BIwjDuu5gX8p60jGxLsuoAGwUBIF6uBYGnuel5PjeH6AU%2Bb54R%2BX4/i%2Bf6wfBD6nqBKGDiAAIgc4vLMKekxmqyHKcp8fJdLRya8sQTEsWyXIkbyXEUfRyD8eabEgeyImkJRVGDmJvLEsBzFSVyzicQpimTDRp6MWp1AJjaonARJRn2jp/wOk6kYQWMciyNZfwSAeR5iCe5lGv%2BOHAS5KH6f59GGSM6msVyHGyWZdG8nYkkRZywkxTxFlhQJ0mcfJyG6bWwUqQlgmclp0UBeBQUjKFzFWom6AxWlzFWTlg62QpLpqOizqOawznNSOkzegGvIBjRCAiOg7CTKgS6OJMxrrJMaC6B4eDsMQ0gKRp7F8js9GTBxKZdaiHVUNKd7Oj8QozpYEAEkmzoygpQpbTtPE7DKnx2l9%2B23smdn6qSFKGtSUGxqyAqcK1zUsgQvS0OuRXCX9Z1IgMXSsCAAzsgMpAGAMnw46gmOHNIPR9CuKKcDjBCYwTHRdAA1iAIyuAAdOyrifK43DrOynCfALKyGOyQiY9wON4wTpBEwMOPSCAn00/jaOkHAsBIEtK1reQlCa6tFTIMA3CcCMpCzKwBCOPLEB2LTON2JYaRkpjVOkEtuiqAQAa0KwzvK6QWAzqI7B2wHeAskkeKYPL/uYMaiTaJbLs44ycih%2BmdjEE7mhYMnpAEMQeC6MnXQ0PQTBsBwPD8IIlbiJIQh4HY8uQF0qAeAUtAxwAtAGziTN3VBrt3ujOCMcsJEkygQKYdTZCYailFEMSCF4Pid3Pq%2BhJ3S/lE4nDxPkyRNJvB95IkndFOku9tPvjTFKf9/Xy0y8VJD3S9P0XDo5j2O46HMt5prG7msbgkxgDIFxNwVmnBWbpVwIQEgAJnAH0mJoZa%2BtiDIMhmg6mdt6akCZs4QwrNPjC0MJwFYnxODsjWGsdkKxRYDHFv/f2Ms5YK3zvg1WMBEAoFQBg7WFAIB6zWigCsIhgDOE%2BubS261KC239g7WgTs87u09t7X2odA6SJDv7fAEdFBRxjlLOOCck4DFdqnDG/sM5Z2IGSHOgxXYFyLiXM2dBGAsBDtXAQps64gAkDSRuzd4Btw7n4HufcB5D2eIcEeY8J5H2nrPLQWRBCmBvivA%2Ba8wj%2BDSfUEI68/BZLfofC%2Bx8H4FPnufKetAr7NEiHvQQWJajVJaU0Up%2B8uik0/lXH%2BWMJYAMxkAkBYCJGiEmM4UhpDmIIKIFgymAp0Fa1miiEY2x1B4OVgQoh0znAHMOUco5TCWGS0JpjDhit8EDPHqwqW7CuE7K6FHdafgQDcCAA)