### PR TITLE
DEP: Do not cast boolean indices to integers in np.delete

### DIFF
--- a/doc/release/upcoming_changes/15815.expired.rst
+++ b/doc/release/upcoming_changes/15815.expired.rst
@@ -1,0 +1,6 @@
+`numpy.delete` no longer casts boolean indices to integers
+----------------------------------------------------------
+This concludes a deprecation from 1.8, where ``np.delete`` would cast boolean
+arrays and scalars passed as an index argument into integer indices. The
+behavior now is to treat boolean arrays as a mask, and to raise an error
+on boolean scalars.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4212,7 +4212,7 @@ def delete(arr, obj, axis=None):
         Indicate indices of sub-arrays to remove along the specified axis.
 
         .. versionchanged:: 1.19.0
-            Boolean indices are now treated as as mask of elements to remove,
+            Boolean indices are now treated as a mask of elements to remove,
             rather than being cast to the integers 0 and 1.
 
     axis : int, optional

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4368,7 +4368,7 @@ def delete(arr, obj, axis=None):
 
         if obj.dtype == bool:
             if obj.shape != (N,):
-                raise ValueError('boolean array argument obj to insert '
+                raise ValueError('boolean array argument obj to delete '
                                  'must be one dimensional and match the axis '
                                  'length of {}'.format(N))
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4207,12 +4207,17 @@ def delete(arr, obj, axis=None):
     Parameters
     ----------
     arr : array_like
-      Input array.
+        Input array.
     obj : slice, int or array of ints
-      Indicate indices of sub-arrays to remove along the specified axis.
+        Indicate indices of sub-arrays to remove along the specified axis.
+
+        .. versionchanged:: 1.19.0
+            Boolean indices are now treated as as mask of elements to remove,
+            rather than being cast to the integers 0 and 1.
+
     axis : int, optional
-      The axis along which to delete the subarray defined by `obj`.
-      If `axis` is None, `obj` is applied to the flattened array.
+        The axis along which to delete the subarray defined by `obj`.
+        If `axis` is None, `obj` is applied to the flattened array.
 
     Returns
     -------
@@ -4339,19 +4344,8 @@ def delete(arr, obj, axis=None):
         else:
             return new
 
-    _obj = obj
-    obj = np.asarray(obj)
-    # After removing the special handling of booleans and out of
-    # bounds values, the conversion to the array can be removed.
-    if obj.dtype == bool:
-        # 2012-10-11, NumPy 1.8
-        warnings.warn("in the future insert will treat boolean arrays and "
-                      "array-likes as boolean index instead of casting it "
-                      "to integer", FutureWarning, stacklevel=3)
-        obj = obj.astype(intp)
-    if isinstance(_obj, (int, long, integer)):
+    if isinstance(obj, (int, integer)) and not isinstance(obj, bool):
         # optimization for a single value
-        obj = obj.item()
         if (obj < -N or obj >= N):
             raise IndexError(
                 "index %i is out of bounds for axis %i with "
@@ -4367,11 +4361,23 @@ def delete(arr, obj, axis=None):
         slobj2[axis] = slice(obj+1, None)
         new[tuple(slobj)] = arr[tuple(slobj2)]
     else:
+        _obj = obj
+        obj = np.asarray(obj)
         if obj.size == 0 and not isinstance(_obj, np.ndarray):
             obj = obj.astype(intp)
-        keep = ones(N, dtype=bool)
 
-        keep[obj, ] = False
+        if obj.dtype == bool:
+            if obj.shape != (N,):
+                raise ValueError('boolean array argument obj to insert '
+                                 'must be one dimensional and match the axis '
+                                 'length of {}'.format(N))
+
+            # optimization, the other branch is slower
+            keep = ~obj
+        else:
+            keep = ones(N, dtype=bool)
+            keep[obj,] = False
+
         slobj[axis] = keep
         new = arr[tuple(slobj)]
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -810,9 +810,6 @@ class TestDelete:
         a_del = delete(self.a, indices)
         nd_a_del = delete(self.nd_a, indices, axis=1)
         msg = 'Delete failed for obj: %r' % indices
-        # NOTE: The cast should be removed after warning phase for bools
-        if not isinstance(indices, (slice, int, long, np.integer)):
-            indices = np.asarray(indices, dtype=np.intp)
         assert_array_equal(setxor1d(a_del, self.a[indices, ]), self.a,
                            err_msg=msg)
         xor = setxor1d(nd_a_del[0,:, 0], self.nd_a[0, indices, 0])
@@ -828,7 +825,6 @@ class TestDelete:
                     self._check_inverse_of_slicing(s)
 
     def test_fancy(self):
-        # Deprecation/FutureWarning tests should be kept after change.
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
         with pytest.raises(IndexError):
             delete(self.a, [100])
@@ -837,14 +833,17 @@ class TestDelete:
 
         self._check_inverse_of_slicing([0, -1, 2, 2])
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', category=FutureWarning)
-            obj = np.array([True, False, False], dtype=bool)
-            self._check_inverse_of_slicing(obj)
-            # _check_inverse_of_slicing operates on two arrays, so warns twice
-            assert len(w) == 2
-            assert_(w[0].category is FutureWarning)
-            assert_(w[1].category is FutureWarning)
+        self._check_inverse_of_slicing([True, False, False, True, False])
+
+        # not legal, indexing with these would change the dimension
+        with pytest.raises(ValueError):
+            delete(self.a, True)
+        with pytest.raises(ValueError):
+            delete(self.a, False)
+
+        # not enough items
+        with pytest.raises(ValueError):
+            delete(self.a, [False]*4)
 
     def test_single(self):
         self._check_inverse_of_slicing(0)


### PR DESCRIPTION
This expires a deprecation from 1.8.

The corresponding deprecation in `np.insert` has less clear semantics, so has been left to a future patch.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
