### PR TITLE
BUG: Respect dtype of all-zero argument to poly1d

### DIFF
--- a/doc/release/upcoming_changes/17577.compatibility.rst
+++ b/doc/release/upcoming_changes/17577.compatibility.rst
@@ -1,0 +1,6 @@
+poly1d respects the dtype of all-zero argument
+----------------------------------------------
+Previously, constructing an instance of ``poly1d`` with all-zero
+coefficients would cast the coefficients to ``np.float64``.
+This affected the output dtype of methods which construct
+``poly1d`` instances internally, such as ``np.polymul``.

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1236,7 +1236,7 @@ class poly1d:
             raise ValueError("Polynomial must be 1d only.")
         c_or_r = trim_zeros(c_or_r, trim='f')
         if len(c_or_r) == 0:
-            c_or_r = NX.array([0.], dtype=c_or_r.dtype)
+            c_or_r = NX.array([0], dtype=c_or_r.dtype)
         self._coeffs = c_or_r
         if variable is None:
             variable = 'x'

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1236,7 +1236,7 @@ class poly1d:
             raise ValueError("Polynomial must be 1d only.")
         c_or_r = trim_zeros(c_or_r, trim='f')
         if len(c_or_r) == 0:
-            c_or_r = NX.array([0.])
+            c_or_r = NX.array([0.], dtype=c_or_r.dtype)
         self._coeffs = c_or_r
         if variable is None:
             variable = 'x'

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -426,7 +426,7 @@ def polyder(p, m=1):
     >>> np.polyder(p, 3)
     poly1d([6])
     >>> np.polyder(p, 4)
-    poly1d([0.])
+    poly1d([0])
 
     """
     m = int(m)
@@ -754,11 +754,11 @@ def polyval(p, x):
     >>> np.polyval([3,0,1], 5)  # 3 * 5**2 + 0 * 5**1 + 1
     76
     >>> np.polyval([3,0,1], np.poly1d(5))
-    poly1d([76.])
+    poly1d([76])
     >>> np.polyval(np.poly1d([3,0,1]), 5)
     76
     >>> np.polyval(np.poly1d([3,0,1]), np.poly1d(5))
-    poly1d([76.])
+    poly1d([76])
 
     """
     p = NX.asarray(p)

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -227,6 +227,20 @@ class TestPolynomial:
         v = np.arange(1, 21)
         assert_almost_equal(np.poly(v), np.poly(np.diag(v)))
 
+    def test_zero_poly_dtype(self):
+        """
+        Regression test for gh-16354.
+        """
+        z = np.array([0, 0, 0])
+        p = np.poly1d(z.astype(np.int64))
+        assert_equal(p.coeffs.dtype, np.int64)
+
+        p = np.poly1d(z.astype(np.float32))
+        assert_equal(p.coeffs.dtype, np.float32)
+
+        p = np.poly1d(z.astype(np.complex64))
+        assert_equal(p.coeffs.dtype, np.complex64)
+
     def test_poly_eq(self):
         p = np.poly1d([1, 2, 3])
         p2 = np.poly1d([1, 2, 4])


### PR DESCRIPTION
Fixes gh-16354. 
Previously, `np.poly1d(z).coeffs.dtype` would always be `np.float64` for zero array `z`, regardless of `z`'s dtype.

This led to unexpected dtype promotion in methods such as `np.polymul`:
```python
>>> np.polymul(np.array([1, 2, 3], dtype=np.int64), np.array([0, 0, 0], dtype=np.int64)).dtype
dtype('float64')
```

This PR retains the dtype of zero array inputs.
```python
>>> np.polymul(np.array([1, 2, 3], dtype=np.int64), np.array([0, 0, 0], dtype=np.int64)).dtype
dtype('int64')
```
