### PR TITLE
DOC: Fix empty 'C style guide' page

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -13,7 +13,7 @@ Contributing to NumPy
    development_environment
    development_workflow
    ../benchmarking
-   style_guide
+   NumPy C style guide <https://numpy.org/neps/nep-0045-c_style_guide.html>
    releasing
    governance/index
    howto-docs
@@ -296,7 +296,7 @@ The rest of the story
    development_environment
    development_workflow
    ../benchmarking
-   style_guide
+   NumPy C style guide <https://numpy.org/neps/nep-0045-c_style_guide.html>
    releasing
    governance/index
    howto-docs

--- a/doc/source/dev/style_guide.rst
+++ b/doc/source/dev/style_guide.rst
@@ -1,7 +1,0 @@
-.. _style_guide:
-
-===================
-NumPy C style guide
-===================
-
-See :ref:`NEP45`.

--- a/doc/source/dev/style_guide.rst
+++ b/doc/source/dev/style_guide.rst
@@ -1,8 +1,7 @@
 .. _style_guide:
 
 ===================
-NumPy C Style Guide
+NumPy C style guide
 ===================
 
-.. include:: ../../C_STYLE_GUIDE.rst.txt
-   :start-line: 4
+See :ref:`NEP45`.


### PR DESCRIPTION
The page had been left empty when C_STYLE_GUIDE.rst.txt was migrated to NEP 45. 

Added link to NEP 45. Fixed uppercasing in title.
