### PR TITLE
MAINT: Unused argument range

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -196,7 +196,7 @@ def _hist_bin_doane(x, range):
     return 0.0
 
 
-def _hist_bin_fd(x, range):
+def _hist_bin_fd(x, range=None):
     """
     The Freedman-Diaconis histogram bin estimator.
 


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

The default value of range, which is an unused argument, has been set to `None`
I cannot delete a function considering compatibility, but we do not need to assign a range when calling a function.