### PR TITLE
MAINT: ``__array_interface__`` data address cannot be bytes

### DIFF
--- a/doc/release/upcoming_changes/17241.compatibility.rst
+++ b/doc/release/upcoming_changes/17241.compatibility.rst
@@ -1,0 +1,6 @@
+The first element of the ``__array_interface__["data"]`` tuple  must be an integer
+----------------------------------------------------------------------------------
+This has been the documented interface for many years, but there was still
+code that would accept a byte string representation of the pointer address.
+That code has been removed, passing the address as a byte string will now
+raise an error.

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1840,7 +1840,7 @@ PyArray_FromInterface(PyObject *origin)
     PyArray_Descr *dtype = NULL;
     char *data = NULL;
     Py_buffer view;
-    int res, i, n;
+    int i, n;
     npy_intp dims[NPY_MAXDIMS], strides[NPY_MAXDIMS];
     int dataflags = NPY_ARRAY_BEHAVED;
 
@@ -1977,17 +1977,8 @@ PyArray_FromInterface(PyObject *origin)
                     "(data pointer integer, read-only flag)");
             goto fail;
         }
-
         dataptr = PyTuple_GET_ITEM(attr, 0);
-        if (PyBytes_Check(dataptr)) {
-            res = sscanf(PyBytes_AsString(dataptr), "%p", (void **)&data);
-            if (res < 1) {
-                PyErr_SetString(PyExc_TypeError,
-                        "__array_interface__ data string cannot be converted");
-                goto fail;
-            }
-        }
-        else if (PyLong_Check(dataptr)) {
+        if (PyLong_Check(dataptr)) {
             data = PyLong_AsVoidPtr(dataptr);
             if (data == NULL && PyErr_Occurred()) {
                 goto fail;
@@ -1996,7 +1987,7 @@ PyArray_FromInterface(PyObject *origin)
         else {
             PyErr_SetString(PyExc_TypeError,
                     "first element of __array_interface__ data tuple "
-                    "must be integer or string.");
+                    "must be an integer.");
             goto fail;
         }
         if (PyObject_IsTrue(PyTuple_GET_ITEM(attr,1))) {


### PR DESCRIPTION
The old version 1 ``__array_interface__`` implementation allowed the
data pointer value to be passed as a string, in version 2 an integer was
required, but the old code accepting a string remained. Remove that bit
of code from PyArray_FromInterface.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
