### PR TITLE
DOC: document inconsistency between the shape of data and mask in numpy.ma

### DIFF
--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -33,7 +33,7 @@ defines several constants.
 
    Value indicating that a masked array has no invalid entry.
    :attr:`nomask` is used internally to speed up computations when the mask
-   is not needed. It's represented internally as `np.False_`.
+   is not needed. It is represented internally as ``np.False_``.
 
 
 .. data:: masked_print_options

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -33,7 +33,7 @@ defines several constants.
 
    Value indicating that a masked array has no invalid entry.
    :attr:`nomask` is used internally to speed up computations when the mask
-   is not needed.
+   is not needed. It's represented internally as `np.False_`.
 
 
 .. data:: masked_print_options

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2755,6 +2755,52 @@ class MaskedArray(ndarray):
         in any order (either C-, Fortran-contiguous, or even discontiguous),
         unless a copy is required, in which case it will be C-contiguous.
 
+    Examples
+    --------
+
+    The ``mask`` can be initialized with an array of boolean values
+    with the same shape as ``data``.
+
+    >>> data = np.arange(6).reshape((2, 3))
+    >>> np.ma.MaskedArray(data, mask=[[False, True, False],
+    ...                               [False, False, True]])
+    masked_array(
+      data=[[0, --, 2],
+            [3, 4, --]],
+      mask=[[False,  True, False],
+            [False, False,  True]],
+      fill_value=999999)
+
+    Alternatively, the ``mask`` can be initialized to homogeneous boolean
+    array with the same shape as ``data`` by passing in a scalar
+    boolean value:
+
+    >>> np.ma.MaskedArray(data, mask=False)
+    masked_array(
+      data=[[0, 1, 2],
+            [3, 4, 5]],
+      mask=[[False, False, False],
+            [False, False, False]],
+      fill_value=999999)
+
+    >>> np.ma.MaskedArray(data, mask=True)
+    masked_array(
+      data=[[--, --, --],
+            [--, --, --]],
+      mask=[[ True,  True,  True],
+            [ True,  True,  True]],
+      fill_value=999999,
+      dtype=int64)
+
+    .. note::
+        The recommended practice for initializing ``mask`` with a scalar
+        boolean value is to use ``True``/``False`` rather than
+        ``np.True_``/``np.False_``. The reason is :attr:`nomask`
+        is represented internally as ``np.False_``.
+
+        >>> np.False_ is np.ma.nomask
+        True
+
     """
 
     __array_priority__ = 15


### PR DESCRIPTION
There is inconsistency (pointed out in gh-13758) when initializing np.ma.MaskedArray with mask=np.False_. This PR documents it and is continuation of gh-13980.

Co-Authored-By: Tianxiang “Ronnie” Gao <tienhsiangkao@tamu.edu>
