### PR TITLE
MAINT: ma: Remove unused `**options` from MaskedArray `__new__` method.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2812,7 +2812,7 @@ class MaskedArray(ndarray):
 
     def __new__(cls, data=None, mask=nomask, dtype=None, copy=False,
                 subok=True, ndmin=0, fill_value=None, keep_mask=True,
-                hard_mask=None, shrink=True, order=None, **options):
+                hard_mask=None, shrink=True, order=None):
         """
         Create a new masked array from scratch.
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -244,6 +244,10 @@ class TestMaskedArray:
                                         'offsets':[0,8]})
         array(x)  # used to fail due to 'V' padding field in x.dtype.descr
 
+    def test_unknown_keyword_parameter(self):
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            MaskedArray([1, 2, 3], maks=[0, 1, 0])  # `mask` is misspelled.
+
     def test_asarray(self):
         (x, y, a10, m1, m2, xm, ym, z, zm, xf) = self.d
         xm.fill_value = -9999
@@ -4601,7 +4605,7 @@ class TestMaskedArrayFunctions:
         class M(MaskedArray):
             pass
 
-        test = np.ma.compressed(M(shape=(0,1,2)))
+        test = np.ma.compressed(M([[[]], [[]]]))
         assert_equal(test.ndim, 1)
 
         # with .compressed() overridden
@@ -4609,7 +4613,7 @@ class TestMaskedArrayFunctions:
             def compressed(self):
                 return 42
 
-        test = np.ma.compressed(M(shape=(0,1,2)))
+        test = np.ma.compressed(M([[[]], [[]]]))
         assert_equal(test, 42)
 
     def test_convolve(self):


### PR DESCRIPTION
The `__new__` method of `MaskedArray` has the parameter `**options`,
but it is not used.  This means a mistyped parameter is silently ignored,
e.g. if I mistype the `mask` parameter like this, I don't get an error:

    In [2]: m = np.ma.MaskedArray([1, 2, 3], maks=[0, 1, 0])

    In [3]: m
    Out[3]:
    masked_array(data=[1, 2, 3],
                 mask=False,
           fill_value=999999)

In this PR, I simply remove `**options` from the signature of
`MaskedArray.__new__`.  This affected one test.  That test was passing the
argument `shape=(0, 1, 2)` to the constructor of a subclass of `MaskedArray`,
but since any unknown keywords were silently ignored, that use of `shape` had
no effect.  I replaced it with the positional argument `[[[]], [[]]]`, which
I believe has the effect that was originally intended with the use of the
`shape` argument.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
