### PR TITLE
BUG: sysconfig attributes/distutils issue

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2499,13 +2499,12 @@ class _numpy_info(system_info):
             except AttributeError:
                 pass
 
-            include_dirs.append(distutils.get_python_inc(
-                                        prefix=os.sep.join(prefix)))
+            include_dirs.append(sysconfig.get_path('include'))
         except ImportError:
             pass
-        py_incl_dir = sysconfig.get_python_inc()
+        py_incl_dir = sysconfig.get_path('include')
         include_dirs.append(py_incl_dir)
-        py_pincl_dir = sysconfig.get_python_inc(plat_specific=True)
+        py_pincl_dir = sysconfig.get_path('platinclude')
         if py_pincl_dir not in include_dirs:
             include_dirs.append(py_pincl_dir)
         for d in default_include_dirs:
@@ -2632,8 +2631,8 @@ class boost_python_info(system_info):
                 break
         if not src_dir:
             return
-        py_incl_dirs = [sysconfig.get_python_inc()]
-        py_pincl_dir = sysconfig.get_python_inc(plat_specific=True)
+        py_incl_dirs = [sysconfig.get_path('include')]
+        py_pincl_dir = sysconfig.get_path('platinclude')
         if py_pincl_dir not in py_incl_dirs:
             py_incl_dirs.append(py_pincl_dir)
         srcs_dir = os.path.join(src_dir, 'libs', 'python', 'src')


### PR DESCRIPTION
* gh-17223 started the `distutils` modernization
process because of the various upstream stuff
going on (thanks)

* that set of changes caused build issues with NumPy
pre-release wheels + SciPy `master`:
https://travis-ci.org/github/scipy/scipy/builds/725002838

* I was able to patch two separate issues and confirm
that this feature branch restores the SciPy build locally:
1) in one case, `distutils.sysconfig.get_python_inc` was
replaced with `distutils.get_python_inc`, which does not
exist (probably a typo)
2) a bit more serious; even `sysconfig.get_python_inc` does
not appear to exist; the closest match I could find (and
that worked) was `sysconfig.get_path()` with options for
general and platform-specific header paths as needed

* I'm not claiming that these stdlib replacements are perfect
either (the prefix case may still be slightly different?), but
it does prevent the SciPy build break originally introduced
as a start

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
