### PR TITLE
BUG: Check for initial value in various min and max functions.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3641,7 +3641,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
     PyArrayObject *identityArray = (PyArrayObject*) PyArray_FROM_O(identity);
-    if(PyArrayCanCastTo(&initialArray->descr,&identityArray->descr)) {
+    if(PyArrayCanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(identityArray))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
                     "type1","type2");

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -41,7 +41,7 @@
 #include "reduction.h"
 #include "mem_overlap.h"
 
-#include "convert_datatype.h"
+//#include "convert_datatype.h"
 
 #include "ufunc_object.h"
 #include "override.h"
@@ -3643,7 +3643,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
     PyArrayObject *identityArray = (PyArrayObject*) PyArray_FROM_O(identity);
-    if(PyArrayCanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(identityArray))) {
+    if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(identityArray))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
                     "type1","type2");

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3642,7 +3642,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
+    if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
                     Py_TYPE(initial),Py_TYPE(identity));

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3641,12 +3641,14 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    if(initial != Py_None && !PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
-        PyErr_Format(PyExc_TypeError,
-                    "initial type %R does not match the array type %R",
-                    Py_TYPE(initial),PyArray_TYPE(arr));
-        return NULL;
+    if(initial != Py_None && PyArray_ISOBJECT(arr) && PyArray_SIZE(arr) != 0) { //if initial has a value and the arr is filled
+        PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial); //cast initial to an array
+        if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) { //check the types
+            PyErr_Format(PyExc_TypeError,
+                        "initial type %R does not match the array type %R",
+                        Py_TYPE(initial),PyArray_TYPE(arr));
+            return NULL;
+        }
     }
 
     /* Get the reduction dtype */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,7 +3632,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(strcmp(initial->ob_type->tp_name,identity->ob_type->tp_name) != 0) {
+    } else if(PY_TYPE(initial) != PY_TYPE(identity)) {
         PyErr_Format(PyExc_TypeError,
                     "initial type does not match the array type");
         return NULL;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3642,7 +3642,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    if(initial != Py_None && !PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
+    if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
                     Py_TYPE(initial),PyArray_TYPE(arr));

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,8 +3632,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(*initial.ob_type != *identity.ob_type) {
-        PyErr_Format(PyExc_TypeError,`
+    } else if(initial->ob_type != identity->ob_type) { //if initial is not null --> check that we have the same types
+        PyErr_Format(PyExc_TypeError,
                     "initial type does not match the array type");
         return NULL;
     } else {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3634,7 +3634,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         }
     } else if(initial != identity) {
         PyErr_Format(PyExc_TypeError,
-                    "initial type does not match the array type")
+                    "initial type does not match the array type");
         return NULL;
     } else {
         Py_DECREF(identity);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,7 +3632,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(PY_TYPE(initial) != PY_TYPE(identity)) {
+    } else if(Py_TYPE(initial) != Py_TYPE(identity)) {
         PyErr_Format(PyExc_TypeError,
                     "initial type does not match the array type");
         return NULL;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3639,13 +3639,12 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    PyArrayObject *initialArray = (PyArrayObject) *initial
-    PyArrayObject *identityArray = (PyArrayObject) *identity
-
-    if(PyArray_CanCastTo(initialArray->descr,identityArray->descr)) {
+    PyArrayObject initialArray = (PyArrayObject*) initial;
+    PyArrayObject identityArray = (PyArrayObject*) identity;
+    if(PyArray_CanCastTo(initialArray.descr,identityArray.descr)) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
-                    initialArray->descr->kind,identityArray->descr->kind);
+                    initialArray.descr.kind,identityArray.descr.kind);
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3645,7 +3645,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
-                    Py_TYPE(initial),Py_TYPE(identity));
+                    Py_TYPE(initial),Py_TYPE(arr));
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,7 +3632,9 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(initial != identity){
+    } else if(initial != identity) {
+        PyErr_Format(PyExc_TypeError,
+                    "initial type does not match the array type")
         return NULL;
     } else {
         Py_DECREF(identity);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3639,12 +3639,12 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    PyObject *check1 = PyArray_FROM_O(initial);
-    PyObject *check2 = PyArray_FROM_O(identity);
-    if(check1 == check2) {
+    PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
+    PyArrayObject *identityArray = (PyArrayObject*) PyArray_FROM_O(identity);
+    if(PyArrayCanCastTo(&initialArray->descr,&identityArray->descr)) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
-                    "typ1","type2");
+                    "type1","type2");
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3639,12 +3639,12 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    PyArrayObject initialArray = (PyArrayObject*) initial;
-    PyArrayObject identityArray = (PyArrayObject*) identity;
-    if(PyArray_CanCastTo(initialArray.descr,identityArray.descr)) {
+    PyObject* check1 = PyArray_FROM_O(initial)
+    PyObject* check2 = PyArray_FROM_O(identity)
+    if(check1 == check2) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
-                    initialArray.descr.kind,identityArray.descr.kind);
+                    "typ1","type2");
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -41,6 +41,8 @@
 #include "reduction.h"
 #include "mem_overlap.h"
 
+#include "convert_datatype.h"
+
 #include "ufunc_object.h"
 #include "override.h"
 #include "npy_import.h"

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,7 +3632,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(initial->ob_type != identity->ob_type) { //if initial is not null --> check that we have the same types
+    } else if(strcmp(initial->ob_type->tp_name,identity->ob_type->tp_name) != 0) {
         PyErr_Format(PyExc_TypeError,
                     "initial type does not match the array type");
         return NULL;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3641,8 +3641,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    if(initial != Py_None && PyArray_ISOBJECT(arr) && PyArray_SIZE(arr) != 0) { //if initial has a value and the arr is filled
-        PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial); //cast initial to an array
+    if(initial != Py_None && PyArray_SIZE(arr) != 0) { //if initial has a value and the arr is filled
+        PyArrayObject *initialArray = (PyArrayObject*) (initial); //cast initial to an array
         if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) { //check the types
             PyErr_Format(PyExc_TypeError,
                         "initial type %R does not match the array type %R",

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3619,6 +3619,10 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         return NULL;
     }
 
+    if(initial != identity){
+        return NULL; // we are suppose to throw an error here?
+    }
+
     /* Get the initial value */
     if (initial == NULL || initial == NoValue) {
         initial = identity;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3645,7 +3645,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
-                    Py_Type(initial),Py_Type(identity));
+                    Py_TYPE(initial),Py_TYPE(identity));
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3622,7 +3622,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     }
 
     /* Get the initial value */
-    if (initial == NULL || initial == NoValue) {
+    if (initial == NULL || initial == NoValue) { //if initial has no value
         initial = identity;
 
         /*
@@ -3634,19 +3634,14 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else {
+    } else { //if initial has a value
         Py_DECREF(identity);
         Py_INCREF(initial);  /* match the reference count in the if above */
-    }
 
-    
-    /*make sure the types are castable*/
-    if(initial != Py_None && PyArray_SIZE(arr) != 0) { //if initial has a value and the arr is filled
-        PyArrayObject *initialArray = (PyArrayObject*) (initial); //cast initial to an array
+        /* check castable values */
+        PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial); //cast initial to an array
         if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) { //check the types
-            PyErr_Format(PyExc_TypeError,
-                        "initial type %R does not match the array type %R",
-                        Py_TYPE(initial),PyArray_TYPE(arr));
+            PyErr_SetString(PyExc_TypeError,"initial datatype does not match array type!");
             return NULL;
         }
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,14 +3632,21 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(Py_TYPE(initial) != Py_TYPE(identity)) {
-        PyErr_Format(PyExc_TypeError,
-                    "initial type %s does not match the array type %s",
-                    initial->ob_type->tp_name,identity->ob_type->tp_name);
-        return NULL;
     } else {
         Py_DECREF(identity);
         Py_INCREF(initial);  /* match the reference count in the if above */
+    }
+
+    
+    /*make sure the types are castable*/
+    PyArrayObject *initialArray = (PyArrayObject) *initial
+    PyArrayObject *identityArray = (PyArrayObject) *identity
+
+    if(PyArray_CanCastTo(initialArray->descr,identityArray->descr)) {
+        PyErr_Format(PyExc_TypeError,
+                    "initial type %s does not match the array type %s",
+                    initialArray->descr->kind,identityArray->descr->kind);
+        return NULL;
     }
 
     /* Get the reduction dtype */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3615,8 +3615,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     /* Get the identity */
     identity = _get_identity(ufunc, &reorderable);
-    if (identity == NULL || initial != identity) {
-        return NULL; //is this returning an error or do we have to break it up
+    if (identity == NULL) {
+        return NULL;
     }
 
     /* Get the initial value */
@@ -3632,6 +3632,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
+    } else if(initial != identity){
+        return NULL;
     } else {
         Py_DECREF(identity);
         Py_INCREF(initial);  /* match the reference count in the if above */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,7 +3632,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(*(initial->ob_type) != *(identity->ob_type)) {
+    } else if(*initial.ob_type != *identity.ob_type) {
         PyErr_Format(PyExc_TypeError,`
                     "initial type does not match the array type");
         return NULL;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3639,8 +3639,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     
     /*make sure the types are castable*/
-    PyObject* check1 = PyArray_FROM_O(initial)
-    PyObject* check2 = PyArray_FROM_O(identity)
+    PyObject *check1 = PyArray_FROM_O(initial);
+    PyObject *check2 = PyArray_FROM_O(identity);
     if(check1 == check2) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3642,7 +3642,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
+    if(initial != Py_None && !PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
                     Py_TYPE(initial),PyArray_TYPE(arr));

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3638,11 +3638,13 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         Py_DECREF(identity);
         Py_INCREF(initial);  /* match the reference count in the if above */
 
-        /* check castable values */
-        PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial); //cast initial to an array
-        if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) { //check the types
-            PyErr_SetString(PyExc_TypeError,"initial datatype does not match array type!");
-            return NULL;
+        /* check if castable values */
+        if(initial != Py_None && PyArray_SIZE(arr) != 0) {
+            PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial); //cast initial to an array
+            if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) { //check the types
+                PyErr_SetString(PyExc_TypeError,"initial datatype does not match array datatype!");
+                return NULL;
+            }
         }
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3645,7 +3645,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     if(initial != Py_None && !PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
-                    Py_TYPE(initial),Py_TYPE(arr));
+                    Py_TYPE(initial),PyArray_TYPE(arr));
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3634,7 +3634,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         }
     } else if(Py_TYPE(initial) != Py_TYPE(identity)) {
         PyErr_Format(PyExc_TypeError,
-                    "initial type does not match the array type");
+                    "initial type %s does not match the array type %s",
+                    initial->ob_type->tp_name,identity->ob_type->tp_name);
         return NULL;
     } else {
         Py_DECREF(identity);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3642,10 +3642,9 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    PyArrayObject *identityArray = (PyArrayObject*) PyArray_FROM_O(identity);
-    if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(identityArray))) {
+    if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
-                    "initial type %s does not match the array type %s",
+                    "initial type %R does not match the array type %R",
                     Py_Type(initial),Py_Type(identity));
         return NULL;
     }
@@ -4470,8 +4469,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     if (operation == UFUNC_REDUCEAT) {
         PyArray_Descr *indtype;
         indtype = PyArray_DescrFromType(NPY_INTP);
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&:reduceat", 
-                                         reduceat_kwlist,
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&:reduceat", reduceat_kwlist,
                                          &op,
                                          &obj_ind,
                                          &axes_in,

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3646,7 +3646,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     if(PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(identityArray))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %s does not match the array type %s",
-                    "type1","type2");
+                    Py_Type(initial),Py_Type(identity));
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3642,7 +3642,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     
     /*make sure the types are castable*/
     PyArrayObject *initialArray = (PyArrayObject*) PyArray_FROM_O(initial);
-    if(!PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
+    if(initial != Py_None && !PyArray_CanCastTo(PyArray_DESCR(initialArray),PyArray_DESCR(arr))) {
         PyErr_Format(PyExc_TypeError,
                     "initial type %R does not match the array type %R",
                     Py_TYPE(initial),Py_TYPE(arr));

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3615,12 +3615,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     /* Get the identity */
     identity = _get_identity(ufunc, &reorderable);
-    if (identity == NULL) {
-        return NULL;
-    }
-
-    if(initial != identity){
-        return NULL; // we are suppose to throw an error here?
+    if (identity == NULL || initial != identity) {
+        return NULL; //is this returning an error or do we have to break it up
     }
 
     /* Get the initial value */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3632,8 +3632,8 @@ PyUFunc_Reduce(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             initial = Py_None;
             Py_INCREF(initial);
         }
-    } else if(initial != identity) {
-        PyErr_Format(PyExc_TypeError,
+    } else if(*(initial->ob_type) != *(identity->ob_type)) {
+        PyErr_Format(PyExc_TypeError,`
                     "initial type does not match the array type");
         return NULL;
     } else {
@@ -4461,7 +4461,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
     if (operation == UFUNC_REDUCEAT) {
         PyArray_Descr *indtype;
         indtype = PyArray_DescrFromType(NPY_INTP);
-        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&:reduceat", reduceat_kwlist,
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|OO&O&:reduceat", 
+                                         reduceat_kwlist,
                                          &op,
                                          &obj_ind,
                                          &axes_in,

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1939,6 +1939,42 @@ class TestUfunc:
             pass  # ok, just not implemented
 
 
+    def test_initial_types(self):
+        py_arr1 = [-10.0,20.0,30.0,-25.0]
+        py_arr2 = [-10,20,30,-25]
+        np_arr1 = np.array(py_arr1)
+        np_arr2 = np.array(py_arr2)
+
+
+        assert_equal( np_arr1.min(initial=np.inf) , -25.0)
+        assert_equal( np_arr1.min(initial=-np.inf) , -np.inf)
+        assert_equal( np_arr1.min(initial=None) , -25.0)
+        assert_equal( np_arr1.max(initial=np.inf) , np.inf)
+        assert_equal( np_arr1.max(initial=-np.inf) , 30.0)
+        assert_equal( np_arr1.max(initial=None) , 30.0)
+
+        assert_equal( np.min([-10.0,20.0,30.0,-25.0],initial=np.inf) , -25.0)
+        assert_equal( np.min([-10.0,20.0,30.0,-25.0],initial=-np.inf) , -np.inf)
+        assert_equal( np.min([-10.0,20.0,30.0,-25.0],initial=None) , -25.0)
+        assert_equal( np.max([-10.0,20.0,30.0,-25.0],initial=np.inf) , np.inf)
+        assert_equal( np.max([-10.0,20.0,30.0,-25.0],initial=-np.inf) , 30.0)
+        assert_equal( np.max([-10.0,20.0,30.0,-25.0],initial=None) , 30.0)
+
+        assert_raises(TypeError,np_arr2.min,initial=np.inf)
+        assert_raises(TypeError,np_arr2.min,initial=-np.inf)
+        assert_raises(TypeError,np_arr1.min,initial='a')
+        assert_raises(TypeError,np_arr2.max,initial=np.inf)
+        assert_raises(TypeError,np_arr2.max,initial=-np.inf)
+        assert_raises(TypeError,np_arr1.max,initial='a')
+
+        assert_raises(TypeError,np.min,py_arr2,initial=np.inf)
+        assert_raises(TypeError,np.min,py_arr2,initial=-np.inf)
+        assert_raises(TypeError,np.min,py_arr1,initial='a')
+        assert_raises(TypeError,np.max,py_arr2,initial=np.inf)
+        assert_raises(TypeError,np.max,py_arr2,initial=-np.inf)
+        assert_raises(TypeError,np.max,py_arr1,initial='a')
+
+
 @pytest.mark.parametrize('ufunc', [getattr(np, x) for x in dir(np)
                                 if isinstance(getattr(np, x), np.ufunc)])
 def test_ufunc_types(ufunc):


### PR DESCRIPTION
BUG: bug in np.min, np.max, np.ndarray.min, np.ndarray.max

changes: added an else if statement to lines 3635,3636 to check for initial == indentity

---

note: this is far from done I haven't test because I do not believe that this will solve the bug. I more just wanted to talk about my thoughts:

From what I can tell from debugging the current code, initial and identity are PyObjects with a member called ob_type. As I change the data types of the np.array and the initial max/min guess in mytest.py I can change what the PyObjects/ob_types are of initial and identity. This leads me to assume that the check will be something pretty simple like a conditional, which is why I wrote the 'else-if'.

I am also unsure of how to raise an error in this part of the code, so I returned NULL. I have seen some stuff like 'PyErr_Format(...) --> goto fail' and I am fairly confident that creates an error message, and if it does how would I format that error.


---

Fixes #15905