### PR TITLE
DOC,BLD: Update make dist html target.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -103,11 +103,11 @@ dist: build/dist.tar.gz
 build/dist.tar.gz:
 	make $(DIST_VARS) real-dist
 
-real-dist: dist-build html-build html-scipyorg
+real-dist: dist-build html-build
 	test -d build/latex || make latex-build
 	make -C build/latex all-pdf
 	-rm -rf build/dist
-	cp -r build/html-scipyorg build/dist
+	cp -r build/html build/dist
 	cd build/html && zip -9r ../dist/numpy-html.zip .
 	cp build/latex/numpy-ref.pdf build/dist
 	cp build/latex/numpy-user.pdf build/dist


### PR DESCRIPTION
Switch html target for `make dist` to depend on `html` instead of `html-scipyorg`. Makes the theme of the archived docs, including `stable`, consistent with the devdocs. This should only really affect the process of releasing documentation where the `dist` target is relevant.