### PR TITLE
ENH: Add aliases for common scalar unions

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -908,10 +908,22 @@ _Number = TypeVar("_Number", bound=number)
 
 # An array-like object consisting of integers
 _IntOrBool = Union[_IntLike, _BoolLike]
+_ArrayLikeIntNested = ArrayLike  # TODO: wait for support for recursive types
+_ArrayLikeBoolNested = ArrayLike  # TODO: wait for support for recursive types
 
 # Integers and booleans can generally be used interchangeably
-_ArrayLikeIntOrBool = ArrayLike[_IntOrBool]
-_ArrayLikeBool = ArrayLike[_BoolLike]
+_ArrayLikeIntOrBool = Union[
+    _IntOrBool,
+    ndarray,
+    Sequence[_IntOrBool],
+    Sequence[_ArrayLikeIntNested],
+    Sequence[_ArrayLikeBoolNested],
+]
+_ArrayLikeBool = Union[
+    _BoolLike,
+    Sequence[_BoolLike],
+    ndarray
+]
 
 # The signature of take() follows a common theme with its overloads:
 # 1. A generic comes in; the same generic comes out

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -911,11 +911,7 @@ _IntOrBool = Union[_IntLike, _BoolLike]
 
 # Integers and booleans can generally be used interchangeably
 _ArrayLikeIntOrBool = ArrayLike[_IntOrBool]
-_ArrayLikeBool = Union[
-    _BoolLike,
-    Sequence[_BoolLike],
-    ndarray
-]
+_ArrayLikeBool = ArrayLike[_BoolLike]
 
 # The signature of take() follows a common theme with its overloads:
 # 1. A generic comes in; the same generic comes out

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -15,6 +15,7 @@ from numpy.typing import (
     _StrLike,
     _BytesLike,
     _DatetimeLike,
+    _ScalarLike,
 )
 
 from typing import (
@@ -907,17 +908,9 @@ _Number = TypeVar("_Number", bound=number)
 
 # An array-like object consisting of integers
 _IntOrBool = Union[_IntLike, _BoolLike]
-_ArrayLikeIntNested = ArrayLike  # TODO: wait for support for recursive types
-_ArrayLikeBoolNested = ArrayLike  # TODO: wait for support for recursive types
 
 # Integers and booleans can generally be used interchangeably
-_ArrayLikeIntOrBool = Union[
-    _IntOrBool,
-    ndarray,
-    Sequence[_IntOrBool],
-    Sequence[_ArrayLikeIntNested],
-    Sequence[_ArrayLikeBoolNested],
-]
+_ArrayLikeIntOrBool = ArrayLike[_IntOrBool]
 _ArrayLikeBool = Union[
     _BoolLike,
     Sequence[_BoolLike],
@@ -939,7 +932,7 @@ def take(
 ) -> _ScalarGenericDT: ...
 @overload
 def take(
-    a: _Scalar,
+    a: _ScalarLike,
     indices: int,
     axis: Optional[int] = ...,
     out: Optional[ndarray] = ...,
@@ -1048,7 +1041,7 @@ def argmin(
 @overload
 def searchsorted(
     a: ArrayLike,
-    v: _Scalar,
+    v: _ScalarLike,
     side: _Side = ...,
     sorter: Optional[_ArrayLikeIntOrBool] = ...,  # 1D int array
 ) -> integer: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4,7 +4,18 @@ import datetime as dt
 from abc import abstractmethod
 
 from numpy.core._internal import _ctypes
-from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike
+from numpy.typing import (
+    ArrayLike,
+    DtypeLike,
+    _Shape,
+    _ShapeLike,
+    _IntLike,
+    _BoolLike,
+    _NumberLike,
+    _StrLike,
+    _BytesLike,
+    _DatetimeLike,
+)
 
 from typing import (
     Any,
@@ -396,7 +407,7 @@ class datetime64:
     @overload
     def __init__(
         self,
-        __value: Union[None, datetime64, str, dt.datetime] = ...,
+        __value: Union[None, _DatetimeLike, _StrLike] = ...,
         __format: str = ...
     ) -> None: ...
     @overload
@@ -488,7 +499,7 @@ class complex128(complexfloating):
 class flexible(_real_generic): ...  # type: ignore
 
 class void(flexible):
-    def __init__(self, __value: Union[int, integer, bool_, bytes, bytes_]): ...
+    def __init__(self, __value: Union[_IntLike, _BoolLike, _BytesLike]): ...
 
 class character(_real_generic): ...  # type: ignore
 
@@ -497,7 +508,7 @@ class bytes_(character):
     def __init__(self, __value: object = ...) -> None: ...
     @overload
     def __init__(
-        self, __value: Union[str, str_], encoding: str = ..., errors: str = ...
+        self, __value: _StrLike, encoding: str = ..., errors: str = ...
     ) -> None: ...
 
 class str_(character):
@@ -505,7 +516,7 @@ class str_(character):
     def __init__(self, __value: object = ...) -> None: ...
     @overload
     def __init__(
-        self, __value: Union[bytes, bytes_], encoding: str = ..., errors: str = ...
+        self, __value: _BytesLike, encoding: str = ..., errors: str = ...
     ) -> None: ...
 
 # TODO(alan): Platform dependent types
@@ -892,13 +903,10 @@ _ScalarGenericDT = TypeVar(
     "_ScalarGenericDT", bound=Union[dt.datetime, dt.timedelta, generic]
 )
 
-_Number = TypeVar('_Number', bound=number)
-_NumberLike = Union[int, float, complex, number, bool_]
+_Number = TypeVar("_Number", bound=number)
 
 # An array-like object consisting of integers
-_Int = Union[int, integer]
-_Bool = Union[bool, bool_]
-_IntOrBool = Union[_Int, _Bool]
+_IntOrBool = Union[_IntLike, _BoolLike]
 _ArrayLikeIntNested = ArrayLike  # TODO: wait for support for recursive types
 _ArrayLikeBoolNested = ArrayLike  # TODO: wait for support for recursive types
 
@@ -911,8 +919,8 @@ _ArrayLikeIntOrBool = Union[
     Sequence[_ArrayLikeBoolNested],
 ]
 _ArrayLikeBool = Union[
-    _Bool,
-    Sequence[_Bool],
+    _BoolLike,
+    Sequence[_BoolLike],
     ndarray
 ]
 

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -90,9 +90,6 @@ since its usage is discouraged.
 Please see : https://numpy.org/devdocs/reference/arrays.dtypes.html
 
 """
-from ._array_like import _SupportsArray, ArrayLike
-from ._shape import _Shape, _ShapeLike
-from ._dtype_like import DtypeLike
 from ._scalars import (
     _DatetimeLike,
     _TimedeltaLike,
@@ -105,4 +102,8 @@ from ._scalars import (
     _BytesLike,
     _CharacterLike,
     _VoidLike,
+    _ScalarLike,
 )
+from ._array_like import _SupportsArray, ArrayLike
+from ._shape import _Shape, _ShapeLike
+from ._dtype_like import DtypeLike

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -93,3 +93,16 @@ Please see : https://numpy.org/devdocs/reference/arrays.dtypes.html
 from ._array_like import _SupportsArray, ArrayLike
 from ._shape import _Shape, _ShapeLike
 from ._dtype_like import DtypeLike
+from ._scalars import (
+    _DatetimeLike,
+    _TimedeltaLike,
+    _IntLike,
+    _FloatLike,
+    _ComplexLike,
+    _BoolLike,
+    _NumberLike,
+    _StrLike,
+    _BytesLike,
+    _CharacterLike,
+    _VoidLike,
+)

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -2,6 +2,7 @@ import sys
 from typing import Any, overload, Sequence, TYPE_CHECKING, Union
 
 from numpy import ndarray
+from ._scalars import _ScalarLike
 from ._dtype_like import DtypeLike
 
 if sys.version_info >= (3, 8):
@@ -31,4 +32,4 @@ else:
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]
+ArrayLike = Union[_ScalarLike, _SupportsArray, Sequence]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING or HAVE_PROTOCOL:
 else:
     _SupportsArray = Any
 
+_ScalarType = TypeVar('_ScalarType', bound=_ScalarLike)
+
+# TODO: wait for support for recursive types
+_ArrayLikeNested = Sequence[Sequence[Any]]
+
 # TODO: support buffer protocols once
 #
 # https://bugs.python.org/issue27501
@@ -32,5 +37,4 @@ else:
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-_ScalarType = TypeVar('_ScalarType', bound=_ScalarLike)
-ArrayLike = Union[_ScalarType, _SupportsArray, Sequence]
+ArrayLike = Union[_ScalarType, Sequence[_ScalarType], _SupportsArray, _ArrayLikeNested]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -1,9 +1,8 @@
 import sys
-from typing import Any, overload, Sequence, TYPE_CHECKING, Union, TypeVar
+from typing import Any, overload, Sequence, TYPE_CHECKING, Union
 
 from numpy import ndarray
 from ._dtype_like import DtypeLike
-from ._scalars import _ScalarLike
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -25,11 +24,6 @@ if TYPE_CHECKING or HAVE_PROTOCOL:
 else:
     _SupportsArray = Any
 
-_ScalarType = TypeVar('_ScalarType', bound=_ScalarLike)
-
-# TODO: wait for support for recursive types
-_ArrayLikeNested = Sequence[Sequence[Any]]
-
 # TODO: support buffer protocols once
 #
 # https://bugs.python.org/issue27501
@@ -37,4 +31,4 @@ _ArrayLikeNested = Sequence[Sequence[Any]]
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = Union[_ScalarType, Sequence[_ScalarType], _SupportsArray, _ArrayLikeNested]
+ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -1,8 +1,9 @@
 import sys
-from typing import Any, overload, Sequence, TYPE_CHECKING, Union
+from typing import Any, overload, Sequence, TYPE_CHECKING, Union, TypeVar
 
 from numpy import ndarray
 from ._dtype_like import DtypeLike
+from ._scalars import _ScalarLike
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -31,4 +32,5 @@ else:
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]
+_ScalarType = TypeVar('_ScalarType', bound=_ScalarLike)
+ArrayLike = Union[_ScalarType, _SupportsArray, Sequence]

--- a/numpy/typing/_scalars.py
+++ b/numpy/typing/_scalars.py
@@ -6,9 +6,13 @@ import numpy as np
 _DatetimeLike = Union[datetime, np.datetime64]
 _TimedeltaLike = Union[timedelta, np.timedelta64]
 
+# NOTE: mypy has special rules which ensures that `int` is treated as
+# a `float` (and `complex`) superclass, however these rules do not apply
+# to its `np.generic` counterparts.
+# Solution: manually add them them to the unions below
 _IntLike = Union[int, np.integer]
-_FloatLike = Union[float, np.floating]
-_ComplexLike = Union[complex, np.complexfloating]
+_FloatLike = Union[float, np.floating, np.integer]
+_ComplexLike = Union[complex, np.complexfloating, np.floating, np.integer]
 _BoolLike = Union[bool, np.bool_]
 _NumberLike = Union[int, float, complex, timedelta, np.number, np.bool_]
 

--- a/numpy/typing/_scalars.py
+++ b/numpy/typing/_scalars.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Tuple, Any
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -16,9 +16,18 @@ _StrLike = Union[str, np.str_]
 _BytesLike = Union[bytes, np.bytes_]
 _CharacterLike = Union[str, bytes, np.character]
 
-# _VoidLike is technically not a scalar, but it's close enough
-_VoidLike = Union[tuple, np.void]
-
+_VoidLikeNested = Any  # TODO: wait for support for recursive types
 _ScalarLike = Union[
-    datetime, timedelta, int, float, complex, str, bytes, tuple, np.generic
+    datetime,
+    timedelta,
+    int,
+    float,
+    complex,
+    str,
+    bytes,
+    Tuple[_VoidLikeNested, ...],
+    np.generic,
 ]
+
+# _VoidLike is technically not a scalar, but it's close enough
+_VoidLike = Union[Tuple[_ScalarLike, ...], np.void]

--- a/numpy/typing/_scalars.py
+++ b/numpy/typing/_scalars.py
@@ -1,0 +1,19 @@
+from typing import Union
+from datetime import datetime, timedelta
+
+import numpy as np
+
+_DatetimeLike = Union[datetime, np.datetime64]
+_TimedeltaLike = Union[timedelta, np.timedelta64]
+
+_IntLike = Union[int, np.integer]
+_FloatLike = Union[float, np.floating]
+_ComplexLike = Union[complex, np.complexfloating]
+_BoolLike = Union[bool, np.bool_]
+_NumberLike = Union[int, float, complex, timedelta, np.number, np.bool_]
+
+_StrLike = Union[str, np.str_]
+_BytesLike = Union[bytes, np.bytes_]
+_CharacterLike = Union[str, bytes, np.character]
+
+_VoidLike = Union[tuple, np.void]

--- a/numpy/typing/_scalars.py
+++ b/numpy/typing/_scalars.py
@@ -16,4 +16,9 @@ _StrLike = Union[str, np.str_]
 _BytesLike = Union[bytes, np.bytes_]
 _CharacterLike = Union[str, bytes, np.character]
 
+# _VoidLike is technically not a scalar, but it's close enough
 _VoidLike = Union[tuple, np.void]
+
+_ScalarLike = Union[
+    datetime, timedelta, int, float, complex, str, bytes, tuple, np.generic
+]


### PR DESCRIPTION
This pull request adds a number of aliases for common scalar unions.

Numpy and builtin scalars can generally be used interchangeably, and this is reflected in the annotations of a number of functions (often when a plain `ArrayLike` is insufficiently descriptive).
The goal of this pull request is to define such annotations for common scalar-like objects and store them in a centralized location.

Examples
---------
``` python
>>> from typing import Union
>>> import numpy as np

>>> _IntLike = Union[int, np.integer]
>>> _StrLike = Union[str, np.str_]
...
```