### PR TITLE
BUG: Fix np.average with object array weights

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -954,7 +954,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = np.array(wgt, copy=0, ndmin=a.ndim).swapaxes(-1, axis)
 
         scl = wgt.sum(axis=axis, dtype=np.result_type(a.dtype, wgt.dtype))
-        if (scl == 0.0).any():
+        if np.any(scl == 0.0):
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -168,6 +168,15 @@ class TestAverage(TestCase):
         assert_array_equal(scl, np.array([1., 6.]))
 
 
+    def test_object_dtype(self):
+        a = np.array([x for x in range(10)])
+        w = np.array([None for _ in range(10)])
+
+        for i, _ in enumerate(w):
+            w[i] = float(1.)
+
+        assert_almost_equal(a.mean(0), average(a, weights=w))
+
 class TestSelect(TestCase):
     choices = [np.array([1, 2, 3]),
                np.array([4, 5, 6]),


### PR DESCRIPTION
**Problem:**
Preallocating lists may lead into the issue #8696.  The patch brought by #8750 seems to be applied only to numpy >= 1.14.x.

Found this bug first running at `Python 2.7.12` and `numpy 1:1.11.0-1ubuntu1` and reproduced it againg inside a docker container using the `python:2.7.12` image. The bug can be easily catched in the following code:

```py
import numpy as np

vals = np.random.rand(10)
weights = np.array([None for _ in range(10)])

for i, _ in enumerate(weights):
	weights[i] = np.random.random()

x_model = np.average(vals, weights=weights)
```

Please notice that by the end `weights` is a `'numpy.ndarray'` of `'float'`s, while `vals` array uses the `'numpy.float64'` type. This was causing the `np.result_type` results in a `object` type and incurring in the issue #8696

**Fix:**
  - Backports 1588ae39ffb51ea916f03510671aab711fdfb568
   - Changes the `test_object_dtype` to be compatible with 1.11.x version (the one provided by the fix was not passing, maybe depending on changes that doesn't exists at 1.11.x)