### PR TITLE
BUG,DOC: Fix bad MPL kwarg in docs

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -675,7 +675,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     >>> fig = plt.figure(figsize=(7, 3))
     >>> ax = fig.add_subplot(131, title='imshow: square bins')
-    >>> plt.imshow(H, interpolation='nearest', origin='low',
+    >>> plt.imshow(H, interpolation='nearest', origin='lower',
     ...         extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]])
     <matplotlib.image.AxesImage object at 0x...>
 


### PR DESCRIPTION
An example in a `.. plot` directive had an invalid value for the `origin` parameter of `imshow`. It seems that input validation was added in matplotlib/matplotlib#16265, causing the numpy documentation build to fail with the following warning:

<details>
  <summary>sphinx error with matplotlib v3.3</summary>
<pre>
WARNING: Exception occurred in plotting numpy-histogram2d-1
 from /home/ross/repos/numpy/doc/source/reference/generated/numpy.histogram2d.rst:
Traceback (most recent call last):
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/sphinxext/plot_directive.py", line 472, in run_code
    exec(code, ns)
  File "<string>", line 21, in <module>
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/pyplot.py", line 2707, in imshow
    __ret = gca().imshow(
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/__init__.py", line 1431, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/axes/_axes.py", line 5515, in imshow
    im = mimage.AxesImage(self, cmap, norm, interpolation, origin, extent,
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/image.py", line 897, in __init__
    super().__init__(
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/image.py", line 247, in __init__
    cbook._check_in_list(["upper", "lower"], origin=origin)
  File "/home/ross/.virtualenvs/numpy-dev/lib/python3.8/site-packages/matplotlib/cbook/__init__.py", line 2248, in _check_in_list
    raise ValueError(
ValueError: 'low' is not a valid value for origin; supported values are 'upper', 'lower'
</pre>
</details>

This is also causing the doc building CI to fail.