### PR TITLE
BUG: add missing numpy/__init__.pxd to the wheel

### DIFF
--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -976,3 +976,10 @@ cdef inline int import_ufunc() except -1:
         _import_umath()
     except Exception:
         raise ImportError("numpy.core.umath failed to import")
+
+cdef extern from *:
+    # Leave a marker that the NumPy declarations came from this file
+    # See https://github.com/cython/cython/issues/3573
+    """
+    /* NumPy API declarations from "numpy/__init__.pxd" */
+    """

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('numpy')
     config.add_data_files(('numpy', 'LICENSE.txt'))
+    config.add_data_files(('numpy', 'numpy/__init__.pxd'))
 
     config.get_version('numpy/version.py') # sets config.version
 


### PR DESCRIPTION
It turns out gh-12284 did not actually bundle the `__init__.pxd` into the wheels. It does appears in the sdist (due to the `MANIFEST.in`).
