### PR TITLE
BUG: fix reciprocal of `0+0j` to be `inf+nanj`

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2247,10 +2247,17 @@ NPY_NO_EXPORT void
         const @ftype@ in1r = ((@ftype@ *)ip1)[0];
         const @ftype@ in1i = ((@ftype@ *)ip1)[1];
         if (npy_fabs@c@(in1i) <= npy_fabs@c@(in1r)) {
-            const @ftype@ r = in1i/in1r;
-            const @ftype@ d = in1r + in1i*r;
-            ((@ftype@ *)op1)[0] = 1/d;
-            ((@ftype@ *)op1)[1] = -r/d;
+            if (in1r == 0 && in1i == 0) {
+                /* reciprocal of zero should contain at least one infinity */
+                ((@ftype@ *)op1)[0] = NPY_INFINITY;
+                ((@ftype@ *)op1)[1] = NPY_NAN;
+                npy_set_floatstatus_divbyzero();
+            } else {
+                const @ftype@ r = in1i/in1r;
+                const @ftype@ d = in1r + in1i*r;
+                ((@ftype@ *)op1)[0] = 1/d;
+                ((@ftype@ *)op1)[1] = -r/d;
+            }
         } else {
             const @ftype@ r = in1r/in1i;
             const @ftype@ d = in1r*r + in1i;

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -6,7 +6,8 @@ import numpy as np
 # import the c-extension module directly since _arg is not exported via umath
 import numpy.core._multiarray_umath as ncu
 from numpy.testing import (
-    assert_raises, assert_equal, assert_array_equal, assert_almost_equal, assert_array_max_ulp
+    assert_raises, assert_equal, assert_array_equal, assert_almost_equal,
+    assert_array_max_ulp, suppress_warnings
     )
 
 # TODO: branch cuts (use Pauli code)
@@ -28,6 +29,19 @@ platform_skip = pytest.mark.skipif(xfail_complex_tests,
                                    reason="Inadequate C99 complex support")
 
 
+class TestCreciprocal:
+    def test_simple(self):
+        check = check_complex_value
+        f = np.reciprocal
+        div_by_0_msg = "divide by zero encountered in reciprocal"
+
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, div_by_0_msg)
+            check(f, 0, 0, np.inf, np.nan, True)
+
+        with np.errstate(divide='raise', over='raise'):
+            with pytest.raises(FloatingPointError, match=div_by_0_msg):
+                np.reciprocal(0 + 0j)
 
 class TestCexp:
     def test_simple(self):


### PR DESCRIPTION
This change makes `np.reciprocal(0+0j)` return the same result as
`1 / np.array(0+0j)`. See #17425

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->

<!-- If you're submitting a new feature or substantial change in functionality,
make sure you discuss your changes in the numpy-discussion mailing list first: 
https://mail.python.org/mailman/listinfo/numpy-discussion -->

<!-- We try to review your pull request as soon as we can, typically within a week.
If you do not get any review comments within two weeks, please feel free to ask for
feedback by adding a new comment on your PR (this will notify maintainers). If your
PR is large or complicated, asking for input on the numpy-discussion mailing
list may also be useful.
-->
