### PR TITLE
BLD: Avoid "visibility attribute not supported" warning

### DIFF
--- a/numpy/distutils/command/autodist.py
+++ b/numpy/distutils/command/autodist.py
@@ -69,7 +69,10 @@ def check_gcc_function_attribute(cmd, attribute, name):
         #pragma GCC diagnostic error "-Wattributes"
         #pragma clang diagnostic error "-Wattributes"
 
-        int %s %s(void*);
+        int %s %s(void* unused)
+        {
+            return 0;
+        }
 
         int
         main()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 cython==0.29.17
-hypothesis==5.12.0
+hypothesis==5.14.0
 pytest==5.4.2
 pytz==2020.1
 pytest-cov==2.8.1


### PR DESCRIPTION
I found that when building the latest `master` branch on Cygwin, while testing #16246, that thousands of warnings were generated at build time like:

```
numpy/core/src/npysort/binsearch.c.src: In function ‘binsearch_left_bool’:
numpy/core/src/npysort/binsearch.c.src:82:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
```

Granted this is just a warning, so I don't think it's a serious issue.

It seems the test that was supposed to check for `__attribute__` support was not working as expected.  The `#pragma`s only take effect if I provide a function body--they are ignored for bare declarations.  I don't know if that's by intent, or if it's a GCC issue.  For reference:

```
$ gcc --version
gcc (GCC) 7.4.0
```