### PR TITLE
MAINT: Fix capitalization in error message in `mtrand.pyx`

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -948,7 +948,7 @@ cdef class RandomState:
                 raise ValueError("Cannot take a larger sample than "
                                  "population when 'replace=False'")
             elif size < 0:
-                raise ValueError("negative dimensions are not allowed")
+                raise ValueError("Negative dimensions are not allowed")
 
             if p is not None:
                 if np.count_nonzero(p > 0) < size:


### PR DESCRIPTION
`ValueError` message about negative dimension in `np.random.choice` was lowercased.