### PR TITLE
DOC: update val to be scalar or array like optional closes #16901

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -770,8 +770,8 @@ def fill_diagonal(a, val, wrap=False):
       Array whose diagonal is to be filled, it gets modified in-place.
 
     val : scalar or array_like
-      Scalar value or array representing the value to be written on the diagonal, its type must be compatible with
-      that of the array a.
+      Value or values to write on the diagonal; type must be compatible with that of array a. If an array of values, the range of values must be equal to the 
+      main diagonal to fill.
 
     wrap : bool
       For tall matrices in NumPy version up to 1.6.2, the

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -769,8 +769,8 @@ def fill_diagonal(a, val, wrap=False):
     a : array, at least 2-D.
       Array whose diagonal is to be filled, it gets modified in-place.
 
-    val : scalar
-      Value to be written on the diagonal, its type must be compatible with
+    val : scalar or array_like optional
+      Scalar value or array representing the value to be written on the diagonal, its type must be compatible with
       that of the array a.
 
     wrap : bool

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -770,7 +770,7 @@ def fill_diagonal(a, val, wrap=False):
       Array whose diagonal is to be filled, it gets modified in-place.
 
     val : scalar or array_like
-      Value or values to write on the diagonal; type must be compatible with that of array a. If an array of values, the range of values must be equal to the 
+      Value or values to write on the diagonal; type must be compatible with that of array a. If an array of values, the length of values must be equal to the 
       main diagonal to fill.
 
     wrap : bool

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -769,7 +769,7 @@ def fill_diagonal(a, val, wrap=False):
     a : array, at least 2-D.
       Array whose diagonal is to be filled, it gets modified in-place.
 
-    val : scalar or array_like optional
+    val : scalar or array_like
       Scalar value or array representing the value to be written on the diagonal, its type must be compatible with
       that of the array a.
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -770,8 +770,10 @@ def fill_diagonal(a, val, wrap=False):
       Array whose diagonal is to be filled, it gets modified in-place.
 
     val : scalar or array_like
-      Value or values to write on the diagonal; type must be compatible with that of array a. If an array of values, the length of values must be equal to the 
-      main diagonal to fill.
+      Value(s) to write on the diagonal. If `val` is scalar, the value is
+      written along the diagonal. If array-like, the flattened `val` is
+      written along the diagonal, repeating if necessary to fill all
+      diagonal entries.
 
     wrap : bool
       For tall matrices in NumPy version up to 1.6.2, the


### PR DESCRIPTION
Closes #16901 

Updates the docstring on `fill_diagonal` to change `val` param to be scalar or array like as optional. Modeled off docstring in [filled](https://github.com/numpy/numpy/blob/master/numpy/ma/core.py#L582)

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
