### PR TITLE
BUG: Fix failures in master related to userdtype registeration

### DIFF
--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -251,12 +251,16 @@ PyArray_RegisterDataType(PyArray_Descr *descr)
         PyErr_SetString(PyExc_MemoryError, "RegisterDataType");
         return -1;
     }
+
     userdescrs[NPY_NUMUSERTYPES++] = descr;
 
+    descr->type_num = typenum;
     if (dtypemeta_wrap_legacy_descriptor(descr) < 0) {
+        descr->type_num = -1;
+        NPY_NUMUSERTYPES--;
         return -1;
     }
-    descr->type_num = typenum;
+
     return typenum;
 }
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1355,10 +1355,6 @@ class TestUserDType:
         # unnecessary restriction, but one that has been around forever:
         assert np.dtype(mytype) == np.dtype("O")
 
-        with pytest.raises(RuntimeError):
-            # Registering a second time should fail
-            create_custom_field_dtype(blueprint, mytype, 0)
-
     def test_custom_structured_dtype_errors(self):
         class mytype:
             pass


### PR DESCRIPTION
There are two failures that needed fixing here:

1. If a legacy user dtype has a `dype.type`  which does not subclass from `np.generic`, we do not use the type during dtype discovery in `np.array([...])`, so I must not set up such a mapping, but current master did set it up.

2. Because xpress was missing the error, it seemed safer to keep the typenumber as -1 if there is a failure during creating the DType. But I pushed setting the type number too far back, meaning that it ended up as -1 on the DType class.  That, together with other changes probably, caused master to fail.

This is the fix instead of the revert in gh-17499