### PR TITLE
DOC, BLD: update release howto and walkthrough for ananconda.org storage

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -1,4 +1,4 @@
-This file gives an overview of what is necessary to build binary releases forattr(cf.name()) = cf;
+This file gives an overview of what is necessary to build binary releases for
 NumPy.
 
 Current build and release info
@@ -362,13 +362,17 @@ In that repository edit the files:
 - ``azure/windows.yml``.
 
 In both cases, set the ``BUILD_COMMIT`` variable to the current release tag -
-e.g. ``v1.19.0``.
+e.g. ``v1.19.0``::
+
+    $ gvim azure/posix.yml azure/windows.yml
+    $ git commit -a
+    $ git push upstream HEAD
 
 Make sure that the release tag has been pushed.
 
 Trigger a build by pushing a commit of your edits to the repository. Note that
-you can do this on a branch, but it must be pushed to the
-``MacPython/numpy-wheels`` repository before the uploads will happen since only
+you can do this on a branch, but it must be pushed upstream to the
+``MacPython/numpy-wheels`` repository to trigger uploads since only
 that repo has the appropriate tokens to allow uploads.
 
 The wheels, once built, appear at https://anaconda.org/multibuild-wheels-staging/numpy

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -1,4 +1,4 @@
-This file gives an overview of what is necessary to build binary releases for
+This file gives an overview of what is necessary to build binary releases forattr(cf.name()) = cf;
 NumPy.
 
 Current build and release info
@@ -352,36 +352,26 @@ Also create a new version hash in cversions.txt and a corresponding version
 define NPY_x_y_API_VERSION in numpyconfig.h
 
 
-Trigger the wheel builds on travis-ci and Appveyor
---------------------------------------------------
-See the `numpy wheels` repository.
+Trigger the wheel builds
+------------------------
+See the `MacPython/numpy wheels` repository.
 
 In that repository edit the files:
 
-- ``.travis.yml``;
-- ``appveyor.yml``.
+- ``azure/posix.yml``
+- ``azure/windows.yml``.
 
 In both cases, set the ``BUILD_COMMIT`` variable to the current release tag -
-e.g. ``v1.11.1``.
+e.g. ``v1.19.0``.
 
 Make sure that the release tag has been pushed.
 
-Trigger a build by doing a commit of your edits to ``.travis.yml`` and
-``appveyor.yml`` to the repository::
+Trigger a build by pushing a commit of your edits to the repository. Note that
+you can do this on a branch, but it must be pushed to the
+``MacPython/numpy-wheels`` repository before the uploads will happen since only
+that repo has the appropriate tokens to allow uploads.
 
-    cd /path/to/numpy-wheels
-    # Edit .travis.yml, appveyor.yml
-    git commit
-    git push
-
-The wheels, once built, appear at a Rackspace container pointed at by:
-
-- http://wheels.scipy.org
-- https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com
-
-The HTTP address may update first, and you should wait 15 minutes after the
-build finishes before fetching the binaries.
-
+The wheels, once built, appear at https://anaconda.org/multibuild-wheels-staging/numpy
 
 Make the release
 ----------------
@@ -423,7 +413,7 @@ https://github.com/MacPython/terryfy.  Here is the recommended incantation for
 downloading all the Windows, Manylinux, OSX wheels and uploading to PyPI. ::
 
     NPY_WHLS=~/wheelhouse   # local directory to cache wheel downloads
-    CDN_URL=https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com
+    CDN_URL=https://anaconda.org/multibuild-wheels-staging/numpy/files
     wheel-uploader -u $CDN_URL -w $NPY_WHLS -v -s -t win numpy 1.11.1rc1
     wheel-uploader -u $CDN_URL -w warehouse -v -s -t macosx numpy 1.11.1rc1
     wheel-uploader -u $CDN_URL -w warehouse -v -s -t manylinux1 numpy 1.11.1rc1

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -110,8 +110,6 @@ created above for ``BUILD_COMMIT``, see an _example::
     $ git commit -a
     $ git push upstream HEAD
 
-Push and, if you are on a fork of the repo, merge the branch.
-
 Now wait. If you get nervous at the amount of time taken -- the builds can take
 a while -- you can check the build progress by following the links
 provided at `<https://github.com/MacPython/numpy-wheels>`_ to check the 

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -1,4 +1,5 @@
-This file contains a walkthrough of the NumPy 1.14.5 release on Linux.
+This file contains a walkthrough of the NumPy 1.14.5 release on Linux, modified
+for building on azure and uploading to anaconda.org
 The commands can be copied into the command line, but be sure to
 replace 1.14.5 by the correct version.
 
@@ -92,7 +93,7 @@ Build wheels
 ------------
 
 Trigger the wheels build by pointing the numpy-wheels repository at this
-commit. The numpy-wheels repository is cloned from
+commit. This can take up to an hour. The numpy-wheels repository is cloned from
 `<https://github.com/MacPython/numpy-wheels>`_. Start with a pull as the repo
 may have been accessed and changed by someone else and a push will fail::
 
@@ -103,13 +104,27 @@ may have been accessed and changed by someone else and a push will fail::
 
 Edit the ``azure/posix.yml`` and ``azure/windows.yml`` files to make sure they
 have the correct version, and put in the commit hash for the ``REL`` commit
-created above for ``BUILD_COMMIT``. Push and, if you are on a fork of the repo,
-merge the branch.
+created above for ``BUILD_COMMIT``, see an _example::
 
-Check if all the needed wheels have been built and
-uploaded before proceeding. There should currently be 22 of them at
-`<https://anaconda.org/multibuild-wheels-staging/numpy>`_, 4 for Mac, 8 for
-Windows, and 10 for Linux.  Note that sometimes builds, like tests, fail for
+    $ gvim azure/posix.yml azure/windows.yml
+    $ git commit -a
+    $ git push upstream HEAD
+
+Push and, if you are on a fork of the repo, merge the branch.
+
+Now wait. If you get nervous at the amount of time taken -- the builds can take
+a while -- you can check the build progress by following the links
+provided at `<https://github.com/MacPython/numpy-wheels>`_ to check the 
+build status. Check if all the needed wheels have been built and
+uploaded before proceeding. There should currently be 21 of them at
+`<https://anaconda.org/multibuild-wheels-staging/numpy/files>`_, 3 for Mac, 6
+for Windows, and 12 for Linux.
+Note that sometimes builds, like tests, fail for unrelated reasons and you will
+need to restart them.
+
+.. example_: https://github.com/MacPython/numpy-wheels/pull/80/commits/cbf4af4
+
+Note that sometimes builds, like tests, fail for
 unrelated reasons and you will need to restart them.
 
 Download wheels

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -117,13 +117,11 @@ build status. Check if all the needed wheels have been built and
 uploaded before proceeding. There should currently be 21 of them at
 `<https://anaconda.org/multibuild-wheels-staging/numpy/files>`_, 3 for Mac, 6
 for Windows, and 12 for Linux.
-Note that sometimes builds, like tests, fail for unrelated reasons and you will
-need to restart them.
 
 .. example_: https://github.com/MacPython/numpy-wheels/pull/80/commits/cbf4af4
 
-Note that sometimes builds, like tests, fail for
-unrelated reasons and you will need to restart them.
+Note that sometimes builds, like tests, fail for unrelated reasons and
+you will need to restart them.
 
 Download wheels
 ---------------

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -2,6 +2,8 @@ This file contains a walkthrough of the NumPy 1.14.5 release on Linux.
 The commands can be copied into the command line, but be sure to
 replace 1.14.5 by the correct version.
 
+This should be read together with the general directions in `releasing`.
+
 
 Release  Walkthrough
 ====================
@@ -90,7 +92,7 @@ Build wheels
 ------------
 
 Trigger the wheels build by pointing the numpy-wheels repository at this
-commit. This can take a while. The numpy-wheels repository is cloned from
+commit. The numpy-wheels repository is cloned from
 `<https://github.com/MacPython/numpy-wheels>`_. Start with a pull as the repo
 may have been accessed and changed by someone else and a push will fail::
 
@@ -99,25 +101,16 @@ may have been accessed and changed by someone else and a push will fail::
     $ git branch <new version>  # only when starting new numpy version
     $ git checkout v1.14.x  # v1.14.x already existed for the 1.14.4 release
 
-Edit the ``.travis.yml`` and ``.appveyor.yml`` files to make sure they have the
-correct version, and put in the commit hash for the ``REL`` commit created
-above for ``BUILD_COMMIT``, see the _example from `v1.14.3`::
+Edit the ``azure/posix.yml`` and ``azure/windows.yml`` files to make sure they
+have the correct version, and put in the commit hash for the ``REL`` commit
+created above for ``BUILD_COMMIT``. Push and, if you are on a fork of the repo,
+merge the branch.
 
-    $ gvim .travis.yml .appveyor.yml
-    $ git commit -a
-    $ git push upstream HEAD
-
-Now wait. If you get nervous at the amount of time taken -- the builds can take
-several hours-- you can check the build progress by following the links
-provided at `<https://github.com/MacPython/numpy-wheels>`_ to check the travis
-and appveyor build status. Check if all the needed wheels have been built and
+Check if all the needed wheels have been built and
 uploaded before proceeding. There should currently be 22 of them at
-`<https://wheels.scipy.org>`_, 4 for Mac, 8 for Windows, and 10 for Linux.
-Note that sometimes builds, like tests, fail for unrelated reasons and you will
-need to restart them.
-
-.. example_: https://github.com/MacPython/numpy-wheels/commit/fed9c04629c155e7804282eb803d81097244598d
-
+`<https://anaconda.org/multibuild-wheels-staging/numpy>`_, 4 for Mac, 8 for
+Windows, and 10 for Linux.  Note that sometimes builds, like tests, fail for
+unrelated reasons and you will need to restart them.
 
 Download wheels
 ---------------
@@ -131,7 +124,7 @@ upload later using ``twine``::
 
     $ cd ../terryfy
     $ git pull upstream master
-    $ CDN_URL=https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com
+    $ CDN_URL=https://anaconda.org/multibuild-wheels-staging/numpy/files
     $ NPY_WHLS=../numpy/release/installers
     $ ./wheel-uploader -u $CDN_URL -n -v -w $NPY_WHLS -t win numpy 1.14.5
     $ ./wheel-uploader -u $CDN_URL -n -v -w $NPY_WHLS -t manylinux1 numpy 1.14.5


### PR DESCRIPTION
xref MacPython/numpy-wheels#78 which changed the upload to https://anaconda.org/multibuild-wheels-staging for releases.