### PR TITLE
DOC: Correct error in description of ndarray.base

### DIFF
--- a/numpy/doc/subclassing.py
+++ b/numpy/doc/subclassing.py
@@ -685,8 +685,8 @@ True
 True
 >>> # Take a view of a view
 >>> v2 = v1[1:]
->>> # base points to the view it derived from
->>> v2.base is v1
+>>> # base points to the original array that it was derived from
+>>> v2.base is arr
 True
 
 In general, if the array owns its own memory, as for ``arr`` in this


### PR DESCRIPTION
Found in subsection of Subclassing ndarray in python: Extra gotchas - custom __del__ methods and ndarray.base

The following code snippet demonstrates that the current docs are incorrect:

```python
# A normal ndarray, that owns its own data
arr = np.zeros((4,))
# In this case, base is None
assert arr.base is None

# We take a view
v1 = arr[1:]
# base now points to the array that it derived from
assert v1.base is arr

# Take a view of a view
v2 = v1[1:]

# this should fail according to the current docs
assert v2.base is arr

# this should fail according to the current docs
assert v2.base is not v1
```
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
