### PR TITLE
BUG: fix sin/cos bug when input is strided array

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -2698,17 +2698,17 @@ static NPY_GCC_OPT_3 NPY_GCC_TARGET_@ISA@ void
 
         /* process elements using glibc for large elements */
         if (my_trig_op == npy_compute_cos) {
-            for (int ii = 0; iglibc_mask != 0; ii++) {
+            for (int ii = 0, jj = 0; iglibc_mask != 0; ii++, jj += stride) {
                 if (iglibc_mask & 0x01) {
-                    op[ii] = npy_cosf(ip[ii]);
+                    op[ii] = npy_cosf(ip[jj]);
                 }
                 iglibc_mask  = iglibc_mask >> 1;
             }
         }
         else {
-            for (int ii = 0; iglibc_mask != 0; ii++) {
+            for (int ii = 0, jj = 0; iglibc_mask != 0; ii++, jj += stride) {
                 if (iglibc_mask & 0x01) {
-                    op[ii] = npy_sinf(ip[ii]);
+                    op[ii] = npy_sinf(ip[jj]);
                 }
                 iglibc_mask  = iglibc_mask >> 1;
             }

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -890,15 +890,17 @@ class TestAVXFloat32Transcendental:
         sizes = np.arange(2,100)
         for ii in sizes:
             x_f32 = np.float32(np.random.uniform(low=0.01,high=88.1,size=ii))
+            x_f32_large = x_f32.copy()
+            x_f32_large[3:-1:4] = 120000.0
             exp_true = np.exp(x_f32)
             log_true = np.log(x_f32)
-            sin_true = np.sin(x_f32)
-            cos_true = np.cos(x_f32)
+            sin_true = np.sin(x_f32_large)
+            cos_true = np.cos(x_f32_large)
             for jj in strides:
                 assert_array_almost_equal_nulp(np.exp(x_f32[::jj]), exp_true[::jj], nulp=2)
                 assert_array_almost_equal_nulp(np.log(x_f32[::jj]), log_true[::jj], nulp=2)
-                assert_array_almost_equal_nulp(np.sin(x_f32[::jj]), sin_true[::jj], nulp=2)
-                assert_array_almost_equal_nulp(np.cos(x_f32[::jj]), cos_true[::jj], nulp=2)
+                assert_array_almost_equal_nulp(np.sin(x_f32_large[::jj]), sin_true[::jj], nulp=2)
+                assert_array_almost_equal_nulp(np.cos(x_f32_large[::jj]), cos_true[::jj], nulp=2)
 
 class TestLogAddExp(_FilterInvalids):
     def test_logaddexp_values(self):


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

When the input array is strided and the number is larger than some threshold, np.sin/np.cos will cause some incorrect output. A sample example:
```
import numpy as np

x = np.float32(np.zeros(20))
x[4] = 72000.0

y = np.cos(x)
print("stride np.cos(x) with 2:")
print(np.cos(x[::2]))
print("stride y with 2:")
print(y[::2])
```
The reason is that in numpy/core/src/umath/simd.inc.src:2703, the index of ip array should be multiplied by the stride.

If you want to reproduce this problem, be sure your machine supports AVX512. 
