### PR TITLE
DOC: Fix up links, code blocks of release note fragments

### DIFF
--- a/doc/release/upcoming_changes/16056.deprecation.rst
+++ b/doc/release/upcoming_changes/16056.deprecation.rst
@@ -3,7 +3,7 @@ Inexact matches for mode and searchside are deprecated
 Inexact and case insensitive matches for mode and searchside were
 valid inputs earlier and will give a DeprecationWarning now.
 For example, below are some example usages which are now deprecated and will
-give a DeprecationWarning.
+give a DeprecationWarning::
 
     import numpy as np
     arr = np.array([[3, 6, 6], [4, 5, 1]])

--- a/doc/release/upcoming_changes/16134.compatibility.rst
+++ b/doc/release/upcoming_changes/16134.compatibility.rst
@@ -1,6 +1,6 @@
 Same kind casting in concatenate with ``axis=None``
 ---------------------------------------------------
-When `~numpy.concatenate` is called with `axis=None`,
+When `~numpy.concatenate` is called with ``axis=None``,
 the flattened arrays were cast with ``unsafe``. Any other axis
 choice uses "same kind". That different default
 has been deprecated and "same kind" casting will be used

--- a/doc/release/upcoming_changes/16200.compatibility.rst
+++ b/doc/release/upcoming_changes/16200.compatibility.rst
@@ -17,7 +17,7 @@ At this time, NumPy retains the behaviour for::
 
     np.array(np.float64(np.nan), dtype=np.int64)
 
-The above changes do not affect Python scalars:
+The above changes do not affect Python scalars::
 
     np.array([float("NaN")], dtype=np.int64)
 

--- a/doc/release/upcoming_changes/16815.compatibility.rst
+++ b/doc/release/upcoming_changes/16815.compatibility.rst
@@ -1,8 +1,8 @@
-`mgrid`, `r_`, etc. fixed to consistently return correct outputs for non-default precision inputs
--------------------------------------------------------------------------------------------------
+``mgrid``, ``r_``, etc. consistently return correct outputs for non-default precision input
+-------------------------------------------------------------------------------------------
 Previously, ``np.mgrid[np.float32(0.1):np.float32(0.35):np.float32(0.1),]``
 and ``np.r_[0:10:np.complex64(3j)]`` failed to return meaningful output.
-This bug potentially affects `mgrid`, `ogrid`, `r_`, and `c_` when an
-input with dtype other than the default `float64` and `complex128`
-and equivalent Python types were used.
+This bug potentially affects `~numpy.mgrid`, `~numpy.ogrid`, `~numpy.r_`,
+and `~numpy.c_` when an input with dtype other than the default
+``float64`` and ``complex128`` and equivalent Python types were used.
 The methods have been fixed to handle varying precision correctly.

--- a/doc/release/upcoming_changes/16841.change.rst
+++ b/doc/release/upcoming_changes/16841.change.rst
@@ -1,5 +1,5 @@
-`np.linspace` on integers now use floor
----------------------------------------
+``np.linspace`` on integers now use floor
+-----------------------------------------
 When using a `int` dtype in `numpy.linspace`, previously float values would
 be rounded towards zero. Now `numpy.floor` is used instead, which rounds toward
 ``-inf``. This changes the results for negative values. For example, the 

--- a/doc/release/upcoming_changes/17219.new_feature.rst
+++ b/doc/release/upcoming_changes/17219.new_feature.rst
@@ -1,9 +1,9 @@
 Negation of user-defined BLAS/LAPACK detection order
 ----------------------------------------------------
-`distutils` allows negation of libraries when determining BLAS/LAPACK
+`~numpy.distutils` allows negation of libraries when determining BLAS/LAPACK
 libraries.
 This may be used to remove an item from the library resolution phase, i.e.
-to disallow NetLIB libraries one could do::
+to disallow NetLIB libraries one could do:
 
 .. code:: bash
 

--- a/doc/release/upcoming_changes/17535.new_function.rst
+++ b/doc/release/upcoming_changes/17535.new_function.rst
@@ -1,6 +1,6 @@
 `numpy.broadcast_shapes` is a new user-facing function
 ------------------------------------------------------
-`broadcast_shapes` gets the resulting shape from
+`~numpy.broadcast_shapes` gets the resulting shape from
 broadcasting the given shape tuples against each other.
 
 .. code:: python

--- a/doc/release/upcoming_changes/17596.future.rst
+++ b/doc/release/upcoming_changes/17596.future.rst
@@ -12,7 +12,7 @@ For such a ``dtype`` the following behaviour is true::
     res.dtype is dtype.base
     res.shape == arr.shape + dtype.shape
 
-But ``res`` is filled using the logic:
+But ``res`` is filled using the logic::
 
     res = np.empty(arr.shape + dtype.shape, dtype=dtype.base)
     res[...] = arr


### PR DESCRIPTION
This should fix hopefully all broken links and missing code blocks.
I also slight shortened one of the very long titles.