### PR TITLE
TST: Remove nose from the test_requirements.txt file.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,6 +5,5 @@ pytz==2019.3
 pytest-cov==2.8.1
 pickle5; python_version == '3.7'
 pickle5; python_version == '3.6' and platform_python_implementation != 'PyPy'
-nose
 # for numpy.random.test.test_extending
 cffi


### PR DESCRIPTION
Nose is unmaintained and raises a DeprecationWarning on import.
Removing it from the requirements will cause the legacy tests that need
it to be skipped.

Nose testing was ended in July 2019 but was raised from the dead when
the test_requirements.py file was added in August 2019.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
