### PR TITLE
BUG : Fixed Issue with masked array in calculating the minimum element

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5691,14 +5691,18 @@ class MaskedArray(ndarray):
             fill_value = minimum_fill_value(self)
         # No explicit output
         if out is None:
-            result = self.filled(fill_value).min(
-                axis=axis, out=out, **kwargs).view(type(self))
+            """ The result of self.filled(fill_value).min(
+                axis=axis, out=out, **kwargs) is an integer.
+                It should be an ndarray object.
+                """
+            result = np.array(self.filled(fill_value).min(axis=axis, out=out, **kwargs)).view(type(self))
+
             if result.ndim:
-                # Set the mask
-                result.__setmask__(newmask)
-                # Get rid of Infs
-                if newmask.ndim:
-                    np.copyto(result, result.fill_value, where=newmask)
+                    # Set the mask
+                    result.__setmask__(newmask)
+                    # Get rid of Infs
+                    if newmask.ndim:
+                        np.copyto(result, result.fill_value, where=newmask)
             elif newmask:
                 result = masked
             return result

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5698,11 +5698,11 @@ class MaskedArray(ndarray):
             result = np.array(self.filled(fill_value).min(axis=axis, out=out, **kwargs)).view(type(self))
 
             if result.ndim:
-                    # Set the mask
-                    result.__setmask__(newmask)
-                    # Get rid of Infs
-                    if newmask.ndim:
-                        np.copyto(result, result.fill_value, where=newmask)
+                # Set the mask
+                result.__setmask__(newmask)
+                # Get rid of Infs
+                if newmask.ndim:
+                    np.copyto(result, result.fill_value, where=newmask)
             elif newmask:
                 result = masked
             return result

--- a/numpy/tests/test_masked_min.py
+++ b/numpy/tests/test_masked_min.py
@@ -1,0 +1,8 @@
+import sys
+import numpy as np
+sys.path.insert(1, 'numpy/numpy/ma')
+
+import core
+a = np.array([1, 2, 3], dtype=np.object)
+a_masked = core.masked_array(a)
+print(a_masked.min())


### PR DESCRIPTION
BUG : Fixed Issue with masked array in calculating the minimum element

This pull request intends to fix the bug when finding the min element of a masked numpy array. For more information see the issue : - https://github.com/numpy/numpy/issues/17612 i.e issue #17612 . Here is some reproducible code 
```import numpy as np
a = np.array([1, 2, 3], dtype=np.object)
print(a.min())

a_masked = np.ma.masked_array(a)
print(a_masked.min())
```

Here is the error message 
```---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-155-e7c8a9bbb3e9> in <module>
      4 
      5 a_masked = np.ma.masked_array(a)
----> 6 print(a_masked.min())

~/miniconda3/envs/seaborn-py38-latest/lib/python3.8/site-packages/numpy/ma/core.py in min(self, axis, out, fill_value, keepdims)
   5698         # No explicit output
   5699         if out is None:
-> 5700             result = self.filled(fill_value).min(
   5701                 axis=axis, out=out, **kwargs).view(type(self))
   5702             if result.ndim:

AttributeError: 'int' object has no attribute 'view'```