### PR TITLE
ENH: Throw TypeError on operator concat on Numpy Arrays

### DIFF
--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -50,9 +50,24 @@ array_contains(PyArrayObject *self, PyObject *el)
     return ret;
 }
 
+static PyObject *
+array_concat(PyObject *self, PyObject *other)
+{
+    /*
+     * Throw a type error, when trying to concat NDArrays
+     * NOTE: This error is not Thrown when running with PyPy
+     */
+    PyErr_SetString(PyExc_TypeError,
+            "Concatenation operation is not implemented for NumPy arrays, "
+            "use np.concatenate() instead. Please do not rely on this error; "
+            "it may not be given on all Python implementations.");
+    return NULL;
+}
+
+
 NPY_NO_EXPORT PySequenceMethods array_as_sequence = {
     (lenfunc)array_length,                  /*sq_length*/
-    (binaryfunc)NULL,                       /*sq_concat is handled by nb_add*/
+    (binaryfunc)array_concat,               /*sq_concat for operator.concat*/
     (ssizeargfunc)NULL,
     (ssizeargfunc)array_item,
     (ssizessizeargfunc)NULL,

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -8,7 +8,7 @@ from numpy.core.shape_base import (_block_dispatcher, _block_setup,
                                    _block_concatenate, _block_slicing)
 from numpy.testing import (
     assert_, assert_raises, assert_array_equal, assert_equal,
-    assert_raises_regex, assert_warns
+    assert_raises_regex, assert_warns, IS_PYPY
     )
 
 
@@ -319,6 +319,19 @@ class TestConcatenate:
         rout = concatenate((a0, a1, a2), 2, out=out)
         assert_(out is rout)
         assert_equal(res, rout)
+
+    @pytest.mark.skipif(IS_PYPY, reason="PYPY handles sq_concat, nb_add differently than cpython")
+    def test_operator_concat(self):
+        import operator
+        a = array([1, 2])
+        b = array([3, 4])
+        n = [1,2]
+        res = array([1, 2, 3, 4])
+        assert_raises(TypeError, operator.concat, a, b)
+        assert_raises(TypeError, operator.concat, a, n)
+        assert_raises(TypeError, operator.concat, n, a)
+        assert_raises(TypeError, operator.concat, a, 1)
+        assert_raises(TypeError, operator.concat, 1, a)
 
     def test_bad_out_shape(self):
         a = array([1, 2])


### PR DESCRIPTION
Fixes #16489 

New to Python C-API, requesting feedback on Reference counter handling, does it look correct?

Tried to reuse Numpy concatenate. 