### PR TITLE
BUG: Fix memoryleaks related to NEP 37 function overrides

### DIFF
--- a/numpy/core/src/multiarray/arrayfunction_override.c
+++ b/numpy/core/src/multiarray/arrayfunction_override.c
@@ -388,15 +388,18 @@ array_implement_c_array_function_creation(
 
     PyObject *numpy_module = PyImport_Import(npy_ma_str_numpy);
     if (numpy_module == NULL) {
+        Py_DECREF(relevant_args);
         return NULL;
     }
 
     PyObject *public_api = PyObject_GetAttrString(numpy_module, function_name);
     Py_DECREF(numpy_module);
     if (public_api == NULL) {
+        Py_DECREF(relevant_args);
         return NULL;
     }
     if (!PyCallable_Check(public_api)) {
+        Py_DECREF(relevant_args);
         Py_DECREF(public_api);
         return PyErr_Format(PyExc_RuntimeError,
                             "numpy.%s is not callable.",
@@ -406,6 +409,7 @@ array_implement_c_array_function_creation(
     PyObject* result = array_implement_array_function_internal(
             public_api, relevant_args, args, kwargs);
 
+    Py_DECREF(relevant_args);
     Py_DECREF(public_api);
     return result;
 }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2296,6 +2296,7 @@ array_fromiter(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     array_function_result = array_implement_c_array_function_creation(
             "fromiter", args, keywds);
     if (array_function_result != Py_NotImplemented) {
+        Py_DECREF(descr);
         return array_function_result;
     }
 
@@ -2942,6 +2943,7 @@ array_arange(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kws) {
     array_function_result = array_implement_c_array_function_creation(
             "arange", args, kws);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(typecode);
         return array_function_result;
     }
 


### PR DESCRIPTION
This adds a few missing DECREFs/XDECREFs, all of these are already
covered by the tests and can be found running a leak-checker.