### PR TITLE
SIMD: Optimize the performance of einsum's submodule multiply by using universal intrinsics

### DIFF
--- a/numpy/core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/core/src/multiarray/einsum_sumprod.c.src
@@ -311,6 +311,7 @@ static void
     }
     npyv_cleanup();
 #else
+#ifndef NPY_DISABLE_OPTIMIZATION
     for (; count >= 4; count -= 4, data0 += 4, data1 += 4, data_out += 4) {
         /**begin repeat2
          * #i = 0, 1, 2, 3#
@@ -330,13 +331,15 @@ static void
         data_out[@i@] = @to@(abc@i@);
         /**end repeat2**/
     }
-#endif // NPYV check for @type@
+#endif // !NPY_DISABLE_OPTIMIZATION
     for (; count > 0; --count, ++data0, ++data1, ++data_out) {
         const @type@ a = @from@(*data0);
         const @type@ b = @from@(*data1);
         const @type@ c = @from@(*data_out);
         *data_out = @to@(a * b + c);
     }
+#endif // NPYV check for @type@
+
 }
 
 /* Some extra specializations for the two operand case */

--- a/numpy/core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/core/src/multiarray/einsum_sumprod.c.src
@@ -17,7 +17,8 @@
 
 #include "einsum_sumprod.h"
 #include "einsum_debug.h"
-
+#include "simd/simd.h"
+#include "common.h"
 
 #ifdef NPY_HAVE_SSE_INTRINSICS
 #define EINSUM_USE_SSE1 1
@@ -41,6 +42,28 @@
 
 #define EINSUM_IS_SSE_ALIGNED(x) ((((npy_intp)x)&0xf) == 0)
 
+// ARM/Neon don't have instructions for aligned memory access
+#ifdef NPY_HAVE_NEON
+    #define EINSUM_IS_ALIGNED(x) 0
+#else
+    #define EINSUM_IS_ALIGNED(x) npy_is_aligned(x, NPY_SIMD_WIDTH)
+#endif
+
+/**
+ * This macro is used to enable a scalar loop which advances 4 elements at a
+ * time, which appears after a main SIMD loop gated by `CHK` that unrolls by
+ * `NPY_SIMD_WIDTH * unroll_by` elements, and before a non-unrolled scalar loop
+ * that finishes up all the remaining scalars. The purpose of the unrolled loop
+ * is to enable auto-vectorization in cases when all of the following are true:
+ *
+ *  - optimization is allowed
+ *  - either:
+ *    - we did not run the SIMD loop at all, due to NPV being disabled.
+ *    - the SIMD loop was larger than 128bit, so there are likely to be many
+ *      elements left to process.
+ */
+#define EINSUM_UNROLL_4_SCALARS(CHK) (!defined(NPY_DISABLE_OPTIMIZATION) && (!(CHK) || NPY_SIMD > 128))
+
 /**********************************************/
 
 /**begin repeat
@@ -56,6 +79,10 @@
  *             npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,
  *             npy_float, npy_float, npy_double, npy_longdouble,
  *             npy_float, npy_double, npy_longdouble#
+ * #sfx  = s8, s16, s32, long, s64,
+ *        u8, u16, u32, ulong, u64,
+ *        half, f32, f64, longdouble,
+ *        f32, f64, clongdouble#
  * #to = ,,,,,
  *       ,,,,,
  *       npy_float_to_half,,,,
@@ -76,6 +103,10 @@
  *            0*5,
  *            0,0,1,0,
  *            0*3#
+ * #NPYV_CHK = 0*5,
+ *             0*5,
+ *             0, NPY_SIMD, NPY_SIMD_F64, 0,
+ *             0*3#
  */
 
 /**begin repeat1
@@ -250,115 +281,73 @@ static void
     @type@ *data0 = (@type@ *)dataptr[0];
     @type@ *data1 = (@type@ *)dataptr[1];
     @type@ *data_out = (@type@ *)dataptr[2];
-
-#if EINSUM_USE_SSE1 && @float32@
-    __m128 a, b;
-#elif EINSUM_USE_SSE2 && @float64@
-    __m128d a, b;
-#endif
-
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_two (%d)\n",
                                                             (int)count);
-
-/* This is placed before the main loop to make small counts faster */
-finish_after_unrolled_loop:
-    switch (count) {
-/**begin repeat2
- * #i = 6, 5, 4, 3, 2, 1, 0#
- */
-        case @i@+1:
-            data_out[@i@] = @to@(@from@(data0[@i@]) *
-                                 @from@(data1[@i@]) +
-                                 @from@(data_out[@i@]));
-/**end repeat2**/
-        case 0:
-            return;
-    }
-
-#if EINSUM_USE_SSE1 && @float32@
+    // NPYV check for @type@, in X86, 128bits intrinsincs have a side effect in optimization
+#if @NPYV_CHK@
     /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data1) &&
-        EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
+    const int is_aligned = EINSUM_IS_ALIGNED(data0) && EINSUM_IS_ALIGNED(data1) &&
+                        EINSUM_IS_ALIGNED(data_out);
+    const int vstep = npyv_nlanes_@sfx@;
 
-/**begin repeat2
- * #i = 0, 4#
- */
-            a = _mm_mul_ps(_mm_load_ps(data0+@i@), _mm_load_ps(data1+@i@));
-            b = _mm_add_ps(a, _mm_load_ps(data_out+@i@));
-            _mm_store_ps(data_out+@i@, b);
-/**end repeat2**/
-            data0 += 8;
-            data1 += 8;
-            data_out += 8;
+    /**begin repeat2
+     * #cond = if(is_aligned), else#
+     * #ld = loada, load#
+     * #st = storea, store#
+     */
+    @cond@ {
+        const npy_intp vstepx4 = vstep * 4;
+        for (; count >= vstepx4; count -= vstepx4, data0 += vstepx4, data1 += vstepx4, data_out += vstepx4) {
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@sfx@ a@i@ = npyv_@ld@_@sfx@(data0 + vstep * @i@);
+            npyv_@sfx@ b@i@ = npyv_@ld@_@sfx@(data1 + vstep * @i@);
+            npyv_@sfx@ c@i@ = npyv_@ld@_@sfx@(data_out + vstep * @i@);
+            /**end repeat3**/
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@sfx@ abc@i@ = npyv_muladd_@sfx@(a@i@, b@i@, c@i@);
+            /**end repeat3**/
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@st@_@sfx@(data_out + vstep * @i@, abc@i@);
+            /**end repeat3**/
         }
-
-        /* Finish off the loop */
-        goto finish_after_unrolled_loop;
     }
-#elif EINSUM_USE_SSE2 && @float64@
-    /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data1) &&
-        EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
+    /**end repeat2**/
+    npyv_cleanup();
+#endif // NPYV check for @type@
 
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-            a = _mm_mul_pd(_mm_load_pd(data0+@i@), _mm_load_pd(data1+@i@));
-            b = _mm_add_pd(a, _mm_load_pd(data_out+@i@));
-            _mm_store_pd(data_out+@i@, b);
-/**end repeat2**/
-            data0 += 8;
-            data1 += 8;
-            data_out += 8;
-        }
-
-        /* Finish off the loop */
-        goto finish_after_unrolled_loop;
+#if EINSUM_UNROLL_4_SCALARS(@NPYV_CHK@)
+    for (; count >= 4; count -= 4, data0 += 4, data1 += 4, data_out += 4) {
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        const @type@ a@i@ = @from@(data0[@i@]);
+        const @type@ b@i@ = @from@(data1[@i@]);
+        const @type@ c@i@ = @from@(data_out[@i@]);
+        /**end repeat2**/
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        const @type@ abc@i@ = a@i@ * b@i@ + c@i@;
+        /**end repeat2**/
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        data_out[@i@] = @to@(abc@i@);
+        /**end repeat2**/
     }
 #endif
-
-    /* Unroll the loop by 8 */
-    while (count >= 8) {
-        count -= 8;
-
-#if EINSUM_USE_SSE1 && @float32@
-/**begin repeat2
- * #i = 0, 4#
- */
-        a = _mm_mul_ps(_mm_loadu_ps(data0+@i@), _mm_loadu_ps(data1+@i@));
-        b = _mm_add_ps(a, _mm_loadu_ps(data_out+@i@));
-        _mm_storeu_ps(data_out+@i@, b);
-/**end repeat2**/
-#elif EINSUM_USE_SSE2 && @float64@
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-        a = _mm_mul_pd(_mm_loadu_pd(data0+@i@), _mm_loadu_pd(data1+@i@));
-        b = _mm_add_pd(a, _mm_loadu_pd(data_out+@i@));
-        _mm_storeu_pd(data_out+@i@, b);
-/**end repeat2**/
-#else
-/**begin repeat2
- * #i = 0, 1, 2, 3, 4, 5, 6, 7#
- */
-        data_out[@i@] = @to@(@from@(data0[@i@]) *
-                             @from@(data1[@i@]) +
-                             @from@(data_out[@i@]));
-/**end repeat2**/
-#endif
-        data0 += 8;
-        data1 += 8;
-        data_out += 8;
+    for (; count > 0; --count, ++data0, ++data1, ++data_out) {
+        const @type@ a = @from@(*data0);
+        const @type@ b = @from@(*data1);
+        const @type@ c = @from@(*data_out);
+        *data_out = @to@(a * b + c);
     }
-
-    /* Finish off the loop */
-    goto finish_after_unrolled_loop;
 }
 
 /* Some extra specializations for the two operand case */

--- a/numpy/core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/core/src/multiarray/einsum_sumprod.c.src
@@ -283,7 +283,7 @@ static void
     @type@ *data_out = (@type@ *)dataptr[2];
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_two (%d)\n",
                                                             (int)count);
-    // NPYV check for @type@, in X86, 128bits intrinsincs have a side effect in optimization
+    // NPYV check for @type@
 #if @NPYV_CHK@
     /* Use aligned instructions if possible */
     const int is_aligned = EINSUM_IS_ALIGNED(data0) && EINSUM_IS_ALIGNED(data1) &&

--- a/numpy/core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/core/src/multiarray/einsum_sumprod.c.src
@@ -49,21 +49,6 @@
     #define EINSUM_IS_ALIGNED(x) npy_is_aligned(x, NPY_SIMD_WIDTH)
 #endif
 
-/**
- * This macro is used to enable a scalar loop which advances 4 elements at a
- * time, which appears after a main SIMD loop gated by `CHK` that unrolls by
- * `NPY_SIMD_WIDTH * unroll_by` elements, and before a non-unrolled scalar loop
- * that finishes up all the remaining scalars. The purpose of the unrolled loop
- * is to enable auto-vectorization in cases when all of the following are true:
- *
- *  - optimization is allowed
- *  - either:
- *    - we did not run the SIMD loop at all, due to NPV being disabled.
- *    - the SIMD loop was larger than 128bit, so there are likely to be many
- *      elements left to process.
- */
-#define EINSUM_UNROLL_4_SCALARS(CHK) (!defined(NPY_DISABLE_OPTIMIZATION) && (!(CHK) || NPY_SIMD > 128))
-
 /**********************************************/
 
 /**begin repeat
@@ -318,10 +303,14 @@ static void
         }
     }
     /**end repeat2**/
+    for (; count > 0; count -= vstep, data0 += vstep, data1 += vstep, data_out += vstep) {
+        npyv_@sfx@ a = npyv_load_tillz_@sfx@(data0, count);
+        npyv_@sfx@ b = npyv_load_tillz_@sfx@(data1, count);
+        npyv_@sfx@ c = npyv_load_tillz_@sfx@(data_out, count);
+        npyv_store_till_@sfx@(data_out, count, npyv_muladd_@sfx@(a, b, c));
+    }
     npyv_cleanup();
-#endif // NPYV check for @type@
-
-#if EINSUM_UNROLL_4_SCALARS(@NPYV_CHK@)
+#else
     for (; count >= 4; count -= 4, data0 += 4, data1 += 4, data_out += 4) {
         /**begin repeat2
          * #i = 0, 1, 2, 3#
@@ -341,7 +330,7 @@ static void
         data_out[@i@] = @to@(abc@i@);
         /**end repeat2**/
     }
-#endif
+#endif // NPYV check for @type@
     for (; count > 0; --count, ++data0, ++data1, ++data_out) {
         const @type@ a = @from@(*data0);
         const @type@ b = @from@(*data1);


### PR DESCRIPTION
This is the third part of #17049 , There has no impact on X86 platform and about 9%~16% increased performance in ARM. Here is the benchmark results:

<details>
<summary>X86(SSE2 enabled) BENCHMARKS NOT SIGNIFICANTLY CHANGED.</summary>
<pre><code>
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython
·· Building 97ba579b <einsum-muladd> for virtualenv-py3.7-Cython
·· Installing 97ba579b <einsum-muladd> into virtualenv-py3.7-Cython
· Running 28 total benchmarks (2 commits * 1 environments * 14 benchmarks)
[  0.00%] · For numpy commit 360ba057 <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[  1.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 25.00%] · For numpy commit 97ba579b <einsum-muladd> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 26.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 50.00%] · For numpy commit 97ba579b <einsum-muladd> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 51.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                     ok
[ 51.79%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   151±9μs
               numpy.float64   249±6μs
              =============== =========

[ 53.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                                 ok
[ 53.57%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   248±5μs
               numpy.float64   455±4μs
              =============== =========

[ 55.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                               ok
[ 55.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.38±0.03ms
               numpy.float64    2.85±0.1ms
              =============== =============

[ 57.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                          ok
[ 57.14%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   75.0±4μs
               numpy.float64   84.3±3μs
              =============== ==========

[ 58.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                              ok
[ 58.93%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   44.1±1μs
               numpy.float64   49.1±2μs
              =============== ==========

[ 60.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                          ok
[ 60.71%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32    35.0±1μs
               numpy.float64   35.4±0.7μs
              =============== ============

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                        ok
[ 62.50%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   42.3±0.8μs
               numpy.float64    43.6±1μs
              =============== ============

[ 64.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                   ok
[ 64.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   70.2±2μs
               numpy.float64   95.9±2μs
              =============== ==========

[ 66.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                      ok
[ 66.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   11.3±0.2ms
               numpy.float64   22.5±0.3ms
              =============== ============

[ 67.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                    ok
[ 67.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   70.7±2μs
               numpy.float64   81.3±3μs
              =============== ==========

[ 69.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                   ok
[ 69.64%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   67.7±2μs
               numpy.float64   86.3±4μs
              =============== ==========

[ 71.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                             ok
[ 71.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   25.7±0.5ms
               numpy.float64   50.4±0.2ms
              =============== ============

[ 73.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                           ok
[ 73.21%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   60.2±1μs
               numpy.float64   66.3±3μs
              =============== ==========

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                          ok
[ 75.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   61.7±6μs
               numpy.float64   68.0±3μs
              =============== ==========

[ 75.00%] · For numpy commit 360ba057 <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 76.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                     ok
[ 76.79%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   150±20μs
               numpy.float64   249±4μs
              =============== ==========

[ 78.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                                 ok
[ 78.57%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   262±8μs
               numpy.float64   461±20μs
              =============== ==========

[ 80.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                               ok
[ 80.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.33±0.01ms
               numpy.float64   2.72±0.07ms
              =============== =============

[ 82.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                          ok
[ 82.14%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   73.0±2μs
               numpy.float64   83.1±4μs
              =============== ==========

[ 83.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                              ok
[ 83.93%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32    45.4±4μs
               numpy.float64   47.5±0.8μs
              =============== ============

[ 85.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                          ok
[ 85.71%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   35.2±2μs
               numpy.float64   38.2±2μs
              =============== ==========

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                        ok
[ 87.50%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   41.8±0.9μs
               numpy.float64    45.0±3μs
              =============== ============

[ 89.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                   ok
[ 89.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   72.8±2μs
               numpy.float64   79.0±2μs
              =============== ==========

[ 91.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                      ok
[ 91.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   10.9±0.2ms
               numpy.float64   22.1±0.3ms
              =============== ============

[ 92.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                    ok
[ 92.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   67.4±1μs
               numpy.float64   78.8±2μs
              =============== ==========

[ 94.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                   ok
[ 94.64%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   66.8±3μs
               numpy.float64   83.5±3μs
              =============== ==========

[ 96.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                             ok
[ 96.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   25.7±0.8ms
               numpy.float64   50.1±0.4ms
              =============== ============

[ 98.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                           ok
[ 98.21%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   60.3±2μs
               numpy.float64   66.7±2μs
              =============== ==========

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                          ok
[100.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   71.5±5μs
               numpy.float64   72.8±4μs
              =============== ==========


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
</code></pre>
</details>

<details>
<summary>ARM(NEON enabled) PERFORMANCE INCREASED</summary>
<pre><code>
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython.
·· Building 94681fbf <einsum-muladd> for virtualenv-py3.7-Cython.....................................
·· Installing 94681fbf <einsum-muladd> into virtualenv-py3.7-Cython.
· Running 28 total benchmarks (2 commits * 1 environments * 14 benchmarks)
[  0.00%] · For numpy commit 360ba057 <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython.......................................
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[  1.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 25.00%] · For numpy commit 94681fbf <einsum-muladd> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython..
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 26.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 50.00%] · For numpy commit 94681fbf <einsum-muladd> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 51.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                ok
[ 51.79%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   554±1μs 
               numpy.float64   509±2μs 
              =============== =========

[ 53.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                            ok
[ 53.57%] ··· =============== ==========
                   dtype                
              --------------- ----------
               numpy.float32   1.02±0ms 
               numpy.float64   865±7μs  
              =============== ==========

[ 55.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                          ok
[ 55.36%] ··· =============== ==========
                   dtype                
              --------------- ----------
               numpy.float32   780±10μs 
               numpy.float64   976±20μs 
              =============== ==========

[ 57.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                     ok
[ 57.14%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   116±0.6μs 
               numpy.float64    143±2μs  
              =============== ===========

[ 58.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                         ok
[ 58.93%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   74.9±0.9μs 
               numpy.float64    75.6±1μs  
              =============== ============

[ 60.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                     ok
[ 60.71%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   63.2±0.3μs 
               numpy.float64   63.1±0.5μs 
              =============== ============

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                   ok
[ 62.50%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   72.3±0.2μs 
               numpy.float64   73.2±0.4μs 
              =============== ============

[ 64.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                              ok
[ 64.29%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   115±0.6μs 
               numpy.float64    140±1μs  
              =============== ===========

[ 66.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                 ok
[ 66.07%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   5.36±0.3ms 
               numpy.float64   7.02±0.3ms 
              =============== ============

[ 67.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                               ok
[ 67.86%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   141±0.5μs 
               numpy.float64   134±0.9μs 
              =============== ===========

[ 69.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                              ok
[ 69.64%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   140±0.5μs 
               numpy.float64   135±0.5μs 
              =============== ===========

[ 71.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                        ok
[ 71.43%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   17.6±0.9ms 
               numpy.float64    23.1±2ms  
              =============== ============

[ 73.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                      ok
[ 73.21%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   112±0.4μs 
               numpy.float64   111±0.6μs 
              =============== ===========

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                     ok
[ 75.00%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   112±0.5μs 
               numpy.float64   111±0.8μs 
              =============== ===========

[ 75.00%] · For numpy commit 360ba057 <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython..
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 76.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                ok
[ 76.79%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   552±2μs 
               numpy.float64   502±4μs 
              =============== =========

[ 78.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                            ok
[ 78.57%] ··· =============== ==========
                   dtype                
              --------------- ----------
               numpy.float32   1.02±0ms 
               numpy.float64   874±4μs  
              =============== ==========

[ 80.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                          ok
[ 80.36%] ··· =============== =============
                   dtype                   
              --------------- -------------
               numpy.float32     796±9μs   
               numpy.float64   1.00±0.03ms 
              =============== =============

[ 82.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                     ok
[ 82.14%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   137±0.7μs 
               numpy.float64    158±2μs  
              =============== ===========

[ 83.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                         ok
[ 83.93%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   76.1±0.3μs 
               numpy.float64   75.3±0.2μs 
              =============== ============

[ 85.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                     ok
[ 85.71%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   63.9±0.2μs 
               numpy.float64   63.1±0.5μs 
              =============== ============

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                   ok
[ 87.50%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   72.5±0.3μs 
               numpy.float64   74.0±0.2μs 
              =============== ============

[ 89.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                              ok
[ 89.29%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   136±0.3μs 
               numpy.float64   155±0.6μs 
              =============== ===========

[ 91.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                 ok
[ 91.07%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   5.20±0.1ms 
               numpy.float64   7.15±0.2ms 
              =============== ============

[ 92.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                               ok
[ 92.86%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   141±0.8μs 
               numpy.float64   135±0.6μs 
              =============== ===========

[ 94.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                              ok
[ 94.64%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   142±0.5μs 
               numpy.float64   135±0.5μs 
              =============== ===========

[ 96.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                        ok
[ 96.43%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   17.8±0.7ms 
               numpy.float64   23.7±0.9ms 
              =============== ============

[ 98.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                      ok
[ 98.21%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   113±0.5μs 
               numpy.float64   111±0.8μs 
              =============== ===========

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                     ok
[100.00%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   113±0.7μs 
               numpy.float64   110±0.5μs 
              =============== ===========

       before           after         ratio
     [360ba057]       [94681fbf]
     <master>         <einsum-muladd>
-       155±0.6μs          140±1μs     0.91  bench_linalg.Einsum.time_einsum_noncon_multiply(<class 'numpy.float64'>)
-         158±2μs          143±2μs     0.91  bench_linalg.Einsum.time_einsum_multiply(<class 'numpy.float64'>)
-       136±0.3μs        115±0.6μs     0.85  bench_linalg.Einsum.time_einsum_noncon_multiply(<class 'numpy.float32'>)
-       137±0.7μs        116±0.6μs     0.84  bench_linalg.Einsum.time_einsum_multiply(<class 'numpy.float32'>)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
</code></pre>
</details>

**System Info**
  | Arm | x86
-- | -- | --
Hardware | KunPeng |  
Processor | ARMv8 2.6GMHZ 8 processors | Intel(R) Xeon(R) Gold 6161 CPU @ 2.20GHz
OS | Linux ecs-9d50 4.19.36-vhulk1905.1.0.h276.eulerosv2r8.aarch64 | Windows Server 2008 R2 Enterprise
Compiler | gcc (GCC) 7.3.0 | MSVC14.06

