### PR TITLE
ENH: improved error message `IndexError: too many indices for array`

### DIFF
--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -729,7 +729,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
     else if (used_ndim > PyArray_NDIM(self)) {
         PyErr_Format(PyExc_IndexError,
                      "too many indices for array: "
-                     "array has %d-dimension, but %d were indexed",
+                     "array is %d-dimensional, but %d were indexed",
                      PyArray_NDIM(self),
                      used_ndim);
         goto failed_building_indices;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -728,8 +728,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
     }
     else if (used_ndim > PyArray_NDIM(self)) {
         PyErr_Format(PyExc_IndexError,
-                     "array has %"NPY_INTP_FMT
-                     "-dimension, but %d were indexed",
+                     "too many indices for array: "
+                     "array has %d-dimension, but %d were indexed",
                      PyArray_NDIM(self),
                      used_ndim);
         goto failed_building_indices;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -727,8 +727,11 @@ prepare_index(PyArrayObject *self, PyObject *index,
         }
     }
     else if (used_ndim > PyArray_NDIM(self)) {
-        PyErr_SetString(PyExc_IndexError,
-                        "too many indices for array");
+        PyErr_Format(PyExc_IndexError,
+                     "array has %"NPY_INTP_FMT
+                     "-dimension, but %d were indexed",
+                     PyArray_NDIM(self),
+                     used_ndim);
         goto failed_building_indices;
     }
     else if (index_ndim == 0) {

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,5 +1,8 @@
 import numpy as np
-from numpy.testing import assert_raises
+from numpy.testing import (
+        assert_raises, assert_raises_regex
+        )
+
 
 class TestIndexErrors:
     '''Tests to exercise indexerrors not covered by other tests.'''
@@ -109,6 +112,14 @@ class TestIndexErrors:
         a = np.zeros((3, 0))
         assert_raises(IndexError, lambda: a[(1, [0, 1])])
         assert_raises(IndexError, lambda: assign(a, (1, [0, 1]), 1))
+
+    def test_mapping_error_message(self):
+        a = np.zeros((3, 5))
+        index = (1, 2, 3, 4, 5)
+        assert_raises_regex(
+                IndexError,
+                "array has 2-dimension, but 5 were indexed",
+                lambda: a[index])
 
     def test_methods(self):
         "cases from methods.c"

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import (
-        assert_raises, assert_raises_regex
+        assert_raises, assert_raises_regex,
         )
 
 
@@ -118,6 +118,7 @@ class TestIndexErrors:
         index = (1, 2, 3, 4, 5)
         assert_raises_regex(
                 IndexError,
+                "too many indices for array: "
                 "array has 2-dimension, but 5 were indexed",
                 lambda: a[index])
 

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -119,7 +119,7 @@ class TestIndexErrors:
         assert_raises_regex(
                 IndexError,
                 "too many indices for array: "
-                "array has 2-dimension, but 5 were indexed",
+                "array is 2-dimensional, but 5 were indexed",
                 lambda: a[index])
 
     def test_methods(self):


### PR DESCRIPTION
ENH: improved error message `IndexError: too many indices for array` when the dimension of the index is larger than the dimension of the array, fixes #15321

Author:  Yilin Li <yilin.lasia@gmail.com>
