### PR TITLE
BUG: Don't segfault on bad __len__ when assigning. (gh-16327)

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -988,7 +988,22 @@ class TestCreation:
             def __len__(self):
                 return 42
 
-        assert_raises(ValueError, np.array, C()) # segfault?
+        a = np.array(C()) # segfault?
+        assert_equal(len(a), 0)
+
+    def test_false_len_iterable(self):
+        # Special case where a bad __getitem__ makes us fall back on __iter__:
+        class C:
+            def __getitem__(self, x):
+                raise Exception
+            def __iter__(self):
+                return iter(())
+            def __len__(self):
+                return 2
+
+        a = np.empty(2)
+        with assert_raises(ValueError):
+            a[:] = C()  # Segfault!
 
     def test_failed_len_sequence(self):
         # gh-7393
@@ -1799,7 +1814,7 @@ class TestMethods:
             c = b.copy()
             c.sort(kind=kind)
             assert_equal(c, a, msg)
-            
+
     def test_sort_structured(self):
         # test record array sorts.
         dt = np.dtype([('f', float), ('i', int)])


### PR DESCRIPTION
Backport of #16327. 

When __getitem__ fails, assignment falls back on __iter__, which may not
have the same length as __len__, resulting in a segfault.
See gh-7264.

* BUG: Don't rely on __len__ for safe iteration.

Skip __len__ checking entirely, since this has no guarantees of being
correct. Instead, first convert to PySequence_Fast and use that length.
Also fixes a refleak when creating a tmp array fails.
See gh-7264.

* TST: Update test for related edge-case.

The previous fix more gracefully handles this edge case by skipping the
__len__ check. Rather than raising with an unhelpful error message, just
create the array with whatever elements C() actually yields.
See gh-7264.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
