### PR TITLE
ENH: Add `Typing :: Typed` to the PyPi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
 Topic :: Scientific/Engineering
+Typing :: Typed
 Operating System :: Microsoft :: Windows
 Operating System :: POSIX
 Operating System :: Unix


### PR DESCRIPTION
This PR adds the `Typing :: Typed` [PyPi classifier](https://pypi.org/classifiers/) to setup.py, as numpy will be a typed package starting from 1.20.