### PR TITLE
MAINT: CI: Add an explicit 'pr' section to azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,11 @@ trigger:
       - master
       - maintenance/*
 
+pr:
+  branches:
+    include:
+    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
 stages:
 - stage: InitialTests
   jobs:

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -6,6 +6,7 @@ set -o pipefail
 # Print expanded commands
 set -x
 
+sudo apt-get -yq update
 sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5 python3-urllib3
 F77=gfortran-5 F90=gfortran-5 \
 


### PR DESCRIPTION
Azure-pipelines is currently experiencing an "incident":

    https://status.dev.azure.com/_event/179641421)

From that web page:

> Currently CI and PR triggers in YAML for GitHub and Bitbucket
> repositories are not working when they are not explicitly listed
> in the YAML file. Our expected behavior is that when there are
> no explicit triggers in the YAML, the pipelines will trigger on
> all commits on all branches and all pull requests. This is
> currently not happening. To workaround, please explicitly list
> the triggers you want in the YAML file for your pipeline.

This PR adds the suggested explicit 'pr' triggers to the YAML file.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
