### PR TITLE
ENH: enable pickle protocol 5 support for python3.5

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1768,18 +1768,18 @@ array_reduce_ex_picklebuffer(PyArrayObject *self, int protocol)
 #if PY_VERSION_HEX >= 0x03080000
     /* we expect protocol 5 to be available in Python 3.8 */
     pickle_module = PyImport_ImportModule("pickle");
-#elif PY_VERSION_HEX >= 0x03060000
+#elif PY_VERSION_HEX >= 0x03050000
     pickle_module = PyImport_ImportModule("pickle5");
     if (pickle_module == NULL) {
         /* for protocol 5, raise a clear ImportError if pickle5 is not found
          */
         PyErr_SetString(PyExc_ImportError, "Using pickle protocol 5 "
-                "requires the pickle5 module for Python >=3.6 and <3.8");
+                "requires the pickle5 module for Python >=3.5 and <3.8");
         return NULL;
     }
 #else
     PyErr_SetString(PyExc_ValueError, "pickle protocol 5 is not available "
-                                      "for Python < 3.6");
+                                      "for Python < 3.5");
     return NULL;
 #endif
     if (pickle_module == NULL){

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3808,14 +3808,14 @@ class TestPickling(object):
     def test_correct_protocol5_error_message(self):
         array = np.arange(10)
 
-        if sys.version_info[:2] in ((3, 6), (3, 7)):
+        if sys.version_info[:2] in ((3, 5), (3, 6), (3, 7)):
             # For the specific case of python3.6 and 3.7, raise a clear import
             # error about the pickle5 backport when trying to use protocol=5
             # without the pickle5 package
             with pytest.raises(ImportError):
                 array.__reduce_ex__(5)
 
-        elif sys.version_info[:2] < (3, 6):
+        elif sys.version_info[:2] < (3, 5):
             # when calling __reduce_ex__ explicitly with protocol=5 on python
             # raise a ValueError saying that protocol 5 is not available for
             # this python version

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,5 +4,6 @@ pytz==2019.3
 pytest-cov==2.8.1
 pickle5; python_version == '3.7'
 pickle5; python_version == '3.6' and platform_python_implementation != 'PyPy'
+pickle5>=0.0.10; python_version == '3.5' and platform_python_implementation != 'PyPy'
 # for numpy.random.test.test_extending
 cffi


### PR DESCRIPTION
Since the pickle5 library has enabled pickle protocol 5 support for python3.5 (https://github.com/pitrou/pickle5-backport, pitrou/pickle5-backport#15), it is reasonable to relax the constraints to support pickle protocol 5 under python3.5.

This PR follows #16421 