### PR TITLE
MAINT: Add a fast path to var for complex input

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -180,3 +180,14 @@ class UnpackBits(Benchmark):
 class Indices(Benchmark):
     def time_indices(self):
         np.indices((1000, 500))
+
+class VarComplex(Benchmark):
+    params = [10**n for n in range(1, 9)]
+    def setup(self, n):
+        self.arr = np.random.randn(n) + 1j * np.random.randn(n)
+
+    def teardown(self, n):
+        del self.arr
+
+    def time_var(self, n):
+        self.arr.var()


### PR DESCRIPTION
`var` currently has a conditional that results in `conjugate` being called for the variance calculation of complex inputs.

This leg of the computation is slower than it could be if `conjugate` were avoided altogether. This PR avoids this computational leg for complex inputs via a type check.

Closes #15684.

Here are the results of a benchmark on my system:

On 6894bbc6 (i.e. pre-change):
```
             =========== =============
                 arr size                
              ----------- -------------
                   10        35.3±1μs  
                  100      35.3±0.05μs 
                  1000       41.1±2μs  
                 10000       72.9±5μs  
                 100000     725±300μs  
                1000000     8.21±0.9ms 
                10000000     94.0±3ms  
               100000000     898±10ms  
              =========== =============
```

This PR (with fast path):
```
             =========== =============
                 arr size                
              ----------- -------------
                   10       77.7±0.3μs 
                  100      77.6±0.08μs 
                  1000       85.7±4μs  
                 10000       111±7μs   
                 100000      339±2μs   
                1000000      6.03±1ms  
                10000000     75.4±6ms  
               100000000     756±30ms  
              =========== =============
```

I'm not sure adding the additional complexity is necessarily worth the speed-up, especially since the change results in a slow-down for the non-computation-constrained case (i.e. smaller arrays) - please let me know what you think. 