### PR TITLE
MAINT: Simplify ufunc pickling

### DIFF
--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -461,6 +461,15 @@ addUfuncs(PyObject *dictionary) {
     PyDict_SetItemString(dictionary, "cross1d", f);
     Py_DECREF(f);
 
+    f = PyUFunc_FromFuncAndDataAndSignature(NULL, NULL,
+            NULL, 0, 0, 0, PyUFunc_None, "_pickleable_module_global.ufunc",
+            "A dotted name for pickle testing, does nothing.", 0, NULL);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "_pickleable_module_global_ufunc", f);
+    Py_DECREF(f);
+
     return 0;
 }
 

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -178,6 +178,10 @@ class TestUfuncGenericLoops:
                 assert_array_equal(res_num.astype("O"), res_obj)
 
 
+def _pickleable_module_global():
+    pass
+
+
 class TestUfunc:
     def test_pickle(self):
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
@@ -194,6 +198,15 @@ class TestUfunc:
         astring = (b"cnumpy.core\n_ufunc_reconstruct\np0\n"
                    b"(S'numpy.core.umath'\np1\nS'cos'\np2\ntp3\nRp4\n.")
         assert_(pickle.loads(astring) is np.cos)
+
+    def test_pickle_name_is_qualname(self):
+        # This tests that a simplification of our ufunc pickle code will
+        # lead to allowing qualnames as names.  Future ufuncs should
+        # possible add a specific qualname, or a hook into pickling instead
+        # (dask+numba may benefit).
+        _pickleable_module_global.ufunc = umt._pickleable_module_global_ufunc
+        obj = pickle.loads(pickle.dumps(_pickleable_module_global.ufunc))
+        assert obj is umt._pickleable_module_global_ufunc
 
     def test_reduceat_shifting_sum(self):
         L = 6


### PR DESCRIPTION
This also allows at least in principle numba dynamically
generated ufuncs to be pickled (with some hacking), see:

https://github.com/dask/distributed/issues/3450

If the name of the ufunc is set to a qualname, using this method,
pickle should be able to unpickle the ufunc correctly.
We may want to allow setting the module and qualname explicitly
on the ufunc object to remove the need for the custom pickler
completely.

---

We do have tests for rationals (which are much like scipy's ufuncs), and an old "pickle" (manually created string) which can still load with this.  I am not 100% sure on it, but to be honest, it seems cleaner to me to rely on pickle calling `whichmodule` rather than calling it ourselves, at least unless we want to actually store `__module__` and `__qualname__` on the ufunc itself, which I think may be a good idea.