### PR TITLE
MAINT: Replace npyiter_order_converter with PyArray_OrderConverter

### DIFF
--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -232,50 +232,6 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
     return 1;
 }
 
-/* TODO: Use PyArray_OrderConverter once 'K' is added there */
-static int
-npyiter_order_converter(PyObject *order_in, NPY_ORDER *order)
-{
-    char *str = NULL;
-    Py_ssize_t length = 0;
-
-    if (PyUnicode_Check(order_in)) {
-        /* accept unicode input */
-        PyObject *str_obj;
-        int ret;
-        str_obj = PyUnicode_AsASCIIString(order_in);
-        if (str_obj == NULL) {
-            return 0;
-        }
-        ret = npyiter_order_converter(str_obj, order);
-        Py_DECREF(str_obj);
-        return ret;
-    }
-
-    if (PyBytes_AsStringAndSize(order_in, &str, &length) < 0) {
-        return 0;
-    }
-
-    if (length == 1) switch (str[0]) {
-        case 'C':
-            *order = NPY_CORDER;
-            return 1;
-        case 'F':
-            *order = NPY_FORTRANORDER;
-            return 1;
-        case 'A':
-            *order = NPY_ANYORDER;
-            return 1;
-        case 'K':
-            *order = NPY_KEEPORDER;
-            return 1;
-    }
-
-    PyErr_SetString(PyExc_ValueError,
-                    "order must be one of 'C', 'F', 'A', or 'K'");
-    return 0;
-}
-
 static int
 NpyIter_OpFlagsConverter(PyObject *op_flags_in,
                          npy_uint32 *op_flags)
@@ -763,7 +719,7 @@ npyiter_init(NewNpyArrayIterObject *self, PyObject *args, PyObject *kwds)
                     NpyIter_GlobalFlagsConverter, &flags,
                     &op_flags_in,
                     &op_dtypes_in,
-                    npyiter_order_converter, &order,
+                    PyArray_OrderConverter, &order,
                     PyArray_CastingConverter, &casting,
                     &op_axes_in,
                     PyArray_OptionalIntpConverter, &itershape,
@@ -892,7 +848,7 @@ NpyIter_NestedIters(PyObject *NPY_UNUSED(self),
                     NpyIter_GlobalFlagsConverter, &flags,
                     &op_flags_in,
                     &op_dtypes_in,
-                    npyiter_order_converter, &order,
+                    PyArray_OrderConverter, &order,
                     PyArray_CastingConverter, &casting,
                     &buffersize)) {
         return NULL;


### PR DESCRIPTION
~~Builds upon #16008, marking as draft until that is merged~~

---

The TODO precondition now holds, so we no longer need this function.function_base.py

A consequence of this change is that:
* `None` is now accepted as an alias for `'K'`
* Lowercase letters are now accepted as a replacement for the corresponding uppercase letter

Neither of these are particularly desirable, but we could always deprecate them in `PyArray_OrderConverter` at a later date.