### PR TITLE
ENH: Add ``full_output`` argument to ``f2py.compile``.

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -109,9 +109,10 @@ def compile(source,
                                    stderr=subprocess.PIPE)
         except OSError:
             # preserve historic status code used by exec_command()
-            cp = subprocess.CompletedProcess(c, 127, stdout='', stderr='')
-        if verbose:
-            print(cp.stdout.decode())
+            cp = subprocess.CompletedProcess(c, 127, stdout=b'', stderr=b'')
+        else:
+            if verbose:
+                print(cp.stdout.decode())
     finally:
         if source_fn is None:
             os.remove(fname)


### PR DESCRIPTION
fixes #12756 by providing a straightforward way to return the stdout/stderr
from compiling the FORTRAN module to the caller

TODO:
* [ ] Include a test?  I think this is fairly trivial so I'm not sure if it's interesting to test.
* [ ] Add message to release notes.