### PR TITLE
BENCH: Expand array-creation benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -7,9 +7,13 @@ class Core(Benchmark):
     def setup(self):
         self.l100 = range(100)
         self.l50 = range(50)
+        self.float_l1000 = [float(i) for i in range(1000)]
+        self.float64_l1000 = [np.float64(i) for i in range(1000)]
+        self.int_l1000 = list(range(1000))
         self.l = [np.arange(1000), np.arange(1000)]
         self.l_view = [memoryview(a) for a in self.l]
         self.l10x10 = np.ones((10, 10))
+        self.float64_dtype = np.dtype(np.float64)
 
     def time_array_1(self):
         np.array(1)
@@ -22,6 +26,18 @@ class Core(Benchmark):
 
     def time_array_l100(self):
         np.array(self.l100)
+
+    def time_array_float_l1000(self):
+        np.array(self.float_l1000)
+
+    def time_array_float_l1000_dtype(self):
+        np.array(self.float_l1000, dtype=self.float64_dtype)
+
+    def time_array_float64_l1000(self):
+        np.array(self.float64_l1000)
+
+    def time_array_int_l1000(self):
+        np.array(self.int_l1000)
 
     def time_array_l(self):
         np.array(self.l)


### PR DESCRIPTION
This adds some simple additional tests, one for a list of NumPy
scalars. Another for generally lists, both integers and floats
as one common cases (floats previously had some super-fast paths).
As well as a test with the dtype given, since that may make
some differences.

---

These benchmarks are barely worth it, but do cover some cases currently not covered. Basically, the float (and probably the float+dtype a bit more), are slower in my branch, and all other cases seem faster or much faster.

The one other case is slower, but at this moment a bit hard to test directly, is coercion when the input is already an array.  That is mainly because I do not want to mess with the special `np.array()` code on top of everything else.

The best test I have found for this is:
```
arr1 = np.zeros(10, dtype=bool); arr2 = arr1.copy(); arr3 = arr1.copy()
%timeit np.putmask(arr1, arr2, arr3)
```
Simply because it coerces 2 arrays in one call.  This particular call has a performance loss of less than 10% right now.