### PR TITLE
MAINT, DOC: add index for user docs.

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -16,6 +16,9 @@ classes contained in the package, see the :ref:`reference`.
 
    setting-up
    quickstart
+   absolute_beginners
+   tutorials_index
+   howtos_index
    basics
    misc
    numpy-for-matlab-users

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -17,10 +17,10 @@ classes contained in the package, see the :ref:`reference`.
    setting-up
    quickstart
    absolute_beginners
-   tutorials_index
-   howtos_index
    basics
    misc
    numpy-for-matlab-users
    building
    c-info
+   tutorials_index
+   howtos_index

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -1,0 +1,23 @@
+:orphan:
+
+.. _user:
+
+################
+NumPy User Guide
+################
+
+This guide is intended as an introductory overview of NumPy and
+explains how to install and make use of the most important features of
+NumPy. For detailed reference documentation of the functions and
+classes contained in the package, see the :ref:`reference`.
+
+.. toctree::
+   :maxdepth: 1
+
+   setting-up
+   quickstart
+   basics
+   misc
+   numpy-for-matlab-users
+   building
+   c-info


### PR DESCRIPTION
This PR represents one option to resolve #16372 

Re-adds an index.rst for the user documentation to serve as a start page for the latex/pdf version of the user documentation. The index.rst is taken verbatim from the source prior to the doc restructuring per NEP 44 (see 22356fc e.g.). The index is now marked as an orphan, so it should not interfere with the build/display of the html documentation, though this means that the page *will* be visible if someone manually navigates to `docs/user`.