### PR TITLE
ENH: Add NumPy declarations to be used by Cython 3.0+

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,7 +16,7 @@ include .coveragerc
 include test_requirements.txt
 recursive-include numpy/random *.pyx *.pxd *.pyx.in *.pxd.in
 include numpy/random/include/*
-include numpy/__init__.pxd
+include numpy/*.pxd
 # Add build support that should go in sdist, but not go in bdist/be installed
 # Note that sub-directories that don't have __init__ are apparently not
 # included by 'recursive-include', so list those separately

--- a/doc/release/upcoming_changes/16986.improvement.rst
+++ b/doc/release/upcoming_changes/16986.improvement.rst
@@ -1,0 +1,7 @@
+Add NumPy declarations for Cython 3.0 and later
+-----------------------------------------------
+
+The pxd declarations for Cython 3.0 were improved to avoid using deprecated
+NumPy C-API features.  Extension modules built with Cython 3.0+ that use NumPy
+can now set the C macro ``NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION`` to avoid
+C compiler warnings about deprecated API usage.

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('numpy')
     config.add_data_files(('numpy', 'LICENSE.txt'))
-    config.add_data_files(('numpy', 'numpy/__init__.pxd'))
+    config.add_data_files(('numpy', 'numpy/*.pxd'))
 
     config.get_version('numpy/version.py') # sets config.version
 


### PR DESCRIPTION
Backport of #16986. 

As discussed in https://github.com/cython/cython/issues/3573, the latest alpha versions of Cython 3.0 need updated NumPy declarations to allow users to set `-D NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION`. Currently, builds with that setting fail with NumPy 1.19.[01] because the `numpy/__init__.pxd` in NumPy overrides the more current one in Cython 3.0.

This PR adds an updated copy of `numpy/__init__.pxd` as `numpy/__init__.cython-30.pxd` to make Cython 3.0+ use it.

I first created a copy of the original `__init__.pxd` in order to make the changes visible in the diff. Two additional changes:

- I'm not sure if we want the `check_size ignore` declarations in there. Cython has never had them (except for the one on `ndarray`), and that's what people were probably using, but … not my decision, I guess.
- `numpy.broadcast` used to have struct fields defined in the NumPy version but not in the Cython version previously, so keeping them out is probably ok, but would now break backwards compatibility with NumPy 1.19.[01], where Cython 0.29.x already picks up the (old) NumPy version. Can't say how important that is for you. If at all, then they should rather be added as C-properties (as with the `ndarray` fields).

Whatever you decide, I'll follow in the Cython-3.0-side version of the file.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
