### PR TITLE
ENH: add dtype option to numpy.lib.function_base.cov and corrcoef

### DIFF
--- a/doc/release/upcoming_changes/17456.new_feature.rst
+++ b/doc/release/upcoming_changes/17456.new_feature.rst
@@ -1,0 +1,5 @@
+``dtype`` option for `cov` and `corrcoef`
+----------------------------------------------------
+The ``dtype`` option is now available for `cov` and `corrcoef`. It specifies
+which data-type the returned result should have. By default the functions still 
+return a np.float64 result.

--- a/doc/release/upcoming_changes/17456.new_feature.rst
+++ b/doc/release/upcoming_changes/17456.new_feature.rst
@@ -1,5 +1,5 @@
 ``dtype`` option for `cov` and `corrcoef`
 ----------------------------------------------------
-The ``dtype`` option is now available for `cov` and `corrcoef`. It specifies
-which data-type the returned result should have. By default the functions still 
-return a np.float64 result.
+The ``dtype`` option is now available for `numpy.cov` and `numpy.corrcoef`.
+It specifies which data-type the returned result should have.
+By default the functions still return a `numpy.float64` result.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2400,15 +2400,16 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     if m.ndim > 2:
         raise ValueError("m has more than 2 dimensions")
 
+    if y is not None:
+        y = np.asarray(y)
+        if y.ndim > 2:
+            raise ValueError("y has more than 2 dimensions")
+
     if dtype is None:
-        dtype = np.float64
         if y is None:
-            dtype = np.result_type(m, dtype)
+            dtype = np.result_type(m, np.float64)
         else:
-            y = np.asarray(y)
-            if y.ndim > 2:
-                raise ValueError("y has more than 2 dimensions")
-            dtype = np.result_type(m, y, dtype)
+            dtype = np.result_type(m, y, np.float64)
 
     X = array(m, ndmin=2, dtype=dtype)
     if not rowvar and X.shape[0] != 1:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2325,6 +2325,10 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         weights can be used to assign probabilities to observation vectors.
 
         .. versionadded:: 1.10
+    dtype : data-type, optional
+        Data-type of the result. By default, the return data-type is np.float64.
+
+        .. versionadded:: 1.20.0
 
     Returns
     -------
@@ -2530,6 +2534,10 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
         Has no effect, do not use.
 
         .. deprecated:: 1.10.0
+    dtype : data-type, optional
+        Data-type of the result. By default, the return data-type is np.float64.
+
+        .. versionadded:: 1.20.0
 
     Returns
     -------

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2268,13 +2268,13 @@ class vectorize:
 
 
 def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
-                    fweights=None, aweights=None):
+                    fweights=None, aweights=None, dtype=None):
     return (m, y, fweights, aweights)
 
 
 @array_function_dispatch(_cov_dispatcher)
 def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
-        aweights=None):
+        aweights=None, dtype=None):
     """
     Estimate a covariance matrix, given data and weights.
 
@@ -2400,13 +2400,15 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     if m.ndim > 2:
         raise ValueError("m has more than 2 dimensions")
 
-    if y is None:
-        dtype = np.result_type(m, np.float64)
-    else:
-        y = np.asarray(y)
-        if y.ndim > 2:
-            raise ValueError("y has more than 2 dimensions")
-        dtype = np.result_type(m, y, np.float64)
+    if dtype is None:
+        dtype = np.float64
+        if y is None:
+            dtype = np.result_type(m, dtype)
+        else:
+            y = np.asarray(y)
+            if y.ndim > 2:
+                raise ValueError("y has more than 2 dimensions")
+            dtype = np.result_type(m, y, dtype)
 
     X = array(m, ndmin=2, dtype=dtype)
     if not rowvar and X.shape[0] != 1:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2326,8 +2326,8 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
         .. versionadded:: 1.10
     dtype : data-type, optional
-        Data-type of the result. By default, the return data-type is
-        `numpy.float64`.
+        Data-type of the result. By default, the return data-type will have
+        at least `numpy.float64` precision.
 
         .. versionadded:: 1.20
 
@@ -2536,8 +2536,8 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
 
         .. deprecated:: 1.10.0
     dtype : data-type, optional
-        Data-type of the result. By default, the return data-type is
-        `numpy.float64`.
+        Data-type of the result. By default, the return data-type will have
+        at least `numpy.float64` precision.
 
         .. versionadded:: 1.20
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2488,12 +2488,14 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None):
+def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None,
+                         dtype=None):
     return (x, y)
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue):
+def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue,
+             dtype=None):
     """
     Return Pearson product-moment correlation coefficients.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2268,7 +2268,7 @@ class vectorize:
 
 
 def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
-                    fweights=None, aweights=None, dtype=None):
+                    fweights=None, aweights=None, *, dtype=None):
     return (m, y, fweights, aweights)
 
 
@@ -2489,7 +2489,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None,
+def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
                          dtype=None):
     return (x, y)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2620,7 +2620,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue,
         # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning, stacklevel=3)
-    c = cov(x, y, rowvar)
+    c = cov(x, y, rowvar, dtype=dtype)
     try:
         d = diag(c)
     except ValueError:

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2326,7 +2326,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
         .. versionadded:: 1.10
     dtype : data-type, optional
-        Data-type of the result. By default, the return data-type is np.float64.
+        Data-type of the result. By default, the return data-type is `numpy.float64`.
 
         .. versionadded:: 1.20.0
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2495,7 +2495,7 @@ def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None,
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue,
+def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
              dtype=None):
     """
     Return Pearson product-moment correlation coefficients.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2274,7 +2274,7 @@ def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
 
 @array_function_dispatch(_cov_dispatcher)
 def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
-        aweights=None, dtype=None):
+        aweights=None, *, dtype=None):
     """
     Estimate a covariance matrix, given data and weights.
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2326,9 +2326,10 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
         .. versionadded:: 1.10
     dtype : data-type, optional
-        Data-type of the result. By default, the return data-type is `numpy.float64`.
+        Data-type of the result. By default, the return data-type is
+        `numpy.float64`.
 
-        .. versionadded:: 1.20.0
+        .. versionadded:: 1.20
 
     Returns
     -------
@@ -2535,9 +2536,10 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
 
         .. deprecated:: 1.10.0
     dtype : data-type, optional
-        Data-type of the result. By default, the return data-type is np.float64.
+        Data-type of the result. By default, the return data-type is
+        `numpy.float64`.
 
-        .. versionadded:: 1.20.0
+        .. versionadded:: 1.20
 
     Returns
     -------

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2023,11 +2023,8 @@ class TestCorrCoef:
         assert_array_almost_equal(c, np.array([[1., -1.], [-1., 1.]]))
         assert_(np.all(np.abs(c) <= 1.0))
 
-    @pytest.mark.parametrize("test_type", [getattr(np, dtype, None) for dtype \
-    in ['float32', 'float64', 'float96', 'float128']])
+    @pytest.mark.parametrize("test_type", [np.half, np.single, np.double, np.longdouble])
     def test_cov_dtype(self, test_type):
-        if test_type is None:
-            pytest.skip("Data type not available")
         cast_A = self.A.astype(test_type)
         res = corrcoef(cast_A, dtype=test_type)
         assert test_type == res.dtype

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2129,11 +2129,8 @@ class TestCov:
                             aweights=self.unit_weights),
                         self.res1)
 
-    @pytest.mark.parametrize("test_type", [getattr(np, dtype, None) for dtype \
-        in ['float32', 'float64', 'float96', 'float128']])
+    @pytest.mark.parametrize("test_type", [np.half, np.single, np.double, np.longdouble])
     def test_cov_dtype(self, test_type):
-        if test_type is None:
-            pytest.skip("Data type not available")
         cast_x1 = self.x1.astype(test_type)
         res = cov(cast_x1, dtype=test_type)
         assert test_type == res.dtype

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2024,7 +2024,7 @@ class TestCorrCoef:
         assert_(np.all(np.abs(c) <= 1.0))
 
     @pytest.mark.parametrize("test_type", [np.half, np.single, np.double, np.longdouble])
-    def test_cov_dtype(self, test_type):
+    def test_corrcoef_dtype(self, test_type):
         cast_A = self.A.astype(test_type)
         res = corrcoef(cast_A, dtype=test_type)
         assert test_type == res.dtype

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2123,6 +2123,15 @@ class TestCov:
                             aweights=self.unit_weights),
                         self.res1)
 
+    @pytest.mark.parametrize("test_type", [getattr(np, dtype, None) for dtype \
+        in ['float32', 'float64', 'float96', 'float128']])
+    def test_cov_dtype(self, test_type):
+        if test_type is None:
+            pytest.skip("Data type not available")
+        cast_x1 = self.x1.astype(test_type)
+        res = cov(cast_x1, dtype=test_type)
+        assert test_type == res.dtype
+
 
 class Test_I0:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2023,6 +2023,15 @@ class TestCorrCoef:
         assert_array_almost_equal(c, np.array([[1., -1.], [-1., 1.]]))
         assert_(np.all(np.abs(c) <= 1.0))
 
+    @pytest.mark.parametrize("test_type", [getattr(np, dtype, None) for dtype \
+    in ['float32', 'float64', 'float96', 'float128']])
+    def test_cov_dtype(self, test_type):
+        if test_type is None:
+            pytest.skip("Data type not available")
+        cast_A = self.A.astype(test_type)
+        res = corrcoef(cast_A, dtype=test_type)
+        assert test_type == res.dtype
+
 
 class TestCov:
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T


### PR DESCRIPTION
I tried to implement the changes suggested in [Issue #17395](https://github.com/numpy/numpy/issues/17395#issue-711108059), by adding a dtype keyword to the cov and corrcoef functions in numpy/lib/function_base.py. I also wrote tests for the changes.

Closes #17395 