### PR TITLE
BUG: Find dtype in genfromtxt for single column of data

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1968,7 +1968,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             else:
                 # Set to a default converter (but w/ different missing values)
                 zipit = zip(missing_values, filling_values)
-                converters = [StringConverter(dtype, locked=True,
+                converters = [StringConverter(dtype_flat[0], locked=True,
                                               missing_values=miss, default=fill)
                               for (miss, fill) in zipit]
         # Update the converters to use the user-defined ones

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1918,6 +1918,15 @@ M   33  21.99
                         dtype=[(_, float) for _ in "abc"])
         assert_equal(mtest, ctrl)
 
+    def test_single_col_w_implicit_names(self):
+        # Test single column w implicit names
+        data = 'a_row_to_skip\na_header\n5\n6'
+        mtest = np.genfromtxt(TextIO(data), skip_header=1, delimiter=",", names=True, usecols=0)
+        # Note that squeeze doesn't work when specifying names
+        ctrl = np.array([(5,), (6,)],
+                        dtype=[('a_header', int)])
+        assert_equal(mtest, ctrl)
+
     def test_easy_structured_dtype(self):
         # Test easy structured dtype
         data = "0, 1, 2.3\n4, 5, 6.7"


### PR DESCRIPTION
BUG: Find dtype in genfromtxt for single column of data

When single column of data is given to genfromtxt and names=True,
 StringConverter was not given the right dtype. 
The bug caused version 1.19 to fail to load single column text files. 
However, a fix for the failure to load has already been provided in 
the master branch, so that the dtype is found. 
The fix proposed here is consistent with the 2D behaviour.
