### PR TITLE
DEP: Deprecate passing shape=None to mean shape=()

### DIFF
--- a/doc/release/upcoming_changes/15886.deprecation.rst
+++ b/doc/release/upcoming_changes/15886.deprecation.rst
@@ -1,0 +1,7 @@
+Passing ``shape=None`` to functions with a non-optional shape argument is deprecated
+------------------------------------------------------------------------------------
+Previously, this was an alias for passing ``shape=()``.
+This deprecation is emitted by `PyArray_IntpConverter` in the C API. If your
+API is intended to support passing `None`, then you should check for `None`
+prior to invoking the converter, so as to be able to distinguish `None` and
+``()``.

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -95,9 +95,21 @@ PyArray_IntpConverter(PyObject *obj, PyArray_Dims *seq)
 
     seq->ptr = NULL;
     seq->len = 0;
+
+    /*
+     * When the deprecation below expires, remove the `if` statement, and
+     * update the comment for PyArray_OptionalIntpConverter.
+     */
     if (obj == Py_None) {
+        /* Numpy 1.20, 2020-05-31 */
+        if (DEPRECATE(
+                "Passing None into shape arguments as an alias for () is "
+                "deprecated.") < 0){
+            return NPY_FAIL;
+        }
         return NPY_SUCCEED;
     }
+
     len = PySequence_Size(obj);
     if (len == -1) {
         /* Check to see if it is an integer number */

--- a/numpy/core/tests/test_conversion_utils.py
+++ b/numpy/core/tests/test_conversion_utils.py
@@ -167,8 +167,9 @@ class TestIntpConverter:
         assert self.conv(()) == ()
 
     def test_none(self):
-        # gh-15886: could deprecate this
-        assert self.conv(None) == ()
+        # once the warning expires, this will raise TypeError
+        with pytest.warns(DeprecationWarning):
+            assert self.conv(None) == ()
 
     def test_float(self):
         with pytest.raises(TypeError):

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -646,10 +646,14 @@ cdef class Generator:
             if abs(p_sum - 1.) > atol:
                 raise ValueError("probabilities do not sum to 1")
 
-        shape = size
-        if shape is not None:
+        # `shape == None` means `shape == ()`, but with scalar unpacking at the
+        # end
+        is_scalar = size is None
+        if not is_scalar:
+            shape = size
             size = np.prod(shape, dtype=np.intp)
         else:
+            shape = ()
             size = 1
 
         # Actual sampling
@@ -733,10 +737,9 @@ cdef class Generator:
                                 idx_data[j - pop_size_i + size_i] = j
                         if shuffle:
                             self._shuffle_int(size_i, 1, idx_data)
-                if shape is not None:
-                    idx.shape = shape
+                idx.shape = shape
 
-        if shape is None and isinstance(idx, np.ndarray):
+        if is_scalar and isinstance(idx, np.ndarray):
             # In most cases a scalar will have been made an array
             idx = idx.item(0)
 
@@ -744,7 +747,7 @@ cdef class Generator:
         if a.ndim == 0:
             return idx
 
-        if shape is not None and idx.ndim == 0:
+        if not is_scalar and idx.ndim == 0:
             # If size == () then the user requested a 0-d array as opposed to
             # a scalar object when size is None. However a[idx] is always a
             # scalar and not an array. So this makes sure the result is an


### PR DESCRIPTION
This requires some minor tweaks in `np.random` because there the two have different meanings, with `()` meaning 0d array and `None` meaning scalar.

Made primarily to answer the question of how noisy this would be, from https://github.com/numpy/numpy/pull/15877#discussion_r401013393.

