### PR TITLE
DOC: Replace Sphinx search with Algolia

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -1,0 +1,32 @@
+.main {
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+div.top-scipy-org-logo-header {
+  background-color: #fafafa;
+  border-bottom: 2px solid #013243; /* Warm Black */
+  margin-top: 0;
+  box-shadow: none;
+}
+div.top-scipy-org-logo-header img {
+  height: 100px;
+  padding-left: 27px;
+  display: inline-block;
+}
+
+#algolia-searchbar {
+  float: right;
+  padding-top:36px;
+  padding-right: 27px;
+}
+
+div.spc-navbar .nav-pills > li > a {
+  background-color: #4d77cf; /* Han Blue */
+}
+
+/* Eliminate the Quick Search boxes in the sidebar;
+the search results get clipped by the sidebar margin */
+#searchbox {
+  visibility: hidden;
+}

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,35 +1,22 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-<style>
-  .main {
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-  }
-  div.top-scipy-org-logo-header {
-    background-color: #fafafa;
-    border-bottom: 2px solid #013243; /* Warm Black */
-    margin-top: 0;
-    box-shadow: none;
-  }
-  div.top-scipy-org-logo-header img {
-    height: 100px;
-    padding-left: 27px;
-  }
-  div.spc-navbar .nav-pills > li > a {
-    background-color: #4d77cf; /* Han Blue */
-  }
-</style>
 {{ super() }}
+<link rel="stylesheet" href="{{ pathto('_static/numpy.css', 1) }}" type="text/css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 {% endblock %}
 
 {%- block header %}
 <div class="container">
   <div class="top-scipy-org-logo-header">
-    <a href="{{ pathto('index') }}">
+    <a href="https://numpy.org">
       <img border=0 alt="NumPy" src="{{ pathto('_static/numpylogo.svg', 1) }}">
     </a>
+    <span id="algolia-searchbar">
+    <form action="" method="get">
+      <input type="text" aria-labelledby="search-documentation" placeholder="Search">
+    </form>
+    </span>
   </div>
 </div>
 
@@ -52,3 +39,17 @@
 {%- endif %}
 {{ super() }}
 {% endblock %}
+
+{%- block footer %}
+{{ super() }}
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: 'c8367ae0f87be4fd19cb01bae97ef4f2',
+indexName: 'numpy',
+inputSelector: 'form input[type=text]',
+algoliaOptions: { 'facetFilters': ["tags:devdocs,stable"] },
+debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>
+{% endblock %}
+

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -47,7 +47,7 @@
 apiKey: 'c8367ae0f87be4fd19cb01bae97ef4f2',
 indexName: 'numpy',
 inputSelector: '#algolia-searchbar form input[type=text]',
-algoliaOptions: { 'facetFilters': ["tags:devdocs,stable"] },
+algoliaOptions: { },
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -9,7 +9,7 @@
 {%- block header %}
 <div class="container">
   <div class="top-scipy-org-logo-header">
-    <a href="https://numpy.org">
+    <a href="{{ pathto('index') }}">
       <img border=0 alt="NumPy" src="{{ pathto('_static/numpylogo.svg', 1) }}">
     </a>
     <span id="algolia-searchbar">
@@ -46,7 +46,7 @@
 <script type="text/javascript"> docsearch({
 apiKey: 'c8367ae0f87be4fd19cb01bae97ef4f2',
 indexName: 'numpy',
-inputSelector: 'form input[type=text]',
+inputSelector: '#algolia-searchbar form input[type=text]',
 algoliaOptions: { 'facetFilters': ["tags:devdocs,stable"] },
 debug: false // Set debug to true if you want to inspect the dropdown
 });


### PR DESCRIPTION
'Quick search' removed from sidebars; all pages now have a searchbar at the top. Sphinx search remains accessible in a dedicated page.

This is the search used in pytorch.org (among [many others](https://docsearch.algolia.com/)).

I'll post the CI artifact to demonstrate the look and feel. However,  WIP -- always says "no results found."  The PR gets a live version up for Algolia to take a look at.

Closes gh-17037.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
