### PR TITLE
TST: use a more standard workflow for PyPy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,12 +242,15 @@ stages:
         python -c "import sys; print(sys.version)"
         python -m pip install --upgrade "setuptools<49.2.0"
         python -m pip install urllib3
-        basedir = $(python numpy/tools/openblas_support.py)
-        cp -r $basedir/lib/* /usr/local/lib
-        cp $basedir/include/* /usr/local/include
+        python -m pip install -r test_requirements.txt
+        basedir=$(python ./tools/openblas_support.py)
+        sudo cp -r $basedir/lib/* /usr/local/lib
+        sudo cp $basedir/include/* /usr/local/include
+        sudo ldconfig /usr/local/lib
       displayName: 'Get OpenBLAS'
     - script: |
         python setup.py build_src --verbose-cfg bdist_wheel 
+        # do the rest in a subdirectory so 'import numpy' works
         pushd dist
         python -mpip install ./numpy*
         python ../tools/openblas_support.py --check_version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,8 +235,28 @@ stages:
     pool:
       vmIMage: 'ubuntu-18.04'
     steps:
-    - script: source tools/pypy-test.sh
-      displayName: 'Run PyPy3 Build / Tests'
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: pypy3
+    - script: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install --upgrade "setuptools<49.2.0"
+        python -m pip install urllib3
+        basedir = $(python numpy/tools/openblas_support.py)
+        cp -r $basedir/lib/* /usr/local/lib
+        cp $basedir/include/* /usr/local/include
+      displayName: 'Get OpenBLAS'
+    - script: |
+        python setup.py build_src --verbose-cfg bdist_wheel 
+        pushd dist
+        python -mpip install ./numpy*
+        python ../tools/openblas_support.py --check_version
+        popd
+      displayName: 'Build, check OpenBLAS version'
+    - script: |
+        python runtests.py --debug-info --show-build-log -v -- -rsx \
+                --junitxml=junit/test-results.xml --durations 10 
+      displayName: 'Test'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -28,8 +28,8 @@ include_dirs = $target/lib:$LIB
 runtime_library_dirs = $target/lib
 EOF
 
-echo getting PyPy 3.6-v7.3.1
-wget -q https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 -O pypy.tar.bz2
+echo getting PyPy 3.6-v7.3.2
+wget -q https://downloads.python.org/pypy/pypy3.6-v7.3.2-linux64.tar.bz2 -O pypy.tar.bz2
 mkdir -p pypy3
 (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
 pypy3/bin/pypy3 -mensurepip


### PR DESCRIPTION
Now that PyPy is available on azure pipelines, there is no reason to download it specially. 
- Update the (now unused) build script, just in case we decided to go that route
- Update the PyPy job and break it into steps
- check the OpenBLAS version before running tests, just in case the tests segfault, so it is clear which OpenBLAS is being used