### PR TITLE
MAINT: Catch remaining cases of Py_SIZE and Py_TYPE as lvalues

### DIFF
--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -230,7 +230,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr)
     }
 
     /* Finally, replace the current class of the descr */
-    Py_TYPE(descr) = (PyTypeObject *)dtype_class;
+    Py_SET_TYPE(descr, (PyTypeObject *)dtype_class);
 
     return 0;
 }
@@ -266,4 +266,3 @@ NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type = {
     .tp_is_gc = dtypemeta_is_gc,
     .tp_traverse = (traverseproc)dtypemeta_traverse,
 };
-

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2498,9 +2498,9 @@ einsum_list_to_subscripts(PyObject *obj, char *subscripts, int subsize)
                         "subscript is not within the valid range [0, 52)");
                 Py_DECREF(obj);
                 return -1;
-            }              
+            }
         }
-        
+
     }
 
     Py_DECREF(obj);
@@ -4453,7 +4453,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     }
 
     PyArrayDescr_Type.tp_hash = PyArray_DescrHash;
-    Py_TYPE(&PyArrayDescr_Type) = &PyArrayDTypeMeta_Type;
+    Py_SET_TYPE(&PyArrayDescr_Type, &PyArrayDTypeMeta_Type);
     if (PyType_Ready(&PyArrayDescr_Type) < 0) {
         goto err;
     }


### PR DESCRIPTION
I missed these in #16417 because they came in with the code that broke compilation with gcc 10.1 .  This PR won't need to be backported. 