### PR TITLE
DOC: Add transition note to all lib/poly functions

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -46,6 +46,12 @@ def poly(seq_of_zeros):
     """
     Find the coefficients of a polynomial with the given sequence of roots.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     Returns the coefficients of the polynomial whose leading coefficient
     is one for the given sequence of zeros (multiple roots must be included
     in the sequence as many times as their multiplicity; see Examples).
@@ -168,6 +174,12 @@ def roots(p):
     """
     Return the roots of a polynomial with coefficients given in p.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     The values in the rank-1 array `p` are coefficients of a polynomial.
     If the length of `p` is n+1 then the polynomial is described by::
 
@@ -257,6 +269,12 @@ def _polyint_dispatcher(p, m=None, k=None):
 def polyint(p, m=1, k=None):
     """
     Return an antiderivative (indefinite integral) of a polynomial.
+
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
 
     The returned order `m` antiderivative `P` of polynomial `p` satisfies
     :math:`\\frac{d^m}{dx^m}P(x) = p(x)` and is defined up to `m - 1`
@@ -357,6 +375,12 @@ def polyder(p, m=1):
     """
     Return the derivative of the specified order of a polynomial.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     Parameters
     ----------
     p : poly1d or sequence
@@ -430,6 +454,12 @@ def _polyfit_dispatcher(x, y, deg, rcond=None, full=None, w=None, cov=None):
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares polynomial fit.
+
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
 
     Fit a polynomial ``p(x) = p[0] * x**deg + ... + p[deg]`` of degree `deg`
     to points `(x, y)`. Returns a vector of coefficients `p` that minimises
@@ -667,6 +697,12 @@ def polyval(p, x):
     """
     Evaluate a polynomial at specific values.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     If `p` is of length N, this function returns the value:
 
         ``p[0]*x**(N-1) + p[1]*x**(N-2) + ... + p[N-2]*x + p[N-1]``
@@ -744,6 +780,12 @@ def polyadd(a1, a2):
     """
     Find the sum of two polynomials.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     Returns the polynomial resulting from the sum of two input polynomials.
     Each input must be either a poly1d object or a 1D sequence of polynomial
     coefficients, from highest to lowest degree.
@@ -806,6 +848,12 @@ def polysub(a1, a2):
     """
     Difference (subtraction) of two polynomials.
 
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
+
     Given two polynomials `a1` and `a2`, returns ``a1 - a2``.
     `a1` and `a2` can be either array_like sequences of the polynomials'
     coefficients (including coefficients equal to zero), or `poly1d` objects.
@@ -853,6 +901,12 @@ def polysub(a1, a2):
 def polymul(a1, a2):
     """
     Find the product of two polynomials.
+
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
 
     Finds the polynomial resulting from the multiplication of the two input
     polynomials. Each input must be either a poly1d object or a 1D sequence
@@ -914,6 +968,12 @@ def _polydiv_dispatcher(u, v):
 def polydiv(u, v):
     """
     Returns the quotient and remainder of polynomial division.
+
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
 
     The input arrays are the coefficients (including any coefficients
     equal to zero) of the "numerator" (dividend) and "denominator"
@@ -1008,6 +1068,12 @@ def _raise_power(astr, wrap=70):
 class poly1d:
     """
     A one-dimensional polynomial class.
+
+    .. note::
+       This forms part of the old polynomial API. Since version 1.4, the
+       new polynomial API defined in `numpy.polynomial` is preferred.
+       A summary of the differences can be found in the
+       :doc:`transition guide </reference/routines.polynomials>`.
 
     A convenience class, used to encapsulate "natural" operations on
     polynomials so that said operations may take on their customary


### PR DESCRIPTION
Adds a `.. note::` right after the description to all functions/classes
from the numpy.lib.polynomial module notifying the user that the
numpy.polynomial package is preferred.

This works in conjunction with #16164 and #16167 to attempt to improve the polynomial documentation to highlight the distinction between the `numpy.lib.polynomial` module, and the newer, preferred `numpy.polynomial` package. The wording here derives from a [suggestion](https://github.com/numpy/numpy/pull/13601#issuecomment-525591808) in #13601.