### PR TITLE
MAINT, DOC: add index for user docs.

### DIFF
--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -1,0 +1,26 @@
+:orphan:
+
+.. _user:
+
+################
+NumPy User Guide
+################
+
+This guide is intended as an introductory overview of NumPy and
+explains how to install and make use of the most important features of
+NumPy. For detailed reference documentation of the functions and
+classes contained in the package, see the :ref:`reference`.
+
+.. toctree::
+   :maxdepth: 1
+
+   setting-up
+   quickstart
+   absolute_beginners
+   basics
+   misc
+   numpy-for-matlab-users
+   building
+   c-info
+   tutorials_index
+   howtos_index


### PR DESCRIPTION
Backport of #16373. 

This PR represents one option to resolve #16372 

Re-adds an index.rst for the user documentation to serve as a start page for the latex/pdf version of the user documentation. The index.rst is taken verbatim from the source prior to the doc restructuring per NEP 44 (see 22356fc e.g.). The index is now marked as an orphan, so it should not interfere with the build/display of the html documentation, though this means that the page *will* be visible if someone manually navigates to `docs/user`.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
