### PR TITLE
REV: Revert gh-17654 - f2py incorrectly translates dimension declarations. 

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2177,15 +2177,6 @@ def getlincoef(e, xset):  # e = a*x+b ; x in xset
                     m1 = re_1.match(ee)
                 c2 = myeval(ee, {}, {})
                 if (a * 0.5 + b == c and a * 1.5 + b == c2):
-                    # gh-8062: return integers instead of floats if possible.
-                    try:
-                        a = int(a)
-                    except:
-                        pass
-                    try:
-                        b = int(b)
-                    except:
-                        pass
                     return a, b, x
             except Exception:
                 pass

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -86,25 +86,3 @@ class TestPublicPrivate():
         assert 'public' not in mod['vars']['a']['attrspec']
         assert 'private' not in mod['vars']['seta']['attrspec']
         assert 'public' in mod['vars']['seta']['attrspec']
-
-
-class TestArrayDimCalculation(util.F2PyTest):
-    # Issue gh-8062.  Calculations that occur in the dimensions of fortran
-    # array declarations should be interpreted by f2py as integers not floats.
-    # Prior to fix, test fails as generated fortran wrapper does not compile.
-    code = """
-        function test(n, a)
-          integer, intent(in) :: n
-          real(8), intent(out) :: a(0:2*n/2)
-          integer :: test
-          a(:) = n
-          test = 1
-        endfunction
-    """
-
-    def test_issue_8062(self):
-        for n in (5, 11):
-            _, a = self.module.test(n)
-            assert(a.shape == (n+1,))
-            assert_array_equal(a, n)
-        


### PR DESCRIPTION
PR gh-17654 was supposed to fix issue gh-8062 but didn't. This reverts the changes, pending a correct solution.

See also conversation in PR gh-17687.