### PR TITLE
BUG: Check that `pvals` is 1D in `_generator.multinomial`.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3746,12 +3746,12 @@ cdef class Generator:
         cdef int64_t ni
         cdef np.broadcast it
 
-        if np.ndim(pvals) != 1:
-            raise ValueError("pvals must be 1d array")
         d = len(pvals)
         on = <np.ndarray>np.PyArray_FROM_OTF(n, np.NPY_INT64, np.NPY_ALIGNED)
         parr = <np.ndarray>np.PyArray_FROM_OTF(
             pvals, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
+        if np.PyArray_NDIM(parr) != 1:
+            raise ValueError("pvals must be 1d array")
         pix = <double*>np.PyArray_DATA(parr)
         check_array_constraint(parr, 'pvals', CONS_BOUNDED_0_1)
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3748,10 +3748,8 @@ cdef class Generator:
 
         d = len(pvals)
         on = <np.ndarray>np.PyArray_FROM_OTF(n, np.NPY_INT64, np.NPY_ALIGNED)
-        parr = <np.ndarray>np.PyArray_FROM_OTF(
-            pvals, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
-        if np.PyArray_NDIM(parr) != 1:
-            raise ValueError("pvals must be 1d array")
+        parr = <np.ndarray>np.PyArray_FROMANY(
+            pvals, np.NPY_DOUBLE, 1, 1, np.NPY_ARRAY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
         pix = <double*>np.PyArray_DATA(parr)
         check_array_constraint(parr, 'pvals', CONS_BOUNDED_0_1)
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3746,6 +3746,8 @@ cdef class Generator:
         cdef int64_t ni
         cdef np.broadcast it
 
+        if np.ndim(pvals) != 1:
+            raise ValueError("pvals must be 1d array")
         d = len(pvals)
         on = <np.ndarray>np.PyArray_FROM_OTF(n, np.NPY_INT64, np.NPY_ALIGNED)
         parr = <np.ndarray>np.PyArray_FROM_OTF(

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4190,6 +4190,8 @@ cdef class RandomState:
         cdef long *mnix
         cdef long ni
 
+        if np.ndim(pvals) != 1:
+            raise ValueError("pvals must be 1d array")
         d = len(pvals)
         parr = <np.ndarray>np.PyArray_FROM_OTF(
             pvals, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4190,11 +4190,11 @@ cdef class RandomState:
         cdef long *mnix
         cdef long ni
 
-        if np.ndim(pvals) != 1:
-            raise ValueError("pvals must be 1d array")
         d = len(pvals)
         parr = <np.ndarray>np.PyArray_FROM_OTF(
             pvals, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
+        if np.PyArray_NDIM(parr) != 1:
+            raise ValueError("pvals must be 1d array")
         pix = <double*>np.PyArray_DATA(parr)
         check_array_constraint(parr, 'pvals', CONS_BOUNDED_0_1)
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4191,10 +4191,8 @@ cdef class RandomState:
         cdef long ni
 
         d = len(pvals)
-        parr = <np.ndarray>np.PyArray_FROM_OTF(
-            pvals, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
-        if np.PyArray_NDIM(parr) != 1:
-            raise ValueError("pvals must be 1d array")
+        parr = <np.ndarray>np.PyArray_FROMANY(
+            pvals, np.NPY_DOUBLE, 1, 1, np.NPY_ARRAY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
         pix = <double*>np.PyArray_DATA(parr)
         check_array_constraint(parr, 'pvals', CONS_BOUNDED_0_1)
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -116,6 +116,12 @@ class TestMultinomial(object):
         contig = random.multinomial(100, pvals=np.ascontiguousarray(pvals))
         assert_array_equal(non_contig, contig)
 
+    def test_multidimensional_pvals(self):
+        assert_raises(ValueError, random.multinomial, 10, [[0, 1], [1, 0]])
+        assert_raises(ValueError, random.multinomial, 10, [[0], [1]])
+        assert_raises(ValueError, random.multinomial, 10, [[[0], [1]], [[1], [0]]])
+        assert_raises(ValueError, random.multinomial, 10, np.array([[0, 1], [1, 0]]))
+
 
 class TestMultivariateHypergeometric(object):
 

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -117,7 +117,7 @@ class TestMultinomial(object):
         assert_array_equal(non_contig, contig)
 
     def test_multidimensional_pvals(self):
-        assert_raises(ValueError, random.multinomial, 10, [[0, 1], [1, 0]])
+        assert_raises(ValueError, random.multinomial, 10, [[0, 1]])
         assert_raises(ValueError, random.multinomial, 10, [[0], [1]])
         assert_raises(ValueError, random.multinomial, 10, [[[0], [1]], [[1], [0]]])
         assert_raises(ValueError, random.multinomial, 10, np.array([[0, 1], [1, 0]]))

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -93,7 +93,7 @@ class TestMultinomial(object):
                       float(1))
 
     def test_multidimensional_pvals(self):
-        assert_raises(ValueError, np.random.multinomial, 10, [[0, 1], [1, 0]])
+        assert_raises(ValueError, np.random.multinomial, 10, [[0, 1]])
         assert_raises(ValueError, np.random.multinomial, 10, [[0], [1]])
         assert_raises(ValueError, np.random.multinomial, 10, [[[0], [1]], [[1], [0]]])
         assert_raises(ValueError, np.random.multinomial, 10, np.array([[0, 1], [1, 0]]))

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -92,6 +92,12 @@ class TestMultinomial(object):
         assert_raises(TypeError, np.random.multinomial, 1, p,
                       float(1))
 
+    def test_multidimensional_pvals(self):
+        assert_raises(ValueError, np.random.multinomial, 10, [[0, 1], [1, 0]])
+        assert_raises(ValueError, np.random.multinomial, 10, [[0], [1]])
+        assert_raises(ValueError, np.random.multinomial, 10, [[[0], [1]], [[1], [0]]])
+        assert_raises(ValueError, np.random.multinomial, 10, np.array([[0, 1], [1, 0]]))
+
 
 class TestSetState(object):
     def setup(self):


### PR DESCRIPTION
Backport of #15876. 

Fixes gh-15492.

Unfortunately I found no flags to ensure pvals is 1d within np.PyArray_FROM_OTF.
Alternatively I can check number of dimensions with PyArray_NDIM after calling above method .
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
