### PR TITLE
MAINT: Remove deprecated python function 'file()'

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1900,7 +1900,7 @@ class Configuration:
                 revision0 = f.read().strip()
 
             branch_map = {}
-            for line in file(branch_cache_fn, 'r'):
+            for line in open(branch_cache_fn, 'r'):
                 branch1, revision1  = line.split()[:2]
                 if revision1==revision0:
                     branch0 = branch1


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

`file()`, which was Python build-in function, is no longer supported. That's why we should to use `open`