### PR TITLE
BUG: avoid infinite recurrence on dependencies in crackfortran

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2227,7 +2227,9 @@ def _get_depend_dict(name, vars, deps):
 
         if '=' in vars[name] and not isstring(vars[name]):
             for word in word_pattern.findall(vars[name]['=']):
-                if word not in words and word in vars:
+                # The word_pattern may return values that are not
+                # only variables, they can be string content for instance
+                if word not in words and word in vars and word != name:
                     words.append(word)
         for word in words[:]:
             for w in deps.get(word, []) \

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -264,3 +264,20 @@ class TestDimSpec(util.F2PyTest):
             # the same sized array
             sz1, _ = get_arr_size(n1)
             assert sz == sz1, (n, n1, sz, sz1)
+
+
+class TestModuleDeclaration():
+    def test_dependencies(self, tmp_path):
+        f_path = tmp_path / "mod.f90"
+        with f_path.open('w') as ff:
+            ff.write(textwrap.dedent("""\
+            module foo
+              type bar
+                character(len = 4) :: text
+              end type bar
+              type(bar), parameter :: abar = bar('abar')
+            end module foo
+            """))
+        mod = crackfortran.crackfortran([str(f_path)])
+        assert len(mod) == 1
+        assert mod[0]['vars']['abar']['='] == "bar('abar')"


### PR DESCRIPTION
When looking at dependencies in affectation in crackfortran, strings are not detected as strings and internal of strings can be seen as variable to look for dependencies. For instance:
```
            module foo
              type bar
                character(len = 4) :: text
              end type bar
              type(bar), parameter :: abar = bar('abar')
            end module foo
```
abar variable is defined by a text that is "abar", making an infinite loop to look for definition of abar.

The simplest way to break this infinite loop is to check that we're not going to call it with the same name as it was called.

It's a simple fix that is not taking into account possible loops where 'a' depends on 'b' which depends on 'a' again. The complete fix would be to properly detect strings and not recurs on them. But it's quite complicated to do so and the proposed fix should address most of the common cases already.

What do you think ?