### PR TITLE
MAINT: support python 3.10

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -546,4 +546,10 @@ NpyCapsule_Check(PyObject *ptr)
 }
 #endif
 
+// account for changing PyType
+#if PY_VERSION_HEX < 0x03090000
+    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
+    #define Py_SET_SIZE(obj, typ) (Py_SIZE(obj) = typ)
+#endif
+
 #endif /* _NPY_3KCOMPAT_H_ */

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -60,6 +60,14 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
     PySlice_GetIndicesEx((PySliceObject *)op, nop, start, end, step, slicelength)
 #endif
 
+#if PY_VERSION_HEX < 0x030900a4
+    /* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
+    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
+    /* Introduced in https://github.com/python/cpython/commit/b10dc3e7a11fcdb97e285882eba6da92594f90f9 */
+    #define Py_SET_SIZE(obj, size) (Py_SIZE(obj) = size)
+#endif
+
+
 #define Npy_EnterRecursiveCall(x) Py_EnterRecursiveCall(x)
 
 /* Py_SETREF was added in 3.5.2, and only if Py_LIMITED_API is absent */
@@ -546,10 +554,5 @@ NpyCapsule_Check(PyObject *ptr)
 }
 #endif
 
-// account for changing PyType
-#if PY_VERSION_HEX < 0x03090000
-    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
-    #define Py_SET_SIZE(obj, typ) (Py_SIZE(obj) = typ)
-#endif
 
 #endif /* _NPY_3KCOMPAT_H_ */

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -755,7 +755,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             vobj->descr = descr;
             Py_INCREF(descr);
             vobj->obval = NULL;
-            Py_SIZE(vobj) = itemsize;
+            Py_SET_SIZE(vobj, itemsize);
             vobj->flags = NPY_ARRAY_CARRAY | NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_OWNDATA;
             swap = 0;
             if (PyDataType_HASFIELDS(descr)) {

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -345,7 +345,7 @@ format_@name@(@type@ val, npy_bool scientific,
  * over-ride repr and str of array-scalar strings and unicode to
  * remove NULL bytes and then call the corresponding functions
  * of string and unicode.
- * 
+ *
  * FIXME:
  *   is this really a good idea?
  *   stop using Py_UNICODE here.
@@ -1542,7 +1542,7 @@ static PyObject *
         return NULL;
     }
 #endif
-    
+
     PyObject *tup;
     if (ndigits == Py_None) {
         tup = PyTuple_Pack(0);
@@ -1568,7 +1568,7 @@ static PyObject *
         return ret;
     }
 #endif
-    
+
     return obj;
 }
 /**end repeat**/
@@ -2774,7 +2774,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             return PyErr_NoMemory();
         }
         ((PyVoidScalarObject *)ret)->obval = destptr;
-        Py_SIZE((PyVoidScalarObject *)ret) = (int) memu;
+        Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
         ((PyVoidScalarObject *)ret)->descr =
             PyArray_DescrNewFromType(NPY_VOID);
         ((PyVoidScalarObject *)ret)->descr->elsize = (int) memu;

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -1158,7 +1158,7 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     npyrational_arrfuncs.fill = npyrational_fill;
     npyrational_arrfuncs.fillwithscalar = npyrational_fillwithscalar;
     /* Left undefined: scanfunc, fromstr, sort, argsort */
-    Py_TYPE(&npyrational_descr) = &PyArrayDescr_Type;
+    Py_SET_TYPE(&npyrational_descr, &PyArrayDescr_Type);
     npy_rational = PyArray_RegisterDataType(&npyrational_descr);
     if (npy_rational<0) {
         goto fail;

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -194,7 +194,7 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 \tint i;
 \tPyObject *m,*d, *s, *tmp;
 \tm = #modulename#_module = PyModule_Create(&moduledef);
-\tPy_TYPE(&PyFortran_Type) = &PyType_Type;
+\tPy_SET_TYPE(&PyFortran_Type, &PyType_Type);
 \timport_array();
 \tif (PyErr_Occurred())
 \t\t{PyErr_SetString(PyExc_ImportError, \"can't initialize module #modulename# (failed to import numpy)\"); return m;}

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -144,7 +144,7 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC PyInit_test_array_from_pyobj_ext(void) {
   PyObject *m,*d, *s;
   m = wrap_module = PyModule_Create(&moduledef);
-  Py_TYPE(&PyFortran_Type) = &PyType_Type;
+  Py_SET_TYPE(&PyFortran_Type, &PyType_Type);
   import_array();
   if (PyErr_Occurred())
     Py_FatalError("can't initialize module wrap (failed to import numpy)");


### PR DESCRIPTION
In https://github.com/python/cpython/pull/20290 CPython changed
`Py_TYPE` from a macro to an inline function.  This requires a code
change to us `Py_SET_TYPE` instead when using `Py_TYPE()` as a lvalue
in c code.

~This is a draft (and I expect it to fail all of the tests) because `Py_SET_TYPE` was only introduced in py39.  Can I please have some guidance on how to do version gating (or have someone who knows take over this PR ;) )~