### PR TITLE
MAINT: Added the `order` parameter to `np.array()` 

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -520,6 +520,7 @@ def array(
     object: object,
     dtype: DtypeLike = ...,
     copy: bool = ...,
+    order: Optional[str] = ...,
     subok: bool = ...,
     ndmin: int = ...,
 ) -> ndarray: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -519,6 +519,7 @@ class str_(character):
 def array(
     object: object,
     dtype: DtypeLike = ...,
+    *,
     copy: bool = ...,
     order: Optional[str] = ...,
     subok: bool = ...,

--- a/numpy/tests/typing/fail/simple.py
+++ b/numpy/tests/typing/fail/simple.py
@@ -8,3 +8,5 @@ np.zeros()  # E: Too few arguments
 
 np.ones("test")  # E: incompatible type
 np.ones()  # E: Too few arguments
+
+np.array(0, float, True)  # E: Too many positional

--- a/numpy/tests/typing/pass/simple.py
+++ b/numpy/tests/typing/pass/simple.py
@@ -18,6 +18,14 @@ array == 1
 array.dtype == float
 
 # Array creation routines checks
+np.array(1, dtype=float)
+np.array(1, copy=False)
+np.array(1, order='F')
+np.array(1, order=None)
+np.array(1, subok=True)
+np.array(1, ndmin=3)
+np.array(1, str, copy=True, order='C', subok=False, ndmin=2)
+
 ndarray_func(np.zeros([1, 2]))
 ndarray_func(np.ones([1, 2]))
 ndarray_func(np.empty([1, 2]))


### PR DESCRIPTION
This pull request implements two fixes to the annotations of `np.array()`:
* It adds the previously missing `order` parameter.
* It clarifies that a number of parameters are keyword-only.