### PR TITLE
TST: skip typing tests if mypyc not installed

### DIFF
--- a/numpy/tests/test_typing.py
+++ b/numpy/tests/test_typing.py
@@ -13,7 +13,9 @@ except ImportError:
 try:
     import mypyc
 except ImportError:
-    pytest.skip("tests too slow without mypyc", allow_module_level=True)
+    mark_slow_without_mypyc = pytest.mark.slow
+else:
+    mark_slow_without_mypyc = lambda f: f
 
 
 TESTS_DIR = os.path.join(
@@ -41,7 +43,7 @@ def get_test_cases(directory):
                     id=relpath,
                 )
 
-
+@mark_slow_without_mypyc
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
     stdout, stderr, exitcode = api.run([
@@ -54,7 +56,7 @@ def test_success(path):
     assert exitcode == 0, stdout
     assert re.match(r"Success: no issues found in \d+ source files?", stdout.strip())
 
-
+@mark_slow_without_mypyc
 @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
 def test_fail(path):
     stdout, stderr, exitcode = api.run([
@@ -103,6 +105,7 @@ def test_fail(path):
             pytest.fail(f"Error {repr(errors[lineno])} not found")
 
 
+@mark_slow_without_mypyc
 @pytest.mark.parametrize("path", get_test_cases(REVEAL_DIR))
 def test_reveal(path):
     stdout, stderr, exitcode = api.run([
@@ -133,6 +136,7 @@ def test_reveal(path):
         assert marker in error_line
 
 
+@mark_slow_without_mypyc
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_code_runs(path):
     path_without_extension, _ = os.path.splitext(path)

--- a/numpy/tests/test_typing.py
+++ b/numpy/tests/test_typing.py
@@ -8,9 +8,13 @@ import pytest
 try:
     from mypy import api
 except ImportError:
-    NO_MYPY = True
-else:
-    NO_MYPY = False
+    pytest.skip("Mypy is not installed", allow_module_level=True)
+
+try:
+    import mypyc
+except ImportError:
+    pytest.skip("tests too slow without mypyc", allow_module_level=True)
+
 
 TESTS_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -38,7 +42,6 @@ def get_test_cases(directory):
                 )
 
 
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
     stdout, stderr, exitcode = api.run([
@@ -52,7 +55,6 @@ def test_success(path):
     assert re.match(r"Success: no issues found in \d+ source files?", stdout.strip())
 
 
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
 def test_fail(path):
     stdout, stderr, exitcode = api.run([
@@ -101,7 +103,6 @@ def test_fail(path):
             pytest.fail(f"Error {repr(errors[lineno])} not found")
 
 
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(REVEAL_DIR))
 def test_reveal(path):
     stdout, stderr, exitcode = api.run([
@@ -132,7 +133,6 @@ def test_reveal(path):
         assert marker in error_line
 
 
-@pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_code_runs(path):
     path_without_extension, _ = os.path.splitext(path)


### PR DESCRIPTION
Fixes gh-16980

I would have preferred to somehow mark the tests as `slow` only __conditionally__ if mypyc is not installed, but couldn't find an easy way to do that. @Zac-HD is there a simple way to conditionally mark a test as slow in an obvious way that is not too convoluted?

Also slightly refactor the way skip is done.