### PR TITLE
DOC: update first section of NEP 37 (``__array_function__`` downsides)

### DIFF
--- a/doc/neps/nep-0037-array-module.rst
+++ b/doc/neps/nep-0037-array-module.rst
@@ -13,8 +13,8 @@ Abstract
 --------
 
 NEP-18's ``__array_function__`` has been a mixed success. Some projects (e.g.,
-dask, CuPy, xarray, sparse, Pint) have enthusiastically adopted it. Others
-(e.g., PyTorch, JAX, SciPy) have been more reluctant. Here we propose a new
+dask, CuPy, xarray, sparse, Pint, MXNet) have enthusiastically adopted it.
+Others (e.g., JAX) have been more reluctant. Here we propose a new
 protocol, ``__array_module__``, that we expect could eventually subsume most
 use-cases for ``__array_function__``. The protocol requires explicit adoption
 by both users and library authors, which ensures backwards compatibility, and
@@ -26,32 +26,28 @@ Why ``__array_function__`` hasn't been enough
 
 There are two broad ways in which NEP-18 has fallen short of its goals:
 
-1. **Maintainability concerns**. `__array_function__` has significant
+1. **Backwards compatibility concerns**. `__array_function__` has significant
    implications for libraries that use it:
 
-   - Projects like `PyTorch
-     <https://github.com/pytorch/pytorch/issues/22402>`_, `JAX
-     <https://github.com/google/jax/issues/1565>`_ and even `scipy.sparse
-     <https://github.com/scipy/scipy/issues/10362>`_ have been reluctant to
-     implement `__array_function__` in part because they are concerned about
-     **breaking existing code**: users expect NumPy functions like
+   - `JAX <https://github.com/google/jax/issues/1565>`_ has been reluctant
+     to implement ``__array_function__`` in part because it is concerned about
+     breaking existing code: users expect NumPy functions like
      ``np.concatenate`` to return NumPy arrays. This is a fundamental
      limitation of the ``__array_function__`` design, which we chose to allow
      overriding the existing ``numpy`` namespace.
+
+     Note that projects like `PyTorch
+     <https://github.com/pytorch/pytorch/issues/22402>`_ and `scipy.sparse
+     <https://github.com/scipy/scipy/issues/10362>`_ have also not
+     adopted ``__array_function__`` yet, because they don't have a
+     NumPy-compatible API or semantics. In the case of PyTorch, that is likely
+     to be added in the future; ``scipy.sparse`` is in the same situation as
+     ``numpy.matrix``.*
    - ``__array_function__`` currently requires an "all or nothing" approach to
      implementing NumPy's API. There is no good pathway for **incremental
      adoption**, which is particularly problematic for established projects
      for which adopting ``__array_function__`` would result in breaking
      changes.
-   - It is no longer possible to use **aliases to NumPy functions** within
-     modules that support overrides. For example, both CuPy and JAX set
-     ``result_type = np.result_type``.
-   - Implementing **fall-back mechanisms** for unimplemented NumPy functions
-     by using NumPy's implementation is hard to get right (but see the
-     `version from dask <https://github.com/dask/dask/pull/5043>`_), because
-     ``__array_function__`` does not present a consistent interface.
-     Converting all arguments of array type requires recursing into generic
-     arguments of the form ``*args, **kwargs``.
 
 2. **Limitations on what can be overridden.** ``__array_function__`` has some
    important gaps, most notably array creation and coercion functions:
@@ -70,6 +66,19 @@ There are two broad ways in which NEP-18 has fallen short of its goals:
      <https://numpy.org/neps/nep-0030-duck-array-protocol.html>`_ proposal for
      a separate ``np.duckarray`` function, but this still does not resolve how
      to cast one duck array into a type matching another duck array.
+
+Other issues of lesser importance include:
+
+- It is no longer possible to use **aliases to NumPy functions** within
+  modules that support overrides. For example, both CuPy and JAX set
+  ``result_type = np.result_type`` and now have to wrap use of
+  ``np.result_type`` in their own ``result_type`` function instead.
+- Implementing **fall-back mechanisms** for unimplemented NumPy functions
+  by using NumPy's implementation is hard to get right (but see the
+  `version from dask <https://github.com/dask/dask/pull/5043>`_), because
+  ``__array_function__`` does not present a consistent interface.
+  Converting all arguments of array type requires recursing into generic
+  arguments of the form ``*args, **kwargs``.
 
 ``get_array_module`` and the ``__array_module__`` protocol
 ----------------------------------------------------------
@@ -505,6 +514,10 @@ operators in Python, but it has two downsides:
 In contrast, importing a new library (e.g., ``import  dask.array as da``) with
 an API matching NumPy is entirely explicit. There is no overhead from dispatch
 or ambiguity about which implementation is being used.
+*FIXME: the above statement on overhead doesn't seem completely true, given
+that there is no explicit import but rather a ``get_array_module(some_array)``
+call for every public method or function in the consuming library (e.g.
+Scikit-learn) which also needs to do type-checking.*
 
 Explicit and implicit choice of implementations are not mutually exclusive
 options. Indeed, most implementations of NumPy API overrides via


### PR DESCRIPTION
`[ci skip]`

Reflecting the discussion on the mailing list and trying to separate better the key issues (e.g. array creation, and JAX concern on backwards compat) from the less important stuff.

Also clarify the status of PyTorch and `scipy.sparse`, and added that MXNet adopted `__array_function__`.