### PR TITLE
BUG: fixing regex to avoid DoS vulnerabilities

### DIFF
--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -152,7 +152,7 @@ def parse_values(astr):
 
 
 stripast = re.compile(r"\n\s*\*?")
-named_re = re.compile(r"#\s*(\w*)\s*=([^#]*)#")
+named_re = re.compile(r"#\s*([\S\w]*)\s*=([^#]*)#")
 exclude_vars_re = re.compile(r"(\w*)=(\w*)")
 exclude_re = re.compile(":exclude:")
 def parse_loop_header(loophead) :

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -152,7 +152,11 @@ def parse_values(astr):
 
 
 stripast = re.compile(r"\n\s*\*?")
-named_re = re.compile(r"#\s*([\S\w]*)\s*=([^#]*)#")
+named_re = re.compile(r"""\#  # number sign 
+        \s*                   # followed by whitespace
+        (\w+\s*)?             # possibly 1+ words, whitespace
+        =([^#]*)\#            # equals anything followed by #
+        """, re.VERBOSE)
 exclude_vars_re = re.compile(r"(\w*)=(\w*)")
 exclude_re = re.compile(":exclude:")
 def parse_loop_header(loophead) :

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -83,8 +83,16 @@ def parse_structure(astr):
     return spanlist
 
 template_re = re.compile(r"<\s*(\w[\w\d]*)\s*>")
-named_re = re.compile(r"<\s*(\w[\w\d]*)\s*=\s*(\S*?)\s*>")
-list_re = re.compile(r"<\s*((\S*?))\s*>")
+list_re = re.compile(r""""
+        <\s*         # < whitespace
+        (\S+\s*)?>   # 1+ nonwhitepace 0+ space possibly, then >
+        """, re.VERBOSE)
+named_re = re.compile(r"""
+        <\s*         # < 0 or more whitespace
+        (\w[\w\d]*)  # word, 0 or more word digits
+        \s*=\s*      # equals surrounded by whitespace
+        (\S+\s*)?>   # 1+ nonwhitepace 0+ space possibly, then >
+        """, re.VERBOSE)
 
 def find_repl_patterns(astr):
     reps = named_re.findall(astr)

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -83,7 +83,7 @@ def parse_structure(astr):
     return spanlist
 
 template_re = re.compile(r"<\s*(\w[\w\d]*)\s*>")
-list_re = re.compile(r""""
+list_re = re.compile(r"""
         <\s*         # < whitespace
         (\S+\s*)?>   # 1+ nonwhitepace 0+ space possibly, then >
         """, re.VERBOSE)

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -83,8 +83,8 @@ def parse_structure(astr):
     return spanlist
 
 template_re = re.compile(r"<\s*(\w[\w\d]*)\s*>")
-named_re = re.compile(r"<\s*(\w[\w\d]*)\s*=\s*(.*?)\s*>")
-list_re = re.compile(r"<\s*((.*?))\s*>")
+named_re = re.compile(r"<\s*(\w[\w\d]*)\s*=\s*(\S*?)\s*>")
+list_re = re.compile(r"<\s*((\S*?))\s*>")
 
 def find_repl_patterns(astr):
     reps = named_re.findall(astr)


### PR DESCRIPTION
Regexes which can match over long parts of strings but then
be rejected by nonmatching at the end can be used for
denial-of-service.  This addresses #17255 and #17254.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
