### PR TITLE
DOC: Disclaimer for FFT library

### DIFF
--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -4,6 +4,9 @@ Discrete Fourier Transform (:mod:`numpy.fft`)
 
 .. currentmodule:: numpy.fft
 
+The SciPy module `scipy.fft` is a more comprehensive superset
+of ``numpy.fft``, which includes only a basic set of routines.
+
 Standard FFTs
 -------------
 


### PR DESCRIPTION
Adds sentence to the top of `routines.fft.html` explaining that `scipy.fft`
is a more comprehensive collection, per mailing list discussion
(http://numpy-discussion.10968.n7.nabble.com/Add-Chebyshev-cosine-transforms-implemented-via-FFTs-td48373.html#a48382)


