### PR TITLE
BLD, MAINT: Pin setuptools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,7 +249,8 @@ stages:
             fi
       displayName: 'add gcc 4.8'
     - script: |
-            python3 -m pip install --user --upgrade pip
+            # python3 has no setuptools, so install one to get us going
+            python3 -m pip install --user --upgrade pip setuptools!=49.2.0
             python3 -m pip install --user -r test_requirements.txt
             CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
             python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,7 +249,7 @@ stages:
             fi
       displayName: 'add gcc 4.8'
     - script: |
-            python3 -m pip install --user --upgrade pip setuptools
+            python3 -m pip install --user --upgrade pip
             python3 -m pip install --user -r test_requirements.txt
             CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
             python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -4,7 +4,7 @@ steps:
     versionSpec: $(PYTHON_VERSION)
     addToPath: true
     architecture: $(PYTHON_ARCH)
-- script: python -m pip install --upgrade pip setuptools wheel
+- script: python -m pip install --upgrade pip
   displayName: 'Install tools'
 - script: python -m pip install -r test_requirements.txt
   displayName: 'Install dependencies; some are optional to avoid test skips'

--- a/numpy/distutils/__init__.py
+++ b/numpy/distutils/__init__.py
@@ -18,9 +18,7 @@ LAPACK, and for setting include paths and similar build options, please see
 ``site.cfg.example`` in the root of the NumPy repository or sdist.
 
 """
-# from setuptools v49.2.0, setuptools warns if distutils is imported first,
-# so pre-emptively import setuptools
-import setuptools
+
 # Must import local ccompiler ASAP in order to get
 # customized CCompiler.spawn effective.
 from . import ccompiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools",
+    "setuptools!=49.2.0",
     "wheel",
     "Cython>=0.29.21",  # Note: keep in sync with tools/cythonize.py
 ]

--- a/runtests.py
+++ b/runtests.py
@@ -335,9 +335,6 @@ def build_project(args):
 
     """
 
-    # from setuptools v49.2.0, setuptools warns if distutils is imported first,
-    # so pre-emptively import setuptools
-    import setuptools
     import distutils.sysconfig
 
     root_ok = [os.path.exists(os.path.join(ROOT_DIR, fn))

--- a/setup.py
+++ b/setup.py
@@ -219,10 +219,6 @@ class concat_license_files():
             f.write(self.bsd_text)
 
 
-# from setuptools v49.2.0, setuptools warns if distutils is imported first,
-# so pre-emptively import setuptools. Eventually we can migrate to using
-# setuptools.command
-import setuptools
 from distutils.command.sdist import sdist
 class sdist_checked(sdist):
     """ check submodules on sdist to prevent incomplete tarballs """

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 branches:
     only:
-       - master
-       - maintenance/*
+        - master
+        - maintenance/*
 
 language: python
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,7 @@
 cython==0.29.21
-hypothesis==5.19.0
+wheel
+setuptools!=49.2.0
+hypothesis==5.19.1
 pytest==5.4.3
 pytz==2020.1
 pytest-cov==2.8.1

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -33,7 +33,7 @@ wget -q https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 -O pypy
 mkdir -p pypy3
 (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
 pypy3/bin/pypy3 -mensurepip
-pypy3/bin/pypy3 -m pip install --upgrade pip setuptools wheel
+pypy3/bin/pypy3 -m pip install --upgrade pip
 pypy3/bin/pypy3 -m pip install --user -r test_requirements.txt --no-warn-script-location
 
 echo

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -29,7 +29,7 @@ gcc --version
 
 popd
 
-pip install --upgrade pip
+pip install --upgrade pip setuptools!=49.2.0 wheel
 
 # 'setuptools', 'wheel' and 'cython' are build dependencies.  This information
 # is stored in pyproject.toml, but there is not yet a standard way to install
@@ -41,7 +41,7 @@ pip install --upgrade pip
 # A specific version of cython is required, so we read the cython package
 # requirement using `grep cython test_requirements.txt` instead of simply
 # writing 'pip install setuptools wheel cython'.
-pip install setuptools wheel `grep cython test_requirements.txt`
+pip install `grep cython test_requirements.txt`
 
 if [ -n "$DOWNLOAD_OPENBLAS" ]; then
   pwd


### PR DESCRIPTION
Backport of #16870. 

- back out gh-16822 (leave the non-setuptools-changest)
- avoid setuptools 49.2.0 and refactor how it is found.

All the CI runs except travis use the `test_requirements.txt` or `pyproject.toml`, so I moved all the setuptools version requirement to those files.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
