### PR TITLE
ENH: update numpy.linalg.multi_dot to accept an `out` argument

### DIFF
--- a/doc/release/upcoming_changes/15715.new_feature.rst
+++ b/doc/release/upcoming_changes/15715.new_feature.rst
@@ -1,4 +1,5 @@
 `numpy.linalg.multi_dot` now accepts an ``out`` argument
 --------------------------------------------------------
 
-``out`` can be used to avoid creating unnecessary copies of the final product computed by `numpy.linalg.multidot`.
+``out`` can be used to avoid creating unnecessary copies of the final product
+computed by `numpy.linalg.multidot`.

--- a/doc/release/upcoming_changes/15715.new_feature.rst
+++ b/doc/release/upcoming_changes/15715.new_feature.rst
@@ -1,0 +1,4 @@
+``numpy.linalg.multi_dot`` now accepts an out argument
+------------------------------------------------------
+
+``out`` can be used to avoid creating unnecessary copies of the final product computed by ``numpy.linalg.multidot``.

--- a/doc/release/upcoming_changes/15715.new_feature.rst
+++ b/doc/release/upcoming_changes/15715.new_feature.rst
@@ -1,4 +1,4 @@
-``numpy.linalg.multi_dot`` now accepts an out argument
+`numpy.linalg.multi_dot` now accepts an ``out`` argument
 ------------------------------------------------------
 
-``out`` can be used to avoid creating unnecessary copies of the final product computed by ``numpy.linalg.multidot``.
+``out`` can be used to avoid creating unnecessary copies of the final product computed by `numpy.linalg.multidot`.

--- a/doc/release/upcoming_changes/15715.new_feature.rst
+++ b/doc/release/upcoming_changes/15715.new_feature.rst
@@ -1,4 +1,4 @@
 `numpy.linalg.multi_dot` now accepts an ``out`` argument
-------------------------------------------------------
+--------------------------------------------------------
 
 ``out`` can be used to avoid creating unnecessary copies of the final product computed by `numpy.linalg.multidot`.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2643,7 +2643,7 @@ def multi_dot(arrays, out=None):
         Output argument. This must have the exact kind that would be returned
         if it was not used. In particular, it must have the right type, must be
         C-contiguous, and its dtype must be the dtype that would be returned
-        for `dot(a,b)`. This is a performance feature. Therefore, if these
+        for `dot(a, b)`. This is a performance feature. Therefore, if these
         conditions are not met, an exception is raised, instead of attempting
         to be flexible.
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2611,7 +2611,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
 # multi_dot
 
 def _multidot_dispatcher(arrays, out=None):
-    return arrays
+    return (arrays, out)
 
 
 @array_function_dispatch(_multidot_dispatcher)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2798,6 +2798,9 @@ def _multi_dot_matrix_chain_order(arrays, return_costs=False):
 def _multi_dot(arrays, order, i, j, out=None):
     """Actually do the multiplication with the given order."""
     if i == j:
+        # the initial call with non-None out should never get here
+        assert out is None
+
         return arrays[i]
     else:
         return dot(_multi_dot(arrays, order, i, order[i, j]),

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2647,6 +2647,8 @@ def multi_dot(arrays, out=None):
         conditions are not met, an exception is raised, instead of attempting
         to be flexible.
 
+        .. versionadded:: 1.19.0
+
     Returns
     -------
     output : ndarray

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2611,7 +2611,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
 # multi_dot
 
 def _multidot_dispatcher(arrays, *, out=None):
-    return (arrays, out)
+    return tuple(arrays) + (out,)
 
 
 @array_function_dispatch(_multidot_dispatcher)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2610,12 +2610,12 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
 # multi_dot
 
-def _multidot_dispatcher(arrays, out=None):
+def _multidot_dispatcher(arrays, *, out=None):
     return (arrays, out)
 
 
 @array_function_dispatch(_multidot_dispatcher)
-def multi_dot(arrays, out=None):
+def multi_dot(arrays, *, out=None):
     """
     Compute the dot product of two or more arrays in a single function call,
     while automatically selecting the fastest evaluation order.

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2611,7 +2611,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
 # multi_dot
 
 def _multidot_dispatcher(arrays, *, out=None):
-    return tuple(arrays) + (out,)
+    yield from arrays
+    yield out
 
 
 @array_function_dispatch(_multidot_dispatcher)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2610,12 +2610,12 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
 # multi_dot
 
-def _multidot_dispatcher(arrays):
+def _multidot_dispatcher(arrays, out=None):
     return arrays
 
 
 @array_function_dispatch(_multidot_dispatcher)
-def multi_dot(arrays):
+def multi_dot(arrays, out=None):
     """
     Compute the dot product of two or more arrays in a single function call,
     while automatically selecting the fastest evaluation order.
@@ -2639,6 +2639,13 @@ def multi_dot(arrays):
         If the first argument is 1-D it is treated as row vector.
         If the last argument is 1-D it is treated as column vector.
         The other arguments must be 2-D.
+    out : ndarray, optional
+        Output argument. This must have the exact kind that would be returned
+        if it was not used. In particular, it must have the right type, must be
+        C-contiguous, and its dtype must be the dtype that would be returned
+        for `dot(a,b)`. This is a performance feature. Therefore, if these
+        conditions are not met, an exception is raised, instead of attempting
+        to be flexible.
 
     Returns
     -------
@@ -2696,7 +2703,7 @@ def multi_dot(arrays):
     if n < 2:
         raise ValueError("Expecting at least two arrays.")
     elif n == 2:
-        return dot(arrays[0], arrays[1])
+        return dot(arrays[0], arrays[1], out=out)
 
     arrays = [asanyarray(a) for a in arrays]
 
@@ -2712,10 +2719,10 @@ def multi_dot(arrays):
 
     # _multi_dot_three is much faster than _multi_dot_matrix_chain_order
     if n == 3:
-        result = _multi_dot_three(arrays[0], arrays[1], arrays[2])
+        result = _multi_dot_three(arrays[0], arrays[1], arrays[2], out=out)
     else:
         order = _multi_dot_matrix_chain_order(arrays)
-        result = _multi_dot(arrays, order, 0, n - 1)
+        result = _multi_dot(arrays, order, 0, n - 1, out=out)
 
     # return proper shape
     if ndim_first == 1 and ndim_last == 1:
@@ -2726,7 +2733,7 @@ def multi_dot(arrays):
         return result
 
 
-def _multi_dot_three(A, B, C):
+def _multi_dot_three(A, B, C, out=None):
     """
     Find the best order for three arrays and do the multiplication.
 
@@ -2742,9 +2749,9 @@ def _multi_dot_three(A, B, C):
     cost2 = a1b0 * c1 * (a0 + b1c0)
 
     if cost1 < cost2:
-        return dot(dot(A, B), C)
+        return dot(dot(A, B), C, out=out)
     else:
-        return dot(A, dot(B, C))
+        return dot(A, dot(B, C), out=out)
 
 
 def _multi_dot_matrix_chain_order(arrays, return_costs=False):
@@ -2788,10 +2795,11 @@ def _multi_dot_matrix_chain_order(arrays, return_costs=False):
     return (s, m) if return_costs else s
 
 
-def _multi_dot(arrays, order, i, j):
+def _multi_dot(arrays, order, i, j, out=None):
     """Actually do the multiplication with the given order."""
     if i == j:
         return arrays[i]
     else:
         return dot(_multi_dot(arrays, order, i, order[i, j]),
-                   _multi_dot(arrays, order, order[i, j] + 1, j))
+                   _multi_dot(arrays, order, order[i, j] + 1, j),
+                   out=out)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1929,7 +1929,7 @@ class TestMultiDot:
         # the result should be a scalar
         assert_equal(multi_dot([A1d, B, C, D1d]).shape, ())
 
-    def test_basic_function_with_three_arguments_with_out_argument(self):
+    def test_three_arguments_and_out(self):
         # multi_dot with three arguments uses a fast hand coded algorithm to
         # determine the optimal order. Therefore test it separately.
         A = np.random.random((6, 2))
@@ -1942,7 +1942,7 @@ class TestMultiDot:
         assert_almost_equal(out, A.dot(B).dot(C))
         assert_almost_equal(out, np.dot(A, np.dot(B, C)))
 
-    def test_basic_function_with_two_arguments_with_out_argument(self):
+    def test_two_arguments_and_out(self):
         # separate code path with two arguments
         A = np.random.random((6, 2))
         B = np.random.random((2, 6))
@@ -1952,9 +1952,9 @@ class TestMultiDot:
         assert_almost_equal(out, A.dot(B))
         assert_almost_equal(out, np.dot(A, B))
 
-    def test_basic_function_with_dynamic_programing_optimization_with_out_argument(self):
+    def test_dynamic_programing_optimization_and_out(self):
         # multi_dot with four or more arguments uses the dynamic programing
-        # optimization and therefore deserve a separate
+        # optimization and therefore deserve a separate test
         A = np.random.random((6, 2))
         B = np.random.random((2, 6))
         C = np.random.random((6, 2))

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1937,7 +1937,8 @@ class TestMultiDot:
         C = np.random.random((6, 2))
 
         out = np.zeros((6, 2))
-        multi_dot([A, B, C], out=out)
+        ret = multi_dot([A, B, C], out=out)
+        assert out is ret
         assert_almost_equal(out, A.dot(B).dot(C))
         assert_almost_equal(out, np.dot(A, np.dot(B, C)))
 
@@ -1946,7 +1947,8 @@ class TestMultiDot:
         A = np.random.random((6, 2))
         B = np.random.random((2, 6))
         out = np.zeros((6, 6))
-        multi_dot([A, B], out=out)
+        ret = multi_dot([A, B], out=out)
+        assert out is ret
         assert_almost_equal(out, A.dot(B))
         assert_almost_equal(out, np.dot(A, B))
 
@@ -1958,7 +1960,8 @@ class TestMultiDot:
         C = np.random.random((6, 2))
         D = np.random.random((2, 1))
         out = np.zeros((6, 1))
-        multi_dot([A, B, C, D], out=out)
+        ret = multi_dot([A, B, C, D], out=out)
+        assert out is ret
         assert_almost_equal(out, A.dot(B).dot(C).dot(D))
 
     def test_dynamic_programming_logic(self):

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1929,6 +1929,38 @@ class TestMultiDot:
         # the result should be a scalar
         assert_equal(multi_dot([A1d, B, C, D1d]).shape, ())
 
+    def test_basic_function_with_three_arguments_with_out_argument(self):
+        # multi_dot with three arguments uses a fast hand coded algorithm to
+        # determine the optimal order. Therefore test it separately.
+        A = np.random.random((6, 2))
+        B = np.random.random((2, 6))
+        C = np.random.random((6, 2))
+
+        out = np.zeros((6, 2))
+        multi_dot([A, B, C], out=out)
+        assert_almost_equal(out, A.dot(B).dot(C))
+        assert_almost_equal(out, np.dot(A, np.dot(B, C)))
+
+    def test_basic_function_with_two_arguments_with_out_argument(self):
+        # separate code path with two arguments
+        A = np.random.random((6, 2))
+        B = np.random.random((2, 6))
+        out = np.zeros((6, 6))
+        multi_dot([A, B], out=out)
+        assert_almost_equal(out, A.dot(B))
+        assert_almost_equal(out, np.dot(A, B))
+
+    def test_basic_function_with_dynamic_programing_optimization_with_out_argument(self):
+        # multi_dot with four or more arguments uses the dynamic programing
+        # optimization and therefore deserve a separate
+        A = np.random.random((6, 2))
+        B = np.random.random((2, 6))
+        C = np.random.random((6, 2))
+        D = np.random.random((2, 1))
+        out = np.zeros((6, 1))
+        multi_dot([A, B, C, D], out=out)
+        assert_almost_equal(out, A.dot(B).dot(C).dot(D))
+
     def test_dynamic_programming_logic(self):
         # Test for the dynamic programming part
         # This test is directly taken from Cormen page 376.


### PR DESCRIPTION
`out` is a common argument in numpy functions that specifies where the result of the function should be stored. A typical use case for `out` is performance-critical situations where it is desirable to avoid creating unnecessary copies of the result array. `numpy.linalg.multi_dot` is also commonly used in such situations, so it would be nice if it could accept an `out` argument. This PR adds `out` functionality to `numpy.linalg.multi_dot`