### PR TITLE
ENH: Allow arrays to be passed into the initial kwarg of reductions

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4741,14 +4741,18 @@ add_newdoc('numpy.core', 'ufunc', ('reduce',
         the result will broadcast correctly against the original `arr`.
 
         .. versionadded:: 1.7.0
-    initial : scalar, optional
+    initial : array_like, optional
         The value with which to start the reduction.
         If the ufunc has no identity or the dtype is object, this defaults
         to None - otherwise it defaults to ufunc.identity.
         If ``None`` is given, the first element of the reduction is used,
         and an error is thrown if the reduction is empty.
+        If an array, this is broadcast against the result.
 
         .. versionadded:: 1.15.0
+
+        .. versionchanged:: 1.19.0
+            Passing an array is now supported.
 
     where : array_like of bool, optional
         A boolean array which is broadcasted to match the dimensions

--- a/numpy/core/src/umath/reduction.h
+++ b/numpy/core/src/umath/reduction.h
@@ -130,8 +130,8 @@ typedef int (PyArray_ReduceLoopFunc)(NpyIter *iter,
  *               with size one.
  * subok       : If true, the result uses the subclass of operand, otherwise
  *               it is always a base class ndarray.
- * identity    : If Py_None, PyArray_InitializeReduceResult is used, otherwise
- *               this value is used to initialize the result to
+ * identity    : If NULL, PyArray_InitializeReduceResult is used, otherwise
+ *               this array is broadcast to initialize the result to
  *               the reduction's unit.
  * loop        : The loop which does the reduction.
  * data        : Data which is passed to the inner loop.
@@ -148,7 +148,7 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
                       npy_bool *axis_flags, int reorderable,
                       int keepdims,
                       int subok,
-                      PyObject *identity,
+                      PyArrayObject *identity,
                       PyArray_ReduceLoopFunc *loop,
                       void *data, npy_intp buffersize, const char *funcname,
                       int errormask);


### PR DESCRIPTION
This enables something like:
```python
bound_upper = np.full((3,), -np.inf)
bound_lower = np.full((3,), np.inf)
for vertex_array in vertex_arrays:
    data_arr.max(out=bound_upper, initial=bound_upper)
    data_arr.min(out=bound_lower, initial=bound_lower)
```

It also resolves #15905, as same_kind casting is now used:
```
In [7]: np.array([-10,20,30,-25]).min(initial=np.inf)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-7-966c5d8ff062> in <module>
----> 1 np.array([-10,20,30,-25]).min(initial=np.inf)

~\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\_methods.py in _amin(a, axis, out, keepdims, initial, where)
     41 def _amin(a, axis=None, out=None, keepdims=False,
     42           initial=_NoValue, where=True):
---> 43     return umr_minimum(a, axis, None, out, keepdims, initial, where)
     44
     45 def _sum(a, axis=None, dtype=None, out=None, keepdims=False,

TypeError: Cannot cast scalar from dtype('float64') to dtype('int32') according to the rule 'same_kind'
```

