### PR TITLE
TST: Test division by zero both with scalar and with array

### DIFF
--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -1,9 +1,16 @@
 import platform
 import pytest
+import sysconfig
 
 import numpy as np
 from numpy.testing import assert_, assert_raises
 
+# The floating point emulation on ARM EABI systems lacking a hardware FPU is
+# known to be buggy. This is an attempt to identify these hosts. It may not
+# catch all possible cases, but it catches the known cases of gh-413 and
+# gh-15562.
+hosttype = sysconfig.get_config_var('HOST_GNU_TYPE')
+arm_softfloat = False if hosttype is None else hosttype.endswith('gnueabi')
 
 class TestErrstate:
     @pytest.mark.skipif(platform.machine() == "armv5tel", reason="See gh-413.")
@@ -17,6 +24,8 @@ class TestErrstate:
             with assert_raises(FloatingPointError):
                 np.sqrt(a)
 
+    @pytest.mark.skipif(arm_softfloat,
+                        reason='platform/cpu issue with FPU (gh-15562)')
     def test_divide(self):
         with np.errstate(all='raise', under='ignore'):
             a = -np.arange(3)

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -1,4 +1,3 @@
-import platform
 import pytest
 import sysconfig
 
@@ -13,7 +12,8 @@ hosttype = sysconfig.get_config_var('HOST_GNU_TYPE')
 arm_softfloat = False if hosttype is None else hosttype.endswith('gnueabi')
 
 class TestErrstate:
-    @pytest.mark.skipif(platform.machine() == "armv5tel", reason="See gh-413.")
+    @pytest.mark.skipif(arm_softfloat,
+                        reason='platform/cpu issue with FPU (gh-413,-15562)')
     def test_invalid(self):
         with np.errstate(all='raise', under='ignore'):
             a = -np.arange(3)

--- a/numpy/core/tests/test_errstate.py
+++ b/numpy/core/tests/test_errstate.py
@@ -26,6 +26,9 @@ class TestErrstate:
             # While this should fail!
             with assert_raises(FloatingPointError):
                 a // 0
+            # As should this, see gh-15562
+            with assert_raises(FloatingPointError):
+                a // a
 
     def test_errcall(self):
         def foo(*args):


### PR DESCRIPTION
These two approaches may produce different results. See #15562, where on
armv7l, the latter approach did not raise as expected.