### PR TITLE
MAINT: Remove nickname from polynomial classes.

### DIFF
--- a/doc/release/upcoming_changes/16589.compatibility.rst
+++ b/doc/release/upcoming_changes/16589.compatibility.rst
@@ -1,9 +1,8 @@
 ``nickname`` attribute removed from ABCPolyBase
 -----------------------------------------------
 
-An abstract property ``nickname`` has been removed from 
-`~numpy.polynomial._polybase.ABCPolyBase` as it was no longer used in any of
-the derived :doc:`convenience classes <routines.polynomials.classes>`.
+An abstract property ``nickname`` has been removed from  ``ABCPolyBase`` as it
+was no longer used in the derived convenience classes.
 This may affect users who have derived classes from ``ABCPolyBase`` and 
 overridden the methods for representation and display, e.g. ``__str__``, 
 ``__repr__``, ``_repr_latex``, etc.

--- a/doc/release/upcoming_changes/16589.compatibility.rst
+++ b/doc/release/upcoming_changes/16589.compatibility.rst
@@ -1,0 +1,9 @@
+``nickname`` attribute removed from ABCPolyBase
+-----------------------------------------------
+
+An abstract property ``nickname`` has been removed from 
+`~numpy.polynomial._polybase.ABCPolyBase` as it was no longer used in any of
+the derived :doc:`convenience classes <routines.polynomials.classes>`.
+This may affect users who have derived classes from ``ABCPolyBase`` and 
+overridden the methods for representation and display, e.g. ``__str__``, 
+``__repr__``, ``_repr_latex``, etc.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -111,11 +111,6 @@ class ABCPolyBase(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def nickname(self):
-        pass
-
-    @property
-    @abc.abstractmethod
     def basis_name(self):
         pass
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -2058,7 +2058,6 @@ class Chebyshev(ABCPolyBase):
         return cls(coef, domain=domain)
 
     # Virtual properties
-    nickname = 'cheb'
     domain = np.array(chebdomain)
     window = np.array(chebdomain)
     basis_name = 'T'

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1675,7 +1675,6 @@ class Hermite(ABCPolyBase):
     _fromroots = staticmethod(hermfromroots)
 
     # Virtual properties
-    nickname = 'herm'
     domain = np.array(hermdomain)
     window = np.array(hermdomain)
     basis_name = 'H'

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1669,7 +1669,6 @@ class HermiteE(ABCPolyBase):
     _fromroots = staticmethod(hermefromroots)
 
     # Virtual properties
-    nickname = 'herme'
     domain = np.array(hermedomain)
     window = np.array(hermedomain)
     basis_name = 'He'

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1626,7 +1626,6 @@ class Laguerre(ABCPolyBase):
     _fromroots = staticmethod(lagfromroots)
 
     # Virtual properties
-    nickname = 'lag'
     domain = np.array(lagdomain)
     window = np.array(lagdomain)
     basis_name = 'L'

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1642,7 +1642,6 @@ class Legendre(ABCPolyBase):
     _fromroots = staticmethod(legfromroots)
 
     # Virtual properties
-    nickname = 'leg'
     domain = np.array(legdomain)
     window = np.array(legdomain)
     basis_name = 'P'

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1490,7 +1490,6 @@ class Polynomial(ABCPolyBase):
     _fromroots = staticmethod(polyfromroots)
 
     # Virtual properties
-    nickname = 'poly'
     domain = np.array(polydomain)
     window = np.array(polydomain)
     basis_name = None


### PR DESCRIPTION
This is a bit of proposed cleanup following the changes to polynomial printing in #15666.

The convenience classes derived from ABCPolyBase have a `nickname` attribute that was only used internally in the previous implementation of `__str__`. After the overhaul of `__str__` in #15666, this attr is no longer used anywhere internally, nor is it documented.

This change would technically break backward compatibility as the attribute was not prepended with `_`, but as it was an undocumented attribute that was only used internally in one specific place (and is no longer used anywhere) I thought it might be worth at least considering its removal.
