### PR TITLE
BUG: revert trim_zeros changes from gh-16911

### DIFF
--- a/doc/release/upcoming_changes/16911.deprecation.rst
+++ b/doc/release/upcoming_changes/16911.deprecation.rst
@@ -1,7 +1,0 @@
-``trim_zeros`` now requires a 1D array compatible with ``ndarray.astype(bool)``
--------------------------------------------------------------------------------
-The ``trim_zeros`` function will, in the future, require an array with the
-following two properties:
-
-* It must be 1D.
-* It must support elementwise comparisons with zero.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -707,24 +707,3 @@ class TestRaggedArray(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.array([arr, [0]], dtype=np.float64))
         self.assert_deprecated(lambda: np.array([[0], arr], dtype=np.float64))
 
-
-class TestTrimZeros(_DeprecationTestCase):
-    # Numpy 1.20.0, 2020-07-31
-    @pytest.mark.parametrize(
-        "arr,exc_type",
-        [(np.random.rand(10, 10).tolist(), ValueError),
-         (np.random.rand(10).astype(str), FutureWarning)]
-    )
-    def test_deprecated(self, arr, exc_type):
-        with warnings.catch_warnings():
-            warnings.simplefilter('error', DeprecationWarning)
-            try:
-                np.trim_zeros(arr)
-            except DeprecationWarning as ex:
-                ex_cause = ex.__cause__
-                assert_(isinstance(ex_cause, exc_type))
-            else:
-                raise AssertionError("No error raised during function call")
-
-        out = np.lib.function_base._trim_zeros_old(arr)
-        assert_array_equal(arr, out)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1625,63 +1625,7 @@ def trim_zeros(filt, trim='fb'):
     [1, 2]
 
     """
-    try:
-        return _trim_zeros_new(filt, trim)
-    except Exception as ex:
-        # Numpy 1.20.0, 2020-07-31
-        warning = DeprecationWarning(
-            "in the future trim_zeros will require a 1-D array as input "
-            "that supports elementwise comparisons with zero"
-        )
-        warning.__cause__ = ex
 
-    # Fall back to the old implementation if an exception is encountered
-    # Note that the same exception may or may not be raised here as well
-    ret = _trim_zeros_old(filt, trim)
-    warnings.warn(warning, stacklevel=3)
-    return ret
-
-
-def _trim_zeros_new(filt, trim='fb'):
-    """Newer optimized implementation of ``trim_zeros()``."""
-    arr_any = np.asanyarray(filt)
-    arr = arr_any != 0 if arr_any.dtype != bool else arr_any
-
-    if arr is False:
-        # not all dtypes support elementwise comparisons with `0` (e.g. str);
-        # they will return `False` instead
-        raise TypeError('elementwise comparison failed; unsupported data type')
-    elif arr.ndim != 1:
-        raise ValueError('trim_zeros requires an array of exactly one dimension')
-    elif not len(arr):
-        return filt
-
-    trim_upper = trim.upper()
-    first = last = None
-
-    if 'F' in trim_upper:
-        first = arr.argmax()
-        # If `arr[first] is False` then so are all other elements
-        if not arr[first]:
-            return filt[:0]
-
-    if 'B' in trim_upper:
-        last = len(arr) - arr[::-1].argmax()
-        # If `arr[last - 1] is False` then so are all other elements
-        if not arr[last - 1]:
-            return filt[:0]
-
-    return filt[first:last]
-
-
-def _trim_zeros_old(filt, trim='fb'):
-    """
-    Older unoptimized implementation of ``trim_zeros()``.
-
-    Used as fallback in case an exception is encountered
-    in ``_trim_zeros_new()``.
-
-    """
     first = 0
     trim = trim.upper()
     if 'F' in trim:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1225,6 +1225,10 @@ class TestTrimZeros:
         assert_array_equal(arr, res)
 
 
+    def test_list_to_list(self):
+        res = trim_zeros(self.a.tolist())
+        assert isinstance(res, list)
+
 class TestExtins:
 
     def test_basic(self):


### PR DESCRIPTION
xref PRs gh-16911, gh-17058, gh-17131 and issue gh-16783.

While the effort to speed up and rethink `trim_zeros` is appreciated, in this case I think we should unfortunately revert these changes. I have added a test that lists remain unchanged.