### PR TITLE
DOC: Fix documentation rendering,

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1139,7 +1139,7 @@ def packbits(a, axis=None, bitorder='big'):
         ``None`` implies packing the flattened array.
     bitorder : {'big', 'little'}, optional
         The order of the input bits. 'big' will mimic bin(val),
-        ``[0, 0, 0, 0, 0, 0, 1, 1] => 3 = 0b00000011 => ``, 'little' will
+        ``[0, 0, 0, 0, 0, 0, 1, 1] => 3 = 0b00000011``, 'little' will
         reverse the order so ``[1, 1, 0, 0, 0, 0, 0, 0] => 3``.
         Defaults to 'big'.
 


### PR DESCRIPTION
Backport of #16305. 

The => seem to be extra and rst seem to not interprete backtick with
leading space as closing a directive, the the full line on text was put
in a html pre-tag when building the docs.

see current https://numpy.org/doc/stable/reference/generated/numpy.packbits.html

<img width="1003" alt="Screen Shot 2020-05-19 at 14 43 24" src="https://user-images.githubusercontent.com/335567/82381463-18bcbb00-99df-11ea-9828-ae21e5b93900.png">

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
