### PR TITLE
MRG, ENH: added edge keyword argument to digitize

### DIFF
--- a/doc/release/upcoming_changes/16248.new_feature.rst
+++ b/doc/release/upcoming_changes/16248.new_feature.rst
@@ -1,0 +1,13 @@
+Digitize Keyword Egde
+---------------------
+A keyword argument has been added to `np.digitize` so that the
+edge case is covered in the last bin. For example,
+
+```
+x = [1, 2, 3]
+bins = [0, 1.5, 3]
+```
+
+`np.digitize(x, bins, right=False, edge=True)` yields `[1, 2, 2]`
+whereas before the edge keyword argument existed it would yield
+`[1, 2, 3]`.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4844,11 +4844,16 @@ def digitize(x, bins, right=False, edge=False):
         raise ValueError("bins must be monotonically increasing or decreasing")
 
     if edge:
-        # move first bin eps if right edge not included else move last bin
-        idx = 0 if right else -1
-        # move bin down if going up and using right or going down and using
-        # left else move bin up
-        delta = -mono if right else mono
+        # =========  =============  ============================ ===== =====
+        # `right`    order of bins  returned index `i` satisfies delta index
+        # =========  =============  ============================ ===== =====
+        # ``False``  increasing     ``bins[i-1] <= x < bins[i]``   1    -1
+        # ``True``   increasing     ``bins[i-1] < x <= bins[i]``   -1    0
+        # ``False``  decreasing     ``bins[i-1] > x >= bins[i]``   1    0
+        # ``True``   decreasing     ``bins[i-1] >= x > bins[i]``   -1    -1
+        # =========  =============  ============================ ===== =====
+        delta = -1 if right else 1
+        idx = 0 if delta != mono else -1
         if np.issubdtype(bins.dtype, _nx.integer):
             bins[idx] += delta
         else:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4847,9 +4847,9 @@ def digitize(x, bins, right=False, edge=False):
         # if cannot make round trip, cannot use eps
         if np.issubdtype(bins.dtype, _nx.integer):
             if right:
-                bins[0] -= 1
+                bins[0] -= mono
             else:
-                bins[-1] += 1
+                bins[-1] += mono
         else:
             bins = bins.astype(_nx.float64)
             if right:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4768,9 +4768,9 @@ def digitize(x, bins, right=False, edge=False):
         case, i.e., bins[i-1] <= x < bins[i] is the default behavior for
         monotonically increasing bins.
     edge : bool, optional
-        Whether to include the last right edge if right == False or the first
-        left edge if right == True. If egde==True, the entire interval is
-        included that would otherwise not be for the first or last edge case.
+        Whether to include the last right edge if right==False or the first
+        left edge if right==True so that the whole interval from the least
+        to the greatest value of bins is covered.
 
     Returns
     -------
@@ -4786,7 +4786,7 @@ def digitize(x, bins, right=False, edge=False):
 
     See Also
     --------
-    bincount, histogram, unique, searchsorted
+    bincount, histogram, unique, nextafter, searchsorted
 
     Notes
     -----
@@ -4844,18 +4844,15 @@ def digitize(x, bins, right=False, edge=False):
         raise ValueError("bins must be monotonically increasing or decreasing")
 
     if edge:
-        # if cannot make round trip, cannot use eps
+        # move first bin eps if right edge not included else move last bin
+        idx = 0 if right else -1
+        # move bin down if going up and using right or going down and using
+        # left else move bin up
+        delta = -mono if right else mono
         if np.issubdtype(bins.dtype, _nx.integer):
-            if right:
-                bins[0] -= mono
-            else:
-                bins[-1] += mono
+            bins[idx] += delta
         else:
-            bins = bins.astype(_nx.float64)
-            if right:
-                bins[0] -= np.finfo(_nx.float64).eps * 2 * mono
-            else:
-                bins[-1] += np.finfo(_nx.float64).eps * 2 * mono
+            bins[idx] = np.nextafter(bins[idx], bins[idx] + delta)
 
     # this is backwards because the arguments below are swapped
     side = 'left' if right else 'right'

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4853,7 +4853,7 @@ def digitize(x, bins, right=False, edge=False):
         # ``True``   decreasing     ``bins[i-1] >= x > bins[i]``   -1    -1
         # =========  =============  ============================ ===== =====
         delta = -1 if right else 1
-        idx = 0 if delta != mono else -1
+        idx = -1 if delta == mono else 0
         if np.issubdtype(bins.dtype, _nx.integer):
             bins[idx] += delta
         else:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4845,15 +4845,17 @@ def digitize(x, bins, right=False, edge=False):
 
     if edge:
         # if cannot make round trip, cannot use eps
-        if np.issubdtype(bins.dtype, _nx.int64):
-            if (bins != bins.astype(_nx.float64).astype(_nx.int64)).any():
-                raise ValueError("bins have too large values to use"
-                                 "'edges=True'")
-        bins = bins.astype(_nx.float64)
-        if right:
-            bins[0] -= np.finfo(_nx.float64).eps * 2 * mono
+        if np.issubdtype(bins.dtype, _nx.integer):
+            if right:
+                bins[0] -= 1
+            else:
+                bins[-1] += 1
         else:
-            bins[-1] += np.finfo(_nx.float64).eps * 2 * mono
+            bins = bins.astype(_nx.float64)
+            if right:
+                bins[0] -= np.finfo(_nx.float64).eps * 2 * mono
+            else:
+                bins[-1] += np.finfo(_nx.float64).eps * 2 * mono
 
     # this is backwards because the arguments below are swapped
     side = 'left' if right else 'right'

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1712,6 +1712,9 @@ class TestDigitize:
         bins = [1, 1, 0]
         assert_array_equal(digitize(x, bins, False), [3, 2, 0, 0])
         assert_array_equal(digitize(x, bins, True), [3, 3, 2, 0])
+        bins = [-1, 0, 1, 2]
+        assert_array_equal(digitize(x, bins, False, True), [1, 2, 3, 3])
+        assert_array_equal(digitize(x, bins, True, True), [1, 1, 2, 3])
         bins = [1, 1, 1, 1]
         assert_array_equal(digitize(x, bins, False), [0, 0, 4, 4])
         assert_array_equal(digitize(x, bins, True), [0, 0, 0, 4])
@@ -1740,6 +1743,7 @@ class TestDigitize:
         # gh-11022
         x = 2**54  # loses precision in a float
         assert_equal(np.digitize(x, [x - 1, x + 1]), 1)
+        assert_raises(ValueError, digitize, x, [x - 1, x + 1], False, True)
 
     @pytest.mark.xfail(
         reason="gh-11022: np.core.multiarray._monoticity loses precision")

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1715,6 +1715,9 @@ class TestDigitize:
         bins = [-1, 0, 1, 2]
         assert_array_equal(digitize(x, bins, False, True), [1, 2, 3, 3])
         assert_array_equal(digitize(x, bins, True, True), [1, 1, 2, 3])
+        bins = [2, 1, 0, -1]
+        assert_array_equal(digitize(x, bins, False, True), [3, 2, 1, 1])
+        assert_array_equal(digitize(x, bins, True, True), [3, 3, 2, 1])
         bins = [1, 1, 1, 1]
         assert_array_equal(digitize(x, bins, False), [0, 0, 4, 4])
         assert_array_equal(digitize(x, bins, True), [0, 0, 0, 4])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1743,7 +1743,7 @@ class TestDigitize:
         # gh-11022
         x = 2**54  # loses precision in a float
         assert_equal(np.digitize(x, [x - 1, x + 1]), 1)
-        assert_raises(ValueError, digitize, x, [x - 1, x + 1], False, True)
+        assert_equal(np.digitize(x, [x - 1, x + 1], False, True), 1)
 
     @pytest.mark.xfail(
         reason="gh-11022: np.core.multiarray._monoticity loses precision")


### PR DESCRIPTION
Adding an edge keyword allows a simpler syntax for passing in bins while including edge cases that would otherwise provoke slightly weird behavior as in

```
x = [1, 2, 3]
bins = [0, 1.5, 3]
```

resulting in
```
np.digitize = [1, 2, 3]
```

when users might prefer

```
np.digitize = [1, 2, 2]
```

as they only passed two ranges and all the values were within the ranges including edge cases.

I thought it would be useful but if not, no worries.
