### PR TITLE
MAINT: Run slow CI jobs earlier so builds finishes sooner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,34 @@ jobs:
       python: 3.8
 
     - stage: Comprehensive tests
-      python: 3.6
+      python: 3.7
+      os: linux
+      arch: ppc64le
+      env:
+       # use OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
+       - ATLAS=None
+
+    - python: 3.7
+      os: linux
+      arch: s390x
+      env:
+       # use OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
+       - NPY_USE_BLAS_ILP64=1
+       - ATLAS=None
+
+    - python: 3.7
+      os: linux
+      arch: arm64
+      env:
+       # use OpenBLAS build, not system ATLAS
+       - DOWNLOAD_OPENBLAS=1
+       - ATLAS=None
+
+
+
+    - python: 3.6
     - python: 3.7
     - python: 3.9-dev
 
@@ -90,31 +117,6 @@ jobs:
       env:
        - BLAS=None
        - LAPACK=None
-       - ATLAS=None
-
-    - python: 3.7
-      os: linux
-      arch: ppc64le
-      env:
-       # use OpenBLAS build, not system ATLAS
-       - DOWNLOAD_OPENBLAS=1
-       - ATLAS=None
-
-    - python: 3.7
-      os: linux
-      arch: s390x
-      env:
-       # use OpenBLAS build, not system ATLAS
-       - DOWNLOAD_OPENBLAS=1
-       - NPY_USE_BLAS_ILP64=1
-       - ATLAS=None
-
-    - python: 3.7
-      os: linux
-      arch: arm64
-      env:
-       # use OpenBLAS build, not system ATLAS
-       - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
 
 


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
Travis CI gives 5 parallel jobs.

We can run slow jobs earlier, to free up a runner and make the most of the parallelism.

Looking at the 15 jobs in the main "Comprehensive tests" stage of a [master](https://travis-ci.org/github/hugovk/numpy/builds/723801302) build, here's a visualisation of how long it takes:

```
ID Duration in mins
 1 *******
 2 ********
 3 **********
 4 *********
 5 ******************
 6        ********
 7         ***********
 8          ********
 9           **********
10                ********
11                  ********
12                   *****************
13                    ********
14                     **************************
End: 46
   ----------------------------------------------
```

(This simplification rounds jobs to the nearest minute, and assumes no delay starting new jobs.)

OK, the visualisation is fairly accurate, the real thing took 46 min 58 sec (start-to-finish time).

Theoretically, optimising this drops it to around 34 minutes:

```
ID Duration in mins
14 **************************
 5 ******************
12 *****************
 7 ***********
 3 **********
 9           **********
 4            *********
 2                  ********
 6                   ********
 8                     ********
10                     ********
11                          ********
13                           ********
 1                           *******
End: 34
   ----------------------------------
```

Now, we don't need to lose all the semantic grouping of jobs by shuffling them by duration.

A minimal change is to move the final group of three (12-14 above, the `DOWNLOAD_OPENBLAS` trio) to the start of the stage. They're the slowest group (17min+8min+26min) and cause a long wait when all the others have finished.

For example, the main stage of this [build](https://travis-ci.org/github/hugovk/numpy/builds/723772806) took only 36 min 32 sec, a good 10 minutes sooner than before! Also not far off the theoretical best from the visualisation above.

Putting this build through the visualisation:

```
ID Duration in mins
 1 *********************
 2 *******
 3 ***********************
 4 *******
 5 *******
 6        *********
 7        *********
 8        ******************
 9                 ********
10                 ***********
11                      ********
12                        **********
13                         ********
14                          ********
End: 33
   ---------------------------------
```

This shows the slow ones are dealt with first, freeing up jobs to make good use of all 5 parallel jobs.

