### PR TITLE
DOC: Remove links for C codes

### DIFF
--- a/doc/DISTUTILS.rst.txt
+++ b/doc/DISTUTILS.rst.txt
@@ -385,14 +385,14 @@ that should be repeated using a variable expansion similar to the
 named repeat rules of the Fortran-specific repeats.
 
 NumPy Distutils preprocesses C source files (extension: :file:`.c.src`) written
-in a custom templating language to generate C code. The :c:data:`@` symbol is
+in a custom templating language to generate C code. The ``@`` symbol is
 used to wrap macro-style variables to empower a string substitution mechanism
 that might describe (for instance) a set of data types.
 
-The template language blocks are delimited by :c:data:`/**begin repeat`
-and :c:data:`/**end repeat**/` lines, which may also be nested using
-consecutively numbered delimiting lines such as :c:data:`/**begin repeat1`
-and :c:data:`/**end repeat1**/`:
+The template language blocks are delimited by ``/**begin repeat``
+and ``/**end repeat**/`` lines, which may also be nested using
+consecutively numbered delimiting lines such as ``/**begin repeat1``
+and ``/**end repeat1**/``:
 
 1. "/\**begin repeat "on a line by itself marks the beginning of
 a segment that should be repeated.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3120,15 +3120,15 @@ the C-API is needed then some additional steps must be taken.
     Internally, these #defines work as follows:
 
         * If neither is defined, the C-API is declared to be
-          :c:type:`static void**`, so it is only visible within the
+          ``static void**``, so it is only visible within the
           compilation unit that #includes numpy/arrayobject.h.
         * If :c:macro:`PY_ARRAY_UNIQUE_SYMBOL` is #defined, but
           :c:macro:`NO_IMPORT_ARRAY` is not, the C-API is declared to
-          be :c:type:`void**`, so that it will also be visible to other
+          be ``void**``, so that it will also be visible to other
           compilation units.
         * If :c:macro:`NO_IMPORT_ARRAY` is #defined, regardless of
           whether :c:macro:`PY_ARRAY_UNIQUE_SYMBOL` is, the C-API is
-          declared to be :c:type:`extern void**`, so it is expected to
+          declared to be ``extern void**``, so it is expected to
           be defined in another compilation unit.
         * Whenever :c:macro:`PY_ARRAY_UNIQUE_SYMBOL` is #defined, it
           also changes the name of the variable holding the C-API, which

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -428,44 +428,44 @@ From other objects
     have :c:data:`NPY_ARRAY_DEFAULT` as its flags member. The *context*
     argument is unused.
 
-    .. c:var:: NPY_ARRAY_C_CONTIGUOUS
+    .. c:macro:: NPY_ARRAY_C_CONTIGUOUS
 
         Make sure the returned array is C-style contiguous
 
-    .. c:var:: NPY_ARRAY_F_CONTIGUOUS
+    .. c:macro:: NPY_ARRAY_F_CONTIGUOUS
 
         Make sure the returned array is Fortran-style contiguous.
 
-    .. c:var:: NPY_ARRAY_ALIGNED
+    .. c:macro:: NPY_ARRAY_ALIGNED
 
         Make sure the returned array is aligned on proper boundaries for its
         data type. An aligned array has the data pointer and every strides
         factor as a multiple of the alignment factor for the data-type-
         descriptor.
 
-    .. c:var:: NPY_ARRAY_WRITEABLE
+    .. c:macro:: NPY_ARRAY_WRITEABLE
 
         Make sure the returned array can be written to.
 
-    .. c:var:: NPY_ARRAY_ENSURECOPY
+    .. c:macro:: NPY_ARRAY_ENSURECOPY
 
         Make sure a copy is made of *op*. If this flag is not
         present, data is not copied if it can be avoided.
 
-    .. c:var:: NPY_ARRAY_ENSUREARRAY
+    .. c:macro:: NPY_ARRAY_ENSUREARRAY
 
         Make sure the result is a base-class ndarray. By
         default, if *op* is an instance of a subclass of
         ndarray, an instance of that same subclass is returned. If
         this flag is set, an ndarray object will be returned instead.
 
-    .. c:var:: NPY_ARRAY_FORCECAST
+    .. c:macro:: NPY_ARRAY_FORCECAST
 
         Force a cast to the output type even if it cannot be done
         safely.  Without this flag, a data cast will occur only if it
         can be done safely, otherwise an error is raised.
 
-    .. c:var:: NPY_ARRAY_WRITEBACKIFCOPY
+    .. c:macro:: NPY_ARRAY_WRITEBACKIFCOPY
 
         If *op* is already an array, but does not satisfy the
         requirements, then a copy is made (which will satisfy the
@@ -478,67 +478,67 @@ From other objects
         will be made writeable again. If *op* is not writeable to begin
         with, or if it is not already an array, then an error is raised.
 
-    .. c:var:: NPY_ARRAY_UPDATEIFCOPY
+    .. c:macro:: NPY_ARRAY_UPDATEIFCOPY
 
         Deprecated. Use :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`, which is similar.
         This flag "automatically" copies the data back when the returned
         array is deallocated, which is not supported in all python
         implementations.
 
-    .. c:var:: NPY_ARRAY_BEHAVED
+    .. c:macro:: NPY_ARRAY_BEHAVED
 
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE`
 
-    .. c:var:: NPY_ARRAY_CARRAY
+    .. c:macro:: NPY_ARRAY_CARRAY
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-    .. c:var:: NPY_ARRAY_CARRAY_RO
+    .. c:macro:: NPY_ARRAY_CARRAY_RO
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_ARRAY_FARRAY
+    .. c:macro:: NPY_ARRAY_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-    .. c:var:: NPY_ARRAY_FARRAY_RO
+    .. c:macro:: NPY_ARRAY_FARRAY_RO
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_ARRAY_DEFAULT
+    .. c:macro:: NPY_ARRAY_DEFAULT
 
         :c:data:`NPY_ARRAY_CARRAY`
 
-    .. c:var:: NPY_ARRAY_IN_ARRAY
+    .. c:macro:: NPY_ARRAY_IN_ARRAY
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_ARRAY_IN_FARRAY
+    .. c:macro:: NPY_ARRAY_IN_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_OUT_ARRAY
+    .. c:macro:: NPY_OUT_ARRAY
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_ARRAY_OUT_ARRAY
+    .. c:macro:: NPY_ARRAY_OUT_ARRAY
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED` \|
         :c:data:`NPY_ARRAY_WRITEABLE`
 
-    .. c:var:: NPY_ARRAY_OUT_FARRAY
+    .. c:macro:: NPY_ARRAY_OUT_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:var:: NPY_ARRAY_INOUT_ARRAY
+    .. c:macro:: NPY_ARRAY_INOUT_ARRAY
 
         :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` \|
         :c:data:`NPY_ARRAY_UPDATEIFCOPY`
 
-    .. c:var:: NPY_ARRAY_INOUT_FARRAY
+    .. c:macro:: NPY_ARRAY_INOUT_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` \|
@@ -574,7 +574,7 @@ From other objects
     did not have the _ARRAY_ macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
-.. c:var:: NPY_ARRAY_NOTSWAPPED
+.. c:macro:: NPY_ARRAY_NOTSWAPPED
 
     Make sure the returned array has a data-type descriptor that is in
     machine byte-order, over-riding any specification in the *dtype*
@@ -585,11 +585,11 @@ From other objects
     not in machine byte- order), then a new data-type descriptor is
     created and used with its byte-order field set to native.
 
-.. c:var:: NPY_ARRAY_BEHAVED_NS
+.. c:macro:: NPY_ARRAY_BEHAVED_NS
 
     :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \| :c:data:`NPY_ARRAY_NOTSWAPPED`
 
-.. c:var:: NPY_ARRAY_ELEMENTSTRIDES
+.. c:macro:: NPY_ARRAY_ELEMENTSTRIDES
 
     Make sure the returned array has strides that are multiples of the
     element size.
@@ -1397,12 +1397,12 @@ In versions 1.6 and earlier of NumPy, the following flags
 did not have the _ARRAY_ macro namespace in them. That form
 of the constant names is deprecated in 1.7.
 
-.. c:var:: NPY_ARRAY_C_CONTIGUOUS
+.. c:macro:: NPY_ARRAY_C_CONTIGUOUS
 
     The data area is in C-style contiguous order (last index varies the
     fastest).
 
-.. c:var:: NPY_ARRAY_F_CONTIGUOUS
+.. c:macro:: NPY_ARRAY_F_CONTIGUOUS
 
     The data area is in Fortran-style contiguous order (first index varies
     the fastest).
@@ -1423,22 +1423,22 @@ of the constant names is deprecated in 1.7.
 
     .. seealso:: :ref:`Internal memory layout of an ndarray <arrays.ndarray>`
 
-.. c:var:: NPY_ARRAY_OWNDATA
+.. c:macro:: NPY_ARRAY_OWNDATA
 
     The data area is owned by this array.
 
-.. c:var:: NPY_ARRAY_ALIGNED
+.. c:macro:: NPY_ARRAY_ALIGNED
 
     The data area and all array elements are aligned appropriately.
 
-.. c:var:: NPY_ARRAY_WRITEABLE
+.. c:macro:: NPY_ARRAY_WRITEABLE
 
     The data area can be written to.
 
     Notice that the above 3 flags are defined so that a new, well-
     behaved array has these flags defined as true.
 
-.. c:var:: NPY_ARRAY_WRITEBACKIFCOPY
+.. c:macro:: NPY_ARRAY_WRITEBACKIFCOPY
 
     The data area represents a (well-behaved) copy whose information
     should be transferred back to the original when
@@ -1457,7 +1457,7 @@ of the constant names is deprecated in 1.7.
     would have returned an error because :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`
     would not have been possible.
 
-.. c:var:: NPY_ARRAY_UPDATEIFCOPY
+.. c:macro:: NPY_ARRAY_UPDATEIFCOPY
 
     A deprecated version of :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` which
     depends upon ``dealloc`` to trigger the writeback. For backwards
@@ -1474,31 +1474,31 @@ for ``flags`` which can be any of :c:data:`NPY_ARRAY_C_CONTIGUOUS`,
 Combinations of array flags
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. c:var:: NPY_ARRAY_BEHAVED
+.. c:macro:: NPY_ARRAY_BEHAVED
 
     :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE`
 
-.. c:var:: NPY_ARRAY_CARRAY
+.. c:macro:: NPY_ARRAY_CARRAY
 
     :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-.. c:var:: NPY_ARRAY_CARRAY_RO
+.. c:macro:: NPY_ARRAY_CARRAY_RO
 
     :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-.. c:var:: NPY_ARRAY_FARRAY
+.. c:macro:: NPY_ARRAY_FARRAY
 
     :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_BEHAVED`
 
-.. c:var:: NPY_ARRAY_FARRAY_RO
+.. c:macro:: NPY_ARRAY_FARRAY_RO
 
     :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-.. c:var:: NPY_ARRAY_DEFAULT
+.. c:macro:: NPY_ARRAY_DEFAULT
 
     :c:data:`NPY_ARRAY_CARRAY`
 
-.. c:var:: NPY_ARRAY_UPDATE_ALL
+.. c:macro:: NPY_ARRAY_UPDATE_ALL
 
     :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
@@ -1509,25 +1509,25 @@ Flag-like constants
 These constants are used in :c:func:`PyArray_FromAny` (and its macro forms) to
 specify desired properties of the new array.
 
-.. c:var:: NPY_ARRAY_FORCECAST
+.. c:macro:: NPY_ARRAY_FORCECAST
 
     Cast to the desired type, even if it can't be done without losing
     information.
 
-.. c:var:: NPY_ARRAY_ENSURECOPY
+.. c:macro:: NPY_ARRAY_ENSURECOPY
 
     Make sure the resulting array is a copy of the original.
 
-.. c:var:: NPY_ARRAY_ENSUREARRAY
+.. c:macro:: NPY_ARRAY_ENSUREARRAY
 
     Make sure the resulting object is an actual ndarray, and not a sub-class.
 
-.. c:var:: NPY_ARRAY_NOTSWAPPED
+.. c:macro:: NPY_ARRAY_NOTSWAPPED
 
     Only used in :c:func:`PyArray_CheckFromAny` to over-ride the byteorder
     of the data-type object passed in.
 
-.. c:var:: NPY_ARRAY_BEHAVED_NS
+.. c:macro:: NPY_ARRAY_BEHAVED_NS
 
     :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \| :c:data:`NPY_ARRAY_NOTSWAPPED`
 
@@ -1876,16 +1876,16 @@ Item selection and manipulation
     created. The *clipmode* argument determines behavior for when
     entries in *self* are not between 0 and len(*op*).
 
-    .. c:var:: NPY_RAISE
+    .. c:macro:: NPY_RAISE
 
         raise a ValueError;
 
-    .. c:var:: NPY_WRAP
+    .. c:macro:: NPY_WRAP
 
         wrap values < 0 by adding len(*op*) and values >=len(*op*)
         by subtracting len(*op*) until they are in range;
 
-    .. c:var:: NPY_CLIP
+    .. c:macro:: NPY_CLIP
 
         all values are clipped to the region [0, len(*op*) ).
 
@@ -3388,15 +3388,15 @@ Group 2
 Priority
 ^^^^^^^^
 
-.. c:var:: NPY_PRIORITY
+.. c:macro:: NPY_PRIORITY
 
     Default priority for arrays.
 
-.. c:var:: NPY_SUBTYPE_PRIORITY
+.. c:macro:: NPY_SUBTYPE_PRIORITY
 
     Default subtype priority.
 
-.. c:var:: NPY_SCALAR_PRIORITY
+.. c:macro:: NPY_SCALAR_PRIORITY
 
     Default scalar priority (very small)
 
@@ -3411,15 +3411,15 @@ Priority
 Default buffers
 ^^^^^^^^^^^^^^^
 
-.. c:var:: NPY_BUFSIZE
+.. c:macro:: NPY_BUFSIZE
 
     Default size of the user-settable internal buffers.
 
-.. c:var:: NPY_MIN_BUFSIZE
+.. c:macro:: NPY_MIN_BUFSIZE
 
     Smallest size of user-settable internal buffers.
 
-.. c:var:: NPY_MAX_BUFSIZE
+.. c:macro:: NPY_MAX_BUFSIZE
 
     Largest size allowed for the user-settable buffers.
 
@@ -3427,38 +3427,38 @@ Default buffers
 Other constants
 ^^^^^^^^^^^^^^^
 
-.. c:var:: NPY_NUM_FLOATTYPE
+.. c:macro:: NPY_NUM_FLOATTYPE
 
     The number of floating-point types
 
-.. c:var:: NPY_MAXDIMS
+.. c:macro:: NPY_MAXDIMS
 
     The maximum number of dimensions allowed in arrays.
 
-.. c:var:: NPY_MAXARGS
+.. c:macro:: NPY_MAXARGS
 
     The maximum number of array arguments that can be used in functions.
 
-.. c:var:: NPY_VERSION
+.. c:macro:: NPY_VERSION
 
     The current version of the ndarray object (check to see if this
     variable is defined to guarantee the numpy/arrayobject.h header is
     being used).
 
-.. c:var:: NPY_FALSE
+.. c:macro:: NPY_FALSE
 
     Defined as 0 for use with Bool.
 
-.. c:var:: NPY_TRUE
+.. c:macro:: NPY_TRUE
 
     Defined as 1 for use with Bool.
 
-.. c:var:: NPY_FAIL
+.. c:macro:: NPY_FAIL
 
     The return value of failed converter functions which are called using
     the "O&" syntax in :c:func:`PyArg_ParseTuple`-like functions.
 
-.. c:var:: NPY_SUCCEED
+.. c:macro:: NPY_SUCCEED
 
     The return value of successful converter functions which are called
     using the "O&" syntax in :c:func:`PyArg_ParseTuple`-like functions.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1343,7 +1343,7 @@ Special functions for NPY_OBJECT
     Precondition: ``arr`` is a copy of ``base`` (though possibly with different
     strides, ordering, etc.) Set the UPDATEIFCOPY flag and ``arr->base`` so
     that when ``arr`` is destructed, it will copy any changes back to ``base``.
-    DEPRECATED, use :c:func:`PyArray_SetWritebackIfCopyBase``.
+    DEPRECATED, use :c:func:`PyArray_SetWritebackIfCopyBase`.
 
     Returns 0 for success, -1 for failure.
 
@@ -1521,15 +1521,6 @@ specify desired properties of the new array.
 .. c:macro:: NPY_ARRAY_ENSUREARRAY
 
     Make sure the resulting object is an actual ndarray, and not a sub-class.
-
-.. c:macro:: NPY_ARRAY_NOTSWAPPED
-
-    Only used in :c:func:`PyArray_CheckFromAny` to over-ride the byteorder
-    of the data-type object passed in.
-
-.. c:macro:: NPY_ARRAY_BEHAVED_NS
-
-    :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \| :c:data:`NPY_ARRAY_NOTSWAPPED`
 
 
 Flag checking
@@ -2263,7 +2254,7 @@ Array Functions
 
     See the :func:`~numpy.einsum` function for more details.
 
-.. c:function:: PyObject* PyArray_CopyAndTranspose(PyObject \* op)
+.. c:function:: PyObject* PyArray_CopyAndTranspose(PyObject * op)
 
     A specialized copy and transpose function that works only for 2-d
     arrays. The returned array is a transposed copy of *op*.
@@ -2453,7 +2444,7 @@ this useful approach to looping over an array.
     it easy to loop over an N-dimensional non-contiguous array in
     C-style contiguous fashion.
 
-.. c:function:: PyObject* PyArray_IterAllButAxis(PyObject* arr, int \*axis)
+.. c:function:: PyObject* PyArray_IterAllButAxis(PyObject* arr, int* axis)
 
     Return an array iterator that will iterate over all axes but the
     one provided in *\*axis*. The returned iterator cannot be used
@@ -2960,7 +2951,7 @@ to.
     the :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writeable buffer
     interface.
 
-.. c:function:: int PyArray_AxisConverter(PyObject \* obj, int* axis)
+.. c:function:: int PyArray_AxisConverter(PyObject* obj, int* axis)
 
     Convert a Python object, *obj*, representing an axis argument to
     the proper value for passing to the functions that take an integer

--- a/doc/source/reference/c-api/config.rst
+++ b/doc/source/reference/c-api/config.rst
@@ -22,39 +22,39 @@ Data type sizes
 The :c:data:`NPY_SIZEOF_{CTYPE}` constants are defined so that sizeof
 information is available to the pre-processor.
 
-.. c:var:: NPY_SIZEOF_SHORT
+.. c:macro:: NPY_SIZEOF_SHORT
 
     sizeof(short)
 
-.. c:var:: NPY_SIZEOF_INT
+.. c:macro:: NPY_SIZEOF_INT
 
     sizeof(int)
 
-.. c:var:: NPY_SIZEOF_LONG
+.. c:macro:: NPY_SIZEOF_LONG
 
     sizeof(long)
 
-.. c:var:: NPY_SIZEOF_LONGLONG
+.. c:macro:: NPY_SIZEOF_LONGLONG
 
     sizeof(longlong) where longlong is defined appropriately on the
     platform.
 
-.. c:var:: NPY_SIZEOF_PY_LONG_LONG
+.. c:macro:: NPY_SIZEOF_PY_LONG_LONG
 
 
-.. c:var:: NPY_SIZEOF_FLOAT
+.. c:macro:: NPY_SIZEOF_FLOAT
 
     sizeof(float)
 
-.. c:var:: NPY_SIZEOF_DOUBLE
+.. c:macro:: NPY_SIZEOF_DOUBLE
 
     sizeof(double)
 
-.. c:var:: NPY_SIZEOF_LONG_DOUBLE
+.. c:macro:: NPY_SIZEOF_LONG_DOUBLE
 
     sizeof(longdouble) (A macro defines **NPY_SIZEOF_LONGDOUBLE** as well.)
 
-.. c:var:: NPY_SIZEOF_PY_INTPTR_T
+.. c:macro:: NPY_SIZEOF_PY_INTPTR_T
 
     Size of a pointer on this platform (sizeof(void \*)) (A macro defines
     NPY_SIZEOF_INTP as well.)
@@ -63,15 +63,15 @@ information is available to the pre-processor.
 Platform information
 --------------------
 
-.. c:var:: NPY_CPU_X86
-.. c:var:: NPY_CPU_AMD64
-.. c:var:: NPY_CPU_IA64
-.. c:var:: NPY_CPU_PPC
-.. c:var:: NPY_CPU_PPC64
-.. c:var:: NPY_CPU_SPARC
-.. c:var:: NPY_CPU_SPARC64
-.. c:var:: NPY_CPU_S390
-.. c:var:: NPY_CPU_PARISC
+.. c:macro:: NPY_CPU_X86
+.. c:macro:: NPY_CPU_AMD64
+.. c:macro:: NPY_CPU_IA64
+.. c:macro:: NPY_CPU_PPC
+.. c:macro:: NPY_CPU_PPC64
+.. c:macro:: NPY_CPU_SPARC
+.. c:macro:: NPY_CPU_SPARC64
+.. c:macro:: NPY_CPU_S390
+.. c:macro:: NPY_CPU_PARISC
 
     .. versionadded:: 1.3.0
 
@@ -80,11 +80,11 @@ Platform information
 
     Defined in ``numpy/npy_cpu.h``
 
-.. c:var:: NPY_LITTLE_ENDIAN
+.. c:macro:: NPY_LITTLE_ENDIAN
 
-.. c:var:: NPY_BIG_ENDIAN
+.. c:macro:: NPY_BIG_ENDIAN
 
-.. c:var:: NPY_BYTE_ORDER
+.. c:macro:: NPY_BYTE_ORDER
 
     .. versionadded:: 1.3.0
 
@@ -106,17 +106,17 @@ Platform information
 Compiler directives
 -------------------
 
-.. c:var:: NPY_LIKELY
-.. c:var:: NPY_UNLIKELY
-.. c:var:: NPY_UNUSED
+.. c:macro:: NPY_LIKELY
+.. c:macro:: NPY_UNLIKELY
+.. c:macro:: NPY_UNUSED
 
 
 Interrupt Handling
 ------------------
 
-.. c:var:: NPY_INTERRUPT_H
-.. c:var:: NPY_SIGSETJMP
-.. c:var:: NPY_SIGLONGJMP
-.. c:var:: NPY_SIGJMP_BUF
-.. c:var:: NPY_SIGINT_ON
-.. c:var:: NPY_SIGINT_OFF
+.. c:macro:: NPY_INTERRUPT_H
+.. c:macro:: NPY_SIGSETJMP
+.. c:macro:: NPY_SIGLONGJMP
+.. c:macro:: NPY_SIGJMP_BUF
+.. c:macro:: NPY_SIGINT_ON
+.. c:macro:: NPY_SIGINT_OFF

--- a/doc/source/reference/c-api/coremath.rst
+++ b/doc/source/reference/c-api/coremath.rst
@@ -24,23 +24,23 @@ in doubt.
 Floating point classification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. c:var:: NPY_NAN
+.. c:macro:: NPY_NAN
 
     This macro is defined to a NaN (Not a Number), and is guaranteed to have
     the signbit unset ('positive' NaN). The corresponding single and extension
     precision macro are available with the suffix F and L.
 
-.. c:var:: NPY_INFINITY
+.. c:macro:: NPY_INFINITY
 
     This macro is defined to a positive inf. The corresponding single and
     extension precision macro are available with the suffix F and L.
 
-.. c:var:: NPY_PZERO
+.. c:macro:: NPY_PZERO
 
     This macro is defined to positive zero. The corresponding single and
     extension precision macro are available with the suffix F and L.
 
-.. c:var:: NPY_NZERO
+.. c:macro:: NPY_NZERO
 
     This macro is defined to negative zero (that is with the sign bit set). The
     corresponding single and extension precision macro are available with the
@@ -84,47 +84,47 @@ The following math constants are available in ``npy_math.h``. Single
 and extended precision are also available by adding the ``f`` and
 ``l`` suffixes respectively.
 
-.. c:var:: NPY_E
+.. c:macro:: NPY_E
 
     Base of natural logarithm (:math:`e`)
 
-.. c:var:: NPY_LOG2E
+.. c:macro:: NPY_LOG2E
 
     Logarithm to base 2 of the Euler constant (:math:`\frac{\ln(e)}{\ln(2)}`)
 
-.. c:var:: NPY_LOG10E
+.. c:macro:: NPY_LOG10E
 
     Logarithm to base 10 of the Euler constant (:math:`\frac{\ln(e)}{\ln(10)}`)
 
-.. c:var:: NPY_LOGE2
+.. c:macro:: NPY_LOGE2
 
     Natural logarithm of 2 (:math:`\ln(2)`)
 
-.. c:var:: NPY_LOGE10
+.. c:macro:: NPY_LOGE10
 
     Natural logarithm of 10 (:math:`\ln(10)`)
 
-.. c:var:: NPY_PI
+.. c:macro:: NPY_PI
 
     Pi (:math:`\pi`)
 
-.. c:var:: NPY_PI_2
+.. c:macro:: NPY_PI_2
 
     Pi divided by 2 (:math:`\frac{\pi}{2}`)
 
-.. c:var:: NPY_PI_4
+.. c:macro:: NPY_PI_4
 
     Pi divided by 4 (:math:`\frac{\pi}{4}`)
 
-.. c:var:: NPY_1_PI
+.. c:macro:: NPY_1_PI
 
     Reciprocal of pi (:math:`\frac{1}{\pi}`)
 
-.. c:var:: NPY_2_PI
+.. c:macro:: NPY_2_PI
 
     Two times the reciprocal of pi (:math:`\frac{2}{\pi}`)
 
-.. c:var:: NPY_EULER
+.. c:macro:: NPY_EULER
 
     The Euler constant
         :math:`\lim_{n\rightarrow\infty}({\sum_{k=1}^n{\frac{1}{k}}-\ln n})`
@@ -308,35 +308,35 @@ __ https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 __ https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_half_float_pixel.txt
 __ https://www.openexr.com/about.html
 
-.. c:var:: NPY_HALF_ZERO
+.. c:macro:: NPY_HALF_ZERO
 
     This macro is defined to positive zero.
 
-.. c:var:: NPY_HALF_PZERO
+.. c:macro:: NPY_HALF_PZERO
 
     This macro is defined to positive zero.
 
-.. c:var:: NPY_HALF_NZERO
+.. c:macro:: NPY_HALF_NZERO
 
     This macro is defined to negative zero.
 
-.. c:var:: NPY_HALF_ONE
+.. c:macro:: NPY_HALF_ONE
 
     This macro is defined to 1.0.
 
-.. c:var:: NPY_HALF_NEGONE
+.. c:macro:: NPY_HALF_NEGONE
 
     This macro is defined to -1.0.
 
-.. c:var:: NPY_HALF_PINF
+.. c:macro:: NPY_HALF_PINF
 
     This macro is defined to +inf.
 
-.. c:var:: NPY_HALF_NINF
+.. c:macro:: NPY_HALF_NINF
 
     This macro is defined to -inf.
 
-.. c:var:: NPY_HALF_NAN
+.. c:macro:: NPY_HALF_NAN
 
     This macro is defined to a NaN value, guaranteed to have its sign bit unset.
 

--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -183,16 +183,16 @@ Some useful aliases of the above types are
 
 Other useful related constants are
 
-.. c:var:: NPY_NTYPES
+.. c:macro:: NPY_NTYPES
 
     The total number of built-in NumPy types. The enumeration covers
     the range from 0 to NPY_NTYPES-1.
 
-.. c:var:: NPY_NOTYPE
+.. c:macro:: NPY_NOTYPE
 
     A signal value guaranteed not to be a valid type enumeration number.
 
-.. c:var:: NPY_USERDEF
+.. c:macro:: NPY_USERDEF
 
     The start of type numbers used for Custom Data types.
 

--- a/doc/source/reference/c-api/iterator.rst
+++ b/doc/source/reference/c-api/iterator.rst
@@ -313,17 +313,17 @@ Construction and Destruction
     Flags that may be passed in ``flags``, applying to the whole
     iterator, are:
 
-        .. c:var:: NPY_ITER_C_INDEX
+        .. c:macro:: NPY_ITER_C_INDEX
 
             Causes the iterator to track a raveled flat index matching C
             order. This option cannot be used with :c:data:`NPY_ITER_F_INDEX`.
 
-        .. c:var:: NPY_ITER_F_INDEX
+        .. c:macro:: NPY_ITER_F_INDEX
 
             Causes the iterator to track a raveled flat index matching Fortran
             order. This option cannot be used with :c:data:`NPY_ITER_C_INDEX`.
 
-        .. c:var:: NPY_ITER_MULTI_INDEX
+        .. c:macro:: NPY_ITER_MULTI_INDEX
 
             Causes the iterator to track a multi-index.
             This prevents the iterator from coalescing axes to
@@ -336,7 +336,7 @@ Construction and Destruction
             However, it is possible to remove axes again and use the iterator
             normally if the size is small enough after removal.
 
-        .. c:var:: NPY_ITER_EXTERNAL_LOOP
+        .. c:macro:: NPY_ITER_EXTERNAL_LOOP
 
             Causes the iterator to skip iteration of the innermost
             loop, requiring the user of the iterator to handle it.
@@ -344,7 +344,7 @@ Construction and Destruction
             This flag is incompatible with :c:data:`NPY_ITER_C_INDEX`,
             :c:data:`NPY_ITER_F_INDEX`, and :c:data:`NPY_ITER_MULTI_INDEX`.
 
-        .. c:var:: NPY_ITER_DONT_NEGATE_STRIDES
+        .. c:macro:: NPY_ITER_DONT_NEGATE_STRIDES
 
             This only affects the iterator when :c:type:`NPY_KEEPORDER` is
             specified for the order parameter.  By default with
@@ -355,7 +355,7 @@ Construction and Destruction
             but don't want an axis reversed. This is the behavior of
             ``numpy.ravel(a, order='K')``, for instance.
 
-        .. c:var:: NPY_ITER_COMMON_DTYPE
+        .. c:macro:: NPY_ITER_COMMON_DTYPE
 
             Causes the iterator to convert all the operands to a common
             data type, calculated based on the ufunc type promotion rules.
@@ -364,7 +364,7 @@ Construction and Destruction
             If the common data type is known ahead of time, don't use this
             flag.  Instead, set the requested dtype for all the operands.
 
-        .. c:var:: NPY_ITER_REFS_OK
+        .. c:macro:: NPY_ITER_REFS_OK
 
             Indicates that arrays with reference types (object
             arrays or structured arrays containing an object type)
@@ -373,7 +373,7 @@ Construction and Destruction
             :c:func:`NpyIter_IterationNeedsAPI(iter)` is true, in which case
             it may not release the GIL during iteration.
 
-        .. c:var:: NPY_ITER_ZEROSIZE_OK
+        .. c:macro:: NPY_ITER_ZEROSIZE_OK
 
             Indicates that arrays with a size of zero should be permitted.
             Since the typical iteration loop does not naturally work with
@@ -381,7 +381,7 @@ Construction and Destruction
             than zero before entering the iteration loop.
             Currently only the operands are checked, not a forced shape.
 
-        .. c:var:: NPY_ITER_REDUCE_OK
+        .. c:macro:: NPY_ITER_REDUCE_OK
 
             Permits writeable operands with a dimension with zero
             stride and size greater than one.  Note that such operands
@@ -400,7 +400,7 @@ Construction and Destruction
             after initializing the allocated operand to prepare the
             buffers.
 
-        .. c:var:: NPY_ITER_RANGED
+        .. c:macro:: NPY_ITER_RANGED
 
             Enables support for iteration of sub-ranges of the full
             ``iterindex`` range ``[0, NpyIter_IterSize(iter))``.  Use
@@ -414,7 +414,7 @@ Construction and Destruction
             would require special handling, effectively making it more
             like the buffered version.
 
-        .. c:var:: NPY_ITER_BUFFERED
+        .. c:macro:: NPY_ITER_BUFFERED
 
             Causes the iterator to store buffering data, and use buffering
             to satisfy data type, alignment, and byte-order requirements.
@@ -441,7 +441,7 @@ Construction and Destruction
             the inner loops may become smaller depending
             on the structure of the reduction.
 
-        .. c:var:: NPY_ITER_GROWINNER
+        .. c:macro:: NPY_ITER_GROWINNER
 
             When buffering is enabled, this allows the size of the inner
             loop to grow when buffering isn't necessary.  This option
@@ -449,7 +449,7 @@ Construction and Destruction
             data, rather than anything with small cache-friendly arrays
             of temporary values for each inner loop.
 
-        .. c:var:: NPY_ITER_DELAY_BUFALLOC
+        .. c:macro:: NPY_ITER_DELAY_BUFALLOC
 
             When buffering is enabled, this delays allocation of the
             buffers until :c:func:`NpyIter_Reset` or another reset function is
@@ -465,7 +465,7 @@ Construction and Destruction
             Then, call :c:func:`NpyIter_Reset` to allocate and fill the buffers
             with their initial values.
 
-        .. c:var:: NPY_ITER_COPY_IF_OVERLAP
+        .. c:macro:: NPY_ITER_COPY_IF_OVERLAP
 
             If any write operand has overlap with any read operand, eliminate all
             overlap by making temporary copies (enabling UPDATEIFCOPY for write
@@ -484,9 +484,9 @@ Construction and Destruction
 
     Flags that may be passed in ``op_flags[i]``, where ``0 <= i < nop``:
 
-        .. c:var:: NPY_ITER_READWRITE
-        .. c:var:: NPY_ITER_READONLY
-        .. c:var:: NPY_ITER_WRITEONLY
+        .. c:macro:: NPY_ITER_READWRITE
+        .. c:macro:: NPY_ITER_READONLY
+        .. c:macro:: NPY_ITER_WRITEONLY
 
             Indicate how the user of the iterator will read or write
             to ``op[i]``.  Exactly one of these flags must be specified
@@ -495,13 +495,13 @@ Construction and Destruction
             semantics. The data will be written back to the original array
             when ``NpyIter_Deallocate`` is called.
 
-        .. c:var:: NPY_ITER_COPY
+        .. c:macro:: NPY_ITER_COPY
 
             Allow a copy of ``op[i]`` to be made if it does not
             meet the data type or alignment requirements as specified
             by the constructor flags and parameters.
 
-        .. c:var:: NPY_ITER_UPDATEIFCOPY
+        .. c:macro:: NPY_ITER_UPDATEIFCOPY
 
             Triggers :c:data:`NPY_ITER_COPY`, and when an array operand
             is flagged for writing and is copied, causes the data
@@ -513,9 +513,9 @@ Construction and Destruction
             to back to ``op[i]`` on calling ``NpyIter_Deallocate``, instead of
             doing the unnecessary copy operation.
 
-        .. c:var:: NPY_ITER_NBO
-        .. c:var:: NPY_ITER_ALIGNED
-        .. c:var:: NPY_ITER_CONTIG
+        .. c:macro:: NPY_ITER_NBO
+        .. c:macro:: NPY_ITER_ALIGNED
+        .. c:macro:: NPY_ITER_CONTIG
 
             Causes the iterator to provide data for ``op[i]``
             that is in native byte order, aligned according to
@@ -534,7 +534,7 @@ Construction and Destruction
             the NBO flag overrides it and the requested data type is
             converted to be in native byte order.
 
-        .. c:var:: NPY_ITER_ALLOCATE
+        .. c:macro:: NPY_ITER_ALLOCATE
 
             This is for output arrays, and requires that the flag
             :c:data:`NPY_ITER_WRITEONLY` or :c:data:`NPY_ITER_READWRITE`
@@ -557,7 +557,7 @@ Construction and Destruction
             getting the i-th object in the returned C array.  The caller
             must call Py_INCREF on it to claim a reference to the array.
 
-        .. c:var:: NPY_ITER_NO_SUBTYPE
+        .. c:macro:: NPY_ITER_NO_SUBTYPE
 
             For use with :c:data:`NPY_ITER_ALLOCATE`, this flag disables
             allocating an array subtype for the output, forcing
@@ -566,12 +566,12 @@ Construction and Destruction
             TODO: Maybe it would be better to introduce a function
             ``NpyIter_GetWrappedOutput`` and remove this flag?
 
-        .. c:var:: NPY_ITER_NO_BROADCAST
+        .. c:macro:: NPY_ITER_NO_BROADCAST
 
             Ensures that the input or output matches the iteration
             dimensions exactly.
 
-        .. c:var:: NPY_ITER_ARRAYMASK
+        .. c:macro:: NPY_ITER_ARRAYMASK
 
             .. versionadded:: 1.7
 
@@ -595,7 +595,7 @@ Construction and Destruction
             modified. This is useful when the mask should be a combination
             of input masks.
 
-        .. c:var:: NPY_ITER_WRITEMASKED
+        .. c:macro:: NPY_ITER_WRITEMASKED
 
             .. versionadded:: 1.7
 
@@ -613,7 +613,7 @@ Construction and Destruction
             returns true from the corresponding element in the ARRAYMASK
             operand.
 
-        .. c:var:: NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE
+        .. c:macro:: NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE
 
             In memory overlap checks, assume that operands with
             ``NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE`` enabled are accessed only

--- a/doc/source/reference/c-api/iterator.rst
+++ b/doc/source/reference/c-api/iterator.rst
@@ -707,7 +707,7 @@ Construction and Destruction
 
     :c:func:`NpyIter_Deallocate` must be called for each copy.
 
-.. c:function:: int NpyIter_RemoveAxis(NpyIter* iter, int axis)``
+.. c:function:: int NpyIter_RemoveAxis(NpyIter* iter, int axis)
 
     Removes an axis from iteration.  This requires that
     :c:data:`NPY_ITER_MULTI_INDEX` was set for iterator creation, and does

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -261,57 +261,57 @@ PyArrayDescr_Type and PyArray_Descr
     array like behavior. Each bit in this member is a flag which are named
     as:
 
-    .. c:var:: NPY_ITEM_REFCOUNT
+    .. c:macro:: NPY_ITEM_REFCOUNT
 
         Indicates that items of this data-type must be reference
         counted (using :c:func:`Py_INCREF` and :c:func:`Py_DECREF` ).
 
-    .. c:var:: NPY_ITEM_HASOBJECT
+    .. c:macro:: NPY_ITEM_HASOBJECT
 
         Same as :c:data:`NPY_ITEM_REFCOUNT`.
 
-    .. c:var:: NPY_LIST_PICKLE
+    .. c:macro:: NPY_LIST_PICKLE
 
         Indicates arrays of this data-type must be converted to a list
         before pickling.
 
-    .. c:var:: NPY_ITEM_IS_POINTER
+    .. c:macro:: NPY_ITEM_IS_POINTER
 
         Indicates the item is a pointer to some other data-type
 
-    .. c:var:: NPY_NEEDS_INIT
+    .. c:macro:: NPY_NEEDS_INIT
 
         Indicates memory for this data-type must be initialized (set
         to 0) on creation.
 
-    .. c:var:: NPY_NEEDS_PYAPI
+    .. c:macro:: NPY_NEEDS_PYAPI
 
         Indicates this data-type requires the Python C-API during
         access (so don't give up the GIL if array access is going to
         be needed).
 
-    .. c:var:: NPY_USE_GETITEM
+    .. c:macro:: NPY_USE_GETITEM
 
         On array access use the ``f->getitem`` function pointer
         instead of the standard conversion to an array scalar. Must
         use if you don't define an array scalar to go along with
         the data-type.
 
-    .. c:var:: NPY_USE_SETITEM
+    .. c:macro:: NPY_USE_SETITEM
 
         When creating a 0-d array from an array scalar use
         ``f->setitem`` instead of the standard copy from an array
         scalar. Must use if you don't define an array scalar to go
         along with the data-type.
 
-    .. c:var:: NPY_FROM_FIELDS
+    .. c:macro:: NPY_FROM_FIELDS
 
         The bits that are inherited for the parent data-type if these
         bits are set in any field of the data-type. Currently (
         :c:data:`NPY_NEEDS_INIT` \| :c:data:`NPY_LIST_PICKLE` \|
         :c:data:`NPY_ITEM_REFCOUNT` \| :c:data:`NPY_NEEDS_PYAPI` ).
 
-    .. c:var:: NPY_OBJECT_DTYPE_FLAGS
+    .. c:macro:: NPY_OBJECT_DTYPE_FLAGS
 
         Bits set for the object data-type: ( :c:data:`NPY_LIST_PICKLE`
         \| :c:data:`NPY_USE_GETITEM` \| :c:data:`NPY_ITEM_IS_POINTER` \|

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -21,17 +21,17 @@ Constants
 
 .. c:var:: PyUFunc_{VALUE}
 
-    .. c:var:: PyUFunc_One
+    .. c:macro:: PyUFunc_One
 
-    .. c:var:: PyUFunc_Zero
+    .. c:macro:: PyUFunc_Zero
 
-    .. c:var:: PyUFunc_MinusOne
+    .. c:macro:: PyUFunc_MinusOne
 
-    .. c:var:: PyUFunc_ReorderableNone
+    .. c:macro:: PyUFunc_ReorderableNone
 
-    .. c:var:: PyUFunc_None
+    .. c:macro:: PyUFunc_None
 
-    .. c:var:: PyUFunc_IdentityValue
+    .. c:macro:: PyUFunc_IdentityValue
 
 
 Macros
@@ -459,9 +459,9 @@ structure.
 Importing the API
 -----------------
 
-.. c:var:: PY_UFUNC_UNIQUE_SYMBOL
+.. c:macro:: PY_UFUNC_UNIQUE_SYMBOL
 
-.. c:var:: NO_IMPORT_UFUNC
+.. c:macro:: NO_IMPORT_UFUNC
 
 .. c:function:: void import_ufunc(void)
 


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

Related to #13114 and #16217 : separated from #16370 . `:c:expr:` is a new feature in sphinx 3, so it cannot be used here.

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
