### PR TITLE
MAINT: Don't always make full copies in (arg)searchsorted.

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -285,3 +285,27 @@ class Where(Benchmark):
 
     def time_2_broadcast(self):
         np.where(self.cond, self.d, 0)
+
+class SearchSorted(Benchmark):
+    params = [[1, 10, 100, 1000, 10000, 100000],
+              [10, 1000, 10000, 100000, 1000000],
+              ['sorted', 'random'],
+              [('f8', 'f8'), ('i8', 'i8'), ('i4', 'i8'), ('i8', 'i4'),  ('i4', 'u4')],]
+
+    param_names = ['needlesize', 'haystacksize', 'needletype', 'dtype']
+
+    def setup(self, needlesize, haystacksize, needletype, dtype):
+        self.random = np.random.RandomState(3333).random_integers(0, haystacksize, needlesize).astype(dtype[1])
+        self.sorted = np.sort(self.random)
+        if needletype == 'sorted':
+            self.needle = self.sorted
+        else:
+            self.needle = self.random
+        self.haystack = np.arange(haystacksize, dtype=dtype[0])
+        self.sorter = np.arange(haystacksize, dtype=np.intp)
+
+    def time_searchsorted(self, *args):
+        self.haystack.searchsorted(self.needle)
+
+    def time_argsearchsorted(self, *args):
+        self.haystack.searchsorted(self.needle, sorter=self.sorter)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -687,26 +687,6 @@ def configuration(parent_package='',top_path=None):
             subst_dict)
 
     #######################################################################
-    #                         npysort library                             #
-    #######################################################################
-
-    # This library is created for the build but it is not installed
-    npysort_sources = [join('src', 'common', 'npy_sort.h.src'),
-                       join('src', 'npysort', 'quicksort.c.src'),
-                       join('src', 'npysort', 'mergesort.c.src'),
-                       join('src', 'npysort', 'timsort.c.src'),
-                       join('src', 'npysort', 'heapsort.c.src'),
-                       join('src', 'npysort', 'radixsort.c.src'),
-                       join('src', 'common', 'npy_partition.h.src'),
-                       join('src', 'npysort', 'selection.c.src'),
-                       join('src', 'common', 'npy_binsearch.h.src'),
-                       join('src', 'npysort', 'binsearch.c.src'),
-                       ]
-    config.add_library('npysort',
-                       sources=npysort_sources,
-                       include_dirs=[])
-
-    #######################################################################
     #                     multiarray_tests module                         #
     #######################################################################
 
@@ -825,7 +805,7 @@ def configuration(parent_package='',top_path=None):
             join('include', 'numpy', 'npy_1_7_deprecated_api.h'),
             # add library sources as distuils does not consider libraries
             # dependencies
-            ] + npysort_sources + npymath_sources
+            ] + npymath_sources
 
     multiarray_src = [
             join('src', 'multiarray', 'abstractdtypes.c'),
@@ -877,6 +857,16 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'typeinfo.c'),
             join('src', 'multiarray', 'usertypes.c'),
             join('src', 'multiarray', 'vdot.c'),
+            join('src', 'common', 'npy_sort.h.src'),
+            join('src', 'npysort', 'quicksort.c.src'),
+            join('src', 'npysort', 'mergesort.c.src'),
+            join('src', 'npysort', 'timsort.c.src'),
+            join('src', 'npysort', 'heapsort.c.src'),
+            join('src', 'npysort', 'radixsort.c.src'),
+            join('src', 'common', 'npy_partition.h.src'),
+            join('src', 'npysort', 'selection.c.src'),
+            join('src', 'common', 'npy_binsearch.h.src'),
+            join('src', 'npysort', 'binsearch.c.src'),
             ]
 
     #######################################################################
@@ -938,7 +928,7 @@ def configuration(parent_package='',top_path=None):
                                  ],
                          depends=deps + multiarray_deps + umath_deps +
                                 common_deps,
-                         libraries=['npymath', 'npysort'],
+                         libraries=['npymath'],
                          extra_info=extra_info)
 
     #######################################################################

--- a/numpy/core/src/common/array_assign.c
+++ b/numpy/core/src/common/array_assign.c
@@ -150,7 +150,46 @@ IsUintAligned(PyArrayObject *ap)
                                 npy_uint_alignment(PyArray_DESCR(ap)->elsize));
 }
 
+/*
+ * Check that array data is both uint-aligned and true-aligned for all array
+ * elements, as required by the copy/casting code in lowlevel_strided_loops.c
+ */
+NPY_NO_EXPORT int
+copycast_isaligned(int ndim, npy_intp const *shape,
+        PyArray_Descr *dtype, char *data, npy_intp const *strides)
+{
+    int aligned;
+    int big_aln, small_aln;
 
+    int uint_aln = npy_uint_alignment(dtype->elsize);
+    int true_aln = dtype->alignment;
+
+    /* uint alignment can be 0, meaning not uint alignable */
+    if (uint_aln == 0) {
+        return 0;
+    }
+
+    /*
+     * As an optimization, it is unnecessary to check the alignment to the
+     * smaller of (uint_aln, true_aln) if the data is aligned to the bigger of
+     * the two and the big is a multiple of the small aln. We check the bigger
+     * one first and only check the smaller if necessary.
+     */
+    if (true_aln >= uint_aln) {
+        big_aln = true_aln;
+        small_aln = uint_aln;
+    }
+    else {
+        big_aln = uint_aln;
+        small_aln = true_aln;
+    }
+
+    aligned = raw_array_is_aligned(ndim, shape, data, strides, big_aln);
+    if (aligned && big_aln % small_aln != 0) {
+        aligned = raw_array_is_aligned(ndim, shape, data, strides, small_aln);
+    }
+    return aligned;
+}
 
 /* Returns 1 if the arrays have overlapping data, 0 otherwise */
 NPY_NO_EXPORT int

--- a/numpy/core/src/common/array_assign.h
+++ b/numpy/core/src/common/array_assign.h
@@ -114,5 +114,12 @@ IsUintAligned(PyArrayObject *ap);
 NPY_NO_EXPORT int
 arrays_overlap(PyArrayObject *arr1, PyArrayObject *arr2);
 
+/*
+ * Check that array data is both uint-aligned and true-aligned for all array
+ * elements, as required by the copy/casting code in lowlevel_strided_loops.c
+ */
+NPY_NO_EXPORT int
+copycast_isaligned(int ndim, npy_intp const *shape,
+        PyArray_Descr *dtype, char *data, npy_intp const *strides);
 
 #endif

--- a/numpy/core/src/common/npy_binsearch.h.src
+++ b/numpy/core/src/common/npy_binsearch.h.src
@@ -1,7 +1,11 @@
 #ifndef __NPY_BINSEARCH_H__
 #define __NPY_BINSEARCH_H__
 
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+#include "lowlevel_strided_loops.h"
 #include "npy_sort.h"
+
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 
@@ -12,20 +16,35 @@ typedef void (PyArray_BinSearchFunc)(const char*, const char*, char*,
                                      npy_intp, npy_intp, npy_intp,
                                      PyArrayObject*);
 
+typedef void (PyArray_TransferBinSearchFunc)(char*, const char*, char*,
+                                     npy_intp, npy_intp,
+                                     npy_intp, npy_intp, npy_intp,
+                                     npy_intp, PyArray_StridedUnaryOp*, NpyAuxData*,
+                                     PyArrayObject*);
+
 typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
                                        const char*, char*,
                                        npy_intp, npy_intp, npy_intp,
                                        npy_intp, npy_intp, npy_intp,
                                        PyArrayObject*);
 
+typedef int (PyArray_TransferArgBinSearchFunc)(char*, const char*,
+                                       const char*, char*,
+                                       npy_intp, npy_intp, npy_intp,
+                                       npy_intp, npy_intp, npy_intp,
+                                       npy_intp, PyArray_StridedUnaryOp*, NpyAuxData*,
+                                       PyArrayObject*);
+
 typedef struct {
     int typenum;
     PyArray_BinSearchFunc *binsearch[NPY_NSEARCHSIDES];
+    PyArray_TransferBinSearchFunc *transferbinsearch[NPY_NSEARCHSIDES];
 } binsearch_map;
 
 typedef struct {
     int typenum;
     PyArray_ArgBinSearchFunc *argbinsearch[NPY_NSEARCHSIDES];
+    PyArray_TransferArgBinSearchFunc *transferargbinsearch[NPY_NSEARCHSIDES];
 } argbinsearch_map;
 
 /**begin repeat
@@ -45,6 +64,12 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
                         PyArrayObject *unused);
+NPY_VISIBILITY_HIDDEN void
+transferbinsearch_@side@_@suff@(char *arr, const char *key, char *ret,
+                        npy_intp arr_len, npy_intp key_len,
+                        npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
+                        npy_intp arr_itemsize, PyArray_StridedUnaryOp *transfer,
+                        NpyAuxData *transfer_data, PyArrayObject *NOT_USED);
 NPY_VISIBILITY_HIDDEN int
 argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            const char *sort, char *ret,
@@ -52,6 +77,14 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                            npy_intp arr_str, npy_intp key_str,
                            npy_intp sort_str, npy_intp ret_str,
                            PyArrayObject *unused);
+NPY_VISIBILITY_HIDDEN int
+transferargbinsearch_@side@_@suff@(char *arr, const char *key,
+                           const char *sort, char *ret,
+                           npy_intp arr_len, npy_intp key_len,
+                           npy_intp arr_str, npy_intp key_str,
+                           npy_intp sort_str, npy_intp ret_str,
+                           npy_intp arr_itemsize, PyArray_StridedUnaryOp *transfer,
+                           NpyAuxData *transfer_data, PyArrayObject *unused);
 /**end repeat1**/
 
 NPY_VISIBILITY_HIDDEN void
@@ -90,6 +123,10 @@ static @arg@binsearch_map _@arg@binsearch_map[] = {
             &@arg@binsearch_left_@suff@,
             &@arg@binsearch_right_@suff@,
         },
+        {
+            &transfer@arg@binsearch_left_@suff@,
+            &transfer@arg@binsearch_right_@suff@
+        }
     },
     /**end repeat1**/
 };
@@ -99,8 +136,10 @@ static PyArray_@Arg@BinSearchFunc *gen@arg@binsearch_map[] = {
     &npy_@arg@binsearch_right,
 };
 
-static NPY_INLINE PyArray_@Arg@BinSearchFunc*
-get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
+static NPY_INLINE void
+get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side,
+    PyArray_@Arg@BinSearchFunc **func,
+    PyArray_Transfer@Arg@BinSearchFunc **transferfunc)
 {
     npy_intp nfuncs = ARRAY_SIZE(_@arg@binsearch_map);
     npy_intp min_idx = 0;
@@ -108,7 +147,9 @@ get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
     int type = dtype->type_num;
 
     if (side >= NPY_NSEARCHSIDES) {
-        return NULL;
+        (*func)= NULL;
+        (*transferfunc) = NULL;
+        return;
     }
 
     /*
@@ -128,14 +169,19 @@ get_@arg@binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side)
 
     if (min_idx < nfuncs &&
             _@arg@binsearch_map[min_idx].typenum == type) {
-        return _@arg@binsearch_map[min_idx].@arg@binsearch[side];
+        (*func) = _@arg@binsearch_map[min_idx].@arg@binsearch[side];
+        (*transferfunc) = _@arg@binsearch_map[min_idx].transfer@arg@binsearch[side];
+        return;
     }
 
     if (dtype->f->compare) {
-        return gen@arg@binsearch_map[side];
+        (*func) = gen@arg@binsearch_map[side];
+        (*transferfunc) = NULL;
+        return;
     }
 
-    return NULL;
+    (*func) = NULL;
+    (*transferfunc) = NULL;
 }
 /**end repeat**/
 

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -25,47 +25,6 @@
 #include "array_assign.h"
 
 /*
- * Check that array data is both uint-aligned and true-aligned for all array
- * elements, as required by the copy/casting code in lowlevel_strided_loops.c
- */
-NPY_NO_EXPORT int
-copycast_isaligned(int ndim, npy_intp const *shape,
-        PyArray_Descr *dtype, char *data, npy_intp const *strides)
-{
-    int aligned;
-    int big_aln, small_aln;
-
-    int uint_aln = npy_uint_alignment(dtype->elsize);
-    int true_aln = dtype->alignment;
-
-    /* uint alignment can be 0, meaning not uint alignable */
-    if (uint_aln == 0) {
-        return 0;
-    }
-
-    /*
-     * As an optimization, it is unnecessary to check the alignment to the
-     * smaller of (uint_aln, true_aln) if the data is aligned to the bigger of
-     * the two and the big is a multiple of the small aln. We check the bigger
-     * one first and only check the smaller if necessary.
-     */
-    if (true_aln >= uint_aln) {
-        big_aln = true_aln;
-        small_aln = uint_aln;
-    }
-    else {
-        big_aln = uint_aln;
-        small_aln = true_aln;
-    }
-
-    aligned = raw_array_is_aligned(ndim, shape, data, strides, big_aln);
-    if (aligned && big_aln % small_aln != 0) {
-        aligned = raw_array_is_aligned(ndim, shape, data, strides, small_aln);
-    }
-    return aligned;
-}
-
-/*
  * Assigns the array from 'src' to 'dst'. The strides must already have
  * been broadcast.
  *

--- a/numpy/core/src/npysort/binsearch.c.src
+++ b/numpy/core/src/npysort/binsearch.c.src
@@ -35,10 +35,21 @@
  * #CMP  = LT, LTE#
  */
 
+ /**begin repeat2
+  *
+  * #transfer = , transfer#
+  * #use_transfer = 0, 1#
+  * #const = const, #
+  */
+
 NPY_VISIBILITY_HIDDEN void
-binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
+@transfer@binsearch_@side@_@suff@(@const@ char *arr, const char *key, char *ret,
                         npy_intp arr_len, npy_intp key_len,
                         npy_intp arr_str, npy_intp key_str, npy_intp ret_str,
+#if @use_transfer@
+                        npy_intp arr_itemsize, PyArray_StridedUnaryOp *transfer,
+                        NpyAuxData *transfer_data,
+#endif
                         PyArrayObject *NOT_USED)
 {
     npy_intp min_idx = 0;
@@ -69,7 +80,12 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
 
         while (min_idx < max_idx) {
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
+#if @use_transfer@
+            @type@ mid_val;
+            transfer((char*)&mid_val, 0, arr + mid_idx*arr_str, 0, 1, arr_itemsize, transfer_data);
+#else
             const @type@ mid_val = *(const @type@ *)(arr + mid_idx*arr_str);
+#endif
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
             }
@@ -82,11 +98,15 @@ binsearch_@side@_@suff@(const char *arr, const char *key, char *ret,
 }
 
 NPY_VISIBILITY_HIDDEN int
-argbinsearch_@side@_@suff@(const char *arr, const char *key,
+@transfer@argbinsearch_@side@_@suff@(@const@ char *arr, const char *key,
                            const char *sort, char *ret,
                            npy_intp arr_len, npy_intp key_len,
                            npy_intp arr_str, npy_intp key_str,
                            npy_intp sort_str, npy_intp ret_str,
+#if @use_transfer@
+                           npy_intp arr_itemsize, PyArray_StridedUnaryOp *transfer,
+                           NpyAuxData *transfer_data,
+#endif
                            PyArrayObject *NOT_USED)
 {
     npy_intp min_idx = 0;
@@ -124,7 +144,11 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
                 return -1;
             }
 
+#if @use_transfer@
+            transfer((char*)&mid_val, 0, arr + sort_idx*arr_str, 0, 1, arr_itemsize, transfer_data);
+#else
             mid_val = *(const @type@ *)(arr + sort_idx*arr_str);
+#endif
 
             if (@TYPE@_@CMP@(mid_val, key_val)) {
                 min_idx = mid_idx + 1;
@@ -138,6 +162,7 @@ argbinsearch_@side@_@suff@(const char *arr, const char *key,
     return 0;
 }
 
+/**end repeat2**/
 /**end repeat1**/
 /**end repeat**/
 

--- a/runtests.py
+++ b/runtests.py
@@ -163,9 +163,9 @@ def main(argv):
         sys.path.insert(0, site_dir)
         sys.path.insert(0, site_dir_noarch)
         os.environ['PYTHONPATH'] = site_dir + os.pathsep + site_dir_noarch
-    else:
-        _temp = __import__(PROJECT_MODULE)
-        site_dir = os.path.sep.join(_temp.__file__.split(os.path.sep)[:-2])
+    #else:
+        #_temp = __import__(PROJECT_MODULE)
+        #site_dir = os.path.sep.join(_temp.__file__.split(os.path.sep)[:-2])
 
     extra_argv = args.args[:]
     if not args.bench:


### PR DESCRIPTION
When running `searchsorted` on arrays with different dtypes currently full copies are made of of each to a common dtype.  This is rather inefficient since we really only need a few elements to be converted.  This makes `searchsorted` and `argsearchsorted` only copy when necessary.  This would close gh-13579.

I've labeled this WIP since either the approach I'm using will be rejected or we will need to move some more code around so that the dtype transfer functions are expose enough that they can be called from with npysort.  I'm not sure what is gained really by having the sorting code off by itself, so hopefully compiling it with the rest of multiarray will be fine.  I don't think it is linked to anything else.  

I've added a benchmark for these changes. The results are included below.  It almost certainly has too many sets of parameters for keeping around forever, but since there will be changes needed here, that can change too.  I'm not entirely sure why those three floating point loops are slowed a little bit, everything is as fast or faster.

This PR also has a change to `runtests.py`, maybe this isn't needed, but --bench-compare wouldn't work for me without it.

Looking forward to your feedback. 

```

       before           after         ratio
     [327327dd]       [0d82f47d]
     <ss_nocopy_orig~1>       <ss_nocopy_orig>
+         453±1μs          510±1μs     1.13  bench_function_base.SearchSorted.time_argsearchsorted(10000, 1000, 'sorted', ('f8', 'f8'))
+     70.1±0.02μs       76.1±0.1μs     1.08  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000, 'sorted', ('f8', 'f8'))
+       403±0.2μs          426±1μs     1.06  bench_function_base.SearchSorted.time_searchsorted(10000, 1000, 'sorted', ('f8', 'f8'))
-     18.7±0.02μs      17.8±0.05μs     0.95  bench_function_base.SearchSorted.time_argsearchsorted(100, 10000, 'random', ('i8', 'i8'))
-     1.63±0.01μs      1.54±0.01μs     0.95  bench_function_base.SearchSorted.time_searchsorted(1, 1000, 'sorted', ('i8', 'i8'))
-     4.46±0.02μs      4.23±0.02μs     0.95  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000, 'sorted', ('i8', 'i4'))
-         712±3μs          674±6μs     0.95  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000000, 'sorted', ('i8', 'i4'))
-     27.7±0.09μs      26.1±0.04μs     0.94  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'random', ('i8', 'i4'))
-     2.48±0.04μs      2.34±0.02μs     0.94  bench_function_base.SearchSorted.time_searchsorted(1, 10, 'sorted', ('i4', 'i8'))
-      26.5±0.1μs      24.9±0.07μs     0.94  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'random', ('i8', 'i8'))
-     16.1±0.09μs      15.1±0.02μs     0.94  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000, 'random', ('i4', 'u4'))
-     15.5±0.07μs      14.4±0.03μs     0.93  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000, 'random', ('i4', 'i8'))
-     6.50±0.05μs      6.05±0.03μs     0.93  bench_function_base.SearchSorted.time_argsearchsorted(100, 10, 'random', ('i4', 'i8'))
-     13.4±0.06μs      12.5±0.07μs     0.93  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000, 'random', ('i8', 'i4'))
-     2.58±0.02μs      2.40±0.03μs     0.93  bench_function_base.SearchSorted.time_searchsorted(10, 10, 'random', ('i4', 'i8'))
-     6.64±0.03μs      6.15±0.05μs     0.93  bench_function_base.SearchSorted.time_argsearchsorted(100, 10, 'random', ('i8', 'i4'))
-     12.2±0.04μs      11.3±0.06μs     0.93  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000, 'random', ('i8', 'i8'))
-     7.21±0.04μs      6.66±0.06μs     0.92  bench_function_base.SearchSorted.time_argsearchsorted(100, 10, 'random', ('i4', 'u4'))
-        3.63±0ms         3.30±0ms     0.91  bench_function_base.SearchSorted.time_searchsorted(100000, 1000, 'sorted', ('f8', 'f8'))
-     5.44±0.05μs      4.94±0.02μs     0.91  bench_function_base.SearchSorted.time_argsearchsorted(100, 10, 'random', ('i8', 'i8'))
-         385±2μs        296±0.5μs     0.77  bench_function_base.SearchSorted.time_argsearchsorted(1000, 100000, 'random', ('i4', 'i8'))
-     21.2±0.08ms      16.2±0.06ms     0.77  bench_function_base.SearchSorted.time_argsearchsorted(10000, 1000000, 'random', ('i4', 'i8'))
-         390±7μs        298±0.5μs     0.76  bench_function_base.SearchSorted.time_argsearchsorted(1000, 100000, 'random', ('i4', 'u4'))
-     21.4±0.07ms      16.3±0.07ms     0.76  bench_function_base.SearchSorted.time_argsearchsorted(10000, 1000000, 'random', ('i4', 'u4'))
-      33.7±0.2μs      25.3±0.05μs     0.75  bench_function_base.SearchSorted.time_argsearchsorted(100, 10000, 'random', ('i4', 'u4'))
-      32.9±0.1μs      24.5±0.08μs     0.74  bench_function_base.SearchSorted.time_argsearchsorted(100, 10000, 'random', ('i4', 'i8'))
-         270±4μs        197±0.3μs     0.73  bench_function_base.SearchSorted.time_argsearchsorted(1000, 100000, 'sorted', ('i4', 'i8'))
-       294±0.5μs        213±0.3μs     0.73  bench_function_base.SearchSorted.time_searchsorted(1000, 100000, 'random', ('i4', 'u4'))
-       292±0.6μs        211±0.3μs     0.72  bench_function_base.SearchSorted.time_searchsorted(1000, 100000, 'random', ('i4', 'i8'))
-         277±2μs        200±0.2μs     0.72  bench_function_base.SearchSorted.time_argsearchsorted(1000, 100000, 'sorted', ('i4', 'u4'))
-     10.3±0.06ms      7.43±0.02ms     0.72  bench_function_base.SearchSorted.time_argsearchsorted(10000, 1000000, 'sorted', ('i4', 'u4'))
-     10.3±0.05ms      7.36±0.02ms     0.72  bench_function_base.SearchSorted.time_argsearchsorted(10000, 1000000, 'sorted', ('i4', 'i8'))
-     7.17±0.06μs      4.99±0.04μs     0.70  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000, 'random', ('i4', 'u4'))
-      30.1±0.1μs      20.7±0.05μs     0.69  bench_function_base.SearchSorted.time_argsearchsorted(100, 10000, 'sorted', ('i4', 'u4'))
-     29.3±0.06μs      19.7±0.04μs     0.67  bench_function_base.SearchSorted.time_argsearchsorted(100, 10000, 'sorted', ('i4', 'i8'))
-     7.25±0.06μs      4.85±0.03μs     0.67  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000, 'sorted', ('i4', 'u4'))
-      27.2±0.1μs      18.2±0.03μs     0.67  bench_function_base.SearchSorted.time_searchsorted(100, 10000, 'random', ('i4', 'u4'))
-     26.5±0.09μs      17.4±0.03μs     0.66  bench_function_base.SearchSorted.time_searchsorted(100, 10000, 'random', ('i4', 'i8'))
-     6.50±0.06μs      4.17±0.01μs     0.64  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000, 'random', ('i4', 'i8'))
-     5.31±0.02μs      3.35±0.04μs     0.63  bench_function_base.SearchSorted.time_searchsorted(10, 1000, 'sorted', ('i4', 'u4'))
-       228±0.3μs        142±0.1μs     0.62  bench_function_base.SearchSorted.time_searchsorted(1000, 100000, 'sorted', ('i4', 'u4'))
-       225±0.2μs        140±0.1μs     0.62  bench_function_base.SearchSorted.time_searchsorted(1000, 100000, 'sorted', ('i4', 'i8'))
-     6.61±0.03μs      4.09±0.03μs     0.62  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000, 'sorted', ('i4', 'i8'))
-     5.29±0.03μs      3.27±0.05μs     0.62  bench_function_base.SearchSorted.time_searchsorted(10, 1000, 'random', ('i4', 'u4'))
-     24.8±0.05μs      14.8±0.02μs     0.60  bench_function_base.SearchSorted.time_searchsorted(100, 10000, 'sorted', ('i4', 'u4'))
-     6.56±0.03μs      3.87±0.01μs     0.59  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000, 'random', ('i4', 'u4'))
-     6.62±0.02μs      3.86±0.01μs     0.58  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000, 'sorted', ('i4', 'u4'))
-     4.69±0.03μs      2.73±0.01μs     0.58  bench_function_base.SearchSorted.time_searchsorted(10, 1000, 'sorted', ('i4', 'i8'))
-      24.2±0.1μs      14.0±0.04μs     0.58  bench_function_base.SearchSorted.time_searchsorted(100, 10000, 'sorted', ('i4', 'i8'))
-     4.68±0.02μs      2.65±0.02μs     0.57  bench_function_base.SearchSorted.time_searchsorted(10, 1000, 'random', ('i4', 'i8'))
-     5.90±0.07μs      3.11±0.03μs     0.53  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000, 'random', ('i4', 'i8'))
-     5.95±0.05μs      3.09±0.02μs     0.52  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000, 'sorted', ('i4', 'i8'))
-     4.95±0.02μs      2.41±0.06μs     0.49  bench_function_base.SearchSorted.time_searchsorted(1, 1000, 'random', ('i4', 'u4'))
-     4.96±0.03μs      2.39±0.06μs     0.48  bench_function_base.SearchSorted.time_searchsorted(1, 1000, 'sorted', ('i4', 'u4'))
-     4.39±0.01μs      1.80±0.03μs     0.41  bench_function_base.SearchSorted.time_searchsorted(1, 1000, 'random', ('i4', 'i8'))
-     4.42±0.03μs      1.79±0.03μs     0.41  bench_function_base.SearchSorted.time_searchsorted(1, 1000, 'sorted', ('i4', 'i8'))
-      11.9±0.1ms      4.54±0.03ms     0.38  bench_function_base.SearchSorted.time_searchsorted(10000, 1000000, 'random', ('i4', 'u4'))
-     11.7±0.08ms      4.41±0.05ms     0.38  bench_function_base.SearchSorted.time_searchsorted(10000, 1000000, 'random', ('i4', 'i8'))
-     7.05±0.04ms      2.56±0.01ms     0.36  bench_function_base.SearchSorted.time_searchsorted(10000, 1000000, 'sorted', ('i4', 'u4'))
-     6.97±0.02ms      2.53±0.02ms     0.36  bench_function_base.SearchSorted.time_searchsorted(10000, 1000000, 'sorted', ('i4', 'i8'))
-     18.8±0.06μs      5.72±0.04μs     0.30  bench_function_base.SearchSorted.time_argsearchsorted(10, 10000, 'random', ('i4', 'u4'))
-     19.0±0.07μs      5.73±0.03μs     0.30  bench_function_base.SearchSorted.time_argsearchsorted(10, 10000, 'sorted', ('i4', 'u4'))
-     18.2±0.06μs      4.90±0.02μs     0.27  bench_function_base.SearchSorted.time_argsearchsorted(10, 10000, 'random', ('i4', 'i8'))
-     18.3±0.07μs      4.91±0.02μs     0.27  bench_function_base.SearchSorted.time_argsearchsorted(10, 10000, 'sorted', ('i4', 'i8'))
-     17.0±0.03μs      3.80±0.06μs     0.22  bench_function_base.SearchSorted.time_searchsorted(10, 10000, 'random', ('i4', 'u4'))
-         155±1μs      34.0±0.06μs     0.22  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'random', ('i4', 'u4'))
-     18.0±0.06μs      3.91±0.03μs     0.22  bench_function_base.SearchSorted.time_argsearchsorted(1, 10000, 'random', ('i4', 'u4'))
-       154±0.2μs      33.1±0.08μs     0.22  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'random', ('i4', 'i8'))
-     17.0±0.04μs      3.64±0.07μs     0.21  bench_function_base.SearchSorted.time_searchsorted(10, 10000, 'sorted', ('i4', 'u4'))
-     18.0±0.09μs      3.87±0.03μs     0.21  bench_function_base.SearchSorted.time_argsearchsorted(1, 10000, 'sorted', ('i4', 'u4'))
-     16.4±0.06μs      3.14±0.02μs     0.19  bench_function_base.SearchSorted.time_searchsorted(10, 10000, 'random', ('i4', 'i8'))
-       149±0.3μs      27.9±0.06μs     0.19  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'sorted', ('i4', 'u4'))
-     16.3±0.08μs      3.03±0.01μs     0.19  bench_function_base.SearchSorted.time_searchsorted(10, 10000, 'sorted', ('i4', 'i8'))
-     17.3±0.05μs      3.14±0.01μs     0.18  bench_function_base.SearchSorted.time_argsearchsorted(1, 10000, 'random', ('i4', 'i8'))
-       148±0.3μs      26.9±0.08μs     0.18  bench_function_base.SearchSorted.time_argsearchsorted(100, 100000, 'sorted', ('i4', 'i8'))
-     17.3±0.04μs      3.13±0.04μs     0.18  bench_function_base.SearchSorted.time_argsearchsorted(1, 10000, 'sorted', ('i4', 'i8'))
-     5.74±0.03ms          969±7μs     0.17  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000000, 'random', ('i4', 'u4'))
-       144±0.2μs      23.7±0.05μs     0.16  bench_function_base.SearchSorted.time_searchsorted(100, 100000, 'random', ('i4', 'u4'))
-     5.75±0.02ms         944±10μs     0.16  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000000, 'random', ('i4', 'i8'))
-       143±0.2μs      23.0±0.08μs     0.16  bench_function_base.SearchSorted.time_searchsorted(100, 100000, 'random', ('i4', 'i8'))
-     16.3±0.04μs      2.49±0.06μs     0.15  bench_function_base.SearchSorted.time_searchsorted(1, 10000, 'random', ('i4', 'u4'))
-     16.4±0.04μs      2.49±0.03μs     0.15  bench_function_base.SearchSorted.time_searchsorted(1, 10000, 'sorted', ('i4', 'u4'))
-       141±0.2μs      19.3±0.06μs     0.14  bench_function_base.SearchSorted.time_searchsorted(100, 100000, 'sorted', ('i4', 'u4'))
-       140±0.2μs      18.6±0.09μs     0.13  bench_function_base.SearchSorted.time_searchsorted(100, 100000, 'sorted', ('i4', 'i8'))
-     15.7±0.03μs      1.86±0.03μs     0.12  bench_function_base.SearchSorted.time_searchsorted(1, 10000, 'random', ('i4', 'i8'))
-     15.7±0.07μs      1.84±0.01μs     0.12  bench_function_base.SearchSorted.time_searchsorted(1, 10000, 'sorted', ('i4', 'i8'))
-     5.07±0.02ms         413±10μs     0.08  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000000, 'sorted', ('i4', 'u4'))
-     5.05±0.02ms          394±8μs     0.08  bench_function_base.SearchSorted.time_argsearchsorted(1000, 1000000, 'sorted', ('i4', 'i8'))
-     4.62±0.04ms        291±0.3μs     0.06  bench_function_base.SearchSorted.time_searchsorted(1000, 1000000, 'random', ('i4', 'u4'))
-     4.67±0.02ms        287±0.5μs     0.06  bench_function_base.SearchSorted.time_searchsorted(1000, 1000000, 'random', ('i4', 'i8'))
-       133±0.1μs      6.90±0.04μs     0.05  bench_function_base.SearchSorted.time_argsearchsorted(10, 100000, 'random', ('i4', 'u4'))
-       132±0.2μs      6.60±0.05μs     0.05  bench_function_base.SearchSorted.time_argsearchsorted(10, 100000, 'sorted', ('i4', 'u4'))
-     4.42±0.04ms        209±0.2μs     0.05  bench_function_base.SearchSorted.time_searchsorted(1000, 1000000, 'sorted', ('i4', 'u4'))
-     4.46±0.02ms        206±0.3μs     0.05  bench_function_base.SearchSorted.time_searchsorted(1000, 1000000, 'sorted', ('i4', 'i8'))
-       132±0.2μs      6.09±0.07μs     0.05  bench_function_base.SearchSorted.time_argsearchsorted(10, 100000, 'random', ('i4', 'i8'))
-       132±0.2μs      5.79±0.08μs     0.04  bench_function_base.SearchSorted.time_argsearchsorted(10, 100000, 'sorted', ('i4', 'i8'))
-       130±0.2μs      4.33±0.03μs     0.03  bench_function_base.SearchSorted.time_searchsorted(10, 100000, 'random', ('i4', 'u4'))
-       130±0.2μs      4.03±0.09μs     0.03  bench_function_base.SearchSorted.time_searchsorted(10, 100000, 'sorted', ('i4', 'u4'))
-       131±0.3μs      3.92±0.02μs     0.03  bench_function_base.SearchSorted.time_argsearchsorted(1, 100000, 'sorted', ('i4', 'u4'))
-       131±0.2μs      3.90±0.03μs     0.03  bench_function_base.SearchSorted.time_argsearchsorted(1, 100000, 'random', ('i4', 'u4'))
-       130±0.1μs      3.69±0.02μs     0.03  bench_function_base.SearchSorted.time_searchsorted(10, 100000, 'random', ('i4', 'i8'))
-       129±0.2μs      3.36±0.03μs     0.03  bench_function_base.SearchSorted.time_searchsorted(10, 100000, 'sorted', ('i4', 'i8'))
-       130±0.3μs      3.19±0.03μs     0.02  bench_function_base.SearchSorted.time_argsearchsorted(1, 100000, 'random', ('i4', 'i8'))
-       130±0.2μs      3.18±0.03μs     0.02  bench_function_base.SearchSorted.time_argsearchsorted(1, 100000, 'sorted', ('i4', 'i8'))
-       129±0.2μs      2.47±0.06μs     0.02  bench_function_base.SearchSorted.time_searchsorted(1, 100000, 'sorted', ('i4', 'u4'))
-       129±0.3μs      2.46±0.06μs     0.02  bench_function_base.SearchSorted.time_searchsorted(1, 100000, 'random', ('i4', 'u4'))
-       128±0.2μs      1.87±0.02μs     0.01  bench_function_base.SearchSorted.time_searchsorted(1, 100000, 'sorted', ('i4', 'i8'))
-       129±0.2μs      1.86±0.02μs     0.01  bench_function_base.SearchSorted.time_searchsorted(1, 100000, 'random', ('i4', 'i8'))
-     4.12±0.03ms       40.7±0.5μs     0.01  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000000, 'random', ('i4', 'u4'))
-     4.15±0.02ms       39.7±0.6μs     0.01  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000000, 'random', ('i4', 'i8'))
-     4.11±0.02ms       36.4±0.4μs     0.01  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000000, 'sorted', ('i4', 'u4'))
-     4.11±0.02ms       35.5±0.3μs     0.01  bench_function_base.SearchSorted.time_argsearchsorted(100, 1000000, 'sorted', ('i4', 'i8'))
-     4.04±0.01ms       29.1±0.2μs     0.01  bench_function_base.SearchSorted.time_searchsorted(100, 1000000, 'random', ('i4', 'u4'))
-     4.02±0.02ms       28.4±0.1μs     0.01  bench_function_base.SearchSorted.time_searchsorted(100, 1000000, 'random', ('i4', 'i8'))
-     4.02±0.02ms      25.9±0.06μs     0.01  bench_function_base.SearchSorted.time_searchsorted(100, 1000000, 'sorted', ('i4', 'u4'))
-     4.04±0.03ms      25.2±0.08μs     0.01  bench_function_base.SearchSorted.time_searchsorted(100, 1000000, 'sorted', ('i4', 'i8'))
-     3.93±0.02ms      7.20±0.08μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000000, 'random', ('i4', 'u4'))
-     3.96±0.01ms      7.10±0.08μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000000, 'sorted', ('i4', 'u4'))
-     3.94±0.04ms      6.39±0.09μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000000, 'random', ('i4', 'i8'))
-     3.97±0.03ms       6.32±0.1μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(10, 1000000, 'sorted', ('i4', 'i8'))
-     3.96±0.03ms       4.72±0.1μs     0.00  bench_function_base.SearchSorted.time_searchsorted(10, 1000000, 'sorted', ('i4', 'u4'))
-     3.93±0.02ms      4.67±0.04μs     0.00  bench_function_base.SearchSorted.time_searchsorted(10, 1000000, 'random', ('i4', 'u4'))
-     3.95±0.02ms      4.01±0.06μs     0.00  bench_function_base.SearchSorted.time_searchsorted(10, 1000000, 'sorted', ('i4', 'i8'))
-     3.94±0.04ms      3.99±0.02μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000000, 'sorted', ('i4', 'u4'))
-     3.93±0.02ms      3.97±0.03μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000000, 'random', ('i4', 'u4'))
-     3.96±0.03ms      3.95±0.03μs     0.00  bench_function_base.SearchSorted.time_searchsorted(10, 1000000, 'random', ('i4', 'i8'))
-     3.95±0.01ms      3.24±0.03μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000000, 'random', ('i4', 'i8'))
-     3.96±0.03ms      3.23±0.04μs     0.00  bench_function_base.SearchSorted.time_argsearchsorted(1, 1000000, 'sorted', ('i4', 'i8'))
-     3.94±0.02ms      2.53±0.06μs     0.00  bench_function_base.SearchSorted.time_searchsorted(1, 1000000, 'random', ('i4', 'u4'))
-     3.96±0.02ms      2.54±0.07μs     0.00  bench_function_base.SearchSorted.time_searchsorted(1, 1000000, 'sorted', ('i4', 'u4'))
-     3.98±0.03ms      1.93±0.05μs     0.00  bench_function_base.SearchSorted.time_searchsorted(1, 1000000, 'random', ('i4', 'i8'))
-     3.94±0.03ms      1.90±0.06μs     0.00  bench_function_base.SearchSorted.time_searchsorted(1, 1000000, 'sorted', ('i4', 'i8'))

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.


```
