### PR TITLE
BUG: fix mgrid output for lower precision float inputs

### DIFF
--- a/doc/release/upcoming_changes/16815.compatibility.rst
+++ b/doc/release/upcoming_changes/16815.compatibility.rst
@@ -1,0 +1,8 @@
+`mgrid`, `r_`, etc. fixed to consistently return correct outputs for non-default precision inputs
+-------------------------------------------------------------------------------------------------
+Previously, ``np.mgrid[np.float32(0.1):np.float32(0.35):np.float32(0.1),]``
+and ``np.r_[0:10:np.complex64(3j)]`` failed to return meaningful output.
+This bug potentially affects `mgrid`, `ogrid`, `r_`, and `c_` when an
+input with dtype other than the default `float64` and `complex128`
+and equivalent Python types were used.
+The methods have been fixed to handle varying precision correctly.

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -154,15 +154,15 @@ class nd_grid:
                     start = 0
                 if step is None:
                     step = 1
-                if isinstance(step, complex):
+                if isinstance(step, (_nx.complexfloating, complex)):
                     size.append(int(abs(step)))
                     typ = float
                 else:
                     size.append(
                         int(math.ceil((key[k].stop - start)/(step*1.0))))
-                if (isinstance(step, float) or
-                        isinstance(start, float) or
-                        isinstance(key[k].stop, float)):
+                if (isinstance(step, (_nx.floating, float)) or
+                        isinstance(start, (_nx.floating, float)) or
+                        isinstance(key[k].stop, (_nx.floating, float))):
                     typ = float
             if self.sparse:
                 nn = [_nx.arange(_x, dtype=_t)
@@ -176,7 +176,7 @@ class nd_grid:
                     start = 0
                 if step is None:
                     step = 1
-                if isinstance(step, complex):
+                if isinstance(step, (_nx.complexfloating, complex)):
                     step = int(abs(step))
                     if step != 1:
                         step = (key[k].stop - start)/float(step-1)
@@ -194,7 +194,7 @@ class nd_grid:
             start = key.start
             if start is None:
                 start = 0
-            if isinstance(step, complex):
+            if isinstance(step, (_nx.complexfloating, complex)):
                 step = abs(step)
                 length = int(step)
                 if step != 1:
@@ -344,7 +344,7 @@ class AxisConcatenator:
                     start = 0
                 if step is None:
                     step = 1
-                if isinstance(step, complex):
+                if isinstance(step, (_nx.complexfloating, complex)):
                     size = int(abs(step))
                     newobj = linspace(start, stop, num=size)
                 else:

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -263,12 +263,14 @@ class TestGrid:
         assert_array_almost_equal(grid64, grid32)
 
     def test_accepts_npcomplexfloating(self):
-        grid = mgrid[0.1:0.3:np.complex64(3j), ]
-        assert_array_almost_equal(grid, np.array([[0.1, 0.2, 0.3]]))
+        assert_array_almost_equal(
+            mgrid[0.1:0.3:3j, ], mgrid[0.1:0.3:np.complex64(3j), ]
+        )
 
         # different code path for single slice
-        grid = mgrid[0.1:0.3:np.complex64(3j)]
-        assert_array_almost_equal(grid, np.array([0.1, 0.2, 0.3]))
+        assert_array_almost_equal(
+            mgrid[0.1:0.3:3j], mgrid[0.1:0.3:np.complex64(3j)]
+        )
 
 class TestConcatenator:
     def test_1d(self):

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -263,6 +263,7 @@ class TestGrid:
         assert_array_almost_equal(grid64, grid32)
 
     def test_accepts_npcomplexfloating(self):
+        # Related to #16466
         assert_array_almost_equal(
             mgrid[0.1:0.3:3j, ], mgrid[0.1:0.3:np.complex64(3j), ]
         )
@@ -292,6 +293,7 @@ class TestConcatenator:
         g = r_[0:36:100j]
         assert_(g.shape == (100,))
 
+        # Related to #16466
         g = r_[0:36:np.complex64(100j)]
         assert_(g.shape == (100,))
 

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -249,6 +249,26 @@ class TestGrid:
         assert_equal(grid.size, expected[0])
         assert_equal(grid_small.size, expected[1])
 
+    def test_accepts_npfloating(self):
+        # regression test for #16466
+        grid64 = mgrid[0.1:0.33:0.1, ]
+        grid32 = mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1), ]
+        assert_(not isinstance(grid32.dtype, int))
+        assert_array_almost_equal(grid64, grid32)
+
+        # different code path for single slice
+        grid64 = mgrid[0.1:0.33:0.1]
+        grid32 = mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1)]
+        assert_(not isinstance(grid32.dtype, int))
+        assert_array_almost_equal(grid64, grid32)
+
+    def test_accepts_npcomplexfloating(self):
+        grid = mgrid[0.1:0.3:np.complex64(3j), ]
+        assert_array_almost_equal(grid, np.array([[0.1, 0.2, 0.3]]))
+
+        # different code path for single slice
+        grid = mgrid[0.1:0.3:np.complex64(3j)]
+        assert_array_almost_equal(grid, np.array([0.1, 0.2, 0.3]))
 
 class TestConcatenator:
     def test_1d(self):
@@ -268,6 +288,9 @@ class TestConcatenator:
     def test_complex_step(self):
         # Regression test for #12262
         g = r_[0:36:100j]
+        assert_(g.shape == (100,))
+
+        g = r_[0:36:np.complex64(100j)]
         assert_(g.shape == (100,))
 
     def test_2d(self):

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -253,13 +253,13 @@ class TestGrid:
         # regression test for #16466
         grid64 = mgrid[0.1:0.33:0.1, ]
         grid32 = mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1), ]
-        assert_(not isinstance(grid32.dtype, int))
+        assert_(grid32.dtype == np.float64)
         assert_array_almost_equal(grid64, grid32)
 
         # different code path for single slice
         grid64 = mgrid[0.1:0.33:0.1]
         grid32 = mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1)]
-        assert_(not isinstance(grid32.dtype, int))
+        assert_(grid32.dtype == np.float64)
         assert_array_almost_equal(grid64, grid32)
 
     def test_accepts_npcomplexfloating(self):


### PR DESCRIPTION
Floats besides float64 were being coerced to integers in np.mgrid and complex step sizes for the index trick classes would fail for complex64 input. Fixes #16466

Before:
```python
>>> np.mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1),]
array([[0, 0, 0]])
>>> np.r_[0:10:np.complex64(3j)]
array([], dtype=complex128)
```
After:
```python
>>> np.mgrid[np.float32(0.1):np.float32(0.33):np.float32(0.1),]
array([[0.1, 0.2, 0.3]])
>>> np.r_[0:10:np.complex64(3j)]
array([ 0.,  5., 10.])
```

The input types do not affect the output dtype, which are always int64 or float64, but they can affect the output in other ways due to `arange` precision issues (#5808).
```python
>>> np.mgrid[np.float32(0.1):np.float32(0.3):np.float32(0.1)]
array([0.1, 0.2, 0.3])
>>> np.mgrid[np.float64(0.1):np.float64(0.3):np.float64(0.1)]
array([0.1, 0.2])
```

@seberg [mentioned](https://github.com/numpy/numpy/issues/16466#issuecomment-636928083) that the `mgrid` code could use a refactor. A lot of its functionality is duplicated in `AxisConcatenator` and `meshgrid`. I think the code could almost be replaced by `np.meshgrid(*[np.r_[k.start:k.stop:k.step] for k in key], sparse=self.sparse)`. I could verify this and clean it up if it sounds reasonable.