### PR TITLE
MAINT: Move aliases for common scalar unions to `numpy.typing`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4,7 +4,18 @@ import datetime as dt
 from abc import abstractmethod
 
 from numpy.core._internal import _ctypes
-from numpy.typing import ArrayLike, DtypeLike, _Shape, _ShapeLike
+from numpy.typing import (
+    ArrayLike,
+    DtypeLike,
+    _Shape,
+    _ShapeLike,
+    _CharLike,
+    _BoolLike,
+    _IntLike,
+    _FloatLike,
+    _ComplexLike,
+    _NumberLike,
+)
 from numpy.typing._callable import (
     _BoolOp,
     _BoolSub,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1279,13 +1279,6 @@ class ndarray(_ArrayOrScalarCommon, Iterable, Sized, Container):
 
 # See https://github.com/numpy/numpy-stubs/pull/80 for more details.
 
-_CharLike = Union[str, bytes]
-_BoolLike = Union[bool, bool_]
-_IntLike = Union[int, integer]
-_FloatLike = Union[_IntLike, float, floating]
-_ComplexLike = Union[_FloatLike, complex, complexfloating]
-_NumberLike = Union[int, float, complex, number, bool_]
-
 class generic(_ArrayOrScalarCommon):
     @abstractmethod
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -10,6 +10,12 @@ from numpy import (
     generic,
     _OrderKACF,
     _OrderACF,
+)
+from numpy.typing import (
+    DtypeLike,
+    ArrayLike,
+    _ShapeLike,
+    _Shape,
     _IntLike,
     _BoolLike,
     _NumberLike,
@@ -20,7 +26,6 @@ from numpy import (
     _SortKind,
     _SortSide,
 )
-from numpy.typing import DtypeLike, ArrayLike, _ShapeLike, _Shape
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -10,6 +10,12 @@ from numpy import (
     generic,
     _OrderKACF,
     _OrderACF,
+    _ArrayLikeBool,
+    _ArrayLikeIntOrBool,
+    _ModeKind,
+    _PartitionKind,
+    _SortKind,
+    _SortSide,
 )
 from numpy.typing import (
     DtypeLike,
@@ -19,12 +25,6 @@ from numpy.typing import (
     _IntLike,
     _BoolLike,
     _NumberLike,
-    _ArrayLikeBool,
-    _ArrayLikeIntOrBool,
-    _ModeKind,
-    _PartitionKind,
-    _SortKind,
-    _SortSide,
 )
 
 if sys.version_info >= (3, 8):

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,8 +1,8 @@
 import sys
 from typing import overload, Tuple, Union, Sequence, Any
 
-from numpy import ndarray, inexact, _NumberLike
-from numpy.typing import ArrayLike, DtypeLike, _SupportsArray
+from numpy import ndarray, inexact
+from numpy.typing import ArrayLike, DtypeLike, _SupportsArray, _NumberLike
 
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex, Literal

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -90,6 +90,16 @@ since its usage is discouraged.
 Please see : https://numpy.org/devdocs/reference/arrays.dtypes.html
 
 """
+from ._scalars import (
+    _CharLike,
+    _BoolLike,
+    _IntLike,
+    _FloatLike,
+    _ComplexLike,
+    _NumberLike,
+    _ScalarLike,
+    _VoidLike,
+)
 from ._array_like import _SupportsArray, ArrayLike
 from ._shape import _Shape, _ShapeLike
 from ._dtype_like import DtypeLike
@@ -97,4 +107,3 @@ from ._dtype_like import DtypeLike
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)
 del PytestTester
-

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -2,6 +2,7 @@ import sys
 from typing import Any, overload, Sequence, TYPE_CHECKING, Union
 
 from numpy import ndarray
+from ._scalars import _ScalarLike
 from ._dtype_like import DtypeLike
 
 if sys.version_info >= (3, 8):
@@ -31,4 +32,9 @@ else:
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = Union[bool, int, float, complex, _SupportsArray, Sequence]
+ArrayLike = Union[
+    _ScalarLike,
+    Sequence[_ScalarLike],
+    Sequence[Sequence[Any]],  # TODO: Wait for support for recursive types
+    _SupportsArray,
+]

--- a/numpy/typing/_callable.py
+++ b/numpy/typing/_callable.py
@@ -12,11 +12,6 @@ import sys
 from typing import Union, TypeVar, overload, Any
 
 from numpy import (
-    _BoolLike,
-    _IntLike,
-    _FloatLike,
-    _ComplexLike,
-    _NumberLike,
     generic,
     bool_,
     timedelta64,
@@ -31,6 +26,13 @@ from numpy import (
     float64,
     complexfloating,
     complex128,
+)
+from ._scalars import (
+    _BoolLike,
+    _IntLike,
+    _FloatLike,
+    _ComplexLike,
+    _NumberLike,
 )
 
 if sys.version_info >= (3, 8):

--- a/numpy/typing/_scalars.py
+++ b/numpy/typing/_scalars.py
@@ -1,0 +1,26 @@
+from typing import Union, Tuple, Any
+
+import numpy as np
+
+# NOTE: `_StrLike` and `_BytesLike` are pointless, as `np.str_` and `np.bytes_`
+# are already subclasses of their builtin counterpart
+
+_CharLike = Union[str, bytes]
+
+_BoolLike = Union[bool, np.bool_]
+_IntLike = Union[int, np.integer]
+_FloatLike = Union[_IntLike, float, np.floating]
+_ComplexLike = Union[_FloatLike, complex, np.complexfloating]
+_NumberLike = Union[int, float, complex, np.number, np.bool_]
+
+_ScalarLike = Union[
+    int,
+    float,
+    complex,
+    str,
+    bytes,
+    np.generic,
+]
+
+# `_VoidLike` is technically not a scalar, but it's close enough
+_VoidLike = Union[Tuple[Any, ...], np.void]


### PR DESCRIPTION
Continuation of https://github.com/numpy/numpy/pull/17096: This PR adds aliases for common scalar union.

More specifically, it moves them from `numpy` to `numpy.typing`, as they had been 
naturally popping up in the former as time progressed. 

Examples
----------
``` python
>>> from typing import Union
>>> import numpy as np

>>> _IntLike = Union[int, np.integer]
>>> _FloatLike = Union[_IntLike, float, np.floating]
...
```