### PR TITLE
BLD: Avoid "visibility attribute not supported" warning.

### DIFF
--- a/numpy/distutils/command/autodist.py
+++ b/numpy/distutils/command/autodist.py
@@ -69,7 +69,10 @@ def check_gcc_function_attribute(cmd, attribute, name):
         #pragma GCC diagnostic error "-Wattributes"
         #pragma clang diagnostic error "-Wattributes"
 
-        int %s %s(void*);
+        int %s %s(void* unused)
+        {
+            return 0;
+        }
 
         int
         main()


### PR DESCRIPTION
Backport of #16288. 

I found that when building the latest master branch on Cygwin, while
testing #16246, that thousands of warnings were generated at build time
like:

numpy/core/src/npysort/binsearch.c.src: In function
‘binsearch_left_bool’: numpy/core/src/npysort/binsearch.c.src:82:1:
warning: visibility attribute not supported in this configuration;
ignored [-Wattributes] Granted this is just a warning, so I don't think
it's a serious issue.

It seems the test that was supposed to check for __attribute__ support
was not working as expected. The #pragmas only take effect if I provide
a function body--they are ignored for bare declarations. I don't know if
that's by intent, or if it's a GCC issue. For reference:

$ gcc --version
gcc (GCC) 7.4.0

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
