### PR TITLE
WIP, BLD: xlc build support

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -710,12 +710,24 @@ def configuration(parent_package='',top_path=None):
     #                     multiarray_tests module                         #
     #######################################################################
 
+    # NOTE: LIBRARY_PATH must be set to pick up libxl.a
+    # this variable is not set by default on a typical
+    # Power9 node with an xlc module loaded
+    # NOTE: 'xlc' is probably too specific re: case
+    # sensitivity, etc.
+    # also, probably better to use a proper distutils
+    # variable where C compiler info is stored
+    if os.environ.get('CC') == 'xlc':
+        extra_libs = ['xl']
+    else:
+        extra_libs = []
+
     config.add_extension('_multiarray_tests',
                     sources=[join('src', 'multiarray', '_multiarray_tests.c.src'),
                              join('src', 'common', 'mem_overlap.c')],
                     depends=[join('src', 'common', 'mem_overlap.h'),
                              join('src', 'common', 'npy_extint128.h')],
-                    libraries=['npymath'])
+                    libraries=['npymath'] + extra_libs)
 
     #######################################################################
     #             _multiarray_umath module - common part                  #
@@ -938,7 +950,7 @@ def configuration(parent_package='',top_path=None):
                                  ],
                          depends=deps + multiarray_deps + umath_deps +
                                 common_deps,
-                         libraries=['npymath', 'npysort'],
+                         libraries=['npymath', 'npysort'] + extra_libs,
                          extra_info=extra_info)
 
     #######################################################################

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -513,6 +513,13 @@ def CCompiler_customize(self, dist, need_cxx=0):
 
 
     # check if compiler supports gcc style automatic dependencies
+    if self.compiler[0] == 'xlc':
+        # remove unsupported options or options
+        # causing issues with IBM xlc builds
+        # TODO: substitute equivalents where possible
+        self.compiler_so.remove('-fwrapv')
+        self.compiler_so.remove('-O3')
+        #self.compiler_so.append('-O2')
     # run on every extension so skip for known good compilers
     if hasattr(self, 'compiler') and ('gcc' in self.compiler[0] or
                                       'g++' in self.compiler[0] or

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -72,13 +72,18 @@ def configuration(parent_package='', top_path=None):
         extra_info=lapack_info,
     )
 
+    if os.environ.get('CC') == 'xlc':
+        extra_libs = ['xl']
+    else:
+        extra_libs = []
+
     # umath_linalg module
     config.add_extension(
         '_umath_linalg',
         sources=['umath_linalg.c.src', get_lapack_lite_sources],
         depends=['lapack_lite/f2c.h'],
         extra_info=lapack_info,
-        libraries=['npymath'],
+        libraries=['npymath'] + extra_libs,
     )
     return config
 

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -37,9 +37,14 @@ def configuration(parent_package='', top_path=None):
 
     EXTRA_LINK_ARGS = []
     EXTRA_LIBRARIES = ['npyrandom']
+    if os.environ.get('CC') == 'xlc':
+        extra_libs = ['xl']
+    else:
+        extra_libs = []
     if os.name != 'nt':
         # Math lib
         EXTRA_LIBRARIES.append('m')
+    EXTRA_LIBRARIES += extra_libs
     # Some bit generators exclude GCC inlining
     EXTRA_COMPILE_ARGS = ['-U__GNUC_GNU_INLINE__']
 


### PR DESCRIPTION
* early draft support for building with IBM XLC compiler version `16.1.1.7`;
test suite result:
`3 failed, 11178 passed, 548 skipped, 109 deselected, 19 xfailed, 5
xpassed, 1 warnings in 162.02s (0:02:42)`

* most likely f2py tests currently skipped until I set up
xlf stuff (which includes some strange `_` symbol mangling
also tackled in other WIP PRs I think)--could maybe defer
to those other PR(s)

* only supports `CC=xlc python setup.py install` incantation,
rather than the incantation used in gh-16172; also, `runtests.py`
incantation can only succeed from above pre-install using `-n`
for now

* contains excessive code duplication, depends too heavily
on the `CC` environment variable rather than `distutils` internals,
and depends  on `LIBRARY_PATH` being set to contain path to `libxl.a`

* optimization level currently crippled to speed up development
iteration, but `-03` is prone to ICE at the moment it seems

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
