### PR TITLE
MAINT: Chaining exceptions in numpy/core/_internal.py

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -161,10 +161,10 @@ def _commastring(astr):
         mo = format_re.match(astr, pos=startindex)
         try:
             (order1, repeats, order2, dtype) = mo.groups()
-        except (TypeError, AttributeError) as e:
+        except (TypeError, AttributeError):
             raise ValueError(
                 f'format number {len(result)+1} of "{astr}" is not recognized'
-                ) from e
+                ) from None
         startindex = mo.end()
         # Separator or ending padding
         if startindex < len(astr):
@@ -372,11 +372,11 @@ def _newnames(datatype, order):
         for name in order:
             try:
                 nameslist.remove(name)
-            except ValueError as e:
+            except ValueError:
                 if name in seen:
-                    raise ValueError(f"duplicate field name: {name}") from e
+                    raise ValueError(f"duplicate field name: {name}") from None
                 else:
-                    raise ValueError(f"unknown field name: {name}") from e
+                    raise ValueError(f"unknown field name: {name}") from None
             seen.add(name)
         return tuple(list(order) + nameslist)
     raise ValueError("unsupported order value: %s" % (order,))

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -161,9 +161,10 @@ def _commastring(astr):
         mo = format_re.match(astr, pos=startindex)
         try:
             (order1, repeats, order2, dtype) = mo.groups()
-        except (TypeError, AttributeError):
-            raise ValueError('format number %d of "%s" is not recognized' %
-                                            (len(result)+1, astr))
+        except (TypeError, AttributeError) as e:
+            raise ValueError(
+                f'format number {len(result)+1} of "{astr}" is not recognized'
+                ) from e
         startindex = mo.end()
         # Separator or ending padding
         if startindex < len(astr):
@@ -371,11 +372,11 @@ def _newnames(datatype, order):
         for name in order:
             try:
                 nameslist.remove(name)
-            except ValueError:
+            except ValueError as e:
                 if name in seen:
-                    raise ValueError("duplicate field name: %s" % (name,))
+                    raise ValueError(f"duplicate field name: {name}") from e
                 else:
-                    raise ValueError("unknown field name: %s" % (name,))
+                    raise ValueError(f"unknown field name: {name}") from e
             seen.add(name)
         return tuple(list(order) + nameslist)
     raise ValueError("unsupported order value: %s" % (order,))


### PR DESCRIPTION
Changes related to #15986
- added chaining for ValueError, TypeError, AttributeError
- updated % formatted strings to f strings

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
