### PR TITLE
ENH: Fix exception causes in _iotools.py

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -699,12 +699,12 @@ class StringConverter:
             # We're still here so we can now return the new value
             return new_value
 
-        except ValueError:
+        except ValueError as e:
             if value.strip() in self.missing_values:
                 if not self._status:
                     self._checked = False
                 return self.default
-            raise ValueError("Cannot convert string '%s'" % value)
+            raise ValueError("Cannot convert string '%s'" % value) from e
     #
 
     def __call__(self, value):
@@ -735,17 +735,17 @@ class StringConverter:
         self._checked = True
         try:
             return self._strict_call(value)
-        except ValueError:
+        except ValueError as e:
             # Raise an exception if we locked the converter...
             if self._locked:
                 errmsg = "Converter is locked and cannot be upgraded"
-                raise ConverterLockError(errmsg)
+                raise ConverterLockError(errmsg) from e
             _statusmax = len(self._mapper)
             # Complains if we try to upgrade by the maximum
             _status = self._status
             if _status == _statusmax:
                 errmsg = "Could not find a valid conversion function"
-                raise ConverterError(errmsg)
+                raise ConverterError(errmsg) from e
             elif _status < _statusmax - 1:
                 _status += 1
             (self.type, self.func, default) = self._mapper[_status]
@@ -764,18 +764,18 @@ class StringConverter:
         try:
             for _m in value:
                 _strict_call(_m)
-        except ValueError:
+        except ValueError as e:
             # Raise an exception if we locked the converter...
             if self._locked:
                 errmsg = "Converter is locked and cannot be upgraded"
-                raise ConverterLockError(errmsg)
+                raise ConverterLockError(errmsg) from e
             _statusmax = len(self._mapper)
             # Complains if we try to upgrade by the maximum
             _status = self._status
             if _status == _statusmax:
                 raise ConverterError(
                     "Could not find a valid conversion function"
-                    )
+                    ) from e
             elif _status < _statusmax - 1:
                 _status += 1
             (self.type, self.func, default) = self._mapper[_status]


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706) and [Pandas](https://github.com/pandas-dev/pandas/pull/32322), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 