### PR TITLE
DOC: numpy.clip is equivalent to minimum(..., maximum(...))

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2039,8 +2039,8 @@ def clip(a, a_min, a_max, out=None, **kwargs):
     is specified, values smaller than 0 become 0, and values larger
     than 1 become 1.
 
-    Equivalent to but faster than ``np.maximum(a_min, np.minimum(a, a_max))``
-    assuming ``a_min < a_max``.
+    Equivalent to but faster than ``np.minimum(a_max, np.maximum(a, a_min))``.
+
     No check is performed to ensure ``a_min < a_max``.
 
     Parameters


### PR DESCRIPTION
As reflected in the property-based test for `numpy.clip`, this function is equivalent - for all bound orderings - to `minimum(a_max, maximum(a, a_min))`:

https://github.com/numpy/numpy/blob/cd02ddc9c0ea2b7f5f879c0564709eabcec6f1af/numpy/core/tests/test_numeric.py#L2082-L2084

This PR updates the docs to reflect this.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
