### PR TITLE
DOC: Remove references to PyCObject

### DIFF
--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -330,8 +330,10 @@ largely aesthetic.  In particular:
            Now it must be a tuple whose first element is a string with "PyArrayInterface Version #" and whose
            second element is the object exposing the array.
 
-       This design was retracted in <https://mail.python.org/pipermail/numpy-discussion/2006-June/020995.html>, and is an error to have relied
-       upon in the intermediate 14 years.
+       This design was retracted almost immediately after it was proposed, in
+       <https://mail.python.org/pipermail/numpy-discussion/2006-June/020995.html>.
+       Despite 14 years of documentation to the contrary, at no point was it valid
+       to assume that ``__array_interface__`` capsules held this tuple content.
 
 3. The tuple returned from ``__array_interface__['data']`` used to be a
    hex-string (now it is an integer or a long integer).

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -327,13 +327,15 @@ largely aesthetic.  In particular:
 
        Until August 2020, this said:
 
-           Now it must be a tuple whose first element is a string with "PyArrayInterface Version #" and whose
-           second element is the object exposing the array.
+           Now it must be a tuple whose first element is a string with
+           "PyArrayInterface Version #" and whose second element is the object
+           exposing the array.
 
        This design was retracted almost immediately after it was proposed, in
        <https://mail.python.org/pipermail/numpy-discussion/2006-June/020995.html>.
-       Despite 14 years of documentation to the contrary, at no point was it valid
-       to assume that ``__array_interface__`` capsules held this tuple content.
+       Despite 14 years of documentation to the contrary, at no point was it
+       valid to assume that ``__array_interface__`` capsules held this tuple
+       content.
 
 3. The tuple returned from ``__array_interface__['data']`` used to be a
    hex-string (now it is an integer or a long integer).

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1759,8 +1759,8 @@ typedef struct {
 } npy_stride_sort_item;
 
 /************************************************************
- * This is the form of the struct that's returned pointed by the
- * PyCObject attribute of an array __array_struct__. See
+ * This is the form of the struct that's stored in the
+ * PyCapsule returned by an array's __array_struct__ attribute. See
  * https://docs.scipy.org/doc/numpy/reference/arrays.interface.html for the full
  * documentation.
  ************************************************************/


### PR DESCRIPTION
This has been replaced by PyCapsule, and no longer exists as of 3.2.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
