### PR TITLE
BUG: remove stray '+' from f-string upgrade in numba/extending.py

### DIFF
--- a/numpy/random/_examples/numba/extending.py
+++ b/numpy/random/_examples/numba/extending.py
@@ -44,7 +44,7 @@ assert r1.shape == (n,)
 assert r1.shape == r2.shape
 
 t1 = timeit(numbacall, number=1000)
-+print(f'{t1:.2f} secs for {n} PCG64 (Numba/PCG64) gaussian randoms')
+print(f'{t1:.2f} secs for {n} PCG64 (Numba/PCG64) gaussian randoms')
 t2 = timeit(numpycall, number=1000)
 print(f'{t2:.2f} secs for {n} PCG64 (NumPy/PCG64) gaussian randoms')
 


### PR DESCRIPTION
Fixing test error from https://github.com/numpy/numpy/commit/b6e5711fd50969fb87d784e835d9ccc62dde716d#r44802919