### PR TITLE
DOC: Fix description of dtype default in linspace

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -52,8 +52,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         If True, return (`samples`, `step`), where `step` is the spacing
         between samples.
     dtype : dtype, optional
-        The type of the output array.  If `dtype` is not given, infer the data
-        type from the other input arguments.
+        The type of the output array.  If `dtype` is not given, the data type
+        is inferred from `start`, `stop`, and `num`, but it will never be smaller
+        than float.
 
         .. versionadded:: 1.9.0
 

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -53,9 +53,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         between samples.
     dtype : dtype, optional
         The type of the output array.  If `dtype` is not given, the data type
-        is inferred from `start`, `stop`, and `num`. The inferred dtype will
-        never be an integer; `float` is chosen even if all three arguments are
-        integers.
+        is inferred from `start` and `stop`. The inferred dtype will
+        never be an integer; `float` is chosen even if the arguments would
+        produce an array of integers.
 
         .. versionadded:: 1.9.0
 

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -53,8 +53,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         between samples.
     dtype : dtype, optional
         The type of the output array.  If `dtype` is not given, the data type
-        is inferred from `start`, `stop`, and `num`, but it will never be smaller
-        than float.
+        is inferred from `start`, `stop`, and `num`. The inferred dtype will
+        never be an integer; `float` is chosen even if all three arguments are
+        integers.
 
         .. versionadded:: 1.9.0
 


### PR DESCRIPTION
Clarify linspace docstring to say the default dtype will never be smaller than float.

Fixes gh-8597

