### PR TITLE
MAINT: Make the development version timestamp a build tag.

### DIFF
--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -8,7 +8,7 @@ def test_valid_numpy_version():
     # Verify that the numpy version is a valid one (no .post suffix or other
     # nonsense).  See gh-6431 for an issue caused by an invalid version.
     version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(|a[0-9]|b[0-9]|rc[0-9])"
-    dev_suffix = r"(\.dev0\+([0-9a-f]{7}|Unknown))"
+    dev_suffix = r"\.dev0(|\+[0-9a-f]{7}|\+Unknown)"
     if np.version.release:
         res = re.match(version_pattern, np.__version__)
     else:


### PR DESCRIPTION
This takes a diffent approach for wheel naming and versioning
for development versions

- For non-wheel builds the `<version>.dev0+<short-hash>` form is
  preserved.
- For wheel builds, the version is `<version>.dev0` but the wheel name
  is has a <build_number> addition comprised of
  `<timestamp>.<short-hash>`.

The drawback of this approach is that `np.__version__` has no hash
for wheel installed development versions. On the other hand, that
makes the version usable for pypi like wheel providers. One solution
might be a `np.__githash__` attribute for numpy.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
