### PR TITLE
BUG: fix logic error when nm fails on 32-bit

### DIFF
--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -19,12 +19,15 @@ def test_build_import():
     except FileNotFoundError:
         pytest.skip("'nm.exe' not on path, is mingw installed?")
     supported = out[out.find(b'supported targets:'):]
-    if sys.maxsize < 2**32 and b'pe-i386' not in supported:
-        raise ValueError("'nm.exe' found but it does not support 32-bit "
-                         "dlls when using 32-bit python")
+    if sys.maxsize < 2**32:
+        if b'pe-i386' not in supported:
+            raise ValueError("'nm.exe' found but it does not support 32-bit "
+                             "dlls when using 32-bit python. Supported "
+                             "formats: '%s'" % supported)
     elif b'pe-x86-64' not in supported:
         raise ValueError("'nm.exe' found but it does not support 64-bit "
-                         "dlls when using 64-bit python")
+                         "dlls when using 64-bit python. Supported "
+                         "formats: '%s'" % supported)
     # Hide the import library to force a build
     has_import_lib, fullpath = mingw32ccompiler._check_for_import_lib()
     if has_import_lib: 


### PR DESCRIPTION
The new test on windows for mingw32ccompiler's `nm` supporting the proper format has a logic bug. This turned up when trying it out in [building wheels](https://ci.appveyor.com/project/matthew-brett/numpy-wheels/builds/31317124/job/tq15bc02f88am2io#L2302) on 32 bit. I am not sure what is going on, but at least now the test will fail with more information.

Another option is to skip the test if `nm` is unusable.