### PR TITLE
ENH: Enforce constraints on polynomial attrs window and domain

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -128,6 +128,9 @@ class ABCPolyBase(metaclass=ABCPolyBaseProperties):
     @domain.setter
     @abc.abstractmethod
     def domain(self, domain):
+        [domain] = pu.as_series([domain], trim=False)
+        if len(domain) != 2:
+            raise ValueError("Domain has wrong number of elements.")
         self._domain = domain
 
     @property
@@ -138,6 +141,9 @@ class ABCPolyBase(metaclass=ABCPolyBaseProperties):
     @window.setter
     @abc.abstractmethod
     def window(self, window):
+        [window] = pu.as_series([window], trim=False)
+        if len(window) != 2:
+            raise ValueError("Window has wrong number of elements.")
         self._window = window
 
     @property
@@ -325,16 +331,10 @@ class ABCPolyBase(metaclass=ABCPolyBaseProperties):
         self.coef = coef
 
         if domain is not None:
-            [domain] = pu.as_series([domain], trim=False)
-            if len(domain) != 2:
-                raise ValueError("Domain has wrong number of elements.")
-            self._domain = domain
+            self.domain = domain
 
         if window is not None:
-            [window] = pu.as_series([window], trim=False)
-            if len(window) != 2:
-                raise ValueError("Window has wrong number of elements.")
-            self._window = window
+            self.window = window
 
         # Validation for symbol
         try:

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -15,7 +15,7 @@ from . import polyutils as pu
 
 __all__ = ['ABCPolyBase']
 
-class ABCPolyBaseProperties(abc.ABC, type):
+class ABCPolyBaseMeta(abc.ABC, type):
     @property
     def domain(cls):
         return cls._domain
@@ -24,7 +24,7 @@ class ABCPolyBaseProperties(abc.ABC, type):
     def window(cls):
         return cls._window
 
-class ABCPolyBase(metaclass=ABCPolyBaseProperties):
+class ABCPolyBase(metaclass=ABCPolyBaseMeta):
     """An abstract base class for immutable series classes.
 
     ABCPolyBase provides the standard Python numerical methods

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -15,7 +15,16 @@ from . import polyutils as pu
 
 __all__ = ['ABCPolyBase']
 
-class ABCPolyBase(abc.ABC):
+class ABCPolyBaseProperties(abc.ABC, type):
+    @property
+    def domain(cls):
+        return cls._domain
+
+    @property
+    def window(cls):
+        return cls._window
+
+class ABCPolyBase(metaclass=ABCPolyBaseProperties):
     """An abstract base class for immutable series classes.
 
     ABCPolyBase provides the standard Python numerical methods
@@ -114,12 +123,22 @@ class ABCPolyBase(abc.ABC):
     @property
     @abc.abstractmethod
     def domain(self):
-        pass
+        return self._domain
+
+    @domain.setter
+    @abc.abstractmethod
+    def domain(self, domain):
+        self._domain = domain
 
     @property
     @abc.abstractmethod
     def window(self):
-        pass
+        return self._window
+
+    @window.setter
+    @abc.abstractmethod
+    def window(self, window):
+        self._window = window
 
     @property
     @abc.abstractmethod
@@ -309,13 +328,13 @@ class ABCPolyBase(abc.ABC):
             [domain] = pu.as_series([domain], trim=False)
             if len(domain) != 2:
                 raise ValueError("Domain has wrong number of elements.")
-            self.domain = domain
+            self._domain = domain
 
         if window is not None:
             [window] = pu.as_series([window], trim=False)
             if len(window) != 2:
                 raise ValueError("Window has wrong number of elements.")
-            self.window = window
+            self._window = window
 
         # Validation for symbol
         try:

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -2070,6 +2070,6 @@ class Chebyshev(ABCPolyBase):
         return cls(coef, domain=domain)
 
     # Virtual properties
-    domain = np.array(chebdomain)
-    window = np.array(chebdomain)
+    _domain = np.array(chebdomain)
+    _window = np.array(chebdomain)
     basis_name = 'T'

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1692,6 +1692,6 @@ class Hermite(ABCPolyBase):
     _fromroots = staticmethod(hermfromroots)
 
     # Virtual properties
-    domain = np.array(hermdomain)
-    window = np.array(hermdomain)
+    _domain = np.array(hermdomain)
+    _window = np.array(hermdomain)
     basis_name = 'H'

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1684,6 +1684,6 @@ class HermiteE(ABCPolyBase):
     _fromroots = staticmethod(hermefromroots)
 
     # Virtual properties
-    domain = np.array(hermedomain)
-    window = np.array(hermedomain)
+    _domain = np.array(hermedomain)
+    _window = np.array(hermedomain)
     basis_name = 'He'

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1640,6 +1640,6 @@ class Laguerre(ABCPolyBase):
     _fromroots = staticmethod(lagfromroots)
 
     # Virtual properties
-    domain = np.array(lagdomain)
-    window = np.array(lagdomain)
+    _domain = np.array(lagdomain)
+    _window = np.array(lagdomain)
     basis_name = 'L'

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1653,6 +1653,6 @@ class Legendre(ABCPolyBase):
     _fromroots = staticmethod(legfromroots)
 
     # Virtual properties
-    domain = np.array(legdomain)
-    window = np.array(legdomain)
+    _domain = np.array(legdomain)
+    _window = np.array(legdomain)
     basis_name = 'P'

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1506,8 +1506,8 @@ class Polynomial(ABCPolyBase):
     _fromroots = staticmethod(polyfromroots)
 
     # Virtual properties
-    domain = np.array(polydomain)
-    window = np.array(polydomain)
+    _domain = np.array(polydomain)
+    _window = np.array(polydomain)
     basis_name = None
 
     @classmethod

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -570,6 +570,39 @@ def test_ufunc_override(Poly):
     assert_raises(TypeError, np.add, x, p)
 
 
+class TestDomainWindowValidation:
+    """
+    Test validation when attempting to set either window or domain
+    parameters.
+    """
+    coefs = [1, 2, 3]
+
+    def test_class_domain_window_readonly(self, Poly):
+        with pytest.raises(AttributeError):
+            Poly.domain = [-1, 1]
+
+    @pytest.mark.parametrize('bad_dw', (
+        [0, 10, 100],   # domain/window must have len==2
+        'foo',          # domain/window must be array-like
+    ))
+    def test_constructor_bad_domain_window(self, Poly, bad_dw):
+        with pytest.raises(ValueError):
+            Poly(self.coefs, window=bad_dw)
+        with pytest.raises(ValueError):
+            Poly(self.coefs, domain=bad_dw)
+
+    @pytest.mark.parametrize('bad_dw', (
+        [0, 10, 100],   # domain/window must have len==2
+        'foo',          # domain/window must be array-like
+    ))
+    def test_setter_bad_domain_window(self, Poly, bad_dw):
+        p = Poly(self.coefs)
+        with pytest.raises(ValueError):
+            p.domain = bad_dw
+        with pytest.raises(ValueError):
+            p.window = bad_dw
+
+
 #
 # Test class method that only exists for some classes
 #


### PR DESCRIPTION
Related to #16059 

The changes here represent a potential solution to the mutability of two (of the three) defining attributes of polynomials: the `domain` and `window` attributes.

The mutability of these attrs leads to some undesirable behavior. For example, any `array-like` with len == 2 is currently allowed, but the `__repr__` expects that they *must* be arrays. Thus setting the `domain` or `window` with a `list` will cause problems:

```python
>>> p = np.polynomial.Polynomial([1, 2, 3])
>>> p
Polynomial([1., 2., 3.], domain=[-1,  1], window=[-1,  1])
>>> p.domain = [-2, 2]
>>> p
Polynomial([1., 2., 3.], domain=, window=[-1,  1])
```

Note that `__init__` does input validation and converts `array-like` to the expected format:

```python
>>> p = np.polynomial.Polynomial([1, 2, 3], domain="foo")   # invalid
ValueError: Coefficient arrays have no common type
>>> p = np.polynomial.Polynomial([1, 2, 3], domain=[-2, 2])
>>> p
Polynomial([1., 2., 3.], domain=[-2.,  2.], window=[-1,  1])
```

This PR reorganizes the classes in the polynomial module to add the same input validation used by `__init__` to a general setter for the `domain` and `window` attributes.