### PR TITLE
TST: Add pypy win32 CI testing.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,11 @@ stages:
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
             OPENBLAS_SUFFIX: '64_'
+          PyPy36-32bit:
+            PYTHON_VERSION: 'PyPy3.6'
+            PYTHON_ARCH: 'x32'
+            TEST_MODE: fast
+            BITS: 32
     steps:
     - template: azure-steps-windows.yml
   - job: Linux_PyPy3

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -4,10 +4,31 @@ steps:
     versionSpec: $(PYTHON_VERSION)
     addToPath: true
     architecture: $(PYTHON_ARCH)
-- script: python -m pip install --upgrade pip
+  condition: not(contains(variables['PYTHON_VERSION'], 'PyPy'))
+- powershell: |
+    $url = "http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-win32.zip"
+    $output = "pypy.zip"
+    $wc = New-Object System.Net.WebClient
+    $wc.DownloadFile($url, $output)
+    echo "downloaded $url to $output"
+    mkdir pypy3
+    Expand-Archive $output -DestinationPath pypy3
+    move pypy3/pypy-c-*/* pypy3
+    cp pypy3/pypy3.exe pypy3/python.exe
+    $pypypath = Join-Path (Get-Item .).FullName pypy3
+    $env:Path = $pypypath + ";" + $env:Path
+    setx PATH $env:Path
+    python -mensurepip
+    echo "##vso[task.prependpath]$pypypath"
+  condition: contains(variables['PYTHON_VERSION'], 'PyPy')
+  displayName: "Install PyPy pre-release"
+
+- script: python -m pip install --upgrade pip wheel
   displayName: 'Install tools'
+
 - script: python -m pip install -r test_requirements.txt
   displayName: 'Install dependencies; some are optional to avoid test skips'
+
 - powershell: |
     $ErrorActionPreference = "Stop"
     # Download and get the path to "openblas.a". We cannot copy it
@@ -16,7 +37,7 @@ steps:
     # since OPENBLAS will be picked up by the openblas discovery
     $target = $(python tools/openblas_support.py)
     mkdir openblas
-    echo Copying $target to openblas/openblas$env:OPENBLAS_SUFFIX.a
+    echo "Copying $target to openblas/openblas$env:OPENBLAS_SUFFIX.a"
     cp $target openblas/openblas$env:OPENBLAS_SUFFIX.a
     If ( Test-Path env:NPY_USE_BLAS_ILP64 ){
         echo "##vso[task.setvariable variable=OPENBLAS64_]$pwd\openblas"
@@ -27,35 +48,40 @@ steps:
 
 - powershell: |
     choco install -y mingw --forcex86 --force --version=7.3.0
+    refreshenv
   displayName: 'Install 32-bit mingw for 32-bit builds'
   condition: eq(variables['BITS'], 32)
 # NOTE: for Windows builds it seems much more tractable to use runtests.py
 # vs. manual setup.py and then runtests.py for testing only
+
 - powershell: |
     If ($(BITS) -eq 32) {
         $env:CFLAGS = "-m32"
         $env:LDFLAGS = "-m32"
         $env:PATH = "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\mingw$(BITS)\\bin;" + $env:PATH
-        refreshenv
     }
     python -c "from tools import openblas_support; openblas_support.make_init('numpy')"
-    pip wheel -v -v -v --no-build-isolation --no-use-pep517 --wheel-dir=dist .
+    python -m pip wheel -v -v -v --no-build-isolation --no-use-pep517 --wheel-dir=dist .
 
     ls dist -r | Foreach-Object {
-        pip install $_.FullName
+        python -m pip install $_.FullName
     }
   displayName: 'Build NumPy'
+
 - bash: |
     pushd . && cd .. && target=$(python -c "import numpy, os; print(os.path.abspath(os.path.join(os.path.dirname(numpy.__file__), '.libs')))") && popd
-    pip download -d destination --only-binary :all: --no-deps numpy==1.14
+    python -m pip download -d destination --only-binary :all: --no-deps numpy==1.14
     cd destination && unzip numpy*.whl && cp numpy/.libs/*.dll $target
     ls $target
   displayName: 'Add extraneous & older DLL to numpy/.libs to probe DLL handling robustness'
   condition: eq(variables['PYTHON_VERSION'], '3.6')
 - script: pushd . && cd .. && python -c "from ctypes import windll; windll.kernel32.SetDefaultDllDirectories(0x00000800); import numpy" && popd
   displayName: 'For gh-12667; Windows DLL resolution'
+  condition: eq(variables['PYTHON_VERSION'], '3.6')
+
 - script: python runtests.py -n --show-build-log --mode=$(TEST_MODE) -- -rsx --junitxml=junit/test-results.xml
   displayName: 'Run NumPy Test Suite'
+
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -11,7 +11,8 @@ from numpy import (
 
 from numpy import arange, allclose, asarray
 from numpy.testing import (
-    assert_, assert_equal, assert_array_equal, suppress_warnings
+    assert_, assert_equal, assert_array_equal, suppress_warnings, IS_PYPY,
+    break_cycles
     )
 
 class TestMemmap:
@@ -25,6 +26,10 @@ class TestMemmap:
 
     def teardown(self):
         self.tmpfp.close()
+        self.data = None
+        if IS_PYPY:
+            break_cycles()
+            break_cycles()
         shutil.rmtree(self.tempdir)
 
     def test_roundtrip(self):

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -8,6 +8,7 @@ Support code for building Python extensions on Windows.
 
 """
 import os
+import platform
 import sys
 import subprocess
 import re
@@ -265,16 +266,19 @@ def find_python_dll():
 
     # search in the file system for possible candidates
     major_version, minor_version = tuple(sys.version_info[:2])
-    patterns = ['python%d%d.dll']
-
-    for pat in patterns:
-        dllname = pat % (major_version, minor_version)
-        print("Looking for %s" % dllname)
-        for folder in lib_dirs:
-            dll = os.path.join(folder, dllname)
-            if os.path.exists(dll):
-                return dll
-
+    implementation = platform.python_implementation()
+    if implementation == 'CPython':
+        dllname = f'python{major_version}{minor_version}.dll'
+    elif implementation == 'PyPy':
+        dllname = f'libpypy{major_version}-c.dll'
+    else:
+        dllname = 'Unknown platform {implementation}' 
+    print("Looking for %s" % dllname)
+    for folder in lib_dirs:
+        dll = os.path.join(folder, dllname)
+        if os.path.exists(dll):
+            return dll
+ 
     raise ValueError("%s not found in %s" % (dllname, lib_dirs))
 
 def dump_table(dll):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -24,7 +24,8 @@ from numpy.ma.testutils import assert_equal
 from numpy.testing import (
     assert_warns, assert_, assert_raises_regex, assert_raises,
     assert_allclose, assert_array_equal, temppath, tempdir, IS_PYPY,
-    HAS_REFCOUNT, suppress_warnings, assert_no_gc_cycles, assert_no_warnings
+    HAS_REFCOUNT, suppress_warnings, assert_no_gc_cycles, assert_no_warnings,
+    break_cycles
     )
 from numpy.testing._private.utils import requires_memory
 
@@ -2387,6 +2388,9 @@ class TestPathUsage:
             assert_array_equal(data, a)
             # close the mem-mapped file
             del data
+            if IS_PYPY:
+                break_cycles()
+                break_cycles()
 
     def test_save_load_memmap_readwrite(self):
         # Test that pathlib.Path instances can be written mem-mapped.
@@ -2398,6 +2402,9 @@ class TestPathUsage:
             a[0][0] = 5
             b[0][0] = 5
             del b  # closes the file
+            if IS_PYPY:
+                break_cycles()
+                break_cycles()
             data = np.load(path)
             assert_array_equal(data, a)
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2403,7 +2403,8 @@ def break_cycles():
     if IS_PYPY:
         # interpreter runs now, to call deleted objects' __del__ methods
         gc.collect()
-        # one more, just to make sure
+        # two more, just to make sure
+        gc.collect()
         gc.collect()
 
 


### PR DESCRIPTION
This PR adds a CI run for the nightly PyPy windows python3.6 build. I used the nightly since the latest released version on windows does not pass the NumPy test suite. As it is, I needed to fix tests that depend on refcounting to close open files
- loading from compressed `npz` files uses a class that can act as a context manager 
- ndarrays backed by `mmap` files depend on refcounting to release the mmap reference. Here I needed to call `gc.collect`.

My goal is to fix numpy so MacPython/numpy-wheels#97 can move forward. Once that is working, maybe we could move some of the CI runs to a different schedule so as to not clog up the CI pipeline