### PR TITLE
ENH: Add annotations to 3 functions in `np.core.function_base`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -44,6 +44,17 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal, Protocol
 
+from numpy.core.function_base import (
+    linspace,
+    logspace,
+    geomspace,
+)
+
+# Add an object to `__all__` if their stubs are defined in an external file;
+# their stubs will not be recognized otherwise.
+# NOTE: This is redundant for objects defined within this file.
+__all__ = ["linspace", "logspace", "geomspace"]
+
 # TODO: remove when the full numpy namespace is defined
 def __getattr__(name: str) -> Any: ...
 

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -165,7 +165,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     if axis != 0:
         y = _nx.moveaxis(y, 0, axis)
-    
+
     if _nx.issubdtype(dtype, _nx.integer):
         _nx.floor(y, out=y)
 
@@ -207,7 +207,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
     endpoint : boolean, optional
         If true, `stop` is the last sample. Otherwise, it is not included.
         Default is True.
-    base : float, optional
+    base : array_like, optional
         The base of the log space. The step size between the elements in
         ``ln(samples) / ln(base)`` (or ``log_base(samples)``) is uniform.
         Default is 10.0.

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,7 +1,7 @@
 import sys
 from typing import overload, Tuple, Union, Sequence, Any
 
-from numpy import ndarray, floating, _NumberLike
+from numpy import ndarray, inexact, _NumberLike
 from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
 
 if sys.version_info >= (3, 8):
@@ -36,7 +36,7 @@ def linspace(
     retstep: Literal[True] = ...,
     dtype: DtypeLike = ...,
     axis: int = ...,
-) -> Tuple[ndarray, floating]: ...
+) -> Tuple[ndarray, inexact]: ...
 def logspace(
     start: _ArrayLikeNumber,
     stop: _ArrayLikeNumber,

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,7 +1,7 @@
 import sys
 from typing import overload, Tuple, Union, Sequence, Any
 
-from numpy import ndarray, floating, number, _NumberLike
+from numpy import ndarray, floating, _NumberLike
 from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
 
 if sys.version_info >= (3, 8):

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -7,10 +7,7 @@ from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex, Literal
 else:
-    from typing_extensions import Literal, Protocol
-
-    class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...
+    from typing_extensions import SupportsIndex, Literal
 
 # TODO: wait for support for recursive types
 _ArrayLikeNested = Sequence[Sequence[Any]]

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -25,7 +25,7 @@ def linspace(
     endpoint: bool = ...,
     retstep: Literal[False] = ...,
     dtype: DtypeLike = ...,
-    axis: int = ...,
+    axis: SupportsIndex = ...,
 ) -> ndarray: ...
 @overload
 def linspace(
@@ -35,7 +35,7 @@ def linspace(
     endpoint: bool = ...,
     retstep: Literal[True] = ...,
     dtype: DtypeLike = ...,
-    axis: int = ...,
+    axis: SupportsIndex = ...,
 ) -> Tuple[ndarray, inexact]: ...
 def logspace(
     start: _ArrayLikeNumber,
@@ -44,7 +44,7 @@ def logspace(
     endpoint: bool = ...,
     base: _ArrayLikeNumber = ...,
     dtype: DtypeLike = ...,
-    axis: int = ...,
+    axis: SupportsIndex = ...,
 ) -> ndarray: ...
 def geomspace(
     start: _ArrayLikeNumber,
@@ -52,5 +52,5 @@ def geomspace(
     num: SupportsIndex = ...,
     endpoint: bool = ...,
     dtype: DtypeLike = ...,
-    axis: int = ...,
+    axis: SupportsIndex = ...,
 ) -> ndarray: ...

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,0 +1,53 @@
+import sys
+from typing import overload, Tuple, Union, Sequence, Any
+
+from numpy import ndarray, floating, number, _NumberLike
+from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
+
+if sys.version_info >= (3, 8):
+    from typing import SupportsIndex, Literal
+else:
+    from typing_extensions import SupportsIndex, Literal
+
+# TODO: wait for support for recursive types
+_ArrayLikeNested = Sequence[Sequence[Any]]
+_ArrayLikeNumber = Union[
+    _NumberLike, Sequence[_NumberLike], ndarray, _SupportsArray, _ArrayLikeNested
+]
+@overload
+def linspace(
+    start: _ArrayLikeNumber,
+    stop: _ArrayLikeNumber,
+    num: SupportsIndex = ...,
+    endpoint: bool = ...,
+    retstep: Literal[False] = ...,
+    dtype: DtypeLike = ...,
+    axis: int = ...,
+) -> ndarray: ...
+@overload
+def linspace(
+    start: _ArrayLikeNumber,
+    stop: _ArrayLikeNumber,
+    num: SupportsIndex = ...,
+    endpoint: bool = ...,
+    retstep: Literal[True] = ...,
+    dtype: DtypeLike = ...,
+    axis: int = ...,
+) -> Tuple[ndarray, floating]: ...
+def logspace(
+    start: _ArrayLikeNumber,
+    stop: _ArrayLikeNumber,
+    num: SupportsIndex = ...,
+    endpoint: bool = ...,
+    base: _ArrayLikeNumber = ...,
+    dtype: DtypeLike = ...,
+    axis: int = ...,
+) -> ndarray: ...
+def geomspace(
+    start: _ArrayLikeNumber,
+    stop: _ArrayLikeNumber,
+    num: SupportsIndex = ...,
+    endpoint: bool = ...,
+    dtype: DtypeLike = ...,
+    axis: int = ...,
+) -> ndarray: ...

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -7,7 +7,10 @@ from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex, Literal
 else:
-    from typing_extensions import SupportsIndex, Literal
+    from typing_extensions import Literal, Protocol
+
+    class SupportsIndex(Protocol):
+        def __index__(self) -> int: ...
 
 # TODO: wait for support for recursive types
 _ArrayLikeNested = Sequence[Sequence[Any]]

--- a/numpy/tests/typing/fail/linspace.py
+++ b/numpy/tests/typing/fail/linspace.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+np.linspace(None, 'bob')  # E: No overload variant
+np.linspace(0, 2, num=10.0)  # E: No overload variant
+np.linspace(0, 2, endpoint='True')  # E: No overload variant
+np.linspace(0, 2, retstep=b'False')  # E: No overload variant
+np.linspace(0, 2, dtype=0)  # E: No overload variant
+np.linspace(0, 2, axis=None)  # E: No overload variant
+
+np.logspace(None, 'bob')  # E: Argument 1
+np.logspace(0, 2, base=None)  # E: Argument "base"
+
+np.geomspace(None, 'bob')  # E: Argument 1

--- a/numpy/tests/typing/pass/linspace.py
+++ b/numpy/tests/typing/pass/linspace.py
@@ -1,5 +1,9 @@
 import numpy as np
 
+class Index:
+    def __index__(self) -> int:
+        return 0
+
 np.linspace(0, 2)
 np.linspace(0.5, [0, 1, 2])
 np.linspace([0, 1, 2], 3)
@@ -9,7 +13,7 @@ np.linspace(0, 2, endpoint=True)
 np.linspace(0, 2, retstep=True)
 np.linspace(0j, 2j, retstep=True)
 np.linspace(0, 2, dtype=bool)
-np.linspace([0, 1], [2, 3], axis=1)
+np.linspace([0, 1], [2, 3], axis=Index())
 
 np.logspace(0, 2, base=2)
 np.logspace(0, 2, base=2)

--- a/numpy/tests/typing/pass/linspace.py
+++ b/numpy/tests/typing/pass/linspace.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+np.linspace(0, 2)
+np.linspace(0.5, [0, 1, 2])
+np.linspace([0, 1, 2], 3)
+np.linspace(0j, 2)
+np.linspace(0, 2, num=10)
+np.linspace(0, 2, endpoint=True)
+np.linspace(0, 2, retstep=True)
+np.linspace(0, 2, dtype=bool)
+np.linspace([0, 1], [2, 3], axis=1)
+
+np.logspace(0, 2, base=2)
+np.logspace(0, 2, base=2)
+np.logspace(0, 2, base=[1j, 2j], num=2)
+
+np.geomspace(1, 2)

--- a/numpy/tests/typing/pass/linspace.py
+++ b/numpy/tests/typing/pass/linspace.py
@@ -7,6 +7,7 @@ np.linspace(0j, 2)
 np.linspace(0, 2, num=10)
 np.linspace(0, 2, endpoint=True)
 np.linspace(0, 2, retstep=True)
+np.linspace(0j, 2j, retstep=True)
 np.linspace(0, 2, dtype=bool)
 np.linspace([0, 1], [2, 3], axis=1)
 

--- a/numpy/tests/typing/reveal/linspace.py
+++ b/numpy/tests/typing/reveal/linspace.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+reveal_type(np.linspace(0, 10))  # E: numpy.ndarray
+reveal_type(np.linspace(0, 10, retstep=True))  # E: Tuple[numpy.ndarray, numpy.floating]
+reveal_type(np.logspace(0, 10))  # E: numpy.ndarray
+reveal_type(np.geomspace(1, 10))  # E: numpy.ndarray

--- a/numpy/tests/typing/reveal/linspace.py
+++ b/numpy/tests/typing/reveal/linspace.py
@@ -1,6 +1,6 @@
 import numpy as np
 
 reveal_type(np.linspace(0, 10))  # E: numpy.ndarray
-reveal_type(np.linspace(0, 10, retstep=True))  # E: Tuple[numpy.ndarray, numpy.floating]
+reveal_type(np.linspace(0, 10, retstep=True))  # E: Tuple[numpy.ndarray, numpy.inexact]
 reveal_type(np.logspace(0, 10))  # E: numpy.ndarray
 reveal_type(np.geomspace(1, 10))  # E: numpy.ndarray

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,4 +14,4 @@ cffi
 # - Mypy doesn't currently work on Python 3.9
 # - Python 3.6 doesn't work because it doesn't understand py.typed
 mypy==0.782; platform_python_implementation != "PyPy" and python_version > "3.6"
-typing_extensions
+typing_extensions>=3.7.4.3

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,4 +14,4 @@ cffi
 # - Mypy doesn't currently work on Python 3.9
 # - Python 3.6 doesn't work because it doesn't understand py.typed
 mypy==0.782; platform_python_implementation != "PyPy" and python_version > "3.6"
-typing_extensions>=3.7.4.3
+typing_extensions

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,4 +14,4 @@ cffi
 # - Mypy doesn't currently work on Python 3.9
 # - Python 3.6 doesn't work because it doesn't understand py.typed
 mypy==0.782; platform_python_implementation != "PyPy" and python_version > "3.6"
-typing_extensions>=3.7.4.2
+typing_extensions

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,4 +14,4 @@ cffi
 # - Mypy doesn't currently work on Python 3.9
 # - Python 3.6 doesn't work because it doesn't understand py.typed
 mypy==0.782; platform_python_implementation != "PyPy" and python_version > "3.6"
-typing_extensions
+typing_extensions>=3.7.4.2


### PR DESCRIPTION
This pull requests adds annotations to 3 functions in `np.core.function_base`:

- [x] `linspace`
- [x] `logspace`
- [x] `geomspace`

As the main `__init__.pyi` file in numpy is starting to get somewhat cluttered
the respective stubs have been defined for the relevant sub-module instead.

Secondly, the docstring of `logspace` has been updated in order to clarify that
its `base` parameter can be array_like; not just a float.