### PR TITLE
MAINT: Fix ``runtest.py`` warning. 

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -341,6 +341,9 @@ def build_project(args):
 
     """
 
+    # from setuptools v49.2.0, setuptools warns if distutils is imported first,
+    # so pre-emptively import setuptools
+    import setuptools
     import distutils.sysconfig
 
     root_ok = [os.path.exists(os.path.join(ROOT_DIR, fn))


### PR DESCRIPTION
Continuation of gh-16822

One more place where distutils is imported (I put an `xxx = xxx` in my `lib/python3-8/distutils/__init__.py` to error out on import)