### PR TITLE
BUG: Fixes #17797 f2py assumed shape and callbacks

### DIFF
--- a/numpy/f2py/func2subr.py
+++ b/numpy/f2py/func2subr.py
@@ -130,7 +130,7 @@ def createfuncwrapper(rout, signature=0):
             l = l + ', ' + fortranname
     if need_interface:
         for line in rout['saved_interface'].split('\n'):
-            if line.lstrip().startswith('use '):
+            if line.lstrip().startswith('use ') and not '__user__' in line:
                 add(line)
 
     args = args[1:]
@@ -164,7 +164,10 @@ def createfuncwrapper(rout, signature=0):
             pass
         else:
             add('interface')
-            add(rout['saved_interface'].lstrip())
+            saved_interface = rout['saved_interface'].lstrip().split('\n')
+            for line in saved_interface:
+                if not ('use' in line and '__user__' in line):
+                    add(line)
             add('end interface')
 
     sargs = ', '.join([a for a in args if a not in extra_args])
@@ -222,7 +225,7 @@ def createsubrwrapper(rout, signature=0):
 
     if need_interface:
         for line in rout['saved_interface'].split('\n'):
-            if line.lstrip().startswith('use '):
+            if line.lstrip().startswith('use ') and not '__user__' in line:
                 add(line)
 
     dumped_args = []
@@ -247,7 +250,10 @@ def createsubrwrapper(rout, signature=0):
             pass
         else:
             add('interface')
-            add(rout['saved_interface'].lstrip())
+            saved_interface = rout['saved_interface'].lstrip().split('\n')
+            for line in saved_interface:
+                if not ('use' in line and '__user__' in line):
+                    add(line)
             add('end interface')
 
     sargs = ', '.join([a for a in args if a not in extra_args])

--- a/numpy/f2py/func2subr.py
+++ b/numpy/f2py/func2subr.py
@@ -166,7 +166,9 @@ def createfuncwrapper(rout, signature=0):
             add('interface')
             saved_interface = rout['saved_interface'].lstrip().split('\n')
             for line in saved_interface:
-                if not ('use' in line and '__user__' in line):
+                if line.lstrip().startswith('use ') and '__user__' in line:
+                    continue
+                else:
                     add(line)
             add('end interface')
 
@@ -252,7 +254,9 @@ def createsubrwrapper(rout, signature=0):
             add('interface')
             saved_interface = rout['saved_interface'].lstrip().split('\n')
             for line in saved_interface:
-                if not ('use' in line and '__user__' in line):
+                if line.lstrip().startswith('use ') and '__user__' in line:
+                    continue
+                else:
                     add(line)
             add('end interface')
 


### PR DESCRIPTION
This is a small fix for #17797 that checks if a custom `__user__` use statement was inserted for callback functionality in f2py. I figured that `func2subr.py` was the best place to do these changes, as the generation happens there, and the code is already quite intertwined. Going directly into `crackfortran.py` instead would affect too many other things. 