### PR TITLE
DOC: Clarify that `np.char` comparison functions always return ndarrays

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -114,8 +114,8 @@ def equal(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------
@@ -140,8 +140,8 @@ def not_equal(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------
@@ -167,8 +167,8 @@ def greater_equal(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------
@@ -193,8 +193,8 @@ def less_equal(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------
@@ -219,8 +219,8 @@ def greater(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------
@@ -245,8 +245,8 @@ def less(x1, x2):
 
     Returns
     -------
-    out : ndarray or bool
-        Output array of bools, or a single bool if x1 and x2 are scalars.
+    out : ndarray
+        Output array of bools.
 
     See Also
     --------

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -179,6 +179,12 @@ class TestComparisons:
     def test_less(self):
         assert_array_equal((self.A < self.B), [[True, False], [False, False]])
 
+    def test_type(self):
+        out1 = np.char.equal(self.A, self.B)
+        out2 = np.char.equal('a', 'a')
+        assert_(isinstance(out1, np.ndarray))
+        assert_(isinstance(out2, np.ndarray))
+
 class TestComparisonsMixed1(TestComparisons):
     """Ticket #1276"""
 


### PR DESCRIPTION
The docstring of `np.char.equal()`, and all other comparison functions in the `np.char` module, incorrectly claim that a boolean is returned if two scalars are compared. This is incorrect, as the respective function(s) _always_ return an `ndarray` (0d in the case of scalar comparisons).

This pull requests thus corrects the docstrings of aforementioned functions.

Examples
----------
``` python
In [1]: import numpy as np

In [2]: np.__version__
Out[2]: '1.20.0.dev0+961b56f'

In [3]: np.char.equal('a', 'a')
Out[3]: array(True)  # That's definitely not a bool

In [4]: np.char.equal(['a', 'b'], ['a', 'b'])
Out[4]: array([ True,  True])
```