### PR TITLE
BLD: Fix installing Numpy on z/OS

### DIFF
--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -19,6 +19,15 @@
 
 #endif
 
+/* Disable broken functions on z/OS */
+#if defined (__MVS__)
+
+#undef HAVE_POWF
+#undef HAVE_EXPF
+#undef HAVE___THREAD
+
+#endif
+
 /* Disable broken MS math functions */
 #if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__MINGW32_VERSION)
 

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -3,6 +3,8 @@ unixccompiler - can handle very long argument lists for ar.
 
 """
 import os
+import sys
+import subprocess
 
 from distutils.errors import CompileError, DistutilsExecError, LibError
 from distutils.unixccompiler import UnixCCompiler
@@ -56,6 +58,11 @@ def UnixCCompiler__compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts
 
     # add commandline flags to dependency file
     if deps:
+        # After running the compiler, the file created will be in EBCDIC
+        # but will not be tagged as such. This tags it so the file does not
+        # have multiple different encodings being written to it
+        if sys.platform == 'zos':
+            subprocess.check_output(['chtag', '-tc', 'IBM1047', obj + '.d'])
         with open(obj + '.d', 'a') as f:
             f.write(_commandline_dep_string(cc_args, extra_postargs, pp_opts))
 


### PR DESCRIPTION
This change allows Numpy to install on z/OS

1) On z/OS, EBCDIC is the default encoding and not UTF/ascii, and conversions between encodings can be automatically handled through a filesystem tagging mechanism. The dependency file created by the c compiler contains EBCDIC data, so we need to tag it as such. After the tagging, the conversion is then handled automatically and we can read/write to that file without it containing a mixture of encodings

2) It unsets some macros for broken functions to allow it to build
