### PR TITLE
BUG: Do not inherit flags from the structured part of a union dtype

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -885,7 +885,17 @@ _try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj)
         new->metadata = conv->metadata;
         Py_XINCREF(new->metadata);
     }
-    new->flags = conv->flags;
+    /*
+     * Certain flags must be inherited from the fields.  This is needed
+     * only for void dtypes (or subclasses of it such as a record dtype).
+     * For other dtypes, the field part will only be used for direct field
+     * access and thus flag inheritance should not be necessary.
+     * (We only allow object fields if the dtype is object as well.)
+     * This ensures copying over of the NPY_FROM_FIELDS "inherited" flags.
+     */
+    if (new->type_num == NPY_VOID) {
+        new->flags = conv->flags;
+    }
     Py_DECREF(conv);
     return new;
 

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2325,6 +2325,10 @@ class TestRegression:
         # allowed as a special case due to existing use, see gh-2798
         a = np.ones(1, dtype=('O', [('name', 'O')]))
         assert_equal(a[0], 1)
+        # In particular, the above union dtype (and union dtypes in general)
+        # should mainly behave like the main (object) dtype:
+        assert a[0] is a.item()
+        assert type(a[0]) is int
 
     def test_correct_hash_dict(self):
         # gh-8887 - __hash__ would be None despite tp_hash being set


### PR DESCRIPTION
Such a union dtype (I would like to just not have them...) should
behave like the main dtype normally.  The only use of the union
part should be to allow field access.  In all other cases behaviour
should not be affected by the existance of fields, but inheriting
fields will affect it.
The exception is the `void` dtype, which explicitly uses its fields
and thus must inherit flags from the contained dtypes.

---

This fixes an annoying bug with such union dtypes (specifically union of objects), which came back to bite me in another cleanup (for, quite honestly reasons I did not yet understand).  In any case, I am sure that this is the right way to do handle it here. Union dtypes are weird, and I would like them not existing, but tagging on fields to a dtype should definitely not change its main behaviour.