### PR TITLE
MAINT: Revert boolean casting back to elementwise comparisons in `trim_zeros`

### DIFF
--- a/doc/release/upcoming_changes/16911.deprecation.rst
+++ b/doc/release/upcoming_changes/16911.deprecation.rst
@@ -4,4 +4,4 @@ The ``trim_zeros`` function will, in the future, require an array with the
 following two properties:
 
 * It must be 1D.
-* It must be convertable into a boolean array.
+* It must support elementwise comparisons with zero.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -710,15 +710,19 @@ class TestRaggedArray(_DeprecationTestCase):
 
 class TestTrimZeros(_DeprecationTestCase):
     # Numpy 1.20.0, 2020-07-31
-    @pytest.mark.parametrize("arr", [np.random.rand(10, 10).tolist(),
-                                     np.random.rand(10).astype(str)])
-    def test_deprecated(self, arr):
+    @pytest.mark.parametrize(
+        "arr,exc_type",
+        [(np.random.rand(10, 10).tolist(), ValueError),
+         (np.random.rand(10).astype(str), FutureWarning)]
+    )
+    def test_deprecated(self, arr, exc_type):
         with warnings.catch_warnings():
             warnings.simplefilter('error', DeprecationWarning)
             try:
                 np.trim_zeros(arr)
             except DeprecationWarning as ex:
-                assert_(isinstance(ex.__cause__, ValueError))
+                ex_cause = ex.__cause__
+                assert_(isinstance(ex_cause, exc_type))
             else:
                 raise AssertionError("No error raised during function call")
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1634,11 +1634,12 @@ def trim_zeros(filt, trim='fb'):
             "that supports elementwise comparisons with zero"
         )
         warning.__cause__ = ex
-        warnings.warn(warning, stacklevel=3)
 
-        # Fall back to the old implementation if an exception is encountered
-        # Note that the same exception may or may not be raised here as well
-        return _trim_zeros_old(filt, trim)
+    # Fall back to the old implementation if an exception is encountered
+    # Note that the same exception may or may not be raised here as well
+    ret = _trim_zeros_old(filt, trim)
+    warnings.warn(warning, stacklevel=3)
+    return ret
 
 
 def _trim_zeros_new(filt, trim='fb'):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1631,7 +1631,7 @@ def trim_zeros(filt, trim='fb'):
         # Numpy 1.20.0, 2020-07-31
         warning = DeprecationWarning(
             "in the future trim_zeros will require a 1-D array as input "
-            "that is compatible with ndarray.astype(bool)"
+            "that supports elementwise comparisons with zero"
         )
         warning.__cause__ = ex
         warnings.warn(warning, stacklevel=3)
@@ -1643,7 +1643,11 @@ def trim_zeros(filt, trim='fb'):
 
 def _trim_zeros_new(filt, trim='fb'):
     """Newer optimized implementation of ``trim_zeros()``."""
-    arr = np.asanyarray(filt).astype(bool, copy=False)
+    arr_any = np.asanyarray(filt)
+    with warnings.catch_warnings():
+        # not all dtypes support elementwise comparisons with `0` (e.g. str)
+        warnings.simplefilter('error', FutureWarning)
+        arr = arr_any != 0 if arr_any.dtype != bool else arr_any
 
     if arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1644,12 +1644,13 @@ def trim_zeros(filt, trim='fb'):
 def _trim_zeros_new(filt, trim='fb'):
     """Newer optimized implementation of ``trim_zeros()``."""
     arr_any = np.asanyarray(filt)
-    with warnings.catch_warnings():
-        # not all dtypes support elementwise comparisons with `0` (e.g. str)
-        warnings.simplefilter('error', FutureWarning)
-        arr = arr_any != 0 if arr_any.dtype != bool else arr_any
+    arr = arr_any != 0 if arr_any.dtype != bool else arr_any
 
-    if arr.ndim != 1:
+    if arr is False:
+        # not all dtypes support elementwise comparisons with `0` (e.g. str);
+        # they will return `False` instead
+        raise TypeError('elementwise comparison failed; unsupported data type')
+    elif arr.ndim != 1:
         raise ValueError('trim_zeros requires an array of exactly one dimension')
     elif not len(arr):
         return filt

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1169,10 +1169,9 @@ class TestTrimZeros:
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
     b = a.astype(float)
     c = a.astype(complex)
-    d = np.array([None, [], 1, False, 'b', 3.0, range(4), b''], dtype=object)
 
     def values(self):
-        attr_names = ('a', 'b', 'c', 'd')
+        attr_names = ('a', 'b', 'c')
         return (getattr(self, name) for name in attr_names)
 
     def test_basic(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1169,9 +1169,10 @@ class TestTrimZeros:
     a = np.array([0, 0, 1, 0, 2, 3, 4, 0])
     b = a.astype(float)
     c = a.astype(complex)
+    d = a.astype(object)
 
     def values(self):
-        attr_names = ('a', 'b', 'c')
+        attr_names = ('a', 'b', 'c', 'd')
         return (getattr(self, name) for name in attr_names)
 
     def test_basic(self):
@@ -1204,6 +1205,22 @@ class TestTrimZeros:
 
     def test_size_zero(self):
         arr = np.zeros(0)
+        res = trim_zeros(arr)
+        assert_array_equal(arr, res)
+
+    @pytest.mark.parametrize(
+        'arr',
+        [np.array([0, 2**62, 0]),
+         np.array([0, 2**63, 0]),
+         np.array([0, 2**64, 0])]
+    )
+    def test_overflow(self, arr):
+        slc = np.s_[1:2]
+        res = trim_zeros(arr)
+        assert_array_equal(res, arr[slc])
+
+    def test_no_trim(self):
+        arr = np.array([None, 1, None])
         res = trim_zeros(arr)
         assert_array_equal(arr, res)
 


### PR DESCRIPTION
Followup on https://github.com/numpy/numpy/pull/16911:

Replaces the boolean casting added in aforementioned pull request with an (elementwise) comparison to `0`.
This his two main consequences:

1. It further speed ups calls to `trim_zeros()`. Note that the performance gains seem to vary on a system by system basis (https://github.com/numpy/numpy/pull/16911#issuecomment-671654140, https://github.com/numpy/numpy/pull/16911#issuecomment-671661613 & https://github.com/numpy/numpy/pull/16911#issuecomment-671954423).
2. It ensures that the function still works on `ndarray` subclasses which do not support direct boolean casting such as `astropy.Quantity` (https://github.com/astropy/astropy/issues/10638 & https://github.com/numpy/numpy/pull/16911#issuecomment-671654140). Note that the original spirit of the function is retained: finding and trimming leading/trailing `0`s. 