### PR TITLE
BUG: Respect itershape=() in nditer

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -152,7 +152,7 @@ add_newdoc('numpy.core', 'flatiter', ('copy',
 
 add_newdoc('numpy.core', 'nditer',
     """
-    nditer(op, flags=None, op_flags=None, op_dtypes=None, order='K', casting='safe', op_axes=None, itershape=(), buffersize=0)
+    nditer(op, flags=None, op_flags=None, op_dtypes=None, order='K', casting='safe', op_axes=None, itershape=None, buffersize=0)
 
     Efficient multi-dimensional iterator object to iterate over arrays.
     To get started using this object, see the

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2689,12 +2689,14 @@ def test_0d_iter():
     assert_equal(i.ndim, 0)
     assert_equal(len(i), 1)
 
-    i = nditer(np.arange(5), ['multi_index'], [['readonly']], op_axes=[()], itershape=())
+    i = nditer(np.arange(5), ['multi_index'], [['readonly']],
+               op_axes=[()], itershape=())
     assert_equal(i.ndim, 0)
     assert_equal(len(i), 1)
 
     # passing an itershape alone is not enough, the op_axes are also needed
-    assert_raises(ValueError, nditer, np.arange(5), ['multi_index'], [['readonly']], itershape=())
+    with assert_raises(ValueError):
+        nditer(np.arange(5), ['multi_index'], [['readonly']], itershape=())
 
     # Test a more complex buffered casting case (same as another test above)
     sdt = [('a', 'f4'), ('b', 'i8'), ('c', 'c8', (2, 3)), ('d', 'O')]

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2688,7 +2688,13 @@ def test_0d_iter():
     i = nditer(np.arange(5), ['multi_index'], [['readonly']], op_axes=[()])
     assert_equal(i.ndim, 0)
     assert_equal(len(i), 1)
-    # note that itershape=(), still behaves like None due to the conversions
+
+    i = nditer(np.arange(5), ['multi_index'], [['readonly']], op_axes=[()], itershape=())
+    assert_equal(i.ndim, 0)
+    assert_equal(len(i), 1)
+
+    # passing an itershape alone is not enough, the op_axes are also needed
+    assert_raises(ValueError, nditer, np.arange(5), ['multi_index'], [['readonly']], itershape=())
 
     # Test a more complex buffered casting case (same as another test above)
     sdt = [('a', 'f4'), ('b', 'i8'), ('c', 'c8', (2, 3)), ('d', 'O')]


### PR DESCRIPTION
Previously this was treated as itershape=None, which meant something else.

The docstring was added only a handful of commits ago, so it shouldn't matter that the documented default "changed".

---
Good catch @seberg, you were right about the default in #15877.
Thanks for opening this can of worms.

More like gh-15881 and gh-15882