### PR TITLE
DOC: link np.interp to SciPy's interpolation functions (closes #14154)

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1332,6 +1332,10 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         If `xp` or `fp` are not 1-D sequences
         If `period == 0`
 
+    See also
+    --------
+    scipy.interpolate 
+
     Notes
     -----
     The x-coordinate sequence is expected to be increasing, but this is not

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1332,7 +1332,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         If `xp` or `fp` are not 1-D sequences
         If `period == 0`
 
-    See also
+    See Also
     --------
     scipy.interpolate 
 


### PR DESCRIPTION
I've added a cross-link to SciPy's interpolation functions in the docstring of np.interp as suggested in #14154 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
