### PR TITLE
ENH: make the base of views warn when writing to them

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -232,6 +232,9 @@ PyArray_SetBaseObject(PyArrayObject *arr, PyObject *obj)
     }
 
     ((PyArrayObject_fields *)arr)->base = obj;
+    if (PyArray_Check(obj)) {
+        PyArray_ENABLEFLAGS(obj, NPY_ARRAY_WARN_ON_WRITE);
+    }
 
     return 0;
 }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -31,6 +31,7 @@
 
 #include "get_attr_string.h"
 #include "array_coercion.h"
+#include "arrayobject.h"  /* from this directory */
 
 /*
  * Reading from a file or a string.
@@ -552,6 +553,7 @@ PyArray_AssignFromCache_Recursive(
             else {
                 PyArrayObject *view;
                 view = (PyArrayObject *)array_item_asarray(self, i);
+                PyArray_CLEARFLAGS(view, NPY_ARRAY_WARN_ON_WRITE);
                 if (view < 0) {
                     goto fail;
                 }

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -289,6 +289,7 @@ def _stride_comb_iter(x):
         # new array with different strides, but same data
         xi = np.empty(new_shape, dtype=x.dtype)
         xi.view(np.uint32).fill(0xdeadbeef)
+        xi.flags.writeable = True
         xi = xi[slices]
         xi[...] = x
         xi = xi.view(x.__class__)


### PR DESCRIPTION
@rgommers Here is what we talked about. I didn't re-purpose the warning in [`array_might_be_written](https://github.com/numpy/numpy/blob/v1.19.1/numpy/core/src/multiarray/arrayobject.c#L653) so it emits a strange message. It fails when creating a masked array with a structure dtype in collecting tests, so doesn't even start running the tests. This is the failing part of the collection. There are tons of places where nupy/ma/core.py takes a view of an array, I tried figuring out the offending one but got lost.

```
import numpy as np
def test():
    ilist = [1, 2, 3, 4, 5]
    flist = [1.1, 2.2, 3.3, 4.4, 5.5]
    slist = [b'one', b'two', b'three', b'four', b'five']
    ddtype = np.dtype([('a', int), ('b', float), ('c', '|S8')])
    mask = [0, 1, 0, 0, 1]
    return np.ma.array(list(zip(ilist, flist, slist)), mask=mask, dtype=ddtype)

```
