### PR TITLE
ENH, BLD: Add windows arm64 support

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -39,6 +39,12 @@
      * _M_AMD64 defined by MS compiler
      */
     #define NPY_CPU_AMD64
+#elif defined(_M_ARM64)
+    /*
+     * _M_ARM64 is defined by VS compiler >= 2017 to build native
+     * ARM64 packages on Windows
+     */
+    #define NPY_CPU_ARMEL_AARCH64
 #elif defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
     #define NPY_CPU_PPC64LE
 #elif defined(__powerpc64__) && defined(__BIG_ENDIAN__)
@@ -82,7 +88,7 @@
         #endif
     #else
         # error Unknown ARM CPU, please report this to numpy maintainers with \
-	information about your platform (OS, CPU and compiler)
+        information about your platform (OS, CPU and compiler)
     #endif
 #elif defined(__sh__) && defined(__LITTLE_ENDIAN__)
     #define NPY_CPU_SH_LE

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -32,6 +32,15 @@ static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
   *hip = product >> 64;
   return (uint64_t)product;
 }
+#elif defined(_M_X64) || defined(_M_ARM64)
+#include <intrin.h>
+#pragma intrinsic(__umulh)
+static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
+  uint64_t p0 = a * b;
+  uint64_t p1 = __umulh(a, b);
+  *hip = p1;
+  return p0;
+}
 #else
 #ifdef _WIN32
 #include <intrin.h>


### PR DESCRIPTION
Added support for building numpy for Windows ARM64:

  * fix philox generator to use correct arm64 intrinsic __umulh
  * fix cpu recognition

Test results:

```bash
python.exe -c "import numpy; numpy.test(label='fast',verbose=3)

>> 11404 passed, 705 skipped, 1205 deselected, 19 failed in 497.70s (0:08:17)
```

You need a tweaked version of the msvc compiler for Python, which you can download from here: https://github.com/ader1990/CPython-Windows-ARM64/releases
Source code for Python 3.8.5: https://github.com/ader1990/cpython/tree/v3.8.5-win-arm64 (basically is just a hack to recognise the emulated build tools for ARM64). You can rebase the commit that fixes the build on recent Python versions too: https://github.com/ader1990/cpython/commit/b8c59c9b96a7ad11094224b5631aae3b89323f7a

This fix is an alternative solution for https://github.com/numpy/numpy/issues/17747
