### PR TITLE
TST: Mark the typing tests as slow

### DIFF
--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -36,6 +36,7 @@ def get_test_cases(directory):
                 )
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
@@ -50,6 +51,7 @@ def test_success(path):
     assert re.match(r"Success: no issues found in \d+ source files?", stdout.strip())
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
 def test_fail(path):
@@ -99,6 +101,7 @@ def test_fail(path):
             pytest.fail(f"Error {repr(errors[lineno])} not found")
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(REVEAL_DIR))
 def test_reveal(path):
@@ -130,6 +133,7 @@ def test_reveal(path):
         assert marker in error_line
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_code_runs(path):


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/17316.

Per the community meeting of 30 Sep 2020: 
This PR marks the typing tests as slow, serving as a band aid for some rather difficult to 
debug mypy crashes (see the linked issue). Marking them as slow ensures that they should 
not impede any local test runs (unless one wants to explicitly run the typing tests...). 

The typing tests can still be run by switching the mode from `fast` (default) to `full`:
```shell
python ./runtest.py -t numpy/typing --mode=full
```

