### PR TITLE
DOC: Add Matti Picus to steering council page

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -18,8 +18,6 @@ Steering council
 
 * Stephan Hoyer
 
-* Marten van Kerkwijk
-
 * Matti Picus
 
 * Nathaniel Smith
@@ -40,6 +38,8 @@ Emeritus members
 * Travis Oliphant -- project founder / emeritus leader (2005-2012)
 
 * Alex Griffing (2015-2017)
+
+* Marten van Kerkwijk (2017-2019)
 
 
 NumFOCUS Subcommittee

--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -12,7 +12,15 @@ Steering council
 
 * Ralf Gommers
 
+* Allan Haldane
+
 * Charles Harris
+
+* Stephan Hoyer
+
+* Marten van Kerkwijk
+
+* Matti Picus
 
 * Nathaniel Smith
 
@@ -20,23 +28,18 @@ Steering council
 
 * Pauli Virtanen
 
+* Stéfan van der Walt
+
 * Eric Wieser
 
-* Marten van Kerkwijk
-
-* Stephan Hoyer
-
-* Allan Haldane
-
-* Stefan van der Walt
 
 
 Emeritus members
 ----------------
 
-* Travis Oliphant - Project Founder / Emeritus Leader (served: 2005-2012)
+* Travis Oliphant -- project founder / emeritus leader (2005-2012)
 
-* Alex Griffing (served: 2015-2017)
+* Alex Griffing (2015-2017)
 
 
 NumFOCUS Subcommittee
@@ -56,7 +59,7 @@ NumFOCUS Subcommittee
 Institutional Partners
 ----------------------
 
-* UC Berkeley (Stefan van der Walt, Sebastian Berg, Warren Weckesser, Ross Barnowski)
+* UC Berkeley (Stéfan van der Walt, Sebastian Berg, Warren Weckesser, Ross Barnowski)
 
 * Quansight (Ralf Gommers, Hameer Abbasi, Melissa Weber Mendonça, Mars Lee, Matti Picus)
 


### PR DESCRIPTION
Per announcement in https://mail.python.org/pipermail/numpy-discussion/2020-June/080760.html.

I've alphabetized the steering council names (some but not all had been
alphabetized). Added diacritical mark in Stéfan.

This page partially overlaps https://numpy.org/about/. Submitting a
separate PR. I imagine at some point we want to transfer over the remaining contents
of this older page and cleanly remove it.
