### PR TITLE
add close after mmap

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -279,7 +279,7 @@ class memmap(ndarray):
             # same as memmap copies (e.g. memmap + 1)
             else:
                 self.filename = None
-
+        f_ctx.close()
         return self
 
     def __array_finalize__(self, obj):


### PR DESCRIPTION
 From my experience with mmap in armadillo/julia, it should be safe to close file afterwards [c - Do I need to keep a file open after calling mmap on it? - Stack Overflow](https://stackoverflow.com/questions/17490033/do-i-need-to-keep-a-file-open-after-calling-mmap-on-it#:~:text=No%2C%20at%20least%20not%20on,fine%20to%20close%20the%20file.&text=The%20mmap()%20function%20adds,more%20mappings%20to%20the%20file.)..  Otherwise I would have to deal with `ulimit`.