### PR TITLE
ENH,API: Store exported buffer info on the array

### DIFF
--- a/doc/release/upcoming_changes/16938.c_api.rst
+++ b/doc/release/upcoming_changes/16938.c_api.rst
@@ -1,17 +1,18 @@
 Size of ``np.ndarray`` and ``np.void_`` changed
 -----------------------------------------------
 The size of the ``PyArrayObject`` and ``PyVoidScalarObject``
-structures have changed.  This also modifies the header
-definition::
+structures have changed.  The following header definition has been
+removed::
 
-    #define NPY_SIZEOF_PYARRAYOBJECT (PyArray_Type.tp_basicsize)
+    #define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
 
-since the size should not be considered a compile time constant.
+since the size must not be considered a compile time constant.
 
-In the case that your code subclasses any of these on the C-level,
-it will have to be recompiled and should add guards against such
-size changes for the future.  NumPy will attempt to give a graceful
-warning, but in many cases crashes are likely if this is done.
+The most likely relevant use are potential subclasses written in C which
+will have to be recompiled and should be updated.  Please see the
+documentation for :c:type:`PyArrayObject` for more details and contact
+the NumPy developers if you are affected by this change.
 
-We are not aware of any user impacted by this change. If your
-project is, please get in touch with the NumPy developers.
+NumPy will attempt to give a graceful error but a program expecting a
+fixed structure size may have undefined behaviour and likely crash.
+

--- a/doc/release/upcoming_changes/16938.c_api.rst
+++ b/doc/release/upcoming_changes/16938.c_api.rst
@@ -2,7 +2,7 @@ Size of ``np.ndarray`` and ``np.void_`` changed
 -----------------------------------------------
 The size of the ``PyArrayObject`` and ``PyVoidScalarObject``
 structures have changed.  The following header definition has been
-deprecated::
+removed::
 
     #define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
 

--- a/doc/release/upcoming_changes/16938.c_api.rst
+++ b/doc/release/upcoming_changes/16938.c_api.rst
@@ -1,0 +1,17 @@
+Size of ``np.ndarray`` and ``np.void_`` changed
+-----------------------------------------------
+The size of the ``PyArrayObject`` and ``PyVoidScalarObject``
+structures have changed.  This also modifies the header
+definition::
+
+    #define NPY_SIZEOF_PYARRAYOBJECT (PyArray_Type.tp_basicsize)
+
+since the size should not be considered a compile time constant.
+
+In the case that your code subclasses any of these on the C-level,
+it will have to be recompiled and should add guards against such
+size changes for the future.  NumPy will attempt to give a graceful
+warning, but in many cases crashes are likely if this is done.
+
+We are not aware of any user impacted by this change. If your
+project is, please get in touch with the NumPy developers.

--- a/doc/release/upcoming_changes/16938.c_api.rst
+++ b/doc/release/upcoming_changes/16938.c_api.rst
@@ -2,11 +2,12 @@ Size of ``np.ndarray`` and ``np.void_`` changed
 -----------------------------------------------
 The size of the ``PyArrayObject`` and ``PyVoidScalarObject``
 structures have changed.  The following header definition has been
-removed::
+deprecated::
 
     #define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
 
-since the size must not be considered a compile time constant.
+since the size must not be considered a compile time constant: it will
+change for different runtime versions of NumPy.
 
 The most likely relevant use are potential subclasses written in C which
 will have to be recompiled and should be updated.  Please see the

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -79,6 +79,8 @@ PyArray_Type and PyArrayObject
    of :c:type:`NPY_AO` (deprecated) which is defined to be equivalent to
    :c:type:`PyArrayObject`. Direct access to the struct fields are
    deprecated. Use the ``PyArray_*(arr)`` form instead.
+   As of NumPy 1.20, the size of this struct is not considered part of
+   the NumPy ABI (see note at the end of the member list).
 
    .. code-block:: c
 
@@ -92,6 +94,7 @@ PyArray_Type and PyArrayObject
           PyArray_Descr *descr;
           int flags;
           PyObject *weakreflist;
+          /* version dependend private members */
       } PyArrayObject;
 
    .. c:macro:: PyObject_HEAD
@@ -172,6 +175,27 @@ PyArray_Type and PyArrayObject
 
        This member allows array objects to have weak references (using the
        weakref module).
+
+   .. note::
+
+      Further members are considered private and version dependend. If the size
+      of the struct is important for your code, special care must be taken.
+      A possible use-case when this is relevant is subclassing in C.
+      If your code relies on ``sizeof(PyArrayObject)`` to be constant,
+      you must add the following check at import time:
+
+      .. code-block:: c
+
+         if (sizeof(PyArrayObject) < PyArray_Type.tp_basicsize) {
+             PyErr_SetString(PyExc_ImportError,
+                "Binary incompatibility with NumPy, must recompile/update X.");
+             return NULL;
+         }
+
+      To ensure that your code does not have to be compiled for a specific
+      NumPy version, you may add a constant, leaving room for changes in NumPy.
+      A solution guaranteed to be compatible with any future NumPy version
+      requires the use of a runtime calculate offset and allocation size.
 
 
 PyArrayDescr_Type and PyArray_Descr

--- a/numpy/core/include/numpy/arrayscalars.h
+++ b/numpy/core/include/numpy/arrayscalars.h
@@ -149,6 +149,7 @@ typedef struct {
         PyArray_Descr *descr;
         int flags;
         PyObject *base;
+        void *_buffer_info;  /* private buffer info, tagged to allow warning */
 } PyVoidScalarObject;
 
 /* Macros

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -724,7 +724,8 @@ typedef struct tagPyArrayObject {
 /* 2020-Nov-25 1.20 */
 #define NPY_SIZEOF_PYARRAYOBJECT \
     (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
-     "and is not constant across different runtime versions of NumPy\n")<0? -1: PyArray_Type.tp_basicsize)
+               "and is not constant across different runtime versions of NumPy\n") < 0 ? \
+               PyErr_WriteUnraisable(NULL) : NULL, PyArray_Type.tp_basicsize)
 
 
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -721,6 +721,12 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
+/* 2020-Nov-25 1.20 */
+#define NPY_SIZEOF_PYARRAYOBJECT \
+    (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
+     "and is not constant across different runtime versions of NumPy\n")<0? -1: PyArray_Type.tp_basicsize)
+
+
 
 /* Array Flags Object */
 typedef struct PyArrayFlagsObject {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -731,7 +731,7 @@ typedef struct tagPyArrayObject {
 #define NPY_SIZEOF_PYARRAYOBJECT \
     (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
                "and is not constant across different runtime versions of NumPy\n") < 0 ? \
-                   (PyErr_WriteUnraisable(NULL), PyArray_Type.tp_basicsize) : \
+                   (PyErr_WriteUnraisable(Py_None), PyArray_Type.tp_basicsize) : \
                    PyArray_Type.tp_basicsize)
 
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -721,7 +721,6 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
-#define NPY_SIZEOF_PYARRAYOBJECT (PyArray_Type.tp_basicsize)
 
 /* Array Flags Object */
 typedef struct PyArrayFlagsObject {

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -721,19 +721,17 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
-/* 2020-Nov-25, NumPy 1.20 */
 /*
- * The following macro makes some best efforts to give a deprecation warning
- * and return the correct runtime size of the structure. The macro should
- * be replaced with `PyArray_Type.tp_basicsize` or similar, the size
- * may change in the future.
+ * Removed 2020-Nov-25, NumPy 1.20
+ * #define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
+ *
+ * The above macro was removed as it gave a false sense of a stable ABI
+ * with respect to the structures size.  If you require a runtime constant,
+ * you can use `PyArray_Type.tp_basicsize` instead.  Otherwise, please
+ * see the PyArrayObject documentation or ask the NumPy developers for
+ * information on how to correctly replace the macro in a way that is
+ * compatible with multiple NumPy versions.
  */
-#define NPY_SIZEOF_PYARRAYOBJECT \
-    (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
-               "and is not constant across different runtime versions of NumPy\n") < 0 ? \
-                   (PyErr_WriteUnraisable(Py_None), PyArray_Type.tp_basicsize) : \
-                   PyArray_Type.tp_basicsize)
-
 
 
 /* Array Flags Object */

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -721,11 +721,18 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
-/* 2020-Nov-25 1.20 */
+/* 2020-Nov-25, NumPy 1.20 */
+/*
+ * The following macro makes some best efforts to give a deprecation warning
+ * and return the correct runtime size of the structure. The macro should
+ * be replaced with `PyArray_Type.tp_basicsize` or similar, the size
+ * may change in the future.
+ */
 #define NPY_SIZEOF_PYARRAYOBJECT \
     (DEPRECATE("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be used at compile time " \
                "and is not constant across different runtime versions of NumPy\n") < 0 ? \
-               PyErr_WriteUnraisable(NULL) : NULL, PyArray_Type.tp_basicsize)
+                   (PyErr_WriteUnraisable(NULL), PyArray_Type.tp_basicsize) : \
+                   PyArray_Type.tp_basicsize)
 
 
 

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -701,6 +701,7 @@ typedef struct tagPyArrayObject_fields {
     int flags;
     /* For weak references */
     PyObject *weakreflist;
+    void *_buffer_info;  /* private buffer info, tagged to allow warning */
 } PyArrayObject_fields;
 
 /*
@@ -720,7 +721,7 @@ typedef struct tagPyArrayObject {
 } PyArrayObject;
 #endif
 
-#define NPY_SIZEOF_PYARRAYOBJECT (sizeof(PyArrayObject_fields))
+#define NPY_SIZEOF_PYARRAYOBJECT (PyArray_Type.tp_basicsize)
 
 /* Array Flags Object */
 typedef struct PyArrayFlagsObject {

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2167,6 +2167,17 @@ run_intp_converter(PyObject* NPY_UNUSED(self), PyObject *args)
     return tup;
 }
 
+static PyObject *
+test_macro(PyObject* NPY_UNUSED(self), PyObject *args)
+{
+    int ret = NPY_SIZEOF_PYARRAYOBJECT;
+    if (ret < 0) {
+        return NULL;
+    }
+    return PyLong_FromLong(ret);
+}
+
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"IsPythonScalar",
         IsPythonScalar,
@@ -2347,6 +2358,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
         METH_VARARGS, NULL},
     {"run_intp_converter",
         run_intp_converter,
+        METH_VARARGS, NULL},
+    {"test_macro",
+        test_macro,
         METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2167,17 +2167,6 @@ run_intp_converter(PyObject* NPY_UNUSED(self), PyObject *args)
     return tup;
 }
 
-static PyObject *
-test_macro(PyObject* NPY_UNUSED(self), PyObject *args)
-{
-    int ret = NPY_SIZEOF_PYARRAYOBJECT;
-    if (ret < 0) {
-        return NULL;
-    }
-    return PyLong_FromLong(ret);
-}
-
-
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"IsPythonScalar",
         IsPythonScalar,
@@ -2358,9 +2347,6 @@ static PyMethodDef Multiarray_TestsMethods[] = {
         METH_VARARGS, NULL},
     {"run_intp_converter",
         run_intp_converter,
-        METH_VARARGS, NULL},
-    {"test_macro",
-        test_macro,
         METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -36,6 +36,7 @@ IsPythonScalar(PyObject * dummy, PyObject *args)
 
 #include "npy_pycompat.h"
 
+
 /** Function to test calling via ctypes */
 EXPORT(void*) forward_pointer(void *x)
 {
@@ -681,6 +682,38 @@ create_custom_field_dtype(PyObject *NPY_UNUSED(mod), PyObject *args)
     }
     Py_INCREF(dtype);
     return (PyObject *)dtype;
+}
+
+
+PyObject *
+corrupt_or_fix_bufferinfo(PyObject *dummy, PyObject *obj)
+{
+    void **buffer_info_ptr;
+    if (PyArray_Check(obj)) {
+        buffer_info_ptr = &((PyArrayObject_fields *)obj)->_buffer_info;
+    }
+    else if (PyArray_IsScalar(obj, Void)) {
+        buffer_info_ptr = &((PyVoidScalarObject *)obj)->_buffer_info;
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "argument must be an array or void scalar");
+        return NULL;
+    }
+    if (*buffer_info_ptr == NULL) {
+        /* set to an invalid value (as a subclass might accidentally) */
+        *buffer_info_ptr = &corrupt_or_fix_bufferinfo;
+    }
+    else if (*buffer_info_ptr == &corrupt_or_fix_bufferinfo) {
+        /* Reset to a NULL (good value) */
+        *buffer_info_ptr = NULL;
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "buffer was already exported, this test doesn't support that");
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }
 
 
@@ -2158,6 +2191,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"create_custom_field_dtype",
         create_custom_field_dtype,
         METH_VARARGS, NULL},
+    {"corrupt_or_fix_bufferinfo",
+        corrupt_or_fix_bufferinfo,
+        METH_O, NULL},
     {"incref_elide",
         incref_elide,
         METH_VARARGS, NULL},

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -702,9 +702,10 @@ corrupt_or_fix_bufferinfo(PyObject *dummy, PyObject *obj)
     }
     if (*buffer_info_ptr == NULL) {
         /* set to an invalid value (as a subclass might accidentally) */
-        *buffer_info_ptr = &corrupt_or_fix_bufferinfo;
+        *buffer_info_ptr = obj;
+        assert(((uintptr_t)obj & 7) == 0);
     }
-    else if (*buffer_info_ptr == &corrupt_or_fix_bufferinfo) {
+    else if (*buffer_info_ptr == obj) {
         /* Reset to a NULL (good value) */
         *buffer_info_ptr = NULL;
     }

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -432,7 +432,7 @@ WARN_IN_DEALLOC(PyObject* warning, const char * msg) {
 static void
 array_dealloc(PyArrayObject *self)
 {
-    PyArrayObject_fields *fa = (PyArrayObject_fields *) self;
+    PyArrayObject_fields *fa = (PyArrayObject_fields *)self;
 
     if (_buffer_info_free(fa->_buffer_info, (PyObject *)self) < 0) {
         PyErr_WriteUnraisable(NULL);
@@ -1733,7 +1733,6 @@ array_alloc(PyTypeObject *type, Py_ssize_t NPY_UNUSED(nitems))
     /* nitems will always be 0 */
     PyObject *obj = PyObject_Malloc(type->tp_basicsize);
     PyObject_Init(obj, type);
-
     return obj;
 }
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -428,31 +428,23 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
 
 
 /*
- * Global information about all active buffers
+ * Information about all active buffers is stored as a linked list on
+ * the ndarray. The initial pointer is currently tagged to have a chance of
+ * detecting incompatible subclasses.
  *
  * Note: because for backward compatibility we cannot define bf_releasebuffer,
  * we must manually keep track of the additional data required by the buffers.
  */
 
 /* Additional per-array data required for providing the buffer interface */
-typedef struct {
+typedef struct _buffer_info_t_tag {
     char *format;
     int ndim;
     Py_ssize_t *strides;
     Py_ssize_t *shape;
+    struct _buffer_info_t_tag *next;
 } _buffer_info_t;
 
-/*
- * { id(array): [list of pointers to _buffer_info_t, the last one is latest] }
- *
- * Because shape, strides, and format can be different for different buffers,
- * we may need to keep track of multiple buffer infos for each array.
- *
- * However, when none of them has changed, the same buffer info may be reused.
- *
- * Thread-safety is provided by GIL.
- */
-static PyObject *_buffer_info_cache = NULL;
 
 /* Fill in the info structure */
 static _buffer_info_t*
@@ -564,6 +556,7 @@ _buffer_info_new(PyObject *obj, int flags)
         Py_DECREF(descr);
         info->format = NULL;
     }
+    info->next = NULL;
     return info;
 
 fail:
@@ -596,144 +589,141 @@ _buffer_info_cmp(_buffer_info_t *a, _buffer_info_t *b)
     return 0;
 }
 
-static void
-_buffer_info_free(_buffer_info_t *info)
+
+/*
+ * We tag the pointer by adding 2, to ensure that we are most likely to
+ * notice if a C defined subclass extends our structure and does not take
+ * into account that it may grow.
+ */
+static int
+_buffer_info_untag(
+        void *tagged_buffer_info, _buffer_info_t **buffer_info, PyObject *obj)
 {
-    if (info->format) {
-        PyObject_Free(info->format);
+    if (NPY_UNLIKELY(((uintptr_t)tagged_buffer_info & 0x7) != 2)) {
+        PyErr_Format(PyExc_RuntimeError,
+                "Object of type %S appears to be C subclassed NumPy array, "
+                "void scalar, or allocated in a non-standard way."
+                "NumPy reserves the right to change the size of these "
+                "structures. Projects are required to take this into account "
+                "by either recompiling against a specific NumPy version or "
+                "padding the struct and enforcing a maximum NumPy version.",
+                Py_TYPE(obj));
+        return -1;
     }
-    PyObject_Free(info);
+    *buffer_info = (void *)((uintptr_t)tagged_buffer_info - 2);
+    return 0;
 }
 
-/* Get buffer info from the global dictionary */
-static _buffer_info_t*
-_buffer_get_info(PyObject *obj, int flags)
+
+/*
+ * NOTE: for backward compatibility (esp. with PyArg_ParseTuple("s#", ...))
+ * we do *not* define bf_releasebuffer at all.
+ *
+ * Instead, any extra data allocated with the buffer is released only in
+ * array_dealloc.
+ *
+ * Ensuring that the buffer stays in place is taken care by refcounting;
+ * ndarrays do not reallocate if there are references to them, and a buffer
+ * view holds one reference.
+ *
+ * This is stored in the array's _buffer_info slot (currently as a void *).
+ */
+static void
+_buffer_info_free_untagged(void *_buffer_info)
 {
-    PyObject *key = NULL, *item_list = NULL, *item = NULL;
-    _buffer_info_t *info = NULL, *old_info = NULL;
-
-    if (_buffer_info_cache == NULL) {
-        _buffer_info_cache = PyDict_New();
-        if (_buffer_info_cache == NULL) {
-            return NULL;
+    _buffer_info_t *next = _buffer_info;
+    while (next != NULL) {
+        _buffer_info_t *curr = next;
+        next = curr->next;
+        if (curr->format) {
+            PyObject_Free(curr->format);
         }
+        /* Shape is allocated as part of info */
+        PyObject_Free(curr);
     }
+}
 
-    /* Compute information */
+
+/*
+ * Checks whether the pointer is tagged, and then frees the cache list.
+ * (The tag check is only for transition due to changed structure size in 1.20)
+ */
+NPY_NO_EXPORT int
+_buffer_info_free(void *buffer_info, PyObject *obj)
+{
+    _buffer_info_t *untagged_buffer_info;
+    if (_buffer_info_untag(buffer_info, &untagged_buffer_info, obj) < 0) {
+        return -1;
+    }
+    _buffer_info_free_untagged(untagged_buffer_info);
+    return 0;
+}
+
+
+/*
+ * Get the buffer info returning either the old one (passed in) or a new
+ * buffer info which adds holds on to (and thus replaces) the old one.
+ */
+static _buffer_info_t*
+_buffer_get_info(void **buffer_info_cache_ptr, PyObject *obj, int flags)
+{
+    _buffer_info_t *info = NULL;
+    _buffer_info_t *stored_info;  /* First currently stored buffer info */
+
+    if (_buffer_info_untag(*buffer_info_cache_ptr, &stored_info, obj) < 0) {
+        return NULL;
+    }
+    _buffer_info_t *old_info = stored_info;
+
+    /* Compute information (it would be nice to skip this in simple cases) */
     info = _buffer_info_new(obj, flags);
     if (info == NULL) {
         return NULL;
     }
 
-    /* Check if it is identical with an old one; reuse old one, if yes */
-    key = PyLong_FromVoidPtr((void*)obj);
-    if (key == NULL) {
-        goto fail;
+    if (old_info != NULL && _buffer_info_cmp(info, old_info) != 0) {
+        _buffer_info_t *next_info = old_info->next;
+        old_info = NULL;  /* Can't use this one, but possibly next */
+
+         if (info->ndim > 1 && next_info != NULL) {
+             /*
+              * Some arrays are C- and F-contiguous and if they have more
+              * than one dimension, the buffer-info may differ between
+              * the two due to RELAXED_STRIDES_CHECKING.
+              * If we export both buffers, the first stored one may be
+              * the one for the other contiguity, so check both.
+              * This is generally very unlikely in all other cases, since
+              * in all other cases the first one will match unless array
+              * metadata was modified in-place (which is discouraged).
+              */
+             if (_buffer_info_cmp(info, next_info) == 0) {
+                 old_info = next_info;
+             }
+         }
     }
-    item_list = PyDict_GetItem(_buffer_info_cache, key);
-
-    if (item_list != NULL) {
-        Py_ssize_t item_list_length = PyList_GET_SIZE(item_list);
-        Py_INCREF(item_list);
-        if (item_list_length > 0) {
-            item = PyList_GetItem(item_list, item_list_length - 1);
-            old_info = (_buffer_info_t*)PyLong_AsVoidPtr(item);
-            if (_buffer_info_cmp(info, old_info) != 0) {
-                old_info = NULL;  /* Can't use this one, but possibly next */
-
-                if (item_list_length > 1 && info->ndim > 1) {
-                    /*
-                     * Some arrays are C- and F-contiguous and if they have more
-                     * than one dimension, the buffer-info may differ between
-                     * the two due to RELAXED_STRIDES_CHECKING.
-                     * If we export both buffers, the first stored one may be
-                     * the one for the other contiguity, so check both.
-                     * This is generally very unlikely in all other cases, since
-                     * in all other cases the first one will match unless array
-                     * metadata was modified in-place (which is discouraged).
-                     */
-                    item = PyList_GetItem(item_list, item_list_length - 2);
-                    old_info = (_buffer_info_t*)PyLong_AsVoidPtr(item);
-                    if (_buffer_info_cmp(info, old_info) != 0) {
-                        old_info = NULL;
-                    }
-                }
-            }
-
-            if (old_info != NULL) {
-                /*
-                 * The two info->format are considered equal if one of them
-                 * has no format set (meaning the format is arbitrary and can
-                 * be modified). If the new info has a format, but we reuse
-                 * the old one, this transfers the ownership to the old one.
-                 */
-                if (old_info->format == NULL) {
-                    old_info->format = info->format;
-                    info->format = NULL;
-                }
-                _buffer_info_free(info);
-                info = old_info;
-            }
+    if (old_info != NULL) {
+        /*
+         * The two info->format are considered equal if one of them
+         * has no format set (meaning the format is arbitrary and can
+         * be modified). If the new info has a format, but we reuse
+         * the old one, this transfers the ownership to the old one.
+         */
+        if (old_info->format == NULL) {
+            old_info->format = info->format;
+            info->format = NULL;
         }
+        _buffer_info_free_untagged(info);
+        info = old_info;
     }
     else {
-        item_list = PyList_New(0);
-        if (item_list == NULL) {
-            goto fail;
-        }
-        if (PyDict_SetItem(_buffer_info_cache, key, item_list) != 0) {
-            goto fail;
-        }
+        /* Insert new info as first item in the linked buffer-info list. */
+        info->next = stored_info;
+        *buffer_info_cache_ptr = buffer_info_tag(info);
     }
 
-    if (info != old_info) {
-        /* Needs insertion */
-        item = PyLong_FromVoidPtr((void*)info);
-        if (item == NULL) {
-            goto fail;
-        }
-        PyList_Append(item_list, item);
-        Py_DECREF(item);
-    }
-
-    Py_DECREF(item_list);
-    Py_DECREF(key);
     return info;
-
-fail:
-    if (info != NULL && info != old_info) {
-        _buffer_info_free(info);
-    }
-    Py_XDECREF(item_list);
-    Py_XDECREF(key);
-    return NULL;
 }
 
-/* Clear buffer info from the global dictionary */
-static void
-_buffer_clear_info(PyObject *arr)
-{
-    PyObject *key, *item_list, *item;
-    _buffer_info_t *info;
-    int k;
-
-    if (_buffer_info_cache == NULL) {
-        return;
-    }
-
-    key = PyLong_FromVoidPtr((void*)arr);
-    item_list = PyDict_GetItem(_buffer_info_cache, key);
-    if (item_list != NULL) {
-        for (k = 0; k < PyList_GET_SIZE(item_list); ++k) {
-            item = PyList_GET_ITEM(item_list, k);
-            info = (_buffer_info_t*)PyLong_AsVoidPtr(item);
-            _buffer_info_free(info);
-        }
-        PyDict_DelItem(_buffer_info_cache, key);
-    }
-
-    Py_DECREF(key);
-}
 
 /*
  * Retrieving buffers for ndarray
@@ -779,8 +769,9 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
         goto fail;
     }
 
-    /* Fill in information */
-    info = _buffer_get_info(obj, flags);
+    /* Fill in information (and add it to _buffer_info if necessary) */
+    info = _buffer_get_info(
+            &((PyArrayObject_fields *)self)->_buffer_info, obj, flags);
     if (info == NULL) {
         goto fail;
     }
@@ -830,90 +821,48 @@ fail:
 }
 
 /*
- * Retrieving buffers for scalars
+ * Retrieving buffers for void scalar (which can contain any complex types),
+ * defined in buffer.c since it requires the complex format building logic.
  */
-int
+NPY_NO_EXPORT int
 void_getbuffer(PyObject *self, Py_buffer *view, int flags)
 {
-    _buffer_info_t *info = NULL;
-    PyArray_Descr *descr = NULL;
-    int elsize;
+    PyVoidScalarObject *scalar = (PyVoidScalarObject *)self;
 
     if (flags & PyBUF_WRITABLE) {
         PyErr_SetString(PyExc_BufferError, "scalar buffer is readonly");
-        goto fail;
+        return -1;
     }
 
-    /* Fill in information */
-    info = _buffer_get_info(self, flags);
-    if (info == NULL) {
-        goto fail;
-    }
-
-    view->ndim = info->ndim;
-    view->shape = info->shape;
-    view->strides = info->strides;
-
-    if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT) {
-        view->format = info->format;
-    } else {
-        view->format = NULL;
-    }
-
-    descr = PyArray_DescrFromScalar(self);
-    view->buf = (void *)scalar_value(self, descr);
-    elsize = descr->elsize;
-    view->len = elsize;
-    if (PyArray_IsScalar(self, Datetime) || PyArray_IsScalar(self, Timedelta)) {
-        elsize = 1; /* descr->elsize,char is 8,'M', but we return 1,'B' */
-    }
-    view->itemsize = elsize;
-
-    Py_DECREF(descr);
-
+    view->ndim = 0;
+    view->shape = NULL;
+    view->strides = NULL;
+    view->suboffsets = NULL;
+    view->len = scalar->descr->elsize;
+    view->itemsize = scalar->descr->elsize;
     view->readonly = 1;
     view->suboffsets = NULL;
-    view->obj = self;
     Py_INCREF(self);
-    return 0;
+    view->obj = self;
+    view->buf = scalar->obval;
 
-fail:
-    view->obj = NULL;
-    return -1;
-}
+    if (((flags & PyBUF_FORMAT) != PyBUF_FORMAT)) {
+        /* It is unnecessary to find the correct format */
+        view->format = NULL;
+        return 0;
+    }
 
-/*
- * NOTE: for backward compatibility (esp. with PyArg_ParseTuple("s#", ...))
- * we do *not* define bf_releasebuffer at all.
- *
- * Instead, any extra data allocated with the buffer is released only in
- * array_dealloc.
- *
- * Ensuring that the buffer stays in place is taken care by refcounting;
- * ndarrays do not reallocate if there are references to them, and a buffer
- * view holds one reference.
- */
-
-NPY_NO_EXPORT void
-_dealloc_cached_buffer_info(PyObject *self)
-{
-    int reset_error_state = 0;
-    PyObject *ptype, *pvalue, *ptraceback;
-
-    /* This function may be called when processing an exception --
-     * we need to stash the error state to avoid confusing PyDict
+    /*
+     * If a format is being exported, we need to use _buffer_get_info
+     * to find the correct format.  This format must also be stored, since
+     * at least in theory it can change (in practice it should never change).
      */
-
-    if (PyErr_Occurred()) {
-        reset_error_state = 1;
-        PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+    _buffer_info_t *info = _buffer_get_info(&scalar->_buffer_info, self, flags);
+    if (info == NULL) {
+        return -1;
     }
-
-    _buffer_clear_info(self);
-
-    if (reset_error_state) {
-        PyErr_Restore(ptype, pvalue, ptraceback);
-    }
+    view->format = info->format;
+    return 0;
 }
 
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -605,7 +605,7 @@ buffer_info_tag(void *buffer_info)
         return buffer_info;
     }
     else {
-        return (void *)((uintptr_t)buffer_info + 2);
+        return (void *)((uintptr_t)buffer_info + 3);
     }
 }
 
@@ -618,7 +618,7 @@ _buffer_info_untag(
         *buffer_info = NULL;
         return 0;
     }
-    if (NPY_UNLIKELY(((uintptr_t)tagged_buffer_info & 0x7) != 2)) {
+    if (NPY_UNLIKELY(((uintptr_t)tagged_buffer_info & 0x7) != 3)) {
         PyErr_Format(PyExc_RuntimeError,
                 "Object of type %S appears to be C subclassed NumPy array, "
                 "void scalar, or allocated in a non-standard way."
@@ -629,7 +629,7 @@ _buffer_info_untag(
                 Py_TYPE(obj));
         return -1;
     }
-    *buffer_info = (void *)((uintptr_t)tagged_buffer_info - 2);
+    *buffer_info = (void *)((uintptr_t)tagged_buffer_info - 3);
     return 0;
 }
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -752,6 +752,8 @@ PyArray_NewFromDescr_int(
     }
 
     fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
+    ((PyArrayObject_fields *)fa)->_buffer_info = buffer_info_tag(NULL);
+
     if (fa == NULL) {
         Py_DECREF(descr);
         return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -752,15 +752,15 @@ PyArray_NewFromDescr_int(
     }
 
     fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
-    ((PyArrayObject_fields *)fa)->_buffer_info = buffer_info_tag(NULL);
-
     if (fa == NULL) {
         Py_DECREF(descr);
         return NULL;
     }
+    fa->_buffer_info = NULL;
     fa->nd = nd;
     fa->dimensions = NULL;
     fa->data = NULL;
+
     if (data == NULL) {
         fa->flags = NPY_ARRAY_DEFAULT;
         if (flags) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2180,7 +2180,7 @@ static PyObject *
 array_sizeof(PyArrayObject *self)
 {
     /* object + dimension and strides */
-    Py_ssize_t nbytes = NPY_SIZEOF_PYARRAYOBJECT +
+    Py_ssize_t nbytes = Py_TYPE(self)->tp_basicsize +
         PyArray_NDIM(self) * sizeof(npy_intp) * 2;
     if (PyArray_CHKFLAGS(self, NPY_ARRAY_OWNDATA)) {
         nbytes += PyArray_NBYTES(self);

--- a/numpy/core/src/multiarray/npy_buffer.h
+++ b/numpy/core/src/multiarray/npy_buffer.h
@@ -6,18 +6,6 @@ extern NPY_NO_EXPORT PyBufferProcs array_as_buffer;
 NPY_NO_EXPORT int
 _buffer_info_free(void *buffer_info, PyObject *obj);
 
-/*
- * Tag the buffer info pointer. This was appended to the array struct
- * in NumPy 1.20, tagging the pointer gives us a chance to raise/print
- * a useful error message when a user modifies fields that should belong to
- * us.
- */
-static NPY_INLINE void *
-buffer_info_tag(void *buffer_info)
-{
-    return (void *)((uintptr_t)buffer_info + 2);
-}
-
 NPY_NO_EXPORT PyArray_Descr*
 _descriptor_from_pep3118_format(char const *s);
 

--- a/numpy/core/src/multiarray/npy_buffer.h
+++ b/numpy/core/src/multiarray/npy_buffer.h
@@ -3,8 +3,20 @@
 
 extern NPY_NO_EXPORT PyBufferProcs array_as_buffer;
 
-NPY_NO_EXPORT void
-_dealloc_cached_buffer_info(PyObject *self);
+NPY_NO_EXPORT int
+_buffer_info_free(void *buffer_info, PyObject *obj);
+
+/*
+ * Tag the buffer info pointer. This was appended to the array struct
+ * in NumPy 1.20, tagging the pointer gives us a chance to raise/print
+ * a useful error message when a user modifies fields that should belong to
+ * us.
+ */
+static NPY_INLINE void *
+buffer_info_tag(void *buffer_info)
+{
+    return (void *)((uintptr_t)buffer_info + 2);
+}
 
 NPY_NO_EXPORT PyArray_Descr*
 _descriptor_from_pep3118_format(char const *s);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -67,8 +67,11 @@ gentype_alloc(PyTypeObject *type, Py_ssize_t nitems)
     const size_t size = _PyObject_VAR_SIZE(type, nitems + 1);
 
     obj = (PyObject *)PyObject_Malloc(size);
+    if (obj == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
     /*
-     * Fixme. Need to check for no memory.
      * If we don't need to zero memory, we could use
      * PyObject_{New, NewVar} for this whole function.
      */
@@ -2596,16 +2599,30 @@ NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
     .tp_basicsize = sizeof(PyObject),
 };
 
+
+static PyObject *
+void_alloc(PyTypeObject *type, Py_ssize_t items)
+{
+    PyVoidScalarObject *self = (PyVoidScalarObject *)gentype_alloc(type, items);
+    if (self == NULL) {
+        return NULL;
+    }
+    self->_buffer_info = buffer_info_tag(NULL);
+    return (PyObject *)self;
+}
+
+
 static void
 void_dealloc(PyVoidScalarObject *v)
 {
-    _dealloc_cached_buffer_info((PyObject *)v);
-
     if (v->flags & NPY_ARRAY_OWNDATA) {
         npy_free_cache(v->obval, Py_SIZE(v));
     }
     Py_XDECREF(v->descr);
     Py_XDECREF(v->base);
+    if (_buffer_info_free(v->_buffer_info, (PyObject *)v) < 0) {
+        PyErr_WriteUnraisable(NULL);
+    }
     Py_TYPE(v)->tp_free(v);
 }
 
@@ -3014,6 +3031,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             npy_free_cache(destptr, memu);
             return PyErr_NoMemory();
         }
+        ((PyVoidScalarObject *)ret)->_buffer_info = buffer_info_tag(NULL);
         ((PyVoidScalarObject *)ret)->obval = destptr;
         Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
         ((PyVoidScalarObject *)ret)->descr =
@@ -4010,6 +4028,7 @@ initialize_numeric_types(void)
     /**end repeat**/
 
     PyStringArrType_Type.tp_itemsize = sizeof(char);
+    PyVoidArrType_Type.tp_alloc = void_alloc;
     PyVoidArrType_Type.tp_dealloc = (destructor) void_dealloc;
 
     PyArrayIter_Type.tp_iter = PyObject_SelfIter;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2600,18 +2600,6 @@ NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
 };
 
 
-static PyObject *
-void_alloc(PyTypeObject *type, Py_ssize_t items)
-{
-    PyVoidScalarObject *self = (PyVoidScalarObject *)gentype_alloc(type, items);
-    if (self == NULL) {
-        return NULL;
-    }
-    self->_buffer_info = buffer_info_tag(NULL);
-    return (PyObject *)self;
-}
-
-
 static void
 void_dealloc(PyVoidScalarObject *v)
 {
@@ -3031,7 +3019,6 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             npy_free_cache(destptr, memu);
             return PyErr_NoMemory();
         }
-        ((PyVoidScalarObject *)ret)->_buffer_info = buffer_info_tag(NULL);
         ((PyVoidScalarObject *)ret)->obval = destptr;
         Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
         ((PyVoidScalarObject *)ret)->descr =
@@ -4028,7 +4015,6 @@ initialize_numeric_types(void)
     /**end repeat**/
 
     PyStringArrType_Type.tp_itemsize = sizeof(char);
-    PyVoidArrType_Type.tp_alloc = void_alloc;
     PyVoidArrType_Type.tp_dealloc = (destructor) void_dealloc;
 
     PyArrayIter_Type.tp_iter = PyObject_SelfIter;

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -785,3 +785,11 @@ class TestDeprecatedUnpickleObjectScalar(_DeprecationTestCase):
     def test_deprecated(self):
         ctor = np.core.multiarray.scalar
         self.assert_deprecated(lambda: ctor(np.dtype("O"), 1))
+
+
+class TestMacros(_DeprecationTestCase):
+    # 2020-11-25
+    def test_macro(self):
+        from numpy.core._multiarray_tests import test_macro
+        assert_(test_macro() > 32)
+        self.assert_deprecated(test_macro)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -785,30 +785,3 @@ class TestDeprecatedUnpickleObjectScalar(_DeprecationTestCase):
     def test_deprecated(self):
         ctor = np.core.multiarray.scalar
         self.assert_deprecated(lambda: ctor(np.dtype("O"), 1))
-
-
-class TestMacros(_DeprecationTestCase):
-    # 2020-11-25
-    def test_macro_warning(self):
-        from numpy.core._multiarray_tests import test_macro
-
-        with pytest.warns(DeprecationWarning):
-            res = test_macro()
-
-        assert res > 32
-
-    def test_macro_error_print(self, capsys):
-        from numpy.core._multiarray_tests import test_macro
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            res = test_macro()
-
-        assert res > 32
-
-        msg = ("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be "
-               "used at compile time and is not constant across different "
-               "runtime versions of NumPy\n")
-        captured = capsys.readouterr()
-        # There may also be a traceback in there, so lets match pedantic:
-        assert captured.err.count(msg) == 1

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -789,7 +789,26 @@ class TestDeprecatedUnpickleObjectScalar(_DeprecationTestCase):
 
 class TestMacros(_DeprecationTestCase):
     # 2020-11-25
-    def test_macro(self):
+    def test_macro_warning(self):
         from numpy.core._multiarray_tests import test_macro
-        assert_(test_macro() > 32)
-        self.assert_deprecated(test_macro)
+
+        with pytest.warns(DeprecationWarning):
+            res = test_macro()
+
+        assert res > 32
+
+    def test_macro_error_print(self, capsys):
+        from numpy.core._multiarray_tests import test_macro
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            res = test_macro()
+
+        assert res > 32
+
+        msg = ("NPY_SIZEOF_PYARRAYOBJECT is deprecated since it cannot be "
+               "used at compile time and is not constant across different "
+               "runtime versions of NumPy\n")
+        captured = capsys.readouterr()
+        # There may also be a traceback in there, so lets match pedantic:
+        assert captured.err.count(msg) == 1


### PR DESCRIPTION
This speeds up array deallocation and buffer exports, since it
removes the need to global dictionary lookups.  It also somewhat
simplifies the logic.  The main advantage is prossibly less the
speedup itself (which is not large compared to most things that
happen in the livetime of an array), but rather that no unnecessary
work is done for shortlived arrays, which never export a buffer.

The downside of this approach is that the ABI changes for anyone
who would be subclassing ndarray in C.

---

I am not super invested in this, but I do feel its worth considering.  This requires breaking the ABI slightly (so would need release notes), because it extends the array struct (and void, but that is much less likely to be used).  Marking as draft since there are probably some smaller moving parts.  But since I was looking at the buffer interface today, thought I would wrap this up and show it at least.