### PR TITLE
BUG,DEP: Make `scalar.__round__()` behave like pythons round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ numpy/core/include/numpy/multiarray_api.txt
 numpy/core/include/numpy/ufunc_api.txt
 numpy/core/lib/
 numpy/core/src/common/npy_binsearch.h
+numpy/core/src/common/npy_cpu_features.c
 numpy/core/src/common/npy_partition.h
 numpy/core/src/common/npy_sort.h
 numpy/core/src/common/templ_common.h

--- a/doc/release/upcoming_changes/15840.compatibility.rst
+++ b/doc/release/upcoming_changes/15840.compatibility.rst
@@ -1,0 +1,7 @@
+Change output of ``round`` on scalars to be consistent with Python
+------------------------------------------------------------------
+
+Output of the ``__round__`` dunder method and consequently the Python
+built-in `round` has been changed to be a Python `int` to be consistent
+with calling it on Python ``float`` objects when called with no arguments.
+Previously, it would return a scalar of the `np.dtype` that was passed in.

--- a/doc/release/upcoming_changes/15840.deprecation.rst
+++ b/doc/release/upcoming_changes/15840.deprecation.rst
@@ -1,0 +1,6 @@
+Deprecation of `round` for ``np.complexfloating`` scalars
+-----------------------------------------------------------
+
+Output of the ``__round__`` dunder method and consequently the Python built-in
+`round` has been deprecated on complex scalars. This does not affect
+`np.round`.

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1549,6 +1549,58 @@ gentype_@name@(PyObject *self, PyObject *args, PyObject *kwds)
 }
 /**end repeat**/
 
+
+/**begin repeat
+ * #name = integer, floating, complexfloating#
+ * #complex = 0, 0, 1#
+ */
+static PyObject *
+@name@type_dunder_round(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    static char *kwlist[] = {"ndigits", NULL};
+    PyObject *ndigits = Py_None;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:__round__", kwlist, &ndigits)) {
+        return NULL;
+    }
+
+#if @complex@
+    if (DEPRECATE("The Python built-in `round` is deprecated for complex "
+                  "scalars, and will raise a `TypeError` in a future release. "
+                  "Use `np.round` or `scalar.round` instead.") < 0) {
+        return NULL;
+    }
+#endif
+    
+    PyObject *tup;
+    if (ndigits == Py_None) {
+        tup = PyTuple_Pack(0);
+    }
+    else {
+        tup = PyTuple_Pack(1, ndigits);
+    }
+
+    if (tup == NULL) {
+        return NULL;
+    }
+
+    PyObject *obj = gentype_round(self, tup, NULL);
+    Py_DECREF(tup);
+    if (obj == NULL) {
+        return NULL;
+    }
+
+#if !@complex@
+    if (ndigits == Py_None) {
+        PyObject *ret = PyNumber_Long(obj);
+        Py_DECREF(obj);
+        return ret;
+    }
+#endif
+    
+    return obj;
+}
+/**end repeat**/
+
 static PyObject *
 voidtype_getfield(PyVoidScalarObject *self, PyObject *args, PyObject *kwds)
 {
@@ -2056,10 +2108,6 @@ static PyMethodDef gentype_methods[] = {
     {"round",
         (PyCFunction)gentype_round,
         METH_VARARGS | METH_KEYWORDS, NULL},
-    /* Hook for the round() builtin */
-    {"__round__",
-        (PyCFunction)gentype_round,
-        METH_VARARGS | METH_KEYWORDS, NULL},
     /* For the format function */
     {"__format__",
         gentype_format,
@@ -2126,6 +2174,18 @@ static PyMethodDef @name@type_methods[] = {
         (PyCFunction)@name@_complex,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {NULL, NULL, 0, NULL}
+};
+/**end repeat**/
+
+/**begin repeat
+ * #name = integer,floating, complexfloating#
+ */
+static PyMethodDef @name@type_methods[] = {
+    /* Hook for the round() builtin */
+    {"__round__",
+        (PyCFunction)@name@type_dunder_round,
+        METH_VARARGS | METH_KEYWORDS, NULL},
+    {NULL, NULL, 0, NULL} /* sentinel */
 };
 /**end repeat**/
 
@@ -3655,8 +3715,8 @@ initialize_numeric_types(void)
     /**end repeat**/
 
     /**begin repeat
-     * #name = cfloat, clongdouble#
-     * #NAME = CFloat, CLongDouble#
+     * #name = cfloat, clongdouble, floating, integer, complexfloating#
+     * #NAME = CFloat, CLongDouble, Floating, Integer, ComplexFloating#
      */
 
     Py@NAME@ArrType_Type.tp_methods = @name@type_methods;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -577,3 +577,27 @@ class TestDTypeCoercion(_DeprecationTestCase):
         for scalar_type in [type, dict, list, tuple]:
             # Typical python types are coerced to object currently:
             self.assert_not_deprecated(np.dtype, args=(scalar_type,))
+
+
+class BuiltInRoundComplexDType(_DeprecationTestCase):
+    # 2020-03-31 1.19.0
+    deprecated_types = [np.csingle, np.cdouble, np.clongdouble]
+    not_deprecated_types = [
+        np.int8, np.int16, np.int32, np.int64,
+        np.uint8, np.uint16, np.uint32, np.uint64,
+        np.float16, np.float32, np.float64,
+    ]
+
+    def test_deprecated(self):
+        for scalar_type in self.deprecated_types:
+            scalar = scalar_type(0)
+            self.assert_deprecated(round, args=(scalar,))
+            self.assert_deprecated(round, args=(scalar, 0))
+            self.assert_deprecated(round, args=(scalar,), kwargs={'ndigits': 0})
+    
+    def test_not_deprecated(self):
+        for scalar_type in self.not_deprecated_types:
+            scalar = scalar_type(0)
+            self.assert_not_deprecated(round, args=(scalar,))
+            self.assert_not_deprecated(round, args=(scalar, 0))
+            self.assert_not_deprecated(round, args=(scalar,), kwargs={'ndigits': 0})


### PR DESCRIPTION
Fixes #15297.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
