### PR TITLE
ENH: adds type hints to numpy.version

### DIFF
--- a/numpy/typing/tests/test_isfile.py
+++ b/numpy/typing/tests/test_isfile.py
@@ -12,7 +12,6 @@ FILES = [
     ROOT / "ctypeslib.pyi",
     ROOT / "emath.pyi",
     ROOT / "rec.pyi",
-    ROOT / "version.pyi",
     ROOT / "core" / "__init__.pyi",
     ROOT / "distutils" / "__init__.pyi",
     ROOT / "f2py" / "__init__.pyi",

--- a/numpy/version.pyi
+++ b/numpy/version.pyi
@@ -1,7 +1,0 @@
-from typing import Any
-
-short_version: Any
-version: Any
-full_version: Any
-git_revision: Any
-release: Any

--- a/setup.py
+++ b/setup.py
@@ -140,11 +140,11 @@ def write_version_py(filename='numpy/version.py'):
 # THIS FILE IS GENERATED FROM NUMPY SETUP.PY
 #
 # To compare versions robustly, use `numpy.lib.NumpyVersion`
-short_version = '%(version)s'
-version = '%(version)s'
-full_version = '%(full_version)s'
-git_revision = '%(git_revision)s'
-release = %(isrelease)s
+short_version: str = '%(version)s'
+version: str = '%(version)s'
+full_version: str = '%(full_version)s'
+git_revision: str = '%(git_revision)s'
+release: bool = %(isrelease)s
 
 if not release:
     version = full_version


### PR DESCRIPTION
To address #17702,  adds type annotations to the generated `numpy.version` submodule