### PR TITLE
BUG, TST: use python-version not PYTHON_VERSION

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,7 +36,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: ${{ matrix.python-version }}
     - uses: ./.github/actions
 
   debug:


### PR DESCRIPTION
Fixes gh-17865. The setup of the github actions was not using the correct python versions for the 3.8, 3.9 runs. All the others use the PYTHON_VERSION in the setup-python step.