### PR TITLE
BLD: check if std=c99 is really required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,6 +233,7 @@ def get_build_overrides():
     """
     from numpy.distutils.command.build_clib import build_clib
     from numpy.distutils.command.build_ext import build_ext
+    from distutils.version import LooseVersion
 
     def _is_using_old_gcc(obj):
         is_old_gcc = False
@@ -242,11 +243,10 @@ def get_build_overrides():
                 out = subprocess.run([cc, '-dumpversion'],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
+                                     universal_newlines=True,
                                     )
-                # will print something like b'4.2.1\n'
-                ver_parts = out.stdout.split(b'.')
-                if int(ver_parts[0]) < 6:
-                    # perhaps 5 is OK?
+                # will print something like '4.2.1\n'
+                if LooseVersion(out.stdout) < LooseVersion('5.0'):
                     is_old_gcc = True
         return is_old_gcc
 

--- a/setup.py
+++ b/setup.py
@@ -238,13 +238,14 @@ def get_build_overrides():
         is_old_gcc = False
         if obj.compiler.compiler_type == 'unix':
             cc = obj.compiler.compiler[0]
-            if cc == "gcc":
+            if "gcc" in cc:
                 out = subprocess.run([cc, '-dumpversion'],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                     )
-                ver = float(out.stdout)
-                if ver < 6:
+                # will print something like b'4.2.1\n'
+                ver_parts = out.stdout.split(b'.')
+                if int(ver_parts[0]) < 6:
                     # perhaps 5 is OK?
                     is_old_gcc = True
         return is_old_gcc


### PR DESCRIPTION
Fixes gh-15237. We were unconditionally setting `std=c99` even where not needed, which in some cases degraded the compiler.

@pv ping.

At some point we can just give up, rip all this out, and tell users to update their compiler.