### PR TITLE
BUG: Raise promotion error if a DType was provided in array coercion

### DIFF
--- a/doc/release/upcoming_changes/17706.compatibility.rst
+++ b/doc/release/upcoming_changes/17706.compatibility.rst
@@ -1,0 +1,10 @@
+Void dtype discovery in ``np.array``
+------------------------------------
+In calls using ``np.array(..., dtype="V")``, ``arr.astype("V")``,
+and similar a TypeError will now be correctly raised unless all
+elements have the identical void length. An example for this is::
+
+     np.array([b"1", b"12"], dtype="V")
+
+Which previously returned an array with dtype ``"V2"`` which
+cannot represent ``b"1"`` faithfully.

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -602,6 +602,7 @@ npy_free_coercion_cache(coercion_cache_obj *next) {
  *
  * @param out_descr The current descriptor.
  * @param descr The newly found descriptor to promote with
+ * @param fixed_DType The user provided (fixed) DType or NULL
  * @param flags dtype discover flags to signal failed promotion.
  * @return -1 on error, 0 on success.
  */
@@ -636,13 +637,15 @@ handle_promotion(PyArray_Descr **out_descr, PyArray_Descr *descr,
  * Handle a leave node (known scalar) during dtype and shape discovery.
  *
  * @param obj The python object or nested sequence to convert
- * @param max_dims The maximum number of dimensions.
  * @param curr_dims The current number of dimensions (depth in the recursion)
+ * @param max_dims The maximum number of dimensions.
  * @param out_shape The discovered output shape, will be filled
- * @param coercion_cache The coercion cache object to use.
- * @param DType the DType class that should be used, or NULL, if not provided.
+ * @param fixed_DType The user provided (fixed) DType or NULL
  * @param flags used signal that this is a ragged array, used internally and
  *        can be expanded if necessary.
+ * @param DType the DType class that should be used, or NULL, if not provided.
+ *
+ * @return 0 on success -1 on error
  */
 static NPY_INLINE int
 handle_scalar(

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -258,6 +258,18 @@ string_unicode_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 static PyArray_Descr *
 void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 {
+    /* Specifically allow unstructured promotion (new in 1.20) */
+    if (descr1->subarray == NULL && descr1->names == NULL &&
+            descr2->subarray == NULL && descr2->names == NULL) {
+        if (descr1->elsize >= descr2->elsize) {
+            Py_INCREF(descr1);
+            return descr1;
+        }
+        else {
+            Py_INCREF(descr2);
+            return descr2;
+        }
+    }
     /*
      * We currently do not support promotion of void types unless they
      * are equivalent.

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -263,8 +263,17 @@ void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
      * are equivalent.
      */
     if (!PyArray_CanCastTypeTo(descr1, descr2, NPY_EQUIV_CASTING)) {
-        PyErr_SetString(PyExc_TypeError,
-                "invalid type promotion with structured or void datatype(s).");
+        if (descr1->subarray == NULL && descr1->names == NULL &&
+                descr2->subarray == NULL && descr2->names == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                    "invalid type promotion with void datatypes of different "
+                    "length. You may use instead `np.bytes_` if the data "
+                    "contains no trailing zero bytes.");
+        }
+        else {
+            PyErr_SetString(PyExc_TypeError,
+                    "invalid type promotion with structured datatype(s).");
+        }
         return NULL;
     }
     Py_INCREF(descr1);

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -266,9 +266,9 @@ void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
         if (descr1->subarray == NULL && descr1->names == NULL &&
                 descr2->subarray == NULL && descr2->names == NULL) {
             PyErr_SetString(PyExc_TypeError,
-                    "invalid type promotion with void datatypes of different "
-                    "length. You may use instead `np.bytes_` if the data "
-                    "contains no trailing zero bytes.");
+                    "Invalid type promotion with void datatypes of different "
+                    "lengths. Use the `np.bytes_` datatype instead to pad the "
+                    "shorter value with trailing zero bytes.");
         }
         else {
             PyErr_SetString(PyExc_TypeError,

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -258,7 +258,7 @@ string_unicode_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 static PyArray_Descr *
 void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 {
-    /* Specifically allow unstructured promotion (new in 1.20) */
+    /* Allow unstructured, flexible void promotion (new in 1.20) */
     if (descr1->subarray == NULL && descr1->names == NULL &&
             descr2->subarray == NULL && descr2->names == NULL) {
         if (descr1->elsize >= descr2->elsize) {

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -258,18 +258,6 @@ string_unicode_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 static PyArray_Descr *
 void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
 {
-    /* Allow unstructured, flexible void promotion (new in 1.20) */
-    if (descr1->subarray == NULL && descr1->names == NULL &&
-            descr2->subarray == NULL && descr2->names == NULL) {
-        if (descr1->elsize >= descr2->elsize) {
-            Py_INCREF(descr1);
-            return descr1;
-        }
-        else {
-            Py_INCREF(descr2);
-            return descr2;
-        }
-    }
     /*
      * We currently do not support promotion of void types unless they
      * are equivalent.

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -844,7 +844,29 @@ class TestCreation:
 
     def test_void(self):
         arr = np.array([], dtype='V')
-        assert_equal(arr.dtype.kind, 'V')
+        assert arr.dtype == 'V8'  # current default
+        # Check that promotion of different length works:
+        arr = np.array([b"1234", b"12345"], dtype="V")
+        assert arr.dtype == 'V5'
+        arr = np.array([b"12345", b"1234"], dtype="V")
+        assert arr.dtype == 'V5'
+        # Check the same for the casting path:
+        arr = np.array([b"1234", b"12345"], dtype="O").astype("V")
+        assert arr.dtype == 'V5'
+
+    @pytest.mark.parametrize("idx",
+            [pytest.param(Ellipsis, id="arr"), pytest.param((), id="scalar")])
+    def test_structured_void_promotion(self, idx):
+        arr = np.array(
+            [np.array(1, dtype="i,i")[idx], np.array(2, dtype='i,i')[idx]],
+            dtype="V")
+        assert_array_equal(arr, np.array([(1, 1), (2, 2)], dtype="i,i"))
+        # The following fails to promote the two dtypes, resulting in an error
+        with pytest.raises(TypeError):
+            np.array(
+                [np.array(1, dtype="i,i")[idx], np.array(2, dtype='i,i,i')[idx]],
+                dtype="V")
+
 
     def test_too_big_error(self):
         # 45341 is the smallest integer greater than sqrt(2**31 - 1).

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -845,14 +845,22 @@ class TestCreation:
     def test_void(self):
         arr = np.array([], dtype='V')
         assert arr.dtype == 'V8'  # current default
-        # Check that promotion of different length works:
-        arr = np.array([b"1234", b"12345"], dtype="V")
-        assert arr.dtype == 'V5'
-        arr = np.array([b"12345", b"1234"], dtype="V")
-        assert arr.dtype == 'V5'
+        # Same length scalars (those that go to the same void) work:
+        arr = np.array([b"1234", b"1234"], dtype="V")
+        assert arr.dtype == "V4"
+
+        # Promoting different lengths will fail (pre 1.20 this worked)
+        # by going via S5 and casting to V5.
+        with pytest.raises(TypeError):
+            np.array([b"1234", b"12345"], dtype="V")
+        with pytest.raises(TypeError):
+            np.array([b"12345", b"1234"], dtype="V")
+
         # Check the same for the casting path:
-        arr = np.array([b"1234", b"12345"], dtype="O").astype("V")
-        assert arr.dtype == 'V5'
+        arr = np.array([b"1234", b"1234"], dtype="O").astype("V")
+        assert arr.dtype == "V4"
+        with pytest.raises(TypeError):
+            np.array([b"1234", b"12345"], dtype="O").astype("V")
 
     @pytest.mark.parametrize("idx",
             [pytest.param(Ellipsis, id="arr"), pytest.param((), id="scalar")])

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1005,7 +1005,8 @@ class TestTypes:
         assert res_bs.metadata == res.metadata
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
+            [[np.dtype("V9"), np.dtype("V10")],
+             [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
              [np.dtype("i8,i8"), np.dtype("i4,i4")],
             ])
     def test_invalid_void_promotion(self, dtype1, dtype2):
@@ -1015,8 +1016,7 @@ class TestTypes:
             np.promote_types(dtype1, dtype2)
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V10"), np.dtype("V9")],
-             [np.dtype("V10"), np.dtype("V10")],
+            [[np.dtype("V10"), np.dtype("V10")],
              [np.dtype([("name1", "<i8")]), np.dtype([("name1", ">i8")])],
              [np.dtype("i8,i8"), np.dtype("i8,>i8")],
             ])

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1005,8 +1005,7 @@ class TestTypes:
         assert res_bs.metadata == res.metadata
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V6"), np.dtype("V10")],
-             [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
+            [[np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
              [np.dtype("i8,i8"), np.dtype("i4,i4")],
             ])
     def test_invalid_void_promotion(self, dtype1, dtype2):
@@ -1016,7 +1015,8 @@ class TestTypes:
             np.promote_types(dtype1, dtype2)
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V10"), np.dtype("V10")],
+            [[np.dtype("V10"), np.dtype("V9")],
+             [np.dtype("V10"), np.dtype("V10")],
              [np.dtype([("name1", "<i8")]), np.dtype([("name1", ">i8")])],
              [np.dtype("i8,i8"), np.dtype("i8,>i8")],
             ])

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1005,7 +1005,7 @@ class TestTypes:
         assert res_bs.metadata == res.metadata
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V9"), np.dtype("V10")],
+            [[np.dtype("V6"), np.dtype("V10")],
              [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
              [np.dtype("i8,i8"), np.dtype("i4,i4")],
             ])


### PR DESCRIPTION
This fixes mainly the creation of unstructured void arrays from
scalars, by allowing promotion two unstructured void dtypes.

Structured voids will fail promoting. This promotion error is
now correctly floated out instead of using `object` dtype which
is incorrect when a dtype was passed in.
