### PR TITLE
BUG: Fix default void, datetime, and timedelta in array coercion

### DIFF
--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -324,6 +324,22 @@ class TestScalarDiscovery:
             ass[()] = scalar
             assert_array_equal(ass, cast)
 
+    @pytest.mark.parametrize("dtype_char", np.typecodes["All"])
+    def test_default_dtype_instance(self, dtype_char):
+        if dtype_char in "SU":
+            dtype = np.dtype(dtype_char + "1")
+        elif dtype_char == "V":
+            # Legacy behaviour was to use V8. The reason was float64 being the
+            # default dtype and that having 8 bytes.
+            dtype = np.dtype("V8")
+        else:
+            dtype = np.dtype(dtype_char)
+
+        discovered_dtype, _ = _discover_array_parameters([], type(dtype))
+
+        assert discovered_dtype == dtype
+        assert discovered_dtype.itemsize == dtype.itemsize
+
 
 class TestTimeScalars:
     @pytest.mark.parametrize("dtype", [np.int64, np.float32])


### PR DESCRIPTION
When converting an empty sequence to an array, datetimes would
use an incorrect itemsize (on master only).
The legacy behaviour of void is that it uses 8 bytes, which is
due to the fact that `[]` uses `float64` by default which has
8 bytes.

---

To be honest, the void one doesn't really make sense to me, and this also makes "V8" the default in other places potentially.  So, I think in the long run I might just want to change it. But right now this was an oversight.