### PR TITLE
BUG, DOC: restore missing import

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -12,6 +12,9 @@ import warnings
 from . import overrides
 from . import _multiarray_umath
 from ._multiarray_umath import *  # noqa: F403
+# These imports are needed for backward compatibility,
+# do not change them. issue gh-15518
+# _get_ndarray_c_version is semi-public, on purpose not added to __all__
 from ._multiarray_umath import (
     _fastCopyAndTranspose, _flagdict, _insert, _reconstruct, _vec_string,
     _ARRAY_API, _monotonicity, _get_ndarray_c_version

--- a/numpy/core/umath.py
+++ b/numpy/core/umath.py
@@ -8,7 +8,10 @@ by importing from the extension module.
 
 from . import _multiarray_umath
 from ._multiarray_umath import *  # noqa: F403
-from ._multiarray_umath import _UFUNC_API, _add_newdoc_ufunc
+# These imports are needed for backward compatibility,
+# do not change them. issue gh-11862
+# _ones_like is semi-public, on purpose not added to __all__
+from ._multiarray_umath import _UFUNC_API, _add_newdoc_ufunc, _ones_like
 
 __all__ = [
     '_UFUNC_API', 'ERR_CALL', 'ERR_DEFAULT', 'ERR_IGNORE', 'ERR_LOG',


### PR DESCRIPTION
Closes gh-15518

PR gh-15465 removed an import needed by downstream libraries, even though it is not in `__all__`. Add a comment so hopefully it will not happen again.