### PR TITLE
ENH: optimize np.histogramdd for uniform binning.

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -20,6 +20,7 @@ class Histogram1D(Benchmark):
 class Histogram2D(Benchmark):
     def setup(self):
         self.d = np.linspace(0, 100, 200000).reshape((-1,2))
+        self.normal = np.random.normal(0, 1, 5000000).reshape((-1,2))
 
     def time_full_coverage(self):
         np.histogramdd(self.d, (200, 200), ((0, 100), (0, 100)))
@@ -29,6 +30,9 @@ class Histogram2D(Benchmark):
 
     def time_fine_binning(self):
         np.histogramdd(self.d, (10000, 10000), ((0, 100), (0, 100)))
+
+    def time_normal_distribution(self):
+        np.histogramdd(self.normal, (1000, 1000), ((-10, 10), (-10, 10)))
 
 
 class Bincount(Benchmark):


### PR DESCRIPTION
Based on [this issue](https://github.com/numpy/numpy/issues/17676), this PR modifies `histogramdd` to directly calculate bin indices instead of using `searchsorted` when uniform binning is specified (via `bins` and `range` kwargs). This optimization is already being done for 1D `histogram`. For large enough inputs, this can result in 4-5x speedups for 2D uniform binning over the current `searchsorted` method:

![image](https://user-images.githubusercontent.com/5760027/97631496-5130de00-19ee-11eb-802f-719b314b69b7.png)
