### PR TITLE
BLD: Copy npy_load_module to numpy.distutils to avoid importing numpy

### DIFF
--- a/doc/release/upcoming_changes/17731.deprecation.rst
+++ b/doc/release/upcoming_changes/17731.deprecation.rst
@@ -1,0 +1,5 @@
+``compat.npy_load_module`` deprecated
+-------------------------------------
+
+The undocumented ``numpy.compat.npy_load_module`` is deprecated. Use
+``SourcFileLoader`` instead.

--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -111,6 +111,8 @@ def npy_load_module(name, fn, info=None):
     Load a module.
 
     .. versionadded:: 1.11.2
+    .. deprecated:: 1.20
+        Use SourceFileLoader(name, fn).load_module() instead.
 
     Parameters
     ----------

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -395,7 +395,7 @@ def visibility_define(config):
         return ''
 
 def configuration(parent_package='',top_path=None):
-    from numpy.distutils.misc_util import Configuration, under_join
+    from numpy.distutils.misc_util import Configuration
     from numpy.distutils.system_info import (get_info, blas_opt_info,
                                              lapack_opt_info)
     from importlib.machinery import SourceFileLoader
@@ -417,8 +417,9 @@ def configuration(parent_package='',top_path=None):
     check_api_version(C_API_VERSION, codegen_dir)
 
     generate_umath_py = join(codegen_dir, 'generate_umath.py')
-    n = under_join(config.name, 'generate_umath')
-    generate_umath = SourceFileLoader(n, generate_umath_py).load_module()
+    generate_umath = SourceFileLoader('_'.join(config.name, 'generate_umath'),
+                                      generate_umath_py,
+                                     ).load_module()
 
     header_dir = 'include/numpy'  # this is relative to config.path_in_package
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -417,7 +417,7 @@ def configuration(parent_package='',top_path=None):
     check_api_version(C_API_VERSION, codegen_dir)
 
     generate_umath_py = join(codegen_dir, 'generate_umath.py')
-    generate_umath = SourceFileLoader('_'.join(config.name, 'generate_umath'),
+    generate_umath = SourceFileLoader('_'.join((config.name, 'generate_umath')),
                                       generate_umath_py,
                                      ).load_module()
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -10,7 +10,6 @@ from os.path import join
 from numpy.distutils import log
 from distutils.dep_util import newer
 from sysconfig import get_config_var
-from numpy.compat import npy_load_module
 from setup_common import *  # noqa: F403
 
 # Set to True to enable relaxed strides checking. This (mostly) means
@@ -396,9 +395,10 @@ def visibility_define(config):
         return ''
 
 def configuration(parent_package='',top_path=None):
-    from numpy.distutils.misc_util import Configuration, dot_join
+    from numpy.distutils.misc_util import Configuration, under_join
     from numpy.distutils.system_info import (get_info, blas_opt_info,
                                              lapack_opt_info)
+    from importlib.machinery import SourceFileLoader
 
     # Accelerate is buggy, disallow it. See also numpy/linalg/setup.py
     for opt_order in (blas_opt_info.blas_order, lapack_opt_info.lapack_order):
@@ -417,9 +417,8 @@ def configuration(parent_package='',top_path=None):
     check_api_version(C_API_VERSION, codegen_dir)
 
     generate_umath_py = join(codegen_dir, 'generate_umath.py')
-    n = dot_join(config.name, 'generate_umath')
-    generate_umath = npy_load_module('_'.join(n.split('.')),
-                                     generate_umath_py, ('.py', 'U', 1))
+    n = under_join(config.name, 'generate_umath')
+    generate_umath = SourceFileLoader(n, generate_umath_py).load_module()
 
     header_dir = 'include/numpy'  # this is relative to config.path_in_package
 

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -644,9 +644,9 @@ class _Distutils:
     @staticmethod
     def dist_load_module(name, path):
         """Load a module from file, required by the abstract class '_Cache'."""
-        from numpy.compat import npy_load_module
+        from importlib.machinery import SourceFileLoader
         try:
-            return npy_load_module(name, path)
+            return SourceFileLoader(name, path).load_module()
         except Exception as e:
             _Distutils.dist_log(e, stderr=True)
         return None

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -32,7 +32,13 @@ def clean_up_temporary_directory():
 
 atexit.register(clean_up_temporary_directory)
 
-from numpy.compat import npy_load_module
+# copied from numpy.compat to avoid importing numpy directly
+def npy_load_module(name, fn, info=None):
+    # Explicitly lazy import this to avoid paying the cost
+    # of importing importlib at startup
+    from importlib.machinery import SourceFileLoader
+    return SourceFileLoader(name, fn).load_module()
+
 
 __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'dict_append', 'appendpath', 'generate_config_py',

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1957,7 +1957,7 @@ class Configuration:
                 name = os.path.splitext(os.path.basename(fn))[0]
                 try:
                     from importlib.machinery import SourceFileLoader
-                    version_module = SourceFileLoader('_'.join(self.name, name),
+                    version_module = SourceFileLoader('_'.join((self.name, name)),
                                                       fn,
                                                      ).load_module()
                 except ImportError as e:

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -709,10 +709,6 @@ def dot_join(*args):
     return '.'.join([a for a in args if a])
 
 
-def under_join(*args):
-    return '_'.join([a for a in args if a])
-
-
 def get_frame(level=0):
     """Return frame object from call stack with given level.
     """
@@ -910,6 +906,10 @@ class Configuration:
         sys.path.insert(0, os.path.dirname(setup_py))
         try:
             from importlib.machinery import SourceFileLoader
+
+            def under_join(*args):
+                return '_'.join([a for a in args if a])
+
             setup_name = os.path.splitext(os.path.basename(setup_py))[0]
             n = under_join(self.name, subpackage_name, setup_name)
             setup_module = SourceFileLoader(n, setup_py).load_module()
@@ -1955,10 +1955,11 @@ class Configuration:
             fn = njoin(self.local_path, f)
             if os.path.isfile(fn):
                 name = os.path.splitext(os.path.basename(fn))[0]
-                n = under_join(self.name, name)
                 try:
                     from importlib.machinery import SourceFileLoader
-                    version_module = SourceFileLoader(n, fn,).load_module()
+                    version_module = SourceFileLoader('_'.join(self.name, name),
+                                                      fn,
+                                                     ).load_module()
                 except ImportError as e:
                     self.warn(str(e))
                     version_module = None

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1226,13 +1226,13 @@ def rundocs(filename=None, raise_on_error=True):
 
     >>> np.lib.test(doctests=True)  # doctest: +SKIP
     """
-    from numpy.compat import npy_load_module
+    from importlib.machinery import SourceFileLoader
     import doctest
     if filename is None:
         f = sys._getframe(1)
         filename = f.f_globals['__file__']
     name = os.path.splitext(os.path.basename(filename))[0]
-    m = npy_load_module(name, filename)
+    m = SourceFileLoader(name, filename).load_module()
 
     tests = doctest.DocTestFinder().find(m)
     runner = doctest.DocTestRunner(verbose=False)


### PR DESCRIPTION
Part of changes for #17620 (and split from #17632) to support cross compilation by avoiding numpy imports from distutils. Haven't tested this individually, will let CI do it's thing.

This one is also a bit weird standing alone.