### PR TITLE
MAINT: Use a raw string for the fromstring docstring.

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -772,7 +772,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
 
 def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
                names=None, titles=None, aligned=False, byteorder=None):
-    """Create a record array from binary data
+    r"""Create a record array from binary data
 
     Note that despite the name of this function it does not accept `str`
     instances.


### PR DESCRIPTION
The `numpy.core.records.fromstring` docstring needs to 
be a raw string so the backslashes in the example are not
processed by Python or Sphinx.

Closes gh-16390.
