### PR TITLE
DOC: Correct documentation of ``__array__`` when used as output array.

### DIFF
--- a/doc/release/upcoming_changes/13458.changes.rst
+++ b/doc/release/upcoming_changes/13458.changes.rst
@@ -1,5 +1,5 @@
-Remove handling of extra argument to ``__array__``
+Remove handling of extra argument to `__array__`
 Update the documentation for `__array__` interface behaviour 
 --------------------------------------------------
-Earlier the ``__array__`` documentation said:
-If a class (ndarray subclass or not) having the ``__array__`` method is used as the output object of an ufunc, results will be written to the object returned by ``__array__``. However the behaviour of ``__array__``did not support it, the documentation was modified to avoid confusion.
+Earlier the `__array__` documentation said:
+If a class (ndarray subclass or not) having the `__array__` method is used as the output object of an ufunc, results will be written to the object returned by `__array__` However the behaviour of `__array__` did not support it, the documentation was modified to avoid confusion.

--- a/doc/release/upcoming_changes/13458.changes.rst
+++ b/doc/release/upcoming_changes/13458.changes.rst
@@ -1,0 +1,5 @@
+Remove handling of extra argument to ``__array__``
+Update the documentation for `__array__` interface behaviour 
+--------------------------------------------------
+Earlier the ``__array__`` documentation said:
+If a class (ndarray subclass or not) having the ``__array__`` method is used as the output object of an ufunc, results will be written to the object returned by ``__array__``. However the behaviour of ``__array__``did not support it, the documentation was modified to avoid confusion.

--- a/doc/release/upcoming_changes/13458.changes.rst
+++ b/doc/release/upcoming_changes/13458.changes.rst
@@ -1,4 +1,3 @@
-Remove handling of extra argument to `__array__`
 Update the documentation for `__array__` interface behaviour 
 --------------------------------------------------
 Earlier the `__array__` documentation said:

--- a/doc/release/upcoming_changes/13458.changes.rst
+++ b/doc/release/upcoming_changes/13458.changes.rst
@@ -1,4 +1,0 @@
-Update the documentation for `__array__` interface behaviour 
---------------------------------------------------
-Earlier the `__array__` documentation said:
-If a class (ndarray subclass or not) having the `__array__` method is used as the output object of an ufunc, results will be written to the object returned by `__array__` However the behaviour of `__array__` did not support it, the documentation was modified to avoid confusion.

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -326,8 +326,8 @@ NumPy provides several hooks that classes can customize:
 
    If a class (ndarray subclass or not) having the :func:`__array__`
    method is used as the output object of an :ref:`ufunc
-   <ufuncs-output-type>`, results will ``not`` be written to the object
-   returned by :func:`__array__`. This practice will return `TypeError`.
+   <ufuncs-output-type>`, results will *not* be written to the object
+   returned by :func:`__array__`. This practice will return ``TypeError``.
 
 
 Matrix objects

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -326,7 +326,8 @@ NumPy provides several hooks that classes can customize:
 
    If a class (ndarray subclass or not) having the :func:`__array__`
    method is used as the output object of an :ref:`ufunc
-   <ufuncs-output-type>`, gives `TypeError`.
+   <ufuncs-output-type>`, results will ``not`` be written to the object
+   returned by :func:`__array__`. This practice will return `TypeError`.
 
 
 Matrix objects

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -326,9 +326,7 @@ NumPy provides several hooks that classes can customize:
 
    If a class (ndarray subclass or not) having the :func:`__array__`
    method is used as the output object of an :ref:`ufunc
-   <ufuncs-output-type>`, results will be written to the object
-   returned by :func:`__array__`. Similar conversion is done on
-   input arrays.
+   <ufuncs-output-type>`, gives `TypeError`.
 
 
 Matrix objects


### PR DESCRIPTION
- Update `__array__` interface behaviour in documentation
- Add update file in docs/release/upcoming_changes

Closes https://github.com/numpy/numpy/issues/13458