### PR TITLE
ENH: Add weights option to numpy.quantile

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1224,7 +1224,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
 
 def _nanpercentile_dispatcher(
         a, q, axis=None, out=None, overwrite_input=None,
-        method=None, keepdims=None, *, interpolation=None):
+        method=None, keepdims=None, *, interpolation=None,
+        aweights=None):
     return (a, q, out)
 
 
@@ -1239,6 +1240,7 @@ def nanpercentile(
         keepdims=np._NoValue,
         *,
         interpolation=None,
+        aweights=None,
 ):
     """
     Compute the qth percentile of the data along the specified axis,
@@ -1386,7 +1388,8 @@ def nanpercentile(
 
 
 def _nanquantile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
-                            method=None, keepdims=None, *, interpolation=None):
+                            method=None, keepdims=None, *, interpolation=None,
+                            aweights=None):
     return (a, q, out)
 
 
@@ -1401,6 +1404,7 @@ def nanquantile(
         keepdims=np._NoValue,
         *,
         interpolation=None,
+        aweights=None,
 ):
     """
     Compute the qth quantile of the data along the specified axis,


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
* We add a new feature to  numpy.quantile and numpy.percentile.
* Now, user can specify the weights of samples when computing quantiles.
* The reference is: https://stats.stackexchange.com/questions/13169/defining-quantiles-over-a-weighted-sample?fbclid=IwAR07lNSQsmd40zMB_DAgTdFLxpDoLKlv9QdrvoexSATfiQ_BdU_4aU9YtLI

####
* w must have the same shape with a.shape or a[axis] when axis is int or None.

* When w.shape == a.shape, it's the weights of each samples in a.

* If w.shape != a.shape, it's the weights for each dimensions in a.

  For example, 

            a = np.array([[1,2,3],[4,5,6]])

            w = np.array([10,11,12])

            axis = 1

  both weights of [1,2,3] and [4,5,6] are [10,11,12]