### PR TITLE
DOC: updated gcc minimum recommend version to build from source

### DIFF
--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -31,7 +31,7 @@ Building NumPy requires the following software installed:
    MSVC and Clang compilers. Compilers from other vendors such as Intel,
    Absoft, Sun, NAG, Compaq, Vast, Portland, Lahey, HP, IBM are only supported
    in the form of community feedback, and may not work out of the box.
-   GCC 4.x (and later) compilers are recommended.
+   GCC 8.x (and later) compilers are recommended.
 
 3) Linear Algebra libraries
 

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -31,7 +31,7 @@ Building NumPy requires the following software installed:
    MSVC and Clang compilers. Compilers from other vendors such as Intel,
    Absoft, Sun, NAG, Compaq, Vast, Portland, Lahey, HP, IBM are only supported
    in the form of community feedback, and may not work out of the box.
-   GCC 8.x (and later) compilers are recommended.
+   GCC 4.x (and later) compilers are recommended. On ARM64 (aarch64) GCC 8.x (and later) are recommended.
 
 3) Linear Algebra libraries
 


### PR DESCRIPTION
PR to solve the gcc minimum recommend version documentation issue observed in #16576 .

