### PR TITLE
BUG: remove `sys` from the type stubs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -487,7 +487,6 @@ split: Any
 stack: Any
 str0: Any
 string_: Any
-sys: Any
 take_along_axis: Any
 testing: Any
 tile: Any


### PR DESCRIPTION
It is the builtin `sys` module, which people should not be accessing
through the NumPy namespace.