### PR TITLE
DOC: Add neps to intersphinx mapping.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,11 +240,12 @@ texinfo_documents = [
 # Intersphinx configuration
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
+    'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/dev', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
-    'skimage': ('https://scikit-image.org/docs/stable', None)
+    'skimage': ('https://scikit-image.org/docs/stable', None),
 }
 
 


### PR DESCRIPTION
Adds the NEPs to the intersphinx mapping, allowing cross-references to the NEPs from the NumPy documentation proper.

See #16472 for motivation.
