### PR TITLE
TST: Add slow_pypy support

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -169,7 +169,10 @@ class PytestTester:
             pytest_args += ["--cov=" + module_path]
 
         if label == "fast":
-            pytest_args += ["-m", "not slow"]
+            # not importing at the top level to avoid circular import of module
+            from numpy.testing import IS_PYPY
+            pytest_args += ["-m", "not slow and not slow_pypy"] \
+                           if IS_PYPY else ["-m", "not slow"]
         elif label != "full":
             pytest_args += ["-m", label]
 

--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -171,8 +171,11 @@ class PytestTester:
         if label == "fast":
             # not importing at the top level to avoid circular import of module
             from numpy.testing import IS_PYPY
-            pytest_args += ["-m", "not slow and not slow_pypy"] \
-                           if IS_PYPY else ["-m", "not slow"]
+            if IS_PYPY:
+                pytest_args += ["-m", "not slow and not slow_pypy"]
+            else:
+                pytest_args += ["-m", "not slow"]
+
         elif label != "full":
             pytest_args += ["-m", label]
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -27,6 +27,8 @@ def pytest_configure(config):
         "leaks_references: Tests that are known to leak references.")
     config.addinivalue_line("markers",
         "slow: Tests that are very slow.")
+    config.addinivalue_line("markers",
+        "slow_pypy: Tests that are very slow on pypy.")
 
 
 def pytest_addoption(parser):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2030,6 +2030,7 @@ class TestRegression:
         a[...] = [[1, 2]]
         assert_equal(a, [[1, 2], [1, 2]])
 
+    @pytest.mark.slow_pypy
     def test_memoryleak(self):
         # Ticket #1917 - ensure that array data doesn't leak
         for i in range(1000):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -278,6 +278,7 @@ class TestSavezLoad(RoundtripTest):
                 fp.seek(0)
                 assert_(not fp.closed)
 
+    @pytest.mark.slow_pypy
     def test_closing_fid(self):
         # Test that issue #1517 (too many opened files) remains closed
         # It might be a "weak" test since failed to get triggered on


### PR DESCRIPTION
Follow up for : https://github.com/numpy/numpy/pull/15893

Added a slow_pypy marker for tests that are slow on pypy.
Marked two tests with slow_pypy : 1. test_memoryleak 2. test_closing_fid , based on pypy logs obtained from #15893 

@mattip 