### PR TITLE
DOC: clip()  allows arguments.

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2057,7 +2057,7 @@ def clip(a, a_min, a_max, out=None, **kwargs):
 
     Parameters
     ----------
-    a : array_like
+    a : scalar or array_like
         Array containing elements to clip.
     a_min : scalar or array_like or None
         Minimum value. If None, clipping is not performed on lower

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2059,14 +2059,10 @@ def clip(a, a_min, a_max, out=None, **kwargs):
     ----------
     a : array_like
         Array containing elements to clip.
-    a_min : array_like or None
-        Minimum value. If None, clipping is not performed on lower
-        interval edge. Not more than one of `a_min` and `a_max` may be
-        None.
-    a_max : array_like or None
-        Maximum value. If None, clipping is not performed on upper
-        interval edge. Not more than one of `a_min` and `a_max` may be
-        None. `a_min` and  `a_max` are broadcast against `a`.
+    a_min, a_max : array_like or None
+        Minimum and maximum value. If ``None``, clipping is not performed on
+        the corresponding edge. Only one of `a_min` and `a_max` may be
+        ``None``. Both are broadcast against `a`.
     out : ndarray, optional
         The results will be placed in this array. It may be the input
         array for in-place clipping.  `out` must be of the right shape

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2057,13 +2057,13 @@ def clip(a, a_min, a_max, out=None, **kwargs):
 
     Parameters
     ----------
-    a : scalar or array_like
+    a : array_like
         Array containing elements to clip.
-    a_min : scalar or array_like or None
+    a_min : array_like or None
         Minimum value. If None, clipping is not performed on lower
         interval edge. Not more than one of `a_min` and `a_max` may be
         None.
-    a_max : scalar or array_like or None
+    a_max : array_like or None
         Maximum value. If None, clipping is not performed on upper
         interval edge. Not more than one of `a_min` and `a_max` may be
         None. If `a_min` or `a_max` are array_like, then the three

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -2066,8 +2066,7 @@ def clip(a, a_min, a_max, out=None, **kwargs):
     a_max : array_like or None
         Maximum value. If None, clipping is not performed on upper
         interval edge. Not more than one of `a_min` and `a_max` may be
-        None. If `a_min` or `a_max` are array_like, then the three
-        arrays will be broadcasted to match their shapes.
+        None. `a_min` and  `a_max` are broadcast against `a`.
     out : ndarray, optional
         The results will be placed in this array. It may be the input
         array for in-place clipping.  `out` must be of the right shape


### PR DESCRIPTION
This works in practice and could thus be reflected by the docs, right?