### PR TITLE
ENH: Use TypeError in `np.array` for python consistency

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -784,7 +784,7 @@ add_newdoc('numpy.core', 'broadcast', ('reset',
 
 add_newdoc('numpy.core.multiarray', 'array',
     """
-    array(object, dtype=None, copy=True, order='K', subok=False, ndmin=0)
+    array(object, dtype=None, *, copy=True, order='K', subok=False, ndmin=0)
 
     Create an array.
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1583,7 +1583,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
 
     if (PyTuple_GET_SIZE(args) > 2) {
         PyErr_Format(PyExc_TypeError,
-                     "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args)));
+                     "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args));
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1583,7 +1583,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
 
     if (PyTuple_GET_SIZE(args) > 2) {
         PyErr_SetString(PyExc_ValueError,
-                        "only 2 non-keyword arguments accepted in np.array.");
+                        "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args)));
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1583,7 +1583,8 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
 
     if (PyTuple_GET_SIZE(args) > 2) {
         PyErr_Format(PyExc_TypeError,
-                     "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args));
+                     "array() takes from 1 to 2 positional arguments but "
+                     "%zd were given", PyTuple_GET_SIZE(args));
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1582,7 +1582,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
                          "ndmin", NULL};
 
     if (PyTuple_GET_SIZE(args) > 2) {
-        PyErr_SetString(PyExc_ValueError,
+        PyErr_Format(PyExc_TypeError,
                      "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args)));
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1583,7 +1583,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
 
     if (PyTuple_GET_SIZE(args) > 2) {
         PyErr_SetString(PyExc_ValueError,
-                        "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args)));
+                     "array() takes from 1 to 2 positional arguments but %zd were given", PyTuple_GET_SIZE(args)));
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1583,7 +1583,7 @@ _array_fromobject(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws)
 
     if (PyTuple_GET_SIZE(args) > 2) {
         PyErr_SetString(PyExc_ValueError,
-                        "only 2 non-keyword arguments accepted");
+                        "only 2 non-keyword arguments accepted in np.array.");
         return NULL;
     }
 


### PR DESCRIPTION
Currently, when writing something like 
```
pd.DataFrame({'arr': np.array(1., 2., 3.)})
```
```
ValueError                                Traceback (most recent call last)
<ipython-input-1-ffdb00ae9b74> in <module>()
      1 import numpy as np
      2 import pandas as pd
----> 3 pd.DataFrame({'arr': np.array(1., 2., 3.)})

ValueError: only 2 non-keyword arguments accepted
```
This stack trace that doesn't include a frame for the np constructor, because the constructor is generated python code. This may lead users to look elsewhere for the issuer of the ValueError, which may create red-herrings in that folks may look elsewhere.

This changes makes it more obvious where the error is coming from.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
