### PR TITLE
DOC: Fixes for 18 broken links

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -19,18 +19,20 @@ Source tree
 NumPy Docs
 ----------
 - https://github.com/numpy/numpy/blob/master/doc/HOWTO_RELEASE.rst.txt
-- http://projects.scipy.org/numpy/wiki/MicrosoftToolchainSupport (dead link)
+
+.. - http://projects.scipy.org/numpy/wiki/MicrosoftToolchainSupport (dead link)
 
 
 SciPy.org wiki
 --------------
 - https://www.scipy.org/Installing_SciPy and links on that page.
-- http://new.scipy.org/building/windows.html (dead link)
+
+.. - http://new.scipy.org/building/windows.html (dead link)
 
 
-Doc wiki
---------
-- http://docs.scipy.org/numpy/docs/numpy-docs/user/install.rst/ (dead link)
+.. Doc wiki
+.. --------
+.. - http://docs.scipy.org/numpy/docs/numpy-docs/user/install.rst/ (dead link)
 
 
 Release Scripts

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -20,19 +20,10 @@ NumPy Docs
 ----------
 - https://github.com/numpy/numpy/blob/master/doc/HOWTO_RELEASE.rst.txt
 
-.. - http://projects.scipy.org/numpy/wiki/MicrosoftToolchainSupport (dead link)
-
 
 SciPy.org wiki
 --------------
 - https://www.scipy.org/Installing_SciPy and links on that page.
-
-.. - http://new.scipy.org/building/windows.html (dead link)
-
-
-.. Doc wiki
-.. --------
-.. - http://docs.scipy.org/numpy/docs/numpy-docs/user/install.rst/ (dead link)
 
 
 Release Scripts

--- a/doc/source/dev/gitwash/git_links.inc
+++ b/doc/source/dev/gitwash/git_links.inc
@@ -16,7 +16,7 @@
 .. _subversion: http://subversion.tigris.org/
 .. _git cheat sheet: http://cheat.errtheblog.com/s/git
 .. _pro git book: https://git-scm.com/book/
-.. _git svn crash course: https://git-scm.com/course/svn.html
+.. _git svn crash course: https://git.wiki.kernel.org/index.php/GitSvnCrashCourse
 .. _learn.github: https://learn.github.com/
 .. _network graph visualizer: https://github.blog/2008-04-10-say-hello-to-the-network-graph-visualizer/
 .. _git user manual: https://www.kernel.org/pub/software/scm/git/docs/user-manual.html
@@ -42,7 +42,7 @@
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _tangled working copy problem: https://tomayko.com/writings/the-thing-about-git
-.. _git management: http://kerneltrap.org/Linux/Git_Management
+.. _git management: https://web.archive.org/web/20090328043540/http://kerneltrap.org/Linux/Git_Management
 .. _linux git workflow: https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _ipython git workflow: https://mail.python.org/pipermail/ipython-dev/2010-October/005632.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html

--- a/doc/source/dev/governance/governance.rst
+++ b/doc/source/dev/governance/governance.rst
@@ -381,7 +381,7 @@ A list of current Institutional Partners is maintained at the page
 Document history
 ================
 
-https://github.com/numpy/numpy/blob/master/doc/source/dev/governance/governance.rst
+https://github.com/numpy/numpy/commits/master/doc/source/dev/governance/governance.rst
 
 Acknowledgements
 ================

--- a/doc/source/dev/governance/governance.rst
+++ b/doc/source/dev/governance/governance.rst
@@ -381,14 +381,13 @@ A list of current Institutional Partners is maintained at the page
 Document history
 ================
 
-https://github.com/numpy/numpy/commits/master/doc/source/dev/governance/governance.rst
+https://github.com/numpy/numpy/blob/master/doc/source/dev/governance/governance.rst
 
 Acknowledgements
 ================
 
 Substantial portions of this document were adapted from the
-`Jupyter/IPython project's governance document
-<https://github.com/jupyter/governance/blob/master/governance.md>`_.
+`Jupyter/IPython project's governance document <https://github.com/jupyter/governance>`_
 
 License
 =======

--- a/doc/source/dev/howto-docs.rst
+++ b/doc/source/dev/howto-docs.rst
@@ -87,7 +87,7 @@ check out the following specific guides:
 Major additions to the documentation (e.g. new tutorials) should be proposed to
 the `mailing list
 <https://mail.python.org/mailman/listinfo/numpy-discussion>`__.
-  
+
 Other ways to contribute
 ------------------------
 
@@ -145,5 +145,5 @@ the quality of the documentation.
   resources for technical writing.
 - Google offers two free `Technical Writing Courses
   <https://developers.google.com/tech-writing>`__
-- `Software Carpentry <https://software-carpentry.org/software>`__ has a lot of
+- `Software Carpentry <https://carpentries.github.io/curriculum-development/>`__ has a lot of
   nice recommendations for creating educational material.

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -256,7 +256,7 @@ From the ``doc/`` directory:
     git submodule update --init
 
 The documentation includes mathematical formulae with LaTeX formatting.
-A working LaTeX document production system 
+A working LaTeX document production system
 (e.g. `texlive <https://www.tug.org/texlive/>`__) is required for the
 proper rendering of the LaTeX math in the documentation.
 
@@ -291,4 +291,4 @@ The rest of the story
 NumPy-specific workflow is in :ref:`numpy-development-workflow
 <development-workflow>`.
 
-.. _`mailing list`: https://mail.python.org/mailman/listinfo/numpy-devel
+.. _`mailing list`: https://mail.python.org/mailman/listinfo/numpy-discussion

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -173,7 +173,7 @@ NumPy provides several hooks that classes can customize:
 
    -  ``func`` is an arbitrary callable exposed by NumPy's public API,
       which was called in the form ``func(*args, **kwargs)``.
-   -  ``types`` is a `collection <https://docs.python.org/3/library/collections.abc.html#collections.abc.Collection>`_
+   -  ``types`` is a collection :py:class:`collections.abc.Collection`
       of unique argument types from the original NumPy function call that
       implement ``__array_function__``.
    -  The tuple ``args`` and dict ``kwargs`` are directly passed on from the

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -173,7 +173,7 @@ NumPy provides several hooks that classes can customize:
 
    -  ``func`` is an arbitrary callable exposed by NumPy's public API,
       which was called in the form ``func(*args, **kwargs)``.
-   -  ``types`` is a `collection <collections.abc.Collection>`_
+   -  ``types`` is a `collection <https://docs.python.org/3/library/collections.abc.html#collections.abc.Collection>`_
       of unique argument types from the original NumPy function call that
       implement ``__array_function__``.
    -  The tuple ``args`` and dict ``kwargs`` are directly passed on from the

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -82,4 +82,4 @@ debug option can be interesting for testing code written
 in C which iterates through arrays that may or may not be
 contiguous in memory.
 Most users will have no reason to change these, for details
-please see the `memory layout <memory-layout>`_ documentation.
+please see :ref:`Internal memory layout of an ndarray <arrays.ndarray>`

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -81,5 +81,5 @@ This setting should always be enabled. Setting the
 debug option can be interesting for testing code written
 in C which iterates through arrays that may or may not be
 contiguous in memory.
-Most users will have no reason to change these, for details
-please see :ref:`Internal memory layout of an ndarray <arrays.ndarray>`
+Most users will have no reason to change these; for details
+see the :ref:`memory layout <memory-layout>` documentation.

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -15,7 +15,7 @@ What's New or Different
   streams, use `RandomState`, i.e., `RandomState.gamma` or
   `RandomState.standard_t`.
 
-Quick comparison of legacy `mtrand <legacy>`_ to the new `Generator`
+Quick comparison of legacy :ref:`mtrand <legacy>` to the new `Generator`
 
 ================== ==================== =============
 Feature            Older Equivalent     Notes
@@ -52,7 +52,7 @@ And in more detail:
   methods which are 2-10 times faster than NumPy's default implementation in
   `~.Generator.standard_normal`, `~.Generator.standard_exponential` or
   `~.Generator.standard_gamma`.
-   
+
 
 .. ipython:: python
 

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -109,7 +109,7 @@ The output of the ufunc (and its methods) is not necessarily an
 :class:`ndarray`, if all input arguments are not :class:`ndarrays <ndarray>`.
 Indeed, if any input defines an :obj:`~class.__array_ufunc__` method,
 control will be passed completely to that function, i.e., the ufunc is
-`overridden <ufuncs.overrides>`_.
+`overridden <https://www.numpy.org/neps/nep-0013-ufunc-overrides.html>`_.
 
 If none of the inputs overrides the ufunc, then
 all output arrays will be passed to the :obj:`~class.__array_prepare__` and

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -109,7 +109,7 @@ The output of the ufunc (and its methods) is not necessarily an
 :class:`ndarray`, if all input arguments are not :class:`ndarrays <ndarray>`.
 Indeed, if any input defines an :obj:`~class.__array_ufunc__` method,
 control will be passed completely to that function, i.e., the ufunc is
-`overridden <https://www.numpy.org/neps/nep-0013-ufunc-overrides.html>`_.
+:ref:`overridden <ufuncs.overrides>`.
 
 If none of the inputs overrides the ufunc, then
 all output arrays will be passed to the :obj:`~class.__array_prepare__` and

--- a/doc/source/release/1.19.0-notes.rst
+++ b/doc/source/release/1.19.0-notes.rst
@@ -24,14 +24,14 @@ Calling ``np.array([[1, [1, 2, 3]])`` will issue a ``DeprecationWarning`` as
 per `NEP 34`_. Users should explicitly use ``dtype=object`` to avoid the
 warning.
 
-.. _`NEP 34`: https://numpy.org/neps/nep-0034.html
+.. _`NEP 34`: https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
 
 (`gh-15119 <https://github.com/numpy/numpy/pull/15119>`__)
 
 Passing ``shape=0`` to factory functions in ``numpy.rec`` is deprecated
 -----------------------------------------------------------------------
 
-``0`` is treated as a special case and is aliased to ``None`` in the functions: 
+``0`` is treated as a special case and is aliased to ``None`` in the functions:
 
 * `numpy.core.records.fromarrays`
 * `numpy.core.records.fromrecords`
@@ -316,12 +316,12 @@ now expose this through the buffer interface, meaning
 
 ``subok`` option for `numpy.copy`
 ---------------------------------
-A new kwarg, ``subok``, was added to `numpy.copy` to allow users to toggle the 
+A new kwarg, ``subok``, was added to `numpy.copy` to allow users to toggle the
 behavior of `numpy.copy` with respect to array subclasses. The default value
-is ``False`` which is consistent with the behavior of `numpy.copy` for 
+is ``False`` which is consistent with the behavior of `numpy.copy` for
 previous numpy versions. To create a copy that preserves an array subclass with
 `numpy.copy`, call ``np.copy(arr, subok=True)``. This addition better documents
-that the default behavior of `numpy.copy` differs from the 
+that the default behavior of `numpy.copy` differs from the
 `numpy.ndarray.copy` method which respects array subclasses by default.
 
 (`gh-15685 <https://github.com/numpy/numpy/pull/15685>`__)
@@ -345,8 +345,8 @@ as `numpy.sum` or `numpy.mean`.
 ``equal_nan`` parameter for `numpy.array_equal`
 ------------------------------------------------
 The keyword argument ``equal_nan`` was added to `numpy.array_equal`.
-``equal_nan`` is a boolean value that toggles whether or not ``nan`` values 
-are considered equal in comparison (default is ``False``). This matches API 
+``equal_nan`` is a boolean value that toggles whether or not ``nan`` values
+are considered equal in comparison (default is ``False``). This matches API
 used in related functions such as `numpy.isclose` and `numpy.allclose`.
 
 (`gh-16128 <https://github.com/numpy/numpy/pull/16128>`__)
@@ -376,9 +376,9 @@ linear algebra for large arrays.
 
 Use AVX512 intrinsic to implement ``np.exp`` when input is ``np.float64``
 --------------------------------------------------------------------------
-Use AVX512 intrinsic to implement ``np.exp`` when input is ``np.float64``, 
+Use AVX512 intrinsic to implement ``np.exp`` when input is ``np.float64``,
 which can improve the performance of ``np.exp`` with ``np.float64`` input 5-7x
-faster than before. The _multiarray_umath.so module has grown about 63 KB on 
+faster than before. The _multiarray_umath.so module has grown about 63 KB on
 linux64.
 
 (`gh-15648 <https://github.com/numpy/numpy/pull/15648>`__)

--- a/doc/source/release/1.5.0-notes.rst
+++ b/doc/source/release/1.5.0-notes.rst
@@ -12,11 +12,11 @@ Python 3 compatibility
 This is the first NumPy release which is compatible with Python 3. Support for
 Python 3 and Python 2 is done from a single code base. Extensive notes on
 changes can be found at
-`<http://projects.scipy.org/numpy/browser/trunk/doc/Py3K.txt>`_.
+`<https://web.archive.org/web/20100814160313/http://projects.scipy.org/numpy/browser/trunk/doc/Py3K.txt>`_.
 
 Note that the Numpy testing framework relies on nose, which does not have a
 Python 3 compatible release yet. A working Python 3 branch of nose can be found
-at `<http://bitbucket.org/jpellerin/nose3/>`_ however.
+at `<https://web.archive.org/web/20100817112505/http://bitbucket.org/jpellerin/nose3/>`_ however.
 
 Porting of SciPy to Python 3 is expected to be completed soon.
 

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -1531,19 +1531,19 @@ Importing and exporting a CSV
 -----------------------------
 
 .. save a csv
-   
+
    >>> with open('music.csv', 'w') as fid:
    ...     n = fid.write('Artist,Genre,Listeners,Plays\n')
    ...     n = fid.write('Billie Holiday,Jazz,1300000,27000000\n')
    ...     n = fid.write('Jimmie Hendrix,Rock,2700000,70000000\n')
    ...     n = fid.write('Miles Davis,Jazz,1500000,48000000\n')
    ...     n = fid.write('SIA,Pop,2000000,74000000\n')
-   
+
 
 
 It's simple to read in a CSV that contains existing information. The best and
 easiest way to do this is to use
-`Pandas <https://pandas.pydata.org/getpandas.html>`_. ::
+`Pandas <https://pandas.pydata.org>`_. ::
 
   >>> import pandas as pd
 

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -22,7 +22,7 @@ https://scipy.org/install.html for instructions.
 
 **Learner profile**
 
-This tutorial is intended as a quick overview of 
+This tutorial is intended as a quick overview of
 algebra and arrays in NumPy and want to understand how n-dimensional
 (:math:`n>=2`) arrays are represented and can be manipulated. In particular, if
 you don't know how to apply common functions to n-dimensional arrays (without
@@ -1036,6 +1036,8 @@ Basic Linear Algebra
 Less Basic
 ==========
 
+.. _broadcasting-rules:
+
 Broadcasting rules
 ------------------
 
@@ -1054,7 +1056,7 @@ element is assumed to be the same along that dimension for the
 "broadcast" array.
 
 After application of the broadcasting rules, the sizes of all arrays
-must match. More details can be found in :doc:`basics.broadcasting`.
+must match. More details can be found in :ref:`basics.broadcasting`.
 
 Advanced indexing and index tricks
 ==================================
@@ -1390,8 +1392,8 @@ and then use it as::
             [14, 13, 15, 17, 12]]])
 
 The advantage of this version of reduce compared to the normal
-ufunc.reduce is that it makes use of the `Broadcasting
-Rules <Tentative_NumPy_Tutorial.html#head-c43f3f81719d84f09ae2b33a22eaf50b26333db8>`__
+ufunc.reduce is that it makes use of the
+:ref:`broadcasting rules <broadcasting-rules>`
 in order to avoid creating an argument array the size of the output
 times the number of vectors.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1334,7 +1334,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
 
     See Also
     --------
-    scipy.interpolate 
+    scipy.interpolate
 
     Notes
     -----
@@ -1974,7 +1974,7 @@ class vectorize:
     References
     ----------
     .. [1] NumPy Reference, section `Generalized Universal Function API
-           <https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html>`_.
+           <https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html>`_.
 
     Examples
     --------
@@ -3122,7 +3122,7 @@ def i0(x):
     .. [2] M. Abramowitz and I. A. Stegun, *Handbook of Mathematical
            Functions*, 10th printing, New York: Dover, 1964, pp. 379.
            http://www.math.sfu.ca/~cbm/aands/page_379.htm
-    .. [3] http://kobesearch.cpan.org/htdocs/Math-Cephes/Math/Cephes.html
+    .. [3] https://metacpan.org/pod/distribution/Math-Cephes/lib/Math/Cephes.pod#i0:-Modified-Bessel-function-of-order-zero
 
     Examples
     --------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1973,8 +1973,7 @@ class vectorize:
 
     References
     ----------
-    .. [1] NumPy Reference, section `Generalized Universal Function API
-           <https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html>`_.
+    .. [1] :doc:`/reference/c-api/generalized-ufuncs`
 
     Examples
     --------

--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -68,7 +68,7 @@ class NDArrayOperatorsMixin:
     It is useful for writing classes that do not inherit from `numpy.ndarray`,
     but that should support arithmetic and numpy universal functions like
     arrays as described in `A Mechanism for Overriding Ufuncs
-    <../../neps/nep-0013-ufunc-overrides.html>`_.
+    <https://numpy.org/neps/nep-0013-ufunc-overrides.html>`_.
 
     As an trivial example, consider this implementation of an ``ArrayLike``
     class that simply wraps a NumPy array and ensures that the result of any

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -104,7 +104,7 @@ References
 ----------
 .. [1] A. T. Benjamin, et al., "Combinatorial Trigonometry with Chebyshev
   Polynomials," *Journal of Statistical Planning and Inference 14*, 2008
-  (preprint: https://www.math.hmc.edu/~benjamin/papers/CombTrig.pdf, pg. 4)
+  (https://web.archive.org/web/20080221202153/https://www.math.hmc.edu/~benjamin/papers/CombTrig.pdf, pg. 4)
 
 """
 import numpy as np

--- a/numpy/testing/_private/nosetester.py
+++ b/numpy/testing/_private/nosetester.py
@@ -352,7 +352,7 @@ class NoseTester:
         coverage : bool, optional
             If True, report coverage of NumPy code. Default is False.
             (This requires the
-            `coverage module <https://nedbatchelder.com/code/modules/coveragehtml>`_).
+            `coverage module <https://pypi.org/project/coverage/>`_).
         raise_warnings : None, str or sequence of warnings, optional
             This specifies which warnings to configure as 'raise' instead
             of being shown once during the test execution. Valid strings are:


### PR DESCRIPTION
This, with PR #16465, should fix nearly all the remaining broken links
on the site. 4 or 5 others should be easy to fix and just
need attention from someone more knowledgeable -- will
open an issue. For release notes with dead links,
I could usually find links on archive.org for roughly contemporary
versions.
