### PR TITLE
TST: use latest released PyPy instead of nightly builds

### DIFF
--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -6,8 +6,8 @@ set -o pipefail
 # Print expanded commands
 set -x
 
-sudo apt-get -yq update
-sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5 python3-urllib3
+#sudo apt-get -yq update
+#sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5 python3-urllib3
 F77=gfortran-5 F90=gfortran-5 \
 
 # Download the proper OpenBLAS x64 precompiled library
@@ -27,8 +27,8 @@ include_dirs = $target/lib:$LIB
 runtime_library_dirs = $target/lib
 EOF
 
-echo getting PyPy 3.6 nightly
-wget -q http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-linux64.tar.bz2 -O pypy.tar.bz2
+echo getting PyPy 3.6-v7.3.1
+wget -q https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 -O pypy.tar.bz2
 mkdir -p pypy3
 (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
 pypy3/bin/pypy3 -mensurepip


### PR DESCRIPTION
Fixes gh-16092 by using a released version of PyPy rather than a nightly build