### PR TITLE
DOC: Fix indexing docs to pass refguide

### DIFF
--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -270,9 +270,9 @@ understood with an example.
     previously one could write:
 
     >>> x = np.array([[ 0,  1,  2],
-    ...            [ 3,  4,  5],
-    ...            [ 6,  7,  8],
-    ...            [ 9, 10, 11]])
+    ...               [ 3,  4,  5],
+    ...               [ 6,  7,  8],
+    ...               [ 9, 10, 11]])
     >>> rows = np.array([[0, 0],
     ...                  [3, 3]], dtype=np.intp)
     >>> columns = np.array([[0, 2],

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -1,5 +1,9 @@
 .. _arrays.indexing:
 
+.. for doctests
+   >>> import numpy as np
+
+
 Indexing
 ========
 
@@ -265,7 +269,7 @@ understood with an example.
     one needs to select all elements *explicitly*. Using the method explained
     previously one could write:
 
-    >>> x = array([[ 0,  1,  2],
+    >>> x = np.array([[ 0,  1,  2],
     ...            [ 3,  4,  5],
     ...            [ 6,  7,  8],
     ...            [ 9, 10, 11]])
@@ -392,7 +396,7 @@ smaller than *x* it is identical to filling it with :const:`False`.
 
     >>> x = np.array([[1., 2.], [np.nan, 3.], [np.nan, np.nan]])
     >>> x[~np.isnan(x)]
-    array([ 1.,  2.,  3.])
+    array([1.,  2.,  3.])
 
     Or wish to add a constant to all negative elements:
 
@@ -447,7 +451,7 @@ also supports boolean arrays and will work without any surprises.
     advanced integer index. Using the :func:`ix_` function this can be done
     with:
 
-    >>> x = array([[ 0,  1,  2],
+    >>> x = np.array([[ 0,  1,  2],
     ...            [ 3,  4,  5],
     ...            [ 6,  7,  8],
     ...            [ 9, 10, 11]])

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -1,8 +1,7 @@
-.. _arrays.indexing:
-
 .. for doctests
    >>> import numpy as np
 
+.. _arrays.indexing:
 
 Indexing
 ========

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -426,18 +426,6 @@ with.
     array([[0, 1],
            [1, 1]])
 
-    But if ``rowsum`` would have two dimensions as well:
-
-    >>> rowsum = x.sum(-1, keepdims=True)
-    >>> rowsum.shape
-    (3, 1)
-    >>> x[rowsum <= 2, :]    # fails
-    IndexError: too many indices
-    >>> x[rowsum <= 2]
-    array([0, 1])
-
-    The last one giving only the first elements because of the extra dimension.
-    Compare ``rowsum.nonzero()`` to understand this example.
 
 Combining multiple Boolean indexing arrays or a Boolean with an integer
 indexing array can best be understood with the

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -440,9 +440,9 @@ also supports boolean arrays and will work without any surprises.
     with:
 
     >>> x = np.array([[ 0,  1,  2],
-    ...            [ 3,  4,  5],
-    ...            [ 6,  7,  8],
-    ...            [ 9, 10, 11]])
+    ...               [ 3,  4,  5],
+    ...               [ 6,  7,  8],
+    ...               [ 9, 10, 11]])
     >>> rows = (x.sum(-1) % 2) == 0
     >>> rows
     array([False,  True, False,  True])

--- a/doc/source/reference/arrays.indexing.rst
+++ b/doc/source/reference/arrays.indexing.rst
@@ -396,7 +396,7 @@ smaller than *x* it is identical to filling it with :const:`False`.
 
     >>> x = np.array([[1., 2.], [np.nan, 3.], [np.nan, np.nan]])
     >>> x[~np.isnan(x)]
-    array([1.,  2.,  3.])
+    array([1., 2., 3.])
 
     Or wish to add a constant to all negative elements:
 


### PR DESCRIPTION
Related to #14970

This PR fixes the refguide_check.py for arrays.indexing.rst