### PR TITLE
MAINT: use list-based APIs to call subprocesses

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1868,8 +1868,7 @@ class Configuration(object):
         """Return path's SVN revision number.
         """
         try:
-            output = subprocess.check_output(
-                ['svnversion'], shell=True, cwd=path)
+            output = subprocess.check_output(['svnversion'], cwd=path)
         except (subprocess.CalledProcessError, OSError):
             pass
         else:
@@ -1899,7 +1898,7 @@ class Configuration(object):
         """
         try:
             output = subprocess.check_output(
-                ['hg identify --num'], shell=True, cwd=path)
+                ['hg', 'identify', '--num'], cwd=path)
         except (subprocess.CalledProcessError, OSError):
             pass
         else:

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -1,0 +1,39 @@
+import shutil
+import subprocess
+import sys
+import pytest
+
+from numpy.distutils import mingw32ccompiler
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='win32 only test')
+def test_build_import():
+    '''Test the mingw32ccompiler.build_import_library, which builds a
+    `python.a` from the MSVC `python.lib`
+    '''
+
+    # make sure `nm.exe` exists and supports the current python version. This
+    # can get mixed up when the PATH has a 64-bit nm but the python is 32-bit
+    try:
+        out = subprocess.check_output(['nm.exe', '--help'])
+    except FileNotFoundError:
+        pytest.skip("'nm.exe' not on path, is mingw installed?")
+    supported = out[out.find(b'supported targets:'):]
+    if sys.maxsize < 2**32 and b'pe-i386' not in supported:
+        raise ValueError("'nm.exe' found but it does not support 32-bit "
+                         "dlls when using 32-bit python")
+    elif b'pe-x86-64' not in supported:
+        raise ValueError("'nm.exe' found but it does not support 64-bit "
+                         "dlls when using 64-bit python")
+    # Hide the import library to force a build
+    has_import_lib, fullpath = mingw32ccompiler._check_for_import_lib()
+    if has_import_lib: 
+        shutil.move(fullpath, fullpath + '.bak')
+
+    try: 
+        # Whew, now we can actually test the function
+        mingw32ccompiler.build_import_library()
+
+    finally:
+        if has_import_lib:
+            shutil.move(fullpath + '.bak', fullpath)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 addopts = -l
 norecursedirs = doc tools numpy/linalg/lapack_lite numpy/core/code_generators
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS ALLOW_UNICODE ALLOW_BYTES
+junit_family=xunit2
 
 filterwarnings =
     error

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,8 @@
-cython==0.29.14
-pytest==5.3.1
+cython==0.29.15
+pytest==5.3.5
 pytz==2019.3
 pytest-cov==2.8.1
 pickle5; python_version == '3.7'
 pickle5; python_version == '3.6' and platform_python_implementation != 'PyPy'
-nose
 # for numpy.random.test.test_extending
 cffi

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -45,5 +45,5 @@ pypy3/bin/pypy3 runtests.py --debug-info --show-build-log -v -- -rsx \
 
 echo Make sure the correct openblas has been linked in
 
-pypy3/bin/pip install .
+pypy3/bin/pypy3 -m pip install .
 pypy3/bin/pypy3 tools/openblas_support.py --check_version "$OpenBLAS_version"


### PR DESCRIPTION
Backport of #15714.

* MAINT: use list-based APIs to call subprocesses
* TST, MAINT: add a test for mingw32ccompiler.build_import, clean up lib2def
Co-authored-by: Matti Picus <matti.picus@gmail.com>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

Also end nose tests.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
