### PR TITLE
ENH: add function to get broadcast shape from a given set of shapes.

### DIFF
--- a/doc/release/upcoming_changes/17535.new_function.rst
+++ b/doc/release/upcoming_changes/17535.new_function.rst
@@ -1,0 +1,15 @@
+`numpy.broadcast_shape` is a new user-facing function
+-----------------------------------------------------
+`broadcast_shape` gets the resulting shape from 
+broadcasting the given shape tuples against each other.
+
+.. code:: python
+
+    >>> np.broadcast_shape((1, 2), (3, 1))
+    (3, 2)
+
+    >>> np.broadcast_shape(2, (3, 1))
+    (3, 2)
+
+    >>> np.broadcast_shape((6, 7), (5, 6, 1), (7,), (5, 1, 7))
+    (5, 6, 7)

--- a/doc/release/upcoming_changes/17535.new_function.rst
+++ b/doc/release/upcoming_changes/17535.new_function.rst
@@ -1,15 +1,15 @@
-`numpy.broadcast_shape` is a new user-facing function
------------------------------------------------------
-`broadcast_shape` gets the resulting shape from 
+`numpy.broadcast_shapes` is a new user-facing function
+------------------------------------------------------
+`broadcast_shapes` gets the resulting shape from
 broadcasting the given shape tuples against each other.
 
 .. code:: python
 
-    >>> np.broadcast_shape((1, 2), (3, 1))
+    >>> np.broadcast_shapes((1, 2), (3, 1))
     (3, 2)
 
-    >>> np.broadcast_shape(2, (3, 1))
+    >>> np.broadcast_shapes(2, (3, 1))
     (3, 2)
 
-    >>> np.broadcast_shape((6, 7), (5, 6, 1), (7,), (5, 1, 7))
+    >>> np.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7))
     (5, 6, 7)

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -47,6 +47,7 @@ Utility
    show_config
    deprecate
    deprecate_with_doc
+   broadcast_shapes
 
 Matlab-like Functions
 ---------------------

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1590,6 +1590,8 @@ def empty(
     like: ArrayLike = ...,
 ) -> ndarray: ...
 
+def broadcast_shapes(*args: _ShapeLike) -> _Shape: ...
+
 #
 # Constants
 #

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -605,6 +605,7 @@ add_newdoc('numpy.core', 'broadcast',
     --------
     broadcast_arrays
     broadcast_to
+    broadcast_shapes
 
     Examples
     --------

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -6,7 +6,7 @@ NumPy reference guide.
 
 """
 import numpy as np
-from numpy.core.overrides import array_function_dispatch
+from numpy.core.overrides import array_function_dispatch, set_module
 
 __all__ = ['broadcast_to', 'broadcast_arrays', 'broadcast_shape']
 
@@ -197,6 +197,7 @@ def _broadcast_shape(*args):
     return b.shape
 
 
+@set_module('numpy')
 def broadcast_shape(*args):
     """
     Get Broadcast shape from a list of shape tuples.

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -8,7 +8,7 @@ NumPy reference guide.
 import numpy as np
 from numpy.core.overrides import array_function_dispatch
 
-__all__ = ['broadcast_to', 'broadcast_arrays']
+__all__ = ['broadcast_to', 'broadcast_arrays', 'broadcast_shape']
 
 
 class DummyArray:
@@ -195,6 +195,37 @@ def _broadcast_shape(*args):
         b = broadcast_to(0, b.shape)
         b = np.broadcast(b, *args[pos:(pos + 31)])
     return b.shape
+
+
+def _broadcast_shape_dispatcher(*args):
+    return args
+
+
+@array_function_dispatch(_broadcast_shape_dispatcher, module='numpy')
+def broadcast_shape(*args):
+    """
+    Get Broadcast shape from a list of shape tuples.
+
+    Parameters
+    ----------
+    `*args` : tuples
+        The shapes to be broadcast against each other.
+
+    Returns
+    -------
+    tuple
+        Broadcasted shape.
+
+    Examples
+    --------
+    >>> np.broadcast_shape((1, 2), (3, 1), (3,2))
+    (3, 2)
+
+    >>> np.broadcast_shape((6, 7), (5, 6, 1), (7,), (5, 1, 7))
+    (5, 6, 7)
+    """
+    arrays = list(map(lambda x: np.empty(x), args))
+    return _broadcast_shape(*arrays)
 
 
 def _broadcast_arrays_dispatcher(*args, subok=None):

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -224,7 +224,7 @@ def broadcast_shape(*args):
     >>> np.broadcast_shape((6, 7), (5, 6, 1), (7,), (5, 1, 7))
     (5, 6, 7)
     """
-    arrays = list(map(lambda x: np.empty(x), args))
+    arrays = [np.empty(x, dtype=[]) for x in args]
     return _broadcast_shape(*arrays)
 
 

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -202,6 +202,10 @@ def broadcast_shapes(*args):
     """
     Broadcast the input shapes into a single shape.
 
+    :ref:`Learn more about broadcasting here <basics.broadcasting>`.
+
+    .. versionadded:: 1.20.0
+
     Parameters
     ----------
     `*args` : tuples of ints, or ints
@@ -217,10 +221,6 @@ def broadcast_shapes(*args):
     ValueError
         If the shapes are not compatible and cannot be broadcast according
         to NumPy's broadcasting rules.
-
-    Notes
-    -----
-    .. versionadded:: 1.20.0
 
     Examples
     --------

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -197,11 +197,6 @@ def _broadcast_shape(*args):
     return b.shape
 
 
-def _broadcast_shape_dispatcher(*args):
-    return args
-
-
-@array_function_dispatch(_broadcast_shape_dispatcher, module='numpy')
 def broadcast_shape(*args):
     """
     Get Broadcast shape from a list of shape tuples.

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -224,7 +224,7 @@ def broadcast_shapes(*args):
 
     Examples
     --------
-    >>> np.broadcast_shapes((1, 2), (3, 1), (3,2))
+    >>> np.broadcast_shapes((1, 2), (3, 1), (3, 2))
     (3, 2)
 
     >>> np.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7))

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -8,7 +8,7 @@ NumPy reference guide.
 import numpy as np
 from numpy.core.overrides import array_function_dispatch, set_module
 
-__all__ = ['broadcast_to', 'broadcast_arrays', 'broadcast_shape']
+__all__ = ['broadcast_to', 'broadcast_arrays', 'broadcast_shapes']
 
 
 class DummyArray:
@@ -198,7 +198,7 @@ def _broadcast_shape(*args):
 
 
 @set_module('numpy')
-def broadcast_shape(*args):
+def broadcast_shapes(*args):
     """
     Get Broadcast shape from the given shape tuples.
 
@@ -224,10 +224,10 @@ def broadcast_shape(*args):
 
     Examples
     --------
-    >>> np.broadcast_shape((1, 2), (3, 1), (3,2))
+    >>> np.broadcast_shapes((1, 2), (3, 1), (3,2))
     (3, 2)
 
-    >>> np.broadcast_shape((6, 7), (5, 6, 1), (7,), (5, 1, 7))
+    >>> np.broadcast_shapes((6, 7), (5, 6, 1), (7,), (5, 1, 7))
     (5, 6, 7)
     """
     arrays = [np.empty(x, dtype=[]) for x in args]

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -200,7 +200,7 @@ def _broadcast_shape(*args):
 @set_module('numpy')
 def broadcast_shape(*args):
     """
-    Get Broadcast shape from a list of shape tuples.
+    Get Broadcast shape from the given shape tuples.
 
     Parameters
     ----------
@@ -211,6 +211,16 @@ def broadcast_shape(*args):
     -------
     tuple
         Broadcasted shape.
+
+    Raises
+    ------
+    ValueError
+        If the shapes are not compatible and cannot be broadcast according
+        to NumPy's broadcasting rules.
+
+    Notes
+    -----
+    .. versionadded:: 1.20.0
 
     Examples
     --------

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -200,7 +200,7 @@ def _broadcast_shape(*args):
 @set_module('numpy')
 def broadcast_shapes(*args):
     """
-    Get Broadcast shape from the given shape tuples.
+    Broadcast the input shapes into a single shape.
 
     Parameters
     ----------

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -165,6 +165,12 @@ def broadcast_to(array, shape, subok=False):
         If the array is not compatible with the new shape according to NumPy's
         broadcasting rules.
 
+    See Also
+    --------
+    broadcast
+    broadcast_arrays
+    broadcast_shapes
+
     Notes
     -----
     .. versionadded:: 1.10.0
@@ -222,6 +228,12 @@ def broadcast_shapes(*args):
         If the shapes are not compatible and cannot be broadcast according
         to NumPy's broadcasting rules.
 
+    See Also
+    --------
+    broadcast
+    broadcast_arrays
+    broadcast_to
+
     Examples
     --------
     >>> np.broadcast_shapes((1, 2), (3, 1), (3, 2))
@@ -266,6 +278,12 @@ def broadcast_arrays(*args, subok=False):
             The output is currently marked so that if written to, a deprecation
             warning will be emitted. A future version will set the
             ``writable`` flag False so writing to it will raise an error.
+
+    See Also
+    --------
+    broadcast
+    broadcast_to
+    broadcast_shapes
 
     Examples
     --------

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -208,7 +208,7 @@ def broadcast_shape(*args):
 
     Parameters
     ----------
-    `*args` : tuples
+    `*args` : tuples of ints, or ints
         The shapes to be broadcast against each other.
 
     Returns

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -6,7 +6,7 @@ from numpy.testing import (
     )
 from numpy.lib.stride_tricks import (
     as_strided, broadcast_arrays, _broadcast_shape, broadcast_to,
-    broadcast_shape,
+    broadcast_shapes,
     )
 
 def assert_shapes_correct(input_shapes, expected_shape):
@@ -277,7 +277,7 @@ def test_broadcast_to_raises():
 def test_broadcast_shape():
     # tests internal _broadcast_shape
     # _broadcast_shape is already exercized indirectly by broadcast_arrays
-    # _broadcast_shape is also exercized by the public broadcast_shape function
+    # _broadcast_shape is also exercized by the public broadcast_shapes function
     assert_equal(_broadcast_shape(), ())
     assert_equal(_broadcast_shape([1, 2]), (2,))
     assert_equal(_broadcast_shape(np.ones((1, 1))), (1, 1))
@@ -291,9 +291,10 @@ def test_broadcast_shape():
     assert_raises(ValueError, lambda: _broadcast_shape(*bad_args))
 
 
-def test_broadcast_shape_succeeds():
-    # tests public broadcast_shape
+def test_broadcast_shapes_succeeds():
+    # tests public broadcast_shapes
     data = [
+        [[], ()],
         [[()], ()],
         [[(7,)], (7,)],
         [[(1, 2), (2,)], (1, 2)],
@@ -322,17 +323,17 @@ def test_broadcast_shape_succeeds():
         [[2, (3, 2)], (3, 2)],
     ]
     for input_shapes, target_shape in data:
-        assert_equal(broadcast_shape(*input_shapes), target_shape)
+        assert_equal(broadcast_shapes(*input_shapes), target_shape)
 
-    assert_equal(broadcast_shape(*([(1, 2)] * 32)), (1, 2))
-    assert_equal(broadcast_shape(*([(1, 2)] * 100)), (1, 2))
+    assert_equal(broadcast_shapes(*([(1, 2)] * 32)), (1, 2))
+    assert_equal(broadcast_shapes(*([(1, 2)] * 100)), (1, 2))
 
     # regression tests for gh-5862
-    assert_equal(broadcast_shape(*([(2,)] * 32)), (2,))
+    assert_equal(broadcast_shapes(*([(2,)] * 32)), (2,))
 
 
-def test_broadcast_shape_raises():
-    # tests public broadcast_shape
+def test_broadcast_shapes_raises():
+    # tests public broadcast_shapes
     data = [
         [(3,), (4,)],
         [(2, 3), (2,)],
@@ -342,10 +343,10 @@ def test_broadcast_shape_raises():
         [2, (2, 3)],
     ]
     for input_shapes in data:
-        assert_raises(ValueError, lambda: broadcast_shape(*input_shapes))
+        assert_raises(ValueError, lambda: broadcast_shapes(*input_shapes))
 
     bad_args = [(2,)] * 32 + [(3,)] * 32
-    assert_raises(ValueError, lambda: broadcast_shape(*bad_args))
+    assert_raises(ValueError, lambda: broadcast_shapes(*bad_args))
 
 
 def test_as_strided():

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -6,7 +6,7 @@ from numpy.testing import (
     )
 from numpy.lib.stride_tricks import (
     as_strided, broadcast_arrays, _broadcast_shape, broadcast_to,
-    broadcast_shape
+    broadcast_shape,
     )
 
 def assert_shapes_correct(input_shapes, expected_shape):

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -319,6 +319,7 @@ def test_broadcast_shape_succeeds():
         [[(), (1, 0)], (1, 0)],
         [[(), (0, 1)], (0, 1)],
         [[(1,), (3,)], (3,)],
+        [[2, (3, 2)], (3, 2)],
     ]
     for input_shapes, target_shape in data:
         assert_equal(broadcast_shape(*input_shapes), target_shape)
@@ -338,6 +339,7 @@ def test_broadcast_shape_raises():
         [(3,), (3,), (4,)],
         [(1, 3, 4), (2, 3, 3)],
         [(1, 2), (3,1), (3,2), (10, 5)],
+        [2, (2, 3)],
     ]
     for input_shapes in data:
         assert_raises(ValueError, lambda: broadcast_shape(*input_shapes))

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -276,8 +276,8 @@ def test_broadcast_to_raises():
 
 def test_broadcast_shape():
     # tests internal _broadcast_shape
-    # _broadcast_shape is already exercized indirectly by broadcast_arrays
-    # _broadcast_shape is also exercized by the public broadcast_shapes function
+    # _broadcast_shape is already exercised indirectly by broadcast_arrays
+    # _broadcast_shape is also exercised by the public broadcast_shapes function
     assert_equal(_broadcast_shape(), ())
     assert_equal(_broadcast_shape([1, 2]), (2,))
     assert_equal(_broadcast_shape(np.ones((1, 1))), (1, 1))


### PR DESCRIPTION
Add new function numpy.broadcast_shape which takes tuples
for the shapes to be broadcast against each other.
Return the broadcasted shape as a tuple.
See #17217