### PR TITLE
DOC: Add axis to random module "new or different" docs

### DIFF
--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -168,6 +168,9 @@ What's New or Different
   Python's `random.random`.
 * All BitGenerators in numpy use `SeedSequence` to convert seeds into
   initialized states.
+* The addition of an ``axis`` keyword argument to methods such as 
+  `Generator.choice` and `Generator.shuffle` improves support for 
+  sampling from and shuffling multi-dimensional arrays.
 
 See :ref:`new-or-different` for a complete list of improvements and
 differences from the traditional ``Randomstate``.

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -169,8 +169,8 @@ What's New or Different
 * All BitGenerators in numpy use `SeedSequence` to convert seeds into
   initialized states.
 * The addition of an ``axis`` keyword argument to methods such as 
-  `Generator.choice` and `Generator.shuffle` improves support for 
-  sampling from and shuffling multi-dimensional arrays.
+  `Generator.choice`, `Generator.permutation`,  and `Generator.shuffle` 
+  improves support for sampling from and shuffling multi-dimensional arrays.
 
 See :ref:`new-or-different` for a complete list of improvements and
 differences from the traditional ``Randomstate``.

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -114,3 +114,14 @@ And in more detail:
   rg.random(out=existing[:2])
   print(existing)
 
+* Optional ``axis`` argument for methods like `~.Generator.choice` and
+  `~.Generator.shuffle` to control which axis an operation is performed
+  over for higher-dimensional arrays.
+
+.. ipython:: python
+
+  a = np.arange(12).reshape((3, 4))
+  a
+  rg.choice(a, axis=1, size=2)
+  rg.shuffle(a, axis=1)        # Shuffle in-place
+  a

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -114,14 +114,15 @@ And in more detail:
   rg.random(out=existing[:2])
   print(existing)
 
-* Optional ``axis`` argument for methods like `~.Generator.choice` and
-  `~.Generator.shuffle` to control which axis an operation is performed
-  over for higher-dimensional arrays.
+* Optional ``axis`` argument for methods like `~.Generator.choice`,
+  `~.Generator.permutation` and `~.Generator.shuffle` that controls which
+  axis an operation is performed over for multi-dimensional arrays.
 
 .. ipython:: python
 
+  rg = Generator(PCG64(123456789))
   a = np.arange(12).reshape((3, 4))
   a
-  rg.choice(a, axis=1, size=2)
+  rg.choice(a, axis=1, size=5)
   rg.shuffle(a, axis=1)        # Shuffle in-place
   a


### PR DESCRIPTION
A slight extension of #16075. Adds a bullet point to the "What's New or Different" section of the `random` docs that highlights the addition of the `axis` kwarg to some of the Generator methods like `choice`, `shuffle`, and `permutation`.

A bullet point has been added to both the shorter list in the random quickstart docs (rendered for comparison: [original](https://numpy.org/devdocs/reference/random/index.html#what-s-new-or-different) / [this PR](https://rossbar.github.io/numpy/reference/random/index.html#what-s-new-or-different)) and the more detailed "What's New or Different" doc (rendered for comparison: [original](https://numpy.org/devdocs/reference/random/new-or-different.html#new-or-different) / [this PR](https://rossbar.github.io/numpy/reference/random/new-or-different.html#new-or-different)) which includes an example.
