### PR TITLE
ENH: include dt64/td64 isinstance checks in ``__init__.pxd``

### DIFF
--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -692,6 +692,8 @@ cdef extern from "numpy/arrayobject.h":
 cdef extern from "numpy/ndarrayobject.h":
     PyTypeObject PyTimedeltaArrType_Type
     PyTypeObject PyDatetimeArrType_Type
+    ctypedef int64_t npy_timedelta
+    ctypedef int64_t npy_datetime
 
 cdef extern from "numpy/arrayscalars.h":
     ctypedef struct PyDatetimeScalarObject:
@@ -699,10 +701,31 @@ cdef extern from "numpy/arrayscalars.h":
         npy_datetime obval
         PyArray_DatetimeMetaData obmeta
 
+    ctypedef struct PyTimedeltaScalarObject:
+        # PyObject_HEAD
+        npy_timedelta obval
+        PyArray_DatetimeMetaData obmeta
+
 cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct PyArray_DatetimeMetaData:
         NPY_DATETIMEUNIT base
         int64_t num
+
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_B
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
 
 
 # Typedefs that matches the runtime dtype objects in

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -693,16 +693,16 @@ cdef extern from "numpy/ndarrayobject.h":
     PyTypeObject PyTimedeltaArrType_Type
     PyTypeObject PyDatetimeArrType_Type
 
-cdef extern from "numpy/ndarraytypes.h":
-    ctypedef struct PyArray_DatetimeMetaData:
-        NPY_DATETIMEUNIT base
-        int64_t num
-
 cdef extern from "numpy/arrayscalars.h":
     ctypedef struct PyDatetimeScalarObject:
         # PyObject_HEAD
         npy_datetime obval
         PyArray_DatetimeMetaData obmeta
+
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef struct PyArray_DatetimeMetaData:
+        NPY_DATETIMEUNIT base
+        int64_t num
 
 
 # Typedefs that matches the runtime dtype objects in

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -221,7 +221,7 @@ cdef extern from "numpy/arrayobject.h":
         cdef int type_num
         cdef int itemsize "elsize"
         cdef int alignment
-        cdef dict fields
+        cdef object fields
         cdef tuple names
         # Use PyDataType_HASSUBARRAY to test whether this field is
         # valid (the pointer can be NULL). Most users should access

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -26,7 +26,7 @@ cimport libc.stdio as stdio
 
 cdef extern from "Python.h":
     ctypedef int Py_intptr_t
-    bint PyObject_TypeCheck(object obj, PyTypeObject* type) nogil
+    bint PyObject_TypeCheck(object obj, PyTypeObject* type)
 
 cdef extern from "numpy/arrayobject.h":
     ctypedef Py_intptr_t npy_intp
@@ -1018,7 +1018,7 @@ cdef extern from *:
     """
 
 
-cdef inline bint is_timedelta64_object(object obj) nogil:
+cdef inline bint is_timedelta64_object(object obj):
     """
     Cython equivalent of `isinstance(obj, np.timedelta64)`
 
@@ -1033,7 +1033,7 @@ cdef inline bint is_timedelta64_object(object obj) nogil:
     return PyObject_TypeCheck(obj, &PyTimedeltaArrType_Type)
 
 
-cdef inline bint is_datetime64_object(object obj) nogil:
+cdef inline bint is_datetime64_object(object obj):
     """
     Cython equivalent of `isinstance(obj, np.datetime64)`
 

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -689,45 +689,6 @@ cdef extern from "numpy/arrayobject.h":
     int PyArray_SetBaseObject(ndarray, base)  # NOTE: steals a reference to base! Use "set_array_base()" instead.
 
 
-cdef extern from "numpy/ndarrayobject.h":
-    PyTypeObject PyTimedeltaArrType_Type
-    PyTypeObject PyDatetimeArrType_Type
-    ctypedef int64_t npy_timedelta
-    ctypedef int64_t npy_datetime
-
-cdef extern from "numpy/arrayscalars.h":
-    ctypedef struct PyDatetimeScalarObject:
-        # PyObject_HEAD
-        npy_datetime obval
-        PyArray_DatetimeMetaData obmeta
-
-    ctypedef struct PyTimedeltaScalarObject:
-        # PyObject_HEAD
-        npy_timedelta obval
-        PyArray_DatetimeMetaData obmeta
-
-cdef extern from "numpy/ndarraytypes.h":
-    ctypedef struct PyArray_DatetimeMetaData:
-        NPY_DATETIMEUNIT base
-        int64_t num
-
-    ctypedef enum NPY_DATETIMEUNIT:
-        NPY_FR_Y
-        NPY_FR_M
-        NPY_FR_W
-        NPY_FR_D
-        NPY_FR_B
-        NPY_FR_h
-        NPY_FR_m
-        NPY_FR_s
-        NPY_FR_ms
-        NPY_FR_us
-        NPY_FR_ns
-        NPY_FR_ps
-        NPY_FR_fs
-        NPY_FR_as
-
-
 # Typedefs that matches the runtime dtype objects in
 # the numpy module.
 
@@ -866,6 +827,45 @@ cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset
             # so don't output it
             f = _util_dtypestring(child, f, end, offset)
     return f
+
+
+cdef extern from "numpy/ndarrayobject.h":
+    PyTypeObject PyTimedeltaArrType_Type
+    PyTypeObject PyDatetimeArrType_Type
+    ctypedef int64_t npy_timedelta
+    ctypedef int64_t npy_datetime
+
+cdef extern from "numpy/arrayscalars.h":
+    ctypedef struct PyDatetimeScalarObject:
+        # PyObject_HEAD
+        npy_datetime obval
+        PyArray_DatetimeMetaData obmeta
+
+    ctypedef struct PyTimedeltaScalarObject:
+        # PyObject_HEAD
+        npy_timedelta obval
+        PyArray_DatetimeMetaData obmeta
+
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef struct PyArray_DatetimeMetaData:
+        NPY_DATETIMEUNIT base
+        int64_t num
+
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_B
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
 
 
 #

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -835,6 +835,11 @@ cdef extern from "numpy/ndarrayobject.h":
     ctypedef int64_t npy_timedelta
     ctypedef int64_t npy_datetime
 
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef struct PyArray_DatetimeMetaData:
+        NPY_DATETIMEUNIT base
+        int64_t num
+
 cdef extern from "numpy/arrayscalars.h":
     ctypedef struct PyDatetimeScalarObject:
         # PyObject_HEAD
@@ -845,11 +850,6 @@ cdef extern from "numpy/arrayscalars.h":
         # PyObject_HEAD
         npy_timedelta obval
         PyArray_DatetimeMetaData obmeta
-
-cdef extern from "numpy/ndarraytypes.h":
-    ctypedef struct PyArray_DatetimeMetaData:
-        NPY_DATETIMEUNIT base
-        int64_t num
 
     ctypedef enum NPY_DATETIMEUNIT:
         NPY_FR_Y

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -963,6 +963,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('tests')
     config.add_data_dir('tests/data')
+    config.add_data_dir('tests/examples')
 
     config.make_svn_version_py()
 

--- a/numpy/core/tests/examples/checks.pyx
+++ b/numpy/core/tests/examples/checks.pyx
@@ -1,0 +1,26 @@
+"""
+Functions in this module give python-space wrappers for cython functions
+exposed in numpy/__init__.pxd, so they can be tested in test_cython.py
+"""
+cimport numpy as cnp
+cnp.import_array()
+
+
+def is_td64(obj):
+    return cnp.is_timedelta64_object(obj)
+
+
+def is_dt64(obj):
+    return cnp.is_datetime64_object(obj)
+
+
+def get_dt64_value(obj):
+    return cnp.get_datetime64_value(obj)
+
+
+def get_td64_value(obj):
+    return cnp.get_timedelta64_value(obj)
+
+
+def get_dt64_unit(obj):
+    return cnp.get_datetime64_unit(obj)

--- a/numpy/core/tests/examples/setup.py
+++ b/numpy/core/tests/examples/setup.py
@@ -1,0 +1,26 @@
+"""
+Provide python-space access to the functions exposed in numpy/__init__.pxd
+for testing.
+"""
+
+import numpy as np
+from distutils.core import setup
+from Cython.Build import cythonize
+from setuptools.extension import Extension
+import os
+
+here = os.path.dirname(__file__)
+macros = [("NPY_NO_DEPRECATED_API", 0)]
+
+checks = Extension(
+    "checks",
+    sources=[os.path.join(here, "checks.pyx")],
+    include_dirs=[np.get_include()],
+    define_macros=macros,
+)
+
+extensions = [checks]
+
+setup(
+    ext_modules=cythonize(extensions)
+)

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -1,4 +1,3 @@
-
 import os
 import shutil
 import subprocess
@@ -15,6 +14,7 @@ except ImportError:
     cython = None
 else:
     from distutils.version import LooseVersion
+
     # Cython 0.29.14 is required for Python 3.8 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
@@ -34,28 +34,33 @@ def install_temp(request, tmp_path):
     here = os.path.dirname(__file__)
     ext_dir = os.path.join(here, "examples")
 
-    #assert False
-    tmp_path = tmp_path._str  # str(tmp_path)
+    tmp_path = tmp_path._str
     cytest = os.path.join(tmp_path, "cytest")
 
     shutil.copytree(ext_dir, cytest)
     # build the examples and "install" them into a temporary directory
-    
-    build_dir = os.path.join(tmp_path, "examples")
+
     install_log = os.path.join(tmp_path, "tmp_install_log.txt")
-    subprocess.check_call([sys.executable, "setup.py", "build", "install",
-                           "--prefix", os.path.join(tmp_path, "installdir"),
-                           "--single-version-externally-managed",
-                           "--record", install_log,
-                          ],
-                          cwd=cytest,
-                      )
+    subprocess.check_call(
+        [
+            sys.executable,
+            "setup.py",
+            "build",
+            "install",
+            "--prefix",
+            os.path.join(tmp_path, "installdir"),
+            "--single-version-externally-managed",
+            "--record",
+            install_log,
+        ],
+        cwd=cytest,
+    )
 
     # In order to import the built module, we need its path to sys.path
     # so parse that out of the record
     with open(install_log) as fid:
         for line in fid:
-            if 'checks' in line:
+            if "checks" in line:
                 sys.path.append(os.path.dirname(line))
                 break
         else:
@@ -72,13 +77,12 @@ def test_is_timedelta64_object(install_temp):
     assert not checks.is_td64(1)
     assert not checks.is_td64(None)
     assert not checks.is_td64("foo")
-    assert not checks.is_td64(np.datetime64("now"))
+    assert not checks.is_td64(np.datetime64("now", "s"))
 
 
 def test_is_datetime64_object(install_temp):
     import checks
 
-    assert checks.is_dt64(np.datetime64(1234))
     assert checks.is_dt64(np.datetime64(1234, "ns"))
     assert checks.is_dt64(np.datetime64("NaT", "ns"))
 
@@ -115,10 +119,10 @@ def test_get_datetime64_unit(install_temp):
 
     dt64 = np.datetime64("2016-01-01", "ns")
     result = checks.get_dt64_unit(dt64)
-    expected = 11
+    expected = 10
     assert result == expected
 
     td64 = np.timedelta64(12345, "h")
-    result = checks.get_dt64_unit(dt64)
+    result = checks.get_dt64_unit(td64)
     expected = 5
     assert result == expected

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -1,0 +1,114 @@
+
+import os
+import shutil
+import subprocess
+import sys
+import pytest
+
+import numpy as np
+
+# This import is copied from random.tests.test_extending
+try:
+    import cython
+    from Cython.Compiler.Version import version as cython_version
+except ImportError:
+    cython = None
+else:
+    from distutils.version import LooseVersion
+    # Cython 0.29.14 is required for Python 3.8 and there are
+    # other fixes in the 0.29 series that are needed even for earlier
+    # Python versions.
+    # Note: keep in sync with the one in pyproject.toml
+    required_version = LooseVersion("0.29.14")
+    if LooseVersion(cython_version) < required_version:
+        # too old or wrong cython, skip the test
+        cython = None
+
+pytestmark = pytest.mark.skipif(cython is None, reason="requires cython")
+
+
+@pytest.fixture
+def install_temp(request, tmp_path):
+    # Based in part on test_cython from random.tests.test_extending
+
+    here = os.path.dirname(__file__)
+    ext_dir = os.path.join(here, "examples")
+
+    #assert False
+    tmp_path = tmp_path._str#str(tmp_path)
+    cytest = os.path.join(tmp_path, "cytest")
+
+    shutil.copytree(ext_dir, cytest)
+    # build the examples and "install" them into a temporary directory
+    
+    build_dir = os.path.join(tmp_path, "examples")
+    subprocess.check_call([sys.executable, "setup.py", "build", "install",
+                           "--prefix", os.path.join(tmp_path, "installdir"),
+                           "--single-version-externally-managed",
+                           "--record", os.path.join(tmp_path, "tmp_install_log.txt"),
+                          ],
+                          cwd=cytest,
+                      )
+    sys.path.append(cytest)
+
+
+def test_is_timedelta64_object(install_temp):
+    import checks
+
+    assert checks.is_td64(np.timedelta64(1234))
+    assert checks.is_td64(np.timedelta64(1234, "ns"))
+    assert checks.is_td64(np.timedelta64("NaT", "ns"))
+
+    assert not checks.is_td64(1)
+    assert not checks.is_td64(None)
+    assert not checks.is_td64("foo")
+    assert not checks.is_td64(np.datetime64("now"))
+
+
+def test_is_datetime64_object(install_temp):
+    import checks
+
+    assert checks.is_dt64(np.datetime64(1234))
+    assert checks.is_dt64(np.datetime64(1234, "ns"))
+    assert checks.is_dt64(np.datetime64("NaT", "ns"))
+
+    assert not checks.is_dt64(1)
+    assert not checks.is_dt64(None)
+    assert not checks.is_dt64("foo")
+    assert not checks.is_dt64(np.timedelta64(1234))
+
+
+def test_get_datetime64_value(install_temp):
+    import checks
+
+    dt64 = np.datetime64("2016-01-01", "ns")
+
+    result = checks.get_dt64_value(dt64)
+    expected = dt64.view("i8")
+
+    assert result == expected
+
+
+def test_get_timedelta64_value(install_temp):
+    import checks
+
+    td64 = np.timedelta(12345, "h")
+
+    result = checks.get_td64_value(dt64)
+    expected = td64.view("i8")
+
+    assert result == expected
+
+
+def test_get_datetime64_unit(install_temp):
+    import checks
+
+    dt64 = np.datetime64("2016-01-01", "ns")
+    result = checks.get_dt64_unit(dt64)
+    expected = 11
+    assert result == expected
+
+    td64 = np.timedelta(12345, "h")
+    result = checks.get_dt64_unit(dt64)
+    expected = 5
+    assert result == expected


### PR DESCRIPTION
There are a handful of checks related to datetime64/timedelta64 objects that pandas implements but would make more sense to have directly in numpy.  This PR ports those checks over and puts them in the `__init__.pxd` file.  If this PR is accepted, I'll make the same PR on the cython version of this file.

Suggestions on where tests for these belong?