### PR TITLE
ENH: Support for the NVIDIA HPC SDK nvfortran compiler

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -745,7 +745,7 @@ _default_compilers = (
     ('win32', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95',
                'intelvem', 'intelem', 'flang')),
     ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
-    ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
+    ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
                  'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
     ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
     ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),

--- a/numpy/distutils/fcompiler/nv.py
+++ b/numpy/distutils/fcompiler/nv.py
@@ -1,15 +1,18 @@
-# https://developer.nvidia.com/hpc-sdk
 import sys
 
 from numpy.distutils.fcompiler import FCompiler
 
 compilers = ['NVHPCFCompiler']
 
-"""
-Since august 2020 the NVIDIA HPC SDK includes the compilers formely known as The Portland Group compilers.
-https://www.pgroup.com/index.htm
-"""
 class NVHPCFCompiler(FCompiler):
+   """ NVIDIA High Performance Computing (HPC) SDK Fortran Compiler
+   
+   https://developer.nvidia.com/hpc-sdk
+   
+   Since august 2020 the NVIDIA HPC SDK includes the compilers formerly known as The Portland Group compilers,
+   https://www.pgroup.com/index.htm.
+   See also `numpy.distutils.fcompiler.pg`.
+   """
 
     compiler_type = 'nv'
     description = 'NVIDIA HPC SDK'

--- a/numpy/distutils/fcompiler/nv.py
+++ b/numpy/distutils/fcompiler/nv.py
@@ -1,0 +1,48 @@
+# https://developer.nvidia.com/hpc-sdk
+import sys
+
+from numpy.distutils.fcompiler import FCompiler
+
+compilers = ['NVHPCFCompiler']
+
+class NVHPCFCompiler(FCompiler):
+
+    compiler_type = 'nv'
+    description = 'NVIDIA HPC SDK'
+    version_pattern = r'\s*(nvfortran|(pg(f77|f90|fortran)) \(aka nvfortran\)) (?P<version>[\d.-]+).*'
+
+    executables = {
+        'version_cmd': ["<F90>", "-V"],
+        'compiler_f77': ["nvfortran"],
+        'compiler_fix': ["nvfortran", "-Mfixed"],
+        'compiler_f90': ["nvfortran"],
+        'linker_so': ["<F90>"],
+        'archiver': ["ar", "-cr"],
+        'ranlib': ["ranlib"]
+    }
+    pic_flags = ['-fpic']
+
+    module_dir_switch = '-module '
+    module_include_switch = '-I'
+
+    def get_flags(self):
+        opt = ['-Minform=inform', '-Mnosecond_underscore']
+        return self.pic_flags + opt
+
+    def get_flags_opt(self):
+        return ['-fast']
+
+    def get_flags_debug(self):
+        return ['-g']
+
+    def get_flags_linker_so(self):
+        return ["-shared", '-fpic']
+
+    def runtime_library_dir_option(self, dir):
+        return '-R%s' % dir
+
+if __name__ == '__main__':
+    from distutils import log
+    log.set_verbosity(2)
+    from numpy.distutils import customized_fcompiler
+    print(customized_fcompiler(compiler='nv').get_version())

--- a/numpy/distutils/fcompiler/nv.py
+++ b/numpy/distutils/fcompiler/nv.py
@@ -5,6 +5,10 @@ from numpy.distutils.fcompiler import FCompiler
 
 compilers = ['NVHPCFCompiler']
 
+"""
+Since august 2020 the NVIDIA HPC SDK includes the compilers formely known as The Portland Group compilers.
+https://www.pgroup.com/index.htm
+"""
 class NVHPCFCompiler(FCompiler):
 
     compiler_type = 'nv'

--- a/numpy/distutils/fcompiler/nv.py
+++ b/numpy/distutils/fcompiler/nv.py
@@ -5,14 +5,14 @@ from numpy.distutils.fcompiler import FCompiler
 compilers = ['NVHPCFCompiler']
 
 class NVHPCFCompiler(FCompiler):
-   """ NVIDIA High Performance Computing (HPC) SDK Fortran Compiler
+    """ NVIDIA High Performance Computing (HPC) SDK Fortran Compiler
    
-   https://developer.nvidia.com/hpc-sdk
+    https://developer.nvidia.com/hpc-sdk
    
-   Since august 2020 the NVIDIA HPC SDK includes the compilers formerly known as The Portland Group compilers,
-   https://www.pgroup.com/index.htm.
-   See also `numpy.distutils.fcompiler.pg`.
-   """
+    Since august 2020 the NVIDIA HPC SDK includes the compilers formerly known as The Portland Group compilers,
+    https://www.pgroup.com/index.htm.
+    See also `numpy.distutils.fcompiler.pg`.
+    """
 
     compiler_type = 'nv'
     description = 'NVIDIA HPC SDK'

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -246,6 +246,7 @@ PRIVATE_BUT_PRESENT_MODULES = ['numpy.' + s for s in [
     "distutils.fcompiler.none",
     "distutils.fcompiler.pathf95",
     "distutils.fcompiler.pg",
+    "distutils.fcompiler.nv",
     "distutils.fcompiler.sun",
     "distutils.fcompiler.vast",
     "distutils.from_template",


### PR DESCRIPTION
Backport of #17344. 

Add support for the nvfortran compiler, a version of pgfortran.

Closes #17341.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
