### PR TITLE
MAINT: Remove non-native byte order from _var check.

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -31,10 +31,6 @@ if nt.dtype(nt.longdouble) != nt.dtype(nt.double):
     _complex_to_float.update({
         nt.dtype(nt.clongdouble) : nt.dtype(nt.longdouble),
     })
-# Add reverse-endian types
-_complex_to_float.update({
-    k.newbyteorder() : v.newbyteorder() for k, v in _complex_to_float.items()
-})
 
 # avoid keyword arguments to speed up parsing, saves about 15%-20% for very
 # small reductions


### PR DESCRIPTION
Removes unnecessary code introduced in #15696.

Non-native byte orders were explicitly added to the fast-path
check in _var for complex numbers. However, the non-native
path is unreachable due to coercion in upstream ufuncs.