### PR TITLE
DOC: Create templates for ``ma`` documents

### DIFF
--- a/doc/source/_templates/autosummary/attribute.rst
+++ b/doc/source/_templates/autosummary/attribute.rst
@@ -2,9 +2,7 @@
 
 {{ fullname | escape | underline}}
 
-.. currentmodule:: {{ module }}
-
 attribute
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {% block prefix %}{{ module }}{% endblock %}.{{ objname }}
 

--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -4,11 +4,9 @@
 
 {{ fullname | escape | underline}}
 
-.. currentmodule:: {{ module }}
-
 {% if objtype == 'property' %}
 property
 {% endif %}
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {% block prefix %}{{ module }}{% endblock %}.{{ objname }}
 

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -5,6 +5,7 @@
    .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
       .. autosummary::
          :toctree:
+         {% block methodoption %}{% endblock %}
       {% for item in all_methods %}
          {%- if not item.startswith('_') or item in ['__call__'] %}
          {{ name }}.{{ item }}
@@ -18,6 +19,7 @@
    .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
       .. autosummary::
          :toctree:
+         {% block attributeoption %}{% endblock %}
       {% for item in all_attributes %}
          {%- if not item.startswith('_') %}
          {{ name }}.{{ item }}

--- a/doc/source/_templates/autosummary/ma/attribute.rst
+++ b/doc/source/_templates/autosummary/ma/attribute.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: numpy
+
+attribute
+
+.. auto{{ objtype }}:: numpy::ma.{{ objname }}
+

--- a/doc/source/_templates/autosummary/ma/attribute.rst
+++ b/doc/source/_templates/autosummary/ma/attribute.rst
@@ -1,10 +1,2 @@
-:orphan:
-
-{{ fullname | escape | underline}}
-
-.. currentmodule:: numpy
-
-attribute
-
-.. auto{{ objtype }}:: numpy::ma.{{ objname }}
-
+{% extends "autosummary/attribute.rst" %}
+{% block prefix %}numpy::ma{% endblock %}

--- a/doc/source/_templates/autosummary/ma/base.rst
+++ b/doc/source/_templates/autosummary/ma/base.rst
@@ -1,14 +1,2 @@
-{% if objtype == 'property' %}
-:orphan:
-{% endif %}
-
-{{ fullname | escape | underline}}
-
-.. currentmodule:: numpy
-
-{% if objtype == 'property' %}
-property
-{% endif %}
-
-.. auto{{ objtype }}:: numpy::ma.{{ objname }}
-
+{% extends "autosummary/base.rst" %}
+{% block prefix %}numpy::ma{% endblock %}

--- a/doc/source/_templates/autosummary/ma/base.rst
+++ b/doc/source/_templates/autosummary/ma/base.rst
@@ -1,0 +1,14 @@
+{% if objtype == 'property' %}
+:orphan:
+{% endif %}
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: numpy
+
+{% if objtype == 'property' %}
+property
+{% endif %}
+
+.. auto{{ objtype }}:: numpy::ma.{{ objname }}
+

--- a/doc/source/_templates/autosummary/ma/class.rst
+++ b/doc/source/_templates/autosummary/ma/class.rst
@@ -1,29 +1,3 @@
-{% extends "!autosummary/class.rst" %}
-
-{% block methods %}
-{% if methods %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-         :template: autosummary/ma/method.rst
-      {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__'] %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-{% endif %}
-{% endblock %}
-
-{% block attributes %}
-{% if attributes %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-         :template: autosummary/ma/attribute.rst
-      {% for item in all_attributes %}
-         {%- if not item.startswith('_') %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-{% endif %}
-{% endblock %}
+{% extends "autosummary/class.rst" %}
+{% block methodoption %}:template: autosummary/ma/method.rst{% endblock %}
+{% block attributeoption %}:template: autosummary/ma/attribute.rst{% endblock %}

--- a/doc/source/_templates/autosummary/ma/class.rst
+++ b/doc/source/_templates/autosummary/ma/class.rst
@@ -1,0 +1,29 @@
+{% extends "!autosummary/class.rst" %}
+
+{% block methods %}
+{% if methods %}
+   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
+      .. autosummary::
+         :toctree:
+         :template: autosummary/ma/method.rst
+      {% for item in all_methods %}
+         {%- if not item.startswith('_') or item in ['__call__'] %}
+         {{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes %}
+{% if attributes %}
+   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
+      .. autosummary::
+         :toctree:
+         :template: autosummary/ma/attribute.rst
+      {% for item in all_attributes %}
+         {%- if not item.startswith('_') %}
+         {{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/source/_templates/autosummary/ma/member.rst
+++ b/doc/source/_templates/autosummary/ma/member.rst
@@ -1,11 +1,2 @@
-:orphan:
-
-{{ fullname | escape | underline}}
-
-.. currentmodule:: numpy
-
-member
-
-.. auto{{ objtype }}:: numpy::ma.{{ objname }}
-
-
+{% extends "autosummary/member.rst" %}
+{% block prefix %}numpy::ma{% endblock %}

--- a/doc/source/_templates/autosummary/ma/member.rst
+++ b/doc/source/_templates/autosummary/ma/member.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: numpy
+
+member
+
+.. auto{{ objtype }}:: numpy::ma.{{ objname }}
+
+

--- a/doc/source/_templates/autosummary/ma/method.rst
+++ b/doc/source/_templates/autosummary/ma/method.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: numpy
+
+method
+
+.. auto{{ objtype }}:: numpy::ma.{{ objname }}
+

--- a/doc/source/_templates/autosummary/ma/method.rst
+++ b/doc/source/_templates/autosummary/ma/method.rst
@@ -1,10 +1,2 @@
-:orphan:
-
-{{ fullname | escape | underline}}
-
-.. currentmodule:: numpy
-
-method
-
-.. auto{{ objtype }}:: numpy::ma.{{ objname }}
-
+{% extends "autosummary/method.rst" %}
+{% block prefix %}numpy::ma{% endblock %}

--- a/doc/source/_templates/autosummary/ma/minimal_module.rst
+++ b/doc/source/_templates/autosummary/ma/minimal_module.rst
@@ -1,0 +1,8 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block docstring %}
+   {% endblock %}
+
+

--- a/doc/source/_templates/autosummary/ma/minimal_module.rst
+++ b/doc/source/_templates/autosummary/ma/minimal_module.rst
@@ -1,8 +1,1 @@
-{{ fullname | escape | underline}}
-
-.. automodule:: {{ fullname }}
-
-   {% block docstring %}
-   {% endblock %}
-
-
+{% extends "autosummary/minimal_module.rst" %}

--- a/doc/source/_templates/autosummary/member.rst
+++ b/doc/source/_templates/autosummary/member.rst
@@ -2,10 +2,7 @@
 
 {{ fullname | escape | underline}}
 
-.. currentmodule:: {{ module }}
-
 member
 
-.. auto{{ objtype }}:: {{ objname }}
-
+.. auto{{ objtype }}:: {% block prefix %}{{ module }}{% endblock %}.{{ objname }}
 

--- a/doc/source/_templates/autosummary/method.rst
+++ b/doc/source/_templates/autosummary/method.rst
@@ -2,9 +2,7 @@
 
 {{ fullname | escape | underline}}
 
-.. currentmodule:: {{ module }}
-
 method
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {% block prefix %}{{ module }}{% endblock %}.{{ objname }}
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -90,6 +90,7 @@ As :class:`MaskedArray` is a subclass of :class:`~numpy.ndarray`, a masked array
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/attribute.rst
 
    MaskedArray.base
    MaskedArray.ctypes
@@ -122,6 +123,7 @@ Conversion
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__float__
    MaskedArray.__int__
@@ -148,6 +150,7 @@ replaced with ``n`` integers which will be interpreted as an n-tuple.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.flatten
    MaskedArray.ravel
@@ -169,6 +172,7 @@ the operation should proceed.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.argmax
    MaskedArray.argmin
@@ -191,6 +195,7 @@ Pickling and copy
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.copy
    MaskedArray.dump
@@ -202,6 +207,7 @@ Calculations
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.all
    MaskedArray.anom
@@ -234,6 +240,7 @@ Comparison operators:
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__lt__
    MaskedArray.__le__
@@ -247,6 +254,7 @@ Truth value of an array (:func:`bool()`):
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__bool__
 
@@ -256,6 +264,7 @@ Arithmetic:
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__abs__
    MaskedArray.__add__
@@ -292,6 +301,7 @@ Arithmetic, in-place:
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__iadd__
    MaskedArray.__isub__
@@ -313,6 +323,7 @@ Representation
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__repr__
    MaskedArray.__str__
@@ -328,6 +339,7 @@ For standard library functions:
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__copy__
    MaskedArray.__deepcopy__
@@ -339,6 +351,7 @@ Basic customization:
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__new__
    MaskedArray.__array__
@@ -348,6 +361,7 @@ Container customization: (see :ref:`Indexing <arrays.indexing>`)
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__len__
    MaskedArray.__getitem__
@@ -368,6 +382,7 @@ manipulate the mask.
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.__setmask__
 
@@ -382,6 +397,7 @@ Handling the `fill_value`
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.get_fill_value
    MaskedArray.set_fill_value
@@ -393,5 +409,6 @@ Counting the missing elements
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    MaskedArray.count

--- a/doc/source/reference/routines.ma.rst
+++ b/doc/source/reference/routines.ma.rst
@@ -23,8 +23,12 @@ From existing data
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/class.rst
 
    ma.masked_array
+
+   :template: autosummary/ma/method.rst
+
    ma.array
    ma.copy
    ma.frombuffer
@@ -38,6 +42,7 @@ Ones and zeros
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.empty
    ma.empty_like
@@ -54,6 +59,7 @@ Inspecting the array
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.all
    ma.any
@@ -93,6 +99,7 @@ Changing the shape
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.ravel
    ma.reshape
@@ -108,6 +115,7 @@ Modifying axes
 ~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.swapaxes
    ma.transpose
@@ -120,6 +128,7 @@ Changing the number of dimensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.atleast_1d
    ma.atleast_2d
@@ -144,6 +153,7 @@ Joining arrays
 ~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.concatenate
    ma.stack
@@ -163,6 +173,7 @@ Creating a mask
 ~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.make_mask
    ma.make_mask_none
@@ -174,6 +185,7 @@ Accessing a mask
 ~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.getmask
    ma.getmaskarray
@@ -184,6 +196,7 @@ Finding masked data
 ~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.flatnotmasked_contiguous
    ma.flatnotmasked_edges
@@ -197,6 +210,7 @@ Modifying a mask
 ~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.mask_cols
    ma.mask_or
@@ -220,6 +234,7 @@ Conversion operations
 ~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.asarray
    ma.asanyarray
@@ -242,6 +257,7 @@ Conversion operations
 ~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.compress_cols
    ma.compress_rowcols
@@ -257,6 +273,7 @@ Conversion operations
 ~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.MaskedArray.tofile
    ma.MaskedArray.tolist
@@ -268,6 +285,7 @@ Filling a masked array
 ~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.common_fill_value
    ma.default_fill_value
@@ -291,6 +309,7 @@ Arithmetics
 ~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.anom
    ma.anomalies
@@ -322,6 +341,7 @@ Minimum/maximum
 ~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.argmax
    ma.argmin
@@ -340,6 +360,7 @@ Sorting
 ~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.argsort
    ma.sort
@@ -351,6 +372,7 @@ Algebra
 ~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.diag
    ma.dot
@@ -370,6 +392,7 @@ Polynomial fit
 ~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.vander
    ma.polyfit
@@ -379,6 +402,7 @@ Clipping and rounding
 ~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.around
    ma.clip
@@ -392,6 +416,7 @@ Miscellanea
 ~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/ma/method.rst
 
    ma.allequal
    ma.allclose


### PR DESCRIPTION
Related to #13114. See https://github.com/numpy/numpy/pull/16736#issuecomment-704512009. `.. currentmodule` didn't work, so I used `.. auto*:: numpy::ma.*` instead. After this change, methods in `numpy`(e.g. `lexsort`) can be found, but methods in `numpy.ma`(e.g. `MaskedArray.*`) cannot be found.