### PR TITLE
BUG: fix logic error when nm fails on 32-bit

### DIFF
--- a/doc/changelog/1.18.2-changelog.rst
+++ b/doc/changelog/1.18.2-changelog.rst
@@ -14,7 +14,7 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 6 pull requests were merged for this release.
+A total of 7 pull requests were merged for this release.
 
 * `#15675 <https://github.com/numpy/numpy/pull/15675>`__: TST: move _no_tracing to testing._private
 * `#15676 <https://github.com/numpy/numpy/pull/15676>`__: MAINT: Large overhead in some random functions
@@ -22,3 +22,4 @@ A total of 6 pull requests were merged for this release.
 * `#15679 <https://github.com/numpy/numpy/pull/15679>`__: BUG: Added missing error check in `ndarray.__contains__`
 * `#15722 <https://github.com/numpy/numpy/pull/15722>`__: MAINT: use list-based APIs to call subprocesses
 * `#15729 <https://github.com/numpy/numpy/pull/15729>`__: REL: Prepare for 1.18.2 release.
+* `#15734 <https://github.com/numpy/numpy/pull/15734>`__: BUG: fix logic error when nm fails on 32-bit

--- a/doc/source/release/1.18.2-notes.rst
+++ b/doc/source/release/1.18.2-notes.rst
@@ -28,7 +28,7 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 6 pull requests were merged for this release.
+A total of 7 pull requests were merged for this release.
 
 * `#15675 <https://github.com/numpy/numpy/pull/15675>`__: TST: move _no_tracing to testing._private
 * `#15676 <https://github.com/numpy/numpy/pull/15676>`__: MAINT: Large overhead in some random functions
@@ -36,3 +36,4 @@ A total of 6 pull requests were merged for this release.
 * `#15679 <https://github.com/numpy/numpy/pull/15679>`__: BUG: Added missing error check in `ndarray.__contains__`
 * `#15722 <https://github.com/numpy/numpy/pull/15722>`__: MAINT: use list-based APIs to call subprocesses
 * `#15729 <https://github.com/numpy/numpy/pull/15729>`__: REL: Prepare for 1.18.2 release.
+* `#15734 <https://github.com/numpy/numpy/pull/15734>`__: BUG: fix logic error when nm fails on 32-bit

--- a/numpy/distutils/tests/test_mingw32ccompiler.py
+++ b/numpy/distutils/tests/test_mingw32ccompiler.py
@@ -19,12 +19,15 @@ def test_build_import():
     except FileNotFoundError:
         pytest.skip("'nm.exe' not on path, is mingw installed?")
     supported = out[out.find(b'supported targets:'):]
-    if sys.maxsize < 2**32 and b'pe-i386' not in supported:
-        raise ValueError("'nm.exe' found but it does not support 32-bit "
-                         "dlls when using 32-bit python")
+    if sys.maxsize < 2**32:
+        if b'pe-i386' not in supported:
+            raise ValueError("'nm.exe' found but it does not support 32-bit "
+                             "dlls when using 32-bit python. Supported "
+                             "formats: '%s'" % supported)
     elif b'pe-x86-64' not in supported:
         raise ValueError("'nm.exe' found but it does not support 64-bit "
-                         "dlls when using 64-bit python")
+                         "dlls when using 64-bit python. Supported "
+                         "formats: '%s'" % supported)
     # Hide the import library to force a build
     has_import_lib, fullpath = mingw32ccompiler._check_for_import_lib()
     if has_import_lib: 


### PR DESCRIPTION
Backport of #15723.

The new test on windows for mingw32ccompiler's `nm` supporting the proper format has a logic bug. This turned up when trying it out in [building wheels](https://ci.appveyor.com/project/matthew-brett/numpy-wheels/builds/31317124/job/tq15bc02f88am2io#L2302) on 32 bit. I am not sure what is going on, but at least now the test will fail with more information.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
