### PR TITLE
DOC: Unify cross-references between array joining methods

### DIFF
--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -69,11 +69,11 @@ Joining arrays
 
    concatenate
    stack
-   column_stack
-   dstack
-   hstack
-   vstack
    block
+   vstack
+   hstack
+   dstack
+   column_stack
 
 Splitting arrays
 ================

--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -145,13 +145,13 @@ Joining arrays
 .. autosummary::
    :toctree: generated/
 
-   ma.stack
-   ma.column_stack
    ma.concatenate
-   ma.append
-   ma.dstack
-   ma.hstack
+   ma.stack
    ma.vstack
+   ma.hstack
+   ma.dstack
+   ma.column_stack
+   ma.append
 
 
 _____

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -171,14 +171,15 @@ def concatenate(arrays, axis=None, out=None):
     array_split : Split an array into multiple sub-arrays of equal or
                   near-equal size.
     split : Split array into a list of multiple sub-arrays of equal size.
-    hsplit : Split array into multiple sub-arrays horizontally (column wise)
-    vsplit : Split array into multiple sub-arrays vertically (row wise)
+    hsplit : Split array into multiple sub-arrays horizontally (column wise).
+    vsplit : Split array into multiple sub-arrays vertically (row wise).
     dsplit : Split array into multiple sub-arrays along the 3rd axis (depth).
     stack : Stack a sequence of arrays along a new axis.
-    hstack : Stack arrays in sequence horizontally (column wise)
-    vstack : Stack arrays in sequence vertically (row wise)
-    dstack : Stack arrays in sequence depth wise (along third dimension)
     block : Assemble arrays from blocks.
+    hstack : Stack arrays in sequence horizontally (column wise).
+    vstack : Stack arrays in sequence vertically (row wise).
+    dstack : Stack arrays in sequence depth wise (along third dimension).
+    column_stack : Stack 1-D arrays as columns into a 2-D array.
 
     Notes
     -----

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -247,12 +247,13 @@ def vstack(tup):
 
     See Also
     --------
-    stack : Join a sequence of arrays along a new axis.
-    hstack : Stack arrays in sequence horizontally (column wise).
-    dstack : Stack arrays in sequence depth wise (along third dimension).
     concatenate : Join a sequence of arrays along an existing axis.
-    vsplit : Split array into a list of multiple sub-arrays vertically.
-    block : Assemble arrays from blocks.
+    stack : Join a sequence of arrays along a new axis.
+    block : Assemble an nd-array from nested lists of blocks.
+    hstack : Stack arrays in sequence horizontally (column wise).
+    dstack : Stack arrays in sequence depth wise (along third axis).
+    column_stack : Stack 1-D arrays as columns into a 2-D array.
+    vsplit : Split an array into multiple sub-arrays vertically (row-wise).
 
     Examples
     --------
@@ -309,12 +310,13 @@ def hstack(tup):
 
     See Also
     --------
+    concatenate : Join a sequence of arrays along an existing axis.
     stack : Join a sequence of arrays along a new axis.
+    block : Assemble an nd-array from nested lists of blocks.
     vstack : Stack arrays in sequence vertically (row wise).
     dstack : Stack arrays in sequence depth wise (along third axis).
-    concatenate : Join a sequence of arrays along an existing axis.
-    hsplit : Split array along second axis.
-    block : Assemble arrays from blocks.
+    column_stack : Stack 1-D arrays as columns into a 2-D array.
+    hsplit : Split an array into multiple sub-arrays horizontally (column-wise).
 
     Examples
     --------
@@ -385,8 +387,8 @@ def stack(arrays, axis=0, out=None):
     See Also
     --------
     concatenate : Join a sequence of arrays along an existing axis.
+    block : Assemble an nd-array from nested lists of blocks.
     split : Split array into a list of multiple sub-arrays of equal size.
-    block : Assemble arrays from blocks.
 
     Examples
     --------
@@ -723,12 +725,13 @@ def block(arrays):
 
     See Also
     --------
-    concatenate : Join a sequence of arrays together.
-    stack : Stack arrays in sequence along a new dimension.
-    hstack : Stack arrays in sequence horizontally (column wise).
+    concatenate : Join a sequence of arrays along an existing axis.
+    stack : Join a sequence of arrays along a new axis.
     vstack : Stack arrays in sequence vertically (row wise).
-    dstack : Stack arrays in sequence depth wise (along third dimension).
-    vsplit : Split array into a list of multiple sub-arrays vertically.
+    hstack : Stack arrays in sequence horizontally (column wise).
+    dstack : Stack arrays in sequence depth wise (along third axis).
+    column_stack : Stack 1-D arrays as columns into a 2-D array.
+    vsplit : Split an array into multiple sub-arrays vertically (row-wise).
 
     Notes
     -----

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -688,10 +688,12 @@ def dstack(tup):
 
     See Also
     --------
-    stack : Join a sequence of arrays along a new axis.
-    vstack : Stack along first axis.
-    hstack : Stack along second axis.
     concatenate : Join a sequence of arrays along an existing axis.
+    stack : Join a sequence of arrays along a new axis.
+    block : Assemble an nd-array from nested lists of blocks.
+    vstack : Stack arrays in sequence vertically (row wise).
+    hstack : Stack arrays in sequence horizontally (column wise).
+    column_stack : Stack 1-D arrays as columns into a 2-D array.
     dsplit : Split array along third axis.
 
     Examples


### PR DESCRIPTION
Essentially, always reference the following functions:

~~~
    concatenate
    stack
    vstack
    hstack
    dstack
    column_stack
    block
~~~
but omitting the documented function itself (of course), and appending the corresponding inverse split operation instead.

In particular:
- unified the order.
- updated descriptions from docstring summary.