### PR TITLE
MAINT: Add error return to all casting functionality and NpyIter

### DIFF
--- a/doc/release/upcoming_changes/17029.compatibility.rst
+++ b/doc/release/upcoming_changes/17029.compatibility.rst
@@ -1,0 +1,23 @@
+Casting errors interrupt Iteration
+----------------------------------
+NumPy sometimes has issues reporting errors during casting
+correctly. This is rare, since the vast majority of casts
+will never result in errors.
+However, in some cases of casting errors less of the result
+may be written back. The state of arrays involved in errors
+should *always* be considered undefined.
+Possible changes occur for:
+
+* Universal functions when casting is unsafe (rare)
+* Advanced index assignments
+* The lowlevel `numpy.nditer` API.
+
+For users of the ``NpyIter`` C-API such cast errors will now
+cause the `iternext()` function to return 0 and thus abort
+iteration.
+Currently, there is no API to detect such an error directly.
+It is necessary to check ``PyErr_Occurred()``, which
+may be problematic in combination with ``NpyIter_Reset``.
+These issues always existed, but new API could be added
+if required by users.
+

--- a/doc/release/upcoming_changes/17029.compatibility.rst
+++ b/doc/release/upcoming_changes/17029.compatibility.rst
@@ -1,17 +1,9 @@
 Casting errors interrupt Iteration
 ----------------------------------
-NumPy sometimes has issues reporting errors during casting
-correctly. This is rare, since the vast majority of casts
-will never result in errors.
-However, in some cases of casting errors less of the result
-may be written back. The state of arrays involved in errors
-should *always* be considered undefined.
-Possible changes occur for:
-
-* Universal functions when casting is unsafe (rare)
-* Advanced index assignments
-* The lowlevel `numpy.nditer` API.
-
+When iterating while casting values, an error may stop the iteration
+earlier than before. In any case, a failed casting operation always
+returned undefined, partial results. Those may now be even more
+undefined and partial.
 For users of the ``NpyIter`` C-API such cast errors will now
 cause the `iternext()` function to return 0 and thus abort
 iteration.
@@ -20,4 +12,3 @@ It is necessary to check ``PyErr_Occurred()``, which
 may be problematic in combination with ``NpyIter_Reset``.
 These issues always existed, but new API could be added
 if required by users.
-

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -30,10 +30,9 @@
  * Use NPY_AUXDATA_CLONE and NPY_AUXDATA_FREE to deal with this data.
  *
  */
-typedef void (PyArray_StridedUnaryOp)(char *dst, npy_intp dst_stride,
-                                    char *src, npy_intp src_stride,
-                                    npy_intp N, npy_intp src_itemsize,
-                                    NpyAuxData *transferdata);
+typedef int (PyArray_StridedUnaryOp)(
+        char *dst, npy_intp dst_stride, char *src, npy_intp src_stride,
+        npy_intp N, npy_intp src_itemsize, NpyAuxData *transferdata);
 
 /*
  * This is for pointers to functions which behave exactly as
@@ -43,31 +42,10 @@ typedef void (PyArray_StridedUnaryOp)(char *dst, npy_intp dst_stride,
  * In particular, the 'i'-th element is operated on if and only if
  * mask[i*mask_stride] is true.
  */
-typedef void (PyArray_MaskedStridedUnaryOp)(char *dst, npy_intp dst_stride,
-                                    char *src, npy_intp src_stride,
-                                    npy_bool *mask, npy_intp mask_stride,
-                                    npy_intp N, npy_intp src_itemsize,
-                                    NpyAuxData *transferdata);
-
-/*
- * This function pointer is for binary operations that input two
- * arbitrarily strided one-dimensional array segments and output
- * an arbitrarily strided array segment of the same size.
- * It may be a fully general function, or a specialized function
- * when the strides or item size have particular known values.
- *
- * Examples of binary operations are the basic arithmetic operations,
- * logical operators AND, OR, and many others.
- *
- * The 'transferdata' parameter is slightly special, following a
- * generic auxiliary data pattern defined in ndarraytypes.h
- * Use NPY_AUXDATA_CLONE and NPY_AUXDATA_FREE to deal with this data.
- *
- */
-typedef void (PyArray_StridedBinaryOp)(char *dst, npy_intp dst_stride,
-                                    char *src0, npy_intp src0_stride,
-                                    char *src1, npy_intp src1_stride,
-                                    npy_intp N, NpyAuxData *transferdata);
+typedef int (PyArray_MaskedStridedUnaryOp)(
+        char *dst, npy_intp dst_stride, char *src, npy_intp src_stride,
+        npy_bool *mask, npy_intp mask_stride,
+        npy_intp N, npy_intp src_itemsize, NpyAuxData *transferdata);
 
 /*
  * Gives back a function pointer to a specialized function for copying
@@ -271,6 +249,7 @@ PyArray_CastRawArrays(npy_intp count,
  * The return value is the number of elements it couldn't copy.  A return value
  * of 0 means all elements were copied, a larger value means the end of
  * the n-dimensional array was reached before 'count' elements were copied.
+ * A negative return value indicates an error occurred.
  *
  * ndim:
  *      The number of dimensions of the n-dimensional array.

--- a/numpy/core/src/multiarray/array_assign_array.c
+++ b/numpy/core/src/multiarray/array_assign_array.c
@@ -132,17 +132,22 @@ raw_array_assign_array(int ndim, npy_intp const *shape,
 
     NPY_RAW_ITER_START(idim, ndim, coord, shape_it) {
         /* Process the innermost dimension */
-        stransfer(dst_data, dst_strides_it[0], src_data, src_strides_it[0],
-                    shape_it[0], src_itemsize, transferdata);
+        if (stransfer(
+                dst_data, dst_strides_it[0], src_data, src_strides_it[0],
+                shape_it[0], src_itemsize, transferdata) < 0) {
+            goto fail;
+        }
     } NPY_RAW_ITER_TWO_NEXT(idim, ndim, coord, shape_it,
                             dst_data, dst_strides_it,
                             src_data, src_strides_it);
 
     NPY_END_THREADS;
-
     NPY_AUXDATA_FREE(transferdata);
-
-    return (needs_api && PyErr_Occurred()) ? -1 : 0;
+    return 0;
+fail:
+    NPY_END_THREADS;
+    NPY_AUXDATA_FREE(transferdata);
+    return -1;
 }
 
 /*

--- a/numpy/core/src/multiarray/array_assign_scalar.c
+++ b/numpy/core/src/multiarray/array_assign_scalar.c
@@ -82,16 +82,21 @@ raw_array_assign_scalar(int ndim, npy_intp const *shape,
 
     NPY_RAW_ITER_START(idim, ndim, coord, shape_it) {
         /* Process the innermost dimension */
-        stransfer(dst_data, dst_strides_it[0], src_data, 0,
-                    shape_it[0], src_itemsize, transferdata);
+        if (stransfer(
+                dst_data, dst_strides_it[0], src_data, 0,
+                shape_it[0], src_itemsize, transferdata) < 0) {
+            goto fail;
+        }
     } NPY_RAW_ITER_ONE_NEXT(idim, ndim, coord,
                             shape_it, dst_data, dst_strides_it);
 
     NPY_END_THREADS;
-
     NPY_AUXDATA_FREE(transferdata);
-
-    return (needs_api && PyErr_Occurred()) ? -1 : 0;
+    return 0;
+fail:
+    NPY_END_THREADS;
+    NPY_AUXDATA_FREE(transferdata);
+    return -1;
 }
 
 /*

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -495,12 +495,10 @@ PyArray_Pack(PyArray_Descr *descr, char *item, PyObject *value)
         res = -1;
         goto finish;
     }
-    stransfer(item, 0, data, 0, 1, tmp_descr->elsize, transferdata);
-    NPY_AUXDATA_FREE(transferdata);
-
-    if (needs_api && PyErr_Occurred()) {
+    if (stransfer(item, 0, data, 0, 1, tmp_descr->elsize, transferdata) < 0) {
         res = -1;
     }
+    NPY_AUXDATA_FREE(transferdata);
 
   finish:
     if (PyDataType_REFCHK(tmp_descr)) {

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -110,7 +110,7 @@
  * if not it can decrease performance
  * tested to improve performance on intel xeon 5x/7x, core2duo, amd phenom x4
  */
-static void
+static int
 #if @is_aligned@ && @is_swap@ == 0 && @elsize@ <= NPY_SIZEOF_INTP
     NPY_GCC_UNROLL_LOOPS
 #endif
@@ -171,6 +171,7 @@ static void
 
         --N;
     }
+    return 0;
 }
 #endif
 
@@ -182,7 +183,7 @@ static void
  * but it profits from vectorization enabled with -O3
  */
 #if (@src_contig@ == 0) && @is_aligned@
-static NPY_GCC_OPT_3 void
+static NPY_GCC_OPT_3 int
 @prefix@_@oper@_size@elsize@_srcstride0(char *dst,
                         npy_intp dst_stride,
                         char *src, npy_intp NPY_UNUSED(src_stride),
@@ -197,7 +198,7 @@ static NPY_GCC_OPT_3 void
     npy_uint64 temp0, temp1;
 #endif
     if (N == 0) {
-        return;
+        return 0;
     }
 #if @is_aligned@ && @elsize@ != 16
     /* sanity check */
@@ -238,6 +239,7 @@ static NPY_GCC_OPT_3 void
         --N;
     }
 #endif/* @elsize == 1 && @dst_contig@ -- else */
+    return 0;
 }
 #endif/* (@src_contig@ == 0) && @is_aligned@ */
 
@@ -247,7 +249,7 @@ static NPY_GCC_OPT_3 void
 /**end repeat1**/
 /**end repeat**/
 
-static void
+static int
 _strided_to_strided(char *dst, npy_intp dst_stride,
                         char *src, npy_intp src_stride,
                         npy_intp N, npy_intp src_itemsize,
@@ -259,9 +261,10 @@ _strided_to_strided(char *dst, npy_intp dst_stride,
         src += src_stride;
         --N;
     }
+    return 0;
 }
 
-static void
+static int
 _swap_strided_to_strided(char *dst, npy_intp dst_stride,
                         char *src, npy_intp src_stride,
                         npy_intp N, npy_intp src_itemsize,
@@ -284,9 +287,10 @@ _swap_strided_to_strided(char *dst, npy_intp dst_stride,
         src += src_stride;
         --N;
     }
+    return 0;
 }
 
-static void
+static int
 _swap_pair_strided_to_strided(char *dst, npy_intp dst_stride,
                         char *src, npy_intp src_stride,
                         npy_intp N, npy_intp src_itemsize,
@@ -319,15 +323,17 @@ _swap_pair_strided_to_strided(char *dst, npy_intp dst_stride,
         src += src_stride;
         --N;
     }
+    return 0;
 }
 
-static void
+static int
 _contig_to_contig(char *dst, npy_intp NPY_UNUSED(dst_stride),
                         char *src, npy_intp NPY_UNUSED(src_stride),
                         npy_intp N, npy_intp src_itemsize,
                         NpyAuxData *NPY_UNUSED(data))
 {
     memmove(dst, src, src_itemsize*N);
+    return 0;
 }
 
 
@@ -787,7 +793,7 @@ NPY_NO_EXPORT PyArray_StridedUnaryOp *
 
 #endif
 
-static NPY_GCC_OPT_3 void
+static NPY_GCC_OPT_3 int
 @prefix@_cast_@name1@_to_@name2@(
                         char *dst, npy_intp dst_stride,
                         char *src, npy_intp src_stride,
@@ -873,6 +879,7 @@ static NPY_GCC_OPT_3 void
         src += src_stride;
 #endif
     }
+    return 0;
 }
 
 #undef _CONVERT_FN
@@ -989,10 +996,14 @@ PyArray_TransferNDimToStrided(npy_intp ndim,
     src_stride0 = src_strides[0];
     N = shape0 - coord0;
     if (N >= count) {
-        stransfer(dst, dst_stride, src, src_stride0, count, src_itemsize, data);
-        return 0;
+        return stransfer(dst, dst_stride, src, src_stride0,
+                         count, src_itemsize, data);
     }
-    stransfer(dst, dst_stride, src, src_stride0, N, src_itemsize, data);
+    int res = stransfer(dst, dst_stride, src, src_stride0,
+                        N, src_itemsize, data);
+    if (res < 0) {
+        return -1;
+    }
     count -= N;
 
     /* If it's 1-dimensional, there's no more to copy */
@@ -1012,13 +1023,15 @@ PyArray_TransferNDimToStrided(npy_intp ndim,
     N = shape0*M;
     for (i = 0; i < M; ++i) {
         if (shape0 >= count) {
-            stransfer(dst, dst_stride, src, src_stride0,
-                        count, src_itemsize, data);
-            return 0;
+            return stransfer(dst, dst_stride, src, src_stride0,
+                             count, src_itemsize, data);
         }
         else {
-            stransfer(dst, dst_stride, src, src_stride0,
-                        shape0, src_itemsize, data);
+            res = stransfer(dst, dst_stride, src, src_stride0,
+                            shape0, src_itemsize, data);
+            if (res < 0) {
+                return -1;
+            }
         }
         count -= shape0;
         src += src_stride1;
@@ -1073,13 +1086,15 @@ PyArray_TransferNDimToStrided(npy_intp ndim,
             /* A loop for dimensions 0 and 1 */
             for (i = 0; i < shape1; ++i) {
                 if (shape0 >= count) {
-                    stransfer(dst, dst_stride, src, src_stride0,
-                                count, src_itemsize, data);
-                    return 0;
+                    return stransfer(dst, dst_stride, src, src_stride0,
+                                     count, src_itemsize, data);
                 }
                 else {
-                    stransfer(dst, dst_stride, src, src_stride0,
-                                shape0, src_itemsize, data);
+                    res = stransfer(dst, dst_stride, src, src_stride0,
+                                    shape0, src_itemsize, data);
+                    if (res < 0) {
+                        return -1;
+                    }
                 }
                 count -= shape0;
                 src += src_stride1;
@@ -1108,10 +1123,14 @@ PyArray_TransferStridedToNDim(npy_intp ndim,
     dst_stride0 = dst_strides[0];
     N = shape0 - coord0;
     if (N >= count) {
-        stransfer(dst, dst_stride0, src, src_stride, count, src_itemsize, data);
-        return 0;
+        return stransfer(dst, dst_stride0, src, src_stride,
+                         count, src_itemsize, data);
     }
-    stransfer(dst, dst_stride0, src, src_stride, N, src_itemsize, data);
+    int res = stransfer(dst, dst_stride0, src, src_stride,
+                        N, src_itemsize, data);
+    if (res < 0) {
+        return -1;
+    }
     count -= N;
 
     /* If it's 1-dimensional, there's no more to copy */
@@ -1131,13 +1150,15 @@ PyArray_TransferStridedToNDim(npy_intp ndim,
     N = shape0*M;
     for (i = 0; i < M; ++i) {
         if (shape0 >= count) {
-            stransfer(dst, dst_stride0, src, src_stride,
-                        count, src_itemsize, data);
-            return 0;
+            return stransfer(dst, dst_stride0, src, src_stride,
+                             count, src_itemsize, data);
         }
         else {
-            stransfer(dst, dst_stride0, src, src_stride,
-                        shape0, src_itemsize, data);
+            res = stransfer(dst, dst_stride0, src, src_stride,
+                            shape0, src_itemsize, data);
+            if (res < 0) {
+                return -1;
+            }
         }
         count -= shape0;
         dst += dst_stride1;
@@ -1192,13 +1213,15 @@ PyArray_TransferStridedToNDim(npy_intp ndim,
             /* A loop for dimensions 0 and 1 */
             for (i = 0; i < shape1; ++i) {
                 if (shape0 >= count) {
-                    stransfer(dst, dst_stride0, src, src_stride,
-                                count, src_itemsize, data);
-                    return 0;
+                    return stransfer(dst, dst_stride0, src, src_stride,
+                                     count, src_itemsize, data);
                 }
                 else {
-                    stransfer(dst, dst_stride0, src, src_stride,
-                                shape0, src_itemsize, data);
+                    res = stransfer(dst, dst_stride0, src, src_stride,
+                                    shape0, src_itemsize, data);
+                    if (res < 0) {
+                        return -1;
+                    }
                 }
                 count -= shape0;
                 dst += dst_stride1;
@@ -1228,16 +1251,18 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
     dst_stride0 = dst_strides[0];
     N = shape0 - coord0;
     if (N >= count) {
-        stransfer(dst, dst_stride0,
-                    src, src_stride,
-                    mask, mask_stride,
-                    count, src_itemsize, data);
-        return 0;
-    }
-    stransfer(dst, dst_stride0,
-                src, src_stride,
+        return stransfer(
+                dst, dst_stride0, src, src_stride,
                 mask, mask_stride,
-                N, src_itemsize, data);
+                count, src_itemsize, data);
+    }
+    int res = stransfer(
+            dst, dst_stride0, src, src_stride,
+            mask, mask_stride,
+            N, src_itemsize, data);
+    if (res < 0) {
+        return -1;
+    }
     count -= N;
 
     /* If it's 1-dimensional, there's no more to copy */
@@ -1258,17 +1283,19 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
     N = shape0*M;
     for (i = 0; i < M; ++i) {
         if (shape0 >= count) {
-            stransfer(dst, dst_stride0,
-                        src, src_stride,
-                        mask, mask_stride,
-                        count, src_itemsize, data);
-            return 0;
+            return stransfer(
+                    dst, dst_stride0, src, src_stride,
+                    mask, mask_stride,
+                    count, src_itemsize, data);
         }
         else {
-            stransfer(dst, dst_stride0,
-                        src, src_stride,
-                        mask, mask_stride,
-                        shape0, src_itemsize, data);
+            int res = stransfer(
+                    dst, dst_stride0, src, src_stride,
+                    mask, mask_stride,
+                    N, src_itemsize, data);
+            if (res < 0) {
+                return -1;
+            }
         }
         count -= shape0;
         dst += dst_stride1;
@@ -1324,17 +1351,19 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
             /* A loop for dimensions 0 and 1 */
             for (i = 0; i < shape1; ++i) {
                 if (shape0 >= count) {
-                    stransfer(dst, dst_stride0,
-                                src, src_stride,
-                                mask, mask_stride,
-                                count, src_itemsize, data);
-                    return 0;
+                    return stransfer(
+                            dst, dst_stride0, src, src_stride,
+                            mask, mask_stride,
+                            count, src_itemsize, data);
                 }
                 else {
-                    stransfer(dst, dst_stride0,
-                                src, src_stride,
-                                mask, mask_stride,
-                                shape0, src_itemsize, data);
+                    res = stransfer(
+                            dst, dst_stride0, src, src_stride,
+                            mask, mask_stride,
+                            shape0, src_itemsize, data);
+                    if (res < 0) {
+                        return -1;
+                    }
                 }
                 count -= shape0;
                 dst += dst_stride1;
@@ -1760,13 +1789,23 @@ mapiter_@name@(PyArrayMapIterObject *mit)
                 do {
 
 #if @isget@
-                    stransfer(subspace_ptrs[1], subspace_strides[1],
-                              subspace_ptrs[0], subspace_strides[0],
-                              *counter, src_itemsize, transferdata);
+                    if (NPY_UNLIKELY(stransfer(
+                            subspace_ptrs[1], subspace_strides[1],
+                            subspace_ptrs[0], subspace_strides[0],
+                            *counter, src_itemsize, transferdata) < 0)) {
+                        NPY_END_THREADS;
+                        NPY_AUXDATA_FREE(transferdata);
+                        return -1;
+                    }
 #else
-                    stransfer(subspace_ptrs[0], subspace_strides[0],
-                              subspace_ptrs[1], subspace_strides[1],
-                              *counter, src_itemsize, transferdata);
+                    if (NPY_UNLIKELY(stransfer(
+                            subspace_ptrs[0], subspace_strides[0],
+                            subspace_ptrs[1], subspace_strides[1],
+                            *counter, src_itemsize, transferdata) < 0)) {
+                        NPY_END_THREADS;
+                        NPY_AUXDATA_FREE(transferdata);
+                        return -1;
+                    }
 #endif
                 } while (mit->subspace_next(mit->subspace_iter));
 

--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -229,13 +229,22 @@ NpyIter_EnableExternalLoop(NpyIter *iter)
     return NpyIter_Reset(iter, NULL);
 }
 
+
+static char *_reset_cast_error = (
+        "Iterator reset failed due to a casting failure. "
+        "This error is set as a Python error.");
+
 /*NUMPY_API
  * Resets the iterator to its initial state
+ *
+ * The use of errmsg is discouraged, it cannot be guaranteed that the GIL
+ * will not be grabbed on casting errors even when this is passed.
  *
  * If errmsg is non-NULL, it should point to a variable which will
  * receive the error message, and no Python exception will be set.
  * This is so that the function can be called from code not holding
- * the GIL.
+ * the GIL. Note that cast errors may still lead to the GIL being
+ * grabbed temporarily.
  */
 NPY_NO_EXPORT int
 NpyIter_Reset(NpyIter *iter, char **errmsg)
@@ -250,6 +259,9 @@ NpyIter_Reset(NpyIter *iter, char **errmsg)
         /* If buffer allocation was delayed, do it now */
         if (itflags&NPY_ITFLAG_DELAYBUF) {
             if (!npyiter_allocate_buffers(iter, errmsg)) {
+                if (errmsg != NULL) {
+                    *errmsg = _reset_cast_error;
+                }
                 return NPY_FAIL;
             }
             NIT_ITFLAGS(iter) &= ~NPY_ITFLAG_DELAYBUF;
@@ -257,7 +269,7 @@ NpyIter_Reset(NpyIter *iter, char **errmsg)
         else {
             /*
              * If the iterindex is already right, no need to
-             * do anything
+             * do anything (and no cast error has previously occurred).
              */
             bufferdata = NIT_BUFFERDATA(iter);
             if (NIT_ITERINDEX(iter) == NIT_ITERSTART(iter) &&
@@ -265,9 +277,12 @@ NpyIter_Reset(NpyIter *iter, char **errmsg)
                     NBF_SIZE(bufferdata) > 0) {
                 return NPY_SUCCEED;
             }
-
-            /* Copy any data from the buffers back to the arrays */
-            npyiter_copy_from_buffers(iter);
+            if (npyiter_copy_from_buffers(iter) < 0) {
+                if (errmsg != NULL) {
+                    *errmsg = _reset_cast_error;
+                }
+                return NPY_FAIL;
+            }
         }
     }
 
@@ -275,7 +290,12 @@ NpyIter_Reset(NpyIter *iter, char **errmsg)
 
     if (itflags&NPY_ITFLAG_BUFFER) {
         /* Prepare the next buffers and set iterend/size */
-        npyiter_copy_to_buffers(iter, NULL);
+        if (npyiter_copy_to_buffers(iter, NULL) < 0) {
+            if (errmsg != NULL) {
+                *errmsg = _reset_cast_error;
+            }
+            return NPY_FAIL;
+        }
     }
 
     return NPY_SUCCEED;
@@ -288,7 +308,8 @@ NpyIter_Reset(NpyIter *iter, char **errmsg)
  * If errmsg is non-NULL, it should point to a variable which will
  * receive the error message, and no Python exception will be set.
  * This is so that the function can be called from code not holding
- * the GIL.
+ * the GIL. Note that cast errors may still lead to the GIL being
+ * grabbed temporarily.
  */
 NPY_NO_EXPORT int
 NpyIter_ResetBasePointers(NpyIter *iter, char **baseptrs, char **errmsg)
@@ -309,8 +330,12 @@ NpyIter_ResetBasePointers(NpyIter *iter, char **baseptrs, char **errmsg)
             NIT_ITFLAGS(iter) &= ~NPY_ITFLAG_DELAYBUF;
         }
         else {
-            /* Copy any data from the buffers back to the arrays */
-            npyiter_copy_from_buffers(iter);
+            if (npyiter_copy_from_buffers(iter) < 0) {
+                if (errmsg != NULL) {
+                    *errmsg = _reset_cast_error;
+                }
+                return NPY_FAIL;
+            }
         }
     }
 
@@ -323,7 +348,12 @@ NpyIter_ResetBasePointers(NpyIter *iter, char **baseptrs, char **errmsg)
 
     if (itflags&NPY_ITFLAG_BUFFER) {
         /* Prepare the next buffers and set iterend/size */
-        npyiter_copy_to_buffers(iter, NULL);
+        if (npyiter_copy_to_buffers(iter, NULL) < 0) {
+            if (errmsg != NULL) {
+                *errmsg = _reset_cast_error;
+            }
+            return NPY_FAIL;
+        }
     }
 
     return NPY_SUCCEED;
@@ -335,7 +365,8 @@ NpyIter_ResetBasePointers(NpyIter *iter, char **baseptrs, char **errmsg)
  * If errmsg is non-NULL, it should point to a variable which will
  * receive the error message, and no Python exception will be set.
  * This is so that the function can be called from code not holding
- * the GIL.
+ * the GIL. Note that cast errors may still lead to the GIL being
+ * grabbed temporarily.
  */
 NPY_NO_EXPORT int
 NpyIter_ResetToIterIndexRange(NpyIter *iter,
@@ -633,12 +664,16 @@ NpyIter_GotoIterIndex(NpyIter *iter, npy_intp iterindex)
         /* Start the buffer at the provided iterindex */
         else {
             /* Write back to the arrays */
-            npyiter_copy_from_buffers(iter);
+            if (npyiter_copy_from_buffers(iter) < 0) {
+                return NPY_FAIL;
+            }
 
             npyiter_goto_iterindex(iter, iterindex);
 
             /* Prepare the next buffers and set iterend/size */
-            npyiter_copy_to_buffers(iter, NULL);
+            if (npyiter_copy_to_buffers(iter, NULL) < 0) {
+                return NPY_FAIL;
+            }
         }
     }
     else {
@@ -1376,6 +1411,7 @@ NpyIter_GetInnerLoopSizePtr(NpyIter *iter)
     }
 }
 
+
 /*NUMPY_API
  * For debugging
  */
@@ -1828,7 +1864,7 @@ npyiter_goto_iterindex(NpyIter *iter, npy_intp iterindex)
  * their data needs to be written back to the arrays.  The multi-index
  * must be positioned for the beginning of the buffer.
  */
-NPY_NO_EXPORT void
+NPY_NO_EXPORT int
 npyiter_copy_from_buffers(NpyIter *iter)
 {
     npy_uint32 itflags = NIT_ITFLAGS(iter);
@@ -1861,7 +1897,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
 
     /* If we're past the end, nothing to copy */
     if (NBF_SIZE(bufferdata) == 0) {
-        return;
+        return 0;
     }
 
     NPY_IT_DBG_PRINT("Iterator: Copying buffers to outputs\n");
@@ -1968,7 +2004,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
                     maskptr = (npy_bool *)ad_ptrs[maskop];
                 }
 
-                PyArray_TransferMaskedStridedToNDim(ndim_transfer,
+                if (PyArray_TransferMaskedStridedToNDim(ndim_transfer,
                         ad_ptrs[iop], dst_strides, axisdata_incr,
                         buffer, src_stride,
                         maskptr, strides[maskop],
@@ -1976,18 +2012,22 @@ npyiter_copy_from_buffers(NpyIter *iter)
                         dst_shape, axisdata_incr,
                         op_transfersize, dtypes[iop]->elsize,
                         (PyArray_MaskedStridedUnaryOp *)stransfer,
-                        transferdata);
+                        transferdata) < 0) {
+                    return -1;
+                }
             }
             /* Regular operand */
             else {
-                PyArray_TransferStridedToNDim(ndim_transfer,
+                if (PyArray_TransferStridedToNDim(ndim_transfer,
                         ad_ptrs[iop], dst_strides, axisdata_incr,
                         buffer, src_stride,
                         dst_coords, axisdata_incr,
                         dst_shape, axisdata_incr,
                         op_transfersize, dtypes[iop]->elsize,
                         stransfer,
-                        transferdata);
+                        transferdata) < 0) {
+                    return -1;
+                }
             }
         }
         /* If there's no copy back, we may have to decrement refs.  In
@@ -2002,9 +2042,13 @@ npyiter_copy_from_buffers(NpyIter *iter)
             NPY_IT_DBG_PRINT1("Iterator: Freeing refs and zeroing buffer "
                                 "of operand %d\n", (int)iop);
             /* Decrement refs */
-            stransfer(NULL, 0, buffer, dtypes[iop]->elsize,
-                        transfersize, dtypes[iop]->elsize,
-                        transferdata);
+            if (stransfer(NULL, 0, buffer, dtypes[iop]->elsize,
+                          transfersize, dtypes[iop]->elsize,
+                          transferdata) < 0) {
+                /* Since this should only decrement, it should never error */
+                assert(0);
+                return -1;
+            }
             /*
              * Zero out the memory for safety.  For instance,
              * if during iteration some Python code copied an
@@ -2016,6 +2060,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
     }
 
     NPY_IT_DBG_PRINT("Iterator: Finished copying buffers to outputs\n");
+    return 0;
 }
 
 /*
@@ -2023,7 +2068,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
  * for the start of a buffer.  It decides which operands need a buffer,
  * and copies the data into the buffers.
  */
-NPY_NO_EXPORT void
+NPY_NO_EXPORT int
 npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
 {
     npy_uint32 itflags = NIT_ITFLAGS(iter);
@@ -2142,7 +2187,7 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
         NBF_BUFITEREND(bufferdata) = iterindex + reduce_innersize;
         if (reduce_innersize == 0) {
             NBF_REDUCE_OUTERSIZE(bufferdata) = 0;
-            return;
+            return 0;
         }
         else {
             NBF_REDUCE_OUTERSIZE(bufferdata) = transfersize/reduce_innersize;
@@ -2508,14 +2553,15 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
                                 "buffer (%d items)\n",
                                 (int)iop, (int)op_transfersize);
 
-                PyArray_TransferNDimToStrided(ndim_transfer,
-                        ptrs[iop], dst_stride,
-                        ad_ptrs[iop], src_strides, axisdata_incr,
-                        src_coords, axisdata_incr,
-                        src_shape, axisdata_incr,
-                        op_transfersize, src_itemsize,
-                        stransfer,
-                        transferdata);
+                if (PyArray_TransferNDimToStrided(
+                                ndim_transfer, ptrs[iop], dst_stride,
+                                ad_ptrs[iop], src_strides, axisdata_incr,
+                                src_coords, axisdata_incr,
+                                src_shape, axisdata_incr,
+                                op_transfersize, src_itemsize,
+                                stransfer, transferdata) < 0) {
+                    return -1;
+                }
             }
         }
         else if (ptrs[iop] == buffers[iop]) {
@@ -2551,7 +2597,79 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
 
     NPY_IT_DBG_PRINT1("Iterator: Finished copying inputs to buffers "
                         "(buffered size is %d)\n", (int)NBF_SIZE(bufferdata));
+    return 0;
 }
+
+
+/**
+ * This function clears any references still held by the buffers and should
+ * only be used to discard buffers if an error occurred.
+ *
+ * @param iter Iterator
+ */
+NPY_NO_EXPORT void
+npyiter_clear_buffers(NpyIter *iter)
+{
+    int nop = iter->nop;
+    NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
+
+    if (NBF_SIZE(bufferdata) == 0) {
+        /* if the buffers are empty already, there is nothing to do */
+        return;
+    }
+
+    if (!(NIT_ITFLAGS(iter) & NPY_ITFLAG_NEEDSAPI)) {
+        /* Buffers do not require clearing, but should not be copied back */
+        NBF_SIZE(bufferdata) = 0;
+        return;
+    }
+
+    /*
+     * The iterator may be using a dtype with references, which always
+     * requires the API. In that case, further cleanup may be necessary.
+     *
+     * TODO: At this time, we assume that a dtype having references
+     *       implies the need to hold the GIL at all times. In theory
+     *       we could broaden this definition for a new
+     *       `PyArray_Item_XDECREF` API and the assumption may become
+     *       incorrect.
+     */
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type,  &value, &traceback);
+
+    /* Cleanup any buffers with references */
+    char **buffers = NBF_BUFFERS(bufferdata);
+    PyArray_Descr **dtypes = NIT_DTYPES(iter);
+    for (int iop = 0; iop < nop; ++iop, ++buffers) {
+        /*
+         * We may want to find a better way to do this, on the other hand,
+         * this cleanup seems rare and fairly special.  A dtype using
+         * references (right now only us) must always keep the buffer in
+         * a well defined state (either NULL or owning the reference).
+         * Only we implement cleanup
+         */
+        if (!PyDataType_REFCHK(dtypes[iop])) {
+            continue;
+        }
+        if (*buffers == 0) {
+            continue;
+        }
+        int itemsize = dtypes[iop]->elsize;
+        for (npy_intp i = 0; i < NBF_SIZE(bufferdata); i++) {
+            /*
+             * See above comment, if this API is expanded the GIL assumption
+             * could become incorrect.
+             */
+            PyArray_Item_XDECREF(*buffers + (itemsize * i), dtypes[iop]);
+        }
+        /* Clear out the buffer just to be sure */
+        memset(*buffers, 0, NBF_SIZE(bufferdata) * itemsize);
+    }
+    /* Signal that the buffers are empty */
+    NBF_SIZE(bufferdata) = 0;
+    PyErr_Restore(type, value, traceback);
+}
+
 
 /*
  * This checks how much space can be buffered without encountering the

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -342,10 +342,11 @@ NPY_NO_EXPORT int
 npyiter_allocate_buffers(NpyIter *iter, char **errmsg);
 NPY_NO_EXPORT void
 npyiter_goto_iterindex(NpyIter *iter, npy_intp iterindex);
-NPY_NO_EXPORT void
+NPY_NO_EXPORT int
 npyiter_copy_from_buffers(NpyIter *iter);
-NPY_NO_EXPORT void
+NPY_NO_EXPORT int
 npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs);
-
+NPY_NO_EXPORT void
+npyiter_clear_buffers(NpyIter *iter);
 
 #endif

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1268,6 +1268,10 @@ npyiter_iternext(NewNpyArrayIterObject *self)
         Py_RETURN_TRUE;
     }
     else {
+        if (PyErr_Occurred()) {
+            /* casting error, buffer cleanup will occur at reset or dealloc */
+            return NULL;
+        }
         self->finished = 1;
         Py_RETURN_FALSE;
     }
@@ -1483,6 +1487,10 @@ npyiter_next(NewNpyArrayIterObject *self)
      */
     if (self->started) {
         if (!self->iternext(self->iter)) {
+            /*
+             * A casting error may be set here (or no error causing a
+             * StopIteration). Buffers may only be cleaned up later.
+             */
             self->finished = 1;
             return NULL;
         }

--- a/numpy/core/src/multiarray/nditer_templ.c.src
+++ b/numpy/core/src/multiarray/nditer_templ.c.src
@@ -249,7 +249,10 @@ npyiter_buffered_reduce_iternext_iters@tag_nop@(NpyIter *iter)
     memcpy(prev_dataptrs, NAD_PTRS(axisdata), NPY_SIZEOF_INTP*nop);
 
     /* Write back to the arrays */
-    npyiter_copy_from_buffers(iter);
+    if (npyiter_copy_from_buffers(iter) < 0) {
+        npyiter_clear_buffers(iter);
+        return 0;
+    }
 
     /* Check if we're past the end */
     if (NIT_ITERINDEX(iter) >= NIT_ITEREND(iter)) {
@@ -262,7 +265,10 @@ npyiter_buffered_reduce_iternext_iters@tag_nop@(NpyIter *iter)
     }
 
     /* Prepare the next buffers and set iterend/size */
-    npyiter_copy_to_buffers(iter, prev_dataptrs);
+    if (npyiter_copy_to_buffers(iter, prev_dataptrs) < 0) {
+        npyiter_clear_buffers(iter);
+        return 0;
+    }
 
     return 1;
 }
@@ -303,7 +309,10 @@ npyiter_buffered_iternext(NpyIter *iter)
     }
 
     /* Write back to the arrays */
-    npyiter_copy_from_buffers(iter);
+    if (npyiter_copy_from_buffers(iter) < 0) {
+        npyiter_clear_buffers(iter);
+        return 0;
+    }
 
     /* Check if we're past the end */
     if (NIT_ITERINDEX(iter) >= NIT_ITEREND(iter)) {
@@ -316,7 +325,10 @@ npyiter_buffered_iternext(NpyIter *iter)
     }
 
     /* Prepare the next buffers and set iterend/size */
-    npyiter_copy_to_buffers(iter, NULL);
+    if (npyiter_copy_to_buffers(iter, NULL) < 0) {
+        npyiter_clear_buffers(iter);
+        return 0;
+    }
 
     return 1;
 }

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -254,7 +254,6 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
         }
         op_flags[2] = NPY_ITER_READONLY;
     }
-
     /* Set up result array axes mapping, operand and wheremask use default */
     int result_axes[NPY_MAXDIMS];
     int *op_axes[3] = {result_axes, NULL, NULL};
@@ -363,7 +362,6 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
 
         if (loop(iter, dataptr, strideptr, countptr,
                         iternext, needs_api, skip_first_count, data) < 0) {
-
             goto fail;
         }
     }
@@ -379,7 +377,10 @@ PyUFunc_ReduceWrapper(PyArrayObject *operand, PyArrayObject *out,
     }
     Py_INCREF(result);
 
-    NpyIter_Deallocate(iter);
+    if (!NpyIter_Deallocate(iter)) {
+        Py_DECREF(result);
+        return NULL;
+    }
     return result;
 
 fail:


### PR DESCRIPTION
NpyIter cannot properly indicate errors right away, defering them
in some case until the actual cleanup occurs. to make that slightly
with easier, this adds a new API function with (non-standard for
NpyIter) error return as -1.
A second function is one which only checks whether an error
occurred (i.e. `NpyIter_ErrOccurred()`) which is necessary in the
(more rare) case the iterator is not deallocated promptly after
the iteration is finished.

---

Well, this was mostly surprisingly straight forward, I am sure there are some stranger fallout in error-case corner cases, but those were always somewhat buggy, so more likely a few got fixed.

What we will have to discuss is the `NpyIter` API.  Since the iteration functions cannot indicate an error, the first place where we can set it for sure is the deallocation (although many places forget to check for error returns). None of that actually makes the situation worse, but it made me feel like adding a slight modification of the `NpyIter_Deallocate`, as well as a function to check for such an error earlier if desired (needed for the python exposure).

At some point, we may want to (or need to) pass the `PyThreadState` to the casting functions as a next step. To do that, we would require new API.  I frankly still have no idea whether `PyGILState` functions are considered bad, or if they are OK. If they are OK, there is not too much to worry about for now. (I send an email to python c-sig about it).

In any case, on this topic: I think we have to do this retrofitting, the main discussion that is needed is the NpyIter modification.  ~There are currently two tests failing with regards to structured array fields. So I will owe a beer or two to whoever notices the (hopefully stupid) mistake leading to that :/.~

Marking this as draft, because at least the NpyIter changes should get a test probably.