### PR TITLE
MAINT: Cleanup remaining PyUString_ConcatAndDel use.

### DIFF
--- a/numpy/core/src/common/array_assign.c
+++ b/numpy/core/src/common/array_assign.c
@@ -64,19 +64,22 @@ broadcast_strides(int ndim, npy_intp const *shape,
     return 0;
 
 broadcast_error: {
-        PyObject *errmsg;
+        PyObject *shape1 = convert_shape_to_string(strides_ndim,
+                                                   strides_shape, "");
+        if (shape1 == NULL) {
+            return -1;
+        }
 
-        errmsg = PyUnicode_FromFormat("could not broadcast %s from shape ",
-                                strides_name);
-        PyUString_ConcatAndDel(&errmsg,
-                build_shape_string(strides_ndim, strides_shape));
-        PyUString_ConcatAndDel(&errmsg,
-                PyUnicode_FromString(" into shape "));
-        PyUString_ConcatAndDel(&errmsg,
-                build_shape_string(ndim, shape));
-        PyErr_SetObject(PyExc_ValueError, errmsg);
-        Py_DECREF(errmsg);
-
+        PyObject *shape2 = convert_shape_to_string(ndim, shape, "");
+        if (shape2 == NULL) {
+            Py_DECREF(shape1);
+            return -1;
+        }
+        PyErr_Format(PyExc_ValueError,
+                "could not broadcast %s from shape %S into shape %S",
+                strides_name, shape1, shape2);
+        Py_DECREF(shape1);
+        Py_DECREF(shape2);
         return -1;
     }
 }

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -233,7 +233,6 @@ NPY_NO_EXPORT PyObject *
 convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending)
 {
     npy_intp i;
-    PyObject *ret, *tmp;
 
     /*
      * Negative dimension indicates "newaxis", which can
@@ -245,14 +244,14 @@ convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending)
     if (i == n) {
         return PyUnicode_FromFormat("()%s", ending);
     }
-    else {
-        ret = PyUnicode_FromFormat("(%" NPY_INTP_FMT, vals[i++]);
-        if (ret == NULL) {
-            return NULL;
-        }
-    }
 
+    PyObject *ret = PyUnicode_FromFormat("%" NPY_INTP_FMT, vals[i++]);
+    if (ret == NULL) {
+        return NULL;
+    }
     for (; i < n; ++i) {
+        PyObject *tmp;
+
         if (vals[i] < 0) {
             tmp = PyUnicode_FromString(",newaxis");
         }
@@ -264,19 +263,19 @@ convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending)
             return NULL;
         }
 
-        PyUString_ConcatAndDel(&ret, tmp);
+        Py_SETREF(ret, PyUnicode_Concat(ret, tmp));
+        Py_DECREF(tmp);
         if (ret == NULL) {
             return NULL;
         }
     }
 
     if (i == 1) {
-        tmp = PyUnicode_FromFormat(",)%s", ending);
+        Py_SETREF(ret, PyUnicode_FromFormat("(%S,)%s", ret, ending));
     }
     else {
-        tmp = PyUnicode_FromFormat(")%s", ending);
+        Py_SETREF(ret, PyUnicode_FromFormat("(%S)%s", ret, ending));
     }
-    PyUString_ConcatAndDel(&ret, tmp);
     return ret;
 }
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2898,14 +2898,13 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
     }
 
     if (PyDataType_ISDATETIME(self) && (metadata != NULL)) {
-        PyObject *old_metadata, *errmsg;
+        PyObject *old_metadata;
         PyArray_DatetimeMetaData temp_dt_data;
 
         if ((! PyTuple_Check(metadata)) || (PyTuple_Size(metadata) != 2)) {
-            errmsg = PyUnicode_FromString("Invalid datetime dtype (metadata, c_metadata): ");
-            PyUString_ConcatAndDel(&errmsg, PyObject_Repr(metadata));
-            PyErr_SetObject(PyExc_ValueError, errmsg);
-            Py_DECREF(errmsg);
+            PyErr_Format(PyExc_ValueError,
+                    "Invalid datetime dtype (metadata, c_metadata): %R",
+                    metadata);
             return NULL;
         }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -660,14 +660,12 @@ timedeltatype_str(PyObject *self)
          * Can't use "%lld" if HAVE_LONG_LONG is not defined
          */
 #if defined(HAVE_LONG_LONG)
-        ret = PyUnicode_FromFormat("%lld ",
-                                (long long)(scal->obval * scal->obmeta.num));
+        ret = PyUnicode_FromFormat("%lld %s",
+            (long long)(scal->obval * scal->obmeta.num), basestr);
 #else
-        ret = PyUnicode_FromFormat("%ld ",
-                                (long)(scal->obval * scal->obmeta.num));
+        ret = PyUnicode_FromFormat("%ld %s",
+            (long)(scal->obval * scal->obmeta.num), basestr);
 #endif
-        PyUString_ConcatAndDel(&ret,
-                PyUnicode_FromString(basestr));
     }
 
     return ret;
@@ -886,7 +884,7 @@ static PyObject *
 static PyObject *
 c@name@type_@kind@(PyObject *self)
 {
-    PyObject *rstr, *istr, *ret;
+    PyObject *rstr, *istr;
     npy_c@name@ val = PyArrayScalar_VAL(self, C@Name@);
     TrimMode trim = TrimMode_DptZeros;
 
@@ -899,16 +897,13 @@ c@name@type_@kind@(PyObject *self)
         if (istr == NULL) {
             return NULL;
         }
-
-        PyUString_ConcatAndDel(&istr, PyUnicode_FromString("j"));
-        return istr;
+        PyObject *ret = PyUnicode_FromFormat("%Sj", istr);
+        Py_DECREF(istr);
+        return ret;
     }
 
     if (npy_isfinite(val.real)) {
         rstr = @name@type_@kind@_either(val.real, trim, trim, 0);
-        if (rstr == NULL) {
-            return NULL;
-        }
     }
     else if (npy_isnan(val.real)) {
         rstr = PyUnicode_FromString("nan");
@@ -919,12 +914,12 @@ c@name@type_@kind@(PyObject *self)
     else {
         rstr = PyUnicode_FromString("-inf");
     }
+    if (rstr == NULL) {
+        return NULL;
+    }
 
     if (npy_isfinite(val.imag)) {
         istr = @name@type_@kind@_either(val.imag, trim, trim, 1);
-        if (istr == NULL) {
-            return NULL;
-        }
     }
     else if (npy_isnan(val.imag)) {
         istr = PyUnicode_FromString("+nan");
@@ -935,11 +930,14 @@ c@name@type_@kind@(PyObject *self)
     else {
         istr = PyUnicode_FromString("-inf");
     }
+    if (istr == NULL) {
+        Py_DECREF(rstr);
+        return NULL;
+    }
 
-    ret = PyUnicode_FromString("(");
-    PyUString_ConcatAndDel(&ret, rstr);
-    PyUString_ConcatAndDel(&ret, istr);
-    PyUString_ConcatAndDel(&ret, PyUnicode_FromString("j)"));
+    PyObject *ret = PyUnicode_FromFormat("(%S%Sj)", rstr, istr);
+    Py_DECREF(rstr);
+    Py_DECREF(istr);
     return ret;
 }
 

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -977,51 +977,6 @@ PyArray_Flatten(PyArrayObject *a, NPY_ORDER order)
     return (PyObject *)ret;
 }
 
-/* See shape.h for parameters documentation */
-NPY_NO_EXPORT PyObject *
-build_shape_string(npy_intp n, npy_intp const *vals)
-{
-    npy_intp i;
-
-    /*
-     * Negative dimension indicates "newaxis", which can
-     * be discarded for printing if it's a leading dimension.
-     * Find the first non-"newaxis" dimension.
-     */
-    for (i = 0; i < n && vals[i] < 0; ++i);
-
-    if (i == n) {
-        return PyUnicode_FromFormat("()");
-    }
-
-    PyObject *ret = PyUnicode_FromFormat("%" NPY_INTP_FMT, vals[i++]);
-    if (ret == NULL) {
-        return NULL;
-    }
-    for (; i < n; ++i) {
-        PyObject *tmp;
-
-        if (vals[i] < 0) {
-            tmp = PyUnicode_FromString(",newaxis");
-        }
-        else {
-            tmp = PyUnicode_FromFormat(",%" NPY_INTP_FMT, vals[i]);
-        }
-        if (tmp == NULL) {
-            Py_DECREF(ret);
-            return NULL;
-        }
-
-        Py_SETREF(ret, PyUnicode_Concat(ret, tmp));
-        Py_DECREF(tmp);
-        if (ret == NULL) {
-            return NULL;
-        }
-    }
-
-    Py_SETREF(ret, PyUnicode_FromFormat("(%S)", ret));
-    return ret;
-}
 
 /*NUMPY_API
  *

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -458,14 +458,12 @@ _attempt_nocopy_reshape(PyArrayObject *self, int newnd, const npy_intp *newdims,
 static void
 raise_reshape_size_mismatch(PyArray_Dims *newshape, PyArrayObject *arr)
 {
-    PyObject *msg = PyUnicode_FromFormat("cannot reshape array of size %zd "
-                                         "into shape ", PyArray_SIZE(arr));
     PyObject *tmp = convert_shape_to_string(newshape->len, newshape->ptr, "");
-
-    PyUString_ConcatAndDel(&msg, tmp);
-    if (msg != NULL) {
-        PyErr_SetObject(PyExc_ValueError, msg);
-        Py_DECREF(msg);
+    if (tmp != NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "cannot reshape array of size %zd into shape %S",
+                PyArray_SIZE(arr), tmp);
+        Py_DECREF(tmp);
     }
 }
 
@@ -984,29 +982,25 @@ NPY_NO_EXPORT PyObject *
 build_shape_string(npy_intp n, npy_intp const *vals)
 {
     npy_intp i;
-    PyObject *ret, *tmp;
 
     /*
      * Negative dimension indicates "newaxis", which can
      * be discarded for printing if it's a leading dimension.
      * Find the first non-"newaxis" dimension.
      */
-    i = 0;
-    while (i < n && vals[i] < 0) {
-        ++i;
-    }
+    for (i = 0; i < n && vals[i] < 0; ++i);
 
     if (i == n) {
         return PyUnicode_FromFormat("()");
     }
-    else {
-        ret = PyUnicode_FromFormat("(%" NPY_INTP_FMT, vals[i++]);
-        if (ret == NULL) {
-            return NULL;
-        }
-    }
 
+    PyObject *ret = PyUnicode_FromFormat("%" NPY_INTP_FMT, vals[i++]);
+    if (ret == NULL) {
+        return NULL;
+    }
     for (; i < n; ++i) {
+        PyObject *tmp;
+
         if (vals[i] < 0) {
             tmp = PyUnicode_FromString(",newaxis");
         }
@@ -1018,14 +1012,14 @@ build_shape_string(npy_intp n, npy_intp const *vals)
             return NULL;
         }
 
-        PyUString_ConcatAndDel(&ret, tmp);
+        Py_SETREF(ret, PyUnicode_Concat(ret, tmp));
+        Py_DECREF(tmp);
         if (ret == NULL) {
             return NULL;
         }
     }
 
-    tmp = PyUnicode_FromFormat(")");
-    PyUString_ConcatAndDel(&ret, tmp);
+    Py_SETREF(ret, PyUnicode_FromFormat("(%S)", ret));
     return ret;
 }
 

--- a/numpy/core/src/multiarray/shape.h
+++ b/numpy/core/src/multiarray/shape.h
@@ -2,13 +2,6 @@
 #define _NPY_ARRAY_SHAPE_H_
 
 /*
- * Builds a string representation of the shape given in 'vals'.
- * A negative value in 'vals' gets interpreted as newaxis.
- */
-NPY_NO_EXPORT PyObject *
-build_shape_string(npy_intp n, npy_intp const *vals);
-
-/*
  * Creates a sorted stride perm matching the KEEPORDER behavior
  * of the NpyIter object. Because this operates based on multiple
  * input strides, the 'stride' member of the npy_stride_sort_item

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5977,6 +5977,7 @@ _typecharfromnum(int num) {
     return ret;
 }
 
+
 static PyObject *
 ufunc_get_doc(PyUFuncObject *ufunc)
 {
@@ -5997,17 +5998,17 @@ ufunc_get_doc(PyUFuncObject *ufunc)
      * introspection on name and nin + nout to automate the first part
      * of it the doc string shouldn't need the calling convention
      */
-    doc = PyObject_CallFunctionObjArgs(
-        _sig_formatter, (PyObject *)ufunc, NULL);
+    doc = PyObject_CallFunctionObjArgs(_sig_formatter,
+                                       (PyObject *)ufunc, NULL);
     if (doc == NULL) {
         return NULL;
     }
     if (ufunc->doc != NULL) {
-        PyUString_ConcatAndDel(&doc,
-            PyUnicode_FromFormat("\n\n%s", ufunc->doc));
+        Py_SETREF(doc, PyUnicode_FromFormat("%S\n\n%s", doc, ufunc->doc));
     }
     return doc;
 }
+
 
 static PyObject *
 ufunc_get_nin(PyUFuncObject *ufunc)


### PR DESCRIPTION
The `build_shape_string` function has also been removes as a duplicate of `convert_shape_to_string`.

This should probably be squash merged.

