### PR TITLE
DEP: Make np.delete on out-of-bounds indices an error

### DIFF
--- a/doc/release/upcoming_changes/15804.expired.rst
+++ b/doc/release/upcoming_changes/15804.expired.rst
@@ -1,0 +1,8 @@
+`numpy.delete` no longer ignores out-of-bounds indices
+------------------------------------------------------
+This concludes deprecations from 1.8 and 1.9, where ``np.delete`` would ignore
+both negative and out-of-bounds items in a sequence of indices. This was at
+odds with its behavior when passed a single index.
+
+Now out-of-bounds items throw ``IndexError``, and negative items index from the
+end.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4379,23 +4379,6 @@ def delete(arr, obj, axis=None):
             obj = obj.astype(intp)
         keep = ones(N, dtype=bool)
 
-        # Test if there are out of bound indices, this is deprecated
-        inside_bounds = (obj < N) & (obj >= -N)
-        if not inside_bounds.all():
-            # 2013-09-24, NumPy 1.9
-            warnings.warn(
-                "in the future out of bounds indices will raise an error "
-                "instead of being ignored by `numpy.delete`.",
-                DeprecationWarning, stacklevel=3)
-            obj = obj[inside_bounds]
-        positive_indices = obj >= 0
-        if not positive_indices.all():
-            # 2013-04-11, NumPy 1.8
-            warnings.warn(
-                "in the future negative indices will not be ignored by "
-                "`numpy.delete`.", FutureWarning, stacklevel=3)
-            obj = obj[positive_indices]
-
         keep[obj, ] = False
         slobj[axis] = keep
         new = arr[tuple(slobj)]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -807,7 +807,6 @@ class TestDelete:
         # NOTE: The cast should be removed after warning phase for bools
         if not isinstance(indices, (slice, int, long, np.integer)):
             indices = np.asarray(indices, dtype=np.intp)
-            indices = indices[(indices >= 0) & (indices < 5)]
         assert_array_equal(setxor1d(a_del, self.a[indices, ]), self.a,
                            err_msg=msg)
         xor = setxor1d(nd_a_del[0,:, 0], self.nd_a[0, indices, 0])
@@ -825,10 +824,10 @@ class TestDelete:
     def test_fancy(self):
         # Deprecation/FutureWarning tests should be kept after change.
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error', category=DeprecationWarning)
-            assert_raises(DeprecationWarning, delete, self.a, [100])
-            assert_raises(DeprecationWarning, delete, self.a, [-100])
+        with pytest.raises(IndexError):
+            delete(self.a, [100])
+        with pytest.raises(IndexError):
+            delete(self.a, [-100])
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', category=FutureWarning)
             self._check_inverse_of_slicing([0, -1, 2, 2])


### PR DESCRIPTION
Note that this only affects lists of indices.

```python
>>> a = np.arange(3)
````
Before:
```python
>>> np.delete(a, 100)
IndexError
>>> np.delete(a, [100])
DeprecationWarning
array([0, 1, 2])

>>> np.delete(a, -1)
array([0, 1])
>>> np.delete(a, [-1])
FutureWarning
array([0, 1, 2])
```

After:
```python
>>> np.delete(a, 100)
IndexError
>>> np.delete(a, [100])
IndexError

>>> np.delete(a, -1)
array([0, 1])
>>> np.delete(a, [-1])
array([0, 1])
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Similar to gh-15802