### PR TITLE
DOC: fix SVD tutorial to pass refguide

### DIFF
--- a/doc/source/user/tutorial-svd.rst
+++ b/doc/source/user/tutorial-svd.rst
@@ -62,7 +62,7 @@ image. We'll use the ``face`` image from the `scipy.misc` module:
 Now, ``img`` is a NumPy array, as we can see when using the ``type`` function::
 
     >>> type(img)
-    numpy.ndarray
+    <class 'numpy.ndarray'>
 
 We can see the image using the `matplotlib.pyplot.imshow` function::
 
@@ -266,6 +266,9 @@ have a second axis. Executing
 ::
 
     >>> s @ Vt
+    Traceback (most recent call last):
+    ...
+    ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1024 is different from 768)
 
 results in a ``ValueError``. This happens because having a one-dimensional
 array for ``s``, in this case, is much more economic in practice than building a

--- a/doc/source/user/tutorial-svd.rst
+++ b/doc/source/user/tutorial-svd.rst
@@ -267,7 +267,7 @@ have a second axis. Executing
 
     >>> s @ Vt
     Traceback (most recent call last):
-    ...
+      ...
     ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1024 is different from 768)
 
 results in a ``ValueError``. This happens because having a one-dimensional

--- a/doc/source/user/tutorial-svd.rst
+++ b/doc/source/user/tutorial-svd.rst
@@ -268,7 +268,9 @@ have a second axis. Executing
     >>> s @ Vt
     Traceback (most recent call last):
       ...
-    ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0, with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1024 is different from 768)
+    ValueError: matmul: Input operand 1 has a mismatch in its core dimension 0,
+    with gufunc signature (n?,k),(k,m?)->(n?,m?) (size 1024 is different from
+    768)
 
 results in a ``ValueError``. This happens because having a one-dimensional
 array for ``s``, in this case, is much more economic in practice than building a


### PR DESCRIPTION
Related to #14970 

Fix the file tutorial-svd.rst for refguide_check.py

- Fix output of type for class ndarray
- Add traceback for shape mismatch

pytest did not show any whitespace difference in the output.