### PR TITLE
ENH: add annotation for abs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -737,7 +737,6 @@ class ufunc:
     @property
     def at(self) -> Any: ...
 
-abs: ufunc
 absolute: ufunc
 add: ufunc
 arccos: ufunc
@@ -824,6 +823,8 @@ tan: ufunc
 tanh: ufunc
 true_divide: ufunc
 trunc: ufunc
+
+abs = absolute
 
 # Warnings
 class ModuleDeprecationWarning(DeprecationWarning): ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -737,6 +737,7 @@ class ufunc:
     @property
     def at(self) -> Any: ...
 
+abs: ufunc
 absolute: ufunc
 add: ufunc
 arccos: ufunc

--- a/numpy/tests/typing/fail/ufuncs.py
+++ b/numpy/tests/typing/fail/ufuncs.py
@@ -3,3 +3,5 @@ import numpy as np
 np.sin.nin + "foo"  # E: Unsupported operand types
 np.sin(1, foo="bar")  # E: Unexpected keyword argument
 np.sin(1, extobj=["foo", "foo", "foo"])  # E: incompatible type
+
+np.abs(None)  # E: incompatible type

--- a/numpy/tests/typing/pass/ufuncs.py
+++ b/numpy/tests/typing/pass/ufuncs.py
@@ -9,3 +9,5 @@ np.sin(1, extobj=[16, 1, lambda: None])
 np.sin(1) + np.sin(1)
 np.sin.types[0]
 np.sin.__name__
+
+np.abs(np.array([1]))


### PR DESCRIPTION
`numpy.abs` is alias of `numpy.absolute`. I added its type annotation.