### PR TITLE
MAINT: core: Use a raw string for the fromstring docstring.

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -772,7 +772,7 @@ def fromrecords(recList, dtype=None, shape=None, formats=None, names=None,
 
 def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
                names=None, titles=None, aligned=False, byteorder=None):
-    """Create a record array from binary data
+    r"""Create a record array from binary data
 
     Note that despite the name of this function it does not accept `str`
     instances.


### PR DESCRIPTION
Backport of #16393. 

This docstring needs to be a raw string so the backslashes
in the example are not processed by Python or Sphinx.

Closes gh-16390.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
