### PR TITLE
ENH: add `norm=forward,backward` to numpy.fft functions

### DIFF
--- a/doc/release/upcoming_changes/16476.new_feature.rst
+++ b/doc/release/upcoming_changes/16476.new_feature.rst
@@ -5,5 +5,5 @@ and acts as the default option; using it has the direct transforms unscaled
 and the inverse transforms scaled by ``1/n``.
 
 Using the new keyword argument option ``norm=forward`` has the direct
-transforms scaled by ``1/n`` and the inverse transforms unscaled (i.e. directly
+transforms scaled by ``1/n`` and the inverse transforms unscaled (i.e. exactly
 opposite to the default option ``norm=backward``).

--- a/doc/release/upcoming_changes/16476.new_feature.rst
+++ b/doc/release/upcoming_changes/16476.new_feature.rst
@@ -1,5 +1,9 @@
-``norm=forward`` keyword option available for ``numpy.fft`` functions
----------------------------------------------------------------------
-Using the keyword argument option ``norm=forward`` has the direct transforms
-scaled by ``1/n`` and the inverse transforms unscaled (i.e. directly opposite
-to the default option ``norm=None``).
+``norm=backward``, ``forward`` keyword options for ``numpy.fft`` functions
+--------------------------------------------------------------------------
+The keyword argument option ``norm=backward`` is added as an alias for ``None``
+and acts as the default option; using it has the direct transforms unscaled
+and the inverse transforms scaled by ``1/n``.
+
+Using the new keyword argument option ``norm=forward`` has the direct
+transforms scaled by ``1/n`` and the inverse transforms unscaled (i.e. directly
+opposite to the default option ``norm=backward``).

--- a/doc/release/upcoming_changes/16476.new_feature.rst
+++ b/doc/release/upcoming_changes/16476.new_feature.rst
@@ -1,0 +1,5 @@
+``norm=forward`` keyword option available for ``numpy.fft`` functions
+---------------------------------------------------------------------
+Using the keyword argument option ``norm=forward`` has the direct transforms
+scaled by ``1/n`` and the inverse transforms unscaled (i.e. directly opposite
+to the default option ``norm=None``).

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -134,7 +134,8 @@ unitary transforms by setting the keyword argument ``norm`` to ``"ortho"``
 (default is ``"backward"``) so that both direct and inverse transforms are
 scaled by :math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
 ``"forward"`` has the direct transforms scaled by :math:`1/n` and the inverse
-transforms unscaled (i.e. directly oppposite to the default ``"backward"``).
+transforms unscaled (i.e. exactly opposite to the default ``"backward"``).
+`None` is an alias of the default option ``"backward"`` for backward compatibility.
 
 Real and Hermitian transforms
 -----------------------------

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -128,13 +128,13 @@ promote input arrays, see `scipy.fftpack`.
 Normalization
 -------------
 
-The default normalization has the direct transforms unscaled and the inverse
-transforms are scaled by :math:`1/n`. It is possible to obtain unitary
-transforms by setting the keyword argument ``norm`` to ``"ortho"`` (default is
-`None`) so that both direct and inverse transforms will be scaled by
-:math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
+The default normalization has the direct (forward) transforms unscaled and the
+inverse (backward) transforms scaled by :math:`1/n`. It is possible to obtain
+unitary transforms by setting the keyword argument ``norm`` to ``"ortho"``
+(default is ``"backward"``) so that both direct and inverse transforms are
+scaled by :math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
 ``"forward"`` has the direct transforms scaled by :math:`1/n` and the inverse
-transforms unscaled (i.e. directly oppposite to the default option ``None``).
+transforms unscaled (i.e. directly oppposite to the default ``"backward"``).
 
 Real and Hermitian transforms
 -----------------------------

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -112,8 +112,8 @@ The phase spectrum is obtained by ``np.angle(A)``.
 The inverse DFT is defined as
 
 .. math::
-   a_m = \\frac{1}{n}\\sum_{k=0}^{n-1}A_k\\exp\\left\\{2\\pi i{mk\\over n}
-   \\right\\}\\qquad m = 0,\\ldots,n-1.
+   a_m = \\frac{1}{n}\\sum_{k=0}^{n-1}A_k\\exp\\left\\{2\\pi i{mk\\over n}\\right\\}
+   \\qquad m = 0,\\ldots,n-1.
 
 It differs from the forward transform by the sign of the exponential
 argument and the default normalization by :math:`1/n`.
@@ -167,8 +167,8 @@ In two dimensions, the DFT is defined as
 
 .. math::
    A_{kl} =  \\sum_{m=0}^{M-1} \\sum_{n=0}^{N-1}
-   a_{mn}\\exp\\left\\{-2\\pi i \\left({mk\\over M}+{nl\\over N}\\right)
-   \\right\\}\\qquad k = 0, \\ldots, M-1;\\quad l = 0, \\ldots, N-1,
+   a_{mn}\\exp\\left\\{-2\\pi i \\left({mk\\over M}+{nl\\over N}\\right)\\right\\}
+   \\qquad k = 0, \\ldots, M-1;\\quad l = 0, \\ldots, N-1,
 
 which extends in the obvious way to higher dimensions, and the inverses
 in higher dimensions also extend in the same way.

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -112,8 +112,8 @@ The phase spectrum is obtained by ``np.angle(A)``.
 The inverse DFT is defined as
 
 .. math::
-   a_m = \\frac{1}{n}\\sum_{k=0}^{n-1}A_k\\exp\\left\\{2\\pi i{mk\\over n}\\right\\}
-   \\qquad m = 0,\\ldots,n-1.
+   a_m = \\frac{1}{n}\\sum_{k=0}^{n-1}A_k\\exp\\left\\{2\\pi i{mk\\over n}
+   \\right\\}\\qquad m = 0,\\ldots,n-1.
 
 It differs from the forward transform by the sign of the exponential
 argument and the default normalization by :math:`1/n`.
@@ -167,8 +167,8 @@ In two dimensions, the DFT is defined as
 
 .. math::
    A_{kl} =  \\sum_{m=0}^{M-1} \\sum_{n=0}^{N-1}
-   a_{mn}\\exp\\left\\{-2\\pi i \\left({mk\\over M}+{nl\\over N}\\right)\\right\\}
-   \\qquad k = 0, \\ldots, M-1;\\quad l = 0, \\ldots, N-1,
+   a_{mn}\\exp\\left\\{-2\\pi i \\left({mk\\over M}+{nl\\over N}\\right)
+   \\right\\}\\qquad k = 0, \\ldots, M-1;\\quad l = 0, \\ldots, N-1,
 
 which extends in the obvious way to higher dimensions, and the inverses
 in higher dimensions also extend in the same way.

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -134,7 +134,7 @@ transforms by setting the keyword argument ``norm`` to ``"ortho"`` (default is
 `None`) so that both direct and inverse transforms will be scaled by
 :math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
 ``"forward"`` has the direct transforms scaled by :math:`1/n` and the inverse
-transforms unscaled (i.e. directly oppposite to the default option `None`).
+transforms unscaled (i.e. directly oppposite to the default option ``None``).
 
 Real and Hermitian transforms
 -----------------------------

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -128,14 +128,17 @@ promote input arrays, see `scipy.fftpack`.
 Normalization
 -------------
 
-The default normalization has the direct (forward) transforms unscaled and the
-inverse (backward) transforms scaled by :math:`1/n`. It is possible to obtain
-unitary transforms by setting the keyword argument ``norm`` to ``"ortho"``
-(default is ``"backward"``) so that both direct and inverse transforms are
-scaled by :math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
+The argument ``norm`` indicates which direction of the pair of direct/inverse
+transforms is scaled and with what normalization factor.
+The default normalization (``"backward"``) has the direct (forward) transforms
+unscaled and the inverse (backward) transforms scaled by :math:`1/n`. It is
+possible to obtain unitary transforms by setting the keyword argument ``norm``
+to ``"ortho"`` so that both direct and inverse transforms are scaled by
+:math:`1/\\sqrt{n}`. Finally, setting the keyword argument ``norm`` to
 ``"forward"`` has the direct transforms scaled by :math:`1/n` and the inverse
 transforms unscaled (i.e. exactly opposite to the default ``"backward"``).
-`None` is an alias of the default option ``"backward"`` for backward compatibility.
+`None` is an alias of the default option ``"backward"`` for backward
+compatibility.
 
 Real and Hermitian transforms
 -----------------------------

--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -132,7 +132,9 @@ The default normalization has the direct transforms unscaled and the inverse
 transforms are scaled by :math:`1/n`. It is possible to obtain unitary
 transforms by setting the keyword argument ``norm`` to ``"ortho"`` (default is
 `None`) so that both direct and inverse transforms will be scaled by
-:math:`1/\\sqrt{n}`.
+:math:`1/\\sqrt{n}`. Finally, setting the keyword argument "norm" to
+``"forward"`` has the direct transforms scaled by :math:`1/n` and the inverse
+transforms unscaled (i.e. directly oppposite to the default option `None`).
 
 Real and Hermitian transforms
 -----------------------------

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -636,7 +636,7 @@ def ihfft(a, n=None, axis=-1, norm=None):
     if _unitary(norm):
         output *= 1./sqrt(n)
     elif norm is None:
-        output *= n
+        output *= 1./n
     return output
 
 

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -75,7 +75,7 @@ def _raw_fft(a, n, axis, is_real, is_forward, inv_norm):
     return r
 
 
-def _go_forw(n, norm):
+def _get_forward_norm(n, norm):
     if n < 1:
         raise ValueError(f"Invalid number of FFT data points ({n}) specified.")
 
@@ -85,11 +85,11 @@ def _go_forw(n, norm):
         return sqrt(n)
     elif norm == "forward":
         return n
-    raise ValueError(f'Invalid norm value {norm}; should be "backward",\
-                     "ortho" or "forward".')
+    raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+                     '"ortho" or "forward".')
 
 
-def _go_back(n, norm):
+def _get_backward_norm(n, norm):
     if n < 1:
         raise ValueError(f"Invalid number of FFT data points ({n}) specified.")
 
@@ -99,18 +99,20 @@ def _go_back(n, norm):
         return sqrt(n)
     elif norm == "forward":
         return 1
-    raise ValueError(f'Invalid norm value {norm}; should be "backward",\
-                     "ortho" or "forward".')
+    raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+                     '"ortho" or "forward".')
+
 
 _SWAP_DIRECTION_MAP = {"backward": "forward", None: "forward",
                        "ortho": "ortho", "forward": "backward"}
+
 
 def _swap_direction(norm):
     try:
         return _SWAP_DIRECTION_MAP[norm]
     except KeyError:
-        raise ValueError(f'Invalid norm value {norm}; should be "backward",\
-                         "ortho" or "forward".')
+        raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+                         '"ortho" or "forward".')
 
 
 def _fft_dispatcher(a, n=None, axis=None, norm=None):
@@ -142,6 +144,8 @@ def fft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -207,7 +211,7 @@ def fft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    inv_norm = _go_forw(n, norm)
+    inv_norm = _get_forward_norm(n, norm)
     output = _raw_fft(a, n, axis, False, True, inv_norm)
     return output
 
@@ -252,6 +256,8 @@ def ifft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -304,7 +310,7 @@ def ifft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    inv_norm = _go_back(n, norm)
+    inv_norm = _get_backward_norm(n, norm)
     output = _raw_fft(a, n, axis, False, False, inv_norm)
     return output
 
@@ -334,6 +340,8 @@ def rfft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -395,7 +403,7 @@ def rfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    inv_norm = _go_forw(n, norm)
+    inv_norm = _get_forward_norm(n, norm)
     output = _raw_fft(a, n, axis, True, True, inv_norm)
     return output
 
@@ -434,6 +442,8 @@ def irfft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -497,7 +507,7 @@ def irfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = (a.shape[axis] - 1) * 2
-    inv_norm = _go_back(n, norm)
+    inv_norm = _get_backward_norm(n, norm)
     output = _raw_fft(a, n, axis, True, False, inv_norm)
     return output
 
@@ -526,6 +536,8 @@ def hfft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -620,6 +632,8 @@ def ihfft(a, n=None, axis=-1, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -726,6 +740,8 @@ def fftn(a, s=None, axes=None, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -836,6 +852,8 @@ def ifftn(a, s=None, axes=None, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -929,6 +947,8 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -1030,6 +1050,8 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -1114,6 +1136,8 @@ def rfftn(a, s=None, axes=None, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -1196,6 +1220,8 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -1259,6 +1285,8 @@ def irfftn(a, s=None, axes=None, norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 
@@ -1346,6 +1374,8 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
         .. versionadded:: 1.10.0
 
         Normalization mode (see `numpy.fft`). Default is "backward".
+        Indicates which direction of the forward/backward pair of transforms
+        is scaled and with what normalization factor.
 
         .. versionadded:: 1.20.0
 

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -3,20 +3,20 @@ Discrete Fourier Transforms
 
 Routines in this module:
 
-fft(a, n=None, axis=-1)
-ifft(a, n=None, axis=-1)
-rfft(a, n=None, axis=-1)
-irfft(a, n=None, axis=-1)
-hfft(a, n=None, axis=-1)
-ihfft(a, n=None, axis=-1)
-fftn(a, s=None, axes=None)
-ifftn(a, s=None, axes=None)
-rfftn(a, s=None, axes=None)
-irfftn(a, s=None, axes=None)
-fft2(a, s=None, axes=(-2,-1))
-ifft2(a, s=None, axes=(-2, -1))
-rfft2(a, s=None, axes=(-2,-1))
-irfft2(a, s=None, axes=(-2, -1))
+fft(a, n=None, axis=-1, norm=None)
+ifft(a, n=None, axis=-1, norm=None)
+rfft(a, n=None, axis=-1, norm=None)
+irfft(a, n=None, axis=-1, norm=None)
+hfft(a, n=None, axis=-1, norm=None)
+ihfft(a, n=None, axis=-1, norm=None)
+fftn(a, s=None, axes=None, norm=None)
+ifftn(a, s=None, axes=None, norm=None)
+rfftn(a, s=None, axes=None, norm=None)
+irfftn(a, s=None, axes=None, norm=None)
+fft2(a, s=None, axes=(-2,-1), norm=None)
+ifft2(a, s=None, axes=(-2, -1), norm=None)
+rfft2(a, s=None, axes=(-2,-1), norm=None)
+irfft2(a, s=None, axes=(-2, -1), norm=None)
 
 i = inverse transform
 r = transform of purely real data

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -115,7 +115,7 @@ def fft(a, n=None, axis=-1, norm=None):
         used.
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: ?? #TODO
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -227,7 +227,7 @@ def ifft(a, n=None, axis=-1, norm=None):
         axis is used.
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: ?? #TODO
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -310,7 +310,7 @@ def rfft(a, n=None, axis=-1, norm=None):
         used.
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: ?? #TODO
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -410,7 +410,7 @@ def irfft(a, n=None, axis=-1, norm=None):
         axis is used.
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: ?? #TODO
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -500,10 +500,10 @@ def hfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `numpy.fft`). Default is None.
-
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
+        .. versionadded:: 1.20.0
+        Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
     -------
@@ -568,8 +568,12 @@ def hfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = (a.shape[axis] - 1) * 2
-    unitary = _unitary(norm)
-    return irfft(conjugate(a), n, axis) * (sqrt(n) if unitary else n)
+    output = irfft(conjugate(a), n, axis)
+    if _unitary(norm):
+        output *= sqrt(n)
+    elif norm is None:
+        output *= n
+    return output
 
 
 @array_function_dispatch(_fft_dispatcher)
@@ -590,10 +594,10 @@ def ihfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
-        Normalization mode (see `numpy.fft`). Default is None.
-
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
+        .. versionadded:: 1.20.0
+        Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
     -------
@@ -628,9 +632,12 @@ def ihfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    unitary = _unitary(norm)
     output = conjugate(rfft(a, n, axis))
-    return output * (1 / (sqrt(n) if unitary else n))
+    if _unitary(norm):
+        output *= 1./sqrt(n)
+    elif norm is None:
+        output *= n
+    return output
 
 
 def _cook_nd_args(a, s=None, axes=None, invreal=0):
@@ -692,9 +699,9 @@ def fftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the transform over that axis is
         performed multiple times.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -799,9 +806,9 @@ def ifftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -889,9 +896,9 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -988,9 +995,9 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -1069,9 +1076,9 @@ def rfftn(a, s=None, axes=None, norm=None):
     axes : sequence of ints, optional
         Axes over which to compute the FFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -1147,9 +1154,9 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
         Shape of the FFT.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -1207,9 +1214,9 @@ def irfftn(a, s=None, axes=None, norm=None):
         `len(s)` axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -1290,9 +1297,9 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
         Default is the last two axes.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: 1.20.0
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -81,10 +81,10 @@ def _raw_fft(a, n, axis, is_real, is_forward, inv_norm):
 def _unitary(norm):
     if norm == "ortho":
         return True
-    if norm is None or norm == "forward":
+    if norm == "backward" or norm == "forward" or norm is None:
         return False
-    raise ValueError(f"Invalid norm value {norm}; should be None, \"ortho\" or\
-                     \"forward\".")
+    raise ValueError(f"Invalid norm value {norm}; should be \"backward\" (None\
+                     alias), \"ortho\" or \"forward\".")
 
 
 def _fft_dispatcher(a, n=None, axis=None, norm=None):
@@ -112,14 +112,15 @@ def fft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT.  If not given, the last axis is
         used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`).
+        Default is "backward" (alias of None).
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" options were added.
 
     Returns
     -------
@@ -586,7 +587,7 @@ def hfft(a, n=None, axis=-1, norm=None):
     output = irfft(conjugate(a), n, axis)
     if _unitary(norm):
         output *= sqrt(n)
-    elif norm is None:
+    elif norm == "backward" or norm is None:
         output *= n
     return output
 
@@ -654,7 +655,7 @@ def ihfft(a, n=None, axis=-1, norm=None):
     output = conjugate(rfft(a, n, axis))
     if _unitary(norm):
         output *= 1./sqrt(n)
-    elif norm is None:
+    elif norm == "backward" or norm is None:
         output *= 1./n
     return output
 

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -3,20 +3,20 @@ Discrete Fourier Transforms
 
 Routines in this module:
 
-fft(a, n=None, axis=-1, norm=None)
-ifft(a, n=None, axis=-1, norm=None)
-rfft(a, n=None, axis=-1, norm=None)
-irfft(a, n=None, axis=-1, norm=None)
-hfft(a, n=None, axis=-1, norm=None)
-ihfft(a, n=None, axis=-1, norm=None)
-fftn(a, s=None, axes=None, norm=None)
-ifftn(a, s=None, axes=None, norm=None)
-rfftn(a, s=None, axes=None, norm=None)
-irfftn(a, s=None, axes=None, norm=None)
-fft2(a, s=None, axes=(-2,-1), norm=None)
-ifft2(a, s=None, axes=(-2, -1), norm=None)
-rfft2(a, s=None, axes=(-2,-1), norm=None)
-irfft2(a, s=None, axes=(-2, -1), norm=None)
+fft(a, n=None, axis=-1, norm="backward")
+ifft(a, n=None, axis=-1, norm="backward")
+rfft(a, n=None, axis=-1, norm="backward")
+irfft(a, n=None, axis=-1, norm="backward")
+hfft(a, n=None, axis=-1, norm="backward")
+ihfft(a, n=None, axis=-1, norm="backward")
+fftn(a, s=None, axes=None, norm="backward")
+ifftn(a, s=None, axes=None, norm="backward")
+rfftn(a, s=None, axes=None, norm="backward")
+irfftn(a, s=None, axes=None, norm="backward")
+fft2(a, s=None, axes=(-2,-1), norm="backward")
+ifft2(a, s=None, axes=(-2, -1), norm="backward")
+rfft2(a, s=None, axes=(-2,-1), norm="backward")
+irfft2(a, s=None, axes=(-2, -1), norm="backward")
 
 i = inverse transform
 r = transform of purely real data
@@ -85,8 +85,8 @@ def _go_forw(n, norm):
         return sqrt(n)
     elif norm == "forward":
         return n
-    raise ValueError(f"Invalid norm value {norm}; should be \"backward\"\
-                     (None), \"ortho\" or \"forward\".")
+    raise ValueError(f'Invalid norm value {norm}; should be "backward",\
+                     "ortho" or "forward".')
 
 
 def _go_back(n, norm):
@@ -99,8 +99,17 @@ def _go_back(n, norm):
         return sqrt(n)
     elif norm == "forward":
         return 1
-    raise ValueError(f"Invalid norm value {norm}; should be \"backward\"\
-                     (None), \"ortho\" or \"forward\".")
+    raise ValueError(f'Invalid norm value {norm}; should be "backward",\
+                     "ortho" or "forward".')
+
+
+def _swap_direction(norm):
+    try:
+        return {"backward": "forward", None: "forward",
+                "ortho": "ortho", "forward": "backward"}[norm]
+    except KeyError:
+        raise ValueError(f'Invalid norm value {norm}; should be "backward",\
+                         "ortho" or "forward".')
 
 
 def _fft_dispatcher(a, n=None, axis=None, norm=None):
@@ -131,12 +140,11 @@ def fft(a, n=None, axis=-1, norm=None):
     norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`).
-        Default is "backward" (alias of None).
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "backward", "forward" options were added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -239,14 +247,14 @@ def ifft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse DFT.  If not given, the last
         axis is used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -321,14 +329,14 @@ def rfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -421,14 +429,14 @@ def irfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -513,14 +521,14 @@ def hfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -584,8 +592,8 @@ def hfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = (a.shape[axis] - 1) * 2
-    output = irfft(conjugate(a), n, axis)
-    output *= _go_back(n, norm)
+    new_norm = _swap_direction(norm)
+    output = irfft(conjugate(a), n, axis, norm=new_norm)
     return output
 
 
@@ -607,14 +615,14 @@ def ihfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -649,8 +657,8 @@ def ihfft(a, n=None, axis=-1, norm=None):
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
-    output = conjugate(rfft(a, n, axis))
-    output *= 1./_go_back(n, norm)
+    new_norm = _swap_direction(norm)
+    output = conjugate(rfft(a, n, axis, norm=new_norm))
     return output
 
 
@@ -713,14 +721,14 @@ def fftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the transform over that axis is
         performed multiple times.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -823,14 +831,14 @@ def ifftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -916,14 +924,14 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -1017,14 +1025,14 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -1101,14 +1109,14 @@ def rfftn(a, s=None, axes=None, norm=None):
     axes : sequence of ints, optional
         Axes over which to compute the FFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -1183,14 +1191,14 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
         Shape of the FFT.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -1246,14 +1254,14 @@ def irfftn(a, s=None, axes=None, norm=None):
         `len(s)` axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------
@@ -1333,14 +1341,14 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
         Default is the last two axes.
-    norm : {None, "ortho", "forward"}, optional
+    norm : {"backward", "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
 
-        Normalization mode (see `numpy.fft`). Default is None.
+        Normalization mode (see `numpy.fft`). Default is "backward".
 
         .. versionadded:: 1.20.0
 
-            The "forward" option was added.
+            The "backward", "forward" values were added.
 
     Returns
     -------

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -1,5 +1,5 @@
 """
-Discrete Fourier Transforms.
+Discrete Fourier Transforms
 
 Routines in this module:
 
@@ -84,7 +84,7 @@ def _unitary(norm):
     if norm is None or norm == "forward":
         return False
     raise ValueError(f"Invalid norm value {norm}; should be None, \"ortho\" or\
-                    \"forward\".")
+                     \"forward\".")
 
 
 def _fft_dispatcher(a, n=None, axis=None, norm=None):

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -102,11 +102,12 @@ def _go_back(n, norm):
     raise ValueError(f'Invalid norm value {norm}; should be "backward",\
                      "ortho" or "forward".')
 
+_SWAP_DIRECTION_MAP = {"backward": "forward", None: "forward",
+                       "ortho": "ortho", "forward": "backward"}
 
 def _swap_direction(norm):
     try:
-        return {"backward": "forward", None: "forward",
-                "ortho": "ortho", "forward": "backward"}[norm]
+        return _SWAP_DIRECTION_MAP[norm]
     except KeyError:
         raise ValueError(f'Invalid norm value {norm}; should be "backward",\
                          "ortho" or "forward".')

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -52,8 +52,7 @@ def _raw_fft(a, n, axis, is_real, is_forward, inv_norm):
         n = a.shape[axis]
 
     if n < 1:
-        raise ValueError("Invalid number of FFT data points (%d) specified."
-                         % n)
+        raise ValueError(f"Invalid number of FFT data points ({n}) specified.")
 
     fct = 1/inv_norm
 
@@ -82,10 +81,10 @@ def _raw_fft(a, n, axis, is_real, is_forward, inv_norm):
 def _unitary(norm):
     if norm == "ortho":
         return True
-    if norm is None or norm == "inverse":
+    if norm is None or norm == "forward":
         return False
-    raise ValueError("Invalid norm value %s; should be None, \"ortho\" or\
-                    \"inverse\"." % norm)
+    raise ValueError(f"Invalid norm value {norm}; should be None, \"ortho\" or\
+                    \"forward\".")
 
 
 def _fft_dispatcher(a, n=None, axis=None, norm=None):
@@ -113,10 +112,14 @@ def fft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT.  If not given, the last axis is
         used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -175,14 +178,13 @@ def fft(a, n=None, axis=-1, norm=None):
     >>> plt.show()
 
     """
-
     a = asarray(a)
     if n is None:
         n = a.shape[axis]
     inv_norm = 1
     if _unitary(norm):
         inv_norm = sqrt(n)
-    elif norm == "inverse":
+    elif norm == "forward":
         inv_norm = n
     output = _raw_fft(a, n, axis, False, True, inv_norm)
     return output
@@ -224,10 +226,14 @@ def ifft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse DFT.  If not given, the last
         axis is used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -279,7 +285,7 @@ def ifft(a, n=None, axis=-1, norm=None):
     inv_norm = n
     if _unitary(norm):
         inv_norm = sqrt(n)
-    elif norm == "inverse":
+    elif norm == "forward":
         inv_norm = 1
     output = _raw_fft(a, n, axis, False, False, inv_norm)
     return output
@@ -306,10 +312,14 @@ def rfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -370,7 +380,7 @@ def rfft(a, n=None, axis=-1, norm=None):
     inv_norm = 1
     if _unitary(norm):
         inv_norm = sqrt(n)
-    elif norm == "inverse":
+    elif norm == "forward":
         inv_norm = n
     output = _raw_fft(a, n, axis, True, True, inv_norm)
     return output
@@ -406,10 +416,14 @@ def irfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -472,7 +486,7 @@ def irfft(a, n=None, axis=-1, norm=None):
     inv_norm = n
     if _unitary(norm):
         inv_norm = sqrt(n)
-    elif norm == "inverse":
+    elif norm == "forward":
         inv_norm = 1
     output = _raw_fft(a, n, axis, True, False, inv_norm)
     return output
@@ -498,10 +512,14 @@ def hfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -591,10 +609,14 @@ def ihfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -696,10 +718,14 @@ def fftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the transform over that axis is
         performed multiple times.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -764,7 +790,6 @@ def fftn(a, s=None, axes=None, norm=None):
     >>> plt.show()
 
     """
-
     return _raw_fftnd(a, s, axes, fft, norm)
 
 
@@ -803,10 +828,14 @@ def ifftn(a, s=None, axes=None, norm=None):
         axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -862,14 +891,13 @@ def ifftn(a, s=None, axes=None, norm=None):
     >>> plt.show()
 
     """
-
     return _raw_fftnd(a, s, axes, ifft, norm)
 
 
 @array_function_dispatch(_fftn_dispatcher)
 def fft2(a, s=None, axes=(-2, -1), norm=None):
     """
-    Compute the 2-dimensional discrete Fourier Transform
+    Compute the 2-dimensional discrete Fourier Transform.
 
     This function computes the *n*-dimensional discrete Fourier Transform
     over any axes in an *M*-dimensional array by means of the
@@ -893,10 +921,14 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -953,7 +985,6 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
               0.  +0.j        ,   0.  +0.j        ]])
 
     """
-
     return _raw_fftnd(a, s, axes, fft, norm)
 
 
@@ -991,10 +1022,14 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
         axes are used.  A repeated index in `axes` means the transform over
         that axis is performed multiple times.  A one-element sequence means
         that a one-dimensional FFT is performed.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -1041,7 +1076,6 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None):
            [0.+0.j,  1.+0.j,  0.+0.j,  0.+0.j]])
 
     """
-
     return _raw_fftnd(a, s, axes, ifft, norm)
 
 
@@ -1072,10 +1106,14 @@ def rfftn(a, s=None, axes=None, norm=None):
     axes : sequence of ints, optional
         Axes over which to compute the FFT.  If not given, the last ``len(s)``
         axes are used, or all axes if `s` is also not specified.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -1150,10 +1188,14 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
         Shape of the FFT.
     axes : sequence of ints, optional
         Axes over which to compute the FFT.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -1171,7 +1213,6 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None):
     For more details see `rfftn`.
 
     """
-
     return rfftn(a, s, axes, norm)
 
 
@@ -1210,10 +1251,14 @@ def irfftn(a, s=None, axes=None, norm=None):
         `len(s)` axes are used, or all axes if `s` is also not specified.
         Repeated indices in `axes` means that the inverse transform over that
         axis is performed multiple times.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -1293,10 +1338,14 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
     axes : sequence of ints, optional
         The axes over which to compute the inverse fft.
         Default is the last two axes.
-    norm : {None, "ortho", "inverse"}, optional
+    norm : {None, "ortho", "forward"}, optional
         .. versionadded:: 1.10.0
-        .. versionadded:: 1.20.0
+
         Normalization mode (see `numpy.fft`). Default is None.
+
+        .. versionadded:: 1.20.0
+
+            The "forward" option was added.
 
     Returns
     -------
@@ -1313,5 +1362,4 @@ def irfft2(a, s=None, axes=(-2, -1), norm=None):
     For more details see `irfftn`.
 
     """
-
     return irfftn(a, s, axes, norm)

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -116,7 +116,6 @@ def fft(a, n=None, axis=-1, norm=None):
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
         .. versionadded:: ?? #TODO
-
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -229,7 +228,6 @@ def ifft(a, n=None, axis=-1, norm=None):
     norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
         .. versionadded:: ?? #TODO
-
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -310,9 +308,9 @@ def rfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: ?? #TODO
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -369,11 +367,13 @@ def rfft(a, n=None, axis=-1, norm=None):
 
     """
     a = asarray(a)
+    if n is None:
+        n = a.shape[axis]
     inv_norm = 1
-    if norm is not None and _unitary(norm):
-        if n is None:
-            n = a.shape[axis]
+    if _unitary(norm):
         inv_norm = sqrt(n)
+    elif norm == "inverse":
+        inv_norm = n
     output = _raw_fft(a, n, axis, True, True, inv_norm)
     return output
 
@@ -408,9 +408,9 @@ def irfft(a, n=None, axis=-1, norm=None):
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
-    norm : {None, "ortho"}, optional
+    norm : {None, "ortho", "inverse"}, optional
         .. versionadded:: 1.10.0
-
+        .. versionadded:: ?? #TODO
         Normalization mode (see `numpy.fft`). Default is None.
 
     Returns
@@ -472,8 +472,10 @@ def irfft(a, n=None, axis=-1, norm=None):
     if n is None:
         n = (a.shape[axis] - 1) * 2
     inv_norm = n
-    if norm is not None and _unitary(norm):
+    if _unitary(norm):
         inv_norm = sqrt(n)
+    elif norm == "inverse":
+        inv_norm = 1
     output = _raw_fft(a, n, axis, True, False, inv_norm)
     return output
 

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -99,7 +99,7 @@ def _get_backward_norm(n, norm):
         return sqrt(n)
     elif norm == "forward":
         return 1
-    raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+    raise ValueError(f'Invalid norm value {norm}; should be "backward", '
                      '"ortho" or "forward".')
 
 
@@ -111,7 +111,7 @@ def _swap_direction(norm):
     try:
         return _SWAP_DIRECTION_MAP[norm]
     except KeyError:
-        raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+        raise ValueError(f'Invalid norm value {norm}; should be "backward", '
                          '"ortho" or "forward".')
 
 

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -1,5 +1,5 @@
 """
-Discrete Fourier Transforms
+Discrete Fourier Transforms.
 
 Routines in this module:
 
@@ -171,8 +171,7 @@ def fft(a, n=None, axis=-1, norm=None):
     >>> sp = np.fft.fft(np.sin(t))
     >>> freq = np.fft.fftfreq(t.shape[-1])
     >>> plt.plot(freq, sp.real, freq, sp.imag)
-    [<matplotlib.lines.Line2D object at 0x...>, <matplotlib.lines.Line2D object
-                    at 0x...>]
+    [<matplotlib.lines.Line2D object at 0x...>, <matplotlib.lines.Line2D object at 0x...>]
     >>> plt.show()
 
     """
@@ -268,8 +267,7 @@ def ifft(a, n=None, axis=-1, norm=None):
     >>> n[40:60] = np.exp(1j*np.random.uniform(0, 2*np.pi, (20,)))
     >>> s = np.fft.ifft(n)
     >>> plt.plot(t, s.real, 'b-', t, s.imag, 'r--')
-    [<matplotlib.lines.Line2D object at ...>, <matplotlib.lines.Line2D object
-                    at ...>]
+    [<matplotlib.lines.Line2D object at ...>, <matplotlib.lines.Line2D object at ...>]
     >>> plt.legend(('real', 'imaginary'))
     <matplotlib.legend.Legend object at ...>
     >>> plt.show()
@@ -547,8 +545,7 @@ def hfft(a, n=None, axis=-1, norm=None):
     --------
     >>> signal = np.array([1, 2, 3, 4, 3, 2])
     >>> np.fft.fft(signal)
-    array([15.+0.j,  -4.+0.j,   0.+0.j,  -1.-0.j,   0.+0.j,  -4.+0.j]) # may
-                    vary
+    array([15.+0.j,  -4.+0.j,   0.+0.j,  -1.-0.j,   0.+0.j,  -4.+0.j]) # may vary
     >>> np.fft.hfft(signal[:4]) # Input first half of signal
     array([15.,  -4.,   0.,  -1.,   0.,  -4.])
     >>> np.fft.hfft(signal, 6)  # Input entire signal and truncate
@@ -944,8 +941,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None):
     --------
     >>> a = np.mgrid[:5, :5][0]
     >>> np.fft.fft2(a)
-    array([[ 50.  +0.j        ,   0.  +0.j        ,   0.  +0.j        , # may
-                    vary
+    array([[ 50.  +0.j        ,   0.  +0.j        ,   0.  +0.j        , # may vary
               0.  +0.j        ,   0.  +0.j        ],
            [-12.5+17.20477401j,   0.  +0.j        ,   0.  +0.j        ,
               0.  +0.j        ,   0.  +0.j        ],

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -36,12 +36,13 @@ class TestFFT1D:
     def test_fft(self):
         x = random(30) + 1j*random(30)
         assert_allclose(fft1(x), np.fft.fft(x), atol=1e-6)
+        assert_allclose(fft1(x), np.fft.fft(x, norm="backward"), atol=1e-6)
         assert_allclose(fft1(x) / np.sqrt(30),
                         np.fft.fft(x, norm="ortho"), atol=1e-6)
         assert_allclose(fft1(x) / 30.,
                         np.fft.fft(x, norm="forward"), atol=1e-6)
 
-    @pytest.mark.parametrize('norm', (None, 'ortho', 'forward'))
+    @pytest.mark.parametrize('norm', (None, 'backward', 'ortho', 'forward'))
     def test_ifft(self, norm):
         x = random(30) + 1j*random(30)
         assert_allclose(
@@ -56,6 +57,8 @@ class TestFFT1D:
         x = random((30, 20)) + 1j*random((30, 20))
         assert_allclose(np.fft.fft(np.fft.fft(x, axis=1), axis=0),
                         np.fft.fft2(x), atol=1e-6)
+        assert_allclose(np.fft.fft2(x),
+                        np.fft.fft2(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.fft2(x) / np.sqrt(30 * 20),
                         np.fft.fft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.fft2(x) / (30. * 20.),
@@ -65,6 +68,8 @@ class TestFFT1D:
         x = random((30, 20)) + 1j*random((30, 20))
         assert_allclose(np.fft.ifft(np.fft.ifft(x, axis=1), axis=0),
                         np.fft.ifft2(x), atol=1e-6)
+        assert_allclose(np.fft.ifft2(x),
+                        np.fft.ifft2(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.ifft2(x) * np.sqrt(30 * 20),
                         np.fft.ifft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.ifft2(x) * (30. * 20.),
@@ -75,6 +80,8 @@ class TestFFT1D:
         assert_allclose(
             np.fft.fft(np.fft.fft(np.fft.fft(x, axis=2), axis=1), axis=0),
             np.fft.fftn(x), atol=1e-6)
+        assert_allclose(np.fft.fftn(x),
+                        np.fft.fftn(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.fftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.fftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.fftn(x) / (30. * 20. * 10.),
@@ -85,6 +92,8 @@ class TestFFT1D:
         assert_allclose(
             np.fft.ifft(np.fft.ifft(np.fft.ifft(x, axis=2), axis=1), axis=0),
             np.fft.ifftn(x), atol=1e-6)
+        assert_allclose(np.fft.ifftn(x),
+                        np.fft.ifftn(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.ifftn(x) * np.sqrt(30 * 20 * 10),
                         np.fft.ifftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.ifftn(x) * (30. * 20. * 10.),
@@ -93,10 +102,13 @@ class TestFFT1D:
     def test_rfft(self):
         x = random(30)
         for n in [x.size, 2*x.size]:
-            for norm in [None, 'ortho', 'forward']:
+            for norm in [None, 'backward', 'ortho', 'forward']:
                 assert_allclose(
                     np.fft.fft(x, n=n, norm=norm)[:(n//2 + 1)],
                     np.fft.rfft(x, n=n, norm=norm), atol=1e-6)
+            assert_allclose(
+                np.fft.rfft(x, n=n),
+                np.fft.rfft(x, n=n, norm="backward"), atol=1e-6)
             assert_allclose(
                 np.fft.rfft(x, n=n) / np.sqrt(n),
                 np.fft.rfft(x, n=n, norm="ortho"), atol=1e-6)
@@ -107,6 +119,8 @@ class TestFFT1D:
     def test_irfft(self):
         x = random(30)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x)), atol=1e-6)
+        assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="backward"),
+                        norm="backward"), atol=1e-6)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="forward"),
@@ -115,6 +129,8 @@ class TestFFT1D:
     def test_rfft2(self):
         x = random((30, 20))
         assert_allclose(np.fft.fft2(x)[:, :11], np.fft.rfft2(x), atol=1e-6)
+        assert_allclose(np.fft.rfft2(x),
+                        np.fft.rfft2(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.rfft2(x) / np.sqrt(30 * 20),
                         np.fft.rfft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.rfft2(x) / (30. * 20.),
@@ -123,6 +139,8 @@ class TestFFT1D:
     def test_irfft2(self):
         x = random((30, 20))
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x)), atol=1e-6)
+        assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="backward"),
+                        norm="backward"), atol=1e-6)
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="forward"),
@@ -131,6 +149,8 @@ class TestFFT1D:
     def test_rfftn(self):
         x = random((30, 20, 10))
         assert_allclose(np.fft.fftn(x)[:, :, :6], np.fft.rfftn(x), atol=1e-6)
+        assert_allclose(np.fft.rfftn(x),
+                        np.fft.rfftn(x, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.rfftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.rfftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.rfftn(x) / (30. * 20. * 10.),
@@ -139,6 +159,8 @@ class TestFFT1D:
     def test_irfftn(self):
         x = random((30, 20, 10))
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x)), atol=1e-6)
+        assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="backward"),
+                        norm="backward"), atol=1e-6)
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="forward"),
@@ -149,6 +171,8 @@ class TestFFT1D:
         x_herm = np.concatenate((random(1), x, random(1)))
         x = np.concatenate((x_herm, x[::-1].conj()))
         assert_allclose(np.fft.fft(x), np.fft.hfft(x_herm), atol=1e-6)
+        assert_allclose(np.fft.hfft(x_herm),
+                        np.fft.hfft(x_herm, norm="backward"), atol=1e-6)
         assert_allclose(np.fft.hfft(x_herm) / np.sqrt(30),
                         np.fft.hfft(x_herm, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.hfft(x_herm) / 30.,
@@ -159,6 +183,8 @@ class TestFFT1D:
         x_herm = np.concatenate((random(1), x, random(1)))
         x = np.concatenate((x_herm, x[::-1].conj()))
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm)), atol=1e-6)
+        assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
+                        norm="backward"), norm="backward"), atol=1e-6)
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
                         norm="ortho"), norm="ortho"), atol=1e-6)
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
@@ -187,7 +213,7 @@ class TestFFT1D:
                       ]
         for forw, back in func_pairs:
             for n in [x.size, 2*x.size]:
-                for norm in [None, 'ortho', 'forward']:
+                for norm in [None, 'backward', 'ortho', 'forward']:
                     tmp = forw(x, n=n, norm=norm)
                     tmp = back(tmp, n=n, norm=norm)
                     assert_allclose(x_norm,

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -39,9 +39,9 @@ class TestFFT1D:
         assert_allclose(fft1(x) / np.sqrt(30),
                         np.fft.fft(x, norm="ortho"), atol=1e-6)
         assert_allclose(fft1(x) / 30.,
-                        np.fft.fft(x, norm="inverse"), atol=1e-6)
+                        np.fft.fft(x, norm="forward"), atol=1e-6)
 
-    @pytest.mark.parametrize('norm', (None, 'ortho', 'inverse'))
+    @pytest.mark.parametrize('norm', (None, 'ortho', 'forward'))
     def test_ifft(self, norm):
         x = random(30) + 1j*random(30)
         assert_allclose(
@@ -59,7 +59,7 @@ class TestFFT1D:
         assert_allclose(np.fft.fft2(x) / np.sqrt(30 * 20),
                         np.fft.fft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.fft2(x) / (30. * 20.),
-                        np.fft.fft2(x, norm="inverse"), atol=1e-6)
+                        np.fft.fft2(x, norm="forward"), atol=1e-6)
 
     def test_ifft2(self):
         x = random((30, 20)) + 1j*random((30, 20))
@@ -68,7 +68,7 @@ class TestFFT1D:
         assert_allclose(np.fft.ifft2(x) * np.sqrt(30 * 20),
                         np.fft.ifft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.ifft2(x) * (30. * 20.),
-                        np.fft.ifft2(x, norm="inverse"), atol=1e-6)
+                        np.fft.ifft2(x, norm="forward"), atol=1e-6)
 
     def test_fftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
@@ -78,7 +78,7 @@ class TestFFT1D:
         assert_allclose(np.fft.fftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.fftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.fftn(x) / (30. * 20. * 10.),
-                        np.fft.fftn(x, norm="inverse"), atol=1e-6)
+                        np.fft.fftn(x, norm="forward"), atol=1e-6)
 
     def test_ifftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
@@ -88,12 +88,12 @@ class TestFFT1D:
         assert_allclose(np.fft.ifftn(x) * np.sqrt(30 * 20 * 10),
                         np.fft.ifftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.ifftn(x) * (30. * 20. * 10.),
-                        np.fft.ifftn(x, norm="inverse"), atol=1e-6)
+                        np.fft.ifftn(x, norm="forward"), atol=1e-6)
 
     def test_rfft(self):
         x = random(30)
         for n in [x.size, 2*x.size]:
-            for norm in [None, 'ortho', 'inverse']:
+            for norm in [None, 'ortho', 'forward']:
                 assert_allclose(
                     np.fft.fft(x, n=n, norm=norm)[:(n//2 + 1)],
                     np.fft.rfft(x, n=n, norm=norm), atol=1e-6)
@@ -102,15 +102,15 @@ class TestFFT1D:
                 np.fft.rfft(x, n=n, norm="ortho"), atol=1e-6)
             assert_allclose(
                 np.fft.rfft(x, n=n) / n,
-                np.fft.rfft(x, n=n, norm="inverse"), atol=1e-6)
+                np.fft.rfft(x, n=n, norm="forward"), atol=1e-6)
 
     def test_irfft(self):
         x = random(30)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x)), atol=1e-6)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
-        assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="inverse"),
-                        norm="inverse"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="forward"),
+                        norm="forward"), atol=1e-6)
 
     def test_rfft2(self):
         x = random((30, 20))
@@ -118,15 +118,15 @@ class TestFFT1D:
         assert_allclose(np.fft.rfft2(x) / np.sqrt(30 * 20),
                         np.fft.rfft2(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.rfft2(x) / (30. * 20.),
-                        np.fft.rfft2(x, norm="inverse"), atol=1e-6)
+                        np.fft.rfft2(x, norm="forward"), atol=1e-6)
 
     def test_irfft2(self):
         x = random((30, 20))
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x)), atol=1e-6)
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
-        assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="inverse"),
-                        norm="inverse"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="forward"),
+                        norm="forward"), atol=1e-6)
 
     def test_rfftn(self):
         x = random((30, 20, 10))
@@ -134,15 +134,15 @@ class TestFFT1D:
         assert_allclose(np.fft.rfftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.rfftn(x, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.rfftn(x) / (30. * 20. * 10.),
-                        np.fft.rfftn(x, norm="inverse"), atol=1e-6)
+                        np.fft.rfftn(x, norm="forward"), atol=1e-6)
 
     def test_irfftn(self):
         x = random((30, 20, 10))
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x)), atol=1e-6)
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="ortho"),
                         norm="ortho"), atol=1e-6)
-        assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="inverse"),
-                        norm="inverse"), atol=1e-6)
+        assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="forward"),
+                        norm="forward"), atol=1e-6)
 
     def test_hfft(self):
         x = random(14) + 1j*random(14)
@@ -152,7 +152,7 @@ class TestFFT1D:
         assert_allclose(np.fft.hfft(x_herm) / np.sqrt(30),
                         np.fft.hfft(x_herm, norm="ortho"), atol=1e-6)
         assert_allclose(np.fft.hfft(x_herm) / 30.,
-                        np.fft.hfft(x_herm, norm="inverse"), atol=1e-6)
+                        np.fft.hfft(x_herm, norm="forward"), atol=1e-6)
 
     def test_ihfft(self):
         x = random(14) + 1j*random(14)
@@ -162,7 +162,7 @@ class TestFFT1D:
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
                         norm="ortho"), norm="ortho"), atol=1e-6)
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
-                        norm="inverse"), norm="inverse"), atol=1e-6)
+                        norm="forward"), norm="forward"), atol=1e-6)
 
     @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
                                     np.fft.rfftn, np.fft.irfftn])
@@ -188,7 +188,7 @@ class TestFFT1D:
                       ]
         for forw, back in func_pairs:
             for n in [x.size, 2*x.size]:
-                for norm in [None, 'ortho', 'inverse']:
+                for norm in [None, 'ortho', 'forward']:
                     tmp = forw(x, n=n, norm=norm)
                     tmp = back(tmp, n=n, norm=norm)
                     assert_allclose(x_norm,

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -168,8 +168,7 @@ class TestFFT1D:
                                     np.fft.rfftn, np.fft.irfftn])
     def test_axes(self, op):
         x = random((30, 20, 10))
-        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1),
-                (2, 1, 0)]
+        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
         for a in axes:
             op_tr = op(np.transpose(x, a))
             tr_op = np.transpose(op(x, axes=a), a)
@@ -263,7 +262,7 @@ class TestFFTThreadSafe:
         # Make sure all threads returned the correct value
         for i in range(self.threads):
             assert_array_equal(q.get(timeout=5), expected,
-                    'Function returned wrong value in multithreade context')
+                'Function returned wrong value in multithreaded context')
 
     def test_fft(self):
         a = np.ones(self.input_shape) * 1+0j

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -27,10 +27,10 @@ class TestFFT1D:
         maxlen = 512
         x = random(maxlen) + 1j*random(maxlen)
         xr = random(maxlen)
-        for i in range(1,maxlen):
+        for i in range(1, maxlen):
             assert_allclose(np.fft.ifft(np.fft.fft(x[0:i])), x[0:i],
                             atol=1e-12)
-            assert_allclose(np.fft.irfft(np.fft.rfft(xr[0:i]),i),
+            assert_allclose(np.fft.irfft(np.fft.rfft(xr[0:i]), i),
                             xr[0:i], atol=1e-12)
 
     def test_fft(self):
@@ -38,6 +38,8 @@ class TestFFT1D:
         assert_allclose(fft1(x), np.fft.fft(x), atol=1e-6)
         assert_allclose(fft1(x) / np.sqrt(30),
                         np.fft.fft(x, norm="ortho"), atol=1e-6)
+        assert_allclose(fft1(x) / 30.,
+                        np.fft.fft(x, norm="inverse"), atol=1e-6)
 
     @pytest.mark.parametrize('norm', (None, 'ortho', 'inverse'))
     def test_ifft(self, norm):
@@ -56,6 +58,8 @@ class TestFFT1D:
                         np.fft.fft2(x), atol=1e-6)
         assert_allclose(np.fft.fft2(x) / np.sqrt(30 * 20),
                         np.fft.fft2(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.fft2(x) / (30. * 20.),
+                        np.fft.fft2(x, norm="inverse"), atol=1e-6)
 
     def test_ifft2(self):
         x = random((30, 20)) + 1j*random((30, 20))
@@ -63,6 +67,8 @@ class TestFFT1D:
                         np.fft.ifft2(x), atol=1e-6)
         assert_allclose(np.fft.ifft2(x) * np.sqrt(30 * 20),
                         np.fft.ifft2(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.ifft2(x) * (30. * 20.),
+                        np.fft.ifft2(x, norm="inverse"), atol=1e-6)
 
     def test_fftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
@@ -71,6 +77,8 @@ class TestFFT1D:
             np.fft.fftn(x), atol=1e-6)
         assert_allclose(np.fft.fftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.fftn(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.fftn(x) / (30. * 20. * 10.),
+                        np.fft.fftn(x, norm="inverse"), atol=1e-6)
 
     def test_ifftn(self):
         x = random((30, 20, 10)) + 1j*random((30, 20, 10))
@@ -79,6 +87,8 @@ class TestFFT1D:
             np.fft.ifftn(x), atol=1e-6)
         assert_allclose(np.fft.ifftn(x) * np.sqrt(30 * 20 * 10),
                         np.fft.ifftn(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.ifftn(x) * (30. * 20. * 10.),
+                        np.fft.ifftn(x, norm="inverse"), atol=1e-6)
 
     def test_rfft(self):
         x = random(30)
@@ -90,36 +100,49 @@ class TestFFT1D:
             assert_allclose(
                 np.fft.rfft(x, n=n) / np.sqrt(n),
                 np.fft.rfft(x, n=n, norm="ortho"), atol=1e-6)
+            assert_allclose(
+                np.fft.rfft(x, n=n) / n,
+                np.fft.rfft(x, n=n, norm="inverse"), atol=1e-6)
 
     def test_irfft(self):
         x = random(30)
         assert_allclose(x, np.fft.irfft(np.fft.rfft(x)), atol=1e-6)
-        assert_allclose(
-            x, np.fft.irfft(np.fft.rfft(x, norm="ortho"), norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="ortho"),
+                        norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft(np.fft.rfft(x, norm="inverse"),
+                        norm="inverse"), atol=1e-6)
 
     def test_rfft2(self):
         x = random((30, 20))
         assert_allclose(np.fft.fft2(x)[:, :11], np.fft.rfft2(x), atol=1e-6)
         assert_allclose(np.fft.rfft2(x) / np.sqrt(30 * 20),
                         np.fft.rfft2(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.rfft2(x) / (30. * 20.),
+                        np.fft.rfft2(x, norm="inverse"), atol=1e-6)
 
     def test_irfft2(self):
         x = random((30, 20))
         assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x)), atol=1e-6)
-        assert_allclose(
-            x, np.fft.irfft2(np.fft.rfft2(x, norm="ortho"), norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="ortho"),
+                        norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfft2(np.fft.rfft2(x, norm="inverse"),
+                        norm="inverse"), atol=1e-6)
 
     def test_rfftn(self):
         x = random((30, 20, 10))
         assert_allclose(np.fft.fftn(x)[:, :, :6], np.fft.rfftn(x), atol=1e-6)
         assert_allclose(np.fft.rfftn(x) / np.sqrt(30 * 20 * 10),
                         np.fft.rfftn(x, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.rfftn(x) / (30. * 20. * 10.),
+                        np.fft.rfftn(x, norm="inverse"), atol=1e-6)
 
     def test_irfftn(self):
         x = random((30, 20, 10))
         assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x)), atol=1e-6)
-        assert_allclose(
-            x, np.fft.irfftn(np.fft.rfftn(x, norm="ortho"), norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="ortho"),
+                        norm="ortho"), atol=1e-6)
+        assert_allclose(x, np.fft.irfftn(np.fft.rfftn(x, norm="inverse"),
+                        norm="inverse"), atol=1e-6)
 
     def test_hfft(self):
         x = random(14) + 1j*random(14)
@@ -128,21 +151,25 @@ class TestFFT1D:
         assert_allclose(np.fft.fft(x), np.fft.hfft(x_herm), atol=1e-6)
         assert_allclose(np.fft.hfft(x_herm) / np.sqrt(30),
                         np.fft.hfft(x_herm, norm="ortho"), atol=1e-6)
+        assert_allclose(np.fft.hfft(x_herm) / 30.,
+                        np.fft.hfft(x_herm, norm="inverse"), atol=1e-6)
 
-    def test_ihttf(self):
+    def test_ihfft(self):
         x = random(14) + 1j*random(14)
         x_herm = np.concatenate((random(1), x, random(1)))
         x = np.concatenate((x_herm, x[::-1].conj()))
         assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm)), atol=1e-6)
-        assert_allclose(
-            x_herm, np.fft.ihfft(np.fft.hfft(x_herm, norm="ortho"),
-                                 norm="ortho"), atol=1e-6)
+        assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
+                        norm="ortho"), norm="ortho"), atol=1e-6)
+        assert_allclose(x_herm, np.fft.ihfft(np.fft.hfft(x_herm,
+                        norm="inverse"), norm="inverse"), atol=1e-6)
 
     @pytest.mark.parametrize("op", [np.fft.fftn, np.fft.ifftn,
                                     np.fft.rfftn, np.fft.irfftn])
     def test_axes(self, op):
         x = random((30, 20, 10))
-        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
+        axes = [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1),
+                (2, 1, 0)]
         for a in axes:
             op_tr = op(np.transpose(x, a))
             tr_op = np.transpose(op(x, axes=a), a)
@@ -235,8 +262,8 @@ class TestFFTThreadSafe:
         [x.join() for x in t]
         # Make sure all threads returned the correct value
         for i in range(self.threads):
-            assert_array_equal(q.get(timeout=5), expected,
-                'Function returned wrong value in multithreaded context')
+            assert_array_equal(q.get(timeout=5), expected, 'Function returned\
+                            wrong value in multithreade context')
 
     def test_fft(self):
         a = np.ones(self.input_shape) * 1+0j

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -39,7 +39,7 @@ class TestFFT1D:
         assert_allclose(fft1(x) / np.sqrt(30),
                         np.fft.fft(x, norm="ortho"), atol=1e-6)
 
-    @pytest.mark.parametrize('norm', (None, 'ortho'))
+    @pytest.mark.parametrize('norm', (None, 'ortho', 'inverse'))
     def test_ifft(self, norm):
         x = random(30) + 1j*random(30)
         assert_allclose(
@@ -83,7 +83,7 @@ class TestFFT1D:
     def test_rfft(self):
         x = random(30)
         for n in [x.size, 2*x.size]:
-            for norm in [None, 'ortho']:
+            for norm in [None, 'ortho', 'inverse']:
                 assert_allclose(
                     np.fft.fft(x, n=n, norm=norm)[:(n//2 + 1)],
                     np.fft.rfft(x, n=n, norm=norm), atol=1e-6)
@@ -161,7 +161,7 @@ class TestFFT1D:
                       ]
         for forw, back in func_pairs:
             for n in [x.size, 2*x.size]:
-                for norm in [None, 'ortho']:
+                for norm in [None, 'ortho', 'inverse']:
                     tmp = forw(x, n=n, norm=norm)
                     tmp = back(tmp, n=n, norm=norm)
                     assert_allclose(x_norm,

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -262,8 +262,8 @@ class TestFFTThreadSafe:
         [x.join() for x in t]
         # Make sure all threads returned the correct value
         for i in range(self.threads):
-            assert_array_equal(q.get(timeout=5), expected, 'Function returned\
-                            wrong value in multithreade context')
+            assert_array_equal(q.get(timeout=5), expected,
+                    'Function returned wrong value in multithreade context')
 
     def test_fft(self):
         a = np.ones(self.input_shape) * 1+0j


### PR DESCRIPTION
ENH: add new kwarg value `norm=inverse` to numpy.fft

The kwarg option `norm=inverse` leads to scaling of the transforms
inverse (opposite) to that of the default option `norm=None`; i.e. the
forward transform is normalized with `1/n` whereas the backward one
with `1`. The fft routines and their tests have been modified to
reflect the changes; all tests have been passed successfully.

Closes #16126

cc @leofang @anirudh2290 @charris @mattvend