### PR TITLE
DOC: NumPy restyling for pydata theme

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -1,0 +1,40 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
+
+.navbar-brand img {
+   height: 75px;
+}
+.navbar-brand {
+   height: 75px;
+}
+
+body {
+  font-family: 'Open Sans', sans-serif;
+  color:#4A4A4A; /* numpy.org body color */
+}
+
+pre, code {
+  font-size: 100%;
+  line-height: 155%;
+}
+
+h1 {
+  font-style: "Lato", sans-serif;
+  color: #013243; /* warm black */
+  font-weight: 700;
+  letter-spacing: -.04em;
+  text-align: right;
+  margin-top: 3rem;
+  margin-bottom: 4rem;
+  font-size: 3rem;
+}
+
+
+h2 {
+  color: #4d77cf; /* han blue */
+  letter-spacing: -.03em;
+}
+
+h3 {
+  color: #013243; /* warm black */
+  letter-spacing: -.03em;
+}

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,16 +1,10 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-    <!-- this is added via javascript in versionwarning.js  -->
+{{ super() }}
+<link rel="stylesheet" href="{{ pathto('_static/numpy.css', 1) }}" type="text/css" />
+
+    <!-- PR #17220: This is added via javascript in versionwarning.js  -->
     <!-- link rel="canonical" href="http://numpy.org/doc/stable/{{ pagename }}{{ file_suffix }}" / -->
 
-<style>
-.navbar-brand img {
-   height: 75px;
-}
-.navbar-brand {
-   height: 75px;
-}
-</style>
-{{ super() }}
 {% endblock %}


### PR DESCRIPTION
Modifies the new pydata theme to use numpy.org fonts and colors.

**Before**

![before](https://user-images.githubusercontent.com/6691888/94371162-5e427080-00c2-11eb-8a00-a752f063258f.png)

<br>

**After**

![after](https://user-images.githubusercontent.com/6691888/94371529-399bc800-00c5-11eb-9293-92543944c32b.png)
