### PR TITLE
BUG: Avoid duplication in stack trace of `linspace(a, b, num=1.5)`

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -110,13 +110,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     >>> plt.show()
 
     """
-    try:
-        num = operator.index(num)
-    except TypeError:
-        raise TypeError(
-            "object of type {} cannot be safely interpreted as an integer."
-                .format(type(num)))
-
+    num = operator.index(num)
     if num < 0:
         raise ValueError("Number of samples, %s, must be non-negative." % num)
     div = (num - 1) if endpoint else num


### PR DESCRIPTION
Before this commit, the stack trace was:
```
Traceback (most recent call last):
  File "C:\Users\wiese\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\function_base.py", line 114, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "<ipython-input-13-802b8c6e85f6>", line 1, in <module>
    np.linspace(1, 2, 1.5)
  File "<__array_function__ internals>", line 5, in linspace
  File "C:\Users\wiese\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\function_base.py", line 116, in linspace
    raise TypeError(
TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.
```

Now it is
```
Traceback (most recent call last):
  File "C:\Users\wiese\Repos\numeric-python\numpy\build\testenv\Lib\site-packages\numpy\core\function_base.py", line 114, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer
```

This noisy traceback was introduced in f4dfe833e3e037bb69113f7250fad3699f918cfc.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
