### PR TITLE
BUG: f2py incorrectly translates dimension declarations.

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2156,6 +2156,15 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
                     m1 = re_1.match(ee)
                 c2 = myeval(ee, {}, {})
                 if (a * 0.5 + b == c and a * 1.5 + b == c2):
+                    # gh-8062: return integers instead of floats if possible.
+                    try:
+                        a = int(a)
+                    except:
+                        pass
+                    try:
+                        b = int(b)
+                    except:
+                        pass
                     return a, b, x
             except Exception:
                 pass


### PR DESCRIPTION
In fortran functions passed to f2py, calculations that occur in the dimensions of array declarations are interpreted as floats.  Valid
fortran requires integers.  Problem only occurs with fortran functions not subroutines as only for the former does f2py generate fortran wrapper code that fails to compile.

Relevant code is in `numpy.f2py.crackfortran.getlincoef()`, which calculates and returns the coefficients to `getarrlen()` for writing to the fortran wrapper code.

To convert floats to ints I have opted for `try`..`except` blocks which are common in `crackfortran.py` rather than explicit `is_int()` checks and conversion using `int()`.

Fixes gh-8062.