### PR TITLE
MAINT, DOC: Improve grammar on a comment in the quickstart

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -760,7 +760,7 @@ stacks 1D arrays as columns into a 2D array. It is equivalent to
            [2., 8.]])
     >>> np.hstack((a,b))           # the result is different
     array([4., 2., 3., 8.])
-    >>> a[:,newaxis]               # this allows to have a 2D columns vector
+    >>> a[:,newaxis]               # view `a` as a 2D column vector
     array([[4.],
            [2.]])
     >>> np.column_stack((a[:,newaxis],b[:,newaxis]))


### PR DESCRIPTION
This is a documentation change changing the following comment

"this allows to have a 2D columns vector"

to

"view `a` as a 2D column vector"

Rationale:
- "allows to" and "columns vector" don't read well

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
