### PR TITLE
[DOC]: Wrong length for underline in docstring.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4023,7 +4023,7 @@ cdef class Generator:
             The drawn samples, of shape ``(size, k)``.
 
         Raises
-        -------
+        ------
         ValueError
             If any value in ``alpha`` is less than or equal to zero
 


### PR DESCRIPTION
This can trip-up doc parsers like Numpydoc
