### PR TITLE
TST, CI: turn on codecov patch diffs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,6 @@ coverage:
       default:
         # Require 1% coverage, i.e., always succeed
         target: 1
-    patch: false
+    patch: true
     changes: false
 comment: off


### PR DESCRIPTION
* given discussion in gh-16405, and activation of
the codecov app instead of webhook, try turning
on patch diffs again to show the coverage for a given
PR

* not sure if this will show any change before the `yml`
is in master; could maybe test on fork initially if needed

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
