### PR TITLE
DOC: Minor RST formatting.

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -221,7 +221,7 @@ class MGridClass(nd_grid):
     the stop value **is inclusive**.
 
     Returns
-    ----------
+    -------
     mesh-grid `ndarrays` all of the same dimensions
 
     See Also
@@ -896,7 +896,7 @@ def diag_indices(n, ndim=2):
     ndim : int, optional
       The number of dimensions.
 
-    See also
+    See Also
     --------
     diag_indices_from
 

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1685,7 +1685,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
            <https://docs.scipy.org/doc/numpy/user/basics.io.genfromtxt.html>`_.
 
     Examples
-    ---------
+    --------
     >>> from io import StringIO
     >>> import numpy as np
 

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -452,7 +452,7 @@ def apply_over_axes(func, a, axes):
         Apply a function to 1-D slices of an array along the given axis.
 
     Notes
-    ------
+    -----
     This function is equivalent to tuple axis arguments to reorderable ufuncs
     with keepdims=True. Tuple axis arguments to ufuncs have been available since
     version 1.7.0.


### PR DESCRIPTION
Usually `See Also` is uppercase A, and number of dashes match the length
of the header.
