### PR TITLE
API: Remove `np.ctypeslib.ctypes_load_library`

### DIFF
--- a/doc/release/upcoming_changes/17116.expired.rst
+++ b/doc/release/upcoming_changes/17116.expired.rst
@@ -1,0 +1,2 @@
+* The 14-year deprecation of ``np.ctypeslib.ctypes_load_library`` is expired.
+  Use :func:`~numpy.ctypeslib.load_library` instead, which is identical.

--- a/doc/source/reference/routines.ctypeslib.rst
+++ b/doc/source/reference/routines.ctypeslib.rst
@@ -9,6 +9,5 @@ C-Types Foreign Function Interface (:mod:`numpy.ctypeslib`)
 .. autofunction:: as_array
 .. autofunction:: as_ctypes
 .. autofunction:: as_ctypes_type
-.. autofunction:: ctypes_load_library
 .. autofunction:: load_library
 .. autofunction:: ndpointer

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -49,12 +49,11 @@ Then, we're ready to call ``foo_func``:
 >>> _lib.foo_func(out, len(out))                #doctest: +SKIP
 
 """
-__all__ = ['load_library', 'ndpointer', 'ctypes_load_library',
-           'c_intp', 'as_ctypes', 'as_array']
+__all__ = ['load_library', 'ndpointer', 'c_intp', 'as_ctypes', 'as_array']
 
 import os
 from numpy import (
-    integer, ndarray, dtype as _dtype, deprecate, array, frombuffer
+    integer, ndarray, dtype as _dtype, array, frombuffer
 )
 from numpy.core.multiarray import _flagdict, flagsobj
 
@@ -75,7 +74,6 @@ if ctypes is None:
 
         """
         raise ImportError("ctypes is not available.")
-    ctypes_load_library = _dummy
     load_library = _dummy
     as_ctypes = _dummy
     as_array = _dummy
@@ -154,8 +152,6 @@ else:
         ## if no successful return in the libname_ext loop:
         raise OSError("no file with expected extension")
 
-    ctypes_load_library = deprecate(load_library, 'ctypes_load_library',
-                                    'load_library')
 
 def _num_fromflags(flaglist):
     num = 0


### PR DESCRIPTION
This function has been deprecated since fcee1ad856089a7ecb7b6865d280c0273dacb638 (Numpy v1.0b3).

14 years is more than enough time for users to switch from it.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
