### PR TITLE
Update _add_newdocs.py

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3938,19 +3938,23 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     Construct Python bytes containing the raw data bytes in the array.
 
     Constructs Python bytes showing a copy of the raw contents of
-    data memory. The bytes object can be produced in either 'C' or 'Fortran',
-    or 'Any' order (the default is 'C'-order). 'Any' order means C-order
+    data memory. The bytes object can be produced in either 'C' or 'Fortran' or 'K'
+    order or 'A' order (the default is 'C'-order). 'A' order means C-order
     unless the F_CONTIGUOUS flag in the array is set, in which case it
-    means 'Fortran' order.
+    means 'Fortran' order. 'K' order is as close to the order array elements appear
+    in memory.
 
     .. versionadded:: 1.9.0
 
     Parameters
     ----------
-    order : {'C', 'F', None}, optional
+    order : {'C', 'F', 'A', 'K', None}, optional
         Order of the data for multidimensional arrays:
-        C, Fortran, or the same as for the original array.
-
+        'C': C order
+        'F': Fortran order
+        'A': 'F' order if all elements of array are Fortran Contiguous
+        'K': Match the layout of array as closely as possible
+        
     Returns
     -------
     s : bytes
@@ -3965,7 +3969,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     True
     >>> x.tobytes('F')
     b'\\x00\\x00\\x02\\x00\\x01\\x00\\x03\\x00'
-
+    >>> x.tobytes('A') == x.tobytes()
+    True
+    >>>x.tobytes('K') == x.tobytes()
+    True
+    
     """))
 
 


### PR DESCRIPTION
DOC: Modified incorrect listing of `order` parameter in tobytes in numpy.core.

This commit clarifies a statement in the docstring for `tobytes`. It seemed that `Any` is a valid input for the `order` argument, but that was not the case. It should have been `A` order. corrected this ambiguous statement.

This commit also modifies the doc for listing of `order` parameter to include the 'A' and 'K' parameters too just like the docstring for `copy`.

Closes #16282
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
