### PR TITLE
MAINT: Deprecate Complex Ordering comparisons

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -330,12 +330,13 @@ PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
      * or object arrays.
      */
     if (PyArray_ISCOMPLEX(operands[0]) &&
-        PyArray_ISCOMPLEX(operands[1]) &&
-        strcmp(ufunc_get_name_cstr(ufunc), "equal") != 0 &&
-        strcmp(ufunc_get_name_cstr(ufunc), "not_equal") != 0) {
+        PyArray_ISCOMPLEX(operands[1]) &&(
+        strcmp(ufunc_name, "greater") == 0 ||
+        strcmp(ufunc_name, "greater_equal") == 0 ||
+        strcmp(ufunc_name, "less") == 0 ||
+        strcmp(ufunc_name, "less_equal") == 0)) {
             PyErr_WarnEx(PyExc_DeprecationWarning,
             "Ordering Comparisons (>, <, >=, <=) on complex types is being deprecated", 1);
-
     }
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -471,13 +472,21 @@ PyUFunc_SimpleUniformOperationTypeResolver(
         PyObject *type_tup,
         PyArray_Descr **out_dtypes)
 {
+
+    static PyObject *visibleDeprecationWarning = NULL;
+    npy_cache_import(
+        "numpy", "VisibleDeprecationWarning",
+         &visibleDeprecationWarning);
+    if (visibleDeprecationWarning == NULL) {
+                return -1;
+    }
     const char *ufunc_name = ufunc_get_name_cstr(ufunc);
     if (PyArray_ISCOMPLEX(operands[0]) &&
         (strcmp(ufunc_name, "maximum") == 0 ||
         strcmp(ufunc_name, "minimum") == 0 ||
         strcmp(ufunc_name, "fmax") == 0 ||
         strcmp(ufunc_name, "fmin") == 0)) {
-            PyErr_WarnEx(PyExc_DeprecationWarning,
+            PyErr_WarnEx(visibleDeprecationWarning,
             "Ordering Comparisons (>, <, >=, <=) on complex types is being deprecated", 1);
     }
     if (ufunc->nin < 1) {

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -325,11 +325,18 @@ PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                 ufunc_name);
         return -1;
     }
-
     /*
      * Use the default type resolution if there's a custom data type
      * or object arrays.
      */
+    if (PyArray_ISCOMPLEX(operands[0]) &&
+        PyArray_ISCOMPLEX(operands[1]) &&
+        strcmp(ufunc_get_name_cstr(ufunc), "equal") != 0 &&
+        strcmp(ufunc_get_name_cstr(ufunc), "not_equal") != 0) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+            "Ordering Comparisons (>, <, >=, <=) on complex types is being deprecated", 1);
+
+    }
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
     if (type_num1 >= NPY_NTYPES || type_num2 >= NPY_NTYPES ||
@@ -465,7 +472,14 @@ PyUFunc_SimpleUniformOperationTypeResolver(
         PyArray_Descr **out_dtypes)
 {
     const char *ufunc_name = ufunc_get_name_cstr(ufunc);
-
+    if (PyArray_ISCOMPLEX(operands[0]) &&
+        (strcmp(ufunc_name, "maximum") == 0 ||
+        strcmp(ufunc_name, "minimum") == 0 ||
+        strcmp(ufunc_name, "fmax") == 0 ||
+        strcmp(ufunc_name, "fmin") == 0)) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+            "Ordering Comparisons (>, <, >=, <=) on complex types is being deprecated", 1);
+    }
     if (ufunc->nin < 1) {
         PyErr_Format(PyExc_RuntimeError, "ufunc %s is configured "
                 "to use uniform operation type resolution but has "

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2633,7 +2633,7 @@ class TestMethods:
             assert_raises(ValueError, np.argpartition, d, 9, axis=1)
             assert_raises(ValueError, np.argpartition, d, 11, axis=None)
 
-            td = [(dt, s) for dt in [np.int32, np.float32, np.complex64]
+            td = [(dt, s) for dt in [np.int32, np.float32, np.float64]
                   for s in (9, 16)]
             for dt, s in td:
                 aae = assert_array_equal
@@ -4101,19 +4101,6 @@ class TestArgmax:
         ([0, 1, 2, np.nan, 3], 3),
         ([np.nan, 0, 1, 2, 3], 0),
         ([np.nan, 0, np.nan, 2, 3], 0),
-        ([0, 1, 2, 3, complex(0, np.nan)], 4),
-        ([0, 1, 2, 3, complex(np.nan, 0)], 4),
-        ([0, 1, 2, complex(np.nan, 0), 3], 3),
-        ([0, 1, 2, complex(0, np.nan), 3], 3),
-        ([complex(0, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
-
-        ([complex(0, 0), complex(0, 2), complex(0, 1)], 1),
-        ([complex(1, 0), complex(0, 2), complex(0, 1)], 0),
-        ([complex(1, 0), complex(0, 2), complex(1, 1)], 2),
 
         ([np.datetime64('1923-04-14T12:43:12'),
           np.datetime64('1994-06-21T14:43:15'),
@@ -4243,19 +4230,7 @@ class TestArgmin:
         ([0, 1, 2, np.nan, 3], 3),
         ([np.nan, 0, 1, 2, 3], 0),
         ([np.nan, 0, np.nan, 2, 3], 0),
-        ([0, 1, 2, 3, complex(0, np.nan)], 4),
-        ([0, 1, 2, 3, complex(np.nan, 0)], 4),
-        ([0, 1, 2, complex(np.nan, 0), 3], 3),
-        ([0, 1, 2, complex(0, np.nan), 3], 3),
-        ([complex(0, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, np.nan), 0, 1, 2, 3], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, np.nan), complex(np.nan, 2), complex(np.nan, 1)], 0),
-        ([complex(np.nan, 0), complex(np.nan, 2), complex(np.nan, np.nan)], 0),
 
-        ([complex(0, 0), complex(0, 2), complex(0, 1)], 0),
-        ([complex(1, 0), complex(0, 2), complex(0, 1)], 2),
-        ([complex(1, 0), complex(0, 2), complex(1, 1)], 1),
 
         ([np.datetime64('1923-04-14T12:43:12'),
           np.datetime64('1994-06-21T14:43:15'),

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1693,18 +1693,6 @@ class TestClip:
         act = self.clip(a, m, M)
         assert_array_strict_equal(ac, act)
 
-    def test_clip_complex(self):
-        # Address Issue gh-5354 for clipping complex arrays
-        # Test native complex input without explicit min/max
-        # ie, either min=None or max=None
-        a = np.ones(10, dtype=complex)
-        m = a.min()
-        M = a.max()
-        am = self.fastclip(a, m, None)
-        aM = self.fastclip(a, None, M)
-        assert_array_strict_equal(am, a)
-        assert_array_strict_equal(aM, a)
-
     def test_clip_non_contig(self):
         # Test clip for non contiguous native input and native scalar min/max.
         a = self._generate_data(self.nr * 2, self.nc * 3)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1153,7 +1153,7 @@ class TestLdexp:
 
 class TestMaximum(_FilterInvalids):
     def test_reduce(self):
-        dflt = np.typecodes['AllFloat']
+        dflt = np.typecodes['AllFloat'][:-3]
         dint = np.typecodes['AllInteger']
         seq1 = np.arange(11)
         seq2 = seq1[::-1]
@@ -1173,10 +1173,6 @@ class TestMaximum(_FilterInvalids):
             assert_equal(func(tmp1), np.nan)
             assert_equal(func(tmp2), np.nan)
 
-    def test_reduce_complex(self):
-        assert_equal(np.maximum.reduce([1, 2j]), 1)
-        assert_equal(np.maximum.reduce([1+3j, 2j]), 1+3j)
-
     def test_float_nans(self):
         nan = np.nan
         arg1 = np.array([0,   nan, nan])
@@ -1194,14 +1190,6 @@ class TestMaximum(_FilterInvalids):
             z = np.array(float('nan'), object)
             assert_(np.maximum(x, y) == 1.0)
             assert_(np.maximum(z, y) == 1.0)
-
-    def test_complex_nans(self):
-        nan = np.nan
-        for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=complex)
-            out = np.array([nan, nan, nan], dtype=complex)
-            assert_equal(np.maximum(arg1, arg2), out)
 
     def test_object_array(self):
         arg1 = np.arange(5, dtype=object)
@@ -1224,7 +1212,7 @@ class TestMaximum(_FilterInvalids):
 
 class TestMinimum(_FilterInvalids):
     def test_reduce(self):
-        dflt = np.typecodes['AllFloat']
+        dflt = np.typecodes['AllFloat'][:-3]
         dint = np.typecodes['AllInteger']
         seq1 = np.arange(11)
         seq2 = seq1[::-1]
@@ -1244,10 +1232,6 @@ class TestMinimum(_FilterInvalids):
             assert_equal(func(tmp1), np.nan)
             assert_equal(func(tmp2), np.nan)
 
-    def test_reduce_complex(self):
-        assert_equal(np.minimum.reduce([1, 2j]), 2j)
-        assert_equal(np.minimum.reduce([1+3j, 2j]), 2j)
-
     def test_float_nans(self):
         nan = np.nan
         arg1 = np.array([0,   nan, nan])
@@ -1265,14 +1249,6 @@ class TestMinimum(_FilterInvalids):
             z = np.array(float('nan'), object)
             assert_(np.minimum(x, y) == 1.0)
             assert_(np.minimum(z, y) == 1.0)
-
-    def test_complex_nans(self):
-        nan = np.nan
-        for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=complex)
-            out = np.array([nan, nan, nan], dtype=complex)
-            assert_equal(np.minimum(arg1, arg2), out)
 
     def test_object_array(self):
         arg1 = np.arange(5, dtype=object)
@@ -1294,7 +1270,7 @@ class TestMinimum(_FilterInvalids):
 
 class TestFmax(_FilterInvalids):
     def test_reduce(self):
-        dflt = np.typecodes['AllFloat']
+        dflt = np.typecodes['AllFloat'][:-3]
         dint = np.typecodes['AllInteger']
         seq1 = np.arange(11)
         seq2 = seq1[::-1]
@@ -1314,10 +1290,6 @@ class TestFmax(_FilterInvalids):
             assert_equal(func(tmp1), 9)
             assert_equal(func(tmp2), 9)
 
-    def test_reduce_complex(self):
-        assert_equal(np.fmax.reduce([1, 2j]), 1)
-        assert_equal(np.fmax.reduce([1+3j, 2j]), 1+3j)
-
     def test_float_nans(self):
         nan = np.nan
         arg1 = np.array([0,   nan, nan])
@@ -1325,18 +1297,10 @@ class TestFmax(_FilterInvalids):
         out = np.array([0,   0,   nan])
         assert_equal(np.fmax(arg1, arg2), out)
 
-    def test_complex_nans(self):
-        nan = np.nan
-        for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=complex)
-            out = np.array([0,    0, nan], dtype=complex)
-            assert_equal(np.fmax(arg1, arg2), out)
-
 
 class TestFmin(_FilterInvalids):
     def test_reduce(self):
-        dflt = np.typecodes['AllFloat']
+        dflt = np.typecodes['AllFloat'][:-3]
         dint = np.typecodes['AllInteger']
         seq1 = np.arange(11)
         seq2 = seq1[::-1]
@@ -1356,24 +1320,12 @@ class TestFmin(_FilterInvalids):
             assert_equal(func(tmp1), 1)
             assert_equal(func(tmp2), 1)
 
-    def test_reduce_complex(self):
-        assert_equal(np.fmin.reduce([1, 2j]), 2j)
-        assert_equal(np.fmin.reduce([1+3j, 2j]), 2j)
-
     def test_float_nans(self):
         nan = np.nan
         arg1 = np.array([0,   nan, nan])
         arg2 = np.array([nan, 0,   nan])
         out = np.array([0,   0,   nan])
         assert_equal(np.fmin(arg1, arg2), out)
-
-    def test_complex_nans(self):
-        nan = np.nan
-        for cnan in [complex(nan, 0), complex(0, nan), complex(nan, nan)]:
-            arg1 = np.array([0, cnan, cnan], dtype=complex)
-            arg2 = np.array([cnan, 0, cnan], dtype=complex)
-            out = np.array([0,    0, nan], dtype=complex)
-            assert_equal(np.fmin(arg1, arg2), out)
 
 
 class TestBool:
@@ -1388,7 +1340,7 @@ class TestBool:
         input1 = [0, 0, 3, 2]
         input2 = [0, 4, 0, 2]
 
-        typecodes = (np.typecodes['AllFloat']
+        typecodes = (np.typecodes['AllFloat'][:-3]
                      + np.typecodes['AllInteger']
                      + '?')     # boolean
         for dtype in map(np.dtype, typecodes):
@@ -1638,7 +1590,7 @@ class TestMinMax:
         # and put it before the call to an intrisic function that causes
         # invalid status to be set. Also make sure warnings are not emitted
         for n in (2, 4, 8, 16, 32):
-            for dt in (np.float32, np.float16, np.complex64):
+            for dt in (np.float32, np.float16, np.float64):
                 for r in np.diagflat(np.array([np.nan] * n, dtype=dt)):
                     assert_equal(np.min(r), np.nan)
 
@@ -3228,27 +3180,6 @@ def test_reduceat_empty():
     result = np.add.reduceat(x, [], axis=1)
     assert_equal(result.dtype, x.dtype)
     assert_equal(result.shape, (5, 0))
-
-def test_complex_nan_comparisons():
-    nans = [complex(np.nan, 0), complex(0, np.nan), complex(np.nan, np.nan)]
-    fins = [complex(1, 0), complex(-1, 0), complex(0, 1), complex(0, -1),
-            complex(1, 1), complex(-1, -1), complex(0, 0)]
-
-    with np.errstate(invalid='ignore'):
-        for x in nans + fins:
-            x = np.array([x])
-            for y in nans + fins:
-                y = np.array([y])
-
-                if np.isfinite(x) and np.isfinite(y):
-                    continue
-
-                assert_equal(x < y, False, err_msg="%r < %r" % (x, y))
-                assert_equal(x > y, False, err_msg="%r > %r" % (x, y))
-                assert_equal(x <= y, False, err_msg="%r <= %r" % (x, y))
-                assert_equal(x >= y, False, err_msg="%r >= %r" % (x, y))
-                assert_equal(x == y, False, err_msg="%r == %r" % (x, y))
-
 
 def test_rint_big_int():
     # np.rint bug for large integer values on Windows 32-bit and MKL

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -1356,7 +1356,7 @@ def test_memory_layout_persistence(mode):
     assert np.pad(x, 5, mode).flags["F_CONTIGUOUS"]
 
 
-@pytest.mark.parametrize("dtype", _numeric_dtypes)
+@pytest.mark.parametrize("dtype", _numeric_dtypes[:-3])
 @pytest.mark.parametrize("mode", _all_modes.keys())
 def test_dtype_persistence(dtype, mode):
     arr = np.zeros((3, 2, 1), dtype=dtype)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -65,7 +65,7 @@ class TestNanFunctions_MinMax:
             assert_almost_equal(res, tgt)
 
     def test_dtype_from_input(self):
-        codes = 'efdgFDG'
+        codes = 'efdg'
         for nf, rf in zip(self.nanfuncs, self.stdfuncs):
             for c in codes:
                 mat = np.eye(3, dtype=c)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1265,7 +1265,7 @@ class TestMaskedArrayArithmetic:
         xm = masked_array(x, mask=m1)
         xm.set_fill_value(1e+20)
         float_dtypes = [np.half, np.single, np.double,
-                        np.longdouble, np.cfloat, np.cdouble, np.clongdouble]
+                        np.longdouble]
         for float_dtype in float_dtypes:
             assert_equal(masked_array(x, mask=m1, dtype=float_dtype).max(),
                          float_dtype(a10))
@@ -1275,28 +1275,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(xm.min(), an10)
         assert_equal(xm.max(), a10)
 
-        # Non-complex type only test
-        for float_dtype in float_dtypes[:4]:
+        for float_dtype in float_dtypes:
             assert_equal(masked_array(x, mask=m1, dtype=float_dtype).max(),
                          float_dtype(a10))
             assert_equal(masked_array(x, mask=m1, dtype=float_dtype).min(),
                          float_dtype(an10))
-
-        # Complex types only test
-        for float_dtype in float_dtypes[-3:]:
-            ym = masked_array([1e20+1j, 1e20-2j, 1e20-1j], mask=[0, 1, 0],
-                          dtype=float_dtype)
-            assert_equal(ym.min(), float_dtype(1e20-1j))
-            assert_equal(ym.max(), float_dtype(1e20+1j))
-
-            zm = masked_array([np.inf+2j, np.inf+3j, -np.inf-1j], mask=[0, 1, 0],
-                              dtype=float_dtype)
-            assert_equal(zm.min(), float_dtype(-np.inf-1j))
-            assert_equal(zm.max(), float_dtype(np.inf+2j))
-            
-            cmax = np.inf - 1j * np.finfo(np.float64).max
-            assert masked_array([-cmax, 0], mask=[0, 1]).max() == -cmax
-            assert masked_array([cmax, 0], mask=[0, 1]).min() == cmax
 
     def test_addsumprod(self):
         # Tests add, sum, product.


### PR DESCRIPTION
Depends on [gh-16700](https://github.com/numpy/numpy/pull/16700)

Follows up on the above PR. This PR deals with deprecation messages, and relevant tests that used complex type ordering comparisons