### PR TITLE
DOC: Explaining why datetime64 doesn't work for allclose + isclose

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2173,7 +2173,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     ``allclose(a, b)`` to evaluate to True.  The same is true for
     `equal` but not `array_equal`.
 
-    ``allclose`` is currently not defined for non-numeric data types.
+    `allclose` is not defined for non-numeric data types.
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2173,6 +2173,8 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     ``allclose(a, b)`` to evaluate to True.  The same is true for
     `equal` but not `array_equal`.
 
+    ``allclose`` is currently not defined for non-numeric data types.
+
     Examples
     --------
     >>> np.allclose([1e10,1e-7], [1.00001e10,1e-8])
@@ -2251,6 +2253,8 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     are significantly smaller than one, it can result in false positives.
     `atol` should be carefully selected for the use case at hand. A zero value
     for `atol` will result in `False` if either `a` or `b` is zero.
+
+    ``isclose`` is currently not defined for non-numeric data types.
 
     Examples
     --------

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -2254,7 +2254,7 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     `atol` should be carefully selected for the use case at hand. A zero value
     for `atol` will result in `False` if either `a` or `b` is zero.
 
-    ``isclose`` is currently not defined for non-numeric data types.
+    `isclose` is not defined for non-numeric data types.
 
     Examples
     --------


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Providing documentation to detail why datetime64 doesn't work with functions `allclose` and `isclose` .
See #16065 for details. 

Fixes #16065