### PR TITLE
BLD, TST: move linux jobs to github actions

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1,0 +1,26 @@
+name: DoTheWork
+description: "checkout repo, build and run tests"
+runs:
+  using: composite
+  steps:
+  - name: Show env
+    shell: bash
+    run: |
+      echo NPY_RELAXED_STRIDES_DEBUG $NPY_RELAXED_STRIDES_DEBUG
+      echo NPY_RELAXED_STRIDES_CHECKING $NPY_RELAXED_STRIDES_CHECKING
+      echo CHECK_BLAS $CHECK_BLAS
+      echo DOWNLOAD_OPENBLAS $DOWNLOAD_OPENBLAS
+      echo USE_DEBUG $USE_DEBUG
+      echo NPY_USE_BLAS_ILP64 $NPY_USE_BLAS_ILP64
+      echo NUMPY_EXPERIMENTAL_ARRAY_FUNCTION $NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
+      echo USE_ASV $USE_ASV
+      python -c "import sys; print(sys.version)"
+
+  - name: BeforeInstall
+    shell: bash
+    run: ./tools/travis-before-install.sh
+
+  - name: Test
+    shell: bash
+    run: ./tools/travis-test.sh
+      

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,91 @@
+name: Build_Test
+
+on: [push, pull_request]
+
+jobs:
+  smoke_test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: BeforeInstall
+      run: ./tools/travis-before-install.sh
+
+    - name: Test
+      run: ./tools/travis-test.sh
+ 
+  build_test:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        exclude:
+          # This ran in the smoke_test
+          - python-version: 3.8
+        include:
+          - env:
+              USE_DEBUG: 1
+            python-version: 3.8
+          - env: 
+              NPY_USE_BLAS_ILP64: 1
+            python-version: 3.8
+          - env:
+              USE_WHEEL: 1
+              RUN_FULL_TESTS: 1
+              RUN_COVERAGE: 1
+              INSTALL_PICKLE5: 1
+            python-version: 3.7
+          - env:
+              PYTHONOPTIMIZE: 2
+              BLAS: None
+              LAPACK: None
+              ATLAS: None
+              NPY_BLAS_ORDER: mkl,blis,openblas,atlas,blas
+              NPY_LAPACK_ORDER: MKL,OPENBLAS,ATLAS,LAPACK
+              USE_ASV: 1
+            python-version: 3.7
+          - env:
+              NPY_RELAXED_STRIDES_CHECKING: 0
+              DOWNLOAD_OPENBLAS: 1
+              CHECK_BLAS: 1
+              NPY_USE_BLAS_ILP64: 1
+            python-version: 3.7
+          - env:
+              USE_WHEEL: 1
+              NPY_RELAXED_STRIDES_DEBUG: 1
+            python-version: 3.7
+          - env:
+              NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: 0
+            python-version: 3.7
+          - env:
+              BLAS: None
+              LAPACK: None
+              ATLAS: None
+            python-version: 3.7
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: BeforeInstall
+      run: ./tools/travis-before-install.sh
+
+    - name: Test
+      run: ./tools/travis-test.sh
+        

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,90 +2,176 @@ name: Build_Test
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
+env: 
+  DOWNLOAD_OPENBLAS: 1
+  PYTHON_VERSION: 3.7
+
 jobs:
   smoke_test:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 0
-
-    - name: BeforeInstall
-      run: ./tools/travis-before-install.sh
-
-    - name: Test
-      run: ./tools/travis-test.sh
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
  
-  build_test:
+  basic:
     needs: smoke_test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        exclude:
-          # This ran in the smoke_test
-          - python-version: 3.8
-        include:
-          - env:
-              USE_DEBUG: 1
-            python-version: 3.8
-          - env: 
-              NPY_USE_BLAS_ILP64: 1
-            python-version: 3.8
-          - env:
-              USE_WHEEL: 1
-              RUN_FULL_TESTS: 1
-              RUN_COVERAGE: 1
-              INSTALL_PICKLE5: 1
-            python-version: 3.7
-          - env:
-              PYTHONOPTIMIZE: 2
-              BLAS: None
-              LAPACK: None
-              ATLAS: None
-              NPY_BLAS_ORDER: mkl,blis,openblas,atlas,blas
-              NPY_LAPACK_ORDER: MKL,OPENBLAS,ATLAS,LAPACK
-              USE_ASV: 1
-            python-version: 3.7
-          - env:
-              NPY_RELAXED_STRIDES_CHECKING: 0
-              DOWNLOAD_OPENBLAS: 1
-              CHECK_BLAS: 1
-              NPY_USE_BLAS_ILP64: 1
-            python-version: 3.7
-          - env:
-              USE_WHEEL: 1
-              NPY_RELAXED_STRIDES_DEBUG: 1
-            python-version: 3.7
-          - env:
-              NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: 0
-            python-version: 3.7
-          - env:
-              BLAS: None
-              LAPACK: None
-              ATLAS: None
-            python-version: 3.7
-
+        python-version: [3.8, 3.9]
     steps:
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
 
-    - name: BeforeInstall
-      run: ./tools/travis-before-install.sh
+  debug:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      USE_DEBUG: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
 
-    - name: Test
-      run: ./tools/travis-test.sh
-        
+  blas64:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      NPY_USE_BLAS_ILP64: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  full:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      USE_WHEEL: 1
+      RUN_FULL_TESTS: 1
+      RUN_COVERAGE: 1
+      INSTALL_PICKLE5: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  benchmark:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      PYTHONOPTIMIZE: 2
+      BLAS: None
+      LAPACK: None
+      ATLAS: None
+      NPY_BLAS_ORDER: mkl,blis,openblas,atlas,blas
+      NPY_LAPACK_ORDER: MKL,OPENBLAS,ATLAS,LAPACK
+      USE_ASV: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  no_relaxed_strides:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      NPY_RELAXED_STRIDES_CHECKING: 0
+      CHECK_BLAS: 1
+      NPY_USE_BLAS_ILP64: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  use_wheel:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      USE_WHEEL: 1
+      NPY_RELAXED_STRIDES_DEBUG: 1
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  no_array_func:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: 0
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+  no_openblas:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      BLAS: None
+      LAPACK: None
+      ATLAS: None
+      DOWNLOAD_OPENBLAS: ''
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - uses: ./.github/actions
+
+       

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,9 @@ cache:
   directories:
     - $HOME/.cache/pip
 
-stages:
-    # Do the style check and a single test job, don't proceed if it fails
-    - name: Initial tests
-    # Do the rest of the tests
-    - name: Comprehensive tests
-
 jobs:
   include:
-    # Do all python versions without environment variables set
-    - stage: Initial tests
-      python: 3.8
-
-    - stage: Comprehensive tests
-      python: 3.7
+    - python: 3.7
       os: linux
       arch: ppc64le
       env:
@@ -57,68 +46,6 @@ jobs:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
        - ATLAS=None
-
-
-
-    - python: 3.6
-    - python: 3.7
-    - python: 3.9-dev
-
-    - python: 3.8
-      dist: focal
-      env: USE_DEBUG=1
-      addons:
-        apt:
-          packages:
-            - *common_packages
-            - cython3-dbg
-            - python3-dbg
-            - python3-dev
-            - python3-setuptools
-
-    - python: 3.7
-      env: USE_WHEEL=1 RUN_FULL_TESTS=1 RUN_COVERAGE=1 INSTALL_PICKLE5=1
-
-    - python: 3.7
-      env: USE_SDIST=1
-
-    - python: 3.7
-      env:
-       - PYTHONOPTIMIZE=2
-       - BLAS=None
-       - LAPACK=None
-       - ATLAS=None
-       - NPY_BLAS_ORDER=mkl,blis,openblas,atlas,blas
-       - NPY_LAPACK_ORDER=MKL,OPENBLAS,ATLAS,LAPACK
-       - USE_ASV=1
-
-    - python: 3.7
-      env:
-        - NPY_RELAXED_STRIDES_CHECKING=0
-        # use custom symbol-suffixed openblas build, not system ATLAS
-        - DOWNLOAD_OPENBLAS=1
-        - CHECK_BLAS=1
-        - NPY_USE_BLAS_ILP64=1
-      addons:
-        apt:
-          packages:
-            - gfortran
-            - eatmydata
-            - libgfortran5
-            - libgfortran3
-
-    - python: 3.7
-      env: USE_WHEEL=1 NPY_RELAXED_STRIDES_DEBUG=1
-
-    - python: 3.7
-      env: NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
-
-    - python: 3.7
-      env:
-       - BLAS=None
-       - LAPACK=None
-       - ATLAS=None
-
 
 
 before_install:

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -13,7 +13,7 @@ sudo apt install gfortran eatmydata libgfortran3 libgfortran5
 
 if [ "$USE_DEBUG" ]
 then
-    sudo apt install cpython3-dbg python3-dbg python3-dev python3-setuptools
+    sudo apt install python3-dbg python3-dev python3-setuptools
 fi
 
 mkdir builds

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -9,6 +9,13 @@ free -m
 df -h
 ulimit -a
 
+sudo apt install gfortran eatmydata libgfortran3 libgfortran5
+
+if [ "$USE_DEBUG" ]
+then
+    sudo apt install cpython3-dbg python3-dbg python3-dev python3-setuptools
+fi
+
 mkdir builds
 pushd builds
 


### PR DESCRIPTION
[azpipelines skip]

Let's move what we can off travis before we are blocked. We already build windows and macOSx on azure pipelines.

- drop all linux x86 jobs from travis
- rebuild them on github actions
- remove python 3.6
Once this runs we should carefully check that each special job is actually doing what it is supposed to.