### PR TITLE
MAINT: Change handling of the expired financial functions.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -219,7 +219,7 @@ else:
     # a warning, and calling the function will raise an exception.
     _financial_names = ['fv', 'ipmt', 'irr', 'mirr', 'nper', 'npv', 'pmt',
                         'ppmt', 'pv', 'rate']
-    __expired_attrs__ = {
+    __expired_functions__ = {
         name: (f'In accordance with NEP 32, the function {name} was removed '
                'from NumPy version 1.20.  A replacement for this function '
                'is available in the numpy_financial library: '
@@ -243,7 +243,7 @@ else:
             # Warn for expired attributes, and return a dummy function
             # that always raises an exception.
             try:
-                msg = __expired_attrs__[attr]
+                msg = __expired_functions__[attr]
             except KeyError:
                 pass
             else:

--- a/numpy/lib/tests/test_financial_expired.py
+++ b/numpy/lib/tests/test_financial_expired.py
@@ -3,10 +3,11 @@ import pytest
 import numpy as np
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 7),
+                    reason="requires python 3.7 or higher")
 def test_financial_expired():
-    if sys.version_info[:2] >= (3, 7):
-        match = 'NEP 32'
-    else:
-        match = None
-    with pytest.raises(AttributeError, match=match):
-        np.fv
+    match = 'NEP 32'
+    with pytest.warns(RuntimeWarning, match=match):
+        func = np.fv
+    with pytest.raises(RuntimeError, match=match):
+        func(1, 2, 3)


### PR DESCRIPTION
In a previous commit, the expired financial functions were removed
from NumPy, and code was added to `__init__.py` using the module
`__getattr__` to raise a customized AttributeError on any attempt to
reference the expired names in the numpy namespace.

That change broke released versions astropy, which has code that
imports the financial functions.  astropy never calls the functions,
so they never saw the deprecation warnings that have been in place
since numpy 1.18.  This means that attempting to use a released
version of astropy with numpy 1.20 will cause astropy to crash
with the custom AttributeError.

In this commit, instead of raising an exception when one of the
expired names is referenced, a warning is generated.  If the
function is *called*, an exception is raised.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
