### PR TITLE
ENH:Distutils Remove debugging symbols by default

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -357,7 +357,10 @@ def build_project(args):
                 '-Werror=unused-function',
             ])
             env['CFLAGS'] = warnings_as_errors + ' ' + env.get('CFLAGS', '')
+
+    cmd += ["build"]
     if args.debug or args.gcov:
+        cmd += ["--debug"]
         # assume everyone uses gcc/gfortran
         env['OPT'] = '-O0 -ggdb'
         env['FOPT'] = '-O0 -ggdb'
@@ -371,7 +374,6 @@ def build_project(args):
             env['LDSHARED'] = cvars['LDSHARED'] + ' --coverage'
             env['LDFLAGS'] = " ".join(cvars['LDSHARED'].split()[1:]) + ' --coverage'
 
-    cmd += ["build"]
     if args.parallel > 1:
         cmd += ["-j", str(args.parallel)]
     if args.debug_info:


### PR DESCRIPTION
  Debug info flags are always set by the default which increases
  the binary size to over 600%, in case of the debug info
  is required for backtraces, the user has to rebuild NumPy
  with build option --debug.

**Shared object sizes with debug flags**
```Bash
du */*.so
396	core/_multiarray_tests.cpython-37m-x86_64-linux-gnu.so
19144	core/_multiarray_umath.cpython-37m-x86_64-linux-gnu.so
48	core/_operand_flag_tests.cpython-37m-x86_64-linux-gnu.so
256	core/_rational_tests.cpython-37m-x86_64-linux-gnu.so
52	core/_struct_ufunc_tests.cpython-37m-x86_64-linux-gnu.so
104	core/_umath_tests.cpython-37m-x86_64-linux-gnu.so
360	fft/_pocketfft_internal.cpython-37m-x86_64-linux-gnu.so
4928	linalg/lapack_lite.cpython-37m-x86_64-linux-gnu.so
5536	linalg/_umath_linalg.cpython-37m-x86_64-linux-gnu.so
904	random/bit_generator.cpython-37m-x86_64-linux-gnu.so
2028	random/_bounded_integers.cpython-37m-x86_64-linux-gnu.so
1504	random/_common.cpython-37m-x86_64-linux-gnu.so
2940	random/_generator.cpython-37m-x86_64-linux-gnu.so
556	random/_mt19937.cpython-37m-x86_64-linux-gnu.so
2372	random/mtrand.cpython-37m-x86_64-linux-gnu.so
376	random/_pcg64.cpython-37m-x86_64-linux-gnu.so
540	random/_philox.cpython-37m-x86_64-linux-gnu.so
304	random/_sfc64.cpython-37m-x86_64-linux-gnu.so
````
**Shared object sizes "without" debug flags**
```Bash
du */*.so
136	core/_multiarray_tests.cpython-37m-x86_64-linux-gnu.so
3564	core/_multiarray_umath.cpython-37m-x86_64-linux-gnu.so
20	core/_operand_flag_tests.cpython-37m-x86_64-linux-gnu.so
52	core/_rational_tests.cpython-37m-x86_64-linux-gnu.so
20	core/_struct_ufunc_tests.cpython-37m-x86_64-linux-gnu.so
28	core/_umath_tests.cpython-37m-x86_64-linux-gnu.so
76	fft/_pocketfft_internal.cpython-37m-x86_64-linux-gnu.so
1792	linalg/lapack_lite.cpython-37m-x86_64-linux-gnu.so
1924	linalg/_umath_linalg.cpython-37m-x86_64-linux-gnu.so
224	random/bit_generator.cpython-37m-x86_64-linux-gnu.so
388	random/_bounded_integers.cpython-37m-x86_64-linux-gnu.so
268	random/_common.cpython-37m-x86_64-linux-gnu.so
864	random/_generator.cpython-37m-x86_64-linux-gnu.so
140	random/_mt19937.cpython-37m-x86_64-linux-gnu.so
748	random/mtrand.cpython-37m-x86_64-linux-gnu.so
92	random/_pcg64.cpython-37m-x86_64-linux-gnu.so
116	random/_philox.cpython-37m-x86_64-linux-gnu.so
76	random/_sfc64.cpython-37m-x86_64-linux-gnu.so
````

**Umath extension binary info via Bloaty with debug flags**
```Bash
bloaty core/_multiarray_umath.cpython-37m-x86_64-linux-gnu.so
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  45.0%  9.39Mi   0.0%       0    .debug_loc
  22.0%  4.58Mi   0.0%       0    .debug_info
  11.4%  2.38Mi  71.8%  2.38Mi    .text
   9.7%  2.03Mi   0.0%       0    .debug_line
   5.3%  1.10Mi   0.0%       0    .debug_ranges
   1.2%   263Ki   7.8%   263Ki    .eh_frame
   1.1%   233Ki   6.9%   233Ki    .rodata
   0.9%   182Ki   0.0%       0    .symtab
   0.8%   174Ki   0.0%       0    .debug_str
   0.0%       0   3.9%   130Ki    .bss
   0.6%   117Ki   0.0%       0    .strtab
   0.5%   110Ki   3.3%   110Ki    .data
   0.5%   107Ki   0.0%       0    .debug_abbrev
   0.5%   100Ki   3.0%   100Ki    .rela.dyn
   0.2%  50.0Ki   1.5%  49.9Ki    .eh_frame_hdr
   0.1%  22.1Ki   0.6%  22.0Ki    .dynsym
   0.1%  22.0Ki   0.4%  12.5Ki    [21 Others]
   0.1%  10.9Ki   0.3%  10.9Ki    .dynstr
   0.0%  9.46Ki   0.3%  9.40Ki    .rela.plt
   0.0%  6.34Ki   0.2%  6.28Ki    .plt
   0.0%  5.94Ki   0.2%  5.88Ki    .gnu.hash
 100.0%  20.9Mi 100.0%  3.31Mi    TOTAL
````

**Umath extension binary info via Bloaty "without" debug flags**
```Bash
bloaty core/_multiarray_umath.cpython-37m-x86_64-linux-gnu.so
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  68.3%  2.38Mi  71.8%  2.38Mi    .text
   7.4%   263Ki   7.8%   263Ki    .eh_frame
   6.6%   233Ki   6.9%   233Ki    .rodata
   5.1%   182Ki   0.0%       0    .symtab
   0.0%       0   3.9%   130Ki    .bss
   3.3%   117Ki   0.0%       0    .strtab
   3.1%   110Ki   3.3%   110Ki    .data
   2.8%   100Ki   3.0%   100Ki    .rela.dyn
   1.4%  50.0Ki   1.5%  49.9Ki    .eh_frame_hdr
   0.6%  22.1Ki   0.6%  22.0Ki    .dynsym
   0.3%  10.9Ki   0.3%  10.9Ki    .dynstr
   0.3%  9.46Ki   0.3%  9.40Ki    .rela.plt
   0.2%  6.34Ki   0.2%  6.28Ki    .plt
   0.2%  5.94Ki   0.2%  5.88Ki    .gnu.hash
   0.2%  5.40Ki   0.2%  5.15Ki    .data.rel.ro
   0.1%  4.56Ki   0.0%       0    [Unmapped]
   0.1%  3.22Ki   0.1%  3.16Ki    .got.plt
   0.1%  2.03Ki   0.0%  1.12Ki    [14 Others]
   0.1%  1.90Ki   0.1%  1.83Ki    .gnu.version
   0.0%     712   0.0%     648    .got
   0.0%     632   0.0%     632    [LOAD #0 [R]]
 100.0%  3.48Mi 100.0%  3.31Mi    TOTAL
````