### PR TITLE
ENH: Add ndmax param for numpy.array

### DIFF
--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -350,6 +350,7 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
+    'PyArray_FromAny_MaxDim':               (304, StealRef(2)),
 }
 
 ufunc_types_api = {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -280,7 +280,8 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      * if there isn't a convenient array available.
      */
     if (PyArray_GetArrayParamsFromObject_int(src_object,
-                PyArray_DESCR(dest), 0, &dtype, &ndim, dims, &src) < 0) {
+                PyArray_DESCR(dest), 0, &dtype, NPY_MAXDIMS, &ndim, dims,
+                &src) < 0) {
         Py_DECREF(src_object);
         return -1;
     }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -264,7 +264,7 @@ PyArray_AdaptFlexibleDType(PyObject *data_obj, PyArray_Descr *data_dtype,
                                     list,
                                     retval,
                                     0, &dtype,
-                                    &ndim, dims, &arr);
+                                    NPY_MAXDIMS, &ndim, dims, &arr);
                             Py_DECREF(list);
                             Py_XDECREF(arr);
                             if (result < 0) {

--- a/numpy/core/src/multiarray/ctors.h
+++ b/numpy/core/src/multiarray/ctors.h
@@ -35,7 +35,7 @@ PyArray_GetArrayParamsFromObject_int(PyObject *op,
          PyArray_Descr *requested_dtype,
          npy_bool writeable,
          PyArray_Descr **out_dtype,
-         int *out_ndim, npy_intp *out_dims,
+         int maxdims, int *out_ndim, npy_intp *out_dims,
          PyArrayObject **out_arr);
 
 NPY_NO_EXPORT PyObject *
@@ -43,8 +43,17 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
                 int max_depth, int flags, PyObject *context);
 
 NPY_NO_EXPORT PyObject *
+PyArray_FromAny_MaxDim(PyObject *op, PyArray_Descr *newtype, int maxdims,
+                int min_depth, int max_depth, int flags, PyObject *context);
+
+NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
                      int max_depth, int requires, PyObject *context);
+
+NPY_NO_EXPORT PyObject *
+PyArray_CheckFromAny_MaxDim(PyObject *op, PyArray_Descr *descr, int maxdims,
+                     int min_depth, int max_depth, int requires,
+                     PyObject *context);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags);

--- a/numpy/core/src/multiarray/multiarraymodule.h
+++ b/numpy/core/src/multiarray/multiarraymodule.h
@@ -11,6 +11,7 @@ NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_order;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_copy;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_dtype;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ndmin;
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ndmax;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_axis1;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_axis2;
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1096,6 +1096,12 @@ class TestCreation:
         a = np.array([1, Decimal(1)])
         a = np.array([[1], [Decimal(1)]])
 
+    def test_ndmax(self):
+        assert np.array([1], ndmax=0).ndim == 0
+        assert np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], ndmax=1).ndim == 1
+        assert np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], ndmax=2).ndim == 2
+        assert np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]).ndim == 3
+
 class TestStructured:
     def test_subarray_field_access(self):
         a = np.zeros((3, 5), dtype=[('a', ('i4', (2, 2)))])


### PR DESCRIPTION
This PR implements the proposal in #5933.

The parameter makes it possible to prevent `array` from digging deeper into the input, even if the lengths at the the next level are all equal.

Example:
```python
np.array([[1, 2], [3, 4]], ndmax=1)
# array([list([1, 2]), list([3, 4])], dtype=object)
```