### PR TITLE
DOC: Added a warning about fractional steps in np.arange

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1619,7 +1619,8 @@ add_newdoc('numpy.core.multiarray', 'arange',
     --------
     The length of the output might not be numerically stable.
 
-    Another stability issue is due to the internal implementation of `numpy.arange`.
+    Another stability issue is due to the internal implementation of
+    `numpy.arange`.
     The actual step value used to populate the array is
     ``dtype(start + step) - dtype(start)`` and not `step`. Precision loss
     can occur here, due to casting or due to using floating points when

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1581,9 +1581,6 @@ add_newdoc('numpy.core.multiarray', 'arange',
     For integer arguments the function is equivalent to the Python built-in
     `range` function, but returns an ndarray rather than a list.
 
-    When using a non-integer step, such as 0.1, the results will often not
-    be consistent.  It is better to use `numpy.linspace` for these cases.
-
     Parameters
     ----------
     start : integer or real, optional
@@ -1614,6 +1611,25 @@ add_newdoc('numpy.core.multiarray', 'arange',
         ``ceil((stop - start)/step)``.  Because of floating point overflow,
         this rule may result in the last element of `out` being greater
         than `stop`.
+
+    Warnings
+    --------
+    The length of the output might not be numerically stable.
+
+    Another stability issue is due to the internal implementation of `numpy.arange`.
+    The actual step value used to populate the array is
+    ``dtype(start + step) - dtype(start)`` and not `step`. Precision loss
+    can occur here, due to casting or due to using floating points when
+    `start` is much larger than `step`. This can lead to unexpected
+    behaviour. For example::
+
+      >>> np.arange(0, 5, 0.5, dtype=int)
+      array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      >>> np.arange(-3, 3, 0.5, dtype=int)
+      array([-3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])
+
+    A workaround to these problems is to use `numpy.linspace`, which has a
+    numerically stable implementation.
 
     See Also
     --------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1581,6 +1581,9 @@ add_newdoc('numpy.core.multiarray', 'arange',
     For integer arguments the function is equivalent to the Python built-in
     `range` function, but returns an ndarray rather than a list.
 
+    When using a non-integer step, such as 0.1, it is often better to use 
+    `numpy.linspace`. See the warnings section below for more information.
+
     Parameters
     ----------
     start : integer or real, optional

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1631,8 +1631,7 @@ add_newdoc('numpy.core.multiarray', 'arange',
       >>> np.arange(-3, 3, 0.5, dtype=int)
       array([-3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])
 
-    A workaround to these problems is to use `numpy.linspace`, which has a
-    numerically stable implementation.
+    In such cases, the use of `numpy.linspace` should be preferred.
 
     See Also
     --------


### PR DESCRIPTION
Documented the ways that `np.arange` might fail because of fractional steps issues, and added three examples of such cases to the documentation.

Here is a discussion of similar problems:
https://github.com/numpy/numpy/issues/5808

As said in the discussion, a fix is not likely to be made at this point, so I thought this will be helpful.