### PR TITLE
DOC: Fix non-matching pronoun.

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -41,7 +41,7 @@ Capabilities
 - Is straightforward to reverse engineer. Datasets often live longer than
   the programs that created them. A competent developer should be
   able to create a solution in their preferred programming language to
-  read most ``.npy`` files that he has been given without much
+  read most ``.npy`` files that they have been given without much
   documentation.
 
 - Allows memory-mapping of the data. See `open_memmep`.


### PR DESCRIPTION
Follow up to #5349, which missed the second pronoun in this sentence.