### PR TITLE
BUG: Fix dtype leak in `PyArray_FromAny` error path

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2029,12 +2029,14 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
             PyErr_SetString(PyExc_ValueError,
                             "object of too small depth for desired array");
             Py_DECREF(arr);
+            Py_XDECREF(newtype);
             ret = NULL;
         }
         else if (max_depth != 0 && PyArray_NDIM(arr) > max_depth) {
             PyErr_SetString(PyExc_ValueError,
                             "object too deep for desired array");
             Py_DECREF(arr);
+            Py_XDECREF(newtype);
             ret = NULL;
         }
         else {

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2423,6 +2423,15 @@ class TestBincount:
         assert_equal(sys.getrefcount(np.dtype(np.intp)), intp_refcount)
         assert_equal(sys.getrefcount(np.dtype(np.double)), double_refcount)
 
+    @pytest.mark.parametrize("vals", [[[2, 2]], 2])
+    def test_error_not_1d(self, vals):
+        # Test that values has to be 1-D (both as array and nested list)
+        vals_arr = np.asarray(vals)
+        with assert_raises(ValueError):
+            np.bincount(vals_arr)
+        with assert_raises(ValueError):
+            np.bincount(vals)
+
 
 class TestInterp:
 


### PR DESCRIPTION
Also adds a test to bincount which will run into this path.
The leak can be triggered by using a reference count checker
on the test suit (e.g. pytest-leaks).

Closes gh-16339

---

Fairly harmless leak (most of the time, since only structured descriptors or some with metadata are really bad to leak).