### PR TITLE
BUILD: pin pygments to 2.6.1, 2.7.0 breaks custom NumPyC lexer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.8.4
 
     working_directory: ~/repo
 
@@ -18,11 +18,10 @@ jobs:
       - run:
           name: create virtual environment, install dependencies
           command: |
-            python3 -m venv venv
-            ln -s $(which python3) venv/bin/python3.6
-            . venv/bin/activate
             sudo apt-get update
             sudo apt-get install -y graphviz texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex
+            python3.8 -m venv venv
+            . venv/bin/activate
 
       - run:
           name: build numpy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
           name: build numpy
           command: |
             . venv/bin/activate
-            pip install --upgrade pip 'setuptools<49.2.0'
-            pip install -r test_requirements.txt
+            pip install --progress-bar=off --upgrade pip 'setuptools<49.2.0'
+            pip install --progress-bar=off -r test_requirements.txt
             pip install .
-            pip install -r doc_requirements.txt
+            pip install --progress-bar=off -r doc_requirements.txt
 
       - run:
           name: create release notes

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,4 @@
+pygments==2.6.1
 sphinx>=2.2.0,<3.0
 ipython
 scipy


### PR DESCRIPTION
Try to figure out what is going on with circleCI and doc building. Maybe time to move to githbu actions?