### PR TITLE
ENH: Support pickle5 on Python 3.5

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1762,18 +1762,18 @@ array_reduce_ex_picklebuffer(PyArrayObject *self, int protocol)
 #if PY_VERSION_HEX >= 0x03080000
     /* we expect protocol 5 to be available in Python 3.8 */
     pickle_module = PyImport_ImportModule("pickle");
-#elif PY_VERSION_HEX >= 0x03060000
+#elif PY_VERSION_HEX >= 0x03050000
     pickle_module = PyImport_ImportModule("pickle5");
     if (pickle_module == NULL) {
         /* for protocol 5, raise a clear ImportError if pickle5 is not found
          */
         PyErr_SetString(PyExc_ImportError, "Using pickle protocol 5 "
-                "requires the pickle5 module for Python >=3.6 and <3.8");
+                "requires the pickle5 module for Python >=3.5 and <3.8");
         return NULL;
     }
 #else
     PyErr_SetString(PyExc_ValueError, "pickle protocol 5 is not available "
-                                      "for Python < 3.6");
+                                      "for Python < 3.5");
     return NULL;
 #endif
     if (pickle_module == NULL){

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,5 +5,6 @@ pytz==2020.1
 pytest-cov==2.9.0
 pickle5; python_version == '3.7'
 pickle5; python_version == '3.6' and platform_python_implementation != 'PyPy'
+pickle5>=0.0.10; python_version == '3.5' and platform_python_implementation != 'PyPy'
 # for numpy.random.test.test_extending
 cffi


### PR DESCRIPTION
As of pickle5 0.0.10+, Python 3.5+ is now supported. So update the checks to allow Python 3.5 to be used as well.

xref: https://github.com/pitrou/pickle5-backport/pull/15

cc @pierreglaser @suquark