### PR TITLE
BUG: Add missing decref in fromarray error path

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2183,6 +2183,7 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
         PyErr_Clear();
         npy_set_invalid_cast_error(
                 PyArray_DESCR(arr), newtype, casting, PyArray_NDIM(arr) == 0);
+        Py_DECREF(newtype);
         return NULL;
     }
 


### PR DESCRIPTION
This function steals the dtype, so it must decref it also
on error. This is fixup of ffe76ac8df65c8e7831df9924a782276e060f3e6
which accidentally deleted the decref.

---

A small issue with the recent maintenance commit where I deleted too much. Found using pytest-leaks (unfortunately my run failed before it finished, the leak-check did not run fully yet...)