### PR TITLE
MAINT: Syntax-highlight .src files on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@ numpy/lib/tests/data/*.npy binary
 
 # Release notes, reduce number of conflicts.
 doc/release/*.rst merge=union
+
+# Highlight our custom templating language as C, since it's hopefully better
+# than nothing. This also affects repo statistics.
+*.c.src linguist-language=C
+*.h.src linguist-language=C


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->


Before: https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/einsum_sumprod.c.src

After: https://github.com/eric-wieser/numpy/blob/_c.src-highlight/numpy/core/src/multiarray/einsum_sumprod.c.src