### PR TITLE
BUG: Fix cython warning in random/_common.pyx.

### DIFF
--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -219,7 +219,8 @@ cdef np.ndarray int_to_array(object value, object name, object bits, object uint
 
 
 cdef validate_output_shape(iter_shape, np.ndarray output):
-    cdef np.npy_intp *shape, ndim, i
+    cdef np.npy_intp *shape
+    cdef ndim, i
     cdef bint error
     dims = np.PyArray_DIMS(output)
     ndim = np.PyArray_NDIM(output)


### PR DESCRIPTION
Fix for #16503. Cython wants every pointer declaration to be on a
separate line.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
