### PR TITLE
BUG: Fix error from np.array_equal with equal_nan=True

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2395,10 +2395,7 @@ def array_equal(a1, a2, equal_nan=False):
         # When we can use isnan
         _isnan = isnan
     # Check if all failed comparisons were due to nans
-    if not _isnan(a1[~comp]).all() or not _isnan(a2[~comp]).all():
-        return False
-    else:
-        return True
+    return all(comp | (_isnan(a1) & _isnan(a2)))
 
 
 def _array_equiv_dispatcher(a1, a2):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1475,6 +1475,14 @@ class TestArrayComparisons:
         a.real, b.imag = np.nan, np.nan
         assert_(not np.array_equal(a, b, equal_nan=False))
         assert_(np.array_equal(a, b, equal_nan=True))
+        # String values (checking for issue #16377)
+        a = np.array(list("abc"))
+        assert_(np.array_equal(a, a, equal_nan=False))
+        assert_(np.array_equal(a, a, equal_nan=True))
+        # Object arrays
+        a = np.array(["a", None, np.nan], dtype=object)
+        assert_(not np.array_equal(a, a, equal_nan=False))
+        assert_(np.array_equal(a, a, equal_nan=True))
 
     def test_none_compares_elementwise(self):
         a = np.array([None, 1, None], dtype=object)


### PR DESCRIPTION
Fix for #16377. Previously, this would error:

```python
np.array_equal(list("abc"), list("abc"), equal_nan=True)
```

This fixes that bug, and tests for it. 

This is a little messy, but I'm not sure if there is a nicer way to check if a ufunc could be applied to a given type.
