### PR TITLE
TST: Change aarch64 to arm64 in travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
 
     - python: 3.7
       os: linux
-      arch: aarch64
+      arch: arm64
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1


### PR DESCRIPTION
TravisCI doesn't recognize aarch64 and was falling back to x86_64.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
