### PR TITLE
DOC: reword random c-api introduction, cython is documented in Extending

### DIFF
--- a/doc/source/reference/random/c-api.rst
+++ b/doc/source/reference/random/c-api.rst
@@ -1,20 +1,13 @@
-Cython API for random
----------------------
-
-.. currentmodule:: numpy.random
-
-Typed versions of many of the `Generator` and `BitGenerator` methods as well as
-the classes themselves can be accessed directly from Cython via
-
-.. code-block:: cython
-
-    cimport numpy.random
-
 C API for random
 ----------------
 
-Access to various distributions is available via Cython or C-wrapper libraries
-like CFFI. All the functions accept a :c:type:`bitgen_t` as their first argument.
+.. currentmodule:: numpy.random
+Access to various distributions below is available via Cython or C-wrapper
+libraries like CFFI. All the functions accept a :c:type:`bitgen_t` as their
+first argument.  To access these from Cython or C, you must link with the
+``npyrandom`` library which is part of the NumPy distribution, located in
+``numpy/random/lib``.
+
 
 .. c:type:: bitgen_t
 

--- a/doc/source/reference/random/c-api.rst
+++ b/doc/source/reference/random/c-api.rst
@@ -2,6 +2,7 @@ C API for random
 ----------------
 
 .. currentmodule:: numpy.random
+
 Access to various distributions below is available via Cython or C-wrapper
 libraries like CFFI. All the functions accept a :c:type:`bitgen_t` as their
 first argument.  To access these from Cython or C, you must link with the


### PR DESCRIPTION
Closes #16597. The heading section doesn't really belong on the C-API page, and there was some confusion about linking a library to access the C-API functions