### PR TITLE
BUG: Add _LARGE_FILES to def_macros[] when platform is AIX.

### DIFF
--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -1,3 +1,4 @@
+import sys
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -5,9 +6,12 @@ def configuration(parent_package='',top_path=None):
 
     config.add_data_dir('tests')
 
+    # AIX needs to be told to use large file support - at all times
+    defs = [('_LARGE_FILES', None)] if sys.platform[:3] == "aix" else []
     # Configure pocketfft_internal
     config.add_extension('_pocketfft_internal',
-                         sources=['_pocketfft.c']
+                         sources=['_pocketfft.c'],
+                         define_macros=defs
                          )
 
     return config

--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -11,7 +11,7 @@ def configuration(parent_package='',top_path=None):
     # Configure pocketfft_internal
     config.add_extension('_pocketfft_internal',
                          sources=['_pocketfft.c'],
-                         define_macros=defs
+                         define_macros=defs,
                          )
 
     return config


### PR DESCRIPTION
AIX needs to be told to use large file support at all times.

Closes #15801 (in part)


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
