### PR TITLE
DOC: Fixing boilerplate code example

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -6,7 +6,7 @@ boiler plate for doing that is to put the following in the module
 ``__init__.py`` file::
 
     from numpy._pytesttester import PytestTester
-    test = PytestTester(__name__).test
+    test = PytestTester(__name__)
     del PytestTester
 
 


### PR DESCRIPTION
A simple docstring change. 

`numpy/_pytesttester.py` gave boiler plate code for implementing `test()` function for NumPy modules. It was either on old implementation or a wrong one, so I updated it with the current practice. 


