### PR TITLE
ENH: Close memmap file with a public function close()

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -201,6 +201,13 @@ class memmap(ndarray):
     >>> fpo
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 
+    Close all memmap files:
+
+    >>> fp.close()
+    >>> newfp.close()
+    >>> fpr.close()
+    >>> fpc.close()
+    >>> fpo.close()
     """
 
     __array_priority__ = -100.0
@@ -335,3 +342,24 @@ class memmap(ndarray):
         if type(res) is memmap and res._mmap is None:
             return res.view(type=ndarray)
         return res
+
+    def close(self):
+        """
+        Close the memmap file and reduce reference count by 1.
+        If the reference count is zero, the file is unlocked.
+        
+        It has no effect if no file is memory-mapped.
+
+        For further information, see `memmap`.
+
+        Parameters
+        ----------
+        None
+
+        See Also
+        --------
+        memmap
+
+        """
+        if self._mmap:
+            self._mmap.close()


### PR DESCRIPTION
Create a public function `close()` to properly close mmap

See [Method to explicitly close memmap #13510](https://github.com/numpy/numpy/issues/13510), there are two ways to un-mapped a memory-mapped file:
a.  `del fp` or
b.  `fp._mmap.close()`

The first method may leave the file locked for a long period of time. The second method exposes internal variable `_mmap`.

The solution provides public function to close the memmap object.