### PR TITLE
MAINT: simplify code that assumes str/unicode and int/long are different types

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -834,7 +834,7 @@ General check of Python Type
 .. c:function:: PyArray_IsPythonScalar(op)
 
     Evaluates true if *op* is a builtin Python scalar object (int,
-    float, complex, str, unicode, long, bool).
+    float, complex, bytes, str, long, bool).
 
 .. c:function:: PyArray_IsAnyScalar(op)
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -125,7 +125,6 @@ Conversion
 
    MaskedArray.__float__
    MaskedArray.__int__
-   MaskedArray.__long__
 
    MaskedArray.view
    MaskedArray.astype

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -153,13 +153,12 @@ else:
     from . import ma
     from . import matrixlib as _mat
     from .matrixlib import *
-    from .compat import long
 
     # Make these accessible from numpy name-space
     # but not imported in from numpy import *
     # TODO[gh-6103]: Deprecate these
     from builtins import bool, int, float, complex, object, str
-    unicode = str
+    from .compat import long, unicode
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -9,7 +9,6 @@ import re
 import sys
 import platform
 
-from numpy.compat import unicode
 from .multiarray import dtype, array, ndarray
 try:
     import ctypes
@@ -365,7 +364,7 @@ def _newnames(datatype, order):
     """
     oldnames = datatype.names
     nameslist = list(oldnames)
-    if isinstance(order, (str, unicode)):
+    if isinstance(order, str):
         order = [order]
     seen = set()
     if isinstance(order, (list, tuple)):

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -24,7 +24,7 @@ from .numeric import array as narray
 from numpy.core.multiarray import _vec_string
 from numpy.core.overrides import set_module
 from numpy.core import overrides
-from numpy.compat import asbytes, long
+from numpy.compat import asbytes
 import numpy
 
 __all__ = [
@@ -340,7 +340,7 @@ def multiply(a, i):
     i_arr = numpy.asarray(i)
     if not issubclass(i_arr.dtype.type, integer):
         raise ValueError("Can only multiply by integers")
-    out_size = _get_num_chars(a_arr) * max(long(i_arr.max()), 0)
+    out_size = _get_num_chars(a_arr) * max(int(i_arr.max()), 0)
     return _vec_string(
         a_arr, (a_arr.dtype.type, out_size), '__mul__', (i_arr,))
 
@@ -450,7 +450,7 @@ def center(a, width, fillchar=' '):
     """
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
-    size = long(numpy.max(width_arr.flat))
+    size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
@@ -995,7 +995,7 @@ def ljust(a, width, fillchar=' '):
     """
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
-    size = long(numpy.max(width_arr.flat))
+    size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
@@ -1265,7 +1265,7 @@ def rjust(a, width, fillchar=' '):
     """
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
-    size = long(numpy.max(width_arr.flat))
+    size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
         fillchar = asbytes(fillchar)
     return _vec_string(
@@ -1733,7 +1733,7 @@ def zfill(a, width):
     """
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
-    size = long(numpy.max(width_arr.flat))
+    size = int(numpy.max(width_arr.flat))
     return _vec_string(
         a_arr, (a_arr.dtype.type, size), 'zfill', (width_arr,))
 
@@ -1952,10 +1952,10 @@ class chararray(ndarray):
         else:
             dtype = string_
 
-        # force itemsize to be a Python long, since using NumPy integer
+        # force itemsize to be a Python int, since using NumPy integer
         # types results in itemsize.itemsize being used as the size of
         # strings in the new array.
-        itemsize = long(itemsize)
+        itemsize = int(itemsize)
 
         if isinstance(buffer, str):
             # unicode objects do not have the buffer interface
@@ -2720,7 +2720,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
                 (itemsize != obj.itemsize) or
                 (not unicode and isinstance(obj, unicode_)) or
                 (unicode and isinstance(obj, string_))):
-            obj = obj.astype((dtype, long(itemsize)))
+            obj = obj.astype((dtype, int(itemsize)))
         return obj
 
     if isinstance(obj, ndarray) and issubclass(obj.dtype.type, object):

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -1,7 +1,7 @@
 import numpy as np
 from .numeric import uint8, ndarray, dtype
 from numpy.compat import (
-    long, os_fspath, contextlib_nullcontext, is_pathlib_path
+    os_fspath, contextlib_nullcontext, is_pathlib_path
 )
 from numpy.core.overrides import set_module
 
@@ -242,7 +242,7 @@ class memmap(ndarray):
                 for k in shape:
                     size *= k
 
-            bytes = long(offset + size*_dbytes)
+            bytes = int(offset + size*_dbytes)
 
             if mode in ('w+', 'r+') and flen < bytes:
                 fid.seek(bytes - 1, 0)

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -83,7 +83,6 @@ import types as _types
 import numbers
 import warnings
 
-from numpy.compat import bytes, long
 from numpy.core.multiarray import (
         typeinfo, ndarray, array, empty, dtype, datetime_data,
         datetime_as_string, busday_offset, busday_count, is_busday,
@@ -119,8 +118,8 @@ from ._dtype import _kind_name
 
 # we don't export these for import *, but we do want them accessible
 # as numerictypes.bool, etc.
-from builtins import bool, int, float, complex, object, str
-unicode = str
+from builtins import bool, int, float, complex, object, str, bytes
+from numpy.compat import long, unicode
 
 
 # We use this later

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -40,7 +40,7 @@ from collections import Counter, OrderedDict
 from . import numeric as sb
 from . import numerictypes as nt
 from numpy.compat import (
-    isfileobj, bytes, long, unicode, os_fspath, contextlib_nullcontext
+    isfileobj, os_fspath, contextlib_nullcontext
 )
 from numpy.core.overrides import set_module
 from .arrayprint import get_printoptions
@@ -188,7 +188,7 @@ class format_parser:
         if names:
             if type(names) in [list, tuple]:
                 pass
-            elif isinstance(names, (str, unicode)):
+            elif isinstance(names, str):
                 names = names.split(',')
             else:
                 raise NameError("illegal input names %s" % repr(names))
@@ -703,7 +703,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
         shape = _deprecate_shape_0_as_None(shape)
         if shape is None:
             shape = len(recList)
-        if isinstance(shape, (int, long)):
+        if isinstance(shape, int):
             shape = (shape,)
         if len(shape) > 1:
             raise ValueError("Can only deal with 1-d array.")
@@ -792,7 +792,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
 
     if shape is None:
         shape = (-1,)
-    elif isinstance(shape, (int, long)):
+    elif isinstance(shape, int):
         shape = (shape,)
 
     if isfileobj(fd):

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -475,9 +475,7 @@ class TestPrintOptions:
         assert_equal(repr(x), "array([0., 1., 2.])")
 
     def test_0d_arrays(self):
-        unicode = type(u'')
-
-        assert_equal(unicode(np.array(u'café', '<U4')), u'café')
+        assert_equal(str(np.array(u'café', '<U4')), u'café')
 
         assert_equal(repr(np.array('café', '<U4')),
                      "array('café', dtype='<U4')")

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.core._multiarray_tests import solve_diophantine, internal_overlap
 from numpy.core import _umath_tests
 from numpy.lib.stride_tricks import as_strided
-from numpy.compat import long
 from numpy.testing import (
     assert_, assert_raises, assert_equal, assert_array_equal
     )
@@ -387,7 +386,6 @@ def test_shares_memory_api():
     assert_equal(np.shares_memory(a, b), True)
     assert_equal(np.shares_memory(a, b, max_work=None), True)
     assert_raises(np.TooHardError, np.shares_memory, a, b, max_work=1)
-    assert_raises(np.TooHardError, np.shares_memory, a, b, max_work=long(1))
 
 
 def test_may_share_memory_bad_max_work():

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -21,7 +21,7 @@ import builtins
 from decimal import Decimal
 
 import numpy as np
-from numpy.compat import strchar, unicode
+from numpy.compat import strchar
 import numpy.core._multiarray_tests as _multiarray_tests
 from numpy.testing import (
     assert_, assert_raises, assert_warns, assert_equal, assert_almost_equal,
@@ -1457,12 +1457,12 @@ class TestZeroSizeFlexible:
         assert_equal(zs.itemsize, 0)
         zs = self._zeros(10, np.void)
         assert_equal(zs.itemsize, 0)
-        zs = self._zeros(10, unicode)
+        zs = self._zeros(10, str)
         assert_equal(zs.itemsize, 0)
 
     def _test_sort_partition(self, name, kinds, **kwargs):
         # Previously, these would all hang
-        for dt in [bytes, np.void, unicode]:
+        for dt in [bytes, np.void, str]:
             zs = self._zeros(10, dt)
             sort_method = getattr(zs, name)
             sort_func = getattr(np, name)
@@ -1484,13 +1484,13 @@ class TestZeroSizeFlexible:
 
     def test_resize(self):
         # previously an error
-        for dt in [bytes, np.void, unicode]:
+        for dt in [bytes, np.void, str]:
             zs = self._zeros(10, dt)
             zs.resize(25)
             zs.resize((10, 10))
 
     def test_view(self):
-        for dt in [bytes, np.void, unicode]:
+        for dt in [bytes, np.void, str]:
             zs = self._zeros(10, dt)
 
             # viewing as itself should be allowed
@@ -1505,7 +1505,7 @@ class TestZeroSizeFlexible:
 
     def test_pickle(self):
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
-            for dt in [bytes, np.void, unicode]:
+            for dt in [bytes, np.void, str]:
                 zs = self._zeros(10, dt)
                 p = pickle.dumps(zs, protocol=proto)
                 zs2 = pickle.loads(p)
@@ -4449,7 +4449,7 @@ class TestPutmask:
         assert_equal(x[mask], np.array(val, T))
 
     def test_ip_types(self):
-        unchecked_types = [bytes, unicode, np.void]
+        unchecked_types = [bytes, str, np.void]
 
         x = np.random.random(1000)*100
         mask = x < 40
@@ -4503,7 +4503,7 @@ class TestTake:
         assert_array_equal(x.take(ind, axis=0), x)
 
     def test_ip_types(self):
-        unchecked_types = [bytes, unicode, np.void]
+        unchecked_types = [bytes, str, np.void]
 
         x = np.random.random(24)*100
         x.shape = 2, 3, 4

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -15,7 +15,7 @@ from numpy.testing import (
         _assert_valid_refcount, HAS_REFCOUNT,
         )
 from numpy.testing._private.utils import _no_tracing
-from numpy.compat import asbytes, asunicode, long, pickle
+from numpy.compat import asbytes, asunicode, pickle
 
 try:
     RecursionError
@@ -1504,7 +1504,7 @@ class TestRegression:
             min //= -1
 
         with np.errstate(divide="ignore"):
-            for t in (np.int8, np.int16, np.int32, np.int64, int, np.compat.long):
+            for t in (np.int8, np.int16, np.int32, np.int64, int):
                 test_type(t)
 
     def test_buffer_hashlib(self):
@@ -1803,7 +1803,6 @@ class TestRegression:
         a = np.array(0, dtype=object)
         a[()] = a
         assert_raises(RecursionError, int, a)
-        assert_raises(RecursionError, long, a)
         assert_raises(RecursionError, float, a)
         a[()] = None
 
@@ -1829,7 +1828,6 @@ class TestRegression:
         b = np.array(0, dtype=object)
         a[()] = b
         assert_equal(int(a), int(0))
-        assert_equal(long(a), long(0))
         assert_equal(float(a), float(0))
 
     def test_object_array_self_copy(self):

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -11,7 +11,6 @@ from numpy.testing import (
     assert_raises_regex, assert_warns
     )
 
-from numpy.compat import long
 
 class TestAtleast1d:
     def test_0D_array(self):
@@ -49,7 +48,6 @@ class TestAtleast1d:
         """
         assert_(atleast_1d(3).shape == (1,))
         assert_(atleast_1d(3j).shape == (1,))
-        assert_(atleast_1d(long(3)).shape == (1,))
         assert_(atleast_1d(3.0).shape == (1,))
         assert_(atleast_1d([[2, 3], [4, 5]]).shape == (2, 2))
 

--- a/numpy/core/tests/test_unicode.py
+++ b/numpy/core/tests/test_unicode.py
@@ -1,10 +1,8 @@
 import numpy as np
-from numpy.compat import unicode
 from numpy.testing import assert_, assert_equal, assert_array_equal
 
 def buffer_length(arr):
-    if isinstance(arr, unicode):
-        arr = str(arr)
+    if isinstance(arr, str):
         if not arr:
             charmax = 0
         else:

--- a/numpy/doc/indexing.py
+++ b/numpy/doc/indexing.py
@@ -372,8 +372,7 @@ exceptions (assigning complex to floats or ints): ::
  >>> x[1]
  1
  >>> x[1] = 1.2j
- <type 'exceptions.TypeError'>: can't convert complex to long; use
- long(abs(z))
+ TypeError: can't convert complex to int
 
 
 Unlike some of the references (such as array and mask indices)

--- a/numpy/f2py/tests/test_return_complex.py
+++ b/numpy/f2py/tests/test_return_complex.py
@@ -1,7 +1,6 @@
 import pytest
 
 from numpy import array
-from numpy.compat import long
 from numpy.testing import assert_, assert_raises
 from . import util
 
@@ -15,7 +14,7 @@ class TestReturnComplex(util.F2PyTest):
             err = 0.0
         assert_(abs(t(234j) - 234.0j) <= err)
         assert_(abs(t(234.6) - 234.6) <= err)
-        assert_(abs(t(long(234)) - 234.0) <= err)
+        assert_(abs(t(234) - 234.0) <= err)
         assert_(abs(t(234.6 + 3j) - (234.6 + 3j)) <= err)
         #assert_( abs(t('234')-234.)<=err)
         #assert_( abs(t('234.6')-234.6)<=err)

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -1,7 +1,6 @@
 import pytest
 
 from numpy import array
-from numpy.compat import long
 from numpy.testing import assert_, assert_raises
 from . import util
 
@@ -11,7 +10,6 @@ class TestReturnInteger(util.F2PyTest):
     def check_function(self, t, tname):
         assert_(t(123) == 123, repr(t(123)))
         assert_(t(123.6) == 123)
-        assert_(t(long(123)) == 123)
         assert_(t('123') == 123)
         assert_(t(-123) == -123)
         assert_(t([123]) == 123)

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -1,7 +1,6 @@
 import pytest
 
 from numpy import array
-from numpy.compat import long
 from numpy.testing import assert_, assert_raises
 from . import util
 
@@ -18,7 +17,6 @@ class TestReturnLogical(util.F2PyTest):
         assert_(t(1j) == 1)
         assert_(t(234) == 1)
         assert_(t(234.6) == 1)
-        assert_(t(long(234)) == 1)
         assert_(t(234.6 + 3j) == 1)
         assert_(t('234') == 1)
         assert_(t('aaa') == 1)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -2,7 +2,6 @@ import platform
 import pytest
 
 from numpy import array
-from numpy.compat import long
 from numpy.testing import assert_, assert_raises
 from . import util
 
@@ -16,7 +15,6 @@ class TestReturnReal(util.F2PyTest):
             err = 0.0
         assert_(abs(t(234) - 234.0) <= err)
         assert_(abs(t(234.6) - 234.6) <= err)
-        assert_(abs(t(long(234)) - 234.0) <= err)
         assert_(abs(t('234') - 234) <= err)
         assert_(abs(t('234.6') - 234.6) <= err)
         assert_(abs(t(-234) + 234) <= err)

--- a/numpy/lib/arrayterator.py
+++ b/numpy/lib/arrayterator.py
@@ -10,8 +10,6 @@ a user-specified number of elements.
 from operator import mul
 from functools import reduce
 
-from numpy.compat import long
-
 __all__ = ['Arrayterator']
 
 
@@ -108,7 +106,7 @@ class Arrayterator:
             if slice_ is Ellipsis:
                 fixed.extend([slice(None)] * (dims-length+1))
                 length = len(fixed)
-            elif isinstance(slice_, (int, long)):
+            elif isinstance(slice_, int):
                 fixed.append(slice(slice_, slice_+1, 1))
             else:
                 fixed.append(slice_)

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -166,7 +166,7 @@ import io
 import warnings
 from numpy.lib.utils import safe_eval
 from numpy.compat import (
-    isfileobj, long, os_fspath, pickle
+    isfileobj, os_fspath, pickle
     )
 
 
@@ -594,7 +594,7 @@ def _read_array_header(fp, version):
 
     # Sanity-check the values.
     if (not isinstance(d['shape'], tuple) or
-            not numpy.all([isinstance(x, (int, long)) for x in d['shape']])):
+            not numpy.all([isinstance(x, int) for x in d['shape']])):
         msg = "shape is not valid: {!r}"
         raise ValueError(msg.format(d['shape']))
     if not isinstance(d['fortran_order'], bool):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -29,7 +29,6 @@ from numpy.core.multiarray import (
     interp as compiled_interp, interp_complex as compiled_interp_complex
     )
 from numpy.core.umath import _add_newdoc_ufunc as add_newdoc_ufunc
-from numpy.compat import long
 
 import builtins
 

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -9,7 +9,6 @@ from numpy.lib._iotools import (
     LineSplitter, NameValidator, StringConverter,
     has_nested_fields, easy_dtype, flatten_dtype
     )
-from numpy.compat import unicode
 
 
 class TestLineSplitter:
@@ -179,10 +178,10 @@ class TestStringConverter:
         # note that the longdouble type has been skipped, so the
         # _status increases by 2. Everything should succeed with
         # unicode conversion (5).
-        for s in ['a', u'a', b'a']:
+        for s in ['a', b'a']:
             res = converter.upgrade(s)
-            assert_(type(res) is unicode)
-            assert_equal(res, u'a')
+            assert_(type(res) is str)
+            assert_equal(res, 'a')
             assert_equal(converter._status, 5 + status_offset)
 
     def test_missing(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -21,7 +21,6 @@ from numpy.lib import (
     select, setxor1d, sinc, trapz, trim_zeros, unwrap, unique, vectorize
     )
 
-from numpy.compat import long
 
 def get_mat(n):
     data = np.arange(n)

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -5,7 +5,6 @@ from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_array_almost_equal,
     assert_raises, _assert_valid_refcount,
     )
-from numpy.compat import unicode
 
 
 class TestRegression:
@@ -180,7 +179,7 @@ class TestRegression:
         # related to ticket #1405.
         include_dirs = [np.get_include()]
         for path in include_dirs:
-            assert_(isinstance(path, (str, unicode)))
+            assert_(isinstance(path, str))
             assert_(path != '')
 
     def test_polyder_return_type(self):

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.compat import long
 from numpy.testing import (
     assert_, assert_equal, assert_array_equal, assert_raises
     )
@@ -86,7 +85,6 @@ class TestIsscalar:
         assert_(not np.isscalar([3]))
         assert_(not np.isscalar((3,)))
         assert_(np.isscalar(3j))
-        assert_(np.isscalar(long(10)))
         assert_(np.isscalar(4.0))
 
 

--- a/numpy/lib/user_array.py
+++ b/numpy/lib/user_array.py
@@ -11,7 +11,6 @@ from numpy.core import (
     bitwise_xor, invert, less, less_equal, not_equal, equal, greater,
     greater_equal, shape, reshape, arange, sin, sqrt, transpose
 )
-from numpy.compat import long
 
 
 class container:
@@ -195,9 +194,6 @@ class container:
 
     def __int__(self):
         return self._scalarfunc(int)
-
-    def __long__(self):
-        return self._scalarfunc(long)
 
     def __hex__(self):
         return self._scalarfunc(hex)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4327,17 +4327,6 @@ class MaskedArray(ndarray):
             raise MaskError('Cannot convert masked element to a Python int.')
         return int(self.item())
 
-    def __long__(self):
-        """
-        Convert to long.
-        """
-        if self.size > 1:
-            raise TypeError("Only length-1 arrays can be converted "
-                            "to Python scalars")
-        elif self._mask:
-            raise MaskError('Cannot convert masked element to a Python long.')
-        return long(self.item())
-
     @property
     def imag(self):
         """

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -13,7 +13,6 @@ from numpy.polynomial import (
 from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
     )
-from numpy.compat import long
 from numpy.polynomial.polyutils import RankWarning
 
 #
@@ -315,7 +314,7 @@ def test_truediv(Poly):
         s = stype(5)
         assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)
-    for stype in (int, long, float):
+    for stype in (int, float):
         s = stype(5)
         assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -1,5 +1,4 @@
 from numpy.testing import (assert_, assert_array_equal)
-from numpy.compat import long
 import numpy as np
 import pytest
 from numpy.random import Generator, MT19937
@@ -40,13 +39,6 @@ class TestRegression:
         freq = np.sum(rvsn == 2) / float(N)
         msg = "Frequency was %f, should be < 0.23" % freq
         assert_(freq < 0.23, msg)
-
-    def test_permutation_longs(self):
-        mt19937 = Generator(MT19937(1234))
-        a = mt19937.permutation(12)
-        mt19937 = Generator(MT19937(1234))
-        b = mt19937.permutation(long(12))
-        assert_array_equal(a, b)
 
     def test_shuffle_mixed_dimension(self):
         # Test for trac ticket #2074

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -5,7 +5,6 @@ import pytest
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises,
     )
-from numpy.compat import long
 import numpy as np
 
 from numpy import random
@@ -51,13 +50,6 @@ class TestRegression:
         freq = np.sum(rvsn == 2) / float(N)
         msg = "Frequency was %f, should be < 0.23" % freq
         assert_(freq < 0.23, msg)
-
-    def test_permutation_longs(self):
-        random.seed(1234)
-        a = random.permutation(12)
-        random.seed(1234)
-        b = random.permutation(long(12))
-        assert_array_equal(a, b)
 
     def test_shuffle_mixed_dimension(self):
         # Test for trac ticket #2074

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -3,7 +3,6 @@ from numpy.testing import (
     assert_, assert_array_equal, assert_raises,
     )
 from numpy import random
-from numpy.compat import long
 import numpy as np
 
 
@@ -47,13 +46,6 @@ class TestRegression:
         freq = np.sum(rvsn == 2) / float(N)
         msg = "Frequency was %f, should be < 0.23" % freq
         assert_(freq < 0.23, msg)
-
-    def test_permutation_longs(self):
-        np.random.seed(1234)
-        a = np.random.permutation(12)
-        np.random.seed(1234)
-        b = np.random.permutation(long(12))
-        assert_array_equal(a, b)
 
     def test_shuffle_mixed_dimension(self):
         # Test for trac ticket #2074


### PR DESCRIPTION
Cleanup from the dropping of python 2

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
