### PR TITLE
BUG: fix unique(arr, axis=n) when `0 in arr.shape`

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -289,7 +289,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
             extra_output = ()
             if return_index:
-                # first index is the first occurance of an empty element
+                # first index is the first occurrence of an empty element
                 extra_output += (np.zeros(1, dtype=np.intp),)
             if return_inverse:
                 # all `ar` elements are equal to the 0th element of the output

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -569,24 +569,40 @@ class TestUnique:
         uniq, idx, inv, cnt = unique(single_zero, axis=0, return_index=True,
                                      return_inverse=True, return_counts=True)
 
+        # there's 1 element of shape (0,) along axis 0
         assert_equal(uniq.dtype, single_zero.dtype)
         msg = "Unique with shape=(2, 0) and axis=0 failed"
-        assert_array_equal(uniq, np.empty(shape=(0, 0)), msg)
+        assert_array_equal(uniq, np.empty(shape=(1, 0)), msg)
         msg = "Unique with shape=(2, 0) and axis=0 idx failed"
-        assert_array_equal(idx, np.empty(shape=(0,)), msg)
+        assert_array_equal(idx, np.array([0]), msg)
         msg = "Unique with shape=(2, 0) and axis=0 inv failed"
-        assert_array_equal(inv, np.empty(shape=(0,)), msg)
+        assert_array_equal(inv, np.array([0, 0]), msg)
         msg = "Unique with shape=(2, 0) and axis=0 cnt failed"
-        assert_array_equal(cnt, np.empty(shape=(0,)), msg)
+        assert_array_equal(cnt, np.array([2]), msg)
 
+        # there's 0 elements of shape (2,) along axis 1
+        uniq, idx, inv, cnt = unique(single_zero, axis=1, return_index=True,
+                                     return_inverse=True, return_counts=True)
+
+        assert_equal(uniq.dtype, single_zero.dtype)
         msg = "Unique with shape=(2, 0) and axis=1 failed"
-        assert_array_equal(unique(single_zero, axis=1), np.empty(shape=(2, 0)), msg)
+        assert_array_equal(uniq, np.empty(shape=(2, 0)), msg)
+        msg = "Unique with shape=(2, 0) and axis=1 idx failed"
+        assert_array_equal(idx, np.array([]), msg)
+        msg = "Unique with shape=(2, 0) and axis=1 inv failed"
+        assert_array_equal(inv, np.array([]), msg)
+        msg = "Unique with shape=(2, 0) and axis=1 cnt failed"
+        assert_array_equal(cnt, np.array([]), msg)
 
+        # test a "complicated" shape
         shape = (0, 2, 0, 3, 0, 4, 0)
         multiple_zeros = np.empty(shape=shape)
         for axis in range(len(shape)):
             expected_shape = list(shape)
-            expected_shape[axis] = 0
+            if shape[axis] == 0:
+                expected_shape[axis] = 0
+            else:
+                expected_shape[axis] = 1
 
             msg = "Unique with shape={} and axis={} failed".format(shape, axis)
             assert_array_equal(unique(multiple_zeros, axis=axis), np.empty(shape=expected_shape), msg)
@@ -655,4 +671,3 @@ class TestUnique:
         assert_array_equal(uniq[:, inv], data)
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
-

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -563,6 +563,34 @@ class TestUnique:
         result = np.array([[-0.0, 0.0]])
         assert_array_equal(unique(data, axis=0), result, msg)
 
+    def test_unique_axis_zeros(self):
+        # issue 15559
+        single_zero = np.empty(shape=(2, 0), dtype=np.int8)
+        uniq, idx, inv, cnt = unique(single_zero, axis=0, return_index=True,
+                                     return_inverse=True, return_counts=True)
+
+        assert_equal(uniq.dtype, single_zero.dtype)
+        msg = "Unique with shape=(2, 0) and axis=0 failed"
+        assert_array_equal(uniq, np.empty(shape=(0, 0)), msg)
+        msg = "Unique with shape=(2, 0) and axis=0 idx failed"
+        assert_array_equal(idx, np.empty(shape=(0,)), msg)
+        msg = "Unique with shape=(2, 0) and axis=0 inv failed"
+        assert_array_equal(inv, np.empty(shape=(0,)), msg)
+        msg = "Unique with shape=(2, 0) and axis=0 cnt failed"
+        assert_array_equal(cnt, np.empty(shape=(0,)), msg)
+
+        msg = "Unique with shape=(2, 0) and axis=1 failed"
+        assert_array_equal(unique(single_zero, axis=1), np.empty(shape=(2, 0)), msg)
+
+        shape = (0, 2, 0, 3, 0, 4, 0)
+        multiple_zeros = np.empty(shape=shape)
+        for axis in range(len(shape)):
+            expected_shape = list(shape)
+            expected_shape[axis] = 0
+
+            msg = "Unique with shape={} and axis={} failed".format(shape, axis)
+            assert_array_equal(unique(multiple_zeros, axis=axis), np.empty(shape=expected_shape), msg)
+
     def test_unique_masked(self):
         # issue 8664
         x = np.array([64, 0, 1, 2, 3, 63, 63, 0, 0, 0, 1, 2, 0, 63, 0], dtype='uint8')
@@ -627,3 +655,4 @@ class TestUnique:
         assert_array_equal(uniq[:, inv], data)
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
+

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -534,6 +534,9 @@ class TestUnique:
         assert_raises(np.AxisError, unique, np.arange(10), axis=2)
         assert_raises(np.AxisError, unique, np.arange(10), axis=-2)
 
+        assert_raises(np.AxisError, unique, np.empty(shape=(2, 0)), axis=2)
+        assert_raises(np.AxisError, unique, np.empty(shape=(2, 0)), axis=-3)
+
     def test_unique_axis_list(self):
         msg = "Unique failed on list of lists"
         inp = [[0, 1, 0], [0, 1, 0]]
@@ -571,28 +574,20 @@ class TestUnique:
 
         # there's 1 element of shape (0,) along axis 0
         assert_equal(uniq.dtype, single_zero.dtype)
-        msg = "Unique with shape=(2, 0) and axis=0 failed"
-        assert_array_equal(uniq, np.empty(shape=(1, 0)), msg)
-        msg = "Unique with shape=(2, 0) and axis=0 idx failed"
-        assert_array_equal(idx, np.array([0]), msg)
-        msg = "Unique with shape=(2, 0) and axis=0 inv failed"
-        assert_array_equal(inv, np.array([0, 0]), msg)
-        msg = "Unique with shape=(2, 0) and axis=0 cnt failed"
-        assert_array_equal(cnt, np.array([2]), msg)
+        assert_array_equal(uniq, np.empty(shape=(1, 0)))
+        assert_array_equal(idx, np.array([0]))
+        assert_array_equal(inv, np.array([0, 0]))
+        assert_array_equal(cnt, np.array([2]))
 
         # there's 0 elements of shape (2,) along axis 1
         uniq, idx, inv, cnt = unique(single_zero, axis=1, return_index=True,
                                      return_inverse=True, return_counts=True)
 
         assert_equal(uniq.dtype, single_zero.dtype)
-        msg = "Unique with shape=(2, 0) and axis=1 failed"
-        assert_array_equal(uniq, np.empty(shape=(2, 0)), msg)
-        msg = "Unique with shape=(2, 0) and axis=1 idx failed"
-        assert_array_equal(idx, np.array([]), msg)
-        msg = "Unique with shape=(2, 0) and axis=1 inv failed"
-        assert_array_equal(inv, np.array([]), msg)
-        msg = "Unique with shape=(2, 0) and axis=1 cnt failed"
-        assert_array_equal(cnt, np.array([]), msg)
+        assert_array_equal(uniq, np.empty(shape=(2, 0)))
+        assert_array_equal(idx, np.array([]))
+        assert_array_equal(inv, np.array([]))
+        assert_array_equal(cnt, np.array([]))
 
         # test a "complicated" shape
         shape = (0, 2, 0, 3, 0, 4, 0)
@@ -604,8 +599,7 @@ class TestUnique:
             else:
                 expected_shape[axis] = 1
 
-            msg = "Unique with shape={} and axis={} failed".format(shape, axis)
-            assert_array_equal(unique(multiple_zeros, axis=axis), np.empty(shape=expected_shape), msg)
+            assert_array_equal(unique(multiple_zeros, axis=axis), np.empty(shape=expected_shape))
 
     def test_unique_masked(self):
         # issue 8664


### PR DESCRIPTION
Previously, `unique` failed with two forms of errors if:

- the `axis` argument is used, not `None` (e.g. `axis=0`)
- the input array has a zero in one or more of its dimensions (e.g. `shape=(1, 0, 2)`)

If `axis` is one of the zero dimensions (`arr.shape[axis] == 0`), it failed in the first `reshape`
with:

    ValueError: cannot reshape array of size 0 into shape (0,newaxis)

If `axis` is not one of the zero dimensions (`arr.shape[axis] != 0`), it failed at `consolidated =
ar.view(...)` with:

    ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original
    dtype

This patch special cases empty arrays to skip over all of that reshaping logic, because it isn't
needed: when the array is empty, the result(s) are empty too, and that can be deduced without any
data reshaping or transformations.

Fixes: #15559

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
