### PR TITLE
BUG: relpath fails for different drives on windows

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -520,11 +520,7 @@ class build_ext (old_build_ext):
 
         # Wrap unlinkable objects to a linkable one
         if unlinkable_fobjects:
-            if os.name == 'nt':
-                # relpath fails if we are on a different drive
-                fobjects = [os.path.abspath(obj) for obj in unlinkable_fobjects]
-            else:
-                fobjects = [os.path.relpath(obj) for obj in unlinkable_fobjects]
+            fobjects = [os.path.abspath(obj) for obj in unlinkable_fobjects]
             wrapped = fcompiler.wrap_unlinkable_objects(
                     fobjects, output_dir=self.build_temp,
                     extra_dll_dir=self.extra_dll_dir)

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -520,7 +520,11 @@ class build_ext (old_build_ext):
 
         # Wrap unlinkable objects to a linkable one
         if unlinkable_fobjects:
-            fobjects = [os.path.relpath(obj) for obj in unlinkable_fobjects]
+            if os.name == 'nt':
+                # relpath fails if we are on a different drive
+                fobjects = [os.path.abspath(obj) for obj in unlinkable_fobjects]
+            else:
+                fobjects = [os.path.relpath(obj) for obj in unlinkable_fobjects]
             wrapped = fcompiler.wrap_unlinkable_objects(
                     fobjects, output_dir=self.build_temp,
                     extra_dll_dir=self.extra_dll_dir)


### PR DESCRIPTION
Revive gh-12535. Fixes gh-12530. Sorry, no test.

This PR should fix the immediate problem of broken CI runs or smoke out the reason `relpath` was used in the first place.