### PR TITLE
BUG, DOC: comment out metadata added via javascript

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,7 +1,8 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-    <link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" />
+    <!-- this is added via javascript in versionwarning.js  -->
+    <!-- link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" / -->
 
 <style>
 .navbar-brand img {


### PR DESCRIPTION
Reverts gh-17210, closes gh-17069

Rather than remove the uneeded line, I commented it out. Perhaps next time this come up it will remind us how this is done. Note for future self: `versionwarning.js` is added via [`update.py`](https://github.com/numpy/doc/blob/master/update.py), which is run as part of the deployment on the numpy/doc repo, as documented in the [README there](https://github.com/numpy/doc/blob/master/README.md).