### PR TITLE
BENCH: Default to building HEAD instead of master

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -15,7 +15,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "tip" (for mercurial).
-    "branches": ["master"],
+    "branches": ["HEAD"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL


### PR DESCRIPTION
asv executes the benchmarks of the current branch building the code specified in "branches". Previously this was "master" instead of "HEAD" (the code currently worked on). This PR changes "master" -> "HEAD" as it seems more likely for a user to be generating benchmarks for the code they are currently working on.

see [scipy-11998](https://github.com/scipy/scipy/pull/11998)
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
