### PR TITLE
BUG: Avoid using ``np.random`` in typing tests.

### DIFF
--- a/numpy/tests/typing/pass/flatiter.py
+++ b/numpy/tests/typing/pass/flatiter.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-a = np.random.rand(5).flat
+a = np.empty((2, 2)).flat
 
 a.base
 a.copy()


### PR DESCRIPTION
Using `np.random` can cause mysterious test failures in  mypy `api.run`
with a report that 'error: Module has no attribute "rand"'.  The fix
here is to use `np.empty` instead of `np.random.rand`. Why this works
is unknown at present.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
