### PR TITLE
BUG: Check for NULL pointer in ``get_decsrcref_fields_transfer_function``.

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2773,7 +2773,10 @@ get_decsrcref_fields_transfer_function(int aligned,
     _single_field_transfer *fields;
 
     names = src_dtype->names;
-    names_size = PyTuple_GET_SIZE(src_dtype->names);
+    if(src_dtype->names != NULL)
+        names_size = PyTuple_GET_SIZE(src_dtype->names);
+    else
+        names_size = 0;
 
     field_count = names_size;
     structsize = sizeof(_field_transfer_data) +


### PR DESCRIPTION
Check that  src_dtype->names is not NULL in get_decsrcref_fields_transfer_function.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->







<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
