### PR TITLE
TST: Disable Python 3.9-dev testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - stage: Comprehensive tests
       python: 3.6
     - python: 3.7
-    - python: 3.9-dev
+#    - python: 3.9-dev
 
     - python: 3.6
       env: USE_DEBUG=1


### PR DESCRIPTION
Disable testing with Python 3.9-dev until a fix for the current
failures is forthcoming. The test failures are annoying.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
