### PR TITLE
BUG: Set deprecated fields to null in PyArray_InitArrFuncs

### DIFF
--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -127,6 +127,9 @@ PyArray_InitArrFuncs(PyArray_ArrFuncs *f)
     f->scalarkind = NULL;
     f->cancastscalarkindto = NULL;
     f->cancastto = NULL;
+    f->fastclip = NULL;
+    f->fastputmask = NULL;
+    f->fasttake = NULL;
 }
 
 


### PR DESCRIPTION
Fixes gh-17318.

Initializing the deprecated fields to null ensures that if a user sets them to their own function pointers, this can be detected and the warning about using deprecated fields can be printed.
