### PR TITLE
ENH: Allow toggling madvise hugepage and fix default

### DIFF
--- a/doc/release/upcoming_changes/15769.improvement.rst
+++ b/doc/release/upcoming_changes/15769.improvement.rst
@@ -1,0 +1,15 @@
+Ability to disable madvise hugepages
+------------------------------------
+
+On Linux NumPy has previously added support for madavise
+hugepages which can improve performance for very large arrays.
+Unfortunately, on older Kernel versions this led to peformance
+regressions, thus by default the support has been disabled on
+kernels before version 4.6. To override the default, you can
+use the environment variable::
+
+    NUMPY_MADVISE_HUGEPAGE=0
+
+or set it to 1 to force enabling support. Note that this only makes
+a difference if the operating system is set up to use madvise
+transparent hugepage.

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -1,24 +1,24 @@
-.. _globale_state:
+.. _global_state:
 
 ************
 Global State
 ************
 
-NumPy has a few startup time, compile, or runtime options
+NumPy has a few import-time, compile-time, or runtime options
 which change the global behaviour.
 Most of these are related to performance or for debugging
 purposes and will not be interesting to the vast majority
 of users.
 
 
-Performance Related Options
+Performance-Related Options
 ===========================
 
 Number of Threads used for Linear Algebra
 -----------------------------------------
 
 NumPy itself is normally intentionally limited to a single thread
-during function calls, however it does support multiple python
+during function calls, however it does support multiple Python
 threads running at the same time.
 Note that for performant linear algebra NumPy uses a BLAS backend
 such as OpenBLAS or MKL, which may use multiple threads that may
@@ -34,13 +34,13 @@ Madvise Hugepage on Linux
 When working with very large arrays on modern Linux kernels,
 you can experience a significant speedup when transparent
 hugepage is enabled.
-This may always be the case or may use ``madvise`` option as
+The current system policy for transparent hugepages can be 
 seen by::
 
     cat /sys/kernel/mm/transparent_hugepage/enabled
 
 on most kernels.  When set to ``madvise`` NumPy will typically
-use enable hugepages for a performance boost. This behaviour can
+use hugepages for a performance boost. This behaviour can
 be set through the environment variable::
 
     NUMPY_MADVISE_HUGEPAGE=0
@@ -51,7 +51,7 @@ experience a large speedup when set.
 This flag is checked at import time.
 
 
-Interpoerabilty
+Interoperability
 ===============
 
 The array function protocol which allows array-like objects to
@@ -60,7 +60,7 @@ It can be disabled using::
 
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
 
-See also `class.__array_function__` for more information.
+See also :py:meth:`numpy.class.__array_function__` for more information.
 This flag is checked at import time.
 
 
@@ -70,7 +70,7 @@ Debugging
 Relaxed Strides Checking
 ------------------------
 
-The *compile* time environment variables::
+The *compile-time* environment variables::
 
     NPY_RELAXED_STRIDES_DEBUG=0
     NPY_RELAXED_STRIDES_CHECKING=1
@@ -82,4 +82,4 @@ debug option can be interesting for testing code written
 in C which iterates through arrays that may or may not be
 contiguous in memory.
 Most users will have no reason to change these, for details
-please see the `memory layout <memory-layout>`_ documentation.
+please see the :ref:`memory layout <memory-layout>`_ documentation.

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -32,31 +32,31 @@ Madvise Hugepage on Linux
 -------------------------
 
 When working with very large arrays on modern Linux kernels,
-you can experience a significant speedup when transparent
-hugepage is enabled.
-The current system policy for transparent hugepages can be 
-seen by::
+you can experience a significant speedup when
+`transparent hugepage <https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html>`_
+is used.
+The current system policy for transparent hugepages can be seen by::
 
     cat /sys/kernel/mm/transparent_hugepage/enabled
 
-on most kernels.  When set to ``madvise`` NumPy will typically
-use hugepages for a performance boost. This behaviour can
-be set through the environment variable::
+When set to ``madvise`` NumPy will typically use hugepages for a performance
+boost. This behaviour can be modified by setting the environment variable::
 
     NUMPY_MADVISE_HUGEPAGE=0
 
-or ``1`` for enabling it. When not set, the default is to use
-madvise on Kernels 4.6 and newer. These kernels presumably
-experience a large speedup when set.
+or setting it to ``1`` to always enable it. When not set, the default
+is to use madvise on Kernels 4.6 and newer. These kernels presumably
+experience a large speedup with hugepage support.
 This flag is checked at import time.
 
 
-Interoperability
-===============
+Interoperability-Related Options
+================================
 
 The array function protocol which allows array-like objects to
 hook into the NumPy API is currently enabled by default.
-It can be disabled using::
+This option exists since NumPy 1.16 and is enabled by default since
+NumPy 1.17. It can be disabled using::
 
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
 
@@ -64,8 +64,8 @@ See also :py:meth:`numpy.class.__array_function__` for more information.
 This flag is checked at import time.
 
 
-Debugging
-=========
+Debugging-Related Options
+=========================
 
 Relaxed Strides Checking
 ------------------------
@@ -82,4 +82,4 @@ debug option can be interesting for testing code written
 in C which iterates through arrays that may or may not be
 contiguous in memory.
 Most users will have no reason to change these, for details
-please see the :ref:`memory layout <memory-layout>`_ documentation.
+please see the `memory layout <memory-layout>`_ documentation.

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -1,0 +1,85 @@
+.. _globale_state:
+
+************
+Global State
+************
+
+NumPy has a few startup time, compile, or runtime options
+which change the global behaviour.
+Most of these are related to performance or for debugging
+purposes and will not be interesting to the vast majority
+of users.
+
+
+Performance Related Options
+===========================
+
+Number of Threads used for Linear Algebra
+-----------------------------------------
+
+NumPy itself is normally intentionally limited to a single thread
+during function calls, however it does support multiple python
+threads running at the same time.
+Note that for performant linear algebra NumPy uses a BLAS backend
+such as OpenBLAS or MKL, which may use multiple threads that may
+be controlled by environment variables such as ``OMP_NUM_THREADS``
+depending on what is used.
+One way to control the number of threads is the package
+`threadpoolctl <https://pypi.org/project/threadpoolctl/>`_
+
+
+Madvise Hugepage on Linux
+-------------------------
+
+When working with very large arrays on modern Linux kernels,
+you can experience a significant speedup when transparent
+hugepage is enabled.
+This may always be the case or may use ``madvise`` option as
+seen by::
+
+    cat /sys/kernel/mm/transparent_hugepage/enabled
+
+on most kernels.  When set to ``madvise`` NumPy will typically
+use enable hugepages for a performance boost. This behaviour can
+be set through the environment variable::
+
+    NUMPY_MADVISE_HUGEPAGE=0
+
+or ``1`` for enabling it. When not set, the default is to use
+madvise on Kernels 4.6 and newer. These kernels presumably
+experience a large speedup when set.
+This flag is checked at import time.
+
+
+Interpoerabilty
+===============
+
+The array function protocol which allows array-like objects to
+hook into the NumPy API is currently enabled by default.
+It can be disabled using::
+
+    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
+
+See also `class.__array_function__` for more information.
+This flag is checked at import time.
+
+
+Debugging
+=========
+
+Relaxed Strides Checking
+------------------------
+
+The *compile* time environment variables::
+
+    NPY_RELAXED_STRIDES_DEBUG=0
+    NPY_RELAXED_STRIDES_CHECKING=1
+
+control how NumPy reports contiguity for arrays.
+The default that it is enabled and the debug mode is disabled.
+This setting should always be enabled. Setting the
+debug option can be interesting for testing code written
+in C which iterates through arrays that may or may not be
+contiguous in memory.
+Most users will have no reason to change these, for details
+please see the `memory layout <memory-layout>`_ documentation.

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -22,6 +22,7 @@ For learning how to use NumPy, see also :ref:`user`.
    constants
    ufuncs
    routines
+   global_state
    distutils
    distutils_guide
    c-api/index

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -306,4 +306,4 @@ else:
         use_hugepage = int(use_hugepage)
 
     # Note that this will currently only make a difference on Linux
-    core.multiarray._multiarray_umath._set_madvise_hugepage(use_hugepage)
+    core.multiarray._set_madvise_hugepage(use_hugepage)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4391,6 +4391,14 @@ add_newdoc('numpy.core.umath', '_add_newdoc_ufunc',
     and then throwing away the ufunc.
     """)
 
+add_newdoc('numpy.core.multiarray', '_set_madvise_hugepage',
+    """
+    _set_madvise_hugepage(enabled: bool) -> bool
+
+    Set  or unset use of ``madvise (2)`` MADV_HUGEPAGE support when
+    allocating the array data. Returns the previously set value.
+    See `global_state` for more information.
+    """)
 
 add_newdoc('numpy.core._multiarray_tests', 'format_float_OSprintf_g',
     """

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -17,7 +17,7 @@ from ._multiarray_umath import *  # noqa: F403
 # _get_ndarray_c_version is semi-public, on purpose not added to __all__
 from ._multiarray_umath import (
     _fastCopyAndTranspose, _flagdict, _insert, _reconstruct, _vec_string,
-    _ARRAY_API, _monotonicity, _get_ndarray_c_version
+    _ARRAY_API, _monotonicity, _get_ndarray_c_version, _set_madvise_hugepage,
     )
 
 __all__ = [

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -50,6 +50,13 @@ static cache_bucket dimcache[NBUCKETS_DIM];
 static int _madvise_hugepage = 1;
 
 
+/*
+ * This function enables or disables the use of `MADV_HUGEPAGE` on Linux
+ * by modifying the global static `_madvise_hugepage`.
+ * It returns the previous value of `_madvise_hugepage`.
+ *
+ * It is exposed to Python as `np.core.multiarray._set_madvise_hugepage`.
+ */
 NPY_NO_EXPORT PyObject *
 _set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj)
 {

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -47,6 +47,25 @@ typedef struct {
 static cache_bucket datacache[NBUCKETS];
 static cache_bucket dimcache[NBUCKETS_DIM];
 
+static int _madvise_hugepage = 1;
+
+
+NPY_NO_EXPORT PyObject *
+_set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj)
+{
+    int was_enabled = _madvise_hugepage;
+    int enabled = PyObject_IsTrue(enabled_obj);
+    if (enabled < 0) {
+        return NULL;
+    }
+    _madvise_hugepage = enabled;
+    if (was_enabled) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+
 /* as the cache is managed in global variables verify the GIL is held */
 
 /*
@@ -75,7 +94,7 @@ _npy_alloc_cache(npy_uintp nelem, npy_uintp esz, npy_uint msz,
 #endif
 #ifdef NPY_OS_LINUX
         /* allow kernel allocating huge pages for large arrays */
-        if (NPY_UNLIKELY(nelem * esz >= ((1u<<22u)))) {
+        if (NPY_UNLIKELY(nelem * esz >= ((1u<<22u))) && _madvise_hugepage) {
             npy_uintp offset = 4096u - (npy_uintp)p % (4096u);
             npy_uintp length = nelem * esz - offset;
             /**

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -6,6 +6,9 @@
 
 #define NPY_TRACE_DOMAIN 389047
 
+NPY_NO_EXPORT PyObject *
+_set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj);
+
 NPY_NO_EXPORT void *
 npy_alloc_cache(npy_uintp sz);
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -34,6 +34,7 @@
 NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 
 /* Internal APIs */
+#include "alloc.h"
 #include "arrayfunction_override.h"
 #include "arraytypes.h"
 #include "arrayobject.h"
@@ -3971,6 +3972,7 @@ normalize_axis_index(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     return PyInt_FromLong(axis);
 }
 
+
 static struct PyMethodDef array_module_methods[] = {
     {"_get_implementing_args",
         (PyCFunction)array__get_implementing_args,
@@ -4159,6 +4161,8 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS, NULL},
     {"_add_newdoc_ufunc", (PyCFunction)add_newdoc_ufunc,
         METH_VARARGS, NULL},
+    {"_set_madvise_hugepage", (PyCFunction)_set_madvise_hugepage,
+        METH_O, "Toggle and return madvise hugepage (no OS support check)."},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3972,7 +3972,6 @@ normalize_axis_index(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwds)
     return PyInt_FromLong(axis);
 }
 
-
 static struct PyMethodDef array_module_methods[] = {
     {"_get_implementing_args",
         (PyCFunction)array__get_implementing_args,
@@ -4162,7 +4161,7 @@ static struct PyMethodDef array_module_methods[] = {
     {"_add_newdoc_ufunc", (PyCFunction)add_newdoc_ufunc,
         METH_VARARGS, NULL},
     {"_set_madvise_hugepage", (PyCFunction)_set_madvise_hugepage,
-        METH_O, "Toggle and return madvise hugepage (no OS support check)."},
+        METH_O, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 


### PR DESCRIPTION
By default this disables madvise hugepage on kernels before 4.6, since
we expect that these typically see large performance regressions when
using hugepages due to slow defragementation code presumably fixed by:

https://github.com/torvalds/linux/commit/7cf91a98e607c2f935dbcc177d70011e95b8faff

This adds support to set the behaviour at startup time through the
``NUMPY_MADVISE_HUGEPAGE`` environment variable.

Fixes gh-15545

----

Still needs some documentation somewhere probably... I am not sure where though, a new site listing all environment variables used during compile or startup time? Relaxed strides, experimental array function protocol, this one, ...?