### PR TITLE
BLD, MAINT: update cython to 0.29.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - stage: Comprehensive tests
       python: 3.6
     - python: 3.7
-#    - python: 3.9-dev
+    - python: 3.9-dev
 
     - python: 3.6
       env: USE_DEBUG=1

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -20,7 +20,7 @@ Building NumPy requires the following installed software:
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 0.29.14
+2) Cython >= 0.29.21
 
 3) pytest__ (optional) 1.15 or later
 

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -15,11 +15,11 @@ except ImportError:
 else:
     from distutils.version import LooseVersion
 
-    # Cython 0.29.14 is required for Python 3.8 and there are
+    # Cython 0.29.21 is required for Python 3.9 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    required_version = LooseVersion("0.29.14")
+    required_version = LooseVersion("0.29.21")
     if LooseVersion(cython_version) < required_version:
         # too old or wrong cython, skip the test
         cython = None

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -31,11 +31,11 @@ except ImportError:
     cython = None
 else:
     from distutils.version import LooseVersion
-    # Cython 0.29.14 is required for Python 3.8 and there are
+    # Cython 0.29.21 is required for Python 3.9 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    required_version = LooseVersion('0.29.14')
+    required_version = LooseVersion('0.29.21')
     if LooseVersion(cython_version) < required_version:
         # too old or wrong cython, skip the test
         cython = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.29.14",  # Note: keep in sync with tools/cythonize.py
+    "Cython>=0.29.21",  # Note: keep in sync with tools/cythonize.py
 ]
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-cython==0.29.19
+cython==0.29.21
 hypothesis==5.19.0
 pytest==5.4.3
 pytz==2020.1

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -66,11 +66,11 @@ def process_pyx(fromfile, tofile):
         # check the version, and invoke through python
         from distutils.version import LooseVersion
 
-        # Cython 0.29.14 is required for Python 3.8 and there are
+        # Cython 0.29.21 is required for Python 3.9 and there are
         # other fixes in the 0.29 series that are needed even for earlier
         # Python versions.
         # Note: keep in sync with that in pyproject.toml
-        required_version = LooseVersion('0.29.14')
+        required_version = LooseVersion('0.29.21')
 
         if LooseVersion(cython_version) < required_version:
             raise RuntimeError(f'Building {VENDOR} requires Cython >= {required_version}')


### PR DESCRIPTION
After a series of PRs, this enables Python3.9 testing and bumps the cython version needed by numpy to 0.29.21

We should try to make upgrading cython easier, there are way too many places to change.

xref gh-16746