### PR TITLE
BLD: add i686 for 1.18 builds

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -33,7 +33,7 @@ def get_arch():
         ret = 'arm';
     elif 'aarch64' in os.uname()[-1]:
         ret = 'arm';
-    elif 'x86' in os.uname()[-1]:
+    elif 'x86' in os.uname()[-1] or os.uname()[-1] == 'i686':
         ret = 'x86'
     elif 'ppc64' in os.uname()[-1]:
         ret = 'ppc64'


### PR DESCRIPTION
Add `i686` as a valid uname for openblas architecture determination. Should fix the failing 1.18 builds on MacPython/numpy-wheels. This has already been fixed with a major refactor of this file on master.