### PR TITLE
DOC: add references to einops and opt_einsum

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -1062,6 +1062,17 @@ def einsum(*operands, out=None, optimize=False, **kwargs):
     --------
     einsum_path, dot, inner, outer, tensordot, linalg.multi_dot
 
+    einops:
+        similar verbose interface is provided by
+        `einops <https://github.com/arogozhnikov/einops>`_ package to cover
+        additional operations: transpose, reshape/flatten, repeat/tile,
+        squeeze/unsqueeze and reductions.
+
+    opt_einsum:
+        `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_
+        optimizes contraction order for einsum-like expressions
+        in backend-agnostic manner.
+
     Notes
     -----
     .. versionadded:: 1.6.0


### PR DESCRIPTION
Following discussion in mailing list, this PR
adds mentions to third-party libs einops and opt_einsum
to einsum documentation.