### PR TITLE
TST: simplify source path names in compilation test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,6 +217,13 @@ stages:
             BITS: 64
             NPY_USE_BLAS_ILP64: '1'
             OPENBLAS_SUFFIX: '64_'
+          Python39-64bit-full:
+            PYTHON_VERSION: '3.9'
+            PYTHON_ARCH: 'x64'
+            TEST_MODE: full
+            BITS: 64
+            NPY_USE_BLAS_ILP64: '1'
+            OPENBLAS_SUFFIX: '64_'
           #PyPy36-32bit:
             #PYTHON_VERSION: 'PyPy3.6'
             #PYTHON_ARCH: 'x32'

--- a/numpy/core/tests/examples/setup.py
+++ b/numpy/core/tests/examples/setup.py
@@ -9,12 +9,11 @@ from Cython.Build import cythonize
 from setuptools.extension import Extension
 import os
 
-here = os.path.dirname(__file__)
 macros = [("NPY_NO_DEPRECATED_API", 0)]
 
 checks = Extension(
     "checks",
-    sources=[os.path.join(here, "checks.pyx")],
+    sources=[os.path.join('.', "checks.pyx")],
     include_dirs=[np.get_include()],
     define_macros=macros,
 )

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -34,21 +34,19 @@ def install_temp(request, tmp_path):
     here = os.path.dirname(__file__)
     ext_dir = os.path.join(here, "examples")
 
-    tmp_path = tmp_path._str
-    cytest = os.path.join(tmp_path, "cytest")
+    cytest = str(tmp_path / "cytest")
 
     shutil.copytree(ext_dir, cytest)
     # build the examples and "install" them into a temporary directory
 
-    install_log = os.path.join(tmp_path, "tmp_install_log.txt")
+    install_log = str(tmp_path / "tmp_install_log.txt")
     subprocess.check_call(
         [
             sys.executable,
             "setup.py",
             "build",
             "install",
-            "--prefix",
-            os.path.join(tmp_path, "installdir"),
+            "--prefix", str(tmp_path / "installdir"),
             "--single-version-externally-managed",
             "--record",
             install_log,

--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -19,7 +19,7 @@ inc_path = np.get_include()
 lib_path = join(np.get_include(), '..', '..', 'random', 'lib')
 
 extending = Extension("extending",
-                      sources=[join(path, 'extending.pyx')],
+                      sources=[join('.', 'extending.pyx')],
                       include_dirs=[
                             np.get_include(),
                             join(path, '..', '..')
@@ -27,7 +27,7 @@ extending = Extension("extending",
                       define_macros=defs,
                       )
 distributions = Extension("extending_distributions",
-                          sources=[join(path, 'extending_distributions.pyx')],
+                          sources=[join('.', 'extending_distributions.pyx')],
                           include_dirs=[inc_path],
                           library_dirs=[lib_path],
                           libraries=['npyrandom'],


### PR DESCRIPTION
In [`distutils/_msvccompiler.object_filenames`](https://github.com/python/cpython/blob/master/Lib/distutils/_msvccompiler.py#L285), the source's filename is repeated into the `temp` directory, so if the source file is `a/b/c/d/e/f/source.c` that whole hierarchy will be repeated into `temp-platformname`, unless the `strip_dir` argument is not False. When we run the tests, the starting directory is already quite long on windows, it might be something like `C:\Users\VssAdministrator\AppData\Local\Temp\pytest-of-VssAdministrator\pytest-0\test_cython0\random\_examples\cython`, so the final output directory is `C:\Users\VssAdministrator\AppData\Local\Temp\pytest-of-VssAdministrator\pytest-0\test_cython0\random\_examples\cython\build\temp.win-amd64-3.9\Release\Users\VssAdministrator\AppData\Local\Temp\pytest-of-VssAdministrator\pytest-0\test_cython0\random\_examples\cython`.

I think this is too long for windows to handle. I propose to shorten the source file name, so it will not include the full path.