### PR TITLE
BLD: upgrade setuptools on shippable

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -10,6 +10,9 @@ import shutil
 import multiprocessing
 import textwrap
 
+# from setuptools v49.2.0, setuptools warns if distutils is imported first,
+# so pre-emptively import setuptools
+import setuptools
 import distutils
 from distutils.errors import DistutilsError
 try:

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,7 +29,7 @@ build:
     - ls -lR "${target}"
     - sudo cp -r "${target}"/lib/* /usr/lib
     - sudo cp "${target}"/include/* /usr/include
-    - python -m pip install --upgrade pip
+    - python -m pip install --upgrade pip setuptools
 
     # we will pay the ~13 minute cost of compiling Cython only when a new
     # version is scraped in by pip; otherwise, use the cached


### PR DESCRIPTION
Shippable (arm64 builds) is apparently using an older version of setuptools that still has `import imp` which is now deprecated. The log is only visible if you log in, it is showing:
```
        warnings   = <module 'warnings' from '/root/venv/3.7/lib/python3.7/warnings.py'>
/root/venv/3.7/lib/python3.7/site-packages/setuptools/depends.py:2: in <module>
    import imp
        __builtins__ = <builtins>
        __cached__ = '/root/venv/3.7/lib/python3.7/site-packages/setuptools/__pycache__/depends.cpython-37.pyc'
        __doc__    = None
        __file__   = '/root/venv/3.7/lib/python3.7/site-packages/setuptools/depends.py'
        __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0xffff1a835f98>
        __name__   = 'setuptools.depends'
        __package__ = 'setuptools'
        __spec__   = ModuleSpec(name='setuptools.depends', loader=<_frozen_importlib_external.SourceFileLoader object at 0xffff1a835f98>, origin='/root/venv/3.7/lib/python3.7/site-packages/setuptools/depends.py')
        __warningregistry__ = {'version': 27}
        sys        = <module 'sys' (built-in)>
/root/venv/3.7/lib/python3.7/imp.py:33: in <module>
    DeprecationWarning, stacklevel=2)
E   DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```