### PR TITLE
BLD: Don't load numpy.testing from f2py toplevel

### DIFF
--- a/numpy/f2py/f2py_testing.py
+++ b/numpy/f2py/f2py_testing.py
@@ -1,8 +1,6 @@
 import sys
 import re
 
-from numpy.testing import jiffies, memusage
-
 
 def cmdline():
     m = re.compile(r'\A\d+\Z')
@@ -18,6 +16,9 @@ def cmdline():
 
 
 def run(runtest, test_functions, repeat=1):
+    # Avoiding importing numpy from the toplevel of the module
+    from numpy.testing import jiffies, memusage
+
     l = [(t, repr(t.__doc__.split('\n')[1].strip())) for t in test_functions]
     start_memusage = memusage()
     diff_memusage = None


### PR DESCRIPTION
Part of changes for #17620 (split from #17632) to prevent importing numpy during builds to support cross compilation. I haven't tested this individually, will let CI do it for me.

It's fine to load it while running the test because actually running the test can't be done while cross compiling.