### PR TITLE
BLD: Add CPU entry for Emscripten / WebAssembly

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -18,6 +18,7 @@
  *              NPY_CPU_ARCEL
  *              NPY_CPU_ARCEB
  *              NPY_CPU_RISCV64
+ *              NPY_CPU_WASM
  */
 #ifndef _NPY_CPUARCH_H_
 #define _NPY_CPUARCH_H_
@@ -102,6 +103,9 @@
     #define NPY_CPU_ARCEB
 #elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
     #define NPY_CPU_RISCV64
+#elif defined(__EMSCRIPTEN__)
+    /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */
+    #define NPY_CPU_WASM
 #else
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -48,7 +48,8 @@
             || defined(NPY_CPU_MIPSEL)        \
             || defined(NPY_CPU_PPC64LE)       \
             || defined(NPY_CPU_ARCEL)         \
-            || defined(NPY_CPU_RISCV64)
+            || defined(NPY_CPU_RISCV64)       \
+            || defined(NPY_CPU_WASM)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)                \
             || defined(NPY_CPU_SPARC)         \


### PR DESCRIPTION
Backport of #16702. 

This adds a CPU entry for the case when numpy is built with [emscripten](https://github.com/emscripten-core/emscripten). It is one of [the patches](https://github.com/iodide-project/pyodide/tree/master/packages/numpy/patches) used to build numpy in [pyodide](https://github.com/iodide-project/pyodide).

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
