### PR TITLE
BUG: Fix incorrect cython definition of npy_cfloat

### DIFF
--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -329,8 +329,8 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef long double  npy_float128
 
     ctypedef struct npy_cfloat:
-        double real
-        double imag
+        float real
+        float imag
 
     ctypedef struct npy_cdouble:
         double real

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -290,8 +290,8 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef long double  npy_float128
 
     ctypedef struct npy_cfloat:
-        double real
-        double imag
+        float real
+        float imag
 
     ctypedef struct npy_cdouble:
         double real


### PR DESCRIPTION
The definition in the numpy headers is a pair of `float`s not `double`s.

https://github.com/numpy/numpy/blob/b4d2295bb5ba3c866553c1d7c10938f7f00c3286/numpy/core/include/numpy/npy_common.h#L425

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
