### PR TITLE
ENH: add inline definition of access rights for Fortran types

### DIFF
--- a/doc/release/upcoming_changes/15844.new_feature.rst
+++ b/doc/release/upcoming_changes/15844.new_feature.rst
@@ -1,0 +1,4 @@
+f2py supports reading access type attributes from derived type statements
+-------------------------------------------------------------------------
+As a result, one does not need to use `public` or `private` statements to
+specify derived type access properties.

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -884,6 +884,9 @@ def appenddecl(decl, decl2, force=1):
 
 selectpattern = re.compile(
     r'\s*(?P<this>(@\(@.*?@\)@|\*[\d*]+|\*\s*@\(@.*?@\)@|))(?P<after>.*)\Z', re.I)
+typedefpattern = re.compile(
+    r'(?:,(?P<attributes>[\w(),]+))?(::)?(?P<name>\b[a-z$_][\w$]*\b)'
+    r'(?:\((?P<params>[\w,]*)\))?\Z', re.I)
 nameargspattern = re.compile(
     r'\s*(?P<name>\b[\w$]+\b)\s*(@\(@\s*(?P<args>[\w\s,]*)\s*@\)@|)\s*((result(\s*@\(@\s*(?P<result>\b[\w$]+\b)\s*@\)@|))|(bind\s*@\(@\s*(?P<bind>.*)\s*@\)@))*\s*\Z', re.I)
 callnameargspattern = re.compile(
@@ -901,6 +904,17 @@ def _is_intent_callback(vdecl):
         if _intentcallbackpattern.match(a):
             return 1
     return 0
+
+
+def _resolvetypedefpattern(line):
+    line = ''.join(line.split())  # removes whitespace
+    m1 = typedefpattern.match(line)
+    print(line, m1)
+    if m1:
+        attrs = m1.group('attributes')
+        attrs = [a.lower() for a in attrs.split(',')] if attrs else []
+        return m1.group('name'), attrs, m1.group('params')
+    return None, [], None
 
 
 def _resolvenameargspattern(line):
@@ -947,7 +961,13 @@ def analyzeline(m, case, line):
             block = 'python module'
         elif re.match(r'abstract\s*interface', block, re.I):
             block = 'abstract interface'
-        name, args, result, bind = _resolvenameargspattern(m.group('after'))
+        if block == 'type':
+            name, attrs, _ = _resolvetypedefpattern(m.group('after'))
+            groupcache[groupcounter]['vars'][name] = dict(attrspec = attrs)
+            args = []
+            result = None
+        else:
+            name, args, result, _ = _resolvenameargspattern(m.group('after'))
         if name is None:
             if block == 'block data':
                 name = '_BLOCK_DATA_'

--- a/numpy/f2py/tests/src/crackfortran/accesstype.f90
+++ b/numpy/f2py/tests/src/crackfortran/accesstype.f90
@@ -1,0 +1,13 @@
+module foo
+  public
+  type, private, bind(c) :: a
+     integer :: i
+  end type a
+  type, bind(c) :: b_
+     integer :: j
+  end type b_
+  public :: b_
+  type :: c
+     integer :: k
+  end type c
+end module foo

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -44,6 +44,15 @@ class TestPublicPrivate:
         assert "private" not in mod["vars"]["seta"]["attrspec"]
         assert "public" in mod["vars"]["seta"]["attrspec"]
 
+    def test_access_type(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "accesstype.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        tt = mod[0]['vars']
+        assert set(tt['a']['attrspec']) == {'private', 'bind(c)'}
+        assert set(tt['b_']['attrspec']) == {'public', 'bind(c)'}
+        assert set(tt['c']['attrspec']) == {'public'}
+
 
 class TestExternal(util.F2PyTest):
     # issue gh-17859: add external attribute support


### PR DESCRIPTION
Allow to parse type definition with inline access specifier, like:
 type, public :: foo
 end type foo

This is allowed in Fortran90, see for instance https://software.intel.com/en-us/fortran-compiler-developer-guide-and-reference-type-statement-derived-types
Before this MR, only:
```
 type foo
 end type foo
 public :: foo
```
is understood by crackfortran.