### PR TITLE
ENH: expose cython isinstance checks for np.bool_, np.integer_, np.floating

### DIFF
--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -954,6 +954,9 @@ cdef inline bint is_integer_object(object obj):
 
     `isinstance(val, (int, np.integer)) and not isinstance(val, bool)`
 
+    Cython cannot optimize this into a C call on its own because
+    np.integer is not available as a C type.
+
     Parameters
     ----------
     val : object
@@ -972,7 +975,10 @@ cdef inline bint is_integer_object(object obj):
 
 cdef inline bint is_float_object(object obj):
     """
-    Cython equivalent of `isinstance(val, (float, np.float_))`
+    Cython equivalent of `isinstance(val, (float, np.floating))`
+
+    Cython cannot optimize this into a C call on its own because
+    np.floating is not available as a C type.
 
     Parameters
     ----------
@@ -988,7 +994,10 @@ cdef inline bint is_float_object(object obj):
 
 cdef inline bint is_complex_object(object obj):
     """
-    Cython equivalent of `isinstance(val, (complex, np.complex_))`
+    Cython equivalent of `isinstance(val, (complex, np.complexfloating))`
+
+    Cython cannot optimize this into a C call on its own because
+    np.complexfloating is not available as a C type.
 
     Parameters
     ----------
@@ -1005,6 +1014,9 @@ cdef inline bint is_complex_object(object obj):
 cdef inline bint is_bool_object(object obj):
     """
     Cython equivalent of `isinstance(val, (bool, np.bool_))`
+
+    Cython cannot optimize this into a C call on its own because
+    np.bool_ is not available as a C type.
 
     Parameters
     ----------

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -18,6 +18,7 @@ cimport libc.stdio as stdio
 
 cdef extern from "Python.h":
     ctypedef int Py_intptr_t
+    bint PyBool_Check(object obj)
 
 cdef extern from "numpy/arrayobject.h":
     PyTypeObject PyFloatingArrType_Type
@@ -951,7 +952,7 @@ cdef inline bint is_integer_object(object obj):
     """
     Cython equivalent of
 
-    `isinstance(val, (int, long, np.integer)) and not isinstance(val, bool)`
+    `isinstance(val, (int, np.integer)) and not isinstance(val, bool)`
 
     Parameters
     ----------
@@ -965,7 +966,7 @@ cdef inline bint is_integer_object(object obj):
     -----
     This does not counts np.timedelta64 objects as integers.
     """
-    return (not isinstance(obj, bool) and PyArray_IsIntegerScalar(obj)
+    return (not PyBool_Check(obj) and PyArray_IsIntegerScalar(obj)
             and not is_timedelta64_object(obj))
 
 
@@ -1013,7 +1014,7 @@ cdef inline bint is_bool_object(object obj):
     -------
     bool
     """
-    return (isinstance(obj, bool) or
+    return (PyBool_Check(obj) or
             PyObject_TypeCheck(obj, &PyBoolArrType_Type))
 
 

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -946,7 +946,7 @@ cdef extern from *:
     /* NumPy API declarations from "numpy/__init__.pxd" */
     """
 
-cdef extern from "numpy/scalartypes.h":
+cdef extern from *:
     ctypedef class numpy.floating [object PyObject]:
         pass
 

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -21,7 +21,6 @@ cdef extern from "Python.h":
     bint PyBool_Check(object obj)
 
 cdef extern from "numpy/arrayobject.h":
-    PyTypeObject PyFloatingArrType_Type
     ctypedef Py_intptr_t npy_intp
     ctypedef size_t npy_uintp
 
@@ -947,6 +946,10 @@ cdef extern from *:
     /* NumPy API declarations from "numpy/__init__.pxd" */
     """
 
+cdef extern from "numpy/scalartypes.h":
+    ctypedef class numpy.floating [object PyObject]:
+        pass
+
 
 cdef inline bint is_integer_object(object obj):
     """
@@ -988,8 +991,7 @@ cdef inline bint is_float_object(object obj):
     -------
     is_float : bool
     """
-    return (isinstance(obj, float) or
-            (PyObject_TypeCheck(obj, &PyFloatingArrType_Type)))
+    return isinstance(obj, (float, floating))
 
 
 cdef inline bint is_complex_object(object obj):

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -971,7 +971,7 @@ cdef inline bint is_integer_object(object obj):
 
 cdef inline bint is_float_object(object obj):
     """
-    Cython equivalent of `isinstance(val, (float, np.complex_))`
+    Cython equivalent of `isinstance(val, (float, np.float_))`
 
     Parameters
     ----------

--- a/numpy/core/tests/examples/checks.pyx
+++ b/numpy/core/tests/examples/checks.pyx
@@ -24,3 +24,19 @@ def get_td64_value(obj):
 
 def get_dt64_unit(obj):
     return cnp.get_datetime64_unit(obj)
+
+
+def is_integer(obj):
+    return cnp.is_integer_object(obj)
+
+
+def is_bool(obj):
+    return cnp.is_bool_object(obj)
+
+
+def is_float(obj):
+    return cnp.is_float_object(obj)
+
+
+def is_complex(obj):
+    return cnp.is_complex_object(obj)

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -75,8 +75,8 @@ def test_is_integer_object(install_temp):
 
     assert not checks.is_integer("a")
 
-    assert not checks.is_float(float("nan"))
-    assert not checks.is_float(np.nan)
+    assert not checks.is_integer(float("nan"))
+    assert not checks.is_integer(np.nan)
     assert not checks.is_integer(2.0)
     assert not checks.is_integer(np.float64(2.0))
 

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -67,6 +67,103 @@ def install_temp(request, tmp_path):
             raise RuntimeError(f'could not parse "{install_log}"')
 
 
+def test_is_integer_object(install_temp):
+    import checks
+
+    assert not checks.is_integer(np.timedelta64(1234))
+    assert not checks.is_integer(np.datetime64(1234, "D"))
+
+    assert not checks.is_integer("a")
+
+    assert not checks.is_float(float("nan"))
+    assert not checks.is_float(np.nan)
+    assert not checks.is_integer(2.0)
+    assert not checks.is_integer(np.float64(2.0))
+
+    assert checks.is_integer(1)
+    assert checks.is_integer(np.int64(2))
+    assert checks.is_integer(np.uint32(4))
+
+    # Only scalars, not integer-dtyped ndarrays
+    assert not checks.is_integer(np.array([1]))
+
+
+def test_is_float_object(install_temp):
+    import checks
+
+    assert not checks.is_float(np.timedelta64(1234))
+    assert not checks.is_float(np.datetime64(1234, "D"))
+
+    assert not checks.is_float("a")
+
+    assert checks.is_float(float("nan"))
+    assert checks.is_float(np.nan)
+    assert checks.is_float(2.0)
+    assert checks.is_float(np.float64(2.0))
+
+    assert not checks.is_float(1)
+    assert not checks.is_float(np.int64(2))
+    assert not checks.is_float(np.uint32(4))
+
+    # Only scalars, not float-dtyped ndarrays
+    assert not checks.is_float(np.array([1.0]))
+
+
+def test_is_complex_object(install_temp):
+    import checks
+
+    assert not checks.is_complex(np.timedelta64(1234))
+    assert not checks.is_complex(np.datetime64(1234, "D"))
+
+    assert not checks.is_complex("a")
+
+    assert not checks.is_complex(float("nan"))
+    assert not checks.is_complex(np.nan)
+    assert not checks.is_complex(2.0)
+    assert not checks.is_complex(np.float64(2.0))
+
+    assert not checks.is_complex(1)
+    assert not checks.is_complex(np.int64(2))
+    assert not checks.is_complex(np.uint32(4))
+
+    assert checks.is_complex(2.0j)
+    assert checks.is_complex(np.complex64(2.0))
+    assert checks.is_complex(np.complex64(np.nan))
+
+    # Only scalars, not float-dtyped ndarrays
+    assert not checks.is_complex(np.array([1.0], dtype="c8"))
+
+
+def test_is_bool_object(install_temp):
+    import checks
+
+    assert not checks.is_bool(np.timedelta64(1234))
+    assert not checks.is_bool(np.datetime64(1234, "D"))
+
+    assert not checks.is_bool("a")
+    assert not checks.is_bool("True")
+
+    assert not checks.is_bool(float("nan"))
+    assert not checks.is_bool(np.nan)
+    assert not checks.is_bool(2.0)
+    assert not checks.is_bool(np.float64(2.0))
+
+    assert not checks.is_bool(1)
+    assert not checks.is_bool(np.int64(2))
+    assert not checks.is_bool(np.uint32(4))
+
+    assert not checks.is_bool(2.0j)
+    assert not checks.is_bool(np.complex64(2.0))
+    assert not checks.is_bool(np.complex64(np.nan))
+
+    assert checks.is_bool(True)
+    assert checks.is_bool(np.bool_(False))
+
+
+    # Only scalars, not bool-dtyped ndarrays
+    assert not checks.is_bool(np.array([True], dtype=bool))
+
+
 def test_is_timedelta64_object(install_temp):
     import checks
 


### PR DESCRIPTION
Follows #16266 to upstream a few more cython-isinstance checks from pandas.