### PR TITLE
DOC,BLD: Limit timeit iterations in random docs.

### DIFF
--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -69,18 +69,18 @@ And in more detail:
   from  numpy.random import Generator, PCG64
   import numpy.random
   rg = Generator(PCG64())
-  %timeit rg.standard_normal(100000)
-  %timeit numpy.random.standard_normal(100000)
+  %timeit -n 1 rg.standard_normal(100000)
+  %timeit -n 1 numpy.random.standard_normal(100000)
 
 .. ipython:: python
 
-  %timeit rg.standard_exponential(100000)
-  %timeit numpy.random.standard_exponential(100000)
+  %timeit -n 1 rg.standard_exponential(100000)
+  %timeit -n 1 numpy.random.standard_exponential(100000)
 
 .. ipython:: python
 
-  %timeit rg.standard_gamma(3.0, 100000)
-  %timeit numpy.random.standard_gamma(3.0, 100000)
+  %timeit -n 1 rg.standard_gamma(3.0, 100000)
+  %timeit -n 1 numpy.random.standard_gamma(3.0, 100000)
 
 * Optional ``dtype`` argument that accepts ``np.float32`` or ``np.float64``
   to produce either single or double prevision uniform random variables for

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -52,17 +52,7 @@ And in more detail:
   methods which are 2-10 times faster than NumPy's default implementation in
   `~.Generator.standard_normal`, `~.Generator.standard_exponential` or
   `~.Generator.standard_gamma`.
-* `~.Generator.integers` is now the canonical way to generate integer
-  random numbers from a discrete uniform distribution. The ``rand`` and
-  ``randn`` methods are only available through the legacy `~.RandomState`.
-  This replaces both ``randint`` and the deprecated ``random_integers``.
-* The Box-Muller method used to produce NumPy's normals is no longer available.
-* All bit generators can produce doubles, uint64s and
-  uint32s via CTypes (`~PCG64.ctypes`) and CFFI (`~PCG64.cffi`).
-  This allows these bit generators to be used in numba.
-* The bit generators can be used in downstream projects via
-  Cython.
-
+   
 
 .. ipython:: python
 
@@ -82,6 +72,17 @@ And in more detail:
   %timeit -n 1 rg.standard_gamma(3.0, 100000)
   %timeit -n 1 numpy.random.standard_gamma(3.0, 100000)
 
+
+* `~.Generator.integers` is now the canonical way to generate integer
+  random numbers from a discrete uniform distribution. The ``rand`` and
+  ``randn`` methods are only available through the legacy `~.RandomState`.
+  This replaces both ``randint`` and the deprecated ``random_integers``.
+* The Box-Muller method used to produce NumPy's normals is no longer available.
+* All bit generators can produce doubles, uint64s and
+  uint32s via CTypes (`~PCG64.ctypes`) and CFFI (`~PCG64.cffi`).
+  This allows these bit generators to be used in numba.
+* The bit generators can be used in downstream projects via
+  Cython.
 * Optional ``dtype`` argument that accepts ``np.float32`` or ``np.float64``
   to produce either single or double prevision uniform random variables for
   select distributions


### PR DESCRIPTION
There are several `%timeit` commands in `doc/source/reference/random/new-or-different.rst` that constitute a significant fraction of the total build time for the documentation. 

Limiting these commands with the `-n` flag resulted in a ~20% speed-up in building the docs on my system:

### Results of `time make html`

#### Original
```
real    5m51.581s
user    5m29.464s
sys     0m22.387s
```
#### With this PR
```
real    4m55.797s
user    4m34.291s
sys     0m21.954s
```

Limiting the number of loops makes the `timeit` results less accurate, but the results are still sufficient to illustrate the original point that the `Generator` sampling methods are more performant than their `RandomState` counterparts.

Note that I'm limiting to a single loop (`-n 1`) - this could be modified (`-n 3` or `-n 10` for instance) to try to control the trade off between build time and `timeit` accuracy (though pinning to higher values of `n` may increase build times for systems with limited computing resources).