### PR TITLE
BLD: set upper versions for build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools<49.2.0",
-    "wheel",
-    "Cython>=0.29.21",  # Note: keep in sync with tools/cythonize.py
+    "wheel<=0.35.1",
+    "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 
 


### PR DESCRIPTION
Backport of #17297. 

This is something we really should do for all dependencies,
but I expect it to become more important now that build-related
packages are all starting to update regarding the upcoming
distutils deprecation.

And Cython has a major release coming up - just in case, avoid it.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
