### PR TITLE
DOC: Point Contributing page to new NEP 45

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -40,16 +40,17 @@ Release Scripts
 
 Supported platforms and versions
 ================================
-`NEP 29`_ outlines which Python versions are supported; For the first half of
-2020, this will be Python >= 3.6. We test NumPy against all these versions
-every time we merge code to master.  Binary installers may be available for a
-subset of these versions (see below).
+:doc:`NEP 29<neps:nep-0029-deprecation_policy>` outlines which Python versions
+are supported; For the first half of 2020, this will be Python >= 3.6. We test
+NumPy against all these versions every time we merge code to master.  Binary
+installers may be available for a subset of these versions (see below).
 
 OS X
 ----
-OS X versions >= 10.9 are supported, for Python version support see `NEP 29`_.
-We build binary wheels for OSX that are compatible with Python.org Python,
-system Python, homebrew and macports - see this `OSX wheel building summary
+OS X versions >= 10.9 are supported, for Python version support see
+:doc:`NEP 29<neps:nep-0029-deprecation_policy>`. We build binary wheels for
+OSX that are compatible with Python.org Python, system Python, homebrew and
+macports - see this `OSX wheel building summary
 <https://github.com/MacPython/wiki/wiki/Spinning-wheels>`_ for details.
 
 
@@ -95,7 +96,6 @@ You will need Cython for building the binaries.  Cython compiles the ``.pyx``
 files in the NumPy distribution to ``.c`` files.
 
 .. _mingw-w64 toolchain : https://mingwpy.github.io
-.. _NEP 29 : https://numpy.org/neps/nep-0029-deprecation_policy.html
 
 OpenBLAS
 ------------

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -40,7 +40,7 @@ Release Scripts
 
 Supported platforms and versions
 ================================
-:doc:`NEP 29<neps:nep-0029-deprecation_policy>` outlines which Python versions
+:ref:`NEP 29 <NEP29>` outlines which Python versions
 are supported; For the first half of 2020, this will be Python >= 3.6. We test
 NumPy against all these versions every time we merge code to master.  Binary
 installers may be available for a subset of these versions (see below).
@@ -48,7 +48,7 @@ installers may be available for a subset of these versions (see below).
 OS X
 ----
 OS X versions >= 10.9 are supported, for Python version support see
-:doc:`NEP 29<neps:nep-0029-deprecation_policy>`. We build binary wheels for
+:ref:`NEP 29 <NEP29>`. We build binary wheels for
 OSX that are compatible with Python.org Python, system Python, homebrew and
 macports - see this `OSX wheel building summary
 <https://github.com/MacPython/wiki/wiki/Spinning-wheels>`_ for details.

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -1,4 +1,4 @@
-.. _NEP0029:
+.. _NEP29:
 
 ==================================================================================
 NEP 29 — Recommend Python and Numpy version support as a community policy standard

--- a/doc/neps/nep-0045-c_style_guide.rst
+++ b/doc/neps/nep-0045-c_style_guide.rst
@@ -1,3 +1,5 @@
+.. _NEP45:
+
 =================================
 NEP 45 — C Style Guide
 =================================
@@ -244,7 +246,7 @@ C functions, see the files in ``doc/cdoc/``.
 Related Work
 ------------
 
-Based on Van Rossum and Warsaw, :pep:`7`_
+Based on Van Rossum and Warsaw, :pep:`7`
 
 
 Discussion

--- a/doc/neps/nep-0045-c_style_guide.rst
+++ b/doc/neps/nep-0045-c_style_guide.rst
@@ -244,7 +244,7 @@ C functions, see the files in ``doc/cdoc/``.
 Related Work
 ------------
 
-Based on Van Rossum and Warsaw, `PEP 7 -- Style Guide for C Code <https://www.python.org/dev/peps/pep-0007>`_
+Based on Van Rossum and Warsaw, :pep:`7`_
 
 
 Discussion

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,11 +240,12 @@ texinfo_documents = [
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
+    'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/dev', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
-    'skimage': ('https://scikit-image.org/docs/stable', None)
+    'skimage': ('https://scikit-image.org/docs/stable', None),
 }
 
 

--- a/doc/source/dev/howto-docs.rst
+++ b/doc/source/dev/howto-docs.rst
@@ -36,8 +36,7 @@ Current vision for the documentation: NEP 44
 
 Recently, the NumPy community approved a *NumPy Enhancement Proposal (NEP)*
 about documentation,
-:doc:`NEP 44 - Restructuring the NumPy Documentation
-     <neps:nep-0044-restructuring-numpy-docs>`.
+:ref:`NEP 44 - Restructuring the NumPy Documentation <NEP44>`.
 
 **Where is the documentation?**
 

--- a/doc/source/dev/howto-docs.rst
+++ b/doc/source/dev/howto-docs.rst
@@ -35,8 +35,9 @@ Current vision for the documentation: NEP 44
 --------------------------------------------
 
 Recently, the NumPy community approved a *NumPy Enhancement Proposal (NEP)*
-about documentation, `NEP 44 - Restructuring the NumPy Documentation
-<https://www.numpy.org/neps/nep-0044-restructuring-numpy-docs>`__.
+about documentation,
+:doc:`NEP 44 - Restructuring the NumPy Documentation
+     <neps:nep-0044-restructuring-numpy-docs>`.
 
 **Where is the documentation?**
 
@@ -87,7 +88,7 @@ check out the following specific guides:
 Major additions to the documentation (e.g. new tutorials) should be proposed to
 the `mailing list
 <https://mail.python.org/mailman/listinfo/numpy-discussion>`__.
-  
+
 Other ways to contribute
 ------------------------
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -189,7 +189,7 @@ Stylistic Guidelines
 
    import numpy as np
 
-* For C code, see the :ref:`numpy-c-style-guide<style_guide>`
+* For C code, see `NEP 45 <https://numpy.org/neps/nep-0045-c_style_guide.html>`_.
 
 
 Test coverage
@@ -256,7 +256,7 @@ From the ``doc/`` directory:
     git submodule update --init
 
 The documentation includes mathematical formulae with LaTeX formatting.
-A working LaTeX document production system 
+A working LaTeX document production system
 (e.g. `texlive <https://www.tug.org/texlive/>`__) is required for the
 proper rendering of the LaTeX math in the documentation.
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -140,8 +140,7 @@ Here's the short summary, complete TOC links are below:
 
    If your change introduces a deprecation, make sure to discuss this first on
    GitHub or the mailing list first. If agreement on the deprecation is
-   reached, follow `NEP 23 deprecation policy <http://www.numpy.org/neps/
-   nep-0023-backwards-compatibility.html>`_  to add the deprecation.
+   reached, follow :ref:`NEP 23 deprecation policy <NEP23>`  to add the deprecation.
 
 6. Cross referencing issues
 
@@ -189,7 +188,7 @@ Stylistic Guidelines
 
    import numpy as np
 
-* For C code, see `NEP 45 <https://numpy.org/neps/nep-0045-c_style_guide.html>`_.
+* For C code, see :ref:`NEP 45 <NEP45>`.
 
 
 Test coverage

--- a/numpy/doc/dispatch.py
+++ b/numpy/doc/dispatch.py
@@ -267,5 +267,5 @@ Refer to the `dask source code <https://github.com/dask/dask>`_ and
 `cupy source code <https://github.com/cupy/cupy>`_  for more fully-worked
 examples of custom array containers.
 
-See also `NEP 18 <http://www.numpy.org/neps/nep-0018-array-function-protocol.html>`_.
+See also :doc:`NEP 18<neps:nep-0018-array-function-protocol>`.
 """

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -156,8 +156,8 @@ names.
 Notes
 -----
 The ``.npy`` format, including motivation for creating it and a comparison of
-alternatives, is described in the `"npy-format" NEP
-<https://www.numpy.org/neps/nep-0001-npy-format.html>`_, however details have
+alternatives, is described in the
+:doc:`"npy-format" NEP <neps:nep-0001-npy-format>`, however details have
 evolved with time and this document is more current.
 
 """


### PR DESCRIPTION
Moved the link for C style in the "Contributing to NumPy" page to NEP 45.

In NEP 45, replaced explicit link to PEP 7 with a :pep: link.

Fixes problem raised in https://github.com/numpy/numpy/pull/16430#issuecomment-638789051.

The new link points to the NEP's URL. Since NEPs are built separately from the rest of the docs, I wasn't sure an intersphinx link would work. I searched the docs for markup like `:nep:` or `:ref:.*nep` or `:doc:.*nep` but found nothing.
