### PR TITLE
DEP: Remove deprecated numeric types and deprecate remaining

### DIFF
--- a/doc/release/upcoming_changes/16554.compatibility.rst
+++ b/doc/release/upcoming_changes/16554.compatibility.rst
@@ -1,5 +1,5 @@
-Numeric style types removed from type dictionaries
---------------------------------------------------
+Numeric-style type names have been removed from type dictionaries
+-----------------------------------------------------------------
 
 To stay in sync with the deprecation for ``np.dtype("Complex64")``
 and other numeric-style (capital case) types.  These were removed

--- a/doc/release/upcoming_changes/16554.compatibility.rst
+++ b/doc/release/upcoming_changes/16554.compatibility.rst
@@ -1,0 +1,10 @@
+Numeric style types removed from type dictionaries
+--------------------------------------------------
+
+To stay in sync with the deprecation for ``np.dtype("Complex64")``
+and other numeric-style (capital case) types.  These were removed
+from ``np.sctypeDict`` and ``np.typeDict``.  You should use
+the lower case versions instead.  Note that ``"Complex64"``
+corresponds to ``"complex128"`` and ``"Complex32"`` corresponds
+to ``"complex64"``.  The numpy style (new) versions, denote the full
+size and not the size of the real/imaginary part.

--- a/doc/release/upcoming_changes/16554.deprecation.rst
+++ b/doc/release/upcoming_changes/16554.deprecation.rst
@@ -1,7 +1,7 @@
 Further Numeric Style types Deprecated
 --------------------------------------
 
-The remaining numeric-style type codes ``"Bytes0"``,
+The remaining numeric-style type codes ``Bytes0``,
 ``Str0``, ``Uint64``, and ``Datetime64`` have been
 deprecated.  The lower-case variants should be used
 instead.  For bytes and string ``"S"`` and ``"U"``

--- a/doc/release/upcoming_changes/16554.deprecation.rst
+++ b/doc/release/upcoming_changes/16554.deprecation.rst
@@ -1,0 +1,8 @@
+Further Numeric Style types Deprecated
+--------------------------------------
+
+The remaining numeric-style type codes ``"Bytes0"``,
+``Str0``, ``Uint64``, and ``Datetime64`` have been
+deprecated.  The lower-case variants should be used
+instead.  For bytes and string ``"S"`` and ``"U"``
+are further alternatives.

--- a/doc/release/upcoming_changes/16554.deprecation.rst
+++ b/doc/release/upcoming_changes/16554.deprecation.rst
@@ -1,8 +1,8 @@
 Further Numeric Style types Deprecated
 --------------------------------------
 
-The remaining numeric-style type codes ``Bytes0``,
-``Str0``, ``Uint64``, and ``Datetime64`` have been
-deprecated.  The lower-case variants should be used
+The remaining numeric-style type codes ``Bytes0``, ``Str0``,
+``Uint32``, ``Uint64``, and ``Datetime64``
+have been deprecated.  The lower-case variants should be used
 instead.  For bytes and string ``"S"`` and ``"U"``
 are further alternatives.

--- a/doc/release/upcoming_changes/16554.expired.rst
+++ b/doc/release/upcoming_changes/16554.expired.rst
@@ -1,5 +1,5 @@
 * The deprecation of numeric style type-codes ``np.dtype("Complex64")``
-  (with upper case spelling), is expired.  ``"Complex64"`` corresponds to
-  ``"complex128"`` and ``"Complex32"`` corresponds to ``"complex64"``.
+  (with upper case spelling), is expired.  ``"Complex64"`` corresponded to
+  ``"complex128"`` and ``"Complex32"`` corresponded to ``"complex64"``.
 * The deprecation of ``np.sctypeNA`` and ``np.typeNA`` is expired. Both
   have been removed from the public API. Use ``np.typeDict`` instead.

--- a/doc/release/upcoming_changes/16554.expired.rst
+++ b/doc/release/upcoming_changes/16554.expired.rst
@@ -1,0 +1,5 @@
+* The deprecation of numeric style type-codes ``np.dtype("Complex64")``
+  (with upper case spelling), is expired.  ``"Complex64"`` corresponds to
+  ``"complex128"`` and ``"Complex32"`` corresponds to ``"complex64"``.
+* The deprecation of ``np.sctypeNA`` and ``np.typeNA`` is expired. Both
+  have been removed from the public API. Use ``np.typeDict`` instead.

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -116,9 +116,10 @@ def _add_aliases():
 
     # Add deprecated numeric-style type aliases manually, at some point
     # we may want to deprecate the lower case "bytes0" version as well.
-    for name in ["Bytes0", "Datetime64", "Str0", "Uint64"]:
-        if name == "Uint64" and "uint64" not in allTypes:
-            # Due to the integer priority, this was not always defined
+    for name in ["Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"]:
+        if english_lower(name) not in allTypes:
+            # Only Uint32 or Uint64 was (and is) defined, note that this
+            # is not UInt23/UInt64 (capital i), which is removed.
             continue
         allTypes[name] = allTypes[english_lower(name)]
         sctypeDict[name] = sctypeDict[english_lower(name)]

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -119,7 +119,7 @@ def _add_aliases():
     for name in ["Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"]:
         if english_lower(name) not in allTypes:
             # Only Uint32 or Uint64 was (and is) defined, note that this
-            # is not UInt23/UInt64 (capital i), which is removed.
+            # is not UInt32/UInt64 (capital i), which is removed.
             continue
         allTypes[name] = allTypes[english_lower(name)]
         sctypeDict[name] = sctypeDict[english_lower(name)]

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -118,7 +118,7 @@ def _add_aliases():
     # we may want to deprecate the lower case "bytes0" version as well.
     for name in ["Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"]:
         if english_lower(name) not in allTypes:
-            # Only Uint32 or Uint64 was (and is) defined, note that this
+            # Only one of Uint32 or Uint64, aliases of `np.uintp`, was (and is) defined, note that this
             # is not UInt32/UInt64 (capital i), which is removed.
             continue
         allTypes[name] = allTypes[english_lower(name)]

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -11,40 +11,19 @@ and sometimes other mappings too.
 .. data:: sctypeDict
     Similar to `allTypes`, but maps a broader set of aliases to their types.
 
-.. data:: sctypeNA
-    NumArray-compatible names for the scalar types. Contains not only
-    ``name: type`` mappings, but ``char: name`` mappings too.
-
-    .. deprecated:: 1.16
-
 .. data:: sctypes
     A dictionary keyed by a "type group" string, providing a list of types
     under that group.
 
 """
-import warnings
 
 from numpy.compat import unicode
-from numpy._globals import VisibleDeprecationWarning
-from numpy.core._string_helpers import english_lower, english_capitalize
+from numpy.core._string_helpers import english_lower
 from numpy.core.multiarray import typeinfo, dtype
 from numpy.core._dtype import _kind_name
 
 
 sctypeDict = {}      # Contains all leaf-node scalar types with aliases
-class TypeNADict(dict):
-    def __getitem__(self, key):
-        # 2018-06-24, 1.16
-        warnings.warn('sctypeNA and typeNA will be removed in v1.18 '
-                      'of numpy', VisibleDeprecationWarning, stacklevel=2)
-        return dict.__getitem__(self, key)
-    def get(self, key, default=None):
-        # 2018-06-24, 1.16
-        warnings.warn('sctypeNA and typeNA will be removed in v1.18 '
-                      'of numpy', VisibleDeprecationWarning, stacklevel=2)
-        return dict.get(self, key, default)
-
-sctypeNA = TypeNADict()  # Contails all leaf-node types -> numarray type equivalences
 allTypes = {}            # Collect the types we will add to the module
 
 
@@ -127,27 +106,23 @@ def _add_aliases():
         if name in ('longdouble', 'clongdouble') and myname in allTypes:
             continue
 
-        base_capitalize = english_capitalize(base)
-        if base == 'complex':
-            na_name = '%s%d' % (base_capitalize, bit//2)
-        elif base == 'bool':
-            na_name = base_capitalize
-        else:
-            na_name = "%s%d" % (base_capitalize, bit)
-
         allTypes[myname] = info.type
 
         # add mapping for both the bit name and the numarray name
         sctypeDict[myname] = info.type
-        sctypeDict[na_name] = info.type
 
         # add forward, reverse, and string mapping to numarray
-        sctypeNA[na_name] = info.type
-        sctypeNA[info.type] = na_name
-        sctypeNA[info.char] = na_name
-
         sctypeDict[char] = info.type
-        sctypeNA[char] = na_name
+
+    # Add deprecated numeric-style type aliases manually, at some point
+    # we may want to deprecate the lower case "bytes0" version as well.
+    for name in ["Bytes0", "Datetime64", "Str0", "Uint64"]:
+        if name == "Uint64" and "uint64" not in allTypes:
+            # Due to the integer priority, this was not always defined
+            continue
+        allTypes[name] = allTypes[english_lower(name)]
+        sctypeDict[name] = sctypeDict[english_lower(name)]
+
 _add_aliases()
 
 def _add_integer_aliases():
@@ -157,20 +132,15 @@ def _add_integer_aliases():
         u_info = _concrete_typeinfo[u_ctype]
         bits = i_info.bits  # same for both
 
-        for info, charname, intname, Intname in [
-                (i_info,'i%d' % (bits//8,), 'int%d' % bits, 'Int%d' % bits),
-                (u_info,'u%d' % (bits//8,), 'uint%d' % bits, 'UInt%d' % bits)]:
+        for info, charname, intname in [
+                (i_info,'i%d' % (bits//8,), 'int%d' % bits),
+                (u_info,'u%d' % (bits//8,), 'uint%d' % bits)]:
             if bits not in seen_bits:
                 # sometimes two different types have the same number of bits
                 # if so, the one iterated over first takes precedence
                 allTypes[intname] = info.type
                 sctypeDict[intname] = info.type
-                sctypeDict[Intname] = info.type
                 sctypeDict[charname] = info.type
-                sctypeNA[Intname] = info.type
-                sctypeNA[charname] = info.type
-            sctypeNA[info.type] = Intname
-            sctypeNA[info.char] = Intname
 
         seen_bits.add(bits)
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -91,7 +91,7 @@ from numpy.core.multiarray import (
 from numpy.core.overrides import set_module
 
 # we add more at the bottom
-__all__ = ['sctypeDict', 'sctypeNA', 'typeDict', 'typeNA', 'sctypes',
+__all__ = ['sctypeDict', 'typeDict', 'sctypes',
            'ScalarType', 'obj2sctype', 'cast', 'nbytes', 'sctype2char',
            'maximum_sctype', 'issctype', 'typecodes', 'find_common_type',
            'issubdtype', 'datetime_data', 'datetime_as_string',
@@ -106,7 +106,6 @@ from ._string_helpers import (
 
 from ._type_aliases import (
     sctypeDict,
-    sctypeNA,
     allTypes,
     bitname,
     sctypes,
@@ -512,7 +511,6 @@ typecodes = {'Character':'c',
 
 # backwards compatibility --- deprecated name
 typeDict = sctypeDict
-typeNA = sctypeNA
 
 # b -> boolean
 # u -> unsigned integer

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1678,14 +1678,13 @@ _convert_from_str(PyObject *obj, int align)
         }
 
         /* Check for a deprecated Numeric-style typecode */
-        char *dep_tps[] = {"Bool", "Complex", "Float", "Int",
-                           "Object0", "String0", "Timedelta64",
-                           "Unicode0", "UInt", "Void0"};
+        char *dep_tps[] = {"Bytes", "Datetime64", "Str", "Uint64"};
         int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
         for (int i = 0; i < ndep_tps; ++i) {
             char *dep_tp = dep_tps[i];
 
             if (strncmp(type, dep_tp, strlen(dep_tp)) == 0) {
+                /* Deprecated 2020-06-09, NumPy 1.20 */
                 if (DEPRECATE("Numeric-style type codes are "
                               "deprecated and will result in "
                               "an error in the future.") < 0) {

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1678,7 +1678,8 @@ _convert_from_str(PyObject *obj, int align)
         }
 
         /* Check for a deprecated Numeric-style typecode */
-        char *dep_tps[] = {"Bytes", "Datetime64", "Str", "Uint64"};
+        /* `Uint` has deliberately weird uppercasing */
+        char *dep_tps[] = {"Bytes", "Datetime64", "Str", "Uint"};
         int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
         for (int i = 0; i < ndep_tps; ++i) {
             char *dep_tp = dep_tps[i];

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -313,20 +313,16 @@ class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTest
 
 class TestNumericStyleTypecodes(_DeprecationTestCase):
     """
-    Deprecate the old numeric-style dtypes, which are especially
-    confusing for complex types, e.g. Complex32 -> complex64. When the
-    deprecation cycle is complete, the check for the strings should be
-    removed from PyArray_DescrConverter in descriptor.c, and the
-    deprecated keys should not be added as capitalized aliases in
-    _add_aliases in numerictypes.py.
+     Most numeric style typecodes were previously deprecated (and removed)
+     in 1.20. This also deprecates the remaining ones.
     """
+    # 2020-06-09, NumPy 1.20
     def test_all_dtypes(self):
-        deprecated_types = [
-            'Bool', 'Complex32', 'Complex64', 'Float16', 'Float32', 'Float64',
-            'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
-            'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0'
-            ]
+        deprecated_types = ['Bytes0', 'Datetime64', 'Str0', 'Uint64']
         for dt in deprecated_types:
+            if dt == 'Uint64' and dt not in np.typeDict:
+                # Uint64 was only (accidentally) added on some platforms
+                continue
             self.assert_deprecated(np.dtype, exceptions=(TypeError,),
                                    args=(dt,))
 
@@ -436,14 +432,6 @@ class TestGeneratorSum(_DeprecationTestCase):
     # 2018-02-25, 1.15.0
     def test_generator_sum(self):
         self.assert_deprecated(np.sum, args=((i for i in range(5)),))
-
-
-class TestSctypeNA(_VisibleDeprecationTestCase):
-    # 2018-06-24, 1.16
-    def test_sctypeNA(self):
-        self.assert_deprecated(lambda: np.sctypeNA['?'])
-        self.assert_deprecated(lambda: np.typeNA['?'])
-        self.assert_deprecated(lambda: np.typeNA.get('?'))
 
 
 class TestPositiveOnNonNumerical(_DeprecationTestCase):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -313,16 +313,15 @@ class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTest
 
 class TestNumericStyleTypecodes(_DeprecationTestCase):
     """
-     Most numeric style typecodes were previously deprecated (and removed)
-     in 1.20. This also deprecates the remaining ones.
+    Most numeric style typecodes were previously deprecated (and removed)
+    in 1.20. This also deprecates the remaining ones.
     """
     # 2020-06-09, NumPy 1.20
     def test_all_dtypes(self):
-        deprecated_types = ['Bytes0', 'Datetime64', 'Str0', 'Uint64']
+        deprecated_types = ['Bytes0', 'Datetime64', 'Str0']
+        # Depending on intp size, either Uint32 or Uint64 is defined:
+        deprecated_types.append(f"U{np.dtype(np.intp).name}")
         for dt in deprecated_types:
-            if dt == 'Uint64' and dt not in np.typeDict:
-                # Uint64 was only (accidentally) added on some platforms
-                continue
             self.assert_deprecated(np.dtype, exceptions=(TypeError,),
                                    args=(dt,))
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -86,6 +86,15 @@ class TestBuiltin:
             assert_raises(TypeError, np.dtype, 'q8')
             assert_raises(TypeError, np.dtype, 'Q8')
 
+    @pytest.mark.parametrize("dtype",
+             ['Bool', 'Complex32', 'Complex64', 'Float16', 'Float32', 'Float64',
+              'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
+              'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0',
+              "Float128", "Complex128"])
+    def test_numeric_style_types_are_invalid(self, dtype):
+        with assert_raises(TypeError):
+            np.dtype(dtype)
+
     @pytest.mark.parametrize(
         'value',
         ['m8', 'M8', 'datetime64', 'timedelta64',

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -42,13 +42,6 @@ class TestRegression:
                 b = pickle.load(f)
             assert_array_equal(a, b)
 
-    def test_typeNA(self):
-        # Issue gh-515
-        with suppress_warnings() as sup:
-            sup.filter(np.VisibleDeprecationWarning)
-            assert_equal(np.typeNA[np.int64], 'Int64')
-            assert_equal(np.typeNA[np.uint64], 'UInt64')
-
     def test_dtype_names(self):
         # Ticket #35
         # Should succeed


### PR DESCRIPTION
This removes the types from usage for `np.dtype()`, since the
two are closely related, also finishes the deprecation of
`typeNA` and `sctypeNA` (thus removing them from the public API).

The deprecation for the numeric types was only shown for
`np.dtype("Complex64")`, etc. however, here they are also
removed from `np.typeDict` and `np.sctypeDict`.