### PR TITLE
MAINT: Make void scalar to array creation copy when dtype is given

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1438,11 +1438,15 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     }
     else if (cache == NULL && PyArray_IsScalar(op, Void) &&
             !(((PyVoidScalarObject *)op)->flags & NPY_ARRAY_OWNDATA) &&
-            PyArray_EquivTypes(((PyVoidScalarObject *)op)->descr, dtype)) {
+            newtype == NULL) {
         /*
          * Special case, we return a *view* into void scalars, mainly to
-         * allow "reversed" assignment:
+         * allow things similar to the "reversed" assignment:
          *    arr[indx]["field"] = val  # instead of arr["field"][indx] = val
+         *
+         * It is unclear that this is necessary in this particular code path.
+         * Note that this path is only activated when the user did _not_
+         * provide a dtype (newtype is NULL).
          */
         assert(ndim == 0);
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1390,6 +1390,21 @@ class TestStructured:
         assert_raises(ValueError, lambda : a[['b','b']])  # field exists, but repeated
         a[['b','c']]  # no exception
 
+    def test_structured_asarray_is_view(self):
+        # A scalar viewing an array preserves its view even when creating a
+        # new array. This test documents behaviour, it may not be the best
+        # desired behaviour.
+        arr = np.array([1], dtype="i,i")
+        scalar = arr[0]
+        assert not scalar.flags.owndata  # view into the array
+        assert np.asarray(scalar).base is scalar
+        # But never when a dtype is passed in:
+        assert np.asarray(scalar, dtype=scalar.dtype).base is None
+        # A scalar which owns its data does not have this property.
+        # It is not easy to create one, one method is to use pickle:
+        scalar = pickle.loads(pickle.dumps(scalar))
+        assert scalar.flags.owndata
+        assert np.asarray(scalar).base is None
 
 class TestBool:
     def test_test_interning(self):


### PR DESCRIPTION
This retains the old behaviour, where the non-copy semtantics
was only used when no dtype is passed in at all.

---

this is a small followup to gh-16200 simply because right now it slightly changed behaviour as it was.