### PR TITLE
MAINT: Replace append_metastr_to_string function.

### DIFF
--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -176,7 +176,7 @@ def _byte_order_str(dtype):
 
 
 def _datetime_metadata_str(dtype):
-    # TODO: this duplicates the C append_metastr_to_string
+    # TODO: this duplicates the C metastr_to_unicode functionality
     unit, count = np.datetime_data(dtype)
     if unit == 'generic':
         return ''

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -200,6 +200,16 @@ convert_pyobject_to_datetime_metadata(PyObject *obj,
                                         PyArray_DatetimeMetaData *out_meta);
 
 /*
+ * Returns datetime metadata as a new reference a Unicode object.
+ * Returns NULL on error.
+ *
+ * If 'skip_brackets' is true, skips the '[]'.
+ *
+ */
+NPY_NO_EXPORT PyObject *
+metastr_to_unicode(PyArray_DatetimeMetaData *meta, int skip_brackets);
+
+/*
  * 'ret' is a PyUString containing the datetime string, and this
  * function appends the metadata string to it.
  *

--- a/numpy/core/src/multiarray/_datetime.h
+++ b/numpy/core/src/multiarray/_datetime.h
@@ -209,18 +209,6 @@ convert_pyobject_to_datetime_metadata(PyObject *obj,
 NPY_NO_EXPORT PyObject *
 metastr_to_unicode(PyArray_DatetimeMetaData *meta, int skip_brackets);
 
-/*
- * 'ret' is a PyUString containing the datetime string, and this
- * function appends the metadata string to it.
- *
- * If 'skip_brackets' is true, skips the '[]'.
- *
- * This function steals the reference 'ret'
- */
-NPY_NO_EXPORT PyObject *
-append_metastr_to_string(PyArray_DatetimeMetaData *meta,
-                                    int skip_brackets,
-                                    PyObject *ret);
 
 /*
  * Tests for and converts a Python datetime.datetime or datetime.date

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1434,18 +1434,20 @@ raise_if_datetime64_metadata_cast_error(char *object_type,
         return 0;
     }
     else {
-        PyObject *errmsg;
-        errmsg = PyUnicode_FromFormat("Cannot cast %s "
-                    "from metadata ", object_type);
-        errmsg = append_metastr_to_string(src_meta, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" to "));
-        errmsg = append_metastr_to_string(dst_meta, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromFormat(" according to the rule %s",
-                        npy_casting_to_string(casting)));
-        PyErr_SetObject(PyExc_TypeError, errmsg);
-        Py_DECREF(errmsg);
+        PyObject *src = metastr_to_unicode(src_meta, 0);
+        if (src == NULL) {
+            return -1;
+        }
+        PyObject *dst = metastr_to_unicode(dst_meta, 0);
+        if (dst == NULL) {
+            Py_DECREF(src);
+            return -1;
+        }
+        PyErr_Format(PyExc_TypeError,
+            "Cannot cast %s from metadata %S to %S according to the rule %s",
+            object_type, src, dst, npy_casting_to_string(casting));
+        Py_DECREF(src);
+        Py_DECREF(dst);
         return -1;
     }
 }
@@ -1466,18 +1468,20 @@ raise_if_timedelta64_metadata_cast_error(char *object_type,
         return 0;
     }
     else {
-        PyObject *errmsg;
-        errmsg = PyUnicode_FromFormat("Cannot cast %s "
-                    "from metadata ", object_type);
-        errmsg = append_metastr_to_string(src_meta, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" to "));
-        errmsg = append_metastr_to_string(dst_meta, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromFormat(" according to the rule %s",
-                        npy_casting_to_string(casting)));
-        PyErr_SetObject(PyExc_TypeError, errmsg);
-        Py_DECREF(errmsg);
+        PyObject *src = metastr_to_unicode(src_meta, 0);
+        if (src == NULL) {
+            return -1;
+        }
+        PyObject *dst = metastr_to_unicode(dst_meta, 0);
+        if (dst == NULL) {
+            Py_DECREF(src);
+            return -1;
+        }
+        PyErr_Format(PyExc_TypeError,
+             "Cannot cast %s from metadata %S to %S according to the rule %s",
+             object_type, src, dst, npy_casting_to_string(casting));
+        Py_DECREF(src);
+        Py_DECREF(dst);
         return -1;
     }
 }
@@ -1600,32 +1604,38 @@ compute_datetime_metadata_greatest_common_divisor(
     return 0;
 
 incompatible_units: {
-        PyObject *errmsg;
-        errmsg = PyUnicode_FromString("Cannot get "
-                    "a common metadata divisor for "
-                    "NumPy datetime metadata ");
-        errmsg = append_metastr_to_string(meta1, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" and "));
-        errmsg = append_metastr_to_string(meta2, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" because they have "
-                    "incompatible nonlinear base time units"));
-        PyErr_SetObject(PyExc_TypeError, errmsg);
-        Py_DECREF(errmsg);
+        PyObject *umeta1 = metastr_to_unicode(meta1, 0);
+        if (umeta1 == NULL) {
+            return -1;
+        }
+        PyObject *umeta2 = metastr_to_unicode(meta2, 0);
+        if (umeta2 == NULL) {
+            Py_DECREF(umeta1);
+            return -1;
+        }
+        PyErr_Format(PyExc_TypeError,
+            "Cannot get a common metadata divisor for Numpy datatime "
+            "metadata %S and %S because they have incompatible nonlinear "
+            "base time units.", umeta1, umeta2);
+        Py_DECREF(umeta1);
+        Py_DECREF(umeta2);
         return -1;
     }
 units_overflow: {
-        PyObject *errmsg;
-        errmsg = PyUnicode_FromString("Integer overflow "
-                    "getting a common metadata divisor for "
-                    "NumPy datetime metadata ");
-        errmsg = append_metastr_to_string(meta1, 0, errmsg);
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" and "));
-        errmsg = append_metastr_to_string(meta2, 0, errmsg);
-        PyErr_SetObject(PyExc_OverflowError, errmsg);
-        Py_DECREF(errmsg);
+        PyObject *umeta1 = metastr_to_unicode(meta1, 0);
+        if (umeta1 == NULL) {
+            return -1;
+        }
+        PyObject *umeta2 = metastr_to_unicode(meta2, 0);
+        if (umeta2 == NULL) {
+            Py_DECREF(umeta1);
+            return -1;
+        }
+        PyErr_Format(PyExc_OverflowError,
+            "Integer overflow getting a common metadata divisor for "
+            "NumPy datetime metadata %S and %S.", umeta1, umeta2);
+        Py_DECREF(umeta1);
+        Py_DECREF(umeta2);
         return -1;
     }
 }
@@ -1948,6 +1958,60 @@ convert_pyobject_to_datetime_metadata(PyObject *obj,
         return 0;
     }
 }
+
+/*
+ * Return the datetime metadata as a Unicode object.
+ *
+ * Returns new reference, NULL on error.
+ *
+ * If 'skip_brackets' is true, skips the '[]'.
+ *
+ */
+NPY_NO_EXPORT PyObject *
+metastr_to_unicode(PyArray_DatetimeMetaData *meta, int skip_brackets)
+{
+    int num;
+    char const *basestr;
+
+    if (meta->base == NPY_FR_GENERIC) {
+        /* Without brackets, give a string "generic" */
+        if (skip_brackets) {
+            return PyUnicode_FromString("generic");
+        }
+        /* But with brackets, append nothing */
+        else {
+            return PyUnicode_FromString("");
+        }
+    }
+
+    num = meta->num;
+    if (meta->base >= 0 && meta->base < NPY_DATETIME_NUMUNITS) {
+        basestr = _datetime_strings[meta->base];
+    }
+    else {
+        PyErr_SetString(PyExc_RuntimeError,
+                "NumPy datetime metadata is corrupted");
+        return NULL;
+    }
+
+    if (num == 1) {
+        if (skip_brackets) {
+            return PyUnicode_FromFormat("%s", basestr);
+        }
+        else {
+            return PyUnicode_FromFormat("[%s]", basestr);
+        }
+    }
+    else {
+        if (skip_brackets) {
+            return PyUnicode_FromFormat("%d%s", num, basestr);
+        }
+        else {
+            return PyUnicode_FromFormat("[%d%s]", num, basestr);
+        }
+    }
+}
+
 
 /*
  * 'ret' is a PyUString containing the datetime string, and this

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1978,7 +1978,7 @@ metastr_to_unicode(PyArray_DatetimeMetaData *meta, int skip_brackets)
         if (skip_brackets) {
             return PyUnicode_FromString("generic");
         }
-        /* But with brackets, append nothing */
+        /* But with brackets, return nothing */
         else {
             return PyUnicode_FromString("");
         }
@@ -2012,70 +2012,6 @@ metastr_to_unicode(PyArray_DatetimeMetaData *meta, int skip_brackets)
     }
 }
 
-
-/*
- * 'ret' is a PyUString containing the datetime string, and this
- * function appends the metadata string to it.
- *
- * If 'skip_brackets' is true, skips the '[]'.
- *
- * This function steals the reference 'ret'
- */
-NPY_NO_EXPORT PyObject *
-append_metastr_to_string(PyArray_DatetimeMetaData *meta,
-                                    int skip_brackets,
-                                    PyObject *ret)
-{
-    PyObject *res;
-    int num;
-    char const *basestr;
-
-    if (ret == NULL) {
-        return NULL;
-    }
-
-    if (meta->base == NPY_FR_GENERIC) {
-        /* Without brackets, give a string "generic" */
-        if (skip_brackets) {
-            PyUString_ConcatAndDel(&ret, PyUnicode_FromString("generic"));
-            return ret;
-        }
-        /* But with brackets, append nothing */
-        else {
-            return ret;
-        }
-    }
-
-    num = meta->num;
-    if (meta->base >= 0 && meta->base < NPY_DATETIME_NUMUNITS) {
-        basestr = _datetime_strings[meta->base];
-    }
-    else {
-        PyErr_SetString(PyExc_RuntimeError,
-                "NumPy datetime metadata is corrupted");
-        return NULL;
-    }
-
-    if (num == 1) {
-        if (skip_brackets) {
-            res = PyUnicode_FromFormat("%s", basestr);
-        }
-        else {
-            res = PyUnicode_FromFormat("[%s]", basestr);
-        }
-    }
-    else {
-        if (skip_brackets) {
-            res = PyUnicode_FromFormat("%d%s", num, basestr);
-        }
-        else {
-            res = PyUnicode_FromFormat("[%d%s]", num, basestr);
-        }
-    }
-
-    PyUString_ConcatAndDel(&ret, res);
-    return ret;
-}
 
 /*
  * Adjusts a datetimestruct based on a seconds offset. Assumes

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1892,18 +1892,26 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self)
     else {
         ret = PyUnicode_FromFormat("%c%c%d", endian, basic_, size);
     }
+    if (ret == NULL) {
+        return NULL;
+    }
+
     if (PyDataType_ISDATETIME(self)) {
         PyArray_DatetimeMetaData *meta;
-
         meta = get_datetime_metadata_from_dtype(self);
         if (meta == NULL) {
             Py_DECREF(ret);
             return NULL;
         }
+        PyObject *umeta = metastr_to_unicode(meta, 0);
+        if (umeta == NULL) {
+            Py_DECREF(ret);
+            return NULL;
+        }
 
-        ret = append_metastr_to_string(meta, 0, ret);
+        Py_SETREF(ret, PyUnicode_Concat(ret, umeta));
+        Py_DECREF(umeta);
     }
-
     return ret;
 }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -518,21 +518,15 @@ datetimetype_repr(PyObject *self)
      */
     if ((scal->obmeta.num == 1 && scal->obmeta.base != NPY_FR_h) ||
             scal->obmeta.base == NPY_FR_GENERIC) {
-        ret = PyUnicode_FromString("numpy.datetime64('");
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString(iso));
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString("')"));
+        ret = PyUnicode_FromFormat("numpy.datetime64('%s')", iso);
     }
     else {
-        ret = PyUnicode_FromString("numpy.datetime64('");
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString(iso));
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString("','"));
-        ret = append_metastr_to_string(&scal->obmeta, 1, ret);
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString("')"));
+        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
+        if (meta == NULL) {
+            return NULL;
+        }
+        ret = PyUnicode_FromFormat("numpy.datetime64('%s','%S')", iso, meta);
+        Py_DECREF(meta);
     }
 
     return ret;
@@ -542,7 +536,7 @@ static PyObject *
 timedeltatype_repr(PyObject *self)
 {
     PyTimedeltaScalarObject *scal;
-    PyObject *ret;
+    PyObject *val, *ret;
 
     if (!PyArray_IsScalar(self, Timedelta)) {
         PyErr_SetString(PyExc_RuntimeError,
@@ -554,32 +548,34 @@ timedeltatype_repr(PyObject *self)
 
     /* The value */
     if (scal->obval == NPY_DATETIME_NAT) {
-        ret = PyUnicode_FromString("numpy.timedelta64('NaT'");
+        val = PyUnicode_FromString("'NaT'");
     }
     else {
-        /*
-         * Can't use "%lld" if HAVE_LONG_LONG is not defined
-         */
+         /* Can't use "%lld" if HAVE_LONG_LONG is not defined */
 #if defined(HAVE_LONG_LONG)
-        ret = PyUnicode_FromFormat("numpy.timedelta64(%lld",
-                                            (long long)scal->obval);
+        val = PyUnicode_FromFormat("%lld", (long long)scal->obval);
 #else
-        ret = PyUnicode_FromFormat("numpy.timedelta64(%ld",
-                                            (long)scal->obval);
+        val = PyUnicode_FromFormat("%ld", (long)scal->obval);
 #endif
     }
+    if (val == NULL) {
+        return NULL;
+    }
+
     /* The metadata unit */
     if (scal->obmeta.base == NPY_FR_GENERIC) {
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString(")"));
+        ret = PyUnicode_FromFormat("numpy.timedelta64(%S)", val);
     }
     else {
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString(",'"));
-        ret = append_metastr_to_string(&scal->obmeta, 1, ret);
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString("')"));
+        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
+        if (meta == NULL) {
+            Py_DECREF(val);
+            return NULL;
+        }
+        ret = PyUnicode_FromFormat("numpy.timedelta64(%S,'%S')", val, meta);
+        Py_DECREF(meta);
     }
+    Py_DECREF(val);
 
     return ret;
 }


### PR DESCRIPTION
This is part of removing the PyUString_ConcatAndDel cleanup and allows
 us to write more readable code when generating strings. There is also 
more checking for errors after this change.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

<!-- If you're submitting a new feature or substantial change in functionality,
make sure you discuss your changes in the numpy-discussion mailing list first: 
https://mail.python.org/mailman/listinfo/numpy-discussion -->
