### PR TITLE
ENH: Make `np.complexfloating` generic w.r.t. `np.floating`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -454,6 +454,8 @@ class uint64(unsignedinteger):
 class inexact(number): ...  # type: ignore
 class floating(inexact, _real_generic): ...  # type: ignore
 
+_FloatType = TypeVar('_FloatType', bound=floating)
+
 class float16(floating):
     def __init__(self, __value: Optional[SupportsFloat] = ...) -> None: ...
 
@@ -463,27 +465,24 @@ class float32(floating):
 class float64(floating):
     def __init__(self, __value: Optional[SupportsFloat] = ...) -> None: ...
 
-class complexfloating(inexact): ...  # type: ignore
+class complexfloating(inexact, Generic[_FloatType]):  # type: ignore
+    @property
+    def real(self) -> _FloatType: ...
+    @property
+    def imag(self) -> _FloatType: ...
+    def __abs__(self) -> _FloatType: ...  # type: ignore[override]
 
-class complex64(complexfloating):
+class complex64(complexfloating[float32]):
     def __init__(
         self,
         __value: Union[None, SupportsInt, SupportsFloat, SupportsComplex] = ...
     ) -> None: ...
-    @property
-    def real(self) -> float32: ...
-    @property
-    def imag(self) -> float32: ...
 
-class complex128(complexfloating):
+class complex128(complexfloating[float64]):
     def __init__(
         self,
         __value: Union[None, SupportsInt, SupportsFloat, SupportsComplex] = ...
     ) -> None: ...
-    @property
-    def real(self) -> float64: ...
-    @property
-    def imag(self) -> float64: ...
 
 class flexible(_real_generic): ...  # type: ignore
 

--- a/numpy/tests/typing/reveal/scalars.py
+++ b/numpy/tests/typing/reveal/scalars.py
@@ -28,3 +28,6 @@ reveal_type(td - 1)  # E: numpy.timedelta64
 reveal_type(td / 1.0)  # E: numpy.timedelta64
 reveal_type(td / td)  # E: float
 reveal_type(td % td)  # E: numpy.timedelta64
+
+reveal_type(np.complex64().real)  # numpy.float32
+reveal_type(np.complex128().imag)  # numpy.float64

--- a/numpy/tests/typing/reveal/scalars.py
+++ b/numpy/tests/typing/reveal/scalars.py
@@ -29,5 +29,5 @@ reveal_type(td / 1.0)  # E: numpy.timedelta64
 reveal_type(td / td)  # E: float
 reveal_type(td % td)  # E: numpy.timedelta64
 
-reveal_type(np.complex64().real)  # numpy.float32
-reveal_type(np.complex128().imag)  # numpy.float64
+reveal_type(np.complex64().real)  # E: numpy.float32
+reveal_type(np.complex128().imag)  # E: numpy.float64


### PR DESCRIPTION
This pull requests makes `np.complexfloating` generic with respect to `np.floating`.

The main advantage of this is to make it easier to access the `.real`/`.imag` type of 
`np.complexfloating` sub-classes as is illustrated below.

Examples
---------
``` python
from typing import TypeVar
import numpy as np

FloatType = TypeVar('FloatType', bound=np.floating)

def get_real(complex_value: 'np.compexfloating[FloatType]') -> FloatType:
    return complex_value.real

```