### PR TITLE
CI: unpin 32-bit manylinux2010 image tag

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,9 @@ stages:
       vmImage: 'ubuntu-18.04'
     steps:
     - script: |
-            docker pull quay.io/pypa/manylinux2010_i686:2020-04-29-0e1afc5
+            docker pull quay.io/pypa/manylinux2010_i686
             docker run -v $(pwd):/numpy -e CFLAGS="-msse2 -std=c99 -UNDEBUG" \
-            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686:2020-04-29-0e1afc5 \
+            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686 \
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \


### PR DESCRIPTION
Revert the temporary workaround changes from NumPy gh-16147 now that the manylinux2010_i686 has been updated to be compatible with the pre-built version of OpenBLAS used. See NumPy gh-16146 for details.
