### PR TITLE
MAINT:ARMHF Fix detecting feature groups NEON_HALF and NEON_VFPV4

### DIFF
--- a/numpy/core/src/common/npy_cpu_features.c.src
+++ b/numpy/core/src/common/npy_cpu_features.c.src
@@ -367,9 +367,10 @@ npy__cpu_init_features_linux(void)
         npy__cpu_init_features_arm8();
     } else {
         npy__cpu_have[NPY_CPU_FEATURE_NEON]       = (hwcap & NPY__HWCAP_NEON)   != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_NEON_FP16]  = (hwcap & (NPY__HWCAP_NEON | NPY__HWCAP_VFPv3 |
-                                                              NPY__HWCAP_HALF)) != 0;
-        npy__cpu_have[NPY_CPU_FEATURE_NEON_VFPV4] = (hwcap & (NPY__HWCAP_NEON | NPY__HWCAP_VFPv4)) != 0;
+        if (npy__cpu_have[NPY_CPU_FEATURE_NEON]) {
+            npy__cpu_have[NPY_CPU_FEATURE_NEON_FP16]  = (hwcap & NPY__HWCAP_HALF) != 0;
+            npy__cpu_have[NPY_CPU_FEATURE_NEON_VFPV4] = (hwcap & NPY__HWCAP_VFPv4) != 0;
+        }
     }
     return 1;
 }


### PR DESCRIPTION
Backport of #16522. 

Fix detecting feature groups NEON_HALF and NEON_VFPV4 when NEON isn't available.

The modified code was assuming the availability of NEON if HALF(half-precision hardware conversion) or VFPV4 is available and the other way round too, which is totally wrong.
In other words, ARMHF chips can have NEON without HALF and vice versa.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
