### PR TITLE
MAINT: Add better error handling in linalg.norm for vectors and clarify it in documentation

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2561,10 +2561,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
             # special case for speedup
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
-        elif ord in ('f', 'fro', 'nuc'):
+        elif isinstance(ord, str):
             raise ValueError(f"Invalid norm order '{ord}' for vectors")
-        elif not isinstance(ord, numbers.Integral):
-            raise ValueError("Invalid norm order for vectors.")
         else:
             absx = abs(x)
             absx **= ord

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -15,6 +15,7 @@ __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
            'LinAlgError', 'multi_dot']
 
 import functools
+import numbers
 import operator
 import warnings
 
@@ -2560,13 +2561,15 @@ def norm(x, ord=None, axis=None, keepdims=False):
             # special case for speedup
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
+        elif ord in ('f', 'fro'):
+            raise ValueError("Cannot compute Frobenius norm for vectors, "
+                             "vectors only support integer norm orders. For "
+                             "example for the L2 norm use ord=2 instead")
+        elif ord is 'nuc':
+            raise ValueError("Nuclear norm is not supported for vectors")
+        elif not isinstance(ord, numbers.Integral):
+            raise ValueError("Invalid norm order for vectors.")
         else:
-            if ord in ('f', 'fro'):
-                raise ValueError("Cannot compute Frobenius norm for vectors, vectors only support integer norm orders. For example for the L2 norm use ord=2 instead")
-            try:
-                ord + 1
-            except TypeError:
-                raise ValueError("Invalid norm order for vectors.")
             absx = abs(x)
             absx **= ord
             ret = add.reduce(absx, axis=axis, keepdims=keepdims)

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2559,6 +2559,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
             # special case for speedup
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
+        # None of the str-type keywords for ord ('fro', 'nuc') 
+        # are valid for vectors
         elif isinstance(ord, str):
             raise ValueError(f"Invalid norm order '{ord}' for vectors")
         else:

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2431,11 +2431,11 @@ def norm(x, ord=None, axis=None, keepdims=False):
     The Frobenius norm is given by [1]_:
 
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
-        
-    Both the Frobenius and nuclear norm orders are only defined for
-    matrices and raise a ValueError when `x.ndim != 2`.
 
     The nuclear norm is the sum of the singular values.
+
+    Both the Frobenius and nuclear norm orders are only defined for
+    matrices and raise a ValueError when ``x.ndim != 2``.
 
     References
     ----------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2562,7 +2562,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
         else:
             if ord in ('f', 'fro'):
-                raise TypeError("Cannot compute Frobenius norm for vectors, vectors only support integer norm orders. For example for the L2 norm use ord=2 instead")
+                raise ValueError("Cannot compute Frobenius norm for vectors, vectors only support integer norm orders. For example for the L2 norm use ord=2 instead")
             try:
                 ord + 1
             except TypeError:

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2433,9 +2433,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
         
-    As mentioned in the table above, the Frobenius norm is only 
-    defined for 2-dimensional matrices. It is not defined for
-    vectors.
+    Both the Frobenius and nuclear norm orders are only defined for
+    matrices and raise a ValueError when `x.ndim != 2`.
 
     The nuclear norm is the sum of the singular values.
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2431,6 +2431,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
     The Frobenius norm is given by [1]_:
 
         :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+        
+    As mentioned in the table above, the Frobenius norm is only 
+    defined for 2-dimensional matrices. It is not defined for
+    vectors.
 
     The nuclear norm is the sum of the singular values.
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2561,6 +2561,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
         else:
+            if ord in ('f', 'fro'):
+                raise TypeError("Cannot compute Frobenius norm for vectors, vectors only support integer norm orders. For example for the L2 norm use ord=2 instead")
             try:
                 ord + 1
             except TypeError:

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -15,7 +15,6 @@ __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
            'LinAlgError', 'multi_dot']
 
 import functools
-import numbers
 import operator
 import warnings
 

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2561,12 +2561,8 @@ def norm(x, ord=None, axis=None, keepdims=False):
             # special case for speedup
             s = (x.conj() * x).real
             return sqrt(add.reduce(s, axis=axis, keepdims=keepdims))
-        elif ord in ('f', 'fro'):
-            raise ValueError("Cannot compute Frobenius norm for vectors, "
-                             "vectors only support integer norm orders. For "
-                             "example for the L2 norm use ord=2 instead")
-        elif ord is 'nuc':
-            raise ValueError("Nuclear norm is not supported for vectors")
+        elif ord in ('f', 'fro', 'nuc'):
+            raise ValueError(f"Invalid norm order '{ord}' for vectors")
         elif not isinstance(ord, numbers.Integral):
             raise ValueError("Invalid norm order for vectors.")
         else:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1480,11 +1480,12 @@ class _TestNorm2D(_TestNormBase):
 
         # Using `axis=<integer>` or passing in a 1-D array implies vector
         # norms are being computed, so also using `ord='fro'`
-        # or `ord='nuc'` raises a ValueError.
+        # or `ord='nuc'` or any other string raises a ValueError.
         assert_raises(ValueError, norm, A, 'fro', 0)
         assert_raises(ValueError, norm, A, 'nuc', 0)
         assert_raises(ValueError, norm, [3, 4], 'fro', None)
         assert_raises(ValueError, norm, [3, 4], 'nuc', None)
+        assert_raises(ValueError, norm, [3, 4], 'test', None)
 
         # Similarly, norm should raise an exception when ord is any finite
         # number other than 1, 2, -1 or -2 when computing matrix norms.

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -57,8 +57,8 @@ class TestRegression:
         assert_array_almost_equal(b, np.zeros((2, 2)))
 
     def test_norm_vector_badarg(self):
-        # Regression for #786: Froebenius norm for vectors raises
-        # TypeError.
+        # Regression for #786: Frobenius norm for vectors raises
+        # ValueError.
         assert_raises(ValueError, linalg.norm, array([1., 2., 3.]), 'fro')
 
     def test_lapack_endian(self):


### PR DESCRIPTION
From PR #15535 the conclusion was that the documentation for linalg.norm needed to be improved and a better error message needed to be shown when calling `norm` with a vector and `ord='fro'`. This PR enhances the documentation for the linalg.norm() function to explicitly state that the frobenius norm is only defined for two dimensional arrays. See issue #15533 and PR #15535.
