### PR TITLE
DOC: Update quickstart.rst

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1126,7 +1126,7 @@ indices for each dimension must have the same shape.
     array([[ 2,  6],
            [ 6, 10]])
     >>>
-    >>> a[:, j]                                     # i.e., a[ : , j]
+    >>> a[:, j]                                     # i.e., a[0:4, j]
     array([[[ 2,  1],
             [ 3,  3]],
     <BLANKLINE>


### PR DESCRIPTION
Tutorial said
>>> a[:, j]                                     # i.e., a[ : , j]
It meant
>>> a[:, j]                                     # i.e., a[..., j]
or
>>> a[:, j]                                     # i.e., a[0:4, j]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
