### PR TITLE
ENH: Speed up trim_zeros

### DIFF
--- a/benchmarks/benchmarks/bench_trim_zeros.py
+++ b/benchmarks/benchmarks/bench_trim_zeros.py
@@ -1,0 +1,25 @@
+from .common import Benchmark
+
+import numpy as np
+
+
+class TrimZeros(Benchmark):
+    def setup(self):
+        self.ar_float = np.hstack([
+            np.zeros(100_000),
+            np.random.uniform(size=100_000),
+            np.zeros(100_000),
+        ])
+
+        dtype = [('a', 'int64'), ('b', 'float64'), ('c', bool)]
+        self.ar_void = self.ar_float.astype(dtype)
+        self.ar_str = self.ar_float.astype(str)
+
+    def time_trim_zeros_float(self):
+        np.trim_zeros(self.ar_float)
+
+    def time_trim_zeros_void(self):
+        np.trim_zeros(self.ar_void)
+
+    def time_trim_zeros_str(self):
+        np.trim_zeros(self.ar_str)

--- a/benchmarks/benchmarks/bench_trim_zeros.py
+++ b/benchmarks/benchmarks/bench_trim_zeros.py
@@ -2,24 +2,29 @@ from .common import Benchmark
 
 import numpy as np
 
+_FLOAT = np.dtype('float64')
+_COMPLEX = np.dtype('complex128')
+_INT = np.dtype('int64')
+_BOOL = np.dtype('bool')
+_VOID = np.dtype([('a', 'int64'), ('b', 'float64'), ('c', bool)])
+_STR = np.dtype('U32')
+_BYTES = np.dtype('S32')
+
 
 class TrimZeros(Benchmark):
-    def setup(self):
-        self.ar_float = np.hstack([
-            np.zeros(100_000),
-            np.random.uniform(size=100_000),
-            np.zeros(100_000),
-        ])
+    param_names = ["dtype", "size"]
+    params = [
+        [_INT, _FLOAT, _COMPLEX, _BOOL, _STR, _BYTES, _VOID],
+        [3000, 30_000, 300_000]
+    ]
 
-        dtype = [('a', 'int64'), ('b', 'float64'), ('c', bool)]
-        self.ar_void = self.ar_float.astype(dtype)
-        self.ar_str = self.ar_float.astype(str)
+    def setup(self, dtype, size):
+        n = size // 3
+        self.array = np.hstack([
+            np.zeros(n),
+            np.random.uniform(size=n),
+            np.zeros(n),
+        ]).astype(dtype)
 
-    def time_trim_zeros_float(self):
-        np.trim_zeros(self.ar_float)
-
-    def time_trim_zeros_void(self):
-        np.trim_zeros(self.ar_void)
-
-    def time_trim_zeros_str(self):
-        np.trim_zeros(self.ar_str)
+    def time_trim_zeros(self, dtype, size):
+        np.trim_zeros(self.array)

--- a/benchmarks/benchmarks/bench_trim_zeros.py
+++ b/benchmarks/benchmarks/bench_trim_zeros.py
@@ -6,15 +6,12 @@ _FLOAT = np.dtype('float64')
 _COMPLEX = np.dtype('complex128')
 _INT = np.dtype('int64')
 _BOOL = np.dtype('bool')
-_VOID = np.dtype([('a', 'int64'), ('b', 'float64'), ('c', bool)])
-_STR = np.dtype('U32')
-_BYTES = np.dtype('S32')
 
 
 class TrimZeros(Benchmark):
     param_names = ["dtype", "size"]
     params = [
-        [_INT, _FLOAT, _COMPLEX, _BOOL, _STR, _BYTES, _VOID],
+        [_INT, _FLOAT, _COMPLEX, _BOOL],
         [3000, 30_000, 300_000]
     ]
 

--- a/doc/release/upcoming_changes/16911.deprecation.rst
+++ b/doc/release/upcoming_changes/16911.deprecation.rst
@@ -1,0 +1,7 @@
+``trim_zeros`` now requires a 1D array compatible with ``ndarray.astype(bool)``
+-------------------------------------------------------------------------------
+The ``trim_zeros`` function will, in the future, require an array with the
+following two properties:
+
+* It must be 1D.
+* It must be convertable into a boolean array.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -615,7 +615,7 @@ class BuiltInRoundComplexDType(_DeprecationTestCase):
             self.assert_deprecated(round, args=(scalar,))
             self.assert_deprecated(round, args=(scalar, 0))
             self.assert_deprecated(round, args=(scalar,), kwargs={'ndigits': 0})
-    
+
     def test_not_deprecated(self):
         for scalar_type in self.not_deprecated_types:
             scalar = scalar_type(0)
@@ -706,3 +706,15 @@ class TestRaggedArray(_DeprecationTestCase):
         # And when it is an assignment into a lower dimensional subarray:
         self.assert_deprecated(lambda: np.array([arr, [0]], dtype=np.float64))
         self.assert_deprecated(lambda: np.array([[0], arr], dtype=np.float64))
+
+
+class TestTrimZeros(_DeprecationTestCase):
+    # Numpy 1.20.0, 2020-07-31
+    def test_deprecated(self):
+        # Expects a 1D array-like objects
+        a = np.random.rand(10, 10).tolist()
+        self.assert_deprecated(np.trim_zeros, args=(a,))
+
+        # Must be compatible with ndarray.astype(str)
+        b = np.random.rand(10).astype(str)
+        self.assert_deprecated(np.trim_zeros, args=(b,))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -710,11 +710,17 @@ class TestRaggedArray(_DeprecationTestCase):
 
 class TestTrimZeros(_DeprecationTestCase):
     # Numpy 1.20.0, 2020-07-31
-    def test_deprecated(self):
-        # Expects a 1D array-like objects
-        a = np.random.rand(10, 10).tolist()
-        self.assert_deprecated(np.trim_zeros, args=(a,))
+    @pytest.mark.parametrize("arr", [np.random.rand(10, 10).tolist(),
+                                     np.random.rand(10).astype(str)])
+    def test_deprecated(self, arr):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            try:
+                np.trim_zeros(arr)
+            except DeprecationWarning as ex:
+                assert_(isinstance(ex.__cause__, ValueError))
+            else:
+                raise AssertionError("No error raised during function call")
 
-        # Must be compatible with ndarray.astype(str)
-        b = np.random.rand(10).astype(str)
-        self.assert_deprecated(np.trim_zeros, args=(b,))
+        out = np.lib.function_base._trim_zeros_old(arr)
+        assert_array_equal(arr, out)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1628,6 +1628,7 @@ def trim_zeros(filt, trim='fb'):
     try:
         return _trim_zeros_new(filt, trim)
     except Exception as ex:
+        # Numpy 1.20.0, 2020-07-31
         warning = DeprecationWarning(
             "in the future trim_zeros will require a 1-D array as input"
             "that is compatible with ndarray.astype(bool)"
@@ -1636,7 +1637,7 @@ def trim_zeros(filt, trim='fb'):
         warnings.warn(warning, stacklevel=3)
 
         # Fall back to the old implementation if an exception is encountered
-        # Note that the same exception may or may not raised here as well
+        # Note that the same exception may or may not be raised here as well
         return _trim_zeros_old(filt, trim)
 
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1644,6 +1644,8 @@ def trim_zeros(filt, trim='fb'):
 
     if arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')
+    elif not len(arr):
+        return filt
 
     trim_upper = trim.upper()
     len_arr = len(arr)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1644,8 +1644,8 @@ def trim_zeros(filt, trim='fb'):
 
     if 'B' in trim_upper:
         last = len_arr - arr[::-1].argmax()
-        # If `last == len(arr) and arr[-1] is False` then all elements are False
-        if last == len_arr and not arr[-1]:
+        # If `arr[last - 1] is False` then so are all other elements
+        if not arr[last - 1]:
             return filt[len_arr:]
 
     return filt[first:last]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1630,7 +1630,7 @@ def trim_zeros(filt, trim='fb'):
     except Exception as ex:
         # Numpy 1.20.0, 2020-07-31
         warning = DeprecationWarning(
-            "in the future trim_zeros will require a 1-D array as input"
+            "in the future trim_zeros will require a 1-D array as input "
             "that is compatible with ndarray.astype(bool)"
         )
         warning.__cause__ = ex

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1630,7 +1630,7 @@ def trim_zeros(filt, trim='fb'):
     except Exception as ex:
         warning = DeprecationWarning(
             "in the future trim_zeros will require a 1-D array as input"
-            "which is compatible with ndarray.astype(bool)"
+            "that is compatible with ndarray.astype(bool)"
         )
         warning.__cause__ = ex
         warnings.warn(warning, stacklevel=3)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1594,7 +1594,10 @@ def _trim_zeros(filt, trim=None):
 @array_function_dispatch(_trim_zeros)
 def trim_zeros(filt, trim='fb'):
     """
-    Trim the leading and/or trailing zeros from a 1-D array or sequence.
+    Trim all leading and/or trailing elements which evaluate to ``False``.
+
+    .. versionchanged:: 1.20.0
+        Trim any element which evaluates to ``False`` instead of just zeros.
 
     Parameters
     ----------
@@ -1622,7 +1625,7 @@ def trim_zeros(filt, trim='fb'):
     In practice all leading and/or trailing elements will be trimmed as
     long as they evaluate to ``False``.
 
-    >>> b = np.array(('', '', '' ,'a', 'b', 'c', '', 'b', 'a', ''))
+    >>> b = np.array(['', '', '' ,'a', 'b', 'c', '', 'b', 'a', ''])
     >>> np.trim_zeros(b)
     array(['a', 'b', 'c', '', 'b', 'a'], dtype='<U1')
 
@@ -1656,12 +1659,9 @@ def trim_zeros(filt, trim='fb'):
             return filt[len_arr:]
 
     if 'B' in trim_upper:
-        last = len_arr -arr[::-1].argmax()
-        # `last == len(arr)` if all elements in `arr` are zero;
-        # `arr[last]` will thus raise an IndexError
-        try:
-            arr[last]
-        except IndexError:
+        last = len_arr - arr[::-1].argmax()
+        # If `last == 0 and arr[0] is False` then all elements are False
+        if not last and not arr[last]:
             return filt[len_arr:]
 
     return filt[first:last]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1644,16 +1644,22 @@ def trim_zeros(filt, trim='fb'):
 
     if arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')
-    elif not arr.any():
-        return filt[len(arr):]
 
     trim_upper = trim.upper()
+    len_arr = len(arr)
     first = last = None
 
     if 'F' in trim_upper:
         first = arr.argmax()
+        # If `arr[first] is False` then so are all other elements
+        if not arr[first]:
+            return filt[len_arr:]
+
     if 'B' in trim_upper:
-        last = len(arr) - arr[::-1].argmax()
+        last = len_arr - arr[::-1].argmax()
+        # If `last == 0 and arr[0] is False` then all elements are False
+        if not last and not arr[last]:
+            return filt[len_arr:]
 
     return filt[first:last]
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1622,9 +1622,6 @@ def trim_zeros(filt, trim='fb'):
     >>> np.trim_zeros(a, 'b')
     array([0, 0, 0, ..., 0, 2, 1])
 
-    In practice all leading and/or trailing elements will be trimmed as
-    long as they evaluate to ``False``.
-
     >>> b = np.array(['', '', '' ,'a', 'b', 'c', '', 'b', 'a', ''])
     >>> np.trim_zeros(b)
     array(['a', 'b', 'c', '', 'b', 'a'], dtype='<U1')

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -433,7 +433,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
         By default, the data-type is inferred from the input data.
     order : {'C', 'F', 'A', 'K'}, optional
         Memory layout.  'A' and 'K' depend on the order of input array a.
-        'C' row-major (C-style), 
+        'C' row-major (C-style),
         'F' column-major (Fortran-style) memory representation.
         'A' (any) means 'F' if `a` is Fortran contiguous, 'C' otherwise
         'K' (keep) preserve input order
@@ -2596,11 +2596,11 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
     for backwards compatibility with previous versions of this function.  These
     arguments had no effect on the return values of the function and can be
     safely ignored in this and previous versions of numpy.
-    
+
     Examples
-    --------   
+    --------
     In this example we generate two random arrays, ``xarr`` and ``yarr``, and
-    compute the row-wise and column-wise Pearson correlation coefficients, 
+    compute the row-wise and column-wise Pearson correlation coefficients,
     ``R``. Since ``rowvar`` is  true by  default, we first find the row-wise
     Pearson correlation coefficients between the variables of ``xarr``.
 
@@ -2616,11 +2616,11 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
     array([[ 1.        ,  0.99256089, -0.68080986],
            [ 0.99256089,  1.        , -0.76492172],
            [-0.68080986, -0.76492172,  1.        ]])
-    
-    If we add another set of variables and observations ``yarr``, we can 
+
+    If we add another set of variables and observations ``yarr``, we can
     compute the row-wise Pearson correlation coefficients between the
     variables in ``xarr`` and ``yarr``.
-   
+
     >>> yarr = rng.random((3, 3))
     >>> yarr
     array([[0.45038594, 0.37079802, 0.92676499],
@@ -2642,7 +2642,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
              1.        ]])
 
     Finally if we use the option ``rowvar=False``, the columns are now
-    being treated as the variables and we will find the column-wise Pearson 
+    being treated as the variables and we will find the column-wise Pearson
     correlation coefficients between variables in ``xarr`` and ``yarr``.
 
     >>> R3 = np.corrcoef(xarr, yarr, rowvar=False)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1601,7 +1601,7 @@ def trim_zeros(filt, trim='fb'):
 
     Parameters
     ----------
-    filt : array_like, 1 dimension
+    filt : 1-D array or sequence
         Input array.
     trim : str, optional
         A string with 'f' representing trim from front and 'b' to trim from

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1624,7 +1624,7 @@ def trim_zeros(filt, trim='fb'):
 
     >>> b = np.array(('', '', '' ,'a', 'b', 'c', '', 'b', 'a', ''))
     >>> np.trim_zeros(b)
-    array(['a', 'b', 'c', '', 'b', 'a'])
+    array(['a', 'b', 'c', '', 'b', 'a'], dtype='<U1')
 
     The input data type is preserved, list/tuple in means list/tuple out.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1657,8 +1657,8 @@ def trim_zeros(filt, trim='fb'):
 
     if 'B' in trim_upper:
         last = len_arr - arr[::-1].argmax()
-        # If `last == 0 and arr[0] is False` then all elements are False
-        if not last and not arr[last]:
+        # If `last == len(arr) and arr[-1] is False` then all elements are False
+        if last == len_arr and not arr[-1]:
             return filt[len_arr:]
 
     return filt[first:last]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1633,20 +1633,19 @@ def trim_zeros(filt, trim='fb'):
         return filt
 
     trim_upper = trim.upper()
-    len_arr = len(arr)
     first = last = None
 
     if 'F' in trim_upper:
         first = arr.argmax()
         # If `arr[first] is False` then so are all other elements
         if not arr[first]:
-            return filt[len_arr:]
+            return filt[:0]
 
     if 'B' in trim_upper:
-        last = len_arr - arr[::-1].argmax()
+        last = len(arr) - arr[::-1].argmax()
         # If `arr[last - 1] is False` then so are all other elements
         if not arr[last - 1]:
-            return filt[len_arr:]
+            return filt[:0]
 
     return filt[first:last]
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1644,22 +1644,16 @@ def trim_zeros(filt, trim='fb'):
 
     if arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')
+    elif not arr.any():
+        return filt[len(arr):]
 
     trim_upper = trim.upper()
-    len_arr = len(arr)
     first = last = None
 
     if 'F' in trim_upper:
         first = arr.argmax()
-        # If `arr[first] is False` then so are all other elements
-        if not arr[first]:
-            return filt[len_arr:]
-
     if 'B' in trim_upper:
-        last = len_arr - arr[::-1].argmax()
-        # If `last == 0 and arr[0] is False` then all elements are False
-        if not last and not arr[last]:
-            return filt[len_arr:]
+        last = len(arr) - arr[::-1].argmax()
 
     return filt[first:last]
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1594,10 +1594,7 @@ def _trim_zeros(filt, trim=None):
 @array_function_dispatch(_trim_zeros)
 def trim_zeros(filt, trim='fb'):
     """
-    Trim all leading and/or trailing elements which evaluate to ``False``.
-
-    .. versionchanged:: 1.20.0
-        Trim any element which evaluates to ``False`` instead of just zeros.
+    Trim the leading and/or trailing zeros from a 1-D array or sequence.
 
     Parameters
     ----------
@@ -1622,25 +1619,13 @@ def trim_zeros(filt, trim='fb'):
     >>> np.trim_zeros(a, 'b')
     array([0, 0, 0, ..., 0, 2, 1])
 
-    >>> b = np.array(['', '', '' ,'a', 'b', 'c', '', 'b', 'a', ''])
-    >>> np.trim_zeros(b)
-    array(['a', 'b', 'c', '', 'b', 'a'], dtype='<U1')
-
     The input data type is preserved, list/tuple in means list/tuple out.
 
     >>> np.trim_zeros([0, 1, 2, 0])
     [1, 2]
 
     """
-    try:
-        arr = np.asanyarray(filt, dtype=bool)
-
-    # str/bytes and structured arrays cannot be directly converted into bool arrays
-    except (TypeError, ValueError):
-        arr_any = np.asanyarray(filt)
-        _arr = arr_any.view(bool)
-        _arr.shape = arr_any.shape + (arr_any.dtype.itemsize,)
-        arr = _arr.any(axis=-1)
+    arr = np.asanyarray(filt).astype(bool, copy=False)
 
     if arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1166,25 +1166,47 @@ class TestAngle:
 
 class TestTrimZeros:
 
-    """
-    Only testing for integer splits.
+    a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
+    b = a.astype(float)
+    c = a.astype(complex)
+    d = a.astype([('a', int), ('b', float), ('c', bool)])
 
-    """
+    e = np.array([None, [], 1, False, 'b', 3.0, range(4), b''], dtype=object)
+    f = np.array(['', '', 'a', '', 'b', 'c', 'd', ''])
+    g = f.astype(bytes)
+
+    def values(self):
+        attr_names = ('a', 'b', 'c', 'd', 'e', 'f', 'g')
+        return (getattr(self, name) for name in attr_names)
 
     def test_basic(self):
-        a = np.array([0, 0, 1, 2, 3, 4, 0])
-        res = trim_zeros(a)
-        assert_array_equal(res, np.array([1, 2, 3, 4]))
+        slc = np.s_[2:-1]
+        for arr in self.values():
+            res = trim_zeros(arr)
+            assert_array_equal(res, arr[slc])
 
     def test_leading_skip(self):
-        a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
-        res = trim_zeros(a)
-        assert_array_equal(res, np.array([1, 0, 2, 3, 4]))
+        slc = np.s_[:-1]
+        for arr in self.values():
+            res = trim_zeros(arr, trim='b')
+            assert_array_equal(res, arr[slc])
 
     def test_trailing_skip(self):
-        a = np.array([0, 0, 1, 0, 2, 3, 0, 4, 0])
-        res = trim_zeros(a)
-        assert_array_equal(res, np.array([1, 0, 2, 3, 0, 4]))
+        slc = np.s_[2:]
+        for arr in self.values():
+            res = trim_zeros(arr, trim='F')
+            assert_array_equal(res, arr[slc])
+
+    def test_all_zero(self):
+        for _arr in self.values():
+            arr = np.zeros_like(_arr, dtype=_arr.dtype)
+            ref = np.zeros((), dtype=_arr.dtype)
+
+            res1 = trim_zeros(arr, trim='B')
+            assert_array_equal(res1, ref)
+
+            res2 = trim_zeros(arr, trim='f')
+            assert_array_equal(res2, ref)
 
 
 class TestExtins:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1208,22 +1208,6 @@ class TestTrimZeros:
         res = trim_zeros(arr)
         assert_array_equal(arr, res)
 
-    def test_deprecation(self):
-        arr = np.random.rand(10, 10).tolist()
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', DeprecationWarning)
-            try:
-                trim_zeros(arr)
-            except Exception as ex:
-                assert isinstance(ex, DeprecationWarning)
-                assert isinstance(ex.__cause__, ValueError)
-            else:
-                raise AssertionError('Failed to raise an exception')
-
-        out = nfb._trim_zeros_old(arr)
-        assert_allclose(out, arr)
-
 
 class TestExtins:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1221,10 +1221,8 @@ class TestTrimZeros:
             else:
                 raise Assertion('Failed to raise an exception')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
-            out = trim_zeros(arr)
-            assert_allclose(out, arr)
+        out = nfb._trim_zeros_old(arr)
+        assert_allclose(out, arr)
 
 
 class TestExtins:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1219,7 +1219,7 @@ class TestTrimZeros:
                 assert isinstance(ex, DeprecationWarning)
                 assert isinstance(ex.__cause__, ValueError)
             else:
-                raise Assertion('Failed to raise an exception')
+                raise AssertionError('Failed to raise an exception')
 
         out = nfb._trim_zeros_old(arr)
         assert_allclose(out, arr)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1169,7 +1169,7 @@ class TestTrimZeros:
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
     b = a.astype(float)
     c = a.astype(complex)
-    d = a.astype([('a', int), ('b', float), ('c', bool)])
+    d = a.astype([('a', int, (2, 3)), ('b', float), ('c', bool)])
 
     e = np.array([None, [], 1, False, 'b', 3.0, range(4), b''], dtype=object)
     f = np.array(['', '', 'a', '', 'b', 'c', 'd', ''])
@@ -1200,13 +1200,12 @@ class TestTrimZeros:
     def test_all_zero(self):
         for _arr in self.values():
             arr = np.zeros_like(_arr, dtype=_arr.dtype)
-            ref = np.zeros((), dtype=_arr.dtype)
 
             res1 = trim_zeros(arr, trim='B')
-            assert_array_equal(res1, ref)
+            assert len(res1) == 0
 
             res2 = trim_zeros(arr, trim='f')
-            assert_array_equal(res2, ref)
+            assert len(res2) == 0
 
 
 class TestExtins:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1169,14 +1169,10 @@ class TestTrimZeros:
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
     b = a.astype(float)
     c = a.astype(complex)
-    d = a.astype([('a', int, (2, 3)), ('b', float), ('c', bool)])
-
-    e = np.array([None, [], 1, False, 'b', 3.0, range(4), b''], dtype=object)
-    f = np.array(['', '', 'a', '', 'b', 'c', 'd', ''])
-    g = f.astype(bytes)
+    d = np.array([None, [], 1, False, 'b', 3.0, range(4), b''], dtype=object)
 
     def values(self):
-        attr_names = ('a', 'b', 'c', 'd', 'e', 'f', 'g')
+        attr_names = ('a', 'b', 'c', 'd')
         return (getattr(self, name) for name in attr_names)
 
     def test_basic(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1207,6 +1207,11 @@ class TestTrimZeros:
             res2 = trim_zeros(arr, trim='f')
             assert len(res2) == 0
 
+    def test_size_zero(self):
+        arr = np.zeros(0)
+        res = trim_zeros(arr)
+        assert_array_equal(arr, res)
+
 
 class TestExtins:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1208,6 +1208,24 @@ class TestTrimZeros:
         res = trim_zeros(arr)
         assert_array_equal(arr, res)
 
+    def test_deprecation(self):
+        arr = np.random.rand(10, 10).tolist()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', DeprecationWarning)
+            try:
+                trim_zeros(arr)
+            except Exception as ex:
+                assert isinstance(ex, DeprecationWarning)
+                assert isinstance(ex.__cause__, ValueError)
+            else:
+                raise Assertion('Failed to raise an exception')
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            out = trim_zeros(arr)
+            assert_allclose(out, arr)
+
 
 class TestExtins:
 


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16783.

As was noted in aforementioned issue the current `trim_zeros()` implementation, 
as of 1.19.0, is very slow with plenty of room for further optimization. 
This pull request addresses the previous optimization issue. 

Before
-------
``` python
In [1]: import numpy as np

In [2]: a = np.hstack([
   ...:     np.zeros(100_000),
   ...:     np.random.uniform(size=100_000),
   ...:     np.zeros(100_000),
   ...: ])

In [3]: np.__version__
Out[3]: '1.19.0'

In [4]: %timeit np.trim_zeros(a)
45.8 ms ± 6.38 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After
-----
``` python
In [3]: np.__version__
Out[3]: '1.20.0.dev0+2823c98'

In [4]: %timeit np.trim_zeros(a)
303 µs ± 15 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

To summarize the new implementation: the passed array is now first converted a boolean array,
after which `argmax()` is used for identifying the first and/or last non-zero element.

~~A side effect of the new approach is that it will trim any leading and/or trailing elements
which evaluates to ``False``; not just ``0``.~~

Lastly, a new benchmark has been added as was requested in https://github.com/numpy/numpy/issues/16783#issuecomment-655856960.