### PR TITLE
BLD: pin setuptools < 49.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: build numpy
           command: |
             . venv/bin/activate
-            pip install --upgrade pip setuptools
+            pip install --upgrade pip 'setuptools<49.2.0'
             pip install cython
             pip install .
             pip install scipy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ stages:
         otool -L /usr/local/lib/libopenblas*
       displayName: 'install pre-built openblas'
       condition: eq(variables['USE_OPENBLAS'], '1')
-    - script: python -m pip install --upgrade pip setuptools wheel
+    - script: python -m pip install --upgrade pip 'setuptools<49.2.0' wheel
       displayName: 'Install tools'
     - script: |
         python -m pip install -r test_requirements.txt
@@ -250,7 +250,7 @@ stages:
       displayName: 'add gcc 4.8'
     - script: |
             # python3 has no setuptools, so install one to get us going
-            python3 -m pip install --user --upgrade pip setuptools!=49.2.0
+            python3 -m pip install --user --upgrade pip 'setuptools<49.2.0'
             python3 -m pip install --user -r test_requirements.txt
             CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
             python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools!=49.2.0",
+    "setuptools<49.2.0",
     "wheel",
     "Cython>=0.29.21",  # Note: keep in sync with tools/cythonize.py
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 cython==0.29.21
 wheel
-setuptools!=49.2.0
-hypothesis==5.19.1
+setuptools<49.2.0
+hypothesis==5.23.2
 pytest==5.4.3
 pytz==2020.1
 pytest-cov==2.8.1

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -29,7 +29,7 @@ gcc --version
 
 popd
 
-pip install --upgrade pip setuptools!=49.2.0 wheel
+pip install --upgrade pip 'setuptools<49.2.0' wheel
 
 # 'setuptools', 'wheel' and 'cython' are build dependencies.  This information
 # is stored in pyproject.toml, but there is not yet a standard way to install


### PR DESCRIPTION
Backport of #16993. 

It seems setuptools has [released 49.2.1](https://pypi.org/project/setuptools/) without fixing issue pypa/setuptools#2259. Pin to a lower version.
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
