### PR TITLE
BUG: Fix kwonly args ignored in compat/_inspect.py

### DIFF
--- a/numpy/compat/_inspect.py
+++ b/numpy/compat/_inspect.py
@@ -74,7 +74,7 @@ def getargs(co):
     if not iscode(co):
         raise TypeError('arg is not a code object')
 
-    nargs = co.co_argcount
+    nargs = co.co_argcount + co.co_kwonlyargcount
     names = co.co_varnames
     args = list(names[:nargs])
 
@@ -108,7 +108,12 @@ def getargspec(func):
     if not isfunction(func):
         raise TypeError('arg is not a Python function')
     args, varargs, varkw = getargs(func.__code__)
-    return args, varargs, varkw, func.__defaults__
+    defaults = func.__defaults__
+    if func.__kwdefaults__:
+        if not defaults:
+            defaults = tuple()
+        defaults += tuple(func.__kwdefaults__.values())
+    return args, varargs, varkw, defaults
 
 def getargvalues(frame):
     """Get information about arguments passed into a particular frame.

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -263,6 +263,8 @@ class TestVerifyMatchingSignatures:
             verify_matching_signatures(lambda x=None: 0, lambda y=None: 0)
         with assert_raises(RuntimeError):
             verify_matching_signatures(lambda x=1: 0, lambda y=1: 0)
+        with assert_raises(RuntimeError):
+            verify_matching_signatures(lambda *, x=1:0, lambda *, y=1: 0)
 
     def test_array_function_dispatch(self):
 


### PR DESCRIPTION
Fixes #16299 . The issue was with `numpy.compat._inspect.py` ignoring keyword-only arguments. This caused incomplete and even incorrect output in the inspection functions (example in issue), which was the root-cause for `numpy.core.overrides.verify_matching_signatures` ignoring keyword-only arguments.

I can't imagine this slowing the import in any meaningful way, but I'm not completely familiar with the optimization being done with the file in general. If someone has a better way of handing the `function.__defaults__` and `function__kwdefaults__` tuples, that would be nice. Since either can be `None`, I had to perform those if blocks. I cannot recall any smoother ways of combining them.

I would have liked to add tests to this, but there don't seem to be any tests for this module. I assume this is related to the import optimization.

