### PR TITLE
BUG: Refactor complex floor_divide to avoid osx-arm64 opt warnings

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -2521,21 +2521,16 @@ NPY_NO_EXPORT void
 NPY_NO_EXPORT void
 @TYPE@_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
+    @ftype@ mod;
     BINARY_LOOP {
         const @ftype@ in1r = ((@ftype@ *)ip1)[0];
         const @ftype@ in1i = ((@ftype@ *)ip1)[1];
         const @ftype@ in2r = ((@ftype@ *)ip2)[0];
         const @ftype@ in2i = ((@ftype@ *)ip2)[1];
-        if (npy_fabs@c@(in2r) >= npy_fabs@c@(in2i)) {
-            const @ftype@ rat = in2i/in2r;
-            ((@ftype@ *)op1)[0] = npy_floor@c@((in1r + in1i*rat)/(in2r + in2i*rat));
-            ((@ftype@ *)op1)[1] = 0;
-        }
-        else {
-            const @ftype@ rat = in2r/in2i;
-            ((@ftype@ *)op1)[0] = npy_floor@c@((in1r*rat + in1i)/(in2i + in2r*rat));
-            ((@ftype@ *)op1)[1] = 0;
-        }
+        ((@ftype@ *)op1)[0] = npy_divmod@c@(in1r*in2r + in1i*in2i,
+                                            in2r*in2r + in2i*in2i,
+                                            &mod);
+        ((@ftype@ *)op1)[1] = 0;
     }
 }
 


### PR DESCRIPTION
When building `numpy` on the new Apple Silicon osx-arm64 platform using clang11 (see https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/ for details), numpy fails tests because of extra divide-by-zero warnings when performing floor division with complex number arrays, even though the computations themselves work just fine.

I tracked this to the code in `@TYPE@_floor_divide` for complex types, where it appears that the optimizer on arm64 ends up dispatching both branches at the same time.  Even though the second branch is discarded because it is not the code path, the divide-by-zero leaves behind a "ghost" floating point exception, and the tests fail.  

Replacing the code with the same routine that is used for scalar complex floor division in `scalarmath.c` (using `npy_divmod`) does not suffer from this problem.  It is also reasonable, I believe, for scalar and array methods to use the same algorithm.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
