### PR TITLE
DOC: Improve "tobytes" docstring.

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3938,7 +3938,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     Construct Python bytes containing the raw data bytes in the array.
 
     Constructs Python bytes showing a copy of the raw contents of
-    data memory. The bytes object can be produced in C-order by default.
+    data memory. The bytes object is produced in C-order by default.
     This behavior is controlled by the order parameter.
 
     .. versionadded:: 1.9.0

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1525,7 +1525,7 @@ add_newdoc('numpy.core.multiarray', 'c_einsum',
         Controls the memory layout of the output. 'C' means it should
         be C contiguous. 'F' means it should be Fortran contiguous,
         'A' means it should be 'F' if the inputs are all 'F', 'C' otherwise.
-        'K' means it should be as close to the layout as the inputs as
+        'K' means it should be as close to the layout of the inputs as
         is possible, including arbitrarily permuted axes.
         Default is 'K'.
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
@@ -3939,9 +3939,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
 
     Constructs Python bytes showing a copy of the raw contents of
     data memory. The bytes object can be produced in either 'C' or 'Fortran',
-    or 'Any' order (the default is 'C'-order). 'Any' order means C-order
+    or 'K' or 'A' order (the default is 'C'-order). 'A' order means C-order
     unless the F_CONTIGUOUS flag in the array is set, in which case it
-    means 'Fortran' order.
+    means 'Fortran' order. 'K' order is as close to the order array elements appear
+    in memory.
 
     .. versionadded:: 1.9.0
 
@@ -3949,7 +3950,11 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     ----------
     order : {'C', 'F', None}, optional
         Order of the data for multidimensional arrays:
-        C, Fortran, or the same as for the original array.
+        'C' means it should be C contiguous,
+        'F' means it should be Fortran contiguous,
+        'A' means it should be 'F' if the inputs are all 'F', 'C' otherwise.
+        'K' means it should be as close to the layout of the inputs as
+        is possible, including arbitrarily permuted axes.
 
     Returns
     -------
@@ -3965,6 +3970,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     True
     >>> x.tobytes('F')
     b'\\x00\\x00\\x02\\x00\\x01\\x00\\x03\\x00'
+    >>> x.tobytes('A') == x.tobytes()
+    True
+    >>> x.tobytes('K') == x.tobytes()
+    True
 
     """))
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3939,7 +3939,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
 
     Constructs Python bytes showing a copy of the raw contents of
     data memory. The bytes object is produced in C-order by default.
-    This behavior is controlled by the order parameter.
+    This behavior is controlled by the ``order`` parameter.
 
     .. versionadded:: 1.9.0
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3938,23 +3938,19 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     Construct Python bytes containing the raw data bytes in the array.
 
     Constructs Python bytes showing a copy of the raw contents of
-    data memory. The bytes object can be produced in either 'C' or 'Fortran',
-    or 'K' or 'A' order (the default is 'C'-order). 'A' order means C-order
-    unless the F_CONTIGUOUS flag in the array is set, in which case it
-    means 'Fortran' order. 'K' order is as close to the order array elements appear
-    in memory.
+    data memory. The bytes object can be produced in C-order by default.
+    This behavior is controlled by the order parameter.
 
     .. versionadded:: 1.9.0
 
     Parameters
     ----------
-    order : {'C', 'F', None}, optional
-        Order of the data for multidimensional arrays:
-        'C' means it should be C contiguous,
-        'F' means it should be Fortran contiguous,
-        'A' means it should be 'F' if the inputs are all 'F', 'C' otherwise.
-        'K' means it should be as close to the layout of the inputs as
-        is possible, including arbitrarily permuted axes.
+    order : {'C', 'F', 'A', 'K'}, optional
+        Controls the memory layout of the copy. 'C' means C-order,
+        'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
+        'C' otherwise. 'K' means match the layout of `a` as closely
+        as possible.
+        Default is 'C'.
 
     Returns
     -------
@@ -3970,10 +3966,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     True
     >>> x.tobytes('F')
     b'\\x00\\x00\\x02\\x00\\x01\\x00\\x03\\x00'
-    >>> x.tobytes('A') == x.tobytes()
-    True
-    >>> x.tobytes('K') == x.tobytes()
-    True
 
     """))
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3946,7 +3946,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     Parameters
     ----------
     order : {'C', 'F', 'A', 'K'}, optional
-        Controls the memory layout of the copy. 'C' means C-order,
+        Controls the memory layout of the bytes object. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible. Default is 'C'.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3945,11 +3945,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
 
     Parameters
     ----------
-    order : {'C', 'F', 'A', 'K'}, optional
+    order : {'C', 'F', 'A'}, optional
         Controls the memory layout of the bytes object. 'C' means C-order,
-        'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
-        'C' otherwise. 'K' means match the layout of `a` as closely
-        as possible. Default is 'C'.
+        'F' means F-order, 'A' (short for *Any*) means 'F' if `a` is
+        Fortran contiguous, 'C' otherwise. Default is 'C'.
 
     Returns
     -------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3949,8 +3949,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
         Controls the memory layout of the copy. 'C' means C-order,
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
-        as possible.
-        Default is 'C'.
+        as possible. Default is 'C'.
 
     Returns
     -------


### PR DESCRIPTION
DOC: Modified incorrect listing of order parameter in tobytes in numpy.core.

This commit clarifies a statement in the docstring for `tobytes`. It seemed that `Any` is a valid input for the order argument, but that was not the case. It should have been `A` order. corrected this ambiguous statement.

This commit also modifies the doc for listing of order parameter to include the `A` and `K` parameters too just like the docstring for `copy`.

Closes #16282
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
