### PR TITLE
MAINT: Clean-up 'next = __next__' used for Python 2 compatibility

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -597,8 +597,6 @@ class ndenumerate:
     def __iter__(self):
         return self
 
-    next = __next__
-
 
 @set_module('numpy')
 class ndindex:
@@ -664,8 +662,6 @@ class ndindex:
         """
         next(self._it)
         return self._it.multi_index
-
-    next = __next__
 
 
 # You can do all this with slice() plus a few special objects,

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -44,8 +44,6 @@ class LineIterator:
         line = line.rstrip()
         return line
 
-    next = __next__
-
 
 class PushbackIterator:
     """PushbackIterator(iterable)
@@ -70,8 +68,6 @@ class PushbackIterator:
 
     def pushback(self, item):
         self.buffer.append(item)
-
-    next = __next__
 
 
 def fortranSourceLines(fo):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2699,8 +2699,6 @@ class MaskedIterator:
                 return masked
         return d
 
-    next = __next__
-
 
 class MaskedArray(ndarray):
     """

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -105,8 +105,6 @@ class CSAIterator:
     def __next__(self):
         return next(self._dataiter).__array__().view(type(self._original))
 
-    next = __next__
-
 
 class ComplicatedSubArray(SubArray):
 


### PR DESCRIPTION
[PEP 3114](https://www.python.org/dev/peps/pep-3114/) renamed `iterator.next()` to `iterator.__next__()` for Python 3.0.

Backwards compatibility for Python 2 was provided for classes using `next = __next__`, but these can now be removed as Python 2 is no longer supported. I don't expect much impact on downstream users, except for folks still using `obj.next()` instead of `next(obj)`.