### PR TITLE
DOC: Improve assert_warns docstring with example

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1768,15 +1768,28 @@ def assert_warns(warning_class, *args, **kwargs):
     ----------
     warning_class : class
         The class defining the warning that `func` is expected to throw.
-    \\*args : List of function and arguments
-        `func` and arguments for `func`.
-    \\*\\*kwargs : Kwargs
+    func : callable, optional
+        Callable to test
+    *args : Arguments
+        Arguments for `func`.
+    **kwargs : Kwargs
         Keyword arguments for `func`.
 
     Returns
     -------
     The value returned by `func`.
 
+    Examples
+    --------
+    >>> import warnings
+    >>> def deprecated_func(num):
+    ...     warnings.warn("Please upgrade", DeprecationWarning)
+    ...     return num*num
+    >>> with np.testing.assert_warns(DeprecationWarning):
+    ...     assert deprecated_func(4) == 16
+    >>> # or passing a func
+    >>> ret = np.testing.assert_warns(DeprecationWarning, deprecated_func, 4)
+    >>> assert ret == 16
     """
     if not args:
         return _assert_warns_context(warning_class)


### PR DESCRIPTION
Follow up from @eric-wieser's comment in https://github.com/numpy/numpy/pull/16422 

Tested with
```
pip install -U .
python tools/refguide_check.py --doctests
cd doc && time make html SPHINXOPTS=-j4
```
![Screenshot from 2020-06-01 00-33-58](https://user-images.githubusercontent.com/10172976/83386275-9e594700-a39f-11ea-95af-7b0006da6dcf.png)
