### PR TITLE
ENH: Add ``__f2py_numpy_version__`` attribute to Fortran modules.

### DIFF
--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -55,6 +55,9 @@ __version__ = "$Revision: 1.129 $"[10:-1]
 from . import __version__
 f2py_version = __version__.version
 
+from .. import version as _numpy_version
+numpy_version = _numpy_version.version
+
 import os
 import time
 import copy
@@ -205,6 +208,9 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
 \ts = PyUnicode_FromString(
 \t\t\"This module '#modulename#' is auto-generated with f2py (version:#f2py_version#).\\nFunctions:\\n\"\n#docs#\".\");
 \tPyDict_SetItemString(d, \"__doc__\", s);
+\tPy_DECREF(s);
+\ts = PyUnicode_FromString(\"""" + numpy_version + """\");
+\tPyDict_SetItemString(d, \"__f2py_numpy_version__\", s);
 \tPy_DECREF(s);
 \t#modulename#_error = PyErr_NewException (\"#modulename#.error\", NULL, NULL);
 \t/*

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 import numpy as np
-from numpy.testing import assert_raises, assert_equal
+from numpy.testing import assert_, assert_raises, assert_equal, assert_string_equal
 
 from . import util
 
@@ -25,3 +25,23 @@ class TestIntentInOut(util.F2PyTest):
         x = np.arange(3, dtype=np.float32)
         self.module.foo(x)
         assert_equal(x, [3, 1, 2])
+ 
+
+class TestNumpyVersionAttribute(util.F2PyTest):
+    # Check that th attribute __f2py_numpy_version__ is present
+    # in the compiled module and that has the value np.__version__.
+    sources = [_path('src', 'regression', 'inout.f90')]
+    
+    @pytest.mark.slow
+    def test_numpy_version_attribute(self):
+        
+        # Check that self.module has an attribute named "__f2py_numpy_version__"
+        assert_(hasattr(self.module, "__f2py_numpy_version__"), 
+                msg="Fortran module does not have __f2py_numpy_version__")
+        
+        # Check that the attribute __f2py_numpy_version__ is a string
+        assert_(isinstance(self.module.__f2py_numpy_version__, str),
+                msg="__f2py_numpy_version__ is not a string")
+        
+        # Check that __f2py_numpy_version__ has the value numpy.__version__
+        assert_string_equal(np.__version__, self.module.__f2py_numpy_version__)


### PR DESCRIPTION
The Fortran module now reports the version of NumPy associated with the f2py used for compilation. Closes gh-16525.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
