### PR TITLE
MAINT: Chain exception in ``distutils/fcompiler/environment.py``.

### DIFF
--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -33,7 +33,7 @@ class EnvironmentConfig:
         try:
             conf_desc = self._conf_keys[name]
         except KeyError:
-            raise AttributeError(name)
+            raise AttributeError(name) from None
         return self._get_var(name, conf_desc)
 
     def get(self, name, default=None):

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -33,7 +33,9 @@ class EnvironmentConfig:
         try:
             conf_desc = self._conf_keys[name]
         except KeyError:
-            raise AttributeError("'EnvironmentConfig' object has no attribute '%s'" % name) from None
+            raise AttributeError(
+                f"'EnvironmentConfig' object has no attribute '{name}'"
+            ) from None
 
         return self._get_var(name, conf_desc)
 

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -33,7 +33,8 @@ class EnvironmentConfig:
         try:
             conf_desc = self._conf_keys[name]
         except KeyError:
-            raise AttributeError(name) from None
+            raise AttributeError("'dict' object has no attribute %s" % name) from None
+
         return self._get_var(name, conf_desc)
 
     def get(self, name, default=None):

--- a/numpy/distutils/fcompiler/environment.py
+++ b/numpy/distutils/fcompiler/environment.py
@@ -33,7 +33,7 @@ class EnvironmentConfig:
         try:
             conf_desc = self._conf_keys[name]
         except KeyError:
-            raise AttributeError("'dict' object has no attribute %s" % name) from None
+            raise AttributeError("'EnvironmentConfig' object has no attribute '%s'" % name) from None
 
         return self._get_var(name, conf_desc)
 


### PR DESCRIPTION
Fix distutils.fcompiler.environment module with appropriate chaining of exceptions.
Fixes #15986
