### PR TITLE
ENH: Add support for the abstract scalars to cython code

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -808,6 +808,29 @@ cdef extern from "numpy/ndarraytypes.h":
         int64_t num
 
 cdef extern from "numpy/arrayscalars.h":
+
+    # abstract types
+    ctypedef class numpy.generic [object PyObject]:
+        pass
+    ctypedef class numpy.number [object PyObject]:
+        pass
+    ctypedef class numpy.integer [object PyObject]:
+        pass
+    ctypedef class numpy.signedinteger [object PyObject]:
+        pass
+    ctypedef class numpy.unsignedinteger [object PyObject]:
+        pass
+    ctypedef class numpy.inexact [object PyObject]:
+        pass
+    ctypedef class numpy.floating [object PyObject]:
+        pass
+    ctypedef class numpy.complexfloating [object PyObject]:
+        pass
+    ctypedef class numpy.flexible [object PyObject]:
+        pass
+    ctypedef class numpy.character [object PyObject]:
+        pass
+
     ctypedef struct PyDatetimeScalarObject:
         # PyObject_HEAD
         npy_datetime obval

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -766,6 +766,29 @@ cdef extern from "numpy/ndarraytypes.h":
         int64_t num
 
 cdef extern from "numpy/arrayscalars.h":
+
+    # abstract types
+    ctypedef class numpy.generic [object PyObject]:
+        pass
+    ctypedef class numpy.number [object PyObject]:
+        pass
+    ctypedef class numpy.integer [object PyObject]:
+        pass
+    ctypedef class numpy.signedinteger [object PyObject]:
+        pass
+    ctypedef class numpy.unsignedinteger [object PyObject]:
+        pass
+    ctypedef class numpy.inexact [object PyObject]:
+        pass
+    ctypedef class numpy.floating [object PyObject]:
+        pass
+    ctypedef class numpy.complexfloating [object PyObject]:
+        pass
+    ctypedef class numpy.flexible [object PyObject]:
+        pass
+    ctypedef class numpy.character [object PyObject]:
+        pass
+
     ctypedef struct PyDatetimeScalarObject:
         # PyObject_HEAD
         npy_datetime obval

--- a/numpy/core/tests/examples/checks.pyx
+++ b/numpy/core/tests/examples/checks.pyx
@@ -24,3 +24,7 @@ def get_td64_value(obj):
 
 def get_dt64_unit(obj):
     return cnp.get_datetime64_unit(obj)
+
+
+def is_integer(obj):
+    return isinstance(obj, (cnp.integer, int))

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -126,3 +126,11 @@ def test_get_datetime64_unit(install_temp):
     result = checks.get_dt64_unit(td64)
     expected = 5
     assert result == expected
+
+
+def test_abstract_scalars(install_temp):
+    import checks
+
+    assert checks.is_integer(1)
+    assert checks.is_integer(np.int8(1))
+    assert checks.is_integer(np.uint64(1))


### PR DESCRIPTION
This makes `isinstance` checks slightly faster..

This aims to replace #16363.

I'm not invested enough to go through the effort of writing the tests it would entail, but a nice follow-up for someone interested would be to add something like:
```python
    # concrete types
    ctypedef class numpy.bool_ [object PyBoolScalarObject]:
        cdef npy_bool obval
    ctypedef class numpy.byte [object PyByteScalarObject]:
        cdef npy_byte obval
    ctypedef class numpy.short [object PyShortScalarObject]:
        cdef npy_short obval
    ctypedef class numpy.intc [object PyIntScalarObject]:
        cdef npy_intc obval
    ctypedef class numpy.int_ [object PyLongScalarObject]:
        cdef npy_int_ obval
    ctypedef class numpy.longlong [object PyLongLongScalarObject]:
        cdef npy_longlong obval
    ctypedef class numpy.ubyte [object PyUByteScalarObject]:
        cdef npy_ubyte obval
    ctypedef class numpy.ushort [object PyUShortScalarObject]:
        cdef npy_ushort obval
    ctypedef class numpy.uintc [object PyUIntScalarObject]:
        cdef npy_uintc obval
    ctypedef class numpy.uint [object PyULongScalarObject]:
        cdef npy_uint obval
    ctypedef class numpy.ulonglong [object PyULongLongScalarObject]:
        cdef npy_ulonglong obval
    ctypedef class numpy.half [object PyHalfScalarObject]:
        pass  # no C type exists
    ctypedef class numpy.single [object PyFloatScalarObject]:
        cdef npy_float obval
    ctypedef class numpy.double [object PyDoubleScalarObject]:
        cdef npy_double obval
    ctypedef class numpy.longdouble [object PyLongDoubleScalarObject]:
        cdef npy_longdouble obval
    ctypedef class numpy.csingle [object PyFloatScalarObject]:
        cdef npy_cfloat obval
    ctypedef class numpy.cdouble [object PyDoubleScalarObject]:
        cdef npy_cdouble obval
    ctypedef class numpy.clongdouble [object PyLongDoubleScalarObject]:
        cdef npy_clongdouble obval
    # TODO: add non-numeric types
```

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
