### PR TITLE
ENH: expose datetime64 conversion functions

### DIFF
--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -835,10 +835,34 @@ cdef extern from "numpy/ndarrayobject.h":
     ctypedef int64_t npy_timedelta
     ctypedef int64_t npy_datetime
 
+    # These are exposed for re-use by pandas.  They are not considered
+    #  part of the public API.
+    int convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
+                                           npy_datetime dt,
+                                           npy_datetimestruct *out)
+    int convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
+                                           const npy_datetimestruct *dts,
+                                           npy_datetime *out)
+    int parse_iso_8601_datetime(const char *str, Py_ssize_t len,
+                                NPY_DATETIMEUNIT unit,
+                                NPY_CASTING casting,
+                                npy_datetimestruct *out,
+                                NPY_DATETIMEUNIT *out_bestunit,
+                                npy_bool *out_special)
+    int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
+    int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
+                               int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
+                               NPY_CASTING casting)
+
+
 cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct PyArray_DatetimeMetaData:
         NPY_DATETIMEUNIT base
         int64_t num
+
+    ctypedef struct npy_datetimestruct:
+        int64_t year
+        int32_t month, day, hour, min, sec, us, ps, as
 
 cdef extern from "numpy/arrayscalars.h":
     ctypedef struct PyDatetimeScalarObject:

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -50,8 +50,7 @@ datetime_type_promotion(PyArray_Descr *type1, PyArray_Descr *type2);
  * Converts a datetime from a datetimestruct to a datetime based
  * on some metadata.
  */
-NPY_NO_EXPORT int
-convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
+int convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                                     const npy_datetimestruct *dts,
                                     npy_datetime *out);
 
@@ -287,8 +286,7 @@ convert_timedelta_to_pyobject(npy_timedelta td, PyArray_DatetimeMetaData *meta);
 /*
  * Converts a datetime based on the given metadata into a datetimestruct
  */
-NPY_NO_EXPORT int
-convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
+int convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
                                     npy_datetime dt,
                                     npy_datetimestruct *out);
 
@@ -300,8 +298,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
  *
  * Returns 0 on success, -1 on failure.
  */
-NPY_NO_EXPORT int
-convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
+int convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                                     const npy_datetimestruct *dts,
                                     npy_datetime *out);
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -269,8 +269,7 @@ set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts)
  *
  * Returns 0 on success, -1 on failure.
  */
-NPY_NO_EXPORT int
-convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
+int convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                                     const npy_datetimestruct *dts,
                                     npy_datetime *out)
 {
@@ -437,8 +436,7 @@ PyArray_TimedeltaStructToTimedelta(
 /*
  * Converts a datetime based on the given metadata into a datetimestruct
  */
-NPY_NO_EXPORT int
-convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
+int convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
                                     npy_datetime dt,
                                     npy_datetimestruct *out)
 {

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -217,8 +217,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
  *
  * Returns 0 on success, -1 on failure.
  */
-NPY_NO_EXPORT int
-parse_iso_8601_datetime(char const *str, Py_ssize_t len,
+int parse_iso_8601_datetime(char const *str, Py_ssize_t len,
                     NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     npy_datetimestruct *out,
@@ -755,8 +754,7 @@ error:
  * Provides a string length to use for converting datetime
  * objects with the given local and unit settings.
  */
-NPY_NO_EXPORT int
-get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
+int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
 {
     int len = 0;
 
@@ -882,8 +880,7 @@ lossless_unit_from_datetimestruct(npy_datetimestruct *dts)
  *  Returns 0 on success, -1 on failure (for example if the output
  *  string was too short).
  */
-NPY_NO_EXPORT int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
+int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
                     int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting)
 {

--- a/numpy/core/src/multiarray/datetime_strings.h
+++ b/numpy/core/src/multiarray/datetime_strings.h
@@ -32,8 +32,7 @@
  *
  * Returns 0 on success, -1 on failure.
  */
-NPY_NO_EXPORT int
-parse_iso_8601_datetime(char const *str, Py_ssize_t len,
+int parse_iso_8601_datetime(char const *str, Py_ssize_t len,
                     NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     npy_datetimestruct *out,
@@ -44,8 +43,7 @@ parse_iso_8601_datetime(char const *str, Py_ssize_t len,
  * Provides a string length to use for converting datetime
  * objects with the given local and unit settings.
  */
-NPY_NO_EXPORT int
-get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
+int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
 
 /*
  * Converts an npy_datetimestruct to an (almost) ISO 8601
@@ -69,8 +67,7 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  *  Returns 0 on success, -1 on failure (for example if the output
  *  string was too short).
  */
-NPY_NO_EXPORT int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
+int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, npy_intp outlen,
                     int local, int utc, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting);
 

--- a/numpy/core/tests/examples/checks.pyx
+++ b/numpy/core/tests/examples/checks.pyx
@@ -2,6 +2,9 @@
 Functions in this module give python-space wrappers for cython functions
 exposed in numpy/__init__.pxd, so they can be tested in test_cython.py
 """
+from datetime import datetime
+
+import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 
@@ -24,3 +27,58 @@ def get_td64_value(obj):
 
 def get_dt64_unit(obj):
     return cnp.get_datetime64_unit(obj)
+
+
+def make_iso_8601_datetime(dt: datetime):
+    cdef:
+        cnp.npy_datetimestruct dts
+        char* result
+        cnp.npy_intp outlen
+        int local = 0
+        int utc = 0
+        int tzoffset = 0
+
+    dts.year = dt.year
+    dts.month = dt.month
+    dts.day = dt.day
+    dts.hour = dt.hour
+    dts.sec = dt.second
+    dts.us = dt.microsecond
+
+    cnp.make_iso_8601_datetime(
+        &dts,
+        result,
+        outlen,
+        local,
+        utc,
+        cnp.NPY_FR_s,
+        tzoffset,
+        cnp.NPY_NO_CASTING,
+    )
+    return result
+
+
+def get_datetime_iso_8601_strlen():
+    return cnp.get_datetime_iso_8601_strlen(0, cnp.NPY_FR_Y)
+
+
+def parse_iso_8601_datetime(obj):
+    # cnp.parse_iso_8601_datetime(...)
+    raise NotImplementedError
+
+def convert_datetime_to_datetimestruct(dt: datetime):
+    cdef:
+        cnp.PyArray_DatetimeMetaData meta
+        cnp.npy_datetimestruct dts
+
+    meta.base = cnp.NPY_FR_us
+    meta.num = 1
+
+    dt64 = np.datetime64(dt)
+    cnp.convert_datetime_to_datetimestruct(&meta, dt64.view("i8"), &dts)
+    return dts  # gets converted to a dict in python-space
+
+
+def convert_datetimestruct_to_datetime(obj):
+    # cnp.convert_datetimestruct_to_datetime(...)
+    raise NotImplementedError

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 import shutil
 import subprocess
@@ -126,3 +127,34 @@ def test_get_datetime64_unit(install_temp):
     result = checks.get_dt64_unit(td64)
     expected = 5
     assert result == expected
+
+
+class TestDatetimeStrings:
+    def test_make_iso_8601_datetime(self, install_temp):
+        dt = datetime(2016, 6, 2, 10, 45, 19)
+        result = checks.make_iso_8601_datetime(dt)
+        assert result == "2016-05-02 10:45:19"
+
+    def test_get_datetime_iso_8601_strlen(self, install_temp):
+        result = checks.get_datetime_iso_8601_strlen()
+        assert result == 22
+
+    def test_parse_iso_8601_datetime(self, install_temp):
+        raise NotImplementedError
+
+
+def test_convert_datetime_to_datetimestruct(install_temp):
+    dt = datetime(2016, 6, 2, 10, 45, 19)
+    result = checks.convert_datetime_to_datetimestruct(dt)
+    assert isinstance(result, dict)
+    assert result["year"] == 2016
+    assert result["month"] = 6
+    assert result["day"] == 2
+    assert result["hour"] = 10
+    assert result["min"] = 45
+    assert result["sec"] = 19
+    # other dts fields aren't pinned down
+
+
+def test_convert_datetimestruct_to_datetime(install_temp):
+    raise NotImplementedError

--- a/numpy/random/__init__.pxd
+++ b/numpy/random/__init__.pxd
@@ -12,5 +12,3 @@ cdef extern from "numpy/random/bitgen.h":
     ctypedef bitgen bitgen_t
 
 from numpy.random.bit_generator cimport BitGenerator, SeedSequence
-
-from numpy cimport parse_iso_8601_datetime  # just checking

--- a/numpy/random/__init__.pxd
+++ b/numpy/random/__init__.pxd
@@ -12,3 +12,5 @@ cdef extern from "numpy/random/bitgen.h":
     ctypedef bitgen bitgen_t
 
 from numpy.random.bit_generator cimport BitGenerator, SeedSequence
+
+from numpy cimport parse_iso_8601_datetime  # just checking


### PR DESCRIPTION
These would allow pandas to remove our copy/pasted implementations.

cc @WillAyd @mroeschke anything else we might need?