### PR TITLE
MAINT: fix exception chaining in format.py

### DIFF
--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -746,7 +746,7 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None):
             # Friendlier error message
             raise UnicodeError("Unpickling a python object failed: %r\n"
                                "You may need to pass the encoding= option "
-                               "to numpy.load" % (err,))
+                               "to numpy.load" % (err,)) from err
     else:
         if isfileobj(fp):
             # We can use the fast fromfile() function.


### PR DESCRIPTION
<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

<!-- If you're submitting a new feature or substantial change in functionality,
make sure you discuss your changes in the numpy-discussion mailing list first: 
https://mail.python.org/mailman/listinfo/numpy-discussion -->

<!-- We try to review your pull request as soon as we can, typically within a week.
If you do not get any review comments within two weeks, please feel free to ask for
feedback by adding a new comment on your PR (this will notify maintainers). If your
PR is large or complicated, asking for input on the numpy-discussion mailing
list may also be useful.
-->
Changes related to #15986 

added chaining for UnicodeError in format.py