### PR TITLE
MAINT: Stop Using PyEval_Call* and simplify some uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
     - stage: Comprehensive tests
       python: 3.6
     - python: 3.7
+    - python: 3.9-dev
 
     - python: 3.6
       env: USE_DEBUG=1

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -168,15 +168,13 @@ array_repr_builtin(PyArrayObject *self, int repr)
 NPY_NO_EXPORT PyObject *
 array_repr(PyArrayObject *self)
 {
-    PyObject *s, *arglist;
+    PyObject *s;
 
     if (PyArray_ReprFunction == NULL) {
         s = array_repr_builtin(self, 1);
     }
     else {
-        arglist = Py_BuildValue("(O)", self);
-        s = PyEval_CallObject(PyArray_ReprFunction, arglist);
-        Py_DECREF(arglist);
+        s = PyObject_CallFunctionObjArgs(PyArray_ReprFunction, self, NULL);
     }
     return s;
 }
@@ -185,15 +183,13 @@ array_repr(PyArrayObject *self)
 NPY_NO_EXPORT PyObject *
 array_str(PyArrayObject *self)
 {
-    PyObject *s, *arglist;
+    PyObject *s;
 
     if (PyArray_StrFunction == NULL) {
         s = array_repr_builtin(self, 0);
     }
     else {
-        arglist = Py_BuildValue("(O)", self);
-        s = PyEval_CallObject(PyArray_StrFunction, arglist);
-        Py_DECREF(arglist);
+        s = PyObject_CallFunctionObjArgs(PyArray_StrFunction, self, NULL);
     }
     return s;
 }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -225,10 +225,6 @@ NPY_NO_EXPORT void
 PyUFunc_O_O_method(char **args, npy_intp const *dimensions, npy_intp const *steps, void *func)
 {
     char *meth = (char *)func;
-    PyObject *tup = PyTuple_New(0);
-    if (tup == NULL) {
-        return;
-    }
     UNARY_LOOP {
         PyObject *in1 = *(PyObject **)ip1;
         PyObject **out = (PyObject **)op1;
@@ -247,20 +243,17 @@ PyUFunc_O_O_method(char **args, npy_intp const *dimensions, npy_intp const *step
                          "type %s which has no callable %s method",
                          i, type->tp_name, meth);
             npy_PyErr_ChainExceptionsCause(exc, val, tb);
-            Py_DECREF(tup);
             Py_XDECREF(func);
             return;
         }
-        ret = PyObject_Call(func, tup, NULL);
+        ret = PyObject_CallObject(func, NULL);
         Py_DECREF(func);
         if (ret == NULL) {
-            Py_DECREF(tup);
             return;
         }
         Py_XDECREF(*out);
         *out = ret;
     }
-    Py_DECREF(tup);
 }
 
 /*UFUNC_API*/
@@ -359,7 +352,7 @@ PyUFunc_On_Om(char **args, npy_intp const *dimensions, npy_intp const *steps, vo
             PyTuple_SET_ITEM(arglist, j, in);
             Py_INCREF(in);
         }
-        result = PyEval_CallObject(tocall, arglist);
+        result = PyObject_CallObject(tocall, arglist);
         Py_DECREF(arglist);
         if (result == NULL) {
             return;


### PR DESCRIPTION
Simple fix to not use the deprecated functions (and slightly simplify the code).
Makes Travis with 3.9-dev pass, not sure if we should activate it in CI right now.