### PR TITLE
TST: Fix a broken `np.core.numeric` test

### DIFF
--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -12,7 +12,7 @@ from typing import (
     Iterable,
 )
 
-from numpy import ndarray, generic, dtype, bool_, int32, int64, _OrderKACF, _OrderCF
+from numpy import ndarray, generic, dtype, bool_, signedinteger, _OrderKACF, _OrderCF
 from numpy.typing import ArrayLike, DtypeLike, _ShapeLike
 
 if sys.version_info >= (3, 8):
@@ -113,7 +113,7 @@ def count_nonzero(
 @overload
 def count_nonzero(
     a: ArrayLike, axis: _ShapeLike = ..., *, keepdims: bool = ...
-) -> Union[int64, int32, ndarray]: ...
+) -> Union[signedinteger[Any], ndarray]: ...  # TODO: np.intp
 def isfortran(a: Union[ndarray, generic]) -> bool: ...
 def argwhere(a: ArrayLike) -> ndarray: ...
 def flatnonzero(a: ArrayLike) -> ndarray: ...

--- a/numpy/typing/tests/data/reveal/numeric.py
+++ b/numpy/typing/tests/data/reveal/numeric.py
@@ -20,8 +20,8 @@ C: SubClass
 reveal_type(np.count_nonzero(i8))  # E: int
 reveal_type(np.count_nonzero(A))  # E: int
 reveal_type(np.count_nonzero(B))  # E: int
-reveal_type(np.count_nonzero(A, keepdims=True))  # E: Union[numpy.int64, numpy.int32, numpy.ndarray]
-reveal_type(np.count_nonzero(A, axis=0))  # E: Union[numpy.int64, numpy.int32, numpy.ndarray]
+reveal_type(np.count_nonzero(A, keepdims=True))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
+reveal_type(np.count_nonzero(A, axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
 
 reveal_type(np.isfortran(i8))  # E: bool
 reveal_type(np.isfortran(A))  # E: bool


### PR DESCRIPTION
It turns out that there was a minor incompatibility between https://github.com/numpy/numpy/pull/17564 and https://github.com/numpy/numpy/pull/17540, resulting in a now broken test.
This PR fixes aforementioned test.