### PR TITLE
MNT: also use Py_SET_REFCNT instead of Py_REFCNT

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -65,6 +65,8 @@ static NPY_INLINE int PyInt_Check(PyObject *op) {
     #define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
     /* Introduced in https://github.com/python/cpython/commit/b10dc3e7a11fcdb97e285882eba6da92594f90f9 */
     #define Py_SET_SIZE(obj, size) ((Py_SIZE(obj) = (size)), (void)0)
+    /* Introduced in https://github.com/python/cpython/commit/c86a11221df7e37da389f9c6ce6e47ea22dc44ff */
+    #define Py_SET_REFCNT(obj, refcnt) ((Py_REFCNT(obj) = (refcnt)), (void)0)
 #endif
 
 

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -434,7 +434,7 @@ PyArray_Pack(PyArray_Descr *descr, char *item, PyObject *value)
             .flags = NPY_ARRAY_WRITEABLE,  /* assume array is not behaved. */
         };
     Py_SET_TYPE(&arr_fields, &PyArray_Type);
-    Py_REFCNT(&arr_fields) = 1;
+    Py_SET_REFCNT(&arr_fields, 1);
 
     if (NPY_UNLIKELY(descr->type_num == NPY_OBJECT)) {
         /*


### PR DESCRIPTION
This is required to support Python 3.10.

This came in via 1035c3f830a71a3e39be35016c6c5410a63891b2 and should be backported to the same branches.

Sorry it took me a while to get this PR opened.