### PR TITLE
CI: drop win32 3.7, 3.6 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,16 +195,6 @@ stages:
     strategy:
       maxParallel: 6
       matrix:
-          Python36-32bit-fast:
-            PYTHON_VERSION: '3.6'
-            PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
-            BITS: 32
-          Python37-32bit-fast:
-            PYTHON_VERSION: '3.7'
-            PYTHON_ARCH: 'x86'
-            TEST_MODE: fast
-            BITS: 32
           Python38-32bit-fast:
             PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'


### PR DESCRIPTION
~Windows builds use the `maxParallel: 6` directive. This seems to cause problems with installing migw32 for gfortran, we too often get a failed build.~ The easiest thing to do is drop the win32 builds on two of the python versions (3.6, 3.7) retaining only 3.8. We still have 64 bit builds on python 3.6, 3.7, and 3.8.

Edit: the build proves the theory is wrong.