### PR TITLE
MAINT: add py.typed sentinel to package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include tox.ini
 include .coveragerc
 include test_requirements.txt
 recursive-include numpy/random *.pyx *.pxd *.pyx.in *.pxd.in
+include numpy/py.typed
 include numpy/random/include/*
 include numpy/__init__.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed


### PR DESCRIPTION
This needs to be added to ensure the py.typed sentinel makes its way into the package. Note that the py.typed sentinel file was not included in the 1.19.0 release as on PyPI.