### PR TITLE
DOC: Tidy up references to str_ / bytes_

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -480,16 +480,16 @@ Character arrays (:mod:`numpy.char`)
    The `chararray` class exists for backwards compatibility with
    Numarray, it is not recommended for new development. Starting from numpy
    1.4, if one needs arrays of strings, it is recommended to use arrays of
-   `dtype` `object_`, `string_` or `unicode_`, and use the free functions
+   `dtype` `object_`, `bytes_` or `str_`, and use the free functions
    in the `numpy.char` module for fast vectorized string operations.
 
-These are enhanced arrays of either :class:`string_` type or
-:class:`unicode_` type.  These arrays inherit from the
+These are enhanced arrays of either :class:`str_` type or
+:class:`bytes_` type.  These arrays inherit from the
 :class:`ndarray`, but specially-define the operations ``+``, ``*``,
 and ``%`` on a (broadcasting) element-by-element basis.  These
 operations are not available on the standard :class:`ndarray` of
 character type. In addition, the :class:`chararray` has all of the
-standard :class:`string <str>` (and :class:`unicode`) methods,
+standard :class:`str` (and :class:`bytes`) methods,
 executing them on an element-by-element basis. Perhaps the easiest
 way to create a chararray is to use :meth:`self.view(chararray)
 <ndarray.view>` where *self* is an ndarray of str or unicode

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -264,9 +264,8 @@ Array-protocol type strings (see :ref:`arrays.interface`)
    .. admonition:: Note on string types
 
     For backward compatibility with Python 2 the ``S`` and ``a`` typestrings
-    remain zero-terminated bytes and ``np.string_`` continues to map to
-    ``np.bytes_``.
-    To use actual strings in Python 3 use ``U`` or ``np.unicode_``.
+    remain zero-terminated bytes and `numpy.string_` continues to alias
+    `numpy.bytes_`. To use actual strings in Python 3 use ``U`` or `numpy.str_`.
     For signed bytes that do not need zero-termination ``b`` or ``i1`` can be
     used.
 
@@ -392,9 +391,9 @@ Type strings
     their values must each be lists of the same length as the *names*
     and *formats* lists. The *offsets* value is a list of byte offsets
     (limited to `ctypes.c_int`) for each field, while the *titles* value is a
-    list of titles for each field (None can be used if no title is
-    desired for that field). The *titles* can be any :class:`string`
-    or :class:`unicode` object and will add another entry to the
+    list of titles for each field (``None`` can be used if no title is
+    desired for that field). The *titles* can be any object, but when a
+    :class:`str` object will add another entry to the
     fields dictionary keyed by the title and referencing the same
     field tuple which will contain the title as an additional tuple
     member.

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -30,8 +30,8 @@ present can be determined using other members of the data type
 hierarchy. Thus, for example ``isinstance(val, np.complexfloating)``
 will return :py:data:`True` if *val* is a complex valued type, while
 ``isinstance(val, np.flexible)`` will return true if *val* is one
-of the flexible itemsize array types (:class:`string`,
-:class:`unicode`, :class:`void`).
+of the flexible itemsize array types (:class:`str_`,
+:class:`bytes_`, :class:`void`).
 
 .. figure:: figures/dtype-hierarchy.png
 

--- a/doc/source/reference/routines.char.rst
+++ b/doc/source/reference/routines.char.rst
@@ -6,7 +6,7 @@ String operations
 .. module:: numpy.char
 
 The `numpy.char` module provides a set of vectorized string
-operations for arrays of type `numpy.string_` or `numpy.unicode_`.
+operations for arrays of type `numpy.str_` or `numpy.bytes_`.
 All of them are based on the string methods in the Python standard library.
 
 String operations


### PR DESCRIPTION
This:
* Fixes some broken references
* Cleans up some use of Python 2 aliases:
  * Switches references to `np.string_` to describe `np.bytes_` instead
  * Switches references to `np.unicode_` to describe `np.str_` instead

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
