### PR TITLE
MAINT: Replace `contextlib_nullcontext` with `contextlib.nullcontext`

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -94,6 +94,9 @@ class contextlib_nullcontext:
     cm = optional_cm if condition else nullcontext()
     with cm:
         # Perform operation, using optional_cm if condition is True
+
+    .. note::
+        Prefer using `contextlib.nullcontext` instead of this context manager.
     """
 
     def __init__(self, enter_result=None):

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -4,6 +4,7 @@ and the Python code for the NumPy-namespace function
 
 """
 import warnings
+from contextlib import nullcontext
 
 from numpy.core import multiarray as mu
 from numpy.core import umath as um
@@ -11,7 +12,7 @@ from numpy.core._asarray import asanyarray
 from numpy.core import numerictypes as nt
 from numpy.core import _exceptions
 from numpy._globals import _NoValue
-from numpy.compat import pickle, os_fspath, contextlib_nullcontext
+from numpy.compat import pickle, os_fspath
 
 # save those O(100) nanoseconds!
 umr_maximum = um.maximum.reduce
@@ -279,7 +280,7 @@ def _ptp(a, axis=None, out=None, keepdims=False):
 
 def _dump(self, file, protocol=2):
     if hasattr(file, 'write'):
-        ctx = contextlib_nullcontext(file)
+        ctx = nullcontext(file)
     else:
         ctx = open(os_fspath(file), "wb")
     with ctx as f:

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -1,8 +1,8 @@
+from contextlib import nullcontext
+
 import numpy as np
 from .numeric import uint8, ndarray, dtype
-from numpy.compat import (
-    os_fspath, contextlib_nullcontext, is_pathlib_path
-)
+from numpy.compat import os_fspath, is_pathlib_path
 from numpy.core.overrides import set_module
 
 __all__ = ['memmap']
@@ -38,7 +38,7 @@ class memmap(ndarray):
     which returns a view into an mmap buffer.
 
     Flush the memmap instance to write the changes to the file. Currently there
-    is no API to close the underlying ``mmap``. It is tricky to ensure the 
+    is no API to close the underlying ``mmap``. It is tricky to ensure the
     resource is actually closed, since it may be shared between different
     memmap instances.
 
@@ -112,7 +112,7 @@ class memmap(ndarray):
     The memmap object can be used anywhere an ndarray is accepted.
     Given a memmap ``fp``, ``isinstance(fp, numpy.ndarray)`` returns
     ``True``.
-    
+
     Memory-mapped files cannot be larger than 2GB on 32-bit systems.
 
     When a memmap causes a file to be created or extended beyond its
@@ -223,7 +223,7 @@ class memmap(ndarray):
             raise ValueError("shape must be given")
 
         if hasattr(filename, 'read'):
-            f_ctx = contextlib_nullcontext(filename)
+            f_ctx = nullcontext(filename)
         else:
             f_ctx = open(os_fspath(filename), ('r' if mode == 'c' else mode)+'b')
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -36,12 +36,11 @@ Record arrays allow us to access fields as properties::
 import os
 import warnings
 from collections import Counter, OrderedDict
+from contextlib import nullcontext
 
 from . import numeric as sb
 from . import numerictypes as nt
-from numpy.compat import (
-    os_fspath, contextlib_nullcontext
-)
+from numpy.compat import os_fspath
 from numpy.core.overrides import set_module
 from .arrayprint import get_printoptions
 
@@ -914,7 +913,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
         # GH issue 2504. fd supports io.RawIOBase or io.BufferedIOBase interface.
         # Example of fd: gzip, BytesIO, BufferedReader
         # file already opened
-        ctx = contextlib_nullcontext(fd)
+        ctx = nullcontext(fd)
     else:
         # open file
         ctx = open(os_fspath(fd), 'rb')

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -24,7 +24,7 @@ from ._iotools import (
 
 from numpy.compat import (
     asbytes, asstr, asunicode, os_fspath, os_PathLike,
-    pickle, contextlib_nullcontext
+    pickle
     )
 
 
@@ -517,7 +517,7 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
     # [1 2] [1 3]
     """
     if hasattr(file, 'write'):
-        file_ctx = contextlib_nullcontext(file)
+        file_ctx = contextlib.nullcontext(file)
     else:
         file = os_fspath(file)
         if not file.endswith('.npy'):
@@ -1792,7 +1792,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             fid_ctx = contextlib.closing(fid)
         else:
             fid = fname
-            fid_ctx = contextlib_nullcontext(fid)
+            fid_ctx = contextlib.nullcontext(fid)
         fhd = iter(fid)
     except TypeError as e:
         raise TypeError(


### PR DESCRIPTION
With the recent dropping of python 3.6 support we can now directly import [`nullcontext`](https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext) from `contextlib`,
rather than using its backport in `np.compat`.