### PR TITLE
BLD: disable f2py test if not available

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -113,6 +113,9 @@ def compile(source,
             os.remove(fname)
     return status
 
-from numpy._pytesttester import PytestTester
-test = PytestTester(__name__)
-del PytestTester
+try:
+    from numpy._pytesttester import PytestTester
+    test = PytestTester(__name__)
+    del PytestTester
+except ImportError:
+    pass


### PR DESCRIPTION
Part of changes for #17620 (and split out from #17632) to prevent importing numpy during builds to support cross compilation. Haven't tried it directly, will let CI figure it out.

This is a weird one standing alone, it really only makes sense when the toplevel packages are moved. But this makes it reviewable separately?
