### PR TITLE
ENH: Timestamp development versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,10 @@ def get_version_info():
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
+        import time
+
+        time_stamp = time.strftime("%Y%m%d%H%M%S", time.localtime())
+        FULLVERSION += f'.dev0+{time_stamp}_{GIT_REVISION[:7]}'
 
     return FULLVERSION, GIT_REVISION
 


### PR DESCRIPTION
This adds a timestamp to development versions of NumPy. We used to add
this for the NumPy nightly build wheel names so that pip would pick up the
latest version, but pip 20.3 breaks that because there is disagreement between
the wheel name and the internal NumPy version.

Closes #17885.

Note that numpy-wheels needs to be fixed if this goes in.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
