### PR TITLE
NEP: Add NEP-35 instructions on reading like= downstream

### DIFF
--- a/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
+++ b/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
@@ -351,7 +351,7 @@ backend type:
     type(np.asarray([1, 2, 3], like=da.array(cp.array(()))).compute())
 
 Note how above the array is backed by ``chunktype=cupy.ndarray``, and the
-resulting array after computing it is also a ``cupy.ndarray``. If Dask does
+resulting array after computing it is also a ``cupy.ndarray``. If Dask did
 not use the ``like=`` argument via the ``self`` attribute from
 ``__array_function__``, the example above would be backed by ``numpy.ndarray``
 instead:

--- a/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
+++ b/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
@@ -120,9 +120,9 @@ conversion, ultimately raising a
 
 Now we should look at how a library like Dask could benefit from ``like=``.
 Before we understand that, it's important to understand a bit about Dask basics
-and ensures correctness with ``__array_function__``. Note that Dask can perform
-computations on different sorts of objects, like dataframes, bags and arrays,
-here we will focus strictly on arrays, which are the objects we can use
+and how it ensures correctness with ``__array_function__``. Note that Dask can
+perform computations on different sorts of objects, like dataframes, bags and
+arrays, here we will focus strictly on arrays, which are the objects we can use
 ``__array_function__`` with.
 
 Dask uses a graph computing model, meaning it breaks down a large problem in


### PR DESCRIPTION
This PR is a follow-up to a discussion in https://github.com/numpy/numpy/pull/17678 where I was attempting to pass `like=` downstream when that keyword is available on the implementation. However, thanks to @hameerabbasi pointing this out, we have a much cleaner solution from NumPy's perspective, where no changes are necessary to code. Everything can be done directly within the downstream implementation, and the changes here are only reference instructions on doing that.