### PR TITLE
ENH: Call str on the third argument of assert_equal()

### DIFF
--- a/doc/release/upcoming_changes/17011.improvement.rst
+++ b/doc/release/upcoming_changes/17011.improvement.rst
@@ -1,5 +1,5 @@
 Call ``str`` automatically on third argument to functions like `assert_equal`
-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
 
 The third argument to functions like `assert_equal` now has ``str`` called on
 it automatically. This way it mimics the built-in ``assert`` statement, where

--- a/doc/release/upcoming_changes/17011.improvement.rst
+++ b/doc/release/upcoming_changes/17011.improvement.rst
@@ -1,0 +1,6 @@
+Call ``str`` automatically on third argument to functions like `assert_equal`
+----------------------------------------------------------------------------
+
+The third argument to functions like `assert_equal` now has ``str`` called on
+it automatically. This way it mimics the built-in ``assert`` statement, where
+``assert_equal(a, b, obj)`` works like ``assert a == b, obj``.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -247,6 +247,7 @@ def build_err_msg(arrays, err_msg, header='Items are not equal:',
                   verbose=True, names=('ACTUAL', 'DESIRED'), precision=8):
     msg = ['\n' + header]
     if err_msg:
+        err_msg = str(err_msg)
         if err_msg.find('\n') == -1 and len(err_msg) < 79-len(header):
             msg = [msg[0] + ' ' + err_msg]
         else:
@@ -2519,4 +2520,3 @@ def _no_tracing(func):
             finally:
                 sys.settrace(original_trace)
         return wrapper
-


### PR DESCRIPTION
This lets you pass any object, similar to how you would do for a native Python

```py
assert a == b, msg
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
