### PR TITLE
ENH: Added missing methods to `np.flatiter`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4,7 +4,7 @@ import datetime as dt
 from abc import abstractmethod
 
 from numpy.core._internal import _ctypes
-from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike
+from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike, _SupportsArray
 
 from typing import (
     Any,
@@ -143,6 +143,14 @@ class _flagsobj:
     def __getitem__(self, key: str) -> bool: ...
     def __setitem__(self, key: str, value: bool) -> None: ...
 
+_ArrayLikeInt = Union[
+    int,
+    integer,
+    Sequence[Union[int, integer]],
+    Sequence[Sequence[Any]],  # TODO: wait for support for recursive types
+    _SupportsArray
+]
+
 _FlatIterSelf = TypeVar("_FlatIterSelf", bound=flatiter)
 
 class flatiter(Generic[_ArraySelf]):
@@ -155,6 +163,14 @@ class flatiter(Generic[_ArraySelf]):
     def copy(self) -> _ArraySelf: ...
     def __iter__(self: _FlatIterSelf) -> _FlatIterSelf: ...
     def __next__(self) -> generic: ...
+    def __len__(self) -> int: ...
+    @overload
+    def __getitem__(self, key: Union[int, integer]) -> generic: ...
+    @overload
+    def __getitem__(
+        self, key: Union[_ArrayLikeInt, slice, ellipsis],
+    ) -> _ArraySelf: ...
+    def __array__(self, __dtype: DtypeLike = ...) -> ndarray: ...
 
 _ArraySelf = TypeVar("_ArraySelf", bound=_ArrayOrScalarCommon)
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4,7 +4,7 @@ import datetime as dt
 from abc import abstractmethod
 
 from numpy.core._internal import _ctypes
-from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike, _SupportsArray
+from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike
 
 from typing import (
     Any,
@@ -148,7 +148,7 @@ _ArrayLikeInt = Union[
     integer,
     Sequence[Union[int, integer]],
     Sequence[Sequence[Any]],  # TODO: wait for support for recursive types
-    _SupportsArray
+    ndarray
 ]
 
 _FlatIterSelf = TypeVar("_FlatIterSelf", bound=flatiter)

--- a/numpy/tests/typing/fail/flatiter.py
+++ b/numpy/tests/typing/fail/flatiter.py
@@ -13,9 +13,9 @@ a: "np.flatiter[np.ndarray]"
 supports_array: _SupportsArray
 
 a.base = Any  # E: Property "base" defined in "flatiter" is read-only
-a.copy = Any  # E: Property "copy" defined in "flatiter" is read-only
 a.coords = Any  # E: Property "coords" defined in "flatiter" is read-only
 a.index = Any  # E: Property "index" defined in "flatiter" is read-only
+a.copy(order='C')  # E: Unexpected keyword argument
 a[np.bool_()]  # E: No overload variant of "__getitem__"
 a[Index()]  # E: No overload variant of "__getitem__"
 a[supports_array]  # E: No overload variant of "__getitem__"

--- a/numpy/tests/typing/fail/flatiter.py
+++ b/numpy/tests/typing/fail/flatiter.py
@@ -1,0 +1,16 @@
+from typing import Any
+import numpy as np
+
+class Index:
+    def __index__(self) -> int:
+        ...
+
+
+a: "np.flatiter[np.ndarray]"
+
+a.base = Any  # E: Property "base" defined in "flatiter" is read-only
+a.copy = Any  # E: Property "copy" defined in "flatiter" is read-only
+a.coords = Any  # E: Property "coords" defined in "flatiter" is read-only
+a.index = Any  # E: Property "index" defined in "flatiter" is read-only
+a[np.bool_()]  # E: No overload variant of "__getitem__"
+a[Index()]  # E: No overload variant of "__getitem__"

--- a/numpy/tests/typing/fail/flatiter.py
+++ b/numpy/tests/typing/fail/flatiter.py
@@ -1,5 +1,8 @@
 from typing import Any
+
 import numpy as np
+from numpy.typing import DtypeLike, _SupportsArray
+
 
 class Index:
     def __index__(self) -> int:
@@ -7,6 +10,7 @@ class Index:
 
 
 a: "np.flatiter[np.ndarray]"
+supports_array: _SupportsArray
 
 a.base = Any  # E: Property "base" defined in "flatiter" is read-only
 a.copy = Any  # E: Property "copy" defined in "flatiter" is read-only
@@ -14,3 +18,4 @@ a.coords = Any  # E: Property "coords" defined in "flatiter" is read-only
 a.index = Any  # E: Property "index" defined in "flatiter" is read-only
 a[np.bool_()]  # E: No overload variant of "__getitem__"
 a[Index()]  # E: No overload variant of "__getitem__"
+a[supports_array]  # E: No overload variant of "__getitem__"

--- a/numpy/tests/typing/fail/flatiter.py
+++ b/numpy/tests/typing/fail/flatiter.py
@@ -16,6 +16,10 @@ a.base = Any  # E: Property "base" defined in "flatiter" is read-only
 a.coords = Any  # E: Property "coords" defined in "flatiter" is read-only
 a.index = Any  # E: Property "index" defined in "flatiter" is read-only
 a.copy(order='C')  # E: Unexpected keyword argument
+
+# NOTE: Contrary to `ndarray.__getitem__` its counterpart in `flatiter`
+# does not accept objects with the `__array__` or `__index__` protocols;
+# boolean indexing is just plain broken (gh-17175)
 a[np.bool_()]  # E: No overload variant of "__getitem__"
 a[Index()]  # E: No overload variant of "__getitem__"
 a[supports_array]  # E: No overload variant of "__getitem__"

--- a/numpy/tests/typing/pass/flatiter.py
+++ b/numpy/tests/typing/pass/flatiter.py
@@ -3,7 +3,7 @@ import numpy as np
 a = np.random.rand(5).flat
 
 a.base
-a.copy
+a.copy()
 a.coords
 a.index
 iter(a)

--- a/numpy/tests/typing/pass/flatiter.py
+++ b/numpy/tests/typing/pass/flatiter.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+a = np.random.rand(5).flat
+
+a.base
+a.copy
+a.coords
+a.index
+iter(a)
+next(a)
+a[0]
+a[[0, 1, 2]]
+a[...]
+a[:]

--- a/numpy/tests/typing/reveal/flatiter.py
+++ b/numpy/tests/typing/reveal/flatiter.py
@@ -4,9 +4,9 @@ a: "np.flatiter[np.ndarray]"
 
 reveal_type(a.base)  # E: numpy.ndarray*
 reveal_type(a.copy)  # E: numpy.ndarray*
-reveal_type(a.coords)  # E: tuple[bultins.int]
+reveal_type(a.coords)  # E: tuple[builtins.int]
 reveal_type(a.index)  # E: int
-reveal_type(iter(a))  # E: typing.Iterator[numpy.generic]
+reveal_type(iter(a))  # E: Iterator[numpy.generic*]
 reveal_type(next(a))  # E: numpy.generic
 reveal_type(a[0])  # E: numpy.generic
 reveal_type(a[[0, 1, 2]])  # E: numpy.ndarray*

--- a/numpy/tests/typing/reveal/flatiter.py
+++ b/numpy/tests/typing/reveal/flatiter.py
@@ -3,7 +3,7 @@ import numpy as np
 a: "np.flatiter[np.ndarray]"
 
 reveal_type(a.base)  # E: numpy.ndarray*
-reveal_type(a.copy)  # E: numpy.ndarray*
+reveal_type(a.copy())  # E: numpy.ndarray*
 reveal_type(a.coords)  # E: tuple[builtins.int]
 reveal_type(a.index)  # E: int
 reveal_type(iter(a))  # E: Iterator[numpy.generic*]

--- a/numpy/tests/typing/reveal/flatiter.py
+++ b/numpy/tests/typing/reveal/flatiter.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+a: "np.flatiter[np.ndarray]"
+
+reveal_type(a.base)  # E: numpy.ndarray*
+reveal_type(a.copy)  # E: numpy.ndarray*
+reveal_type(a.coords)  # E: tuple[bultins.int]
+reveal_type(a.index)  # E: int
+reveal_type(iter(a))  # E: typing.Iterator[numpy.generic]
+reveal_type(next(a))  # E: numpy.generic
+reveal_type(a[0])  # E: numpy.generic
+reveal_type(a[[0, 1, 2]])  # E: numpy.ndarray*
+reveal_type(a[...])  # E: numpy.ndarray*
+reveal_type(a[:])  # E: numpy.ndarray*


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/17114 and https://github.com/numpy/numpy/issues/17113.

This pull requests adds annotations to the following three `np.flatiter` methods:

* `__getitem__()`
* `__len__()`
* `__array__()`
