### PR TITLE
BUG: Add basic __format__ for masked element to fix incorrect print

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6391,7 +6391,7 @@ class MaskedConstant(MaskedArray):
         # the user was expecting - better to not guess.
         try:
             return object.__format__(self, format_spec)
-        except Exception:
+        except TypeError:
             warnings.warn(
                 "Format strings passed to MaskedConstant are ignored, but in future may "
                 "error or produce different behavior",

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6392,6 +6392,7 @@ class MaskedConstant(MaskedArray):
         try:
             return object.__format__(self, format_spec)
         except TypeError:
+            # 2020-03-23, NumPy 1.19.0
             warnings.warn(
                 "Format strings passed to MaskedConstant are ignored, but in future may "
                 "error or produce different behavior",

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6389,7 +6389,15 @@ class MaskedConstant(MaskedArray):
         # Replace ndarray.__format__ with the default, which supports no format characters.
         # Supporting format characters is unwise here, because we do not know what type
         # the user was expecting - better to not guess.
-        return object.__format__(self, format_spec)
+        try:
+            return object.__format__(self, format_spec)
+        except Exception:
+            warnings.warn(
+                "Format strings passed to MaskedConstant are ignored, but in future may "
+                "error or produce different behavior",
+                FutureWarning, stacklevel=2
+            )
+            return object.__format__(self, "")
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6386,7 +6386,7 @@ class MaskedConstant(MaskedArray):
             return object.__repr__(self)
 
     def __format__(self, format_spec):
-        return str(masked_print_option._display)
+        return format(str(masked_print_option._display), format_spec)
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6385,6 +6385,9 @@ class MaskedConstant(MaskedArray):
             # it's a subclass, or something is wrong, make it obvious
             return object.__repr__(self)
 
+    def __format__(self, format_spec):
+        return str(masked_print_option._display)
+
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.
         """

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6386,7 +6386,10 @@ class MaskedConstant(MaskedArray):
             return object.__repr__(self)
 
     def __format__(self, format_spec):
-        return format(str(masked_print_option._display), format_spec)
+        # Replace ndarray.__format__ with the default, which supports no format characters.
+        # Supporting format characters is unwise here, because we do not know what type
+        # the user was expecting - better to not guess.
+        return object.__format__(self, format_spec)
 
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -448,14 +448,14 @@ class TestMaskedArray:
         assert_equal(a.mask, [0, 1, 0])
 
     def test_format(self):
-        # Note: Python 3.6 and above fstring uses __format__, see PEP 498.
-        # Testing with underlying primitive.
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(format(a), "[0 -- 2]")
         assert_equal(format(masked), "--")
         assert_equal(format(masked, ""), "--")
-        assert_equal(format(masked, " >5"), "   --")
-        assert_equal(format(masked, " <5"), "--   ")
+
+        # Postponed from PR #15410, perhaps address in the future.
+        # assert_equal(format(masked, " >5"), "   --")
+        # assert_equal(format(masked, " <5"), "--   ")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -457,11 +457,9 @@ class TestMaskedArray:
         # assert_equal(format(masked, " >5"), "   --")
         # assert_equal(format(masked, " <5"), "--   ")
 
-        # instead we have....
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings("always")
-            assert_equal(format(masked, " >5"), "--")
-            assert_equal(len(w), 1, "Expected a FutureWarning for using format_spec with MaskedElement")
+        # Expect a FutureWarning for using format_spec with MaskedElement
+        with_format_string = assert_warns(FutureWarning, format, masked, " >5")
+        assert_equal(with_format_string, "--")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -458,7 +458,8 @@ class TestMaskedArray:
         # assert_equal(format(masked, " <5"), "--   ")
 
         # Expect a FutureWarning for using format_spec with MaskedElement
-        with_format_string = assert_warns(FutureWarning, format, masked, " >5")
+        with assert_warns(FutureWarning):
+            with_format_string = format(masked, " >5")
         assert_equal(with_format_string, "--")
 
     def test_str_repr(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -457,6 +457,12 @@ class TestMaskedArray:
         # assert_equal(format(masked, " >5"), "   --")
         # assert_equal(format(masked, " <5"), "--   ")
 
+        # instead we have....
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings("always")
+            assert_equal(format(masked, " >5"), "--")
+            assert_equal(len(w), 1, "Expected a FutureWarning for using format_spec with MaskedElement")
+
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(str(a), '[0 -- 2]')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -447,12 +447,15 @@ class TestMaskedArray:
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
-    def test_fstring(self):
-        # fstrings (PEP 498) are a SyntaxError in versions under Py 3.6.
-        # Seeing that as of 20200123, the atravis do not target versions under 3.6, so this is ok.
+    def test_format(self):
+        # Note: Python 3.6 and above fstring uses __format__, see PEP 498.
+        # Testing with underlying primitive.
         a = array([0, 1, 2], mask=[False, True, False])
-        assert_equal(f"{a}", "[0 -- 2]")
-        assert_equal(f"{masked}", "--")
+        assert_equal(format(a), "[0 -- 2]")
+        assert_equal(format(masked), "--")
+        assert_equal(format(masked, ""), "--")
+        assert_equal(format(masked, " >5"), "   --")
+        assert_equal(format(masked, " <5"), "--   ")
 
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -447,6 +447,13 @@ class TestMaskedArray:
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
+    def test_fstring(self):
+        # fstrings (PEP 498) are a SyntaxError in versions under Py 3.6.
+        # Seeing that as of 20200123, the atravis do not target versions under 3.6, so this is ok.
+        a = array([0, 1, 2], mask=[False, True, False])
+        assert_equal(f"{a}", "[0 -- 2]")
+        assert_equal(f"{masked}", "--")
+
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(str(a), '[0 -- 2]')


### PR DESCRIPTION
This PR adds one commit to gh-15410.  The two changes in the new commit were suggested by @seberg in comments to that PR.