### PR TITLE
BUG: np.add does not upcast to intp on Windows, unlike other platforms

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -214,6 +214,16 @@ class TestAdd:
         a['a'] = -1
         assert_equal(a['b'].sum(), 0)
 
+    def test_upcast_to_intp(self):
+        for i in [8, 16, 32]:
+            dtype = np.dtype("int" + str(i))
+            if np.iinfo(dtype).bits >= np.iinfo(np.intp).bits:
+                continue
+
+            arr = np.array([np.iinfo(dtype).max, 1], dtype)
+            arr_upcast = np.array([np.iinfo(dtype).max, 1], np.intp)
+
+            assert_equal(arr.sum(), arr_upcast.sum())
 
 class TestDivision:
     def test_division_int(self):


### PR DESCRIPTION
Happy to turn this into a fix if anyone knows where the root cause might be, but this is just a bug report for the time being.

On Linux/OSX, `np.add()` upcasts to `np.intp` if the input is an integer of lower precision. In fact, the docstring even [says](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html):

> dtype : dtype, optional
>    The type of the returned array and of the accumulator in which the elements are summed. The dtype of a is used by default unless a has an integer dtype of less precision than the default platform integer. **In that case, if a is signed then the platform integer is used while if a is unsigned then an unsigned integer of the same precision as the platform integer is used.**

However, it appears that `np.add` on Windows does not implement this behavior. I have added a test case that demonstrates the issue by failing on 64-bit Windows (w/ 64-bit Python).
