### PR TITLE
TST: Fix the path to `mypy.ini` in `runtests.py`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -230,8 +230,9 @@ def main(argv):
         config = os.path.join(
             site_dir,
             "numpy",
-            "tests",
             "typing",
+            "tests",
+            "data",
             "mypy.ini",
         )
 


### PR DESCRIPTION
Fixed an issue where `./runtests --mypy` was trying to pull the `mypy.ini` file from a path removed in https://github.com/numpy/numpy/pull/16800.