### PR TITLE
MAINT: make Py_SET_SIZE and Py_SET_TYPE macros a bit safer

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -62,9 +62,9 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 
 #if PY_VERSION_HEX < 0x030900a4
     /* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
-    #define Py_SET_TYPE(obj, type) do { Py_TYPE(obj) = (type); } while (0)
+    #define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
     /* Introduced in https://github.com/python/cpython/commit/b10dc3e7a11fcdb97e285882eba6da92594f90f9 */
-    #define Py_SET_SIZE(obj, size) do { Py_SIZE(obj) = (size); } while (0)
+    #define Py_SET_SIZE(obj, size) ((Py_SIZE(obj) = (size)), (void)0)
 #endif
 
 

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -62,9 +62,9 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
 
 #if PY_VERSION_HEX < 0x030900a4
     /* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
-    #define Py_SET_TYPE(obj, typ) (Py_TYPE(obj) = typ)
+    #define Py_SET_TYPE(obj, type) do { Py_TYPE(obj) = (type); } while (0)
     /* Introduced in https://github.com/python/cpython/commit/b10dc3e7a11fcdb97e285882eba6da92594f90f9 */
-    #define Py_SET_SIZE(obj, size) (Py_SIZE(obj) = size)
+    #define Py_SET_SIZE(obj, size) do { Py_SIZE(obj) = (size); } while (0)
 #endif
 
 


### PR DESCRIPTION
This is the spelling of the compatibility macro that CPython is
recommending.

See https://github.com/python/cpython/pull/20610

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
