### PR TITLE
BUG, MAINT: Remove overzealous automatic RST link

### DIFF
--- a/doc/neps/nep-0016-benchmark.py
+++ b/doc/neps/nep-0016-benchmark.py
@@ -1,5 +1,3 @@
-.. _NEP16:
-
 import perf
 import abc
 import numpy as np


### PR DESCRIPTION
When adding links to all the NEPs, one non-rst file was taken in the
crossfire.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
