### PR TITLE
DOC: Use SPDX license expressions with correct license

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -3,22 +3,22 @@ compatibly licensed.  We list these here.
 
 Name: Numpydoc
 Files: doc/sphinxext/numpydoc/*
-License: 2-clause BSD
+License: BSD-2-clause
   For details, see doc/sphinxext/LICENSE.txt
 
 Name: scipy-sphinx-theme
 Files: doc/scipy-sphinx-theme/*
-License: 3-clause BSD, PSF and Apache 2.0
+License: BSD-3-clause AND PSF-2.0 AND Apache-2.0
   For details, see doc/scipy-sphinx-theme/LICENSE.txt
 
 Name: lapack-lite
 Files: numpy/linalg/lapack_lite/*
-License: 3-clause BSD
+License: BSD-3-clause
   For details, see numpy/linalg/lapack_lite/LICENSE.txt
 
 Name: tempita
 Files: tools/npy_tempita/*
-License: BSD derived
+License: MIT
   For details, see tools/npy_tempita/license.txt
 
 Name: dragon4

--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -3,17 +3,17 @@ compatibly licensed.  We list these here.
 
 Name: Numpydoc
 Files: doc/sphinxext/numpydoc/*
-License: BSD-2-clause
+License: BSD-2-Clause
   For details, see doc/sphinxext/LICENSE.txt
 
 Name: scipy-sphinx-theme
 Files: doc/scipy-sphinx-theme/*
-License: BSD-3-clause AND PSF-2.0 AND Apache-2.0
+License: BSD-3-Clause AND PSF-2.0 AND Apache-2.0
   For details, see doc/scipy-sphinx-theme/LICENSE.txt
 
 Name: lapack-lite
 Files: numpy/linalg/lapack_lite/*
-License: BSD-3-clause
+License: BSD-3-Clause
   For details, see numpy/linalg/lapack_lite/LICENSE.txt
 
 Name: tempita


### PR DESCRIPTION
After a check I found that `tools/npy_tempita/license.txt license` is an MIT license and not a "BSD Derived" as reported.
I also propose to use SPDX license identifiers and license expressions for improved clarity and update the file accordingly.

This is based on a scan I ran after an original report at https://github.com/nexB/scancode-toolkit/issues/2189

Reported-by: Frank Viernau <frank.viernau@here.com>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
