### PR TITLE
BUG: Fixed file handle leak in array_tofile.

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -590,7 +590,7 @@ array_tostring(PyArrayObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
-    int own;
+    int own, res1, res2;
     PyObject *file;
     FILE *fd;
     char *sep = "";
@@ -624,10 +624,9 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     if (fd == NULL) {
         goto fail;
     }
-    if (PyArray_ToFile(self, fd, sep, format) < 0) {
-        goto fail;
-    }
-    if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
+    res1 = PyArray_ToFile(self, fd, sep, format);
+    res2 = npy_PyFile_DupClose2(file, fd, orig_pos);
+    if (res1 < 0 || res2 < 0) {
         goto fail;
     }
     if (own && npy_PyFile_CloseFile(file) < 0) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -583,6 +583,28 @@ array_tostring(PyArrayObject *self, PyObject *args, PyObject *kwds)
     return PyArray_ToString(self, order);
 }
 
+/* Like PyArray_ToFile but takes the file as a python object */
+static int
+PyArray_ToFileObject(PyArrayObject *self, PyObject *file, char *sep, char *format)
+{
+    npy_off_t orig_pos = 0;
+    FILE *fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
+
+    if (fd == NULL) {
+        return -1;
+    }
+
+    int write_ret = PyArray_ToFile(self, fd, sep, format);
+    PyObject *err_type, *err_value, *err_traceback;
+    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+    int close_ret = npy_PyFile_DupClose2(file, fd, orig_pos);
+    npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+
+    if (write_ret || close_ret) {
+        return -1;
+    }
+    return 0;
+}
 
 /* This should grow an order= keyword to be consistent
  */
@@ -592,10 +614,8 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     int own;
     PyObject *file;
-    FILE *fd;
     char *sep = "";
     char *format = "";
-    npy_off_t orig_pos = 0;
     static char *kwlist[] = {"file", "sep", "format", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ss:tofile", kwlist,
@@ -620,34 +640,19 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
         own = 0;
     }
 
-    fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
-    PyObject *err_type, *err_value, *err_traceback;
-    int failed = 0;
-
-    if (fd != NULL) {
-        if (PyArray_ToFile(self, fd, sep, format) < 0) {
-            failed = 1;
-        }
-        PyErr_Fetch(&err_type, &err_value, &err_traceback);
-        if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
-            failed = 1;
-        }
-        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
-    } else {
-        failed = 1;
-    }
+    int file_ret = PyArray_ToFileObject(self, file, sep, format);
+    int close_ret = 0;
 
     if (own) {
+        PyObject *err_type, *err_value, *err_traceback;
         PyErr_Fetch(&err_type, &err_value, &err_traceback);
-        if (npy_PyFile_CloseFile(file) < 0) {
-            failed = 1;
-        }
+        close_ret = npy_PyFile_CloseFile(file);
         npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
     }
 
     Py_DECREF(file);
 
-    if (failed) {
+    if (file_ret || close_ret) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -621,29 +621,33 @@ array_tofile(PyArrayObject *self, PyObject *args, PyObject *kwds)
     }
 
     fd = npy_PyFile_Dup2(file, "wb", &orig_pos);
-    if (fd == NULL) {
-        Py_DECREF(file);
-        return NULL;
-    }
-
-    int res_write = PyArray_ToFile(self, fd, sep, format);
     PyObject *err_type, *err_value, *err_traceback;
-    PyErr_Fetch(&err_type, &err_value, &err_traceback);
+    int failed = 0;
 
-    int res_close = npy_PyFile_DupClose2(file, fd, orig_pos);
-    if (res_close < 0) {
+    if (fd != NULL) {
+        if (PyArray_ToFile(self, fd, sep, format) < 0) {
+            failed = 1;
+        }
+        PyErr_Fetch(&err_type, &err_value, &err_traceback);
+        if (npy_PyFile_DupClose2(file, fd, orig_pos) < 0) {
+            failed = 1;
+        }
+        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+    } else {
+        failed = 1;
+    }
+
+    if (own) {
+        PyErr_Fetch(&err_type, &err_value, &err_traceback);
+        if (npy_PyFile_CloseFile(file) < 0) {
+            failed = 1;
+        }
         npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
     }
 
-    if (own && npy_PyFile_CloseFile(file) < 0) {
-        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
-        res_close = -1;
-    }
-
-    PyErr_Restore(err_type, err_value, err_traceback);
     Py_DECREF(file);
 
-    if (res_write < 0 || res_close < 0) {
+    if (failed) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4989,8 +4989,11 @@ class TestIO:
         x = np.zeros((10), dtype=object)
         with open(self.filename, 'wb') as f:
             assert_raises(IOError, lambda: x.tofile(f, sep=''))
+        # Dup-ed file handle should be closed or remove will fail on Windows OS
+        os.remove(self.filename)
 
-        # Dup-ed file handle should be closed or remove will fail.
+        # Also make sure that we close the Python handle
+        assert_raises(IOError, lambda: x.tofile(self.filename))
         os.remove(self.filename)
 
     def test_locale(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4985,6 +4985,14 @@ class TestIO:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
+    def test_tofile_cleanup(self):
+        x = np.zeros((10), dtype=object)
+        with open(self.filename, 'wb') as f:
+            assert_raises(IOError, lambda: x.tofile(f, sep=''))
+
+        # Dup-ed file handle should be closed or remove will fail.
+        os.remove(self.filename)
+
     def test_locale(self):
         with CommaDecimalPointLocale():
             self.test_numbers()


### PR DESCRIPTION
Backport of #17598. 

Closes #17589

If the ```PyArray_ToFile``` call inside ```array_tofile``` fails for any reason, we leak a dup-ed file handle. This causes problems especially on Windows OS, where any subsequent attempt to delete the file will fail because NumPy is still holding an open handle.

This update ensures that we always close the handle.

The added test case forces ```PyArray_ToFile``` to fail, which triggers the original problem.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
