### PR TITLE
MAINT: Mark vendored/generated files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,13 @@ doc/release/*.rst merge=union
 # than nothing. This also affects repo statistics.
 *.c.src linguist-language=C
 *.h.src linguist-language=C
+
+# Mark some files as vendored
+numpy/linalg/lapack_lite/f2c.c linguist-vendored
+numpy/linalg/lapack_lite/f2c.h linguist-vendored
+tools/npy_tempita/* linguist-vendored
+
+# Mark some files as generated
+numpy/linalg/lapack_lite/f2c_*.c linguist-generated
+numpy/linalg/lapack_lite/lapack_lite_names.h linguist-generated
+


### PR DESCRIPTION
This marks some files as vendored or generated. There may be more
files around.
This should mostly change our language statistics on github, so it
probably isn't worth much trouble, but maybe it makes the stats
slightly more representative.

---

Just saw this, and was curious about it. I am happy to also just not do this.