### PR TITLE
DOC: Example of closing memory-mapped file without locking

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -201,6 +201,13 @@ class memmap(ndarray):
     >>> fpo
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 
+    Close the file so that it is not locked:
+    >>> fp._mmap.close()
+    >>> newfp._mmap.close()
+    >>> fpr._mmap.close()
+    >>> fpc._mmap.close()
+    >>> fpo._mmap.close()
+ 
     """
 
     __array_priority__ = -100.0


### PR DESCRIPTION
Provide good examples showing that memmap-ed files are properly closed when they are no longer needed.  Otherwise we will have a lot of locked files and directories.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
