### PR TITLE
MAINT, CI: disable Shippable cache

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -53,15 +53,7 @@ build:
     # run the test suite
     - python runtests.py -n --debug-info --show-build-log -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 
-    cache: true
-    cache_dir_list:
-        # the NumPy project uses a single Amazon S3 cache
-        # so upload the parent path of the Python-specific
-        # version paths to avoid i.e., 3.6 overwriting
-        # 3.7 pip cache (seems to be an issue)
-        - /root/.cache/pip/wheels
-
-
+    cache: false
 
 # disable email notification
 # of CI job result


### PR DESCRIPTION
Backport of #16620. 

Fixes #16611

* a quick look at the NumPy CI failures on Shippable
service clearly shows the full test suite passing
and a negative exit code only because of the failed
cache restore

* since the jobs are running in about 20 minutes
even without the use of a cache, just try turning
if off

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
