### PR TITLE
 MAINT: Implement new casting loops based on NEP 42 and 43

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -10,16 +10,6 @@
 #include <npy_config.h>
 #endif
 
-// compile time environment variables
-#ifndef NPY_RELAXED_STRIDES_CHECKING
-    #define NPY_RELAXED_STRIDES_CHECKING 0
-#endif
-#ifndef NPY_RELAXED_STRIDES_DEBUG
-    #define NPY_RELAXED_STRIDES_DEBUG 0
-#endif
-#ifndef NPY_USE_NEW_CASTINGIMPL
-    #define NPY_USE_NEW_CASTINGIMPL 0
-#endif
 /*
  * using static inline modifiers when defining npy_math functions
  * allows the compiler to make optimizations when possible

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -468,14 +468,20 @@ def configuration(parent_package='',top_path=None):
             # Use relaxed stride checking
             if NPY_RELAXED_STRIDES_CHECKING:
                 moredefs.append(('NPY_RELAXED_STRIDES_CHECKING', 1))
+            else:
+                moredefs.append(('NPY_RELAXED_STRIDES_CHECKING', 0))
 
             # Use bogus stride debug aid when relaxed strides are enabled
             if NPY_RELAXED_STRIDES_DEBUG:
                 moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 1))
+            else:
+                moredefs.append(('NPY_RELAXED_STRIDES_DEBUG', 0))
 
             # Use the new experimental casting implementation in NumPy 1.20:
             if NPY_USE_NEW_CASTINGIMPL:
                 moredefs.append(('NPY_USE_NEW_CASTINGIMPL', 1))
+            else:
+                moredefs.append(('NPY_USE_NEW_CASTINGIMPL', 0))
 
             # Get long double representation
             rep = check_long_double_representation(config_cmd)

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -794,6 +794,7 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'ctors.h'),
             join('src', 'multiarray', 'descriptor.h'),
             join('src', 'multiarray', 'dtypemeta.h'),
+            join('src', 'multiarray', 'dtype_transfer.h'),
             join('src', 'multiarray', 'dragon4.h'),
             join('src', 'multiarray', 'einsum_debug.h'),
             join('src', 'multiarray', 'einsum_sumprod.h'),

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -196,6 +196,88 @@ PyArray_GetDTypeTransferFunction(int aligned,
                             NpyAuxData **out_transferdata,
                             int *out_needs_api);
 
+
+/* Same as above, but only wraps copyswapn or legacy cast functions */
+NPY_NO_EXPORT int
+PyArray_GetLegacyDTypeTransferFunction(int aligned,
+        npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        int move_references,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata,
+        int *out_needs_api, int wrap_if_unaligned);
+
+/* Specialized dtype transfer functions */
+NPY_NO_EXPORT int
+get_nbo_cast_datetime_transfer_function(int aligned,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata);
+
+NPY_NO_EXPORT int
+get_nbo_datetime_to_string_transfer_function(
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer, NpyAuxData **out_transferdata);
+
+NPY_NO_EXPORT int
+get_datetime_to_unicode_transfer_function(int aligned,
+        npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata,
+        int *out_needs_api);
+
+NPY_NO_EXPORT int
+get_nbo_string_to_datetime_transfer_function(
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer, NpyAuxData **out_transferdata);
+
+NPY_NO_EXPORT int
+get_unicode_to_datetime_transfer_function(int aligned,
+        npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata,
+        int *out_needs_api);
+
+NPY_NO_EXPORT int
+get_fields_transfer_function(int aligned,
+        npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        int move_references,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata,
+        int *out_needs_api);
+
+NPY_NO_EXPORT int
+get_subarray_transfer_function(int aligned,
+        npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        int move_references,
+        PyArray_StridedUnaryOp **out_stransfer,
+        NpyAuxData **out_transferdata,
+        int *out_needs_api);
+
+NPY_NO_EXPORT int
+_strided_to_strided_move_references(char *dst, npy_intp dst_stride,
+        char *src, npy_intp src_stride,
+        npy_intp N, npy_intp src_itemsize,
+        NpyAuxData *data);
+
+NPY_NO_EXPORT int
+_strided_to_strided_copy_references(char *dst, npy_intp dst_stride,
+        char *src, npy_intp src_stride,
+        npy_intp N, npy_intp src_itemsize,
+        NpyAuxData *data);
+
+NPY_NO_EXPORT int
+wrap_aligned_contig_transfer_function_with_copyswapn(
+        int aligned, npy_intp src_stride, npy_intp dst_stride,
+        PyArray_Descr *src_dtype, PyArray_Descr *dst_dtype,
+        PyArray_StridedUnaryOp **out_stransfer, NpyAuxData **out_transferdata,
+        int *out_needs_api,
+        PyArray_StridedUnaryOp *caststransfer, NpyAuxData *castdata);
+
 /*
  * This is identical to PyArray_GetDTypeTransferFunction, but returns a
  * transfer function which also takes a mask as a parameter.  The mask is used

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -121,6 +121,19 @@ default_resolve_descriptors(
 }
 
 
+NPY_INLINE static int
+is_contiguous(
+        npy_intp const *strides, PyArray_Descr *const *descriptors, int nargs)
+{
+    for (int i = 0; i < nargs; i++) {
+        if (strides[i] != descriptors[i]->elsize) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+
 /**
  * The default method to fetch the correct loop for a cast or ufunc
  * (at the time of writing only casts).
@@ -138,18 +151,36 @@ default_resolve_descriptors(
  * @param flags
  * @return 0 on success -1 on failure.
  */
-static int
-default_get_strided_loop(
-        PyArrayMethod_Context *NPY_UNUSED(context),
-        int NPY_UNUSED(aligned), int NPY_UNUSED(move_references),
-        npy_intp *NPY_UNUSED(strides),
-        PyArray_StridedUnaryOp **NPY_UNUSED(out_loop),
-        NpyAuxData **NPY_UNUSED(out_transferdata),
-        NPY_ARRAYMETHOD_FLAGS *NPY_UNUSED(flags))
+NPY_NO_EXPORT int
+npy_default_get_strided_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int NPY_UNUSED(move_references), npy_intp *strides,
+        PyArray_StridedUnaryOp **out_loop, NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
 {
-    PyErr_SetString(PyExc_NotImplementedError,
-            "default loop getter is not implemented");
-    return -1;
+    PyArray_Descr **descrs = context->descriptors;
+    PyArrayMethodObject *meth = context->method;
+    *flags = meth->flags & NPY_METH_RUNTIME_FLAGS;
+    *out_transferdata = NULL;
+
+    int nargs = meth->nin + meth->nout;
+    if (aligned) {
+        if (meth->contiguous_loop == NULL ||
+                !is_contiguous(strides, descrs, nargs)) {
+            *out_loop = meth->strided_loop;
+            return 0;
+        }
+        *out_loop = meth->contiguous_loop;
+    }
+    else {
+        if (meth->unaligned_contiguous_loop == NULL ||
+                !is_contiguous(strides, descrs, nargs)) {
+            *out_loop = meth->unaligned_strided_loop;
+            return 0;
+        }
+        *out_loop = meth->unaligned_contiguous_loop;
+    }
+    return 0;
 }
 
 
@@ -225,7 +256,7 @@ fill_arraymethod_from_slots(
     PyArrayMethodObject *meth = res->method;
 
     /* Set the defaults */
-    meth->get_strided_loop = &default_get_strided_loop;
+    meth->get_strided_loop = &npy_default_get_strided_loop;
     meth->resolve_descriptors = &default_resolve_descriptors;
 
     /* Fill in the slots passed by the user */
@@ -295,7 +326,7 @@ fill_arraymethod_from_slots(
             }
         }
     }
-    if (meth->get_strided_loop != &default_get_strided_loop) {
+    if (meth->get_strided_loop != &npy_default_get_strided_loop) {
         /* Do not check the actual loop fields. */
         return 0;
     }
@@ -468,6 +499,9 @@ boundarraymethod_dealloc(PyObject *self)
  * May raise an error, but usually should not.
  * The function validates the casting attribute compared to the returned
  * casting level.
+ *
+ * TODO: This function is not public API, and certain code paths will need
+ *       changes and especially testing if they were to be made public.
  */
 static PyObject *
 boundarraymethod__resolve_descripors(
@@ -481,7 +515,7 @@ boundarraymethod__resolve_descripors(
 
     if (!PyTuple_CheckExact(descr_tuple) ||
             PyTuple_Size(descr_tuple) != nin + nout) {
-        PyErr_Format(PyExc_ValueError,
+        PyErr_Format(PyExc_TypeError,
                 "_resolve_descriptors() takes exactly one tuple with as many "
                 "elements as the method takes arguments (%d+%d).", nin, nout);
         return NULL;
@@ -494,7 +528,7 @@ boundarraymethod__resolve_descripors(
         }
         else if (tmp == Py_None) {
             if (i < nin) {
-                PyErr_SetString(PyExc_ValueError,
+                PyErr_SetString(PyExc_TypeError,
                         "only output dtypes may be omitted (set to None).");
                 return NULL;
             }
@@ -502,7 +536,7 @@ boundarraymethod__resolve_descripors(
         }
         else if (PyArray_DescrCheck(tmp)) {
             if (Py_TYPE(tmp) != (PyTypeObject *)self->dtypes[i]) {
-                PyErr_Format(PyExc_ValueError,
+                PyErr_Format(PyExc_TypeError,
                         "input dtype %S was not an exact instance of the bound "
                         "DType class %S.", tmp, self->dtypes[i]);
                 return NULL;
@@ -580,9 +614,145 @@ boundarraymethod__resolve_descripors(
 }
 
 
+/*
+ * TODO: This function is not public API, and certain code paths will need
+ *       changes and especially testing if they were to be made public.
+ */
+static PyObject *
+boundarraymethod__simple_strided_call(
+        PyBoundArrayMethodObject *self, PyObject *arr_tuple)
+{
+    PyArrayObject *arrays[NPY_MAXARGS];
+    PyArray_Descr *descrs[NPY_MAXARGS];
+    PyArray_Descr *out_descrs[NPY_MAXARGS];
+    ssize_t length = -1;
+    int aligned = 1;
+    npy_intp strides[NPY_MAXARGS];
+    int nin = self->method->nin;
+    int nout = self->method->nout;
+
+    if (!PyTuple_CheckExact(arr_tuple) ||
+            PyTuple_Size(arr_tuple) != nin + nout) {
+        PyErr_Format(PyExc_TypeError,
+                "_simple_strided_call() takes exactly one tuple with as many "
+                "arrays as the method takes arguments (%d+%d).", nin, nout);
+        return NULL;
+    }
+
+    for (int i = 0; i < nin + nout; i++) {
+        PyObject *tmp = PyTuple_GetItem(arr_tuple, i);
+        if (tmp == NULL) {
+            return NULL;
+        }
+        else if (!PyArray_CheckExact(tmp)) {
+            PyErr_SetString(PyExc_TypeError,
+                    "All inputs must be NumPy arrays.");
+            return NULL;
+        }
+        arrays[i] = (PyArrayObject *)tmp;
+        descrs[i] = PyArray_DESCR(arrays[i]);
+
+        /* Check that the input is compatible with a simple method call. */
+        if (Py_TYPE(descrs[i]) != (PyTypeObject *)self->dtypes[i]) {
+            PyErr_Format(PyExc_TypeError,
+                    "input dtype %S was not an exact instance of the bound "
+                    "DType class %S.", descrs[i], self->dtypes[i]);
+            return NULL;
+        }
+        if (PyArray_NDIM(arrays[i]) != 1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "All arrays must be one dimensional.");
+            return NULL;
+        }
+        if (i == 0) {
+            length = PyArray_SIZE(arrays[i]);
+        }
+        else if (PyArray_SIZE(arrays[i]) != length) {
+            PyErr_SetString(PyExc_ValueError,
+                    "All arrays must have the same length.");
+            return NULL;
+        }
+        if (i >= nout) {
+            if (PyArray_FailUnlessWriteable(
+                    arrays[i], "_simple_strided_call() output") < 0) {
+                return NULL;
+            }
+        }
+
+        strides[i] = PyArray_STRIDES(arrays[i])[0];
+        /* TODO: We may need to distinguish aligned and itemsize-aligned */
+        aligned &= PyArray_ISALIGNED(arrays[i]);
+    }
+    if (!aligned && !(self->method->flags & NPY_METH_SUPPORTS_UNALIGNED)) {
+        PyErr_SetString(PyExc_ValueError,
+                "method does not support unaligned input.");
+        return NULL;
+    }
+
+    NPY_CASTING casting = self->method->resolve_descriptors(
+            self->method, self->dtypes, descrs, out_descrs);
+
+    if (casting < 0) {
+        PyObject *err_type = NULL, *err_value = NULL, *err_traceback = NULL;
+        PyErr_Fetch(&err_type, &err_value, &err_traceback);
+        PyErr_SetString(PyExc_TypeError,
+                "cannot perform method call with the given dtypes.");
+        npy_PyErr_ChainExceptions(err_type, err_value, err_traceback);
+        return NULL;
+    }
+
+    int dtypes_were_adapted = 0;
+    for (int i = 0; i < nin + nout; i++) {
+        /* NOTE: This check is probably much stricter than necessary... */
+        dtypes_were_adapted |= descrs[i] != out_descrs[i];
+        Py_DECREF(out_descrs[i]);
+    }
+    if (dtypes_were_adapted) {
+        PyErr_SetString(PyExc_TypeError,
+                "_simple_strided_call(): requires dtypes to not require a cast "
+                "(must match exactly with `_resolve_descriptors()`).");
+        return NULL;
+    }
+
+    PyArrayMethod_Context context = {
+            .caller = NULL,
+            .method = self->method,
+            .descriptors = descrs,
+    };
+    PyArray_StridedUnaryOp *strided_loop = NULL;
+    NpyAuxData *loop_data = NULL;
+    NPY_ARRAYMETHOD_FLAGS flags = 0;
+
+    if (self->method->get_strided_loop(
+            &context, aligned, 0, strides,
+            &strided_loop, &loop_data, &flags) < 0) {
+        return NULL;
+    }
+
+    /*
+     * TODO: Add floating point error checks if requested and
+     *       possibly release GIL if allowed by the flags.
+     */
+    /* TODO: strided_loop is currently a cast loop, this will change. */
+    int res = strided_loop(
+            PyArray_BYTES(arrays[1]), strides[1],
+            PyArray_BYTES(arrays[0]), strides[0],
+            length, descrs[0]->elsize, loop_data);
+    if (loop_data != NULL) {
+        loop_data->free(loop_data);
+    }
+    if (res < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+
 PyMethodDef boundarraymethod_methods[] = {
     {"_resolve_descriptors", (PyCFunction)boundarraymethod__resolve_descripors,
      METH_O, "Resolve the given dtypes."},
+    {"_simple_strided_call", (PyCFunction)boundarraymethod__simple_strided_call,
+     METH_O, "call on 1-d inputs and pre-allocated outputs (single call)."},
     {NULL, 0, 0, NULL},
 };
 

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -144,6 +144,21 @@ extern NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type;
 #define NPY_METH_unaligned_contiguous_loop 6
 
 
+/*
+ * Used internally (initially) for real to complex loops only
+ */
+NPY_NO_EXPORT int
+npy_default_get_strided_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int NPY_UNUSED(move_references), npy_intp *strides,
+        PyArray_StridedUnaryOp **out_loop, NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
+
+
+/*
+ * TODO: This function is the internal version, and its error paths may
+ *       need better tests when a public version is exposed.
+ */
 NPY_NO_EXPORT PyBoundArrayMethodObject *
 PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private);
 

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -6,6 +6,9 @@
 extern NPY_NO_EXPORT npy_intp REQUIRED_STR_LEN[];
 
 NPY_NO_EXPORT PyObject *
+PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to);
+
+NPY_NO_EXPORT PyObject *
 _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args);
 
 NPY_NO_EXPORT PyArray_VectorUnaryFunc *
@@ -72,6 +75,13 @@ legacy_same_dtype_resolve_descriptors(
         PyArray_DTypeMeta **dtypes,
         PyArray_Descr **given_descrs,
         PyArray_Descr **loop_descrs);
+
+NPY_NO_EXPORT int
+legacy_cast_get_strided_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int move_references, npy_intp *strides,
+        PyArray_StridedUnaryOp **out_loop, NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
 
 NPY_NO_EXPORT NPY_CASTING
 simple_cast_resolve_descriptors(

--- a/numpy/core/src/multiarray/dtype_transfer.h
+++ b/numpy/core/src/multiarray/dtype_transfer.h
@@ -1,0 +1,27 @@
+#ifndef _NPY_DTYPE_TRANSFER_H
+#define _NPY_DTYPE_TRANSFER_H
+
+#include "lowlevel_strided_loops.h"
+#include "array_method.h"
+
+
+NPY_NO_EXPORT int
+any_to_object_get_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int move_references,
+        npy_intp *strides,
+        PyArray_StridedUnaryOp **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
+
+NPY_NO_EXPORT int
+object_to_any_get_loop(
+        PyArrayMethod_Context *context,
+        int NPY_UNUSED(aligned), int move_references,
+        npy_intp *NPY_UNUSED(strides),
+        PyArray_StridedUnaryOp **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
+
+
+#endif  /* _NPY_DTYPE_TRANSFER_H */

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -19,6 +19,8 @@
 
 #include "lowlevel_strided_loops.h"
 #include "array_assign.h"
+#include "array_method.h"
+#include "usertypes.h"
 
 
 /*

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -538,7 +538,7 @@ PyArray_AddLegacyWrapping_CastingImpl(
     if (from == to) {
         spec.flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_SUPPORTS_UNALIGNED;
         PyType_Slot slots[] = {
-            {NPY_METH_get_loop, NULL},
+            {NPY_METH_get_loop, &legacy_cast_get_strided_loop},
             {NPY_METH_resolve_descriptors, &legacy_same_dtype_resolve_descriptors},
             {0, NULL}};
         spec.slots = slots;
@@ -547,7 +547,7 @@ PyArray_AddLegacyWrapping_CastingImpl(
     else {
         spec.flags = NPY_METH_REQUIRES_PYAPI;
         PyType_Slot slots[] = {
-            {NPY_METH_get_loop, NULL},
+            {NPY_METH_get_loop, &legacy_cast_get_strided_loop},
             {NPY_METH_resolve_descriptors, &simple_cast_resolve_descriptors},
             {0, NULL}};
         spec.slots = slots;

--- a/numpy/core/tests/test_arraymethod.py
+++ b/numpy/core/tests/test_arraymethod.py
@@ -1,0 +1,58 @@
+"""
+This file tests the generic aspects of ArrayMethod.  At the time of writing
+this is private API, but when added, public API may be added here.
+"""
+
+import pytest
+
+import numpy as np
+from numpy.core._multiarray_umath import _get_castingimpl as get_castingimpl
+
+
+class TestResolveDescriptors:
+    # Test mainly error paths of the resolve_descriptors function,
+    # note that the `casting_unittests` tests exercise this non-error paths.
+
+    # Casting implementations are the main/only current user:
+    method = get_castingimpl(type(np.dtype("d")), type(np.dtype("f")))
+
+    @pytest.mark.parametrize("args", [
+        (True,),  # Not a tuple.
+        ((None,)),  # Too few elements
+        ((None, None, None),),  # Too many
+        ((None, None),),  # Input dtype is None, which is invalid.
+        ((np.dtype("d"), True),),  # Output dtype is not a dtype
+        ((np.dtype("f"), None),),  # Input dtype does not match method
+    ])
+    def test_invalid_arguments(self, args):
+        with pytest.raises(TypeError):
+            self.method._resolve_descriptors(*args)
+
+
+class TestSimpleStridedCall:
+    # Test mainly error paths of the resolve_descriptors function,
+    # note that the `casting_unittests` tests exercise this non-error paths.
+
+    # Casting implementations are the main/only current user:
+    method = get_castingimpl(type(np.dtype("d")), type(np.dtype("f")))
+
+    @pytest.mark.parametrize(["args", "error"], [
+        ((True,), TypeError),  # Not a tuple
+        (((None,),), TypeError),  # Too few elements
+        ((None, None), TypeError),  # Inputs are not arrays.
+        (((None, None, None),), TypeError),  # Too many
+        (((np.arange(3), np.arange(3)),), TypeError),  # Incorrect dtypes
+        (((np.ones(3, dtype=">d"), np.ones(3, dtype="<f")),),
+         TypeError),  # Does not support byte-swapping
+        (((np.ones((2, 2), dtype="d"), np.ones((2, 2), dtype="f")),),
+         ValueError),  # not 1-D
+        (((np.ones(3, dtype="d"), np.ones(4, dtype="f")),),
+          ValueError),  # different length
+        (((np.frombuffer(b"\0x00"*3*2, dtype="d"),
+           np.frombuffer(b"\0x00"*3, dtype="f")),),
+         ValueError),  # output not writeable
+    ])
+    def test_invalid_arguments(self, args, error):
+        # This is private API, which may be modified freely
+        with pytest.raises(error):
+            self.method._simple_strided_call(*args)

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -9,11 +9,14 @@ than integration tests.
 import pytest
 import textwrap
 import enum
+import itertools
+import random
 
 import numpy as np
+from numpy.lib.stride_tricks import as_strided
 
-from numpy.core._multiarray_umath import (
-    _get_castingimpl as get_castingimpl)
+from numpy.testing import assert_array_equal
+from numpy.core._multiarray_umath import _get_castingimpl as get_castingimpl
 from numpy.core._multiarray_tests import uses_new_casts
 
 
@@ -21,7 +24,6 @@ from numpy.core._multiarray_tests import uses_new_casts
 simple_dtypes = "?bhilqBHILQefdFD"
 if np.dtype("l").itemsize != np.dtype("q").itemsize:
     # Remove l and L, the table was generated with 64bit linux in mind.
-    # TODO: Should have two tables or no a different solution.
     simple_dtypes = simple_dtypes.replace("l", "").replace("L", "")
 simple_dtypes = [type(np.dtype(c)) for c in simple_dtypes]
 
@@ -159,6 +161,102 @@ class TestChanges:
 
 
 class TestCasting:
+    size = 1500  # Best larger than NPY_LOWLEVEL_BUFFER_BLOCKSIZE * itemsize
+
+    def get_data(self, dtype1, dtype2):
+        if dtype2 is None or dtype1.itemsize >= dtype2.itemsize:
+            length = self.size // dtype1.itemsize
+        else:
+            length = self.size // dtype2.itemsize
+
+        # Assume that the base array is well enough aligned for all inputs.
+        arr1 = np.empty(length, dtype=dtype1)
+        assert arr1.flags.c_contiguous
+        assert arr1.flags.aligned
+
+        values = [random.randrange(-128, 128) for _ in range(length)]
+
+        for i, value in enumerate(values):
+            # Use item assignment to ensure this is not using casting:
+            arr1[i] = value
+
+        if dtype2 is None:
+            if dtype1.char == "?":
+                values = [bool(v) for v in values]
+            return arr1, values
+
+        if dtype2.char == "?":
+            values = [bool(v) for v in values]
+
+        arr2 = np.empty(length, dtype=dtype2)
+        assert arr2.flags.c_contiguous
+        assert arr2.flags.aligned
+
+        for i, value in enumerate(values):
+            # Use item assignment to ensure this is not using casting:
+            arr2[i] = value
+
+        return arr1, arr2, values
+
+    def get_data_variation(self, arr1, arr2, aligned=True, contig=True):
+        """
+        Returns a copy of arr1 that may be non-contiguous or unaligned, and a
+        matching array for arr2 (although not a copy).
+        """
+        if contig:
+            stride1 = arr1.dtype.itemsize
+            stride2 = arr2.dtype.itemsize
+        elif aligned:
+            stride1 = 2 * arr1.dtype.itemsize
+            stride2 = 2 * arr2.dtype.itemsize
+        else:
+            stride1 = arr1.dtype.itemsize + 1
+            stride2 = arr2.dtype.itemsize + 1
+
+        max_size1 = len(arr1) * 3 * arr1.dtype.itemsize + 1
+        max_size2 = len(arr2) * 3 * arr2.dtype.itemsize + 1
+        from_bytes = np.zeros(max_size1, dtype=np.uint8)
+        to_bytes = np.zeros(max_size2, dtype=np.uint8)
+
+        # Sanity check that the above is large enough:
+        assert stride1 * len(arr1) <= from_bytes.nbytes
+        assert stride2 * len(arr2) <= to_bytes.nbytes
+
+        if aligned:
+            new1 = as_strided(from_bytes[:-1].view(arr1.dtype),
+                              arr1.shape, (stride1,))
+            new2 = as_strided(to_bytes[:-1].view(arr2.dtype),
+                              arr2.shape, (stride2,))
+        else:
+            new1 = as_strided(from_bytes[1:].view(arr1.dtype),
+                              arr1.shape, (stride1,))
+            new2 = as_strided(to_bytes[1:].view(arr2.dtype),
+                              arr2.shape, (stride2,))
+
+        new1[...] = arr1
+
+        if not contig:
+            # Ensure we did not overwrite bytes that should not be written:
+            offset = arr1.dtype.itemsize if aligned else 0
+            buf = from_bytes[offset::stride1].tobytes()
+            assert buf.count(b"\0") == len(buf)
+
+        if contig:
+            assert new1.flags.c_contiguous
+            assert new2.flags.c_contiguous
+        else:
+            assert not new1.flags.c_contiguous
+            assert not new2.flags.c_contiguous
+
+        if aligned:
+            assert new1.flags.aligned
+            assert new2.flags.aligned
+        else:
+            assert not new1.flags.aligned or new1.dtype.alignment == 1
+            assert not new2.flags.aligned or new2.dtype.alignment == 1
+
+        return new1, new2
+
     @pytest.mark.parametrize("from_Dt", simple_dtypes)
     def test_simple_cancast(self, from_Dt):
         for to_Dt in simple_dtypes:
@@ -192,6 +290,183 @@ class TestCasting:
                         assert(from_dt is from_res)
                         assert(to_dt is to_res)
 
+
+    @pytest.mark.filterwarnings("ignore::numpy.ComplexWarning")
+    @pytest.mark.parametrize("from_dt", simple_dtype_instances())
+    def test_simple_direct_casts(self, from_dt):
+        """
+        This test checks numeric direct casts for dtypes supported also by the
+        struct module (plus complex).  It tries to be test a wide range of
+        inputs, but skips over possibly undefined behaviour (e.g. int rollover).
+        Longdouble and CLongdouble are tested, but only using double precision.
+
+        If this test creates issues, it should possibly just be simplified
+        or even removed (checking whether unaligned/non-contiguous casts give
+        the same results is useful, though).
+        """
+        for to_dt in simple_dtype_instances():
+            to_dt = to_dt.values[0]
+            cast = get_castingimpl(type(from_dt), type(to_dt))
+
+            casting, (from_res, to_res) = cast._resolve_descriptors(
+                (from_dt, to_dt))
+
+            if from_res is not from_dt or to_res is not to_dt:
+                # Do not test this case, it is handled in multiple steps,
+                # each of which should is tested individually.
+                return
+
+            safe = (casting & ~Casting.cast_is_view) <= Casting.safe
+            del from_res, to_res, casting
+
+            arr1, arr2, values = self.get_data(from_dt, to_dt)
+
+            cast._simple_strided_call((arr1, arr2))
+
+            # Check via python list
+            assert arr2.tolist() == values
+
+            # Check that the same results are achieved for strided loops
+            arr1_o, arr2_o = self.get_data_variation(arr1, arr2, True, False)
+            cast._simple_strided_call((arr1_o, arr2_o))
+
+            assert_array_equal(arr2_o, arr2)
+            assert arr2_o.tobytes() == arr2.tobytes()
+
+            # Check if alignment makes a difference, but only if supported
+            # and only if the alignment can be wrong
+            if ((from_dt.alignment == 1 and to_dt.alignment == 1) or
+                    not cast._supports_unaligned):
+                return
+
+            arr1_o, arr2_o = self.get_data_variation(arr1, arr2, False, True)
+            cast._simple_strided_call((arr1_o, arr2_o))
+
+            assert_array_equal(arr2_o, arr2)
+            assert arr2_o.tobytes() == arr2.tobytes()
+
+            arr1_o, arr2_o = self.get_data_variation(arr1, arr2, False, False)
+            cast._simple_strided_call((arr1_o, arr2_o))
+
+            assert_array_equal(arr2_o, arr2)
+            assert arr2_o.tobytes() == arr2.tobytes()
+
+            del arr1_o, arr2_o, cast
+
+    @pytest.mark.parametrize("from_Dt", simple_dtypes)
+    def test_numeric_to_times(self, from_Dt):
+        # We currently only implement contiguous loops, so only need to
+        # test those.
+        from_dt = from_Dt()
+
+        time_dtypes = [np.dtype("M8"), np.dtype("M8[ms]"), np.dtype("M8[4D]"),
+                       np.dtype("m8"), np.dtype("m8[ms]"), np.dtype("m8[4D]")]
+        for time_dt in time_dtypes:
+            cast = get_castingimpl(type(from_dt), type(time_dt))
+
+            casting, (from_res, to_res) = cast._resolve_descriptors(
+                (from_dt, time_dt))
+
+            assert from_res is from_dt
+            assert to_res is time_dt
+            del from_res, to_res
+
+            assert(casting & CAST_TABLE[from_Dt][type(time_dt)])
+
+            int64_dt = np.dtype(np.int64)
+            arr1, arr2, values = self.get_data(from_dt, int64_dt)
+            arr2 = arr2.view(time_dt)
+            arr2[...] = np.datetime64("NaT")
+
+            if time_dt == np.dtype("M8"):
+                # This is a bit of a strange path, and could probably be removed
+                arr1[-1] = 0  # ensure at least one value is not NaT
+
+                # The cast currently succeeds, but the values are invalid:
+                cast._simple_strided_call((arr1, arr2))
+                with pytest.raises(ValueError):
+                    str(arr2[-1])  # e.g. conversion to string fails
+                return
+
+            cast._simple_strided_call((arr1, arr2))
+
+            assert [int(v) for v in arr2.tolist()] == values
+
+            # Check that the same results are achieved for strided loops
+            arr1_o, arr2_o = self.get_data_variation(arr1, arr2, True, False)
+            cast._simple_strided_call((arr1_o, arr2_o))
+
+            assert_array_equal(arr2_o, arr2)
+            assert arr2_o.tobytes() == arr2.tobytes()
+
+    @pytest.mark.parametrize(
+            ["from_dt", "to_dt", "expected_casting", "nom", "denom"],
+            [("M8[ns]", None,
+                  Casting.no | Casting.cast_is_view, 1, 1),
+             (str(np.dtype("M8[ns]").newbyteorder()), None, Casting.equiv, 1, 1),
+             ("M8", "M8[ms]", Casting.safe | Casting.cast_is_view, 1, 1),
+             ("M8[ms]", "M8", Casting.unsafe, 1, 1),  # should be invalid cast
+             ("M8[5ms]", "M8[5ms]", Casting.no | Casting.cast_is_view, 1, 1),
+             ("M8[ns]", "M8[ms]", Casting.same_kind, 1, 10**6),
+             ("M8[ms]", "M8[ns]", Casting.safe, 10**6, 1),
+             ("M8[ms]", "M8[7ms]", Casting.same_kind, 1, 7),
+             ("M8[4D]", "M8[1M]", Casting.same_kind, None,
+                  # give full values based on NumPy 1.19.x
+                  [-2**63, 0, -1, 1314, -1315, 564442610]),
+             ("m8[ns]", None, Casting.no | Casting.cast_is_view, 1, 1),
+             (str(np.dtype("m8[ns]").newbyteorder()), None, Casting.equiv, 1, 1),
+             ("m8", "m8[ms]", Casting.safe | Casting.cast_is_view, 1, 1),
+             ("m8[ms]", "m8", Casting.unsafe, 1, 1),  # should be invalid cast
+             ("m8[5ms]", "m8[5ms]", Casting.no | Casting.cast_is_view, 1, 1),
+             ("m8[ns]", "m8[ms]", Casting.same_kind, 1, 10**6),
+             ("m8[ms]", "m8[ns]", Casting.safe, 10**6, 1),
+             ("m8[ms]", "m8[7ms]", Casting.same_kind, 1, 7),
+             ("m8[4D]", "m8[1M]", Casting.unsafe, None,
+                  # give full values based on NumPy 1.19.x
+                  [-2**63, 0, 0, 1314, -1315, 564442610])])
+    def test_time_to_time(self, from_dt, to_dt, expected_casting, nom, denom):
+        from_dt = np.dtype(from_dt)
+        if to_dt is not None:
+            to_dt = np.dtype(to_dt)
+
+        # Test a few values for casting (results generated with NumPy 1.19)
+        values = np.array([-2**63, 1, 2**63-1, 10000, -10000, 2**32])
+        values = values.astype(np.dtype("int64").newbyteorder(from_dt.byteorder))
+        assert values.dtype.byteorder == from_dt.byteorder
+        assert np.isnat(values.view(from_dt)[0])
+
+        DType = type(from_dt)
+        cast = get_castingimpl(DType, DType)
+        casting, (from_res, to_res) = cast._resolve_descriptors((from_dt, to_dt))
+        assert from_res is from_dt
+        assert to_res is to_dt or to_dt is None
+        assert casting == expected_casting
+
+        if nom is not None:
+            expected_out = (values * nom // denom).view(to_res)
+            expected_out[0] = "NaT"
+        else:
+            expected_out = np.empty_like(values)
+            expected_out[...] = denom
+            expected_out = expected_out.view(to_dt)
+
+        orig_arr = values.view(from_dt)
+        orig_out = np.empty_like(expected_out)
+
+        if casting == Casting.unsafe and (to_dt == "m8" or to_dt == "M8"):
+            # Casting from non-generic to generic units is an error and should
+            # probably be reported as an invalid cast earlier.
+            with pytest.raises(ValueError):
+                cast._simple_strided_call((orig_arr, orig_out))
+            return
+
+        for aligned in [True, True]:
+            for contig in [True, True]:
+                arr, out = self.get_data_variation(
+                        orig_arr, orig_out, aligned, contig)
+                out[...] = 0
+                cast._simple_strided_call((arr, out))
+                assert_array_equal(out.view("int64"), expected_out.view("int64"))
 
     def string_with_modified_length(self, dtype, change_length):
         fact = 1 if dtype.char == "S" else 4
@@ -238,6 +513,67 @@ class TestCasting:
         safety, (_, res_dt) = cast._resolve_descriptors((string_dt, None))
         assert safety == Casting.unsafe
         assert other_dt is res_dt  # returns the singleton for simple dtypes
+
+    @pytest.mark.parametrize("string_char", ["S", "U"])
+    @pytest.mark.parametrize("other_dt", simple_dtype_instances())
+    def test_simple_string_casts_roundtrip(self, other_dt, string_char):
+        """
+        Tests casts from and to string by checking the roundtripping property.
+
+        The test also covers some string to string casts (but not all).
+
+        If this test creates issues, it should possibly just be simplified
+        or even removed (checking whether unaligned/non-contiguous casts give
+        the same results is useful, though).
+        """
+        string_DT = type(np.dtype(string_char))
+
+        cast = get_castingimpl(type(other_dt), string_DT)
+        cast_back = get_castingimpl(string_DT, type(other_dt))
+        _, (res_other_dt, string_dt) = cast._resolve_descriptors((other_dt, None))
+
+        if res_other_dt is not other_dt:
+            # do not support non-native byteorder, skip test in that case
+            assert other_dt.byteorder != res_other_dt.byteorder
+            return
+
+        orig_arr, values = self.get_data(other_dt, None)
+        str_arr = np.zeros(len(orig_arr), dtype=string_dt)
+        string_dt_short = self.string_with_modified_length(string_dt, -1)
+        str_arr_short = np.zeros(len(orig_arr), dtype=string_dt_short)
+        string_dt_long = self.string_with_modified_length(string_dt, 1)
+        str_arr_long = np.zeros(len(orig_arr), dtype=string_dt_long)
+
+        assert not cast._supports_unaligned  # if support is added, should test
+        assert not cast_back._supports_unaligned
+
+        for contig in [True, False]:
+            other_arr, str_arr = self.get_data_variation(
+                orig_arr, str_arr, True, contig)
+            _, str_arr_short = self.get_data_variation(
+                orig_arr, str_arr_short.copy(), True, contig)
+            _, str_arr_long = self.get_data_variation(
+                orig_arr, str_arr_long, True, contig)
+
+            cast._simple_strided_call((other_arr, str_arr))
+
+            cast._simple_strided_call((other_arr, str_arr_short))
+            assert_array_equal(str_arr.astype(string_dt_short), str_arr_short)
+
+            cast._simple_strided_call((other_arr, str_arr_long))
+            assert_array_equal(str_arr, str_arr_long)
+
+            if other_dt.kind == "b":
+                # Booleans do not roundtrip
+                continue
+
+            other_arr[...] = 0
+            cast_back._simple_strided_call((str_arr, other_arr))
+            assert_array_equal(orig_arr, other_arr)
+
+            other_arr[...] = 0
+            cast_back._simple_strided_call((str_arr_long, other_arr))
+            assert_array_equal(orig_arr, other_arr)
 
     @pytest.mark.parametrize("other_dt", ["S8", "<U8", ">U8"])
     @pytest.mark.parametrize("string_char", ["S", "U"])


### PR DESCRIPTION
This PR should be mostly finished, but I will still check code-coverage etc.  It is the followup for the initial casting PR, and now changes all casts to go through the `ArrayMethod` machinery (some "legacy" casts will still use the very old machinery though).

There are a few things to note:

* This implements a new "chaining" of casts. Chaining also previously was implemented, but most of it should move into the new style chaining.  (some of it is still old-style also to keep diffs smaller).
* I implemented created new loops for object casts, since it is one of the more important casts stuck on the "legacy" system.  It would have to be fixed eventually (and has higher priority than the others).  This might have switched some crazier corner cases (similar to the array-coercion corner cases).
* ~[ ] Some of headers I added to `numpy/core/src/common/lowlevel_strided_loops.h` should probably move to the new `numpy/core/src/multiarray/dtype_transfer.h`.~ Maybe it doesn't matter, the `object` ones had to be because they use new private API, but the other loops are old-style, so keeping them in the old place is probably just as well.
* Copying a complex array may be slowed down currently. The issue around alignment for complex datatypes kicks in here and makes things a bit tricky.

There are a few things we should possibly discuss, but it is not super pressing right now:

* `move_references` is a flag that we use to say that the source of a casting function (ufuncs would be the same in a sense) is a buffer, and the content of that buffer should be cleared during iteration.  Clearing buffers (also on error!) is a bit tricky and already broken. I have not yet attempted at fixing all of it.  The `move_references` mechanism seems useful for this (although probably it doesn't matter for the "mini buffers" used in `dtype_transfer.c`).  I suppose we should just keep it around, and probably can just live with it also for ufuncs... It could even turn out to be useful there.  Plausibly, we will need to add a flag so that an `ArrayMethod` can indicate that it supports `move_references`.
* I really want to look into finding a better solution for alignment.  But unless we pass alignment information for all operands individually (i.e. by passing all array flags?!), the only other option would be to pass a new `itemsize-aligned` flag (basically for complex).

---

In any case, there should not be much left to do here, so this is ready for review, although maybe not quite for merging.