### PR TITLE
BENCH: remove obsolete goal_time param

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -111,4 +111,4 @@ def get_indexes_rand_():
 
 
 class Benchmark:
-    goal_time = 0.25
+    pass


### PR DESCRIPTION
`goal_time` is obsolete since [0.3.0](https://asv.readthedocs.io/en/stable/changelog.html?highlight=goal_time#id7), making whole Benchmark class unnecessary.