### PR TITLE
DOC: Fix types including curly braces

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -826,7 +826,7 @@ General check of Python Type
 
 .. c:function:: PyArray_IsScalar(op, cls)
 
-    Evaluates true if *op* is an instance of :c:data:`Py{cls}ArrType_Type`.
+    Evaluates true if *op* is an instance of ``Py{cls}ArrType_Type``.
 
 .. c:function:: PyArray_CheckScalar(op)
 

--- a/doc/source/reference/c-api/config.rst
+++ b/doc/source/reference/c-api/config.rst
@@ -19,7 +19,7 @@ avoid namespace pollution.
 Data type sizes
 ---------------
 
-The :c:data:`NPY_SIZEOF_{CTYPE}` constants are defined so that sizeof
+The ``NPY_SIZEOF_{CTYPE}`` constants are defined so that sizeof
 information is available to the pre-processor.
 
 .. c:macro:: NPY_SIZEOF_SHORT

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -30,7 +30,7 @@ Enumerated Types
 There is a list of enumerated types defined providing the basic 24
 data types plus some useful generic names. Whenever the code requires
 a type number, one of these enumerated types is requested. The types
-are all called :c:data:`NPY_{NAME}`:
+are all called ``NPY_{NAME}``:
 
 .. c:var:: NPY_BOOL
 
@@ -199,7 +199,7 @@ Other useful related constants are
 The various character codes indicating certain types are also part of
 an enumerated list. References to type characters (should they be
 needed at all) should always use these enumerations. The form of them
-is :c:data:`NPY_{NAME}LTR` where ``{NAME}`` can be
+is ``NPY_{NAME}LTR`` where ``{NAME}`` can be
 
     **BOOL**, **BYTE**, **UBYTE**, **SHORT**, **USHORT**, **INT**,
     **UINT**, **LONG**, **ULONG**, **LONGLONG**, **ULONGLONG**,
@@ -247,8 +247,8 @@ Max and min values for integers
 Number of bits in data types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All :c:data:`NPY_SIZEOF_{CTYPE}` constants have corresponding
-:c:data:`NPY_BITSOF_{CTYPE}` constants defined. The :c:data:`NPY_BITSOF_{CTYPE}`
+All ``NPY_SIZEOF_{CTYPE}`` constants have corresponding
+``NPY_BITSOF_{CTYPE}`` constants defined. The ``NPY_BITSOF_{CTYPE}``
 constants provide the number of bits in the data type.  Specifically,
 the available ``{CTYPE}s`` are
 
@@ -263,7 +263,7 @@ All of the numeric data types (integer, floating point, and complex)
 have constants that are defined to be a specific enumerated type
 number. Exactly which enumerated type a bit-width type refers to is
 platform dependent. In particular, the constants available are
-:c:data:`PyArray_{NAME}{BITS}` where ``{NAME}`` is **INT**, **UINT**,
+``PyArray_{NAME}{BITS}`` where ``{NAME}`` is **INT**, **UINT**,
 **FLOAT**, **COMPLEX** and ``{BITS}`` can be 8, 16, 32, 64, 80, 96, 128,
 160, 192, 256, and 512.  Obviously not all bit-widths are available on
 all platforms for all the kinds of numeric types. Commonly 8-, 16-,
@@ -397,8 +397,8 @@ There are also typedefs for signed integers, unsigned integers,
 floating point, and complex floating point types of specific bit-
 widths. The available type names are
 
-    :c:type:`npy_int{bits}`, :c:type:`npy_uint{bits}`, :c:type:`npy_float{bits}`,
-    and :c:type:`npy_complex{bits}`
+    ``npy_int{bits}``, ``npy_uint{bits}``, ``npy_float{bits}``,
+    and ``npy_complex{bits}``
 
 where ``{bits}`` is the number of bits in the type and can be **8**,
 **16**, **32**, **64**, 128, and 256 for integer types; 16, **32**

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -26,7 +26,7 @@ By constructing a new Python type you make available a new object for
 Python. The ndarray object is an example of a new type defined in C.
 New types are defined in C by two basic steps:
 
-1. creating a C-structure (usually named :c:type:`Py{Name}Object`) that is
+1. creating a C-structure (usually named ``Py{Name}Object``) that is
    binary- compatible with the :c:type:`PyObject` structure itself but holds
    the additional information needed for that particular object;
 
@@ -1204,7 +1204,7 @@ ScalarArrayTypes
 There is a Python type for each of the different built-in data types
 that can be present in the array Most of these are simple wrappers
 around the corresponding data type in C. The C-names for these types
-are :c:data:`Py{TYPE}ArrType_Type` where ``{TYPE}`` can be
+are ``Py{TYPE}ArrType_Type`` where ``{TYPE}`` can be
 
     **Bool**, **Byte**, **Short**, **Int**, **Long**, **LongLong**,
     **UByte**, **UShort**, **UInt**, **ULong**, **ULongLong**,

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -269,7 +269,7 @@ Functions
 .. c:function:: int PyUFunc_checkfperr(int errmask, PyObject* errobj)
 
     A simple interface to the IEEE error-flag checking support. The
-    *errmask* argument is a mask of :c:data:`UFUNC_MASK_{ERR}` bitmasks
+    *errmask* argument is a mask of ``UFUNC_MASK_{ERR}`` bitmasks
     indicating which errors to check for (and how to check for
     them). The *errobj* must be a Python tuple with two elements: a
     string containing the name which will be used in any communication


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

Related to #13114 . Type names including `{` and `}` does not represent a particular type, so I fixed them in the codes without links.

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
