### PR TITLE
ENH: add Chebyshev (cosine) transforms implemented via FFTs

### DIFF
--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -39,6 +39,15 @@ Hermitian FFTs
    hfft      Hermitian discrete Fourier transform.
    ihfft     Inverse Hermitian discrete Fourier transform.
 
+Chebyshev FFTs
+--------------
+
+.. autosummary::
+   :toctree: generated/
+
+   chebyfft  Discrete Chebyshev (cosine) transform.
+   ichebyfft Inverse discrete Chebyshev (cosine) transform.
+
 Helper routines
 ---------------
 


### PR DESCRIPTION
**ENH: add Chebyshev (cosine) transforms implemented via FFTs**

This PR adds the two 1D Chebyshev transform functions `chebyfft` and `ichebyfft` into the `numpy.fft` module, utilizing the real FFTs `rfft` and `irfft`, respectively. As far as I understand, `pockefft` does not support cosine transforms natively; for this reason, an even extension of the input vector is constructed, whose real FFT corresponds to a cosine transform. 

The motivation behind these two additions is the ability to quickly perform direct and inverse Chebyshev transforms with `numpy`, without the need to write scripts that do the necessary (although minor) modifications. Chebyshev transforms are used often e.g. in the spectral integration of PDE problems; thus, I believe having them implemented in `numpy` would be useful to many people in the community. 

I will also post a message to the mailing list to probe interest and gather feedback from more people that are potentially interested in such a feature. In addition, proper tests should be included to make sure the functions work properly, something that I haven't done yet. 

@seberg @peterbell10 @leofang @grlee77 