### PR TITLE
ENH: Added loadtxt() parameter skipcols, which allows the user to skip the first and last columns

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -825,8 +825,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         Default: None.
     skiprows : int, optional
         Skip the first `skiprows` lines, including comments; default: 0.
-    skipcols : int, optional
-        Skip the first `skipcols` lines; default: 0.
+    skipcols : int or tuple with len 2, optional
+        When skipcols is a positive int, loadtxt will not load the first `skipcols` columns
+        When skipcols is a negative int, loadtxt will not load the last `skipcols` columns
+        When skipcols is a tuple, loadtxt will not load the first `skipcols[0]` columns or
+        Whe last `skipcols[1]` columns
     usecols : int or sequence, optional
         Which columns to read, with 0 being the first. For example,
         ``usecols = (1,4,5)`` will extract the 2nd, 5th and 6th columns.

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -814,6 +814,17 @@ class TestLoadTxt(LoadTxtBase):
             "was provided" % type(random_str),
              np.loadtxt, c, skipcols=random_str)
 
+        #test that skipcols cannot be used in conjunction with usecols
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        assert_raises_regex(
+                    ValueError,
+                    "Arguments for both skipcols and usecols were provided "
+                    "when numpy expected values for only one.",
+                    np.loadtxt, c, skipcols=1, usecols=(1,))   
+
     def test_usecols(self):
         a = np.array([[1, 2], [3, 4]], float)
         c = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -787,6 +787,33 @@ class TestLoadTxt(LoadTxtBase):
         a = np.array([1, 2, 3, 5], int)
         assert_array_equal(x, a)
 
+    def test_skipcols(self):
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=float, skipcols=1)
+        assert_array_equal(x, a[:, 1:])
+
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=float, skipcols=2)
+        assert_array_equal(x, a[:, 2])
+
+        #testing with non-ints
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        random_str="random str"
+        assert_raises_regex(
+            TypeError, 
+            "skipcols must be an int but an element of type %s " 
+            "was provided" % type(random_str),
+             np.loadtxt, c, skipcols=random_str)
+
     def test_usecols(self):
         a = np.array([[1, 2], [3, 4]], float)
         c = BytesIO()


### PR DESCRIPTION
In response to the request in #13878.
Added a parameter for the function loadtxt(), `skipcols`.
If skipcols is a positive integer, loadtxt() will not load the first `skipcols` columns.
If skipcols is a negative integer, loadtxt() will not load the last `skipcols` columns.
If skipcols is a tuple, loadtxt() will not load the first `skipcols[0]` columns or the last `skipcols[1]` columns.
Also added a number of tests to assure that skipcols worked properly under a variety of circumstances, including outliers such as when the txt file has either only one row or column.

I also could change this relatively easily to make it a part of usecols, such that if an integer in usecols is negative, it will skip that column. Another alternative is making it such that if the first or last integers in usecols are negative, it will skip the first `usecols[0]` columns and last `usecols[1]` columns. However, I went with this to mirror the parameter skiprows better.

Side notes:
Currently, if the user tells loadtxt() to skip more columns than are in the txt file, loadtxt() will return an empty array rather than giving an error.
Whether skipcols[1] is positive or negative, it will skip the last `|skipcols[1]|` columns. This would be easy to change, but both scenarios seem natural, so I allowed both of them.