### PR TITLE
CI: pin 32-bit manylinux2010 image tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,9 @@ stages:
       vmImage: 'ubuntu-18.04'
     steps:
     - script: |
-            docker pull quay.io/pypa/manylinux2010_i686
+            docker pull quay.io/pypa/manylinux2010_i686:2020-04-29-0e1afc5
             docker run -v $(pwd):/numpy -e CFLAGS="-msse2 -std=c99 -UNDEBUG" \
-            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686 \
+            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686:2020-04-29-0e1afc5 \
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \


### PR DESCRIPTION
* Azure CI is currently failing Linux 32-bit job
because of a gcc toolchain bump in the base manylinux2010
image (32-bit) from ~12 hours ago; see NumPy gh-16146 for
details; in short, we can't link to OpenBLAS in that matrix
entry because the libgfortran in the new manylinux2010 image
is too new

* as a temporary workaround to constant CI failure, pin the
base image to a tag from a few days ago, before the gcc toolchain
update was merged

* the 32-bit image publications/tags are here: https://quay.io/repository/pypa/manylinux2010_i686?tag=latest&tab=tags
* upstream PR from a few hours ago: https://github.com/pypa/manylinux/pull/565