### PR TITLE
BUG: Fix default fallback in genfromtxt

### DIFF
--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -514,7 +514,8 @@ class StringConverter:
                     # Last, try with the string types (must be last, because
                     # `_mapper[-1]` is used as default in some cases)
                     (nx.unicode_, asunicode, '???'),
-                    (nx.string_, asbytes, '???'),])
+                    (nx.string_, asbytes, '???'),
+                    ])
 
     @classmethod
     def _getdtype(cls, val):

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -506,13 +506,15 @@ class StringConverter:
     _mapper.extend([(nx.float64, float, nx.nan),
                     (nx.complex128, complex, nx.nan + 0j),
                     (nx.longdouble, nx.longdouble, nx.nan),
-                    (nx.unicode_, asunicode, '???'),
-                    (nx.string_, asbytes, '???'),
                     # If a non-default dtype is passed, fall back to generic
                     # ones (should only be used for the converter)
                     (nx.integer, int, -1),
                     (nx.floating, float, nx.nan),
-                    (nx.complexfloating, complex, nx.nan + 0j),])
+                    (nx.complexfloating, complex, nx.nan + 0j),
+                    # Last, try with the string types (must be last, because
+                    # `_mapper[-1]` is used as default in some cases)
+                    (nx.unicode_, asunicode, '???'),
+                    (nx.string_, asbytes, '???'),])
 
     @classmethod
     def _getdtype(cls, val):

--- a/numpy/lib/tests/test__iotools.py
+++ b/numpy/lib/tests/test__iotools.py
@@ -177,12 +177,12 @@ class TestStringConverter:
         # test str
         # note that the longdouble type has been skipped, so the
         # _status increases by 2. Everything should succeed with
-        # unicode conversion (5).
+        # unicode conversion (8).
         for s in ['a', b'a']:
             res = converter.upgrade(s)
             assert_(type(res) is str)
             assert_equal(res, 'a')
-            assert_equal(converter._status, 5 + status_offset)
+            assert_equal(converter._status, 8 + status_offset)
 
     def test_missing(self):
         "Tests the use of missing values."

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1567,6 +1567,13 @@ M   33  21.99
             test = np.genfromtxt(TextIO(data), delimiter=";",
                                  dtype=ndtype, converters=converters)
 
+    def test_dtype_with_object_no_converter(self):
+        # Object without a converter uses bytes:
+        parsed = np.genfromtxt(TextIO("1"), dtype=object)
+        assert parsed[()] == b"1"
+        parsed = np.genfromtxt(TextIO("string"), dtype=object)
+        assert parsed[()] == b"string"
+
     def test_userconverters_with_explicit_dtype(self):
         # Test user_converters w/ explicit (standard) dtype
         data = TextIO('skip,skip,2001-01-01,1.0,skip')


### PR DESCRIPTION
This affected (for example?) if the `dtype=object` was used
without a converter, meaning that the default one is used.
And this is currently the last one, which is `string_` (and thus
bytes).

Closes gh-16189
