### PR TITLE
WIP: add support for element lifecycle hooks

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -434,6 +434,8 @@ typedef int  (PyArray_FastTakeFunc)(void *dest, void *src, npy_intp *indarray,
                                        npy_intp nindarray, npy_intp n_outer,
                                        npy_intp m_middle, npy_intp nelem,
                                        NPY_CLIPMODE clipmode);
+typedef int (PyArray_ConstructFunc)(void *, npy_intp, void *);
+typedef void (PyArray_DestructFunc)(void *, npy_intp, void *);
 
 typedef struct {
         npy_intp *ptr;
@@ -550,6 +552,19 @@ typedef struct {
          */
         PyArray_ArgFunc *argmin;
 
+
+        /*
+         * Function to construct elements
+         * Can be NULL
+         */
+        PyArray_ConstructFunc *construct;
+
+        /*
+         * Function to destroy elements
+         * Can be NULL
+         */
+        PyArray_DestructFunc *destruct;
+
 } PyArray_ArrFuncs;
 
 /* The item must be reference counted when it is inserted or extracted. */
@@ -587,6 +602,12 @@ typedef struct {
 
 #define PyDataType_REFCHK(dtype) \
         PyDataType_FLAGCHK(dtype, NPY_ITEM_REFCOUNT)
+
+#define PyDataType_HASCONSTRUCTOR(dtype) \
+        ((dtype)->f->construct != NULL)
+
+#define PyDataType_HASDESTRUCTOR(dtype) \
+        ((dtype)->f->destruct != NULL)
 
 typedef struct _PyArray_Descr {
         PyObject_HEAD

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -528,6 +528,11 @@ array_dealloc(PyArrayObject *self)
         if (PyDataType_FLAGCHK(fa->descr, NPY_ITEM_REFCOUNT)) {
             PyArray_XDECREF(self);
         }
+        else if (PyDataType_HASDESTRUCTOR(fa->descr)) {
+            fa->descr->f->destruct(fa->data,
+                                   PyArray_NBYTES(self) / fa->descr->elsize,
+                                   fa);
+        }
         npy_free_cache(fa->data, PyArray_NBYTES(self));
     }
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -4041,7 +4041,9 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FastClipFunc *)NULL,
     (PyArray_FastPutmaskFunc *)NULL,
     (PyArray_FastTakeFunc *)NULL,
-    (PyArray_ArgFunc*)@from@_argmin
+    (PyArray_ArgFunc*)@from@_argmin,
+    (PyArray_ConstructFunc *)NULL,
+    (PyArray_DestructFunc *)NULL,
 };
 
 /*
@@ -4191,7 +4193,9 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
     (PyArray_FastClipFunc*)NULL,
     (PyArray_FastPutmaskFunc*)NULL,
     (PyArray_FastTakeFunc*)NULL,
-    (PyArray_ArgFunc*)@from@_argmin
+    (PyArray_ArgFunc*)@from@_argmin,
+    (PyArray_ConstructFunc*)NULL,
+    (PyArray_DestructFunc*)NULL,
 };
 
 /*

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1092,6 +1092,17 @@ PyArray_NewFromDescr_int(
         if (data == NULL) {
             return raise_memory_error(fa->nd, fa->dimensions, descr);
         }
+
+        /*
+         * Call the user's constructor function to initialize the array.
+         */
+        if (PyDataType_HASCONSTRUCTOR(descr)) {
+            if (descr->f->construct(data, nbytes / descr->elsize, fa)) {
+                npy_free_cache(fa->data, nbytes);
+                goto fail;
+            }
+        }
+
         fa->flags |= NPY_ARRAY_OWNDATA;
 
     }


### PR DESCRIPTION
It is currently not possible to define a dtype for objects which require some
non-trivial initialization or destruction. This commit adds support for two new
optional functions in `PyArray_ArrFuncs`: `construct` and `destruct`.

If provided, the `construct` function will be called on all new allocations. The
`construct` function should initialize the array with valid elements of the
given type. The `construct` function is allowed to fail, in which case the array
constructor will throw a Python exception.

If provided, the `destruct` function will be called when the buffer is being
deallocated. The `destruct` function should tear down all of the elements in the
array. The destruct function cannot fail.

One explicit goal of this change is to make it easier to define dtypes for C++ types
which are not trivially constructible or trivially destructible. Trivially
constructible means that `memcpy` is a sufficient implementation for copy.
Trivially destructible means that freeing the storage tears down the object
completely. Things like pointers to heap allocated strings would not fall into
this category because they require a deep copy and destruction should free the
data being pointed to.

In theory, the object dtype could be rewritten to use `destruct` to call decref
on each of the elements instead of relying on a special case; however, I am not
sure it is worth doing that yet.

This change does not introduce a new flag for this feature set because
`PyArray_Descr.flags` is a char and all 8 bits are currently being used.
Changing this to `int` may be an ABI incompatible change so I chose to avoid
that. Instead, the function pointers are checked directly before use.

NOTE: This PR does not include tests nor documentation. I would like to discuss this feature with the numpy developers before making too many changes. I have a [proof of concept repo](https://github.com/llllllllll/sbo-string-dtype) which shows how one may use this feature. The linked repo builds and runs with this change applied.