### PR TITLE
ENH: Make `ndarray` generic w.r.t. its shape and dtype

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -913,8 +913,6 @@ class dtype(Generic[_DTypeScalar]):
     @property
     def type(self) -> Type[generic]: ...
 
-_DType = dtype  # to avoid name conflicts with ndarray.dtype
-
 class _flagsobj:
     aligned: bool
     updateifcopy: bool
@@ -1441,10 +1439,16 @@ class _ArrayOrScalarCommon:
         keepdims: bool = ...,
     ) -> _NdArraySubClass: ...
 
+_DType = TypeVar("_DType", bound=dtype[Any])
+
+# TODO: Set the `bound` to something more suitable once we
+# have proper shape support
+_ShapeType = TypeVar("_ShapeType", bound=Any)
+
 _BufferType = Union[ndarray, bytes, bytearray, memoryview]
 _Casting = Literal["no", "equiv", "safe", "same_kind", "unsafe"]
 
-class ndarray(_ArrayOrScalarCommon, Iterable, Sized, Container):
+class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType]):
     @property
     def base(self) -> Optional[ndarray]: ...
     @property
@@ -1468,8 +1472,6 @@ class ndarray(_ArrayOrScalarCommon, Iterable, Sized, Container):
         strides: _ShapeLike = ...,
         order: _OrderKACF = ...,
     ) -> _ArraySelf: ...
-    @property
-    def dtype(self) -> _DType: ...
     @property
     def ctypes(self) -> _ctypes: ...
     @property
@@ -1625,6 +1627,9 @@ class ndarray(_ArrayOrScalarCommon, Iterable, Sized, Container):
     def __iand__(self: _ArraySelf, other: ArrayLike) -> _ArraySelf: ...
     def __ixor__(self: _ArraySelf, other: ArrayLike) -> _ArraySelf: ...
     def __ior__(self: _ArraySelf, other: ArrayLike) -> _ArraySelf: ...
+    # Keep `dtype` at the bottom to avoid name conflicts with `np.dtype`
+    @property
+    def dtype(self) -> _DType: ...
 
 # NOTE: while `np.generic` is not technically an instance of `ABCMeta`,
 # the `@abstractmethod` decorator is herein used to (forcefully) deny
@@ -1644,8 +1649,6 @@ class generic(_ArrayOrScalarCommon):
     @property
     def base(self) -> None: ...
     @property
-    def dtype(self: _ScalarType) -> _DType[_ScalarType]: ...
-    @property
     def ndim(self) -> Literal[0]: ...
     @property
     def size(self) -> Literal[1]: ...
@@ -1664,6 +1667,9 @@ class generic(_ArrayOrScalarCommon):
         self: _ScalarType, axis: Union[Literal[0], Tuple[()]] = ...
     ) -> _ScalarType: ...
     def transpose(self: _ScalarType, __axes: Tuple[()] = ...) -> _ScalarType: ...
+    # Keep `dtype` at the bottom to avoid name conflicts with `np.dtype`
+    @property
+    def dtype(self: _ScalarType) -> dtype[_ScalarType]: ...
 
 class number(generic, Generic[_NBit_co]):  # type: ignore
     @property

--- a/numpy/typing/tests/data/reveal/array_constructors.py
+++ b/numpy/typing/tests/data/reveal/array_constructors.py
@@ -11,92 +11,92 @@ C: List[int]
 
 def func(i: int, j: int, **kwargs: Any) -> SubClass: ...
 
-reveal_type(np.asarray(A))  # E: ndarray
-reveal_type(np.asarray(B))  # E: ndarray
-reveal_type(np.asarray(C))  # E: ndarray
+reveal_type(np.asarray(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.asarray(B))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.asarray(C))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.asanyarray(A))  # E: ndarray
+reveal_type(np.asanyarray(A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.asanyarray(B))  # E: SubClass
-reveal_type(np.asanyarray(B, dtype=int))  # E: ndarray
-reveal_type(np.asanyarray(C))  # E: ndarray
+reveal_type(np.asanyarray(B, dtype=int))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.asanyarray(C))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.ascontiguousarray(A))  # E: ndarray
-reveal_type(np.ascontiguousarray(B))  # E: ndarray
-reveal_type(np.ascontiguousarray(C))  # E: ndarray
+reveal_type(np.ascontiguousarray(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ascontiguousarray(B))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ascontiguousarray(C))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.asfortranarray(A))  # E: ndarray
-reveal_type(np.asfortranarray(B))  # E: ndarray
-reveal_type(np.asfortranarray(C))  # E: ndarray
+reveal_type(np.asfortranarray(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.asfortranarray(B))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.asfortranarray(C))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.require(A))  # E: ndarray
+reveal_type(np.require(A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.require(B))  # E: SubClass
 reveal_type(np.require(B, requirements=None))  # E: SubClass
-reveal_type(np.require(B, dtype=int))  # E: ndarray
-reveal_type(np.require(B, requirements="E"))  # E: ndarray
-reveal_type(np.require(B, requirements=["ENSUREARRAY"]))  # E: ndarray
-reveal_type(np.require(B, requirements={"F", "E"}))  # E: ndarray
+reveal_type(np.require(B, dtype=int))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.require(B, requirements="E"))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.require(B, requirements=["ENSUREARRAY"]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.require(B, requirements={"F", "E"}))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.require(B, requirements=["C", "OWNDATA"]))  # E: SubClass
 reveal_type(np.require(B, requirements="W"))  # E: SubClass
 reveal_type(np.require(B, requirements="A"))  # E: SubClass
-reveal_type(np.require(C))  # E: ndarray
+reveal_type(np.require(C))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.linspace(0, 10))  # E: numpy.ndarray
-reveal_type(np.linspace(0, 10, retstep=True))  # E: Tuple[numpy.ndarray, numpy.inexact[Any]]
-reveal_type(np.logspace(0, 10))  # E: numpy.ndarray
-reveal_type(np.geomspace(1, 10))  # E: numpy.ndarray
+reveal_type(np.linspace(0, 10))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.linspace(0, 10, retstep=True))  # E: Tuple[numpy.ndarray[Any, Any], numpy.inexact[Any]]
+reveal_type(np.logspace(0, 10))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.geomspace(1, 10))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.zeros_like(A))  # E: numpy.ndarray
-reveal_type(np.zeros_like(C))  # E: numpy.ndarray
+reveal_type(np.zeros_like(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.zeros_like(C))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.zeros_like(B))  # E: SubClass
-reveal_type(np.zeros_like(B, dtype=np.int64))  # E: numpy.ndarray
+reveal_type(np.zeros_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.ones_like(A))  # E: numpy.ndarray
-reveal_type(np.ones_like(C))  # E: numpy.ndarray
+reveal_type(np.ones_like(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ones_like(C))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.ones_like(B))  # E: SubClass
-reveal_type(np.ones_like(B, dtype=np.int64))  # E: numpy.ndarray
+reveal_type(np.ones_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.empty_like(A))  # E: numpy.ndarray
-reveal_type(np.empty_like(C))  # E: numpy.ndarray
+reveal_type(np.empty_like(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.empty_like(C))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.empty_like(B))  # E: SubClass
-reveal_type(np.empty_like(B, dtype=np.int64))  # E: numpy.ndarray
+reveal_type(np.empty_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.full_like(A, i8))  # E: numpy.ndarray
-reveal_type(np.full_like(C, i8))  # E: numpy.ndarray
+reveal_type(np.full_like(A, i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.full_like(C, i8))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.full_like(B, i8))  # E: SubClass
-reveal_type(np.full_like(B, i8, dtype=np.int64))  # E: numpy.ndarray
+reveal_type(np.full_like(B, i8, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.ones(1))  # E: numpy.ndarray
-reveal_type(np.ones([1, 1, 1]))  # E: numpy.ndarray
+reveal_type(np.ones(1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ones([1, 1, 1]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.full(1, i8))  # E: numpy.ndarray
-reveal_type(np.full([1, 1, 1], i8))  # E: numpy.ndarray
+reveal_type(np.full(1, i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.full([1, 1, 1], i8))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.indices([1, 2, 3]))  # E: numpy.ndarray
-reveal_type(np.indices([1, 2, 3], sparse=True))  # E: tuple[numpy.ndarray]
+reveal_type(np.indices([1, 2, 3]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.indices([1, 2, 3], sparse=True))  # E: tuple[numpy.ndarray[Any, Any]]
 
 reveal_type(np.fromfunction(func, (3, 5)))  # E: SubClass
 
-reveal_type(np.identity(10))  # E: numpy.ndarray
+reveal_type(np.identity(10))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.atleast_1d(A))  # E: numpy.ndarray
-reveal_type(np.atleast_1d(C))  # E: numpy.ndarray
-reveal_type(np.atleast_1d(A, A))  # E: list[numpy.ndarray]
-reveal_type(np.atleast_1d(A, C))  # E: list[numpy.ndarray]
-reveal_type(np.atleast_1d(C, C))  # E: list[numpy.ndarray]
+reveal_type(np.atleast_1d(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.atleast_1d(C))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.atleast_1d(A, A))  # E: list[numpy.ndarray[Any, Any]]
+reveal_type(np.atleast_1d(A, C))  # E: list[numpy.ndarray[Any, Any]]
+reveal_type(np.atleast_1d(C, C))  # E: list[numpy.ndarray[Any, Any]]
 
-reveal_type(np.atleast_2d(A))  # E: numpy.ndarray
+reveal_type(np.atleast_2d(A))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.atleast_3d(A))  # E: numpy.ndarray
+reveal_type(np.atleast_3d(A))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.vstack([A, A]))  # E: numpy.ndarray
-reveal_type(np.vstack([A, C]))  # E: numpy.ndarray
-reveal_type(np.vstack([C, C]))  # E: numpy.ndarray
+reveal_type(np.vstack([A, A]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.vstack([A, C]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.vstack([C, C]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.hstack([A, A]))  # E: numpy.ndarray
+reveal_type(np.hstack([A, A]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.stack([A, A]))  # E: numpy.ndarray
-reveal_type(np.stack([A, A], axis=0))  # E: numpy.ndarray
+reveal_type(np.stack([A, A]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.stack([A, A], axis=0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.stack([A, A], out=B))  # E: SubClass
 
-reveal_type(np.block([[A, A], [A, A]]))  # E: numpy.ndarray
-reveal_type(np.block(C))  # E: numpy.ndarray
+reveal_type(np.block([[A, A], [A, A]]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.block(C))  # E: numpy.ndarray[Any, Any]

--- a/numpy/typing/tests/data/reveal/fromnumeric.py
+++ b/numpy/typing/tests/data/reveal/fromnumeric.py
@@ -24,104 +24,104 @@ reveal_type(
     np.take(B, 0)  # E: Union[numpy.generic, datetime.datetime, datetime.timedelta]
 )
 reveal_type(
-    np.take(  # E: Union[Union[numpy.generic, datetime.datetime, datetime.timedelta], numpy.ndarray]
+    np.take(  # E: Union[Union[numpy.generic, datetime.datetime, datetime.timedelta], numpy.ndarray[Any, Any]]
         A, [0]
     )
 )
 reveal_type(
-    np.take(  # E: Union[Union[numpy.generic, datetime.datetime, datetime.timedelta], numpy.ndarray]
+    np.take(  # E: Union[Union[numpy.generic, datetime.datetime, datetime.timedelta], numpy.ndarray[Any, Any]]
         B, [0]
     )
 )
 
-reveal_type(np.reshape(a, 1))  # E: numpy.ndarray
-reveal_type(np.reshape(b, 1))  # E: numpy.ndarray
-reveal_type(np.reshape(c, 1))  # E: numpy.ndarray
-reveal_type(np.reshape(A, 1))  # E: numpy.ndarray
-reveal_type(np.reshape(B, 1))  # E: numpy.ndarray
+reveal_type(np.reshape(a, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.reshape(b, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.reshape(c, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.reshape(A, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.reshape(B, 1))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.choose(a, [True, True]))  # E: numpy.bool_
-reveal_type(np.choose(A, [True, True]))  # E: numpy.ndarray
+reveal_type(np.choose(A, [True, True]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.repeat(a, 1))  # E: numpy.ndarray
-reveal_type(np.repeat(b, 1))  # E: numpy.ndarray
-reveal_type(np.repeat(c, 1))  # E: numpy.ndarray
-reveal_type(np.repeat(A, 1))  # E: numpy.ndarray
-reveal_type(np.repeat(B, 1))  # E: numpy.ndarray
+reveal_type(np.repeat(a, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.repeat(b, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.repeat(c, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.repeat(A, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.repeat(B, 1))  # E: numpy.ndarray[Any, Any]
 
 # TODO: Add tests for np.put()
 
-reveal_type(np.swapaxes(A, 0, 0))  # E: numpy.ndarray
-reveal_type(np.swapaxes(B, 0, 0))  # E: numpy.ndarray
+reveal_type(np.swapaxes(A, 0, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.swapaxes(B, 0, 0))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.transpose(a))  # E: numpy.ndarray
-reveal_type(np.transpose(b))  # E: numpy.ndarray
-reveal_type(np.transpose(c))  # E: numpy.ndarray
-reveal_type(np.transpose(A))  # E: numpy.ndarray
-reveal_type(np.transpose(B))  # E: numpy.ndarray
+reveal_type(np.transpose(a))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.transpose(b))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.transpose(c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.transpose(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.transpose(B))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.partition(a, 0, axis=None))  # E: numpy.ndarray
-reveal_type(np.partition(b, 0, axis=None))  # E: numpy.ndarray
-reveal_type(np.partition(c, 0, axis=None))  # E: numpy.ndarray
-reveal_type(np.partition(A, 0))  # E: numpy.ndarray
-reveal_type(np.partition(B, 0))  # E: numpy.ndarray
+reveal_type(np.partition(a, 0, axis=None))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.partition(b, 0, axis=None))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.partition(c, 0, axis=None))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.partition(A, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.partition(B, 0))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.argpartition(a, 0))  # E: numpy.integer[Any]
 reveal_type(np.argpartition(b, 0))  # E: numpy.integer[Any]
-reveal_type(np.argpartition(c, 0))  # E: numpy.ndarray
-reveal_type(np.argpartition(A, 0))  # E: numpy.ndarray
-reveal_type(np.argpartition(B, 0))  # E: numpy.ndarray
+reveal_type(np.argpartition(c, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.argpartition(A, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.argpartition(B, 0))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.sort(A, 0))  # E: numpy.ndarray
-reveal_type(np.sort(B, 0))  # E: numpy.ndarray
+reveal_type(np.sort(A, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.sort(B, 0))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.argsort(A, 0))  # E: numpy.ndarray
-reveal_type(np.argsort(B, 0))  # E: numpy.ndarray
+reveal_type(np.argsort(A, 0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.argsort(B, 0))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.argmax(A))  # E: numpy.integer[Any]
 reveal_type(np.argmax(B))  # E: numpy.integer[Any]
-reveal_type(np.argmax(A, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray]
-reveal_type(np.argmax(B, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray]
+reveal_type(np.argmax(A, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.argmax(B, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.argmin(A))  # E: numpy.integer[Any]
 reveal_type(np.argmin(B))  # E: numpy.integer[Any]
-reveal_type(np.argmin(A, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray]
-reveal_type(np.argmin(B, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray]
+reveal_type(np.argmin(A, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.argmin(B, axis=0))  # E: Union[numpy.integer[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.searchsorted(A[0], 0))  # E: numpy.integer[Any]
 reveal_type(np.searchsorted(B[0], 0))  # E: numpy.integer[Any]
-reveal_type(np.searchsorted(A[0], [0]))  # E: numpy.ndarray
-reveal_type(np.searchsorted(B[0], [0]))  # E: numpy.ndarray
+reveal_type(np.searchsorted(A[0], [0]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.searchsorted(B[0], [0]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.resize(a, (5, 5)))  # E: numpy.ndarray
-reveal_type(np.resize(b, (5, 5)))  # E: numpy.ndarray
-reveal_type(np.resize(c, (5, 5)))  # E: numpy.ndarray
-reveal_type(np.resize(A, (5, 5)))  # E: numpy.ndarray
-reveal_type(np.resize(B, (5, 5)))  # E: numpy.ndarray
+reveal_type(np.resize(a, (5, 5)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.resize(b, (5, 5)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.resize(c, (5, 5)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.resize(A, (5, 5)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.resize(B, (5, 5)))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.squeeze(a))  # E: numpy.bool_
 reveal_type(np.squeeze(b))  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(np.squeeze(c))  # E: numpy.ndarray
-reveal_type(np.squeeze(A))  # E: numpy.ndarray
-reveal_type(np.squeeze(B))  # E: numpy.ndarray
+reveal_type(np.squeeze(c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.squeeze(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.squeeze(B))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.diagonal(A))  # E: numpy.ndarray
-reveal_type(np.diagonal(B))  # E: numpy.ndarray
+reveal_type(np.diagonal(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.diagonal(B))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.trace(A))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.trace(B))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.trace(A))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.trace(B))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
-reveal_type(np.ravel(a))  # E: numpy.ndarray
-reveal_type(np.ravel(b))  # E: numpy.ndarray
-reveal_type(np.ravel(c))  # E: numpy.ndarray
-reveal_type(np.ravel(A))  # E: numpy.ndarray
-reveal_type(np.ravel(B))  # E: numpy.ndarray
+reveal_type(np.ravel(a))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ravel(b))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ravel(c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ravel(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ravel(B))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.nonzero(a))  # E: tuple[numpy.ndarray]
-reveal_type(np.nonzero(b))  # E: tuple[numpy.ndarray]
-reveal_type(np.nonzero(c))  # E: tuple[numpy.ndarray]
-reveal_type(np.nonzero(A))  # E: tuple[numpy.ndarray]
-reveal_type(np.nonzero(B))  # E: tuple[numpy.ndarray]
+reveal_type(np.nonzero(a))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.nonzero(b))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.nonzero(c))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.nonzero(A))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.nonzero(B))  # E: tuple[numpy.ndarray[Any, Any]]
 
 reveal_type(np.shape(a))  # E: tuple[builtins.int]
 reveal_type(np.shape(b))  # E: tuple[builtins.int]
@@ -129,99 +129,99 @@ reveal_type(np.shape(c))  # E: tuple[builtins.int]
 reveal_type(np.shape(A))  # E: tuple[builtins.int]
 reveal_type(np.shape(B))  # E: tuple[builtins.int]
 
-reveal_type(np.compress([True], a))  # E: numpy.ndarray
-reveal_type(np.compress([True], b))  # E: numpy.ndarray
-reveal_type(np.compress([True], c))  # E: numpy.ndarray
-reveal_type(np.compress([True], A))  # E: numpy.ndarray
-reveal_type(np.compress([True], B))  # E: numpy.ndarray
+reveal_type(np.compress([True], a))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.compress([True], b))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.compress([True], c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.compress([True], A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.compress([True], B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.clip(a, 0, 1.0))  # E: numpy.number[Any]
 reveal_type(np.clip(b, -1, 1))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.clip(c, 0, 1))  # E: numpy.number[Any]
-reveal_type(np.clip(A, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.clip(B, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.clip(A, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.clip(B, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.sum(a))  # E: numpy.number[Any]
 reveal_type(np.sum(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.sum(c))  # E: numpy.number[Any]
 reveal_type(np.sum(A))  # E: numpy.number[Any]
 reveal_type(np.sum(B))  # E: numpy.number[Any]
-reveal_type(np.sum(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.sum(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.sum(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.sum(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.all(a))  # E: numpy.bool_
 reveal_type(np.all(b))  # E: numpy.bool_
 reveal_type(np.all(c))  # E: numpy.bool_
 reveal_type(np.all(A))  # E: numpy.bool_
 reveal_type(np.all(B))  # E: numpy.bool_
-reveal_type(np.all(A, axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.all(B, axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.all(A, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.all(B, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
+reveal_type(np.all(A, axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.all(B, axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.all(A, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.all(B, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 
 reveal_type(np.any(a))  # E: numpy.bool_
 reveal_type(np.any(b))  # E: numpy.bool_
 reveal_type(np.any(c))  # E: numpy.bool_
 reveal_type(np.any(A))  # E: numpy.bool_
 reveal_type(np.any(B))  # E: numpy.bool_
-reveal_type(np.any(A, axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.any(B, axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.any(A, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.any(B, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
+reveal_type(np.any(A, axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.any(B, axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.any(A, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.any(B, keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 
-reveal_type(np.cumsum(a))  # E: numpy.ndarray
-reveal_type(np.cumsum(b))  # E: numpy.ndarray
-reveal_type(np.cumsum(c))  # E: numpy.ndarray
-reveal_type(np.cumsum(A))  # E: numpy.ndarray
-reveal_type(np.cumsum(B))  # E: numpy.ndarray
+reveal_type(np.cumsum(a))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumsum(b))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumsum(c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumsum(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumsum(B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.ptp(a))  # E: numpy.number[Any]
 reveal_type(np.ptp(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.ptp(c))  # E: numpy.number[Any]
 reveal_type(np.ptp(A))  # E: numpy.number[Any]
 reveal_type(np.ptp(B))  # E: numpy.number[Any]
-reveal_type(np.ptp(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.ptp(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.ptp(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.ptp(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.ptp(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.ptp(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.ptp(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.ptp(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.amax(a))  # E: numpy.number[Any]
 reveal_type(np.amax(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.amax(c))  # E: numpy.number[Any]
 reveal_type(np.amax(A))  # E: numpy.number[Any]
 reveal_type(np.amax(B))  # E: numpy.number[Any]
-reveal_type(np.amax(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amax(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amax(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amax(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.amax(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amax(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amax(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amax(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.amin(a))  # E: numpy.number[Any]
 reveal_type(np.amin(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.amin(c))  # E: numpy.number[Any]
 reveal_type(np.amin(A))  # E: numpy.number[Any]
 reveal_type(np.amin(B))  # E: numpy.number[Any]
-reveal_type(np.amin(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amin(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amin(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.amin(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(np.amin(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amin(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amin(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.amin(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.prod(a))  # E: numpy.number[Any]
 reveal_type(np.prod(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.prod(c))  # E: numpy.number[Any]
 reveal_type(np.prod(A))  # E: numpy.number[Any]
 reveal_type(np.prod(B))  # E: numpy.number[Any]
-reveal_type(np.prod(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.prod(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.prod(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.prod(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.prod(b, out=d))  # E: numpy.ndarray
-reveal_type(np.prod(B, out=d))  # E: numpy.ndarray
+reveal_type(np.prod(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.prod(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.prod(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.prod(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.prod(b, out=d))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.prod(B, out=d))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.cumprod(a))  # E: numpy.ndarray
-reveal_type(np.cumprod(b))  # E: numpy.ndarray
-reveal_type(np.cumprod(c))  # E: numpy.ndarray
-reveal_type(np.cumprod(A))  # E: numpy.ndarray
-reveal_type(np.cumprod(B))  # E: numpy.ndarray
+reveal_type(np.cumprod(a))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumprod(b))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumprod(c))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumprod(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cumprod(B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.ndim(a))  # E: int
 reveal_type(np.ndim(b))  # E: int
@@ -238,41 +238,41 @@ reveal_type(np.size(B))  # E: int
 reveal_type(np.around(a))  # E: numpy.number[Any]
 reveal_type(np.around(b))  # E: numpy.floating[numpy.typing._32Bit]
 reveal_type(np.around(c))  # E: numpy.number[Any]
-reveal_type(np.around(A))  # E: numpy.ndarray
-reveal_type(np.around(B))  # E: numpy.ndarray
+reveal_type(np.around(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.around(B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.mean(a))  # E: numpy.number[Any]
 reveal_type(np.mean(b))  # E: numpy.number[Any]
 reveal_type(np.mean(c))  # E: numpy.number[Any]
 reveal_type(np.mean(A))  # E: numpy.number[Any]
 reveal_type(np.mean(B))  # E: numpy.number[Any]
-reveal_type(np.mean(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.mean(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.mean(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.mean(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.mean(b, out=d))  # E: numpy.ndarray
-reveal_type(np.mean(B, out=d))  # E: numpy.ndarray
+reveal_type(np.mean(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.mean(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.mean(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.mean(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.mean(b, out=d))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.mean(B, out=d))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.std(a))  # E: numpy.number[Any]
 reveal_type(np.std(b))  # E: numpy.number[Any]
 reveal_type(np.std(c))  # E: numpy.number[Any]
 reveal_type(np.std(A))  # E: numpy.number[Any]
 reveal_type(np.std(B))  # E: numpy.number[Any]
-reveal_type(np.std(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.std(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.std(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.std(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.std(b, out=d))  # E: numpy.ndarray
-reveal_type(np.std(B, out=d))  # E: numpy.ndarray
+reveal_type(np.std(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.std(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.std(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.std(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.std(b, out=d))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.std(B, out=d))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.var(a))  # E: numpy.number[Any]
 reveal_type(np.var(b))  # E: numpy.number[Any]
 reveal_type(np.var(c))  # E: numpy.number[Any]
 reveal_type(np.var(A))  # E: numpy.number[Any]
 reveal_type(np.var(B))  # E: numpy.number[Any]
-reveal_type(np.var(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.var(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.var(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.var(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(np.var(b, out=d))  # E: numpy.ndarray
-reveal_type(np.var(B, out=d))  # E: numpy.ndarray
+reveal_type(np.var(A, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.var(B, axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.var(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.var(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.var(b, out=d))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.var(B, out=d))  # E: numpy.ndarray[Any, Any]

--- a/numpy/typing/tests/data/reveal/ndarray_misc.py
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.py
@@ -16,135 +16,135 @@ B: SubClass
 
 reveal_type(f8.all())  # E: numpy.bool_
 reveal_type(A.all())  # E: numpy.bool_
-reveal_type(A.all(axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(A.all(keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
+reveal_type(A.all(axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(A.all(keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 reveal_type(A.all(out=B))  # E: SubClass
 
 reveal_type(f8.any())  # E: numpy.bool_
 reveal_type(A.any())  # E: numpy.bool_
-reveal_type(A.any(axis=0))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(A.any(keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray]
+reveal_type(A.any(axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(A.any(keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 reveal_type(A.any(out=B))  # E: SubClass
 
 reveal_type(f8.argmax())  # E: numpy.signedinteger[Any]
 reveal_type(A.argmax())  # E: numpy.signedinteger[Any]
-reveal_type(A.argmax(axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
+reveal_type(A.argmax(axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.argmax(out=B))  # E: SubClass
 
 reveal_type(f8.argmin())  # E: numpy.signedinteger[Any]
 reveal_type(A.argmin())  # E: numpy.signedinteger[Any]
-reveal_type(A.argmin(axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
+reveal_type(A.argmin(axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.argmin(out=B))  # E: SubClass
 
-reveal_type(f8.argsort())  # E: numpy.ndarray
-reveal_type(A.argsort())  # E: numpy.ndarray
+reveal_type(f8.argsort())  # E: numpy.ndarray[Any, Any]
+reveal_type(A.argsort())  # E: numpy.ndarray[Any, Any]
 
-reveal_type(f8.astype(np.int64).choose([()]))  # E: numpy.ndarray
-reveal_type(A.choose([0]))  # E: numpy.ndarray
+reveal_type(f8.astype(np.int64).choose([()]))  # E: numpy.ndarray[Any, Any]
+reveal_type(A.choose([0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(A.choose([0], out=B))  # E: SubClass
 
-reveal_type(f8.clip(1))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.clip(1))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.clip(None, 1))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(f8.clip(1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.clip(1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.clip(None, 1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.clip(1, out=B))  # E: SubClass
 reveal_type(A.clip(None, 1, out=B))  # E: SubClass
 
-reveal_type(f8.compress([0]))  # E: numpy.ndarray
-reveal_type(A.compress([0]))  # E: numpy.ndarray
+reveal_type(f8.compress([0]))  # E: numpy.ndarray[Any, Any]
+reveal_type(A.compress([0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(A.compress([0], out=B))  # E: SubClass
 
 reveal_type(f8.conj())  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(A.conj())  # E: numpy.ndarray
+reveal_type(A.conj())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.conj())  # E: SubClass
 
 reveal_type(f8.conjugate())  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(A.conjugate())  # E: numpy.ndarray
+reveal_type(A.conjugate())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.conjugate())  # E: SubClass
 
-reveal_type(f8.cumprod())  # E: numpy.ndarray
-reveal_type(A.cumprod())  # E: numpy.ndarray
+reveal_type(f8.cumprod())  # E: numpy.ndarray[Any, Any]
+reveal_type(A.cumprod())  # E: numpy.ndarray[Any, Any]
 reveal_type(A.cumprod(out=B))  # E: SubClass
 
-reveal_type(f8.cumsum())  # E: numpy.ndarray
-reveal_type(A.cumsum())  # E: numpy.ndarray
+reveal_type(f8.cumsum())  # E: numpy.ndarray[Any, Any]
+reveal_type(A.cumsum())  # E: numpy.ndarray[Any, Any]
 reveal_type(A.cumsum(out=B))  # E: SubClass
 
 reveal_type(f8.max())  # E: numpy.number[Any]
 reveal_type(A.max())  # E: numpy.number[Any]
-reveal_type(A.max(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.max(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.max(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.max(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.max(out=B))  # E: SubClass
 
 reveal_type(f8.mean())  # E: numpy.number[Any]
 reveal_type(A.mean())  # E: numpy.number[Any]
-reveal_type(A.mean(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.mean(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.mean(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.mean(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.mean(out=B))  # E: SubClass
 
 reveal_type(f8.min())  # E: numpy.number[Any]
 reveal_type(A.min())  # E: numpy.number[Any]
-reveal_type(A.min(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.min(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.min(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.min(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.min(out=B))  # E: SubClass
 
 reveal_type(f8.newbyteorder())  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(A.newbyteorder())  # E: numpy.ndarray
+reveal_type(A.newbyteorder())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.newbyteorder('|'))  # E: SubClass
 
 reveal_type(f8.prod())  # E: numpy.number[Any]
 reveal_type(A.prod())  # E: numpy.number[Any]
-reveal_type(A.prod(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.prod(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.prod(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.prod(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.prod(out=B))  # E: SubClass
 
 reveal_type(f8.ptp())  # E: numpy.number[Any]
 reveal_type(A.ptp())  # E: numpy.number[Any]
-reveal_type(A.ptp(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.ptp(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.ptp(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.ptp(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.ptp(out=B))  # E: SubClass
 
 reveal_type(f8.round())  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(A.round())  # E: numpy.ndarray
+reveal_type(A.round())  # E: numpy.ndarray[Any, Any]
 reveal_type(A.round(out=B))  # E: SubClass
 
-reveal_type(f8.repeat(1))  # E: numpy.ndarray
-reveal_type(A.repeat(1))  # E: numpy.ndarray
-reveal_type(B.repeat(1))  # E: numpy.ndarray
+reveal_type(f8.repeat(1))  # E: numpy.ndarray[Any, Any]
+reveal_type(A.repeat(1))  # E: numpy.ndarray[Any, Any]
+reveal_type(B.repeat(1))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(f8.std())  # E: numpy.number[Any]
 reveal_type(A.std())  # E: numpy.number[Any]
-reveal_type(A.std(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.std(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.std(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.std(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.std(out=B))  # E: SubClass
 
 reveal_type(f8.sum())  # E: numpy.number[Any]
 reveal_type(A.sum())  # E: numpy.number[Any]
-reveal_type(A.sum(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.sum(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.sum(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.sum(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.sum(out=B))  # E: SubClass
 
 reveal_type(f8.take(0))  # E: numpy.generic
 reveal_type(A.take(0))  # E: numpy.generic
-reveal_type(A.take([0]))  # E: numpy.ndarray
+reveal_type(A.take([0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(A.take(0, out=B))  # E: SubClass
 reveal_type(A.take([0], out=B))  # E: SubClass
 
 reveal_type(f8.var())  # E: numpy.number[Any]
 reveal_type(A.var())  # E: numpy.number[Any]
-reveal_type(A.var(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray]
-reveal_type(A.var(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.var(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
+reveal_type(A.var(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.var(out=B))  # E: SubClass
 
-reveal_type(A.argpartition([0]))  # E: numpy.ndarray
+reveal_type(A.argpartition([0]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(A.diagonal())  # E: numpy.ndarray
+reveal_type(A.diagonal())  # E: numpy.ndarray[Any, Any]
 
-reveal_type(A.dot(1))  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.dot(1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.dot(1, out=B))  # E: SubClass
 
-reveal_type(A.nonzero())  # E: tuple[numpy.ndarray]
+reveal_type(A.nonzero())  # E: tuple[numpy.ndarray[Any, Any]]
 
-reveal_type(A.searchsorted([1]))  # E: numpy.ndarray
+reveal_type(A.searchsorted([1]))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(A.trace())  # E: Union[numpy.number[Any], numpy.ndarray]
+reveal_type(A.trace())  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.trace(out=B))  # E: SubClass

--- a/numpy/typing/tests/data/reveal/numeric.py
+++ b/numpy/typing/tests/data/reveal/numeric.py
@@ -20,53 +20,53 @@ C: SubClass
 reveal_type(np.count_nonzero(i8))  # E: int
 reveal_type(np.count_nonzero(A))  # E: int
 reveal_type(np.count_nonzero(B))  # E: int
-reveal_type(np.count_nonzero(A, keepdims=True))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
-reveal_type(np.count_nonzero(A, axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray]
+reveal_type(np.count_nonzero(A, keepdims=True))  # E: Union[numpy.signedinteger[Any], numpy.ndarray[Any, Any]]
+reveal_type(np.count_nonzero(A, axis=0))  # E: Union[numpy.signedinteger[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.isfortran(i8))  # E: bool
 reveal_type(np.isfortran(A))  # E: bool
 
-reveal_type(np.argwhere(i8))  # E: numpy.ndarray
-reveal_type(np.argwhere(A))  # E: numpy.ndarray
+reveal_type(np.argwhere(i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.argwhere(A))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.flatnonzero(i8))  # E: numpy.ndarray
-reveal_type(np.flatnonzero(A))  # E: numpy.ndarray
+reveal_type(np.flatnonzero(i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.flatnonzero(A))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.correlate(B, A, mode="valid"))  # E: numpy.ndarray
-reveal_type(np.correlate(A, A, mode="same"))  # E: numpy.ndarray
+reveal_type(np.correlate(B, A, mode="valid"))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.correlate(A, A, mode="same"))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.convolve(B, A, mode="valid"))  # E: numpy.ndarray
-reveal_type(np.convolve(A, A, mode="same"))  # E: numpy.ndarray
+reveal_type(np.convolve(B, A, mode="valid"))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.convolve(A, A, mode="same"))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.outer(i8, A))  # E: numpy.ndarray
-reveal_type(np.outer(B, A))  # E: numpy.ndarray
-reveal_type(np.outer(A, A))  # E: numpy.ndarray
+reveal_type(np.outer(i8, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.outer(B, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.outer(A, A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.outer(A, A, out=C))  # E: SubClass
 
-reveal_type(np.tensordot(B, A))  # E: numpy.ndarray
-reveal_type(np.tensordot(A, A))  # E: numpy.ndarray
-reveal_type(np.tensordot(A, A, axes=0))  # E: numpy.ndarray
-reveal_type(np.tensordot(A, A, axes=(0, 1)))  # E: numpy.ndarray
+reveal_type(np.tensordot(B, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.tensordot(A, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.tensordot(A, A, axes=0))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.tensordot(A, A, axes=(0, 1)))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.isscalar(i8))  # E: bool
 reveal_type(np.isscalar(A))  # E: bool
 reveal_type(np.isscalar(B))  # E: bool
 
-reveal_type(np.roll(A, 1))  # E: numpy.ndarray
-reveal_type(np.roll(A, (1, 2)))  # E: numpy.ndarray
-reveal_type(np.roll(B, 1))  # E: numpy.ndarray
+reveal_type(np.roll(A, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.roll(A, (1, 2)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.roll(B, 1))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.rollaxis(A, 0, 1))  # E: numpy.ndarray
+reveal_type(np.rollaxis(A, 0, 1))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.moveaxis(A, 0, 1))  # E: numpy.ndarray
-reveal_type(np.moveaxis(A, (0, 1), (1, 2)))  # E: numpy.ndarray
+reveal_type(np.moveaxis(A, 0, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.moveaxis(A, (0, 1), (1, 2)))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.cross(B, A))  # E: numpy.ndarray
-reveal_type(np.cross(A, A))  # E: numpy.ndarray
+reveal_type(np.cross(B, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cross(A, A))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.indices([0, 1, 2]))  # E: numpy.ndarray
-reveal_type(np.indices([0, 1, 2], sparse=False))  # E: numpy.ndarray
-reveal_type(np.indices([0, 1, 2], sparse=True))  # E: tuple[numpy.ndarray]
+reveal_type(np.indices([0, 1, 2]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.indices([0, 1, 2], sparse=False))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.indices([0, 1, 2], sparse=True))  # E: tuple[numpy.ndarray[Any, Any]]
 
 reveal_type(np.binary_repr(1))  # E: str
 
@@ -76,9 +76,9 @@ reveal_type(np.allclose(i8, A))  # E: bool
 reveal_type(np.allclose(B, A))  # E: bool
 reveal_type(np.allclose(A, A))  # E: bool
 
-reveal_type(np.isclose(i8, A))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.isclose(B, A))  # E: Union[numpy.bool_, numpy.ndarray]
-reveal_type(np.isclose(A, A))  # E: Union[numpy.bool_, numpy.ndarray]
+reveal_type(np.isclose(i8, A))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.isclose(B, A))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
+reveal_type(np.isclose(A, A))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 
 reveal_type(np.array_equal(i8, A))  # E: bool
 reveal_type(np.array_equal(B, A))  # E: bool


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16545; closes https://github.com/numpy/numpy/issues/16547.

Well folks, it's finally here: this pull requests makes the `np.ndarray` class generic w.r.t. its 
shape and dtype: `np.ndarray[~Shape, ~DType]`. The shape's bound is currently set
to `Any` (see "Non-Goals") while the dtype's bound is set to `np.dtype`.

~The "generification" of `np.ndarray` is accompanied by the addition of three types to the public 
API of `numpy.typing`, all of which are subscriptable during runtime (similar to the likes of 
`typing.Sequence[~T]`):~
* ~`NDArray`: A generic version of `np.ndarray[~Shape, ~DType]`.~
* ~`DType`: A generic version of `np.dtype[~Scalar]`.~
* ~`ArrayND`: A shortcut for `np.ndarray[Any, np.dtype[~Scalar]]`. I imagine that, at some point in 
  the future, we can expand this with the likes of `Array0D`, `Array1D`, `Array2D`, _etc._.~

Non-Goals
-----------
* EDIT: Providing runtime-subscriptable aliases for `ndarray`, similar to the likes of 
  `collections.abc.Sequence` versus `typing.Sequence`. This will be reserved for a future 
  PR as the exact details might warrant some further discussion.
* We currently lack the tools to properly type the ndarray's shape (_i.e._ we lack variadics).
  As the `~Shape` bound is likelly to change in the future it is recommended to type it as `Any` (for now).
  See https://github.com/numpy/numpy/issues/16544 for the discussion on shape typing.
* The various functions and methods in numpy currently lack the necessary overloads to the utilize 
  the arrays dtype (for now!). This is considered work for future PRs due to the jobs sheer size.
