### PR TITLE
MAINT: clean up a spurious warning in numpy/typing/setup.py

### DIFF
--- a/numpy/typing/setup.py
+++ b/numpy/typing/setup.py
@@ -3,7 +3,6 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('typing', parent_package, top_path)
     config.add_subpackage('tests')
     config.add_data_dir('tests/data')
-    config.add_data_files('*.pyi')
     return config
 
 


### PR DESCRIPTION
Backport of #17874. 

Warning was:

    `could not resolve pattern in 'numpy/typing': '*.pyi'`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
