### PR TITLE
BLD: define NO_APPEND_FORTRAN when libraries are built using xlf and/or xlc on AIX

### DIFF
--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -1,4 +1,3 @@
-import sys
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -6,12 +5,9 @@ def configuration(parent_package='',top_path=None):
 
     config.add_data_dir('tests')
 
-    # AIX needs to be told to use large file support - at all times
-    defs = [('_LARGE_FILES', None)] if sys.platform[:3] == "aix" else []
     # Configure pocketfft_internal
     config.add_extension('_pocketfft_internal',
-                         sources=['_pocketfft.c'],
-                         define_macros=defs
+                         sources=['_pocketfft.c']
                          )
 
     return config

--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -1,3 +1,4 @@
+import sys
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -5,9 +6,12 @@ def configuration(parent_package='',top_path=None):
 
     config.add_data_dir('tests')
 
+    # AIX needs to be told to use large file support - at all times
+    defs = [('_LARGE_FILES', None)] if sys.platform[:3] == "aix" else []
     # Configure pocketfft_internal
     config.add_extension('_pocketfft_internal',
-                         sources=['_pocketfft.c']
+                         sources=['_pocketfft.c'],
+                         define_macros=defs
                          )
 
     return config

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -59,11 +59,17 @@ def configuration(parent_package='', top_path=None):
                 return []
             return [all_sources[0]]
 
+    # AIX needs to be told to not use the extra underscore '_'
+    # Note: this setting is actually dependent on the fortran compiler behavior
+    # used to build liblapack.a (xlf does not append!, maybe gfortran does)
+    # Better way to establish liblapack.a definition is needed.
+    defs = [('NO_APPEND_FORTRAN', None)] if sys.platform[:3] == "aix" else []
     config.add_extension(
         'lapack_lite',
         sources=['lapack_litemodule.c', get_lapack_lite_sources],
         depends=['lapack_lite/f2c.h'],
         extra_info=lapack_info,
+        define_macros=defs,
     )
 
     # umath_linalg module
@@ -73,7 +79,9 @@ def configuration(parent_package='', top_path=None):
         depends=['lapack_lite/f2c.h'],
         extra_info=lapack_info,
         libraries=['npymath'],
+        define_macros=defs,
     )
+
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->
Closes #15801 
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
a) _LARGE_FILES is needed by AIX for proper compilation (done by #15938 )
b) lapack, when compiled using xlf, does not need the underscore (_) added to the function name when calling fortran from C.