### PR TITLE
DEP: Make `np.insert` and `np.delete` on 0d arrays with an axis an error

### DIFF
--- a/doc/release/upcoming_changes/15802.expired.rst
+++ b/doc/release/upcoming_changes/15802.expired.rst
@@ -1,0 +1,9 @@
+`numpy.insert` and `numpy.delete` can no longer be passed an axis on 0d arrays
+------------------------------------------------------------------------------
+This concludes a deprecation from 1.9, where when an ``axis`` argument was
+passed to a call to `~numpy.insert` and `~numpy.delete` on a 0d array, the
+``axis`` and ``obj`` argument and indices would be completely ignored.
+In these cases, ``insert(arr, "nonsense", 42, axis=0)`` would actually overwrite the
+entire array, while ``delete(arr, "nonsense", axis=0)`` would be ``arr.copy()``
+
+Now passing ``axis`` on a 0d array raises `~numpy.AxisError`.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4273,15 +4273,6 @@ def delete(arr, obj, axis=None):
         # needed for np.matrix, which is still not 1d after being ravelled
         ndim = arr.ndim
         axis = ndim - 1
-    elif ndim == 0:
-        # 2013-09-24, 1.9
-        warnings.warn(
-            "in the future the special handling of scalars will be removed "
-            "from delete and raise an error", DeprecationWarning, stacklevel=3)
-        if wrap:
-            return wrap(arr)
-        else:
-            return arr.copy(order=arrorder)
     else:
         axis = normalize_axis_index(axis, ndim)
 
@@ -4515,17 +4506,6 @@ def insert(arr, obj, values, axis=None):
         # needed for np.matrix, which is still not 1d after being ravelled
         ndim = arr.ndim
         axis = ndim - 1
-    elif ndim == 0:
-        # 2013-09-24, 1.9
-        warnings.warn(
-            "in the future the special handling of scalars will be removed "
-            "from insert and raise an error", DeprecationWarning, stacklevel=3)
-        arr = arr.copy(order=arrorder)
-        arr[...] = values
-        if wrap:
-            return wrap(arr)
-        else:
-            return arr
     else:
         axis = normalize_axis_index(axis, ndim)
     slobj = [slice(None)]*ndim

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -509,12 +509,11 @@ class TestInsert:
                      insert(a, 1, a[:, 2, :], axis=1))
 
     def test_0d(self):
-        # This is an error in the future
         a = np.array(1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_equal(insert(a, [], 2, axis=0), np.array(2))
-            assert_(w[0].category is DeprecationWarning)
+        with pytest.raises(np.AxisError):
+            insert(a, [], 2, axis=0)
+        with pytest.raises(TypeError):
+            insert(a, [], 2, axis="nonsense")
 
     def test_subclass(self):
         class SubClass(np.ndarray):
@@ -843,10 +842,10 @@ class TestDelete:
 
     def test_0d(self):
         a = np.array(1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_equal(delete(a, [], axis=0), a)
-            assert_(w[0].category is DeprecationWarning)
+        with pytest.raises(np.AxisError):
+            delete(a, [], axis=0)
+        with pytest.raises(TypeError):
+            delete(a, [], axis="nonsense")
 
     def test_subclass(self):
         class SubClass(np.ndarray):


### PR DESCRIPTION
Before this change, the following code worked:

```python
>>> some_0d = np.array(1)
>>> np.insert(some_0d, "some nonsense", 10, axis=0)
array(10)
>>> np.insert(some_0d, "some nonsense", 42, axis="some nonsense")
array(42)
```

Now these raise AxisError and TypeError, respectively.

`delete` is exactly the same.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
