### PR TITLE
DOC: work around a bug in the new theme

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -4,6 +4,22 @@
 Contributing to NumPy
 #####################
 
+.. TODO: this is hidden because there's a bug in the pydata theme that won't render TOC items under headers
+
+.. toctree::
+   :hidden:
+
+   conduct/code_of_conduct
+   Git Basics <gitwash/index>
+   development_environment
+   development_workflow
+   ../benchmarking
+   style_guide
+   releasing
+   governance/index
+   howto-docs
+
+
 Not a coder? Not a problem! NumPy is multi-faceted, and we can use a lot of help.
 These are all activities we'd like to get help with (they're all important, so
 we list them in alphabetical order):


### PR DESCRIPTION
Due to a bug in the theme, a toctree inside a section title is [not shown](https://numpy.org/devdocs/dev/index.html) in the left navbar. xref pandas-dev/pydata-sphinx-theme#218. A work-around is to copy the toctree to the top of the document. This should be removed when that issue is resolved.

Note this PR only works around the issue, it does not try to clean up the perhaps unneeded links in the TOC.