### PR TITLE
DOC: Correct sentence/statement composition

### DIFF
--- a/doc/source/user/theory.broadcasting.rst
+++ b/doc/source/user/theory.broadcasting.rst
@@ -69,7 +69,7 @@ numpy on Windows 2000 with one million element arrays.
     *Figure 1*
 
     *In the simplest example of broadcasting, the scalar ``b`` is
-    stretched to become an array of with the same shape as ``a`` so the shapes
+    stretched to become an array of same shape as ``a`` so the shapes
     are compatible for element-by-element multiplication.*
 
 


### PR DESCRIPTION
DOC: Incorrect statement spotted 

*In the simplest example of broadcasting, the scalar ``b`` is stretched to become an array ~of with the same~ shape as ``a`` so the shapes are compatible for element-by-element multiplication.*

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
