### PR TITLE
DOC: correct possible list lengths for `extobj` in ufunc calls

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -441,13 +441,13 @@ advanced usage and will not typically be used.
 
 *extobj*
 
-    a list of length 1, 2, or 3 specifying the ufunc buffer-size, the
-    error mode integer, and the error call-back function. Normally, these
+    a list of length 3 specifying the ufunc buffer-size, the error
+    mode integer, and the error call-back function. Normally, these
     values are looked up in a thread-specific dictionary. Passing them
     here circumvents that look up and uses the low-level specification
-    provided for the error mode. This may be useful, for example, as an
-    optimization for calculations requiring many ufunc calls on small arrays
-    in a loop.
+    provided for the error mode. This may be useful, for example, as
+    an optimization for calculations requiring many ufunc calls on
+    small arrays in a loop.
 
 
 


### PR DESCRIPTION
According to the docs:

https://docs.scipy.org/doc/numpy/reference/ufuncs.html#optional-keyword-arguments

the list can be of lengths 1, 2, or 3, but only length 3 appears to work:

```python
>>> import numpy as np
>>> np.sin(1, extobj=[16, 1, lambda: None])
0.8414709848078965
>>> np.sin(1, extobj=[16, 1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: UFUNC_PYVALS must be a length 3 list.
>>> np.sin(1, extobj=[16])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: UFUNC_PYVALS must be a length 3 list.
```