### PR TITLE
ENH: Make the default int intp when a flag is set

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,6 +219,7 @@ stages:
             PYTHON_VERSION: '3.7'
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
+            NPY_INTP_IS_DEFAULT_INTEGER: 1
             BITS: 64
           Python38-64bit-full:
             PYTHON_VERSION: '3.8'

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -11,6 +11,20 @@ purposes and will not be interesting to the vast majority
 of users.
 
 
+User Facing Options
+===================
+
+Default Integer (affects Windows)
+---------------------------------
+
+The ``NPY_INTP_IS_DEFAULT_INTEGER`` environment variable can be changed
+to ensure that the default integer is 32bit on 32bit systems and 64bit
+on 64bit systems.  Without this switch, the default integer will be
+identical to ``long`` as defined by C.
+This setting should only affect 64bit windows systems for which the default
+integer will be 64bit instead of 32bit.
+
+
 Performance-Related Options
 ===========================
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -23,6 +23,11 @@ NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "
 NPY_RELAXED_STRIDES_DEBUG = (os.environ.get('NPY_RELAXED_STRIDES_DEBUG', "0") != "0")
 NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CHECKING
 
+# Use NPY_INTP_IS_DEFAULT_INTEGER=1 in the environment to make the default
+# integer always match the size of intp (64bit on 64bit system 32bit on
+# 32bit systems).  This should only affect windows where long is 32bit.
+NPY_INTP_IS_DEFAULT_INTEGER = (os.environ.get('NPY_INTP_IS_DEFAULT_INTEGER', "0") != "0")
+
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force
 # config.h generation inside an Extension class, and as such sharing
@@ -459,6 +464,11 @@ def configuration(parent_package='',top_path=None):
             # Use bogus stride debug aid when relaxed strides are enabled
             if NPY_RELAXED_STRIDES_DEBUG:
                 moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
+
+            # Use intp as the default integer type if long is 32-bit but
+            # intp is 64-bit.
+            if NPY_INTP_IS_DEFAULT_INTEGER:
+                moredefs.append(('NPY_INTP_IS_DEFAULT_INTEGER', 1))
 
             # Get long double representation
             rep = check_long_double_representation(config_cmd)

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -44,6 +44,7 @@ _array_find_python_scalar_type(PyObject *op)
     else if (PyComplex_Check(op)) {
         return PyArray_DescrFromType(NPY_CDOUBLE);
     }
+#if NPY_DEFAULT_INT == NPY_LONG
     else if (PyInt_Check(op)) {
         /* bools are a subclass of int */
         if (PyBool_Check(op)) {
@@ -53,6 +54,7 @@ _array_find_python_scalar_type(PyObject *op)
             return  PyArray_DescrFromType(NPY_LONG);
         }
     }
+#endif
     else if (PyLong_Check(op)) {
         /* check to see if integer can fit into a longlong or ulonglong
            and return that --- otherwise return object */

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -348,5 +348,23 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
  */
 #define NPY_ITER_REDUCTION_AXIS(axis) (axis + (1 << (NPY_BITSOF_INT - 2)))
 
+
+/*
+ * The default array type and default integer type, if we were to expose
+ * this publically, we would need to put this into the API table so that
+ * it is runtime detected.  Instead assume that we will flip the switch
+ * in some version, and downstream should try to decide based on our
+ * version.
+ */
+#if NPY_INTP_IS_DEFAULT_INTEGER
+    #define NPY_DEFAULT_INT NPY_INTP
+    #define NPY_DEFAULT_UINT NPY_UINTP
+    #define NPY_SIZEOF_DEFAULT_INT NPY_SIZEOF_INTP
+#else
+    #define NPY_DEFAULT_INT NPY_LONG
+    #define NPY_DEFAULT_UINT NPY_ULONG
+    #define NPY_SIZEOF_DEFAULT_INT NPY_SIZEOF_LONG
+#endif
+
 #endif
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3383,8 +3383,8 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
         PyArray_Descr *deftype;
         PyArray_Descr *newtype;
 
-        /* intentionally made to be at least NPY_LONG */
-        deftype = PyArray_DescrFromType(NPY_LONG);
+        /* intentionally made to be at least NPY_DEFAULT_INT */
+        deftype = PyArray_DescrFromType(NPY_DEFAULT_INT);
         newtype = PyArray_DescrFromObject(start, deftype);
         Py_DECREF(deftype);
         if (newtype == NULL) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1387,7 +1387,7 @@ _convert_from_type(PyObject *obj) {
         return PyArray_DescrFromTypeObject(obj);
     }
     else if (typ == &PyLong_Type) {
-        return PyArray_DescrFromType(NPY_LONG);
+        return PyArray_DescrFromType(NPY_DEFAULT_INT);
     }
     else if (typ == &PyFloat_Type) {
         return PyArray_DescrFromType(NPY_DOUBLE);

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4596,14 +4596,14 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc, PyObject *args,
             && ((strcmp(ufunc->name,"add") == 0)
                 || (strcmp(ufunc->name,"multiply") == 0))) {
             if (PyTypeNum_ISBOOL(typenum)) {
-                typenum = NPY_LONG;
+                typenum = NPY_DEFAULT_INT;
             }
-            else if ((size_t)PyArray_DESCR(mp)->elsize < sizeof(long)) {
+            else if ((size_t)PyArray_DESCR(mp)->elsize < NPY_SIZEOF_DEFAULT_INT) {
                 if (PyTypeNum_ISUNSIGNED(typenum)) {
-                    typenum = NPY_ULONG;
+                    typenum = NPY_DEFAULT_UINT;
                 }
                 else {
-                    typenum = NPY_LONG;
+                    typenum = NPY_DEFAULT_INT;
                 }
             }
         }


### PR DESCRIPTION
This will be nice mainly for windows. The only problem here is
right now that we cannot define the macros like this, since they
would be public.  They should not be made public (at least like this),
since if someone uses NPY_DEFAULT_INT in their code they should get
the default they are running against, not the one they are compiled
against.


---

I think we should explore such things and this seems the best first step to me, the changes themselves are easy enough after all.  May need someone to test on windows to be sure it works (and likely some test fixups found by CI).  Marking as draft, since there are probably fixups necessary when tested on windows...

See also gh-6056 or gh-12332, although this uses the `intp` option, which seems a bit easier to me, because we return and use `intp` in a lot of places and many of those might otherwise need to be bumped up as well for a uniform user-experience...
At least with `np.intp` as default, the rule is smiple 64bit on 64bit systems, 32bit on 32bit.

I think we should change this, but I believe flipping the switch is a pretty big API change (even if it is one that very few users will notice).