### PR TITLE
DOC: Add dep directive to alen docstring.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2850,6 +2850,9 @@ def alen(a):
     """
     Return the length of the first dimension of the input array.
 
+    .. deprecated:: 1.18
+       `numpy.alen` is deprecated, use `len` instead.
+
     Parameters
     ----------
     a : array_like


### PR DESCRIPTION
Minor extension of #14181: alen was deprecated in 1.18. Adds corresponding directive to the docstring to make this information more visible to the user.