### PR TITLE
MAINT: Remove internal uses of _inspect module

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -74,11 +74,16 @@ def verify_matching_signatures(implementation, dispatcher):
     implementation_sig_with_none_defaults = implementation_sig.replace(
         parameters=[
             p.replace(
-                annotation=p.empty,
-                default=p.empty if p.default is p.empty else None
+                annotation=inspect.Parameter.empty,
+                default=(
+                    inspect.Parameter.empty
+                    if p.default is inspect.Parameter.empty
+                    else None
+                ),
             )
             for p in implementation_sig.parameters.values()
-        ]
+        ],
+        return_annotation=inspect.Signature.empty
     )
 
     if dispatcher_sig != implementation_sig_with_none_defaults:

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -66,6 +66,10 @@ add_docstring(
     """)
 
 
+# Avoid extra getattr calls in verify_matching_signatures
+_Parameter_empty = inspect.Parameter.empty
+
+
 def verify_matching_signatures(implementation, dispatcher):
     """Verify that a dispatcher function has the right signature."""
     implementation_sig = inspect.signature(implementation)
@@ -74,10 +78,10 @@ def verify_matching_signatures(implementation, dispatcher):
     implementation_sig_with_none_defaults = inspect.Signature(
         parameters=[
             p.replace(
-                annotation=inspect.Parameter.empty,
+                annotation=_Parameter_empty,
                 default=(
-                    inspect.Parameter.empty
-                    if p.default is inspect.Parameter.empty
+                    _Parameter_empty
+                    if p.default is _Parameter_empty
                     else None
                 ),
             )

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -71,7 +71,7 @@ def verify_matching_signatures(implementation, dispatcher):
     implementation_sig = inspect.signature(implementation)
     dispatcher_sig = inspect.signature(dispatcher)
 
-    implementation_sig_with_none_defaults = implementation_sig.replace(
+    implementation_sig_with_none_defaults = inspect.Signature(
         parameters=[
             p.replace(
                 annotation=inspect.Parameter.empty,
@@ -83,7 +83,6 @@ def verify_matching_signatures(implementation, dispatcher):
             )
             for p in implementation_sig.parameters.values()
         ],
-        return_annotation=inspect.Signature.empty
     )
 
     if dispatcher_sig != implementation_sig_with_none_defaults:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -34,9 +34,7 @@ import numpy.core.numerictypes as ntypes
 from numpy import ndarray, amax, amin, iscomplexobj, bool_, _NoValue
 from numpy import array as narray
 from numpy.lib.function_base import angle
-from numpy.compat import (
-    getargspec, formatargspec, long, unicode, bytes
-    )
+from numpy.compat import long, unicode, bytes
 from numpy import expand_dims
 from numpy.core.numeric import normalize_axis_tuple
 from numpy.core._internal import recursive
@@ -135,8 +133,8 @@ def get_object_signature(obj):
 
     """
     try:
-        sig = formatargspec(*getargspec(obj))
-    except TypeError:
+        sig = str(inspect.signature(obj))
+    except ValueError:
         sig = ''
     return sig
 


### PR DESCRIPTION
Refactor functions in `np.ma.core` and `np.core.overrides` to replace uses of functions from the `compat._inspect` module to the standard `inspect` module.

Note in both cases I chose to use the class-based `inspect.Signature` API to replace uses of the deprecated `inspect.getargspec`. If it is preferred, the use of the `Signature` could be replaced instead with usage of `inspect.getfullargspec`, which is more similar to the original.