### PR TITLE
ENH: Optimize Cpu feature detect in X86, fix for GCC on macOS

### DIFF
--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -96,14 +96,14 @@ npy__cpu_cpuid(int reg[4], int func_id)
     __cpuid(reg, func_id);
 #elif defined(__GNUC__) || defined(__clang__)
     #if defined(NPY_CPU_X86) && defined(__PIC__)
-       // %ebx may be the PIC register
-       __asm__("xchg{l}\t{%%}ebx, %1\n\t"
-               "cpuid\n\t"
-               "xchg{l}\t{%%}ebx, %1\n\t"
-               : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),
-                 "=d" (reg[3])
-               : "a" (func_id), "c" (0)
-        );	
+        // %ebx may be the PIC register
+        __asm__("xchg{l}\t{%%}ebx, %1\n\t"
+                "cpuid\n\t"
+                "xchg{l}\t{%%}ebx, %1\n\t"
+                : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),
+                  "=d" (reg[3])
+                : "a" (func_id), "c" (0)
+        );
     #else
         __asm__("cpuid\n\t"
                 : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -77,8 +77,8 @@ npy__cpu_getxcr0(void)
     return _xgetbv(0);
 #elif defined(__GNUC__) || defined(__clang__)
     /* named form of xgetbv not supported on OSX, so must use byte form, see:
-     https://github.com/asmjit/asmjit/issues/78
-   */
+     * https://github.com/asmjit/asmjit/issues/78
+    */
     unsigned int eax, edx;
     __asm(".byte 0x0F, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
     return eax;

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -68,6 +68,8 @@ npy_cpu_features_dict(void)
     #include <intrin.h>
 #elif defined(__INTEL_COMPILER)
     #include <immintrin.h>
+#elif defined(__GNUC__) || defined(__clang__)
+    #include <cpuid.h>
 #endif
 
 static int
@@ -96,7 +98,6 @@ npy__cpu_cpuid(int reg[4], int func_id)
 #elif defined(__INTEL_COMPILER)
     __cpuid(reg, func_id);
 #elif defined(__GNUC__) || defined(__clang__)
-    #include <cpuid.h>
     __cpuid_count(func_id, 0, reg[0], reg[1], reg[2], reg[3]);
 #else
     #error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -83,7 +83,7 @@ npy__cpu_getxcr0(void)
     __asm(".byte 0x0F, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
     return eax;
 #else
-return 0;
+    return 0;
 #endif
 }
 

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -98,11 +98,11 @@ npy__cpu_cpuid(int reg[4], int func_id)
     #if defined(NPY_CPU_X86) && defined(__PIC__)
        // %ebx may be the PIC register
        __asm__("xchg{l}\t{%%}ebx, %1\n\t"	
-                "cpuid\n\t"	
-                "xchg{l}\t{%%}ebx, %1\n\t"	
-                : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),	
-                  "=d" (reg[3])	
-                : "a" (func_id), "c" (0)	
+               "cpuid\n\t"	
+               "xchg{l}\t{%%}ebx, %1\n\t"	
+               : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),	
+                 "=d" (reg[3])	
+               : "a" (func_id), "c" (0)	
         );	
     #else	
         __asm__("cpuid\n\t"	

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -76,12 +76,15 @@ npy__cpu_getxcr0(void)
 #if defined(_MSC_VER) || defined (__INTEL_COMPILER)
     return _xgetbv(0);
 #elif defined(__GNUC__) || defined(__clang__)
+    /* named form of xgetbv not supported on OSX, so must use byte form, see:
+     https://github.com/asmjit/asmjit/issues/78
+   */
     unsigned int eax, edx;
-    __asm__("xgetbv" : "=a" (eax), "=d" (edx) : "c" (0));
-    return (eax | (unsigned long long)edx << 32);
+    __asm(".byte 0x0F, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
+    return eax;
 #else
-    // TODO: handle other x86 compilers
-    return 0;
+#error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."
+return 0;
 #endif
 }
 
@@ -93,24 +96,10 @@ npy__cpu_cpuid(int reg[4], int func_id)
 #elif defined(__INTEL_COMPILER)
     __cpuid(reg, func_id);
 #elif defined(__GNUC__) || defined(__clang__)
-    #if defined(NPY_CPU_X86) && defined(__PIC__)
-        // %ebx may be the PIC register
-        __asm__("xchg{l}\t{%%}ebx, %1\n\t"
-                "cpuid\n\t"
-                "xchg{l}\t{%%}ebx, %1\n\t"
-                : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),
-                  "=d" (reg[3])
-                : "a" (func_id), "c" (0)
-        );
-    #else
-        __asm__("cpuid\n\t"
-                : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),
-                  "=d" (reg[3])
-                : "a" (func_id), "c" (0)
-        );
-    #endif
+    #include <cpuid.h>
+    __cpuid_count(func_id, 0, reg[0], reg[1], reg[2], reg[3]);
 #else
-    // TODO: handle other x86 compilers
+    #error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."
     reg[0] = 0;
 #endif
 }

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -68,8 +68,6 @@ npy_cpu_features_dict(void)
     #include <intrin.h>
 #elif defined(__INTEL_COMPILER)
     #include <immintrin.h>
-#elif defined(__GNUC__) || defined(__clang__)
-    #include <cpuid.h>
 #endif
 
 static int
@@ -85,7 +83,6 @@ npy__cpu_getxcr0(void)
     __asm(".byte 0x0F, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
     return eax;
 #else
-#error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."
 return 0;
 #endif
 }
@@ -98,9 +95,23 @@ npy__cpu_cpuid(int reg[4], int func_id)
 #elif defined(__INTEL_COMPILER)
     __cpuid(reg, func_id);
 #elif defined(__GNUC__) || defined(__clang__)
-    __cpuid_count(func_id, 0, reg[0], reg[1], reg[2], reg[3]);
+    #if defined(NPY_CPU_X86) && defined(__PIC__)
+       // %ebx may be the PIC register
+       __asm__("xchg{l}\t{%%}ebx, %1\n\t"	
+                "cpuid\n\t"	
+                "xchg{l}\t{%%}ebx, %1\n\t"	
+                : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),	
+                  "=d" (reg[3])	
+                : "a" (func_id), "c" (0)	
+        );	
+    #else	
+        __asm__("cpuid\n\t"	
+                : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),	
+                  "=d" (reg[3])	
+                : "a" (func_id), "c" (0)	
+        );
+    #endif
 #else
-    #error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."
     reg[0] = 0;
 #endif
 }
@@ -113,8 +124,15 @@ npy__cpu_init_features(void)
     // validate platform support
     int reg[] = {0, 0, 0, 0};
     npy__cpu_cpuid(reg, 0);
-    if (reg[0] == 0)
-        return;
+    if (reg[0] == 0) {
+       npy__cpu_have[NPY_CPU_FEATURE_MMX]  = 1;
+       npy__cpu_have[NPY_CPU_FEATURE_SSE]  = 1;
+       npy__cpu_have[NPY_CPU_FEATURE_SSE2] = 1;
+       #ifdef NPY_CPU_AMD64
+           npy__cpu_have[NPY_CPU_FEATURE_SSE3] = 1;
+       #endif
+       return;
+    }
 
     npy__cpu_cpuid(reg, 1);
     npy__cpu_have[NPY_CPU_FEATURE_MMX]    = (reg[3] & (1 << 23)) != 0;

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -97,18 +97,18 @@ npy__cpu_cpuid(int reg[4], int func_id)
 #elif defined(__GNUC__) || defined(__clang__)
     #if defined(NPY_CPU_X86) && defined(__PIC__)
        // %ebx may be the PIC register
-       __asm__("xchg{l}\t{%%}ebx, %1\n\t"	
-               "cpuid\n\t"	
-               "xchg{l}\t{%%}ebx, %1\n\t"	
-               : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),	
-                 "=d" (reg[3])	
-               : "a" (func_id), "c" (0)	
+       __asm__("xchg{l}\t{%%}ebx, %1\n\t"
+               "cpuid\n\t"
+               "xchg{l}\t{%%}ebx, %1\n\t"
+               : "=a" (reg[0]), "=r" (reg[1]), "=c" (reg[2]),
+                 "=d" (reg[3])
+               : "a" (func_id), "c" (0)
         );	
-    #else	
-        __asm__("cpuid\n\t"	
-                : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),	
-                  "=d" (reg[3])	
-                : "a" (func_id), "c" (0)	
+    #else
+        __asm__("cpuid\n\t"
+                : "=a" (reg[0]), "=b" (reg[1]), "=c" (reg[2]),
+                  "=d" (reg[3])
+                : "a" (func_id), "c" (0)
         );
     #endif
 #else


### PR DESCRIPTION
This PR made three improvements as follows:

- named form of `xgetbv `not supported on OSX, use `.byte` instead.
- use a GNU/Clang cpuid command instead of inline assembly to get `xcr0`.
- Two `todos ` are cleared by error message.