### PR TITLE
REV: Reverts side-effect changes to casting

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1527,7 +1527,75 @@ OBJECT_to_@TOTYPE@(void *input, void *output, npy_intp n,
  * #oskip = 1*18,(PyArray_DESCR(aop)->elsize)*3,1*2,
  *          1*18,(PyArray_DESCR(aop)->elsize)*3,1*2,
  *          1*18,(PyArray_DESCR(aop)->elsize)*3,1*2#
+ * #convert = 1*14, 0, 1*3, 0*3, 1*2,
+ *            1*14, 0, 1*3, 0*3, 1*2,
+ *            0*23#
+ * #convstr = (Int*9, Long*2, Float*4, Complex*3, Tuple*3, Long*2)*3#
  */
+
+#if @convert@
+
+#define IS_@from@
+
+static void
+@from@_to_@to@(void *input, void *output, npy_intp n,
+        void *vaip, void *aop)
+{
+    @fromtyp@ *ip = input;
+    @totyp@ *op = output;
+    PyArrayObject *aip = vaip;
+
+    npy_intp i;
+    int skip = PyArray_DESCR(aip)->elsize;
+    int oskip = @oskip@;
+
+    for (i = 0; i < n; i++, ip+=skip, op+=oskip) {
+        PyObject *new;
+        PyObject *temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
+        if (temp == NULL) {
+            return;
+        }
+
+#if defined(NPY_PY3K) && defined(IS_STRING)
+        /* Work around some Python 3K */
+        new = PyUnicode_FromEncodedObject(temp, "ascii", "strict");
+        Py_DECREF(temp);
+        temp = new;
+        if (temp == NULL) {
+            return;
+        }
+#endif
+        /* convert from Python object to needed one */
+        {
+            PyObject *args;
+
+            /* call out to the Python builtin given by convstr */
+            args = Py_BuildValue("(N)", temp);
+#if defined(NPY_PY3K)
+#define PyInt_Type PyLong_Type
+#endif
+            new = Py@convstr@_Type.tp_new(&Py@convstr@_Type, args, NULL);
+#if defined(NPY_PY3K)
+#undef PyInt_Type
+#endif
+            Py_DECREF(args);
+            temp = new;
+            if (temp == NULL) {
+                return;
+            }
+        }
+
+        if (@to@_setitem(temp, op, aop)) {
+            Py_DECREF(temp);
+            return;
+        }
+        Py_DECREF(temp);
+    }
+}
+
+#undef IS_@from@
+
+#else
 
 static void
 @from@_to_@to@(void *input, void *output, npy_intp n,
@@ -1554,6 +1622,7 @@ static void
     }
 }
 
+#endif
 
 /**end repeat**/
 


### PR DESCRIPTION
This mostly reverts commit 6b954aa47bcce17cd7497d41f818950f847fbd8e
to ensure only the longdouble floating point numbers are changed, for
which this was a bugfix was relevant.
All other numbers should be unchanged (and were faster with the change),
but revert since this is a bugfix release.

Mainly the string->boolean conversions where accidentally changed to
arguably more correct behaviour. But this should not have happend
accidentally, especially in a bug-fix branch.
Another corner case change is that string->datetime casts within
hypothetical C-extensions doing manual C-level casting was fixed to be in
line with normal string -> datetime casts (the cast was inconsistently
defined).

This revert is only applied as a backport. The second change will remain
included in the next non-bugfix release while the first is fixed in
a more specific in cleaner manner.