### PR TITLE
DOC: Add missing doc of numpy.ma.apply_over_axes in API list.

### DIFF
--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -396,6 +396,7 @@ Miscellanea
    ma.allequal
    ma.allclose
    ma.apply_along_axis
+   ma.apply_over_axes
    ma.arange
    ma.choose
    ma.ediff1d


### PR DESCRIPTION
Thanks for AtsushiSakai's careful examination.
Fix [#15889](https://github.com/numpy/numpy/issues/15889)