### PR TITLE
ENH: Add annotations for `np.core._type_aliases`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -141,6 +141,11 @@ from numpy.core._asarray import (
     require as require,
 )
 
+from numpy.core._type_aliases import (
+    sctypes as sctypes,
+    sctypeDict as sctypeDict,
+)
+
 from numpy.core.numeric import (
     zeros_like as zeros_like,
     ones as ones,
@@ -460,8 +465,6 @@ save: Any
 savetxt: Any
 savez: Any
 savez_compressed: Any
-sctypeDict: Any
-sctypes: Any
 select: Any
 set_printoptions: Any
 set_string_function: Any

--- a/numpy/core/_type_aliases.pyi
+++ b/numpy/core/_type_aliases.pyi
@@ -1,0 +1,19 @@
+import sys
+from typing import Dict, Union, Type, List
+
+from numpy import generic, signedinteger, unsignedinteger, floating, complexfloating
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+class _SCTypes(TypedDict):
+    int: List[Type[signedinteger]]
+    uint: List[Type[unsignedinteger]]
+    float: List[Type[floating]]
+    complex: List[Type[complexfloating]]
+    others: List[type]
+
+sctypeDict: Dict[Union[int, str], Type[generic]]
+sctypes: _SCTypes

--- a/numpy/typing/tests/data/reveal/constants.py
+++ b/numpy/typing/tests/data/reveal/constants.py
@@ -47,3 +47,6 @@ reveal_type(np.True_)  # E: numpy.bool_
 reveal_type(np.False_)  # E: numpy.bool_
 
 reveal_type(np.UFUNC_PYVALS_NAME)  # E: str
+
+reveal_type(np.sctypeDict)  # E: dict
+reveal_type(np.sctypes)  # E: TypedDict


### PR DESCRIPTION
This PR adds annotations for the two dictionaries in `np.core._type_aliases`:
* `sctypes`
* `sctypeDict`

Besides aforementioned dictionaries there is also the `allTypes` dict.
It doesn't appear to be exposed to the main numpy namespace though and is therefore ignored.