### PR TITLE
STY: f2py: replace \t by whitespace for readability

### DIFF
--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -39,108 +39,108 @@ int #name#_nofargs = 0;
 jmp_buf #name#_jmpbuf;
 /*typedef #rctype#(*#name#_typedef)(#optargs_td##args_td##strarglens_td##noargs#);*/
 #static# #rctype# #callbackname# (#optargs##args##strarglens##noargs#) {
-\tPyTupleObject *capi_arglist = #name#_args_capi;
-\tPyObject *capi_return = NULL;
-\tPyObject *capi_tmp = NULL;
-\tPyObject *capi_arglist_list = NULL;
-\tint capi_j,capi_i = 0;
-\tint capi_longjmp_ok = 1;
+    PyTupleObject *capi_arglist = #name#_args_capi;
+    PyObject *capi_return = NULL;
+    PyObject *capi_tmp = NULL;
+    PyObject *capi_arglist_list = NULL;
+    int capi_j,capi_i = 0;
+    int capi_longjmp_ok = 1;
 #decl#
 #ifdef F2PY_REPORT_ATEXIT
 f2py_cb_start_clock();
 #endif
-\tCFUNCSMESS(\"cb:Call-back function #name# (maxnofargs=#maxnofargs#(-#nofoptargs#))\\n\");
-\tCFUNCSMESSPY(\"cb:#name#_capi=\",#name#_capi);
-\tif (#name#_capi==NULL) {
-\t\tcapi_longjmp_ok = 0;
-\t\t#name#_capi = PyObject_GetAttrString(#modulename#_module,\"#argname#\");
-\t}
-\tif (#name#_capi==NULL) {
-\t\tPyErr_SetString(#modulename#_error,\"cb: Callback #argname# not defined (as an argument or module #modulename# attribute).\\n\");
-\t\tgoto capi_fail;
-\t}
-\tif (F2PyCapsule_Check(#name#_capi)) {
-\t#name#_typedef #name#_cptr;
-\t#name#_cptr = F2PyCapsule_AsVoidPtr(#name#_capi);
-\t#returncptr#(*#name#_cptr)(#optargs_nm##args_nm##strarglens_nm#);
-\t#return#
-\t}
-\tif (capi_arglist==NULL) {
-\t\tcapi_longjmp_ok = 0;
-\t\tcapi_tmp = PyObject_GetAttrString(#modulename#_module,\"#argname#_extra_args\");
-\t\tif (capi_tmp) {
-\t\t\tcapi_arglist = (PyTupleObject *)PySequence_Tuple(capi_tmp);
-\t\t\tif (capi_arglist==NULL) {
-\t\t\t\tPyErr_SetString(#modulename#_error,\"Failed to convert #modulename#.#argname#_extra_args to tuple.\\n\");
-\t\t\t\tgoto capi_fail;
-\t\t\t}
-\t\t} else {
-\t\t\tPyErr_Clear();
-\t\t\tcapi_arglist = (PyTupleObject *)Py_BuildValue(\"()\");
-\t\t}
-\t}
-\tif (capi_arglist == NULL) {
-\t\tPyErr_SetString(#modulename#_error,\"Callback #argname# argument list is not set.\\n\");
-\t\tgoto capi_fail;
-\t}
+    CFUNCSMESS(\"cb:Call-back function #name# (maxnofargs=#maxnofargs#(-#nofoptargs#))\\n\");
+    CFUNCSMESSPY(\"cb:#name#_capi=\",#name#_capi);
+    if (#name#_capi==NULL) {
+        capi_longjmp_ok = 0;
+        #name#_capi = PyObject_GetAttrString(#modulename#_module,\"#argname#\");
+    }
+    if (#name#_capi==NULL) {
+        PyErr_SetString(#modulename#_error,\"cb: Callback #argname# not defined (as an argument or module #modulename# attribute).\\n\");
+        goto capi_fail;
+    }
+    if (F2PyCapsule_Check(#name#_capi)) {
+    #name#_typedef #name#_cptr;
+    #name#_cptr = F2PyCapsule_AsVoidPtr(#name#_capi);
+    #returncptr#(*#name#_cptr)(#optargs_nm##args_nm##strarglens_nm#);
+    #return#
+    }
+    if (capi_arglist==NULL) {
+        capi_longjmp_ok = 0;
+        capi_tmp = PyObject_GetAttrString(#modulename#_module,\"#argname#_extra_args\");
+        if (capi_tmp) {
+            capi_arglist = (PyTupleObject *)PySequence_Tuple(capi_tmp);
+            if (capi_arglist==NULL) {
+                PyErr_SetString(#modulename#_error,\"Failed to convert #modulename#.#argname#_extra_args to tuple.\\n\");
+                goto capi_fail;
+            }
+        } else {
+            PyErr_Clear();
+            capi_arglist = (PyTupleObject *)Py_BuildValue(\"()\");
+        }
+    }
+    if (capi_arglist == NULL) {
+        PyErr_SetString(#modulename#_error,\"Callback #argname# argument list is not set.\\n\");
+        goto capi_fail;
+    }
 #setdims#
 #ifdef PYPY_VERSION
 #define CAPI_ARGLIST_SETITEM(idx, value) PyList_SetItem((PyObject *)capi_arglist_list, idx, value)
-\tcapi_arglist_list = PySequence_List(capi_arglist);
-\tif (capi_arglist_list == NULL) goto capi_fail;
+    capi_arglist_list = PySequence_List(capi_arglist);
+    if (capi_arglist_list == NULL) goto capi_fail;
 #else
 #define CAPI_ARGLIST_SETITEM(idx, value) PyTuple_SetItem((PyObject *)capi_arglist, idx, value)
 #endif
 #pyobjfrom#
 #undef CAPI_ARGLIST_SETITEM
 #ifdef PYPY_VERSION
-\tCFUNCSMESSPY(\"cb:capi_arglist=\",capi_arglist_list);
+    CFUNCSMESSPY(\"cb:capi_arglist=\",capi_arglist_list);
 #else
-\tCFUNCSMESSPY(\"cb:capi_arglist=\",capi_arglist);
+    CFUNCSMESSPY(\"cb:capi_arglist=\",capi_arglist);
 #endif
-\tCFUNCSMESS(\"cb:Call-back calling Python function #argname#.\\n\");
+    CFUNCSMESS(\"cb:Call-back calling Python function #argname#.\\n\");
 #ifdef F2PY_REPORT_ATEXIT
 f2py_cb_start_call_clock();
 #endif
 #ifdef PYPY_VERSION
-\tcapi_return = PyObject_CallObject(#name#_capi,(PyObject *)capi_arglist_list);
-\tPy_DECREF(capi_arglist_list);
-\tcapi_arglist_list = NULL;
+    capi_return = PyObject_CallObject(#name#_capi,(PyObject *)capi_arglist_list);
+    Py_DECREF(capi_arglist_list);
+    capi_arglist_list = NULL;
 #else
-\tcapi_return = PyObject_CallObject(#name#_capi,(PyObject *)capi_arglist);
+    capi_return = PyObject_CallObject(#name#_capi,(PyObject *)capi_arglist);
 #endif
 #ifdef F2PY_REPORT_ATEXIT
 f2py_cb_stop_call_clock();
 #endif
-\tCFUNCSMESSPY(\"cb:capi_return=\",capi_return);
-\tif (capi_return == NULL) {
-\t\tfprintf(stderr,\"capi_return is NULL\\n\");
-\t\tgoto capi_fail;
-\t}
-\tif (capi_return == Py_None) {
-\t\tPy_DECREF(capi_return);
-\t\tcapi_return = Py_BuildValue(\"()\");
-\t}
-\telse if (!PyTuple_Check(capi_return)) {
-\t\tcapi_return = Py_BuildValue(\"(N)\",capi_return);
-\t}
-\tcapi_j = PyTuple_Size(capi_return);
-\tcapi_i = 0;
+    CFUNCSMESSPY(\"cb:capi_return=\",capi_return);
+    if (capi_return == NULL) {
+        fprintf(stderr,\"capi_return is NULL\\n\");
+        goto capi_fail;
+    }
+    if (capi_return == Py_None) {
+        Py_DECREF(capi_return);
+        capi_return = Py_BuildValue(\"()\");
+    }
+    else if (!PyTuple_Check(capi_return)) {
+        capi_return = Py_BuildValue(\"(N)\",capi_return);
+    }
+    capi_j = PyTuple_Size(capi_return);
+    capi_i = 0;
 #frompyobj#
-\tCFUNCSMESS(\"cb:#name#:successful\\n\");
-\tPy_DECREF(capi_return);
+    CFUNCSMESS(\"cb:#name#:successful\\n\");
+    Py_DECREF(capi_return);
 #ifdef F2PY_REPORT_ATEXIT
 f2py_cb_stop_clock();
 #endif
-\tgoto capi_return_pt;
+    goto capi_return_pt;
 capi_fail:
-\tfprintf(stderr,\"Call-back #name# failed.\\n\");
-\tPy_XDECREF(capi_return);
-\tPy_XDECREF(capi_arglist_list);
-\tif (capi_longjmp_ok)
-\t\tlongjmp(#name#_jmpbuf,-1);
+    fprintf(stderr,\"Call-back #name# failed.\\n\");
+    Py_XDECREF(capi_return);
+    Py_XDECREF(capi_arglist_list);
+    if (capi_longjmp_ok)
+        longjmp(#name#_jmpbuf,-1);
 capi_return_pt:
-\t;
+    ;
 #return#
 }
 #endtitle#
@@ -188,26 +188,26 @@ cb_rout_rules = [
         'latexdocstrcbs': '\\noindent Call-back functions:',
         'routnote': {hasnote: '--- #note#', l_not(hasnote): ''},
     }, {  # Function
-        'decl': '\t#ctype# return_value;',
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting return_value->");'},
-                      '\tif (capi_j>capi_i)\n\t\tGETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n");',
+        'decl': '    #ctype# return_value;',
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
+                      '    if (capi_j>capi_i)\n        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n");',
                       {debugcapi:
-                       '\tfprintf(stderr,"#showvalueformat#.\\n",return_value);'}
+                       '    fprintf(stderr,"#showvalueformat#.\\n",return_value);'}
                       ],
         'need': ['#ctype#_from_pyobj', {debugcapi: 'CFUNCSMESS'}, 'GETSCALARFROMPYTUPLE'],
-        'return': '\treturn return_value;',
+        'return': '    return return_value;',
         '_check': l_and(isfunction, l_not(isstringfunction), l_not(iscomplexfunction))
     },
     {  # String function
-        'pyobjfrom': {debugcapi: '\tfprintf(stderr,"debug-capi:cb:#name#:%d:\\n",return_value_len);'},
+        'pyobjfrom': {debugcapi: '    fprintf(stderr,"debug-capi:cb:#name#:%d:\\n",return_value_len);'},
         'args': '#ctype# return_value,int return_value_len',
         'args_nm': 'return_value,&return_value_len',
         'args_td': '#ctype# ,int',
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting return_value->\\"");'},
-                      """\tif (capi_j>capi_i)
-\t\tGETSTRFROMPYTUPLE(capi_return,capi_i++,return_value,return_value_len);""",
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->\\"");'},
+                      """    if (capi_j>capi_i)
+        GETSTRFROMPYTUPLE(capi_return,capi_i++,return_value,return_value_len);""",
                       {debugcapi:
-                       '\tfprintf(stderr,"#showvalueformat#\\".\\n",return_value);'}
+                       '    fprintf(stderr,"#showvalueformat#\\".\\n",return_value);'}
                       ],
         'need': ['#ctype#_from_pyobj', {debugcapi: 'CFUNCSMESS'},
                  'string.h', 'GETSTRFROMPYTUPLE'],
@@ -232,32 +232,32 @@ return_value
 """,
         'decl': """
 #ifdef F2PY_CB_RETURNCOMPLEX
-\t#ctype# return_value;
+    #ctype# return_value;
 #endif
 """,
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting return_value->");'},
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
                       """\
-\tif (capi_j>capi_i)
+    if (capi_j>capi_i)
 #ifdef F2PY_CB_RETURNCOMPLEX
-\t\tGETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
+        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
 #else
-\t\tGETSCALARFROMPYTUPLE(capi_return,capi_i++,return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
+        GETSCALARFROMPYTUPLE(capi_return,capi_i++,return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
 #endif
 """,
                       {debugcapi: """
 #ifdef F2PY_CB_RETURNCOMPLEX
-\tfprintf(stderr,\"#showvalueformat#.\\n\",(return_value).r,(return_value).i);
+    fprintf(stderr,\"#showvalueformat#.\\n\",(return_value).r,(return_value).i);
 #else
-\tfprintf(stderr,\"#showvalueformat#.\\n\",(*return_value).r,(*return_value).i);
+    fprintf(stderr,\"#showvalueformat#.\\n\",(*return_value).r,(*return_value).i);
 #endif
 
 """}
                       ],
         'return': """
 #ifdef F2PY_CB_RETURNCOMPLEX
-\treturn return_value;
+    return return_value;
 #else
-\treturn;
+    return;
 #endif
 """,
         'need': ['#ctype#_from_pyobj', {debugcapi: 'CFUNCSMESS'},
@@ -314,61 +314,61 @@ cb_arg_rules = [
         'strarglens_nm': {isstring: ',#varname_i#_cb_len'},
     },
     {  # Scalars
-        'decl': {l_not(isintent_c): '\t#ctype# #varname_i#=(*#varname_i#_cb_capi);'},
+        'decl': {l_not(isintent_c): '    #ctype# #varname_i#=(*#varname_i#_cb_capi);'},
         'error': {l_and(isintent_c, isintent_out,
                         throw_error('intent(c,out) is forbidden for callback scalar arguments')):
                   ''},
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting #varname#->");'},
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting #varname#->");'},
                       {isintent_out:
-                       '\tif (capi_j>capi_i)\n\t\tGETSCALARFROMPYTUPLE(capi_return,capi_i++,#varname_i#_cb_capi,#ctype#,"#ctype#_from_pyobj failed in converting argument #varname# of call-back function #name# to C #ctype#\\n");'},
+                       '    if (capi_j>capi_i)\n        GETSCALARFROMPYTUPLE(capi_return,capi_i++,#varname_i#_cb_capi,#ctype#,"#ctype#_from_pyobj failed in converting argument #varname# of call-back function #name# to C #ctype#\\n");'},
                       {l_and(debugcapi, l_and(l_not(iscomplex), isintent_c)):
-                          '\tfprintf(stderr,"#showvalueformat#.\\n",#varname_i#);'},
+                          '    fprintf(stderr,"#showvalueformat#.\\n",#varname_i#);'},
                       {l_and(debugcapi, l_and(l_not(iscomplex), l_not( isintent_c))):
-                          '\tfprintf(stderr,"#showvalueformat#.\\n",*#varname_i#_cb_capi);'},
+                          '    fprintf(stderr,"#showvalueformat#.\\n",*#varname_i#_cb_capi);'},
                       {l_and(debugcapi, l_and(iscomplex, isintent_c)):
-                          '\tfprintf(stderr,"#showvalueformat#.\\n",(#varname_i#).r,(#varname_i#).i);'},
+                          '    fprintf(stderr,"#showvalueformat#.\\n",(#varname_i#).r,(#varname_i#).i);'},
                       {l_and(debugcapi, l_and(iscomplex, l_not( isintent_c))):
-                          '\tfprintf(stderr,"#showvalueformat#.\\n",(*#varname_i#_cb_capi).r,(*#varname_i#_cb_capi).i);'},
+                          '    fprintf(stderr,"#showvalueformat#.\\n",(*#varname_i#_cb_capi).r,(*#varname_i#_cb_capi).i);'},
                       ],
         'need': [{isintent_out: ['#ctype#_from_pyobj', 'GETSCALARFROMPYTUPLE']},
                  {debugcapi: 'CFUNCSMESS'}],
         '_check': isscalar
     }, {
         'pyobjfrom': [{isintent_in: """\
-\tif (#name#_nofargs>capi_i)
-\t\tif (CAPI_ARGLIST_SETITEM(capi_i++,pyobj_from_#ctype#1(#varname_i#)))
-\t\t\tgoto capi_fail;"""},
+    if (#name#_nofargs>capi_i)
+        if (CAPI_ARGLIST_SETITEM(capi_i++,pyobj_from_#ctype#1(#varname_i#)))
+            goto capi_fail;"""},
                       {isintent_inout: """\
-\tif (#name#_nofargs>capi_i)
-\t\tif (CAPI_ARGLIST_SETITEM(capi_i++,pyarr_from_p_#ctype#1(#varname_i#_cb_capi)))
-\t\t\tgoto capi_fail;"""}],
+    if (#name#_nofargs>capi_i)
+        if (CAPI_ARGLIST_SETITEM(capi_i++,pyarr_from_p_#ctype#1(#varname_i#_cb_capi)))
+            goto capi_fail;"""}],
         'need': [{isintent_in: 'pyobj_from_#ctype#1'},
                  {isintent_inout: 'pyarr_from_p_#ctype#1'},
                  {iscomplex: '#ctype#'}],
         '_check': l_and(isscalar, isintent_nothide),
         '_optional': ''
     }, {  # String
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting #varname#->\\"");'},
-                      """\tif (capi_j>capi_i)
-\t\tGETSTRFROMPYTUPLE(capi_return,capi_i++,#varname_i#,#varname_i#_cb_len);""",
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting #varname#->\\"");'},
+                      """    if (capi_j>capi_i)
+        GETSTRFROMPYTUPLE(capi_return,capi_i++,#varname_i#,#varname_i#_cb_len);""",
                       {debugcapi:
-                       '\tfprintf(stderr,"#showvalueformat#\\":%d:.\\n",#varname_i#,#varname_i#_cb_len);'},
+                       '    fprintf(stderr,"#showvalueformat#\\":%d:.\\n",#varname_i#,#varname_i#_cb_len);'},
                       ],
         'need': ['#ctype#', 'GETSTRFROMPYTUPLE',
                  {debugcapi: 'CFUNCSMESS'}, 'string.h'],
         '_check': l_and(isstring, isintent_out)
     }, {
-        'pyobjfrom': [{debugcapi: '\tfprintf(stderr,"debug-capi:cb:#varname#=\\"#showvalueformat#\\":%d:\\n",#varname_i#,#varname_i#_cb_len);'},
+        'pyobjfrom': [{debugcapi: '    fprintf(stderr,"debug-capi:cb:#varname#=\\"#showvalueformat#\\":%d:\\n",#varname_i#,#varname_i#_cb_len);'},
                       {isintent_in: """\
-\tif (#name#_nofargs>capi_i)
-\t\tif (CAPI_ARGLIST_SETITEM(capi_i++,pyobj_from_#ctype#1size(#varname_i#,#varname_i#_cb_len)))
-\t\t\tgoto capi_fail;"""},
+    if (#name#_nofargs>capi_i)
+        if (CAPI_ARGLIST_SETITEM(capi_i++,pyobj_from_#ctype#1size(#varname_i#,#varname_i#_cb_len)))
+            goto capi_fail;"""},
                       {isintent_inout: """\
-\tif (#name#_nofargs>capi_i) {
-\t\tint #varname_i#_cb_dims[] = {#varname_i#_cb_len};
-\t\tif (CAPI_ARGLIST_SETITEM(capi_i++,pyarr_from_p_#ctype#1(#varname_i#,#varname_i#_cb_dims)))
-\t\t\tgoto capi_fail;
-\t}"""}],
+    if (#name#_nofargs>capi_i) {
+        int #varname_i#_cb_dims[] = {#varname_i#_cb_len};
+        if (CAPI_ARGLIST_SETITEM(capi_i++,pyarr_from_p_#ctype#1(#varname_i#,#varname_i#_cb_dims)))
+            goto capi_fail;
+    }"""}],
         'need': [{isintent_in: 'pyobj_from_#ctype#1size'},
                  {isintent_inout: 'pyarr_from_p_#ctype#1'}],
         '_check': l_and(isstring, isintent_nothide),
@@ -376,52 +376,52 @@ cb_arg_rules = [
     },
     # Array ...
     {
-        'decl': '\tnpy_intp #varname_i#_Dims[#rank#] = {#rank*[-1]#};',
-        'setdims': '\t#cbsetdims#;',
+        'decl': '    npy_intp #varname_i#_Dims[#rank#] = {#rank*[-1]#};',
+        'setdims': '    #cbsetdims#;',
         '_check': isarray,
         '_depend': ''
     },
     {
-        'pyobjfrom': [{debugcapi: '\tfprintf(stderr,"debug-capi:cb:#varname#\\n");'},
+        'pyobjfrom': [{debugcapi: '    fprintf(stderr,"debug-capi:cb:#varname#\\n");'},
                       {isintent_c: """\
-\tif (#name#_nofargs>capi_i) {
-\t\tint itemsize_ = #atype# == NPY_STRING ? 1 : 0;
-\t\t/*XXX: Hmm, what will destroy this array??? */
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_CARRAY,NULL);
+    if (#name#_nofargs>capi_i) {
+        int itemsize_ = #atype# == NPY_STRING ? 1 : 0;
+        /*XXX: Hmm, what will destroy this array??? */
+        PyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_CARRAY,NULL);
 """,
                        l_not(isintent_c): """\
-\tif (#name#_nofargs>capi_i) {
-\t\tint itemsize_ = #atype# == NPY_STRING ? 1 : 0;
-\t\t/*XXX: Hmm, what will destroy this array??? */
-\t\tPyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_FARRAY,NULL);
+    if (#name#_nofargs>capi_i) {
+        int itemsize_ = #atype# == NPY_STRING ? 1 : 0;
+        /*XXX: Hmm, what will destroy this array??? */
+        PyArrayObject *tmp_arr = (PyArrayObject *)PyArray_New(&PyArray_Type,#rank#,#varname_i#_Dims,#atype#,NULL,(char*)#varname_i#,itemsize_,NPY_ARRAY_FARRAY,NULL);
 """,
                        },
                       """
-\t\tif (tmp_arr==NULL)
-\t\t\tgoto capi_fail;
-\t\tif (CAPI_ARGLIST_SETITEM(capi_i++,(PyObject *)tmp_arr))
-\t\t\tgoto capi_fail;
+        if (tmp_arr==NULL)
+            goto capi_fail;
+        if (CAPI_ARGLIST_SETITEM(capi_i++,(PyObject *)tmp_arr))
+            goto capi_fail;
 }"""],
         '_check': l_and(isarray, isintent_nothide, l_or(isintent_in, isintent_inout)),
         '_optional': '',
     }, {
-        'frompyobj': [{debugcapi: '\tCFUNCSMESS("cb:Getting #varname#->");'},
-                      """\tif (capi_j>capi_i) {
-\t\tPyArrayObject *rv_cb_arr = NULL;
-\t\tif ((capi_tmp = PyTuple_GetItem(capi_return,capi_i++))==NULL) goto capi_fail;
-\t\trv_cb_arr =  array_from_pyobj(#atype#,#varname_i#_Dims,#rank#,F2PY_INTENT_IN""",
+        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting #varname#->");'},
+                      """    if (capi_j>capi_i) {
+        PyArrayObject *rv_cb_arr = NULL;
+        if ((capi_tmp = PyTuple_GetItem(capi_return,capi_i++))==NULL) goto capi_fail;
+        rv_cb_arr =  array_from_pyobj(#atype#,#varname_i#_Dims,#rank#,F2PY_INTENT_IN""",
                       {isintent_c: '|F2PY_INTENT_C'},
                       """,capi_tmp);
-\t\tif (rv_cb_arr == NULL) {
-\t\t\tfprintf(stderr,\"rv_cb_arr is NULL\\n\");
-\t\t\tgoto capi_fail;
-\t\t}
-\t\tMEMCOPY(#varname_i#,PyArray_DATA(rv_cb_arr),PyArray_NBYTES(rv_cb_arr));
-\t\tif (capi_tmp != (PyObject *)rv_cb_arr) {
-\t\t\tPy_DECREF(rv_cb_arr);
-\t\t}
-\t}""",
-                      {debugcapi: '\tfprintf(stderr,"<-.\\n");'},
+        if (rv_cb_arr == NULL) {
+            fprintf(stderr,\"rv_cb_arr is NULL\\n\");
+            goto capi_fail;
+        }
+        MEMCOPY(#varname_i#,PyArray_DATA(rv_cb_arr),PyArray_NBYTES(rv_cb_arr));
+        if (capi_tmp != (PyObject *)rv_cb_arr) {
+            Py_DECREF(rv_cb_arr);
+        }
+    }""",
+                      {debugcapi: '    fprintf(stderr,"<-.\\n");'},
                       ],
         'need': ['MEMCOPY', {iscomplexarray: '#ctype#'}],
         '_check': l_and(isarray, isintent_out)

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -266,18 +266,18 @@ static PyObject *#apiname#(const PyObject *capi_self,
                            PyObject *capi_args,
                            PyObject *capi_keywds,
                            #functype# (*f2py_func)(#callprotoargument#)) {
-\tPyObject * volatile capi_buildvalue = NULL;
-\tvolatile int f2py_success = 1;
+    PyObject * volatile capi_buildvalue = NULL;
+    volatile int f2py_success = 1;
 #decl#
-\tstatic char *capi_kwlist[] = {#kwlist##kwlistopt##kwlistxa#NULL};
+    static char *capi_kwlist[] = {#kwlist##kwlistopt##kwlistxa#NULL};
 #usercode#
 #routdebugenter#
 #ifdef F2PY_REPORT_ATEXIT
 f2py_start_clock();
 #endif
-\tif (!PyArg_ParseTupleAndKeywords(capi_args,capi_keywds,\\
-\t\t\"#argformat#|#keyformat##xaformat#:#pyname#\",\\
-\t\tcapi_kwlist#args_capi##keys_capi##keys_xa#))\n\t\treturn NULL;
+    if (!PyArg_ParseTupleAndKeywords(capi_args,capi_keywds,\\
+        \"#argformat#|#keyformat##xaformat#:#pyname#\",\\
+        capi_kwlist#args_capi##keys_capi##keys_xa#))\n        return NULL;
 #frompyobj#
 /*end of frompyobj*/
 #ifdef F2PY_REPORT_ATEXIT
@@ -290,27 +290,27 @@ if (PyErr_Occurred())
 f2py_stop_call_clock();
 #endif
 /*end of callfortranroutine*/
-\t\tif (f2py_success) {
+        if (f2py_success) {
 #pyobjfrom#
 /*end of pyobjfrom*/
-\t\tCFUNCSMESS(\"Building return value.\\n\");
-\t\tcapi_buildvalue = Py_BuildValue(\"#returnformat#\"#return#);
+        CFUNCSMESS(\"Building return value.\\n\");
+        capi_buildvalue = Py_BuildValue(\"#returnformat#\"#return#);
 /*closepyobjfrom*/
 #closepyobjfrom#
-\t\t} /*if (f2py_success) after callfortranroutine*/
+        } /*if (f2py_success) after callfortranroutine*/
 /*cleanupfrompyobj*/
 #cleanupfrompyobj#
-\tif (capi_buildvalue == NULL) {
+    if (capi_buildvalue == NULL) {
 #routdebugfailure#
-\t} else {
+    } else {
 #routdebugleave#
-\t}
-\tCFUNCSMESS(\"Freeing memory.\\n\");
+    }
+    CFUNCSMESS(\"Freeing memory.\\n\");
 #freemem#
 #ifdef F2PY_REPORT_ATEXIT
 f2py_stop_clock();
 #endif
-\treturn capi_buildvalue;
+    return capi_buildvalue;
 }
 #endtitle#
 """,
@@ -749,12 +749,12 @@ arg_rules = [
         'docstrcbs': '#cbdocstr#',
         'latexdocstrcbs': '\\item[] #cblatexdocstr#',
         'latexdocstropt': {isintent_nothide: '\\item[]{{}\\verb@#varname#_extra_args := () input tuple@{}} --- Extra arguments for call-back function {{}\\verb@#varname#@{}}.'},
-        'decl': ['\tPyObject *#varname#_capi = Py_None;',
-                 '\tPyTupleObject *#varname#_xa_capi = NULL;',
-                 '\tPyTupleObject *#varname#_args_capi = NULL;',
-                 '\tint #varname#_nofargs_capi = 0;',
+        'decl': ['    PyObject *#varname#_capi = Py_None;',
+                 '    PyTupleObject *#varname#_xa_capi = NULL;',
+                 '    PyTupleObject *#varname#_args_capi = NULL;',
+                 '    int #varname#_nofargs_capi = 0;',
                  {l_not(isintent_callback):
-                  '\t#cbname#_typedef #varname#_cptr;'}
+                  '    #cbname#_typedef #varname#_cptr;'}
                  ],
         'kwlistxa': {isintent_nothide: '"#varname#_extra_args",'},
         'argformat': {isrequired: 'O'},
@@ -803,28 +803,28 @@ if (#varname#_capi==Py_None) {
 }
 """},
             """\
-\t#varname#_nofargs_capi = #cbname#_nofargs;
-\tif (create_cb_arglist(#varname#_capi,#varname#_xa_capi,#maxnofargs#,#nofoptargs#,&#cbname#_nofargs,&#varname#_args_capi,\"failed in processing argument list for call-back #varname#.\")) {
-\t\tjmp_buf #varname#_jmpbuf;""",
+    #varname#_nofargs_capi = #cbname#_nofargs;
+    if (create_cb_arglist(#varname#_capi,#varname#_xa_capi,#maxnofargs#,#nofoptargs#,&#cbname#_nofargs,&#varname#_args_capi,\"failed in processing argument list for call-back #varname#.\")) {
+        jmp_buf #varname#_jmpbuf;""",
             {debugcapi: ["""\
-\t\tfprintf(stderr,\"debug-capi:Assuming %d arguments; at most #maxnofargs#(-#nofoptargs#) is expected.\\n\",#cbname#_nofargs);
-\t\tCFUNCSMESSPY(\"for #varname#=\",#cbname#_capi);""",
-                         {l_not(isintent_callback): """\t\tfprintf(stderr,\"#vardebugshowvalue# (call-back in C).\\n\",#cbname#);"""}]},
+        fprintf(stderr,\"debug-capi:Assuming %d arguments; at most #maxnofargs#(-#nofoptargs#) is expected.\\n\",#cbname#_nofargs);
+        CFUNCSMESSPY(\"for #varname#=\",#cbname#_capi);""",
+                         {l_not(isintent_callback): """        fprintf(stderr,\"#vardebugshowvalue# (call-back in C).\\n\",#cbname#);"""}]},
             """\
-\t\tCFUNCSMESS(\"Saving jmpbuf for `#varname#`.\\n\");
-\t\tSWAP(#varname#_capi,#cbname#_capi,PyObject);
-\t\tSWAP(#varname#_args_capi,#cbname#_args_capi,PyTupleObject);
-\t\tmemcpy(&#varname#_jmpbuf,&#cbname#_jmpbuf,sizeof(jmp_buf));""",
+        CFUNCSMESS(\"Saving jmpbuf for `#varname#`.\\n\");
+        SWAP(#varname#_capi,#cbname#_capi,PyObject);
+        SWAP(#varname#_args_capi,#cbname#_args_capi,PyTupleObject);
+        memcpy(&#varname#_jmpbuf,&#cbname#_jmpbuf,sizeof(jmp_buf));""",
         ],
         'cleanupfrompyobj':
         """\
-\t\tCFUNCSMESS(\"Restoring jmpbuf for `#varname#`.\\n\");
-\t\t#cbname#_capi = #varname#_capi;
-\t\tPy_DECREF(#cbname#_args_capi);
-\t\t#cbname#_args_capi = #varname#_args_capi;
-\t\t#cbname#_nofargs = #varname#_nofargs_capi;
-\t\tmemcpy(&#cbname#_jmpbuf,&#varname#_jmpbuf,sizeof(jmp_buf));
-\t}""",
+        CFUNCSMESS(\"Restoring jmpbuf for `#varname#`.\\n\");
+        #cbname#_capi = #varname#_capi;
+        Py_DECREF(#cbname#_args_capi);
+        #cbname#_args_capi = #varname#_args_capi;
+        #cbname#_nofargs = #varname#_nofargs_capi;
+        memcpy(&#cbname#_jmpbuf,&#varname#_jmpbuf,sizeof(jmp_buf));
+    }""",
         'need': ['SWAP', 'create_cb_arglist'],
         '_check':isexternal,
         '_depend':''


### PR DESCRIPTION
Replace \t by whitespace to make the template strings more readable.

Factored out of gh-16519