### PR TITLE
DEP: Deprecate size-one ragged array coercion

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -1261,7 +1261,7 @@ PyArray_DiscoverDTypeAndShape(
             }
 
             if (deprecate_single_element_ragged) {
-                /* Deprecated 2019-07-24, NumPy 1.20 */
+                /* Deprecated 2020-07-24, NumPy 1.20 */
                 if (DEPRECATE(
                         "setting an array element with a sequence. "
                         "This was supported in some cases where the elements "

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -441,7 +441,7 @@ class TestNested:
         for i in range(np.MAXDIMS - 1):
             nested = [nested]
 
-        with pytest.raises(ValueError):
+        with pytest.warns(DeprecationWarning):
             # It will refuse to assign the array into
             np.array(nested, dtype="float64")
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -693,3 +693,16 @@ class TestMatrixInOuter(_DeprecationTestCase):
         self.assert_deprecated(np.add.outer, args=(m, arr))
         self.assert_not_deprecated(np.add.outer, args=(arr, arr))
 
+
+class TestRaggedArray(_DeprecationTestCase):
+    # 2020-07-24, NumPy 1.20.0
+    message = "setting an array element with a sequence"
+
+    def test_deprecated(self):
+        arr = np.ones((1, 1))
+        # Deprecated if the array is a leave node:
+        self.assert_deprecated(lambda: np.array([arr, 0], dtype=np.float64))
+        self.assert_deprecated(lambda: np.array([0, arr], dtype=np.float64))
+        # And when it is an assignment into a lower dimensional subarray:
+        self.assert_deprecated(lambda: np.array([arr, [0]], dtype=np.float64))
+        self.assert_deprecated(lambda: np.array([[0], arr], dtype=np.float64))


### PR DESCRIPTION
Previously, code such as:
```
np.array([0, np.array([0])], dtype=np.int64)
```
worked by discovering the array as having a shape of `(2,)` and
then using `int(np.array([0]))` (which currently succeeds).
This is also a ragged array, and thus deprecated here earlier on.
(As a detail, in the new code the assignment should occur as
an array assignment and not using the `__int__`/`__float__`
Python protocols.)

Two details to note:

1. This still skips the deprecation for sequences which are not
   array-likes.  We assume that sequences will always fail the
   conversion to a number.
2. The conversion to a number (or string, etc.) may still fail
   after the DeprecationWarning is given.  This is not ideal, but
   narrowing it down seems tedious, since the actual assignment
   happens in a later step.
   I.e. `np.array([0, np.array([None])], dtype=np.int64)` will give
   the warning, but then fail anyway, since the array cannot be
   assigned.

Closes gh-16939
