### PR TITLE
DOC: Add arraysetops to an autosummary

### DIFF
--- a/doc/source/reference/routines.set.rst
+++ b/doc/source/reference/routines.set.rst
@@ -3,6 +3,11 @@ Set routines
 
 .. currentmodule:: numpy
 
+.. autosummary::
+   :toctree: generated/
+
+   lib.arraysetops
+
 Making proper sets
 ------------------
 .. autosummary::

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -1,28 +1,17 @@
 """
 Set operations for arrays based on sorting.
 
-:Contains:
-  unique,
-  isin,
-  ediff1d,
-  intersect1d,
-  setxor1d,
-  in1d,
-  union1d,
-  setdiff1d
-
-:Notes:
+Notes
+-----
 
 For floating point arrays, inaccurate results may appear due to usual round-off
 and floating point comparison issues.
 
 Speed could be gained in some operations by an implementation of
-sort(), that can provide directly the permutation vectors, avoiding
-thus calls to argsort().
+`numpy.sort`, that can provide directly the permutation vectors, thus avoiding
+calls to `numpy.argsort`.
 
-To do: Optionally return indices analogously to unique for all functions.
-
-:Author: Robert Cimrman
+Original author: Robert Cimrman
 
 """
 import functools


### PR DESCRIPTION
Generates a stub for the `numpy.lib.arraysetops` module which fixes 6 broken links (see #13114).

Also minor modifications to the `arraysetops` module docstring:
 * Remove listing of functions from module docstring.
 * Modify/improve rst formatting.
