### PR TITLE
MAINT: setuptools 49.2.0 emits a warning, avoid it

### DIFF
--- a/numpy/core/src/multiarray/abstractdtypes.h
+++ b/numpy/core/src/multiarray/abstractdtypes.h
@@ -14,6 +14,6 @@ NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyFloatAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyComplexAbstractDType;
 
 NPY_NO_EXPORT int
-initialize_and_map_pytypes_to_dtypes();
+initialize_and_map_pytypes_to_dtypes(void);
 
 #endif  /*_NPY_ABSTRACTDTYPES_H */

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -102,7 +102,7 @@ enum _dtype_discovery_flags {
  * @return -1 on error 0 on success
  */
 static int
-_prime_global_pytype_to_type_dict()
+_prime_global_pytype_to_type_dict(void)
 {
     int res;
 

--- a/numpy/distutils/__init__.py
+++ b/numpy/distutils/__init__.py
@@ -18,7 +18,9 @@ LAPACK, and for setting include paths and similar build options, please see
 ``site.cfg.example`` in the root of the NumPy repository or sdist.
 
 """
-
+# from setuptools v49.2.0, setuptools warns if distutils is imported first,
+# so pre-emptively import setuptools
+import setuptools
 # Must import local ccompiler ASAP in order to get
 # customized CCompiler.spawn effective.
 from . import ccompiler

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,10 @@ class concat_license_files():
             f.write(self.bsd_text)
 
 
+# from setuptools v49.2.0, setuptools warns if distutils is imported first,
+# so pre-emptively import setuptools. Eventually we can migrate to using
+# setuptools.command
+import setuptools
 from distutils.command.sdist import sdist
 class sdist_checked(sdist):
     """ check submodules on sdist to prevent incomplete tarballs """


### PR DESCRIPTION
[setuptools 49.2.0, released today](https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4920), will now emit a warning if distutils is imported before setuptools. This affects the test_api tests, so pre-emtively import setuptools.