### PR TITLE
BUG: Add extern to PyArrayDTypeMeta_Type declaration

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1821,7 +1821,7 @@ typedef void (PyDataMem_EventHookFunc)(void *inp, void *outp, size_t size,
      * may change without warning!
      */
     /* TODO: Make this definition public in the API, as soon as its settled */
-    NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type;
+    NPY_NO_EXPORT extern PyTypeObject PyArrayDTypeMeta_Type;
 
     /*
      * While NumPy DTypes would not need to be heap types the plan is to


### PR DESCRIPTION
This was missing the extern, but pre GCC 10 it seemed to have worked
fine without.

Closes gh-16419
