### PR TITLE
DOC: Use SPDX license expressions with correct license

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -3,22 +3,22 @@ compatibly licensed.  We list these here.
 
 Name: Numpydoc
 Files: doc/sphinxext/numpydoc/*
-License: 2-clause BSD
+License: BSD-2-Clause
   For details, see doc/sphinxext/LICENSE.txt
 
 Name: scipy-sphinx-theme
 Files: doc/scipy-sphinx-theme/*
-License: 3-clause BSD, PSF and Apache 2.0
+License: BSD-3-Clause AND PSF-2.0 AND Apache-2.0
   For details, see doc/scipy-sphinx-theme/LICENSE.txt
 
 Name: lapack-lite
 Files: numpy/linalg/lapack_lite/*
-License: 3-clause BSD
+License: BSD-3-Clause
   For details, see numpy/linalg/lapack_lite/LICENSE.txt
 
 Name: tempita
 Files: tools/npy_tempita/*
-License: BSD derived
+License: MIT
   For details, see tools/npy_tempita/license.txt
 
 Name: dragon4


### PR DESCRIPTION
Backport #17238. 

* Use SPDX license expressions with correct license

tools/npy_tempita/license.txt license is MIT not a "BSD Derived"
Also use SPDX license identifiers and expressions for clarity

Based on original report at https://github.com/nexB/scancode-toolkit/issues/2189

Reported-by: Frank Viernau <frank.viernau@here.com>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

* Use correct case for BSD licenses identifers

Reported-by: Sebastian Berg <sebastian@sipsolutions.net>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
