### PR TITLE
TST: (Travis CI) Use full python3-dbg path for virtual env creation

### DIFF
--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -26,7 +26,7 @@ pip install -U virtualenv
 
 if [ -n "$USE_DEBUG" ]
 then
-  virtualenv --python=python3-dbg venv
+  virtualenv --python=$(which python3-dbg) venv
 else
   virtualenv --python=python venv
 fi


### PR DESCRIPTION
It seems for virtualenv cannot resolve --python=python3-dbg
passing the full path instead fixes the issue.

---

Or is the fix to add the full python version to the debug one?