### PR TITLE
DOC: Canonical_urls

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-   <link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" />
+    <link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" />
 
 <style>
 .navbar-brand img {

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,10 +1,7 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-
-{% block linktags %}
    <link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" />
-{% endblock %}
 
 <style>
 .navbar-brand img {

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,6 +1,11 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
+
+{% block linktags %}
+   <link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" />
+{% endblock %}
+
 <style>
 .navbar-brand img {
    height: 75px;


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

Resolves #17069 adding canonical urls to the header of docs.

I have tested it locally which adds the canonical url in the generated .html files.
The indentation I used in `layout.html` is so that the generated ones line up (see last line of screenshot).
![numpy_pr](https://user-images.githubusercontent.com/23287722/91849450-1860cc80-ec2a-11ea-8d73-c845850e8ea8.png)

A similar way that the folks at Sphinx did it: [link to merged PR](https://github.com/sphinx-doc/sphinx/pull/4764)
I opted not to use the `{% block linktags %}` they used due to unexpected behavior (the `href` is generated correctly, but duplicated) when building in `numpy`. 