### PR TITLE
BLD: temporarily disable OpenBLAS hash checks

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -167,7 +167,7 @@ def download_openblas(target, arch, ilp64, is_32bit):
         raise ValueError(
             f'key "{key}" with hash "{sha256_returned}" not in sha256_vals')
     sha256_expected = sha256_vals[key]
-    if sha256_returned != sha256_expected:
+    if 0 and sha256_returned != sha256_expected:
         raise ValueError(f'sha256 hash mismatch for filename {filename}')
     print("Saving to file", file=sys.stderr)
     with open(target, 'wb') as fid:


### PR DESCRIPTION
xref MacPython/openblas-libs#34 which will change the hashes of the uploaded files. Disable the hash check temporarily until that is merged and we can update the hashes here.