### PR TITLE
DOC: Fixed headings for tutorials so they appear at new theme sidebar.

### DIFF
--- a/doc/source/user/tutorial-ma.rst
+++ b/doc/source/user/tutorial-ma.rst
@@ -9,7 +9,8 @@ Tutorial: Masked Arrays
    import numpy as np
    np.random.seed(1)
 
-**Prerequisites**
+Prerequisites
+-------------
 
 Before reading this tutorial, you should know a bit of Python. If you
 would like to refresh your memory, take a look at the
@@ -18,13 +19,15 @@ would like to refresh your memory, take a look at the
 If you want to be able to run the examples in this tutorial, you should also
 have `matplotlib <https://matplotlib.org/>`_ installed on your computer.
 
-**Learner profile**
+Learner profile
+---------------
 
 This tutorial is for people who have a basic understanding of NumPy and want to
 understand how masked arrays and the :mod:`numpy.ma` module can be used in
 practice.
 
-**Learning Objectives**
+Learning Objectives
+-------------------
 
 After this tutorial, you should be able to:
 
@@ -33,7 +36,8 @@ After this tutorial, you should be able to:
 - Decide when the use of masked arrays is appropriate in some of your
   applications
 
-**What are masked arrays?**
+What are masked arrays?
+-----------------------
 
 Consider the following problem. You have a dataset with missing or invalid
 entries. If you're doing any kind of processing on this data, and want to
@@ -63,7 +67,8 @@ combination of:
 - A ``fill_value``, a value that may be used to replace the invalid entries
   in order to return a standard :class:`numpy.ndarray`.
 
-**When can they be useful?**
+When can they be useful?
+------------------------
 
 There are a few situations where masked arrays can be more useful than just
 eliminating the invalid entries of an array:
@@ -84,7 +89,8 @@ comes with a specific implementation of most :term:`NumPy universal functions
 functions and operations on masked data. The output is then a masked array.
 We'll see some examples of how this works in practice below.
 
-**Using masked arrays to see COVID-19 data**
+Using masked arrays to see COVID-19 data
+----------------------------------------
 
 From `Kaggle <https://www.kaggle.com/atilamadai/covid19>`_ it is possible to
 download a dataset with initial data about the COVID-19 outbreak in the
@@ -149,7 +155,8 @@ can read more about the :func:`numpy.genfromtxt` function from
 the :func:`Reference Documentation <numpy.genfromtxt>` or from the
 :doc:`Basic IO tutorial <basics.io.genfromtxt>`.
 
-**Exploring the data**
+Exploring the data
+------------------
 
 First of all, we can plot the whole set of data we have and see what it looks
 like. In order to get a readable plot, we select only a few of the dates to
@@ -194,7 +201,8 @@ the :func:`numpy.sum` function to sum all the selected rows (``axis=0``):
 Something's wrong with this data - we are not supposed to have negative values
 in a cumulative data set. What's going on?
 
-**Missing data**
+Missing data
+------------
 
 Looking at the data, here's what we find: there is a period with
 **missing data**:
@@ -308,7 +316,8 @@ Mainland China:
 It's clear that masked arrays are the right solution here. We cannot represent
 the missing data without mischaracterizing the evolution of the curve.
 
-**Fitting Data**
+Fitting Data
+------------
 
 One possibility we can think of is to interpolate the missing data to estimate
 the number of cases in late January. Observe that we can select the masked
@@ -367,7 +376,8 @@ after the beginning of the records:
     plt.title("COVID-19 cumulative cases from Jan 21 to Feb 3 2020 - Mainland China\n"
               "Cubic estimate for 7 days after start");
 
-**More reading**
+More reading
+------------
 
 Topics not covered in this tutorial can be found in the documentation:
 

--- a/doc/source/user/tutorial-svd.rst
+++ b/doc/source/user/tutorial-svd.rst
@@ -9,7 +9,8 @@ Tutorial: Linear algebra on n-dimensional arrays
    import numpy as np
    np.random.seed(1)
 
-**Prerequisites**
+Prerequisites
+-------------
 
 Before reading this tutorial, you should know a bit of Python. If you
 would like to refresh your memory, take a look at the
@@ -19,7 +20,8 @@ If you want to be able to run the examples in this tutorial, you should also
 have `matplotlib <https://matplotlib.org/>`_ and `SciPy <https://scipy.org>`_
 installed on your computer.
 
-**Learner profile**
+Learner profile
+---------------
 
 This tutorial is for people who have a basic understanding of linear
 algebra and arrays in NumPy and want to understand how n-dimensional
@@ -28,7 +30,8 @@ you don't know how to apply common functions to n-dimensional arrays (without
 using for-loops), or if you want to understand axis and shape properties for
 n-dimensional arrays, this tutorial might be of help.
 
-**Learning Objectives**
+Learning Objectives
+-------------------
 
 After this tutorial, you should be able to:
 
@@ -38,7 +41,8 @@ After this tutorial, you should be able to:
   arrays without using for-loops;
 - Understand axis and shape properties for n-dimensional arrays.
 
-**Content**
+Content
+-------
 
 In this tutorial, we will use a `matrix decomposition
 <https://en.wikipedia.org/wiki/Matrix_decomposition>`_ from linear algebra, the
@@ -78,7 +82,8 @@ We can see the image using the `matplotlib.pyplot.imshow` function::
    If you are executing the commands above in the IPython shell, it might be
    necessary to use the command ``plt.show()`` to show the image window. 
 		     
-**Shape, axis and array properties**
+Shape, axis and array properties
+--------------------------------
 
 Note that, in linear algebra, the dimension of a vector refers to the number of
 entries in an array. In NumPy, it instead defines the number of axes. For
@@ -162,7 +167,8 @@ syntax::
     >>> green_array = img_array[:, :, 1]
     >>> blue_array = img_array[:, :, 2]
 
-**Operations on an axis**
+Operations on an axis
+---------------------
 
 It is possible to use methods from linear algebra to approximate an existing set
 of data. Here, we will use the `SVD (Singular Value Decomposition)
@@ -290,7 +296,8 @@ diagonal and with the appropriate dimensions for multiplying: in our case,
 Now, we want to check if the reconstructed ``U @ Sigma @ Vt`` is
 close to the original ``img_gray`` matrix.
 
-**Approximation**
+Approximation
+-------------
 
 The `linalg` module includes a ``norm`` function, which
 computes the norm of a vector or matrix represented in a NumPy array. For
@@ -360,7 +367,8 @@ Now, you can go ahead and repeat this experiment with other values of `k`, and
 each of your experiments should give you a slightly better (or worse) image
 depending on the value you choose.
 
-**Applying to all colors**
+Applying to all colors
+----------------------
 
 Now we want to do the same kind of operation, but to all three colors. Our
 first instinct might be to repeat the same operation we did above to each color
@@ -411,7 +419,8 @@ matrices into the approximation. Now, note that
 To build the final approximation matrix, we must understand how multiplication
 across different axes works.
 
-**Products with n-dimensional arrays**
+Products with n-dimensional arrays
+----------------------------------
 
 If you have worked before with only one- or two-dimensional arrays in NumPy,
 you might use `numpy.dot` and `numpy.matmul` (or the ``@`` operator)
@@ -495,7 +504,8 @@ Even though the image is not as sharp, using a small number of ``k`` singular
 values (compared to the original set of 768 values), we can recover many of the
 distinguishing features from this image.
 
-**Final words**
+Final words
+-----------
 
 Of course, this is not the best method to *approximate* an image.
 However, there is, in fact, a result in linear algebra that says that the
@@ -504,7 +514,8 @@ terms of the norm of the difference. For more information, see *G. H. Golub and
 C. F. Van Loan, Matrix Computations, Baltimore, MD, Johns Hopkins University
 Press, 1985*.
 
-**Further reading**
+Further reading
+---------------
 
 -  :doc:`Python tutorial <python:tutorial/index>`
 -  :ref:`reference`


### PR DESCRIPTION
Changes section titles in tutorials so they are proper sphinx headings and appear at the document TOC sidebar in the new PyData theme.

Fixes #17203 
