### PR TITLE
MAINT: Unify cached (C-level static) imports

### DIFF
--- a/numpy/core/src/common/npy_import.h
+++ b/numpy/core/src/common/npy_import.h
@@ -19,7 +19,7 @@
 NPY_INLINE static void
 npy_cache_import(const char *module, const char *attr, PyObject **cache)
 {
-    if (*cache == NULL) {
+    if (NPY_UNLIKELY(*cache == NULL)) {
         PyObject *mod = PyImport_ImportModule(module);
 
         if (mod != NULL) {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -5,6 +5,7 @@
 #include <numpy/npy_cpu.h>
 #include <numpy/ndarraytypes.h>
 #include <limits.h>
+#include "npy_import.h"
 
 #define error_converting(x)  (((x) == -1) && PyErr_Occurred())
 
@@ -148,13 +149,9 @@ check_and_adjust_axis_msg(int *axis, int ndim, PyObject *msg_prefix)
         static PyObject *AxisError_cls = NULL;
         PyObject *exc;
 
+        npy_cache_import("numpy.core._exceptions", "AxisError", &AxisError_cls);
         if (AxisError_cls == NULL) {
-            PyObject *mod = PyImport_ImportModule("numpy.core._exceptions");
-
-            if (mod != NULL) {
-                AxisError_cls = PyObject_GetAttrString(mod, "AxisError");
-                Py_DECREF(mod);
-            }
+            return -1;
         }
 
         /* Invoke the AxisError constructor */

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -696,17 +696,15 @@ get_nbo_cast_numeric_transfer_function(int aligned,
     if (PyTypeNum_ISCOMPLEX(src_type_num) &&
                     !PyTypeNum_ISCOMPLEX(dst_type_num) &&
                     !PyTypeNum_ISBOOL(dst_type_num)) {
-        PyObject *cls = NULL, *obj = NULL;
+        static PyObject *cls = NULL;
         int ret;
-        obj = PyImport_ImportModule("numpy.core");
-        if (obj) {
-            cls = PyObject_GetAttrString(obj, "ComplexWarning");
-            Py_DECREF(obj);
+        npy_cache_import("numpy.core", "ComplexWarning", &cls);
+        if (cls == NULL) {
+            return NPY_FAIL;
         }
         ret = PyErr_WarnEx(cls,
                 "Casting complex values to real discards "
                 "the imaginary part", 1);
-        Py_XDECREF(cls);
         if (ret < 0) {
             return NPY_FAIL;
         }

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -16,6 +16,7 @@
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
 
+#include "npy_import.h"
 #include "npy_pycompat.h"
 
 #include "numpy/halffloat.h"
@@ -1339,13 +1340,9 @@ static int
 emit_complexwarning(void)
 {
     static PyObject *cls = NULL;
+    npy_cache_import("numpy.core", "ComplexWarning", &cls);
     if (cls == NULL) {
-        PyObject *mod;
-        mod = PyImport_ImportModule("numpy.core");
-        assert(mod != NULL);
-        cls = PyObject_GetAttrString(mod, "ComplexWarning");
-        assert(cls != NULL);
-        Py_DECREF(mod);
+        return -1;
     }
     return PyErr_WarnEx(cls,
             "Casting complex values to real discards the imaginary part", 1);


### PR DESCRIPTION
The main idea is that once we unify them, we can think about actually
being able to also clean them up.
This is far away from having no global state, but at this time I do not
see that as a seriousl goal personally. But it could be possible
to reload the module safely in a single interpreter maybe.

The commit adds the cache import for the complex casts, since it doubles
performance for small casts when the warning is not suppressed and it
unifies the handling.

---

Should be a trivial change, I did not think about using cached imports in places where we do not do really currently. My idea is, that unifying these, we could build a linked list with all cached entries and expose a function to clear/reset them. We probably could get reimports safe then (static interned strings are the main other thing, but at least they only leak a reference and don't really matter).