### PR TITLE
WIP,ENH: Adding gitignore test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,16 @@ Thumbs.db
 #############################
 doc/source/savefig/
 
+# Azure Pipeline generated files #
+##################################
+venv/*
+
+# github actions generated files #
+##################################
+log
+warnings
+_configtest.gcno
+pypy3/*
 
 # Things specific to this project #
 ###################################

--- a/numpy/tests/test_gitignore.py
+++ b/numpy/tests/test_gitignore.py
@@ -1,0 +1,14 @@
+import subprocess as sp
+import pytest
+
+
+def test_no_untracked_files():
+    fd_1 = sp.run(["git", "status", "-u", "--porcelain"], stdout=sp.PIPE,
+                  stderr=sp.PIPE, universal_newlines=True, check=True)
+    fd_1 = fd_1.stdout.split('\n')
+
+    untracked_files = [output[3:] for output in fd_1 if
+                       output.startswith('??')]
+
+    msg = f"git detected these untracked files:\n{untracked_files}"
+    assert len(untracked_files) == 0, msg


### PR DESCRIPTION
Continuing the conversation from #17820 
I've created a test that will fail if there are untracked files present in the repository. (to try and resolve  #17718)

 
TODO: 

- ~~As @mattip, this current commit should pass the CI/CD, I will make another commit that should fail.~~
- Current CI/CD should fail, indicating test works for the creation of new files
- Add comments on CI/CD to indicate this tests requires setup.py over pip install .


