### PR TITLE
fix bugs in unwrap function

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1537,10 +1537,10 @@ def unwrap(p, discont=pi, axis=-1):
     slice1 = [slice(None, None)]*nd     # full slices
     slice1[axis] = slice(1, None)
     slice1 = tuple(slice1)
-    ddmod = mod(dd + pi, 2*pi) - pi
-    _nx.copyto(ddmod, pi, where=(ddmod == -pi) & (dd > 0))
+    ddmod = mod(dd + discont, 2 * discont) - discont
+    _nx.copyto(ddmod, discont, where=(ddmod == -discont) & (dd > 0))
     ph_correct = ddmod - dd
-    _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
+    _nx.copyto(ph_correct, 0, where=abs(dd) < discont * 1.5)
     up = array(p, copy=True, dtype='d')
     up[slice1] = p[slice1] + ph_correct.cumsum(axis)
     return up


### PR DESCRIPTION
Fixed the following two bugs.
Bug1: Returned wrong result when the parameter "discont" is not pi.
Bug2: Wrapped when the diff value is a little larger than pi or discont.

Changes:
L1540, L1541 for Bug1.
L1543 for Bug2.

Example for Bug2:
![Fig1](https://user-images.githubusercontent.com/13477884/88953501-ff37c980-d2d3-11ea-9b2c-450e1bfebb99.png)
