### PR TITLE
update doctests, small bugs and changes of repr

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -6,6 +6,10 @@ Standard array subclasses
 
 .. currentmodule:: numpy
 
+.. for doctests
+   >>> import numpy as np
+   >>> np.random.seed(1)
+
 .. note::
 
     Subclassing a ``numpy.ndarray`` is possible but if your goal is to create
@@ -404,23 +408,25 @@ alias for "matrix "in NumPy.
 
 Example 1: Matrix creation from a string
 
->>> a=mat('1 2 3; 4 5 3')
->>> print (a*a.T).I
-[[ 0.2924 -0.1345]
- [-0.1345  0.0819]]
+>>> a = np.mat('1 2 3; 4 5 3')
+>>> print((a*a.T).I)
+    [[ 0.29239766 -0.13450292]
+     [-0.13450292  0.08187135]]
+
 
 Example 2: Matrix creation from nested sequence
 
->>> mat([[1,5,10],[1.0,3,4j]])
+>>> np.mat([[1,5,10],[1.0,3,4j]])
 matrix([[  1.+0.j,   5.+0.j,  10.+0.j],
         [  1.+0.j,   3.+0.j,   0.+4.j]])
 
 Example 3: Matrix creation from an array
 
->>> mat(random.rand(3,3)).T
-matrix([[ 0.7699,  0.7922,  0.3294],
-        [ 0.2792,  0.0101,  0.9219],
-        [ 0.3398,  0.7571,  0.8197]])
+>>> np.mat(np.random.rand(3,3)).T
+matrix([[4.17022005e-01, 3.02332573e-01, 1.86260211e-01],
+        [7.20324493e-01, 1.46755891e-01, 3.45560727e-01],
+        [1.14374817e-04, 9.23385948e-02, 3.96767474e-01]])
+
 
 Memory-mapped file arrays
 =========================
@@ -451,15 +457,15 @@ array actually get written to disk.
 
 Example:
 
->>> a = memmap('newfile.dat', dtype=float, mode='w+', shape=1000)
+>>> a = np.memmap('newfile.dat', dtype=float, mode='w+', shape=1000)
 >>> a[10] = 10.0
 >>> a[30] = 30.0
 >>> del a
->>> b = fromfile('newfile.dat', dtype=float)
->>> print b[10], b[30]
+>>> b = np.fromfile('newfile.dat', dtype=float)
+>>> print(b[10], b[30])
 10.0 30.0
->>> a = memmap('newfile.dat', dtype=float)
->>> print a[10], a[30]
+>>> a = np.memmap('newfile.dat', dtype=float)
+>>> print(a[10], a[30])
 10.0 30.0
 
 
@@ -590,9 +596,9 @@ This default iterator selects a sub-array of dimension :math:`N-1`
 from the array. This can be a useful construct for defining recursive
 algorithms. To loop over the entire array requires :math:`N` for-loops.
 
->>> a = arange(24).reshape(3,2,4)+10
+>>> a = np.arange(24).reshape(3,2,4)+10
 >>> for val in a:
-...     print 'item:', val
+...     print('item:', val)
 item: [[10 11 12 13]
  [14 15 16 17]]
 item: [[18 19 20 21]
@@ -614,7 +620,7 @@ an iterator that will cycle over the entire array in C-style
 contiguous order.
 
 >>> for i, val in enumerate(a.flat):
-...     if i%5 == 0: print i, val
+...     if i%5 == 0: print(i, val)
 0 10
 5 15
 10 20
@@ -636,8 +642,8 @@ N-dimensional enumeration
 Sometimes it may be useful to get the N-dimensional index while
 iterating. The ndenumerate iterator can achieve this.
 
->>> for i, val in ndenumerate(a):
-...     if sum(i)%5 == 0: print i, val
+>>> for i, val in np.ndenumerate(a):
+...     if sum(i)%5 == 0: print(i, val)
 (0, 0, 0) 10
 (1, 1, 3) 25
 (2, 0, 3) 29
@@ -658,8 +664,8 @@ objects as inputs and returns an iterator that returns tuples
 providing each of the input sequence elements in the broadcasted
 result.
 
->>> for val in broadcast([[1,0],[2,3]],[0,1]):
-...     print val
+>>> for val in np.broadcast([[1,0],[2,3]],[0,1]):
+...     print(val)
 (1, 0)
 (0, 1)
 (2, 0)

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -100,9 +100,9 @@ Sub-arrays always have a C-contiguous memory layout.
    >>> x[1]['grades']
    array([ 6.,  7.])
    >>> type(x[1])
-   <type 'numpy.void'>
+   <class 'numpy.void'>
    >>> type(x[1]['grades'])
-   <type 'numpy.ndarray'>
+   <class 'numpy.ndarray'>
 
 .. _arrays.dtypes.constructing:
 
@@ -411,7 +411,7 @@ Type strings
        an 8-bit unsigned integer:
 
        >>> dt = np.dtype({'names': ['r','g','b','a'],
-       ...                'formats': [uint8, uint8, uint8, uint8]})
+       ...                'formats': [np.uint8, np.uint8, np.uint8, np.uint8]})
 
        Data type with fields ``r`` and ``b`` (with the given titles),
        both being 8-bit unsigned integers, the first at byte position
@@ -442,7 +442,7 @@ Type strings
        and ``col3`` (integers at byte position 14):
 
        >>> dt = np.dtype({'col1': ('U10', 0), 'col2': (float32, 10),
-           'col3': (int, 14)})
+       ...                'col3': (int, 14)})
 
 ``(base_dtype, new_dtype)``
 
@@ -464,7 +464,7 @@ Type strings
        32-bit integer, whose first two bytes are interpreted as an integer
        via field ``real``, and the following two bytes via field ``imag``.
 
-       >>> dt = np.dtype((np.int32,{'real':(np.int16, 0),'imag':(np.int16, 2)})
+       >>> dt = np.dtype((np.int32,{'real':(np.int16, 0),'imag':(np.int16, 2)}))
 
        32-bit integer, which is interpreted as consisting of a sub-array
        of shape ``(4,)`` containing 8-bit integers:

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -37,7 +37,7 @@ objects implementing the :class:`buffer` or :ref:`array
 
    >>> x = np.array([[1, 2, 3], [4, 5, 6]], np.int32)
    >>> type(x)
-   <type 'numpy.ndarray'>
+   <class 'numpy.ndarray'>
    >>> x.shape
    (2, 3)
    >>> x.dtype
@@ -47,6 +47,7 @@ objects implementing the :class:`buffer` or :ref:`array
 
    >>> # The element of x in the *second* row, *third* column, namely, 6.
    >>> x[1, 2]
+   6
 
    For example :ref:`slicing <arrays.indexing>` can produce views of
    the array:
@@ -371,6 +372,7 @@ Many of these methods take an argument named *axis*. In such cases,
    A 3-dimensional array of size 3 x 3 x 3, summed over each of its
    three axes
 
+   >>> x = np.arange(27).reshape((3,3,3))
    >>> x
    array([[[ 0,  1,  2],
            [ 3,  4,  5],

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -1,5 +1,8 @@
 .. currentmodule:: numpy.ma
 
+.. for doctests
+   >>> import numpy as np
+   >>> from numpy import ma
 
 .. _numpy.ma.constants:
 
@@ -21,9 +24,9 @@ defines several constants.
       True
       >>> x[-1] = ma.masked
       >>> x
-      masked_array(data = [1 -- --],
-                   mask = [False  True  True],
-             fill_value = 999999)
+      masked_array(data=[1, --, --],
+                   mask=[False,  True,  True],
+             fill_value=999999)
 
 
 .. data:: nomask

--- a/doc/source/reference/routines.polynomials.classes.rst
+++ b/doc/source/reference/routines.polynomials.classes.rst
@@ -52,7 +52,7 @@ the conventional Polynomial class because of its familiarity::
    >>> from numpy.polynomial import Polynomial as P
    >>> p = P([1,2,3])
    >>> p
-   Polynomial([ 1.,  2.,  3.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([1., 2., 3.], domain=[-1,  1], window=[-1,  1])
 
 Note that there are three parts to the long version of the printout. The
 first is the coefficients, the second is the domain, and the third is the
@@ -68,8 +68,8 @@ window::
 Printing a polynomial yields a shorter form without the domain
 and window::
 
-   >>> print p
-   poly([ 1.  2.  3.])
+   >>> print(p)
+   poly([1. 2. 3.])
 
 We will deal with the domain and window when we get to fitting, for the moment
 we ignore them and run through the basic algebraic and arithmetic operations.
@@ -77,19 +77,19 @@ we ignore them and run through the basic algebraic and arithmetic operations.
 Addition and Subtraction::
 
    >>> p + p
-   Polynomial([ 2.,  4.,  6.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([2., 4., 6.], domain=[-1.,  1.], window=[-1.,  1.])
    >>> p - p
-   Polynomial([ 0.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([0.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Multiplication::
 
    >>> p * p
-   Polynomial([  1.,   4.,  10.,  12.,   9.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([ 1.,   4.,  10.,  12.,   9.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Powers::
 
    >>> p**2
-   Polynomial([  1.,   4.,  10.,  12.,   9.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([ 1.,   4., 10., 12.,  9.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Division:
 
@@ -100,20 +100,20 @@ versions the '/' will only work for division by scalars. At some point it
 will be deprecated::
 
    >>> p // P([-1, 1])
-   Polynomial([ 5.,  3.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([5.,  3.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Remainder::
 
    >>> p % P([-1, 1])
-   Polynomial([ 6.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([6.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Divmod::
 
    >>> quo, rem = divmod(p, P([-1, 1]))
    >>> quo
-   Polynomial([ 5.,  3.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([5.,  3.], domain=[-1.,  1.], window=[-1.,  1.])
    >>> rem
-   Polynomial([ 6.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([6.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Evaluation::
 
@@ -134,7 +134,7 @@ the polynomials are regarded as functions this is composition of
 functions::
 
    >>> p(p)
-   Polynomial([  6.,  16.,  36.,  36.,  27.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([ 6., 16., 36., 36., 27.], domain=[-1.,  1.], window=[-1.,  1.])
 
 Roots::
 
@@ -148,11 +148,11 @@ tuples, lists, arrays, and scalars are automatically cast in the arithmetic
 operations::
 
    >>> p + [1, 2, 3]
-   Polynomial([ 2.,  4.,  6.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([2., 4., 6.], domain=[-1.,  1.], window=[-1.,  1.])
    >>> [1, 2, 3] * p
-   Polynomial([  1.,   4.,  10.,  12.,   9.], domain=[-1,  1], window=[-1,  1])
+   Polynomial([ 1.,  4., 10., 12.,  9.], domain=[-1.,  1.], window=[-1.,  1.])
    >>> p / 2
-   Polynomial([ 0.5,  1. ,  1.5], domain=[-1,  1], window=[-1,  1])
+   Polynomial([0.5, 1. , 1.5], domain=[-1.,  1.], window=[-1.,  1.])
 
 Polynomials that differ in domain, window, or class can't be mixed in
 arithmetic::
@@ -180,7 +180,7 @@ conversion of Polynomial classes among themselves is done for type, domain,
 and window casting::
 
     >>> p(T([0, 1]))
-    Chebyshev([ 2.5,  2. ,  1.5], domain=[-1,  1], window=[-1,  1])
+    Chebyshev([2.5, 2. , 1.5], domain=[-1.,  1.], window=[-1.,  1.])
 
 Which gives the polynomial `p` in Chebyshev form. This works because
 :math:`T_1(x) = x` and substituting :math:`x` for :math:`x` doesn't change
@@ -200,18 +200,18 @@ Polynomial instances can be integrated and differentiated.::
     >>> from numpy.polynomial import Polynomial as P
     >>> p = P([2, 6])
     >>> p.integ()
-    Polynomial([ 0.,  2.,  3.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([0., 2., 3.], domain=[-1.,  1.], window=[-1.,  1.])
     >>> p.integ(2)
-    Polynomial([ 0.,  0.,  1.,  1.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([0., 0., 1., 1.], domain=[-1.,  1.], window=[-1.,  1.])
 
 The first example integrates `p` once, the second example integrates it
 twice. By default, the lower bound of the integration and the integration
 constant are 0, but both can be specified.::
 
     >>> p.integ(lbnd=-1)
-    Polynomial([-1.,  2.,  3.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([-1.,  2.,  3.], domain=[-1.,  1.], window=[-1.,  1.])
     >>> p.integ(lbnd=-1, k=1)
-    Polynomial([ 0.,  2.,  3.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([0., 2., 3.], domain=[-1.,  1.], window=[-1.,  1.])
 
 In the first case the lower bound of the integration is set to -1 and the
 integration constant is 0. In the second the constant of integration is set
@@ -220,9 +220,9 @@ number of times the polynomial is differentiated::
 
     >>> p = P([1, 2, 3])
     >>> p.deriv(1)
-    Polynomial([ 2.,  6.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([2., 6.], domain=[-1.,  1.], window=[-1.,  1.])
     >>> p.deriv(2)
-    Polynomial([ 6.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([6.], domain=[-1.,  1.], window=[-1.,  1.])
 
 
 Other Polynomial Constructors
@@ -238,25 +238,25 @@ are demonstrated below::
     >>> from numpy.polynomial import Chebyshev as T
     >>> p = P.fromroots([1, 2, 3])
     >>> p
-    Polynomial([ -6.,  11.,  -6.,   1.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([-6., 11., -6.,  1.], domain=[-1.,  1.], window=[-1.,  1.])
     >>> p.convert(kind=T)
-    Chebyshev([ -9.  ,  11.75,  -3.  ,   0.25], domain=[-1,  1], window=[-1,  1])
+    Chebyshev([-9.  , 11.75, -3.  ,  0.25], domain=[-1.,  1.], window=[-1.,  1.])
 
 The convert method can also convert domain and window::
 
     >>> p.convert(kind=T, domain=[0, 1])
-    Chebyshev([-2.4375 ,  2.96875, -0.5625 ,  0.03125], [ 0.,  1.], [-1.,  1.])
+    Chebyshev([-2.4375 ,  2.96875, -0.5625 ,  0.03125], domain=[0.,  1.], window=[-1.,  1.])
     >>> p.convert(kind=P, domain=[0, 1])
-    Polynomial([-1.875,  2.875, -1.125,  0.125], [ 0.,  1.], [-1.,  1.])
+    Polynomial([-1.875,  2.875, -1.125,  0.125], domain=[0.,  1.], window=[-1.,  1.])
 
 In numpy versions >= 1.7.0 the `basis` and `cast` class methods are also
 available. The cast method works like the convert method while the basis
 method returns the basis polynomial of given degree::
 
     >>> P.basis(3)
-    Polynomial([ 0.,  0.,  0.,  1.], domain=[-1,  1], window=[-1,  1])
+    Polynomial([0., 0., 0., 1.], domain=[-1.,  1.], window=[-1.,  1.])
     >>> T.cast(p)
-    Chebyshev([ -9.  ,  11.75,  -3.  ,   0.25], domain=[-1,  1], window=[-1,  1])
+    Chebyshev([-9.  , 11.75, -3. ,  0.25], domain=[-1.,  1.], window=[-1.,  1.])
 
 Conversions between types can be useful, but it is *not* recommended
 for routine use. The loss of numerical precision in passing from a


### PR DESCRIPTION
part of  #14970 
replaces part of  #15519

Fix missing np prefix.
Fix missing definitions.
Use print function instead of the statement.
Add seed to make output repeatable.

Fixes the tests for arrays.classes.rst, arrays.dtypes.rst, arrays.ndarray.rst, maskedarray.baseclass.rst, and 
routines.polynomials.classes.rst


