### PR TITLE
MAINT: Make the `NPY_CPU_DISPATCH_CALL` macros expressions not statements

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1042,7 +1042,7 @@ def make_arrays(funcdict):
                         #ifndef NPY_DISABLE_OPTIMIZATION
                         #include "{dname}.dispatch.h"
                         #endif
-                        NPY_CPU_DISPATCH_CALL_XB({name}_functions[{k}] = {tname}_{name})
+                        NPY_CPU_DISPATCH_CALL_XB({name}_functions[{k}] = {tname}_{name});
                         """).format(
                             dname=dname, name=name, tname=tname, k=k
                         ))

--- a/numpy/core/src/common/npy_cpu_dispatch.h
+++ b/numpy/core/src/common/npy_cpu_dispatch.h
@@ -217,44 +217,49 @@
  *    func_type the_callee(const int *src, int *dst, func_type *cb)
  *    {
  *        // direct call
- *        NPY_CPU_DISPATCH_CALL(dispatch_me, (src, dst))
+ *        NPY_CPU_DISPATCH_CALL(dispatch_me, (src, dst));
  *        // assign the pointer
- *        NPY_CPU_DISPATCH_CALL(*cb = dispatch_me)
+ *        *cb = NPY_CPU_DISPATCH_CALL(dispatch_me);
+ *        // or
+ *        NPY_CPU_DISPATCH_CALL(*cb = dispatch_me);
  *        // return the pointer
- *        NPY_CPU_DISPATCH_CALL(return dispatch_me)
+ *        return NPY_CPU_DISPATCH_CALL(dispatch_me);
  *    }
  */
 #define NPY_CPU_DISPATCH_CALL(...) \
-    if (0) {/*DUMMY*/} \
     NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, NPY_CPU_DISPATCH_CALL_CB_, __VA_ARGS__) \
     NPY__CPU_DISPATCH_BASELINE_CALL(NPY_CPU_DISPATCH_CALL_BASE_CB_, __VA_ARGS__)
 // Preprocessor callbacks
 #define NPY_CPU_DISPATCH_CALL_CB_(TESTED_FEATURES, TARGET_NAME, LEFT, ...) \
-    else if (TESTED_FEATURES) { NPY_CAT(NPY_CAT(LEFT, _), TARGET_NAME) __VA_ARGS__; }
+    (TESTED_FEATURES) ? (NPY_CAT(NPY_CAT(LEFT, _), TARGET_NAME) __VA_ARGS__) :
 #define NPY_CPU_DISPATCH_CALL_BASE_CB_(LEFT, ...) \
-    else { LEFT __VA_ARGS__; }
+    (LEFT __VA_ARGS__)
 /**
  * Macro NPY_CPU_DISPATCH_CALL_XB(LEFT, ...)
  *
- * Same as `NPY_CPU_DISPATCH_DECLARE` but exclude the baseline declration even
- * if it was provided within the configration statments.
+ * Same as `NPY_CPU_DISPATCH_DECLARE` but exclude the baseline declaration even
+ * if it was provided within the configration statements.
+ * Returns void.
  */
+#define NPY_CPU_DISPATCH_CALL_XB_CB_(TESTED_FEATURES, TARGET_NAME, LEFT, ...) \
+    (TESTED_FEATURES) ? (void) (NPY_CAT(NPY_CAT(LEFT, _), TARGET_NAME) __VA_ARGS__) :
 #define NPY_CPU_DISPATCH_CALL_XB(...) \
-    if (0) {/*DUMMY*/} \
-    NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, NPY_CPU_DISPATCH_CALL_CB_, __VA_ARGS__)
+    NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, NPY_CPU_DISPATCH_CALL_XB_CB_, __VA_ARGS__) \
+    ((void) 0 /* discarded expression value */)
 /**
  * Macro NPY_CPU_DISPATCH_CALL_ALL(LEFT, ...)
  *
  * Same as `NPY_CPU_DISPATCH_CALL` but dispatching all the required optimizations for
  * the exported functions and variables instead of highest interested one.
+ * Returns void.
  */
 #define NPY_CPU_DISPATCH_CALL_ALL(...) \
-    NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, NPY_CPU_DISPATCH_CALL_ALL_CB_, __VA_ARGS__) \
-    NPY__CPU_DISPATCH_BASELINE_CALL(NPY_CPU_DISPATCH_CALL_ALL_BASE_CB_, __VA_ARGS__)
+    (NPY__CPU_DISPATCH_CALL(NPY_CPU_HAVE, NPY_CPU_DISPATCH_CALL_ALL_CB_, __VA_ARGS__) \
+    NPY__CPU_DISPATCH_BASELINE_CALL(NPY_CPU_DISPATCH_CALL_ALL_BASE_CB_, __VA_ARGS__))
 // Preprocessor callbacks
 #define NPY_CPU_DISPATCH_CALL_ALL_CB_(TESTED_FEATURES, TARGET_NAME, LEFT, ...) \
-    if (TESTED_FEATURES) { NPY_CAT(NPY_CAT(LEFT, _), TARGET_NAME) __VA_ARGS__; }
+    ((TESTED_FEATURES) ? (NPY_CAT(NPY_CAT(LEFT, _), TARGET_NAME) __VA_ARGS__) : (void) 0),
 #define NPY_CPU_DISPATCH_CALL_ALL_BASE_CB_(LEFT, ...) \
-    { LEFT __VA_ARGS__; }
+    ( LEFT __VA_ARGS__ )
 
 #endif // NPY_CPU_DISPATCH_H_

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -588,11 +588,11 @@ static PyObject *
 UMath_Tests_test_dispatch(PyObject *NPY_UNUSED(dummy), PyObject *NPY_UNUSED(dummy2))
 {
     const char *highest_func, *highest_var;
-    NPY_CPU_DISPATCH_CALL(highest_func = _umath_tests_dispatch_func, ())
-    NPY_CPU_DISPATCH_CALL(highest_var  = _umath_tests_dispatch_var)
+    NPY_CPU_DISPATCH_CALL(highest_func = _umath_tests_dispatch_func, ());
+    NPY_CPU_DISPATCH_CALL(highest_var  = _umath_tests_dispatch_var);
     const char *highest_func_xb = "nobase", *highest_var_xb = "nobase";
-    NPY_CPU_DISPATCH_CALL_XB(highest_func_xb = _umath_tests_dispatch_func, ())
-    NPY_CPU_DISPATCH_CALL_XB(highest_var_xb  = _umath_tests_dispatch_var)
+    NPY_CPU_DISPATCH_CALL_XB(highest_func_xb = _umath_tests_dispatch_func, ());
+    NPY_CPU_DISPATCH_CALL_XB(highest_var_xb  = _umath_tests_dispatch_var);
 
     PyObject *dict = PyDict_New(), *item;
     if (dict == NULL) {
@@ -610,7 +610,7 @@ UMath_Tests_test_dispatch(PyObject *NPY_UNUSED(dummy), PyObject *NPY_UNUSED(dumm
     if (item == NULL || PyDict_SetItemString(dict, "all", item) < 0) {
         goto err;
     }
-    NPY_CPU_DISPATCH_CALL_ALL(_umath_tests_dispatch_attach, (item))
+    NPY_CPU_DISPATCH_CALL_ALL(_umath_tests_dispatch_attach, (item));
     if (PyErr_Occurred()) {
         goto err;
     }


### PR DESCRIPTION
This means they can return values, and need semicolons.

Not tested locally, but the constructs were tested in godbolt.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

ping @seiko2plus 