### PR TITLE
MAINT: Remove duplicated symbols from link step

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -941,7 +941,7 @@ def configuration(parent_package='',top_path=None):
                                  ],
                          depends=deps + multiarray_deps + umath_deps +
                                 common_deps,
-                         libraries=['npymath', 'npysort'],
+                         libraries=['npysort'],
                          extra_info=extra_info)
 
     #######################################################################

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -930,7 +930,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_extension('_multiarray_umath',
                          sources=multiarray_src + umath_src +
-                                 npymath_sources + common_src +
+                                 common_src +
                                  [generate_config_h,
                                   generate_numpyconfig_h,
                                   generate_numpy_api,
@@ -941,7 +941,7 @@ def configuration(parent_package='',top_path=None):
                                  ],
                          depends=deps + multiarray_deps + umath_deps +
                                 common_deps,
-                         libraries=['npysort'],
+                         libraries=['npymath', 'npysort'],
                          extra_info=extra_info)
 
     #######################################################################


### PR DESCRIPTION
Remove npymath lib from _multiarray_umath since it contains symbols defined
in object files being linked

This was discovered as part of #13816 when using clang's lld-link, which is stricter than link.exe and errored with
numerous complaints of functions defined in multiple files. 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
