### PR TITLE
DOC: Added a section in the 'Iterating over arrays' doc page on basic iteration.

### DIFF
--- a/doc/source/reference/arrays.nditer.rst
+++ b/doc/source/reference/arrays.nditer.rst
@@ -10,6 +10,10 @@
 Iterating Over Arrays
 *********************
 
+.. note:: Arrays support the iterator protocol and can be iterated over like Python
+   lists. See the :ref:`quickstart.indexing-slicing-and-iterating` section in
+   the Quickstart guide for information and examples.
+
 The iterator object :class:`nditer`, introduced in NumPy 1.6, provides
 many flexible ways to visit all the elements of one or more arrays in
 a systematic fashion. This page introduces some basic ways to use the

--- a/doc/source/reference/arrays.nditer.rst
+++ b/doc/source/reference/arrays.nditer.rst
@@ -14,7 +14,9 @@ Iterating Over Arrays
 
    Arrays support the iterator protocol and can be iterated over like Python
    lists. See the :ref:`quickstart.indexing-slicing-and-iterating` section in
-   the Quickstart guide for information and examples.
+   the Quickstart guide for basic usage and examples. The remainder of
+   this document presents the :class:`nditer` object and covers more 
+   advanced usage.
 
 The iterator object :class:`nditer`, introduced in NumPy 1.6, provides
 many flexible ways to visit all the elements of one or more arrays in

--- a/doc/source/reference/arrays.nditer.rst
+++ b/doc/source/reference/arrays.nditer.rst
@@ -10,7 +10,9 @@
 Iterating Over Arrays
 *********************
 
-.. note:: Arrays support the iterator protocol and can be iterated over like Python
+.. note::
+
+   Arrays support the iterator protocol and can be iterated over like Python
    lists. See the :ref:`quickstart.indexing-slicing-and-iterating` section in
    the Quickstart guide for information and examples.
 


### PR DESCRIPTION
It seems strange that basic iteration over arrays is covered only in the Quickstart Tutorial and not mentioned in the reference doc page titled "Iterating Over Arrays". I normally only use the reference section and spent about ten minutes trying to remind myself of how basic iteration works/wondering if it had been removed in an update. This pull request adds a section on basic iteration and moves everything that was there down one header level.