### PR TITLE
DOC: add a "make show" command to doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ ALLSPHINXOPTS   = -WT --keep-going -d build/doctrees $(PAPEROPT_$(PAPER)) \
 
 .PHONY: help clean html web pickle htmlhelp latex changes linkcheck \
 		dist dist-build gitwash-update version-check html-build latex-build \
-		merge-doc
+		merge-doc show
 
 #------------------------------------------------------------------------------
 
@@ -46,6 +46,7 @@ help:
 	@echo "  gitwash-update GITWASH=path/to/gitwash  update gitwash developer docs"
 	@echo "  upload USERNAME=... RELEASE=... to upload built docs to docs.scipy.org"
 	@echo "  merge-doc TAG=... to clone numpy/doc and archive documentation into it"
+	@echo "  show      to show the html output in a browser"
 
 clean:
 	-rm -rf build/* 
@@ -253,3 +254,7 @@ info:
 	@echo "Running Texinfo files through makeinfo..."
 	make -C build/texinfo info
 	@echo "makeinfo finished; the Info files are in build/texinfo."
+
+show:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"
+


### PR DESCRIPTION
Opens the front page of the docs built with `make html` in the default web browser.

Idea copied from SciPy

`[ci skip]`