### PR TITLE
DOC: Add missing imports, definitions and dummy file

### DIFF
--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -1,3 +1,6 @@
+.. for doctests
+   >>> with open('foo.c', 'w') as f: pass
+
 **********************************
 Packaging (:mod:`numpy.distutils`)
 **********************************
@@ -117,6 +120,11 @@ install the C library, you just use the method `add_installed_library` instead o
 `add_library`, which takes the same arguments except for an additional
 ``install_dir`` argument::
 
+.. for doctests
+
+   >>> import numpy.distutils.misc_util
+   >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+
   >>> config.add_installed_library('foo', sources=['foo.c'], install_dir='lib')
 
 npy-pkg-config files
@@ -180,8 +188,8 @@ Reusing a C library from another package
 Info are easily retrieved from the `get_info` function in
 `numpy.distutils.misc_util`::
 
-  >>> info = get_info('npymath')
-  >>> config.add_extension('foo', sources=['foo.c'], extra_info=**info)
+  >>> info = np.distutils.misc_util.get_info('npymath')
+  >>> config.add_extension('foo', sources=['foo.c'], extra_info=info)
 
 An additional list of paths to look for .ini files can be given to `get_info`.
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -120,7 +120,7 @@ install the C library, you just use the method `add_installed_library` instead o
 `add_library`, which takes the same arguments except for an additional
 ``install_dir`` argument::
 
-.. for doctests
+  .. for doctests
     >>> import numpy.distutils.misc_util
     >>> config = np.distutils.misc_util.Configuration(None, '', '.')
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -1,6 +1,3 @@
-.. for doctests
-   >>> with open('foo.c', 'w') as f: pass
-
 **********************************
 Packaging (:mod:`numpy.distutils`)
 **********************************
@@ -123,6 +120,7 @@ install the C library, you just use the method `add_installed_library` instead o
   .. hidden in a comment so as to be included in refguide but not rendered documentation
     >>> import numpy.distutils.misc_util
     >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+    >>> with open('foo.c', 'w') as f: pass
 
   >>> config.add_installed_library('foo', sources=['foo.c'], install_dir='lib')
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -121,7 +121,6 @@ install the C library, you just use the method `add_installed_library` instead o
 ``install_dir`` argument::
 
 .. for doctests
-
    >>> import numpy.distutils.misc_util
    >>> config = np.distutils.misc_util.Configuration(None, '', '.')
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -120,7 +120,7 @@ install the C library, you just use the method `add_installed_library` instead o
 `add_library`, which takes the same arguments except for an additional
 ``install_dir`` argument::
 
-  .. for doctests
+  .. hidden in a comment so as to be included in refguide but not rendered documentation
     >>> import numpy.distutils.misc_util
     >>> config = np.distutils.misc_util.Configuration(None, '', '.')
 

--- a/doc/source/reference/distutils.rst
+++ b/doc/source/reference/distutils.rst
@@ -121,8 +121,8 @@ install the C library, you just use the method `add_installed_library` instead o
 ``install_dir`` argument::
 
 .. for doctests
-   >>> import numpy.distutils.misc_util
-   >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+    >>> import numpy.distutils.misc_util
+    >>> config = np.distutils.misc_util.Configuration(None, '', '.')
 
   >>> config.add_installed_library('foo', sources=['foo.c'], install_dir='lib')
 


### PR DESCRIPTION
Related to #14970 

Here, I fix the rst tests for `distutils.rst`:
- Add dummy file foo.c at runtime
- I added missing imports in an explicit manner, so as not to hide the information for readers