### PR TITLE
MAINT: Explicitly disallow object user dtypes

### DIFF
--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -211,6 +211,14 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
                         " is missing.");
         return -1;
     }
+    if (descr->flags & (NPY_ITEM_IS_POINTER | NPY_ITEM_REFCOUNT)) {
+        PyErr_SetString(PyExc_ValueError,
+                "Legacy user dtypes referencing python objects or generally "
+                "allocated memory are unsupported. "
+                "If you see this error in an existing, working code base, "
+                "please contact the NumPy developers.");
+        return -1;
+    }
     if (descr->typeobj == NULL) {
         PyErr_SetString(PyExc_ValueError, "missing typeobject");
         return -1;


### PR DESCRIPTION
These never worked to the best of my knowledge, so disable
it explicitly to hopefully simplify cleanup in other parts.

---

I don't think this is any limitation, but I would like to bake this in explicitly, so that it may be easier to clean up other parts.
