### PR TITLE
DOC: Clarify dtype default for logspace and geomspace

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -53,9 +53,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         between samples.
     dtype : dtype, optional
         The type of the output array.  If `dtype` is not given, the data type
-        is inferred from `start` and `stop`. The inferred dtype will
-        never be an integer; `float` is chosen even if the arguments would
-        produce an array of integers.
+        is inferred from `start` and `stop`. The inferred dtype will never be
+        an integer; `float` is chosen even if the arguments would produce an
+        array of integers.
 
         .. versionadded:: 1.9.0
 
@@ -204,8 +204,10 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
         ``ln(samples) / ln(base)`` (or ``log_base(samples)``) is uniform.
         Default is 10.0.
     dtype : dtype
-        The type of the output array.  If `dtype` is not given, infer the data
-        type from the other input arguments.
+        The type of the output array.  If `dtype` is not given, the data type
+        is inferred from `start` and `stop`. The inferred type will never be
+        an integer; `float` is chosen even if the arguments would produce an
+        array of integers.
     axis : int, optional
         The axis in the result to store the samples.  Relevant only if start
         or stop are array-like.  By default (0), the samples will be along a
@@ -299,8 +301,10 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
         If true, `stop` is the last sample. Otherwise, it is not included.
         Default is True.
     dtype : dtype
-        The type of the output array.  If `dtype` is not given, infer the data
-        type from the other input arguments.
+        The type of the output array.  If `dtype` is not given, the data type
+        is inferred from `start` and `stop`. The inferred dtype will never be
+        an integer; `float` is chosen even if the arguments would produce an
+        array of integers.
     axis : int, optional
         The axis in the result to store the samples.  Relevant only if start
         or stop are array-like.  By default (0), the samples will be along a


### PR DESCRIPTION
Same clarification for these functions as gh-16433 made for linspace. @Qiyu8 spotted these additional cases.

