### PR TITLE
BUG: ensure _UFuncNoLoopError can be pickled

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -361,7 +361,7 @@ existing array rather than create a new one.
     >>> a += b                            # b is not automatically converted to integer type
     Traceback (most recent call last):
         ...
-    numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
+    numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
 
 When operating with arrays of different types, the type of the resulting
 array corresponds to the more general or precise one (a behavior known

--- a/numpy/core/_exceptions.py
+++ b/numpy/core/_exceptions.py
@@ -26,8 +26,6 @@ def _display_as_base(cls):
     """
     assert issubclass(cls, Exception)
     cls.__name__ = cls.__base__.__name__
-    cls.__qualname__ = cls.__base__.__qualname__
-    set_module(cls.__base__.__module__)(cls)
     return cls
 
 

--- a/numpy/core/tests/test__exceptions.py
+++ b/numpy/core/tests/test__exceptions.py
@@ -10,6 +10,12 @@ _ArrayMemoryError = np.core._exceptions._ArrayMemoryError
 _UFuncNoLoopError = np.core._exceptions._UFuncNoLoopError
 
 class TestArrayMemoryError:
+    def test_pickling(self):
+        """ Test that _ArrayMemoryError can be pickled """
+        error = _ArrayMemoryError((1023,), np.dtype(np.uint8))
+        res = pickle.loads(pickle.dumps(error))
+        assert res._total_size == error._total_size
+
     def test_str(self):
         e = _ArrayMemoryError((1023,), np.dtype(np.uint8))
         str(e)  # not crashing is enough
@@ -48,9 +54,5 @@ class TestArrayMemoryError:
 
 class TestUFuncNoLoopError:
     def test_pickling(self):
-        """ Test that _UFuncNoLoopError, _ArrayMemoryError can be pickled """
+        """ Test that _UFuncNoLoopError can be pickled """
         assert isinstance(pickle.dumps(_UFuncNoLoopError), bytes)
-
-        error = _ArrayMemoryError((1023,), np.dtype(np.uint8))
-        res = pickle.loads(pickle.dumps(error))
-        assert res._total_size == error._total_size

--- a/numpy/core/tests/test__exceptions.py
+++ b/numpy/core/tests/test__exceptions.py
@@ -1,9 +1,13 @@
 """
 Tests of the ._exceptions module. Primarily for exercising the __str__ methods.
 """
+
+import pickle
+
 import numpy as np
 
 _ArrayMemoryError = np.core._exceptions._ArrayMemoryError
+_UFuncNoLoopError = np.core._exceptions._UFuncNoLoopError
 
 class TestArrayMemoryError:
     def test_str(self):
@@ -40,3 +44,9 @@ class TestArrayMemoryError:
 
         e = _ArrayMemoryError((2, 4), np.dtype((np.uint64, 16)))
         assert e._total_size == 1024
+
+
+class TestUFuncNoLoopError:
+    def test_pickling(self):
+        """ Test that _UFuncNoLoopError can be pickled """
+        assert isinstance(pickle.dumps(_UFuncNoLoopError), bytes)

--- a/numpy/core/tests/test__exceptions.py
+++ b/numpy/core/tests/test__exceptions.py
@@ -48,5 +48,9 @@ class TestArrayMemoryError:
 
 class TestUFuncNoLoopError:
     def test_pickling(self):
-        """ Test that _UFuncNoLoopError can be pickled """
+        """ Test that _UFuncNoLoopError, _ArrayMemoryError can be pickled """
         assert isinstance(pickle.dumps(_UFuncNoLoopError), bytes)
+
+        error = _ArrayMemoryError((1023,), np.dtype(np.uint8))
+        res = pickle.loads(pickle.dumps(error))
+        assert res._total_size == error._total_size


### PR DESCRIPTION
Applies the suggested solution in #16490 and adds a simple test.