### PR TITLE
BUG: Fix incorrectly passed size in masked processing

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1292,7 +1292,7 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
             int res = stransfer(
                     dst, dst_stride0, src, src_stride,
                     mask, mask_stride,
-                    N, src_itemsize, data);
+                    shape0, src_itemsize, data);
             if (res < 0) {
                 return -1;
             }

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1333,6 +1333,18 @@ class TestUfunc:
         m = np.array([True], dtype=bool)
         assert_equal(np.sqrt(a, where=m), [1])
 
+    def test_where_with_broadcasting(self):
+        # See gh-17198
+        a = np.random.random((5000, 4))
+        b = np.random.random((5000, 1))
+
+        where = a > 0.3
+        out = np.full_like(a, 0)
+        np.less(a, b, where=where, out=out)
+        b_where = np.broadcast_to(b, a.shape)[where]
+        assert_array_equal((a[where] < b_where), out[where].astype(bool))
+        assert not out[~where].any()  # outside mask, out remains all 0
+
     def check_identityless_reduction(self, a):
         # np.minimum.reduce is an identityless reduction
 


### PR DESCRIPTION
As noted in gh-17198 this was introduced when adding the error
return due to a bad copy or similar. Bad commit is
37dc69cd01934b78bbf9bcccab5fbc4a7ff5eacb

Closes gh-17198