### PR TITLE
BUG: Fix dimension discovery of within array ragged cases

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -548,7 +548,7 @@ update_shape(int curr_ndim, int *max_ndim,
             success = -1;
             if (!sequence) {
                 /* Remove dimensions that we cannot use: */
-                *max_ndim -= new_ndim + i;
+                *max_ndim -= new_ndim - i;
             }
             else {
                 assert(i == 0);

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -11,6 +11,7 @@ from itertools import product
 
 import numpy as np
 from numpy.core._rational_tests import rational
+from numpy.core._multiarray_umath import _discover_array_parameters
 
 from numpy.testing import (
     assert_array_equal, assert_warns, IS_PYPY)
@@ -478,6 +479,26 @@ class TestNested:
         with pytest.raises(ValueError):
             np.array([[], np.empty((0, 1))], dtype=object)
 
+    def test_array_of_different_depths(self):
+        # When multiple arrays (or array-likes) are included in a
+        # sequences and have different depth, we currently discover
+        # as many dimensions as they share. (see also gh-17224)
+        arr = np.zeros((3, 2))
+        mismatch_first_dim = np.zeros((1, 2))
+        mismatch_second_dim = np.zeros((3, 3))
+
+        dtype, shape = _discover_array_parameters(
+            [arr, mismatch_second_dim], dtype=np.dtype("O"))
+        assert shape == (2, 3)
+
+        dtype, shape = _discover_array_parameters(
+            [arr, mismatch_first_dim], dtype=np.dtype("O"))
+        assert shape == (2,)
+        # The second case is currently supported because the arrays
+        # can be stored as objects:
+        res = np.asarray([arr, mismatch_first_dim], dtype=np.dtype("O"))
+        assert res[0] is arr
+        assert res[1] is mismatch_first_dim
 
 class TestBadSequences:
     # These are tests for bad objects passed into `np.array`, in general

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -500,6 +500,7 @@ class TestNested:
         assert res[0] is arr
         assert res[1] is mismatch_first_dim
 
+
 class TestBadSequences:
     # These are tests for bad objects passed into `np.array`, in general
     # these have undefined behaviour.  In the old code they partially worked


### PR DESCRIPTION
When `np.array(...)` finds a shape mismatch while inspecting
an array (or array-like), the current logic is to use only
part of those dimensions (as many as possible).

This case was buggy in the new code, and is now fixed.
In general, we may want to change the logic here, e.g. to
always strip all dimensions of that array (allowing an object
array of arrays), but there are some corner cases where the
current behaviour somewhat "works", so this fixes a bug while
gh-17224 and the issues around it remain independently.
