### PR TITLE
MAINT: Chain exceptions in generate_umath.py

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1030,7 +1030,8 @@ def make_arrays(funcdict):
                     thedict = arity_lookup[uf.nin, uf.nout]
                 except KeyError as e:
                     raise ValueError(
-                        "Could not handle {}[{}]".format(name, t.type)
+                        f"Could not handle {name}[{t.type}] "
+                        f"with nin={uf.nin}, nout={uf.nout}"
                     ) from None
 
                 astype = ''

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1028,8 +1028,10 @@ def make_arrays(funcdict):
                 funclist.append('NULL')
                 try:
                     thedict = arity_lookup[uf.nin, uf.nout]
-                except KeyError:
-                    raise ValueError("Could not handle {}[{}]".format(name, t.type))
+                except KeyError as e:
+                    raise ValueError(
+                        "Could not handle {}[{}]".format(name, t.type)
+                    ) from None
 
                 astype = ''
                 if not t.astype is None:


### PR DESCRIPTION
This edit is in relation to issue #15986 .
Chained exception in:
generate_umath.py