### PR TITLE
CI: Create a link for the circleCI artifact

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+   circleci_artifacts_redirector_job:
+     runs-on: ubuntu-latest
+     name: Run CircleCI artifacts redirector
+     steps:
+       - name: GitHub Action step
+         uses: larsoner/circleci-artifacts-redirector-action@master
+         with:
+           repo-token: ${{ secrets.GITHUB_TOKEN }}
+           artifact-path: 0/doc/build/html/index.html
+           circleci-jobs: build


### PR DESCRIPTION
Supersedes gh-15005, @larsoner is this the correct way to do it, or do I have to set up something else on the github actions to make it work?