### PR TITLE
DOC: Fix RST/numpydoc standard.

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -20,8 +20,8 @@ add_docstring(
 
     All arguments are required, and can only be passed by position.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     implementation : function
         Function that implements the operation on NumPy array without
         overrides when called like ``implementation(*args, **kwargs)``.

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -507,7 +507,7 @@ cdef class BitGenerator():
         lock.
 
     See Also
-    -------
+    --------
     SeedSequence
     """
 


### PR DESCRIPTION
One of the header line was not long enough, make it the same length as
the title.

The section "Arguments" is usually called "Parameters". Update for
consistency.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
