### PR TITLE
DOC: Add missing release fragments to ``upcoming_changes``.

### DIFF
--- a/doc/release/upcoming_changes/15121.new_function.rst
+++ b/doc/release/upcoming_changes/15121.new_function.rst
@@ -1,0 +1,6 @@
+The random.Generator class has a new ``permuted`` function.
+-----------------------------------------------------------
+The new function differs from ``shuffle`` and ``permutation`` in that the
+subarrays indexed by an axis are permuted rather than the axis being treated as
+a separate 1-D array for every combination of the other indexes. For example,
+it is now possible to permute the rows or columns of a 2-D array.

--- a/doc/release/upcoming_changes/16570.compatibility.rst
+++ b/doc/release/upcoming_changes/16570.compatibility.rst
@@ -1,0 +1,4 @@
+The ``operator.concat`` function now raises TypeError for array arguments
+-------------------------------------------------------------------------
+The previous behavior was to fall back to addition and add the two arrays,
+which was thought to be unexpected behavior for a concatenation function.

--- a/doc/release/upcoming_changes/16594.new_feature.rst
+++ b/doc/release/upcoming_changes/16594.new_feature.rst
@@ -1,0 +1,4 @@
+New``__f2py_numpy_version__`` attribute for f2py generated modules.
+-------------------------------------------------------------------
+Because f2py is released together with NumPy, ``__f2py_numpy_version__``
+provides a way to track the version f2py used to generate the module.

--- a/doc/release/upcoming_changes/16710.improvement.rst
+++ b/doc/release/upcoming_changes/16710.improvement.rst
@@ -1,0 +1,3 @@
+RPATH support on AIX added to distutils
+---------------------------------------
+This allows SciPy to be built on AIX.

--- a/doc/release/upcoming_changes/17123.new_feature.rst
+++ b/doc/release/upcoming_changes/17123.new_feature.rst
@@ -1,0 +1,12 @@
+``mypy`` tests can be run via runtests.py
+-----------------------------------------
+Currently running mypy with the NumPy stubs configured requires
+either:
+
+* Installing NumPy
+* Adding the source directory to MYPYPATH and linking to the mypy.ini
+
+Both options are somewhat inconvenient, so add a ``--mypy`` option to runtests
+that handles setting things up for you. This will also be useful in the future
+for any typing codegen since it will ensure the project is built before type
+checking.

--- a/doc/release/upcoming_changes/17195.improvement.rst
+++ b/doc/release/upcoming_changes/17195.improvement.rst
@@ -1,0 +1,5 @@
+Make the window functions exactly symmetric
+-------------------------------------------
+Make sure the window functions provided by NumPy are symmetric. There were
+previously small deviations from symmetry due to numerical precision that are
+now avoided by better arrangement of the computation.

--- a/doc/release/upcoming_changes/17284.new_feature.rst
+++ b/doc/release/upcoming_changes/17284.new_feature.rst
@@ -1,0 +1,6 @@
+Allow passing optimizations arguments to asv build
+--------------------------------------------------
+It is now possible to pass  ``-j``, ``--cpu-baseline``, ``--cpu-dispatch`` and
+``--disable-optimization`` flags to ASV build when the ``--bench-compare``
+argument is used.
+

--- a/doc/release/upcoming_changes/17344.new_feature.rst
+++ b/doc/release/upcoming_changes/17344.new_feature.rst
@@ -1,0 +1,3 @@
+The NVIDIA HPC SDK nvfortran compiler is now supported
+------------------------------------------------------
+Support for the nvfortran compiler, a version of pgfortran, has been added.

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -3,8 +3,15 @@
 
 # download-wheels.py
 urllib3
-beatifulsoup4
+beautifulsoup4
 
 # changelog.py
 pygithub
 gitpython
+
+# uploading wheels
+twine
+
+# building and notes
+Paver
+towncrier


### PR DESCRIPTION
Closes #17533. 

- Adds missing release note entries for NumPy 1.20.0
- Fixes typo in ``release_requirements.txt``.