### PR TITLE
BUG: Fixed Von Mises distribution for big values of kappa

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -844,7 +844,8 @@ double random_vonmises(bitgen_t *bitgen_state, double mu, double kappa) {
   }
   if (kappa < 1e-8) {
     return M_PI * (2 * next_double(bitgen_state) - 1);
-  } else {
+  }
+  else {
     /* with double precision rho is zero until 1.4e-8 */
     if (kappa < 1e-5) {
       /*
@@ -852,11 +853,21 @@ double random_vonmises(bitgen_t *bitgen_state, double mu, double kappa) {
        * precise until relatively large kappas as second order is 0
        */
       s = (1. / kappa + kappa);
-    } else {
-      /* Fallback to normal distribution for big values of kappa*/
-      if (kappa > 1e6){
-        return mu + sqrt(1/kappa) * random_standard_normal(bitgen_state);
-      }else{
+    }
+    else {
+      /* Fallback to normal distribution for big values of kappa */
+      if (kappa > 1e6) {
+        result = mu + sqrt(1. / kappa) * random_standard_normal(bitgen_state);
+        /* Check if result is within bounds */
+        if (result < -M_PI) {
+          return result + 2*M_PI;
+        }
+        if (result > M_PI) {
+          return result - 2*M_PI;
+        }
+        return result;
+      }
+      else {
         double r = 1 + sqrt(1 + 4 * kappa * kappa);
         double rho = (r - sqrt(2 * r)) / (2 * kappa);
         s = (1 + rho * rho) / (2 * rho);

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -853,9 +853,14 @@ double random_vonmises(bitgen_t *bitgen_state, double mu, double kappa) {
        */
       s = (1. / kappa + kappa);
     } else {
-      double r = 1 + sqrt(1 + 4 * kappa * kappa);
-      double rho = (r - sqrt(2 * r)) / (2 * kappa);
-      s = (1 + rho * rho) / (2 * rho);
+      /* Fallback to normal distribution for big values of kappa*/
+      if (kappa > 1e6){
+        return mu + sqrt(1/kappa) * random_standard_normal(bitgen_state);
+      }else{
+        double r = 1 + sqrt(1 + 4 * kappa * kappa);
+        double rho = (r - sqrt(2 * r)) / (2 * kappa);
+        s = (1 + rho * rho) / (2 * rho);
+      }
     }
 
     while (1) {

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -14,6 +14,9 @@ class TestRegression:
         for mu in np.linspace(-7., 7., 5):
             r = mt19937.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
+        for mu in [-np.pi, np.pi]:
+            r = mt19937.vonmises(mu, 10**6 + 1, 50)
+            assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
     def test_hypergeometric_range(self):
         # Test for ticket #921

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -18,6 +18,9 @@ class TestRegression:
         for mu in np.linspace(-7., 7., 5):
             r = random.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
+        for mu in [-np.pi, np.pi]:
+            r = random.vonmises(mu, 10**6 + 1, 50)
+            assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
     def test_hypergeometric_range(self):
         # Test for ticket #921

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -14,6 +14,9 @@ class TestRegression:
         for mu in np.linspace(-7., 7., 5):
             r = random.mtrand.vonmises(mu, 1, 50)
             assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
+        for mu in [-np.pi, np.pi]:
+            r = random.mtrand.vonmises(mu, 10**6 + 1, 50)
+            assert_(np.all(r > -np.pi) and np.all(r <= np.pi))
 
     def test_hypergeometric_range(self):
         # Test for ticket #921


### PR DESCRIPTION
Fixed Von Mises distribution for big values of kappa by falling back to a normal distribution (which the von mises distribution converges to) after kappa > 10^6 to fix #17275. 

The mean squared error between the von mises distribution and normal distribution was shown to grow after kappa > 10^6 before the fix instead of converging, due to floating point precision errors in the acos() calculation.
![Figure_1](https://user-images.githubusercontent.com/21992490/94346973-a4e78a80-0030-11eb-978a-0059b7cf82b6.png)

The von mises function already fell back to the uniform distribution for kappa < 10^(-8) so it seemed appropriate to fall back to the normal distribution on the upper end (kappa > 10^6) since the difference with the normal distribution is vanishingly small.