### PR TITLE
BUG, TST: fix f2py for PyPy, skip one test for PyPy

### DIFF
--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -486,7 +486,8 @@ def test_issctype(rep, expected):
 
 @pytest.mark.skipif(sys.flags.optimize > 1,
                     reason="no docstrings present to inspect when PYTHONOPTIMIZE/Py_OptimizeFlag > 1")
-@pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
+@pytest.mark.xfail(IS_PYPY,
+                   reason="PyPy cannot modify tp_doc after PyType_Ready")
 class TestDocStrings:
     def test_platform_dependent_aliases(self):
         if np.int64 is np.int_:

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1058,6 +1058,10 @@ static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofarg
                 tmp_fun = fun; /* built-in function */
                 Py_INCREF(tmp_fun);
                 tot = maxnofargs;
+                if (PyCFunction_Check(fun)) {
+                    /* In case the function has a co_argcount (like on PyPy) */
+                    di = 0;
+                }
                 if (xa != NULL)
                     tot += PyTuple_Size((PyObject *)xa);
             }

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1033,6 +1033,8 @@ cfuncs[
     'try_pyarr_from_complex_double'] = 'static int try_pyarr_from_complex_double(PyObject* obj,complex_double* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(double,\'D\');\n}\n'
 
 needs['create_cb_arglist'] = ['CFUNCSMESS', 'PRINTPYOBJERR', 'MINMAX']
+
+# create the list of arguments to be used when calling back to python
 cfuncs['create_cb_arglist'] = """\
 static int create_cb_arglist(PyObject* fun,PyTupleObject* xa,const int maxnofargs,const int nofoptargs,int *nofargs,PyTupleObject **args,const char *errmess) {
     PyObject *tmp = NULL;

--- a/numpy/f2py/tests/test_block_docstring.py
+++ b/numpy/f2py/tests/test_block_docstring.py
@@ -16,7 +16,8 @@ class TestBlockDocString(util.F2PyTest):
 
     @pytest.mark.skipif(sys.platform=='win32',
                         reason='Fails with MinGW64 Gfortran (Issue #9673)')
-    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
+    @pytest.mark.xfail(IS_PYPY,
+                       reason="PyPy cannot modify tp_doc after PyType_Ready")
     def test_block_docstring(self):
         expected = "'i'-array(2,3)\n"
         assert_equal(self.module.block.__doc__, expected)

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 import numpy as np
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, IS_PYPY
 from . import util
 
 
@@ -59,12 +59,11 @@ cf2py  intent(out) a
        end
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't,t2'.split(','))
     def test_all(self, name):
         self.check_function(name)
 
-    @pytest.mark.slow
+    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
     def test_docstring(self):
         expected = textwrap.dedent("""\
         a = t(fun,[fun_extra_args])

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -63,7 +63,8 @@ cf2py  intent(out) a
     def test_all(self, name):
         self.check_function(name)
 
-    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
+    @pytest.mark.xfail(IS_PYPY,
+                       reason="PyPy cannot modify tp_doc after PyType_Ready")
     def test_docstring(self):
         expected = textwrap.dedent("""\
         a = t(fun,[fun_extra_args])

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -20,7 +20,8 @@ class TestMixed(util.F2PyTest):
         assert_(self.module.foo_fixed.bar12() == 12)
         assert_(self.module.foo_free.bar13() == 13)
 
-    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
+    @pytest.mark.xfail(IS_PYPY,
+                       reason="PyPy cannot modify tp_doc after PyType_Ready")
     def test_docstring(self):
         expected = textwrap.dedent("""\
         a = bar11()

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 import pytest
 
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, IS_PYPY
 from . import util
 
 
@@ -15,13 +15,12 @@ class TestMixed(util.F2PyTest):
                _path('src', 'mixed', 'foo_fixed.f90'),
                _path('src', 'mixed', 'foo_free.f90')]
 
-    @pytest.mark.slow
     def test_all(self):
         assert_(self.module.bar11() == 11)
         assert_(self.module.foo_fixed.bar12() == 12)
         assert_(self.module.foo_free.bar13() == 13)
 
-    @pytest.mark.slow
+    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
     def test_docstring(self):
         expected = textwrap.dedent("""\
         a = bar11()

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -3,6 +3,8 @@ import pytest
 from numpy import array
 from numpy.testing import assert_
 from . import util
+import platform
+IS_S390X = platform.machine() == 's390x'
 
 
 class TestReturnCharacter(util.F2PyTest):
@@ -78,7 +80,7 @@ cf2py    intent(out) ts
        end
     """
 
-    @pytest.mark.slow
+    @pytest.mark.xfail(IS_S390X, reason="calback returns ' '")
     @pytest.mark.parametrize('name', 't0,t1,t5,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
         self.check_function(getattr(self.module, name), name)
@@ -137,7 +139,7 @@ module f90_return_char
 end module f90_return_char
     """
 
-    @pytest.mark.slow
+    @pytest.mark.xfail(IS_S390X, reason="calback returns ' '")
     @pytest.mark.parametrize('name', 't0,t1,t5,ts,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
         self.check_function(getattr(self.module.f90_return_char, name), name)

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -7,8 +7,7 @@ from . import util
 
 class TestReturnCharacter(util.F2PyTest):
 
-    def check_function(self, t):
-        tname = t.__doc__.split()[0]
+    def check_function(self, t, tname):
         if tname in ['t0', 't1', 's0', 's1']:
             assert_(t(23) == b'2')
             r = t('ab')
@@ -79,10 +78,9 @@ cf2py    intent(out) ts
        end
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t1,t5,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        self.check_function(getattr(self.module, name), name)
 
 
 class TestF90ReturnCharacter(TestReturnCharacter):
@@ -138,7 +136,6 @@ module f90_return_char
 end module f90_return_char
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t1,t5,ts,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module.f90_return_char, name))
+        self.check_function(getattr(self.module.f90_return_char, name), name)

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -137,6 +137,7 @@ module f90_return_char
 end module f90_return_char
     """
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t1,t5,ts,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
         self.check_function(getattr(self.module.f90_return_char, name), name)

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -78,6 +78,7 @@ cf2py    intent(out) ts
        end
     """
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t1,t5,s0,s1,s5,ss'.split(','))
     def test_all(self, name):
         self.check_function(getattr(self.module, name), name)

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -8,8 +8,7 @@ from . import util
 
 class TestReturnComplex(util.F2PyTest):
 
-    def check_function(self, t):
-        tname = t.__doc__.split()[0]
+    def check_function(self, t, tname):
         if tname in ['t0', 't8', 's0', 's8']:
             err = 1e-5
         else:
@@ -102,10 +101,9 @@ cf2py    intent(out) td
        end
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t8,t16,td,s0,s8,s16,sd'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        self.check_function(getattr(self.module, name), name)
 
 
 class TestF90ReturnComplex(TestReturnComplex):
@@ -161,7 +159,6 @@ module f90_return_complex
 end module f90_return_complex
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t8,t16,td,s0,s8,s16,sd'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module.f90_return_complex, name))
+        self.check_function(getattr(self.module.f90_return_complex, name), name)

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -8,7 +8,7 @@ from . import util
 
 class TestReturnInteger(util.F2PyTest):
 
-    def check_function(self, t):
+    def check_function(self, t, tname):
         assert_(t(123) == 123, repr(t(123)))
         assert_(t(123.6) == 123)
         assert_(t(long(123)) == 123)
@@ -36,7 +36,7 @@ class TestReturnInteger(util.F2PyTest):
         assert_raises(Exception, t, t)
         assert_raises(Exception, t, {})
 
-        if t.__doc__.split()[0] in ['t8', 's8']:
+        if tname in ['t8', 's8']:
             assert_raises(OverflowError, t, 100000000000000000000000)
             assert_raises(OverflowError, t, 10000000011111111111111.23)
 
@@ -101,11 +101,10 @@ cf2py    intent(out) t8
        end
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name',
                              't0,t1,t2,t4,t8,s0,s1,s2,s4,s8'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        self.check_function(getattr(self.module, name), name)
 
 
 class TestF90ReturnInteger(TestReturnInteger):
@@ -172,8 +171,7 @@ module f90_return_integer
 end module f90_return_integer
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name',
                              't0,t1,t2,t4,t8,s0,s1,s2,s4,s8'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module.f90_return_integer, name))
+        self.check_function(getattr(self.module.f90_return_integer, name), name)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -9,8 +9,8 @@ from . import util
 
 class TestReturnReal(util.F2PyTest):
 
-    def check_function(self, t):
-        if t.__doc__.split()[0] in ['t0', 't4', 's0', 's4']:
+    def check_function(self, t, tname):
+        if tname in ['t0', 't4', 's0', 's4']:
             err = 1e-5
         else:
             err = 0.0
@@ -32,7 +32,7 @@ class TestReturnReal(util.F2PyTest):
         assert_(abs(t(array([234], 'B')) - 234.) <= err)
         assert_(abs(t(array([234], 'f')) - 234.) <= err)
         assert_(abs(t(array([234], 'd')) - 234.) <= err)
-        if t.__doc__.split()[0] in ['t0', 't4', 's0', 's4']:
+        if tname in ['t0', 't4', 's0', 's4']:
             assert_(t(1e200) == t(1e300))  # inf
 
         #assert_raises(ValueError, t, array([234], 'S1'))
@@ -88,10 +88,9 @@ end interface
 end python module c_ext_return_real
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't4,t8,s4,s8'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        self.check_function(getattr(self.module, name), name)
 
 
 class TestF77ReturnReal(TestReturnReal):
@@ -143,10 +142,9 @@ cf2py    intent(out) td
        end
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module, name))
+        self.check_function(getattr(self.module, name), name)
 
 
 class TestF90ReturnReal(TestReturnReal):
@@ -202,7 +200,6 @@ module f90_return_real
 end module f90_return_real
     """
 
-    @pytest.mark.slow
     @pytest.mark.parametrize('name', 't0,t4,t8,td,s0,s4,s8,sd'.split(','))
     def test_all(self, name):
-        self.check_function(getattr(self.module.f90_return_real, name))
+        self.check_function(getattr(self.module.f90_return_real, name), name)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1,4 +1,5 @@
 import sys
+import gc
 import gzip
 import os
 import threading
@@ -288,11 +289,9 @@ class TestSavezLoad(RoundtripTest):
             # numpy npz file returned by np.load when their reference count
             # goes to zero.  Python 3 running in debug mode raises a
             # ResourceWarning when file closing is left to the garbage
-            # collector, so we catch the warnings.  Because ResourceWarning
-            # is unknown in Python < 3.x, we take the easy way out and
-            # catch all warnings.
+            # collector, so we catch the warnings.
             with suppress_warnings() as sup:
-                sup.filter(Warning)  # TODO: specify exact message
+                sup.filter(ResourceWarning)  # TODO: specify exact message
                 for i in range(1, 1025):
                     try:
                         np.load(tmp)["data"]

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -568,8 +568,9 @@ class TestSaveTxt:
         else:
             assert_equal(s.read(), b"%f\n" % 1.)
 
-    @pytest.mark.skipif(sys.platform=='win32',
-                        reason="large files cause problems")
+    @pytest.mark.skipif(sys.platform=='win32', reason="files>4GB may not work")
+    @pytest.mark.skipif(IS_PYPY,
+         reason="GC problems after test, even after multiple gc.collect calls")
     @pytest.mark.slow
     @requires_memory(free_bytes=7e9)
     def test_large_zip(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -570,7 +570,7 @@ class TestSaveTxt:
 
     @pytest.mark.skipif(sys.platform=='win32', reason="files>4GB may not work")
     @pytest.mark.skipif(IS_PYPY,
-         reason="GC problems after test, even after multiple gc.collect calls")
+         reason="GC problems after test, gc.collect does not help. see gh-15775")
     @pytest.mark.slow
     @requires_memory(free_bytes=7e9)
     def test_large_zip(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -276,8 +276,6 @@ class TestSavezLoad(RoundtripTest):
                 fp.seek(0)
                 assert_(not fp.closed)
 
-    #FIXME: Is this still true?
-    @pytest.mark.skipif(IS_PYPY, reason="Missing context manager on PyPy")
     def test_closing_fid(self):
         # Test that issue #1517 (too many opened files) remains closed
         # It might be a "weak" test since failed to get triggered on
@@ -301,6 +299,9 @@ class TestSavezLoad(RoundtripTest):
                     except Exception as e:
                         msg = "Failed to load data from a file: %s" % e
                         raise AssertionError(msg)
+                    finally:
+                        if IS_PYPY:
+                            gc.collect()
 
     def test_closing_zipfile_after_load(self):
         # Check that zipfile owns file and can close it.  This needs to


### PR DESCRIPTION
Various changes to make `-mfull` tests pass on PyPy

- in f2py, callback argument count was off for `PyCFunction_Check` with an `co_argcount` attribute. CPython does not have the attribute, PyPy does.
- skip a test on PyPy that allocates `>6GB` memory, somehow it is not collected even with a `gc.collect`

- remove the `slow` marker from some of the `f2py` tests, I don't think they are that slow.
- skip tests for `tp_doc` on PyPy