### PR TITLE
ENH: type np.unicode_ as np.str_

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -468,7 +468,6 @@ uint0: Any
 uintc: Any
 uintp: Any
 ulonglong: Any
-unicode_: Any
 union1d: Any
 unique: Any
 unpackbits: Any
@@ -1526,6 +1525,8 @@ class str_(character, str):
     def __init__(
         self, __value: bytes, encoding: str = ..., errors: str = ...
     ) -> None: ...
+
+unicode_ = str_
 
 # TODO(alan): Platform dependent types
 # longcomplex, longdouble, longfloat

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -444,7 +444,6 @@ sort_complex: Any
 source: Any
 split: Any
 stack: Any
-str0: Any
 string_: Any
 sys: Any
 take_along_axis: Any
@@ -1526,7 +1525,7 @@ class str_(character, str):
         self, __value: bytes, encoding: str = ..., errors: str = ...
     ) -> None: ...
 
-unicode_ = str_
+unicode_ = str0 = str_
 
 # TODO(alan): Platform dependent types
 # longcomplex, longdouble, longfloat

--- a/numpy/typing/tests/data/reveal/scalars.py
+++ b/numpy/typing/tests/data/reveal/scalars.py
@@ -14,3 +14,5 @@ reveal_type(x.strides)  # E: tuple[builtins.int]
 
 reveal_type(np.complex64().real)  # E: numpy.float32
 reveal_type(np.complex128().imag)  # E: numpy.float64
+
+reveal_type(np.unicode_('foo'))  # E: numpy.str_

--- a/numpy/typing/tests/data/reveal/scalars.py
+++ b/numpy/typing/tests/data/reveal/scalars.py
@@ -16,3 +16,4 @@ reveal_type(np.complex64().real)  # E: numpy.float32
 reveal_type(np.complex128().imag)  # E: numpy.float64
 
 reveal_type(np.unicode_('foo'))  # E: numpy.str_
+reveal_type(np.str0('foo'))  # E: numpy.str_


### PR DESCRIPTION
The two are aliases; i.e.

```
>>> np.unicode_ is np.str_
True
```

so make them aliases on the typing level too.
