### PR TITLE
DOC: Fix development_workflow links

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -377,10 +377,10 @@ Deleting a branch on github_
    # delete branch locally
    git branch -D my-unwanted-branch
    # delete branch on github
-   git push origin :my-unwanted-branch
+   git push origin --delete my-unwanted-branch
 
-(Note the colon ``:`` before ``test-branch``.  See also:
-https://github.com/guides/remove-a-remote-branch
+See also:
+https://stackoverflow.com/questions/2003505/how-do-i-delete-a-git-branch-locally-and-remotely
 
 
 Several people sharing a single repository
@@ -477,7 +477,7 @@ backport.
 Pushing changes to the main repo
 ================================
 
-*This is only relevant if you have commit rights to the main NumPy repo.*
+*Requires commit rights to the main NumPy repo.*
 
 When you have a set of "ready" changes in a feature branch ready for
 NumPy's ``master`` or ``maintenance`` branches, you can push

--- a/doc/source/dev/gitwash/git_links.inc
+++ b/doc/source/dev/gitwash/git_links.inc
@@ -2,7 +2,7 @@
    and name substitutions.  It may be included in many files,
    therefore it should only contain link targets and name
    substitutions.  Try grepping for "^\.\. _" to find plausible
-   candidates for this list.  
+   candidates for this list.
 
 .. NOTE: reST targets are
    __not_case_sensitive__, so only one target definition is needed for
@@ -18,7 +18,7 @@
 .. _pro git book: https://git-scm.com/book/
 .. _git svn crash course: https://git-scm.com/course/svn.html
 .. _learn.github: https://learn.github.com/
-.. _network graph visualizer: https://github.com/blog/39-say-hello-to-the-network-graph-visualizer
+.. _network graph visualizer: https://github.blog/2008-04-10-say-hello-to-the-network-graph-visualizer/
 .. _git user manual: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html
 .. _git tutorial: https://www.kernel.org/pub/software/scm/git/docs/gittutorial.html
 .. _git community book: https://book.git-scm.com/
@@ -41,18 +41,18 @@
 .. _git config: https://www.kernel.org/pub/software/scm/git/docs/git-config.html
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
-.. _tangled working copy problem: https://tomayko.com/writings/the-thing-about-git 
+.. _tangled working copy problem: https://tomayko.com/writings/the-thing-about-git
 .. _git management: http://kerneltrap.org/Linux/Git_Management
 .. _linux git workflow: https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
-.. _ipython git workflow: http://mail.python.org/pipermail/ipython-dev/2010-October/006746.html
+.. _ipython git workflow: https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
 .. _numpy/master: https://github.com/numpy/numpy
 .. _git cherry-pick: https://www.kernel.org/pub/software/scm/git/docs/git-cherry-pick.html
 .. _git blame: https://www.kernel.org/pub/software/scm/git/docs/git-blame.html
-.. _this blog post: https://github.com/blog/612-introducing-github-compare-view 
-.. _this article on merging conflicts:  https://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging#Basic-Merge-Conflicts 
-.. _learn git: https://www.atlassian.com/git/tutorials/
+.. _this blog post: https://github.com/blog/612-introducing-github-compare-view
+.. _this article on merging conflicts:  https://git-scm.com/book/en/Git-Branching-Basic-Branching-and-Merging#Basic-Merge-Conflicts
+.. _learn git:  https://try.github.io/
 .. _filing pull requests: https://help.github.com/articles/using-pull-requests/#initiating-the-pull-request
 .. _pull request review: https://help.github.com/articles/using-pull-requests/#reviewing-the-pull-request
 


### PR DESCRIPTION
Fixed links for branch delete and graph visualizer.

Updated instructions for branch delete (git since 1.7.0 (Sept 2010)
has allowed --delete sted ':').

'Learn git' link pointed to Bitbucket instructions; replaced with GitHub
instructions.

Minor rewording in 'Pushing changes to the main repo'.

This is NOT a review of the page, only some fixes.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
