### PR TITLE
Initial sort() by support and complex sort() change

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1065,7 +1065,7 @@ def sort(
     axis: Optional[int] = ...,
     kind: Optional[_SortKind] = ...,
     order: Union[None, str, Sequence[str]] = ...,
-    by: Union[None, Sequence[ndarray], ndarray] = ...,
+    by: Optional[Tuple[ArrayLike]] = ...,
 ) -> ndarray: ...
 def argsort(
     a: ArrayLike,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1065,7 +1065,7 @@ def sort(
     axis: Optional[int] = ...,
     kind: Optional[_SortKind] = ...,
     order: Union[None, str, Sequence[str]] = ...,
-    keys: Union[None, Sequence[ndarray]] = ...,
+    by: Union[None, Sequence[ndarray]] = ...,
 ) -> ndarray: ...
 def argsort(
     a: ArrayLike,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1065,6 +1065,7 @@ def sort(
     axis: Optional[int] = ...,
     kind: Optional[_SortKind] = ...,
     order: Union[None, str, Sequence[str]] = ...,
+    keys: Union[None, Sequence[ndarray]] = ...,
 ) -> ndarray: ...
 def argsort(
     a: ArrayLike,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1065,7 +1065,7 @@ def sort(
     axis: Optional[int] = ...,
     kind: Optional[_SortKind] = ...,
     order: Union[None, str, Sequence[str]] = ...,
-    by: Union[None, Sequence[ndarray]] = ...,
+    by: Union[None, Sequence[ndarray], ndarray] = ...,
 ) -> ndarray: ...
 def argsort(
     a: ArrayLike,

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -350,6 +350,8 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
+    'PyArray_KeySort':                      (304,),
+    # End of trial API
 }
 
 ufunc_types_api = {

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -350,8 +350,6 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
-    'PyArray_KeySort':                      (304,),
-    # End of trial API
 }
 
 ufunc_types_api = {

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -837,12 +837,12 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
 
 
-def _sort_dispatcher(a, axis=None, kind=None, order=None):
+def _sort_dispatcher(a, axis=None, kind=None, order=None, keys=None):
     return (a,)
 
 
 @array_function_dispatch(_sort_dispatcher)
-def sort(a, axis=-1, kind=None, order=None):
+def sort(a, axis=-1, kind=None, order=None, keys=None):
     """
     Return a sorted copy of an array.
 
@@ -868,6 +868,11 @@ def sort(a, axis=-1, kind=None, order=None):
         be specified as a string, and not all fields need be specified,
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
+
+    keys: tuple or object, optional
+        With a given array `a` sort the elements not by arithmethic
+        order, but by any abitary order defined by keys, there can
+        be multiple keys in a tuple form , or just a single object
 
     Returns
     -------
@@ -987,13 +992,14 @@ def sort(a, axis=-1, kind=None, order=None):
           dtype=[('name', '|S10'), ('height', '<f8'), ('age', '<i4')])
 
     """
+
     if axis is None:
         # flatten returns (1, N) for np.matrix, so always use the last axis
         a = asanyarray(a).flatten()
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
-    a.sort(axis=axis, kind=kind, order=order)
+    a.sort(axis=axis, kind=kind, order=order, keys=keys)
     return a
 
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -837,12 +837,12 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
 
 
-def _sort_dispatcher(a, axis=None, kind=None, order=None, keys=None):
+def _sort_dispatcher(a, axis=None, kind=None, order=None, by=None):
     return (a,)
 
 
 @array_function_dispatch(_sort_dispatcher)
-def sort(a, axis=-1, kind=None, order=None, keys=None):
+def sort(a, axis=-1, kind=None, order=None, by=None):
     """
     Return a sorted copy of an array.
 
@@ -869,9 +869,9 @@ def sort(a, axis=-1, kind=None, order=None, keys=None):
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
 
-    keys: tuple or object, optional
-        With a given array `a` sort the elements not by arithmethic
-        order, but by any abitary order defined by keys, there can
+    by: tuple or object, optional
+        With a given array `a` sort the elements not by arithmetic
+        order, but by any arbitrary order defined by tuple, there can
         be multiple keys in a tuple form , or just a single object
 
     Returns
@@ -999,7 +999,7 @@ def sort(a, axis=-1, kind=None, order=None, keys=None):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
-    a.sort(axis=axis, kind=kind, order=order, keys=keys)
+    a.sort(axis=axis, kind=kind, order=order, by=by)
     return a
 
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -999,6 +999,11 @@ def sort(a, axis=-1, kind=None, order=None, by=None):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
+
+
+    if by is not None and not isinstance(by, tuple):
+        by = (by,)
+
     a.sort(axis=axis, kind=kind, order=order, by=by)
     return a
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -869,11 +869,11 @@ def sort(a, axis=-1, kind=None, order=None, *, by=None):
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
 
-    by: sequence of array-likes, optional
+    by: tuple of array-likes, optional
         With a given array `a` sort the elements not by arithmetic
         order, but by any arbitrary order defined by tuple, there can
         be multiple keys in a tuple/list form.
-        Tuple/List contains k (N,)-shaped sequences
+        Tuple contains k (N,)-shaped sequences
         The `k` different "columns" to be sorted.  The last column (or row if
         `keys` is a 2D array) is the primary sort key.
 
@@ -1001,9 +1001,6 @@ def sort(a, axis=-1, kind=None, order=None, *, by=None):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
-
-    if by is not None and not isinstance(by, (tuple, list)):
-        raise TypeError("\'by\' is expected to be of a sequence type.")
 
     a.sort(axis=axis, kind=kind, order=order, by=by)
     return a

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -837,12 +837,12 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
 
 
-def _sort_dispatcher(a, axis=None, kind=None, order=None, by=None):
+def _sort_dispatcher(a, axis=None, kind=None, order=None, *, by=None):
     return (a,)
 
 
 @array_function_dispatch(_sort_dispatcher)
-def sort(a, axis=-1, kind=None, order=None, by=None):
+def sort(a, axis=-1, kind=None, order=None, *, by=None):
     """
     Return a sorted copy of an array.
 
@@ -869,10 +869,13 @@ def sort(a, axis=-1, kind=None, order=None, by=None):
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
 
-    by: tuple or object, optional
+    by: sequence of array-likes, optional
         With a given array `a` sort the elements not by arithmetic
         order, but by any arbitrary order defined by tuple, there can
-        be multiple keys in a tuple form , or just a single object
+        be multiple keys in a tuple/list form.
+        Tuple/List contains k (N,)-shaped sequences
+        The `k` different "columns" to be sorted.  The last column (or row if
+        `keys` is a 2D array) is the primary sort key.
 
     Returns
     -------
@@ -992,7 +995,6 @@ def sort(a, axis=-1, kind=None, order=None, by=None):
           dtype=[('name', '|S10'), ('height', '<f8'), ('age', '<i4')])
 
     """
-
     if axis is None:
         # flatten returns (1, N) for np.matrix, so always use the last axis
         a = asanyarray(a).flatten()
@@ -1000,9 +1002,8 @@ def sort(a, axis=-1, kind=None, order=None, by=None):
     else:
         a = asanyarray(a).copy(order="K")
 
-
-    if by is not None and not isinstance(by, tuple):
-        by = (by,)
+    if by is not None and not isinstance(by, (tuple, list)):
+        raise TypeError("\'by\' is expected to be of a sequence type.")
 
     a.sort(axis=axis, kind=kind, order=order, by=by)
     return a

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -356,10 +356,12 @@ struct NpyAuxData_tag {
 #define PyArray_malloc PyMem_RawMalloc
 #define PyArray_free PyMem_RawFree
 #define PyArray_realloc PyMem_RawRealloc
+#define PyArray_calloc  PyMem_RawCalloc
 #else
 #define PyArray_malloc malloc
 #define PyArray_free free
 #define PyArray_realloc realloc
+#define PyArray_calloc calloc
 #endif
 
 /* Dimensions and strides */

--- a/numpy/core/src/multiarray/item_selection.h
+++ b/numpy/core/src/multiarray/item_selection.h
@@ -27,4 +27,14 @@ NPY_NO_EXPORT int
 PyArray_MultiIndexSetItem(PyArrayObject *self, const npy_intp *multi_index,
                                                 PyObject *obj);
 
+/*
+ *Keysort an array providing indices that will sort a collection of arrays
+ *lexicographically.  The first key is sorted on first, followed by the second key
+ *-- requires that arg"merge"sort is available for each sort_key
+ *
+ *Returns None on success, returns NULL on failure
+ */
+NPY_NO_EXPORT PyObject *
+PyArray_KeySort(PyArrayObject *self, PyObject *sort_keys, int axis);
+
 #endif

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1231,15 +1231,75 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int val;
     NPY_SORTKIND sortkind = NPY_QUICKSORT;
     PyObject *order = NULL;
+    PyObject *keys = NULL;
     PyArray_Descr *saved = NULL;
     PyArray_Descr *newd;
-    static char *kwlist[] = {"axis", "kind", "order", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&O:sort", kwlist,
+
+    static char *kwlist[] = {"axis", "kind", "order", "keys", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&OO:sort", kwlist,
                                     &axis,
                                     PyArray_SortkindConverter, &sortkind,
-                                    &order)) {
+                                    &order, &keys)) {
         return NULL;
+    }
+    // If keys are None and We have complex types use c.real, c.imag as keys for lexsort
+    if (keys == Py_None || keys == NULL) {
+        if (PyArray_ISCOMPLEX(self)) {
+            PyArrayObject *real = (PyArrayObject*)PyObject_GetAttrString(
+                (PyObject*)self, "real");
+            if (real == NULL) {
+                return NULL;
+            }
+            PyArrayObject *imag = (PyArrayObject*) PyObject_GetAttrString(
+                    (PyObject*)self, "imag");
+            if (imag == NULL) {
+                Py_DECREF(real);
+                return NULL;
+            }
+            keys = PyTuple_Pack(2, imag, real);
+            Py_DECREF(real);
+            Py_DECREF(imag);
+            if (keys == NULL) {
+                return NULL;
+            }
+        }
+    }
+    /* WIP: The below code is for discussion
+     * purposes use take_along_axis followed by lexsort.
+     */
+    if (keys != Py_None && keys != NULL) {
+        PyObject *indices_obj = PyArray_LexSort(keys, axis);
+        Py_DECREF(keys);
+        if (indices_obj == NULL) {
+            return NULL;
+        }
+        PyObject *_numpy_shape_base;
+        _numpy_shape_base = PyImport_ImportModule("numpy.lib.shape_base");
+        if(_numpy_shape_base == NULL) {
+            Py_DECREF(indices_obj);
+            return NULL;
+        }
+        /* TODO:This parts needs to be replaced with equivalent C function
+         * Needs to be in-place
+         */
+        PyArrayObject *key_sorted_obj  =  (PyArrayObject*)
+            PyObject_CallMethod(_numpy_shape_base, "take_along_axis",
+                "OOi", self, indices_obj, axis);
+
+        Py_DECREF(_numpy_shape_base);
+        Py_DECREF(indices_obj);
+        //end TODO
+        if (key_sorted_obj == NULL) {
+            return NULL;
+        }
+        if (PyArray_CopyInto(self, key_sorted_obj) < 0) {
+            Py_DECREF(key_sorted_obj);
+            return NULL;
+        }
+       Py_DECREF(key_sorted_obj);
+       Py_RETURN_NONE;
+
     }
     if (order == Py_None) {
         order = NULL;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1346,20 +1346,20 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
     int val;
     NPY_SORTKIND sortkind = NPY_QUICKSORT;
     PyObject *order = NULL;
-    PyObject *keys = NULL;
+    PyObject *by = NULL;
     PyArray_Descr *saved = NULL;
     PyArray_Descr *newd;
 
 
-    static char *kwlist[] = {"axis", "kind", "order", "keys", NULL};
+    static char *kwlist[] = {"axis", "kind", "order", "by", NULL};
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&OO:sort", kwlist,
                                     &axis,
                                     PyArray_SortkindConverter, &sortkind,
-                                    &order, &keys)) {
+                                    &order, &by)) {
         return NULL;
     }
     // If keys are None and We have complex types use c.real, c.imag as keys for lexsort
-    if (keys == Py_None || keys == NULL) {
+    if (by == Py_None || by == NULL) {
         if (PyArray_ISCOMPLEX(self)) {
             PyArrayObject *real = (PyArrayObject*)PyObject_GetAttrString(
                 (PyObject*)self, "real");
@@ -1372,10 +1372,10 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
                 Py_DECREF(real);
                 return NULL;
             }
-            keys = PyTuple_Pack(2, imag, real);
+            by = PyTuple_Pack(2, imag, real);
             Py_DECREF(real);
             Py_DECREF(imag);
-            if (keys == NULL) {
+            if (by == NULL) {
                 return NULL;
             }
         }
@@ -1383,8 +1383,8 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
     /* WIP: The below code is for discussion
      * purposes use take_along_axis followed by lexsort.
      */
-    if (keys != Py_None && keys != NULL) {
-        PyObject *indices_obj = PyArray_LexSort(keys, axis);
+    if (by != Py_None && by != NULL) {
+        PyObject *indices_obj = PyArray_LexSort(by, axis);
         PyArrayObject *sorted_out = NULL;
         if (indices_obj == NULL) {
             return NULL;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -28,7 +28,6 @@
 
 #include "methods.h"
 #include "alloc.h"
-#include "mapping.h"
 #include "item_selection.h"
 
 /* NpyArg_ParseKeywords
@@ -1244,40 +1243,18 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
                                     &order, &by)) {
         return NULL;
     }
-    // If keys are None and We have complex types use c.real, c.imag as keys for lexsort
-    if (by == Py_None || by == NULL) {
-        if (PyArray_ISCOMPLEX(self)) {
-            PyArrayObject *real = (PyArrayObject*)PyObject_GetAttrString(
-                (PyObject*)self, "real");
-            if (real == NULL) {
-                return NULL;
-            }
-            PyArrayObject *imag = (PyArrayObject*) PyObject_GetAttrString(
-                    (PyObject*)self, "imag");
-            if (imag == NULL) {
-                Py_DECREF(real);
-                return NULL;
-            }
-            by = PyTuple_Pack(2, imag, real);
-            Py_DECREF(real);
-            Py_DECREF(imag);
-            if (by == NULL) {
-                return NULL;
-            }
-        }
-    }
     if (by != Py_None && by != NULL) {
         if (sortkind == -1) {
             sortkind = NPY_STABLESORT;
         }
         if (sortkind != NPY_STABLESORT) {
-            PyErr_SetString(PyExc_ValueError, "When using by argument " \
-                            "sort-kind can be only \'stable\'.");
+            PyErr_SetString(PyExc_ValueError, "When using by argument " 
+                    "sort-kind can be only \'stable\'.");
             return NULL;
         }
-        if (!PyTuple_CheckExact(by) && !PyList_CheckExact(by)) {
-            PyErr_SetString(PyExc_TypeError, "\'by\' is expected to be"\
-                               "of a sequence type.");
+        if (!PyTuple_CheckExact(by)) {
+            PyErr_SetString(PyExc_TypeError, "\'by\' is expected to be"
+                    "of a sequence type.");
             return NULL;
         }
         return PyArray_KeySort(self, by, axis);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1224,121 +1224,6 @@ array_choose(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 }
 
-static PyObject*
-_make_along_axis_idx(npy_intp *arr_shape, int arr_size, PyObject* indices, int axis) {
-
-    PyObject *dest_dims = NULL;
-    PyObject *fancy_index = NULL;
-    int smaller = 0;
-    int indices_ndim = PyArray_NDIM((PyArrayObject*)indices);
-    if (!PyArray_ISINTEGER((PyArrayObject*)indices)) {
-        PyErr_SetString(PyExc_IndexError, "indices must be an integer array");
-        return NULL;
-    }
-
-    if (arr_size != indices_ndim) {
-        PyErr_SetString(PyExc_ValueError, "indices and array must have same number of dimensions");
-        return NULL;
-    }
-    dest_dims  = PyList_New(0);
-    if (dest_dims == NULL) {
-        goto fail;
-    }
-    for (int i=0; i < axis; i++){
-        PyObject *tmp = Py_BuildValue("i", i);
-        if( PyList_Append(dest_dims, tmp) < -1) {
-            Py_DECREF(tmp);
-            goto fail;
-        }
-        Py_DECREF(tmp);
-    }
-
-    if (PyList_Append(dest_dims, Py_None) < 0) {
-        Py_DECREF(Py_None);
-        goto fail;
-    }
-    Py_DECREF(Py_None);
-    for (int i=axis+1; i < indices_ndim; i++){
-        PyObject *tmp = Py_BuildValue("i", i);
-        if( PyList_Append(dest_dims, tmp) < -1) {
-            Py_DECREF(tmp);
-            goto fail;
-        }
-        Py_DECREF(tmp);
-    }
-
-    fancy_index = PyList_New(0);
-    if (fancy_index == NULL) {
-        goto fail;
-    }
-    smaller = arr_size < PyList_Size(dest_dims) ? arr_size : PyList_Size(dest_dims);
-    for (int i=0; i < smaller; i++) {
-        PyObject *dim = PyList_GET_ITEM(dest_dims, i);
-        if (dim == Py_None) {
-           if (PyList_Append(fancy_index, indices) < -1) {
-                goto fail;
-           }
-
-        }
-        else {
-            // Define index shape of ones
-            PyObject *ind_shape = PyList_New(0);
-            if (ind_shape == NULL){
-                goto fail;
-            }
-            for (int j=0;j<PyLong_AsLong(dim); j++){
-                if (PyList_Append(ind_shape, Py_BuildValue("i", 1)) < -1) {
-                    Py_DECREF(ind_shape);
-                    goto fail;
-                }
-            }
-            if (PyList_Append(ind_shape, Py_BuildValue("i", -1)) < -1) {
-                Py_DECREF(ind_shape);
-                goto fail;
-            }
-            for (int j=PyLong_AsLong(dim)+1;j<indices_ndim; j++){
-                if (PyList_Append(ind_shape, Py_BuildValue("i", 1)) < -1) {
-                    Py_DECREF(ind_shape);
-                    goto fail;
-                }
-            }
-            PyObject *ind_shape_tuple = PyList_AsTuple(ind_shape);
-            Py_DECREF(ind_shape);
-            if (ind_shape_tuple == NULL) {
-                goto fail;
-            }
-            PyObject *range_arr = PyArray_Arange(0.0,(double)arr_shape[i],1.0, NPY_INT64);
-            range_arr = PyArray_Reshape((PyArrayObject*)range_arr, ind_shape_tuple);
-            if (range_arr == NULL) {
-                Py_DECREF(ind_shape_tuple);
-                Py_DECREF(dim);
-                goto fail;
-            }
-            if (PyList_Append(fancy_index, range_arr) < -1){
-                Py_DECREF(ind_shape_tuple);
-                Py_DECREF(range_arr);
-                Py_DECREF(dim);
-                goto fail;
-            }
-            Py_DECREF(ind_shape_tuple);
-            Py_DECREF(range_arr);
-        }
-        Py_DECREF(dim);
-    }
-    PyObject *fancy_tuple =  PyList_AsTuple(fancy_index);
-    if (fancy_tuple == NULL) {
-        goto fail;
-    }
-    Py_DECREF(dest_dims);
-    Py_DECREF(fancy_index);
-    return fancy_tuple;
-
-    fail:
-        Py_XDECREF(dest_dims);
-        Py_XDECREF(fancy_index);
-        return NULL;
-}
-
 static PyObject *
 array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
@@ -1380,33 +1265,18 @@ array_sort(PyArrayObject *self, PyObject *args, PyObject *kwds)
             }
         }
     }
-    /* WIP: The below code is for discussion
-     * purposes use take_along_axis followed by lexsort.
-     */
     if (by != Py_None && by != NULL) {
-        PyObject *indices_obj = PyArray_LexSort(by, axis);
-        PyArrayObject *sorted_out = NULL;
-        if (indices_obj == NULL) {
+        if (!PyTuple_CheckExact(by) && !PyList_CheckExact(by)) {
+            by = PyTuple_Pack(1, by);
+            if (by == NULL) {
+                return NULL;
+            }
+        }
+        PyObject *ret = PyArray_KeySort(self, by, axis);
+        if (ret == NULL){
             return NULL;
         }
-        if (axis == -1) {
-            axis = PyArray_NDIM(self)-1;
-        }
-        PyObject *fancy_tuple = _make_along_axis_idx(PyArray_SHAPE(self),
-                                PyArray_NDIM(self), indices_obj, axis);
-        if (fancy_tuple == NULL) {
-            return NULL;
-        }
-        sorted_out = (PyArrayObject *) array_subscript_asarray(self, fancy_tuple);
-        Py_DECREF(indices_obj);
-        if (sorted_out == NULL) {
-            return NULL;
-        }
-        if (PyArray_CopyInto(self, sorted_out) < 0) {
-            Py_DECREF(sorted_out);
-            return NULL;
-        }
-        Py_DECREF(sorted_out);
+        Py_DECREF(ret);
         Py_RETURN_NONE;
     }
     if (order == Py_None) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1755,9 +1755,9 @@ class TestMethods:
         assert_equal(b, e, msg)
         # Test sorting complex numbers by absolute value
         msg = "Test sorting comple xnumbers by absolute value"
-        carr = np.arange(4, dtype=complex)[::-1].reshape(2, 2)
-        carr_out = np.arange([[2+0j, 3+0j], [0+0j, 1+0j]])
-        carr.sort(axis=1, by=(np.absolute(carr),))
+        carr = np.arange(4, dtype=np.complex128)[::-1].reshape(2, 2)
+        carr_out = np.array([[2+0j, 3+0j], [0+0j, 1+0j]], dtype=np.complex128)
+        carr.sort(axis=1, by=np.absolute(carr))
         assert_equal(carr, carr_out, msg)
 
     def test_sort(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1761,8 +1761,8 @@ class TestMethods:
         # check complex
         msg = "Test complex sort order with nans"
         a = np.zeros(9, dtype=np.complex128)
-        a.real += [np.nan, np.nan, np.nan, 1, 0, 1, 1, 0, 0]
-        a.imag += [np.nan, 1, 0, np.nan, np.nan, 1, 0, 1, 0]
+        a.real += [np.nan, np.nan, np.nan, 1, 1, 1, 0, 0, 0]
+        a.imag += [np.nan, 1, 0, np.nan, 1, 0, np.nan, 1, 0]
         b = np.sort(a)
         assert_equal(b, a[::-1], msg)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1748,17 +1748,30 @@ class TestMethods:
         assert_raises(ValueError, lambda: a.transpose(0, 1, 2))
 
     def test_sort_by(self):
-        msg = "Test sorting by absolute values as keys"
         a = np.array([-2, -3, -4, -1, -6])
         b = np.sort(a, by=(np.absolute(a),))
         e = np.array([-1, -2, -3, -4, -6])
-        assert_equal(b, e, msg)
+        assert_equal(b, e)
         # Test sorting complex numbers by absolute value
-        msg = "Test sorting comple xnumbers by absolute value"
         carr = np.arange(4, dtype=np.complex128)[::-1].reshape(2, 2)
         carr_out = np.array([[2+0j, 3+0j], [0+0j, 1+0j]], dtype=np.complex128)
-        carr.sort(axis=1, by=np.absolute(carr))
-        assert_equal(carr, carr_out, msg)
+        carr.sort(axis=1, by=(np.absolute(carr),))
+        assert_equal(carr, carr_out)
+        #Testing sort by real, imag
+        carr = np.array([1 + 1j, 1-1j], dtype=np.complex128)
+        carr_out = np.array([1-1j, 1+1j], dtype=np.complex128)
+        carr.sort(by=(carr.imag, carr.real))
+        assert_equal(carr, carr_out)
+        # Look for different shape error
+        carr = np.array([[1+1j, 1-1j]], dtype=np.complex128)
+        assert_raises(ValueError, carr.sort, by=(carr.imag[0],))
+        # Only stable sort test
+        carr = np.array([[1+1j, 1-1j]], dtype=np.complex128)
+        assert_raises(ValueError, carr.sort, kind='quicksort')
+        # Passing empty tuple test
+        arr = np.array([4,1,7])
+        new_arr = np.sort(arr, by=())
+        assert_equal(arr, new_arr)
 
     def test_sort(self):
         # test ordering for floats and complex containing nans. It is only
@@ -1831,14 +1844,13 @@ class TestMethods:
         bi = (b * (1+1j)).astype(cdtype)
         setattr(ai, part, 1)
         setattr(bi, part, 1)
-        for kind in self.sort_kinds:
-            msg = "complex sort, %s part == 1, kind=%s" % (part, kind)
-            c = ai.copy()
-            c.sort(kind=kind)
-            assert_equal(c, ai, msg)
-            c = bi.copy()
-            c.sort(kind=kind)
-            assert_equal(c, ai, msg)
+        msg = "complex sort, %s part == 1, kind=%s" % (part, 'stable')
+        c = ai.copy()
+        c.sort(kind='stable')
+        assert_equal(c, ai, msg)
+        c = bi.copy()
+        c.sort(kind='stable')
+        assert_equal(c, ai, msg)
 
     def test_sort_complex_byte_swapping(self):
         # test sorting of complex arrays requiring byte-swapping, gh-5441

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1767,10 +1767,14 @@ class TestMethods:
         assert_raises(ValueError, carr.sort, by=(carr.imag[0],))
         # Only stable sort test
         carr = np.array([[1+1j, 1-1j]], dtype=np.complex128)
-        assert_raises(ValueError, carr.sort, kind='quicksort')
+        assert_raises(ValueError, carr.sort,by=(carr.imag, carr.real), kind='quicksort')
         # Passing empty tuple test
         arr = np.array([4,1,7])
         new_arr = np.sort(arr, by=())
+        assert_equal(arr, new_arr)
+        # Zero dimensional scalar
+        arr = np.array(4+4j)
+        new_arr = np.sort(arr, by=(arr,))
         assert_equal(arr, new_arr)
 
     def test_sort(self):
@@ -1787,8 +1791,8 @@ class TestMethods:
         # check complex
         msg = "Test complex sort order with nans"
         a = np.zeros(9, dtype=np.complex128)
-        a.real += [np.nan, np.nan, np.nan, 1, 1, 1, 0, 0, 0]
-        a.imag += [np.nan, 1, 0, np.nan, 1, 0, np.nan, 1, 0]
+        a.real += [np.nan, np.nan, np.nan, 1, 0, 1, 1, 0, 0]
+        a.imag += [np.nan, 1, 0, np.nan, np.nan, 1, 0, 1, 0]
         b = np.sort(a)
         assert_equal(b, a[::-1], msg)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1747,6 +1747,19 @@ class TestMethods:
         assert_raises(ValueError, lambda: a.transpose(0, 0))
         assert_raises(ValueError, lambda: a.transpose(0, 1, 2))
 
+    def test_sort_by(self):
+        msg = "Test sorting by absolute values as keys"
+        a = np.array([-2, -3, -4, -1, -6])
+        b = np.sort(a, by=(np.absolute(a),))
+        e = np.array([-1, -2, -3, -4, -6])
+        assert_equal(b, e, msg)
+        # Test sorting complex numbers by absolute value
+        msg = "Test sorting comple xnumbers by absolute value"
+        carr = np.arange(4, dtype=complex)[::-1].reshape(2, 2)
+        carr_out = np.arange([[2+0j, 3+0j], [0+0j, 1+0j]])
+        carr.sort(axis=1, by=(np.absolute(carr),))
+        assert_equal(carr, carr_out, msg)
+
     def test_sort(self):
         # test ordering for floats and complex containing nans. It is only
         # necessary to check the less-than comparison, so sorts that


### PR DESCRIPTION
This is the first step in addressing [gh-15981](https://github.com/numpy/numpy/issues/15981)

Related mailing list thread can be found [here](http://numpy-discussion.10968.n7.nabble.com/Improving-Complex-Comparison-Ordering-in-Numpy-td48209.html)

As stated in the original thread, We need to start by having a sort() function for complex numbers that can do it based on keys, rather than plain arithmetic ordering.

There are two broad ways to approach a sorting function that supports keys (Not just for complex numbers).

1. Add a ```key``` kwarg to the ```sort()``` (function and method). To support key based sorting on arrays.
2. Use a new function on the lines off ```sortby(c_arr, key=(c_arr.real, c_arr.imag)```


In this PR I have chosen approach 1 for the following reasons

1. Approach 1 means it is more easier to deal with both in-place method and the function. Since we can make the change in the c-sort function, have minimal change in the python layer. This I hope results, minimal impact on current code that handles complex sorting. One example within numpy is is ```linalg``` module's ```svd()``` function.

2. With approach 2 when we deprecate complex arithmetic ordering, existing methods using sort() for complex types, need to update their signature. 

As it stands the PR does the following 3 things within the Python-C Array method implementation of sort

1. Checks for complex type- If array is of complex-type, it creates a default ```key```(When no key is passed) which mimics the current arithmethic ordering in Numpy .
2. Uses the keys to perform a ``Py_LexSort`` and generate indices.
3. We perform the ```take_along_axis``` via C call back and copy over the result to the original array (pseudo in-place).

I am requesting feedback/help on implementing ``take_along_axis`` logic in C level in a in-place manner and the approach in general.

This will further feed into ``max()`` and ``min()`` as well. Once we figure this out. Next step would be to deprecate  arithmetic ordering for complex types (Which I think will be a PR on it's own)


UPDATE:
   The latest version uses A new Function PyArray_Keysort() to argsort a 1D slice of indices, and then use the indices to move contents of the same 1D slice






