### PR TITLE
DOC: only single-polynomial fitting in np.polynomial.Polynomial.fit()

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -920,7 +920,7 @@ class ABCPolyBase(abc.ABC):
         x : array_like, shape (M,)
             x-coordinates of the M sample points ``(x[i], y[i])``.
         y : array_like, shape (M,)
-            y-coordinates of the sample points.
+            y-coordinates of the sample points ``(x[i], y[i])``.
         deg : int or 1-D array_like
             Degree(s) of the fitting polynomials. If `deg` is a single integer
             all terms up to and including the `deg`'th term are included in the

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -920,7 +920,7 @@ class ABCPolyBase(abc.ABC):
         x : array_like, shape (M,)
             x-coordinates of the M sample points ``(x[i], y[i])``.
         y : array_like, shape (M,)
-            y-coordinates of the sample points ``(x[i], y[i])``.
+            y-coordinates of the M sample points ``(x[i], y[i])``.
         deg : int or 1-D array_like
             Degree(s) of the fitting polynomials. If `deg` is a single integer
             all terms up to and including the `deg`'th term are included in the

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -919,10 +919,8 @@ class ABCPolyBase(abc.ABC):
         ----------
         x : array_like, shape (M,)
             x-coordinates of the M sample points ``(x[i], y[i])``.
-        y : array_like, shape (M,) or (M, K)
-            y-coordinates of the sample points. Several data sets of sample
-            points sharing the same x-coordinates can be fitted at once by
-            passing in a 2D-array that contains one dataset per column.
+        y : array_like, shape (M,)
+            y-coordinates of the sample points.
         deg : int or 1-D array_like
             Degree(s) of the fitting polynomials. If `deg` is a single integer
             all terms up to and including the `deg`'th term are included in the


### PR DESCRIPTION
A fix of the documentation in `np.polynomial.Polynomial.fit()`, Issue #16380.

The discussion in this issue reached a conclusion not to implement the solution proposed in PR #16403, hence the documentation fix as a short-term solution instead.

Also mentioned in Issue #4554 
