### PR TITLE
MAINT: Better error message for linalg.norm

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2607,7 +2607,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
             ret = ret.reshape(ret_shape)
         return ret
     else:
-        raise ValueError("Improper number of dimensions to norm.")
+        raise ValueError("Input must be 1-D or 2-D when axis=None(unless ord is None)")
 
 
 # multi_dot


### PR DESCRIPTION
For example:
`numpy.linalg.norm(2, np.inf)`

raises:
`ValueError: Improper number of dimensions to norm. `

The error messageis a bit vague.
This pull request changes the error message so that it explicitly states the expected dimensions.

Expected error message:
`Input must be 1-D or 2-D when axis=None (unless ord is None)`