### PR TITLE
BLD: Use importlib to find numpy root directory in distutils

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -9,6 +9,7 @@ import subprocess
 import shutil
 import multiprocessing
 import textwrap
+import importlib.util
 
 import distutils
 from distutils.errors import DistutilsError
@@ -2122,12 +2123,11 @@ def get_npy_pkg_dir():
     environment, and using them when cross-compiling.
 
     """
-    # XXX: import here for bootstrapping reasons
-    import numpy
     d = os.environ.get('NPY_PKG_CONFIG_PATH')
     if d is not None:
         return d
-    d = os.path.join(os.path.dirname(numpy.__file__),
+    spec = importlib.util.find_spec('numpy')
+    d = os.path.join(os.path.dirname(spec.origin),
             'core', 'lib', 'npy-pkg-config')
     return d
 


### PR DESCRIPTION
Part of changes for #17620 (split from #17632) to prevent importing numpy during builds to support cross compilation. I haven't tested this individually, will let CI do it for me.

I'm not really sure why the `XXX: import here for bootstrapping reasons` is there, but it's 11 years old at this point so maybe it doesn't apply?