### PR TITLE
MAINT: Chain some exceptions in arraysetops.

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -300,10 +300,10 @@ def unique(ar, return_index=False, return_inverse=False,
             # array with shape `(len(ar),)`.  Because `dtype` in this case has
             # itemsize 0, the total size of the result is still 0 bytes.
             consolidated = np.empty(len(ar), dtype=dtype)
-    except TypeError:
+    except TypeError as e:
         # There's no good way to do this for object arrays, etc...
         msg = 'The axis argument to unique is not supported for dtype {dt}'
-        raise TypeError(msg.format(dt=ar.dtype))
+        raise TypeError(msg.format(dt=ar.dtype)) from e
 
     def reshape_uniq(uniq):
         n = len(uniq)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -276,9 +276,9 @@ def unique(ar, return_index=False, return_inverse=False,
     # axis was specified and not None
     try:
         ar = np.moveaxis(ar, axis, 0)
-    except np.AxisError as e:
+    except np.AxisError:
         # this removes the "axis1" or "axis2" prefix from the error message
-        raise np.AxisError(axis, ar.ndim) from e
+        raise np.AxisError(axis, ar.ndim)
 
     # Must reshape to a contiguous 2D array for this to work...
     orig_shape, orig_dtype = ar.shape, ar.dtype

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -276,9 +276,9 @@ def unique(ar, return_index=False, return_inverse=False,
     # axis was specified and not None
     try:
         ar = np.moveaxis(ar, axis, 0)
-    except np.AxisError:
+    except np.AxisError as e:
         # this removes the "axis1" or "axis2" prefix from the error message
-        raise np.AxisError(axis, ar.ndim)
+        raise np.AxisError(axis, ar.ndim) from e
 
     # Must reshape to a contiguous 2D array for this to work...
     orig_shape, orig_dtype = ar.shape, ar.dtype

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -278,7 +278,7 @@ def unique(ar, return_index=False, return_inverse=False,
         ar = np.moveaxis(ar, axis, 0)
     except np.AxisError:
         # this removes the "axis1" or "axis2" prefix from the error message
-        raise np.AxisError(axis, ar.ndim)
+        raise np.AxisError(axis, ar.ndim) from None
 
     # Must reshape to a contiguous 2D array for this to work...
     orig_shape, orig_dtype = ar.shape, ar.dtype


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->
Changes related to #15986

Adds exception chaining to TypeError and RaiseError in ``numpy/numpy/lib/arraysetops.py ``
<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
