### PR TITLE
MAINT: bump mypy version to 0.780

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,5 +11,5 @@ cffi
 # - Mypy relies on C API features not present in PyPy
 # - Mypy doesn't currently work on Python 3.9
 # - Python 3.6 doesn't work because it doesn't understand py.typed
-mypy==0.770; platform_python_implementation != "PyPy" and python_version > "3.6" and python_version < "3.9"
+mypy==0.780; platform_python_implementation != "PyPy" and python_version > "3.6"
 typing_extensions


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16538.

This should allow us to run mypy in CI against Python 3.9. (At
least the tests pass for me locally on 3.9.)