### PR TITLE
DOC: Minor fix to _hist_bin_fd documentation

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -207,7 +207,7 @@ def _hist_bin_fd(x, range):
     than the standard deviation, so it is less accurate, especially for
     long tailed distributions.
 
-    If the IQR is 0, this function returns 1 for the number of bins.
+    If the IQR is 0, this function returns 0 for the number of bins.
     Binwidth is inversely proportional to the cube root of data size
     (asymptotically optimal).
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -207,7 +207,7 @@ def _hist_bin_fd(x, range):
     than the standard deviation, so it is less accurate, especially for
     long tailed distributions.
 
-    If the IQR is 0, this function returns 0 for the number of bins.
+    If the IQR is 0, this function returns 0 for the bin width.
     Binwidth is inversely proportional to the cube root of data size
     (asymptotically optimal).
 


### PR DESCRIPTION
This function returns 0 when IQR is 0, instead of 1 as mentioned in docstring
