### PR TITLE
ENH: Warn when reloading numpy or using numpy in sub-interpreter

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -389,7 +389,12 @@ else:
     # Note that this will currently only make a difference on Linux
     core.multiarray._set_madvise_hugepage(use_hugepage)
 
+    # Give a warning if NumPy is reloaded or imported on a sub-interpreter
+    # We do this from python, since the C-module may not be reloaded and
+    # it is tidier organized.
+    core.multiarray._multiarray_umath._reload_guard()
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_raises, assert_, assert_equal
+from numpy.testing import assert_raises, assert_warns, assert_, assert_equal
 from numpy.compat import pickle
 
 import sys
@@ -16,13 +16,15 @@ def test_numpy_reloading():
     VisibleDeprecationWarning = np.VisibleDeprecationWarning
     ModuleDeprecationWarning = np.ModuleDeprecationWarning
 
-    reload(np)
+    with assert_warns(UserWarning):
+        reload(np)
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is np.ModuleDeprecationWarning)
     assert_(VisibleDeprecationWarning is np.VisibleDeprecationWarning)
 
     assert_raises(RuntimeError, reload, numpy._globals)
-    reload(np)
+    with assert_warns(UserWarning):
+        reload(np)
     assert_(_NoValue is np._NoValue)
     assert_(ModuleDeprecationWarning is np.ModuleDeprecationWarning)
     assert_(VisibleDeprecationWarning is np.VisibleDeprecationWarning)
@@ -45,13 +47,15 @@ def test_full_reimport():
     # This is generally unsafe, especially, since we also reload the C-modules.
     code = textwrap.dedent(r"""
         import sys
+        from pytest import warns
         import numpy as np
 
         for k in list(sys.modules.keys()):
             if "numpy" in k:
                 del sys.modules[k]
 
-        import numpy as np
+        with warns(UserWarning):
+            import numpy as np
         """)
     p = subprocess.run([sys.executable, '-c', code])
-    assert p.returncode == 0
+


### PR DESCRIPTION
This adds a warning when the main NumPy module is reloaded
 with the assumption that in this case objects such as `np.matrix`,
`np._NoValue` or exceptions may be cached internally.

It also gives a warning when NumPy is imported in a sub-interpreter.

---

I have tested this locally, not sure if adding a tes tmakes sense. The PYPY check was just because I assumed PYPY is different here:

The result for sub-interpreter warning is:
```
>>> import ctypes
>>> ctypes.pythonapi.Py_NewInterpreter()
30257600
import numpy as np
<stdin>:1: UserWarning: NumPy was imported from a Python sub-interpreter but NumPy does not properly support sub-interpreters. This will likely work for most users but might cause hard to track down issues or subtle bugs. A common user of the rare sub-interpreter feature is wsgi which also allows single-interpreter mode.
Improvements in the case of bugs are welcome, but is not on the NumPy roadmap, and full support may require significant effort to achieve.
```

And the other warning:
```
>>> import numpy as np
>>> import importlib
>>> importlib.reload(np)
/usr/lib/python3.8/importlib/__init__.py:169: UserWarning: The NumPy module was reloaded (imported a second time). This can in some cases result in small but subtle issues and is discouraged.
  _bootstrap._exec(spec, module)
<module 'numpy' from '/home/sebastian/forks/numpy/build/testenv/lib/python3.8/site-packages/numpy/__init__.py'>
```

Anyway, just a thought, maybe the warnings are too big, or too small I don't know. Marking as draft because its built to be merged after the `add_newdocs` cleanup.