### PR TITLE
ENH: speed up core._internal._commastring

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -194,7 +194,7 @@ def _commastring(astr):
         if order in ['|', '=', _nbo]:
             order = ''
         dtype = order + dtype
-        if (repeats == ''):
+        if repeats in ('', '()'):
             newitem = dtype
         else:
             newitem = (dtype, ast.literal_eval(repeats))


### PR DESCRIPTION
This speeds up the case when a new dtype is constructed from a list with many fields that have the repeat as an empty tuple

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

With the old code:
![pre](https://user-images.githubusercontent.com/20952040/89873870-be895b80-dbc3-11ea-8fb7-60daabe680f0.PNG)

With the new code:
![post](https://user-images.githubusercontent.com/20952040/89873882-c3e6a600-dbc3-11ea-95b5-b779df310274.PNG)

