### PR TITLE
MAINT: Replace `PyUString_GET_SIZE` with `PyUnicode_GetLength`.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2362,7 +2362,7 @@ _is_default_descr(PyObject *descr, PyObject *typestr) {
         return 0;
     }
     name = PyTuple_GET_ITEM(tuple, 0);
-    if (!(PyUString_Check(name) && PyUString_GET_SIZE(name) == 0)) {
+    if (!(PyUnicode_Check(name) && PyUnicode_GetLength(name) == 0)) {
         return 0;
     }
     typestr2 = PyTuple_GET_ITEM(tuple, 1);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -469,7 +469,7 @@ _convert_from_array_descr(PyObject *obj, int align)
         /* Insert name into nameslist */
         Py_INCREF(name);
 
-        if (PyUString_GET_SIZE(name) == 0) {
+        if (PyUnicode_GetLength(name) == 0) {
             Py_DECREF(name);
             if (title == NULL) {
                 name = PyUString_FromFormat("f%d", i);
@@ -478,7 +478,7 @@ _convert_from_array_descr(PyObject *obj, int align)
                 }
             }
             /* On Py3, allow only non-empty Unicode strings as field names */
-            else if (PyUString_Check(title) && PyUString_GET_SIZE(title) > 0) {
+            else if (PyUnicode_Check(title) && PyUnicode_GetLength(title) > 0) {
                 name = title;
                 Py_INCREF(name);
             }


### PR DESCRIPTION
Backport of #16642. 

The former is deprecated.
While they have slightly different meanings, the difference is irrelevant for comparison against 0.

Also replaces `PyUString_Check` with `PyUnicode_Check` for consistency.

Partially addresses gh-16640.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
