### PR TITLE
ENH, BLD: update OpenBLAS to 0.3.11

### DIFF
--- a/doc/release/upcoming_changes/17609.improvement.rst
+++ b/doc/release/upcoming_changes/17609.improvement.rst
@@ -1,0 +1,4 @@
+Use OpenBLAS 0.3.11
+-------------------
+CI tests and wheels will be built using OpenBLAS 0.3.11
+

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -142,9 +142,9 @@ def download_openblas(target, arch, ilp64, is_32bit):
         typ = 'tar.gz'
     elif arch == 'windows':
         if is_32bit:
-            suffix = 'win32-gcc_7_1_0.zip'
+            suffix = 'win32-gcc_8_1_0.zip'
         else:
-            suffix = 'win_amd64-gcc_7_1_0.zip'
+            suffix = 'win_amd64-gcc_8_1_0.zip'
         filename = f'{BASEURL}/openblas{fnsuffix}-{OPENBLAS_LONG}-{suffix}'
         typ = 'zip'
     if not filename:

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -12,9 +12,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.10'
-# Temporary build of OpenBLAS to test a fix for dynamic detection of CPU
-OPENBLAS_LONG = 'v0.3.9-452-g349b722d'
+OPENBLAS_V = '0.3.11.dev'
+OPENBLAS_LONG = 'v0.3.11-16-g4ad33c46'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86_64',


### PR DESCRIPTION
This new OpenBLAS version contains work arounds for gh-16744. This version of OpenBLAS contains bugfixes for 0.3.11, a 0.3.12 release should come out soon but let's see if this indeed does what it is supposed to do.