### PR TITLE
BUG: remove outdated code exposed by a refactor

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -985,14 +985,6 @@ PyArray_NewFromDescr_int(
     for (i = 0; i < nd; i++) {
         npy_intp dim = dims[i];
 
-        if (dim == 0) {
-            /*
-             * Compare to PyArray_OverflowMultiplyList that
-             * returns 0 in this case.
-             */
-            continue;
-        }
-
         if (dim < 0) {
             PyErr_SetString(PyExc_ValueError,
                 "negative dimensions are not allowed");

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -981,7 +981,10 @@ PyArray_NewFromDescr_int(
         }
     }
 
-    /* Check dimensions and multiply them to nbytes */
+    /*
+     * Check dimensions and multiply them to nbytes
+     * Do this although we only need nbytes if data == NULL for the error check
+     */
     for (i = 0; i < nd; i++) {
         npy_intp dim = dims[i];
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8428,3 +8428,10 @@ def test_getfield():
     pytest.raises(ValueError, a.getfield, 'uint8', -1)
     pytest.raises(ValueError, a.getfield, 'uint8', 16)
     pytest.raises(ValueError, a.getfield, 'uint64', 0)
+
+def test_empty_view():
+    a = np.zeros((100, 100, 0))
+    b = a[1:]
+    assert a.size == 0
+    assert b.size == 0
+    assert a.ctypes.data == b.ctypes.data

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1015,6 +1015,12 @@ class TestCreation:
             assert_raises(ValueError, np.ndarray, buffer=buf, strides=(0,),
                           shape=(max_bytes//itemsize + 1,), dtype=dtype)
 
+    def test_array_from_zero_size(self):
+        # issue gh-15753
+        a = np.array([], dtype=np.int64).reshape([0, 1000, 1000, 1000, 1000])
+        b = np.isnan(a)
+        assert b.size == 0
+
     def _ragged_creation(self, seq):
         # without dtype=object, the ragged object should raise
         with assert_warns(np.VisibleDeprecationWarning):


### PR DESCRIPTION
Closes #15753 

The removed code should have been removed long ago. The zero case was masked because `nbytes` (before gh-7463) was reset to the value returned from `_array_fill_strides`. In gh-7463 `_array_fill_strides` was refactored and no longer returns a value, so `nbytes` was never zeroed out, leading to the bug.