### PR TITLE
TST: use latest pypy37 not pypy36

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -184,7 +184,7 @@ jobs:
         fetch-depth: 0
     - name: get_pypy
       run: |
-        wget -q https://downloads.python.org/pypy/pypy3.6-v7.3.2-linux64.tar.bz2 -O pypy.tar.bz2
+        wget -q https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2 -O pypy.tar.bz2
         mkdir -p pypy3
         (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
         pypy3/bin/pypy3 -mensurepip

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1420,7 +1420,7 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     PyObject *obj;
     PyObject *str;
-    #if (PY_VERSION_HEX >= 0x030700A2)
+    #if PY_VERSION_HEX >= 0x030700A2 && (! defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM > 0x07030300)
     const char *docstr;
     #else
     char *docstr;

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1420,7 +1420,7 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     PyObject *obj;
     PyObject *str;
-    #if PY_VERSION_HEX >= 0x030700A2 && (! defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM > 0x07030300)
+    #if PY_VERSION_HEX >= 0x030700A2 && (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM > 0x07030300)
     const char *docstr;
     #else
     char *docstr;

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ hypothesis==5.41.3
 pytest==6.0.2
 pytz==2020.4
 pytest-cov==2.10.1
-pickle5; python_version == '3.7'
+pickle5; python_version == '3.7' and platform_python_implementation != 'PyPy'
 pickle5; python_version == '3.6' and platform_python_implementation != 'PyPy'
 # for numpy.random.test.test_extending
 cffi


### PR DESCRIPTION
Backport of #17847.

As pointed out in gh-17843, the pypy CI run was using pypy3.6 not pypy3.7. Whoops. xref gh-17745.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
