### PR TITLE
DOC: Change import error "howto" to link to new troubleshooting page

### DIFF
--- a/doc/source/user/setting-up.rst
+++ b/doc/source/user/setting-up.rst
@@ -7,3 +7,4 @@ Setting up
 
    whatisnumpy
    install
+   troubleshooting

--- a/doc/source/user/setting-up.rst
+++ b/doc/source/user/setting-up.rst
@@ -7,4 +7,4 @@ Setting up
 
    whatisnumpy
    install
-   troubleshooting
+   troubleshooting-importerror

--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -1,11 +1,11 @@
-***************
-Troubleshooting
-***************
+***************************
+Troubleshooting ImportError
+***************************
 
 .. note::
 
-    Since this information may be updated regularly, please refer to the
-    most up to date version in the development version of the documentation.
+    Since this information may be updated regularly, please ensure you are
+    viewing the most `up-to-date version <https://numpy.org/devdocs/user/troubleshooting-importerror.html>`_.
 
 
 ImportError

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -1,0 +1,126 @@
+***************
+Troubleshooting
+***************
+
+.. note::
+
+    Since this information may be updated regularly, please refer to the
+    most up to date version in the development version of the documentation.
+
+
+ImportError
+===========
+
+In certain cases a failed installation or setup issue can cause you to
+see the following error message::
+
+    IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
+
+    Importing the numpy c-extensions failed. This error can happen for
+    different reasons, often due to issues with your setup.
+
+The error has a few additional information to help you trouble shoot:
+
+* Your Python version
+* Your NumPy version
+
+Please check both of these carefully to see if they are what you expect.
+You may need to check your ``PATH`` or ``PYTHONPATH`` environment variables
+(see "Check Environment Variables" below).
+
+The following sections list commonly reported issues depending on your Setup.
+If you have an issue/solution that you think should appear please open a
+NumPy issue so that it will be added.
+
+There are a few commonly reported issues depending on your system/setup.
+If none of the following tips help you, please be sure to note the following:
+
+* how you installed Python
+* how you installed NumPy
+* your operating system
+* whether or not you have multiple versions of Python installed
+* if you built from source, your compiler versions and ideally a build log
+
+when investigating further and asking for support.
+
+
+Using Python from ``conda`` (Anaconda)
+--------------------------------------
+
+Please make sure that you have activated your conda environment.
+See also the `conda user-guide <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#activating-an-environment>`_.
+
+
+Using Anaconda/conda Python within PyCharm
+------------------------------------------
+
+There are fairly common issues when using PyCharm together with Anaconda,
+please see the `PyCharm support <https://www.jetbrains.com/help/pycharm/conda-support-creating-conda-virtual-environment.html>`_
+
+
+Raspberry Pi
+------------
+
+There are sometimes issues reported on Raspberry Pi setups when installing
+using ``pip3 install`` (or ``pip`` install). These will typically mention::
+
+    libf77blas.so.3: cannot open shared object file: No such file or directory
+
+
+The solution will be to either::
+
+    sudo apt-get install libatlas-base-dev
+
+to install the missing libraries expected by the self compiled NumPy
+(ATLAS is a possible provider of linear algebra).
+
+*Alternatively* use the NumPy provided by raspian. In which case run::
+
+    pip3 uninstall numpy  # remove previously installed version
+    apt install python3-numpy
+
+
+Debug build on Windows
+----------------------
+
+Rather than building your project in ``DEBUG`` mode on windows, try
+building in ``RELEASE`` mode with debug symbols and no optimization.
+Full ``DEBUG`` mode on windows changes the names of the DLLs python
+expects to find, so if you wish to truly work in ``DEBUG`` mode you will
+need to recompile the entire stack of python modules you work with
+including NumPy
+
+
+All Setups
+----------
+
+Occasionally there may be simple issues with old or bad installations
+of NumPy. In this case you may just try to uninstall and reinstall NumPy.
+Make sure that NumPy is not found after uninstalling.
+
+
+Development Setup
+-----------------
+
+If you are using a development setup, make sure to run ``git clean -xdf``
+to delete all files not under version control (be careful not to lose
+any modifications you made, e.g. ``site.cfg``).
+In many cases files from old builds may lead to incorrect builds.
+
+
+Check Environment Variables
+---------------------------
+
+In general how to set and check your environment variables depends on
+your system. If you can open a correct python shell, you can also run the
+following in python::
+
+    import os
+    PYTHONPATH = os.environ['PYTHONPATH'].split(os.pathsep)
+    print("The PYTHONPATH is:", PYTHONPATH)
+    PATH = os.environ['PATH'].split(os.pathsep)
+    print("The PATH is:", PATH)
+
+This may mainly help you if you are not running the python and/or NumPy
+version you are expecting to run.
+

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -19,16 +19,16 @@ see the following error message::
     Importing the numpy c-extensions failed. This error can happen for
     different reasons, often due to issues with your setup.
 
-The error has a few additional information to help you trouble shoot:
+The error also has additional information to help you troubleshoot:
 
 * Your Python version
 * Your NumPy version
 
 Please check both of these carefully to see if they are what you expect.
 You may need to check your ``PATH`` or ``PYTHONPATH`` environment variables
-(see "Check Environment Variables" below).
+(see `Check Environment Variables`_ below).
 
-The following sections list commonly reported issues depending on your Setup.
+The following sections list commonly reported issues depending on your setup.
 If you have an issue/solution that you think should appear please open a
 NumPy issue so that it will be added.
 
@@ -71,10 +71,10 @@ The solution will be to either::
 
     sudo apt-get install libatlas-base-dev
 
-to install the missing libraries expected by the self compiled NumPy
+to install the missing libraries expected by the self-compiled NumPy
 (ATLAS is a possible provider of linear algebra).
 
-*Alternatively* use the NumPy provided by raspian. In which case run::
+*Alternatively* use the NumPy provided by Raspbian. In which case run::
 
     pip3 uninstall numpy  # remove previously installed version
     apt install python3-numpy
@@ -123,4 +123,3 @@ following in python::
 
 This may mainly help you if you are not running the python and/or NumPy
 version you are expecting to run.
-

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -26,25 +26,21 @@ except ImportError as exc:
 
 IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
 
-Importing the numpy c-extensions failed.
-- Try uninstalling and reinstalling numpy.
-- If you have already done that, then:
-  1. Check that you expected to use Python%d.%d from "%s",
-     and that you have no directories in your PATH or PYTHONPATH that can
-     interfere with the Python and numpy version "%s" you're trying to use.
-  2. If (1) looks fine, you can open a new issue at
-     https://github.com/numpy/numpy/issues.  Please include details on:
-     - how you installed Python
-     - how you installed numpy
-     - your operating system
-     - whether or not you have multiple versions of Python installed
-     - if you built from source, your compiler versions and ideally a build log
+Importing the numpy C-extensions failed. This error can happen for
+many reasons, often due to issues with your setup or how NumPy was
+installed.
 
-- If you're working with a numpy git repository, try `git clean -xdf`
-  (removes all files not under version control) and rebuild numpy.
+We have compiled some common reasons and troubleshooting tips at:
 
-Note: this error has many possible causes, so please don't comment on
-an existing issue about this - open a new one instead.
+    https://numpy.org/devdocs/user/troubleshooting.html
+
+Please note and check the following:
+
+  * The Python version is: Python%d.%d from "%s"
+  * The NumPy version is: "%s"
+
+and make sure that they are the versions you expect.
+Please carefully study the above linked wiki page for further help.
 
 Original error was: %s
 """ % (sys.version_info[0], sys.version_info[1], sys.executable,

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -40,7 +40,7 @@ Please note and check the following:
   * The NumPy version is: "%s"
 
 and make sure that they are the versions you expect.
-Please carefully study the above linked wiki page for further help.
+Please carefully study the documentation linked above for further help.
 
 Original error was: %s
 """ % (sys.version_info[0], sys.version_info[1], sys.executable,

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -32,7 +32,7 @@ installed.
 
 We have compiled some common reasons and troubleshooting tips at:
 
-    https://numpy.org/devdocs/user/troubleshooting.html
+    https://numpy.org/devdocs/user/troubleshooting-importerror.html
 
 Please note and check the following:
 


### PR DESCRIPTION
This replaces the lengthy, but incomplete, text printed when NumPy fails to import with a link to a new troubleshooting section of the documents. That troubleshooting section can be updated as common problems are identified.