### PR TITLE
update numpy/lib/arraypad.py with appropriate chain exception

### DIFF
--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -780,10 +780,10 @@ def pad(array, pad_width, mode='constant', **kwargs):
     try:
         unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
     except KeyError as e:
-        raise ValueError("mode '{}' is not supported".format(mode)) from e
+        raise ValueError("mode '{}' is not supported".format(mode)) from None
     if unsupported_kwargs:
         raise ValueError("unsupported keyword arguments for mode '{}': {}"
-                         .format(mode, unsupported_kwargs)) from None
+                         .format(mode, unsupported_kwargs))
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -779,11 +779,11 @@ def pad(array, pad_width, mode='constant', **kwargs):
     }
     try:
         unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
-    except KeyError:
-        raise ValueError("mode '{}' is not supported".format(mode))
+    except KeyError as e:
+        raise ValueError("mode '{}' is not supported".format(mode)) from e
     if unsupported_kwargs:
         raise ValueError("unsupported keyword arguments for mode '{}': {}"
-                         .format(mode, unsupported_kwargs))
+                         .format(mode, unsupported_kwargs)) from None
 
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -779,7 +779,7 @@ def pad(array, pad_width, mode='constant', **kwargs):
     }
     try:
         unsupported_kwargs = set(kwargs) - set(allowed_kwargs[mode])
-    except KeyError as e:
+    except KeyError:
         raise ValueError("mode '{}' is not supported".format(mode)) from None
     if unsupported_kwargs:
         raise ValueError("unsupported keyword arguments for mode '{}': {}"


### PR DESCRIPTION
Fix numpy.lib.arraypad module with appropriate chaining of exceptions.
Fix #15986