### PR TITLE
MAINT: Implemented two dtype-related TODO's

### DIFF
--- a/numpy/tests/typing/fail/dtype.py
+++ b/numpy/tests/typing/fail/dtype.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+
+class Test:
+    not_dtype = float
+
+
+np.dtype(Test())  # E: Argument 1 to "dtype" has incompatible type

--- a/numpy/tests/typing/fail/dtype.py
+++ b/numpy/tests/typing/fail/dtype.py
@@ -6,3 +6,10 @@ class Test:
 
 
 np.dtype(Test())  # E: Argument 1 to "dtype" has incompatible type
+
+np.dtype(
+    {  # E: Argument 1 to "dtype" has incompatible type
+        "field1": (float, 1),
+        "field2": (int, 3),
+    }
+)

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -9,6 +9,8 @@ np.dtype((int, 2))
 np.dtype((int, (1,)))
 
 np.dtype({"names": ["a", "b"], "formats": [int, float]})
+np.dtype({"names": ["a"], "formats": [int], "titles": [object]})
+np.dtype({"names": ["a"], "formats": [int], "titles": [object()]})
 np.dtype(
     {
         "names": ["a", "b"],

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -2,7 +2,7 @@ import numpy as np
 
 np.dtype(dtype=np.int64)
 np.dtype(int)
-np.dtype('int')
+np.dtype("int")
 np.dtype(None)
 
 np.dtype((int, 1))
@@ -10,13 +10,17 @@ np.dtype((int, (1,)))
 np.dtype([(int, 1)])
 np.dtype([(int, (1,))])
 
-np.dtype({'names': ['a', 'b'], 'formats': [int, float]})
-np.dtype({'names': ['a', 'b'],
-          'formats': [int, float],
-          'itemsize': 9,
-          'aligned': False,
-          'titles': ['x', 'y'],
-          'offsets': [0, 1]})
+np.dtype({"names": ["a", "b"], "formats": [int, float]})
+np.dtype(
+    {
+        "names": ["a", "b"],
+        "formats": [int, float],
+        "itemsize": 9,
+        "aligned": False,
+        "titles": ["x", "y"],
+        "offsets": [0, 1],
+    }
+)
 
-np.dtype({'field1': (float, 1), 'field2': (int, 3)})
+np.dtype({"field1": (float, 1), "field2": (int, 3)})
 np.dtype((np.float_, float))

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -21,3 +21,10 @@ np.dtype(
 
 np.dtype({"field1": (float, 1), "field2": (int, 3)})
 np.dtype((np.float_, float))
+
+
+class Test:
+    dtype = float
+
+
+np.dtype(Test)

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -25,7 +25,6 @@ np.dtype(
     }
 )
 
-np.dtype({"field1": (float, 1), "field2": (int, 3)})
 np.dtype((np.float_, float))
 
 

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -5,10 +5,7 @@ np.dtype(int)
 np.dtype("int")
 np.dtype(None)
 
-np.dtype((int, 1))
 np.dtype((int, (1,)))
-np.dtype([(int, 1)])
-np.dtype([(int, (1,))])
 
 np.dtype({"names": ["a", "b"], "formats": [int, float]})
 np.dtype(

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -5,6 +5,7 @@ np.dtype(int)
 np.dtype("int")
 np.dtype(None)
 
+np.dtype((int, 2))
 np.dtype((int, (1,)))
 
 np.dtype({"names": ["a", "b"], "formats": [int, float]})

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -1,3 +1,22 @@
 import numpy as np
 
 np.dtype(dtype=np.int64)
+np.dtype(int)
+np.dtype('int')
+np.dtype(None)
+
+np.dtype((int, 1))
+np.dtype((int, (1,)))
+np.dtype([(int, 1)])
+np.dtype([(int, (1,))])
+
+np.dtype({'names': ['a', 'b'], 'formats': [int, float]})
+np.dtype({'names': ['a', 'b'],
+          'formats': [int, float],
+          'itemsize': 9,
+          'aligned': False,
+          'titles': ['x', 'y'],
+          'offsets': [0, 1]})
+
+np.dtype({'field1': (float, 1), 'field2': (int, 3)})
+np.dtype((np.float_, float))

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -11,6 +11,9 @@ np.dtype((int, (1,)))
 np.dtype({"names": ["a", "b"], "formats": [int, float]})
 np.dtype({"names": ["a"], "formats": [int], "titles": [object]})
 np.dtype({"names": ["a"], "formats": [int], "titles": [object()]})
+
+np.dtype([("name", np.unicode_, 16), ("grades", np.float64, (2,)), ("age", "int32")])
+
 np.dtype(
     {
         "names": ["a", "b"],

--- a/numpy/tests/typing/pass/dtype.py
+++ b/numpy/tests/typing/pass/dtype.py
@@ -30,4 +30,4 @@ class Test:
     dtype = float
 
 
-np.dtype(Test)
+np.dtype(Test())

--- a/numpy/tests/typing/pass/simple.py
+++ b/numpy/tests/typing/pass/simple.py
@@ -62,8 +62,6 @@ np.dtype(shape_like_dtype)
 object_dtype = [("field1", object)]
 np.dtype(object_dtype)
 
-np.dtype({"col1": ("U10", 0), "col2": ("float32", 10)})
-np.dtype((np.int32, {"real": (np.int16, 0), "imag": (np.int16, 2)}))
 np.dtype((np.int32, (np.int8, 4)))
 
 # Dtype comparision

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -3,7 +3,24 @@ from typing import Any, Dict, List, Sequence, Tuple, Union
 from numpy import dtype
 from ._shape import _ShapeLike
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol, TypedDict
+else:
+    from typing_extensions import Protocol, TypedDict
+
 _DtypeLikeNested = Any  # TODO: wait for support for recursive types
+
+# Mandatory keys
+class _DtypeDictBase(TypedDict):
+    names: Sequence[str]
+    formats: Sequence[_DtypeLikeNested]
+
+# Mandatory + optional keys
+class _DtypeDict(_DtypeDictBase, total=False):
+    offsets: Sequence[int]
+    titles: Sequence[Union[bytes, Text, None]]
+    itemsize: int
+    aligned: bool
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
@@ -25,20 +42,10 @@ DtypeLike = Union[
     # The type here is quite broad because NumPy accepts quite a wide
     # range of inputs inside the list; see the tests for some
     # examples.
-    List[Any],
+    List[_DtypeLikeNested],
     # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
     #  'itemsize': ...}
-    # TODO: use TypedDict when/if it's officially supported
-    Dict[
-        str,
-        Union[
-            Sequence[str],  # names
-            Sequence[_DtypeLikeNested],  # formats
-            Sequence[int],  # offsets
-            Sequence[Union[bytes, str, None]],  # titles
-            int,  # itemsize
-        ],
-    ],
+    _DtypeDict,
     # {'field1': ..., 'field2': ..., ...}
     Dict[str, Tuple[_DtypeLikeNested, int]],
     # (base_dtype, new_dtype)

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -33,16 +33,14 @@ DtypeLike = Union[
     # TODO: add a protocol for anything with a dtype attribute
     # character codes, type strings or comma-separated fields, e.g., 'float64'
     str,
-    # (flexible_dtype, itemsize)
-    Tuple[_DtypeLikeNested, int],
     # (fixed_dtype, shape)
-    Tuple[_DtypeLikeNested, _ShapeLike],
+    Tuple[_DtypeLikeNested, Sequence[int]],  # No integers allowed
     # [(field_name, field_dtype, field_shape), ...]
     #
     # The type here is quite broad because NumPy accepts quite a wide
     # range of inputs inside the list; see the tests for some
     # examples.
-    List[_DtypeLikeNested],
+    List[Any],
     # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
     #  'itemsize': ...}
     _DtypeDict,

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -4,14 +4,20 @@ from typing import Any, List, Sequence, Tuple, Union, TYPE_CHECKING
 from numpy import dtype
 from ._shape import _ShapeLike
 
+if sys.version_info >= (3, 8):
+    from typing import Protocol, TypedDict
+    HAVE_PROTOCOL = True
+else:
+    try:
+        from typing_extensions import Protocol, TypedDict
+    except ImportError:
+        HAVE_PROTOCOL = False
+    else:
+        HAVE_PROTOCOL = True
+
 _DtypeLikeNested = Any  # TODO: wait for support for recursive types
 
-if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import Protocol, TypedDict
-    else:
-        from typing_extensions import Protocol, TypedDict
-
+if TYPE_CHECKING or HAVE_PROTOCOL:
     # Mandatory keys
     class _DtypeDictBase(TypedDict):
         names: Sequence[str]
@@ -28,9 +34,9 @@ if TYPE_CHECKING:
     class _SupportsDtype(Protocol):
         dtype: _DtypeLikeNested
 
-else:  # runtime-only placeholders
-    _DtypeDict = 'numpy.typing._dtype_like._DtypeDict'
-    _SupportsDtype = 'numpy.typing._dtype_like._SupportsDtype'
+else:
+    _DtypeDict = Any
+    _SupportsDtype = Any
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -38,8 +38,10 @@ DtypeLike = Union[
     _SupportsDtype,
     # character codes, type strings or comma-separated fields, e.g., 'float64'
     str,
+    # (flexible_dtype, itemsize)
+    Tuple[_DtypeLikeNested, int],
     # (fixed_dtype, shape)
-    Tuple[_DtypeLikeNested, Sequence[int]],  # No integers allowed
+    Tuple[_DtypeLikeNested, _ShapeLike],  # No integers allowed
     # [(field_name, field_dtype, field_shape), ...]
     #
     # The type here is quite broad because NumPy accepts quite a wide

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Dict, List, Sequence, Tuple, Union
 
 from numpy import dtype

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -18,7 +18,7 @@ class _DtypeDictBase(TypedDict):
 # Mandatory + optional keys
 class _DtypeDict(_DtypeDictBase, total=False):
     offsets: Sequence[int]
-    titles: Sequence[Union[bytes, Text, None]]
+    titles: Sequence[Any]  # Elements should be valid as dict keys
     itemsize: int
     aligned: bool
 

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, List, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import Any, List, Sequence, Tuple, Union, TYPE_CHECKING
 
 from numpy import dtype
 from ._shape import _ShapeLike
@@ -57,8 +57,13 @@ DtypeLike = Union[
     # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
     #  'itemsize': ...}
     _DtypeDict,
-    # {'field1': ..., 'field2': ..., ...}
-    Dict[str, Tuple[_DtypeLikeNested, int]],
     # (base_dtype, new_dtype)
     Tuple[_DtypeLikeNested, _DtypeLikeNested],
 ]
+
+# NOTE: while it is possible to provide the dtype as a dict of
+# dtype-like objects (e.g. `{'field1': ..., 'field2': ..., ...}`),
+# this syntax is officially discourged and
+# therefore not included in the Union defining `DtypeLike`.
+#
+# See https://github.com/numpy/numpy/issues/16891 for more details.

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING or HAVE_PROTOCOL:
     # Mandatory + optional keys
     class _DtypeDict(_DtypeDictBase, total=False):
         offsets: Sequence[int]
-        titles: Sequence[Any]  # Elements should be valid as dict keys
+        titles: Sequence[Any]  # Only `str` elements are usable as indexing aliases, but all objects are legal
         itemsize: int
         aligned: bool
 

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -41,7 +41,7 @@ DtypeLike = Union[
     # (flexible_dtype, itemsize)
     Tuple[_DtypeLikeNested, int],
     # (fixed_dtype, shape)
-    Tuple[_DtypeLikeNested, _ShapeLike],  # No integers allowed
+    Tuple[_DtypeLikeNested, _ShapeLike],
     # [(field_name, field_dtype, field_shape), ...]
     #
     # The type here is quite broad because NumPy accepts quite a wide

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -22,6 +22,10 @@ class _DtypeDict(_DtypeDictBase, total=False):
     itemsize: int
     aligned: bool
 
+# A protocol for anything with the dtype attribute
+class _SupportsDtype:
+    dtype: _DtypeLikeNested
+
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
 DtypeLike = Union[
@@ -30,7 +34,8 @@ DtypeLike = Union[
     None,
     # array-scalar types and generic types
     type,  # TODO: enumerate these when we add type hints for numpy scalars
-    # TODO: add a protocol for anything with a dtype attribute
+    # anything with a dtype attribute
+    _SupportsDtype,
     # character codes, type strings or comma-separated fields, e.g., 'float64'
     str,
     # (fixed_dtype, shape)

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -1,31 +1,36 @@
 import sys
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union, TYPE_CHECKING
 
 from numpy import dtype
 from ._shape import _ShapeLike
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol, TypedDict
-else:
-    from typing_extensions import Protocol, TypedDict
-
 _DtypeLikeNested = Any  # TODO: wait for support for recursive types
 
-# Mandatory keys
-class _DtypeDictBase(TypedDict):
-    names: Sequence[str]
-    formats: Sequence[_DtypeLikeNested]
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 8):
+        from typing import Protocol, TypedDict
+    else:
+        from typing_extensions import Protocol, TypedDict
 
-# Mandatory + optional keys
-class _DtypeDict(_DtypeDictBase, total=False):
-    offsets: Sequence[int]
-    titles: Sequence[Any]  # Elements should be valid as dict keys
-    itemsize: int
-    aligned: bool
+    # Mandatory keys
+    class _DtypeDictBase(TypedDict):
+        names: Sequence[str]
+        formats: Sequence[_DtypeLikeNested]
 
-# A protocol for anything with the dtype attribute
-class _SupportsDtype:
-    dtype: _DtypeLikeNested
+    # Mandatory + optional keys
+    class _DtypeDict(_DtypeDictBase, total=False):
+        offsets: Sequence[int]
+        titles: Sequence[Any]  # Elements should be valid as dict keys
+        itemsize: int
+        aligned: bool
+
+    # A protocol for anything with the dtype attribute
+    class _SupportsDtype(Protocol):
+        dtype: _DtypeLikeNested
+
+else:  # runtime-only placeholders
+    _DtypeDict = 'numpy.typing._dtype_like._DtypeDict'
+    _SupportsDtype = 'numpy.typing._dtype_like._SupportsDtype'
 
 # Anything that can be coerced into numpy.dtype.
 # Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html


### PR DESCRIPTION
This pull requests addresses and implement two previous TODO's in `np.typing._DTypeLike`:
* Added a protocol, `_SupportsDtype`, for objects with the `dtype` attribute.
* Replaced an old dictionary, representing array field parameter, with a `TypedDict`.
