### PR TITLE
DEP: Finalize unravel_index `dims` alias for `shape` keyword

### DIFF
--- a/doc/release/upcoming_changes/17900.expired.rst
+++ b/doc/release/upcoming_changes/17900.expired.rst
@@ -1,0 +1,2 @@
+* The ``shape`` argument `numpy.unravel_index` cannot be passed
+  as ``dims`` keyword argument anymore. (Was deprecated in NumPy 1.16.)

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -999,7 +999,7 @@ def ravel_multi_index(multi_index, dims, mode=None, order=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.unravel_index)
-def unravel_index(indices, shape=None, order=None, dims=None):
+def unravel_index(indices, shape=None, order=None):
     """
     unravel_index(indices, shape, order='C')
 
@@ -1045,9 +1045,6 @@ def unravel_index(indices, shape=None, order=None, dims=None):
     (3, 1, 4, 1)
 
     """
-    if dims is not None:
-        warnings.warn("'shape' argument should be used instead of 'dims'",
-                      DeprecationWarning, stacklevel=3)
     return (indices,)
 
 

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1229,41 +1229,6 @@ arr_unravel_index(PyObject *self, PyObject *args, PyObject *kwds)
 
     char *kwlist[] = {"indices", "shape", "order", NULL};
 
-    /*
-     * TODO: remove this in favor of warning raised in the dispatcher when
-     * __array_function__ is enabled by default.
-     */
-
-    /*
-     * Continue to support the older "dims" argument in place
-     * of the "shape" argument. Issue an appropriate warning
-     * if "dims" is detected in keywords, then replace it with
-     * the new "shape" argument and continue processing as usual.
-     */
-    if (kwds) {
-        PyObject *dims_item, *shape_item;
-        dims_item = _PyDict_GetItemStringWithError(kwds, "dims");
-        if (dims_item == NULL && PyErr_Occurred()){
-            return NULL;
-        }
-        shape_item = _PyDict_GetItemStringWithError(kwds, "shape");
-        if (shape_item == NULL && PyErr_Occurred()){
-            return NULL;
-        }
-        if (dims_item != NULL && shape_item == NULL) {
-            if (DEPRECATE("'shape' argument should be"
-                          " used instead of 'dims'") < 0) {
-                return NULL;
-            }
-            if (PyDict_SetItemString(kwds, "shape", dims_item) < 0) {
-                return NULL;
-            }
-            if (PyDict_DelItemString(kwds, "dims") < 0) {
-                return NULL;
-            }
-        }
-    }
-
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|O&:unravel_index",
                     kwlist,
                     &indices0,

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -16,23 +16,13 @@ class TestRavelUnravelIndex:
     def test_basic(self):
         assert_equal(np.unravel_index(2, (2, 2)), (1, 0))
 
-        # test backwards compatibility with older dims
-        # keyword argument; see Issue #10586
-        with assert_warns(DeprecationWarning):
-            # we should achieve the correct result
-            # AND raise the appropriate warning
-            # when using older "dims" kw argument
-            assert_equal(np.unravel_index(indices=2,
-                                          dims=(2, 2)),
-                                          (1, 0))
-
         # test that new shape argument works properly
         assert_equal(np.unravel_index(indices=2,
                                       shape=(2, 2)),
                                       (1, 0))
 
         # test that an invalid second keyword argument
-        # is properly handled
+        # is properly handled, including the old name `dims`.
         with assert_raises(TypeError):
             np.unravel_index(indices=2, hape=(2, 2))
 
@@ -41,6 +31,9 @@ class TestRavelUnravelIndex:
 
         with assert_raises(TypeError):
             np.unravel_index(254, ims=(17, 94))
+
+        with assert_raises(TypeError):
+            np.unravel_index(254, dims=(17, 94))
 
         assert_equal(np.ravel_multi_index((1, 0), (2, 2)), 2)
         assert_equal(np.unravel_index(254, (17, 94)), (2, 66))


### PR DESCRIPTION
The argument was renamed to `shape` and deprecated since NumPy 1.16,
so the deprecation can now be finalized.
