### PR TITLE
BUG: Fix string to bool cast regression

### DIFF
--- a/doc/release/upcoming_changes/16068.compatibility.rst
+++ b/doc/release/upcoming_changes/16068.compatibility.rst
@@ -1,0 +1,11 @@
+C-Level string to datetime casts changed
+----------------------------------------
+The C-level casts from strings were simplified. This changed
+also fixes string to datetime and timedelta casts to behave
+correctly (i.e. like Python casts using ``string_arr.astype("M8")``
+while previously the cast would behave like
+``string_arr.astype(np.int_).astype("M8")``.
+This only affects code using low-level C-API to do manual casts
+(not full array casts) of single scalar values or using e.g.
+``PyArray_GetCastFunc``, and should thus not affect the vast majority
+of users.

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1489,6 +1489,7 @@ OBJECT_to_@TOTYPE@(void *input, void *output, npy_intp n,
  *
  * #from = STRING*23, UNICODE*23, VOID*23#
  * #fromtyp = npy_char*69#
+ * #is_string_to_bool = 1, 0*22, 1, 0*22, 0*23#
  * #to = (BOOL,
  *           BYTE, UBYTE, SHORT, USHORT, INT, UINT,
  *           LONG, ULONG, LONGLONG, ULONGLONG,
@@ -1525,6 +1526,13 @@ static void
         if (temp == NULL) {
             return;
         }
+#if @is_string_to_bool@
+        /* Legacy behaviour converts strings to integers before going to bool */
+        Py_SETREF(temp, PyNumber_Long(temp));
+        if (temp == NULL) {
+            return;
+        }
+#endif
         if (@to@_setitem(temp, op, aop)) {
             Py_DECREF(temp);
             return;

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -278,6 +278,34 @@ def test_array_astype_warning(t):
     a = np.array(10, dtype=np.complex_)
     assert_warns(np.ComplexWarning, a.astype, t)
 
+@pytest.mark.parametrize(["dtype", "out_dtype"],
+        [(np.bytes_, np.bool_),
+         (np.unicode, np.bool_),
+         (np.dtype("S10,S9"), np.dtype("?,?"))])
+def test_string_to_boolean_cast(dtype, out_dtype):
+    """
+    Currently, for `astype` strings are cast to booleans effectively by
+    calling `bool(int(string)`. This is not consistent (see gh-9875) and
+    will eventually be deprecated.
+    """
+    arr = np.array(["10", "10\0\0\0", "0\0\0", "0"], dtype=dtype)
+    expected = np.array([True, True, False, False], dtype=out_dtype)
+    assert_array_equal(arr.astype(out_dtype), expected)
+
+@pytest.mark.parametrize(["dtype", "out_dtype"],
+        [(np.bytes_, np.bool_),
+         (np.unicode, np.bool_),
+         (np.dtype("S10,S9"), np.dtype("?,?"))])
+def test_string_to_boolean_cast_errors(dtype, out_dtype):
+    """
+    These currently error out, since cast to integers fails, but should not
+    error out in the future.
+    """
+    for invalid in ["False", "True", "", "\0", "non-empty"]:
+        arr = np.array([invalid], dtype=dtype)
+        with assert_raises(ValueError):
+            arr.astype(out_dtype)
+
 def test_copyto_fromscalar():
     a = np.arange(6, dtype='f4').reshape(2, 3)
 


### PR DESCRIPTION
While the legacy behaviour of casting strings to booleans by
first converting the string to an integer is undersireable in
general. It will require a Deprecation/FutureWarning to do the
transition.
Changing this accidentally was thus a regression.

Closes gh-16023