### PR TITLE
ENH: add optional argument `dtype` to numpy.fft.fftfreq (#9126)

### DIFF
--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -3,7 +3,8 @@ Discrete Fourier Transforms - helper.py
 
 """
 from numpy.compat import integer_types
-from numpy.core import integer, empty, arange, asarray, roll
+from numpy.core import (integer, empty, arange, asarray, roll, reciprocal,
+                        float32, float64)
 from numpy.core.overrides import array_function_dispatch, set_module
 
 # Created by Pearu Peterson, September 2002
@@ -122,7 +123,7 @@ def ifftshift(x, axes=None):
 
 
 @set_module('numpy.fft')
-def fftfreq(n, d=1.0):
+def fftfreq(n, d=1.0, dtype=float64):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -140,7 +141,10 @@ def fftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing (inverse of the sampling rate). Defaults to 1.
+        Sample spacing (inverse of the sampling rate). Defaults to 1.0.
+    dtype : object, optional
+        Output data type; either float32 or float64
+        Defaults to float64.
 
     Returns
     -------
@@ -160,18 +164,22 @@ def fftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    val = 1.0 / (n * d)
+    if dtype != float32:
+        dtype = float64
+
+    val = reciprocal(n*d, dtype=dtype)
     results = empty(n, int)
     N = (n-1)//2 + 1
     p1 = arange(0, N, dtype=int)
     results[:N] = p1
     p2 = arange(-(n//2), 0, dtype=int)
     results[N:] = p2
+
     return results * val
 
 
 @set_module('numpy.fft')
-def rfftfreq(n, d=1.0):
+def rfftfreq(n, d=1.0, dtype=float64):
     """
     Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).
@@ -193,7 +201,10 @@ def rfftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing (inverse of the sampling rate). Defaults to 1.
+        Sample spacing (inverse of the sampling rate). Defaults to 1.0.
+    dtype : object, optional
+        Output data type; either float32 or float64
+        Defaults to float64.
 
     Returns
     -------
@@ -216,7 +227,11 @@ def rfftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    val = 1.0/(n*d)
+    if dtype != float32:
+        dtype = float64
+
+    val = reciprocal(n*d, dtype=dtype)
     N = n//2 + 1
     results = arange(0, N, dtype=int)
+
     return results * val

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -3,7 +3,7 @@ Discrete Fourier Transforms - helper.py
 
 """
 from numpy.compat import integer_types
-from numpy.core import integer, empty, arange, asarray, roll
+from numpy.core import integer, empty, arange, asarray, roll, reciprocal
 from numpy.core.overrides import array_function_dispatch, set_module
 
 # Created by Pearu Peterson, September 2002
@@ -122,7 +122,7 @@ def ifftshift(x, axes=None):
 
 
 @set_module('numpy.fft')
-def fftfreq(n, d=1.0):
+def fftfreq(n, d=1.0, dtype=float64):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -140,7 +140,9 @@ def fftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing (inverse of the sampling rate). Defaults to 1.
+        Sample spacing (inverse of the sampling rate). Defaults to 1.0.
+    dtype : object, optional
+        Output data type; defaults to float64.
 
     Returns
     -------
@@ -160,18 +162,22 @@ def fftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    val = 1.0 / (n * d)
+    if not isinstance(dtype, float):
+        raise ValueError("dtype should be a float type")
+
+    val = reciprocal(n*d, dtype=dtype)
     results = empty(n, int)
     N = (n-1)//2 + 1
     p1 = arange(0, N, dtype=int)
     results[:N] = p1
     p2 = arange(-(n//2), 0, dtype=int)
     results[N:] = p2
+
     return results * val
 
 
 @set_module('numpy.fft')
-def rfftfreq(n, d=1.0):
+def rfftfreq(n, d=1.0, dtype=float64):
     """
     Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).
@@ -193,7 +199,9 @@ def rfftfreq(n, d=1.0):
     n : int
         Window length.
     d : scalar, optional
-        Sample spacing (inverse of the sampling rate). Defaults to 1.
+        Sample spacing (inverse of the sampling rate). Defaults to 1.0.
+    dtype : object, optional
+        Output data type; defaults to float64.
 
     Returns
     -------
@@ -216,7 +224,11 @@ def rfftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    val = 1.0/(n*d)
+    if not isinstance(dtype, float):
+        raise ValueError("dtype should be a float type")
+
+    val = reciprocal(n*d, dtype=dtype)
     N = n//2 + 1
     results = arange(0, N, dtype=int)
+
     return results * val


### PR DESCRIPTION
Deals with issue #9126 requesting the addition of dtype argument option for `fftfreq` and `rfftfreq` functions. To do so, I added an optional argument and used the `reciprocal` function to set the type of the array that will return the result. 

A different way to do so would be to leave the calculation as is and instead modify the return line so that it reads `return asarray(results*val, dtype=dtype)`; I think the two ways should be equivalent in terms of the end result, but I was hoping for some feedback. 

I've submitted a PR draft since I'm not entirely sure how to do the check that the required `dtype` is one of the numpy float dtypes; I'm using the `isinstance` function to check, but I'm not sure what would be the proper types to check against and where to import those from. Any additional comments are of course welcome! 

EDIT: I'm now allowing the output array type to be either float32 or float64, with float64 being the default behavior (as before). Let me know what you think; I'm changing the PR from draft to open. 

cc @jakirkham @mhvk @eric-wieser @leofang @charris 

Closes #9126