### PR TITLE
DOC: update Code of Conduct committee

### DIFF
--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -113,8 +113,8 @@ You can report issues to the NumPy Code of Conduct committee, at
 numpy-conduct@googlegroups.com. Currently, the committee consists of:
 
 - Stefan van der Walt
-- Nathaniel J. Smith
-- Ralf Gommers
+- Melissa Weber Mendonça
+- Anirudh Subramanian
 
 If your report involves any members of the committee, or if they feel they have
 a conflict of interest in handling it, then they will recuse themselves from

--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -56,7 +56,7 @@ NumFOCUS Subcommittee
 Institutional Partners
 ----------------------
 
-* UC Berkeley (Stefan van der Walt, Matti Picus, Tyler Reddy, Sebastian Berg)
+* UC Berkeley (Stefan van der Walt, Sebastian Berg, Warren Weckesser, Ross Barnowski)
 
-* Quansight (Ralf Gommers, Hameer Abbasi)
+* Quansight (Ralf Gommers, Hameer Abbasi, Melissa Weber Mendonça, Mars Lee, Matti Picus)
 


### PR DESCRIPTION
See https://mail.python.org/pipermail/numpy-discussion/2020-May/080625.html for the mailing list conversation on the new CoC committee composition.

Also updated the list of people under Institutional Partners now that I'm looking at people's names.

When this is merged I'll deal with adding people to numpy-conduct@googlegroups.com and taking Nathaniel and myself off that list.