### PR TITLE
ENH: Implement divmod and remainder for timedelta and int

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -821,7 +821,8 @@ defdict = {
           docstrings.get('numpy.core.umath.remainder'),
           'PyUFunc_RemainderTypeResolver',
           TD(intflt),
-          [TypeDescription('m', FullTypeDescr, 'mm', 'm')],
+          [TypeDescription('m', FullTypeDescr, 'mq', 'm'),
+           TypeDescription('m', FullTypeDescr, 'mm', 'm')],
           TD(O, f='PyNumber_Remainder'),
           ),
 'divmod':
@@ -829,7 +830,8 @@ defdict = {
           docstrings.get('numpy.core.umath.divmod'),
           'PyUFunc_DivmodTypeResolver',
           TD(intflt),
-          [TypeDescription('m', FullTypeDescr, 'mm', 'qm')],
+          [TypeDescription('m', FullTypeDescr, 'mq', 'mm'),
+           TypeDescription('m', FullTypeDescr, 'mm', 'qm')],
           # TD(O, f='PyNumber_Divmod'),  # gh-9730
           ),
 'hypot':

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1348,22 +1348,6 @@ TIMEDELTA_dm_m_multiply(char **args, npy_intp const *dimensions, npy_intp const 
     }
 }
 
-/* Note: Assuming 'q' == NPY_LONGLONG */
-NPY_NO_EXPORT void
-TIMEDELTA_mq_m_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        const npy_timedelta in1 = *(npy_timedelta *)ip1;
-        const npy_int64 in2 = *(npy_int64 *)ip2;
-        if (in1 == NPY_DATETIME_NAT || in2 == 0) {
-            *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
-        }
-        else {
-            *((npy_timedelta *)op1) = in1 / in2;
-        }
-    }
-}
-
 NPY_NO_EXPORT void
 TIMEDELTA_md_m_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
@@ -1400,13 +1384,26 @@ TIMEDELTA_mm_d_divide(char **args, npy_intp const *dimensions, npy_intp const *s
     }
 }
 
+
+/**begin repeat
+ * #input_sig = mm, mq#
+ * #div_sig = q, m#
+ * #in2_type = npy_timedelta, npy_int64#
+ * #in2_is_timedelta = 1, 0#
+ * #div_op_type = npy_int64, npy_timedelta#
+ * #invalid_result = 0, NPY_DATETIME_NAT#
+ */
 NPY_NO_EXPORT void
-TIMEDELTA_mm_m_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+TIMEDELTA_@input_sig@_m_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
         const npy_timedelta in2 = *(npy_timedelta *)ip2;
+#if @in2_is_timedelta@
         if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
+#else
+        if (in1 == NPY_DATETIME_NAT) {
+#endif
             *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
         }
         else {
@@ -1429,60 +1426,70 @@ TIMEDELTA_mm_m_remainder(char **args, npy_intp const *dimensions, npy_intp const
 }
 
 NPY_NO_EXPORT void
-TIMEDELTA_mm_q_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+TIMEDELTA_@input_sig@_@div_sig@_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
         const npy_timedelta in2 = *(npy_timedelta *)ip2;
+#if @in2_is_timedelta@
         if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
-            npy_set_floatstatus_invalid();
-            *((npy_int64 *)op1) = 0;
+            npy_set_floatstatus_invalid();  /* warn due to 0 result */
+#else
+        if (in1 == NPY_DATETIME_NAT) {
+#endif
+            *((@div_op_type@ *)op1) = @invalid_result@;
         }
         else if (in2 == 0) {
-            npy_set_floatstatus_divbyzero();
-            *((npy_int64 *)op1) = 0;
+            npy_set_floatstatus_invalid();
+            *((@div_op_type@ *)op1) = @invalid_result@;
         }
         else {
             if (((in1 > 0) != (in2 > 0)) && (in1 % in2 != 0)) {
-                *((npy_int64 *)op1) = in1/in2 - 1;
+                *((@div_op_type@ *)op1) = in1/in2 - 1;
             }
             else {
-                *((npy_int64 *)op1) = in1/in2;
+                *((@div_op_type@ *)op1) = in1/in2;
             }
         }
     }
 }
 
 NPY_NO_EXPORT void
-TIMEDELTA_mm_qm_divmod(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+TIMEDELTA_@input_sig@_@div_sig@m_divmod(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP_TWO_OUT {
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
-        const npy_timedelta in2 = *(npy_timedelta *)ip2;
+        const @in2_type@ in2 = *(@in2_type@ *)ip2;
+#if @in2_is_timedelta@
         if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
-            npy_set_floatstatus_invalid();
-            *((npy_int64 *)op1) = 0;
+            npy_set_floatstatus_invalid();  /* warn due to 0 result */
+#else
+        if (in1 == NPY_DATETIME_NAT) {
+#endif
+            *((@div_op_type@ *)op1) = @invalid_result@;
             *((npy_timedelta *)op2) = NPY_DATETIME_NAT;
         }
         else if (in2 == 0) {
-            npy_set_floatstatus_divbyzero();
-            *((npy_int64 *)op1) = 0;
+            npy_set_floatstatus_invalid();
+            *((@div_op_type@ *)op1) = @invalid_result@;
             *((npy_timedelta *)op2) = NPY_DATETIME_NAT;
         }
         else {
             const npy_int64 quo = in1 / in2;
             const npy_timedelta rem = in1 % in2;
             if ((in1 > 0) == (in2 > 0) || rem == 0) {
-                *((npy_int64 *)op1) = quo;
+                *((@div_op_type@ *)op1) = quo;
                 *((npy_timedelta *)op2) = rem;
             }
             else {
-                *((npy_int64 *)op1) = quo - 1;
+                *((@div_op_type@ *)op1) = quo - 1;
                 *((npy_timedelta *)op2) = rem + in2;
             }
         }
     }
 }
+
+/**end repeat**/
 
 /*
  *****************************************************************************

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -557,9 +557,6 @@ NPY_NO_EXPORT void
 TIMEDELTA_dm_m_multiply(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
-TIMEDELTA_mq_m_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
-
-NPY_NO_EXPORT void
 TIMEDELTA_md_m_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
@@ -569,17 +566,28 @@ NPY_NO_EXPORT void
 TIMEDELTA_mm_q_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
+TIMEDELTA_mq_m_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
 TIMEDELTA_mm_m_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT void
+TIMEDELTA_mq_m_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
 TIMEDELTA_mm_qm_divmod(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
+NPY_NO_EXPORT void
+TIMEDELTA_mq_mm_divmod(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+
 /* Special case equivalents to above functions */
 
-#define TIMEDELTA_mq_m_true_divide TIMEDELTA_mq_m_divide
+#define TIMEDELTA_mq_m_true_divide TIMEDELTA_mq_m_floor_divide
 #define TIMEDELTA_md_m_true_divide TIMEDELTA_md_m_divide
 #define TIMEDELTA_mm_d_true_divide TIMEDELTA_mm_d_divide
-#define TIMEDELTA_mq_m_floor_divide TIMEDELTA_mq_m_divide
+#define TIMEDELTA_mm_q_divide TIMEDELTA_mm_q_floor_divide
+#define TIMEDELTA_mq_m_divide TIMEDELTA_mq_m_floor_divide
 #define TIMEDELTA_md_m_floor_divide TIMEDELTA_md_m_divide
 /* #define TIMEDELTA_mm_d_floor_divide TIMEDELTA_mm_d_divide */
 

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1186,11 +1186,6 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
                 return -1;
             }
             out_dtypes[1] = PyArray_DescrFromType(NPY_LONGLONG);
-            if (out_dtypes[1] == NULL) {
-                Py_DECREF(out_dtypes[0]);
-                out_dtypes[0] = NULL;
-                return -1;
-            }
             out_dtypes[2] = out_dtypes[0];
             Py_INCREF(out_dtypes[2]);
 
@@ -1203,11 +1198,6 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
                 return -1;
             }
             out_dtypes[1] = PyArray_DescrNewFromType(NPY_DOUBLE);
-            if (out_dtypes[1] == NULL) {
-                Py_DECREF(out_dtypes[0]);
-                out_dtypes[0] = NULL;
-                return -1;
-            }
             out_dtypes[2] = out_dtypes[0];
             Py_INCREF(out_dtypes[2]);
 
@@ -1261,6 +1251,16 @@ PyUFunc_RemainderTypeResolver(PyUFuncObject *ufunc,
             }
             out_dtypes[1] = out_dtypes[0];
             Py_INCREF(out_dtypes[1]);
+            out_dtypes[2] = out_dtypes[0];
+            Py_INCREF(out_dtypes[2]);
+        }
+        else if (PyTypeNum_ISINTEGER(type_num2)) {
+            out_dtypes[0] = ensure_dtype_nbo(PyArray_DESCR(operands[0]));
+            if (out_dtypes[0] == NULL) {
+                return -1;
+            }
+            Py_INCREF(out_dtypes[0]);
+            out_dtypes[1] = PyArray_DescrFromType(NPY_LONGLONG);
             out_dtypes[2] = out_dtypes[0];
             Py_INCREF(out_dtypes[2]);
         }
@@ -2225,6 +2225,23 @@ PyUFunc_DivmodTypeResolver(PyUFuncObject *ufunc,
             out_dtypes[1] = out_dtypes[0];
             Py_INCREF(out_dtypes[1]);
             out_dtypes[2] = PyArray_DescrFromType(NPY_LONGLONG);
+            out_dtypes[3] = out_dtypes[0];
+            Py_INCREF(out_dtypes[3]);
+        }
+        /* divmod(m8[<A>], int) => m8[<A>], m8[<A>] */
+        else if (PyTypeNum_ISINTEGER(type_num2)) {
+            out_dtypes[0] = ensure_dtype_nbo(PyArray_DESCR(operands[0]));
+            if (out_dtypes[0] == NULL) {
+                return -1;
+            }
+            out_dtypes[1] = PyArray_DescrFromType(NPY_LONGLONG);
+            if (out_dtypes[1] == NULL) {
+                Py_DECREF(out_dtypes[0]);
+                out_dtypes[0] = NULL;
+                return -1;
+            }
+            out_dtypes[2] = out_dtypes[0];
+            Py_INCREF(out_dtypes[2]);
             out_dtypes[3] = out_dtypes[0];
             Py_INCREF(out_dtypes[3]);
         }


### PR DESCRIPTION
Also fixes that we should not be giving warnings when the input is already a NaT.

---

@jbrockmendel maybe you can have a look as well, whether this seems right? Maybe @tylerjereddy if you have the time, since the initial implementation was from you.

Marking as draft, although its probably pretty far.  This probably needs one more iteration, possibly a few more tests.
I may have went down a wrong path when modifying/trying to expand the tests and get the warnings right, it did get somewhat messy. It combines all into one giant test now (including the integers), since we can do at least partial cross checks.

One additional test that may be good, is a test for the integer types other than int64, and I have not yet checked carefully if stealing some pandas tests may be nice.

TODO:

   - [ ] Add basic tests for non-native byte order (timedelta/first argument mainly) and non-int64 integer inputs.