### PR TITLE
BUG: Allow the `fillchar` parameter to accept bytes arrays in `np.char`

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -24,7 +24,6 @@ from .numeric import array as narray
 from numpy.core.multiarray import _vec_string
 from numpy.core.overrides import set_module
 from numpy.core import overrides
-from numpy.compat import asbytes
 import numpy
 
 __all__ = [
@@ -452,7 +451,7 @@ def center(a, width, fillchar=' '):
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
-        fillchar = asbytes(fillchar)
+        fillchar = numpy.asanyarray(fillchar, dtype=numpy.string_)
     return _vec_string(
         a_arr, (a_arr.dtype.type, size), 'center', (width_arr, fillchar))
 
@@ -997,7 +996,7 @@ def ljust(a, width, fillchar=' '):
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
-        fillchar = asbytes(fillchar)
+        fillchar = numpy.asanyarray(fillchar, dtype=numpy.string_)
     return _vec_string(
         a_arr, (a_arr.dtype.type, size), 'ljust', (width_arr, fillchar))
 
@@ -1267,7 +1266,7 @@ def rjust(a, width, fillchar=' '):
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
     if numpy.issubdtype(a_arr.dtype, numpy.string_):
-        fillchar = asbytes(fillchar)
+        fillchar = numpy.asanyarray(fillchar, dtype=numpy.string_)
     return _vec_string(
         a_arr, (a_arr.dtype.type, size), 'rjust', (width_arr, fillchar))
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -345,8 +345,8 @@ class TestMethods:
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
-        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
-        tgt = [b'aaa', b'bbb']
+        C = np.char.center([b'a', b'b'], 3, fillchar=[b'b', b'a'])
+        tgt = [b'bab', b'aba']
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
@@ -391,8 +391,8 @@ class TestMethods:
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
-        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
-        tgt = [b'aaa', b'bbb']
+        C = np.char.ljust([b'a', b'b'], 3, fillchar=[b'b', b'a'])
+        tgt = [b'abb', b'baa']
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
@@ -461,8 +461,8 @@ class TestMethods:
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
-        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
-        tgt = [b'aaa', b'bbb']
+        C = np.char.rjust([b'a', b'b'], 3, fillchar=[b'b', b'a'])
+        tgt = [b'bba', b'aab']
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -345,6 +345,11 @@ class TestMethods:
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
+        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
+        tgt = [b'aaa', b'bbb']
+        assert_(issubclass(C.dtype.type, np.string_))
+        assert_array_equal(C, tgt)
+
     def test_decode(self):
         A = np.char.array([b'\\u03a3'])
         assert_(A.decode('unicode-escape')[0] == '\u03a3')
@@ -383,6 +388,11 @@ class TestMethods:
         C = np.char.ljust(b'FOO', [[10, 20], [15, 8]])
         tgt = [[b'FOO       ', b'FOO                 '],
                [b'FOO            ', b'FOO     ']]
+        assert_(issubclass(C.dtype.type, np.string_))
+        assert_array_equal(C, tgt)
+
+        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
+        tgt = [b'aaa', b'bbb']
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 
@@ -448,6 +458,11 @@ class TestMethods:
         C = np.char.rjust(b'FOO', [[10, 20], [15, 8]])
         tgt = [[b'       FOO', b'                 FOO'],
                [b'            FOO', b'     FOO']]
+        assert_(issubclass(C.dtype.type, np.string_))
+        assert_array_equal(C, tgt)
+
+        C = np.char.center([b'a', b'b'], 3, fillchar=[b'a', b'b'])
+        tgt = [b'aaa', b'bbb']
         assert_(issubclass(C.dtype.type, np.string_))
         assert_array_equal(C, tgt)
 


### PR DESCRIPTION
This pull request addresses an issue with the `fillchar` parameter in three `np.char` functions (_e.g._ `np.char.center()`).

The aforementioned parameter currently accept one of the following three parameters:
* A string-like object.
* A bytes-like object.
* An array-like object of strings (technically a super-set of the first point).

Noted in its absence are array-like objects consisting of bytes.
As it turns out adding support for the latter is quite easy, requiring the replacement of a `bytes(...)` call with one to `np.array(.., dtype=bytes)`.

Side Note
----------
I'm not 100% sure if this is PR would be a bug fix or enhancement, as the `np.char.center()` [docs](https://numpy.org/doc/1.19/reference/generated/numpy.char.center.html) do not explicitly mention array-like objects (for the `fillchar` parameter), just strings or unicode.
As pretty much all `np.char` functions can handle array-like objects of strings/bytes I'm leaning more towards bug fix.

Examples
----------
``` python
In [1]: import numpy as np                                                                                                   

In [2]: np.__version__                                                                                                       
Out[2]: '1.19.1'

In [3]: np.char.center('a', 3, fillchar='a')                                                                                 
Out[3]: array('aaa', dtype='<U3')

In [4]: np.char.center('a', 3, fillchar=['a', 'b', 'c'])                                                                     
Out[4]: array(['aaa', 'bab', 'cac'], dtype='<U3')

In [5]: np.char.center(b'a', 3, fillchar=b'a')                                                                                
Out[5]: array(b'aaa', dtype='|S3')

In [6]: np.char.center(b'a', 3, fillchar=[b'a', b'b', b'c'])                                                                    
Traceback (most recent call last):
  ...
TypeError: center() argument 2 must be a byte string of length 1, not numpy.bytes_
```