### PR TITLE
TST: Add back durations flag for DEBUG builds.

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -25,4 +25,4 @@ runs:
   - name: Test
     shell: bash
     run: ./tools/travis-test.sh
-      
+

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -6,7 +6,7 @@ defaults:
   run:
     shell: bash
 
-env: 
+env:
   DOWNLOAD_OPENBLAS: 1
   PYTHON_VERSION: 3.7
 
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
- 
+
   basic:
     needs: smoke_test
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
 
   debug:
     needs: smoke_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       USE_DEBUG: 1
     steps:
@@ -196,7 +196,6 @@ jobs:
             popd
         fi
         echo $PWD/pypy3/bin >> $GITHUB_PATH
- 
+
     - uses: ./.github/actions
 
-       

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -9,7 +9,7 @@ free -m
 df -h
 ulimit -a
 
-sudo apt install gfortran eatmydata libgfortran3 libgfortran5
+sudo apt install gfortran eatmydata libgfortran5
 
 if [ "$USE_DEBUG" ]
 then

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -72,17 +72,11 @@ run_test()
   # file does not install correctly when Python's optimization level is set
   # to strip docstrings (see https://github.com/eliben/pycparser/issues/291).
   PYTHONOPTIMIZE="" $PIP install -r test_requirements.txt
+  DURATIONS_FLAG="--durations 10"
 
   if [ -n "$USE_DEBUG" ]; then
     export PYTHONPATH=$PWD
     export MYPYPATH=$PWD
-  fi
-
-  # pytest aborts when running --durations with python3.6-dbg, so only enable
-  # it for non-debug tests. That is a cPython bug fixed in later versions of
-  # python3.7 but python3.7-dbg is not currently available on travisCI.
-  if [ -z "$USE_DEBUG" ]; then
-    DURATIONS_FLAG="--durations 10"
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then


### PR DESCRIPTION
The flag should work with newer versions of Python.
    
- Use Ubuntu 20.04 to get Python 3.8 debug.
- Don't install libgfortran3, not needed, not available.
- Whitespace cleanup in action.yml and build_test.yml.
    
Closes #14293.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-
