### PR TITLE
SIMD: SSE2 intrinsic implementation for float64 input of np.einsum

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -107,45 +107,26 @@ class Lstsq(Benchmark):
 
 class Einsum(Benchmark):
     param_names = ['dtype']
-    params = [[np.float32, np.float64]]
+    params = [[np.float64]]
     def setup(self, dtype):
-        self.a = np.arange(3000, dtype=dtype)
-        self.b = np.arange(2990, dtype=dtype)
+        self.a = np.arange(2900, dtype=dtype)
+        self.b = np.arange(3000, dtype=dtype)
         self.c = np.arange(24000, dtype=dtype).reshape(20, 30, 40)
         self.c1 = np.arange(1200, dtype=dtype).reshape(30, 40)
-        self.c2 = np.arange(40, dtype=dtype)
-        self.c3 = np.arange(30000, dtype=dtype).reshape(30, 20, 50)
-        self.d = np.arange(2*1000, dtype=dtype).reshape(2, 1000)
-        self.e = np.arange(100*100, dtype=dtype).reshape(100, 100)
+        self.d = np.arange(10000, dtype=dtype).reshape(10,100,10)
 
-    #outer(a,b)
+    #outer(a,b): trigger sum_of_products_contig_stride0_outcontig_two
     def time_einsum_outer(self, dtype):
         np.einsum("i,j", self.a, self.b, optimize=True)
 
-    #inner(a,b)
-    def time_einsum_inner(self, dtype):
-        np.einsum("...i, ...i", self.c, self.c2, optimize=True)
-
-    # swap axes
-    def time_einsum_swap(self, dtype):
-        np.einsum("ijk->jik", self.c, optimize=True)
-    
-    # sum(a, axis=0)
-    def time_einsum_sum(self, dtype):
-        np.einsum("i...->...", self.d, optimize=True)
-    
-    # trace(a)
-    def time_einsum_trace(self, dtype):
-        np.einsum("ii", self.e, optimize=True)
-
-    # multiply(a, b)
+    # multiply(a, b):trigger sum_of_products_contig_two
     def time_einsum_multiply(self, dtype):
         np.einsum("..., ...", self.c1, self.c , optimize=True)
     
-    # tensordot(a, b)
-    def time_einsum_tensordot(self, dtype):
-        np.einsum("ijk, jil -> kl", self.c, self.c3 , optimize=True)
+    # sum and multiply:trigger sum_of_products_contig_stride0_outstride0_two
+    def time_einsum_sum_mul(self, dtype):
+        np.einsum(",i...->", 300, self.d, optimize=True)
 
-    # a.dot(b)
-    def time_einsum_matmat(self, dtype):
-        np.einsum("ij,jk", self.e, self.e , optimize=True)
+    # sum and multiply:trigger sum_of_products_stride0_contig_outstride0_two
+    def time_einsum_sum_mul2(self, dtype):
+        np.einsum("i...,->", self.d, 300, optimize=True)

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -2,6 +2,7 @@ from .common import Benchmark, get_squares_, get_indexes_rand, TYPES1
 
 import numpy as np
 
+
 class Eindot(Benchmark):
     def setup(self):
         self.a = np.arange(60000.0).reshape(150, 400)

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -2,7 +2,6 @@ from .common import Benchmark, get_squares_, get_indexes_rand, TYPES1
 
 import numpy as np
 
-
 class Eindot(Benchmark):
     def setup(self):
         self.a = np.arange(60000.0).reshape(150, 400)
@@ -105,3 +104,48 @@ class Lstsq(Benchmark):
 
     def time_numpy_linalg_lstsq_a__b_float64(self):
         np.linalg.lstsq(self.a, self.b, rcond=-1)
+
+class Einsum(Benchmark):
+    param_names = ['dtype']
+    params = [[np.float32, np.float64]]
+    def setup(self, dtype):
+        self.a = np.arange(3000, dtype=dtype)
+        self.b = np.arange(2990, dtype=dtype)
+        self.c = np.arange(24000, dtype=dtype).reshape(20, 30, 40)
+        self.c1 = np.arange(1200, dtype=dtype).reshape(30, 40)
+        self.c2 = np.arange(40, dtype=dtype)
+        self.c3 = np.arange(30000, dtype=dtype).reshape(30, 20, 50)
+        self.d = np.arange(2*1000, dtype=dtype).reshape(2, 1000)
+        self.e = np.arange(100*100, dtype=dtype).reshape(100, 100)
+
+    #outer(a,b)
+    def time_einsum_outer(self, dtype):
+        np.einsum("i,j", self.a, self.b, optimize=True)
+
+    #inner(a,b)
+    def time_einsum_inner(self, dtype):
+        np.einsum("...i, ...i", self.c, self.c2, optimize=True)
+
+    # swap axes
+    def time_einsum_swap(self, dtype):
+        np.einsum("ijk->jik", self.c, optimize=True)
+    
+    # sum(a, axis=0)
+    def time_einsum_sum(self, dtype):
+        np.einsum("i...->...", self.d, optimize=True)
+    
+    # trace(a)
+    def time_einsum_trace(self, dtype):
+        np.einsum("ii", self.e, optimize=True)
+
+    # multiply(a, b)
+    def time_einsum_multiply(self, dtype):
+        np.einsum("..., ...", self.c1, self.c , optimize=True)
+    
+    # tensordot(a, b)
+    def time_einsum_tensordot(self, dtype):
+        np.einsum("ijk, jil -> kl", self.c, self.c3 , optimize=True)
+
+    # a.dot(b)
+    def time_einsum_matmat(self, dtype):
+        np.einsum("ij,jk", self.e, self.e , optimize=True)

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -31,9 +31,6 @@
 #define EINSUM_USE_SSE1 0
 #endif
 
-/*
- * TODO: Only some SSE2 for float64 is implemented.
- */
 #ifdef NPY_HAVE_SSE2_INTRINSICS
 #define EINSUM_USE_SSE2 1
 #else

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -546,7 +546,7 @@ finish_after_unrolled_loop:
             return;
     }
 
-#if EINSUM_USE_SSE1 && @float32@
+#if EINSUM_USE_SSE3 && @float32@
     value1_sse = _mm_set_ps1(value1);
 
     /* Use aligned instructions if possible */
@@ -570,6 +570,7 @@ finish_after_unrolled_loop:
         goto finish_after_unrolled_loop;
     }
 #elif EINSUM_USE_SSE2 && @float64@
+    printf("using sse2\n");
     value1_sse = _mm_set1_pd(value1);
 
     /* Use aligned instructions if possible */

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -277,7 +277,7 @@ static void
 #if EINSUM_USE_SSE1 && @float32@
     __m128 a, b;
 #elif EINSUM_USE_SSE2 && @float64@
-__m128d a, b;
+    __m128d a, b;
 #endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_two (%d)\n",
@@ -321,11 +321,6 @@ finish_after_unrolled_loop:
         /* Finish off the loop */
         goto finish_after_unrolled_loop;
     }
-#endif
-
-    /* Unroll the loop by 8 */
-    while (count >= 8) {
-        count -= 8;
 #elif EINSUM_USE_SSE2 && @float64@
     /* Use aligned instructions if possible */
     if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data1) &&
@@ -349,6 +344,12 @@ finish_after_unrolled_loop:
         /* Finish off the loop */
         goto finish_after_unrolled_loop;
     }
+#endif
+
+    /* Unroll the loop by 8 */
+    while (count >= 8) {
+        count -= 8;
+
 #if EINSUM_USE_SSE1 && @float32@
 /**begin repeat2
  * #i = 0, 4#
@@ -523,6 +524,8 @@ static void
 
 #if EINSUM_USE_SSE1 && @float32@
     __m128 a, b, value1_sse;
+#elif EINSUM_USE_SSE2 && @float64@
+    __m128d a, b, value1_sse;
 #endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_stride0_outcontig_two (%d)\n",
@@ -566,6 +569,29 @@ finish_after_unrolled_loop:
         /* Finish off the loop */
         goto finish_after_unrolled_loop;
     }
+#elif EINSUM_USE_SSE2 && @float64@
+    value1_sse = _mm_set1_pd(value1);
+
+    /* Use aligned instructions if possible */
+    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data_out)) {
+        /* Unroll the loop by 8 */
+        while (count >= 8) {
+            count -= 8;
+
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+            a = _mm_mul_pd(_mm_load_pd(data0+@i@), value1_sse);
+            b = _mm_add_pd(a, _mm_load_pd(data_out+@i@));
+            _mm_store_pd(data_out+@i@, b);
+/**end repeat2**/
+            data0 += 8;
+            data_out += 8;
+        }
+
+        /* Finish off the loop */
+        goto finish_after_unrolled_loop;
+    }
 #endif
 
     /* Unroll the loop by 8 */
@@ -579,6 +605,14 @@ finish_after_unrolled_loop:
         a = _mm_mul_ps(_mm_loadu_ps(data0+@i@), value1_sse);
         b = _mm_add_ps(a, _mm_loadu_ps(data_out+@i@));
         _mm_storeu_ps(data_out+@i@, b);
+/**end repeat2**/
+#elif EINSUM_USE_SSE2 && @float64@
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+        a = _mm_mul_pd(_mm_loadu_pd(data0+@i@), value1_sse);
+        b = _mm_add_pd(a, _mm_loadu_pd(data_out+@i@));
+        _mm_storeu_pd(data_out+@i@, b);
 /**end repeat2**/
 #else
 /**begin repeat2

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -546,7 +546,7 @@ finish_after_unrolled_loop:
             return;
     }
 
-#if EINSUM_USE_SSE3 && @float32@
+#if EINSUM_USE_SSE1 && @float32@
     value1_sse = _mm_set_ps1(value1);
 
     /* Use aligned instructions if possible */
@@ -570,7 +570,6 @@ finish_after_unrolled_loop:
         goto finish_after_unrolled_loop;
     }
 #elif EINSUM_USE_SSE2 && @float64@
-    printf("using sse2\n");
     value1_sse = _mm_set1_pd(value1);
 
     /* Use aligned instructions if possible */
@@ -599,7 +598,7 @@ finish_after_unrolled_loop:
     while (count >= 8) {
         count -= 8;
 
-#if EINSUM_USE_SSE3 && @float32@
+#if EINSUM_USE_SSE1 && @float32@
 /**begin repeat2
  * #i = 0, 4#
  */
@@ -802,6 +801,8 @@ static void
 
 #if EINSUM_USE_SSE1 && @float32@
     __m128 a, accum_sse = _mm_setzero_ps();
+#elif EINSUM_USE_SSE2 && @float64@
+    __m128d a, accum_sse = _mm_setzero_pd();
 #endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_stride0_contig_outstride0_two (%d)\n",
@@ -839,15 +840,38 @@ finish_after_unrolled_loop:
 /**end repeat2**/
             data1 += 8;
         }
-
-#if EINSUM_USE_SSE1 && @float32@
         /* Add the four SSE values and put in accum */
         a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(2,3,0,1));
         accum_sse = _mm_add_ps(a, accum_sse);
         a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(1,0,3,2));
         accum_sse = _mm_add_ps(a, accum_sse);
         _mm_store_ss(&accum, accum_sse);
-#endif
+
+        /* Finish off the loop */
+        goto finish_after_unrolled_loop;
+    }
+#elif EINSUM_USE_SSE2 && @float64@
+    /* Use aligned instructions if possible */
+    if (EINSUM_IS_SSE_ALIGNED(data1)) {
+        /* Unroll the loop by 8 */
+        while (count >= 8) {
+            count -= 8;
+
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+            /*
+             * NOTE: This accumulation changes the order, so will likely
+             *       produce slightly different results.
+             */
+            accum_sse = _mm_add_pd(accum_sse, _mm_load_pd(data1+@i@));
+/**end repeat2**/
+            data1 += 8;
+        }
+        /* Add the two SSE2 values and put in accum */
+        a = _mm_shuffle_pd(accum_sse, accum_sse, _MM_SHUFFLE2(0,1));
+        accum_sse = _mm_add_pd(a, accum_sse);
+        _mm_store_sd(&accum, accum_sse);
 
         /* Finish off the loop */
         goto finish_after_unrolled_loop;
@@ -868,6 +892,16 @@ finish_after_unrolled_loop:
          */
         accum_sse = _mm_add_ps(accum_sse, _mm_loadu_ps(data1+@i@));
 /**end repeat2**/
+#elif EINSUM_USE_SSE2 && @float64@
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+        /*
+         * NOTE: This accumulation changes the order, so will likely
+         *       produce slightly different results.
+         */
+        accum_sse = _mm_add_pd(accum_sse, _mm_loadu_pd(data1+@i@));
+/**end repeat2**/
 #else
 /**begin repeat2
  * #i = 0, 1, 2, 3, 4, 5, 6, 7#
@@ -885,6 +919,11 @@ finish_after_unrolled_loop:
     a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(1,0,3,2));
     accum_sse = _mm_add_ps(a, accum_sse);
     _mm_store_ss(&accum, accum_sse);
+#elif EINSUM_USE_SSE2 && @float64@
+    /* Add the two SSE2 values and put in accum */
+    a = _mm_shuffle_pd(accum_sse, accum_sse, _MM_SHUFFLE2(0,1));
+    accum_sse = _mm_add_pd(a, accum_sse);
+    _mm_store_sd(&accum, accum_sse);
 #endif
 
     /* Finish off the loop */
@@ -901,6 +940,8 @@ static void
 
 #if EINSUM_USE_SSE1 && @float32@
     __m128 a, accum_sse = _mm_setzero_ps();
+#elif EINSUM_USE_SSE2 && @float64@
+    __m128d a, accum_sse = _mm_setzero_pd();
 #endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_stride0_outstride0_two (%d)\n",
@@ -938,16 +979,37 @@ finish_after_unrolled_loop:
 /**end repeat2**/
             data0 += 8;
         }
-
-#if EINSUM_USE_SSE1 && @float32@
         /* Add the four SSE values and put in accum */
         a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(2,3,0,1));
         accum_sse = _mm_add_ps(a, accum_sse);
         a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(1,0,3,2));
         accum_sse = _mm_add_ps(a, accum_sse);
         _mm_store_ss(&accum, accum_sse);
-#endif
+        /* Finish off the loop */
+        goto finish_after_unrolled_loop;
+    }
+#elif EINSUM_USE_SSE2 && @float64@
+    /* Use aligned instructions if possible */
+    if (EINSUM_IS_SSE_ALIGNED(data0)) {
+        /* Unroll the loop by 8 */
+        while (count >= 8) {
+            count -= 8;
 
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+            /*
+             * NOTE: This accumulation changes the order, so will likely
+             *       produce slightly different results.
+             */
+            accum_sse = _mm_add_pd(accum_sse, _mm_load_pd(data0+@i@));
+/**end repeat2**/
+            data0 += 8;
+        }
+        /* Add the two SSE2 values and put in accum */
+        a = _mm_shuffle_pd(accum_sse, accum_sse, _MM_SHUFFLE2(0,1));
+        accum_sse = _mm_add_pd(a, accum_sse);
+        _mm_store_sd(&accum, accum_sse);
         /* Finish off the loop */
         goto finish_after_unrolled_loop;
     }
@@ -967,6 +1029,16 @@ finish_after_unrolled_loop:
          */
         accum_sse = _mm_add_ps(accum_sse, _mm_loadu_ps(data0+@i@));
 /**end repeat2**/
+#elif EINSUM_USE_SSE2 && @float64@
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+        /*
+         * NOTE: This accumulation changes the order, so will likely
+         *       produce slightly different results.
+         */
+        accum_sse = _mm_add_pd(accum_sse, _mm_loadu_pd(data0+@i@));
+/**end repeat2**/
 #else
 /**begin repeat2
  * #i = 0, 1, 2, 3, 4, 5, 6, 7#
@@ -984,6 +1056,11 @@ finish_after_unrolled_loop:
     a = _mm_shuffle_ps(accum_sse, accum_sse, _MM_SHUFFLE(1,0,3,2));
     accum_sse = _mm_add_ps(a, accum_sse);
     _mm_store_ss(&accum, accum_sse);
+#elif EINSUM_USE_SSE2 && @float64@
+    /* Add the two SSE2 values and put in accum */
+    a = _mm_shuffle_pd(accum_sse, accum_sse, _MM_SHUFFLE2(0,1));
+    accum_sse = _mm_add_pd(a, accum_sse);
+    _mm_store_sd(&accum, accum_sse);
 #endif
 
     /* Finish off the loop */

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -276,6 +276,8 @@ static void
 
 #if EINSUM_USE_SSE1 && @float32@
     __m128 a, b;
+#elif EINSUM_USE_SSE2 && @float64@
+__m128d a, b;
 #endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_two (%d)\n",
@@ -324,7 +326,29 @@ finish_after_unrolled_loop:
     /* Unroll the loop by 8 */
     while (count >= 8) {
         count -= 8;
+#elif EINSUM_USE_SSE2 && @float64@
+    /* Use aligned instructions if possible */
+    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data1) &&
+        EINSUM_IS_SSE_ALIGNED(data_out)) {
+        /* Unroll the loop by 8 */
+        while (count >= 8) {
+            count -= 8;
 
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+            a = _mm_mul_pd(_mm_load_pd(data0+@i@), _mm_load_pd(data1+@i@));
+            b = _mm_add_pd(a, _mm_load_pd(data_out+@i@));
+            _mm_store_pd(data_out+@i@, b);
+/**end repeat2**/
+            data0 += 8;
+            data1 += 8;
+            data_out += 8;
+        }
+
+        /* Finish off the loop */
+        goto finish_after_unrolled_loop;
+    }
 #if EINSUM_USE_SSE1 && @float32@
 /**begin repeat2
  * #i = 0, 4#
@@ -332,6 +356,14 @@ finish_after_unrolled_loop:
         a = _mm_mul_ps(_mm_loadu_ps(data0+@i@), _mm_loadu_ps(data1+@i@));
         b = _mm_add_ps(a, _mm_loadu_ps(data_out+@i@));
         _mm_storeu_ps(data_out+@i@, b);
+/**end repeat2**/
+#elif EINSUM_USE_SSE2 && @float64@
+/**begin repeat2
+ * #i = 0, 2, 4, 6#
+ */
+        a = _mm_mul_pd(_mm_loadu_pd(data0+@i@), _mm_loadu_pd(data1+@i@));
+        b = _mm_add_pd(a, _mm_loadu_pd(data_out+@i@));
+        _mm_storeu_pd(data_out+@i@, b);
 /**end repeat2**/
 #else
 /**begin repeat2

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -598,7 +598,7 @@ finish_after_unrolled_loop:
     while (count >= 8) {
         count -= 8;
 
-#if EINSUM_USE_SSE1 && @float32@
+#if EINSUM_USE_SSE3 && @float32@
 /**begin repeat2
  * #i = 0, 4#
  */


### PR DESCRIPTION
`np.enisum` is a powerful function like the Swiss Army Knife that implements many different functions, But two defects were found:

- 10 sub modules of `np.enisum`  has been optimized by using SSE1, but only 6 of them has the corresponding SSE2 implementation.
- No benchmark test cases was found to measure the extent of performance improvement of SIMD implementation.

This PR turns to solve above problems:

- Add 4 missing SSE2 implementation. A total of 10+% performance increased.
- Add several benchmark test cases to measure SIMD performance.

Here is the benchmark result.
<details>

Before optimize(master branch):

```
[ 81.25%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                         ok
[ 81.25%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   85.4±8μs
              =============== ==========

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                            ok 
[ 87.50%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   53.0±4ms
              =============== ==========

[ 93.75%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                          ok 
[ 93.75%] ··· =============== ===========
                   dtype
              --------------- -----------
               numpy.float64   86.8±20μs
              =============== ===========

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                         ok 
[100.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   68.8±9μs
              =============== ==========
```
After Optimize(enisum_sse2 branch):
```
[ 56.25%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                         ok
[ 56.25%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   72.3±8μs
              =============== ==========

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                            ok
[ 62.50%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   47.8±2ms
              =============== ==========

[ 68.75%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                          ok
[ 68.75%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   65.8±3μs
              =============== ==========

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                         ok
[ 75.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float64   62.4±6μs
              =============== ==========
```