### PR TITLE
BUG: fix the search dir of dispatch-able sources

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -2136,9 +2136,12 @@ class CCompilerOpt(_Config, _Distutils, _Cache, _CCompiler, _Feature, _Parse):
 
         for src in sources:
             output_dir = os.path.dirname(src)
-            if src_dir and not output_dir.startswith(src_dir):
-                output_dir = os.path.join(src_dir, output_dir)
+            if src_dir:
+                if not output_dir.startswith(src_dir):
+                    output_dir = os.path.join(src_dir, output_dir)
                 if output_dir not in include_dirs:
+                    # To allow including the generated config header(*.dispatch.h)
+                    # by the dispatch-able sources
                     include_dirs.append(output_dir)
 
             has_baseline, targets, extra_flags = self.parse_targets(src)


### PR DESCRIPTION
Fix the search dir of dispatch-able sources to allow including the
generated config headers within the dispatch-able sources.

