### PR TITLE
BLD: update OpenBLAS to pre-0.3.9 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ stages:
 
 env:
   global:
-    - OpenBLAS_version=0.3.8
     - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
     # The following is generated with the command:
     # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,10 +5,6 @@ trigger:
     include:
       - master
       - maintenance/*
-variables:
-  # OpenBLAS_version should be updated
-  # to match numpy-wheels repo
-  OpenBLAS_version: 0.3.8
 
 stages:
 - stage: InitialTests
@@ -47,7 +43,7 @@ stages:
             echo CFLAGS \$CFLAGS && \
             python3 -m pip install -v . && \
             python3 runtests.py -n --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml && \
-            python3 tools/openblas_support.py --check_version $(OpenBLAS_version)"
+            python3 tools/openblas_support.py --check_version"
       displayName: 'Run 32-bit manylinux2010 Docker Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
@@ -138,7 +134,7 @@ stages:
       displayName: 'Run Refuide Check'
     - script: python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
       displayName: 'Run Full NumPy Test Suite'
-    - bash: python tools/openblas_support.py --check_version $(OpenBLAS_version)
+    - bash: python tools/openblas_support.py --check_version
       displayName: 'Verify OpenBLAS version'
     - task: PublishTestResults@2
       condition: succeededOrFailed()

--- a/shippable.yml
+++ b/shippable.yml
@@ -50,7 +50,7 @@ build:
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
     # check OpenBLAS version
-    - python tools/openblas_support.py --check_version 0.3.8
+    - python tools/openblas_support.py --check_version
     # run the test suite
     - python runtests.py -n --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -10,7 +10,7 @@ import zipfile
 import tarfile
 
 OPENBLAS_V = 'v0.3.8'
-OPENBLAS_LONG = 'v0.3.5-605-gc815b8fb'  # the 0.3.5 is misleading
+OPENBLAS_LONG = 'v0.3.7-391-gddcbed66'  # the 0.3.7 is misleading
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -9,7 +9,7 @@ from tempfile import mkstemp, gettempdir
 import zipfile
 import tarfile
 
-OPENBLAS_V = 'v0.3.8'
+OPENBLAS_V = '0.3.9'
 OPENBLAS_LONG = 'v0.3.7-391-gddcbed66'  # the 0.3.7 is misleading
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
@@ -243,8 +243,11 @@ def test_version(expected_version, ilp64=get_ilp64()):
     get_config.restype=ctypes.c_char_p
     res = get_config()
     print('OpenBLAS get_config returned', str(res))
-    check_str = b'OpenBLAS %s' % expected_version[0].encode()
-    assert check_str in res
+    if not expected_version:
+        expected_version = OPENBLAS_V
+    check_str = b'OpenBLAS %s' % expected_version.encode()
+    print(check_str)
+    assert check_str in res, '%s not found in %s' %(expected_version, res)
     if ilp64:
         assert b"USE64BITINT" in res
     else:
@@ -257,10 +260,10 @@ if __name__ == '__main__':
                     'architecture')
     parser.add_argument('--test', nargs='*', default=None,
         help='Test different architectures. "all", or any of %s' % ARCHITECTURES)
-    parser.add_argument('--check_version', nargs=1, default=None,
+    parser.add_argument('--check_version', nargs='?', default='',
         help='Check provided OpenBLAS version string against available OpenBLAS')
     args = parser.parse_args()
-    if args.check_version is not None:
+    if args.check_version != '':
         test_version(args.check_version)
     elif args.test is None:
         print(setup_openblas())

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -45,4 +45,4 @@ pypy3/bin/pypy3 runtests.py --debug-info --show-build-log -v -- -rsx \
 echo Make sure the correct openblas has been linked in
 
 pypy3/bin/pip install .
-pypy3/bin/pypy3 tools/openblas_support.py --check_version "$OpenBLAS_version"
+pypy3/bin/pypy3 tools/openblas_support.py --check_version

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -97,7 +97,7 @@ run_test()
   export PYTHONWARNINGS=default
 
   if [ -n "$CHECK_BLAS" ]; then
-    $PYTHON ../tools/openblas_support.py --check_version $OpenBLAS_version
+    $PYTHON ../tools/openblas_support.py --check_version
   fi
 
   if [ -n "$RUN_FULL_TESTS" ]; then


### PR DESCRIPTION
In discussion with the OpenBLAS devs, they suggested we use this version. 0.3.9 is expected soon, and it would be good to test that everything works before they release it.

xref xianyi/OpenBLAS#2445

we should probably benchmark this as well