### PR TITLE
ENH: Close memmap file with a public function close()

### DIFF
--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -381,7 +381,6 @@ class memmap(ndarray):
         """
         if self._mmap is not None:
             self._mmap.close()
-            self._mmap = None
 
     def __enter__(self):
         return self

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -405,4 +405,4 @@ class memmap(ndarray):
         memmap
 
         """
-        return True if self._mmap is None else False
+        return True if self._mmap is None else self._mmap.closed

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -202,11 +202,31 @@ class memmap(ndarray):
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 
     Close all memmap files:
+
     >>> fp.close()
     >>> newfp.close()
     >>> fpr.close()
     >>> fpc.close()
+    
+    Check if the memmap file is closed:
+    >>> fpo.closed()
+    False
+    
+    Close fpo
     >>> fpo.close()
+    
+    Check if the memmap file is closed:
+    >>> fpo.closed()
+    True
+    
+    Use context manager to read the file into memmap:
+    
+    >>> with np.memmap(filename, dtype='float32', mode='r') as fpcon:
+    >>>     fpcon
+    memmap([[  0.,   1.,   2.,   3.],
+            [  4.,   5.,   6.,   7.],
+            [  8.,   9.,  10.,  11.]], dtype=float32)
+
     """
 
     __array_priority__ = -100.0

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -222,7 +222,7 @@ class memmap(ndarray):
     Use context manager to read the file into memmap:
     
     >>> with np.memmap(filename, dtype='float32', mode='r') as fpcon:
-    ...     print(fpcon)
+    >>>     print(fpcon)
     [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11.]
 
     """

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -349,6 +349,7 @@ class memmap(ndarray):
         
         It has no effect if no file is memory-mapped.
         For further information, see `memmap`.
+        
         Parameters
         ----------
         None

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -222,10 +222,8 @@ class memmap(ndarray):
     Use context manager to read the file into memmap:
     
     >>> with np.memmap(filename, dtype='float32', mode='r') as fpcon:
-    ...     fpcon
-    memmap([[  0.,   1.,   2.,   3.],
-            [  4.,   5.,   6.,   7.],
-            [  8.,   9.,  10.,  11.]], dtype=float32)
+    ...     print(fpcon)
+    [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9. 10. 11.]
 
     """
 

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -361,3 +361,28 @@ class memmap(ndarray):
         """
         if self._mmap is not None:
             self._mmap.close()
+            self._mmap = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+
+    def closed(self):
+        """
+        Return True if the memmap is already closed, 
+        otherwise return False.
+
+        For further information, see `memmap`.
+
+        Parameters
+        ----------
+        None
+
+        See Also
+        --------
+        memmap
+
+        """
+        return True if self._mmap is None else False

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -222,7 +222,7 @@ class memmap(ndarray):
     Use context manager to read the file into memmap:
     
     >>> with np.memmap(filename, dtype='float32', mode='r') as fpcon:
-    >>>     fpcon
+    ...     fpcon
     memmap([[  0.,   1.,   2.,   3.],
             [  4.,   5.,   6.,   7.],
             [  8.,   9.,  10.,  11.]], dtype=float32)

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -201,6 +201,12 @@ class memmap(ndarray):
     >>> fpo
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 
+    Close all memmap files:
+    >>> fp.close()
+    >>> newfp.close()
+    >>> fpr.close()
+    >>> fpc.close()
+    >>> fpo.close()
     """
 
     __array_priority__ = -100.0
@@ -335,3 +341,21 @@ class memmap(ndarray):
         if type(res) is memmap and res._mmap is None:
             return res.view(type=ndarray)
         return res
+
+    def close(self):
+        """
+        Close the memmap file and reduce reference count by 1.
+        If the reference count is zero, the file is unlocked.
+        
+        It has no effect if no file is memory-mapped.
+        For further information, see `memmap`.
+        Parameters
+        ----------
+        None
+        See Also
+        --------
+        memmap
+        
+        """
+        if self._mmap is not None:
+            self._mmap.close()

--- a/numpy/core/memmap.py
+++ b/numpy/core/memmap.py
@@ -353,6 +353,7 @@ class memmap(ndarray):
         Parameters
         ----------
         None
+
         See Also
         --------
         memmap


### PR DESCRIPTION
Create a public function close() to properly close mmap

See Method to explicitly close memmap #13510, there are two ways to un-mapped a memory-mapped file:
a. del fp or
b. fp._mmap.close()

The first method may leave the file locked for a long period of time. The second method exposes internal variable _mmap.

The solution provides public function to close the memmap object.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
