### PR TITLE
TST, BUILD: Add a native x86 baseline build running on ubuntu-20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,3 +258,28 @@ stages:
         failTaskOnFailedTests: true
         testRunTitle: 'Publish test results for gcc 4.8'
 
+  # Native build is based on gcc flag `-march=native`
+  - job: Linux_baseline_native
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+    - script: |
+            if ! `gcc 2>/dev/null`; then
+                sudo apt install gcc
+            fi
+            sudo apt install python3
+            sudo apt install python3-dev
+            # python3 has no setuptools, so install one to get us going
+            python3 -m pip install --user --upgrade pip 'setuptools<49.2.0'
+            python3 -m pip install --user -r test_requirements.txt
+      displayName: 'install python/requirements'
+    - script: |
+            python3 runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
+            --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
+      displayName: 'Run native baseline Build / Tests'
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '**/test-*.xml'
+        failTaskOnFailedTests: true
+        testRunTitle: 'Publish test results for baseline/native'

--- a/runtests.py
+++ b/runtests.py
@@ -432,8 +432,6 @@ def build_project(args):
     cmd += ["build"]
     if args.parallel > 1:
         cmd += ["-j", str(args.parallel)]
-    if args.debug_info:
-        cmd += ["build_src", "--verbose-cfg"]
     if args.warn_error:
         cmd += ["--warn-error"]
     if args.cpu_baseline:
@@ -444,6 +442,8 @@ def build_project(args):
         cmd += ["--disable-optimization"]
     if args.simd_test is not None:
         cmd += ["--simd-test", args.simd_test]
+    if args.debug_info:
+        cmd += ["build_src", "--verbose-cfg"]
     # Install; avoid producing eggs so numpy can be imported from dst_dir.
     cmd += ['install', '--prefix=' + dst_dir,
             '--single-version-externally-managed',
@@ -538,7 +538,7 @@ def asv_clear_cache(bench_path, h_commits, env_dir="env"):
     for asv_build_cache in glob.glob(asv_build_pattern, recursive=True):
         for c in h_commits:
             try: shutil.rmtree(os.path.join(asv_build_cache, c))
-            except OSError: pass 
+            except OSError: pass
 
 def asv_substitute_config(in_config, out_config, **custom_vars):
     """


### PR DESCRIPTION
#### Add a native x86 baseline build running on ubuntu-20.04
  
  to build and test NumPy against the maximum supported CPU features
  by the compiler and the running machine
  
  native baseline build will allow us to test pull-requests like #17958,
  that doesn't use runtime dispatching.