### PR TITLE
BLD: determine size of intp without importing numpy directly

### DIFF
--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -17,8 +17,6 @@ __version__ = "$Revision: 1.27 $"[10:-1]
 
 f2py_version = 'See `f2py -v`'
 
-import numpy as np
-
 from . import capi_maps
 from . import func2subr
 from .crackfortran import undo_rmbadname, undo_rmbadname1
@@ -29,6 +27,10 @@ from .crackfortran import undo_rmbadname, undo_rmbadname1
 from .auxfuncs import *
 
 options = {}
+
+# Equivalent to np.intp().itemsize
+import distutils.sysconfig
+intp_itemsize = distutils.sysconfig.get_config_var("SIZEOF_UINTPTR_T")
 
 
 def findf90modules(m):
@@ -60,7 +62,7 @@ fgetdims1 = """\
             deallocate(d)
          end if
       end if
-      if ((.not.allocated(d)).and.(s(1).ge.1)) then""" % np.intp().itemsize
+      if ((.not.allocated(d)).and.(s(1).ge.1)) then""" % intp_itemsize
 
 fgetdims2 = """\
       end if


### PR DESCRIPTION
Part of changes for #17620 (and split out from #17632) to prevent importing numpy during builds to support cross compilation. Not actually tested separately, letting CI do it for me.

There's probably a better way to get this information, preferably the same way that numpy gets it... but I think it gets it via the Python headers so I'm not sure there's a better way.