### PR TITLE
ENH: Add keepdims argument to count_nonzero

### DIFF
--- a/doc/release/upcoming_changes/15870.new_feature.rst
+++ b/doc/release/upcoming_changes/15870.new_feature.rst
@@ -2,10 +2,4 @@
 ------------------------------------------------
 The parameter ``keepdims`` was added to `numpy.count_nonzero`. The
 parameter has the same meaning as it does in reduction functions such
-as `numpy.sum` or `numpy.mean`.  When an ``axis`` argument is given,
-the slice along that dimension (or dimensions, if ``axis`` is a tuple
-with length greater than one) is reduced to a single number in the
-output.  Normally this means the shape of the output array has fewer
-dimensions than the input.  When ``keepdims=True`` is used, the output
-array has the same number of dimensions as the input, and the lengths
-of the reduced dimensions are one.
+as `numpy.sum` or `numpy.mean`.

--- a/doc/release/upcoming_changes/15870.new_feature.rst
+++ b/doc/release/upcoming_changes/15870.new_feature.rst
@@ -1,0 +1,11 @@
+``keepdims`` parameter for `numpy.count_nonzero`
+------------------------------------------------
+The parameter ``keepdims`` was added to `numpy.count_nonzero`. The
+parameter has the same meaning as it does in reduction functions such
+as `numpy.sum` or `numpy.mean`.  When an ``axis`` argument is given,
+the slice along that dimension (or dimensions, if ``axis`` is a tuple
+with length greater than one) is reduced to a single number in the
+output.  Normally this means the shape of the output array has fewer
+dimensions than the input.  When ``keepdims=True`` is used, the output
+array has the same number of dimensions as the input, and the lengths
+of the reduced dimensions are one.

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -448,7 +448,7 @@ def count_nonzero(a, axis=None, *, keepdims=False):
     array([[2],
            [3]])
     """
-    if axis is None:
+    if axis is None and not keepdims:
         return multiarray.count_nonzero(a)
 
     a = asanyarray(a)

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -384,12 +384,12 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None):
     return res
 
 
-def _count_nonzero_dispatcher(a, axis=None):
+def _count_nonzero_dispatcher(a, axis=None, *, keepdims=False):
     return (a,)
 
 
 @array_function_dispatch(_count_nonzero_dispatcher)
-def count_nonzero(a, axis=None):
+def count_nonzero(a, axis=None, *, keepdims=False):
     """
     Counts the number of non-zero values in the array ``a``.
 
@@ -414,6 +414,13 @@ def count_nonzero(a, axis=None):
 
         .. versionadded:: 1.12.0
 
+    keepdims : bool, optional
+        If this is set to True, the axes that are counted are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the input array.
+
+        .. versionadded:: 1.19.0
+
     Returns
     -------
     count : int or array of int
@@ -429,13 +436,17 @@ def count_nonzero(a, axis=None):
     --------
     >>> np.count_nonzero(np.eye(4))
     4
-    >>> np.count_nonzero([[0,1,7,0,0],[3,0,0,2,19]])
+    >>> a = np.array([[0, 1, 7, 0],
+    ...               [3, 0, 2, 19]])
+    >>> np.count_nonzero(a)
     5
-    >>> np.count_nonzero([[0,1,7,0,0],[3,0,0,2,19]], axis=0)
-    array([1, 1, 1, 1, 1])
-    >>> np.count_nonzero([[0,1,7,0,0],[3,0,0,2,19]], axis=1)
+    >>> np.count_nonzero(a, axis=0)
+    array([1, 1, 2, 1])
+    >>> np.count_nonzero(a, axis=1)
     array([2, 3])
-
+    >>> np.count_nonzero(a, axis=1, keepdims=True)
+    array([[2],
+           [3]])
     """
     if axis is None:
         return multiarray.count_nonzero(a)
@@ -448,7 +459,7 @@ def count_nonzero(a, axis=None):
     else:
         a_bool = a.astype(np.bool_, copy=False)
 
-    return a_bool.sum(axis=axis, dtype=np.intp)
+    return a_bool.sum(axis=axis, dtype=np.intp, keepdims=keepdims)
 
 
 @set_module('numpy')

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -384,7 +384,7 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None):
     return res
 
 
-def _count_nonzero_dispatcher(a, axis=None, *, keepdims=False):
+def _count_nonzero_dispatcher(a, axis=None, *, keepdims=None):
     return (a,)
 
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1201,6 +1201,15 @@ class TestNonzero:
         a = np.array([[0, 0, 1], [1, 0, 1]])
         assert_equal(np.count_nonzero(a, axis=()), a.astype(bool))
 
+    def test_countnonzero_keepdims(self):
+        a = np.array([[0, 0, 1, 0],
+                      [0, 3, 5, 0],
+                      [7, 9, 2, 0]])
+        assert_equal(np.count_nonzero(a, axis=0, keepdims=True),
+                     [[1, 2, 3, 0]])
+        assert_equal(np.count_nonzero(a, axis=1, keepdims=True),
+                     [[1], [2], [3]])
+
     def test_array_method(self):
         # Tests that the array method
         # call to nonzero works

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1209,6 +1209,8 @@ class TestNonzero:
                      [[1, 2, 3, 0]])
         assert_equal(np.count_nonzero(a, axis=1, keepdims=True),
                      [[1], [2], [3]])
+        assert_equal(np.count_nonzero(a, keepdims=True),
+                     [[6]])
 
     def test_array_method(self):
         # Tests that the array method


### PR DESCRIPTION
A simple enhancement to count_nonzero:
```
In [3]: a
Out[3]: 
array([[ 0,  1,  7,  0],
       [ 3,  0,  2, 19]])

In [4]: np.count_nonzero(a, axis=1, keepdims=True)
Out[4]: 
array([[2],
       [3]])
```