### PR TITLE
BUG: prevent warning in np.testing in presence of non-standard NaNs

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -19,6 +19,7 @@ import pprint
 
 from numpy.core import(
      intp, float32, empty, arange, array_repr, ndarray, isnat, array)
+from numpy.lib import isneginf, isposinf
 import numpy.linalg.lapack_lite
 
 from io import StringIO
@@ -765,10 +766,10 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True,
 
             if equal_inf:
                 flagged |= func_assert_same_pos(x, y,
-                                                func=lambda xy: xy == +inf,
+                                                func=lambda xy: isposinf(xy),
                                                 hasval='+inf')
                 flagged |= func_assert_same_pos(x, y,
-                                                func=lambda xy: xy == -inf,
+                                                func=lambda xy: isneginf(xy),
                                                 hasval='-inf')
 
         elif istime(x) and istime(y):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -904,6 +904,15 @@ class TestAssertAllclose:
         msg = str(exc_info.value)
         assert_('Max relative difference: 0.5' in msg)
 
+    def test_nonstandard_nan(self):
+        nonstandard_nan = np.array(
+            [0b_0111_1111_1000_0000_0000_0000_0000_0001],
+            dtype='uint32'
+        ).view('float32')
+        with pytest.warns(RuntimeWarning) as rec:
+            assert_allclose(nonstandard_nan, np.nan)
+        assert len(rec) == 0
+
 
 class TestArrayAlmostEqualNulp:
 


### PR DESCRIPTION
Prevents warnings for non-standard NaN encodings. For example:
```python
import numpy as np 
nonstandard_nan = np.array( 
  [0b_0111_1111_1000_0000_0000_0000_0000_0001], 
  dtype='uint32' 
).view('float32') 
np.testing.assert_allclose(nonstandard_nan, np.nan)           
```
```pytb          
/Users/jakevdp/anaconda/envs/jax/lib/python3.8/site-packages/numpy/testing/_private/utils.py:774: RuntimeWarning: invalid value encountered in equal
  func=lambda xy: xy == +inf,
/Users/jakevdp/anaconda/envs/jax/lib/python3.8/site-packages/numpy/testing/_private/utils.py:777: RuntimeWarning: invalid value encountered in equal
  func=lambda xy: xy == -inf,
```