### PR TITLE
BLD: enabled negation of library choices in NPY_*_ORDER

### DIFF
--- a/doc/release/upcoming_changes/17219.new_feature.rst
+++ b/doc/release/upcoming_changes/17219.new_feature.rst
@@ -1,0 +1,12 @@
+Negation of user-defined BLAS/LAPACK detection order
+----------------------------------------------------
+`distutils` allows negation of libraries when determining BLAS/LAPACK
+libraries.
+This may be used to remove an item from the library resolution phase, i.e.
+to disallow NetLIB libraries one could do::
+
+.. code:: bash
+
+    NPY_BLAS_ORDER='^blas' NPY_LAPACK_ORDER='^lapack' python setup.py build
+
+which will use any of the accelerated libraries instead.

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -4,14 +4,3 @@
 NumPy 1.20.0 Release Notes
 ==========================
 
-Negation of user-defined BLAS/LAPACK detection order
-----------------------------------------------------
-`distutils` now allows negation of libraries when determining BLAS/LAPACK
-libraries.
-This may be used to remove an item from the library resolution phase, i.e.
-to disallow NetLIB libraries one could do::
-
-   NPY_BLAS_ORDER='^blas' NPY_LAPACK_ORDER='^lapack' python setup.py build
-
-which will use any of the accelerated libraries instead.
-

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -4,3 +4,14 @@
 NumPy 1.20.0 Release Notes
 ==========================
 
+Negation of user-defined BLAS/LAPACK detection order
+----------------------------------------------------
+`distutils` now allows negation of libraries when determining BLAS/LAPACK
+libraries.
+This may be used to remove an item from the library resolution phase, i.e.
+to disallow NetLIB libraries one could do::
+
+   NPY_BLAS_ORDER='^blas' NPY_LAPACK_ORDER='^lapack' python setup.py build
+
+which will use any of the accelerated libraries instead.
+

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -142,6 +142,16 @@ will prefer to use ATLAS, then BLIS, then OpenBLAS and as a last resort MKL.
 If neither of these exists the build will fail (names are compared
 lower case).
 
+Alternatively one may use ``!`` or ``^`` to negate all items::
+
+        NPY_BLAS_ORDER='^blas,atlas' python setup.py build
+
+will allow using anything **but** NetLIB BLAS and ATLAS libraries, the order of the above
+list is retained.
+
+One cannot mix negation and positives, nor have multiple negations, such cases will
+raise an error.
+
 LAPACK
 ~~~~~~
 
@@ -164,6 +174,17 @@ for instance::
 will prefer to use ATLAS, then OpenBLAS and as a last resort MKL.
 If neither of these exists the build will fail (names are compared
 lower case).
+
+Alternatively one may use ``!`` or ``^`` to negate all items::
+
+        NPY_LAPACK_ORDER='^lapack' python setup.py build
+
+will allow using anything **but** the NetLIB LAPACK library, the order of the above
+list is retained.
+
+One cannot mix negation and positives, nor have multiple negations, such cases will
+raise an error.
+
 
 .. deprecated:: 1.20
   The native libraries on macOS, provided by Accelerate, are not fit for use

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -414,6 +414,89 @@ def get_standard_file(fname):
     return filenames
 
 
+def _parse_order(base_order, order_str):
+    """ Parse the list of `order_str` by splitting with "," and only returning elements from `base_order`
+
+    This method will sequence `order_str` and check for their invidual elements in `base_order`.
+
+    The items in `order_str` may be negated via '^item' or '!itema,itemb'.
+    The `order_str` must start with ^ to negate all options.
+
+    Raises
+    ------
+    ValueError: for mixed negated and non-negated orders or multiple negated orders
+
+    Parameters
+    ----------
+    base_order : list of str
+       the base list of orders
+    order_str : str or None
+       the orders to be parsed, if none, `base_order` is returned
+
+    Returns
+    -------
+    allow_order : list of str
+        allowed orders in lower-case
+    reject_order : list of str
+        rejected orders in lower-case
+    unknown_order : list of str
+        for values not overlapping with `base_order`
+    """
+    # ensure all base-orders are lower-case (for easier comparison)
+    base_order = [order.lower() for order in base_order]
+    if order_str is None:
+        return base_order, [], []
+
+    neg = order_str.startswith('^') or order_str.startswith('!')
+    # Check format
+    order_str_l = list(order_str)
+    sum_neg = order_str_l.count('^') + order_str_l.count('!')
+    if neg:
+        if sum_neg > 1:
+            raise ValueError(f"Orders must only contain a single (prefixed) negation, do not mix negated an non-negated items: {order_str}")
+        # remove prefix
+        order_str = order_str[1:]
+    elif sum_neg > 0:
+        raise ValueError(f"Orders must not mix negated an non-negated items: {order_str}")
+
+    # Split and lower case
+    orders = order_str.lower().split(',')
+
+    # to inform callee about non-overlapping elements
+    unknown_order = []
+
+    # if negated, we have to remove from the order
+    if neg:
+        allow_order = base_order.copy()
+        reject_order = []
+
+        for order in orders:
+            if order not in base_order:
+                unknown_order.append(order)
+                continue
+
+            if order in allow_order:
+                allow_order.remove(order)
+            if order not in reject_order:
+                reject_order.append(order)
+
+    else:
+        allow_order = []
+        reject_order = base_order.copy()
+
+        for order in orders:
+            if order not in base_order:
+                unknown_order.append(order)
+                continue
+
+            if order not in allow_order:
+                allow_order.append(order)
+            if order in reject_order:
+                reject_order.remove(order)
+
+    return allow_order, reject_order, unknown_order
+
+
 def get_info(name, notfound_action=0):
     """
     notfound_action:
@@ -1766,23 +1849,11 @@ class lapack_opt_info(system_info):
 
     def calc_info(self):
         user_order = os.environ.get(self.order_env_var_name, None)
-        if user_order is None:
-            lapack_order = self.lapack_order
-        else:
-            # the user has requested the order of the
-            # check they are all in the available list, a COMMA SEPARATED list
-            user_order = user_order.lower().split(',')
-            non_existing = []
-            lapack_order = []
-            for order in user_order:
-                if order in self.lapack_order:
-                    lapack_order.append(order)
-                elif len(order) > 0:
-                    non_existing.append(order)
-            if len(non_existing) > 0:
-                raise ValueError("lapack_opt_info user defined "
-                                 "LAPACK order has unacceptable "
-                                 "values: {}".format(non_existing))
+        lapack_order, _, unknown_order = _parse_order(self.lapack_order, user_order)
+        if len(unknown_order) > 0:
+            raise ValueError("lapack_opt_info user defined "
+                             "LAPACK order has unacceptable "
+                             "values: {}".format(unknown_order))
 
         for lapack in lapack_order:
             if self._calc_info(lapack):
@@ -1911,21 +1982,9 @@ class blas_opt_info(system_info):
 
     def calc_info(self):
         user_order = os.environ.get(self.order_env_var_name, None)
-        if user_order is None:
-            blas_order = self.blas_order
-        else:
-            # the user has requested the order of the
-            # check they are all in the available list
-            user_order = user_order.lower().split(',')
-            non_existing = []
-            blas_order = []
-            for order in user_order:
-                if order in self.blas_order:
-                    blas_order.append(order)
-                elif len(order) > 0:
-                    non_existing.append(order)
-            if len(non_existing) > 0:
-                raise ValueError("blas_opt_info user defined BLAS order has unacceptable values: {}".format(non_existing))
+        blas_order, _, unknown_order = _parse_order(self.blas_order, user_order)
+        if len(unknown_order) > 0:
+            raise ValueError("blas_opt_info user defined BLAS order has unacceptable values: {}".format(unknown_order))
 
         for blas in blas_order:
             if self._calc_info(blas):

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -286,12 +286,14 @@ class TestSystemInfoReading:
             os.chdir(previousDir)
         
 
-def test_distutils_parse_order():
-    from numpy.distutils.system_info import _parse_order
+def test_distutils_parse_env_order():
+    from numpy.distutils.system_info import _parse_env_order
+    env = 'NPY_TESTS_DISTUTILS_PARSE_ENV_ORDER'
 
     base_order = list('abcdef')
 
-    order, reject, unknown = _parse_order(base_order, 'b,i,e,f')
+    os.environ[env] = 'b,i,e,f'
+    order, reject, unknown = _parse_env_order(base_order, env)
     assert len(order) == 3
     assert order == list('bef')
     assert len(reject) == len(base_order) - 3
@@ -299,7 +301,8 @@ def test_distutils_parse_order():
     assert len(unknown) == 1
 
     for prefix in '^!':
-        order, reject, unknown = _parse_order(base_order, f'{prefix}b,i,e')
+        os.environ[env] = f'{prefix}b,i,e'
+        order, reject, unknown = _parse_env_order(base_order, env)
         assert len(order) == 4
         assert order == list('acdf')
         assert len(reject) == len(base_order) - 4
@@ -307,7 +310,9 @@ def test_distutils_parse_order():
         assert len(unknown) == 1
 
     with pytest.raises(ValueError):
-        _parse_order(base_order, 'b,^e,i')
+        os.environ[env] = 'b,^e,i'
+        _parse_env_order(base_order, env)
 
     with pytest.raises(ValueError):
-        _parse_order(base_order, '!b,^e,i')
+        os.environ[env] = '!b,^e,i'
+        _parse_env_order(base_order, env)

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -293,20 +293,16 @@ def test_distutils_parse_env_order():
     base_order = list('abcdef')
 
     os.environ[env] = 'b,i,e,f'
-    order, reject, unknown = _parse_env_order(base_order, env)
+    order, unknown = _parse_env_order(base_order, env)
     assert len(order) == 3
     assert order == list('bef')
-    assert len(reject) == len(base_order) - 3
-    assert reject == list('acd')
     assert len(unknown) == 1
 
     for prefix in '^!':
         os.environ[env] = f'{prefix}b,i,e'
-        order, reject, unknown = _parse_env_order(base_order, env)
+        order, unknown = _parse_env_order(base_order, env)
         assert len(order) == 4
         assert order == list('acdf')
-        assert len(reject) == len(base_order) - 4
-        assert reject == list('be')
         assert len(unknown) == 1
 
     with pytest.raises(ValueError):
@@ -316,3 +312,6 @@ def test_distutils_parse_env_order():
     with pytest.raises(ValueError):
         os.environ[env] = '!b,^e,i'
         _parse_env_order(base_order, env)
+
+    # clean-up environment
+    del os.environ[env]

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -285,3 +285,29 @@ class TestSystemInfoReading:
         finally:
             os.chdir(previousDir)
         
+
+def test_distutils_parse_order():
+    from numpy.distutils.system_info import _parse_order
+
+    base_order = list('abcdef')
+
+    order, reject, unknown = _parse_order(base_order, 'b,i,e,f')
+    assert len(order) == 3
+    assert order == list('bef')
+    assert len(reject) == len(base_order) - 3
+    assert reject == list('acd')
+    assert len(unknown) == 1
+
+    for prefix in '^!':
+        order, reject, unknown = _parse_order(base_order, f'{prefix}b,i,e')
+        assert len(order) == 4
+        assert order == list('acdf')
+        assert len(reject) == len(base_order) - 4
+        assert reject == list('be')
+        assert len(unknown) == 1
+
+    with pytest.raises(ValueError):
+        _parse_order(base_order, 'b,^e,i')
+
+    with pytest.raises(ValueError):
+        _parse_order(base_order, '!b,^e,i')

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -286,32 +286,29 @@ class TestSystemInfoReading:
             os.chdir(previousDir)
         
 
-def test_distutils_parse_env_order():
+def test_distutils_parse_env_order(monkeypatch):
     from numpy.distutils.system_info import _parse_env_order
     env = 'NPY_TESTS_DISTUTILS_PARSE_ENV_ORDER'
 
     base_order = list('abcdef')
 
-    os.environ[env] = 'b,i,e,f'
+    monkeypatch.setenv(env, 'b,i,e,f')
     order, unknown = _parse_env_order(base_order, env)
     assert len(order) == 3
     assert order == list('bef')
     assert len(unknown) == 1
 
     for prefix in '^!':
-        os.environ[env] = f'{prefix}b,i,e'
+        monkeypatch.setenv(env, f'{prefix}b,i,e')
         order, unknown = _parse_env_order(base_order, env)
         assert len(order) == 4
         assert order == list('acdf')
         assert len(unknown) == 1
 
     with pytest.raises(ValueError):
-        os.environ[env] = 'b,^e,i'
+        monkeypatch.setenv(env, 'b,^e,i')
         _parse_env_order(base_order, env)
 
     with pytest.raises(ValueError):
-        os.environ[env] = '!b,^e,i'
+        monkeypatch.setenv(env, '!b,^e,i')
         _parse_env_order(base_order, env)
-
-    # clean-up environment
-    del os.environ[env]


### PR DESCRIPTION
When users build for a particular order it may be beneficial
to disallow certain libraries.

In particular a user may not care about which accelerated
BLAS library is used, so long as the NetLIB library isn't used.

This is now possible with:

   NPY_BLAS_ORDER='^blas'

or

   NPY_BLAS_ORDER='!blas'

Since we may envision more BLAS/LAPACK libraries to the pool, this
will provide greater flexibility as they enter.

A new (local) method is added in `system_info.py` which removes duplicate
code and allows for easier usage across libraries.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
