### PR TITLE
ENH:: Enable loadtxt to skip given number of first and last columns.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -825,8 +825,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         Default: None.
     skiprows : int, optional
         Skip the first `skiprows` lines, including comments; default: 0.
-    skipcols : int, optional
-        Skip the first `skipcols` lines; default: 0.
+    skipcols : int or tuple with len 2, optional
+        When skipcols is a positive int, loadtxt will not load the first `skipcols` columns
+        When skipcols is a negative int, loadtxt will not load the last `skipcols` columns
+        When skipcols is a tuple, loadtxt will not load the first `skipcols[0]` columns or
+        Whe last `skipcols[1]` columns
     usecols : int or sequence, optional
         Which columns to read, with 0 being the first. For example,
         ``usecols = (1,4,5)`` will extract the 2nd, 5th and 6th columns.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1095,6 +1095,12 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             if usecols:
                 vals = [vals[j] for j in usecols]
 
+            if skipcols:
+                if skipcols[1] != 0:
+                    vals = vals[skipcols[0]:skipcols[1]]
+                else:
+                    vals = vals[skipcols[0]:]
+
             if len(vals) != N:
                 line_num = i + skiprows + 1
                 raise ValueError("Wrong number of columns at line %d"
@@ -1139,7 +1145,12 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             first_vals = []
             warnings.warn('loadtxt: Empty input file: "%s"' % fname, stacklevel=2)
 
-        N = len(usecols or first_vals)
+        N = len(usecols or first_vals) - (skipcols[0] - skipcols[1] if skipcols else 0)
+        if N <= 0:
+            if ndmin == 2:
+                return np.empty(shape=(0, 1), dtype=dtype)
+            else:
+                return np.empty(shape=(0), dtype=dtype)
 
         dtype_types, packing = flatten_dtype_internal(dtype)
         if len(dtype_types) > 1:
@@ -1206,24 +1217,6 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         raise ValueError('Illegal value of ndmin keyword: %s' % ndmin)
 
     #Tweak the size and shape of the arrays - remove extraneous dimensions
-    if np.squeeze(X).ndim > 1:
-        X = np.squeeze(X)
-    #remove the first `skipcols[0]` columns and last `skipcols[1]` columns          
-    if skipcols and X.ndim > 0:
-        #outlier case for 1D arrays
-        if X.ndim == 1:
-            if skipcols[1] != 0:
-                X = X[skipcols[0]:skipcols[1]]
-            else:
-                X = X[skipcols[0]:]
-        else:
-            if skipcols[1] != 0:
-                X = X[:, skipcols[0]:skipcols[1]]
-            else:
-                X = X[:, skipcols[0]:]
-
-    # Squeeze again in case removing columns has resulted in more extraneous dimensions
-
     if X.ndim > ndmin:
         X = np.squeeze(X)
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -814,6 +814,17 @@ class TestLoadTxt(LoadTxtBase):
             "was provided" % type(random_str),
              np.loadtxt, c, skipcols=random_str)
 
+        #test that skipcols cannot be used in conjunction with usecols
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        assert_raises_regex(
+                    ValueError,
+                    "Arguments for both skipcols and usecols were provided "
+                    "when numpy expected values for only one.",
+                    np.loadtxt, c, skipcols=1, usecols=(1,))   
+
     def test_usecols(self):
         a = np.array([[1, 2], [3, 4]], float)
         c = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -787,6 +787,33 @@ class TestLoadTxt(LoadTxtBase):
         a = np.array([1, 2, 3, 5], int)
         assert_array_equal(x, a)
 
+    def test_skipcols(self):
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=float, skipcols=1)
+        assert_array_equal(x, a[:, 1:])
+
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        x = np.loadtxt(c, dtype=float, skipcols=2)
+        assert_array_equal(x, a[:, 2])
+
+        #testing with non-ints
+        a = np.array([[1, 2, 3], [3, 4, 5]], float)
+        c = BytesIO()
+        np.savetxt(c, a)
+        c.seek(0)
+        random_str="random str"
+        assert_raises_regex(
+            TypeError, 
+            "skipcols must be an int but an element of type %s " 
+            "was provided" % type(random_str),
+             np.loadtxt, c, skipcols=random_str)
+
     def test_usecols(self):
         a = np.array([[1, 2], [3, 4]], float)
         c = BytesIO()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -860,21 +860,21 @@ class TestLoadTxt(LoadTxtBase):
         np.savetxt(c, a)
         c.seek(0)
         x = np.loadtxt(c, dtype=float, skipcols=4)
-        assert_array_equal(x, np.empty(shape=(2,0)))
+        assert_array_equal(x, np.empty(shape=(0)))
 
         a = np.array([[1, 2, 3], [3, 4, 5]], float)
         c = BytesIO()
         np.savetxt(c, a)
         c.seek(0)
         x = np.loadtxt(c, dtype=float, skipcols=4)
-        assert_array_equal(x, np.empty(shape=(2,0)))
+        assert_array_equal(x, np.empty(shape=(0)))
 
         a = np.array([[1, 2, 3], [3, 4, 5]], float)
         c = BytesIO()
         np.savetxt(c, a)
         c.seek(0)
         x = np.loadtxt(c, dtype=float, skipcols=(2, -2))
-        assert_array_equal(x, np.empty(shape=(2,0)))
+        assert_array_equal(x, np.empty(shape=(0)))
 
         #testing with non-ints
         a = np.array([[1, 2, 3], [3, 4, 5]], float)
@@ -889,6 +889,11 @@ class TestLoadTxt(LoadTxtBase):
             type(random_str),
             np.loadtxt, c, skipcols=random_str)
 
+        c = TextIO()
+        c.write('r,1,2,a\nn,3,4,d')
+        c.seek(0)
+        x = np.loadtxt(c, dtype=int, delimiter=',', skipcols=(1, -1))
+        assert_array_equal(x, np.array([[1, 2], [3, 4]]))
         #testing with 1D outlier cases
         c = TextIO()
         c.write('1,2,3\n')
@@ -901,7 +906,7 @@ class TestLoadTxt(LoadTxtBase):
         np.savetxt(c, b)
         c.seek(0)
         x = np.loadtxt(c, skipcols=1)
-        assert_array_equal(x, np.empty(shape=(3, 0)))
+        assert_array_equal(x, np.empty(shape=(0)))
 
         #test that skipcols cannot be used in conjunction with usecols
         a = np.array([[1, 2, 3], [3, 4, 5]], float)


### PR DESCRIPTION
In response to issue #13878.

Added a parameter for the function loadtxt(), `skipcols`.
If skipcols is a positive integer, loadtxt() will not load the first `skipcols` columns.
If skipcols is a negative integer, loadtxt() will not load the last `skipcols` columns.
If skipcols is a tuple, loadtxt() will not load the first `skipcols[0]` columns or the last `skipcols[1]` columns.
Also added a number of tests to assure that skipcols worked properly under a variety of circumstances, including outliers such as when the txt file has either only one row or column.

Side notes:
Currently, if the user tells loadtxt() to skip more columns than are in the txt file, loadtxt() will return an empty array rather than giving an error.
Whether skipcols[1] is positive or negative, it will skip the last `|skipcols[1]|` columns. This would be easy to change, but both scenarios seem natural, so I allowed both of them.