### PR TITLE
DOC,BLD: Add :doc: to whitelisted roles in refguide_check.

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -450,7 +450,7 @@ def validate_rst_syntax(text, name, dots=True):
         return False, "ERROR: %s: no documentation" % (name,)
 
     ok_unknown_items = set([
-        'mod', 'currentmodule', 'autosummary', 'data', 'attr',
+        'mod', 'doc', 'currentmodule', 'autosummary', 'data', 'attr',
         'obj', 'versionadded', 'versionchanged', 'module', 'class',
         'ref', 'func', 'toctree', 'moduleauthor', 'term', 'c:member',
         'sectionauthor', 'codeauthor', 'eq', 'doi', 'DOI', 'arXiv', 'arxiv'


### PR DESCRIPTION
The refguide_check (which currently runs as part of the CI) fails on `:doc:`
roles in the documentation - see #16167 for example. `:doc:` is a 
[valid sphinx role](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-doc) since v0.6 thus its use should not cause problems in
building the NumPy documentation.

This change would fix the `refguide_check` CI failure for #16167.
