### PR TITLE
DOC: cross-reference numpy.dot and numpy.linalg.multi_dot

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -761,6 +761,7 @@ def dot(a, b, out=None):
     tensordot : Sum products over arbitrary axes.
     einsum : Einstein summation convention.
     matmul : '@' operator as method with out parameter.
+    linalg.multi_dot : Chained dot product.
 
     Examples
     --------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2660,7 +2660,7 @@ def multi_dot(arrays, *, out=None):
 
     See Also
     --------
-    dot : dot multiplication with two arguments.
+    numpy.dot : dot multiplication with two arguments.
 
     References
     ----------


### PR DESCRIPTION
I've only now realized that [`numpy.linalg.multi_dot`](https://numpy.org/devdocs/reference/generated/numpy.linalg.multi_dot.html) exists, after a few years of using numpy. This PR helps discovery of the function by adding it to the "See also" of [`numpy.dot`](https://numpy.org/devdocs/reference/generated/numpy.dot.html) where I believe it belongs. Although this means there are now 5 items in that "See also" block which might start being a bit excessive, I believe having it there is more beneficial all things considered.

In order to facilitate the reverse direction I also changed `dot` to `numpy.dot` in the "See also" of `numpy.linalg.multi_dot`, this way the online documentation contains a direct link to `numpy.dot`.