### PR TITLE
BUG: Remove check requiring natural alignment of float/double to run AVX code

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -96,7 +96,6 @@ abs_ptrdiff(char *a, char *b)
  */
 #define IS_OUTPUT_BLOCKABLE_UNARY(esize, vsize) \
     (steps[1] == (esize) && abs(steps[0]) < MAX_STEP_SIZE && \
-     (npy_is_aligned(args[0], esize) && npy_is_aligned(args[1], esize)) && \
      ((abs_ptrdiff(args[1], args[0]) >= (vsize)) || \
       ((abs_ptrdiff(args[1], args[0]) == 0))))
 


### PR DESCRIPTION
I am not entirely sure what is causing the CI failure in https://github.com/numpy/numpy/pull/15610. But the test failure seems to be because of a small ULP error (Max relative difference: 1.1176388e-16
 which should be < 1ULP). This patch uses assert_array_max_ulp instead of assert_equal which should hopefully fix the test failure. 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
