### PR TITLE
ENH: Add `__array_function__` support to a few `random` functions

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4199,6 +4199,10 @@ cdef class Generator:
 
         return diric
 
+    def _permuted_dispatcher(self, object x, *, axis=None, out=None):
+        return (x, )
+
+    @array_function_dispatch(_permuted_dispatcher, verify=False)
     def permuted(self, object x, *, axis=None, out=None):
         """
         permuted(x, axis=None, out=None)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -11,6 +11,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 from numpy.core.multiarray import normalize_axis_index
+from numpy.core.overrides import array_function_dispatch
 
 from .c_distributions cimport *
 from libc cimport string
@@ -593,7 +594,12 @@ cdef class Generator:
         return self.integers(0, 4294967296, size=n_uint32,
                              dtype=np.uint32).astype('<u4').tobytes()[:length]
 
+    def _choice_dispatcher(self, object x, size=None, replace=None, p=None, 
+                           axis=None, shuffle=None):
+        return (x, )
+
     @cython.wraparound(True)
+    @array_function_dispatch(_choice_dispatcher, verify=False)
     def choice(self, a, size=None, replace=True, p=None, axis=0, bint shuffle=True):
         """
         choice(a, size=None, replace=True, p=None, axis=0, shuffle=True)
@@ -4346,6 +4352,10 @@ cdef class Generator:
         PyMem_Free(buf)
         return out
 
+    def _shuffle_dispatcher(self, object x, axis=None):
+        return (x, )
+
+    @array_function_dispatch(_shuffle_dispatcher, verify=False)
     def shuffle(self, object x, axis=0):
         """
         shuffle(x, axis=0)
@@ -4439,6 +4449,10 @@ cdef class Generator:
                     j = random_interval(&self._bitgen, i)
                     x[i], x[j] = x[j], x[i]
 
+    def _permutation_dispatcher(self, object x, axis=None):
+        return (x, )
+
+    @array_function_dispatch(_permutation_dispatcher, verify=False)
     def permutation(self, object x, axis=0):
         """
         permutation(x, axis=0)

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4,7 +4,6 @@ import operator
 import warnings
 
 import numpy as np
-from numpy.core.overrides import array_function_dispatch
 
 from cpython.pycapsule cimport PyCapsule_IsValid, PyCapsule_GetPointer
 from cpython cimport (Py_INCREF, PyFloat_AsDouble)
@@ -802,11 +801,7 @@ cdef class RandomState:
         return self.randint(0, 4294967296, size=n_uint32,
                             dtype=np.uint32).astype('<u4').tobytes()[:length]
 
-    def _choice_dispatcher(self, a, size=None, replace=None, p=None):
-        return (a, )
-
     @cython.wraparound(True)
-    @array_function_dispatch(_choice_dispatcher, verify=False)
     def choice(self, a, size=None, replace=True, p=None):
         """
         choice(a, size=None, replace=True, p=None)
@@ -4390,11 +4385,7 @@ cdef class RandomState:
 
         return diric
 
-    def _unary_op_dispatcher(self, object x):
-        return (x, )
-
     # Shuffling and permutations:
-    @array_function_dispatch(_unary_op_dispatcher, verify=False)
     def shuffle(self, object x):
         """
         shuffle(x)
@@ -4491,7 +4482,6 @@ cdef class RandomState:
             string.memcpy(data + j * stride, data + i * stride, itemsize)
             string.memcpy(data + i * stride, buf, itemsize)
 
-    @array_function_dispatch(_unary_op_dispatcher, verify=False)
     def permutation(self, object x):
         """
         permutation(x)

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4,6 +4,7 @@ import operator
 import warnings
 
 import numpy as np
+from numpy.core.overrides import array_function_dispatch
 
 from cpython.pycapsule cimport PyCapsule_IsValid, PyCapsule_GetPointer
 from cpython cimport (Py_INCREF, PyFloat_AsDouble)
@@ -801,7 +802,11 @@ cdef class RandomState:
         return self.randint(0, 4294967296, size=n_uint32,
                             dtype=np.uint32).astype('<u4').tobytes()[:length]
 
+    def _choice_dispatcher(self, a, size=None, replace=None, p=None):
+        return (a, )
+
     @cython.wraparound(True)
+    @array_function_dispatch(_choice_dispatcher, verify=False)
     def choice(self, a, size=None, replace=True, p=None):
         """
         choice(a, size=None, replace=True, p=None)
@@ -4385,7 +4390,11 @@ cdef class RandomState:
 
         return diric
 
+    def _unary_op_dispatcher(self, object x):
+        return (x, )
+
     # Shuffling and permutations:
+    @array_function_dispatch(_unary_op_dispatcher, verify=False)
     def shuffle(self, object x):
         """
         shuffle(x)
@@ -4482,6 +4491,7 @@ cdef class RandomState:
             string.memcpy(data + j * stride, data + i * stride, itemsize)
             string.memcpy(data + i * stride, buf, itemsize)
 
+    @array_function_dispatch(_unary_op_dispatcher, verify=False)
     def permutation(self, object x):
         """
         permutation(x)


### PR DESCRIPTION
Linked issue: #15123

This pull request adds `__array_function__` support to the following methods in both `Generator` and `RandomState`:
* `permutation`
* `choice`
* `shuffle`
so that `ndarray` subclasses may provide their own implementation. 

If you have an `__array_function__` implementation like this: 
```python
 def __array_function__(self, func, types, args, kwargs):
    if func not in HANDLED_FUNCTIONS:
        return NotImplemented
    if not all(issubclass(t, MyCustomArray) for t in types):
        return NotImplemented
    return HANDLED_FUNCTIONS[func](*args, **kwargs)
```
And an `implements` decorator like this: 
```python
def implements(numpy_function):
    def decorator(func):
        HANDLED_FUNCTIONS[numpy_function] = func
        return func
    return decorator
```

Since `np.random.{suffle, choice, and permutation}` are really bound methods of an instantiated `RandomState` object, when you provide your own implementation, you have to do: 
```python
@implements(np.random.RandomState.choice) # NOT np.random.choice
def shuffle(random_state, array):
    # custom implementation 

# and similarly for np.random.Generator.choice
```
This is a little clunky, but I'm not sure if there's a better alternative. Please do let me know if you have suggestions :) 

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
