### PR TITLE
DOC: removed old references to submodule licenses

### DIFF
--- a/LICENSES_bundled.txt
+++ b/LICENSES_bundled.txt
@@ -1,16 +1,6 @@
 The NumPy repository and source distributions bundle several libraries that are
 compatibly licensed.  We list these here.
 
-Name: Numpydoc
-Files: doc/sphinxext/numpydoc/*
-License: BSD-2-Clause
-  For details, see doc/sphinxext/LICENSE.txt
-
-Name: scipy-sphinx-theme
-Files: doc/scipy-sphinx-theme/*
-License: BSD-3-Clause AND PSF-2.0 AND Apache-2.0
-  For details, see doc/scipy-sphinx-theme/LICENSE.txt
-
 Name: lapack-lite
 Files: numpy/linalg/lapack_lite/*
 License: BSD-3-Clause


### PR DESCRIPTION
Updated the `LICENSES_bundled.txt` to reflect recent changes (see #17606). The sphinxext and scipy sphinx theme submodules were moved/removed in the past few months, but the list of licenses for bundled dependencies wasn't updated accordingly.