### PR TITLE
MAINT: remove useless `global` statements

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -318,7 +318,6 @@ def getstrlength(var):
 
 
 def getarrdims(a, var, verbose=0):
-    global depargs
     ret = {}
     if isstring(var) and not isarray(var):
         ret['dims'] = getstrlength(var)
@@ -514,7 +513,6 @@ def sign2map(a, var):
     varrfromat
     intent
     """
-    global lcb_map, cb_map
     out_a = a
     if isintent_out(var):
         for k in var['intent']:

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -436,7 +436,6 @@ cb_map = {}
 
 
 def buildcallbacks(m):
-    global cb_map
     cb_map[m['name']] = []
     for bi in m['body']:
         if bi['block'] == 'interface':
@@ -448,7 +447,6 @@ def buildcallbacks(m):
 
 
 def buildcallback(rout, um):
-    global cb_map
     from . import capi_maps
 
     outmess('\tConstructing call-back function "cb_%s_in_%s"\n' %

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1156,7 +1156,7 @@ def buildcfuncs():
 ############ Auxiliary functions for sorting needs ###################
 
 def append_needs(need, flag=1):
-    global outneeds, needs
+    # This function modifies the contents of the global `outneeds` dict.
     if isinstance(need, list):
         for n in need:
             append_needs(n, flag)
@@ -1223,7 +1223,7 @@ def append_needs(need, flag=1):
 
 
 def get_needs():
-    global outneeds, needs
+    # This function modifies the contents of the global `outneeds` dict.
     res = {}
     for n in outneeds.keys():
         out = []

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -85,7 +85,6 @@ fgetdims2_sa = """\
 
 
 def buildhooks(pymod):
-    global fgetdims1, fgetdims2
     from . import rules
     ret = {'f90modhooks': [], 'initf90modhooks': [], 'body': [],
            'need': ['F_FUNC', 'arrayobject.h'],

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1157,7 +1157,6 @@ def buildmodule(m, um):
     """
     Return
     """
-    global f2py_version, options
     outmess('\tBuilding module "%s"...\n' % (m['name']))
     ret = {}
     mod_rules = defmod_rules[:]

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -832,7 +832,6 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
         or newly generated.
 
     """
-    global _lookfor_caches
     # Local import to speed up numpy's import time.
     import inspect
 


### PR DESCRIPTION
`global` is only needed if a variable appears on the left of an assignment.
These variables do not.

Most suffer from the misconception that `var[x] = y` requires `var` to be global, but it does not.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
