### PR TITLE
DEP: Deprecate ufunc.outer with matrix inputs

### DIFF
--- a/doc/release/upcoming_changes/16232.deprecation.rst
+++ b/doc/release/upcoming_changes/16232.deprecation.rst
@@ -1,0 +1,6 @@
+``outer`` and ``ufunc.outer`` deprecated for matrix
+---------------------------------------------------
+``np.matrix`` use with `~numpy.outer` or generic ufunc outer
+calls such as ``numpy.add.outer``. Previously, matrix was
+converted to an array here. This will not be done in the future
+requiring a manual conversion to arrays.

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5433,7 +5433,19 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         "matrix",
         &_numpy_matrix);
 
+    const char *matrix_deprecation_msg = (
+            "%s.outer() was passed a numpy matrix as %s argument. "
+            "Special handling of matrix is deprecated and will result in an "
+            "error in most cases. Please convert the matrix to a NumPy "
+            "array to retain the old behaviour. You can use `matrix.A` "
+            "to achieve this.");
+
     if (PyObject_IsInstance(tmp, _numpy_matrix)) {
+        /* DEPRECATED 2020-05-13, NumPy 1.20 */
+        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                matrix_deprecation_msg, ufunc->name, "first") < 0) {
+            return NULL;
+        }
         ap1 = (PyArrayObject *) PyArray_FromObject(tmp, NPY_NOTYPE, 0, 0);
     }
     else {
@@ -5448,6 +5460,11 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         return NULL;
     }
     if (PyObject_IsInstance(tmp, _numpy_matrix)) {
+        /* DEPRECATED 2020-05-13, NumPy 1.20 */
+        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+                matrix_deprecation_msg, ufunc->name, "second") < 0) {
+            return NULL;
+        }
         ap2 = (PyArrayObject *) PyArray_FromObject(tmp, NPY_NOTYPE, 0, 0);
     }
     else {

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -678,3 +678,18 @@ class TestDeprecatedGlobals(_DeprecationTestCase):
         # from np.compat
         self.assert_deprecated(lambda: np.long)
         self.assert_deprecated(lambda: np.unicode)
+
+
+class TestMatrixInOuter(_DeprecationTestCase):
+    # 2020-05-13 NumPy 1.20.0
+    message = (r"add.outer\(\) was passed a numpy matrix as "
+               r"(first|second) argument.")
+
+    def test_deprecated(self):
+        arr = np.array([1, 2, 3])
+        m = np.array([1, 2, 3]).view(np.matrix)
+        self.assert_deprecated(np.add.outer, args=(m, m), num=2)
+        self.assert_deprecated(np.add.outer, args=(arr, m))
+        self.assert_deprecated(np.add.outer, args=(m, arr))
+        self.assert_not_deprecated(np.add.outer, args=(arr, arr))
+

--- a/numpy/matrixlib/tests/test_masked_matrix.py
+++ b/numpy/matrixlib/tests/test_masked_matrix.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_warns
 from numpy.ma.testutils import (assert_, assert_equal, assert_raises,
                                 assert_array_equal)
 from numpy.ma.core import (masked_array, masked_values, masked, allequal,
@@ -198,7 +199,8 @@ class TestSubclassing:
         # Result should work
         assert_equal(add(mx, x), mx+x)
         assert_(isinstance(add(mx, mx)._data, np.matrix))
-        assert_(isinstance(add.outer(mx, mx), MMatrix))
+        with assert_warns(DeprecationWarning):
+            assert_(isinstance(add.outer(mx, mx), MMatrix))
         assert_(isinstance(hypot(mx, mx), MMatrix))
         assert_(isinstance(hypot(mx, x), MMatrix))
 


### PR DESCRIPTION
Previously we converted matrices to arrays for the user, since
`np.outer` does not make sense for matrix. This deprecates that
usage (which in almost all cases will result in an error).

The main reason for this deprecation is to remove all direct
references of matrix from the NumPy codebase, so that it is
easier to move it out of NumPy eventually.

---

I can spin off the first maintenance commit if anyone feels the deprecation is trivial...

EDIT: xref gh-15105 which this closes, but I will remove the 1.19 milestone, since this doesn't really need to be in 1.19. It might just make the next steps to get rid of matrix a tiny bit simpler.

**EDIT: For reviewers, the commits are probably best reviewed separately, just to disentangle things a bit. Both should be very straight forward.**