### PR TITLE
DOC: use the pydata_sphinx_theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ jobs:
           path: doc/build/html/
 
 
-     #  - store_artifacts:
-     #      path: doc/neps/_build/html/
+      - store_artifacts:
+          path: doc/neps/_build/html/
      #      destination: neps
 
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,11 @@ jobs:
       - checkout
 
       - run:
-          name: install dependencies
+          name: create virtual environment, install dependencies
           command: |
             python3 -m venv venv
             ln -s $(which python3) venv/bin/python3.6
             . venv/bin/activate
-            pip install cython sphinx==2.3.1 matplotlib ipython
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
 
@@ -30,10 +29,9 @@ jobs:
           command: |
             . venv/bin/activate
             pip install --upgrade pip 'setuptools<49.2.0'
-            pip install cython
+            pip install -r test_requirements.txt
             pip install .
-            pip install scipy
-            pip install pandas
+            pip install -r doc_requirements.txt
 
       - run:
           name: create release notes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "doc/scipy-sphinx-theme"]
-	path = doc/scipy-sphinx-theme
-	url = https://github.com/scipy/scipy-sphinx-theme.git
 [submodule "doc/sphinxext"]
 	path = doc/sphinxext
 	url = https://github.com/numpy/numpydoc.git

--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -45,7 +45,7 @@ templates_path = ['../source/_templates/']
 source_suffix = '.rst'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = 'content'
 
 # General information about the project.
 project = u'NumPy Enhancement Proposals'
@@ -82,69 +82,21 @@ todo_include_todos = False
 
 ## -- Options for HTML output ----------------------------------------------
 #
-## The theme to use for HTML and HTML Help pages.  See the documentation for
-## a list of builtin themes.
-##
-#html_theme = 'alabaster'
-#
-## Theme options are theme-specific and customize the look and feel of a theme
-## further.  For a list of options available for each theme, see the
-## documentation.
-##
-## html_theme_options = {}
-#
-## Add any paths that contain custom static files (such as style sheets) here,
-## relative to this directory. They are copied after the builtin static files,
-## so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
-#
-## Custom sidebar templates, must be a dictionary that maps document names
-## to template names.
-##
-## This is required for the alabaster theme
-## refs: https://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-#html_sidebars = {
-#    '**': [
-#        'relations.html',  # needs 'show_related': True theme option to display
-#        'searchbox.html',
-#    ]
-#}
 
-## -----------------------------------------------------------------------------
-# HTML output
-# -----------------------------------------------------------------------------
+html_theme = 'pydata_sphinx_theme'
 
-themedir = os.path.join(os.pardir, 'scipy-sphinx-theme', '_theme')
-if not os.path.isdir(themedir):
-    raise RuntimeError("Get the scipy-sphinx-theme first, "
-                       "via git submodule init && git submodule update")
+html_logo = '../source/_static/numpylogo.svg'
 
-html_theme = 'scipy'
-html_theme_path = [themedir]
-
-#if 'scipyorg' in tags:
-if True:
-    # Build for the scipy.org website
-    html_theme_options = {
-        "edit_link": True,
-        "sidebar": "right",
-        "scipy_org_logo": True,
-        "rootlinks": [("https://scipy.org/", "Scipy.org"),
-                      ("https://docs.scipy.org/", "Docs")]
-    }
-else:
-    # Default build
-    html_theme_options = {
-        "edit_link": False,
-        "sidebar": "left",
-        "scipy_org_logo": False,
-        "rootlinks": []
-    }
-    html_sidebars = {'index': 'indexsidebar.html'}
-
-#html_additional_pages = {
-#    'index': 'indexcontent.html',
-#}
+html_theme_options = {
+  "github_url": "https://github.com/numpy/numpy",
+  "twitter_url": "https://twitter.com/numpy_team",
+  "external_links": [
+      {"name": "Wishlist",
+       "url": "https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22",
+      },
+  ],
+  "show_prev_next": False,
+}
 
 html_title = "%s" % (project)
 html_static_path = ['../source/_static']

--- a/doc/neps/content.rst
+++ b/doc/neps/content.rst
@@ -16,6 +16,10 @@ Roadmap
    Index <index>
    The Scope of NumPy <scope>
    Current roadmap <roadmap>
-   Wish list <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
+   Wishlist (opens new window) |wishlist_link|
+
+.. |wishlist_link| raw:: html
+
+   <a href="https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22" target=" blank">WishList</a>
 
 

--- a/doc/neps/content.rst
+++ b/doc/neps/content.rst
@@ -1,0 +1,21 @@
+=====================================
+Roadmap & NumPy Enhancement Proposals
+=====================================
+
+This page provides an overview of development priorities for NumPy.
+Specifically, it contains a roadmap with a higher-level overview, as
+well as NumPy Enhancement Proposals (NEPs)—suggested changes
+to the library—in various stages of discussion or completion (see `NEP
+0 <nep-0000>`__).
+
+Roadmap
+-------
+.. toctree::
+   :maxdepth: 1
+
+   Index <index>
+   The Scope of NumPy <scope>
+   Current roadmap <roadmap>
+   Wish list <https://github.com/numpy/numpy/issues?q=is%3Aopen+is%3Aissue+label%3A%2223+-+Wish+List%22>
+
+

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -2,38 +2,16 @@
 
 {%- block extrahead %}
 <style>
-  .main {
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-  }
-  div.top-scipy-org-logo-header {
-    background-color: #fafafa;
-    border-bottom: 2px solid #013243; /* Warm Black */
-    margin-top: 0;
-    box-shadow: none;
-  }
-  div.top-scipy-org-logo-header img {
-    height: 100px;
-    padding-left: 27px;
-  }
-  div.spc-navbar .nav-pills > li > a {
-    background-color: #4d77cf; /* Han Blue */
-  }
+.navbar-brand img {
+   height: 75px;
+}
+.navbar-brand {
+   height: 75px;
+}
 </style>
 {{ super() }}
 {% endblock %}
 
-{%- block header %}
-<div class="container">
-  <div class="top-scipy-org-logo-header">
-    <a href="{{ pathto('index') }}">
-      <img border=0 alt="NumPy" src="{{ pathto('_static/numpylogo.svg', 1) }}">
-    </a>
-  </div>
-</div>
-
-{% endblock %}
 {% block rootrellink %}
         {% if pagename != 'index' %}
         <li class="active"><a href="{{ pathto('index') }}">{{ shorttitle|e }}</a></li>

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -11,22 +11,3 @@
 </style>
 {{ super() }}
 {% endblock %}
-
-{% block rootrellink %}
-        {% if pagename != 'index' %}
-        <li class="active"><a href="{{ pathto('index') }}">{{ shorttitle|e }}</a></li>
-        {% endif %}
-{% endblock %}
-
-{% block sidebarsearch %}
-{%- if sourcename %}
-<ul class="this-page-menu">
-{%- if 'reference/generated' in sourcename %}
-  <li><a href="/numpy/docs/{{ sourcename.replace('reference/generated/', '').replace('.txt', '') |e }}">{{_('Edit page')}}</a></li>
-{%- else %}
-  <li><a href="/numpy/docs/numpy-docs/{{ sourcename.replace('.txt', '.rst') |e }}">{{_('Edit page')}}</a></li>
-{%- endif %}
-</ul>
-{%- endif %}
-{{ super() }}
-{% endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,34 +94,15 @@ def setup(app):
 # HTML output
 # -----------------------------------------------------------------------------
 
-themedir = os.path.join(os.pardir, 'scipy-sphinx-theme', '_theme')
-if not os.path.isdir(themedir):
-    raise RuntimeError("Get the scipy-sphinx-theme first, "
-                       "via git submodule init && git submodule update")
+html_theme = 'pydata_sphinx_theme'
 
-html_theme = 'scipy'
-html_theme_path = [themedir]
+html_logo = '_static/numpylogo.svg'
 
-if 'scipyorg' in tags:
-    # Build for the scipy.org website
-    html_theme_options = {
-        "edit_link": True,
-        "sidebar": "right",
-        "scipy_org_logo": True,
-        "rootlinks": [("https://scipy.org/", "Scipy.org"),
-                      ("https://docs.scipy.org/", "Docs")]
-    }
-else:
-    # Default build
-    html_theme_options = {
-        "edit_link": False,
-        "sidebar": "left",
-        "scipy_org_logo": False,
-        "rootlinks": [("https://numpy.org/", "NumPy.org"),
-                      ("https://numpy.org/doc", "Docs"),
-                     ]
-    }
-    html_sidebars = {'index': ['indexsidebar.html', 'searchbox.html']}
+html_theme_options = {
+  "github_url": "https://github.com/numpy/numpy",
+  "twitter_url": "https://twitter.com/numpy_team",
+}
+
 
 html_additional_pages = {
     'index': 'indexcontent.html',

--- a/doc/source/contents.rst
+++ b/doc/source/contents.rst
@@ -12,5 +12,5 @@ NumPy Documentation
    Development <dev/index>
 
 .. This is not really the index page, that is found in
-   _templates/intexcontent.html The toctree content here will be added to the
+   _templates/indexcontent.html The toctree content here will be added to the
    top of the template header

--- a/doc/source/contents.rst
+++ b/doc/source/contents.rst
@@ -5,23 +5,12 @@ NumPy Documentation
 ###################
 
 .. toctree::
+   :maxdepth: 1
 
-   user/setting-up
-   user/quickstart
-   user/absolute_beginners
-   user/tutorials_index
-   user/howtos_index
-   reference/index
-   user/explanations_index
-   f2py/index
-   glossary
-   dev/index
-   dev/underthehood
-   docs/index
-   docs/howto_document
-   benchmarking
-   bugs
-   release
-   about
-   license
+   User Guide <user/index>
+   API reference <reference/index>
+   Development <dev/index>
 
+.. This is not really the index page, that is found in
+   _templates/intexcontent.html The toctree content here will be added to the
+   top of the template header

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -24,3 +24,20 @@ classes contained in the package, see the :ref:`reference`.
    c-info
    tutorials_index
    howtos_index
+
+
+.. These are stuck here to avoid the "WARNING: document isn't included in any
+   toctree" message
+
+.. toctree::
+   :hidden:
+
+   explanations_index
+   ../f2py/index
+   ../glossary
+   ../dev/underthehood
+   ../docs/index
+   ../bugs
+   ../release
+   ../about
+   ../license

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,3 +3,4 @@ ipython
 scipy
 matplotlib
 pandas
+pydata-sphinx-theme

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,4 +3,4 @@ ipython
 scipy
 matplotlib
 pandas
-pydata-sphinx-theme
+pydata-sphinx-theme==0.3.1

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,4 +3,4 @@ ipython
 scipy
 matplotlib
 pandas
-pydata-sphinx-theme==0.3.1
+pydata-sphinx-theme==0.3.2


### PR DESCRIPTION
xref gh-17024.
[Here](https://15128-908607-gh.circle-artifacts.com/0/doc/build/html/index.html) is the first build of  the docs
and [here](https://15128-908607-gh.circle-artifacts.com/0/doc/neps/_build/html/index.html) is the first build of the NEPS.

Switch to the panda's [pydata sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/latest/index.html). 

Things to note:
- I added the pydata_sphinx_theme as a `doc_requirements.txt` installation dependency rather than a submodule. We may want to pin to a specific version.
- Since entries in the `content.rst` `toctree` are put into the top navbar as links, I moved some of them to the `doc/source/user/index.rst` as hidden entries. That was needed to prevent warnings.
- The link in the logo is to the `content.html` not the `index.html`
- Styling was removed from `layout.html` to give a feel for what the bare theme can do, except for making the logo a bit bigger.

Edit: copied the links to this top comment from a lower one.