### PR TITLE
ENH,BUG:distutils Remove the origins from the implied features

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -1228,10 +1228,10 @@ class _Feature:
 
         Parameters
         ----------
-        'names': str(single feature) or sequence
-            CPU feature names in uppercase.
+        names: str or sequence of str
+            CPU feature name(s) in uppercase.
 
-        'keep_origins': bool
+        keep_origins: bool
             if False(default) then the returned set will not contain any
             features from 'names'. This case happens only when two features
             imply each other.


### PR DESCRIPTION
  This issue happens only when two features imply each other,
  it doesn't cause any serious problem, it only effects on reports,
  and when it comes to generating features tables for the upcoming doc.
