### PR TITLE
MAINT: Prefer generator expressions over list comprehensions in any()

### DIFF
--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -176,12 +176,12 @@ def as_series(alist, trim=True):
     arrays = [np.array(a, ndmin=1, copy=False) for a in alist]
     if min([a.size for a in arrays]) == 0:
         raise ValueError("Coefficient array is empty")
-    if any([a.ndim != 1 for a in arrays]):
+    if any(a.ndim != 1 for a in arrays):
         raise ValueError("Coefficient array is not 1-d")
     if trim:
         arrays = [trimseq(a) for a in arrays]
 
-    if any([a.dtype == np.dtype(object) for a in arrays]):
+    if any(a.dtype == np.dtype(object) for a in arrays):
         ret = []
         for a in arrays:
             if a.dtype != np.dtype(object):


### PR DESCRIPTION
This PR replaces list comprehensions that are used as input to `any()` with generator expressions. This removes the need to instantiate unnecessary lists and allows the loop to potentially exit early which can improve performance for long iterations.

The changes are not really in a hot code path so this won't noticably improve performance but since it doesn't hurt readability I think it is still useful to include.