### PR TITLE
BUG: fix GCC 10 major version comparison

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -10,6 +10,7 @@ import subprocess
 from subprocess import Popen, PIPE, STDOUT
 from numpy.distutils.exec_command import filepath_from_subprocess_output
 from numpy.distutils.fcompiler import FCompiler
+from distutils.version import LooseVersion
 
 compilers = ['GnuFCompiler', 'Gnu95FCompiler']
 
@@ -273,7 +274,7 @@ class Gnu95FCompiler(GnuFCompiler):
         if not v or v[0] != 'gfortran':
             return None
         v = v[1]
-        if v >= '4.':
+        if LooseVersion(v) >= "4":
             # gcc-4 series releases do not support -mno-cygwin option
             pass
         else:


### PR DESCRIPTION
 The comparison of GCC major version used a string
  comparison, which is known to break when comparing
  single vs. double version numbers. This fix
  compares the integer of the major GCC version.

  Before this fix, GCC/Gfortran 10 would get inappropriate
  flag "-mno-cygwin" applied, which was removed in GCC 4
  and makes GCC error out.