### PR TITLE
ENH: Add __array_priority__ to poly1d class.

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1107,6 +1107,9 @@ class poly1d:
     """
     __hash__ = None
 
+    # Ensure rops with poly1d objects return poly1d objects
+    __array_priority__ = 10.0
+
     @property
     def coeffs(self):
         """ The polynomial coefficients """

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -57,6 +57,20 @@ class TestPolynomial:
         assert_equal(np.polydiv(np.poly1d([1, 0, -1]), np.poly1d([1, 1])),
                      (np.poly1d([1., -1.]), np.poly1d([0.])))
 
+    def test_poly1d_rops(self):
+        """
+        Check that binary operations between poly1d and arrays return poly1d
+        objects
+        """
+        p = np.poly1d([1, 2, 3])
+        a = np.array([3, 2, 1])
+        assert_(isinstance(a + p, np.poly1d))
+        assert_(isinstance(a - p, np.poly1d))
+        assert_(isinstance(a * p, np.poly1d))
+        # Quotient and remainder
+        for val in a / p:
+            assert_(isinstance(val, np.poly1d))
+
     def test_poly1d_misc(self):
         p = np.poly1d([1., 2, 3])
         assert_equal(np.asarray(p), np.array([1., 2., 3.]))


### PR DESCRIPTION
This PR is related to a [discussion from the last NumPy sprint](https://github.com/numpy/archive/blob/20369978042d5147d6561ea14b5985e5053fefb4/status_meetings/status-2019-12-11.md#topics) re: how `poly1d` objects interact with `ndarray` objects. 

By defining an `__array_priority__` class variable for the `poly1d` class, operations that involve both arrays and poly1d objects should preferentially return poly1d objects. This is [most noticeable for the `poly1d.__r*__` operations](https://docs.python.org/3/reference/datamodel.html#object.__radd__), e.g. `__radd__`, `__rsub__`, etc. 