### PR TITLE
BUG: Fix three `complex`- & `float128`-related issues with `nd_grid`

### DIFF
--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -255,6 +255,28 @@ class TestGrid:
         assert_(grid32.dtype == np.float64)
         assert_array_almost_equal(grid64, grid32)
 
+    def test_accepts_longdouble(self):
+        # regression tests for #16945
+        grid64 = mgrid[0.1:0.33:0.1, ]
+        grid128 = mgrid[
+            np.longdouble(0.1):np.longdouble(0.33):np.longdouble(0.1),
+        ]
+        assert_(grid128.dtype == np.longdouble)
+        assert_array_almost_equal(grid64, grid128)
+
+        grid128c_a = mgrid[0:np.longdouble(1):3.4j]
+        grid128c_b = mgrid[0:np.longdouble(1):3.4j, ]
+        assert_(grid128c_a.dtype == grid128c_b.dtype == np.longdouble)
+        assert_array_equal(grid128c_a, grid128c_b[0])
+
+        # different code path for single slice
+        grid64 = mgrid[0.1:0.33:0.1]
+        grid128 = mgrid[
+            np.longdouble(0.1):np.longdouble(0.33):np.longdouble(0.1)
+        ]
+        assert_(grid128.dtype == np.longdouble)
+        assert_array_almost_equal(grid64, grid128)
+
     def test_accepts_npcomplexfloating(self):
         # Related to #16466
         assert_array_almost_equal(
@@ -265,6 +287,18 @@ class TestGrid:
         assert_array_almost_equal(
             mgrid[0.1:0.3:3j], mgrid[0.1:0.3:np.complex64(3j)]
         )
+
+        # Related to #16945
+        grid64_a = mgrid[0.1:0.3:3.3j]
+        grid64_b = mgrid[0.1:0.3:3.3j, ][0]
+        assert_(grid64_a.dtype == grid64_b.dtype == np.float64)
+        assert_array_equal(grid64_a, grid64_b)
+
+        grid128_a = mgrid[0.1:0.3:np.clongdouble(3.3j)]
+        grid128_b = mgrid[0.1:0.3:np.clongdouble(3.3j), ][0]
+        assert_(grid128_a.dtype == grid128_b.dtype == np.longdouble)
+        assert_array_equal(grid64_a, grid64_b)
+
 
 class TestConcatenator:
     def test_1d(self):


### PR DESCRIPTION
This pull request fixes three issues with the `np.nd_grid.__getitem__()` method, 
more specifically a set of discrepancies encountered whenever a `slice` object is passed versus a tuple of `slice` objects. 
These two syntaxes will henceforth be referred to as, respectively, the "tuple of slices"- and "slice"-syntax.

```python
import numpy as np

np.mgrid[0:10]  # "slice" syntax
np.mgrid[0:10,]  # "tuple of slices" syntax
```

To summarize:
* First observed in https://github.com/numpy/numpy/issues/16945 different data types are encountered between the two syntaxes when a `np.float128` instance is passed to `start`, `stop` and/or `step`. This issue has been fixed; the "tuple of slices" syntax now uses the same dtype conversion rules as `np.arange()` (which was already used for the "slice" syntax).
``` python
>>> np.mgrid[0:10:np.float128(0.1)]
array([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.], dtype=float128)

>>> np.mgrid[0:10:np.float128(0.1),]
array([[0., 1., 2., 3., 4., 5., 6., 7., 8., 9.]])

```
* The "tuple of slices" syntax failed to return a `float128` array if `stop` is a `float128` instance and `step` is a complex number.
``` python
>>> np.mgrid[0:np.float128(10):10j]
array([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.])
```
* Non-identical arrays are returned if `step` is a complex number whose absolute value is non-integer. 
  The documentation ([docs](https://numpy.org/doc/stable/reference/generated/numpy.mgrid.html)) specifies that `start` and `stop` should be included, 
  _i.e._ the "tuple-of-slices" syntax produces the correct result.
``` python

>>> np.mgrid[0:10:2.5j]
array([0.        , 6.66666667])

>>> np.mgrid[0:10:2.5j,]
array([[ 0., 10.]])
```