### PR TITLE
MAINT: Use arm64 instead of aarch64 on travisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ jobs:
 
     - python: 3.7
       os: linux
-      arch: aarch64
+      arch: arm64
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3138,8 +3138,8 @@ BOOL_argmax(npy_bool *ip, npy_intp n, npy_intp *max_ind,
     #if defined(__ARM_NEON__) || defined (__ARM_NEON)
         uint8x16_t zero = vdupq_n_u8(0);
         for(; i < n - (n % 32); i+=32) {
-            uint8x16_t d1 = vld1q_u8((char *)&ip[i]);
-            uint8x16_t d2 = vld1q_u8((char *)&ip[i + 16]);
+            uint8x16_t d1 = vld1q_u8((uint8_t *)&ip[i]);
+            uint8x16_t d2 = vld1q_u8((uint8_t *)&ip[i + 16]);
             d1 = vceqq_u8(d1, zero);
             d2 = vceqq_u8(d2, zero);
             if(_mm_movemask_epi8_neon(vminq_u8(d1, d2)) != 0xFFFF) {


### PR DESCRIPTION
Travis didn't recognize aarch65 and ran amd_64 instead. This
also fixes a compiler warning that turned up on with the fix.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
