### PR TITLE
BUG,TST: Fixed an issue in the `trim_zeros` deprecation tests

### DIFF
--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -713,7 +713,7 @@ class TestTrimZeros(_DeprecationTestCase):
     @pytest.mark.parametrize(
         "arr,exc_type",
         [(np.random.rand(10, 10).tolist(), ValueError),
-         (np.random.rand(10).astype(str), FutureWarning)]
+         (np.random.rand(10).astype(str), (FutureWarning, TypeError))]
     )
     def test_deprecated(self, arr, exc_type):
         with warnings.catch_warnings():

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -737,3 +737,8 @@ class TestTrimZeros(_DeprecationTestCase):
         arr = np.random.rand(10).astype(str)
         with pytest.warns(FutureWarning), pytest.raises(TypeError):
             np.lib.function_base._trim_zeros_new(arr)
+
+    def test_warning(self):
+        arr = [0, 0, [1], 0]
+        with pytest.warns(np.VisibleDeprecationWarning):
+            np.lib.function_base._trim_zeros_new(arr)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -732,3 +732,11 @@ class TestTrimZeros(_DeprecationTestCase):
 
         out = np.lib.function_base._trim_zeros_old(arr)
         assert_array_equal(arr, out)
+
+    @pytest.mark.parametrize(
+        "arr", [np.random.rand(10).astype(str), np.zeros((), dtype=str)]
+    )
+    def test_type_error(self, arr):
+        with warnings.catch_warnings(), pytest.raises(TypeError):
+            warnings.simplefilter('ignore', FutureWarning)
+            np.lib.function_base._trim_zeros_new(arr)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -717,7 +717,7 @@ class TestTrimZeros(_DeprecationTestCase):
     @pytest.mark.parametrize(
         "arr,exc_type",
         [(np.random.rand(10, 10).tolist(), ValueError),
-         (np.random.rand(10).astype(str), (FutureWarning, TypeError))]
+         (np.array(["0", "a", "b", ""]), (FutureWarning, TypeError))]
     )
     def test_deprecated(self, arr, exc_type):
         with warnings.catch_warnings():
@@ -734,7 +734,7 @@ class TestTrimZeros(_DeprecationTestCase):
         assert_array_equal(arr, out)
 
     def test_type_error(self):
-        arr = np.random.rand(10).astype(str)
+        arr = np.array(["0", "a", "b", ""])
         with pytest.warns(FutureWarning), pytest.raises(TypeError):
             np.lib.function_base._trim_zeros_new(arr)
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -711,13 +711,10 @@ class TestRaggedArray(_DeprecationTestCase):
 class TestTrimZeros(_DeprecationTestCase):
     # Numpy 1.20.0, 2020-07-31
 
-    # NOTE: An issue was encountered on `MacPython/numpy-wheels` where failed
-    # elementwise comparisons would not issue a `FutureWarning`; a `TypeError`
-    # will be raised in such scenario (see gh-17126)
     @pytest.mark.parametrize(
         "arr,exc_type",
         [(np.random.rand(10, 10).tolist(), ValueError),
-         (np.array(["0", "a", "b", ""]), (FutureWarning, TypeError))]
+         (np.array(["0", "a", "b", ""]), FutureWarning)]
     )
     def test_deprecated(self, arr, exc_type):
         with warnings.catch_warnings():

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -741,4 +741,5 @@ class TestTrimZeros(_DeprecationTestCase):
     def test_warning(self):
         arr = [0, 0, [1], 0]
         with pytest.warns(np.VisibleDeprecationWarning):
-            np.lib.function_base._trim_zeros_new(arr)
+            out = np.lib.function_base._trim_zeros_new(arr)
+            assert_array_equal(out, arr[2:3])

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -733,10 +733,8 @@ class TestTrimZeros(_DeprecationTestCase):
         out = np.lib.function_base._trim_zeros_old(arr)
         assert_array_equal(arr, out)
 
-    @pytest.mark.parametrize(
-        "arr", [np.random.rand(10).astype(str), np.zeros((), dtype=str)]
-    )
-    def test_type_error(self, arr):
+    def test_type_error(self):
+        arr = np.random.rand(10).astype(str)
         simple_filter = warnings.simplefilter
         with warnings.catch_warnings(), pytest.raises(TypeError):
             simple_filter('ignore', FutureWarning)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -741,5 +741,5 @@ class TestTrimZeros(_DeprecationTestCase):
     def test_warning(self):
         arr = [0, 0, [1], 0]
         with pytest.warns(np.VisibleDeprecationWarning):
-            out = np.lib.function_base._trim_zeros_new(arr)
+            out = np.trim_zeros(arr)
             assert_array_equal(out, arr[2:3])

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -737,6 +737,7 @@ class TestTrimZeros(_DeprecationTestCase):
         "arr", [np.random.rand(10).astype(str), np.zeros((), dtype=str)]
     )
     def test_type_error(self, arr):
+        simple_filter = warnings.simplefilter
         with warnings.catch_warnings(), pytest.raises(TypeError):
-            warnings.simplefilter('ignore', FutureWarning)
+            simple_filter('ignore', FutureWarning)
             np.lib.function_base._trim_zeros_new(arr)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -735,7 +735,5 @@ class TestTrimZeros(_DeprecationTestCase):
 
     def test_type_error(self):
         arr = np.random.rand(10).astype(str)
-        simple_filter = warnings.simplefilter
-        with warnings.catch_warnings(), pytest.raises(TypeError):
-            simple_filter('ignore', FutureWarning)
+        with pytest.warns(FutureWarning), pytest.raises(TypeError):
             np.lib.function_base._trim_zeros_new(arr)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -710,6 +710,10 @@ class TestRaggedArray(_DeprecationTestCase):
 
 class TestTrimZeros(_DeprecationTestCase):
     # Numpy 1.20.0, 2020-07-31
+
+    # NOTE: An issue was encountered on `MacPython/numpy-wheels` where failed
+    # elementwise comparisons would not issue a `FutureWarning`; a `TypeError`
+    # will be raised in such scenario (see gh-17126)
     @pytest.mark.parametrize(
         "arr,exc_type",
         [(np.random.rand(10, 10).tolist(), ValueError),

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -720,8 +720,9 @@ class TestTrimZeros(_DeprecationTestCase):
          (np.random.rand(10).astype(str), (FutureWarning, TypeError))]
     )
     def test_deprecated(self, arr, exc_type):
+        simple_filter = warnings.simplefilter
         with warnings.catch_warnings():
-            warnings.simplefilter('error', DeprecationWarning)
+            simple_filter('error', DeprecationWarning)
             try:
                 np.trim_zeros(arr)
             except DeprecationWarning as ex:

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -720,9 +720,8 @@ class TestTrimZeros(_DeprecationTestCase):
          (np.random.rand(10).astype(str), (FutureWarning, TypeError))]
     )
     def test_deprecated(self, arr, exc_type):
-        simple_filter = warnings.simplefilter
         with warnings.catch_warnings():
-            simple_filter('error', DeprecationWarning)
+            warnings.simplefilter('error', DeprecationWarning)
             try:
                 np.trim_zeros(arr)
             except DeprecationWarning as ex:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1647,7 +1647,7 @@ def _trim_zeros_new(filt, trim='fb'):
     arr_any = np.asanyarray(filt)
     arr = arr_any != 0 if arr_any.dtype != bool else arr_any
 
-    if arr is False:
+    if isinstance(arr, bool):
         # not all dtypes support elementwise comparisons with `0` (e.g. str);
         # they will return `False` instead
         raise TypeError('elementwise comparison failed; unsupported data type')

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1645,14 +1645,15 @@ def trim_zeros(filt, trim='fb'):
 def _trim_zeros_new(filt, trim='fb'):
     """Newer optimized implementation of ``trim_zeros()``."""
     arr_any = np.asanyarray(filt)
+    if arr_any.ndim != 1:
+        raise ValueError('trim_zeros requires an array of exactly one dimension')
+
     arr = arr_any != 0 if arr_any.dtype != bool else arr_any
 
     if isinstance(arr, bool):
         # not all dtypes support elementwise comparisons with `0` (e.g. str);
         # they will return `False` instead
         raise TypeError('elementwise comparison failed; unsupported data type')
-    elif arr.ndim != 1:
-        raise ValueError('trim_zeros requires an array of exactly one dimension')
     elif not len(arr):
         return filt
 


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/17126.

Adds precautions for whenever a failed element-wise comparison:
* Returns `True`.
* Does not issue a `FutureWarning`.

Both issues were encountered in https://travis-ci.org/github/MacPython/numpy-wheels/jobs/719738469.
