### PR TITLE
DOC: Fix a parameter type in the `putmask` docs

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1100,7 +1100,7 @@ def putmask(a, mask, values):
 
     Parameters
     ----------
-    a : array_like
+    a : ndarray
         Target array.
     mask : array_like
         Boolean mask array. It has to be the same shape as `a`.


### PR DESCRIPTION
One of the `putmask()` parameters is currently marked as `array_like`, while in reality it can only take `ndarray`s.