### PR TITLE
ENH, BLD: Add RPATH support for AIX

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -253,14 +253,23 @@ class GnuFCompiler(FCompiler):
         return []
 
     def runtime_library_dir_option(self, dir):
-        if sys.platform[:3] == 'aix' or sys.platform == 'win32':
-            # Linux/Solaris/Unix support RPATH, Windows and AIX do not
+        if sys.platform == 'win32':
+            # Linux/Solaris/Unix support RPATH, Windows does not
             raise NotImplementedError
 
         # TODO: could use -Xlinker here, if it's supported
         assert "," not in dir
 
-        sep = ',' if sys.platform == 'darwin' else '='
+        if sys.platform == 'darwin':
+            sep = ','
+        elif sys.platform[:3] == 'aix':
+            sep = ":"
+        else:
+            sep = '='
+
+        # AIX RPATH is called LIBPATH
+        if sys.platform[:3] == 'aix':
+            return '-Wl,-blibpath%s%s' % (sep, dir)
         return '-Wl,-rpath%s%s' % (sep, dir)
 
 

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -261,16 +261,12 @@ class GnuFCompiler(FCompiler):
         assert "," not in dir
 
         if sys.platform == 'darwin':
-            sep = ','
+            return '-Wl,-rpath,%s' % dir
         elif sys.platform[:3] == 'aix':
-            sep = ":"
+            # AIX RPATH is called LIBPATH
+            return '-Wl,-blibpath:%s' % dir
         else:
-            sep = '='
-
-        # AIX RPATH is called LIBPATH
-        if sys.platform[:3] == 'aix':
-            return '-Wl,-blibpath%s%s' % (sep, dir)
-        return '-Wl,-rpath%s%s' % (sep, dir)
+            return '-Wl,-rpath=%s' % dir
 
 
 class Gnu95FCompiler(GnuFCompiler):

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -261,12 +261,12 @@ class GnuFCompiler(FCompiler):
         assert "," not in dir
 
         if sys.platform == 'darwin':
-            return '-Wl,-rpath,%s' % dir
+            return f'-Wl,-rpath,{dir}'
         elif sys.platform[:3] == 'aix':
             # AIX RPATH is called LIBPATH
-            return '-Wl,-blibpath:%s' % dir
+            return f'-Wl,-blibpath:{dir}'
         else:
-            return '-Wl,-rpath=%s' % dir
+            return f'-Wl,-rpath={dir}'
 
 
 class Gnu95FCompiler(GnuFCompiler):


### PR DESCRIPTION
Hello,

The ``runtime_library_dir_option()`` function does not implement the RPATH equivalent on AIX. This PR adds this support, using LIBPATH (= AIX RPATH).
Scipy needs this function to be implemented to be built. With this PR, Scipy can be built.


<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
