### PR TITLE
MAINT: Remove duplicate placeholder annotations

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -56,7 +56,6 @@ else:
 # Ensures that the stubs are picked up
 from numpy import (
     char,
-    compat,
     ctypeslib,
     emath,
     fft,
@@ -248,14 +247,12 @@ can_cast: Any
 cast: Any
 cdouble: Any
 cfloat: Any
-char: Any
 chararray: Any
 clongdouble: Any
 clongfloat: Any
 column_stack: Any
 common_type: Any
 compare_chararrays: Any
-compat: Any
 complex256: Any
 complex_: Any
 concatenate: Any
@@ -265,7 +262,6 @@ copyto: Any
 corrcoef: Any
 cov: Any
 csingle: Any
-ctypeslib: Any
 cumproduct: Any
 datetime_as_string: Any
 datetime_data: Any
@@ -287,12 +283,10 @@ dstack: Any
 ediff1d: Any
 einsum: Any
 einsum_path: Any
-emath: Any
 errstate: Any
 expand_dims: Any
 extract: Any
 eye: Any
-fft: Any
 fill_diagonal: Any
 finfo: Any
 fix: Any
@@ -311,7 +305,6 @@ frompyfunc: Any
 fromregex: Any
 fromstring: Any
 genfromtxt: Any
-geomspace: Any
 get_include: Any
 get_printoptions: Any
 getbufsize: Any
@@ -355,25 +348,18 @@ ix_: Any
 kaiser: Any
 kron: Any
 lexsort: Any
-lib: Any
-linalg: Any
-linspace: Any
 load: Any
 loads: Any
 loadtxt: Any
-logspace: Any
 longcomplex: Any
 longdouble: Any
 longfloat: Any
 longlong: Any
 lookfor: Any
-ma: Any
 mafromtxt: Any
 mask_indices: Any
 mat: Any
-math: Any
 matrix: Any
-matrixlib: Any
 max: Any
 may_share_memory: Any
 median: Any
@@ -423,7 +409,6 @@ polydiv: Any
 polyfit: Any
 polyint: Any
 polymul: Any
-polynomial: Any
 polysub: Any
 polyval: Any
 printoptions: Any
@@ -433,11 +418,9 @@ put_along_axis: Any
 putmask: Any
 quantile: Any
 r_: Any
-random: Any
 ravel_multi_index: Any
 real: Any
 real_if_close: Any
-rec: Any
 recarray: Any
 recfromcsv: Any
 recfromtxt: Any
@@ -476,9 +459,7 @@ split: Any
 stack: Any
 str0: Any
 string_: Any
-sys: Any
 take_along_axis: Any
-testing: Any
 tile: Any
 trapz: Any
 tri: Any
@@ -508,7 +489,6 @@ ushort: Any
 vander: Any
 vdot: Any
 vectorize: Any
-version: Any
 void0: Any
 vsplit: Any
 vstack: Any

--- a/numpy/typing/tests/data/fail/modules.py
+++ b/numpy/typing/tests/data/fail/modules.py
@@ -2,3 +2,9 @@ import numpy as np
 
 np.testing.bob  # E: Module has no attribute
 np.bob  # E: Module has no attribute
+
+# Stdlib modules in the namespace by accident
+np.warnings  # E: Module has no attribute
+np.sys  # E: Module has no attribute
+np.os  # E: Module has no attribute
+np.math  # E: Module has no attribute

--- a/tools/functions_missing_types.py
+++ b/tools/functions_missing_types.py
@@ -37,6 +37,7 @@ EXCLUDE_LIST = {
         "add_newdoc",
         "add_newdoc_ufunc",
         "core",
+        "compat",
         "fastCopyAndTranspose",
         "get_array_wrap",
         "int_asbuffer",

--- a/tools/functions_missing_types.py
+++ b/tools/functions_missing_types.py
@@ -27,6 +27,9 @@ EXCLUDE_LIST = {
         "division",
         "print_function",
         "warnings",
+        "sys",
+        "os",
+        "math",
         # Accidentally public, deprecated, or shouldn't be used
         "Tester",
         "alen",


### PR DESCRIPTION
This PR removes a number of placeholder annotations for objects which already have proper annotations.

This includes 3 functions:
* `geomspace`
* `linspace`
* `logspace`

And a number of sub-modules:
* `char`
* `compat` (removed; not a public module)
* `ctypeslib`
* `emath`
* `fft`
* `lib`
* `linalg`
* `ma`
* `matrixlib`
* `polynomial`
* `random`
* `rec`
* `testing`
* `version`
* `sys` and `math` (builtin modules in the numpy namespace)