### PR TITLE
TST: Upgrade to Python 3.8 for DEBUG testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     packages: &common_packages
       - gfortran
       - libgfortran5
-      - libgfortran3
       - libatlas-base-dev
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
@@ -38,7 +37,8 @@ jobs:
     - python: 3.7
     - python: 3.9-dev
 
-    - python: 3.6
+    - python: 3.8
+      dist: focal
       env: USE_DEBUG=1
       addons:
         apt:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -75,6 +75,7 @@ run_test()
 
   if [ -n "$USE_DEBUG" ]; then
     export PYTHONPATH=$PWD
+    export MYPYPATH=$PWD
   fi
 
   # pytest aborts when running --durations with python3.6-dbg, so only enable


### PR DESCRIPTION
The DEBUG test requires the debug version of Python which is only
available for the default Python of the Ubuntu version being used. The
latest available LTS version available for TravisCI looks to be Focal
Fossa (20.04 LTS) which supports Python 3.8. Give it a shot.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
