### PR TITLE
BUG: Don't segfault on bad __len__ when assigning.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -529,10 +529,11 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
         return 0;
     }
 
-    slen = PySequence_Length(s);
-    if (slen < 0) {
+    PyObject *seq = PySequence_Fast(s, "Could not convert object to sequence");
+    if (seq == NULL) {
         goto fail;
     }
+    slen = PySequence_Fast_GET_SIZE(seq);
 
     /*
      * Either the dimensions match, or the sequence has length 1 and can
@@ -550,16 +551,15 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
         PyObject *o;
         npy_intp alen = PyArray_DIM(a, dim);
 
-        o = PySequence_GetItem(s, 0);
-        if (o == NULL) {
-            goto fail;
-        }
+        o = PySequence_Fast_GET_ITEM(seq, 0);
+        Py_INCREF(o);
 
         for (i = 0; i < alen; i++) {
             if ((PyArray_NDIM(a) - dim) > 1) {
                 PyArrayObject * tmp =
                     (PyArrayObject *)array_item_asarray(dst, i);
                 if (tmp == NULL) {
+                    Py_DECREF(o);
                     goto fail;
                 }
 
@@ -579,18 +579,12 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
     }
     /* Copy element by element */
     else {
-        PyObject * seq;
-        seq = PySequence_Fast(s, "Could not convert object to sequence");
-        if (seq == NULL) {
-            goto fail;
-        }
         for (i = 0; i < slen; i++) {
             PyObject * o = PySequence_Fast_GET_ITEM(seq, i);
             if ((PyArray_NDIM(a) - dim) > 1) {
                 PyArrayObject * tmp =
                     (PyArrayObject *)array_item_asarray(dst, i);
                 if (tmp == NULL) {
-                    Py_DECREF(seq);
                     goto fail;
                 }
 
@@ -602,17 +596,17 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
                 res = PyArray_SETITEM(dst, b, o);
             }
             if (res < 0) {
-                Py_DECREF(seq);
                 goto fail;
             }
         }
-        Py_DECREF(seq);
     }
 
+    Py_DECREF(seq);
     Py_DECREF(s);
     return 0;
 
  fail:
+    Py_XDECREF(seq);
     Py_DECREF(s);
     return res;
 }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -550,10 +550,8 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
 
     /* Broadcast the one element from the sequence to all the outputs */
     if (slen == 1) {
-        PyObject *o;
+        PyObject *o = PySequence_Fast_GET_ITEM(seq, 0);
         npy_intp alen = PyArray_DIM(a, dim);
-
-        o = PySequence_Fast_GET_ITEM(seq, 0);
 
         for (i = 0; i < alen; i++) {
             if ((PyArray_NDIM(a) - dim) > 1) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -483,6 +483,8 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
     /* INCREF on entry DECREF on exit */
     Py_INCREF(s);
 
+    PyObject *seq = NULL;
+
     if (PyArray_Check(s)) {
         if (!(PyArray_CheckExact(s))) {
             /*
@@ -529,7 +531,7 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
         return 0;
     }
 
-    PyObject *seq = PySequence_Fast(s, "Could not convert object to sequence");
+    seq = PySequence_Fast(s, "Could not convert object to sequence");
     if (seq == NULL) {
         goto fail;
     }
@@ -552,14 +554,12 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
         npy_intp alen = PyArray_DIM(a, dim);
 
         o = PySequence_Fast_GET_ITEM(seq, 0);
-        Py_INCREF(o);
 
         for (i = 0; i < alen; i++) {
             if ((PyArray_NDIM(a) - dim) > 1) {
                 PyArrayObject * tmp =
                     (PyArrayObject *)array_item_asarray(dst, i);
                 if (tmp == NULL) {
-                    Py_DECREF(o);
                     goto fail;
                 }
 
@@ -571,11 +571,9 @@ setArrayFromSequence(PyArrayObject *a, PyObject *s,
                 res = PyArray_SETITEM(dst, b, o);
             }
             if (res < 0) {
-                Py_DECREF(o);
                 goto fail;
             }
         }
-        Py_DECREF(o);
     }
     /* Copy element by element */
     else {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -988,7 +988,8 @@ class TestCreation:
             def __len__(self):
                 return 42
 
-        assert_raises(ValueError, np.array, C()) # segfault?
+        a = np.array(C()) # segfault?
+        assert_equal(len(a), 0)
 
     def test_false_len_iterable(self):
         # Special case where a bad __getitem__ makes us fall back on __iter__:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -990,6 +990,20 @@ class TestCreation:
 
         assert_raises(ValueError, np.array, C()) # segfault?
 
+    def test_false_len_iterable(self):
+        # Special case where a bad __getitem__ makes us fall back on __iter__:
+        class C:
+            def __getitem__(self, x):
+                raise Exception
+            def __iter__(self):
+                return iter(())
+            def __len__(self):
+                return 2
+
+        a = np.empty(2)
+        with assert_raises(ValueError):
+            a[:] = C()  # Segfault!
+
     def test_failed_len_sequence(self):
         # gh-7393
         class A:
@@ -1804,7 +1818,7 @@ class TestMethods:
             c = b.copy()
             c.sort(kind=kind)
             assert_equal(c, a, msg)
-            
+
     def test_sort_structured(self):
         # test record array sorts.
         dt = np.dtype([('f', float), ('i', int)])


### PR DESCRIPTION
Related to gh-7264. `__len__` could lie to us here, so just convert to `PySequence_Fast` earlier and use that length as a source of truth instead.

This intentionally changes the result of the edge case tested by `test_false_len_sequence`. Rather than fail with an unhelpful `ValueError: cannot copy sequence with size 42 to array axis with dimension 0`, just ignore `__len__` and create the array with whatever items `C()` gives us.