### PR TITLE
MAINT: Fix random.PCG64 signature

### DIFF
--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -38,7 +38,7 @@ cdef double pcg64_double(void* st) nogil:
 
 cdef class PCG64(BitGenerator):
     """
-    PCG64(seed_seq=None)
+    PCG64(seed=None)
 
     BitGenerator for the PCG-64 pseudo-random number generator.
 


### PR DESCRIPTION
The argument ``seed_seq`` was renamed to ``seed`` in 0ec7f12012bcb613857b3adef2b2d18310838894. However, I think the occurence in the signature in the docstring of ``PCG64`` was missed.