### PR TITLE
ENH: complete the 'vars' list of a module

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2488,10 +2488,10 @@ def analyzevars(block):
         del vars['']
         if 'attrspec' in block['vars']['']:
             gen = block['vars']['']['attrspec']
-            for n in list(vars.keys()):
+            for n in set(vars) | set(b['name'] for b in block['body']):
                 for k in ['public', 'private']:
                     if k in gen:
-                        vars[n] = setattrspec(vars[n], k)
+                        vars[n] = setattrspec(vars.get(n, {}), k)
     svars = []
     args = block['args']
     for a in args:

--- a/numpy/f2py/tests/src/crackfortran/pubprivmod.f90
+++ b/numpy/f2py/tests/src/crackfortran/pubprivmod.f90
@@ -1,0 +1,10 @@
+module foo
+  public
+  integer, private :: a
+  integer :: b
+contains
+  subroutine setA(v)
+    integer, intent(in) :: v
+    a = v
+  end subroutine setA
+end module foo

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -73,6 +73,15 @@ class TestModuleProcedure():
         assert mod["body"][3]["implementedby"] == \
             ["get_int", "get_real"]
 
+    def test_notPublicPrivate(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "pubprivmod.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        mod = mod[0]
+        assert mod['vars']['a']['attrspec'] == ['private', ]
+        assert mod['vars']['b']['attrspec'] == ['public', ]
+        assert mod['vars']['seta']['attrspec'] == ['public', ]
+
 
 class TestExternal(util.F2PyTest):
     # issue gh-17859: add external attribute support


### PR DESCRIPTION
Add to the 'vars' list of a module missing subroutines
or functions listed in the 'body' that have not been
explicitly declared 'public' or 'private'.

For instance, in the following example, the routine foo is
not in the 'vars' list, and thus it's public or private attribute
is not set:
```
module A
   public
contains
  subroutine foo()
  end subroutine foo()
end module A
```
It would have been in the 'vars' list if it was actually declared in the "header" with `public :: foo`, but this declaration is not mandatory since there is a public keyword for all non specified routines.