### PR TITLE
DOC: add note on flatten ordering in matlab page

### DIFF
--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -395,7 +395,7 @@ Linear Algebra Equivalents
    * - ``y=x(:)``
      - ``y = x.flatten()``
      - turn array into vector (note that this forces a copy). To obtain the
-       same data ordering than in Matlab, use ``x.flatten('F')``.
+       same data ordering as in Matlab, use ``x.flatten('F')``.
 
    * - ``1:10``
      - ``arange(1.,11.)`` or ``r_[1.:11.]`` or  ``r_[1:10:10j]``

--- a/doc/source/user/numpy-for-matlab-users.rst
+++ b/doc/source/user/numpy-for-matlab-users.rst
@@ -394,7 +394,8 @@ Linear Algebra Equivalents
 
    * - ``y=x(:)``
      - ``y = x.flatten()``
-     - turn array into vector (note that this forces a copy)
+     - turn array into vector (note that this forces a copy). To obtain the
+       same data ordering than in Matlab, use ``x.flatten('F')``.
 
    * - ``1:10``
      - ``arange(1.,11.)`` or ``r_[1.:11.]`` or  ``r_[1:10:10j]``


### PR DESCRIPTION
Add note on the ordering of matlab's ``x(:)`` vs NumPy ``x.flatten()``

There was an alternative proposal by @tomkilpatrick in #15837 that I can implement if necessary.

fix #15837
