### PR TITLE
MAINT: Make arrayprint str and repr the ndarray defaults.

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1628,6 +1628,3 @@ def set_string_function(f, repr=True):
             return multiarray.set_string_function(_default_array_str, 0)
     else:
         return multiarray.set_string_function(f, repr)
-
-set_string_function(_default_array_str, False)
-set_string_function(_default_array_repr, True)

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -3,13 +3,24 @@
 
 #include <Python.h>
 #include <numpy/arrayobject.h>
-
 #include "npy_pycompat.h"
-
+#include "npy_import.h"
 #include "strfuncs.h"
 
 static PyObject *PyArray_StrFunction = NULL;
 static PyObject *PyArray_ReprFunction = NULL;
+
+
+static void
+npy_PyErr_SetStringChained(PyObject *type, const char *message)
+{
+    PyObject *exc, *val, *tb;
+
+    PyErr_Fetch(&exc, &val, &tb);
+    PyErr_SetString(type, message);
+    npy_PyErr_ChainExceptionsCause(exc, val, tb);
+}
+
 
 /*NUMPY_API
  * Set the array print function to be a Python function.
@@ -36,163 +47,51 @@ PyArray_SetStringFunction(PyObject *op, int repr)
 }
 
 
-/*
- * Extend string. On failure, returns NULL and leaves *strp alone.
- * XXX we do this in multiple places; time for a string library?
- */
-static char *
-extend_str(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
-{
-    char *str = *strp;
-    Py_ssize_t new_cap;
-
-    if (n >= *maxp - 16) {
-        new_cap = *maxp * 2;
-
-        if (new_cap <= *maxp) {     /* overflow */
-            return NULL;
-        }
-        str = PyArray_realloc(*strp, new_cap);
-        if (str != NULL) {
-            *strp = str;
-            *maxp = new_cap;
-        }
-    }
-    return str;
-}
-
-
-static int
-dump_data(char **string, Py_ssize_t *n, Py_ssize_t *max_n, char *data, int nd,
-          npy_intp const *dimensions, npy_intp const *strides, PyArrayObject* self)
-{
-    PyObject *op = NULL, *sp = NULL;
-    char *ostring;
-    npy_intp i, N, ret = 0;
-
-#define CHECK_MEMORY do {                           \
-        if (extend_str(string, *n, max_n) == NULL) {    \
-            ret = -1;                               \
-            goto end;                               \
-        }                                           \
-    } while (0)
-
-    if (nd == 0) {
-        if ((op = PyArray_GETITEM(self, data)) == NULL) {
-            return -1;
-        }
-        sp = PyObject_Repr(op);
-        if (sp == NULL) {
-            ret = -1;
-            goto end;
-        }
-        ostring = PyString_AsString(sp);
-        N = PyString_Size(sp)*sizeof(char);
-        *n += N;
-        CHECK_MEMORY;
-        memmove(*string + (*n - N), ostring, N);
-    }
-    else {
-        CHECK_MEMORY;
-        (*string)[*n] = '[';
-        *n += 1;
-        for (i = 0; i < dimensions[0]; i++) {
-            if (dump_data(string, n, max_n,
-                          data + (*strides)*i,
-                          nd - 1, dimensions + 1,
-                          strides + 1, self) < 0) {
-                return -1;
-            }
-            CHECK_MEMORY;
-            if (i < dimensions[0] - 1) {
-                (*string)[*n] = ',';
-                (*string)[*n+1] = ' ';
-                *n += 2;
-            }
-        }
-        CHECK_MEMORY;
-        (*string)[*n] = ']';
-        *n += 1;
-    }
-
-#undef CHECK_MEMORY
-
-end:
-    Py_XDECREF(op);
-    Py_XDECREF(sp);
-    return ret;
-}
-
-
-static PyObject *
-array_repr_builtin(PyArrayObject *self, int repr)
-{
-    PyObject *ret;
-    char *string;
-    /* max_n initial value is arbitrary, dump_data will extend it */
-    Py_ssize_t n = 0, max_n = PyArray_NBYTES(self) * 4 + 7;
-
-    if ((string = PyArray_malloc(max_n)) == NULL) {
-        return PyErr_NoMemory();
-    }
-
-    if (dump_data(&string, &n, &max_n, PyArray_DATA(self),
-                  PyArray_NDIM(self), PyArray_DIMS(self),
-                  PyArray_STRIDES(self), self) < 0) {
-        PyArray_free(string);
-        return NULL;
-    }
-
-    if (repr) {
-        if (PyArray_ISEXTENDED(self)) {
-            ret = PyUString_FromFormat("array(%s, '%c%d')",
-                                       string,
-                                       PyArray_DESCR(self)->type,
-                                       PyArray_DESCR(self)->elsize);
-        }
-        else {
-            ret = PyUString_FromFormat("array(%s, '%c')",
-                                       string,
-                                       PyArray_DESCR(self)->type);
-        }
-    }
-    else {
-        ret = PyUString_FromStringAndSize(string, n);
-    }
-
-    PyArray_free(string);
-    return ret;
-}
-
-
 NPY_NO_EXPORT PyObject *
 array_repr(PyArrayObject *self)
 {
-    PyObject *s;
+    static PyObject *repr = NULL;
 
-    if (PyArray_ReprFunction == NULL) {
-        s = array_repr_builtin(self, 1);
+    if (PyArray_ReprFunction != NULL) {
+        return PyObject_CallFunctionObjArgs(PyArray_ReprFunction, self, NULL);
     }
-    else {
-        s = PyObject_CallFunctionObjArgs(PyArray_ReprFunction, self, NULL);
+
+    /*
+     * We need to do a delayed import here as initialization on module load
+     * leads to circular import problems.
+     */
+    npy_cache_import("numpy.core.arrayprint", "_default_array_repr", &repr);
+    if (repr == NULL) {
+        npy_PyErr_SetStringChained(PyExc_RuntimeError,
+                "Unable to configure default ndarray.__repr__");
+        return NULL;
     }
-    return s;
+    return PyObject_CallFunctionObjArgs(repr, self, NULL);
 }
 
 
 NPY_NO_EXPORT PyObject *
 array_str(PyArrayObject *self)
 {
-    PyObject *s;
+    static PyObject *str = NULL;
 
-    if (PyArray_StrFunction == NULL) {
-        s = array_repr_builtin(self, 0);
+    if (PyArray_StrFunction != NULL) {
+        return PyObject_CallFunctionObjArgs(PyArray_StrFunction, self, NULL);
     }
-    else {
-        s = PyObject_CallFunctionObjArgs(PyArray_StrFunction, self, NULL);
+
+    /*
+     * We need to do a delayed import here as initialization on module load leads
+     * to circular import problems.
+     */
+    npy_cache_import("numpy.core.arrayprint", "_default_array_str", &str);
+    if (str == NULL) {
+        npy_PyErr_SetStringChained(PyExc_RuntimeError,
+                "Unable to configure default ndarray.__str__");
+        return NULL;
     }
-    return s;
+    return PyObject_CallFunctionObjArgs(str, self, NULL);
 }
+
 
 NPY_NO_EXPORT PyObject *
 array_format(PyArrayObject *self, PyObject *args)
@@ -221,4 +120,3 @@ array_format(PyArrayObject *self, PyObject *args)
         );
     }
 }
-


### PR DESCRIPTION
This removes the old default routines in 'strfunc.c' that were never
used and looked to have unicode/byte problems. The functions now
self initialize from arrayprint when called, so the explicit initialization
previously done when arrayprint module was loaded is no longer needed.

Closes #17138.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
