### PR TITLE
TST: Round-trip test `np.save`/`np.load` with Hypothesis

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -104,7 +104,15 @@ class RoundtripTest:
         try:
             arr = args
 
-            save_func(target_file, *arr, **save_kwds)
+            with warnings.catch_warnings():
+                # Ignore format-version warning caused by saving an array with
+                # non-ascii characters in structured dtype field names or
+                # titles without setting an explicit format version.
+                warnings.filterwarnings(
+                    "ignore", message="Stored array in format 3.0.",
+                    category=UserWarning, module="numpy.lib.format",
+                )
+                save_func(target_file, *arr, **save_kwds)
             target_file.flush()
             target_file.seek(0)
 


### PR DESCRIPTION
This new property-based test - a follow-up to #15189 - attempts to round-trip a wide variety of arrays (and dtypes) through [`np.save`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.save.html) and [`np.load`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html) with varied serialisation options.

It looks like the serialisation is fine, but some testing helpers have issues with size-zero and dimension-zero arrays - test results below for convenience:

```python-traceback
_____________________ TestSaveLoad.test_roundtrip_property _____________________
self = <numpy.lib.tests.test_io.TestSaveLoad object at 0x7fdc1868d5e0>
>   ???
E   hypothesis.errors.MultipleFailures: Hypothesis found 3 distinct failures.
f          = <function given.<locals>.run_test_as_given.<locals>.wrapped_test>
self       = <numpy.lib.tests.test_io.TestSaveLoad object at 0x7fdc1868d5e0>
numpy/lib/tests/test_io.py:192: MultipleFailures
---------------------------------- Hypothesis ----------------------------------
Falsifying example: test_roundtrip_property(
    self=<numpy.lib.tests.test_io.TestSaveLoad at 0x7fdc1868d5e0>,
    arr=array((False,), dtype=[('Ā', '?')]),
    save_kwds={'allow_pickle': False, 'fix_imports': False},
    load_kwds={'encoding': 'ASCII', 'mmap_mode': None},
)
Traceback (most recent call last):
  File "numpy/lib/tests/test_io.py", line 218, in test_roundtrip_property
    RoundtripTest.roundtrip(
  File "numpy/lib/tests/test_io.py", line 107, in roundtrip
    save_func(target_file, *arr, **save_kwds)
  File "<__array_function__ internals>", line 5, in save
  File "numpy/lib/npyio.py", line 528, in save
    format.write_array(fid, arr, allow_pickle=allow_pickle,
  File "numpy/lib/format.py", line 648, in write_array
    _write_array_header(fp, header_data_from_array_1_0(array), version)
  File "numpy/lib/format.py", line 425, in _write_array_header
    header = _wrap_header_guess_version(header)
  File "numpy/lib/format.py", line 398, in _wrap_header_guess_version
    warnings.warn("Stored array in format 3.0. It can only be "
UserWarning: Stored array in format 3.0. It can only be read by NumPy >= 1.17


Falsifying example: test_roundtrip_property(
    self=<numpy.lib.tests.test_io.TestSaveLoad at 0x7fdc1868d5e0>,
    arr=array((0,), dtype=[('f0', 'i1')]),
    save_kwds={'allow_pickle': False, 'fix_imports': False},
    load_kwds={'encoding': 'ASCII', 'mmap_mode': None},
)
Traceback (most recent call last):
  File "numpy/lib/tests/test_io.py", line 226, in test_roundtrip_property
    np.testing.assert_array_equal(arr, self.arr)
  File "numpy/testing/_private/utils.py", line 930, in assert_array_equal
    assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
  File "numpy/testing/_private/utils.py", line 704, in assert_array_compare
    y = array(y, copy=False, subok=True)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'tuple'


Falsifying example: test_roundtrip_property(
    self=<numpy.lib.tests.test_io.TestSaveLoad at 0x7fdc1868d5e0>,
    arr=array([], dtype=[('f0', '?')]),
    save_kwds={'allow_pickle': False, 'fix_imports': False},
    load_kwds={'encoding': 'ASCII', 'mmap_mode': None},
)
DeprecationWarning: The truth value of an empty array is ambiguous.
    Returning False, but in future this will result in an error.
    Use `array.size > 0` to check that an array is not empty.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "numpy/lib/tests/test_io.py", line 226, in test_roundtrip_property
    np.testing.assert_array_equal(arr, self.arr)
  File "numpy/testing/_private/utils.py", line 930, in assert_array_equal
    assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
  File "numpy/testing/_private/utils.py", line 704, in assert_array_compare
    y = array(y, copy=False, subok=True)
ValueError: setting an array element with a sequence.
```