### PR TITLE
ENH: correct identity for logaddexp2 ufunc: -inf

### DIFF
--- a/doc/release/upcoming_changes/16102.improvement.rst
+++ b/doc/release/upcoming_changes/16102.improvement.rst
@@ -1,4 +1,4 @@
 ``np.logaddexp2.identity`` changed to ``-inf``
 ----------------------------------------------
-The ufunc `logaddexp2` now has an identity of ``-inf``, allowing it to
-be called on empty sequences.  This matches the identity of `logaddexp`.
+The ufunc `~numpy.logaddexp2` now has an identity of ``-inf``, allowing it to
+be called on empty sequences.  This matches the identity of `~numpy.logaddexp`.

--- a/doc/release/upcoming_changes/16102.improvement.rst
+++ b/doc/release/upcoming_changes/16102.improvement.rst
@@ -1,0 +1,4 @@
+``np.logaddexp2.identity`` changed to ``-inf``
+----------------------------------------------
+The ufunc `logaddexp2` now has an identity of ``-inf``, allowing it to
+be called on empty sequences.  This matches the identity of `logaddexp`.

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -531,7 +531,7 @@ defdict = {
           TD(flts, f="logaddexp", astype={'e':'f'})
           ),
 'logaddexp2':
-    Ufunc(2, 1, None,
+    Ufunc(2, 1, MinusInfinity,
           docstrings.get('numpy.core.umath.logaddexp2'),
           None,
           TD(flts, f="logaddexp2", astype={'e':'f'})

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -618,6 +618,10 @@ class TestLogAddExp2(_FilterInvalids):
         assert_(np.isnan(np.logaddexp2(0, np.nan)))
         assert_(np.isnan(np.logaddexp2(np.nan, np.nan)))
 
+    def test_reduce(self):
+        assert_equal(np.logaddexp2.identity, -np.inf)
+        assert_equal(np.logaddexp2.reduce([]), -np.inf)
+
 
 class TestLog:
     def test_log_values(self):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -621,6 +621,8 @@ class TestLogAddExp2(_FilterInvalids):
     def test_reduce(self):
         assert_equal(np.logaddexp2.identity, -np.inf)
         assert_equal(np.logaddexp2.reduce([]), -np.inf)
+        assert_equal(np.logaddexp2.reduce([-np.inf]), -np.inf)
+        assert_equal(np.logaddexp2.reduce([-np.inf, 0]), 0)
 
 
 class TestLog:


### PR DESCRIPTION
The lack of identity for `logaddexp2` was first identified in #4599. The implementation in #8955 added `-inf` as identity for `logaddexp`, but missed adding it for `logaddexp2`.

(This is my first PR to numpy!)