### PR TITLE
BLD: circleCI- merge before build, add -n to sphinx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ jobs:
 
     steps:
       - checkout:
-          post:
-            git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+      - run: git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       - run:
           name: create virtual environment, install dependencies
@@ -53,9 +52,13 @@ jobs:
       - run:
           name: build devdocs w/ref warnings
           command: |
+            set +e
+            # allow this to fail for now: issue 13114
             . venv/bin/activate
             cd doc
-            SPHINXOPTS="-q -n" make -e html || echo "ignoring errors for now, see gh-13114"
+            SPHINXOPTS="-q -n" make -e html
+            # clear the error
+            echo ok
 
       - run:
           name: build devdocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - checkout
+      - checkout:
+          post:
+            git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       - run:
           name: create virtual environment, install dependencies
@@ -49,10 +51,22 @@ jobs:
             python tools/refguide_check.py --rst
 
       - run:
+          name: build devdocs w/ref warnings
+          command: |
+            set +e
+            # allow this to fail for now: issue 13114
+            . venv/bin/activate
+            cd doc
+            SPHINXOPTS="-q -n" make -e html
+            # clear the error
+            echo ok
+
+      - run:
           name: build devdocs
           command: |
             . venv/bin/activate
             cd doc
+            make clean
             SPHINXOPTS=-q make -e html
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,10 @@ jobs:
       - run:
           name: build devdocs w/ref warnings
           command: |
-            set +e
-            # allow this to fail for now: issue 13114
             . venv/bin/activate
             cd doc
-            SPHINXOPTS="-q -n" make -e html
-            # clear the error
-            echo ok
+            # Don't use -q, show warning summary"
+            SPHINXOPTS="-n" make -e html || echo "ignoring errors for now, see gh-13114"
 
       - run:
           name: build devdocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,9 @@ jobs:
       - run:
           name: build devdocs w/ref warnings
           command: |
-            set +e
-            # allow this to fail for now: issue 13114
             . venv/bin/activate
             cd doc
-            SPHINXOPTS="-q -n" make -e html
-            # clear the error
-            echo ok
+            SPHINXOPTS="-q -n" make -e html || echo "ignoring errors for now, see gh-13114"
 
       - run:
           name: build devdocs


### PR DESCRIPTION
Add a merge to the checkout step as per [this comment](https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662/14) to merge master into the PR.

Also add a step to show how many warnings are still being emitted with `sphinx-build -n ...`, xref issue gh-13114. It should not cause the build to fail, but those who are interested can dive into the log files and see the progress.