### PR TITLE
ENH: Import setuptools with a try/except

### DIFF
--- a/numpy/distutils/command/install.py
+++ b/numpy/distutils/command/install.py
@@ -1,8 +1,8 @@
 import sys
-if 'setuptools' in sys.modules:
+try:
     import setuptools.command.install as old_install_mod
     have_setuptools = True
-else:
+except ImportError:
     import distutils.command.install as old_install_mod
     have_setuptools = False
 from distutils.file_util import write_file


### PR DESCRIPTION
Checking if setuptools is in sys.modules doesn't actually mean we can't import it. It might not be in sys.modules because no other module loaded it yet.

Therefore use a simple `EAFP` principle, attempt the import and allow a fallback.

It's probably worth noting that most of the other modules in the `numpy.distutils` package don't seem to have these kinds of checks and that it's assumed setuptools is in fact present.

So I'll propose this PR while adding the question as to whether it's a better idea to remove the try/except and simply import setuptools with no catch.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
