### PR TITLE
BUG: Fixed file handle leak in array_tofile.

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -578,6 +578,28 @@ array_tostring(PyArrayObject *self, PyObject *args, PyObject *kwds)
     return PyArray_ToString(self, order);
 }
 
+/* Like PyArray_ToFile but takes the file as a python object */
+static int
+PyArray_ToFileObject(PyArrayObject *self, PyObject *file, char *sep, char *format)
+{
+    npy_off_t orig_pos = 0;
+    FILE *fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
+
+    if (fd == NULL) {
+        return -1;
+    }
+
+    int write_ret = PyArray_ToFile(self, fd, sep, format);
+    PyObject *err_type, *err_value, *err_traceback;
+    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+    int close_ret = npy_PyFile_DupClose2(file, fd, orig_pos);
+    npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+
+    if (write_ret || close_ret) {
+        return -1;
+    }
+    return 0;
+}
 
 /* This should grow an order= keyword to be consistent
  */
@@ -587,10 +609,8 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     int own;
     PyObject *file;
-    FILE *fd;
     char *sep = "";
     char *format = "";
-    npy_off_t orig_pos = 0;
     static char *kwlist[] = {"file", "sep", "format", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss:tofile", kwlist,
@@ -615,34 +635,19 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
         own = 0;
     }
 
-    fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
-    PyObject *err_type, *err_value, *err_traceback;
-    int failed = 0;
-
-    if (fd != NULL) {
-        if (PyArray_ToFile(self, fd, sep, format) < 0) {
-            failed = 1;
-        }
-        PyErr_Fetch(&err_type, &err_value, &err_traceback);
-        if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
-            failed = 1;
-        }
-        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
-    } else {
-        failed = 1;
-    }
+    int file_ret = PyArray_ToFileObject(self, file, sep, format);
+    int close_ret = 0;
 
     if (own) {
+        PyObject *err_type, *err_value, *err_traceback;
         PyErr_Fetch(&err_type, &err_value, &err_traceback);
-        if (npy_PyFile_CloseFile(file) < 0) {
-            failed = 1;
-        }
+        close_ret = npy_PyFile_CloseFile(file);
         npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
     }
 
     Py_DECREF(file);
 
-    if (failed) {
+    if (file_ret || close_ret) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -585,7 +585,7 @@ array_tostring(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    int own;
+    int own, res1, res2;
     PyObject *file;
     FILE *fd;
     char *sep = "";
@@ -619,10 +619,9 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     if (fd == NULL) {
         goto fail;
     }
-    if (PyArray_ToFile(self, fd, sep, format) < 0) {
-        goto fail;
-    }
-    if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
+    res1 = PyArray_ToFile(self, fd, sep, format);
+    res2 = npy_PyFile_DupClose2(file, fd, orig_pos);
+    if (res1 < 0 || res2 < 0) {
         goto fail;
     }
     if (own && npy_PyFile_CloseFile(file) < 0) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -619,10 +619,18 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     if (fd == NULL) {
         goto fail;
     }
-    res1 = PyArray_ToFile(self, fd, sep, format);
-    res2 = npy_PyFile_DupClose2(file, fd, orig_pos);
-    if (res1 < 0 || res2 < 0) {
-        goto fail;
+    int res_write = PyArray_ToFile(self, fd, sep, format);
+    {
+        PyObject *type, *value, *traceback;
+        PyErr_Fetch(&type, &value, &traceback);
+        int res_close = npy_PyFile_DupClose2(file, fd, orig_pos);
+        npy_PyErr_ChainExceptions(type, value, traceback);
+        if (res_close < 0) {
+            return NULL;
+        }
+    }
+    if (res_write < 0) {
+        return NULL;
     }
     if (own && npy_PyFile_CloseFile(file) < 0) {
         goto fail;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -585,7 +585,7 @@ array_tostring(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    int own, res1, res2;
+    int own;
     PyObject *file;
     FILE *fd;
     char *sep = "";
@@ -617,30 +617,31 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 
     fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
     if (fd == NULL) {
-        goto fail;
-    }
-    int res_write = PyArray_ToFile(self, fd, sep, format);
-    {
-        PyObject *type, *value, *traceback;
-        PyErr_Fetch(&type, &value, &traceback);
-        int res_close = npy_PyFile_DupClose2(file, fd, orig_pos);
-        npy_PyErr_ChainExceptions(type, value, traceback);
-        if (res_close < 0) {
-            return NULL;
-        }
-    }
-    if (res_write < 0) {
+        Py_DECREF(file);
         return NULL;
     }
-    if (own && npy_PyFile_CloseFile(file) < 0) {
-        goto fail;
-    }
-    Py_DECREF(file);
-    Py_RETURN_NONE;
 
-fail:
+    int res_write = PyArray_ToFile(self, fd, sep, format);
+    PyObject *err_type, *err_value, *err_traceback;
+    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+
+    int res_close = npy_PyFile_DupClose2(file, fd, orig_pos);
+    if (res_close < 0) {
+        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+    }
+
+    if (own && npy_PyFile_CloseFile(file) < 0) {
+        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+        res_close = -1;
+    }
+
+    PyErr_Restore(err_type, err_value, err_traceback);
     Py_DECREF(file);
-    return NULL;
+
+    if (res_write < 0 || res_close < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -616,29 +616,33 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
-    if (fd == NULL) {
-        Py_DECREF(file);
-        return NULL;
-    }
-
-    int res_write = PyArray_ToFile(self, fd, sep, format);
     PyObject *err_type, *err_value, *err_traceback;
-    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+    int failed = 0;
 
-    int res_close = npy_PyFile_DupClose2(file, fd, orig_pos);
-    if (res_close < 0) {
+    if (fd != NULL) {
+        if (PyArray_ToFile(self, fd, sep, format) < 0) {
+            failed = 1;
+        }
+        PyErr_Fetch(&err_type, &err_value, &err_traceback);
+        if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
+            failed = 1;
+        }
+        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+    } else {
+        failed = 1;
+    }
+
+    if (own) {
+        PyErr_Fetch(&err_type, &err_value, &err_traceback);
+        if (npy_PyFile_CloseFile(file) < 0) {
+            failed = 1;
+        }
         npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
     }
 
-    if (own && npy_PyFile_CloseFile(file) < 0) {
-        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
-        res_close = -1;
-    }
-
-    PyErr_Restore(err_type, err_value, err_traceback);
     Py_DECREF(file);
 
-    if (res_write < 0 || res_close < 0) {
+    if (failed) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5052,8 +5052,11 @@ class TestIO:
         x = np.zeros((10), dtype=object)
         with open(self.filename, 'wb') as f:
             assert_raises(IOError, lambda: x.tofile(f, sep=''))
+        # Dup-ed file handle should be closed or remove will fail on Windows OS
+        os.remove(self.filename)
 
-        # Dup-ed file handle should be closed or remove will fail.
+        # Also make sure that we close the Python handle
+        assert_raises(IOError, lambda: x.tofile(self.filename))
         os.remove(self.filename)
 
     def test_locale(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5048,6 +5048,14 @@ class TestIO:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
+    def test_tofile_cleanup(self):
+        x = np.zeros((10), dtype=object)
+        with open(self.filename, 'wb') as f:
+            assert_raises(IOError, lambda: x.tofile(f, sep=''))
+
+        # Dup-ed file handle should be closed or remove will fail.
+        os.remove(self.filename)
+
     def test_locale(self):
         with CommaDecimalPointLocale():
             self.test_numbers()


### PR DESCRIPTION
Closes #17589

If the ```PyArray_ToFile``` call inside ```array_tofile``` fails for any reason, we leak a dup-ed file handle. This causes problems especially on Windows OS, where any subsequent attempt to delete the file will fail because NumPy is still holding an open handle.

This update ensures that we always close the handle.

The added test case forces ```PyArray_ToFile``` to fail, which triggers the original problem.
