### PR TITLE
DOC: Add note about allocating PyArray_ArrayDescr with PyArray_malloc.

### DIFF
--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -378,6 +378,9 @@ PyArrayDescr_Type and PyArray_Descr
         The shape (always C-style contiguous) of the sub-array as a Python
         tuple.
 
+    The memory will be deallocated internally with ``PyArray_free``, so it
+    must be allocated with ``PyArray_malloc``.
+
 
 .. c:member:: PyObject *PyArray_Descr.fields
 


### PR DESCRIPTION
I didn't find it mentioned anywhere how `PyArray_ArrayDescr` should be constructed so I looked at the source code and found it would be freed internally by `PyArray_free` (line 1818): https://github.com/numpy/numpy/blob/078ac01a85c4db46e7f148829c2e0d0e0f30c36f/numpy/core/src/multiarray/descriptor.c#L1800-L1824
So I feel it might be worth documenting.
