### PR TITLE
Discard np.random.beta samples that are zero or one

### DIFF
--- a/numpy/random/src/legacy/legacy-distributions.c
+++ b/numpy/random/src/legacy/legacy-distributions.c
@@ -175,7 +175,7 @@ double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
   double Ga, Gb;
 
   if ((a <= 1.0) && (b <= 1.0)) {
-    double U, V, X, Y;
+    double U, V, X, Y, Z;
     /* Use Johnk's algorithm */
 
     while (1) {
@@ -186,7 +186,7 @@ double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
 
       if ((X + Y) <= 1.0) {
         if (X + Y > 0) {
-          return X / (X + Y);
+          Z =  X / (X + Y);
         } else {
           double logX = log(U) / a;
           double logY = log(V) / b;
@@ -194,7 +194,10 @@ double legacy_beta(aug_bitgen_t *aug_state, double a, double b) {
           logX -= logM;
           logY -= logM;
 
-          return exp(logX - log(exp(logX) + exp(logY)));
+          Z =  exp(logX - log(exp(logX) + exp(logY)));
+        }
+        if (Z > 0 && Z < 1) {
+          return Z;
         }
       }
     }

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -519,6 +519,12 @@ class TestRandomDist:
                  [1.58405155108498093e-04, 1.26252891949397652e-04]])
         assert_array_almost_equal(actual, desired, decimal=15)
 
+    def test_beta_domain(self):
+        # Test related to issue 16230
+        np.random.seed(self.seed)
+        actual = np.random.beta(0.01, 0.01, size=100000)
+        assert not (np.any(actual == 0) or np.any(actual == 1))
+
     def test_binomial(self):
         np.random.seed(self.seed)
         actual = np.random.binomial(100, .456, size=(3, 2))


### PR DESCRIPTION
This closes #16230.

The beta distribution probability density function isn't well defined when `x` is either 0 or 1, so the pdf's domain should be the open interval (0, 1). The Johnk's algorithm that was used to generate beta variate samples sometimes can return zeroes or ones. This PR fixes that problem by simply discarding any sample that is exactly 0 or 1.