### PR TITLE
BUG: Setting a 0d array's strides to themselves should be legal

### DIFF
--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -13,6 +13,7 @@
 #include "npy_import.h"
 
 #include "common.h"
+#include "conversion_utils.h"
 #include "ctors.h"
 #include "scalartypes.h"
 #include "descriptor.h"
@@ -110,7 +111,7 @@ array_strides_get(PyArrayObject *self)
 static int
 array_strides_set(PyArrayObject *self, PyObject *obj)
 {
-    PyArray_Dims newstrides = {NULL, 0};
+    PyArray_Dims newstrides = {NULL, -1};
     PyArrayObject *new;
     npy_intp numbytes = 0;
     npy_intp offset = 0;
@@ -123,8 +124,8 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
                 "Cannot delete array strides");
         return -1;
     }
-    if (!PyArray_IntpConverter(obj, &newstrides) ||
-        newstrides.ptr == NULL) {
+    if (!PyArray_OptionalIntpConverter(obj, &newstrides) ||
+        newstrides.len == -1) {
         PyErr_SetString(PyExc_TypeError, "invalid strides");
         return -1;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -363,6 +363,11 @@ class TestAttributes:
         a.strides = 1
         a[::2].strides = 2
 
+        # test 0d
+        arr_0d = np.array(0)
+        arr_0d.strides = ()
+        assert_raises(TypeError, set_strides, arr_0d, None)
+
     def test_fill(self):
         for t in "?bhilqpBHILQPfdgFDGO":
             x = np.empty((3, 2, 1), t)


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

More like gh-15881 and gh-15882

Before this patch:
```python
>>> arr_1d = np.array([1, 2])
>>> arr_1d.strides = arr_1d.strides
>>> arr_0d = np.array(3)
>>> arr_0d.strides = arr_0d.strides
TypeError: invalid strides  # wat
```