### PR TITLE
BUG: Create polynomial instance from existing polynomial instance

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -261,8 +261,16 @@ class ABCPolyBase(abc.ABC):
         return other
 
     def __init__(self, coef, domain=None, window=None):
-        [coef] = pu.as_series([coef], trim=False)
-        self.coef = coef
+        if isinstance(coef, ABCPolyBase):
+            self.__setstate__(coef.__getstate__())
+            if self.__class__ is not coef.__class__:
+                raise TypeError(
+                    f'To create an instance of {self.__class__} from {coef}, '
+                    f'please see the convert method'
+                )
+        else:
+            [coef] = pu.as_series([coef], trim=False)
+            self.coef = coef
 
         if domain is not None:
             [domain] = pu.as_series([domain], trim=False)

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -14,6 +14,7 @@ from numpy.testing import (
     assert_almost_equal, assert_raises, assert_equal, assert_,
     )
 from numpy.polynomial.polyutils import RankWarning
+from numpy.polynomial._polybase import ABCPolyBase
 
 #
 # fixtures
@@ -598,3 +599,31 @@ class TestInterpolate:
             for t in range(0, deg + 1):
                 p = Chebyshev.interpolate(powx, deg, domain=[0, 2], args=(t,))
                 assert_almost_equal(p(x), powx(x, t), decimal=12)
+
+
+#
+# Test constructing polynomial instances from other polynomials
+#
+
+
+class TestInitFromPoly:
+    p = Polynomial([1, 2, 3]) 
+
+    def test_coef_not_poly_instance(self):
+        p2 = Polynomial(self.p)
+        assert_(not isinstance(p2.coef[0], ABCPolyBase))
+
+    def test_new_domain(self):
+        new_domain = np.array([-2, 2])
+        p2 = Polynomial(self.p, domain=new_domain)
+        assert_equal(self.p.coef, p2.coef)
+        assert_equal(p2.domain, new_domain)
+
+    def test_new_window(self):
+        new_window = np.array([-10, 10])
+        p2 = Polynomial(self.p, window=new_window)
+        assert_equal(self.p.coef, p2.coef)
+        assert_equal(p2.window, new_window)
+
+    def test_polynomial_conversion_disallowed(self):
+        assert_raises(TypeError, Chebyshev, self.p)


### PR DESCRIPTION
A potential solution to #16071 .

Allows a new polynomial instance to be constructed from an existing polynomial, creating the new instance using the `coef` attribute from the existing instance. Both the `domain` and `window` mapped from the original instance as well, but are overridden by non-default values for the corresponding kwargs in `__init__`. 

This PR also disallows creating a polynomial of a different kind through the constructor, instead raising a TypeError that refers the user to the `convert` method, which does this in an unambiguous way. For example:
```python
>>> p = np.polynomial.Polynomial([1, 2, 3])
>>> c = np.polynomial.Chebyshev(p)
TypeError: To create an instance of <class 'numpy.polynomial.chebyshev.Chebyshev'> from poly([1. 2. 3.]), please see the convert method.
>>> c = p.convert(kind=np.polynomial.Chebyshev)
>>> c
Chebyshev([2.5, 2. , 1.5], domain=[-1.,  1.], window=[-1.,  1.])
```