### PR TITLE
TST: Valid docstring for config_py function show()

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2356,6 +2356,7 @@ def generate_config_py(target):
 
                 Examples
                 --------
+                >>> import numpy as np
                 >>> np.show_config()
                 blas_opt_info:
                     language = c


### PR DESCRIPTION
numpy.distutils generates a function `__config__.show`. This change
makes the docstring of that function complete (with the required
imports) and runnable. This prevents numpy.distutils from adding
doctests that will fail -- if picked-up by the test runner.

Example of failing test: https://travis-ci.org/github/has2k1/scikit-misc/jobs/702785136#L747

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
