### PR TITLE
MAINT: Fix ``runtest.py`` warning.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -341,6 +341,7 @@ def build_project(args):
 
     """
 
+    import setuptools
     import distutils.sysconfig
 
     root_ok = [os.path.exists(os.path.join(ROOT_DIR, fn))


### PR DESCRIPTION
setuptools 49.2.0 emits a warning if imported after distutils, fix that.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
