### PR TITLE
BLD: report clang version on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,6 +76,7 @@ stages:
             PYTHON_VERSION: '3.6'
             NPY_USE_BLAS_ILP64: '1'
             USE_OPENBLAS: '1'
+            USE_XCODE_10: '1'
           Accelerate:
             PYTHON_VERSION: '3.6'
             USE_OPENBLAS: '0'
@@ -89,9 +90,10 @@ stages:
         versionSpec: $(PYTHON_VERSION)
         addToPath: true
         architecture: 'x64'
-    # NOTE: do we have a compelling reason to use older / newer
-    # versions of Xcode toolchain for testing?
-    - script: clang --version
+    - script: |
+        set -xe
+        [ -n "$USE_XCODE_10" ] && /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
+        clang --version
       displayName: 'report clang version'
     # NOTE: might be better if we could avoid installing
     # two C compilers, but with homebrew looks like we're

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,8 +91,8 @@ stages:
         architecture: 'x64'
     # NOTE: do we have a compelling reason to use older / newer
     # versions of Xcode toolchain for testing?
-    - script: /bin/bash -c "sudo xcode-select -s /Applications/Xcode_10.app/Contents/Developer"
-      displayName: 'select Xcode version'
+    - script: clang --version
+      displayName: 'report clang version'
     # NOTE: might be better if we could avoid installing
     # two C compilers, but with homebrew looks like we're
     # now stuck getting the full gcc toolchain instead of


### PR DESCRIPTION
It turns out pinning xcode to xcode10 may not be a good idea. For instance PR gh-15648 needs xcode 11+. The versions of xcode in the [azure image](https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md) is 11.3.1, so just use it, while reporting in the log which version is used.

We may want to update to macos-10.15 soon too.