### PR TITLE
TST: use draft OpenBLAS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ jobs:
       os: linux
       arch: ppc64le
       env:
-       # use ppc64le OpenBLAS build, not system ATLAS
+       # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
 
@@ -113,15 +113,16 @@ jobs:
       os: linux
       arch: s390x
       env:
-       # use s390x OpenBLAS build, not system ATLAS
+       # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
+       - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
 
     - python: 3.7
       os: linux
       arch: aarch64
       env:
-       # use ppc64le OpenBLAS build, not system ATLAS
+       # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,34 +218,18 @@ stages:
             OPENBLAS_SUFFIX: '64_'
     steps:
     - template: azure-steps-windows.yml
-  # - job: Linux_PyPy3
-  #  pool:
-  #    vmIMage: 'ubuntu-18.04'
-  #  steps:
-  #  - script: source tools/pypy-test.sh
-  #    displayName: 'Run PyPy3 Build / Tests'
-  #  - task: PublishTestResults@2
-  #    condition: succeededOrFailed()
-  #    inputs:
-  #      testResultsFiles: '**/test-*.xml'
-  #      testRunTitle: 'Publish test results for PyPy3'
-  #      failTaskOnFailedTests: true
-  - job: Linux_18_04
+  - job: Linux_PyPy3
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmIMage: 'ubuntu-18.04'
     steps:
-    - script: |
-            python3 -m pip install --user --upgrade pip setuptools
-            python3 -m pip install --user -r test_requirements.txt
-            CPPFLAGS='' F77=gfortran-5 F90=gfortran-5 \
-            python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
-      displayName: 'Run Linux 18.04 Build / Tests'
+    - script: source tools/pypy-test.sh
+      displayName: 'Run PyPy3 Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
         testResultsFiles: '**/test-*.xml'
+        testRunTitle: 'Publish test results for PyPy3'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for gcc 4.8'
   - job: Linux_gcc48
     pool:
       vmImage: 'ubuntu-18.04'

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -10,7 +10,8 @@ import zipfile
 import tarfile
 
 OPENBLAS_V = '0.3.9'
-OPENBLAS_LONG = 'v0.3.7-391-gddcbed66'  # the 0.3.7 is misleading
+# Temporary build of OpenBLAS to test a fix for dynamic detection of CPU
+OPENBLAS_LONG = 'v0.3.7-527-g79fd006c'  # the 0.3.7 is misleading
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86', 'ppc64le', 's390x']


### PR DESCRIPTION
Issue gh-15796 pointed out many failing CI builds on PyPy with an "illegal instruction". The PyPy builds were disabled in PR gh-15809. It turns out there may have been a problem with the OpenBlas libs, it may be caused by a DYNAMIC_ARCH=1 compilation on a SKX CPU and then run on a HSW (or lower) CPU, xref xianyi/OpenBLAS#2526. The  proposed fix is on PR xianyi/OpenBLAS#2533. I built OpenBLAS artifacts with this fix. In this PR I
- re-enabled PyPy
- used the new OpenBLAS `v0.3.7-527-g79fd006c`

Let's see if it crashes...