### PR TITLE
ENH: added rivest-floyd selection as option to ndarray.partition method

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -690,7 +690,7 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     axis : int or None, optional
         Axis along which to sort. If None, the array is flattened before
         sorting. The default is -1, which sorts along the last axis.
-    kind : {'introselect'}, optional
+    kind : {'introselect', 'floydselect'}, optional
         Selection algorithm. Default is 'introselect'.
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument
@@ -721,7 +721,8 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     ================= ======= ============= ============ =======
        kind            speed   worst case    work space  stable
     ================= ======= ============= ============ =======
-    'introselect'        1        O(n)           0         no
+    'introselect'        2        O(n)           0         no
+    'floydrivest'        1        O(n^2)         0         no
     ================= ======= ============= ============ =======
 
     All the partition algorithms make temporary copies of the data when
@@ -782,7 +783,7 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     axis : int or None, optional
         Axis along which to sort. The default is -1 (the last axis). If
         None, the flattened array is used.
-    kind : {'introselect'}, optional
+    kind : {'introselect','floydselect'}, optional
         Selection algorithm. Default is 'introselect'
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -690,7 +690,7 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     axis : int or None, optional
         Axis along which to sort. If None, the array is flattened before
         sorting. The default is -1, which sorts along the last axis.
-    kind : {'introselect', 'floydselect'}, optional
+    kind : {'introselect', 'floydrivest'}, optional
         Selection algorithm. Default is 'introselect'.
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -172,10 +172,12 @@ typedef enum {
 #define NPY_NSORTS (NPY_STABLESORT + 1)
 
 
+
 typedef enum {
-        NPY_INTROSELECT=0
+        NPY_INTROSELECT=0,
+        NPY_FLOYDSELECT=1
 } NPY_SELECTKIND;
-#define NPY_NSELECTS (NPY_INTROSELECT + 1)
+#define NPY_NSELECTS (NPY_FLOYDSELECT + 1)
 
 
 typedef enum {

--- a/numpy/core/src/common/npy_partition.h.src
+++ b/numpy/core/src/common/npy_partition.h.src
@@ -52,6 +52,16 @@ NPY_NO_EXPORT int aintroselect_@suff@(@type@ *v, npy_intp* tosort, npy_intp num,
                                               npy_intp * pivots,
                                               npy_intp * npiv,
                                               void *NOT_USED);
+NPY_NO_EXPORT int floydrivest_@suff@(@type@ *v, npy_intp num,
+                                             npy_intp kth,
+                                             npy_intp * pivots,
+                                             npy_intp * npiv,
+                                             void *NOT_USED);
+NPY_NO_EXPORT int afloydrivest_@suff@(@type@ *v, npy_intp* tosort, npy_intp num,
+                                              npy_intp kth,
+                                              npy_intp * pivots,
+                                              npy_intp * npiv,
+                                              void *NOT_USED);
 
 
 /**end repeat**/
@@ -80,9 +90,11 @@ static part_map _part_map[] = {
         NPY_@TYPE@,
         {
             (PyArray_PartitionFunc *)&introselect_@suff@,
+            (PyArray_PartitionFunc *)&floydrivest_@suff@,
         },
         {
             (PyArray_ArgPartitionFunc *)&aintroselect_@suff@,
+            (PyArray_ArgPartitionFunc *)&afloydrivest_@suff@,
         }
     },
 /**end repeat**/

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -2172,6 +2172,7 @@ run_selectkind_converter(PyObject* NPY_UNUSED(self), PyObject *args)
     }
     switch (kind) {
         case NPY_INTROSELECT: return PyUnicode_FromString("NPY_INTROSELECT");
+        case NPY_FLOYDSELECT: return PyUnicode_FromString("NPY_FLOYDSELECT");
     }
     return PyLong_FromLong(kind);
 }

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -491,6 +491,10 @@ static int selectkind_parser(char const *str, Py_ssize_t length, void *data)
         *selectkind = NPY_INTROSELECT;
         return 0;
     }
+    else if (length == 11 && strcmp(str, "floydrivest") == 0) {
+        *selectkind = NPY_FLOYDSELECT;
+        return 0;
+    }
     else {
         return -1;
     }
@@ -504,7 +508,7 @@ PyArray_SelectkindConverter(PyObject *obj, NPY_SELECTKIND *selectkind)
 {
     return string_converter_helper(
         obj, (void *)selectkind, selectkind_parser, "select kind",
-        "must be 'introselect'");
+        "must be 'introselect' or 'floydrivest'");
 }
 
 static int searchside_parser(char const *str, Py_ssize_t length, void *data)

--- a/numpy/core/src/npysort/selection.c.src
+++ b/numpy/core/src/npysort/selection.c.src
@@ -2,7 +2,8 @@
 
 /*
  *
- * The code is loosely based on the quickselect from
+ * This code implements two selection methods: introselect and floydrivest.
+ * The introselect code is loosely based on the quickselect from
  * Nicolas Devillard - 1998 public domain
  * http://ndevilla.free.fr/median/median/
  *
@@ -11,6 +12,10 @@
  * e.g. np.roll(np.arange(x), x / 2)
  * To avoid this if it recurses too much it falls back to the
  * worst case linear median of median of group 5 pivot strategy.
+ *
+ * Floydrivest implements the Rivest-Floyd selection algorithm.
+ * http://people.csail.mit.edu/rivest/pubs/FR75b.pdf
+ * It is faster than introselect on average, but has O(n^2) worst case.
  */
 
 
@@ -48,7 +53,7 @@ static NPY_INLINE void store_pivot(npy_intp pivot, npy_intp kth,
         pivots[*npiv - 1] = pivot;
     }
     /*
-     * we only need pivots larger than current kth, larger pivots are not
+     * we only need pivots larger than current kth, smaller pivots are not
      * useful as partitions on smaller kth would reorder the stored pivots
      */
     else if (pivot >= kth && *npiv < NPY_MAX_PIVOT_STACK) {
@@ -102,6 +107,8 @@ median_of_median5_@suff@(@type@ *v, const npy_intp num,
         aintroselect_@suff@(v, tosort, nmed, nmed / 2, pivots, npiv, NULL)
 #define DUMBSELECT(v, tosort, left, num, kth) \
         adumb_select_@suff@(v, tosort + left, num, kth)
+#define RF_PARTITION(v, tosort, left, right) \
+        arf_partition_@suff@(v, tosort, left, right)
 #else
 #define IDX(x) (x)
 #define SORTEE(x) v[x]
@@ -116,6 +123,8 @@ median_of_median5_@suff@(@type@ *v, const npy_intp num,
         introselect_@suff@(v, nmed, nmed / 2, pivots, npiv, NULL)
 #define DUMBSELECT(v, tosort, left, num, kth) \
         dumb_select_@suff@(v + left, num, kth)
+#define RF_PARTITION(v, tosort, left, right) \
+        rf_partition_@suff@(v, left, right)
 #endif
 
 
@@ -131,13 +140,16 @@ static NPY_INLINE void
 #endif
                           npy_intp low, npy_intp mid, npy_intp high)
 {
-    if (@TYPE@_LT(v[IDX(high)], v[IDX(mid)]))
+    if (@TYPE@_LT(v[IDX(high)], v[IDX(mid)])) {
         SWAP(SORTEE(high), SORTEE(mid));
-    if (@TYPE@_LT(v[IDX(high)], v[IDX(low)]))
+    }
+    if (@TYPE@_LT(v[IDX(high)], v[IDX(low)])) {
         SWAP(SORTEE(high), SORTEE(low));
+    }
     /* move pivot to low */
-    if (@TYPE@_LT(v[IDX(low)], v[IDX(mid)]))
+    if (@TYPE@_LT(v[IDX(low)], v[IDX(mid)])) {
         SWAP(SORTEE(low), SORTEE(mid));
+    }
     /* move 3-lowest element to low + 1 */
     SWAP(SORTEE(mid), SORTEE(low + 1));
 }
@@ -201,14 +213,47 @@ static NPY_INLINE void
         do (*ll)++; while (@TYPE@_LT(v[IDX(*ll)], pivot));
         do (*hh)--; while (@TYPE@_LT(pivot, v[IDX(*hh)]));
 
-        if (*hh < *ll)
+        if (*hh < *ll) {
             break;
-
+        }
         SWAP(SORTEE(*ll), SORTEE(*hh));
     }
 }
-
-
+/* partition for rivest-floyd algorithm around the v[IDX(*ll)] pivot.
+Return the index of the pivot
+*/
+npy_intp @name@rf_partition_@suff@(@type@ *v,
+#if @arg@
+                                 npy_intp *tosort,
+#endif
+                                 npy_intp low,
+                                 npy_intp high)
+{
+    npy_intp i = low;
+    npy_intp j = high;
+    @type@ pivot = v[IDX(low)];
+    //if pivots stays at low, it is going to be swapped to high
+    npy_bool pivot_low = 0;
+    //ensure v[IDX(low)] >= v[IDX(high)]
+    if (@TYPE@_LT(pivot, v[IDX(high)])) {
+        SWAP(SORTEE(low), SORTEE(high));
+        pivot_low = 1;
+    }
+    while (i < j) {
+        SWAP(SORTEE(i), SORTEE(j));
+        do i++; while (@TYPE@_LT(v[IDX(i)], pivot));
+        do j--; while (@TYPE@_LT(pivot, v[IDX(j)]));
+    }
+    //now put pivot in the jth place
+    if (pivot_low) {
+        SWAP(SORTEE(low), SORTEE(j));
+    }
+    else {
+        j++;
+        SWAP(SORTEE(high), SORTEE(j));
+    }
+    return j;
+}
 /*
  * select median of median of blocks of 5
  * if used as partition pivot it splits the range into at least 30%/70%
@@ -231,8 +276,9 @@ static npy_intp
         SWAP(SORTEE(subleft + m), SORTEE(i));
     }
 
-    if (nmed > 2)
+    if (nmed > 2) {
         INTROSELECT(v, tosort, nmed, nmed / 2, pivots, npiv);
+    }
     return nmed / 2;
 }
 
@@ -270,7 +316,7 @@ static int
 /*
  * iterative median of 3 quickselect with cutoff to median-of-medians-of5
  * receives stack of already computed pivots in v to minimize the
- * partition size were kth is searched in
+ * partition size where kth is searched in
  *
  * area that needs partitioning in [...]
  * kth 0:  [8  7  6  5  4  3  2  1  0] -> med3 partitions elements [4, 2, 0]
@@ -388,10 +434,12 @@ NPY_NO_EXPORT int
             store_pivot(hh, kth, pivots, npiv);
         }
 
-        if (hh >= kth)
+        if (hh >= kth) {
             high = hh - 1;
-        if (hh <= kth)
+        }
+        if (hh <= kth) {
             low = ll;
+        }
     }
 
     /* two elements */
@@ -406,6 +454,113 @@ NPY_NO_EXPORT int
 }
 
 
+/*
+ * rivest-floyd selection algorithm
+ */
+#define C1 600
+#define C2 0.5
+#define C3 0.5
+
+/* helper function */
+void
+@name@rf_recursive_@suff@(@type@ *v,
+#if @arg@
+                          npy_intp* tosort,
+#endif
+                          npy_intp left,
+                          npy_intp right,
+                          npy_intp kth)
+{
+    while (right > left) {
+        if (right - left > C1) {
+            npy_float N = (npy_float)(right - left + 1);
+            npy_float II = (npy_float)(kth - left + 1);
+            npy_float Z = npy_log(N);
+            npy_float S = C2 * npy_exp(2*Z/3.0);
+            npy_float SD = C3 * npy_sqrt(Z*S*(N - S)/N) * npy_copysign(1, II - N/2);
+            npy_intp newleft = kth - (npy_intp)(II*S/N - SD);
+            /* why II*S/N - SD can be converted to npy_intp and subtracted from kth without numerical overflow:
+             * 1) converted to npy_intp
+             * Since N >= 600,
+             * 0 <= II <= N,
+             * S = 0.5 N^(2/3) and
+             * |SD| = 0.5 sqrt(log N * 0.5 N^(2/3) * (N - 0.5 N^(2/3) / N) <= 0.5 N^(1/3) sqrt(log N):
+             * |II*S/N - SD| <= |II*S/N| + |SD| <= |S| + |SD| < N <= npy_intp.max
+             * 2) subtracted from kth:
+             * because kth >= 0 and II*S/N - SD >= 0
+             * (Indeed, if SD > 0,
+             * then II - N/2 > 0 => II/N > 0.5 => II*S/N > 0.5 => II*S/N > 0.5 * S > SD)
+             */
+            if (newleft < left) {
+                newleft = left;
+            }
+            npy_intp newright = right;
+            if ((npy_float)(right - kth) > (N - II)*S/N + SD) {
+                newright = kth + (npy_intp)((N - II)*S/N + SD);
+            }
+            /*
+             * |(N-II)*S/N - SD| <= |II*S/N| + |SD| <= |S| + |SD| < N <= npy_intp.max
+             * we only convert (N - II) * S/N + SD to npy_intp and add to kth when
+             * kth + (N-II)*S/N + SD < right <= npy_intp.max, so the sum won't overflow.
+             */
+            @name@rf_recursive_@suff@(v,
+#if @arg@
+                               tosort,
+#endif
+                               newleft, newright, kth);
+        }
+        SWAP(SORTEE(left), SORTEE(kth));
+        npy_intp j = RF_PARTITION(v, tosort, left, right);
+        if (j <= kth) {
+            left = j+1;
+        }
+        if (kth <= j) {
+            right = j-1;
+        }
+    }
+};
+ 
+NPY_NO_EXPORT int
+@name@floydrivest_@suff@(@type@ *v,
+#if @arg@
+                         npy_intp* tosort,
+#endif
+                         npy_intp num, npy_intp kth,
+                         npy_intp * pivots, //not used
+                         npy_intp * npiv, //not used
+                         void *NOT_USED)
+{
+    npy_intp low  = 0;
+    npy_intp high = num - 1;
+    /*
+     * use a faster O(n*kth) algorithm for very small kth
+     * e.g. for interpolating percentile
+     */
+    if (kth - low < 3) {
+        DUMBSELECT(v, tosort, low, high - low + 1, kth - low);
+        return 0;
+    }
+    else if ((@inexact@) && kth == num - 1) {
+        /* useful to check if NaN present via partition(d, (x, -1)) */
+        npy_intp k;
+        npy_intp maxidx = low;
+        @type@ maxval = v[IDX(low)];
+        for (k = low + 1; k < num; k++) {
+            if (!@TYPE@_LT(v[IDX(k)], maxval)) {
+                maxidx = k;
+                maxval = v[IDX(k)];
+            }
+        }
+        SWAP(SORTEE(kth), SORTEE(maxidx));
+        return 0;
+    }
+    @name@rf_recursive_@suff@(v,
+#if @arg@
+                          tosort,
+#endif
+                          low, high, kth);
+    return 0;
+};
 #undef IDX
 #undef SWAP
 #undef SORTEE
@@ -414,6 +569,7 @@ NPY_NO_EXPORT int
 #undef UNGUARDED_PARTITION
 #undef INTROSELECT
 #undef DUMBSELECT
+#undef RF_PARTITION
 /**end repeat1**/
 
 /**end repeat**/

--- a/numpy/core/tests/test_item_selection.py
+++ b/numpy/core/tests/test_item_selection.py
@@ -1,8 +1,9 @@
 import sys
+import pytest
 
 import numpy as np
 from numpy.testing import (
-    assert_, assert_raises, assert_array_equal, HAS_REFCOUNT
+    assert_, assert_raises, assert_array_equal, assert_almost_equal, HAS_REFCOUNT
     )
 
 
@@ -67,20 +68,32 @@ class TestTake:
         k = b'\xc3\xa4'.decode("UTF8")
         assert_raises(ValueError, d.take, 5, mode=k)
 
-    def test_empty_partition(self):
+    @pytest.mark.parametrize('kind', ['introselect', 'floydrivest'])
+    def test_empty_partition(self, kind):
         # In reference to github issue #6530
         a_original = np.array([0, 2, 4, 6, 8, 10])
         a = a_original.copy()
 
         # An empty partition should be a successful no-op
-        a.partition(np.array([], dtype=np.int16))
+        a.partition(np.array([], dtype=np.int16), kind=kind)
 
         assert_array_equal(a, a_original)
 
-    def test_empty_argpartition(self):
+    @pytest.mark.parametrize('kind', ['introselect', 'floydrivest'])
+    def test_empty_argpartition(self, kind):
         # In reference to github issue #6530
         a = np.array([0, 2, 4, 6, 8, 10])
-        a = a.argpartition(np.array([], dtype=np.int16))
+        a = a.argpartition(np.array([], dtype=np.int16), kind=kind)
 
         b = np.array([0, 1, 2, 3, 4, 5])
         assert_array_equal(a, b)
+        
+    def test_floydrivest(self):
+        #test correctness on array size > 600
+        np.random.seed(0)
+        a = np.random.rand(1000)
+        k = 500
+        x = np.partition(a, k, kind='floydrivest')[k]
+        y = sorted(a)[k]
+        assert_almost_equal(x, y)
+        


### PR DESCRIPTION
Implemented the Rivest-Floyd selection algorithm 
http://people.csail.mit.edu/rivest/pubs/FR75b.pdf
as a second option for numpy array partition. 
It has worse worst-cast time than introselect, but runs faster on average.