### PR TITLE
MAINT: Improve buffer speed

### DIFF
--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -2,6 +2,7 @@
 Test scalar buffer interface adheres to PEP 3118
 """
 import numpy as np
+from numpy.core._rational_tests import rational
 import pytest
 
 from numpy.testing import assert_, assert_equal, assert_raises
@@ -117,3 +118,8 @@ class TestScalarPEP3118:
         code_points = np.frombuffer(v, dtype='i4')
 
         assert_equal(code_points, [ord(c) for c in s])
+
+    def test_user_scalar_fails_buffer(self):
+        r = rational(1)
+        with assert_raises(TypeError):
+            memoryview(r)


### PR DESCRIPTION
Tries to partially address gh-16518, but in the end only does 10-15% difference. The deletion of the scalar branch is a follow up to gh-16389 (it was an oversight that I forgot to delete it in the spin-off from the larger change.

A total of 40+% increase over the current speed is easiy (and tidier than the current code) if extend the ndarray struct by an additional pointer to hold the buffer-info.  Although maybe more importantly, that would also speeds up *all* array operations by a small but non-negligible amount.

Further improvements may be possible by trying to speed up the buffer-format in general (although IIRC, at least half of that slowness was the alignment calculation, which this optimizes away).