### PR TITLE
DOC: Add explanation of 'K' and 'A' layout options to 'asarray*' functions

### DIFF
--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -23,12 +23,12 @@ def asarray(a, dtype=None, order=None):
         of lists and ndarrays.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'K', 'A', 'C', 'F'}, optional
-        Memory layout.  'K' and 'A' depend on the order of input array a: 
-        'K' preserve input order
-        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
+    order : {'C', 'F', 'A', 'K'}, optional
+        Memory layout.  'A' and 'K' depend on the order of input array a.
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
+        'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
+        'K' (keep) preserve input order
         Defaults to 'C'.
 
     Returns
@@ -98,12 +98,12 @@ def asanyarray(a, dtype=None, order=None):
         tuples of lists, and ndarrays.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'K', 'A', 'C', 'F'}, optional
-        Memory layout.  'K' and 'A' depend on the order of input array a: 
-        'K' preserve input order
-        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
+    order : {'C', 'F', 'A', 'K'}, optional
+        Memory layout.  'A' and 'K' depend on the order of input array a.
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
+        'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
+        'K' (keep) preserve input order
         Defaults to 'C'.
 
     Returns

--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -26,7 +26,7 @@ def asarray(a, dtype=None, order=None):
     order : {'K', 'A', 'C', 'F'}, optional
         Memory layout.  'K' and 'A' depend on the order of input array a: 
         'K' preserve input order
-        'A' preserve input if 'F', otherwise convert to 'C',
+        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
         Defaults to 'C'.
@@ -101,7 +101,7 @@ def asanyarray(a, dtype=None, order=None):
     order : {'K', 'A', 'C', 'F'}, optional
         Memory layout.  'K' and 'A' depend on the order of input array a: 
         'K' preserve input order
-        'A' preserve input if 'F', otherwise convert to 'C',
+        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
         Defaults to 'C'.

--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -23,9 +23,12 @@ def asarray(a, dtype=None, order=None):
         of lists and ndarrays.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'C', 'F'}, optional
-        Whether to use row-major (C-style) or
-        column-major (Fortran-style) memory representation.
+    order : {'K', 'A', 'C', 'F'}, optional
+        Memory layout.  'K' and 'A' depend on the order of input array a: 
+        'K' preserve input order
+        'A' preserve input if 'F', otherwise convert to 'C',
+        'C' row-major (C-style), 
+        'F' column-major (Fortran-style) memory representation.
         Defaults to 'C'.
 
     Returns
@@ -95,9 +98,13 @@ def asanyarray(a, dtype=None, order=None):
         tuples of lists, and ndarrays.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'C', 'F'}, optional
-        Whether to use row-major (C-style) or column-major
-        (Fortran-style) memory representation.  Defaults to 'C'.
+    order : {'K', 'A', 'C', 'F'}, optional
+        Memory layout.  'K' and 'A' depend on the order of input array a: 
+        'K' preserve input order
+        'A' preserve input if 'F', otherwise convert to 'C',
+        'C' row-major (C-style), 
+        'F' column-major (Fortran-style) memory representation.
+        Defaults to 'C'.
 
     Returns
     -------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -434,7 +434,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
     order : {'K', 'A', 'C', 'F'}, optional
         Memory layout.  'K' and 'A' depend on the order of input array a: 
         'K' preserve input order
-        'A' preserve input if 'F', otherwise convert to 'C',
+        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
         Defaults to 'C'.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -431,12 +431,12 @@ def asarray_chkfinite(a, dtype=None, order=None):
         of lists and ndarrays.  Success requires no NaNs or Infs.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'K', 'A', 'C', 'F'}, optional
-        Memory layout.  'K' and 'A' depend on the order of input array a: 
-        'K' preserve input order
-        'A' means 'F' if `a` is Fortran contiguous, 'C' otherwise
+    order : {'C', 'F', 'A', 'K'}, optional
+        Memory layout.  'A' and 'K' depend on the order of input array a.
         'C' row-major (C-style), 
         'F' column-major (Fortran-style) memory representation.
+        'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
+        'K' (keep) preserve input order
         Defaults to 'C'.
 
     Returns

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -431,10 +431,13 @@ def asarray_chkfinite(a, dtype=None, order=None):
         of lists and ndarrays.  Success requires no NaNs or Infs.
     dtype : data-type, optional
         By default, the data-type is inferred from the input data.
-    order : {'C', 'F'}, optional
-         Whether to use row-major (C-style) or
-         column-major (Fortran-style) memory representation.
-         Defaults to 'C'.
+    order : {'K', 'A', 'C', 'F'}, optional
+        Memory layout.  'K' and 'A' depend on the order of input array a: 
+        'K' preserve input order
+        'A' preserve input if 'F', otherwise convert to 'C',
+        'C' row-major (C-style), 
+        'F' column-major (Fortran-style) memory representation.
+        Defaults to 'C'.
 
     Returns
     -------


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->
This adds documention for the the 'K' and 'A' memory layout for the
`asarray`, `asarray_contiguous`, `asarray_chkfinite` converters

Fixes #16534

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
