### PR TITLE
BLD: install mingw32 v7.3.0 for win32

### DIFF
--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -36,7 +36,7 @@ steps:
     If ($(BITS) -eq 32) {
         $env:CFLAGS = "-m32"
         $env:LDFLAGS = "-m32"
-        $env:PATH = "C:\\tools\\mingw32\\bin;" + $env:PATH
+        $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
         refreshenv
     }
     python -c "from tools import openblas_support; openblas_support.make_init('numpy')"

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Download / Install OpenBLAS'
 
 - powershell: |
-    choco install -y mingw --forcex86 --force --version=5.3.0
+    choco install -y mingw --forcex86 --force --version=7.3.0
   displayName: 'Install 32-bit mingw for 32-bit builds'
   condition: eq(variables['BITS'], 32)
 # NOTE: for Windows builds it seems much more tractable to use runtests.py


### PR DESCRIPTION
Looking at https://sourceforge.net/projects/mingw-w64/files/, it seems 5.3.0 is no longer available. 