### PR TITLE
DOC: Fix coremath.rst to fix refguide_check

### DIFF
--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -249,6 +249,11 @@ Linking against the core math library in an extension
 To use the core math library in your own extension, you need to add the npymath
 compile and link options to your extension in your setup.py:
 
+	.. hidden in a comment so as to be included in refguide but not rendered documentation
+	  >>> import numpy.distutils.misc_util
+	  >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+	  >>> with open('foo.c', 'w') as f: pass
+
         >>> from numpy.distutils.misc_util import get_info
         >>> info = get_info('npymath')
         >>> config.add_extension('foo', sources=['foo.c'], extra_info=info)

--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -249,10 +249,11 @@ Linking against the core math library in an extension
 To use the core math library in your own extension, you need to add the npymath
 compile and link options to your extension in your setup.py:
 
-	.. hidden in a comment so as to be included in refguide but not rendered documentation
-	  >>> import numpy.distutils.misc_util
-	  >>> config = np.distutils.misc_util.Configuration(None, '', '.')
-	  >>> with open('foo.c', 'w') as f: pass
+.. hidden in a comment so as to be included in refguide but not rendered documentation
+        >>> import numpy.distutils.misc_util
+        >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+        >>> with open('foo.c', 'w') as f: pass
+..
 
         >>> from numpy.distutils.misc_util import get_info
         >>> info = get_info('npymath')

--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -249,15 +249,14 @@ Linking against the core math library in an extension
 To use the core math library in your own extension, you need to add the npymath
 compile and link options to your extension in your setup.py:
 
-.. hidden in a comment so as to be included in refguide but not rendered documentation
-        >>> import numpy.distutils.misc_util
-        >>> config = np.distutils.misc_util.Configuration(None, '', '.')
-        >>> with open('foo.c', 'w') as f: pass
-..
+        .. hidden in a comment so as to be included in refguide but not rendered documentation
+          >>> import numpy.distutils.misc_util
+          >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+          >>> with open('foo.c', 'w') as f: pass
 
         >>> from numpy.distutils.misc_util import get_info
         >>> info = get_info('npymath')
-        >>> config.add_extension('foo', sources=['foo.c'], extra_info=info)
+        >>> _ = config.add_extension('foo', sources=['foo.c'], extra_info=info)
 
 In other words, the usage of info is exactly the same as when using blas_info
 and co.

--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -250,9 +250,9 @@ To use the core math library in your own extension, you need to add the npymath
 compile and link options to your extension in your setup.py:
 
         .. hidden in a comment so as to be included in refguide but not rendered documentation
-          >>> import numpy.distutils.misc_util
-          >>> config = np.distutils.misc_util.Configuration(None, '', '.')
-          >>> with open('foo.c', 'w') as f: pass
+                >>> import numpy.distutils.misc_util
+                >>> config = np.distutils.misc_util.Configuration(None, '', '.')
+                >>> with open('foo.c', 'w') as f: pass
 
         >>> from numpy.distutils.misc_util import get_info
         >>> info = get_info('npymath')


### PR DESCRIPTION
Related to #14970

This PR fixes doc/source/reference/c-api/coremath.rst to pass refguide_check

Define config object

Add empty file foo.c at runtime to run distutils config

