### PR TITLE
MAINT: It's faster to use an astype than to multiply by 1.0

### DIFF
--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -145,7 +145,7 @@ def _fix_int_lt_zero(x):
     """
     x = asarray(x)
     if any(isreal(x) & (x < 0)):
-        x = x * 1.0
+        x = x.astype('float64')
     return x
 
 


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

The existing code multiplied by 1.0 to cast `x` as double. However, it is about twice as fast to use an `astype` than that.

```python
In [2]: def case1(x):
   ...:     return x * 1.0
   ...:

In [3]: def case2(x):
   ...:     return x.astype('float64')
   ...:

In [4]: arr = np.random.randint(0, 1000, 10000)

In [5]: %timeit case1(arr)
9.35 µs ± 128 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [6]: %timeit case2(arr)
4.75 µs ± 39.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

Thank You!