### PR TITLE
BUG: numpy.putmask not respecting writeable flag

### DIFF
--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -576,6 +576,10 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
         return NULL;
     }
 
+    if (PyArray_FailUnlessWriteable(self, "putmask: output array") < 0) {
+        return NULL;
+    }
+
     mask = (PyArrayObject *)PyArray_FROM_OTF(mask0, NPY_BOOL,
                                 NPY_ARRAY_CARRAY | NPY_ARRAY_FORCECAST);
     if (mask == NULL) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4643,6 +4643,13 @@ class TestPutmask:
         np.putmask(x[1:4], x[:3], [True, False, True])
         assert_equal(x, np.array([True, True, True, True]))
 
+    def test_writeable(self):
+        a = np.arange(5);
+        a.setflags(write = False)
+
+        with pytest.raises(ValueError):
+            np.putmask(a, a >= 2, 3)
+
 
 class TestTake:
     def tst_basic(self, x):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4644,8 +4644,8 @@ class TestPutmask:
         assert_equal(x, np.array([True, True, True, True]))
 
     def test_writeable(self):
-        a = np.arange(5);
-        a.setflags(write = False)
+        a = np.arange(5)
+        a.flags.writeable = False
 
         with pytest.raises(ValueError):
             np.putmask(a, a >= 2, 3)


### PR DESCRIPTION
This is fixing issue [#17871](https://github.com/numpy/numpy/issues/17871). 

