### PR TITLE
BUG: f2py incorrectly translates dimension declarations - part 2.

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2103,7 +2103,10 @@ def buildimplicitrules(block):
 
 
 def myeval(e, g=None, l=None):
-    """ Like `eval` but returns only integers and floats """
+    """
+    Like `eval` but returns only integers and floats and uses integer division.
+    """
+    e = re.sub(r'/+', r'//', e)
     r = eval(e, g, l)
     if type(r) in [int, float]:
         return r
@@ -2178,14 +2181,10 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
                 c2 = myeval(ee, {}, {})
                 if (a * 0.5 + b == c and a * 1.5 + b == c2):
                     # gh-8062: return integers instead of floats if possible.
-                    try:
+                    if a.is_integer():
                         a = int(a)
-                    except:
-                        pass
-                    try:
+                    if b.is_integer():
                         b = int(b)
-                    except:
-                        pass
                     return a, b, x
             except Exception:
                 pass

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -93,18 +93,22 @@ class TestArrayDimCalculation(util.F2PyTest):
     # array declarations should be interpreted by f2py as integers not floats.
     # Prior to fix, test fails as generated fortran wrapper does not compile.
     code = """
-        function test(n, a)
+        function test(n, a, b)
           integer, intent(in) :: n
           real(8), intent(out) :: a(0:2*n/2)
+          real(8), intent(out) :: b(0:n/2*2)
           integer :: test
           a(:) = n
+          b(:) = 3
           test = 1
         endfunction
     """
 
     def test_issue_8062(self):
-        for n in (5, 11):
-            _, a = self.module.test(n)
+        for n in (5, 12):  # Test both odd and even n.
+            _, a, b = self.module.test(n)
             assert(a.shape == (n+1,))
             assert_array_equal(a, n)
+            assert(b.shape == (2*(n//2)+1,))
+            assert_array_equal(b, 3)
         


### PR DESCRIPTION
Corrections to PR gh-17654 following post-merge review.  Fix now only casts floats to integers if they are definitely integers.  Also, division that occurs in fortran array declarations is evaluated in an integer context, so `f2py.crackfortran.myeval` does the same, converting single to double slashes.

Fixed gh-8062.
