### PR TITLE
MAINT: py3k: remove os.fspath and os.PathLike backports 

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -133,54 +133,5 @@ def npy_load_module(name, fn, info=None):
 
 
 # Backport os.fs_path, os.PathLike, and PurePath.__fspath__
-if sys.version_info[:2] >= (3, 6):
-    os_fspath = os.fspath
-    os_PathLike = os.PathLike
-else:
-    def _PurePath__fspath__(self):
-        return str(self)
-
-    class os_PathLike(abc_ABC):
-        """Abstract base class for implementing the file system path protocol."""
-
-        @abc.abstractmethod
-        def __fspath__(self):
-            """Return the file system path representation of the object."""
-            raise NotImplementedError
-
-        @classmethod
-        def __subclasshook__(cls, subclass):
-            if PurePath is not None and issubclass(subclass, PurePath):
-                return True
-            return hasattr(subclass, '__fspath__')
-
-
-    def os_fspath(path):
-        """Return the path representation of a path-like object.
-        If str or bytes is passed in, it is returned unchanged. Otherwise the
-        os.PathLike interface is used to get the path representation. If the
-        path representation is not str or bytes, TypeError is raised. If the
-        provided path is not str, bytes, or os.PathLike, TypeError is raised.
-        """
-        if isinstance(path, (str, bytes)):
-            return path
-
-        # Work from the object's type to match method resolution of other magic
-        # methods.
-        path_type = type(path)
-        try:
-            path_repr = path_type.__fspath__(path)
-        except AttributeError as e:
-            if hasattr(path_type, '__fspath__'):
-                raise
-            elif PurePath is not None and issubclass(path_type, PurePath):
-                return _PurePath__fspath__(path)
-            else:
-                raise TypeError("expected str, bytes or os.PathLike object, "
-                                "not " + path_type.__name__) from e
-        if isinstance(path_repr, (str, bytes)):
-            return path_repr
-        else:
-            raise TypeError("expected {}.__fspath__() to return str or bytes, "
-                            "not {}".format(path_type.__name__,
-                                            type(path_repr).__name__))
+os_fspath = os.fspath
+os_PathLike = os.PathLike

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -170,14 +170,14 @@ else:
         path_type = type(path)
         try:
             path_repr = path_type.__fspath__(path)
-        except AttributeError:
+        except AttributeError as e:
             if hasattr(path_type, '__fspath__'):
                 raise
             elif PurePath is not None and issubclass(path_type, PurePath):
                 return _PurePath__fspath__(path)
             else:
                 raise TypeError("expected str, bytes or os.PathLike object, "
-                                "not " + path_type.__name__)
+                                "not " + path_type.__name__) from e
         if isinstance(path_repr, (str, bytes)):
             return path_repr
         else:


### PR DESCRIPTION
<!--

                ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------


*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message


*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion


*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines


*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Related to #15986 .
Chain exceptions in "py3k.py" corresponding to exceptions on line 173 as mentioned in this [comment](https://github.com/numpy/numpy/issues/15986#issuecomment-660534157).