### PR TITLE
DOC: Add correctness vs strictness consideration for np.dtype

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -68,12 +68,25 @@ the following code is valid:
 
 .. code-block:: python
 
-    x = np.array([1, 2])
-    x.dtype = np.bool_
+    >>> x = np.array([1, 2])
+    >>> x.dtype = np.bool_
 
 This sort of mutation is not allowed by the types. Users who want to
 write statically typed code should insted use the `numpy.ndarray.view`
 method to create a view of the array with a different dtype.
+
+dtype
+~~~~~
+
+The ``_DTypeLike`` type tries to avoid creation of dtype objects using
+dictionary of fields like below:
+
+.. code-below:: python
+    >>> x = np.dtype({"field1": (float, 1), "field2": (int, 3)})
+
+Although this is valid Numpy code, the type checker will complain about it,
+since its usage is discouraged.
+Please see : https://numpy.org/devdocs/reference/arrays.dtypes.html
 
 """
 from ._array_like import _SupportsArray, ArrayLike

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -82,6 +82,7 @@ The ``_DTypeLike`` type tries to avoid creation of dtype objects using
 dictionary of fields like below:
 
 .. code-block:: python
+
     >>> x = np.dtype({"field1": (float, 1), "field2": (int, 3)})
 
 Although this is valid Numpy code, the type checker will complain about it,

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -34,7 +34,7 @@ differences.
 ArrayLike
 ~~~~~~~~~
 
-The ``ArrayLike`` static type tries to avoid creating object arrays. For
+The ``ArrayLike`` type tries to avoid creating object arrays. For
 example,
 
 .. code-block:: python
@@ -78,7 +78,7 @@ method to create a view of the array with a different dtype.
 dtype
 ~~~~~
 
-The ``_DTypeLike`` static type tries to avoid creation of dtype objects using
+The ``DTypeLike`` type tries to avoid creation of dtype objects using
 dictionary of fields like below:
 
 .. code-block:: python

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -34,7 +34,7 @@ differences.
 ArrayLike
 ~~~~~~~~~
 
-The ``ArrayLike`` type tries to avoid creating object arrays. For
+The ``ArrayLike`` static type tries to avoid creating object arrays. For
 example,
 
 .. code-block:: python
@@ -78,7 +78,7 @@ method to create a view of the array with a different dtype.
 dtype
 ~~~~~
 
-The ``_DTypeLike`` type tries to avoid creation of dtype objects using
+The ``_DTypeLike`` static type tries to avoid creation of dtype objects using
 dictionary of fields like below:
 
 .. code-block:: python

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -81,7 +81,7 @@ dtype
 The ``_DTypeLike`` type tries to avoid creation of dtype objects using
 dictionary of fields like below:
 
-.. code-below:: python
+.. code-block:: python
     >>> x = np.dtype({"field1": (float, 1), "field2": (int, 3)})
 
 Although this is valid Numpy code, the type checker will complain about it,


### PR DESCRIPTION
Document _DTypeLike decision for correctness vs strictness. Please see : https://github.com/numpy/numpy/issues/16891

Depends on https://github.com/numpy/numpy/pull/16622