### PR TITLE
DOC: Fix malformed docstrings in ma.

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -252,10 +252,10 @@ class _fromnxfunction:
         npfunc = getattr(np, self.__name__, None)
         doc = getattr(npfunc, '__doc__', None)
         if doc:
-            sig = self.__name__ + ma.get_object_signature(npfunc) + '\n'
-            doc = ma.doc_note(doc, "The function is applied to both the _data"
-                                   " and the _mask, if any.")
-            return '\n'.join((sig, doc))
+            sig = self.__name__ + ma.get_object_signature(npfunc)
+            doc = ma.doc_note(doc, "The function is applied to both the _data "
+                                   "and the _mask, if any.")
+            return '\n\n'.join((sig, doc))
         return
 
     def __call__(self, *args, **params):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -21,7 +21,6 @@ __all__ = [
     ]
 
 import itertools
-import inspect
 import warnings
 
 from . import core as ma
@@ -245,11 +244,6 @@ class _fromnxfunction:
         the new masked array version of the function. A note on application
         of the function to the mask is appended.
 
-        .. warning::
-          If the function docstring already contained a Notes section, the
-          new docstring will have two Notes sections instead of appending a note
-          to the existing section.
-
         Parameters
         ----------
         None
@@ -259,10 +253,9 @@ class _fromnxfunction:
         doc = getattr(npfunc, '__doc__', None)
         if doc:
             sig = self.__name__ + ma.get_object_signature(npfunc) + '\n'
-            doc = inspect.cleandoc(doc)
-            locdoc = ("Notes\n-----\nThe function is applied to both the _data"
-                      " and the _mask, if any.")
-            return '\n'.join((sig, doc, locdoc))
+            doc = ma.doc_note(doc, "The function is applied to both the _data"
+                                   " and the _mask, if any.")
+            return '\n'.join((sig, doc))
         return
 
     def __call__(self, *args, **params):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -258,7 +258,8 @@ class _fromnxfunction:
         doc = getattr(npfunc, '__doc__', None)
         if doc:
             sig = self.__name__ + ma.get_object_signature(npfunc)
-            locdoc = "Notes\n-----\nThe function is applied to both the _data"\
+            locdoc = "\n\n        Notes\n        -----\n        "\
+                     "The function is applied to both the _data"\
                      " and the _mask, if any."
             return '\n'.join((sig, doc, locdoc))
         return

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -21,6 +21,7 @@ __all__ = [
     ]
 
 import itertools
+import inspect
 import warnings
 
 from . import core as ma
@@ -257,7 +258,8 @@ class _fromnxfunction:
         npfunc = getattr(np, self.__name__, None)
         doc = getattr(npfunc, '__doc__', None)
         if doc:
-            sig = self.__name__ + ma.get_object_signature(npfunc)
+            sig = self.__name__ + ma.get_object_signature(npfunc) + '\n'
+            doc = inspect.cleandoc(doc)
             locdoc = "Notes\n-----\nThe function is applied to both the _data"\
                      " and the _mask, if any."
             return '\n'.join((sig, doc, locdoc))

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -258,8 +258,7 @@ class _fromnxfunction:
         doc = getattr(npfunc, '__doc__', None)
         if doc:
             sig = self.__name__ + ma.get_object_signature(npfunc)
-            locdoc = "\n\n        Notes\n        -----\n        "\
-                     "The function is applied to both the _data"\
+            locdoc = "Notes\n-----\nThe function is applied to both the _data"\
                      " and the _mask, if any."
             return '\n'.join((sig, doc, locdoc))
         return

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -260,8 +260,8 @@ class _fromnxfunction:
         if doc:
             sig = self.__name__ + ma.get_object_signature(npfunc) + '\n'
             doc = inspect.cleandoc(doc)
-            locdoc = "Notes\n-----\nThe function is applied to both the _data"\
-                     " and the _mask, if any."
+            locdoc = ("Notes\n-----\nThe function is applied to both the _data"
+                      " and the _mask, if any.")
             return '\n'.join((sig, doc, locdoc))
         return
 


### PR DESCRIPTION
Fixing documents for some functions in `numpy.ma`(e.g. `numpy.ma.vstack`, https://numpy.org/devdocs/reference/generated/numpy.ma.vstack.html ). The documents is malformed because the indent of notes section is wrong.