### PR TITLE
DOC: Fix spelling typo - homogenous to homogeneous. (#16324)

### DIFF
--- a/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
+++ b/doc/neps/nep-0022-ndarray-duck-typing-overview.rst
@@ -23,7 +23,7 @@ Detailed description
 --------------------
 
 Traditionally, NumPy’s ``ndarray`` objects have provided two things: a
-high level API for expression operations on homogenously-typed,
+high level API for expression operations on homogeneously-typed,
 arbitrary-dimensional, array-structured data, and a concrete
 implementation of the API based on strided in-RAM storage. The API is
 powerful, fairly general, and used ubiquitously across the scientific

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -71,7 +71,7 @@ This approach to the interface consists of the object having an
 
    **typestr** (required)
 
-       A string providing the basic type of the homogenous array The
+       A string providing the basic type of the homogeneous array The
        basic string format consists of 3 parts: a character describing
        the byteorder of the data (``<``: little-endian, ``>``:
        big-endian, ``|``: not-relevant), a character code giving the

--- a/doc/source/reference/arrays.rst
+++ b/doc/source/reference/arrays.rst
@@ -11,7 +11,7 @@ NumPy provides an N-dimensional array type, the :ref:`ndarray
 type. The items can be :ref:`indexed <arrays.indexing>` using for
 example N integers.
 
-All ndarrays are :term:`homogenous`: every item takes up the same size
+All ndarrays are :term:`homogeneous`: every item takes up the same size
 block of memory, and all blocks are interpreted in exactly the same
 way. How each item in the array is to be interpreted is specified by a
 separate :ref:`data-type object <arrays.dtypes>`, one of which is associated

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -100,8 +100,8 @@ What’s the difference between a Python list and a NumPy array?
 NumPy gives you an enormous range of fast and efficient ways of creating arrays
 and manipulating numerical data inside them. While a Python list can contain
 different data types within a single list, all of the elements in a NumPy array
-should be homogenous. The mathematical operations that are meant to be performed
-on arrays would be extremely inefficient if the arrays weren't homogenous.
+should be homogeneous. The mathematical operations that are meant to be performed
+on arrays would be extremely inefficient if the arrays weren't homogeneous.
 
 **Why use NumPy?**
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -929,7 +929,7 @@ class TestCreation:
             d = np.empty(i, dtype='U')
             str(d)
 
-    def test_sequence_non_homogenous(self):
+    def test_sequence_non_homogeneous(self):
         assert_equal(np.array([4, 2**80]).dtype, object)
         assert_equal(np.array([4, 2**80, 4]).dtype, object)
         assert_equal(np.array([2**80, 4]).dtype, object)

--- a/numpy/doc/glossary.py
+++ b/numpy/doc/glossary.py
@@ -169,7 +169,7 @@ Glossary
        Collapsed to a one-dimensional array. See `numpy.ndarray.flatten`
        for details.
 
-   homogenous
+   homogeneous
        Describes a block of memory comprised of blocks, each block comprised of 
        items and of the same size, and blocks are interpreted in exactly the
        same way. In the simplest case each block contains a single item, for


### PR DESCRIPTION
As per issue #16324, "homogeneous" was misspelled in 7 places as "homogenous".  This PR fixes that. 