### PR TITLE
DEP: Formally deprecate `np.typeDict`

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -21,7 +21,7 @@ TYPES1 = [
     'int64', 'float64',  'complex64',
     'longfloat', 'complex128',
 ]
-if 'complex256' in numpy.typeDict:
+if 'complex256' in numpy.sctypeDict:
     TYPES1.append('complex256')
 
 

--- a/doc/release/upcoming_changes/17586.deprecation.rst
+++ b/doc/release/upcoming_changes/17586.deprecation.rst
@@ -1,0 +1,7 @@
+``np.typeDict`` has been formally deprecated
+--------------------------------------------
+``np.typeDict`` is a deprecated alias for ``np.sctypeDict`` and
+has been so for over 14 years (6689502_).
+A deprecation warning will now be issued whenever getting ``np.typeDict``.
+
+.. _6689502: https://github.com/numpy/numpy/commit/668950285c407593a368336ff2e737c5da84af7d

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -192,8 +192,9 @@ else:
         )
         for n, n2 in [("long", "int"), ("unicode", "str")]
     })
+    # Numpy 1.20.0, 2020-10-19
     __deprecated_attrs__["typeDict"] = (
-        getattr(core.numerictypes, "typeDict"),
+        core.numerictypes.typeDict,
         "`np.typeDict` is a deprecated alias for `np.sctypeDict`."
     )
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -192,6 +192,10 @@ else:
         )
         for n, n2 in [("long", "int"), ("unicode", "str")]
     })
+    __deprecated_attrs__["typeDict"] = (
+        getattr(core.numerictypes, "typeDict"),
+        "`np.typeDict` is a deprecated alias for `np.sctypeDict`."
+    )
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -558,7 +558,6 @@ trim_zeros: Any
 triu: Any
 triu_indices: Any
 triu_indices_from: Any
-typeDict: Any
 typecodes: Any
 typename: Any
 union1d: Any

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -542,7 +542,7 @@ typecodes = {'Character':'c',
              'All':'?bhilqpBHILQPefdgFDGSUVOMm'}
 
 # backwards compatibility --- deprecated name
-# Formal deprecation: Numpy 1.20.0, 2020-10-19
+# Formal deprecation: Numpy 1.20.0, 2020-10-19 (see numpy/__init__.py)
 typeDict = sctypeDict
 
 # b -> boolean

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -542,6 +542,7 @@ typecodes = {'Character':'c',
              'All':'?bhilqpBHILQPefdgFDGSUVOMm'}
 
 # backwards compatibility --- deprecated name
+# Formal deprecation: Numpy 1.20.0, 2020-10-19
 typeDict = sctypeDict
 
 # b -> boolean

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -91,7 +91,7 @@ from numpy.core.multiarray import (
 from numpy.core.overrides import set_module
 
 # we add more at the bottom
-__all__ = ['sctypeDict', 'typeDict', 'sctypes',
+__all__ = ['sctypeDict', 'sctypes',
            'ScalarType', 'obj2sctype', 'cast', 'nbytes', 'sctype2char',
            'maximum_sctype', 'issctype', 'typecodes', 'find_common_type',
            'issubdtype', 'datetime_data', 'datetime_as_string',

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -5,7 +5,7 @@ This module is designed so "from numerictypes import \\*" is safe.
 Exported symbols include:
 
   Dictionary with all registered number types (including aliases):
-    typeDict
+    sctypeDict
 
   Type objects (not all will be available, depends on platform):
       see variable sctypes for which ones you have

--- a/numpy/core/numerictypes.pyi
+++ b/numpy/core/numerictypes.pyi
@@ -26,4 +26,4 @@ def find_common_type(
 ) -> dtype: ...
 
 # TODO: Add annotations for the following objects:
-# typeDict, nbytes, cast, ScalarType & typecodes
+# nbytes, cast, ScalarType & typecodes

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -70,7 +70,7 @@ _byteorderconv = {'b':'>',
 # of the letter code '(2,3)f4' and ' (  2 ,  3  )  f4  '
 # are equally allowed
 
-numfmt = nt.typeDict
+numfmt = nt.sctypeDict
 
 # taken from OrderedDict recipes in the Python documentation
 # https://docs.python.org/3.3/library/collections.html#ordereddict-examples-and-recipes

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -698,6 +698,9 @@ class TestDeprecatedGlobals(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.long)
         self.assert_deprecated(lambda: np.unicode)
 
+        # from np.core.numerictypes
+        self.assert_deprecated(lambda: np.typeDict)
+
 
 class TestMatrixInOuter(_DeprecationTestCase):
     # 2020-05-13 NumPy 1.20.0

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -207,7 +207,7 @@ class TestFlags:
             a[2] = 10
             # only warn once
             assert_(len(w) == 1)
-    
+
     @pytest.mark.parametrize(["flag", "flag_value", "writeable"],
             [("writeable", True, True),
              # Delete _warn_on_write after deprecation and simplify
@@ -1418,11 +1418,11 @@ class TestStructured:
         a = np.array([(1,2)], dtype=[('a', 'i4'), ('b', 'i4')])
         a[['a', 'b']] = a[['b', 'a']]
         assert_equal(a[0].item(), (2,1))
-    
+
     def test_scalar_assignment(self):
         with assert_raises(ValueError):
-            arr = np.arange(25).reshape(5, 5)                                                                               
-            arr.itemset(3)  
+            arr = np.arange(25).reshape(5, 5)
+            arr.itemset(3)
 
     def test_structuredscalar_indexing(self):
         # test gh-7262
@@ -7214,7 +7214,7 @@ class TestNewBufferProtocol:
         self._check_roundtrip(x)
 
     def test_roundtrip_single_types(self):
-        for typ in np.typeDict.values():
+        for typ in np.sctypeDict.values():
             dtype = np.dtype(typ)
 
             if dtype.char in 'Mm':

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1531,7 +1531,7 @@ class TestRegression:
             np.fromstring(b'aa, aa, 1.0', sep=',')
 
     def test_ticket_1539(self):
-        dtypes = [x for x in np.typeDict.values()
+        dtypes = [x for x in np.sctypeDict.values()
                   if (issubclass(x, np.number)
                       and not issubclass(x, np.timedelta64))]
         a = np.array([], np.bool_)  # not x[0] because it is unordered
@@ -2332,7 +2332,7 @@ class TestRegression:
 
     def test_correct_hash_dict(self):
         # gh-8887 - __hash__ would be None despite tp_hash being set
-        all_types = set(np.typeDict.values()) - {np.void}
+        all_types = set(np.sctypeDict.values()) - {np.void}
         for t in all_types:
             val = t()
 

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -410,9 +410,9 @@ class TestConversion:
 
     def test_int_raise_behaviour(self):
         def overflow_error_func(dtype):
-            np.sctypeDict[dtype](np.iinfo(dtype).max + 1)
+            dtype(np.iinfo(dtype).max + 1)
 
-        for code in 'lLqQ':
+        for code in [np.int_, np.uint, np.longlong, np.ulonglong]:
             assert_raises(OverflowError, overflow_error_func, code)
 
     def test_int_from_infinite_longdouble(self):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -404,7 +404,7 @@ class TestConversion:
             assert_(res == tgt)
 
         for code in np.typecodes['AllInteger']:
-            res = np.sctypeDict[code](np.iinfo(code).max)
+            res = np.dtype(code).type(np.iinfo(code).max)
             tgt = np.iinfo(code).max
             assert_(res == tgt)
 

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -404,13 +404,13 @@ class TestConversion:
             assert_(res == tgt)
 
         for code in np.typecodes['AllInteger']:
-            res = np.typeDict[code](np.iinfo(code).max)
+            res = np.sctypeDict[code](np.iinfo(code).max)
             tgt = np.iinfo(code).max
             assert_(res == tgt)
 
     def test_int_raise_behaviour(self):
         def overflow_error_func(dtype):
-            np.typeDict[dtype](np.iinfo(dtype).max + 1)
+            np.sctypeDict[dtype](np.iinfo(dtype).max + 1)
 
         for code in 'lLqQ':
             assert_raises(OverflowError, overflow_error_func, code)

--- a/tools/functions_missing_types.py
+++ b/tools/functions_missing_types.py
@@ -45,6 +45,7 @@ EXCLUDE_LIST = {
         "safe_eval",
         "set_numeric_ops",
         "test",
+        "typeDict",
         # Builtins
         "bool",
         "complex",


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/17585.

The `np.typeDict` dictionary is a deprecated alias for `np.sctypeDict` and has been so for over 14 years (https://github.com/numpy/numpy/commit/668950285c407593a368336ff2e737c5da84af7d).

This PR formally marks it a such, the module-level `__getattr__` now issuing a deprecation warning whenever getting `np.typeDict`.