### PR TITLE
DOC: Add module template

### DIFF
--- a/doc/source/_templates/autosummary/module.rst
+++ b/doc/source/_templates/autosummary/module.rst
@@ -1,0 +1,38 @@
+{% extends "!autosummary/module.rst" %}
+
+{% block attributes %}
+{% if attributes %}
+   .. rubric:: Module Attributes
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block functions %}
+{% if functions %}
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block classes %}
+{% if classes %}
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+{% endif %}
+{% endblock %}
+

--- a/doc/source/_templates/autosummary/module.rst
+++ b/doc/source/_templates/autosummary/module.rst
@@ -1,5 +1,8 @@
 {% extends "!autosummary/module.rst" %}
 
+{# This file is almost the same as the default, but adds :toctree: to the autosummary directives.
+   The original can be found at `sphinx/ext/autosummary/templates/autosummary/module.rst`. #}
+
 {% block attributes %}
 {% if attributes %}
    .. rubric:: Module Attributes
@@ -35,4 +38,3 @@
    {%- endfor %}
 {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
Related to #13114. Added `:toctree:` to the lists of attributes, functions, classes, to generate the stub pages of all the members.