### PR TITLE
DOC, BLD: update lexer highlighting and make numpydocs a regular dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "doc/sphinxext"]
-	path = doc/sphinxext
-	url = https://github.com/numpy/numpydoc.git

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -367,15 +367,15 @@ def linkcode_resolve(domain, info):
            numpy.__version__, fn, linespec)
 
 from pygments.lexers import CLexer
-import copy
+from pygments.lexer import inherit, bygroups
+from pygments.token import Comment
 
 class NumPyLexer(CLexer):
     name = 'NUMPYLEXER'
 
-    tokens = copy.deepcopy(CLexer.tokens)
-    # Extend the regex for valid identifiers with @
-    for k, val in tokens.items():
-        for i, v in enumerate(val):
-            if isinstance(v, tuple):
-                if isinstance(v[0], str):
-                    val[i] =  (v[0].replace('a-zA-Z', 'a-zA-Z@'),) + v[1:]
+    tokens = {
+        'statements': [
+            (r'@[a-zA-Z_]*@', Comment.Preproc, 'macro'),
+         inherit,
+        ],
+    }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -376,6 +376,6 @@ class NumPyLexer(CLexer):
     tokens = {
         'statements': [
             (r'@[a-zA-Z_]*@', Comment.Preproc, 'macro'),
-         inherit,
+            inherit,
         ],
     }

--- a/doc/source/docs/howto_document.rst
+++ b/doc/source/docs/howto_document.rst
@@ -40,29 +40,7 @@ after which you may use it::
 
   np.fft.fft2(...)
 
-.. rubric::
-    **For convenience the** `formatting standard`_ **is included below with an
-    example**
-
-.. include:: ../../sphinxext/doc/format.rst
-
-.. _example:
-
-Example Source
-==============
-
-.. literalinclude:: ../../sphinxext/doc/example.py
-
-
-
-Example Rendered
-================
-
-.. ifconfig:: python_version_major < '3'
-
-    The example is rendered only when sphinx is run with python3 and above
-
-.. automodule:: doc.example
-    :members:
+Please use the numpydoc `formatting standard`_ as shown in their example_
 
 .. _`formatting standard`: https://numpydoc.readthedocs.io/en/latest/format.html
+.. _example: https://numpydoc.readthedocs.io/en/latest/example.html

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
-pygments==2.6.1
 sphinx>=2.2.0,<3.0
+numpydoc==1.1.0
 ipython
 scipy
 matplotlib


### PR DESCRIPTION
Cleanup from gh-17304 which pinned ~pylexer~ pygments.

Also numpydoc is stable. So remove the submodule dependency and add it to the regular doc build dependencies. We copied in some of the documentation, I refactored that to be a link instead.