### PR TITLE
BUG: fix a compile and a test warning

### DIFF
--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -105,3 +105,7 @@ def check_fpu_mode(request):
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    monkeypatch.setenv('PYTHONHASHSEED', '0')

--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -23,7 +23,7 @@ cdef class BitGenerator():
 cdef class SeedSequence():
     cdef readonly object entropy
     cdef readonly tuple spawn_key
-    cdef readonly uint32_t pool_size
+    cdef readonly Py_ssize_t pool_size
     cdef readonly object pool
     cdef readonly uint32_t n_children_spawned
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,3 @@ filterwarnings =
     ignore:the matrix subclass is not
     ignore:Importing from numpy.matlib is
 
-env =
-    PYTHONHASHSEED=0


### PR DESCRIPTION
Fixes gh-17019 via [this comment](https://github.com/numpy/numpy/issues/17019#issuecomment-670359367). Also fix a pytest warning when the [pytest-env plugin](https://github.com/MobileDynasty/pytest-env) is not installed, by using monkeypatch which is built-in