### PR TITLE
DEP: Disable PyUFunc_GenericFunction and PyUFunc_SetUsesArraysAsData

### DIFF
--- a/doc/release/upcoming_changes/17902.expired.rst
+++ b/doc/release/upcoming_changes/17902.expired.rst
@@ -1,0 +1,5 @@
+* The C-API function ``PyUFunc_SetUsesArraysAsData`` and corresponding
+  mechanism have been disabled. (Deprecated NumPy 1.19)
+* The C-API function ``PyUFunc_GenericFunction`` has been disabled.
+  In most cases ``PyObject_Call(ufunc, args, kwargs)`` should be a
+  good alternative. (Deprecated NumPy 1.19)


### PR DESCRIPTION
Both of these were deprecated in NumPy 1.19. While technically, it
would be possible to use the `PyUFunc_SetUsesArraysAsData` mechanism
without using the previously deprecated API function, that seems
unlikely and no known user exists.
Further, this mechanism is undocumented, so simply removing it.

The mechanism could in principle allow certain things currently
otherwise not possible, but we should regain that capability before
the 1.21 release.

