### PR TITLE
DOC: Add more information about poly1d -> polynomial to reference guide

### DIFF
--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -15,6 +15,18 @@ more consistent, better-behaved interface for working with polynomial
 expressions.
 Therefore :mod:`numpy.polynomial` is recommended for new coding.
 
+.. note:: **Terminology**
+
+   The term *polynomial module* refers to the old API defined in
+   `numpy.lib.polynomial`, which includes the :class:`numpy.poly1d` class and
+   the polynomial functions prefixed with *poly* accessible from the `numpy`
+   namespace (e.g. `numpy.polyadd`, `numpy.polyval`, `numpy.polyfit`, etc.).
+
+   The term *polynomial package* refers to the new API definied in 
+   `numpy.polynomial`, which includes the convenience classes for the
+   different kinds of polynomials (`numpy.polynomial.Polynomial`,
+   `numpy.polynomial.Chebyshev`, etc.).
+
 Transitioning from `numpy.poly1d` to `numpy.polynomial`
 -------------------------------------------------------
 

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -30,13 +30,13 @@ Quick Reference
 
 The following table highlights some of the main differences between the
 legacy polynomial module and the polynomial package for common tasks.
-The `~numpy.polynomial.Polynomial` class is imported for brevity::
+The `~numpy.polynomial.polynomial.Polynomial` class is imported for brevity::
 
     from numpy.polynomial import Polynomial
 
 
 +------------------------+------------------------------+---------------------------------------+
-|  How to...             | Legacy (`numpy.poly1d`)      | `numpy.polynomial`                    |
+|  **How to...**         | Legacy (`numpy.poly1d`)      | `numpy.polynomial`                    |
 +------------------------+------------------------------+---------------------------------------+
 | Create a               | ``p = np.poly1d([1, 2, 3])`` | ``p = Polynomial([3, 2, 1])``         |
 | polynomial object      |                              |                                       |
@@ -56,8 +56,8 @@ Transition Guide
 ~~~~~~~~~~~~~~~~
 
 There are significant differences between ``numpy.lib.polynomial`` and
-the the polynomial package, `numpy.polynomial`.
-The most significant differences is the ordering of the coefficients for the
+`numpy.polynomial`.
+The most significant difference is the ordering of the coefficients for the
 polynomial expressions.
 The  various routines in `numpy.polynomial` all
 deal with series whose coefficients go from degree zero upward,
@@ -67,19 +67,18 @@ correspond to degree, i.e., ``coef[i]`` is the coefficient of the term of
 degree *i*.
 
 Though the difference in convention may be confusing, it is straightforward to
-convert from the old-style polynomial API to the new.
+convert from the legacy polynomial API to the new.
 For example, the following demonstrates how you would convert a `numpy.poly1d`
 instance representing the expression :math:`x^{2} + 2x + 3` to a
 `~numpy.polynomial.polynomial.Polynomial` instance representing the same
 expression::
 
-    >>> c = [1, 2, 3]                          # x**2 +2*x + 3
-    >>> p1d = np.poly1d(c)                     # Legacy
-    >>> p = np.polynomial.Polynomial(c[::-1])
+    >>> p1d = np.poly1d([1, 2, 3])
+    >>> p = np.polynomial.Polynomial(p1d.coef[::-1])
 
 In addition to the ``coef`` attribute, polynomials from the polynomial
-package also have ``domain`` and ``window`` attributes that define any
-particular polynomial instance. These attributes are most relevant when
+package also have ``domain`` and ``window`` attributes.
+These attributes are most relevant when
 polynomials to data, though it should be noted that polynomials with
 different ``domain`` and ``window`` attributes are not considered equal, and
 can't be mixed in arithmetic::
@@ -94,16 +93,16 @@ can't be mixed in arithmetic::
     TypeError: Domains differ
 
 See the documentation for the
-`convenience classes <routines.polynomials.classes>` for further details on
+`convenience classes <routines.polynomials.classes>`_ for further details on
 the ``domain`` and ``window`` attributes.
 
 Another major difference bewteen the legacy polynomial module and the
-polynomial package is polynomial fitting. In the legacy code, fitting was
+polynomial package is polynomial fitting. In the old module, fitting was
 done via the `~numpy.polyfit` function. In the polynomial package, the
-`Polynomial.fit` classmethod is preferred. For example, consider a simple
-linear fit to the following data:
+`~numpy.polynomial.polynomial.Polynomial.fit`_ class method is preferred. For
+example, consider a simple linear fit to the following data:
 
-.. ipython::
+.. ipython:: python
 
     rg = np.random.default_rng()
     x = np.arange(10)
@@ -112,24 +111,24 @@ linear fit to the following data:
 With the legacy polynomial module, a linear fit (i.e. polynomial of degree 1)
 could be applied to these data with `~numpy.polyfit`:
 
-.. ipython::
+.. ipython:: python
 
     np.polyfit(x, y, deg=1)
 
-With the new polynomial API, the `~numpy.polynomial.polynomial.Polynomial.fit`
+With the new polynomial API, the `~numpy.polynomial.polynomial.Polynomial.fit`_
 class method is preferred:
 
-.. ipython::
+.. ipython:: python
 
     p_fitted = np.polynomial.Polynomial.fit(x, y, deg=1)
     p_fitted
 
-Note that the coefficients are given *in scaled domain* defined by the linear
-mapping between the ``window`` and ``domain``.
+Note that the coefficients are given *in the scaled domain* defined by the
+linear mapping between the ``window`` and ``domain``.
 `~numpy.polynomial.polynomial.Polynomial.convert` can be used to get the
 coefficients in the unscaled data domain.
 
-.. ipython::
+.. ipython:: python
 
     p_fitted.convert()
 
@@ -149,8 +148,8 @@ with polynomials regardless of their type.
 
    routines.polynomials.classes
 
-Documentation pertaining to specific functions defined for each kind of the
-kinds of polynomials can be found in the corresponding module documentation:
+Documentation pertaining to specific functions defined for each kind of
+polynomial individually can be found in the corresponding module documentation:
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -10,18 +10,41 @@ of the `numpy.polynomial` package, introduced in NumPy 1.4.
 Prior to NumPy 1.4, `numpy.poly1d` was the class of choice and it is still
 available in order to maintain backward compatibility.
 However, the newer `polynomial package <numpy.polynomial>` is more complete
-than `numpy.poly1d` and its convenience classes are better behaved in the
-numpy environment.
+than and its `convenience classes <routines.polynomials.classes` provide a
+more consistent, better-behaved interface for working with polynomial
+expressions.
 Therefore :mod:`numpy.polynomial` is recommended for new coding.
 
-Transition notice
------------------
-The  various routines in the Polynomial package all deal with
-series whose coefficients go from degree zero upward,
-which is the *reverse order* of the Poly1d convention.
-The easy way to remember this is that indexes
-correspond to degree, i.e., coef[i] is the coefficient of the term of
-degree i.
+Transitioning from `numpy.poly1d` to `numpy.polynomial`
+-------------------------------------------------------
+
+As noted above, the :class:`poly1d class <numpy.poly1d>` and associated 
+functions defined in ``numpy.lib.polynomial``, such as `numpy.polyfit`
+and `numpy.poly`, are considered legacy and should **not** be used in new
+code.
+Since NumPy version 1.4, the `numpy.polynomial` package provides the 
+preferred tools for working with polynomials.
+
+There are significant differences between ``numpy.lib.polynomial`` and 
+the the polynomial package, `numpy.polynomial`.
+The most significant differences is the ordering of the coefficients for the
+polynomial expressions.
+The  various routines in `numpy.polynomial` all
+deal with series whose coefficients go from degree zero upward,
+which is the *reverse order* of the poly1d convention.
+The easy way to remember this is that indices
+correspond to degree, i.e., ``coef[i]`` is the coefficient of the term of
+degree *i*.
+
+Though the difference in convention may be confusing, it is straightforward to
+convert from the old-style polynomial API to the new.
+For example, the following demonstrates how you would convert a `numpy.poly1d`
+instance representing the expression :math:`x^{2} + 2 \cdot x + 3` to a
+`numpy.polynomial.Polynomial` instance representing the same expression::
+
+    >>> p1d = np.poly1d([1, 2, 3])                    # Legacy
+    >>> p = np.polynomial.Polynomial(p1d.coef[::-1])  # Preferred
+
 
 
 .. toctree::

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -10,7 +10,7 @@ of the `numpy.polynomial` package, introduced in NumPy 1.4.
 Prior to NumPy 1.4, `numpy.poly1d` was the class of choice and it is still
 available in order to maintain backward compatibility.
 However, the newer `polynomial package <numpy.polynomial>` is more complete
-than and its `convenience classes <routines.polynomials.classes` provide a
+and its `convenience classes <routines.polynomials.classes` provide a
 more consistent, better-behaved interface for working with polynomial
 expressions.
 Therefore :mod:`numpy.polynomial` is recommended for new coding.
@@ -22,8 +22,34 @@ As noted above, the :class:`poly1d class <numpy.poly1d>` and associated
 functions defined in ``numpy.lib.polynomial``, such as `numpy.polyfit`
 and `numpy.poly`, are considered legacy and should **not** be used in new
 code.
-Since NumPy version 1.4, the `numpy.polynomial` package provides the 
-preferred tools for working with polynomials.
+Since NumPy version 1.4, the `numpy.polynomial` package is preferred for
+working with polynomials.
+
+Quick Reference
+~~~~~~~~~~~~~~~
+
+The following table highlights some of the main differences between the 
+legacy polynomial module and the polynomial package.
+The `~numpy.polynomial.Polynomial` class is imported for brevity::
+
+    from numpy.polynomial import Polynomial
+
+
++---------------+------------------------------+----------------------------------+
+|  How to...    | Legacy (`numpy.poly1d`)      | `numpy.polynomial`               |
++---------------+------------------------------+----------------------------------+
+| Create a      | ``p = np.poly1d([1, 2, 3])`` | ``p = Polynomial([3, 2, 1])``    |
+| polynomial    |                              |                                  |
+| object [1]_   |                              |                                  |
++---------------+------------------------------+----------------------------------+
+| Fit data with |                              |                                  |
+| a polynomial  | ``np.polyfit(x, y, degree)`` | ``Polynomial.fit(x, y, degree)`` |
+| expression    |                              |                                  |
++---------------+------------------------------+----------------------------------+
+
+
+.. [1] Note the reversed ordering of the coefficients
+
 
 There are significant differences between ``numpy.lib.polynomial`` and 
 the the polynomial package, `numpy.polynomial`.

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -9,8 +9,9 @@ of the `numpy.polynomial` package, introduced in NumPy 1.4.
 
 Prior to NumPy 1.4, `numpy.poly1d` was the class of choice and it is still
 available in order to maintain backward compatibility.
-However, the newer Polynomial package is more complete than `numpy.poly1d`
-and its convenience classes are better behaved in the numpy environment.
+However, the newer `polynomial package <numpy.polynomial>` is more complete
+than `numpy.poly1d` and its convenience classes are better behaved in the
+numpy environment.
 Therefore :mod:`numpy.polynomial` is recommended for new coding.
 
 Transition notice

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -101,7 +101,7 @@ the ``domain`` and ``window`` attributes.
 Another major difference bewteen the legacy polynomial module and the
 polynomial package is polynomial fitting. In the old module, fitting was
 done via the `~numpy.polyfit` function. In the polynomial package, the
-`~numpy.polynomial.polynomial.Polynomial.fit`_ class method is preferred. For
+`~numpy.polynomial.polynomial.Polynomial.fit` class method is preferred. For
 example, consider a simple linear fit to the following data:
 
 .. ipython:: python
@@ -117,7 +117,7 @@ could be applied to these data with `~numpy.polyfit`:
 
     np.polyfit(x, y, deg=1)
 
-With the new polynomial API, the `~numpy.polynomial.polynomial.Polynomial.fit`_
+With the new polynomial API, the `~numpy.polynomial.polynomial.Polynomial.fit`
 class method is preferred:
 
 .. ipython:: python

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -78,7 +78,7 @@ expression::
 
 In addition to the ``coef`` attribute, polynomials from the polynomial
 package also have ``domain`` and ``window`` attributes.
-These attributes are most relevant when
+These attributes are most relevant when fitting
 polynomials to data, though it should be noted that polynomials with
 different ``domain`` and ``window`` attributes are not considered equal, and
 can't be mixed in arithmetic::

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -10,7 +10,7 @@ of the `numpy.polynomial` package, introduced in NumPy 1.4.
 Prior to NumPy 1.4, `numpy.poly1d` was the class of choice and it is still
 available in order to maintain backward compatibility.
 However, the newer `polynomial package <numpy.polynomial>` is more complete
-and its `convenience classes <routines.polynomials.classes` provide a
+and its `convenience classes <routines.polynomials.classes>` provide a
 more consistent, better-behaved interface for working with polynomial
 expressions.
 Therefore :mod:`numpy.polynomial` is recommended for new coding.
@@ -18,7 +18,7 @@ Therefore :mod:`numpy.polynomial` is recommended for new coding.
 Transitioning from `numpy.poly1d` to `numpy.polynomial`
 -------------------------------------------------------
 
-As noted above, the :class:`poly1d class <numpy.poly1d>` and associated 
+As noted above, the :class:`poly1d class <numpy.poly1d>` and associated
 functions defined in ``numpy.lib.polynomial``, such as `numpy.polyfit`
 and `numpy.poly`, are considered legacy and should **not** be used in new
 code.
@@ -28,30 +28,34 @@ working with polynomials.
 Quick Reference
 ~~~~~~~~~~~~~~~
 
-The following table highlights some of the main differences between the 
-legacy polynomial module and the polynomial package.
+The following table highlights some of the main differences between the
+legacy polynomial module and the polynomial package for common tasks.
 The `~numpy.polynomial.Polynomial` class is imported for brevity::
 
     from numpy.polynomial import Polynomial
 
 
-+---------------+------------------------------+----------------------------------+
-|  How to...    | Legacy (`numpy.poly1d`)      | `numpy.polynomial`               |
-+---------------+------------------------------+----------------------------------+
-| Create a      | ``p = np.poly1d([1, 2, 3])`` | ``p = Polynomial([3, 2, 1])``    |
-| polynomial    |                              |                                  |
-| object [1]_   |                              |                                  |
-+---------------+------------------------------+----------------------------------+
-| Fit data with |                              |                                  |
-| a polynomial  | ``np.polyfit(x, y, degree)`` | ``Polynomial.fit(x, y, degree)`` |
-| expression    |                              |                                  |
-+---------------+------------------------------+----------------------------------+
++------------------------+------------------------------+---------------------------------------+
+|  How to...             | Legacy (`numpy.poly1d`)      | `numpy.polynomial`                    |
++------------------------+------------------------------+---------------------------------------+
+| Create a               | ``p = np.poly1d([1, 2, 3])`` | ``p = Polynomial([3, 2, 1])``         |
+| polynomial object      |                              |                                       |
+| from coefficients [1]_ |                              |                                       |
++------------------------+------------------------------+---------------------------------------+
+| Create a polynomial    | ``r = np.poly([-1, 1])``     | ``p = Polynomial.fromroots([-1, 1])`` |
+| object from roots      | ``p = np.poly1d(r)``         |                                       |
++------------------------+------------------------------+---------------------------------------+
+| Fit a polynomial of    |                              |                                       |
+| degree ``deg`` to data | ``np.polyfit(x, y, deg)``    | ``Polynomial.fit(x, y, deg)``         |
++------------------------+------------------------------+---------------------------------------+
 
 
 .. [1] Note the reversed ordering of the coefficients
 
+Transition Guide
+~~~~~~~~~~~~~~~~
 
-There are significant differences between ``numpy.lib.polynomial`` and 
+There are significant differences between ``numpy.lib.polynomial`` and
 the the polynomial package, `numpy.polynomial`.
 The most significant differences is the ordering of the coefficients for the
 polynomial expressions.
@@ -65,18 +69,92 @@ degree *i*.
 Though the difference in convention may be confusing, it is straightforward to
 convert from the old-style polynomial API to the new.
 For example, the following demonstrates how you would convert a `numpy.poly1d`
-instance representing the expression :math:`x^{2} + 2 \cdot x + 3` to a
-`numpy.polynomial.Polynomial` instance representing the same expression::
+instance representing the expression :math:`x^{2} + 2x + 3` to a
+`~numpy.polynomial.polynomial.Polynomial` instance representing the same
+expression::
 
-    >>> p1d = np.poly1d([1, 2, 3])                    # Legacy
-    >>> p = np.polynomial.Polynomial(p1d.coef[::-1])  # Preferred
+    >>> c = [1, 2, 3]                          # x**2 +2*x + 3
+    >>> p1d = np.poly1d(c)                     # Legacy
+    >>> p = np.polynomial.Polynomial(c[::-1])
 
+In addition to the ``coef`` attribute, polynomials from the polynomial
+package also have ``domain`` and ``window`` attributes that define any
+particular polynomial instance. These attributes are most relevant when
+polynomials to data, though it should be noted that polynomials with
+different ``domain`` and ``window`` attributes are not considered equal, and
+can't be mixed in arithmetic::
 
+    >>> p1 = np.polynomial.Polynomial([1, 2, 3])
+    >>> p1
+    Polynomial([1., 2., 3.], domain=[-1,  1], window=[-1,  1])
+    >>> p2 = np.polynomial.Polynomial([1, 2, 3], domain=[-2, 2])
+    >>> p1 == p2
+    False
+    >>> p1 + p2
+    TypeError: Domains differ
+
+See the documentation for the
+`convenience classes <routines.polynomials.classes>` for further details on
+the ``domain`` and ``window`` attributes.
+
+Another major difference bewteen the legacy polynomial module and the
+polynomial package is polynomial fitting. In the legacy code, fitting was
+done via the `~numpy.polyfit` function. In the polynomial package, the
+`Polynomial.fit` classmethod is preferred. For example, consider a simple
+linear fit to the following data:
+
+.. ipython::
+
+    rg = np.random.default_rng()
+    x = np.arange(10)
+    y = np.arange(10) + rg.standard_normal(10)
+
+With the legacy polynomial module, a linear fit (i.e. polynomial of degree 1)
+could be applied to these data with `~numpy.polyfit`:
+
+.. ipython::
+
+    np.polyfit(x, y, deg=1)
+
+With the new polynomial API, the `~numpy.polynomial.polynomial.Polynomial.fit`
+class method is preferred:
+
+.. ipython::
+
+    p_fitted = np.polynomial.Polynomial.fit(x, y, deg=1)
+    p_fitted
+
+Note that the coefficients are given *in scaled domain* defined by the linear
+mapping between the ``window`` and ``domain``.
+`~numpy.polynomial.polynomial.Polynomial.convert` can be used to get the
+coefficients in the unscaled data domain.
+
+.. ipython::
+
+    p_fitted.convert()
+
+Documentation for the `~numpy.polynomial` Package
+-------------------------------------------------
+
+In addition to standard power series polynomials, the polynomial package
+provides several additional kinds of polynomials including Chebyshev,
+Hermite (two subtypes), Laguerre, and Legendre polynomials.
+Each of these has an associated
+`convenience class <routines.polynomials.classes>` available from the
+`numpy.polynomial` namespace that provides a consistent interface for working
+with polynomials regardless of their type.
 
 .. toctree::
    :maxdepth: 1
 
    routines.polynomials.classes
+
+Documentation pertaining to specific functions defined for each kind of the
+kinds of polynomials can be found in the corresponding module documentation:
+
+.. toctree::
+   :maxdepth: 1
+
    routines.polynomials.polynomial
    routines.polynomials.chebyshev
    routines.polynomials.hermite
@@ -85,6 +163,9 @@ instance representing the expression :math:`x^{2} + 2 \cdot x + 3` to a
    routines.polynomials.legendre
    routines.polynomials.polyutils
 
+
+Documentation for Legacy Polynomials
+------------------------------------
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -90,6 +90,8 @@ can't be mixed in arithmetic::
     >>> p1 == p2
     False
     >>> p1 + p2
+    Traceback (most recent call last):
+        ...
     TypeError: Domains differ
 
 See the documentation for the


### PR DESCRIPTION
The [current documentation for polynomials](https://numpy.org/devdocs/reference/routines.polynomials.html) in the reference guide that explains the difference between `poly1d/np.lib.polynomial` and `np.polynomial` doesn't contain a lot of information about the differences between the "old" and "new" approaches to polynomials.

This PR adds documentation that attempts to flesh out the reference doc a bit more, and to further aid/motivate users interested in polynomials to use the newer `np.polynomial` package.

A lot of the wording may be redundant, so please keep that in mind when reviewing - I think the text could certainly be made shorter. I've added a table that lists how to do common tasks (create polynomials from roots, fitting, etc.) with both the old and new polynomial API. This could certainly be expanded to help serve as a "how to" guide for any users interested in transitioning old poly1d code to the newer `np.polynomial` API.
