### PR TITLE
TST: Do not create symbolic link named gfortran.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,9 +97,10 @@ stages:
         # manually link critical gfortran libraries
         ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libgfortran.3.dylib /usr/local/lib/libgfortran.3.dylib
         ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libquadmath.0.dylib /usr/local/lib/libquadmath.0.dylib
-        # manually symlink gfortran-4.9 to plain gfortran
-        # for f2py
-        ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
+        # Manually symlink gfortran-4.9 to plain gfortran for f2py.
+        # No longer needed after Feb 13 2020 as gfortran is already present
+        # and the attempted link errors. Keep this for future reference.
+        # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
       displayName: 'make gfortran available on mac os vm'
     # use the pre-built openblas binary that most closely
     # matches our MacOS wheel builds -- currently based


### PR DESCRIPTION
Apparently `gfortran` has been preinstalled for azure-pipeline Mac testing since February 13, 2020, so do not try to link our fortran version to the same name as it causes an error.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
