### PR TITLE
Avoid using uninitialized bytes in getlimits.py.

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -262,7 +262,6 @@ def _get_machar(ftype):
         raise ValueError(repr(ftype))
     # Detect known / suspected types
     key = ftype('-0.1').newbyteorder('<').tobytes()
-    ma_like = _KNOWN_TYPES.get(key)
     ma_like = None
     if ftype == ntypes.longdouble:
         # Could be 80 bit == 10 byte extended precision, where last bytes can

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -263,10 +263,15 @@ def _get_machar(ftype):
     # Detect known / suspected types
     key = ftype('-0.1').newbyteorder('<').tobytes()
     ma_like = _KNOWN_TYPES.get(key)
-    # Could be 80 bit == 10 byte extended precision, where last bytes can be
-    # random garbage.  Try comparing first 10 bytes to pattern.
-    if ma_like is None and ftype == ntypes.longdouble:
+    ma_like = None
+    if ftype == ntypes.longdouble:
+        # Could be 80 bit == 10 byte extended precision, where last bytes can
+        # be random garbage.
+        # Comparing first 10 bytes to pattern first to avoid branching on the
+        # random garbage.
         ma_like = _KNOWN_TYPES.get(key[:10])
+    if ma_like is None:
+        ma_like = _KNOWN_TYPES.get(key)
     if ma_like is not None:
         return ma_like
     # Fall back to parameter discovery


### PR DESCRIPTION
This very simple flip of ordering avoids an error branching on the last 6 uninitialized bytes. 

msan does not always report this error, likely due to the caching of memory allocation.

