### PR TITLE
BLD: update openblas download to new location, use manylinux2010-base

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,10 +39,10 @@ stages:
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \
+            python3 -m pip install urllib3 && \
             target=\$(python3 tools/openblas_support.py) && \
             cp -r \$target/lib/* /usr/lib && \
             cp \$target/include/* /usr/include && \
-            yum install -y libgfortran-4.4.7 && \
             python3 -m pip install -r test_requirements.txt && \
             echo CFLAGS \$CFLAGS && \
             python3 -m pip install -v . && \
@@ -105,6 +105,7 @@ stages:
     # matches our MacOS wheel builds -- currently based
     # primarily on file size / name details
     - script: |
+        python -mpip install urllib3
         target=$(python tools/openblas_support.py)
         ls -lR $target
         # manually link to appropriate system paths

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -13,6 +13,7 @@ steps:
     Write-Host "Python Version: $pyversion"
     $target = "C:\\hostedtoolcache\\windows\\Python\\$pyversion\\$(PYTHON_ARCH)\\lib\\openblas$env:OPENBLAS_SUFFIX.a"
     Write-Host "target path: $target"
+    python -mpip install urllib3
     $openblas = python tools/openblas_support.py
     cp $openblas $target
   displayName: 'Download / Install OpenBLAS'

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,6 +25,7 @@ build:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
     - sudo apt-get install gcc gfortran libgfortran5
+    - python -mpip install urllib3
     - target=$(python tools/openblas_support.py)
     - ls -lR "${target}"
     - sudo cp -r "${target}"/lib/* /usr/lib

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -6,7 +6,7 @@ set -o pipefail
 # Print expanded commands
 set -x
 
-sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5
+sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5 python3-urllib3
 F77=gfortran-5 F90=gfortran-5 \
 
 # Download the proper OpenBLAS x64 precompiled library

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -9,14 +9,6 @@ free -m
 df -h
 ulimit -a
 
-if [ -n "$DOWNLOAD_OPENBLAS" ]; then
-  pwd
-  ls -ltrh
-  target=$(python tools/openblas_support.py)
-  sudo cp -r $target/lib/* /usr/lib
-  sudo cp $target/include/* /usr/include
-fi
-
 mkdir builds
 pushd builds
 
@@ -49,6 +41,15 @@ pip install --upgrade pip
 # A specific version of cython is required, so we read the cython package
 # requirement using `grep cython test_requirements.txt` instead of simply
 # writing 'pip install setuptools wheel cython'.
-pip install setuptools wheel `grep cython test_requirements.txt`
+# urllib3 is needed for openblas_support
+pip install setuptools wheel urllib3 `grep cython test_requirements.txt`
+
+if [ -n "$DOWNLOAD_OPENBLAS" ]; then
+  pwd
+  target=$(python tools/openblas_support.py)
+  sudo cp -r $target/lib/* /usr/lib
+  sudo cp $target/include/* /usr/include
+fi
+
 
 if [ -n "$USE_ASV" ]; then pip install asv; fi


### PR DESCRIPTION
Since our free rackspace hosting ran out, we have begun uploading build artifacts to anaconda.org. This PR:
- updates the URL to download from anaconda.org
- uses urllib3 to download, since the new URL on anaconda.org does not work with the stdlib urllib (at least not for me)
- uses a manylinux2010 build of openblas instead of the manylinux1 one, perhaps that will help with the segfault on 32-bit linux in MacPython/numpy-wheels#73