### PR TITLE
MAINT: Remove unneeded call to PyUnicode_READY

### DIFF
--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -385,9 +385,7 @@ unicodetype_@form@(PyObject *self)
     PyObject *new;
     PyObject *ret;
 
-    if (PyUnicode_READY(self) < 0) {
-        return NULL;
-    }
+    /* PyUnicode_READY is called by PyUnicode_GetLength */
     len = PyUnicode_GetLength(self);
     ip = PyUnicode_AsUCS4Copy(self);
     if (ip == NULL) {


### PR DESCRIPTION
Both PyUnicode_GetLength and PyUnicode_AsUCS4Copy call PyUnicode_READY
internally.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
