### PR TITLE
MAINT: fix sphinx deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ doc/cdoc/build
 ./.shelf
 MANIFEST
 .cache
+pip-wheel-metadata
 
 # Paver generated files #
 #########################
@@ -105,6 +106,11 @@ Thumbs.db
 # pytest generated files #
 ##########################
 /.pytest_cache
+
+# doc build generated files #
+#############################
+doc/source/savefig/
+
 
 # Things specific to this project #
 ###################################

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,7 +88,7 @@ pygments_style = 'sphinx'
 def setup(app):
     # add a config value for `ifconfig` directives
     app.add_config_value('python_version_major', str(sys.version_info.major), 'env')
-    app.add_lexer('NumPyC', NumPyLexer(stripnl=False))
+    app.add_lexer('NumPyC', NumPyLexer)
 
 # -----------------------------------------------------------------------------
 # HTML output


### PR DESCRIPTION
It fixes the warning during docsbuild:
```
/Users/bsipocz/munka/devel/numpy/doc/source/conf.py:91: RemovedInSphinx40Warning: app.add_lexer() API changed; Please give lexer class instead instance
  app.add_lexer('NumPyC', NumPyLexer(stripnl=False))
```