### PR TITLE
DOC: Add a note about performance of isclose compared to math.isclose

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2250,6 +2250,9 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     `atol` should be carefully selected for the use case at hand. A zero value
     for `atol` will result in `False` if either `a` or `b` is zero.
 
+    For scalar values, `math.isclose` is much faster than `isclose`,
+    subject to the qualifications on asymmetric behavior above.
+
     Examples
     --------
     >>> np.isclose([1e10,1e-7], [1.00001e10,1e-8])

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2230,6 +2230,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     See Also
     --------
     allclose
+    math.isclose
 
     Notes
     -----
@@ -2249,9 +2250,6 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     are significantly smaller than one, it can result in false positives.
     `atol` should be carefully selected for the use case at hand. A zero value
     for `atol` will result in `False` if either `a` or `b` is zero.
-
-    For scalar values, `math.isclose` is much faster than `isclose`,
-    subject to the qualifications on asymmetric behavior above.
 
     Examples
     --------


### PR DESCRIPTION
This patch adds a note to the `isclose` documentation about performance of `isclose` compared to    `math.isclose`.
