### PR TITLE
DOC: Fix syntax errors in docstrings for versionchanged, versionadded

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -163,12 +163,12 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
         If provided, the destination array will have this dtype. Cannot be
         provided together with `out`.
 
-        ..versionadded:: 1.20.0
+        .. versionadded:: 1.20.0
 
     casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
         Controls what kind of data casting may occur. Defaults to 'same_kind'.
 
-        ..versionadded:: 1.20.0
+        .. versionadded:: 1.20.0
 
     Returns
     -------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1450,7 +1450,7 @@ def angle(z, deg=False):
         The counterclockwise angle from the positive real axis on the complex
         plane in the range ``(-pi, pi]``, with dtype as numpy.float64.
 
-        ..versionchanged:: 1.16.0
+        .. versionchanged:: 1.16.0
             This function works on subclasses of ndarray like `ma.array`.
 
     See Also

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -513,7 +513,7 @@ def drop_fields(base, drop_names, usemask=True, asrecarray=False):
 
     Nested fields are supported.
 
-    ..versionchanged: 1.18.0
+    .. versionchanged:: 1.18.0
         `drop_fields` returns an array with 0 fields if all fields are dropped,
         rather than returning ``None`` as it did previously.
 

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1641,7 +1641,7 @@ def flatnotmasked_contiguous(a):
     slice_list : list
         A sorted sequence of `slice` objects (start index, end index).
 
-        ..versionchanged:: 1.15.0
+        .. versionchanged:: 1.15.0
             Now returns an empty list instead of None for a fully masked array
 
     See Also


### PR DESCRIPTION
I noticed a docstring syntax error in [np.angle](https://numpy.org/doc/stable/reference/generated/numpy.angle.html#numpy.angle) for the `.. versionchanged::` rST directive. I fixed 4 instances of this type of error (missing a space or missing a second colon). I built the docs locally and confirmed that each change worked as intended. (And thanks for all your great work, NumPy team!)