### PR TITLE
NEP: Regenerate table in NEP 29 (add numpy 1.18 and 1.19 to list)

### DIFF
--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -113,8 +113,8 @@ Jan 13, 2021 3.7+   1.17+
 Jul 26, 2021 3.7+   1.18+
 Dec 22, 2021 3.7+   1.19+
 Dec 26, 2021 3.8+   1.19+
-Jun 21, 2022 3.8+   1.18+
-Apr 14, 2023 3.9+   1.18+
+Jun 21, 2022 3.8+   1.20+
+Apr 14, 2023 3.9+   1.20+
 ============ ====== =====
 
 
@@ -280,8 +280,12 @@ Code to generate support and drop schedule tables ::
 
   releases = sorted(releases, key=lambda x: x[0])
 
-  minpy = '3.9+'
-  minnum = '1.18+'
+
+  py_major,py_minor = sorted([int(x) for x in r[2].split('.')] for r in releases if r[1] == 'Python')[-1]
+  minpy = f"{py_major}.{py_minor+1}+"
+
+  num_major,num_minor = sorted([int(x) for x in r[2].split('.')] for r in releases if r[1] == 'Numpy')[-1]
+  minnum = f"{num_major}.{num_minor+1}+"
 
   toprint_drop_dates = ['']
   toprint_support_table = []
@@ -295,14 +299,14 @@ Code to generate support and drop schedule tables ::
           minnum = v+'+'
       else:
           minpy = v+'+'
-
-  for e in toprint_drop_dates[::-1]:
+  print("On next release, drop support for Python 3.5 (initially released on Sep 13, 2015)")
+  for e in toprint_drop_dates[-4::-1]:
       print(e)
 
   print('============ ====== =====')
   print('Date         Python NumPy')
   print('------------ ------ -----')
-  for e in toprint_support_table[::-1]:
+  for e in toprint_support_table[-4::-1]:
       print(e)
   print('============ ====== =====')
 

--- a/doc/neps/nep-0029-deprecation_policy.rst
+++ b/doc/neps/nep-0029-deprecation_policy.rst
@@ -111,7 +111,9 @@ Jun 23, 2020 3.7+   1.15+
 Jul 23, 2020 3.7+   1.16+
 Jan 13, 2021 3.7+   1.17+
 Jul 26, 2021 3.7+   1.18+
-Dec 26, 2021 3.8+   1.18+
+Dec 22, 2021 3.7+   1.19+
+Dec 26, 2021 3.8+   1.19+
+Jun 21, 2022 3.8+   1.18+
 Apr 14, 2023 3.9+   1.18+
 ============ ====== =====
 
@@ -127,7 +129,9 @@ Drop Schedule
   On Jul 23, 2020 drop support for Numpy 1.15 (initially released on Jul 23, 2018)
   On Jan 13, 2021 drop support for Numpy 1.16 (initially released on Jan 13, 2019)
   On Jul 26, 2021 drop support for Numpy 1.17 (initially released on Jul 26, 2019)
+  On Dec 22, 2021 drop support for Numpy 1.18 (initially released on Dec 22, 2019)
   On Dec 26, 2021 drop support for Python 3.7 (initially released on Jun 27, 2018)
+  On Jun 21, 2022 drop support for Numpy 1.19 (initially released on Jun 20, 2020)
   On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)
 
 
@@ -255,6 +259,8 @@ Code to generate support and drop schedule tables ::
   Jan 13, 2019: Numpy 1.16
   Jul 26, 2019: Numpy 1.17
   Oct 14, 2019: Python 3.8
+  Dec 22, 2019: Numpy 1.18
+  Jun 20, 2020: Numpy 1.19
   """
 
   releases = []


### PR DESCRIPTION
Numpy 1.18 and 1.19 have been released, which add two new recommended
stop date for recommended numpy support in 2021 and 2022.