### PR TITLE
ENH: Add annotations for `np.core._ufunc_config`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2,6 +2,8 @@ import builtins
 import sys
 import datetime as dt
 from abc import abstractmethod
+from types import TracebackType
+from contextlib import ContextDecorator
 
 from numpy.core._internal import _ctypes
 from numpy.typing import (
@@ -149,6 +151,19 @@ from numpy.core._asarray import (
 from numpy.core._type_aliases import (
     sctypes as sctypes,
     sctypeDict as sctypeDict,
+)
+
+from numpy.core._ufunc_config import (
+    seterr as seterr,
+    geterr as geterr,
+    setbufsize as setbufsize,
+    getbufsize as getbufsize,
+    seterrcall as seterrcall,
+    geterrcall as geterrcall,
+    _SupportsWrite,
+    _ErrKind,
+    _ErrFunc,
+    _ErrDictOptional,
 )
 
 from numpy.core.numeric import (
@@ -317,7 +332,6 @@ dstack: Any
 ediff1d: Any
 einsum: Any
 einsum_path: Any
-errstate: Any
 expand_dims: Any
 extract: Any
 eye: Any
@@ -341,9 +355,6 @@ fromstring: Any
 genfromtxt: Any
 get_include: Any
 get_printoptions: Any
-getbufsize: Any
-geterr: Any
-geterrcall: Any
 geterrobj: Any
 gradient: Any
 half: Any
@@ -473,10 +484,7 @@ savez_compressed: Any
 select: Any
 set_printoptions: Any
 set_string_function: Any
-setbufsize: Any
 setdiff1d: Any
-seterr: Any
-seterrcall: Any
 seterrobj: Any
 setxor1d: Any
 shares_memory: Any
@@ -2156,4 +2164,29 @@ class TooHardError(RuntimeError): ...
 class AxisError(ValueError, IndexError):
     def __init__(
         self, axis: int, ndim: Optional[int] = ..., msg_prefix: Optional[str] = ...
+    ) -> None: ...
+
+_CallType = TypeVar("_CallType", bound=Union[_ErrFunc, _SupportsWrite])
+
+class errstate(Generic[_CallType], ContextDecorator):
+    call: _CallType
+    kwargs: _ErrDictOptional
+
+    # Expand `**kwargs` into explicit keyword-only arguments
+    def __init__(
+        self,
+        *,
+        call: _CallType = ...,
+        all: Optional[_ErrKind] = ...,
+        divide: Optional[_ErrKind] = ...,
+        over: Optional[_ErrKind] = ...,
+        under: Optional[_ErrKind] = ...,
+        invalid: Optional[_ErrKind] = ...,
+    ) -> None: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        __exc_type: Optional[Type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
     ) -> None: ...

--- a/numpy/core/_ufunc_config.pyi
+++ b/numpy/core/_ufunc_config.pyi
@@ -1,0 +1,43 @@
+import sys
+from typing import Optional, Union, Callable, Any
+
+if sys.version_info >= (3, 8):
+    from typing import Literal, Protocol, TypedDict
+else:
+    from typing_extensions import Literal, Protocol, TypedDict
+
+_ErrKind = Literal["ignore", "warn", "raise", "call", "print", "log"]
+_ErrFunc = Callable[[str, int], Any]
+
+class _SupportsWrite(Protocol):
+    def write(self, __msg: str) -> Any: ...
+
+class _ErrDict(TypedDict):
+    divide: _ErrKind
+    over: _ErrKind
+    under: _ErrKind
+    invalid: _ErrKind
+
+class _ErrDictOptional(TypedDict, total=False):
+    all: Optional[_ErrKind]
+    divide: Optional[_ErrKind]
+    over: Optional[_ErrKind]
+    under: Optional[_ErrKind]
+    invalid: Optional[_ErrKind]
+
+def seterr(
+    all: Optional[_ErrKind] = ...,
+    divide: Optional[_ErrKind] = ...,
+    over: Optional[_ErrKind] = ...,
+    under: Optional[_ErrKind] = ...,
+    invalid: Optional[_ErrKind] = ...,
+) -> _ErrDict: ...
+def geterr() -> _ErrDict: ...
+def setbufsize(size: int) -> int: ...
+def getbufsize() -> int: ...
+def seterrcall(
+    func: Union[None, _ErrFunc, _SupportsWrite]
+) -> Union[None, _ErrFunc, _SupportsWrite]: ...
+def geterrcall() -> Union[None, _ErrFunc, _SupportsWrite]: ...
+
+# See `numpy/__init__.pyi` for the `errstate` class

--- a/numpy/typing/tests/data/fail/ufunc_config.py
+++ b/numpy/typing/tests/data/fail/ufunc_config.py
@@ -1,0 +1,21 @@
+"""Typing tests for `numpy.core._ufunc_config`."""
+
+import numpy as np
+
+def func1(a: str, b: int, c: float) -> None: ...
+def func2(a: str, *, b: int) -> None: ...
+
+class Write1:
+    def write1(self, a: str) -> None: ...
+
+class Write2:
+    def write(self, a: str, b: str) -> None: ...
+
+class Write3:
+    def write(self, *, a: str) -> None: ...
+
+np.seterrcall(func1)  # E: Argument 1 to "seterrcall" has incompatible type
+np.seterrcall(func2)  # E: Argument 1 to "seterrcall" has incompatible type
+np.seterrcall(Write1())  # E: Argument 1 to "seterrcall" has incompatible type
+np.seterrcall(Write2())  # E: Argument 1 to "seterrcall" has incompatible type
+np.seterrcall(Write3())  # E: Argument 1 to "seterrcall" has incompatible type

--- a/numpy/typing/tests/data/pass/ufunc_config.py
+++ b/numpy/typing/tests/data/pass/ufunc_config.py
@@ -1,0 +1,50 @@
+"""Typing tests for `numpy.core._ufunc_config`."""
+
+import numpy as np
+
+def func1(a: str, b: int) -> None: ...
+def func2(a: str, b: int, c: float = ...) -> None: ...
+def func3(a: str, b: int) -> int: ...
+
+class Write1:
+    def write(self, a: str) -> None: ...
+
+class Write2:
+    def write(self, a: str, b: int = ...) -> None: ...
+
+class Write3:
+    def write(self, a: str) -> int: ...
+
+
+_err_default = np.geterr()
+_bufsize_default = np.getbufsize()
+_errcall_default = np.geterrcall()
+
+try:
+    np.seterr(all=None)
+    np.seterr(divide="ignore")
+    np.seterr(over="warn")
+    np.seterr(under="call")
+    np.seterr(invalid="raise")
+    np.geterr()
+
+    np.setbufsize(4096)
+    np.getbufsize()
+
+    np.seterrcall(func1)
+    np.seterrcall(func2)
+    np.seterrcall(func3)
+    np.seterrcall(Write1())
+    np.seterrcall(Write2())
+    np.seterrcall(Write3())
+    np.geterrcall()
+
+    with np.errstate(call=func1, all="call"):
+        pass
+    with np.errstate(call=Write1(), divide="log", over="log"):
+        pass
+
+finally:
+    np.seterr(**_err_default)
+    np.setbufsize(_bufsize_default)
+    np.seterrcall(_errcall_default)

--- a/numpy/typing/tests/data/reveal/ufunc_config.py
+++ b/numpy/typing/tests/data/reveal/ufunc_config.py
@@ -1,0 +1,25 @@
+"""Typing tests for `numpy.core._ufunc_config`."""
+
+import numpy as np
+
+def func(a: str, b: int) -> None: ...
+
+class Write:
+    def write(self, value: str) -> None: ...
+
+reveal_type(np.seterr(all=None))  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+reveal_type(np.seterr(divide="ignore"))  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+reveal_type(np.seterr(over="warn"))  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+reveal_type(np.seterr(under="call"))  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+reveal_type(np.seterr(invalid="raise"))  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+reveal_type(np.geterr())  # E: TypedDict('numpy.core._ufunc_config._ErrDict'
+
+reveal_type(np.setbufsize(4096))  # E: int
+reveal_type(np.getbufsize())  # E: int
+
+reveal_type(np.seterrcall(func))  # E: Union[None, def (builtins.str, builtins.int) -> Any, numpy.core._ufunc_config._SupportsWrite]
+reveal_type(np.seterrcall(Write()))  # E: Union[None, def (builtins.str, builtins.int) -> Any, numpy.core._ufunc_config._SupportsWrite]
+reveal_type(np.geterrcall())  # E: Union[None, def (builtins.str, builtins.int) -> Any, numpy.core._ufunc_config._SupportsWrite]
+
+reveal_type(np.errstate(call=func, all="call"))  # E: numpy.errstate[def (a: builtins.str, b: builtins.int)]
+reveal_type(np.errstate(call=Write(), divide="log", over="log"))  # E: numpy.errstate[ufunc_config.Write]


### PR DESCRIPTION
This PR adds annotations for the following 7 objects in `np.core._ufunc_config`:
* `errstate`
* `getbufsize`
* `geterr`
* `geterrcall`
* `setbufsize`
* `seterr`
* `seterrcall`