### PR TITLE
DOC: Remove directives for some constants

### DIFF
--- a/doc/source/reference/c-api/dtype.rst
+++ b/doc/source/reference/c-api/dtype.rst
@@ -221,24 +221,17 @@ Defines
 Max and min values for integers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. c:var:: NPY_MAX_INT{bits}
-
-.. c:var:: NPY_MAX_UINT{bits}
-
-.. c:var:: NPY_MIN_INT{bits}
-
+``NPY_MAX_INT{bits}``, ``NPY_MAX_UINT{bits}``, ``NPY_MIN_INT{bits}``
     These are defined for ``{bits}`` = 8, 16, 32, 64, 128, and 256 and provide
     the maximum (minimum) value of the corresponding (unsigned) integer
     type. Note: the actual integer type may not be available on all
     platforms (i.e. 128-bit and 256-bit integers are rare).
 
-.. c:var:: NPY_MIN_{type}
-
+``NPY_MIN_{type}``
     This is defined for ``{type}`` = **BYTE**, **SHORT**, **INT**,
     **LONG**, **LONGLONG**, **INTP**
 
-.. c:var:: NPY_MAX_{type}
-
+``NPY_MAX_{type}``
     This is defined for all defined for ``{type}`` = **BYTE**, **UBYTE**,
     **SHORT**, **USHORT**, **INT**, **UINT**, **LONG**, **ULONG**,
     **LONGLONG**, **ULONGLONG**, **INTP**, **UINTP**

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -10,8 +10,7 @@ UFunc API
 Constants
 ---------
 
-.. c:var:: UFUNC_ERR_{HANDLER}
-
+``UFUNC_ERR_{HANDLER}``
     .. c:macro:: UFUNC_ERR_IGNORE
 
     .. c:macro:: UFUNC_ERR_WARN
@@ -20,8 +19,7 @@ Constants
 
     .. c:macro:: UFUNC_ERR_CALL
 
-.. c:var:: UFUNC_{THING}_{ERR}
-
+``UFUNC_{THING}_{ERR}``
     .. c:macro:: UFUNC_MASK_DIVIDEBYZERO
 
     .. c:macro:: UFUNC_MASK_OVERFLOW
@@ -46,8 +44,7 @@ Constants
 
     .. c:macro:: UFUNC_FPE_INVALID
 
-.. c:var:: PyUFunc_{VALUE}
-
+``PyUFunc_{VALUE}``
     .. c:macro:: PyUFunc_One
 
     .. c:macro:: PyUFunc_Zero


### PR DESCRIPTION
Related to #16217, and separated ffrom #16370. See https://github.com/numpy/numpy/pull/16370#discussion_r504556248 and https://github.com/numpy/numpy/pull/16370#discussion_r504555662.