### PR TITLE
MAINT: Move the `np.core.numeric` annotations to their own stub file

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -54,10 +54,9 @@ else:
         def __index__(self) -> int: ...
 
 # Ensures that the stubs are picked up
-from . import (
+from numpy import (
     char,
     compat,
-    core,
     ctypeslib,
     emath,
     fft,
@@ -125,6 +124,37 @@ from numpy.core._asarray import (
     ascontiguousarray as ascontiguousarray,
     asfortranarray as asfortranarray,
     require as require,
+)
+
+from numpy.core.numeric import(
+    zeros_like as zeros_like,
+    ones as ones,
+    ones_like as ones_like,
+    empty_like as empty_like,
+    full as full,
+    full_like as full_like,
+    count_nonzero as count_nonzero,
+    isfortran as isfortran,
+    argwhere as argwhere,
+    flatnonzero as flatnonzero,
+    correlate as correlate,
+    convolve as convolve,
+    outer as outer,
+    tensordot as tensordot,
+    roll as roll,
+    rollaxis as rollaxis,
+    moveaxis as moveaxis,
+    cross as cross,
+    indices as indices,
+    fromfunction as fromfunction,
+    isscalar as isscalar,
+    binary_repr as binary_repr,
+    base_repr as base_repr,
+    identity as identity,
+    allclose as allclose,
+    isclose as isclose,
+    array_equal as array_equal,
+    array_equiv as array_equiv,
 )
 
 # Add an object to `__all__` if their stubs are defined in an external file;
@@ -1552,13 +1582,6 @@ def zeros(
     *,
     like: ArrayLike = ...,
 ) -> ndarray: ...
-def ones(
-    shape: _ShapeLike,
-    dtype: DtypeLike = ...,
-    order: _OrderCF = ...,
-    *,
-    like: ArrayLike = ...,
-) -> ndarray: ...
 def empty(
     shape: _ShapeLike,
     dtype: DtypeLike = ...,
@@ -1566,111 +1589,6 @@ def empty(
     *,
     like: ArrayLike = ...,
 ) -> ndarray: ...
-def zeros_like(
-    a: ArrayLike,
-    dtype: DtypeLike = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: Optional[Union[int, Sequence[int]]] = ...,
-) -> ndarray: ...
-def ones_like(
-    a: ArrayLike,
-    dtype: DtypeLike = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
-def empty_like(
-    a: ArrayLike,
-    dtype: DtypeLike = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
-def full(
-    shape: _ShapeLike,
-    fill_value: Any,
-    dtype: DtypeLike = ...,
-    order: _OrderCF = ...,
-    *,
-    like: ArrayLike = ...,
-) -> ndarray: ...
-def full_like(
-    a: ArrayLike,
-    fill_value: Any,
-    dtype: DtypeLike = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
-def count_nonzero(
-    a: ArrayLike, axis: Optional[Union[int, Tuple[int], Tuple[int, int]]] = ...
-) -> Union[int, ndarray]: ...
-def isfortran(a: ndarray) -> bool: ...
-def argwhere(a: ArrayLike) -> ndarray: ...
-def flatnonzero(a: ArrayLike) -> ndarray: ...
-
-_CorrelateMode = Literal["valid", "same", "full"]
-
-def correlate(a: ArrayLike, v: ArrayLike, mode: _CorrelateMode = ...) -> ndarray: ...
-def convolve(a: ArrayLike, v: ArrayLike, mode: _CorrelateMode = ...) -> ndarray: ...
-def outer(a: ArrayLike, b: ArrayLike, out: ndarray = ...) -> ndarray: ...
-def tensordot(
-    a: ArrayLike,
-    b: ArrayLike,
-    axes: Union[
-        int, Tuple[int, int], Tuple[Tuple[int, int], ...], Tuple[List[int, int], ...]
-    ] = ...,
-) -> ndarray: ...
-def roll(
-    a: ArrayLike,
-    shift: Union[int, Tuple[int, ...]],
-    axis: Optional[Union[int, Tuple[int, ...]]] = ...,
-) -> ndarray: ...
-def rollaxis(a: ArrayLike, axis: int, start: int = ...) -> ndarray: ...
-def moveaxis(
-    a: ndarray,
-    source: Union[int, Sequence[int]],
-    destination: Union[int, Sequence[int]],
-) -> ndarray: ...
-def cross(
-    a: ArrayLike,
-    b: ArrayLike,
-    axisa: int = ...,
-    axisb: int = ...,
-    axisc: int = ...,
-    axis: Optional[int] = ...,
-) -> ndarray: ...
-def indices(
-    dimensions: Sequence[int], dtype: dtype = ..., sparse: bool = ...
-) -> Union[ndarray, Tuple[ndarray, ...]]: ...
-def fromfunction(
-    function: Callable,
-    shape: Tuple[int, int],
-    *,
-    like: ArrayLike = ...,
-    **kwargs,
-) -> Any: ...
-def isscalar(element: Any) -> bool: ...
-def binary_repr(num: int, width: Optional[int] = ...) -> str: ...
-def base_repr(number: int, base: int = ..., padding: int = ...) -> str: ...
-def identity(n: int, dtype: DtypeLike = ..., *, like: ArrayLike = ...) -> ndarray: ...
-def allclose(
-    a: ArrayLike,
-    b: ArrayLike,
-    rtol: float = ...,
-    atol: float = ...,
-    equal_nan: bool = ...,
-) -> bool: ...
-def isclose(
-    a: ArrayLike,
-    b: ArrayLike,
-    rtol: float = ...,
-    atol: float = ...,
-    equal_nan: bool = ...,
-) -> Union[bool_, ndarray]: ...
-def array_equal(a1: ArrayLike, a2: ArrayLike) -> bool: ...
-def array_equiv(a1: ArrayLike, a2: ArrayLike) -> bool: ...
 
 #
 # Constants

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -1,0 +1,117 @@
+from typing import Any, Optional, Union, Sequence, Tuple
+
+from numpy import ndarray, dtype, bool_, _OrderKACF, _OrderCF
+from numpy.typing import ArrayLike, DtypeLike, _ShapeLike
+
+def zeros_like(
+    a: ArrayLike,
+    dtype: DtypeLike = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: Optional[Union[int, Sequence[int]]] = ...,
+) -> ndarray: ...
+def ones(
+    shape: _ShapeLike,
+    dtype: DtypeLike = ...,
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> ndarray: ...
+def ones_like(
+    a: ArrayLike,
+    dtype: DtypeLike = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: Optional[_ShapeLike] = ...,
+) -> ndarray: ...
+def empty_like(
+    a: ArrayLike,
+    dtype: DtypeLike = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: Optional[_ShapeLike] = ...,
+) -> ndarray: ...
+def full(
+    shape: _ShapeLike,
+    fill_value: Any,
+    dtype: DtypeLike = ...,
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> ndarray: ...
+def full_like(
+    a: ArrayLike,
+    fill_value: Any,
+    dtype: DtypeLike = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: Optional[_ShapeLike] = ...,
+) -> ndarray: ...
+def count_nonzero(
+    a: ArrayLike, axis: Optional[Union[int, Tuple[int], Tuple[int, int]]] = ...
+) -> Union[int, ndarray]: ...
+def isfortran(a: ndarray) -> bool: ...
+def argwhere(a: ArrayLike) -> ndarray: ...
+def flatnonzero(a: ArrayLike) -> ndarray: ...
+
+_CorrelateMode = Literal["valid", "same", "full"]
+
+def correlate(a: ArrayLike, v: ArrayLike, mode: _CorrelateMode = ...) -> ndarray: ...
+def convolve(a: ArrayLike, v: ArrayLike, mode: _CorrelateMode = ...) -> ndarray: ...
+def outer(a: ArrayLike, b: ArrayLike, out: ndarray = ...) -> ndarray: ...
+def tensordot(
+    a: ArrayLike,
+    b: ArrayLike,
+    axes: Union[
+        int, Tuple[int, int], Tuple[Tuple[int, int], ...], Tuple[List[int, int], ...]
+    ] = ...,
+) -> ndarray: ...
+def roll(
+    a: ArrayLike,
+    shift: Union[int, Tuple[int, ...]],
+    axis: Optional[Union[int, Tuple[int, ...]]] = ...,
+) -> ndarray: ...
+def rollaxis(a: ArrayLike, axis: int, start: int = ...) -> ndarray: ...
+def moveaxis(
+    a: ndarray,
+    source: Union[int, Sequence[int]],
+    destination: Union[int, Sequence[int]],
+) -> ndarray: ...
+def cross(
+    a: ArrayLike,
+    b: ArrayLike,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: Optional[int] = ...,
+) -> ndarray: ...
+def indices(
+    dimensions: Sequence[int], dtype: dtype = ..., sparse: bool = ...
+) -> Union[ndarray, Tuple[ndarray, ...]]: ...
+def fromfunction(
+    function: Callable,
+    shape: Tuple[int, int],
+    *,
+    like: ArrayLike = ...,
+    **kwargs,
+) -> Any: ...
+def isscalar(element: Any) -> bool: ...
+def binary_repr(num: int, width: Optional[int] = ...) -> str: ...
+def base_repr(number: int, base: int = ..., padding: int = ...) -> str: ...
+def identity(n: int, dtype: DtypeLike = ..., *, like: ArrayLike = ...) -> ndarray: ...
+def allclose(
+    a: ArrayLike,
+    b: ArrayLike,
+    rtol: float = ...,
+    atol: float = ...,
+    equal_nan: bool = ...,
+) -> bool: ...
+def isclose(
+    a: ArrayLike,
+    b: ArrayLike,
+    rtol: float = ...,
+    atol: float = ...,
+    equal_nan: bool = ...,
+) -> Union[bool_, ndarray]: ...
+def array_equal(a1: ArrayLike, a2: ArrayLike) -> bool: ...
+def array_equiv(a1: ArrayLike, a2: ArrayLike) -> bool: ...


### PR DESCRIPTION
This pull request moves the `numeric` annotations to their own dedicated stub file.

The purpose of this PR is the same as https://github.com/numpy/numpy/pull/17309: cleaning up the main `__init__.pyi` file a bit.

Note that while there are some places where the functions' existing annotations can be improved, 
such changes are beyond the scope of this PR; this is a simple copy/paste job.