### PR TITLE
DOC,BLD: Update sphinx conf to use xelatex.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -155,6 +155,9 @@ plot_html_show_source_link = False
 # The font size ('10pt', '11pt' or '12pt').
 #latex_font_size = '10pt'
 
+# XeLaTeX for better support of unicode characters
+latex_engine = 'xelatex'
+
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 _stdauthor = 'Written by the NumPy community'


### PR DESCRIPTION
The discussion in #16394 was generally positive, so I'm submitting the proposed change. The main motivations for switching from `pdflatex` to `xelatex` as the build engine for the pdf version of the documentation are:
 * Better support for a fuller range of unicode characters in documentation source files.
 * Resolves an [outstanding issue](https://github.com/numpy/numpy/issues/15155#issuecomment-569846213) related to the resolving of references when building the pdf documentation. 

Closes #16394