### PR TITLE
DOC, TST: enable refguide_check in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
           name: run doctests on documentation
           command: |
             . venv/bin/activate
+            (cd doc ; git submodule update --init)
             python tools/refguide_check.py --rst
 
       - run:
@@ -55,7 +56,6 @@ jobs:
           command: |
             . venv/bin/activate
             cd doc
-            git submodule update --init
             SPHINXOPTS=-q make -e html
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             pip install cython
             pip install .
             pip install scipy
+            pip install pandas
 
       - run:
           name: create release notes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,11 @@ jobs:
             SPHINXOPTS=-q make -e html
 
       - run:
+          name: run doctests on documentation
+          command: |
+            . venv/bin/activate
+            python tools/refguide_check.py --rst
+      - run:
           name: build neps
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,13 @@ jobs:
             VERSION=$(python -c "import setup; print(setup.VERSION)")
             towncrier --version $VERSION --yes
             ./tools/ci/test_all_newsfragments_used.py
+
+      - run:
+          name: run doctests on documentation
+          command: |
+            . venv/bin/activate
+            python tools/refguide_check.py --rst
+
       - run:
           name: build devdocs
           command: |
@@ -51,11 +58,6 @@ jobs:
             git submodule update --init
             SPHINXOPTS=-q make -e html
 
-      - run:
-          name: run doctests on documentation
-          command: |
-            . venv/bin/activate
-            python tools/refguide_check.py --rst
       - run:
           name: build neps
           command: |

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -1576,6 +1576,10 @@ If you created this array "a" ::
   ...               [ 0.76989341,  0.81299683, -0.95068423, 0.11769564],
   ...               [ 0.20484034,  0.34784527,  1.96979195, 0.51992837]])
 
+.. for doctests
+   The continuous integration truncates dataframe display without this setting.
+   >>> pd.set_option('max_columns', 10)
+
 You could create a Pandas dataframe ::
 
   >>> df = pd.DataFrame(a)

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -129,8 +129,8 @@ rather than providing a single sequence as an argument.
 
     >>> a = np.array(1,2,3,4)    # WRONG
     Traceback (most recent call last):
-    ...
-    ValueError: only 2 non-keyword arguments accepted
+      ...
+    TypeError: array() takes from 1 to 2 positional arguments but 4 were given
     >>> a = np.array([1,2,3,4])  # RIGHT
 
 ``array`` transforms sequences of sequences into two-dimensional arrays,


### PR DESCRIPTION
Enable CI testing of refguide_check

* Add entry in `.circleci/config.yml`
* install pandas in circleci environment
* fix traceback message to pass refguide_check in doc/source/user/quickstart.rst `python tools/refguide_check.py --rst doc/source/user/quickstart.rst` fails because of an update of the exception message. This prevents running `python tools/refguide_check.py --rst` as part of the continuous integration.

See https://github.com/numpy/numpy/issues/14970 for background.
