### PR TITLE
DOC,ENH: extend error message when Accelerate is detected

### DIFF
--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -165,7 +165,7 @@ lower case).
 
 .. deprecated:: 1.20
   The native libraries on macOS, provided by Accelerate, are not fit for use
-  in NumPy since they have bugs that cause wrong output under easily reproducable
+  in NumPy since they have bugs that cause wrong output under easily reproducible
   conditions. If the vendor fixes those bugs, the library could be reinstated,
   but until then users compiling for themselves should use another linear
   library or use the built-in (but slower) default, see the next section.

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -163,11 +163,12 @@ will prefer to use ATLAS, then OpenBLAS and as a last resort MKL.
 If neither of these exists the build will fail (names are compared
 lower case).
 
-The native libraries on macOS, provided by Accelerate, are not fit for use
-in NumPy since they have bugs that cause wrong output under easily reproducable
-conditions. If the vendor fixes those bugs, the library could be reinstated,
-but until then users compiling for themselves should use another linear
-library or use the built-in (but slower) default, see the next section. 
+.. deprecated:: 1.20
+  The native libraries on macOS, provided by Accelerate, are not fit for use
+  in NumPy since they have bugs that cause wrong output under easily reproducable
+  conditions. If the vendor fixes those bugs, the library could be reinstated,
+  but until then users compiling for themselves should use another linear
+  library or use the built-in (but slower) default, see the next section.
 
 
 Disabling ATLAS and other accelerated libraries

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -168,7 +168,8 @@ lower case).
   in NumPy since they have bugs that cause wrong output under easily reproducible
   conditions. If the vendor fixes those bugs, the library could be reinstated,
   but until then users compiling for themselves should use another linear
-  library or use the built-in (but slower) default, see the next section.
+  algebra library or use the built-in (but slower) default, see the next
+  section.
 
 
 Disabling ATLAS and other accelerated libraries

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -6,6 +6,10 @@ Building from source
 A general overview of building NumPy from source is given here, with detailed
 instructions for specific platforms given separately.
 
+.. comment::
+  This page is referenced from numpy/numpy/__init__.py. Please keep its
+  location in sync with the link there.
+
 Prerequisites
 -------------
 

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -6,7 +6,7 @@ Building from source
 A general overview of building NumPy from source is given here, with detailed
 instructions for specific platforms given separately.
 
-.. comment::
+.. 
   This page is referenced from numpy/numpy/__init__.py. Please keep its
   location in sync with the link there.
 

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -163,6 +163,12 @@ will prefer to use ATLAS, then OpenBLAS and as a last resort MKL.
 If neither of these exists the build will fail (names are compared
 lower case).
 
+The native libraries on macOS, provided by Accelerate, are not fit for use
+in NumPy since they have bugs that cause wrong output under easily reproducable
+conditions. If the vendor fixes those bugs, the library could be reinstated,
+but until then users compiling for themselves should use another linear
+library or use the built-in (but slower) default, see the next section. 
+
 
 Disabling ATLAS and other accelerated libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -279,12 +279,11 @@ else:
                 error_message = "{}: {}".format(w[-1].category.__name__, str(w[-1].message))
                 msg = (
                     "Polyfit sanity test emitted a warning, most likely due "
-                    "to using a buggy Accelerate backend. "
-                    "If you compiled yourself, "
-                    "see site.cfg.example for information. "
+                    "to using a buggy Accelerate backend. If you compiled "
+                    "yourself, more information is available at "
+                    "https://numpy.org/doc/stable/user/building.html#accelerated-blas-lapack-libraries "
                     "Otherwise report this to the vendor "
-                    "that provided NumPy.\n{}\n".format(
-                        error_message))
+                    "that provided NumPy.\n{}\n".format(error_message))
                 raise RuntimeError(msg)
     del _mac_os_check
 

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -242,14 +242,6 @@
 # library_dirs = C:\Program Files (x86)\IntelSWTools\compilers_and_libraries_2018\windows\mkl\lib\intel64
 # libraries = mkl_rt
 
-# Accelerate
-# ----------
-# Accelerate/vecLib is an OSX framework providing a BLAS and LAPACK implementation.
-#
-# [accelerate]
-# libraries = Accelerate, vecLib
-# #libraries = None
-
 # UMFPACK
 # -------
 # The UMFPACK library is used in scikits.umfpack to factor large sparse matrices.


### PR DESCRIPTION
Building on feedback in gh-16195 (see the [comment](https://github.com/numpy/numpy/issues/16195#issuecomment-627135137) there), this PR expands on the error message when Accelerate is detected. It also adds a comment to the linked-to page to hopefully prevent the link going bad. 

I noticed that we still mention Accelerate in `site.cfg.example`, so removed that as well. There may be downstream projects that use Accelerate, so we did not rip all of it out of `system_info.py`, but do we have to advertise its use?

@jbrockmendel would this have helped you work a way around Accelerate?