### PR TITLE
Fully qualify license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable
 Intended Audience :: Science/Research
 Intended Audience :: Developers
-License :: OSI Approved
+License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3


### PR DESCRIPTION
Tools such as [`pip-licenses`](https://pypi.org/project/pip-licenses/) use the license information that is included as part of the package to generate license reports. The canonical location for this license information is in a fully qualified License trove classifier.

This PR corrects the trove classifier to fully qualify it, so that this package can be properly categorized with other BSD-licensed packages when generating license reports.