### PR TITLE
BUG: Order percentile monotonically

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3875,14 +3875,10 @@ def _quantile_is_valid(q):
 
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
-    #a + (b-a)*t if t < 0.5 else b - (b-a)*(1-t)
-    #if t < 0.5:
-    #    return add(a, subtract(b, a)*t, out=out)
-    #else:
-    #    return subtract(b, subtract(b, a)*(1-t), out=out)
-    # a + (b-a)*t
-    offset = subtract(b, a) * t
-    return add(a, offset, out=out)
+    if t < 0.5:
+        return add(a, subtract(b, a)*t, out=out)
+    else:
+        return subtract(b, subtract(b, a)*(1-t), out=out)
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3875,7 +3875,8 @@ def _quantile_is_valid(q):
 
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
-    return add(a*(1 - t), b*t, out=out)
+    offset = subtract(b, a) * t
+    return add(a, offset, out=out)
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,
@@ -3948,6 +3949,7 @@ def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,
 
     else:
         # weight the points above and below the indices
+        #import pdb; pdb.set_trace()
 
         indices_below = not_scalar(floor(indices)).astype(intp)
         indices_above = not_scalar(indices_below + 1)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3875,10 +3875,10 @@ def _quantile_is_valid(q):
 
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
-    #return add(a, subtract(b, a, out=out)*t, out=out)
     diff_b_a = subtract(b, a)
 
-    if np.isscalar(a) and np.isscalar(b) and (np.isscalar(t) or np.ndim(t) == 0):
+    _scalar_or_0d = lambda x: np.isscalar(a) or np.ndim(x) == 0
+    if _scalar_or_0d(a) and _scalar_or_0d(b) and _scalar_or_0d(t):
         if t <= 0.5:
             return add(a, diff_b_a * t, out=out)
         else:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3959,7 +3959,6 @@ def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,
 
     else:
         # weight the points above and below the indices
-        #import pdb; pdb.set_trace()
 
         indices_below = not_scalar(floor(indices)).astype(intp)
         indices_above = not_scalar(indices_below + 1)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3875,8 +3875,14 @@ def _quantile_is_valid(q):
 
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
-    offset = subtract(b, a) * t
-    return add(a, offset, out=out)
+    #a + (b-a)*t if t < 0.5 else b - (b-a)*(1-t)
+    if t < 0.5:
+        return add(a, subtract(b, a)*t, out=out)
+    else:
+        return subtract(b, subtract(b, a)*(1-t), out=out)
+    # a + (b-a)*t
+    #offset = subtract(b, a) * t
+    #return add(a, offset, out=out)
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3876,17 +3876,12 @@ def _quantile_is_valid(q):
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
     diff_b_a = subtract(b, a)
-
-    _scalar_or_0d = lambda x: np.isscalar(x) or np.ndim(x) == 0
-    if _scalar_or_0d(a) and _scalar_or_0d(b) and _scalar_or_0d(t):
-        if t <= 0.5:
-            return add(a, diff_b_a * t, out=out)
-        else:
-            return subtract(b, diff_b_a * (1 - t), out=out)
-    else:
-        lerp_interpolation = add(a, diff_b_a*t, out=out)
-        subtract(b, diff_b_a * (1 - t), out=lerp_interpolation, where=t>=0.5)
-        return lerp_interpolation
+    # asanyarray is a stop-gap until gh-13105
+    lerp_interpolation = asanyarray(add(a, diff_b_a*t, out=out))
+    subtract(b, diff_b_a * (1 - t), out=lerp_interpolation, where=t>=0.5)
+    if lerp_interpolation.ndim == 0 and out is None:
+        lerp_interpolation = lerp_interpolation[()]  # unpack 0d arrays
+    return lerp_interpolation
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3877,7 +3877,7 @@ def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
     diff_b_a = subtract(b, a)
 
-    _scalar_or_0d = lambda x: np.isscalar(a) or np.ndim(x) == 0
+    _scalar_or_0d = lambda x: np.isscalar(x) or np.ndim(x) == 0
     if _scalar_or_0d(a) and _scalar_or_0d(b) and _scalar_or_0d(t):
         if t <= 0.5:
             return add(a, diff_b_a * t, out=out)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3876,13 +3876,13 @@ def _quantile_is_valid(q):
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
     #a + (b-a)*t if t < 0.5 else b - (b-a)*(1-t)
-    if t < 0.5:
-        return add(a, subtract(b, a)*t, out=out)
-    else:
-        return subtract(b, subtract(b, a)*(1-t), out=out)
+    #if t < 0.5:
+    #    return add(a, subtract(b, a)*t, out=out)
+    #else:
+    #    return subtract(b, subtract(b, a)*(1-t), out=out)
     # a + (b-a)*t
-    #offset = subtract(b, a) * t
-    #return add(a, offset, out=out)
+    offset = subtract(b, a) * t
+    return add(a, offset, out=out)
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3875,10 +3875,18 @@ def _quantile_is_valid(q):
 
 def _lerp(a, b, t, out=None):
     """ Linearly interpolate from a to b by a factor of t """
-    if t < 0.5:
-        return add(a, subtract(b, a)*t, out=out)
+    #return add(a, subtract(b, a, out=out)*t, out=out)
+    diff_b_a = subtract(b, a)
+
+    if np.isscalar(a) and np.isscalar(b) and (np.isscalar(t) or np.ndim(t) == 0):
+        if t <= 0.5:
+            return add(a, diff_b_a * t, out=out)
+        else:
+            return subtract(b, diff_b_a * (1 - t), out=out)
     else:
-        return subtract(b, subtract(b, a)*(1-t), out=out)
+        lerp_interpolation = add(a, diff_b_a*t, out=out)
+        subtract(b, diff_b_a * (1 - t), out=lerp_interpolation, where=t>=0.5)
+        return lerp_interpolation
 
 
 def _quantile_ureduce_func(a, q, axis=None, out=None, overwrite_input=False,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3153,6 +3153,7 @@ class TestLerp:
                       a=st.floats(allow_nan=False, allow_infinity=False),
                       b=st.floats(allow_nan=False, allow_infinity=False))
     def test_lerp_symmetric(self, t, a, b):
+        # double subtraction is needed to remove the extra precision that t < 0.5 has
         assert np.lib.function_base._lerp(a, b, 1 - (1 - t)) == np.lib.function_base._lerp(b, a, 1 - t)
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -5,6 +5,10 @@ import decimal
 from fractions import Fraction
 import math
 import pytest
+import hypothesis
+from hypothesis.extra.numpy import arrays
+import hypothesis.strategies as st
+
 
 import numpy as np
 from numpy import ma
@@ -3104,13 +3108,22 @@ class TestQuantile:
         np.quantile(np.arange(100.), p, interpolation="midpoint")
         assert_array_equal(p, p0)
 
-    def test_quantile_monotic(self):
+    def test_quantile_monotonic(self):
         # GH 14685
         # test that the return value of quantile is monotonic if p0 is ordered
         p0 = np.arange(0, 1, 0.01)
         quantile = np.quantile(np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7]) * 0.1, p0)
         equals_sorted = np.sort(quantile) == quantile
         assert equals_sorted.all()
+
+    @hypothesis.given(arr=arrays(dtype=np.float, shape=st.integers(min_value=3, max_value=1000),
+                                 elements=st.floats(allow_infinity=False, allow_nan=False)))
+    def test_quantile_monotonic_hypo(self, arr):
+        p0 = np.arange(0, 1, 0.01)
+        quantile = np.quantile(arr, p0)
+        equals_sorted = np.sort(quantile) == quantile
+        assert equals_sorted.all()
+
 
 class TestMedian:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3113,16 +3113,14 @@ class TestQuantile:
         # test that the return value of quantile is monotonic if p0 is ordered
         p0 = np.arange(0, 1, 0.01)
         quantile = np.quantile(np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7]) * 0.1, p0)
-        equals_sorted = np.sort(quantile) == quantile
-        assert equals_sorted.all()
+        assert_equal(np.sort(quantile), quantile)
 
     @hypothesis.given(arr=arrays(dtype=np.float, shape=st.integers(min_value=3, max_value=1000),
                                  elements=st.floats(allow_infinity=False, allow_nan=False)))
     def test_quantile_monotonic_hypo(self, arr):
         p0 = np.arange(0, 1, 0.01)
         quantile = np.quantile(arr, p0)
-        equals_sorted = np.sort(quantile) == quantile
-        assert equals_sorted.all()
+        assert_equal(np.sort(quantile), quantile)
 
 
 class TestLerp:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3138,7 +3138,7 @@ class TestLerp:
         if t0 == t1 or a == b:
             assert l0 == l1  # uninteresting
         elif (t0 < t1) == (a < b):
-            assert l0 < l1
+            assert l0 <= l1
         else:
             assert l0 >= l1
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3153,7 +3153,7 @@ class TestLerp:
                       a=st.floats(allow_nan=False, allow_infinity=False),
                       b=st.floats(allow_nan=False, allow_infinity=False))
     def test_lerp_symmetric(self, t, a, b):
-        assert np.lib.function_base._lerp(a, b, t) == np.lib.function_base._lerp(b, a, t)
+        assert np.isclose(np.lib.function_base._lerp(a, b, t), np.lib.function_base._lerp(b, a, (1-t)))
 
 
 class TestMedian:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3130,10 +3130,10 @@ class TestLerp:
                                    min_value=0, max_value=1),
                       t1=st.floats(allow_nan=False, allow_infinity=False,
                                    min_value=0, max_value=1),
-                      a=st.floats(allow_nan=False, allow_infinity=False,
-                                  width=32),
-                      b= st.floats(allow_nan=False, allow_infinity=False,
-                                   width=32))
+                      a = st.floats(allow_nan=False, allow_infinity=False,
+                                    min_value=-1e300, max_value=1e300),
+                      b = st.floats(allow_nan=False, allow_infinity=False,
+                                    min_value=-1e300, max_value=1e300))
     def test_lerp_monotonic(self, t0, t1, a, b):
         l0 = np.lib.function_base._lerp(a, b, t0)
         l1 = np.lib.function_base._lerp(a, b, t1)
@@ -3146,10 +3146,10 @@ class TestLerp:
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),
-                      a=st.floats(allow_nan=False, allow_infinity=False,
-                                  width=32),
-                      b=st.floats(allow_nan=False, allow_infinity=False,
-                                  width=32))
+                      a = st.floats(allow_nan=False, allow_infinity=False,
+                                    min_value=-1e300, max_value=1e300),
+                      b = st.floats(allow_nan=False, allow_infinity=False,
+                                    min_value=-1e300, max_value=1e300))
     def test_lerp_bounded(self, t, a, b):
         if a <= b:
             assert a <= np.lib.function_base._lerp(a, b, t) <= b
@@ -3159,9 +3159,9 @@ class TestLerp:
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),
                       a=st.floats(allow_nan=False, allow_infinity=False,
-                                  width=32),
+                                  min_value=-1e300, max_value=1e300),
                       b=st.floats(allow_nan=False, allow_infinity=False,
-                                  width=32))
+                                  min_value=-1e300, max_value=1e300))
     def test_lerp_symmetric(self, t, a, b):
         # double subtraction is needed to remove the extra precision that t < 0.5 has
         assert np.lib.function_base._lerp(a, b, 1 - (1 - t)) == np.lib.function_base._lerp(b, a, 1 - t)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3140,7 +3140,7 @@ class TestLerp:
         elif (t0 < t1) == (a < b):
             assert l0 < l1
         else:
-            assert l0 > l1
+            assert l0 >= l1
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3135,8 +3135,14 @@ class TestLerp:
                       b= st.floats(allow_nan=False, allow_infinity=False,
                                    width=32))
     def test_lerp_monotonic(self, t0, t1, a, b):
-        assert (np.lib.function_base._lerp(a, b, t1) -
-                np.lib.function_base._lerp(a, b, t0)) * (b - a) * (t1 - t0) >= 0
+        l0 = np.lib.function_base._lerp(a, b, t0)
+        l1 = np.lib.function_base._lerp(a, b, t1)
+        if t0 == t1 or a == b:
+            assert l0 == l1  # uninteresting
+        elif (t0 < t1) == (a < b):
+            assert l0 < l1
+        else:
+            assert l0 > l1
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3153,7 +3153,7 @@ class TestLerp:
                       a=st.floats(allow_nan=False, allow_infinity=False),
                       b=st.floats(allow_nan=False, allow_infinity=False))
     def test_lerp_symmetric(self, t, a, b):
-        assert np.isclose(np.lib.function_base._lerp(a, b, t), np.lib.function_base._lerp(b, a, (1-t)))
+        assert np.lib.function_base._lerp(a, b, 1 - (1 - t)) == np.lib.function_base._lerp(b, a, 1 - t)
 
 
 class TestMedian:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3164,6 +3164,12 @@ class TestLerp:
         # double subtraction is needed to remove the extra precision that t < 0.5 has
         assert np.lib.function_base._lerp(a, b, 1 - (1 - t)) == np.lib.function_base._lerp(b, a, 1 - t)
 
+    def test_lerp_0d_inputs(self):
+        a = np.array(2)
+        b = np.array(5)
+        t = np.array(0.2)
+        assert np.lib.function_base._lerp(a, b, t) == 2.6
+
 
 class TestMedian:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3104,6 +3104,13 @@ class TestQuantile:
         np.quantile(np.arange(100.), p, interpolation="midpoint")
         assert_array_equal(p, p0)
 
+    def test_quantile_monotic(self):
+        # GH 14685
+        # test that the return value of quantile is monotonic if p0 is ordered
+        p0 = np.arange(0, 1, 0.01)
+        quantile = np.quantile(np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7]) * 0.1, p0)
+        equals_sorted = np.sort(quantile) == quantile
+        assert equals_sorted.all()
 
 class TestMedian:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3140,8 +3140,10 @@ class TestLerp:
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),
-                      a=st.floats(allow_nan=False, allow_infinity=False),
-                      b=st.floats(allow_nan=False, allow_infinity=False))
+                      a=st.floats(allow_nan=False, allow_infinity=False,
+                                  width=32),
+                      b=st.floats(allow_nan=False, allow_infinity=False,
+                                  width=32))
     def test_lerp_bounded(self, t, a, b):
         if a <= b:
             assert a <= np.lib.function_base._lerp(a, b, t) <= b
@@ -3150,8 +3152,10 @@ class TestLerp:
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),
-                      a=st.floats(allow_nan=False, allow_infinity=False),
-                      b=st.floats(allow_nan=False, allow_infinity=False))
+                      a=st.floats(allow_nan=False, allow_infinity=False,
+                                  width=32),
+                      b=st.floats(allow_nan=False, allow_infinity=False,
+                                  width=32))
     def test_lerp_symmetric(self, t, a, b):
         # double subtraction is needed to remove the extra precision that t < 0.5 has
         assert np.lib.function_base._lerp(a, b, 1 - (1 - t)) == np.lib.function_base._lerp(b, a, 1 - t)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3144,10 +3144,10 @@ class TestLerp:
 
     @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
                                   min_value=0, max_value=1),
-                      a = st.floats(allow_nan=False, allow_infinity=False,
-                                    min_value=-1e300, max_value=1e300),
-                      b = st.floats(allow_nan=False, allow_infinity=False,
-                                    min_value=-1e300, max_value=1e300))
+                      a=st.floats(allow_nan=False, allow_infinity=False,
+                                  min_value=-1e300, max_value=1e300),
+                      b=st.floats(allow_nan=False, allow_infinity=False,
+                                  min_value=-1e300, max_value=1e300))
     def test_lerp_bounded(self, t, a, b):
         if a <= b:
             assert a <= np.lib.function_base._lerp(a, b, t) <= b

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3125,6 +3125,37 @@ class TestQuantile:
         assert equals_sorted.all()
 
 
+class TestLerp:
+    @hypothesis.given(t0=st.floats(allow_nan=False, allow_infinity=False,
+                                   min_value=0, max_value=1),
+                      t1=st.floats(allow_nan=False, allow_infinity=False,
+                                   min_value=0, max_value=1),
+                      a=st.floats(allow_nan=False, allow_infinity=False,
+                                  width=32),
+                      b= st.floats(allow_nan=False, allow_infinity=False,
+                                   width=32))
+    def test_lerp_monotonic(self, t0, t1, a, b):
+        assert (np.lib.function_base._lerp(a, b, t1) -
+                np.lib.function_base._lerp(a, b, t0)) * (b - a) * (t1 - t0) >= 0
+
+    @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
+                                  min_value=0, max_value=1),
+                      a=st.floats(allow_nan=False, allow_infinity=False),
+                      b=st.floats(allow_nan=False, allow_infinity=False))
+    def test_lerp_bounded(self, t, a, b):
+        if a <= b:
+            assert a <= np.lib.function_base._lerp(a, b, t) <= b
+        else:
+            assert b <= np.lib.function_base._lerp(a, b, t) <= a
+
+    @hypothesis.given(t=st.floats(allow_nan=False, allow_infinity=False,
+                                  min_value=0, max_value=1),
+                      a=st.floats(allow_nan=False, allow_infinity=False),
+                      b=st.floats(allow_nan=False, allow_infinity=False))
+    def test_lerp_symmetric(self, t, a, b):
+        assert np.lib.function_base._lerp(a, b, t) == np.lib.function_base._lerp(b, a, t)
+
+
 class TestMedian:
 
     def test_basic(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3112,11 +3112,16 @@ class TestQuantile:
         # GH 14685
         # test that the return value of quantile is monotonic if p0 is ordered
         p0 = np.arange(0, 1, 0.01)
-        quantile = np.quantile(np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7]) * 0.1, p0)
+        quantile = np.quantile(np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9,
+                                         8, 8, 7]) * 0.1, p0)
         assert_equal(np.sort(quantile), quantile)
 
-    @hypothesis.given(arr=arrays(dtype=np.float, shape=st.integers(min_value=3, max_value=1000),
-                                 elements=st.floats(allow_infinity=False, allow_nan=False)))
+    @hypothesis.given(arr=arrays(dtype=np.float, shape=st.integers(min_value=3,
+                                                                   max_value=1000),
+                                 elements=st.floats(allow_infinity=False,
+                                                    allow_nan=False,
+                                                    min_value=-1e300,
+                                                    max_value=1e300)))
     def test_quantile_monotonic_hypo(self, arr):
         p0 = np.arange(0, 1, 0.01)
         quantile = np.quantile(arr, p0)


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
fixes #14685

Order output of `np.quantile`/`np.percentile` monotonically if quantiles/percentiles are ordered monotonically.

Change the way of performing the linear interpolation from (2) to (1) as given in 
[https://math.stackexchange.com/questions/907327/accurate-floating-point-linear-interpolation](https://math.stackexchange.com/questions/907327/accurate-floating-point-linear-interpolation)