### PR TITLE
BUG: endpoints of array returned by geomspace() should match arguments

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -408,8 +408,18 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
 
     log_start = _nx.log10(start)
     log_stop = _nx.log10(stop)
-    result = out_sign * logspace(log_start, log_stop, num=num,
-                                 endpoint=endpoint, base=10.0, dtype=dtype)
+    result = logspace(log_start, log_stop, num=num,
+                      endpoint=endpoint, base=10.0, dtype=dtype)
+
+    # Make sure the endpoints match the start and stop arguments. This is
+    # necessary because np.exp(np.log(x)) is not necessarily equal to x.
+    if num > 0:
+        result[0] = start
+        if num > 1 and endpoint:
+            result[-1] = stop
+
+    result = out_sign * result
+
     if axis != 0:
         result = _nx.moveaxis(result, 0, axis)
 

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -198,18 +198,34 @@ class TestGeomspace:
 
     def test_start_stop_array(self):
         # Try to use all special cases.
-        start = array([1.e0, 32., 1j, -4j, 1+1j, -1])
-        stop = array([1.e4, 2., 16j, -324j, 10000+10000j, 1])
+        start = array([1.e0, 32., 1j, -4j, 1+1j, -1, 0.3])
+        stop = array([1.e4, 2., 16j, -324j, 10000+10000j, 1, 20.3])
+
         t1 = geomspace(start, stop, 5)
         t2 = stack([geomspace(_start, _stop, 5)
                     for _start, _stop in zip(start, stop)], axis=1)
         assert_equal(t1, t2)
+        for i in range(len(start)):
+            assert_(t1[0, i] == start[i])
+            assert_(t1[-1, i] == stop[i])
+            assert_(t2[0, i] == start[i])
+            assert_(t2[-1, i] == stop[i])
+
         t3 = geomspace(start, stop[0], 5)
         t4 = stack([geomspace(_start, stop[0], 5)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
+        for i in range(len(start)):
+            assert_(t3[0, i] == start[i])
+            assert_(t3[-1, i] == stop[0])
+            assert_(t4[0, i] == start[i])
+            assert_(t4[-1, i] == stop[0])
+
         t5 = geomspace(start, stop, 5, axis=-1)
         assert_equal(t5, t2.T)
+        for i in range(len(start)):
+            assert_(t5[i, 0] == start[i])
+            assert_(t5[i, -1] == stop[i])
 
     def test_physical_quantities(self):
         a = PhysicalQuantity(1.0)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -136,14 +136,16 @@ class TestGeomspace:
     def test_nan_interior(self):
         with errstate(invalid='ignore'):
             y = geomspace(-3, 3, num=4)
-            assert_equal(y[0], -3.0)
-            assert_(isnan(y[1:-1]).all())
-            assert_equal(y[3], 3.0)
+
+        assert_equal(y[0], -3.0)
+        assert_(isnan(y[1:-1]).all())
+        assert_equal(y[3], 3.0)
 
         with errstate(invalid='ignore'):
             y = geomspace(-3, 3, num=4, endpoint=False)
-            assert_equal(y[0], -3.0)
-            assert_(isnan(y[1:]).all())
+
+        assert_equal(y[0], -3.0)
+        assert_(isnan(y[1:]).all())
 
     def test_complex(self):
         # Purely imaginary

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -134,7 +134,7 @@ class TestGeomspace:
         assert_equal(y[0], start)
 
     def test_nan_midpoint(self):
-        with errstate(all='ignore'):
+        with errstate(invalid='ignore'):
             y = geomspace(-3, 3, num=3)
             assert_equal(y[0], -3.0)
             assert_(isnan(y[1]))

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -114,17 +114,17 @@ class TestGeomspace:
         assert_array_equal(y.imag, 0)
 
         y = geomspace(0.3, 20.3, num=1)
-        assert_(y[0] == 0.3)
+        assert_equal(y[0], 0.3)
 
         y = geomspace(0.3, 20.3, num=1, endpoint=False)
-        assert_(y[0] == 0.3)
+        assert_equal(y[0], 0.3)
 
         y = geomspace(0.3, 20.3, num=3)
-        assert_(y[0] == 0.3)
-        assert_(y[-1] == 20.3)
+        assert_equal(y[0], 0.3)
+        assert_equal(y[-1], 20.3)
 
         y = geomspace(0.3, 20.3, num=3, endpoint=False)
-        assert_(y[0] == 0.3)
+        assert_equal(y[0], 0.3)
 
     def test_complex(self):
         # Purely imaginary
@@ -206,26 +206,26 @@ class TestGeomspace:
                     for _start, _stop in zip(start, stop)], axis=1)
         assert_equal(t1, t2)
         for i in range(len(start)):
-            assert_(t1[0, i] == start[i])
-            assert_(t1[-1, i] == stop[i])
-            assert_(t2[0, i] == start[i])
-            assert_(t2[-1, i] == stop[i])
+            assert_equal(t1[0, i], start[i])
+            assert_equal(t1[-1, i], stop[i])
+            assert_equal(t2[0, i], start[i])
+            assert_equal(t2[-1, i], stop[i])
 
         t3 = geomspace(start, stop[0], 5)
         t4 = stack([geomspace(_start, stop[0], 5)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
         for i in range(len(start)):
-            assert_(t3[0, i] == start[i])
-            assert_(t3[-1, i] == stop[0])
-            assert_(t4[0, i] == start[i])
-            assert_(t4[-1, i] == stop[0])
+            assert_(t3[0, i], start[i])
+            assert_(t3[-1, i], stop[0])
+            assert_(t4[0, i], start[i])
+            assert_(t4[-1, i], stop[0])
 
         t5 = geomspace(start, stop, 5, axis=-1)
         assert_equal(t5, t2.T)
         for i in range(len(start)):
-            assert_(t5[i, 0] == start[i])
-            assert_(t5[i, -1] == stop[i])
+            assert_(t5[i, 0], start[i])
+            assert_(t5[i, -1], stop[i])
 
     def test_physical_quantities(self):
         a = PhysicalQuantity(1.0)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -133,6 +133,12 @@ class TestGeomspace:
         y = geomspace(start, stop, num=3, endpoint=False)
         assert_equal(y[0], start)
 
+    def test_nan_midpoint(self):
+        y = geomspace(-3, 3, num=3)
+        assert_equal(y[0], -3.0)
+        assert_(isnan(y[1]))
+        assert_equal(y[2], 3.0)
+
     def test_complex(self):
         # Purely imaginary
         y = geomspace(1j, 16j, num=5)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -133,7 +133,7 @@ class TestGeomspace:
         y = geomspace(start, stop, num=3, endpoint=False)
         assert_equal(y[0], start)
 
-    def test_nan_midpoint(self):
+    def test_nan_interior(self):
         with errstate(invalid='ignore'):
             y = geomspace(-3, 3, num=4)
             assert_equal(y[0], -3.0)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -1,6 +1,6 @@
 from numpy import (
     logspace, linspace, geomspace, dtype, array, sctypes, arange, isnan,
-    ndarray, sqrt, nextafter, stack
+    ndarray, sqrt, nextafter, stack, errstate
     )
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_array_equal, assert_allclose,
@@ -134,10 +134,11 @@ class TestGeomspace:
         assert_equal(y[0], start)
 
     def test_nan_midpoint(self):
-        y = geomspace(-3, 3, num=3)
-        assert_equal(y[0], -3.0)
-        assert_(isnan(y[1]))
-        assert_equal(y[2], 3.0)
+        with errstate(all='ignore'):
+            y = geomspace(-3, 3, num=3)
+            assert_equal(y[0], -3.0)
+            assert_(isnan(y[1]))
+            assert_equal(y[2], 3.0)
 
     def test_complex(self):
         # Purely imaginary

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -115,7 +115,7 @@ class TestGeomspace:
 
     def test_boundaries_match_start_and_stop_exactly(self):
         # make sure that the boundaries of the returned array exactly
-        # equal 'start' and 'stop' - this isnt' obvious because
+        # equal 'start' and 'stop' - this isn't obvious because
         # np.exp(np.log(x)) isn't necessarily exactly equal to x
         start = 0.3
         stop = 20.3

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -140,6 +140,7 @@ class TestGeomspace:
             assert_(isnan(y[1:-1]).all())
             assert_equal(y[3], 3.0)
 
+        with errstate(invalid='ignore'):
             y = geomspace(-3, 3, num=4, endpoint=False)
             assert_equal(y[0], -3.0)
             assert_(isnan(y[1:]).all())

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -113,18 +113,25 @@ class TestGeomspace:
         assert_array_equal(y, [-100, -10, -1])
         assert_array_equal(y.imag, 0)
 
-        y = geomspace(0.3, 20.3, num=1)
-        assert_equal(y[0], 0.3)
+    def test_boundaries_match_start_and_stop_exactly(self):
+        # make sure that the boundaries of the returned array exactly
+        # equal 'start' and 'stop' - this isnt' obvious because
+        # np.exp(np.log(x)) isn't necessarily exactly equal to x
+        start = 0.3
+        stop = 20.3
 
-        y = geomspace(0.3, 20.3, num=1, endpoint=False)
-        assert_equal(y[0], 0.3)
+        y = geomspace(start, stop, num=1)
+        assert_equal(y[0], start)
 
-        y = geomspace(0.3, 20.3, num=3)
-        assert_equal(y[0], 0.3)
-        assert_equal(y[-1], 20.3)
+        y = geomspace(start, stop, num=1, endpoint=False)
+        assert_equal(y[0], start)
 
-        y = geomspace(0.3, 20.3, num=3, endpoint=False)
-        assert_equal(y[0], 0.3)
+        y = geomspace(start, stop, num=3)
+        assert_equal(y[0], start)
+        assert_equal(y[-1], stop)
+
+        y = geomspace(start, stop, num=3, endpoint=False)
+        assert_equal(y[0], start)
 
     def test_complex(self):
         # Purely imaginary
@@ -198,34 +205,18 @@ class TestGeomspace:
 
     def test_start_stop_array(self):
         # Try to use all special cases.
-        start = array([1.e0, 32., 1j, -4j, 1+1j, -1, 0.3])
-        stop = array([1.e4, 2., 16j, -324j, 10000+10000j, 1, 20.3])
-
+        start = array([1.e0, 32., 1j, -4j, 1+1j, -1])
+        stop = array([1.e4, 2., 16j, -324j, 10000+10000j, 1])
         t1 = geomspace(start, stop, 5)
         t2 = stack([geomspace(_start, _stop, 5)
                     for _start, _stop in zip(start, stop)], axis=1)
         assert_equal(t1, t2)
-        for i in range(len(start)):
-            assert_equal(t1[0, i], start[i])
-            assert_equal(t1[-1, i], stop[i])
-            assert_equal(t2[0, i], start[i])
-            assert_equal(t2[-1, i], stop[i])
-
         t3 = geomspace(start, stop[0], 5)
         t4 = stack([geomspace(_start, stop[0], 5)
                     for _start in start], axis=1)
         assert_equal(t3, t4)
-        for i in range(len(start)):
-            assert_(t3[0, i], start[i])
-            assert_(t3[-1, i], stop[0])
-            assert_(t4[0, i], start[i])
-            assert_(t4[-1, i], stop[0])
-
         t5 = geomspace(start, stop, 5, axis=-1)
         assert_equal(t5, t2.T)
-        for i in range(len(start)):
-            assert_(t5[i, 0], start[i])
-            assert_(t5[i, -1], stop[i])
 
     def test_physical_quantities(self):
         a = PhysicalQuantity(1.0)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -140,6 +140,10 @@ class TestGeomspace:
             assert_(isnan(y[1:-1]).all())
             assert_equal(y[3], 3.0)
 
+            y = geomspace(-3, 3, num=4, endpoint=False)
+            assert_equal(y[0], -3.0)
+            assert_(isnan(y[1:]).all())
+
     def test_complex(self):
         # Purely imaginary
         y = geomspace(1j, 16j, num=5)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -138,7 +138,7 @@ class TestGeomspace:
             y = geomspace(-3, 3, num=4)
             assert_equal(y[0], -3.0)
             assert_(isnan(y[1:-1]).all())
-            assert_equal(y[2], 3.0)
+            assert_equal(y[3], 3.0)
 
     def test_complex(self):
         # Purely imaginary

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -113,6 +113,19 @@ class TestGeomspace:
         assert_array_equal(y, [-100, -10, -1])
         assert_array_equal(y.imag, 0)
 
+        y = geomspace(0.3, 20.3, num=1)
+        assert_(y[0] == 0.3)
+
+        y = geomspace(0.3, 20.3, num=1, endpoint=False)
+        assert_(y[0] == 0.3)
+
+        y = geomspace(0.3, 20.3, num=3)
+        assert_(y[0] == 0.3)
+        assert_(y[-1] == 20.3)
+
+        y = geomspace(0.3, 20.3, num=3, endpoint=False)
+        assert_(y[0] == 0.3)
+
     def test_complex(self):
         # Purely imaginary
         y = geomspace(1j, 16j, num=5)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -135,9 +135,9 @@ class TestGeomspace:
 
     def test_nan_midpoint(self):
         with errstate(invalid='ignore'):
-            y = geomspace(-3, 3, num=3)
+            y = geomspace(-3, 3, num=4)
             assert_equal(y[0], -3.0)
-            assert_(isnan(y[1]))
+            assert_(isnan(y[1:-1]).all())
             assert_equal(y[2], 3.0)
 
     def test_complex(self):


### PR DESCRIPTION
The function `numpy.geomspace()` does not respect boundaries exactly, see example below:

```python
import numpy as np

start = 0.3
end = 20.3
gs = np.geomspace(start, end, num=3)
print(start, gs[0])  # prints: 0.3 0.29999999999999993
print(end, gs[-1])  # prints: 20.3 20.300000000000004
```

I think `geomspace()` should explicitly correct the first and the last entry of the generated output array because `np.exp(np.log(x))` is not necessarily equal to `x`. This pull request represents a fix including unit tests.