### PR TITLE
DOC: Remove "matrix" from `triu` docstring.

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -441,7 +441,7 @@ def triu(m, k=0):
     """
     Upper triangle of an array.
 
-    Return a copy of a matrix with the elements below the `k`-th diagonal
+    Return a copy of an array with the elements below the `k`-th diagonal
     zeroed.
 
     Please refer to the documentation for `tril` for further details.


### PR DESCRIPTION
Replace "matrix" with "array" to avoid confusion regarding np.matrix. This was the only instance of "matrix" in the `triu/tril` family of functions.