### PR TITLE
MAINT: explicit disabling `CCompilerOpt` in F2PY

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -406,52 +406,49 @@ class build_ext (old_build_ext):
 
         include_dirs = ext.include_dirs + get_numpy_include_dirs()
 
-        dispatch_objects = []
+        # filtering C dispatch-table sources when optimization is not disabled,
+        # otherwise treated as normal sources.
+        copt_c_sources = []
+        copt_baseline_flags = []
+        copt_macros = []
         if not self.disable_optimization:
-            dispatch_sources  = [
+            copt_build_src = None if self.inplace else self.get_finalized_command("build_src").build_src
+            copt_c_sources = [
                 c_sources.pop(c_sources.index(src))
                 for src in c_sources[:] if src.endswith(".dispatch.c")
             ]
-            if dispatch_sources:
-                if not self.inplace:
-                    build_src = self.get_finalized_command("build_src").build_src
-                else:
-                    build_src = None
-                dispatch_objects = self.compiler_opt.try_dispatch(
-                    dispatch_sources,
-                    output_dir=output_dir,
-                    src_dir=build_src,
-                    macros=macros,
-                    include_dirs=include_dirs,
-                    debug=self.debug,
-                    extra_postargs=extra_args,
-                    **kws
-                )
-            extra_args_baseopt = extra_args + self.compiler_opt.cpu_baseline_flags()
+            copt_baseline_flags = self.compiler_opt.cpu_baseline_flags()
         else:
-            extra_args_baseopt = extra_args
-            macros.append(("NPY_DISABLE_OPTIMIZATION", 1))
+            copt_macros.append(("NPY_DISABLE_OPTIMIZATION", 1))
 
         c_objects = []
+        if copt_c_sources:
+            log.info("compiling C dispatch-able sources")
+            c_objects += self.compiler_opt.try_dispatch(copt_c_sources,
+                                                        output_dir=output_dir,
+                                                        src_dir=copt_build_src,
+                                                        macros=macros + copt_macros,
+                                                        include_dirs=include_dirs,
+                                                        debug=self.debug,
+                                                        extra_postargs=extra_args,
+                                                        **kws)
         if c_sources:
             log.info("compiling C sources")
-            c_objects = self.compiler.compile(c_sources,
-                                              output_dir=output_dir,
-                                              macros=macros,
-                                              include_dirs=include_dirs,
-                                              debug=self.debug,
-                                              extra_postargs=extra_args_baseopt,
-                                              **kws)
-        c_objects.extend(dispatch_objects)
-
+            c_objects += self.compiler.compile(c_sources,
+                                               output_dir=output_dir,
+                                               macros=macros + copt_macros,
+                                               include_dirs=include_dirs,
+                                               debug=self.debug,
+                                               extra_postargs=extra_args + copt_baseline_flags,
+                                               **kws)
         if cxx_sources:
             log.info("compiling C++ sources")
             c_objects += cxx_compiler.compile(cxx_sources,
                                               output_dir=output_dir,
-                                              macros=macros,
+                                              macros=macros + copt_macros,
                                               include_dirs=include_dirs,
                                               debug=self.debug,
-                                              extra_postargs=extra_args,
+                                              extra_postargs=extra_args + copt_baseline_flags,
                                               **kws)
 
         extra_postargs = []

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -650,7 +650,9 @@ def run_compile():
     sys.argv.extend(['build',
                      '--build-temp', build_dir,
                      '--build-base', build_dir,
-                     '--build-platlib', '.'])
+                     '--build-platlib', '.',
+                     # disable CCompilerOpt
+                     '--disable-optimization'])
     if fc_flags:
         sys.argv.extend(['config_fc'] + fc_flags)
     if flib_flags:


### PR DESCRIPTION
#### Explicit disabling `CCompilerOpt` in F2PY
 This patch also cleans up `CCompilerOpt` calls in build_ext and build_clib.

closes #17321