### PR TITLE
DOC: Update assert_warns parameter list

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1768,12 +1768,10 @@ def assert_warns(warning_class, *args, **kwargs):
     ----------
     warning_class : class
         The class defining the warning that `func` is expected to throw.
-    func : callable
-        The callable to test.
-    \\*args : Arguments
-        Arguments passed to `func`.
+    \\*args : List of function and arguments
+        `func` and arguments for `func`.
     \\*\\*kwargs : Kwargs
-        Keyword arguments passed to `func`.
+        Keyword arguments for `func`.
 
     Returns
     -------


### PR DESCRIPTION
assert_warns has only taken `warning_class, *args, **kwargs` since it was made a contextmanager in

https://github.com/numpy/numpy/commit/d588b48a0e2fd4a78cadc1336571f59ba6be83c6