### PR TITLE
BLD: Lazy load f2py test utilities

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -9,7 +9,6 @@ import subprocess
 import os
 
 from . import f2py2e
-from . import f2py_testing
 from . import diagnose
 
 run_main = f2py2e.run_main
@@ -113,6 +112,33 @@ def compile(source,
             os.remove(fname)
     return status
 
-from numpy._pytesttester import PytestTester
-test = PytestTester(__name__)
-del PytestTester
+
+if sys.version_info[:2] >= (3, 7):
+    # module level getattr is only supported in 3.7 onwards
+    # https://www.python.org/dev/peps/pep-0562/
+    def __getattr__(attr):
+
+        # Avoid importing things that aren't needed for building
+        # which might import the main numpy module
+        if attr == "f2py_testing":
+            import numpy.f2py.f2py_testing as f2py_testing
+            return f2py_testing
+
+        elif attr == "test":
+            from numpy._pytesttester import PytestTester
+            test = PytestTester(__name__)
+            return test
+
+        else:
+            raise AttributeError("module {!r} has no attribute "
+                                 "{!r}".format(__name__, attr))
+
+    def __dir__():
+        return list(globals().keys() | {"f2py_testing", "test"})
+
+else:
+    from . import f2py_testing
+
+    from numpy._pytesttester import PytestTester
+    test = PytestTester(__name__)
+    del PytestTester


### PR DESCRIPTION
These are only used during testing. It's fine to load it while running the test because actually running the test can't be done while cross compiling. I haven't tested this at all... but I expect CI will break if it doesn't work.

Part of changes to support #17620 to prevent importing numpy during builds to support cross-compilation

Replaces #17730 and #17732.