### PR TITLE
DOC: add note on type casting to numpy.left_shift().

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1835,6 +1835,18 @@ add_newdoc('numpy.core.umath', 'left_shift',
     >>> np.left_shift(5, [1,2,3])
     array([10, 20, 40])
 
+    Note: As explained in :ref:`Casting Rules <ufuncs.casting>`, if a ufunc
+    does not have a core loop implementation for the input types provided,
+    it will cast one or more inputs to a different type.  This may lead to
+    an unexpected result in some cases.
+
+    >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='u1'))
+    array([254], dtype=uint8)
+    >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='i1'))
+    array([510], dtype=int16)
+    >>> np.left_shift(np.uint8(255), 1)
+    510
+
     """)
 
 add_newdoc('numpy.core.umath', 'less',

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1835,9 +1835,9 @@ add_newdoc('numpy.core.umath', 'left_shift',
     >>> np.left_shift(5, [1,2,3])
     array([10, 20, 40])
 
-    Note: The dtype of the second argument may change the dtype of the first
-    argument (see :ref:`Casting Rules <ufuncs.casting>`) and lead to unexpected
-    results in some cases.
+    Note that the dtype of the second argument may change the dtype of the
+    result and can lead to unexpected results in some cases (see
+    :ref:`Casting Rules <ufuncs.casting>`):
 
     >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='u1'))
     array([254], dtype=uint8)

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1835,10 +1835,9 @@ add_newdoc('numpy.core.umath', 'left_shift',
     >>> np.left_shift(5, [1,2,3])
     array([10, 20, 40])
 
-    Note: As explained in :ref:`Casting Rules <ufuncs.casting>`, if a ufunc
-    does not have a core loop implementation for the input types provided,
-    it will cast one or more inputs to a different type.  This may lead to
-    an unexpected result in some cases.
+    Note: The dtype of the second argument may change the dtype of the first
+    argument (see :ref:`Casting Rules <ufuncs.casting>`) and lead to unexpected
+    results in some cases.
 
     >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='u1'))
     array([254], dtype=uint8)

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1839,12 +1839,10 @@ add_newdoc('numpy.core.umath', 'left_shift',
     result and can lead to unexpected results in some cases (see
     :ref:`Casting Rules <ufuncs.casting>`):
 
-    >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='u1'))
-    array([254], dtype=uint8)
-    >>> np.left_shift(np.array([255], dtype='u1'), np.array([1], dtype='i1'))
-    array([510], dtype=int16)
-    >>> np.left_shift(np.uint8(255), 1)
-    510
+    >>> a = np.left_shift(np.uint8(255), np.uint8(1)); print(a, type(a))
+    254 <class 'numpy.uint8'> # as expected
+    >>> b = np.left_shift(np.uint8(255), 1); print(b, type(b))
+    510 <class 'numpy.int64'> # unexpected
 
     """)
 

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -1839,10 +1839,12 @@ add_newdoc('numpy.core.umath', 'left_shift',
     result and can lead to unexpected results in some cases (see
     :ref:`Casting Rules <ufuncs.casting>`):
 
-    >>> a = np.left_shift(np.uint8(255), np.uint8(1)); print(a, type(a))
-    254 <class 'numpy.uint8'> # as expected
-    >>> b = np.left_shift(np.uint8(255), 1); print(b, type(b))
-    510 <class 'numpy.int64'> # unexpected
+    >>> a = np.left_shift(np.uint8(255), 1) # Expect 254
+    >>> print(a, type(a)) # Unexpected result due to upcasting
+    510 <class 'numpy.int64'>
+    >>> b = np.left_shift(np.uint8(255), np.uint8(1))
+    >>> print(b, type(b))
+    254 <class 'numpy.uint8'>
 
     """)
 


### PR DESCRIPTION
It is not obvious how numpy.left_shift() infers types and this may lead
to unexpected outputs.  Added note to draw attention to the importance
of input types.  Added three examples.  "Closes #12310"

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
