### PR TITLE
BUG,DOC: Fix bad MPL kwarg.

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -675,7 +675,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     >>> fig = plt.figure(figsize=(7, 3))
     >>> ax = fig.add_subplot(131, title='imshow: square bins')
-    >>> plt.imshow(H, interpolation='nearest', origin='low',
+    >>> plt.imshow(H, interpolation='nearest', origin='lower',
     ...         extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]])
     <matplotlib.image.AxesImage object at 0x...>
 


### PR DESCRIPTION
Backport of #16883. 

Invalide kwarg to imshow causes failures in the plot directive
for docs builds using MPL > v3.3

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
