### PR TITLE
BUG: Remove Void special case for "safe casting"

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -343,25 +343,6 @@ PyArray_CanCastSafely(int fromtype, int totype)
     if (fromtype == totype) {
         return 1;
     }
-    /* Special-cases for some types */
-    switch (fromtype) {
-        case NPY_DATETIME:
-        case NPY_TIMEDELTA:
-        case NPY_OBJECT:
-        case NPY_VOID:
-            return 0;
-        case NPY_BOOL:
-            return 1;
-    }
-    switch (totype) {
-        case NPY_BOOL:
-        case NPY_DATETIME:
-        case NPY_TIMEDELTA:
-            return 0;
-        case NPY_OBJECT:
-        case NPY_VOID:
-            return 1;
-    }
 
     from = PyArray_DescrFromType(fromtype);
     /*


### PR DESCRIPTION
There were some (dubious) special cases for "safe casting"
which was only available on the C-side (np.can_cast does not
hit this code).

These special cases are almost only active for user dtypes
and seem generally incorrect and unnecessary.

Without this change, the test will fail due to promoting rational
to the void dtype (whichever that is).
