### PR TITLE
TST: Clean up the errors of the typing tests

### DIFF
--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -3,6 +3,7 @@ import itertools
 import os
 import re
 from collections import defaultdict
+from typing import Optional
 
 import pytest
 try:
@@ -55,6 +56,8 @@ def test_success(path):
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
 def test_fail(path):
+    __tracebackhide__ = True
+
     stdout, stderr, exitcode = api.run([
         "--config-file",
         MYPY_INI,
@@ -95,16 +98,37 @@ def test_fail(path):
         target_line = lines[lineno - 1]
         if "# E:" in target_line:
             marker = target_line.split("# E:")[-1].strip()
-            assert lineno in errors, f'Extra error "{marker}"'
-            assert marker in errors[lineno]
+            expected_error = errors.get(lineno)
+            _test_fail(path, marker, expected_error, lineno)
         else:
             pytest.fail(f"Error {repr(errors[lineno])} not found")
+
+
+_FAIL_MSG1 = """Extra error at line {}
+
+Extra error: {!r}
+"""
+
+_FAIL_MSG2 = """Error mismatch at line {}
+
+Expected error: {!r}
+Observed error: {!r}
+"""
+
+
+def _test_fail(path: str, error: str, expected_error: Optional[str], lineno: int) -> None:
+    if expected_error is None:
+        raise AssertionError(_FAIL_MSG1.format(lineno, error))
+    elif error not in expected_error:
+        raise AssertionError(_FAIL_MSG2.format(lineno, expected_error, error))
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(REVEAL_DIR))
 def test_reveal(path):
+    __tracebackhide__ = True
+
     stdout, stderr, exitcode = api.run([
         "--config-file",
         MYPY_INI,
@@ -127,10 +151,23 @@ def test_reveal(path):
         )
         if match is None:
             raise ValueError(f"Unexpected reveal line format: {error_line}")
-        lineno = int(match.group('lineno'))
+        lineno = int(match.group('lineno')) - 1
         assert "Revealed type is" in error_line
-        marker = lines[lineno - 1].split("# E:")[-1].strip()
-        assert marker in error_line
+
+        marker = lines[lineno].split("# E:")[-1].strip()
+        _test_reveal(path, marker, error_line, lineno)
+
+
+_REVEAL_MSG = """Reveal mismatch at line {}
+
+Expected reveal: {!r}
+Observed reveal: {!r}
+"""
+
+
+def _test_reveal(path: str, reveal: str, expected_reveal: str, lineno: int) -> None:
+    if reveal not in expected_reveal:
+        raise AssertionError(_REVEAL_MSG.format(lineno, expected_reveal, reveal))
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/17460.

The goal of this PR is to clean up the error messages/traceback of the typing tests.

This has been accomplished as following by (partially) rewriting the error messages and 
moving the actual assertion operations to a new dedicated function, allowing increased control
over the traceback message and which objects are present in the local namespace.

Before
-------
<details><summary>Collapse</summary>
<p>

``` python
========================================================================== FAILURES ==========================================================================
__________________________________________________________________ test_fail[arithmetic.py] __________________________________________________________________

path = '/Users/bvanbeek/Documents/GitHub/numpy/build/testenv/lib/python3.8/site-packages/numpy/typing/tests/data/fail/arithmetic.py'

    @pytest.mark.slow
    @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
    @pytest.mark.parametrize("path", get_test_cases(FAIL_DIR))
    def test_fail(path):
        stdout, stderr, exitcode = api.run([
            "--config-file",
            MYPY_INI,
            "--cache-dir",
            CACHE_DIR,
            path,
        ])
        assert exitcode != 0
    
        with open(path) as fin:
            lines = fin.readlines()
    
        errors = defaultdict(lambda: "")
        error_lines = stdout.rstrip("\n").split("\n")
        assert re.match(
            r"Found \d+ errors? in \d+ files? \(checked \d+ source files?\)",
            error_lines[-1].strip(),
        )
        for error_line in error_lines[:-1]:
            error_line = error_line.strip()
            if not error_line:
                continue
    
            match = re.match(
                r"^.+\.py:(?P<lineno>\d+): (error|note): .+$",
                error_line,
            )
            if match is None:
                raise ValueError(f"Unexpected error line format: {error_line}")
            lineno = int(match.group('lineno'))
            errors[lineno] += error_line
    
        for i, line in enumerate(lines):
            lineno = i + 1
            if line.startswith('#') or (" E:" not in line and lineno not in errors):
                continue
    
            target_line = lines[lineno - 1]
            if "# E:" in target_line:
                marker = target_line.split("# E:")[-1].strip()
                assert lineno in errors, f'Extra error "{marker}"'
>               assert marker in errors[lineno]
E               assert 'Test' in 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")'

error_line = 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")'
error_lines = ['numpy/typing/tests/data/fail/arithmetic.py:7: error: No overload variant of "__call__" of "_BoolSub" matches argumen...y/typing/tests/data/fail/arithmetic.py:9: error: Unsupported operand types for + ("datetime64" and "datetime64")', ...]
errors     = defaultdict(<function test_fail.<locals>.<lambda> at 0x7f85cfe18040>, {7: 'numpy/typing/tests/data/fail/arithmetic.py:...lta64', 14: 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")'})
exitcode   = 1
fin        = <_io.TextIOWrapper name='/Users/bvanbeek/Documents/GitHub/numpy/build/testenv/lib/python3.8/site-packages/numpy/typing/tests/data/fail/arithmetic.py' mode='r' encoding='UTF-8'>
i          = 13
line       = "1 / 'a' # E: Test\n"
lineno     = 14
lines      = ['import numpy as np\n', '\n', 'b_ = np.bool_()\n', 'dt = np.datetime64(0, "D")\n', 'td = np.timedelta64(0, "D")\n', '\n', ...]
marker     = 'Test'
match      = <re.Match object; span=(0, 103), match='numpy/typing/tests/data/fail/arithmetic.py:14: er>
path       = '/Users/bvanbeek/Documents/GitHub/numpy/build/testenv/lib/python3.8/site-packages/numpy/typing/tests/data/fail/arithmetic.py'
stderr     = ''
stdout     = 'numpy/typing/tests/data/fail/arithmetic.py:7: error: No overload variant of "__call__" of "_BoolSub" matches argument...ic.py:14: error: Unsupported operand types for / ("int" and "str")\nFound 6 errors in 1 file (checked 1 source file)\n'
target_line = "1 / 'a' # E: Test\n"

numpy/typing/tests/test_typing.py:99: AssertionError
====================================================================== warnings summary ======================================================================
/Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/_pytest/config/__init__.py:1040
  /Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/_pytest/config/__init__.py:1040: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: hypothesis
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== short test summary info ===================================================================
FAILED numpy/typing/tests/test_typing.py::test_fail[arithmetic.py] - assert 'Test' in 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported op...
1 failed, 60 passed, 1 warning in 120.15s (0:02:00)
```
</p>
</details>


After
-----
<details><summary>Collapse</summary>
<p>

``` python
========================================================================== FAILURES ==========================================================================
__________________________________________________________________ test_fail[arithmetic.py] __________________________________________________________________

path = '/Users/bvanbeek/Documents/GitHub/numpy/build/testenv/lib/python3.8/site-packages/numpy/typing/tests/data/fail/arithmetic.py', error = 'Test'
expected_error = 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")', lineno = 14

    def _test_fail(path: str, error: str, expected_error: Optional[str], lineno: int) -> None:
        if expected_error is None:
            raise AssertionError(_FAIL_MSG1.format(lineno, error))
        elif error not in expected_error:
>           raise AssertionError(_FAIL_MSG2.format(lineno, expected_error, error))
E           AssertionError: Error mismatch at line 14
E           
E           Expected error: 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")'
E           Observed error: 'Test'

error      = 'Test'
expected_error = 'numpy/typing/tests/data/fail/arithmetic.py:14: error: Unsupported operand types for / ("int" and "str")'
lineno     = 14
path       = '/Users/bvanbeek/Documents/GitHub/numpy/build/testenv/lib/python3.8/site-packages/numpy/typing/tests/data/fail/arithmetic.py'

numpy/typing/tests/test_typing.py:123: AssertionError
====================================================================== warnings summary ======================================================================
/Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/_pytest/config/__init__.py:1040
  /Users/bvanbeek/opt/anaconda3/envs/numpy/lib/python3.8/site-packages/_pytest/config/__init__.py:1040: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: hypothesis
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================== short test summary info ===================================================================
FAILED numpy/typing/tests/test_typing.py::test_fail[arithmetic.py] - AssertionError: Error mismatch at line 14
1 failed, 62 passed, 1 warning in 171.24s (0:02:51)
```
</p>
</details>