### PR TITLE
API: Allow zero length strings to result in zero length dtypes

### DIFF
--- a/doc/release/upcoming_changes/16825.compatibility.rst
+++ b/doc/release/upcoming_changes/16825.compatibility.rst
@@ -1,0 +1,6 @@
+Zero length string dtypes preserved more often
+----------------------------------------------
+When creating an array from one or more zero length strings,
+the output dtype will now be zero length in many cases as well.
+Note that NumPy will still often convert such dtypes to a length
+one dtype for many operations.

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1480,9 +1480,9 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
          * should be no subarray scalars (they would be arrays).
          */
         PyErr_Format(PyExc_RuntimeError,
-                "dtype changed while creating an array from a python object. "
-                "This should not be possible. Please notify the NumPy "
-                "developers you see this message.",
+                "dtype changed from %R to %R while creating an array from a "
+                "python object. This should not be possible. Please notify the "
+                "NumPy developers you see this message.",
                 PyArray_DESCR(ret), dtype, PyArray_DESCR(ret));
         Py_DECREF(ret);
         return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1483,7 +1483,7 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
                 "dtype changed from %R to %R while creating an array from a "
                 "python object. This should not be possible. Please notify the "
                 "NumPy developers you see this message.",
-                PyArray_DESCR(ret), dtype, PyArray_DESCR(ret));
+                dtype, PyArray_DESCR(ret));
         Py_DECREF(ret);
         return NULL;
     }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -338,10 +338,10 @@ PyArray_FromScalar(PyObject *scalar, PyArray_Descr *outcode)
          * Sanity check, only subarray dtypes should be modified, and there
          * should be no subarray scalars (they would be arrays).
          */
-        PyErr_SetString(PyExc_RuntimeError,
-                "dtype changed while creating an array from a scalar. This "
+        PyErr_Format(PyExc_RuntimeError,
+                "dtype changed from %R to %R while creating an array from a scalar. This "
                 "should not be possible. Please notify the NumPy developers "
-                "you see this message");
+                "you see this message", outcode, PyArray_DESCR(r));
         Py_DECREF(r);
         return NULL;
     }

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -149,7 +149,7 @@ class TestStringDiscovery:
         # For comparison, the current default array path upgrades the dtype,
         # even (or especially) when the array is empty.
         assert np.array([], dtype=type(scalar)).dtype.itemsize != 0
-        # but now not if a concret empty string was found:
+        # but now not if a concrete empty string was found:
         assert np.array([b''], dtype=type(scalar)).dtype.itemsize == 0
 
     @pytest.mark.parametrize("obj",

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -137,6 +137,21 @@ def is_parametric_dtype(dtype):
 
 
 class TestStringDiscovery:
+    @pytest.mark.parametrize("scalar", [np.bytes_(b""), np.unicode_("")])
+    def test_zero_length_string(self, scalar):
+        assert scalar.dtype.itemsize == 0
+        assert np.array(scalar).dtype == scalar.dtype
+        # Scalar methods converting to ndarray internally, end up using
+        # zero length strings (although we do lose 0-length strings in many
+        # places at this time).
+        assert scalar.squeeze().dtype == scalar.dtype
+
+        # For comparison, the current default array path upgrades the dtype,
+        # even (or especially) when the array is empty.
+        assert np.array([], dtype=type(scalar)).dtype.itemsize != 0
+        # but now not if a concret empty string was found:
+        assert np.array([b''], dtype=type(scalar)).dtype.itemsize == 0
+
     @pytest.mark.parametrize("obj",
             [object(), 1.2, 10**43, None, "string"],
             ids=["object", "1.2", "10**43", "None", "string"])


### PR DESCRIPTION
The dtype is of zero length strings is no preserved when creating
an array from a scalar in more cases.
This also simplifies the `PyArray_FromScalar` code so that the
(mainly unused) casting branch reuses `PyArray_Pack` to avoid
implementing similar logic multiple times.
