### PR TITLE
DOC: Use consistent lowercase on docs landing page

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -12,21 +12,21 @@
 <p><strong>For users:</strong></p>
 <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/setting-up") }}">Setting Up</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("user/setting-up") }}">Setting up</a><br/>
 	<span class="linkdescr">Learn about what NumPy is and how to install it</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/quickstart") }}">Quickstart Tutorial</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("user/quickstart") }}">Quickstart</a><br/>
 	<span class="linkdescr">Aimed at domain experts or people migrating to NumPy</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/absolute_beginners") }}">Absolute Beginners Tutorial</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("user/absolute_beginners") }}">Absolute beginner's guide</a><br/>
 	<span class="linkdescr">Start here for an overview of NumPy features and syntax</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("user/tutorials_index") }}">Tutorials</a><br/>
 	<span class="linkdescr">Learn about concepts and submodules</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/howtos_index") }}">How Tos</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("user/howtos_index") }}">How-tos</a><br/>
 	<span class="linkdescr">How to do common tasks with NumPy</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">NumPy API Reference</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">NumPy API reference</a><br/>
         <span class="linkdescr">Automatically generated reference documentation</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("user/explanations_index") }}">Explanations</a><br/>
 	<span class="linkdescr">In depth explanation of concepts, best practices and techniques</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("f2py/index") }}">F2Py Guide</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("f2py/index") }}">F2Py guide</a><br/>
         <span class="linkdescr">Documentation for the f2py module (Fortran extensions for Python)</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">Glossary</a><br/>
         <span class="linkdescr">List of the most important terms</span></p>
@@ -36,11 +36,11 @@
 <p><strong>For developers/contributors:</strong></p>
 <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("dev/index") }}">NumPy Contributor Guide</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("dev/index") }}">NumPy contributor guide</a><br/>
         <span class="linkdescr">Contributing to NumPy</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("dev/underthehood") }}">Under-the-hood docs</a><br/>
 	<span class="linkdescr">Specialized, in-depth documentation</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("docs/index") }}">Building and Extending the Documentation</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("docs/index") }}">Building and extending the documentation</a><br/>
         <span class="linkdescr">How to contribute to this documentation (user and API)</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("docs/howto_document") }}">The numpydoc docstring guide</a><br/>
 	<span class="linkdescr">How to write docstrings in the numpydoc format</span></p>
@@ -54,7 +54,7 @@
   <table class="contentstable" align="center"><tr>
     <td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("bugs") }}">Reporting bugs</a></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("release") }}">Release Notes</a></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("release") }}">Release notes</a></p>
     </td><td width="50%">
       <p class="biglink"><a class="biglink" href="{{ pathto("doc_conventions") }}">Document conventions</a></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("license") }}">License of NumPy</a></p>
@@ -65,13 +65,13 @@
   <p>
     Large parts of this manual originate from Travis E. Oliphant's book
     <a href="https://archive.org/details/NumPyBook">"Guide to NumPy"</a>
-    (which generously entered Public Domain in August 2008). The reference
+    (which generously entered public domain in August 2008). The reference
     documentation for many of the functions are written by numerous
     contributors and developers of NumPy.
   </p>
   <p>
     The preferred way to update the documentation is by submitting a pull
-    request on Github (see the <a href="{{ pathto("docs/index") }}">Documentation Index</a>).
+    request on GitHub (see the <a href="{{ pathto("docs/index") }}">Documentation index</a>).
     Please help us to further improve the NumPy documentation!
   </p>
 {% endblock %}


### PR DESCRIPTION
Corrects links to all use sentence case, per style guide.
