### PR TITLE
DOC: Modify Templates

### DIFF
--- a/doc/source/_templates/autosummary/attribute.rst
+++ b/doc/source/_templates/autosummary/attribute.rst
@@ -6,5 +6,9 @@
 
 attribute
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
+
+{# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
+is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+specifies `numpy` as the module name. #}
 

--- a/doc/source/_templates/autosummary/attribute.rst
+++ b/doc/source/_templates/autosummary/attribute.rst
@@ -9,6 +9,5 @@ attribute
 .. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
 
 {# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
-is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+is ambiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
 specifies `numpy` as the module name. #}
-

--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -10,5 +10,9 @@
 property
 {% endif %}
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
+
+{# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
+is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+specifies `numpy` as the module name. #}
 

--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -13,6 +13,5 @@ property
 .. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
 
 {# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
-is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+is ambiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
 specifies `numpy` as the module name. #}
-

--- a/doc/source/_templates/autosummary/member.rst
+++ b/doc/source/_templates/autosummary/member.rst
@@ -9,6 +9,5 @@ member
 .. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
 
 {# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
-is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+is ambiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
 specifies `numpy` as the module name. #}
-

--- a/doc/source/_templates/autosummary/member.rst
+++ b/doc/source/_templates/autosummary/member.rst
@@ -6,6 +6,9 @@
 
 member
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
 
+{# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
+is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+specifies `numpy` as the module name. #}
 

--- a/doc/source/_templates/autosummary/method.rst
+++ b/doc/source/_templates/autosummary/method.rst
@@ -6,5 +6,9 @@
 
 method
 
-.. auto{{ objtype }}:: {{ objname }}
+.. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
+
+{# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
+is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+specifies `numpy` as the module name. #}
 

--- a/doc/source/_templates/autosummary/method.rst
+++ b/doc/source/_templates/autosummary/method.rst
@@ -9,6 +9,5 @@ method
 .. auto{{ objtype }}:: {{ fullname | replace("numpy.", "numpy::") }}
 
 {# In the fullname (e.g. `numpy.ma.MaskedArray.methodname`), the module name
-is anbiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
+is ambiguous. Using a `::` separator (e.g. `numpy::ma.MaskedArray.methodname`)
 specifies `numpy` as the module name. #}
-


### PR DESCRIPTION
For the comparison with #17515 . The differences are:
* no need to specify the template files (`:template:` option). This also means that we don't have to care the type of the object (`function`, `attribute`, etc.)
* affects all docstrings, not only `numpy.ma` (see https://github.com/numpy/numpy/pull/17515#issue-500450253 for the effect)

I think this is better than #17515, but I'm not sure.