### PR TITLE
DOC: initialise random number generator before first use in quickstart

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -347,7 +347,7 @@ existing array rather than create a new one.
 
 ::
 
-    >>> rg = np.random.default_rng(1)
+    >>> rg = np.random.default_rng(1)     # create instance of default random number generator
     >>> a = np.ones((2,3), dtype=int)
     >>> b = rg.random((2,3))
     >>> a *= 3
@@ -358,7 +358,7 @@ existing array rather than create a new one.
     >>> b
     array([[3.51182162, 3.9504637 , 3.14415961],
            [3.94864945, 3.31183145, 3.42332645]])
-    >>> a += b                  # b is not automatically converted to integer type
+    >>> a += b                            # b is not automatically converted to integer type
     Traceback (most recent call last):
         ...
     numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -348,6 +348,8 @@ existing array rather than create a new one.
 
 ::
 
+    >>> from numpy.random import default_rng
+    >>> rg = default_rng()
     >>> a = np.ones((2,3), dtype=int)
     >>> b = rg.random((2,3))
     >>> a *= 3

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -8,7 +8,6 @@ Quickstart tutorial
 
    >>> import numpy as np
    >>> import sys
-   >>> rg = np.random.default_rng(1)
 
 Prerequisites
 =============
@@ -348,8 +347,7 @@ existing array rather than create a new one.
 
 ::
 
-    >>> from numpy.random import default_rng
-    >>> rg = default_rng()
+    >>> rg = np.random.default_rng(1)
     >>> a = np.ones((2,3), dtype=int)
     >>> b = rg.random((2,3))
     >>> a *= 3


### PR DESCRIPTION
numpy's random number generator is used at several places in the quickstart
but a new user, like me, won't know how to initialise it. Therefore I
recommend adding this at the first place rg is used.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
