### PR TITLE
DOC: Add missing bracket

### DIFF
--- a/doc/DISTUTILS.rst.txt
+++ b/doc/DISTUTILS.rst.txt
@@ -345,7 +345,7 @@ expression, '<...>' will be replaced first with item1, and then with
 item2, and so forth until N repeats are accomplished. Once a named
 repeat specification has been introduced, the same repeat rule may be
 used **in the current block** by referring only to the name
-(i.e. <rule1>.
+(i.e. <rule1>).
 
 
 Short repeat rule

--- a/doc/DISTUTILS.rst.txt
+++ b/doc/DISTUTILS.rst.txt
@@ -345,7 +345,7 @@ expression, '<...>' will be replaced first with item1, and then with
 item2, and so forth until N repeats are accomplished. Once a named
 repeat specification has been introduced, the same repeat rule may be
 used **in the current block** by referring only to the name
-(i.e. <rule1>).
+(i.e. <rule1>.
 
 
 Short repeat rule

--- a/doc/neps/nep-0010-new-iterator-ufunc.rst
+++ b/doc/neps/nep-0010-new-iterator-ufunc.rst
@@ -1291,7 +1291,7 @@ Construction and Destruction
 
     Returns ``NPY_SUCCEED`` or ``NPY_FAIL``.
 
-``int NpyIter_HasInnerLoop(NpyIter *iter``
+``int NpyIter_HasInnerLoop(NpyIter *iter)``
 
     Returns 1 if the iterator handles the inner loop,
     or 0 if the caller needs to handle it.  This is controlled

--- a/doc/neps/nep-0012-missing-data.rst
+++ b/doc/neps/nep-0012-missing-data.rst
@@ -313,7 +313,7 @@ The following works in the current draft implementation::
 For floating point numbers, Inf and NaN are separate concepts from
 missing values. If a division by zero occurs in an array with default
 missing value support, an unmasked Inf or NaN will be produced. To
-mask those values, a further 'a[np.logical_not(a.isfinite(a)] = np.NA'
+mask those values, a further 'a[np.logical_not(a.isfinite(a))] = np.NA'
 can achieve that. For the bitpattern approach, the parameterized
 dtype('NA[f8,InfNan]') described in a later section can be used to get
 these semantics without the extra manipulation.

--- a/doc/neps/nep-0028-website-redesign.rst
+++ b/doc/neps/nep-0028-website-redesign.rst
@@ -131,7 +131,7 @@ Possible options for static site generators
    Unlike the previous options, Docusaurus doesn't come with themes, and thus we
    would not want to use this for our landing page. This is an excellent docs
    option written in React. Docusaurus natively has support for i18n (via
-   Crowdin_, document versioning, and document search.
+   Crowdin_), document versioning, and document search.
 
 Both Jekyll and Hugo are excellent options that should be supported into the
 future and are good choices for NumPy. Docusaurus has several bonus features

--- a/doc/neps/scope.rst
+++ b/doc/neps/scope.rst
@@ -35,7 +35,7 @@ Here, we describe aspects of N-d array computation that are within scope for Num
 
 - NumPy provides some **infrastructure for other packages in the scientific Python ecosystem**:
 
-  - numpy.distutils (build support for C++, Fortran, BLAS/LAPACK, and other relevant libraries for scientific computing
+  - numpy.distutils (build support for C++, Fortran, BLAS/LAPACK, and other relevant libraries for scientific computing)
   - f2py (generating bindings for Fortran code)
   - testing utilities
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -84,7 +84,7 @@ Here's the short summary, complete TOC links are below:
 
    * Enter your GitHub username and password (repeat contributors or advanced
      users can remove this step by connecting to GitHub with
-     :ref:`SSH<set-up-and-configure-a-github-account>` .
+     :ref:`SSH<set-up-and-configure-a-github-account>`).
 
    * Go to GitHub. The new branch will show up with a green Pull Request
      button. Make sure the title and message are clear, concise, and self-

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3026,7 +3026,7 @@ Other conversions
 
     .. code-block:: c
 
-        #define error_converting(x) (((x) == -1) && PyErr_Occurred()
+        #define error_converting(x) (((x) == -1) && PyErr_Occurred())
 
 .. c:function:: npy_intp PyArray_PyIntAsIntp(PyObject* op)
 

--- a/doc/source/user/tutorial-svd.rst
+++ b/doc/source/user/tutorial-svd.rst
@@ -455,7 +455,7 @@ and
     :include-source: 0
     
 should give you an image indistinguishable from the original one (although we
-may introduce floating point errors for this reconstruction. In fact, 
+may introduce floating point errors for this reconstruction). In fact, 
 you might see a warning message saying `"Clipping input data to the
 valid range for imshow with RGB data ([0..1] for floats or [0..255] for
 integers)."` This is expected from the manipulation we just did on the original

--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -214,7 +214,7 @@ PyArray_DiscardWritebackIfCopy(PyArrayObject *arr)
 /*
    Check to see if this key in the dictionary is the "title"
    entry of the tuple (i.e. a duplicate dictionary entry in the fields
-   dict.
+   dict).
 */
 
 static NPY_INLINE int

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -638,7 +638,7 @@ npy_bswap8_unaligned(char * x)
  *
  * Here is example code for a single array:
  *
- *      if (PyArray_TRIVIALLY_ITERABLE(self) {
+ *      if (PyArray_TRIVIALLY_ITERABLE(self)) {
  *          char *data;
  *          npy_intp count, stride;
  *
@@ -656,7 +656,7 @@ npy_bswap8_unaligned(char * x)
  *
  * Here is example code for a pair of arrays:
  *
- *      if (PyArray_TRIVIALLY_ITERABLE_PAIR(a1, a2) {
+ *      if (PyArray_TRIVIALLY_ITERABLE_PAIR(a1, a2)) {
  *          char *data1, *data2;
  *          npy_intp count, stride1, stride2;
  *

--- a/numpy/core/src/common/numpyos.c
+++ b/numpy/core/src/common/numpyos.c
@@ -248,7 +248,7 @@ check_ascii_format(const char *format)
  * Fix the generated string: make sure the decimal is ., that exponent has a
  * minimal number of digits, and that it has a decimal + one digit after that
  * decimal if decimal argument != 0 (Same effect that 'Z' format in
- * PyOS_ascii_formatd
+ * PyOS_ascii_formatd)
  */
 static char*
 fix_ascii_format(char* buf, size_t buflen, int decimal)

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2926,7 +2926,7 @@ PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
 
     /*
      * The first nop strides are for the inner loop (but only can
-     * copy them after removing the core axes
+     * copy them after removing the core axes)
      */
     memcpy(inner_strides, NpyIter_GetInnerStrideArray(iter),
                                     NPY_SIZEOF_INTP * nop);

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -159,7 +159,7 @@ Glossary
 
    field
        In a :term:`structured data type`, each sub-type is called a `field`.
-       The `field` has a name (a string), a type (any valid dtype, and
+       The `field` has a name (a string), a type (any valid dtype), and
        an optional `title`. See :ref:`arrays.dtypes`
 
    Fortran order

--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -72,7 +72,7 @@ class, that points to the data in the original.
 There are other points in the use of ndarrays where we need such views,
 such as copying arrays (``c_arr.copy()``), creating ufunc output arrays
 (see also :ref:`array-wrap`), and reducing methods (like
-``c_arr.mean()``.
+``c_arr.mean()``).
 
 Relationship of view casting and new-from-template
 --------------------------------------------------

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -524,8 +524,8 @@ def hfft(a, n=None, axis=-1, norm=None):
     domain and is real in the frequency domain. So here it's `hfft` for
     which you must supply the length of the result if it is to be odd.
 
-    * even: ``ihfft(hfft(a, 2*len(a) - 2) == a``, within roundoff error,
-    * odd: ``ihfft(hfft(a, 2*len(a) - 1) == a``, within roundoff error.
+    * even: ``ihfft(hfft(a, 2*len(a) - 2)) == a``, within roundoff error,
+    * odd: ``ihfft(hfft(a, 2*len(a) - 1)) == a``, within roundoff error.
 
     The correct interpretation of the hermitian input depends on the length of
     the original data, as given by `n`. This is because each input shape could
@@ -604,8 +604,8 @@ def ihfft(a, n=None, axis=-1, norm=None):
     domain and is real in the frequency domain. So here it's `hfft` for
     which you must supply the length of the result if it is to be odd:
 
-    * even: ``ihfft(hfft(a, 2*len(a) - 2) == a``, within roundoff error,
-    * odd: ``ihfft(hfft(a, 2*len(a) - 1) == a``, within roundoff error.
+    * even: ``ihfft(hfft(a, 2*len(a) - 2)) == a``, within roundoff error,
+    * odd: ``ihfft(hfft(a, 2*len(a) - 1)) == a``, within roundoff error.
 
     Examples
     --------

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1644,7 +1644,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     -----
     * When spaces are used as delimiters, or when no delimiter has been given
       as input, there should not be any missing data between two fields.
-    * When the variables are named (either by a flexible dtype or with `names`,
+    * When the variables are named (either by a flexible dtype or with `names`),
       there must not be any header in the file (else a ValueError
       exception is raised).
     * Individual values are not stripped of spaces by default.

--- a/numpy/linalg/lapack_lite/f2c_c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_c_lapack.c
@@ -12813,7 +12813,7 @@ L330:
 
     RWORK  (workspace) REAL array, dimension at least
            (9*N + 2*N*SMLSIZ + 8*N*NLVL + 3*SMLSIZ*NRHS +
-           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS ),
+           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS )),
            where
            NLVL = MAX( 0, INT( LOG_2( MIN( M,N )/(SMLSIZ+1) ) ) + 1 )
 

--- a/numpy/linalg/lapack_lite/f2c_c_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_c_lapack.c
@@ -12813,7 +12813,7 @@ L330:
 
     RWORK  (workspace) REAL array, dimension at least
            (9*N + 2*N*SMLSIZ + 8*N*NLVL + 3*SMLSIZ*NRHS +
-           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS )),
+           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS ),
            where
            NLVL = MAX( 0, INT( LOG_2( MIN( M,N )/(SMLSIZ+1) ) ) + 1 )
 

--- a/numpy/linalg/lapack_lite/f2c_z_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_z_lapack.c
@@ -12881,7 +12881,7 @@ L330:
 
     RWORK  (workspace) DOUBLE PRECISION array, dimension at least
            (9*N + 2*N*SMLSIZ + 8*N*NLVL + 3*SMLSIZ*NRHS +
-           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS ),
+           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS )),
            where
            NLVL = MAX( 0, INT( LOG_2( MIN( M,N )/(SMLSIZ+1) ) ) + 1 )
 

--- a/numpy/linalg/lapack_lite/f2c_z_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_z_lapack.c
@@ -12881,7 +12881,7 @@ L330:
 
     RWORK  (workspace) DOUBLE PRECISION array, dimension at least
            (9*N + 2*N*SMLSIZ + 8*N*NLVL + 3*SMLSIZ*NRHS +
-           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS )),
+           MAX( (SMLSIZ+1)**2, N*(1+NRHS) + 2*NRHS ),
            where
            NLVL = MAX( 0, INT( LOG_2( MIN( M,N )/(SMLSIZ+1) ) ) + 1 )
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -811,7 +811,7 @@ def compress_nd(x, axis=None):
     ----------
     x : array_like, MaskedArray
         The array to operate on. If not a MaskedArray instance (or if no array
-        elements are masked, `x` is interpreted as a MaskedArray with `mask`
+        elements are masked), `x` is interpreted as a MaskedArray with `mask`
         set to `nomask`.
     axis : tuple of ints or int, optional
         Which dimensions to suppress slices from can be configured with this

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -802,7 +802,7 @@ class matrix(N.ndarray):
         -------
         ret : matrix object
             If `self` is non-singular, `ret` is such that ``ret * self`` ==
-            ``self * ret`` == ``np.matrix(np.eye(self[0,:].size)`` all return
+            ``self * ret`` == ``np.matrix(np.eye(self[0,:].size))`` all return
             ``True``.
 
         Raises

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1471,7 +1471,7 @@ def chebvander2d(x, y, deg):
     -------
     vander2d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)`.  The dtype will be the same
+        :math:`order = (deg[0]+1)*(deg[1]+1)`.  The dtype will be the same
         as the converted `x` and `y`.
 
     See Also
@@ -1525,7 +1525,7 @@ def chebvander3d(x, y, z, deg):
     -------
     vander3d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)*(deg[2]+1)`.  The dtype will
+        :math:`order = (deg[0]+1)*(deg[1]+1)*(deg[2]+1)`.  The dtype will
         be the same as the converted `x`, `y`, and `z`.
 
     See Also

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1194,7 +1194,7 @@ def hermvander2d(x, y, deg):
     -------
     vander2d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)`.  The dtype will be the same
+        :math:`order = (deg[0]+1)*(deg[1]+1)`.  The dtype will be the same
         as the converted `x` and `y`.
 
     See Also
@@ -1248,7 +1248,7 @@ def hermvander3d(x, y, z, deg):
     -------
     vander3d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)*(deg[2]+1)`.  The dtype will
+        :math:`order = (deg[0]+1)*(deg[1]+1)*(deg[2]+1)`.  The dtype will
         be the same as the converted `x`, `y`, and `z`.
 
     See Also
@@ -1369,8 +1369,8 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
 
     Fits using Hermite series are probably most useful when the data can be
     approximated by ``sqrt(w(x)) * p(x)``, where `w(x)` is the Hermite
-    weight. In that case the weight ``sqrt(w(x[i])`` should be used
-    together with data values ``y[i]/sqrt(w(x[i])``. The weight function is
+    weight. In that case the weight ``sqrt(w(x[i]))`` should be used
+    together with data values ``y[i]/sqrt(w(x[i]))``. The weight function is
     available as `hermweight`.
 
     References

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1187,7 +1187,7 @@ def hermevander2d(x, y, deg):
     -------
     vander2d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)`.  The dtype will be the same
+        :math:`order = (deg[0]+1)*(deg[1]+1)`.  The dtype will be the same
         as the converted `x` and `y`.
 
     See Also
@@ -1241,7 +1241,7 @@ def hermevander3d(x, y, z, deg):
     -------
     vander3d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)*(deg[2]+1)`.  The dtype will
+        :math:`order = (deg[0]+1)*(deg[1]+1)*(deg[2]+1)`.  The dtype will
         be the same as the converted `x`, `y`, and `z`.
 
     See Also
@@ -1362,8 +1362,8 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
 
     Fits using HermiteE series are probably most useful when the data can
     be approximated by ``sqrt(w(x)) * p(x)``, where `w(x)` is the HermiteE
-    weight. In that case the weight ``sqrt(w(x[i])`` should be used
-    together with data values ``y[i]/sqrt(w(x[i])``. The weight function is
+    weight. In that case the weight ``sqrt(w(x[i]))`` should be used
+    together with data values ``y[i]/sqrt(w(x[i]))``. The weight function is
     available as `hermeweight`.
 
     References

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1194,7 +1194,7 @@ def lagvander2d(x, y, deg):
     -------
     vander2d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)`.  The dtype will be the same
+        :math:`order = (deg[0]+1)*(deg[1]+1)`.  The dtype will be the same
         as the converted `x` and `y`.
 
     See Also
@@ -1248,7 +1248,7 @@ def lagvander3d(x, y, z, deg):
     -------
     vander3d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)*(deg[2]+1)`.  The dtype will
+        :math:`order = (deg[0]+1)*(deg[1]+1)*(deg[2]+1)`.  The dtype will
         be the same as the converted `x`, `y`, and `z`.
 
     See Also
@@ -1369,8 +1369,8 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
 
     Fits using Laguerre series are probably most useful when the data can
     be approximated by ``sqrt(w(x)) * p(x)``, where `w(x)` is the Laguerre
-    weight. In that case the weight ``sqrt(w(x[i])`` should be used
-    together with data values ``y[i]/sqrt(w(x[i])``. The weight function is
+    weight. In that case the weight ``sqrt(w(x[i]))`` should be used
+    together with data values ``y[i]/sqrt(w(x[i]))``. The weight function is
     available as `lagweight`.
 
     References

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1211,7 +1211,7 @@ def legvander2d(x, y, deg):
     -------
     vander2d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)`.  The dtype will be the same
+        :math:`order = (deg[0]+1)*(deg[1]+1)`.  The dtype will be the same
         as the converted `x` and `y`.
 
     See Also
@@ -1265,7 +1265,7 @@ def legvander3d(x, y, z, deg):
     -------
     vander3d : ndarray
         The shape of the returned matrix is ``x.shape + (order,)``, where
-        :math:`order = (deg[0]+1)*(deg([1]+1)*(deg[2]+1)`.  The dtype will
+        :math:`order = (deg[0]+1)*(deg[1]+1)*(deg[2]+1)`.  The dtype will
         be the same as the converted `x`, `y`, and `z`.
 
     See Also

--- a/numpy/testing/_private/noseclasses.py
+++ b/numpy/testing/_private/noseclasses.py
@@ -210,7 +210,7 @@ class NumpyDoctest(npd.Doctest):
         # starting Python and executing "import numpy as np", and,
         # for SciPy packages, an additional import of the local
         # package (so that scipy.linalg.basic.py's doctests have an
-        # implicit "from scipy import linalg" as well.
+        # implicit "from scipy import linalg" as well).
         #
         # Note: __file__ allows the doctest in NoseTester to run
         # without producing an error

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1620,7 +1620,7 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
     -----
     For computing the ULP difference, this API does not differentiate between
     various representations of NAN (ULP difference between 0x7fc00000 and 0xffc00000
-    is zero.
+    is zero).
 
     See Also
     --------
@@ -1666,7 +1666,7 @@ def nulp_diff(x, y, dtype=None):
     -----
     For computing the ULP difference, this API does not differentiate between
     various representations of NAN (ULP difference between 0x7fc00000 and 0xffc00000
-    is zero.
+    is zero).
 
     Examples
     --------


### PR DESCRIPTION
I noticed that the close parenthesis was missing in a lot of places, which generate:
- example cases that could not be run.
- misleading document.
so I write a script to auto-detect missing bracket:
```
import os

class Stack(object):
    def __init__(self):
        self.stack=[]
    def isEmpty(self):
        return self.stack==[]
    def push(self,item):
        self.stack.append(item)
    def pop(self):
        if self.isEmpty():
            raise IndexError
        return self.stack.pop()
    def peek(self):
        return self.stack[-1]
    def size(self):
        return len(self.stack)

def scanSingleFile(filePath):
    with open(filePath, 'r', encoding ='utf-8') as f:
        contents = f.readlines()
        count = 1
        stack=Stack()
        for line in contents:
            for ch in line:
                if ch == '(':
                    stack.push(count)
                elif ch == ')':
                    if not stack.isEmpty():
                        stack.pop()
            count+=1
        if not stack.isEmpty():
            formatPath = filePath.replace(r'\/'.replace(os.sep,''), os.sep)
        while not stack.isEmpty():
            print(formatPath+":"+str(stack.pop()))

def scanMissingBracket(scanpath):
    for root, dirs, files in os.walk(scanpath):
        for file in files:
            filePath = os.path.join(root,file)
            if os.path.splitext(filePath)[1] in ['.py','.c','.h','.rst','.txt']:
                scanSingleFile(filePath)

if __name__ == "__main__":
    scanMissingBracket("./numpy")
```
All of the results has been carefully filtered. but only `numpy` directory is scanned, should I scan the `doc `directory too?