### PR TITLE
BLD, BUG: aarch64 -> arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ jobs:
 
     - python: 3.7
       os: linux
-      arch: aarch64
+      arch: arm64
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,11 @@ stages:
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
             OPENBLAS_SUFFIX: '64_'
+          PyPy36-32bit:
+            PYTHON_VERSION: 'PyPy3.6'
+            PYTHON_ARCH: 'x32'
+            TEST_MODE: fast
+            BITS: 32
     steps:
     - template: azure-steps-windows.yml
   - job: Linux_PyPy3

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -4,6 +4,18 @@ steps:
     versionSpec: $(PYTHON_VERSION)
     addToPath: true
     architecture: $(PYTHON_ARCH)
+  condition: not(contains(variable.PYTHON_VERSION, 'PyPy'))
+- bash: |
+    set -e
+    echo $PATH
+    wget -q http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-win32.zip -O pypy.zip
+    mkdir -p pypy3
+    unzip -d pypy3 pypy.zip
+    mv pypy3/pypy-c-*/* pypy3
+    cp pypy3/pypy3.exe pypy3/python.exe
+    export PATH=pypy3:$PATH
+  condition: contains(variable.PYTHON_VERSION, 'PyPy')
+  displayName: "Install PyPy pre-release"
 - script: python -m pip install --upgrade pip
   displayName: 'Install tools'
 - script: python -m pip install -r test_requirements.txt

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3138,8 +3138,8 @@ BOOL_argmax(npy_bool *ip, npy_intp n, npy_intp *max_ind,
     #if defined(__ARM_NEON__) || defined (__ARM_NEON)
         uint8x16_t zero = vdupq_n_u8(0);
         for(; i < n - (n % 32); i+=32) {
-            uint8x16_t d1 = vld1q_u8((char *)&ip[i]);
-            uint8x16_t d2 = vld1q_u8((char *)&ip[i + 16]);
+            uint8x16_t d1 = vld1q_u8((uint8_t *)&ip[i]);
+            uint8x16_t d2 = vld1q_u8((uint8_t *)&ip[i + 16]);
             d1 = vceqq_u8(d1, zero);
             d2 = vceqq_u8(d2, zero);
             if(_mm_movemask_epi8_neon(vminq_u8(d1, d2)) != 0xFFFF) {


### PR DESCRIPTION
Fixes gh-16947.

The correct name for the travis architecture is arm64.