### PR TITLE
MAINT: Avoid exception in NpzFile destructor if constructor raises BadZipFile

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -178,6 +178,9 @@ class NpzFile(Mapping):
     array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
     """
+    # Make __exit__ safe if zipfile_factory raises an exception
+    zip = None
+    fid = None
 
     def __init__(self, fid, own_fid=False, allow_pickle=False,
                  pickle_kwargs=None):
@@ -197,8 +200,6 @@ class NpzFile(Mapping):
         self.f = BagObj(self)
         if own_fid:
             self.fid = fid
-        else:
-            self.fid = None
 
     def __enter__(self):
         return self

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -281,6 +281,7 @@ import tempfile
 import warnings
 import pytest
 from io import BytesIO
+import zipfile
 
 import numpy as np
 from numpy.testing import (
@@ -288,6 +289,7 @@ from numpy.testing import (
     assert_warns
     )
 from numpy.lib import format
+from numpy.lib.npyio import NpzFile
 
 
 tempdir = None
@@ -926,6 +928,15 @@ def test_empty_npz():
     fname = os.path.join(tempdir, "nothing.npz")
     np.savez(fname)
     np.load(fname)
+
+def test_loading_invalid_zip_file():
+    with zipfile.ZipFile('spam.zip', 'w') as myzip:
+        myzip.writestr('spam.zip', 'eggs')
+    # Corrupting spam.zip intentionally
+    with open('spam.zip', 'w+b') as fh:
+        fh.seek(2)
+        fh.write(b"\xde\xad\xc0\xde")
+    assert_raises(zipfile.BadZipFile, NpzFile, 'spam.zip')
 
 
 def test_unicode_field_names():

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -281,7 +281,6 @@ import tempfile
 import warnings
 import pytest
 from io import BytesIO
-import zipfile
 
 import numpy as np
 from numpy.testing import (
@@ -289,7 +288,6 @@ from numpy.testing import (
     assert_warns
     )
 from numpy.lib import format
-from numpy.lib.npyio import NpzFile
 
 
 tempdir = None
@@ -928,15 +926,6 @@ def test_empty_npz():
     fname = os.path.join(tempdir, "nothing.npz")
     np.savez(fname)
     np.load(fname)
-
-def test_loading_invalid_zip_file():
-    with zipfile.ZipFile('spam.zip', 'w') as myzip:
-        myzip.writestr('spam.zip', 'eggs')
-    # Corrupting spam.zip intentionally
-    with open('spam.zip', 'w+b') as fh:
-        fh.seek(2)
-        fh.write(b"\xde\xad\xc0\xde")
-    assert_raises(zipfile.BadZipFile, NpzFile, 'spam.zip')
 
 
 def test_unicode_field_names():


### PR DESCRIPTION
Previously if you gave an invalid zip file to NpzFile, zipfile_factory would raise BadZipFile and NpzFile.__exit__ would be called, which accessed members which had not yet been set, leading to a confusing second exception like this:

    zipfile.BadZipFile: File is not a zip file
    Exception ignored in: <function NpzFile.__del__ at 0x9b8ef0>
    Traceback (most recent call last):
      File "numpy/lib/npyio.py", line 230, in __del__
        self.close()
      File "numpy/lib/npyio.py", line 221, in close
        if self.zip is not None:
    AttributeError: 'NpzFile' object has no attribute 'zip'

This change makes __exit__ safe even when __init__ did not complete.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
