### PR TITLE
BUG: Fix inf and NaN-warnings in half float `nextafter`

### DIFF
--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -116,9 +116,6 @@ npy_half npy_half_nextafter(npy_half x, npy_half y)
     npy_half ret;
 
     if (npy_half_isnan(x) || npy_half_isnan(y)) {
-#if NPY_HALF_GENERATE_INVALID
-        npy_set_floatstatus_invalid();
-#endif
         ret = NPY_HALF_NAN;
     } else if (npy_half_eq_nonan(x, y)) {
         ret = x;

--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -115,7 +115,7 @@ npy_half npy_half_nextafter(npy_half x, npy_half y)
 {
     npy_half ret;
 
-    if (!npy_half_isfinite(x) || npy_half_isnan(y)) {
+    if (npy_half_isnan(x) || npy_half_isnan(y)) {
 #if NPY_HALF_GENERATE_INVALID
         npy_set_floatstatus_invalid();
 #endif

--- a/numpy/core/src/npymath/halffloat.c
+++ b/numpy/core/src/npymath/halffloat.c
@@ -138,7 +138,7 @@ npy_half npy_half_nextafter(npy_half x, npy_half y)
         }
     }
 #if NPY_HALF_GENERATE_OVERFLOW
-    if (npy_half_isinf(ret)) {
+    if (npy_half_isinf(ret) && npy_half_isfinite(x)) {
         npy_set_floatstatus_overflow();
     }
 #endif

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -487,8 +487,6 @@ class TestHalf:
             assert_raises_fpe('invalid', np.divide, float16(np.inf), float16(np.inf))
             assert_raises_fpe('invalid', np.spacing, float16(np.inf))
             assert_raises_fpe('invalid', np.spacing, float16(np.nan))
-            assert_raises_fpe('invalid', np.nextafter, float16(np.inf), float16(0))
-            assert_raises_fpe('invalid', np.nextafter, float16(-np.inf), float16(0))
             assert_raises_fpe('invalid', np.nextafter, float16(0), float16(np.nan))
 
             # These should not raise
@@ -498,6 +496,8 @@ class TestHalf:
             np.spacing(float16(-65504))
             np.nextafter(float16(65504), float16(-np.inf))
             np.nextafter(float16(-65504), float16(np.inf))
+            np.nextafter(float16(np.inf), float16(0))
+            np.nextafter(float16(-np.inf), float16(0))
             float16(2**-14)/float16(2**10)
             float16(-2**-14)/float16(2**10)
             float16(2**-14+2**-23)/float16(2)

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -337,6 +337,9 @@ class TestHalf:
         assert_equal(np.nextafter(a_f16[0], -hinf), -a_f16[1])
         assert_equal(np.nextafter(a_f16[1:], -hinf), a_f16[:-1])
 
+        assert_equal(np.nextafter(hinf, a_f16), a_f16[-1])
+        assert_equal(np.nextafter(-hinf, a_f16), -a_f16[-1])
+
         # switch to negatives
         a |= 0x8000
 
@@ -346,6 +349,9 @@ class TestHalf:
         assert_equal(np.nextafter(a_f16[0], hinf), -a_f16[1])
         assert_equal(np.nextafter(a_f16[1:], hinf), a_f16[:-1])
         assert_equal(np.nextafter(a_f16[:-1], -hinf), a_f16[1:])
+
+        assert_equal(np.nextafter(hinf, a_f16), -a_f16[-1])
+        assert_equal(np.nextafter(-hinf, a_f16), a_f16[-1])
 
     def test_half_ufuncs(self):
         """Test the various ufuncs"""

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -329,6 +329,7 @@ class TestHalf:
         # All non-negative finite #'s
         a = np.arange(0x7c00, dtype=uint16)
         hinf = np.array((np.inf,), dtype=float16)
+        hnan = np.array((np.nan,), dtype=float16)
         a_f16 = a.view(dtype=float16)
 
         assert_equal(np.spacing(a_f16[:-1]), a_f16[1:]-a_f16[:-1])
@@ -345,6 +346,13 @@ class TestHalf:
         assert_equal(np.nextafter(-hinf, hinf), -a_f16[-1])
         assert_equal(np.nextafter(-hinf, -hinf), -hinf)
 
+        assert_equal(np.nextafter(a_f16, hnan), hnan[0])
+        assert_equal(np.nextafter(hnan, a_f16), hnan[0])
+
+        assert_equal(np.nextafter(hnan, hnan), hnan)
+        assert_equal(np.nextafter(hinf, hnan), hnan)
+        assert_equal(np.nextafter(hnan, hinf), hnan)
+
         # switch to negatives
         a |= 0x8000
 
@@ -357,6 +365,9 @@ class TestHalf:
 
         assert_equal(np.nextafter(hinf, a_f16), -a_f16[-1])
         assert_equal(np.nextafter(-hinf, a_f16), a_f16[-1])
+
+        assert_equal(np.nextafter(a_f16, hnan), hnan[0])
+        assert_equal(np.nextafter(hnan, a_f16), hnan[0])
 
     def test_half_ufuncs(self):
         """Test the various ufuncs"""
@@ -498,7 +509,6 @@ class TestHalf:
             assert_raises_fpe('invalid', np.divide, float16(np.inf), float16(np.inf))
             assert_raises_fpe('invalid', np.spacing, float16(np.inf))
             assert_raises_fpe('invalid', np.spacing, float16(np.nan))
-            assert_raises_fpe('invalid', np.nextafter, float16(0), float16(np.nan))
 
             # These should not raise
             float16(65472)+float16(32)
@@ -509,6 +519,8 @@ class TestHalf:
             np.nextafter(float16(-65504), float16(np.inf))
             np.nextafter(float16(np.inf), float16(0))
             np.nextafter(float16(-np.inf), float16(0))
+            np.nextafter(float16(0), float16(np.nan))
+            np.nextafter(float16(np.nan), float16(0))
             float16(2**-14)/float16(2**10)
             float16(-2**-14)/float16(2**10)
             float16(2**-14+2**-23)/float16(2)

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -340,6 +340,11 @@ class TestHalf:
         assert_equal(np.nextafter(hinf, a_f16), a_f16[-1])
         assert_equal(np.nextafter(-hinf, a_f16), -a_f16[-1])
 
+        assert_equal(np.nextafter(hinf, hinf), hinf)
+        assert_equal(np.nextafter(hinf, -hinf), a_f16[-1])
+        assert_equal(np.nextafter(-hinf, hinf), -a_f16[-1])
+        assert_equal(np.nextafter(-hinf, -hinf), -hinf)
+
         # switch to negatives
         a |= 0x8000
 


### PR DESCRIPTION
Fix  #15977
