### PR TITLE
ENH: Use sysconfig instead of probing Makefile

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -122,26 +122,18 @@ class GnuFCompiler(FCompiler):
             # error checking.
             if not target:
                 # If MACOSX_DEPLOYMENT_TARGET is not set in the environment,
-                # we try to get it first from the Python Makefile and then we
-                # fall back to setting it to 10.3 to maximize the set of
+                # we try to get it first from sysconfig and then
+                # fall back to setting it to 10.7 to maximize the set of
                 # versions we can work with.  This is a reasonable default
                 # even when using the official Python dist and those derived
                 # from it.
-                import distutils.sysconfig as sc
-                g = {}
-                try:
-                    get_makefile_filename = sc.get_makefile_filename
-                except AttributeError:
-                    pass  # i.e. PyPy
-                else:
-                    filename = get_makefile_filename()
-                    sc.parse_makefile(filename, g)
-                target = g.get('MACOSX_DEPLOYMENT_TARGET', '10.3')
-                os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
-                if target == '10.3':
-                    s = 'Env. variable MACOSX_DEPLOYMENT_TARGET set to 10.3'
+                import sysconfig
+                target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
+                if not target:
+                    target = '10.7'
+                    s = 'Env. variable MACOSX_DEPLOYMENT_TARGET set to 10.7'
                     warnings.warn(s, stacklevel=2)
-
+                os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
             opt.extend(['-undefined', 'dynamic_lookup', '-bundle'])
         else:
             opt.append("-shared")

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -123,15 +123,14 @@ class GnuFCompiler(FCompiler):
             if not target:
                 # If MACOSX_DEPLOYMENT_TARGET is not set in the environment,
                 # we try to get it first from sysconfig and then
-                # fall back to setting it to 10.7 to maximize the set of
-                # versions we can work with.  This is a reasonable default
+                # fall back to setting it to 10.9 This is a reasonable default
                 # even when using the official Python dist and those derived
                 # from it.
                 import sysconfig
                 target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
                 if not target:
-                    target = '10.7'
-                    s = 'Env. variable MACOSX_DEPLOYMENT_TARGET set to 10.7'
+                    target = '10.9'
+                    s = f'Env. variable MACOSX_DEPLOYMENT_TARGET set to {target}'
                     warnings.warn(s, stacklevel=2)
                 os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
             opt.extend(['-undefined', 'dynamic_lookup', '-bundle'])


### PR DESCRIPTION
Use the public interfaces in sysconfig rather than the low-level `get_makefile_filename` that does not exist on all implementations. Also update the lowest-supported `MACOSX_DEPLOYMENT_TARGET` to 10.7. The previous 10.3 is long out of date, it was [released in 2003](https://xcodereleases.com) (bottom of that link) and even 10.7 was last updated in 2013.

xref [comment](https://github.com/joerick/cibuildwheel/issues/301#issuecomment-610087191) in joerick/cibuildwheel#301