### PR TITLE
DOC: Clarify tiny/xmin in finfo and machar (gh-16253)

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -358,11 +358,11 @@ class finfo:
     impacts import times.  These objects are cached, so calling ``finfo()``
     repeatedly inside your functions is not a problem.
 
-    Note that `tiny` is not actually the smallest positive representable
-    value in a NumPy floating point type. As in the IEEE-754 standard[1]_,
+    Note that ``tiny`` is not actually the smallest positive representable
+    value in a NumPy floating point type. As in the IEEE-754 standard [1]_,
     NumPy floating point types make use of subnormal numbers to fill the
-    gap between 0 and `tiny`. However, subnormal numbers may have a 
-    significantly reduced precision[2]_.
+    gap between 0 and ``tiny``. However, subnormal numbers may have
+    significantly reduced precision [2]_.
     
     References
     ----------

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -337,8 +337,9 @@ class finfo:
         The approximate decimal resolution of this type, i.e.,
         ``10**-precision``.
     tiny : float
-        The smallest positive usable number.  Type of `tiny` is an
-        appropriate floating point type.
+        The smallest positive floating point number with there being no
+        leading 0's in the mantissa. Type of `tiny` is an appropriate 
+        floating point type.
 
     Parameters
     ----------
@@ -354,6 +355,15 @@ class finfo:
 
     Notes
     -----
+    As in the IEEE-745 standard, NumPy floating point types use subnormal
+    numbers to fill the gap between 0 and `tiny`. This is achieved by 
+    using bits of the mantissa to allow the representation of smaller 
+    exponents than `minexp`. For example, for 64-bit binary floats in the
+    IEEE-754 standard, the smallest positive value is actually 2**-1074.
+    However, since the number of bits available for the mantissa is 
+    reduced the precision of subnormal floating numbers is also often 
+    reduced significantly.
+    
     For developers of NumPy: do not instantiate this at the module level.
     The initial calculation of these parameters is expensive and negatively
     impacts import times.  These objects are cached, so calling ``finfo()``

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -364,9 +364,12 @@ class finfo:
     number in a NumPy floating point type. As in the IEEE-754 standard,
     NumPy floating point types make use of subnormal numbers to fill the
     gap between 0 and `tiny`. However, subnormal numbers may have a 
-    significantly reduced precision. Compare further with the Wikipedia page
-    `Denormal Numbers <https://en.wikipedia.org/wiki/Denormal_number>`_
+    significantly reduced precision[1]_.
     
+    References
+    ----------
+    .. [1] Wikipedia, "Denormal Numbers",
+           https://en.wikipedia.org/wiki/Denormal_number
     """
 
     _finfo_cache = {}

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -322,8 +322,7 @@ class finfo:
     min : floating point number of the appropriate type
         The smallest representable number, typically ``-max``.
     minexp : int
-        The most negative power of the base (2) consistent with there
-        being no leading 0's in the mantissa.
+        The minimum value of the exponent for a float with full precision.
     negep : int
         The exponent that yields `epsneg`.
     nexp : int
@@ -337,9 +336,8 @@ class finfo:
         The approximate decimal resolution of this type, i.e.,
         ``10**-precision``.
     tiny : float
-        The smallest positive floating point number with there being no
-        leading 0's in the mantissa. Type of `tiny` is an appropriate 
-        floating point type.
+        The smallest positive floating point number with full precision
+        (see Notes).
 
     Parameters
     ----------
@@ -361,7 +359,7 @@ class finfo:
     repeatedly inside your functions is not a problem.
 
     Note that `tiny` is not actually the smallest positive representable
-    number in a NumPy floating point type. As in the IEEE-754 standard[1]_,
+    value in a NumPy floating point type. As in the IEEE-754 standard[1]_,
     NumPy floating point types make use of subnormal numbers to fill the
     gap between 0 and `tiny`. However, subnormal numbers may have a 
     significantly reduced precision[2]_.

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -361,7 +361,7 @@ class finfo:
     repeatedly inside your functions is not a problem.
 
     Note that `tiny` is not actually the smallest positive representable
-    number in a NumPy floating point type. As in the IEEE-745 standard,
+    number in a NumPy floating point type. As in the IEEE-754 standard,
     NumPy floating point types make use of subnormal numbers to fill the
     gap between 0 and `tiny`. However, subnormal numbers may have a 
     significantly reduced precision. Compare further with the Wikipedia page
@@ -554,4 +554,3 @@ class iinfo:
     def __repr__(self):
         return "%s(min=%s, max=%s, dtype=%s)" % (self.__class__.__name__,
                                     self.min, self.max, self.dtype)
-

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -322,7 +322,8 @@ class finfo:
     min : floating point number of the appropriate type
         The smallest representable number, typically ``-max``.
     minexp : int
-        The minimum value of the exponent for a float with full precision.
+        The most negative power of the base (2) consistent with there
+        being no leading 0's in the mantissa.
     negep : int
         The exponent that yields `epsneg`.
     nexp : int
@@ -367,7 +368,7 @@ class finfo:
     References
     ----------
     .. [1] IEEE Standard for Floating-Point Arithmetic, IEEE Std 754-2008,
-           pp.1-70, 2008, http://www.doi.org/10.1109/IEEESTD.2008.4610935.
+           pp.1-70, 2008, http://www.doi.org/10.1109/IEEESTD.2008.4610935
     .. [2] Wikipedia, "Denormal Numbers",
            https://en.wikipedia.org/wiki/Denormal_number
     """

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -361,14 +361,16 @@ class finfo:
     repeatedly inside your functions is not a problem.
 
     Note that `tiny` is not actually the smallest positive representable
-    number in a NumPy floating point type. As in the IEEE-754 standard,
+    number in a NumPy floating point type. As in the IEEE-754 standard[1]_,
     NumPy floating point types make use of subnormal numbers to fill the
     gap between 0 and `tiny`. However, subnormal numbers may have a 
-    significantly reduced precision[1]_.
+    significantly reduced precision[2]_.
     
     References
     ----------
-    .. [1] Wikipedia, "Denormal Numbers",
+    .. [1] IEEE Standard for Floating-Point Arithmetic, IEEE Std 754-2008,
+           pp.1-70, 2008, http://www.doi.org/10.1109/IEEESTD.2008.4610935.
+    .. [2] Wikipedia, "Denormal Numbers",
            https://en.wikipedia.org/wiki/Denormal_number
     """
 

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -355,20 +355,18 @@ class finfo:
 
     Notes
     -----
-    As in the IEEE-745 standard, NumPy floating point types use subnormal
-    numbers to fill the gap between 0 and `tiny`. This is achieved by 
-    using bits of the mantissa to allow the representation of smaller 
-    exponents than `minexp`. For example, for 64-bit binary floats in the
-    IEEE-754 standard, the smallest positive value is actually 2**-1074.
-    However, since the number of bits available for the mantissa is 
-    reduced the precision of subnormal floating numbers is also often 
-    reduced significantly.
-    
     For developers of NumPy: do not instantiate this at the module level.
     The initial calculation of these parameters is expensive and negatively
     impacts import times.  These objects are cached, so calling ``finfo()``
     repeatedly inside your functions is not a problem.
 
+    Note that `tiny` is not actually the smallest positive representable
+    number in a NumPy floating point type. As in the IEEE-745 standard,
+    NumPy floating point types make use of subnormal numbers to fill the
+    gap between 0 and `tiny`. However, subnormal numbers may have a 
+    significantly reduced precision. Compare further with the Wikipedia page
+    `Denormal Numbers <https://en.wikipedia.org/wiki/Denormal_number>`_
+    
     """
 
     _finfo_cache = {}

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -41,7 +41,8 @@ class MachAr:
         being no leading zeros in the mantissa.
     xmin : float
         Floating point number ``beta**minexp`` (the smallest [in
-        magnitude] usable floating value).
+        magnitude] usable floating value) with there
+        being no leading zeros in the mantissa.
     maxexp : int
         Smallest (positive) power of `ibeta` that causes overflow.
     xmax : float

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -37,12 +37,11 @@ class MachAr:
     iexp : int
         Number of bits in the exponent (including its sign and bias).
     minexp : int
-        Smallest (most negative) power of `ibeta` consistent with there
-        being no leading zeros in the mantissa.
+        Smallest (most negative) value of the exponent for float with
+        full precision.
     xmin : float
         Floating point number ``beta**minexp`` (the smallest [in
-        magnitude] usable floating value with there
-        being no leading zeros in the mantissa).
+        magnitude] floating point number with full precision).
     maxexp : int
         Smallest (positive) power of `ibeta` that causes overflow.
     xmax : float

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -41,8 +41,8 @@ class MachAr:
         being no leading zeros in the mantissa.
     xmin : float
         Floating point number ``beta**minexp`` (the smallest [in
-        magnitude] usable floating value) with there
-        being no leading zeros in the mantissa.
+        magnitude] usable floating value with there
+        being no leading zeros in the mantissa).
     maxexp : int
         Smallest (positive) power of `ibeta` that causes overflow.
     xmax : float

--- a/numpy/core/machar.py
+++ b/numpy/core/machar.py
@@ -37,11 +37,11 @@ class MachAr:
     iexp : int
         Number of bits in the exponent (including its sign and bias).
     minexp : int
-        Smallest (most negative) value of the exponent for float with
-        full precision.
+        Smallest (most negative) power of `ibeta` consistent with there
+        being no leading zeros in the mantissa.
     xmin : float
-        Floating point number ``beta**minexp`` (the smallest [in
-        magnitude] floating point number with full precision).
+        Floating-point number ``beta**minexp`` (the smallest [in
+        magnitude] positive floating point number with full precision).
     maxexp : int
         Smallest (positive) power of `ibeta` that causes overflow.
     xmax : float


### PR DESCRIPTION
This commit adds a note to the documentation of finfo clarifying that
the attribute `tiny` does not represent the smallest positive usable
number. Instead, it refers to the smallest positive number with there
being no leading 0's in the mantissa, that is, the smallest positive 
_normalized_ floating-point number.
Alternatively, one can say that `tiny` is the smallest positive floating 
point number with full precision. The smallest positive _subnormal_
floating point number is typically orders of magnitudes smaller, but 
has reduced precision since leading 0's in the mantissa are used to
allow smaller exponents than indicated by `minexp`.

The commit also adds a brief clarification to the docstring of machar.

Closes #16252
