### PR TITLE
BUG: fix signature of PyArray_SearchSorted in __init__.pxd

### DIFF
--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -607,7 +607,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_Choose (ndarray, object, ndarray, NPY_CLIPMODE)
     int PyArray_Sort (ndarray, int, NPY_SORTKIND)
     object PyArray_ArgSort (ndarray, int, NPY_SORTKIND)
-    object PyArray_SearchSorted (ndarray, object, NPY_SEARCHSIDE)
+    object PyArray_SearchSorted (ndarray, object, NPY_SEARCHSIDE, object)
     object PyArray_ArgMax (ndarray, int, ndarray)
     object PyArray_ArgMin (ndarray, int, ndarray)
     object PyArray_Reshape (ndarray, object)


### PR DESCRIPTION
Fixes gh-16219

Not to delay this PR, but I wonder if we could somehow write a test that checks all the signatures, and checks that all the API functions appear in `__init__.pxd`, kind of like the way we [check the API hashes](https://github.com/numpy/numpy/blob/v1.18.4/numpy/core/setup_common.py#L84)