### PR TITLE
DEP: Ensure indexing errors will be raised even on empty results

### DIFF
--- a/doc/release/upcoming_changes/15900.deprecation.rst
+++ b/doc/release/upcoming_changes/15900.deprecation.rst
@@ -1,0 +1,16 @@
+Indexing errors will be reported even when index result is empty
+----------------------------------------------------------------
+In the future, NumPy will raise an IndexError when an
+integer array index contains out of bound values even if a non-indexed
+dimension is of length 0. This will now emit a DeprecationWarning.
+This can happen when the array is previously empty, or an empty
+slice is involved::
+
+    arr1 = np.zeros((5, 0))
+    arr1[[20]]
+    arr2 = np.zeros((5, 5))
+    arr2[[20], :0]
+
+Previously the non-empty index ``[20]`` was not checked for correctness.
+It will now be checked causing a deprecation warning which will be turned
+into an error. This also applies to assignments.


### PR DESCRIPTION
Previously, when the indexing result was empty, no check was done
for backward compatibility with pre 1.9 (assumingly).
This may have been only necessary when the outer iteration is empty
as opposed to when just the inner iteration is empty, though.

In any case, it is arguably buggy to ignore indexing errors in this
case. Since there may have been a reason back in the day, and this
is probably extremely rare, optiming for a brief deprecation period
for now.

Closes gh-15898

---

This opts for a deprecation, but we could decide to skip the deprecation, I suppose we could also decide to make it a `VisibleDeprecationWarning`. I am a bit surprised there are no test for this, since I obviously was aware of this behaviour when I wrote the indexing code... Although it is possible that it was part of those "Automated" tests, and then got revised away accidentally.