### PR TITLE
BUG: raise IEEE exception on AIX

### DIFF
--- a/numpy/core/src/npymath/ieee754.c.src
+++ b/numpy/core/src/npymath/ieee754.c.src
@@ -634,7 +634,7 @@ void npy_set_floatstatus_invalid(void)
     fpsetsticky(FP_X_INV);
 }
 
-#elif defined(_AIX)
+#elif defined(_AIX) && !defined(__GNUC__)
 #include <float.h>
 #include <fpxcp.h>
 


### PR DESCRIPTION
Backport of #16505. 

IEEE exception is not raised correctly on AIX 6.2, GCC 8.3, both 32 and 64 bits.
The PR correct this point to have the attempted behavior.

As an Example, see test ``numpy/linalg/tests/test_linalg.py::TestMatrixPower::test_exceptions_not_invertible[dt10]`` (output below).
In `./numpy/core/src/npymath/ieee754.c.src`, AIX has a specific code to raise an exception. This code is not working correctly with GCC. With the general GCC code, the test passes.
All other similar tests  (all ``TestMatrixPower::test_exceptions_not_invertible`` and ``test_generator_mt19937.py::TestRandomDist::test_multivariate_normal``) pass with this patch.
No regression in test suite.
I cannot build Numpy with XLC, so I cannot confirm if the AIX specific code is useless for other compiler on AIX or not.

```python3
_____________ TestMatrixPower.test_exceptions_not_invertible[dt10] _____________

self = <numpy.linalg.tests.test_linalg.TestMatrixPower object at 0x7000000088642e0>
dt = dtype('float32')

    def test_exceptions_not_invertible(self, dt):
        if dt in self.dtnoinv:
            return
        mat = self.noninv.astype(dt)
>       assert_raises(LinAlgError, matrix_power, mat, -1)

dt         = dtype('float32')
mat        = array([[1., 0.],
       [0., 0.]], dtype=float32)
self       = <numpy.linalg.tests.test_linalg.TestMatrixPower object at 0x7000000088642e0>

numpy/linalg/tests/test_linalg.py:1067: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/freeware/lib64/python3.8/unittest/case.py:816: in assertRaises
    return context.handle('assertRaises', args, kwargs)
        args       = (<function matrix_power at 0x70000000058caf0>, array([[1., 0.],
       [0., 0.]], dtype=float32), -1)
        context    = None
        expected_exception = <class 'numpy.linalg.LinAlgError'>
        kwargs     = {}
        self       = <numpy.testing._private.utils._Dummy testMethod=nop>
/opt/freeware/lib64/python3.8/unittest/case.py:202: in handle
    callable_obj(*args, **kwargs)
        args       = [array([[1., 0.],
       [0., 0.]], dtype=float32), -1]
        callable_obj = <function matrix_power at 0x70000000058caf0>
        kwargs     = {}
        name       = 'assertRaises'
        self       = None
/opt/freeware/lib64/python3.8/unittest/case.py:224: in __exit__
    self._raiseFailure("{} not raised by {}".format(exc_name,
        exc_name   = 'LinAlgError'
        exc_type   = None
        exc_value  = None
        self       = <unittest.case._AssertRaisesContext object at 0x700000008122a90>
        tb         = None
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <unittest.case._AssertRaisesContext object at 0x700000008122a90>
standardMsg = 'LinAlgError not raised by matrix_power'

    def _raiseFailure(self, standardMsg):
        msg = self.test_case._formatMessage(self.msg, standardMsg)
>       raise self.test_case.failureException(msg)
E       AssertionError: LinAlgError not raised by matrix_power

msg        = 'LinAlgError not raised by matrix_power'
self       = <unittest.case._AssertRaisesContext object at 0x700000008122a90>
standardMsg = 'LinAlgError not raised by matrix_power'

/opt/freeware/lib64/python3.8/unittest/case.py:164: AssertionError
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
