### PR TITLE
BUG: Indentation for docstrings

### DIFF
--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -49,7 +49,7 @@ def old_func5(self, x):
         Bizarre indentation.
     """
     return x
-new_func5 = deprecate(old_func5)
+new_func5 = deprecate(old_func5, message="This function is\ndeprecated.")
 
 
 def old_func6(self, x):
@@ -74,10 +74,20 @@ def test_deprecate_fn():
 
 
 @pytest.mark.skipif(sys.flags.optimize == 2, reason="-OO discards docstrings")
-def test_deprecate_help_indentation():
-    _compare_docs(old_func4, new_func4)
-    _compare_docs(old_func5, new_func5)
-    _compare_docs(old_func6, new_func6)
+@pytest.mark.parametrize('old_func, new_func', [
+    (old_func4, new_func4),
+    (old_func5, new_func5),
+    (old_func6, new_func6),
+])
+def test_deprecate_help_indentation(old_func, new_func):
+    _compare_docs(old_func, new_func)
+    # Ensure we don't mess up the indentation
+    for knd, func in (('old', old_func), ('new', new_func)):
+        for li, line in enumerate(func.__doc__.split('\n')):
+            if li == 0:
+                assert line.startswith('    ') or not line.startswith(' '), knd
+            elif line:
+                assert line.startswith('    '), knd
 
 
 def _compare_docs(old_func, new_func):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import textwrap
 import types
 import re
 import warnings
@@ -117,6 +118,7 @@ class _Deprecate:
                         break
                     skip += len(line) + 1
                 doc = doc[skip:]
+            depdoc = textwrap.indent(depdoc, ' ' * indent)
             doc = '\n\n'.join([depdoc, doc])
         newfunc.__doc__ = doc
         try:


### PR DESCRIPTION
[Over in SciPy](https://github.com/scipy/scipy/pull/11431/files/b0920987ba55b53effc52161f5f3238dc0569b95#diff-cc307f50f4eb0f9917b55fdf1dbb9b8c) we are trying to use `np.deprecate` with a variant of:
```
@np.deprecate(message='foo')
def median_absolute_deviation(x, axis=0, ...):
    r"""Compute the median absolute deviation of the data along the given axis.

    The median absolute deviation (MAD, [1]_) computes the median over the
    ...
```
And this results in:
```
$ python -c "from scipy.stats import median_absolute_deviation; print(median_absolute_deviation.__doc__[:200])"
`median_absolute_deviation` is deprecated!
foo

    Compute the median absolute deviation of the data along the given axis.

    The median absolute deviation (MAD, [1]_) computes the median over the
```
This is problematic because the indentation ends up being broken, because the second line is used to determine the indentation by autodoc/sphinx/whoever. This leads to [broken RST rendering](https://19378-1460385-gh.circle-artifacts.com/0/html-scipyorg/generated/scipy.stats.median_absolute_deviation.html#scipy.stats.median_absolute_deviation). This PR changes the output to:
```
$ python -c "from scipy.stats import median_absolute_deviation; print(median_absolute_deviation.__doc__[:200])"
    `median_absolute_deviation` is deprecated!
    foo

    Compute the median absolute deviation of the data along the given axis.

    The median absolute deviation (MAD, [1]_) computes the median o
```
In theory we could just indent the `message` (here the "foo" line), but the `indent` is determined after `message` is appended to `depdoc`, so might as well indent the whole `depdoc`.

Closes #16202