### PR TITLE
MAINT: Include ndarrayobject.h instead of arrayobject.h in C files

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -1,7 +1,3 @@
-/*
- * DON'T INCLUDE THIS DIRECTLY.
- */
-
 #ifndef NPY_NDARRAYOBJECT_H
 #define NPY_NDARRAYOBJECT_H
 #ifdef __cplusplus

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -876,7 +876,7 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
 #define NPY_ARRAY_WRITEBACKIFCOPY 0x2000
 
 /*
- * NOTE: there are also internal flags defined in multiarray/arrayobject.h,
+ * NOTE: there are also internal flags defined in multiarray/ndarrayobject.h,
  * which start at bit 31 and work down.
  */
 

--- a/numpy/core/include/numpy/oldnumeric.h
+++ b/numpy/core/include/numpy/oldnumeric.h
@@ -1,3 +1,4 @@
+/* Use this instead of ndarrayobject.h to support NPY_NO_PREFIX */
 #include "arrayobject.h"
 
 #ifndef PYPY_VERSION

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -232,7 +232,9 @@ typedef struct _tagPyUFuncObject {
 
 } PyUFuncObject;
 
+/* Use this instead of ndarrayobject.h to support NPY_NO_PREFIX */
 #include "arrayobject.h"
+
 /* Generalized ufunc; 0x0001 reserved for possible use as CORE_ENABLED */
 /* the core dimension's size will be determined by the operands. */
 #define UFUNC_CORE_DIM_SIZE_INFERRED 0x0002

--- a/numpy/core/src/common/binop_override.h
+++ b/numpy/core/src/common/binop_override.h
@@ -3,7 +3,7 @@
 
 #include <string.h>
 #include <Python.h>
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "get_attr_string.h"
 

--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -8,7 +8,7 @@
 
 #include <Python.h>
 #include <assert.h>
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 #include "npy_cblas.h"
 #include "arraytypes.h"
 #include "common.h"

--- a/numpy/core/src/common/numpyos.c
+++ b/numpy/core/src/common/numpyos.c
@@ -6,7 +6,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/common/ucsnarrow.c
+++ b/numpy/core/src/common/ucsnarrow.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/npy_math.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/abstractdtypes.c
+++ b/numpy/core/src/multiarray/abstractdtypes.c
@@ -6,7 +6,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "numpy/ndarraytypes.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "abstractdtypes.h"
 #include "array_coercion.h"

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -17,7 +17,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include <numpy/ndarraytypes.h>
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include <numpy/npy_common.h>
 #include "npy_config.h"
 #include "alloc.h"

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -7,7 +7,7 @@
 #include "numpy/npy_3kcompat.h"
 
 #include "lowlevel_strided_loops.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "descriptor.h"
 #include "convert_datatype.h"

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -27,7 +27,7 @@ maintainer email:  oliphant.travis@ieee.org
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
@@ -40,7 +40,7 @@ maintainer email:  oliphant.travis@ieee.org
 #include "usertypes.h"
 #include "arraytypes.h"
 #include "scalartypes.h"
-#include "arrayobject.h"
+#include "ndarrayobject.h"
 #include "conversion_utils.h"
 #include "ctors.h"
 #include "dtypemeta.h"

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
@@ -14,7 +14,6 @@
 #include "npy_buffer.h"
 #include "common.h"
 #include "numpyos.h"
-#include "arrayobject.h"
 #include "scalartypes.h"
 
 /*************************************************************************

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "lowlevel_strided_loops.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -3,7 +3,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/npy_3kcompat.h"
 #include "numpy/npy_math.h"
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -4,9 +4,8 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
-#include "numpy/arrayobject.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -6,7 +6,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
@@ -14,7 +14,7 @@
 #include "npy_pycompat.h"
 
 #include "common.h"
-#include "arrayobject.h"
+#include "ndarrayobject.h"
 #include "ctors.h"
 #include "mapping.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "numpy/npy_math.h"

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -15,7 +15,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/datetime_busday.c
+++ b/numpy/core/src/multiarray/datetime_busday.c
@@ -12,7 +12,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -13,7 +13,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -14,7 +14,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -6,7 +6,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/dragon4.h
+++ b/numpy/core/src/multiarray/dragon4.h
@@ -37,7 +37,7 @@
 #include "structmember.h"
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "npy_config.h"
 #include "npy_pycompat.h"
 #include "numpy/arrayscalars.h"

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -16,7 +16,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 #include <numpy/npy_cpu.h>
 
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -6,8 +6,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
-#include "arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -6,7 +6,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"
@@ -18,7 +18,6 @@
 #include "scalartypes.h"
 #include "descriptor.h"
 #include "getset.h"
-#include "arrayobject.h"
 #include "mem_overlap.h"
 #include "alloc.h"
 #include "npy_buffer.h"

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -2,7 +2,7 @@
 #include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "numpy/npy_math.h"
@@ -16,7 +16,6 @@
 
 #include "multiarraymodule.h"
 #include "common.h"
-#include "arrayobject.h"
 #include "ctors.h"
 #include "lowlevel_strided_loops.h"
 #include "array_assign.h"

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -4,14 +4,13 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"
 
 #include "npy_pycompat.h"
 
-#include "arrayobject.h"
 #include "iterators.h"
 #include "ctors.h"
 #include "common.h"

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -5,8 +5,8 @@
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
-#include "arrayobject.h"
+#include "numpy/ndarrayobject.h"
+#include "ndarrayobject.h"
 
 #include "npy_config.h"
 

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -5,8 +5,8 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
-#include "arrayobject.h"
+#include "numpy/ndarrayobject.h"
+#include "ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "arrayfunction_override.h"

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -22,7 +22,7 @@
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #include <numpy/npy_common.h>
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "numpy/npy_math.h"
@@ -39,7 +39,6 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "array_coercion.h"
 #include "arrayfunction_override.h"
 #include "arraytypes.h"
-#include "arrayobject.h"
 #include "hashdescr.h"
 #include "descriptor.h"
 #include "dragon4.h"

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -15,7 +15,7 @@
 #define NPY_ITERATOR_IMPLEMENTATION_CODE
 #include "nditer_impl.h"
 
-#include "arrayobject.h"
+#include "ndarrayobject.h"
 #include "array_coercion.h"
 #include "templ_common.h"
 #include "array_assign.h"

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -16,7 +16,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 #include <npy_pycompat.h>
 #include "convert_datatype.h"
 

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -12,7 +12,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 #include "npy_config.h"
 #include "npy_pycompat.h"
 #include "alloc.h"

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -5,7 +5,7 @@
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -9,7 +9,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 #include "iterators.h"
 

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "numpy/npy_math.h"

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -4,7 +4,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "numpy/npy_math.h"

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -2,7 +2,7 @@
 #define _MULTIARRAYMODULE
 
 #include <Python.h>
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_pycompat.h"
 

--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -4,7 +4,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "npy_config.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #define NPY_NUMBER_MAX(a, b) ((a) > (b) ? (a) : (b))
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -27,7 +27,7 @@ maintainer email:  oliphant.travis@ieee.org
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/arrayscalars.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -14,7 +14,7 @@
 #include <Python.h>
 
 #include "npy_config.h"
-#include <numpy/arrayobject.h>
+#include <numpy/ndarrayobject.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -33,7 +33,7 @@
 
 #include "npy_pycompat.h"
 
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
 #include "lowlevel_strided_loops.h"

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -23,7 +23,7 @@
 
 #include "npy_config.h"
 
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_3kcompat.h"
 #include "abstract.h"

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -10,7 +10,7 @@ extern "C" {
 #define NO_IMPORT_ARRAY
 #endif
 #define PY_ARRAY_UNIQUE_SYMBOL _npy_f2py_ARRAY_API
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "numpy/npy_3kcompat.h"
 
 

--- a/numpy/fft/_pocketfft.c
+++ b/numpy/fft/_pocketfft.c
@@ -13,7 +13,7 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include "Python.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 
 #include <math.h>
 #include <string.h>

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -5,7 +5,7 @@ More modifications by Jeff Whitaker
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #include "Python.h"
-#include "numpy/arrayobject.h"
+#include "numpy/ndarrayobject.h"
 #include "npy_cblas.h"
 
 


### PR DESCRIPTION
The latter is just the former with some extra unwanted includes.
To avoid breaking downstream users, headers that are part of the public API are left untouched.

In many files these includes appeared twice.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
