### PR TITLE
ENH: make typing module available at runtime

### DIFF
--- a/doc/release/upcoming_changes/16558.new_feature.rst
+++ b/doc/release/upcoming_changes/16558.new_feature.rst
@@ -1,0 +1,9 @@
+``numpy.typing`` is accessible at runtime
+-----------------------------------------
+The types in ``numpy.typing`` can now be imported at runtime. Code
+like the following will now work:
+
+.. code:: python
+
+    from numpy.typing import ArrayLike
+    x: ArrayLike = [1, 2, 3, 4]

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -22,6 +22,7 @@ For learning how to use NumPy, see the :ref:`complete documentation <numpy_docs_
    constants
    ufuncs
    routines
+   typing
    global_state
    distutils
    distutils_guide

--- a/doc/source/reference/typing.rst
+++ b/doc/source/reference/typing.rst
@@ -1,0 +1,2 @@
+.. _typing:
+.. automodule:: numpy.typing

--- a/numpy/setup.py
+++ b/numpy/setup.py
@@ -17,6 +17,7 @@ def configuration(parent_package='',top_path=None):
     config.add_subpackage('polynomial')
     config.add_subpackage('random')
     config.add_subpackage('testing')
+    config.add_subpackage('typing')
     config.add_data_dir('doc')
     config.add_data_files('py.typed')
     config.add_data_files('*.pyi')

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -98,7 +98,7 @@ def test_dir_testing():
     """Assert that output of dir has only one "testing/tester"
     attribute without duplicate"""
     assert len(dir(np)) == len(set(dir(np)))
-    
+
 
 def test_numpy_linalg():
     bad_results = check_dir(np.linalg)
@@ -176,6 +176,7 @@ PUBLIC_MODULES = ['numpy.' + s for s in [
     "polynomial.polyutils",
     "random",
     "testing",
+    "typing",
     "version",
 ]]
 

--- a/numpy/tests/typing/fail/array_like.py
+++ b/numpy/tests/typing/fail/array_like.py
@@ -1,11 +1,5 @@
-from typing import Any, TYPE_CHECKING
-
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike
-else:
-    ArrayLike = Any
+from numpy.typing import ArrayLike
 
 
 class A:

--- a/numpy/tests/typing/pass/array_like.py
+++ b/numpy/tests/typing/pass/array_like.py
@@ -1,13 +1,7 @@
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, List, Optional
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
-else:
-    ArrayLike = Any
-    DtypeLike = Any
-    _SupportsArray = Any
+from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
 
 x1: ArrayLike = True
 x2: ArrayLike = 5

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -39,10 +39,26 @@ example,
 
 .. code-block:: python
 
-  np.array(x**2 for x in range(10))
+    >>> np.array(x**2 for x in range(10))
+    array(<generator object <genexpr> at 0x10c004cd0>, dtype=object)
 
-is valid NumPy code which will create an object array. The types will
-complain about this usage however.
+is valid NumPy code which will create a 0-dimensional object
+array. Type checkers will complain about the above example when using
+the NumPy types however. If you really intended to do the above, then
+you can either use a ``# type: ignore`` comment:
+
+.. code-block:: python
+
+    >>> np.array(x**2 for x in range(10))  # type: ignore
+
+or explicitly type the array like object as ``Any``:
+
+.. code-block:: python
+
+    >>> from typing import Any
+    >>> array_like: Any = (x**2 for x in range(10))
+    >>> np.array(array_like)
+    array(<generator object <genexpr> at 0x1192741d0>, dtype=object)
 
 ndarray
 ~~~~~~~
@@ -52,8 +68,8 @@ the following code is valid:
 
 .. code-block:: python
 
-  x = np.array([1, 2])
-  x.dtype = np.bool_
+    x = np.array([1, 2])
+    x.dtype = np.bool_
 
 This sort of mutation is not allowed by the types. Users who want to
 write statically typed code should insted use the `numpy.ndarray.view`

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -1,0 +1,3 @@
+from ._array_like import _SupportsArray, ArrayLike
+from ._shape import _Shape, _ShapeLike
+from ._dtype_like import DtypeLike

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -3,6 +3,13 @@
 Typing (:mod:`numpy.typing`)
 ============================
 
+.. warning::
+
+  Some of the types in this module rely on features only present in
+  the standard library in Python 3.8 and greater. If you want to use
+  these types in earlier versions of Python, you should install the
+  typing-extensions_ package.
+
 Large parts of the NumPy API have PEP-484-style type annotations. In
 addition, the following type aliases are available for users.
 
@@ -12,6 +19,8 @@ addition, the following type aliases are available for users.
 Roughly speaking, ``typing.ArrayLike`` is "objects that can be used as
 inputs to ``np.array``" and ``typing.DtypeLike`` is "objects that can
 be used as inputs to ``np.dtype``".
+
+.. _typing-extensions: https://pypi.org/project/typing-extensions/
 
 Differences from the runtime NumPy API
 --------------------------------------

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -1,3 +1,56 @@
+"""
+============================
+Typing (:mod:`numpy.typing`)
+============================
+
+Large parts of the NumPy API have PEP-484-style type annotations. In
+addition, the following type aliases are available for users.
+
+- ``typing.ArrayLike``: objects that can be converted to arrays
+- ``typing.DtypeLike``: objects that can be converted to dtypes
+
+Roughly speaking, ``typing.ArrayLike`` is "objects that can be used as
+inputs to ``np.array``" and ``typing.DtypeLike`` is "objects that can
+be used as inputs to ``np.dtype``".
+
+Differences from the runtime NumPy API
+--------------------------------------
+
+NumPy is very flexible. Trying to describe the full range of
+possibilities statically would result in types that are not very
+helpful. For that reason, the typed NumPy API is often stricter than
+the runtime NumPy API. This section describes some notable
+differences.
+
+ArrayLike
+~~~~~~~~~
+
+The ``ArrayLike`` type tries to avoid creating object arrays. For
+example,
+
+.. code-block:: python
+
+  np.array(x**2 for x in range(10))
+
+is valid NumPy code which will create an object array. The types will
+complain about this usage however.
+
+ndarray
+~~~~~~~
+
+It's possible to mutate the dtype of an array at runtime. For example,
+the following code is valid:
+
+.. code-block:: python
+
+  x = np.array([1, 2])
+  x.dtype = np.bool_
+
+This sort of mutation is not allowed by the types. Users who want to
+write statically typed code should insted use the `numpy.ndarray.view`
+method to create a view of the array with a different dtype.
+
+"""
 from ._array_like import _SupportsArray, ArrayLike
 from ._shape import _Shape, _ShapeLike
 from ._dtype_like import DtypeLike

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -1,0 +1,27 @@
+import sys
+from typing import Any, overload, Sequence, Tuple, Union
+
+from numpy import ndarray
+from ._dtype_like import DtypeLike
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+    HAVE_PROTOCOL = True
+else:
+    try:
+        from typing_extensions import Protocol
+    except ImportError:
+        HAVE_PROTOCOL = False
+    else:
+        HAVE_PROTOCOL = True
+
+if HAVE_PROTOCOL:
+    class _SupportsArray(Protocol):
+        @overload
+        def __array__(self, __dtype: DtypeLike = ...) -> ndarray: ...
+        @overload
+        def __array__(self, dtype: DtypeLike = ...) -> ndarray: ...
+else:
+    _SupportsArray = Any
+
+ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -24,4 +24,9 @@ if TYPE_CHECKING or HAVE_PROTOCOL:
 else:
     _SupportsArray = Any
 
+# TODO: support buffer protocols once
+#
+# https://github.com/python/typing/issues/593
+#
+# is resolved.
 ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -26,7 +26,9 @@ else:
 
 # TODO: support buffer protocols once
 #
-# https://github.com/python/typing/issues/593
+# https://bugs.python.org/issue27501
 #
-# is resolved.
+# is resolved. See also the mypy issue:
+#
+# https://github.com/python/typing/issues/593
 ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, overload, Sequence, Tuple, Union
+from typing import Any, overload, Sequence, TYPE_CHECKING, Union
 
 from numpy import ndarray
 from ._dtype_like import DtypeLike
@@ -15,7 +15,7 @@ else:
     else:
         HAVE_PROTOCOL = True
 
-if HAVE_PROTOCOL:
+if TYPE_CHECKING or HAVE_PROTOCOL:
     class _SupportsArray(Protocol):
         @overload
         def __array__(self, __dtype: DtypeLike = ...) -> ndarray: ...

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -1,17 +1,7 @@
-import sys
-from typing import Any, Dict, List, overload, Sequence, Text, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
-from numpy import dtype, ndarray
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
-
-_Shape = Tuple[int, ...]
-
-# Anything that can be coerced to a shape tuple
-_ShapeLike = Union[int, Sequence[int]]
+from numpy import dtype
+from ._shape import _ShapeLike
 
 _DtypeLikeNested = Any  # TODO: wait for support for recursive types
 
@@ -45,7 +35,7 @@ DtypeLike = Union[
             Sequence[str],  # names
             Sequence[_DtypeLikeNested],  # formats
             Sequence[int],  # offsets
-            Sequence[Union[bytes, Text, None]],  # titles
+            Sequence[Union[bytes, str, None]],  # titles
             int,  # itemsize
         ],
     ],
@@ -54,11 +44,3 @@ DtypeLike = Union[
     # (base_dtype, new_dtype)
     Tuple[_DtypeLikeNested, _DtypeLikeNested],
 ]
-
-class _SupportsArray(Protocol):
-    @overload
-    def __array__(self, __dtype: DtypeLike = ...) -> ndarray: ...
-    @overload
-    def __array__(self, dtype: DtypeLike = ...) -> ndarray: ...
-
-ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]

--- a/numpy/typing/_shape.py
+++ b/numpy/typing/_shape.py
@@ -1,0 +1,6 @@
+from typing import Sequence, Tuple, Union
+
+_Shape = Tuple[int, ...]
+
+# Anything that can be coerced to a shape tuple
+_ShapeLike = Union[int, Sequence[int]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16550.

This makes `np.typing.ArrayLike` and `np.typing.DtypeLike` available
at runtime in addition to typing time. Some things to consider:

- `ArrayLike` uses protocols, which are only in the standard library
  in 3.8+, but are backported in `typing_extensions`. This
  conditionally imports `Protocol` and sets `_SupportsArray` to `Any`
  at runtime if the module is not available to prevent NumPy from
  having a hard dependency on `typing_extensions`. Since e.g. mypy
  already includes `typing_extensions` as a dependency, anybody
  actually doing type checking will have it set correctly.
- We are starting to hit the edges of "the fiction of the stubs". In
  particular, they could just cram everything into `__init__.pyi` and
  ignore the real structure of NumPy. But now that typing is available
  a runtime, we have to e.g. carefully import `ndarray` from `numpy`
  in the typing module and not from `..core.multiarray`, because
  otherwise mypy will think you are talking about a different
  ndarray. We will probably need to do some shuffling the stubs into
  more fitting locations to mitigate weirdness like this.