### PR TITLE
BUG: Fixed crash on self-referential dtypes

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -241,6 +241,10 @@ is_datetime_typestr(char const *type, Py_ssize_t len)
 static PyArray_Descr *
 _convert_from_tuple(PyObject *obj, int align)
 {
+    if (Py_EnterRecursiveCall(
+            " while trying to create self-referential dtypes" ) != 0) {
+        return NULL;
+    }
     if (PyTuple_GET_SIZE(obj) != 2) {
         PyErr_Format(PyExc_TypeError, 
 	        "Tuple must have size 2, but has size %zd",
@@ -417,6 +421,10 @@ _convert_from_tuple(PyObject *obj, int align)
 static PyArray_Descr *
 _convert_from_array_descr(PyObject *obj, int align)
 {
+    if (Py_EnterRecursiveCall(
+            " while trying to create self-referential dtypes" ) != 0) {
+        return NULL;
+    }
     int n = PyList_GET_SIZE(obj);
     PyObject *nameslist = PyTuple_New(n);
     if (!nameslist) {
@@ -613,6 +621,10 @@ _convert_from_array_descr(PyObject *obj, int align)
 static PyArray_Descr *
 _convert_from_list(PyObject *obj, int align)
 {
+    if (Py_EnterRecursiveCall(
+            " while trying to create self-referential dtypes" ) != 0) {
+        return NULL;
+    }
     int n = PyList_GET_SIZE(obj);
     /*
      * Ignore any empty string at end which _internal._commastring
@@ -723,6 +735,10 @@ _convert_from_list(PyObject *obj, int align)
 static PyArray_Descr *
 _convert_from_commastring(PyObject *obj, int align)
 {
+    if (Py_EnterRecursiveCall(
+            " while trying to create self-referential dtypes" ) != 0) {
+        return NULL;
+    }
     PyObject *listobj;
     PyArray_Descr *res;
     PyObject *_numpy_internal;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1495,37 +1495,33 @@ _convert_from_any(PyObject *obj, int align)
     }
     else if (PyUnicode_Check(obj)) {
         if (Py_EnterRecursiveCall(
-            " while trying to create self-referential str dtypes" ) != 0) {
-            goto convert_done;
+            " while trying to create self-referential str dtypes" ) == 0) {
+            convert_ret = _convert_from_str(obj, align);
         }
-        convert_ret = _convert_from_str(obj, align);
         goto convert_done;
     }
     else if (PyTuple_Check(obj)) {
         /* or a tuple */
         if (Py_EnterRecursiveCall(
-            " while trying to create self-referential tuple dtypes" ) != 0) {
-            goto convert_done;
+            " while trying to create self-referential tuple dtypes" ) == 0) {
+            convert_ret = _convert_from_tuple(obj, align);
         }
-        convert_ret = _convert_from_tuple(obj, align);
         goto convert_done;
     }
     else if (PyList_Check(obj)) {
         /* or a list */
         if (Py_EnterRecursiveCall(
-            " while trying to create self-referential list dtypes" ) != 0) {
-            goto convert_done;
+            " while trying to create self-referential list dtypes" ) == 0) {
+            convert_ret = _convert_from_array_descr(obj, align);
         }
-        convert_ret = _convert_from_array_descr(obj, align);
         goto convert_done;
     }
     else if (PyDict_Check(obj) || PyDictProxy_Check(obj)) {
         /* or a dictionary */
         if (Py_EnterRecursiveCall(
-            " while trying to create self-referential dict dtypes" ) != 0) {
-            goto convert_done;
+            " while trying to create self-referential dict dtypes" ) == 0) {
+            convert_ret = _convert_from_dict(obj, align);
         }
-        convert_ret = _convert_from_dict(obj, align);
         goto convert_done;
     }
     else if (PyArray_Check(obj)) {
@@ -1533,10 +1529,6 @@ _convert_from_any(PyObject *obj, int align)
         return NULL;
     }
     else {
-        if (Py_EnterRecursiveCall(
-            " while trying to create self-referential dtypes" ) != 0) {
-            goto convert_done;
-        }
         convert_ret = _try_convert_from_dtype_attr(obj);
         if ((PyObject *)convert_ret != Py_NotImplemented) {
             return convert_ret;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1488,14 +1488,20 @@ _convert_from_any(PyObject *obj, int align)
             }
             return NULL;
         }
+        if (Py_EnterRecursiveCall(
+                " while trying to convert the given data type from"
+                " a str object" ) != 0) {
+            return NULL;
+        }
         PyArray_Descr *ret = _convert_from_str(obj2, align);
         Py_DECREF(obj2);
+        Py_LeaveRecursiveCall();
         return ret;
     }
     else if (PyUnicode_Check(obj)) {
         if (Py_EnterRecursiveCall(
-             " while trying to convert the given data type from "
-             "str object" ) != 0) {
+                " while trying to convert the given data type from"
+                " a str object" ) != 0) {
             return NULL;
         }
         PyArray_Descr *ret = _convert_from_str(obj, align);
@@ -1505,8 +1511,8 @@ _convert_from_any(PyObject *obj, int align)
     else if (PyTuple_Check(obj)) {
         /* or a tuple */
         if (Py_EnterRecursiveCall(
-             " while trying to convert the given data type from "
-             "tuple object" ) != 0) {
+                " while trying to convert the given data type from"
+                " a tuple object" ) != 0) {
             return NULL;
         }
         PyArray_Descr *ret = _convert_from_tuple(obj, align);
@@ -1516,8 +1522,8 @@ _convert_from_any(PyObject *obj, int align)
     else if (PyList_Check(obj)) {
         /* or a list */
         if (Py_EnterRecursiveCall(
-             " while trying to convert the given data type from "
-             "list object" ) != 0) {
+                " while trying to convert the given data type from"
+                " a list object" ) != 0) {
             return NULL;
         }
         PyArray_Descr *ret = _convert_from_array_descr(obj, align);
@@ -1527,8 +1533,8 @@ _convert_from_any(PyObject *obj, int align)
     else if (PyDict_Check(obj) || PyDictProxy_Check(obj)) {
         /* or a dictionary */
         if (Py_EnterRecursiveCall(
-             " while trying to convert the given data type from "
-             "dict object" ) != 0) {
+                " while trying to convert the given data type from"
+                " a dict object" ) != 0) {
             return NULL;
         }
         PyArray_Descr *ret = _convert_from_dict(obj, align);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1488,25 +1488,12 @@ _convert_from_any(PyObject *obj, int align)
             }
             return NULL;
         }
-        if (Py_EnterRecursiveCall(
-                " while trying to convert the given data type from"
-                " a str object" ) != 0) {
-            return NULL;
-        }
         PyArray_Descr *ret = _convert_from_str(obj2, align);
         Py_DECREF(obj2);
-        Py_LeaveRecursiveCall();
         return ret;
     }
     else if (PyUnicode_Check(obj)) {
-        if (Py_EnterRecursiveCall(
-                " while trying to convert the given data type from"
-                " a str object" ) != 0) {
-            return NULL;
-        }
-        PyArray_Descr *ret = _convert_from_str(obj, align);
-        Py_LeaveRecursiveCall();
-        return ret;
+        return _convert_from_str(obj, align);
     }
     else if (PyTuple_Check(obj)) {
         /* or a tuple */

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -767,11 +767,18 @@ class TestMonsterType:
             ('yi', np.dtype((a, (3, 2))))])
         assert_dtype_equal(c, d)
 
-    def test_array_recursion(self):
+    def test_list_recursion(self):
         l = list()
         l.append(('f', l))
         with pytest.raises(RecursionError):
             np.dtype(l)
+
+    def test_tuple_recursion(self):
+        d = np.int32
+        for i in range(100000):
+            d = (d, (1,))
+        with pytest.raises(RecursionError):
+            np.dtype(d)
 
     def test_dict_recursion(self):
         d = dict(names=['self'], formats=[None], offsets=[0])

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -773,6 +773,12 @@ class TestMonsterType:
         with pytest.raises(RecursionError):
             np.dtype(l)
 
+    def test_dict_recursion(self):
+        d = dict(names=['self'], formats=[None], offsets=[0])
+        d['formats'][0] = d
+        with pytest.raises(RecursionError):
+            np.dtype(d)
+
 
 class TestMetadata:
     def test_no_metadata(self):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -767,6 +767,13 @@ class TestMonsterType:
             ('yi', np.dtype((a, (3, 2))))])
         assert_dtype_equal(c, d)
 
+    def test_array_recursion(self):
+        l = list()
+        l.append(('f', l))
+        with pytest.raises(RecursionError):
+            np.dtype(l)
+
+
 class TestMetadata:
     def test_no_metadata(self):
         d = np.dtype(int)


### PR DESCRIPTION
## Changes:
Fixed crash on self-referential dtypes

resolves #15301

### Note:
Hey, still new here, some things I had doubts on:
1. Want to add a bit of UT, where do I do that?
2. Willing to change the error string if required.
3. I return NULL, hopefully we free all the objects, else please let me know if any cleanup required.

### After Fix:
```
>>> l = []                                                                                                                                                                      
>>> l.append(('a', l))                                                                  
>>> np.dtype(l)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RecursionError: maximum recursion depth exceeded while trying to create self-referential dtypes
```

cc: @eric-wieser 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->