### PR TITLE
DOC: Add instruction about stable symlink

### DIFF
--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -390,8 +390,11 @@ create an archive of the documentation in the numpy/doc repo::
     # This checks out github.com/numpy/doc and adds (``git add``) the
     # documentation to the checked out repo.
     make merge-doc
-    # Now edit the ``index.html`` file in the repo to reflect the new content,
-    # and commit the changes
+    # Now edit the ``index.html`` file in the repo to reflect the new content.
+    # If the documentation is for a non-patch release (e.g. 1.19 -> 1.20),
+    # make sure to update the ``stable`` symlink to point to the new directory.
+    ln -sfn <latest_stable_directory> stable
+    # Commit the changes
     git -C build/merge commit -am "Add documentation for <version>"
     # Push to numpy/doc repo
     git -C build/merge push


### PR DESCRIPTION
Add comment to ``HOWTO_RELEASE.rst.txt`` about updating the ``stable`` symlink when the minor version number is incremented. This is a new requirement (as of numpy/doc#4) and is only necessary when a new directory is added.