### PR TITLE
MAINT: Configure hypothesis in ``np.test()`` for determinism, use of global tmpdir

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -125,6 +125,9 @@ class PytestTester:
         import pytest
         import warnings
 
+        # Imported after pytest to enable assertion rewriting
+        import hypothesis
+
         module = sys.modules[self.module_name]
         module_path = os.path.abspath(module.__path__[0])
 
@@ -187,6 +190,14 @@ class PytestTester:
 
         pytest_args += ["--pyargs"] + list(tests)
 
+        # This configuration is picked up by numpy.conftest, and ensures that
+        # running `np.test()` is deterministic and does not write any files.
+        # See https://hypothesis.readthedocs.io/en/latest/settings.html
+        hypothesis.settings.register_profile(
+            name="np.test() profile",
+            deadline=None, print_blob=True, database=None, derandomize=True,
+            suppress_health_check=hypothesis.HealthCheck.all(),
+        )
 
         # run tests.
         _show_numpy_info()

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -2,6 +2,7 @@
 Pytest configuration and fixtures for the Numpy test suite.
 """
 import os
+import tempfile
 
 import hypothesis
 import pytest
@@ -13,11 +14,23 @@ from numpy.core._multiarray_tests import get_fpu_mode
 _old_fpu_mode = None
 _collect_results = {}
 
+# Use a known and persistent tmpdir for hypothesis' caches, which
+# can be automatically cleared by the OS or user.
+hypothesis.configuration.set_hypothesis_home_dir(
+    os.path.join(tempfile.gettempdir(), ".hypothesis")
+)
 # See https://hypothesis.readthedocs.io/en/latest/settings.html
 hypothesis.settings.register_profile(
     name="numpy-profile", deadline=None, print_blob=True,
 )
-hypothesis.settings.load_profile("numpy-profile")
+# We try loading the profile defined by np.test(), which disables the
+# database and forces determinism, and fall back to the profile defined
+# above if we're running pytest directly.  The odd dance is required
+# because np.test() executes this file *after* its own setup code.
+try:
+    hypothesis.settings.load_profile("np.test() profile")
+except hypothesis.errors.InvalidArgument:  # profile not found
+    hypothesis.settings.load_profile("numpy-profile")
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Backport of #16879. 

This PR fixes #16859, by ensuring that `np.test()` is deterministic, and that any files written by `np.test()` (or invoking `pytest` directly) go to the same global temporary directory instead of the current working directory.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
