### PR TITLE
DEP: Change the financial name access warning to DeprecationWarning

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -247,7 +247,7 @@ else:
             except KeyError:
                 pass
             else:
-                warnings.warn(msg, RuntimeWarning)
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
                 def _expired(*args, **kwds):
                     raise RuntimeError(msg)

--- a/numpy/lib/tests/test_financial_expired.py
+++ b/numpy/lib/tests/test_financial_expired.py
@@ -7,7 +7,7 @@ import numpy as np
                     reason="requires python 3.7 or higher")
 def test_financial_expired():
     match = 'NEP 32'
-    with pytest.warns(RuntimeWarning, match=match):
+    with pytest.warns(DeprecationWarning, match=match):
         func = np.fv
     with pytest.raises(RuntimeError, match=match):
         func(1, 2, 3)


### PR DESCRIPTION
Most end-users will probably not care about the warning in any case,
since they will not just import the function but also use it.
We can't just remove it, due to gh-17143: Astropy currently pulls
in these functions (but doesn't use them), so that plain removal
would lead to an unusable astropy if a new NumPy is installed.
Even more annoying, due to a (faulty?) astropy pytest plugin, this
affects all pytest runs (which do not use `PYTEST_DISABLE_PLUGIN_AUTOLOAD`).

Changing it to a DeprecationWarning seems to remove the issue from
pytest runs, this may make the warning less visible in rare cases
where it should be seen, but hopefully it will still be visible enough.

---

Not sure this is the solution we want to opt for, we can also just pull the warning out and just wait a year and then hope we don't need to do anything.