### PR TITLE
MAINT: Simplify Hypothesis configuration

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -140,9 +140,6 @@ class PytestTester:
         import pytest
         import warnings
 
-        # Imported after pytest to enable assertion rewriting
-        import hypothesis
-
         module = sys.modules[self.module_name]
         module_path = os.path.abspath(module.__path__[0])
 
@@ -204,15 +201,6 @@ class PytestTester:
             tests = [self.module_name]
 
         pytest_args += ["--pyargs"] + list(tests)
-
-        # This configuration is picked up by numpy.conftest, and ensures that
-        # running `np.test()` is deterministic and does not write any files.
-        # See https://hypothesis.readthedocs.io/en/latest/settings.html
-        hypothesis.settings.register_profile(
-            name="np.test() profile",
-            deadline=None, print_blob=True, database=None, derandomize=True,
-            suppress_health_check=hypothesis.HealthCheck.all(),
-        )
 
         # run tests.
         _show_numpy_info()

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -19,18 +19,26 @@ _collect_results = {}
 hypothesis.configuration.set_hypothesis_home_dir(
     os.path.join(tempfile.gettempdir(), ".hypothesis")
 )
-# See https://hypothesis.readthedocs.io/en/latest/settings.html
+
+# We register two custom profiles for Numpy - for details see
+# https://hypothesis.readthedocs.io/en/latest/settings.html
+# The first is designed for our own CI runs; the latter also 
+# forces determinism and is designed for use via np.test()
 hypothesis.settings.register_profile(
     name="numpy-profile", deadline=None, print_blob=True,
 )
-# We try loading the profile defined by np.test(), which disables the
-# database and forces determinism, and fall back to the profile defined
-# above if we're running pytest directly.  The odd dance is required
-# because np.test() executes this file *after* its own setup code.
-try:
-    hypothesis.settings.load_profile("np.test() profile")
-except hypothesis.errors.InvalidArgument:  # profile not found
-    hypothesis.settings.load_profile("numpy-profile")
+hypothesis.settings.register_profile(
+    name="np.test() profile",
+    deadline=None, print_blob=True, database=None, derandomize=True,
+    suppress_health_check=hypothesis.HealthCheck.all(),
+)
+# Note that the default profile is chosen based on the presence 
+# of pytest.ini, but can be overriden by passing the 
+# --hypothesis-profile=NAME argument to pytest.
+_pytest_ini = os.path.join(os.path.dirname(__file__), "..", "pytest.ini")
+hypothesis.settings.load_profile(
+    "numpy-profile" if os.path.isfile(_pytest_ini) else "np.test() profile"
+)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
All configuration is now done in `conftest.py`, and detection of dev/user mode is based on the presence of `pytest.ini` in the repo root as per @charris' suggestion.  

Follows #16879; closes #17390.  CC also @mattip with apologies for my delays.