### PR TITLE
ENH: Fix deprecated warn for Intel/Apple/Clang Compiler

### DIFF
--- a/numpy/core/include/numpy/npy_1_7_deprecated_api.h
+++ b/numpy/core/include/numpy/npy_1_7_deprecated_api.h
@@ -13,11 +13,10 @@
 #define _WARN___LOC__ __FILE__ "(" _WARN___STR1__(__LINE__) ") : Warning Msg: "
 #pragma message(_WARN___LOC__"Using deprecated NumPy API, disable it with " \
                          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION")
-#elif defined(__GNUC__)
+#else
 #warning "Using deprecated NumPy API, disable it with " \
          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION"
 #endif
-/* TODO: How to do this warning message for other compilers? */
 #endif
 
 /*


### PR DESCRIPTION
A warning will emit if the user did not specifically request the old API, but currently only Microsoft compiler and GNU compiler is supported. After doing some investigation, other compiler(Intel/Apple/Clang) also support `#warning`.