### PR TITLE
MAINT: Disable use_hugepages in case of ValueError

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -338,11 +338,18 @@ else:
     import os
     use_hugepage = os.environ.get("NUMPY_MADVISE_HUGEPAGE", None)
     if sys.platform == "linux" and use_hugepage is None:
-        use_hugepage = 1
-        kernel_version = os.uname().release.split(".")[:2]
-        kernel_version = tuple(int(v) for v in kernel_version)
-        if kernel_version < (4, 6):
-            use_hugepage = 0
+        # If there is an issue with parsing the kernel version,
+        # set use_hugepages to 0. Usage of LooseVersion will handle
+        # the kernel version parsing better, but avoided since it
+        # will increase the import time. See: #16679 for related discussion.
+        try:
+            use_hugepage = 1
+            kernel_version = os.uname().release.split(".")[:2]
+            kernel_version = tuple(int(v) for v in kernel_version)
+            if kernel_version < (4, 6):
+                use_hugepage = 0
+        except ValueError:
+            use_hugepages = 0
     elif use_hugepage is None:
         # This is not Linux, so it should not matter, just enable anyway
         use_hugepage = 1


### PR DESCRIPTION
In accordance with this comment: https://github.com/numpy/numpy/issues/16679#issuecomment-649104387 , adding try except and setting use_hugepages to 0 in case of ValueError, since the additional LooseVersion import increases the import time a bit. From my measurement, it is more than 1 ms increase in import time.

Closes #16679.

EDIT: distutils import is more than 1 ms increase in import time.