### PR TITLE
DOC,BLD: pin sphinx to <3.0 in doc_requirements.txt

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=2.2.0
+sphinx>=2.2.0,<3.0
 ipython
 scipy
 matplotlib


### PR DESCRIPTION
Attempting to build the docs with Sphinx 3 raises a lot of warnings, particularly
re: the documentation for the C components. Pinning to sphinx 2 until
this is resolved.