### PR TITLE
BUG: Fixed an issue where `.pyi` files were ignored by numpy sub-packages

### DIFF
--- a/numpy/distutils/setup.py
+++ b/numpy/distutils/setup.py
@@ -8,6 +8,7 @@ def configuration(parent_package='',top_path=None):
     config.add_data_files('site.cfg')
     config.add_data_files('mingw/gfortran_vs2003_hack.c')
     config.add_data_dir('checks')
+    config.add_data_files('*.pyi')
     config.make_config_py()
     return config
 

--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -30,6 +30,7 @@ def configuration(parent_package='', top_path=None):
     config.add_data_files(
         'src/fortranobject.c',
         'src/fortranobject.h')
+    config.add_data_files('*.pyi')
     return config
 
 

--- a/numpy/fft/setup.py
+++ b/numpy/fft/setup.py
@@ -14,6 +14,7 @@ def configuration(parent_package='',top_path=None):
                          define_macros=defs,
                          )
 
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == '__main__':

--- a/numpy/lib/setup.py
+++ b/numpy/lib/setup.py
@@ -4,6 +4,7 @@ def configuration(parent_package='',top_path=None):
     config = Configuration('lib', parent_package, top_path)
     config.add_subpackage('tests')
     config.add_data_dir('tests/data')
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == '__main__':

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -80,6 +80,7 @@ def configuration(parent_package='', top_path=None):
         extra_info=lapack_info,
         libraries=['npymath'],
     )
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == '__main__':

--- a/numpy/ma/setup.py
+++ b/numpy/ma/setup.py
@@ -3,6 +3,7 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('ma', parent_package, top_path)
     config.add_subpackage('tests')
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == "__main__":

--- a/numpy/matrixlib/setup.py
+++ b/numpy/matrixlib/setup.py
@@ -3,6 +3,7 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('matrixlib', parent_package, top_path)
     config.add_subpackage('tests')
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == "__main__":

--- a/numpy/polynomial/setup.py
+++ b/numpy/polynomial/setup.py
@@ -2,6 +2,7 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('polynomial', parent_package, top_path)
     config.add_subpackage('tests')
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == '__main__':

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -137,6 +137,7 @@ def configuration(parent_package='', top_path=None):
                          define_macros=defs + LEGACY_DEFS,
                          )
     config.add_data_files(*depends)
+    config.add_data_files('*.pyi')
     return config
 
 

--- a/numpy/testing/setup.py
+++ b/numpy/testing/setup.py
@@ -6,6 +6,7 @@ def configuration(parent_package='',top_path=None):
 
     config.add_subpackage('_private')
     config.add_subpackage('tests')
+    config.add_data_files('*.pyi')
     return config
 
 if __name__ == '__main__':

--- a/numpy/typing/setup.py
+++ b/numpy/typing/setup.py
@@ -3,6 +3,7 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('typing', parent_package, top_path)
     config.add_subpackage('tests')
     config.add_data_dir('tests/data')
+    config.add_data_files('*.pyi')
     return config
 
 

--- a/numpy/typing/tests/test_isfile.py
+++ b/numpy/typing/tests/test_isfile.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+
+import numpy as np
+from numpy.testing import assert_
+
+ROOT = Path(np.__file__).parents[0]
+FILES = [
+    ROOT / "py.typed",
+    ROOT / "__init__.pyi",
+    ROOT / "char.pyi",
+    ROOT / "ctypeslib.pyi",
+    ROOT / "emath.pyi",
+    ROOT / "rec.pyi",
+    ROOT / "version.pyi",
+    ROOT / "core" / "__init__.pyi",
+    ROOT / "distutils" / "__init__.pyi",
+    ROOT / "f2py" / "__init__.pyi",
+    ROOT / "fft" / "__init__.pyi",
+    ROOT / "lib" / "__init__.pyi",
+    ROOT / "linalg" / "__init__.pyi",
+    ROOT / "ma" / "__init__.pyi",
+    ROOT / "matrixlib" / "__init__.pyi",
+    ROOT / "polynomial" / "__init__.pyi",
+    ROOT / "random" / "__init__.pyi",
+    ROOT / "testing" / "__init__.pyi",
+]
+
+
+class TestIsFile:
+    def test_isfile(self):
+        """Test if all ``.pyi`` files are properly installed."""
+        for file in FILES:
+            assert_(os.path.isfile(file))


### PR DESCRIPTION
As of the moment `.pyi` stub files are only recognized for the main `numpy` namespace and the `numpy.core` sub-package, 
despite the existence of stub files in other sub-packages such as `numpy.lib` and `numpy.random`.

This PR fixes aforementioned issue.