### PR TITLE
BLD,BUG: Fix a macOS build failure when `NPY_BLAS_ORDER=""`

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -471,6 +471,9 @@ def _parse_env_order(base_order, env):
         allow_order = base_order.copy()
 
         for order in orders:
+            if not order:
+                continue
+
             if order not in base_order:
                 unknown_order.append(order)
                 continue
@@ -482,6 +485,9 @@ def _parse_env_order(base_order, env):
         allow_order = []
 
         for order in orders:
+            if not order:
+                continue
+
             if order not in base_order:
                 unknown_order.append(order)
                 continue

--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -284,7 +284,7 @@ class TestSystemInfoReading:
             assert info.get_lib_dirs() == lib_dirs
         finally:
             os.chdir(previousDir)
-        
+
 
 def test_distutils_parse_env_order(monkeypatch):
     from numpy.distutils.system_info import _parse_env_order
@@ -297,6 +297,12 @@ def test_distutils_parse_env_order(monkeypatch):
     assert len(order) == 3
     assert order == list('bef')
     assert len(unknown) == 1
+
+    # For when LAPACK/BLAS optimization is disabled
+    monkeypatch.setenv(env, '')
+    order, unknown = _parse_env_order(base_order, env)
+    assert len(order) == 0
+    assert len(unknown) == 0
 
     for prefix in '^!':
         monkeypatch.setenv(env, f'{prefix}b,i,e')


### PR DESCRIPTION
The changes introduced in https://github.com/numpy/numpy/pull/17219 currently cause a build failure on macOS whenever `NPY_BLAS_ORDER=""`.

The issue originates from an empty string (_i.e._ the `NPY_BLAS_ORDER` value) being 
append to the `unknown_order` list, thus trigger a `ValueError` down the line. 
Skipping non-truthful strings when constructing aforementioned list fixes the issue.

<details>

```
>>> pip install -e . 
Obtaining file:///Users/bvanbeek/Documents/GitHub/numpy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /Users/bvanbeek/opt/anaconda3/envs/numpy/bin/python /Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /var/folders/1v/8j3msfd95y9c1mt867tsmbt40000gn/T/tmpzv5_ct38
         cwd: /Users/bvanbeek/Documents/GitHub/numpy
    Complete output (60 lines):
    numpy/random/_bounded_integers.pxd.in has not changed
    numpy/random/_philox.pyx has not changed
    numpy/random/_bounded_integers.pyx.in has not changed
    numpy/random/_sfc64.pyx has not changed
    numpy/random/_mt19937.pyx has not changed
    numpy/random/bit_generator.pyx has not changed
    numpy/random/_bounded_integers.pyx has not changed
    numpy/random/mtrand.pyx has not changed
    numpy/random/_generator.pyx has not changed
    numpy/random/_pcg64.pyx has not changed
    numpy/random/_common.pyx has not changed
    Cythonizing sources
    blas_opt_info:
    setup.py:476: UserWarning: Unrecognized setuptools command, proceeding with generating Cython sources and expanding templates
      run_build = parse_setuppy_commands()
    Running from numpy source directory.
    Traceback (most recent call last):
      File "/Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
        main()
      File "/Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 133, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/private/var/folders/1v/8j3msfd95y9c1mt867tsmbt40000gn/T/pip-build-env-v5mclxtw/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 157, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/private/var/folders/1v/8j3msfd95y9c1mt867tsmbt40000gn/T/pip-build-env-v5mclxtw/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 248, in run_setup
        super(_BuildMetaLegacyBackend,
      File "/private/var/folders/1v/8j3msfd95y9c1mt867tsmbt40000gn/T/pip-build-env-v5mclxtw/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 142, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 505, in <module>
        setup_package()
      File "setup.py", line 497, in setup_package
        setup(**metadata)
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/core.py", line 135, in setup
        config = configuration()
      File "setup.py", line 162, in configuration
        config.add_subpackage('numpy')
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 1018, in add_subpackage
        config_list = self.get_subpackage(subpackage_name, subpackage_path,
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 984, in get_subpackage
        config = self._get_configuration_from_setup_py(
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 926, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "numpy/setup.py", line 8, in configuration
        config.add_subpackage('core')
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 1018, in add_subpackage
        config_list = self.get_subpackage(subpackage_name, subpackage_path,
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 984, in get_subpackage
        config = self._get_configuration_from_setup_py(
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/misc_util.py", line 926, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "numpy/core/setup.py", line 739, in configuration
        blas_info = get_info('blas_opt', 0)
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/system_info.py", line 578, in get_info
        return cl().get_info(notfound_action)
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/system_info.py", line 838, in get_info
        self.calc_info()
      File "/Users/bvanbeek/Documents/GitHub/numpy/numpy/distutils/system_info.py", line 1980, in calc_info
        raise ValueError("blas_opt_info user defined BLAS order has unacceptable values: {}".format(unknown_order))
    ValueError: blas_opt_info user defined BLAS order has unacceptable values: ['']
    ----------------------------------------
ERROR: Command errored out with exit status 1: /Users/bvanbeek/opt/anaconda3/envs/numpy/bin/python /Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /var/folders/1v/8j3msfd95y9c1mt867tsmbt40000gn/T/tmpzv5_ct38 Check the logs for full command output.
```

</details>