### PR TITLE
DOC: Add a reST label to /user/building.rst

### DIFF
--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -111,6 +111,8 @@ means that g77 has been used (note: g77 is no longer supported for building NumP
 If libgfortran.so is a dependency, gfortran has been used. If both are dependencies,
 this means both have been used, which is almost always a very bad idea.
 
+.. _accelerated-blas-lapack-libraries:
+
 Accelerated BLAS/LAPACK libraries
 ---------------------------------
 


### PR DESCRIPTION
SciPy's [/building/index.rst](https://github.com/scipy/scipy/blob/master/doc/source/building/index.rst#L44) contains a hyperlink to https://numpy.org/devdocs/user/building.html#accelerated-blas-lapack-libraries

To use an interlink instead, NumPy's [/user/building.rst](https://github.com/numpy/numpy/blob/master/doc/source/user/building.rst) would need to have a reST label added to the "Accelerated BLAS/LAPACK libraries" section. Note that building.rst already has a label for its "Parallel builds" section.

See: https://www.sphinx-doc.org/en/1.7/markup/inline.html

xref https://github.com/scipy/scipy/pull/11129
