### PR TITLE
TST, BUG: Re-raise MemoryError exception in test_large_zip's process

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -13,7 +13,8 @@ from tempfile import NamedTemporaryFile
 from io import BytesIO, StringIO
 from datetime import datetime
 import locale
-from multiprocessing import Process
+from multiprocessing import Process, Value
+from ctypes import c_bool
 
 import numpy as np
 import numpy.ma as ma
@@ -574,16 +575,26 @@ class TestSaveTxt:
     @pytest.mark.slow
     @requires_memory(free_bytes=7e9)
     def test_large_zip(self):
-        def check_large_zip():
+        def check_large_zip(memoryerror_raised):
+            memoryerror_raised.value=False
             # The test takes at least 6GB of memory, writes a file larger than 4GB
             test_data = np.asarray([np.random.rand(np.random.randint(50,100),4)
                                    for i in range(800000)], dtype=object)
             with tempdir() as tmpdir:
-                np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
+                try:
+                    np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
+                except MemoryError:
+                    memoryerror_raised.value=True
+                    raise
         # run in a subprocess to ensure memory is released on PyPy, see gh-15775
-        p = Process(target=check_large_zip)
+        # Use an object in shared memory to re-raise the MemoryError exception
+        # in our process if needed, see gh-16889
+        memoryerror_raised = Value(c_bool)
+        p = Process(target=check_large_zip, args=(memoryerror_raised,))
         p.start()
         p.join()
+        if memoryerror_raised.value:
+            raise MemoryError("Child process raised a MemoryError exception")
         assert p.exitcode == 0
 
 class LoadTxtBase:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -577,15 +577,18 @@ class TestSaveTxt:
     def test_large_zip(self):
         def check_large_zip(memoryerror_raised):
             memoryerror_raised.value = False
-            # The test takes at least 6GB of memory, writes a file larger than 4GB
-            test_data = np.asarray([np.random.rand(np.random.randint(50,100),4)
-                                   for i in range(800000)], dtype=object)
-            with tempdir() as tmpdir:
-                try:
-                    np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
-                except MemoryError:
-                    memoryerror_raised.value = True
-                    raise
+            try:
+                # The test takes at least 6GB of memory, writes a file larger
+                # than 4GB
+                test_data = np.asarray([np.random.rand(
+                                        np.random.randint(50,100),4)
+                                        for i in range(800000)], dtype=object)
+                with tempdir() as tmpdir:
+                    np.savez(os.path.join(tmpdir, 'test.npz'),
+                             test_data=test_data)
+            except MemoryError:
+                memoryerror_raised.value = True
+                raise
         # run in a subprocess to ensure memory is released on PyPy, see gh-15775
         # Use an object in shared memory to re-raise the MemoryError exception
         # in our process if needed, see gh-16889

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -576,7 +576,7 @@ class TestSaveTxt:
     @requires_memory(free_bytes=7e9)
     def test_large_zip(self):
         def check_large_zip(memoryerror_raised):
-            memoryerror_raised.value=False
+            memoryerror_raised.value = False
             # The test takes at least 6GB of memory, writes a file larger than 4GB
             test_data = np.asarray([np.random.rand(np.random.randint(50,100),4)
                                    for i in range(800000)], dtype=object)
@@ -584,7 +584,7 @@ class TestSaveTxt:
                 try:
                     np.savez(os.path.join(tmpdir, 'test.npz'), test_data=test_data)
                 except MemoryError:
-                    memoryerror_raised.value=True
+                    memoryerror_raised.value = True
                     raise
         # run in a subprocess to ensure memory is released on PyPy, see gh-15775
         # Use an object in shared memory to re-raise the MemoryError exception


### PR DESCRIPTION
Since #15893, test_large_zip's actual test is run in a child process,
so when this test raises a MemoryError exception, the exception is
lost and the @requires_memory decorator can't catch it to return
an xfail.

This commit uses a boolean variable in shared memory to flag if
the exception was raised, and in that case, re-raise it in the
parent process.

Fixes #16889