### PR TITLE
DOC: Cleaner template for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,13 +10,13 @@
 
 
 *  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
-     http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion
+      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion
 
 
 *  HIT ALL THE GUIDELINES:
-    https://numpy.org/devdocs/dev/index.html#guidelines
+      https://numpy.org/devdocs/dev/index.html#guidelines
 
 
 *  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
-    http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
+      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,22 @@
-<!-- Please be sure you are following the instructions in the dev guidelines
-http://www.numpy.org/devdocs/dev/development_workflow.html
--->
+<!--
 
-<!-- We'd appreciate it if your commit message is properly formatted
-http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
--->
+                ----------------------------------------------------------------
+                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
+                ----------------------------------------------------------------
 
-<!-- If you're submitting a new feature or substantial change in functionality,
-make sure you discuss your changes in the numpy-discussion mailing list first: 
-https://mail.python.org/mailman/listinfo/numpy-discussion -->
 
-<!-- We try to review your pull request as soon as we can, typically within a week.
-If you do not get any review comments within two weeks, please feel free to ask for
-feedback by adding a new comment on your PR (this will notify maintainers). If your
-PR is large or complicated, asking for input on the numpy-discussion mailing
-list may also be useful.
+*  FORMAT IT RIGHT:
+      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
+
+
+*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS
+     http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion
+
+
+*  HIT ALL THE GUIDELINES:
+    https://numpy.org/devdocs/dev/index.html#guidelines
+
+
+*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
+    http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
       http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
 
 
-*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS
+*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion
 
 

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -188,6 +188,16 @@ Standard acronyms to start the commit message with are::
    REL: related to releasing numpy
 
 
+.. _workflow_mailing_list:
+
+Get the mailing list's opinion
+=======================================================
+
+If you plan a new feature or API change, it's wisest to first email the
+NumPy `mailing list <https://mail.python.org/mailman/listinfo/numpy-discussion>`_
+asking for comment. If you haven't heard back in a week, it's
+OK to ping the list again.
+
 .. _asking-for-merging:
 
 Asking for your changes to be merged with the main repo
@@ -197,15 +207,22 @@ When you feel your work is finished, you can create a pull request (PR). Github
 has a nice help page that outlines the process for `filing pull requests`_.
 
 If your changes involve modifications to the API or addition/modification of a
-function, you should
+function, add a release note to the ``doc/release/upcoming_changes/``
+directory, following the instructions and format in the
+``doc/release/upcoming_changes/README.rst`` file.
 
-- send an email to the `NumPy mailing list`_ with a link to your PR along with
-  a description of and a motivation for your changes. This may generate
-  changes and feedback. It might be prudent to start with this step if your
-  change may be controversial.
-- add a release note to the ``doc/release/upcoming_changes/`` directory,
-  following the instructions and format in the
-  ``doc/release/upcoming_changes/README.rst`` file.
+
+Getting your PR reviewed
+========================
+
+We review pull requests as soon as we can, typically within a week. If you get
+no review comments within two weeks, feel free to ask for feedback by
+adding a comment on your PR (this will notify maintainers).
+
+If your PR is large or complicated, asking for input on the numpy-discussion
+mailing list may also be useful.
+
+
 
 .. _rebasing-on-master:
 

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -212,6 +212,8 @@ directory, following the instructions and format in the
 ``doc/release/upcoming_changes/README.rst`` file.
 
 
+.. _workflow_PR_timeline:
+
 Getting your PR reviewed
 ========================
 


### PR DESCRIPTION
Make the instructions easy to see and hard to delete unread.

Moves some text to new sections in dev/development_workflow.rst.

The dashes above and below the heading, which in monospace seem too long, fit it properly in Chromium browsers and reasonably in Firefox.
