### PR TITLE
MAINT: Add more files to `.gitgnore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,14 @@ numpy/core/include/numpy/config.h
 numpy/core/include/numpy/multiarray_api.txt
 numpy/core/include/numpy/ufunc_api.txt
 numpy/core/lib/
+numpy/core/src/_simd/_simd.dispatch.avx512_skx.c
+numpy/core/src/_simd/_simd.dispatch.avx512f.c
+numpy/core/src/_simd/_simd.dispatch.c
+numpy/core/src/_simd/_simd.dispatch.fma3.avx2.c
+numpy/core/src/_simd/_simd.dispatch.h
+numpy/core/src/_simd/_simd.dispatch.sse42.c
+numpy/core/src/_simd/_simd_data.inc
+numpy/core/src/_simd/_simd_inc.h
 numpy/core/src/common/npy_binsearch.h
 numpy/core/src/common/npy_cpu_features.c
 numpy/core/src/common/npy_partition.h
@@ -140,6 +148,7 @@ numpy/core/src/common/_cpu_dispatch.h
 numpy/core/src/multiarray/_multiarray_tests.c
 numpy/core/src/multiarray/arraytypes.c
 numpy/core/src/multiarray/einsum.c
+numpy/core/src/multiarray/einsum_sumprod.c
 numpy/core/src/multiarray/lowlevel_strided_loops.c
 numpy/core/src/multiarray/multiarray_tests.c
 numpy/core/src/multiarray/nditer_templ.c


### PR DESCRIPTION
NumPy dynamically generates a number of number of files upon installation, some of which have yet to be added to `.gitgnore`. This PR addresses abovementioned issue.

For reference: 
The 9 new `.gitgnore` entries were identified after a numpy installation via `pip install -e .` (MacOS, python 3.8).

Pinging @seiko2plus as this includes a number of SIMD-related files.