### PR TITLE
ENH: Add annotations for three new constants

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -218,11 +218,8 @@ __all__ = [
 ]
 
 DataSource: Any
-False_: Any
 MachAr: Any
 ScalarType: Any
-True_: Any
-UFUNC_PYVALS_NAME: Any
 angle: Any
 append: Any
 apply_along_axis: Any
@@ -1666,6 +1663,11 @@ UFUNC_BUFSIZE_DEFAULT: Final[int]
 WRAP: Final[int]
 little_endian: Final[int]
 tracemalloc_domain: Final[int]
+
+True_: Final[bool_]
+False_: Final[bool_]
+
+UFUNC_PYVALS_NAME: Final[str]
 
 class ufunc:
     @property

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1661,9 +1661,9 @@ SHIFT_OVERFLOW: Final[int]
 SHIFT_UNDERFLOW: Final[int]
 UFUNC_BUFSIZE_DEFAULT: Final[int]
 WRAP: Final[int]
-little_endian: Final[int]
 tracemalloc_domain: Final[int]
 
+little_endian: Final[bool]
 True_: Final[bool_]
 False_: Final[bool_]
 

--- a/numpy/typing/tests/data/fail/constants.py
+++ b/numpy/typing/tests/data/fail/constants.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+np.Inf = np.Inf  # E: Cannot assign to final
+np.ALLOW_THREADS = np.ALLOW_THREADS  # E: Cannot assign to final
+np.little_endian = np.little_endian  # E: Cannot assign to final
+np.UFUNC_PYVALS_NAME = np.UFUNC_PYVALS_NAME  # E: Cannot assign to final

--- a/numpy/typing/tests/data/reveal/constants.py
+++ b/numpy/typing/tests/data/reveal/constants.py
@@ -40,5 +40,10 @@ reveal_type(np.SHIFT_OVERFLOW)  # E: int
 reveal_type(np.SHIFT_UNDERFLOW)  # E: int
 reveal_type(np.UFUNC_BUFSIZE_DEFAULT)  # E: int
 reveal_type(np.WRAP)  # E: int
-reveal_type(np.little_endian)  # E: int
 reveal_type(np.tracemalloc_domain)  # E: int
+
+reveal_type(np.little_endian)  # E: bool
+reveal_type(np.True_)  # E: numpy.bool_
+reveal_type(np.False_)  # E: numpy.bool_
+
+reveal_type(np.UFUNC_PYVALS_NAME)  # E: str


### PR DESCRIPTION
This PR adds annotations for three new constants:
* `True_`
* `False_`
* `UFUNC_PYVALS_NAME`

Secondly, it fixes the type of `little_endian`, which should be a boolean instead of an integer.