### PR TITLE
BUG: Ignore fewer errors during array-coercion

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2122,7 +2122,7 @@ PyArray_FromInterface(PyObject *origin)
 
     if (iface == NULL) {
         if (PyErr_Occurred()) {
-            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+            return NULL;
         }
         return Py_NotImplemented;
     }
@@ -2390,7 +2390,7 @@ PyArray_FromArrayAttr(PyObject *op, PyArray_Descr *typecode, PyObject *context)
     array_meth = PyArray_LookupSpecial_OnInstance(op, "__array__");
     if (array_meth == NULL) {
         if (PyErr_Occurred()) {
-            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+            return NULL;
         }
         return Py_NotImplemented;
     }

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -689,3 +689,33 @@ class TestArrayLikes:
                 np.array(arr)
             with pytest.raises(MemoryError):
                 np.array([arr])
+
+    @pytest.mark.parametrize("attribute",
+        ["__array_interface__", "__array__", "__array_struct__"])
+    def test_bad_array_like_attributes(self, attribute):
+        # Check that errors during attribute retrieval are raised unless
+        # they are Attribute errors.
+
+        class BadInterface:
+            def __getattr__(self, attr):
+                if attr == attribute:
+                    raise RuntimeError
+                super().__getattr__(attr)
+
+        with pytest.raises(RuntimeError):
+            np.array(BadInterface())
+
+    @pytest.mark.parametrize("error", [RecursionError, MemoryError])
+    def test_bad_array_like_bad_length(self, error):
+        # RecursionError and MemoryError are considered "critical" in
+        # sequences. We could expand this more generally though. (NumPy 1.20)
+        class BadSequence:
+            def __len__(self):
+                raise error
+            def __getitem__(self):
+                # must have getitem to be a Sequence
+                return 1
+
+        with pytest.raises(error):
+            np.array(BadSequence())
+


### PR DESCRIPTION
This changes it so that we only ignore attribute errors on
looking up `__array__` and propagate errors when checking
for sequences `len(obj)` if those errors are either
RecursionError or MemoryError (we consider them unrecoverable).

Also adds test for bad recursive array-like with sequence
as reported in gh-17785. The test might be flaky/more complicated
in which case it should probably just be deleted.

---

OK, one more attempt with raising more erros... First attempt with checking for `RecursionError` in the test, but lets see...