### PR TITLE
BUG: Initialize stop-reading in array_from_text

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3580,7 +3580,7 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
     npy_intp i;
     char *dptr, *clean_sep, *tmp;
     int err = 0;
-    int stop_reading_flag;  /* -1 indicates end reached; -2 a parsing error */
+    int stop_reading_flag = 0;  /* -1 means end reached; -2 a parsing error */
     npy_intp thisbuf = 0;
     npy_intp size;
     npy_intp bytes, totalbytes;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4702,6 +4702,10 @@ class TestIO:
         e = np.array([-25041670086757, 104783749223640], dtype=np.int64)
         assert_array_equal(d, e)
 
+    def test_fromstring_count0(self):
+        d = np.fromstring("1,2", sep=",", dtype=np.int64, count=0)
+        assert d.shape == (0,)
+
     def test_empty_files_binary(self):
         with open(self.filename, 'w') as f:
             pass


### PR DESCRIPTION
This should probably be hit with count=0, which is why added
a test which takes that path.  However, I was not actually
able to trigger any issue (not even a warning in valgrind).
I assume that since this is on the stack, its just hard to
trigger.
This came up in another CI-run. I suppose gcc as well as clang seem
to notice that it can be used uninitialized (which is true).