### PR TITLE
MAINT: Cleanup compatibility code for pathlib

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -18,7 +18,7 @@ __all__ = ['bytes', 'asbytes', 'isfileobj', 'getexception', 'strchar',
 
 import sys
 import os
-from pathlib import Path, PurePath
+from pathlib import Path
 import io
 
 import abc
@@ -78,11 +78,11 @@ def asunicode_nested(x):
 
 def is_pathlib_path(obj):
     """
-    Check whether obj is a pathlib.Path object.
+    Check whether obj is a `pathlib.Path` object.
 
-    Prefer using `isinstance(obj, os_PathLike)` instead of this function.
+    Prefer using ``isinstance(obj, os.PathLike)`` instead of this function.
     """
-    return Path is not None and isinstance(obj, Path)
+    return isinstance(obj, Path)
 
 # from Python 3.7
 class contextlib_nullcontext:
@@ -132,6 +132,5 @@ def npy_load_module(name, fn, info=None):
     return SourceFileLoader(name, fn).load_module()
 
 
-# Backport os.fs_path, os.PathLike, and PurePath.__fspath__
 os_fspath = os.fspath
 os_PathLike = os.PathLike


### PR DESCRIPTION
`Path` can now never be none, and `PurePath` is not used and not in `__all__`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
