### PR TITLE
MAINT: replace optparse with argparse for 'doc' and 'tools' scripts

### DIFF
--- a/doc/postprocess.py
+++ b/doc/postprocess.py
@@ -1,27 +1,20 @@
 #!/usr/bin/env python
 """
-%prog MODE FILES...
-
 Post-processes HTML and Latex files output by Sphinx.
-MODE is either 'html' or 'tex'.
-
 """
-import optparse
 import io
 
 def main():
-    p = optparse.OptionParser(__doc__)
-    options, args = p.parse_args()
+    import argparse
 
-    if len(args) < 1:
-        p.error('no mode given')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('mode', help='file mode', choices=('html', 'tex'))
+    parser.add_argument('file', nargs='+', help='input file(s)')
+    args = parser.parse_args()
 
-    mode = args.pop(0)
+    mode = args.mode
 
-    if mode not in ('html', 'tex'):
-        p.error('unknown mode %s' % mode)
-
-    for fn in args:
+    for fn in args.file:
         with io.open(fn, 'r', encoding="utf-8") as f:
             if mode == 'html':
                 lines = process_html(fn, f.readlines())

--- a/doc/summarize.py
+++ b/doc/summarize.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 """
-summarize.py
-
 Show a summary about which NumPy functions are documented and which are not.
 
 """
 import collections.abc
 import glob
 import inspect
-import optparse
 import os
 import sys
 
@@ -59,13 +56,13 @@ ctypeslib ctypeslib.test
 """.split()
 
 def main():
-    p = optparse.OptionParser(__doc__)
-    p.add_option("-c", "--columns", action="store", type="int", dest="cols",
-                 default=3, help="Maximum number of columns")
-    options, args = p.parse_args()
+    import argparse
 
-    if len(args) != 0:
-        p.error('Wrong number of arguments')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-c", "--columns", type=int, default=3,
+        help="Maximum number of columns (default: %(default)d)")
+    args = parser.parse_args()
 
     # prepare
     fn = os.path.join(CUR_DIR, 'dump.xml')
@@ -90,13 +87,13 @@ def main():
             print("--- %s\n" % filename)
         last_filename = filename
         print(" ** ", section)
-        print(format_in_columns(sorted(names), options.cols))
+        print(format_in_columns(sorted(names), args.columns))
         print("\n")
 
     print("")
     print("Undocumented")
     print("============\n")
-    print(format_in_columns(sorted(undocumented.keys()), options.cols))
+    print(format_in_columns(sorted(undocumented.keys()), args.columns))
 
 def check_numpy():
     documented = get_documented(glob.glob(SOURCE_DIR + '/*.rst'))

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -4,7 +4,6 @@ A script to create C code-coverage reports based on the output of
 valgrind's callgrind tool.
 
 """
-import optparse
 import os
 import re
 import sys
@@ -143,39 +142,43 @@ def collect_stats(files, fd, pattern):
 
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser(
-        usage="[options] callgrind_file(s)")
-    parser.add_option(
-        '-d', '--directory', dest='directory',
-        default='coverage',
-        help='Destination directory for output [default: coverage]')
-    parser.add_option(
-        '-p', '--pattern', dest='pattern',
-        default='numpy',
-        help='Regex pattern to match against source file paths [default: numpy]')
-    parser.add_option(
-        '-f', '--format', dest='format', default=[],
-        action='append', type='choice', choices=('text', 'html'),
-        help="Output format(s) to generate, may be 'text' or 'html' [default: both]")
-    (options, args) = parser.parse_args()
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'callgrind_file', nargs='+',
+        help='One or more callgrind files')
+    parser.add_argument(
+        '-d', '--directory', default='coverage',
+        help='Destination directory for output (default: %(default)s)')
+    parser.add_argument(
+        '-p', '--pattern', default='numpy',
+        help='Regex pattern to match against source file paths '
+             '(default: %(default)s)')
+    parser.add_argument(
+        '-f', '--format', action='append', default=[],
+        choices=['text', 'html'],
+        help="Output format(s) to generate. "
+             "If option not provided, both will be generated.")
+    args = parser.parse_args()
 
     files = SourceFiles()
-    for log_file in args:
+    for log_file in args.callgrind_file:
         log_fd = open(log_file, 'r')
-        collect_stats(files, log_fd, options.pattern)
+        collect_stats(files, log_fd, args.pattern)
         log_fd.close()
 
-    if not os.path.exists(options.directory):
-        os.makedirs(options.directory)
+    if not os.path.exists(args.directory):
+        os.makedirs(args.directory)
 
-    if options.format == []:
+    if args.format == []:
         formats = ['text', 'html']
     else:
-        formats = options.format
+        formats = args.format
     if 'text' in formats:
-        files.write_text(options.directory)
+        files.write_text(args.directory)
     if 'html' in formats:
         if not has_pygments:
             print("Pygments 0.11 or later is required to generate HTML")
             sys.exit(1)
-        files.write_html(options.directory)
+        files.write_html(args.directory)


### PR DESCRIPTION
The [optparse](https://docs.python.org/3/library/optparse.html) module is deprecated since Python 2.7/3.2. This PR upgrades a few scripts to use [argparse](https://docs.python.org/3/library/argparse.html).

Because these tools are not really part of the CI testing, they need some manual checks. Here is a summary for each tool:
- [X] `doc/postprocess.py` still in used, and checked with `GITVER=91118b3363 make html`
- [ ] `doc/summarize.py` not used, does not work (ModuleNotFoundErrror), and probably not used since numpy 1.7 (when e.g. `doc/sphinxext/phantom_import.py` existed); follow-up with #15708
- [ ] <s>`numpy/distutils/npy_pkg_config.py` not sure how to test from command line</s>
- [X] <s>`numpy/distutils/system_info.py` appears to still be in-use, and works as before</s>; follow-up with #15728
- [X] `tools/c_coverage/c_coverage_report.py` still in use
- [ ] `tools/npy_tempita/__init__.py` not considered in this PR, as this module is left-alone