### PR TITLE
DOC: Fixes duplication of toctree content (Closes #17077)

### DIFF
--- a/doc/source/user/tutorials_index.rst
+++ b/doc/source/user/tutorials_index.rst
@@ -11,10 +11,6 @@ classes contained in the package, see the :ref:`API reference <reference>`.
 .. toctree::
    :maxdepth: 1
 
-   basics
-   misc
-   numpy-for-matlab-users
    tutorial-svd
    tutorial-ma
-   building
-   c-info
+


### PR DESCRIPTION
Removes items from `tutorials_index.rst` that already included in `index.rst`. 
