### PR TITLE
DOC: Document `dtype.metadata`

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -537,6 +537,13 @@ Attributes providing additional information:
    dtype.alignment
    dtype.base
 
+Metadata attached by the user:
+
+.. autosummary::
+   :toctree: generated/
+
+    dtype.metadata
+
 
 Methods
 -------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5496,9 +5496,15 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('metadata',
     Either ``None`` or a readonly dictionary of metadata (mappingproxy).
 
     The metadata field can be set using any dictionary at data-type
-    creation. Note that whether operations on arrays with metadata
-    attached to their datatypes propagate that metadata is currently
-    not well defined and should not be relied on.
+    creation. NumPy currently has no uniform approach to propagating
+    metadata; although some array operations preserve it there is no
+    guarantee that others will.
+
+    .. warning::
+
+        Although used in certain projects this feature was long undocumented
+        and is not well supported. Some aspects of metadata propagation
+        are expected to change in the future.
 
     Examples
     --------
@@ -5510,13 +5516,13 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('metadata',
     >>> arr.dtype.metadata
     mappingproxy({'key': 'value'})
 
-    Some operations may preserve metadata (identical data types):
+    Adding arrays with identical datatypes currently preserves the metadata:
 
     >>> (arr + arr).dtype.metadata
     mappingproxy({'key': 'value'})
 
-    But for example, adding two arrays with different metadata does not
-    propagate either one:
+    But if the arrays have different dtype metadata, the metadata may be 
+    dropped:
 
     >>> dt2 = np.dtype(float, metadata={"key2": "value2"})
     >>> arr2 = np.array([3, 2, 1], dtype=dt2)

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5497,12 +5497,12 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('metadata',
 
     The metadata field can be set using any dictionary at data-type
     creation. NumPy currently has no uniform approach to propagating
-    metadata; although some array operations preserve it there is no
+    metadata; although some array operations preserve it, there is no
     guarantee that others will.
 
     .. warning::
 
-        Although used in certain projects this feature was long undocumented
+        Although used in certain projects, this feature was long undocumented
         and is not well supported. Some aspects of metadata propagation
         are expected to change in the future.
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5491,6 +5491,39 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('kind',
 
     """))
 
+add_newdoc('numpy.core.multiarray', 'dtype', ('metadata',
+    """
+    Either ``None`` or a readonly dictionary of metadata (mappingproxy).
+
+    The metadata field can be set using any dictionary at data-type
+    creation. Note that whether or not operations on arrays with metadata
+    attached to their datatypes is currently not well defined and should
+    not be relied on.
+
+    Examples
+    --------
+
+    >>> dt = np.dtype(float, metadata={"key": "value"})
+    >>> dt.metadata["key"]
+    'value'
+    >>> arr = np.array([1, 2, 3], dtype=dt)
+    >>> arr.dtype.metadata
+    mappingproxy({'key': 'value'})
+
+    Some operations may preserve metadata (identical data types):
+
+    >>> (arr + arr).dtype.metadata
+    mappingproxy({'key': 'value'})
+
+    But for example, adding two arrays with different metadata does not
+    propagate either one:
+
+    >>> dt2 = np.dtype(float, metadata={"key2": "value2"})
+    >>> arr2 = np.array([3, 2, 1], dtype=dt2)
+    >>> (arr + arr2).dtype.metadata is None
+    True  # The metadata field is cleared so None is returned
+    """))
+
 add_newdoc('numpy.core.multiarray', 'dtype', ('name',
     """
     A bit-width name for this data-type.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -5496,9 +5496,9 @@ add_newdoc('numpy.core.multiarray', 'dtype', ('metadata',
     Either ``None`` or a readonly dictionary of metadata (mappingproxy).
 
     The metadata field can be set using any dictionary at data-type
-    creation. Note that whether or not operations on arrays with metadata
-    attached to their datatypes is currently not well defined and should
-    not be relied on.
+    creation. Note that whether operations on arrays with metadata
+    attached to their datatypes propagate that metadata is currently
+    not well defined and should not be relied on.
 
     Examples
     --------


### PR DESCRIPTION
This adds some basic documentation to the ``dtype.metadata``
attribute.  Note that none of the documentation mentions metadata
including https://numpy.org/devdocs/reference/arrays.dtypes.html

This adds metadata (very subtly), I am not even sure I like it much, but I suppose we should mention it somewhere, considering that it exists?