### PR TITLE
WIP,BLD: Add extras_require to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -449,6 +449,10 @@ def setup_package():
         entry_points={
             'console_scripts': f2py_cmds
         },
+        extras_require={
+            "doc": ["sphinx>=2.2.0", "ipython", "matplotlib", "scipy"],
+            "test": ["pytest", "hypothesis"],
+        },
     )
 
     if "--force" in sys.argv:


### PR DESCRIPTION
Currently, [the development documentation](https://numpy.org/devdocs/dev/index.html#building-docs) lists extra dependencies for things like building NumPy's documentation or testing. Installation of extra dependencies could be made more convenient by making use of the `extras_require` kwarg in the `setup.py`.

For example, if there is a user who would like to make a contribution to the docs, the environment to do so could be set up via: `pip install .[doc]` (from the `numpy/` dir containing the `setup.py` file).

Are there any reasons why defining an `extras_require` should be avoided? The `setup.py` for NumPy is complicated so maybe there are considerations I haven't thought of.

If there is no objection to using `extras_require`, some additional tasks for this PR would include:
 - [ ] Updating the contribution docs to notify users of the new feature
 - [ ] Consider adding additional requirements (e.g. benchmarking)
 - [ ] Evaluate whether this would impact the CI configuration (or could simplify it)