### PR TITLE
MAINT: f2py: move thread-local declaration definition to common macro

### DIFF
--- a/doc/release/upcoming_changes/16519.improvement.rst
+++ b/doc/release/upcoming_changes/16519.improvement.rst
@@ -1,0 +1,4 @@
+Thread-safe f2py callback functions
+-----------------------------------
+
+Callback functions in f2py are now threadsafe.

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -40,25 +40,9 @@ typedef struct {
     jmp_buf jmpbuf;
 } #name#_t;
 
-#if defined(__GNUC__) \
-    && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4))) \
-    && !defined(F2PY_USE_PYTHON_TLS)
+#if defined(F2PY_THREAD_LOCAL_DECL) && !defined(F2PY_USE_PYTHON_TLS)
 
-static __thread #name#_t *_active_#name# = NULL;
-
-static #name#_t *swap_active_#name#(#name#_t *ptr) {
-    #name#_t *prev = _active_#name#;
-    _active_#name# = ptr;
-    return prev;
-}
-
-static #name#_t *get_active_#name#(void) {
-    return _active_#name#;
-}
-
-#elif defined(_MSC_VER) && !defined(F2PY_USE_PYTHON_TLS)
-
-static __declspec(thread) #name#_t *_active_#name# = NULL;
+static F2PY_THREAD_LOCAL_DECL #name#_t *_active_#name# = NULL;
 
 static #name#_t *swap_active_#name#(#name#_t *ptr) {
     #name#_t *prev = _active_#name#;
@@ -196,7 +180,7 @@ capi_return_pt:
 }
 #endtitle#
 """,
-    'need': ['setjmp.h', 'CFUNCSMESS'],
+    'need': ['setjmp.h', 'CFUNCSMESS', 'F2PY_THREAD_LOCAL_DECL'],
     'maxnofargs': '#maxnofargs#',
     'nofoptargs': '#nofoptargs#',
     'docstr': """\

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -543,6 +543,21 @@ cppmacros['OLDPYNUM'] = """\
 #error You need to install NumPy version 0.13 or higher. See https://scipy.org/install.html
 #endif
 """
+cppmacros["F2PY_THREAD_LOCAL_DECL"] = """\
+#ifndef F2PY_THREAD_LOCAL_DECL
+#if defined(_MSC_VER)
+#define F2PY_THREAD_LOCAL_DECL __declspec(thread)
+#elif defined(__STDC_VERSION__) \\
+      && (__STDC_VERSION__ >= 201112L) \\
+      && !defined(__STDC_NO_THREADS__)
+#include <threads.h>
+#define F2PY_THREAD_LOCAL_DECL thread_local
+#elif defined(__GNUC__) \\
+      && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 4)))
+#define F2PY_THREAD_LOCAL_DECL __thread
+#endif
+#endif
+"""
 ################# C functions ###############
 
 cfuncs['calcarrindex'] = """\


### PR DESCRIPTION
Move compiler thread-local declaration detection to a common macro.
Also support C11 thread_local declaration, if available.

Add a release note entry for gh-16519