### PR TITLE
DOC: Add lib.format.open_memmap to autosummary.

### DIFF
--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -56,6 +56,7 @@ Memory mapping files
    :toctree: generated/
 
    memmap
+   lib.format.open_memmap
 
 Text formatting options
 -----------------------
@@ -85,7 +86,6 @@ Data sources
 Binary Format Description
 -------------------------
 .. autosummary::
-   :template: autosummary/minimal_module.rst
    :toctree: generated/
 
     lib.format

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -820,7 +820,7 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
 
     See Also
     --------
-    memmap
+    numpy.memmap
 
     """
     if isfileobj(filename):


### PR DESCRIPTION
An alternative to #13414 to address #12926.

Fixes link in the `See also` section of `np.memmap` docs and ensures
`lib.format.open_memmap` is included in the summary of io functions.