### PR TITLE
BUG: numpy.einsum indexing arrays now accept numpy int type

### DIFF
--- a/doc/release/upcoming_changes/16080.improvement.rst
+++ b/doc/release/upcoming_changes/16080.improvement.rst
@@ -1,0 +1,4 @@
+`numpy.einsum` accepts NumPy ``int64`` type in subscript list
+-------------------------------------------------------------
+There is no longer a type error thrown when `numpy.einsum` is passed
+a NumPy ``int64`` array as its subscript list. 

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -3,6 +3,7 @@ Implementation of optimized einsum.
 
 """
 import itertools
+import operator
 
 from numpy.core.multiarray import c_einsum
 from numpy.core.numeric import asanyarray, tensordot
@@ -576,7 +577,7 @@ def _parse_einsum_input(operands):
             for s in sub:
                 if s is Ellipsis:
                     subscripts += "..."
-                elif isinstance(s, int):
+                elif isinstance(operator.index(s), int) and not isinstance(s, bool):
                     subscripts += einsum_symbols[s]
                 else:
                     raise TypeError("For this input type lists must contain "
@@ -589,7 +590,7 @@ def _parse_einsum_input(operands):
             for s in output_list:
                 if s is Ellipsis:
                     subscripts += "..."
-                elif isinstance(s, int):
+                elif isinstance(operator.index(s), int) and not isinstance(s, bool):
                     subscripts += einsum_symbols[s]
                 else:
                     raise TypeError("For this input type lists must contain "

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -577,11 +577,13 @@ def _parse_einsum_input(operands):
             for s in sub:
                 if s is Ellipsis:
                     subscripts += "..."
-                elif isinstance(operator.index(s), int) and not isinstance(s, bool):
-                    subscripts += einsum_symbols[s]
                 else:
-                    raise TypeError("For this input type lists must contain "
-                                    "either int or Ellipsis")
+                    try:
+                        s = operator.index(s)
+                    except TypeError as e:
+                        raise TypeError("For this input type lists must contain "
+                                        "either int or Ellipsis")
+                    subscripts += einsum_symbols[s]
             if num != last:
                 subscripts += ","
 
@@ -590,11 +592,13 @@ def _parse_einsum_input(operands):
             for s in output_list:
                 if s is Ellipsis:
                     subscripts += "..."
-                elif isinstance(operator.index(s), int) and not isinstance(s, bool):
-                    subscripts += einsum_symbols[s]
                 else:
-                    raise TypeError("For this input type lists must contain "
-                                    "either int or Ellipsis")
+                    try:
+                        s = operator.index(s)
+                    except TypeError as e:
+                        raise TypeError("For this input type lists must contain "
+                                        "either int or Ellipsis")
+                    subscripts += einsum_symbols[s]
     # Check for proper "->"
     if ("-" in subscripts) or (">" in subscripts):
         invalid = (subscripts.count("-") > 1) or (subscripts.count(">") > 1)

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -582,7 +582,7 @@ def _parse_einsum_input(operands):
                         s = operator.index(s)
                     except TypeError as e:
                         raise TypeError("For this input type lists must contain "
-                                        "either int or Ellipsis")
+                                        "either int or Ellipsis") from e
                     subscripts += einsum_symbols[s]
             if num != last:
                 subscripts += ","
@@ -597,7 +597,7 @@ def _parse_einsum_input(operands):
                         s = operator.index(s)
                     except TypeError as e:
                         raise TypeError("For this input type lists must contain "
-                                        "either int or Ellipsis")
+                                        "either int or Ellipsis") from e
                     subscripts += einsum_symbols[s]
     # Check for proper "->"
     if ("-" in subscripts) or (">" in subscripts):

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2437,7 +2437,6 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
     }
     size = PySequence_Size(obj);
 
-
     for (i = 0; i < size; ++i) {
         item = PySequence_Fast_GET_ITEM(obj, i);
         /* Ellipsis */
@@ -2459,46 +2458,48 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
             subscripts[subindex++] = '.';
             ellipsis = 1;
         }
-        /* Subscript */
-        else if (PyInt_Check(item) || PyLong_Check(item)) {
-            long s = PyInt_AsLong(item);
-            npy_bool bad_input = 0;
-
-            if (subindex + 1 >= subsize) {
-                PyErr_SetString(PyExc_ValueError,
-                        "subscripts list is too long");
-                Py_DECREF(obj);
-                return -1;
-            }
-
-            if ( s < 0 ) {
-                bad_input = 1;
-            }
-            else if (s < 26) {
-                subscripts[subindex++] = 'A' + (char)s;
-            }
-            else if (s < 2*26) {
-                subscripts[subindex++] = 'a' + (char)s - 26;
-            }
-            else {
-                bad_input = 1;
-            }
-
-            if (bad_input) {
-                PyErr_SetString(PyExc_ValueError,
-                        "subscript is not within the valid range [0, 52)");
-                Py_DECREF(obj);
-                return -1;
-            }
-        }
-        /* Invalid */
         else {
-            PyErr_SetString(PyExc_ValueError,
-                    "each subscript must be either an integer "
-                    "or an ellipsis");
-            Py_DECREF(obj);
-            return -1;
-        }
+            long s = PyLong_AsLong(item);
+            /* Subscript */
+            if(!PyErr_Occurred()) {
+                npy_bool bad_input = 0;
+
+                if (subindex + 1 >= subsize) {
+                    PyErr_SetString(PyExc_ValueError,
+                            "subscripts list is too long");
+                    Py_DECREF(obj);
+                    return -1;
+                }
+
+                if ( s < 0 ) {
+                    bad_input = 1;
+                }
+                else if (s < 26) {
+                    subscripts[subindex++] = 'A' + (char)s;
+                }
+                else if (s < 2*26) {
+                    subscripts[subindex++] = 'a' + (char)s - 26;
+                }
+                else {
+                    bad_input = 1;
+                }
+
+                if (bad_input) {
+                    PyErr_SetString(PyExc_ValueError,
+                            "subscript is not within the valid range [0, 52)");
+                    Py_DECREF(obj);
+                    return -1;
+                }
+            }
+            /* Invalid */
+            else {
+                PyErr_SetString(PyExc_ValueError,
+                        "each subscript must be either an integer "
+                        "or an ellipsis");
+                Py_DECREF(obj);
+                return -1;
+            }
+        }        
     }
 
     Py_DECREF(obj);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2459,10 +2459,9 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
             ellipsis = 1;
         }
         else {
-            item = PyNumber_Index(item);
-            /* Subscript */
-            if(item != NULL) {
-                long s = PyLong_AsLong(item);
+            npy_intp s = PyArray_PyIntAsIntp(item);
+            if (!PyErr_Occurred()) {
+                /* Subscript */
                 npy_bool bad_input = 0;
 
                 if (subindex + 1 >= subsize) {
@@ -2492,15 +2491,16 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
                     return -1;
                 }
             }
-            /* Invalid */
             else {
+                /* Invalid */
                 PyErr_SetString(PyExc_ValueError,
                         "each subscript must be either an integer "
                         "or an ellipsis");
                 Py_DECREF(obj);
                 return -1;
             }
-        }        
+        }
+        
     }
 
     Py_DECREF(obj);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2459,9 +2459,10 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
             ellipsis = 1;
         }
         else {
-            long s = PyLong_AsLong(item);
+            item = PyNumber_Index(item);
             /* Subscript */
-            if(!PyErr_Occurred()) {
+            if(item != NULL) {
+                long s = PyLong_AsLong(item);
                 npy_bool bad_input = 0;
 
                 if (subindex + 1 >= subsize) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2458,47 +2458,45 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
             subscripts[subindex++] = '.';
             ellipsis = 1;
         }
+        /* Subscript */
         else {
             npy_intp s = PyArray_PyIntAsIntp(item);
-            /* Subscript */
-            if (!PyErr_Occurred()) {
-                npy_bool bad_input = 0;
-
-                if (subindex + 1 >= subsize) {
-                    PyErr_SetString(PyExc_ValueError,
-                            "subscripts list is too long");
-                    Py_DECREF(obj);
-                    return -1;
-                }
-
-                if ( s < 0 ) {
-                    bad_input = 1;
-                }
-                else if (s < 26) {
-                    subscripts[subindex++] = 'A' + (char)s;
-                }
-                else if (s < 2*26) {
-                    subscripts[subindex++] = 'a' + (char)s - 26;
-                }
-                else {
-                    bad_input = 1;
-                }
-
-                if (bad_input) {
-                    PyErr_SetString(PyExc_ValueError,
-                            "subscript is not within the valid range [0, 52)");
-                    Py_DECREF(obj);
-                    return -1;
-                }
-            }                
             /* Invalid */
-            else {
+            if (error_converting(s)) {
                 PyErr_SetString(PyExc_TypeError,
                         "each subscript must be either an integer "
                         "or an ellipsis");
                 Py_DECREF(obj);
                 return -1;
             }
+            npy_bool bad_input = 0;
+
+            if (subindex + 1 >= subsize) {
+                PyErr_SetString(PyExc_ValueError,
+                        "subscripts list is too long");
+                Py_DECREF(obj);
+                return -1;
+            }
+
+            if (s < 0) {
+                bad_input = 1;
+            }
+            else if (s < 26) {
+                subscripts[subindex++] = 'A' + (char)s;
+            }
+            else if (s < 2*26) {
+                subscripts[subindex++] = 'a' + (char)s - 26;
+            }
+            else {
+                bad_input = 1;
+            }
+
+            if (bad_input) {
+                PyErr_SetString(PyExc_ValueError,
+                        "subscript is not within the valid range [0, 52)");
+                Py_DECREF(obj);
+                return -1;
+            }              
         }
         
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2460,8 +2460,8 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
         }
         else {
             npy_intp s = PyArray_PyIntAsIntp(item);
+            /* Subscript */
             if (!PyErr_Occurred()) {
-                /* Subscript */
                 npy_bool bad_input = 0;
 
                 if (subindex + 1 >= subsize) {
@@ -2490,10 +2490,10 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
                     Py_DECREF(obj);
                     return -1;
                 }
-            }
+            }                
+            /* Invalid */
             else {
-                /* Invalid */
-                PyErr_SetString(PyExc_ValueError,
+                PyErr_SetString(PyExc_TypeError,
                         "each subscript must be either an integer "
                         "or an ellipsis");
                 Py_DECREF(obj);

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -93,6 +93,10 @@ class TestEinsum:
                 a = np.ones((3, 3, 4, 5, 6))
                 b = np.ones((3, 4, 5))
                 np.einsum('aabcb,abc', a, b)
+            
+            #do not accept bools in subscript list
+            assert_raises(TypeError, np.einsum, np.arange(6).reshape(2, 3), 
+                          [False, True], [True, False], optimize=do_opt)
 
     def test_einsum_views(self):
         # pass-through
@@ -272,6 +276,13 @@ class TestEinsum:
             assert_equal(np.einsum("ii", a, optimize=do_opt),
                          np.trace(a).astype(dtype))
             assert_equal(np.einsum(a, [0, 0], optimize=do_opt),
+                         np.trace(a).astype(dtype))
+
+            #ticket #15961: should accept numpy int64 type in subscript list
+            np_array = np.asarray([0, 0])
+            assert_equal(np.einsum(a, np_array, optimize=do_opt),
+                         np.trace(a).astype(dtype))
+            assert_equal(np.einsum(a, list(np_array), optimize=do_opt),
                          np.trace(a).astype(dtype))
 
         # multiply(a, b)

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -93,10 +93,6 @@ class TestEinsum:
                 a = np.ones((3, 3, 4, 5, 6))
                 b = np.ones((3, 4, 5))
                 np.einsum('aabcb,abc', a, b)
-            
-            #do not accept bools in subscript list
-            assert_raises(TypeError, np.einsum, np.arange(6).reshape(2, 3), 
-                          [False, True], [True, False], optimize=do_opt)
 
     def test_einsum_views(self):
         # pass-through
@@ -278,7 +274,7 @@ class TestEinsum:
             assert_equal(np.einsum(a, [0, 0], optimize=do_opt),
                          np.trace(a).astype(dtype))
 
-            #ticket #15961: should accept numpy int64 type in subscript list
+            # gh-15961: should accept numpy int64 type in subscript list
             np_array = np.asarray([0, 0])
             assert_equal(np.einsum(a, np_array, optimize=do_opt),
                          np.trace(a).astype(dtype))


### PR DESCRIPTION
Fixes #15961.

All current tests pass. I didn't write any new tests for this though, but perhaps I should do that?

