### PR TITLE
BLD: use BUFFERSIZE=20 in OpenBLAS

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -14,7 +14,7 @@ from urllib.error import HTTPError
 
 OPENBLAS_V = '0.3.12'
 # Temporary build of OpenBLAS to test a fix for dynamic detection of CPU
-OPENBLAS_LONG = 'v0.3.12'
+OPENBLAS_LONG = 'v0.3.12-buffersize20'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86_64',


### PR DESCRIPTION
xref xianyi/OpenBLAS#2970 where it was suggested to compile OpenBLAS with BUFFERSIZE=20 to revert the memory footprint to what it was in OpenBLAS 0.3.9 (we now use 0.3.12). This was done in MacPython/openblas-libs#46, and this PR uses it in NumPy.

xref issue gh-17674, gh-17684 which triggered the discussion. Once we have wheels that use this, we should ask the reporters on those issues @moylop260 and @MarkBel to try it out.