### PR TITLE
ENH: better handle dtype creation with metadata

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -79,6 +79,47 @@ def _usefields(adict, align):
                   "titles": titles}, align)
 
 
+def _is_mistyped_inherited_type_dict(adict):
+    """Inherited dtype is specified by adict with values (see _makenames_list)
+     - val is a tuple of size 2 or 3;
+     - val[1] is non-negative int.
+
+    This function guesses if a user tried to specify such a dict and
+    made a typo.  Specifically, it returns True only if
+     1. all adict values are tuples of size >= 2;
+     2. either of the following is true for at least one tuple
+        a. val[1] is not an integer;
+        b. val[1] is an integer but val[1] < 0;
+        c. len(val) >= 4.
+
+    Note that this function is called AFTER _makenames_list, so we know
+    for sure that there is an error if adict is an inherited_type_dict.
+    """
+    are_all_tuples_of_size_2 = True
+    has_typo = False
+    for val in adict.values():
+        if isinstance(val, tuple):
+            n = len(val)
+            if n < 2:
+                # cond #1 is violated
+                return False
+
+            try:
+                num = int(val[1])
+            except:
+                # cond #2a is violated
+                has_typo = True
+                continue
+
+            are_all_tuples_of_size_2 = are_all_tuples_of_size_2 and (n >= 2)
+            has_typo = has_typo or (n >= 4) or (num < 0)
+        else:
+            # cond #1 is violated
+            return False
+
+    return are_all_tuples_of_size_2 and has_typo
+
+
 # construct an array_protocol descriptor list
 #  from the fields attribute of a descriptor
 # This calls itself recursively but should eventually hit

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -151,6 +151,14 @@ class TestRecord:
         b = np.dtype([('yo', int)])
         assert_dtype_equal(a, b)
 
+    def test_metadata_in_descr(self):
+        """Test whether dtype with metadata can be restored from descr."""
+        a = np.dtype([('a', 'S8')])
+        a_meta = np.dtype([('a', ('S8', {'msg': 'Hello'}))])
+        assert_dtype_equal(a, a_meta)
+
+        assert_dtype_equal(a_meta, np.dtype(a_meta.descr))
+
     def test_different_names(self):
         # In theory, they may hash the same (collision) ?
         a = np.dtype([('yo', int)])

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -159,6 +159,19 @@ class TestRecord:
 
         assert_dtype_equal(a_meta, np.dtype(a_meta.descr))
 
+    def test_metadata_does_not_change_predefined_dtype(self):
+        """Test that metadata does not change build-in and predef dtypes."""
+        # test predefined dtype
+        a_meta = np.dtype(('i8', {'msg': 'Hello'}))
+        assert_(a_meta.metadata is not None)
+        assert_(np.dtype('i8').metadata is None)
+
+        # test custom dtype
+        my_dtype = np.dtype([('a', 'S8')])
+        a_meta = np.dtype([('b', (my_dtype, {'msg': 'Hello'}))])
+        assert_(a_meta['b'].metadata is not None)
+        assert_(my_dtype.metadata is None)
+
     def test_different_names(self):
         # In theory, they may hash the same (collision) ?
         a = np.dtype([('yo', int)])

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -952,17 +952,17 @@ def test_unicode_field_names():
             format.write_array(f, arr, version=None)
 
 
-@pytest.mark.parametrize('dt, fail', [
+@pytest.mark.parametrize('dt, fail, has_metadata', [
     (np.dtype({'names': ['a', 'b'], 'formats':  [float, np.dtype('S3',
-                 metadata={'some': 'stuff'})]}), True),
-    (np.dtype(int, metadata={'some': 'stuff'}), False),
-    (np.dtype([('subarray', (int, (2,)))], metadata={'some': 'stuff'}), False),
+                 metadata={'some': 'stuff'})]}), False, True),
+    (np.dtype(int, metadata={'some': 'stuff'}), False, False),
+    (np.dtype([('subarray', (int, (2,)))], metadata={'some': 'stuff'}), False, False),
     # recursive: metadata on the field of a dtype
     (np.dtype({'names': ['a', 'b'], 'formats': [
         float, np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})
-    ]}), False)
+    ]}), False, False)
     ])
-def test_metadata_dtype(dt, fail):
+def test_metadata_dtype(dt, fail, has_metadata):
     # gh-14142
     arr = np.ones(10, dtype=dt)
     buf = BytesIO()
@@ -978,5 +978,5 @@ def test_metadata_dtype(dt, fail):
         from numpy.lib.format import _has_metadata
         assert_array_equal(arr, arr2)
         assert _has_metadata(arr.dtype)
-        assert not _has_metadata(arr2.dtype)
+        assert _has_metadata(arr2.dtype) or not has_metadata
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -978,5 +978,5 @@ def test_metadata_dtype(dt, fail, has_metadata):
         from numpy.lib.format import _has_metadata
         assert_array_equal(arr, arr2)
         assert _has_metadata(arr.dtype)
-        assert _has_metadata(arr2.dtype) or not has_metadata
+        assert _has_metadata(arr2.dtype) == has_metadata
 


### PR DESCRIPTION
This change fixes the issue #15488: inconsistent behavior of `dtype.descr` with metadata.  Actually the problem with handling metadata appeared in 2016 in the pool request gh-8235 (it even mentioned there that it breaks creation of dtype with metdata).  I fixed the code in such a way that:
 - one can create dtype with metatdata as `np.dtype([('a', ('S8', {'info': 'hello'}))])`;
 - it does **not** break regression tests added in gh-8235.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
