### PR TITLE
ENH: Validate and disable CPU features in runtime

### DIFF
--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -14,16 +14,15 @@ static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 static void
 npy__cpu_init_features(void);
 /*
- * Try to disable CPU dispatched features in runtime,
- * if environment variable 'NPY_DISABLE_CPU_FEATURES' is defined,
- * and it only use 'space' as seprator between features
+ * Disable CPU dispatched features at runtime if environment variable
+ * 'NPY_DISABLE_CPU_FEATURES' is defined.
+ * Multiple features can be present, and separated by space, comma, or tab.
+ * Raises an error if parsing fails or if the feature was not enabled
 */
 static void
 npy__cpu_try_disable_env(void);
-/*
- * check if NumPy build has CPU baseline features
- * that aren't supported by the current hardware
-*/
+
+/* Ensure the build's CPU baseline features are supported at runtime */
 static void
 npy__cpu_validate_baseline(void);
 
@@ -162,8 +161,8 @@ npy__cpu_validate_baseline(void)
     if (baseline_failure[0] != '\0') {
         *(fptr-1) = '\0'; // trim the last space
         PyErr_Format(PyExc_RuntimeError,
-            "The NumPy library was compiled with a minimal set of required optimizations: \n"
-            "(" NPY_WITH_CPU_BASELINE ") but your machine doesn't support:\n(%s).\n",
+            "NumPy was built with baseline optimizations: \n"
+            "(" NPY_WITH_CPU_BASELINE ") but your machine doesn't support:\n(%s).",
             baseline_failure
         );
     }
@@ -177,65 +176,93 @@ npy__cpu_try_disable_env(void)
     if (disenv == NULL || disenv[0] == 0) {
         return;
     }
+    #define NPY__CPU_ENV_ERR_HEAD \
+        "During parsing environment variable 'NPY_DISABLE_CPU_FEATURES':\n"
+
 #if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_DISPATCH_N > 0
     #define NPY__MAX_VAR_LEN 1024 // More than enough for this era
     size_t var_len = strlen(disenv) + 1;
     if (var_len > NPY__MAX_VAR_LEN) {
         PyErr_Format(PyExc_RuntimeError,
-            "Maximum acceptable length of NumPy's environment variable "
-            "'NPY_DISABLE_CPU_FEATURES' is %d",
-            NPY__MAX_VAR_LEN - 1
+            "Length of environment variable 'NPY_DISABLE_CPU_FEATURES' is %d, only %d accepted",
+            var_len, NPY__MAX_VAR_LEN - 1
         );
         return;
     }
     char disable_features[NPY__MAX_VAR_LEN];
     memcpy(disable_features, disenv, var_len);
 
+    char nexist[NPY__MAX_VAR_LEN];
+    char *nexist_cur = &nexist[0];
+
+    char notsupp[sizeof(NPY_WITH_CPU_DISPATCH) + 1];
+    char *notsupp_cur = &notsupp[0];
+
     //comma and space including (htab, vtab, CR, LF, FF)
     const char *delim = ", \t\v\r\n\f";
     char *feature = strtok(disable_features, delim);
     while (feature) {
-        #define NPY__CPU_ENV_ERROR_HEAD \
-            "Invalid use of environment variable 'NPY_DISABLE_CPU_FEATURES',\nsince "
-
         if (npy__cpu_baseline_fid(feature) > 0) {
             PyErr_Format(PyExc_RuntimeError,
-                NPY__CPU_ENV_ERROR_HEAD
-                "CPU feature '%s' is part of the minimal set of required optimizations:\n"
-                "(" NPY_WITH_CPU_BASELINE ").\n",
+                NPY__CPU_ENV_ERR_HEAD
+                "You cannot disable CPU feature '%s', since it is part of "
+                "the baseline optimizations:\n"
+                "(" NPY_WITH_CPU_BASELINE ").",
                 feature
             );
             break;
         }
+        // check if the feature is part of dispatched features
         int feature_id = npy__cpu_dispatch_fid(feature);
         if (feature_id == 0) {
-            PyErr_Format(PyExc_RuntimeError,
-                NPY__CPU_ENV_ERROR_HEAD
-                "CPU feature '%s' is not part of dispatched set of additional optimizations:\n"
-                "(" NPY_WITH_CPU_DISPATCH ").\n",
-                feature
-            );
-            break;
+            int flen = strlen(feature);
+            memcpy(nexist_cur, feature, flen);
+            nexist_cur[flen] = ' '; nexist_cur += flen + 1;
+            goto next;
         }
+        // check if the feature supported by the running machine
         if (!npy__cpu_have[feature_id]) {
-            PyErr_Format(PyExc_RuntimeError,
-                NPY__CPU_ENV_ERROR_HEAD
-                "CPU feature '%s' is not supported by your machine.\n",
-                feature
-            );
-            break;
+            int flen = strlen(feature);
+            memcpy(notsupp_cur, feature, flen);
+            notsupp_cur[flen] = ' '; notsupp_cur += flen + 1;
+            goto next;
         }
-        // Finaly we can disable it, next
+        // Finaly we can disable it
         npy__cpu_have[feature_id] = 0;
+    next:
         feature = strtok(NULL, delim);
     }
+
+    *nexist_cur = '\0';
+    if (nexist[0] != '\0') {
+        *(nexist_cur-1) = '\0'; // trim the last space
+        PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+            NPY__CPU_ENV_ERR_HEAD
+            "You cannot disable CPU features (%s), since "
+            "they are not part of the dispatched optimizations\n"
+            "(" NPY_WITH_CPU_DISPATCH ").",
+            nexist
+        );
+    }
+
+    *notsupp_cur = '\0';
+    if (notsupp[0] != '\0') {
+        *(notsupp_cur-1) = '\0'; // trim the last space
+        PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+            NPY__CPU_ENV_ERR_HEAD
+            "You cannot disable CPU features (%s), since "
+            "they are not supported by your machine.",
+            notsupp
+        );
+    }
 #else
-    PyErr_Format(PyExc_RuntimeError,
-        "Invalid use of environment variable 'NPY_DISABLE_CPU_FEATURES',\nsince "
+    PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+        NPY__CPU_ENV_ERR_HEAD
+        "You cannot use environment variable 'NPY_DISABLE_CPU_FEATURES', since "
     #ifdef NPY_DISABLE_OPTIMIZATION
         "the NumPy library was compiled with optimization disabled."
     #else
-        "the NumPy library was compiled without any additional optimizations."
+        "the NumPy library was compiled without any dispatched optimizations."
     #endif
     );
 #endif

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -13,6 +13,12 @@ static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 // Almost detect all CPU features in runtime
 static void
 npy__cpu_init_features(void);
+/*
+ * check if NumPy build has CPU baseline features
+ * that aren't supported by the current hardware
+*/
+static void
+npy__cpu_validate_baseline(void);
 
 /******************** Public Definitions *********************/
 
@@ -28,6 +34,10 @@ NPY_VISIBILITY_HIDDEN int
 npy_cpu_init(void)
 {
     npy__cpu_init_features();
+    npy__cpu_validate_baseline();
+
+    if (PyErr_Occurred())
+        return -1;
     return 0;
 }
 
@@ -91,6 +101,36 @@ npy_cpu_dispatch_list(void)
     return list;
 #else
     return PyList_New(0);
+#endif
+}
+
+/******************** Private Definitions *********************/
+
+static void
+npy__cpu_validate_baseline(void)
+{
+#if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_BASELINE_N > 0
+
+    char baseline_failure[sizeof(NPY_WITH_CPU_BASELINE) + 1];
+    char *fptr = &baseline_failure[0];
+
+    #define NPY__CPU_VALIDATE_CB(FEATURE, DUMMY) \
+    if (!npy__cpu_have[NPY_CAT(NPY_CPU_FEATURE_, FEATURE)]) { \
+        const int size = sizeof(NPY_TOSTRING(FEATURE));  \
+        memcpy(fptr, NPY_TOSTRING(FEATURE), size); \
+        fptr[size] = ' '; fptr += size + 1; \
+    }
+    NPY_WITH_CPU_BASELINE_CALL(NPY__CPU_VALIDATE_CB, DUMMY) // extra arg for msvc
+    *fptr = '\0';
+
+    if (baseline_failure[0] != '\0') {
+        *(fptr-1) = '\0'; // trim the last space
+        PyErr_Format(PyExc_RuntimeError,
+            "NumPy doesn't support the current hardware.\n"
+            "This NumPy build come with CPU baseline features " NPY_WITH_CPU_BASELINE "\n"
+            "but this CPU doesn't support \"%s\".\n", baseline_failure
+        );
+    }
 #endif
 }
 

--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -14,6 +14,13 @@ static unsigned char npy__cpu_have[NPY_CPU_FEATURE_MAX];
 static void
 npy__cpu_init_features(void);
 /*
+ * Try to disable CPU dispatched features in runtime,
+ * if environment variable 'NPY_DISABLE_CPU_FEATURES' is defined,
+ * and it only use 'space' as seprator between features
+*/
+static void
+npy__cpu_try_disable_env(void);
+/*
  * check if NumPy build has CPU baseline features
  * that aren't supported by the current hardware
 */
@@ -35,6 +42,7 @@ npy_cpu_init(void)
 {
     npy__cpu_init_features();
     npy__cpu_validate_baseline();
+    npy__cpu_try_disable_env();
 
     if (PyErr_Occurred())
         return -1;
@@ -105,32 +113,131 @@ npy_cpu_dispatch_list(void)
 }
 
 /******************** Private Definitions *********************/
+#define NPY__CPU_FEATURE_ID_CB(FEATURE, WITH_FEATURE)     \
+    if (strcmp(NPY_TOSTRING(FEATURE), WITH_FEATURE) == 0) \
+        return NPY_CAT(NPY_CPU_FEATURE_, FEATURE);
+/**
+ * Returns CPU feature's ID, if the 'feature' was part of baseline
+ * features that had been configured via --cpu-baseline
+ * otherwise it returns 0
+*/
+static NPY_INLINE int
+npy__cpu_baseline_fid(const char *feature)
+{
+#if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_BASELINE_N > 0
+    NPY_WITH_CPU_BASELINE_CALL(NPY__CPU_FEATURE_ID_CB, feature)
+#endif
+    return 0;
+}
+/**
+ * Returns CPU feature's ID, if the 'feature' was part of dispatched
+ * features that had been configured via --cpu-dispatch
+ * otherwise it returns 0
+*/
+static NPY_INLINE int
+npy__cpu_dispatch_fid(const char *feature)
+{
+#if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_DISPATCH_N > 0
+    NPY_WITH_CPU_DISPATCH_CALL(NPY__CPU_FEATURE_ID_CB, feature)
+#endif
+    return 0;
+}
 
 static void
 npy__cpu_validate_baseline(void)
 {
 #if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_BASELINE_N > 0
-
     char baseline_failure[sizeof(NPY_WITH_CPU_BASELINE) + 1];
     char *fptr = &baseline_failure[0];
 
-    #define NPY__CPU_VALIDATE_CB(FEATURE, DUMMY) \
-    if (!npy__cpu_have[NPY_CAT(NPY_CPU_FEATURE_, FEATURE)]) { \
-        const int size = sizeof(NPY_TOSTRING(FEATURE));  \
-        memcpy(fptr, NPY_TOSTRING(FEATURE), size); \
-        fptr[size] = ' '; fptr += size + 1; \
-    }
+    #define NPY__CPU_VALIDATE_CB(FEATURE, DUMMY)                  \
+        if (!npy__cpu_have[NPY_CAT(NPY_CPU_FEATURE_, FEATURE)]) { \
+            const int size = sizeof(NPY_TOSTRING(FEATURE));       \
+            memcpy(fptr, NPY_TOSTRING(FEATURE), size);            \
+            fptr[size] = ' '; fptr += size + 1;                   \
+        }
     NPY_WITH_CPU_BASELINE_CALL(NPY__CPU_VALIDATE_CB, DUMMY) // extra arg for msvc
     *fptr = '\0';
 
     if (baseline_failure[0] != '\0') {
         *(fptr-1) = '\0'; // trim the last space
         PyErr_Format(PyExc_RuntimeError,
-            "NumPy doesn't support the current hardware.\n"
-            "This NumPy build come with CPU baseline features " NPY_WITH_CPU_BASELINE "\n"
-            "but this CPU doesn't support \"%s\".\n", baseline_failure
+            "The NumPy library was compiled with a minimal set of required optimizations: \n"
+            "(" NPY_WITH_CPU_BASELINE ") but your machine doesn't support:\n(%s).\n",
+            baseline_failure
         );
     }
+#endif
+}
+
+static void
+npy__cpu_try_disable_env(void)
+{
+    char *disenv = getenv("NPY_DISABLE_CPU_FEATURES");
+    if (disenv == NULL || disenv[0] == 0) {
+        return;
+    }
+#if !defined(NPY_DISABLE_OPTIMIZATION) && NPY_WITH_CPU_DISPATCH_N > 0
+    #define NPY__MAX_VAR_LEN 1024 // More than enough for this era
+    size_t var_len = strlen(disenv) + 1;
+    if (var_len > NPY__MAX_VAR_LEN) {
+        PyErr_Format(PyExc_RuntimeError,
+            "Maximum acceptable length of NumPy's environment variable "
+            "'NPY_DISABLE_CPU_FEATURES' is %d",
+            NPY__MAX_VAR_LEN - 1
+        );
+        return;
+    }
+    char disable_features[NPY__MAX_VAR_LEN];
+    memcpy(disable_features, disenv, var_len);
+
+    //comma and space including (htab, vtab, CR, LF, FF)
+    const char *delim = ", \t\v\r\n\f";
+    char *feature = strtok(disable_features, delim);
+    while (feature) {
+        #define NPY__CPU_ENV_ERROR_HEAD \
+            "Invalid use of environment variable 'NPY_DISABLE_CPU_FEATURES',\nsince "
+
+        if (npy__cpu_baseline_fid(feature) > 0) {
+            PyErr_Format(PyExc_RuntimeError,
+                NPY__CPU_ENV_ERROR_HEAD
+                "CPU feature '%s' is part of the minimal set of required optimizations:\n"
+                "(" NPY_WITH_CPU_BASELINE ").\n",
+                feature
+            );
+            break;
+        }
+        int feature_id = npy__cpu_dispatch_fid(feature);
+        if (feature_id == 0) {
+            PyErr_Format(PyExc_RuntimeError,
+                NPY__CPU_ENV_ERROR_HEAD
+                "CPU feature '%s' is not part of dispatched set of additional optimizations:\n"
+                "(" NPY_WITH_CPU_DISPATCH ").\n",
+                feature
+            );
+            break;
+        }
+        if (!npy__cpu_have[feature_id]) {
+            PyErr_Format(PyExc_RuntimeError,
+                NPY__CPU_ENV_ERROR_HEAD
+                "CPU feature '%s' is not supported by your machine.\n",
+                feature
+            );
+            break;
+        }
+        // Finaly we can disable it, next
+        npy__cpu_have[feature_id] = 0;
+        feature = strtok(NULL, delim);
+    }
+#else
+    PyErr_Format(PyExc_RuntimeError,
+        "Invalid use of environment variable 'NPY_DISABLE_CPU_FEATURES',\nsince "
+    #ifdef NPY_DISABLE_OPTIMIZATION
+        "the NumPy library was compiled with optimization disabled."
+    #else
+        "the NumPy library was compiled without any additional optimizations."
+    #endif
+    );
 #endif
 }
 
@@ -477,5 +584,13 @@ npy__cpu_init_features(void)
 static void
 npy__cpu_init_features(void)
 {
+    /*
+     * just in case if the compiler doesn't respect ANSI
+     * but for knowing paltforms it still nessecery, because @npy__cpu_init_features
+     * may called multiple of times and we need to clear the disabled features by
+     * ENV Var or maybe in the future we can support other methods like
+     * global variables, go back to @npy__cpu_try_disable_env for more understanding
+     */
+    memset(npy__cpu_have, 0, sizeof(npy__cpu_have[0]) * NPY_CPU_FEATURE_MAX);
 }
 #endif

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -87,8 +87,17 @@ enum npy_cpu_features
 
 /*
  * Initialize CPU features
+ *
+ * This function
+ *  - detect CPU features avalibilty in runtime
+ *  - check the sanity of CPU baseline features
+ *
+ * It also trigger Py runtime error when
+ *  - NumPy build has CPU baseline features
+ *    that aren't supported by the current hardware
+ *
  * return 0 on success otherwise return -1
-*/
+ */
 NPY_VISIBILITY_HIDDEN int
 npy_cpu_init(void);
 

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -91,10 +91,13 @@ enum npy_cpu_features
  * This function
  *  - detect CPU features avalibilty in runtime
  *  - check the sanity of CPU baseline features
+ *  - disable CPU dispatched features in runtime,
+ *    depend on given values of environment variable 'NPY_DISABLE_CPU_FEATURES'
  *
  * It also trigger Py runtime error when
  *  - NumPy build has CPU baseline features
  *    that aren't supported by the current hardware
+ *  - The misuse of environment variable 'NPY_DISABLE_CPU_FEATURES'
  *
  * return 0 on success otherwise return -1
  */

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -89,16 +89,16 @@ enum npy_cpu_features
  * Initialize CPU features
  *
  * This function
- *  - detect CPU features avalibilty in runtime
- *  - check the sanity of CPU baseline features
- *  - disable CPU dispatched features in runtime,
- *    depend on given values of environment variable 'NPY_DISABLE_CPU_FEATURES'
+ *  - detects runtime CPU features
+ *  - check that baseline CPU features are present
+ *  - uses 'NPY_DISABLE_CPU_FEATURES' to disable dispatchable features
  *
- * It also trigger Py runtime error when
- *  - NumPy build has CPU baseline features
- *    that aren't supported by the current hardware
- *  - The misuse of environment variable 'NPY_DISABLE_CPU_FEATURES'
- *
+ * It will set a RuntimeError when 
+ *  - CPU baseline features from the build are not supported at runtime
+ *  - 'NPY_DISABLE_CPU_FEATURES' tries to disable a baseline feature
+ * and will warn if 'NPY_DISABLE_CPU_FEATURES' tries to disable a feature that
+ * is not disabled (the machine or build does not support it, or the project was
+ * not built with any feature optimization support)
  * return 0 on success otherwise return -1
  */
 NPY_VISIBILITY_HIDDEN int


### PR DESCRIPTION
### This pullrequest changes

---
#### Validate CPU baseline features during the load of NumPy module

Ensure that the baseline features are supported by the running machine, during the load of umath module or while calling C function `npy_cpu_init()` .

Python runtime error will be raised, If one of the baseline features isn't supported. 

---

#### Add ability to disable dispatched CPU features in runtime

Through environment variable `NPY_DISABLE_CPU_FEATURES`, the parsing process happens during the load of umath module or calling C function `npy_cpu_init()` .

An example (unix-like):

```bash
$ export NPY_DISABLE_CPU_FEATURES="FMA3 AVX2 AVX512F AVX512_SKX"
```

**NOTES**:

- CPU features must be in upper-case
- CPU features must be part of dispatched features, disabling CPU baseline features isn't possible.
- space or comma or both can be used as a separator 
- The environment variable must be set before the load of NumPy module, otherwise it will not be affected.
- Any misuse of `NPY_DISABLE_CPU_FEATURES` will cause a Python runtime error.

