### PR TITLE
DOC: unify the docs for np.transpose and ndarray.transpose

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3998,8 +3998,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('transpose',
 
     Returns a view of the array with axes transposed.
 
-    Refer to `numpy.transpose` for full documentation.
-
     For a 1-D array this has no effect, as a transposed vector is simply the
     same vector. To convert a 1-D array into a 2D column vector, an additional
     dimension must be added. `np.atleast2d(a).T` achieves this, as does
@@ -4029,7 +4027,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('transpose',
 
     See Also
     --------
-    ndarray.transpose : Method to reverse or permute the axes of an array.
+    transpose : Equivalent function
     ndarray.T : Array property returning the array transposed.
     ndarray.reshape : Give a new shape to an array without changing its data.
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3998,6 +3998,8 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('transpose',
 
     Returns a view of the array with axes transposed.
 
+    Refer to `numpy.transpose` for full documentation.
+
     For a 1-D array this has no effect, as a transposed vector is simply the
     same vector. To convert a 1-D array into a 2D column vector, an additional
     dimension must be added. `np.atleast2d(a).T` achieves this, as does
@@ -4027,6 +4029,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('transpose',
 
     See Also
     --------
+    ndarray.transpose : Method to reverse or permute the axes of an array.
     ndarray.T : Array property returning the array transposed.
     ndarray.reshape : Give a new shape to an array without changing its data.
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -605,6 +605,8 @@ def transpose(a, axes=None):
 
     For an array a with two axes, transpose(a) gives the matrix transpose.
 
+    Refer to `numpy.ndarray.transpose` for full documentation.
+
     Parameters
     ----------
     a : array_like
@@ -624,7 +626,7 @@ def transpose(a, axes=None):
 
     See Also
     --------
-    ndarray.transpose : Method to reverse or permute the axes of an array.
+    ndarray.transpose : Equivalent method
     moveaxis
     argsort
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -624,6 +624,7 @@ def transpose(a, axes=None):
 
     See Also
     --------
+    ndarray.transpose : Method to reverse or permute the axes of an array.
     moveaxis
     argsort
 


### PR DESCRIPTION
Added a cross-link between` np.transpose` and `ndarray.transpose` like the one in` ndarray.sort` and `np.sort`

(this is a partial fix to https://github.com/numpy/numpy/issues/16584)