### PR TITLE
DOC: Fewer blank lines in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,15 @@
-<!--
-
-                ----------------------------------------------------------------
+<!--         ----------------------------------------------------------------
                 MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                 ----------------------------------------------------------------
-
 
 *  FORMAT IT RIGHT:
       http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
 
-
 *  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
       http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion
 
-
 *  HIT ALL THE GUIDELINES:
       https://numpy.org/devdocs/dev/index.html#guidelines
-
 
 *  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
       http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed


### PR DESCRIPTION
Reduce the need to scroll, per @mattip suggestion in #17440

Dashes above and below heading look screwy in monospace but line up OK in the PR window.
