### PR TITLE
CI: fix conditional for PR merge command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: pull changes from merge
           command: |
-            [[ ! -z $CI_PULL_REQUEST ]] && git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+            if [[ -v CI_PULL_REQUEST ]] ; then git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge" ; fi
 
       - run:
           name: create virtual environment, install dependencies


### PR DESCRIPTION
Correct bash syntax for checking whether a PR is active in circleCI. Fixes #17524 .