### PR TITLE
DOC: Improve Benchmark README with environment setup and more practical command

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -17,7 +17,7 @@ unless told otherwise. Some of the benchmarking features in
 development version of NumPy to your current Python environment.
 
 *Before beginning, ensure that* airspeed velocity *is installed.*
-By default, `asv` ships with support for anaconda and virtualenv.
+By default, `asv` ships with support for anaconda and virtualenv.:
 
     pip install asv
     pip install virtualenv
@@ -26,7 +26,7 @@ After contributing new benchmarks, you should test them locally
 before submitting a pull request.
 
 To run all benchmarks, navigate to the root NumPy directory at
-the command line and execute:
+the command line and execute::
 
     python runtests.py --bench
 

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -32,9 +32,10 @@ the command line and execute::
 
 where ``--bench`` activates the benchmark suite instead of the
 test suite. This builds NumPy and runs  all available benchmarks
-defined in ``benchmarks/``.*(Note: this could take a while. Benchmarks
-often take longer to run than unit tests, and each benchmark is run
-multiple times to measure the distribution in execution times.)*
+defined in ``benchmarks/``.(Note: this could take a while. Each
+benchmark is run multiple times to measure the distribution in
+execution times.)
+
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::
 

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -32,7 +32,7 @@ the command line and execute::
 
 where ``--bench`` activates the benchmark suite instead of the
 test suite. This builds NumPy and runs  all available benchmarks
-defined in ``benchmarks/``.(Note: this could take a while. Each
+defined in ``benchmarks/``. (Note: this could take a while. Each
 benchmark is run multiple times to measure the distribution in
 execution times.)
 

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -16,7 +16,7 @@ unless told otherwise. Some of the benchmarking features in
 ``runtests.py``. To run the benchmarks, you do not need to install a
 development version of NumPy to your current Python environment.
 
-*Before beginning, ensure that* airspeed velocity *is installed.*
+Before beginning, ensure that *airspeed velocity* is installed.
 By default, `asv` ships with support for anaconda and virtualenv::
 
     pip install asv
@@ -31,7 +31,10 @@ the command line and execute::
     python runtests.py --bench
 
 where ``--bench`` activates the benchmark suite instead of the
-test suite. This builds NumPy and runs the benchmarks.
+test suite. This builds NumPy and runs  all available benchmarks
+defined in ``benchmarks/``.*(Note: this could take a while. Benchmarks
+often take longer to run than unit tests, and each benchmark is run
+multiple times to measure the distribution in execution times.)*
 To run benchmarks from a particular benchmark module, such as
 ``bench_core.py``, simply append the filename without the extension::
 
@@ -55,12 +58,9 @@ have results saved for future comparison you can run ASV commands
 (record results and generate HTML)::
 
     cd benchmarks
-    asv run --skip-existing-commits --steps 10 ALL
+    asv run HEAD
     asv publish
     asv preview
-
-ASV will report that it is running a server. Using any browser,
-you can review the results by navigating to http://127.0.0.1:8080. 
 
 More on how to use ``asv`` can be found in `ASV documentation`_
 Command-line help is available as usual via ``asv --help`` and

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -16,21 +16,47 @@ unless told otherwise. Some of the benchmarking features in
 ``runtests.py``. To run the benchmarks, you do not need to install a
 development version of NumPy to your current Python environment.
 
-Run a benchmark against currently checked out NumPy version (don't
-record the result)::
+*Before beginning, ensure that* [airspeed velocity](https://github.com/airspeed-velocity/asv) *is installed.* By default, `asv` ships with support for [anaconda](https://store.continuum.io/cshop/anaconda/) and [virtualenv](https://pypi.python.org/pypi/virtualenv).
+
+```
+pip install asv
+pip install virtualenv
+```
+
+After contributing new benchmarks, you should test them locally before submitting a pull request.
+
+To run all benchmarks, navigate to the root NumPy directory at the command line and execute:
+
+```
+python runtests.py --bench
+```
+
+ where `--bench` activates the benchmark suite instead of the test suite. This builds NumPy and runs the benchmarks. 
+
+ To run benchmarks from a particular benchmark module, such as `bench_core.py`, simply append the filename without the extension::
 
     python runtests.py --bench bench_core
 
-Compare change in benchmark results to another version::
+To run a benchmark defined in a class, such as `Mandelbrot` from `bench_avx.py`::
+
+```
+python runtests.py --bench bench_avx.Mandelbrot
+```
+
+Compare change in benchmark results to another version/commit/branch::
 
     python runtests.py --bench-compare v1.6.2 bench_core
+    python runtests.py --bench-compare 8bf4e9b bench_core
+    python runtests.py --bench-compare master bench_core
 
-Run ASV commands (record results and generate HTML)::
+ All of the commands above display the results in plain text in the console, and the results are not saved for comparison with future commits. For greater control, a graphical view, and to have results saved for future comparison you can run ASV commands (record results and generate HTML)::
 
     cd benchmarks
     asv run --skip-existing-commits --steps 10 ALL
     asv publish
     asv preview
+
+ ASV will report that it is running a server. Using any browser, you can review the results by navigating to [http://127.0.0.1:8080](http://127.0.0.1:8080/) (local machine, port 8080). 
 
 More on how to use ``asv`` can be found in `ASV documentation`_
 Command-line help is available as usual via ``asv --help`` and

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -59,7 +59,7 @@ have results saved for future comparison you can run ASV commands
 (record results and generate HTML)::
 
     cd benchmarks
-    asv run HEAD
+    asv run -n -e --python=same
     asv publish
     asv preview
 

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -17,7 +17,7 @@ unless told otherwise. Some of the benchmarking features in
 development version of NumPy to your current Python environment.
 
 *Before beginning, ensure that* airspeed velocity *is installed.*
-By default, `asv` ships with support for anaconda and virtualenv.:
+By default, `asv` ships with support for anaconda and virtualenv::
 
     pip install asv
     pip install virtualenv

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -16,32 +16,31 @@ unless told otherwise. Some of the benchmarking features in
 ``runtests.py``. To run the benchmarks, you do not need to install a
 development version of NumPy to your current Python environment.
 
-*Before beginning, ensure that* [airspeed velocity](https://github.com/airspeed-velocity/asv) *is installed.* By default, `asv` ships with support for [anaconda](https://store.continuum.io/cshop/anaconda/) and [virtualenv](https://pypi.python.org/pypi/virtualenv).
+*Before beginning, ensure that* airspeed velocity *is installed.*
+By default, `asv` ships with support for anaconda and virtualenv.
 
-```
-pip install asv
-pip install virtualenv
-```
+    pip install asv
+    pip install virtualenv
 
-After contributing new benchmarks, you should test them locally before submitting a pull request.
+After contributing new benchmarks, you should test them locally
+before submitting a pull request.
 
-To run all benchmarks, navigate to the root NumPy directory at the command line and execute:
+To run all benchmarks, navigate to the root NumPy directory at
+the command line and execute:
 
-```
-python runtests.py --bench
-```
+    python runtests.py --bench
 
- where `--bench` activates the benchmark suite instead of the test suite. This builds NumPy and runs the benchmarks. 
-
- To run benchmarks from a particular benchmark module, such as `bench_core.py`, simply append the filename without the extension::
+where ``--bench`` activates the benchmark suite instead of the
+test suite. This builds NumPy and runs the benchmarks.
+To run benchmarks from a particular benchmark module, such as
+``bench_core.py``, simply append the filename without the extension::
 
     python runtests.py --bench bench_core
 
-To run a benchmark defined in a class, such as `Mandelbrot` from `bench_avx.py`::
+To run a benchmark defined in a class, such as ``Mandelbrot``
+from ``bench_avx.py``::
 
-```
-python runtests.py --bench bench_avx.Mandelbrot
-```
+    python runtests.py --bench bench_avx.Mandelbrot
 
 Compare change in benchmark results to another version/commit/branch::
 
@@ -49,14 +48,19 @@ Compare change in benchmark results to another version/commit/branch::
     python runtests.py --bench-compare 8bf4e9b bench_core
     python runtests.py --bench-compare master bench_core
 
- All of the commands above display the results in plain text in the console, and the results are not saved for comparison with future commits. For greater control, a graphical view, and to have results saved for future comparison you can run ASV commands (record results and generate HTML)::
+All of the commands above display the results in plain text in
+the console, and the results are not saved for comparison with
+future commits. For greater control, a graphical view, and to
+have results saved for future comparison you can run ASV commands
+(record results and generate HTML)::
 
     cd benchmarks
     asv run --skip-existing-commits --steps 10 ALL
     asv publish
     asv preview
 
- ASV will report that it is running a server. Using any browser, you can review the results by navigating to [http://127.0.0.1:8080](http://127.0.0.1:8080/) (local machine, port 8080). 
+ASV will report that it is running a server. Using any browser,
+you can review the results by navigating to http://127.0.0.1:8080. 
 
 More on how to use ``asv`` can be found in `ASV documentation`_
 Command-line help is available as usual via ``asv --help`` and


### PR DESCRIPTION
Related to #15671 

Here, I improved the benchmark readme.rst as @mattip requested:
- Add asv environment setup.
- Add more practical commands and descriptions.

Reference:
http://scipy.github.io/devdocs/dev/contributor/benchmarking.html