### PR TITLE
CI: Make merge ref grabbing conditional on the PR being active

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - checkout:
-      - run: [[ ! -z $CI_PULL_REQUEST ]] git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+      - run: [[ ! -z $CI_PULL_REQUEST ]] && git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       - run:
           name: create virtual environment, install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - checkout:
-      - run: git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+      - run: [[ ! -z $CI_PULL_REQUEST ]] git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       - run:
           name: create virtual environment, install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
 
     steps:
       - checkout:
-      - run: [[ ! -z $CI_PULL_REQUEST ]] && git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+      - run:
+          name: pull changes from merge
+          command: |
+            [[ ! -z $CI_PULL_REQUEST ]] && git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       - run:
           name: create virtual environment, install dependencies


### PR DESCRIPTION
An attempt to fix #17524 . Only attempt to pull from `refs/pull/XXXXX/merge` while the PR is still active. This fix is based on the hypothesis that `CI_PULL_REQUEST` is not set after a PR has been merged.

@mattip does this seem like it's on the right track?