### PR TITLE
MAINT: clean up a spurious warning in numpy/typing/setup.py

### DIFF
--- a/numpy/typing/setup.py
+++ b/numpy/typing/setup.py
@@ -3,7 +3,6 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('typing', parent_package, top_path)
     config.add_subpackage('tests')
     config.add_data_dir('tests/data')
-    config.add_data_files('*.pyi')
     return config
 
 


### PR DESCRIPTION
Warning was:

    could not resolve pattern in 'numpy/typing': '*.pyi'