### PR TITLE
TST: Do not create gfortran link in azure Mac testing.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,9 +97,10 @@ stages:
         # manually link critical gfortran libraries
         ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libgfortran.3.dylib /usr/local/lib/libgfortran.3.dylib
         ln -s /usr/local/Cellar/gcc@4.9/4.9.4_1/lib/gcc/4.9/libquadmath.0.dylib /usr/local/lib/libquadmath.0.dylib
-        # manually symlink gfortran-4.9 to plain gfortran
-        # for f2py
-        ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
+        # Manually symlink gfortran-4.9 to plain gfortran for f2py.
+        # No longer needed after Feb 13 2020 as gfortran is already present
+        # and the attempted link errors. Keep this for future reference.
+        # ln -s /usr/local/bin/gfortran-4.9 /usr/local/bin/gfortran
       displayName: 'make gfortran available on mac os vm'
     # use the pre-built openblas binary that most closely
     # matches our MacOS wheel builds -- currently based

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
 
+# Exit the script immediately if a command exits with a non-zero status,
+# and print commands and their arguments as they are executed.
+set -ex
+
 uname -a
 free -m
 df -h
 ulimit -a
-
-if [ -n "$DOWNLOAD_OPENBLAS" ]; then
-  pwd
-  ls -ltrh
-  target=$(python tools/openblas_support.py)
-  sudo cp -r $target/lib/* /usr/lib
-  sudo cp $target/include/* /usr/include
-fi
 
 mkdir builds
 pushd builds
@@ -22,16 +18,38 @@ pip install -U virtualenv
 
 if [ -n "$USE_DEBUG" ]
 then
-  virtualenv --python=python3-dbg venv
+  virtualenv --python=$(which python3-dbg) venv
 else
   virtualenv --python=python venv
 fi
 
 source venv/bin/activate
 python -V
+gcc --version
 
 popd
 
-pip install --upgrade pip setuptools
-pip install -r test_requirements.txt
+pip install --upgrade pip
+
+# 'setuptools', 'wheel' and 'cython' are build dependencies.  This information
+# is stored in pyproject.toml, but there is not yet a standard way to install
+# those dependencies with, say, a pip command, so we'll just hard-code their
+# installation here.  We only need to install them separately for the cases
+# where numpy is installed with setup.py, which is the case for the Travis jobs
+# where the environment variables USE_DEBUG or USE_WHEEL are set. When pip is
+# used to install numpy, pip gets the build dependencies from pyproject.toml.
+# A specific version of cython is required, so we read the cython package
+# requirement using `grep cython test_requirements.txt` instead of simply
+# writing 'pip install setuptools wheel cython'.
+# urllib3 is needed for openblas_support
+pip install setuptools wheel urllib3 `grep cython test_requirements.txt`
+
+if [ -n "$DOWNLOAD_OPENBLAS" ]; then
+  pwd
+  target=$(python tools/openblas_support.py)
+  sudo cp -r $target/lib/* /usr/lib
+  sudo cp $target/include/* /usr/include
+fi
+
+
 if [ -n "$USE_ASV" ]; then pip install asv; fi

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -48,7 +48,7 @@ setup_base()
   if [ -z "$USE_DEBUG" ]; then
     $PIP install -v . 2>&1 | tee log
   else
-    # Python3.5-dbg on travis seems to need this
+    # The job run with USE_DEBUG=1 on travis needs this.
     export CFLAGS=$CFLAGS" -Wno-maybe-uninitialized"
     $PYTHON setup.py build build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
@@ -65,7 +65,13 @@ setup_base()
 
 run_test()
 {
-  $PIP install -r test_requirements.txt
+  # Install the test dependencies.
+  # Clear PYTHONOPTIMIZE when running `pip install -r test_requirements.txt`
+  # because version 2.19 of pycparser (a dependency of one of the packages
+  # in test_requirements.txt) does not provide a wheel, and the source tar
+  # file does not install correctly when Python's optimization level is set
+  # to strip docstrings (see https://github.com/eliben/pycparser/issues/291).
+  PYTHONOPTIMIZE="" $PIP install -r test_requirements.txt
 
   if [ -n "$USE_DEBUG" ]; then
     export PYTHONPATH=$PWD
@@ -135,16 +141,11 @@ run_test()
   fi
 }
 
+
 export PYTHON
 export PIP
-$PIP install setuptools
 
 if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
-  # Build wheel
-  $PIP install wheel
-  # ensure that the pip / setuptools versions deployed inside
-  # the venv are recent enough
-  $PIP install -U virtualenv
   # ensure some warnings are not issued
   export CFLAGS=$CFLAGS" -Wno-sign-compare -Wno-unused-result"
   # adjust gcc flags if C coverage requested
@@ -155,7 +156,7 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
      export F90='gfortran --coverage'
      export LDFLAGS='--coverage'
   fi
-  $PYTHON setup.py build build_src --verbose-cfg bdist_wheel
+  $PYTHON setup.py build --warn-error build_src --verbose-cfg bdist_wheel
   # Make another virtualenv to install into
   virtualenv --python=`which $PYTHON` venv-for-wheel
   . venv-for-wheel/bin/activate
@@ -167,8 +168,6 @@ if [ -n "$USE_WHEEL" ] && [ $# -eq 0 ]; then
   run_test
 
 elif [ -n "$USE_SDIST" ] && [ $# -eq 0 ]; then
-  # use an up-to-date pip / setuptools inside the venv
-  $PIP install -U virtualenv
   # temporary workaround for sdist failures.
   $PYTHON -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   # ensure some warnings are not issued


### PR DESCRIPTION
Backport of  #15574 and #15275. 

Apparently `gfortran` has been preinstalled for azure-pipeline Mac testing since February 13, 2020, so do not try to link our fortran version to the same name as it causes an error.

Also use master versions of `tools/travis-before-install.py` and `tools/travis-test.py` to get fixes for upstream changes to the testing environments.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
