### PR TITLE
ENH: backport scipy changes to openblas download script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,6 @@ stages:
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \
-            python3 -m pip install urllib3 && \
             target=\$(python3 tools/openblas_support.py) && \
             cp -r \$target/lib/* /usr/lib && \
             cp \$target/include/* /usr/include && \
@@ -122,7 +121,6 @@ stages:
     # primarily on file size / name details
     - script: |
         set -xe
-        python -m pip install urllib3
         target=$(python tools/openblas_support.py)
         ls -lR $target
         # manually link to appropriate system paths

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -14,7 +14,7 @@ steps:
     # to $PYTHON_EXE's directory since that is on a different drive which
     # mingw does not like. Instead copy it to a directory and set OPENBLAS,
     # since OPENBLAS will be picked up by the openblas discovery
-    python -m pip  install urllib3
+    python -m pip  install
     $target = $(python tools/openblas_support.py)
     mkdir openblas
     echo Copying $target to openblas/openblas$env:OPENBLAS_SUFFIX.a

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,7 +25,6 @@ build:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
     - sudo apt-get install gcc gfortran libgfortran5
-    - python -mpip install urllib3
     - target=$(python tools/openblas_support.py)
     - ls -lR "${target}"
     - sudo cp -r "${target}"/lib/* /usr/lib

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -20,6 +20,7 @@ ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86_64', 'i686', 'ppc64le'
 sha256_vals = {
 "openblas-v0.3.7-527-g79fd006c-win_amd64-gcc_7_1_0.zip": "7249d68c02e6b6339e06edfeab1fecddf29ee1e67a3afaa77917c320c43de840",
 "openblas64_-v0.3.7-527-g79fd006c-win_amd64-gcc_7_1_0.zip": "6488e0961a5926e47242f63b63b41cfdd661e6f1d267e8e313e397cde4775c17",
+"openblas-v0.3.7-527-g79fd006c-win32-gcc_7_1_0.zip": "5fb0867ca70b1d0fdbf68dd387c0211f26903d74631420e4aabb49e94aa3930d",
 "openblas-v0.3.7-527-g79fd006c-macosx_10_9_x86_64-gf_1becaaa.tar.gz": "69434bd626bbc495da9ce8c36b005d140c75e3c47f94e88c764a199e820f9259",
 "openblas64_-v0.3.7-527-g79fd006c-macosx_10_9_x86_64-gf_1becaaa.tar.gz": "093f6d953e3fa76a86809be67bd1f0b27656671b5a55b233169cfaa43fd63e22",
 "openblas-v0.3.7-527-g79fd006c-manylinux2014_aarch64.tar.gz": "42676c69dc48cd6e412251b39da6b955a5a0e00323ddd77f9137f7c259d35319",

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -6,9 +6,10 @@ set -o pipefail
 # Print expanded commands
 set -x
 
-#sudo apt-get -yq update
-#sudo apt-get -yq install libatlas-base-dev liblapack-dev gfortran-5 python3-urllib3
-F77=gfortran-5 F90=gfortran-5 \
+sudo apt-get -yq update
+sudo apt-get -yq install gfortran-5
+export F77=gfortran-5
+export F90=gfortran-5
 
 # Download the proper OpenBLAS x64 precompiled library
 target=$(python3 tools/openblas_support.py)

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -41,8 +41,7 @@ pip install --upgrade pip
 # A specific version of cython is required, so we read the cython package
 # requirement using `grep cython test_requirements.txt` instead of simply
 # writing 'pip install setuptools wheel cython'.
-# urllib3 is needed for openblas_support
-pip install setuptools wheel urllib3 `grep cython test_requirements.txt`
+pip install setuptools wheel `grep cython test_requirements.txt`
 
 if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd


### PR DESCRIPTION
xref scipy/scipy#12094

- Add hashes for openblas downloads (using `python3 tools/openblas_support.py --test` to print out the current hases)
- Use a User-Agent instead of requiring `urllib3`
- Fix PyPy installs to still install gfortran for f2py tests