### PR TITLE
BUG: Removed empty String from Nag Compiler's Flags

### DIFF
--- a/numpy/distutils/fcompiler/nag.py
+++ b/numpy/distutils/fcompiler/nag.py
@@ -19,7 +19,7 @@ class BaseNAGFCompiler(FCompiler):
     def get_flags_opt(self):
         return ['-O4']
     def get_flags_arch(self):
-        return ['']
+        return []
 
 class NAGFCompiler(BaseNAGFCompiler):
 


### PR DESCRIPTION
The empty string caused errors when trying to install the sciPy library from source using the NAG's Fortran Compiler(nagfor).
