### PR TITLE
BUG: Fix functional issues on z/OS

### DIFF
--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -4,6 +4,7 @@
 __all__ = ['finfo', 'iinfo']
 
 import warnings
+import sys
 
 from .machar import MachAr
 from .overrides import set_module
@@ -174,10 +175,12 @@ def _register_known_types():
                              huge=huge_f128,
                              tiny=tiny_f128)
     # IEEE 754 128-bit binary float
-    _register_type(float128_ma,
-        b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf')
-    _register_type(float128_ma,
-        b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf')
+    if sys.platform == 'zos':
+        _register_type(float128_ma,
+            b'\x00\x00\x00\x00\x00\x00\x00\xa0\x99\x99\x99\x99\x99\x99\xfb\xbf')
+    else:
+        _register_type(float128_ma,
+            b'\x9a\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\xfb\xbf')
     _float_ma[128] = float128_ma
 
     # Known parameters for float80 (Intel 80-bit extended precision)

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -127,20 +127,12 @@ OPTIONAL_HEADERS = [
 # optional gcc compiler builtins and their call arguments and optional a
 # required header and definition name (HAVE_ prepended)
 # call arguments are required as the compiler will do strict signature checking
-OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
-                       ("__builtin_isinf", '5.'),
-                       ("__builtin_isfinite", '5.'),
-                       ("__builtin_bswap32", '5u'),
-                       ("__builtin_bswap64", '5u'),
-                       ("__builtin_expect", '5, 0'),
-                       ("__builtin_mul_overflow", '5, 5, (int*)5'),
-                       # MMX only needed for icc, but some clangs don't have it
+OPTIONAL_INTRINSICS = [# MMX only needed for icc, but some clangs don't have it
                        ("_m_from_int64", '0', "emmintrin.h"),
                        ("_mm_load_ps", '(float*)0', "xmmintrin.h"),  # SSE
                        ("_mm_prefetch", '(float*)0, _MM_HINT_NTA',
                         "xmmintrin.h"),  # SSE
                        ("_mm_load_pd", '(double*)0', "emmintrin.h"),  # SSE2
-                       ("__builtin_prefetch", "(float*)0, 0, 3"),
                        # check that the linker can handle avx
                        ("__asm__ volatile", '"vpand %xmm1, %xmm2, %xmm3"',
                         "stdio.h", "LINK_AVX"),
@@ -154,6 +146,16 @@ OPTIONAL_INTRINSICS = [("__builtin_isnan", '5.'),
                         "stdio.h", "LINK_AVX512_SKX"),
                        ("__asm__ volatile", '"xgetbv"', "stdio.h", "XGETBV"),
                        ]
+
+if sys.platform != 'zos':
+    OPTIONAL_INTRINSICS.append(("__builtin_expect", '5, 0'))
+    OPTIONAL_INTRINSICS.append(("__builtin_prefetch", "(float*)0, 0, 3"))
+    OPTIONAL_INTRINSICS.append(("__builtin_isnan", '5.'))
+    OPTIONAL_INTRINSICS.append(("__builtin_isfinite", '5.'))
+    OPTIONAL_INTRINSICS.append(("__builtin_isinf", '5.'))
+    OPTIONAL_INTRINSICS.append(("__builtin_bswap32", '5u'))
+    OPTIONAL_INTRINSICS.append(("__builtin_bswap64", '5u'))
+    OPTIONAL_INTRINSICS.append(("__builtin_mul_overflow", '5, 5, (int*)5'))
 
 # function attributes
 # tested via "int %s %s(void *);" % (attribute, name)

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -401,10 +401,10 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
  * #kind = atan2,hypot,pow,copysign#
  * #KIND = ATAN2,HYPOT,POW,COPYSIGN#
  */
+#ifndef HAVE_@KIND@@C@
 #ifdef @kind@@c@
 #undef @kind@@c@
 #endif
-#ifndef HAVE_@KIND@@C@
 NPY_INPLACE @type@ npy_@kind@@c@(@type@ x, @type@ y)
 {
     return (@type@) npy_@kind@((double)x, (double) y);
@@ -416,10 +416,10 @@ NPY_INPLACE @type@ npy_@kind@@c@(@type@ x, @type@ y)
  * #kind = fmod#
  * #KIND = FMOD#
  */
+#ifndef HAVE_MODF@C@
 #ifdef @kind@@c@
 #undef @kind@@c@
 #endif
-#ifndef HAVE_MODF@C@
 NPY_INPLACE @type@
 npy_@kind@@c@(@type@ x, @type@ y)
 {
@@ -438,10 +438,10 @@ npy_@kind@@c@(@type@ x, @type@ y)
 #endif
 /**end repeat1**/
 
+#ifndef HAVE_MODF@C@
 #ifdef modf@c@
 #undef modf@c@
 #endif
-#ifndef HAVE_MODF@C@
 NPY_INPLACE @type@ npy_modf@c@(@type@ x, @type@ *iptr)
 {
     double niptr;

--- a/numpy/core/src/npysort/heapsort.c.src
+++ b/numpy/core/src/npysort/heapsort.c.src
@@ -183,11 +183,10 @@ heapsort_@suff@(void *start, npy_intp n, void *varr)
 {
     PyArrayObject *arr = varr;
     size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
-#ifdef __MVS__
-    @type@ *tmp = malloc(MAX(1, PyArray_ITEMSIZE(arr)));
-#else
+    if (len == 0) { 
+        return 0; 
+    } 
     @type@ *tmp = malloc(PyArray_ITEMSIZE(arr));
-#endif
     @type@ *a = (@type@ *)start - len;
     npy_intp i, j, l;
 
@@ -302,11 +301,11 @@ npy_heapsort(void *start, npy_intp num, void *varr)
     PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
-#ifdef __MVS__
-    char *tmp = malloc(MAX(1, elsize));
-#else
+
+    if (elsize == 0) {
+        return 0;
+    }
     char *tmp = malloc(elsize);
-#endif
     char *a = (char *)start - elsize;
     npy_intp i, j, l;
 

--- a/numpy/core/src/npysort/heapsort.c.src
+++ b/numpy/core/src/npysort/heapsort.c.src
@@ -38,6 +38,7 @@
 #define SMALL_MERGESORT 20
 #define SMALL_STRING 16
 
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
 
 /*
  *****************************************************************************
@@ -182,7 +183,11 @@ heapsort_@suff@(void *start, npy_intp n, void *varr)
 {
     PyArrayObject *arr = varr;
     size_t len = PyArray_ITEMSIZE(arr)/sizeof(@type@);
+#ifdef __MVS__
+    @type@ *tmp = malloc(MAX(1, PyArray_ITEMSIZE(arr)));
+#else
     @type@ *tmp = malloc(PyArray_ITEMSIZE(arr));
+#endif
     @type@ *a = (@type@ *)start - len;
     npy_intp i, j, l;
 
@@ -297,7 +302,11 @@ npy_heapsort(void *start, npy_intp num, void *varr)
     PyArrayObject *arr = varr;
     npy_intp elsize = PyArray_ITEMSIZE(arr);
     PyArray_CompareFunc *cmp = PyArray_DESCR(arr)->f->compare;
+#ifdef __MVS__
+    char *tmp = malloc(MAX(1, elsize));
+#else
     char *tmp = malloc(elsize);
+#endif
     char *a = (char *)start - elsize;
     npy_intp i, j, l;
 

--- a/numpy/distutils/tests/test_exec_command.py
+++ b/numpy/distutils/tests/test_exec_command.py
@@ -116,7 +116,7 @@ class TestExecCommand:
         assert_(s == 0)
         assert_(o == '')
 
-        s, o = exec_command.exec_command('echo "$AAA"', AAA='Tere', **kws)
+        s, o = exec_command.exec_command('echo "$AAA"', AAA='Tere', _BPXK_AUTOCVT='ON', **kws)
         assert_(s == 0)
         assert_(o == 'Tere')
 
@@ -130,7 +130,7 @@ class TestExecCommand:
             assert_(s == 0)
             assert_(o == 'Hi')
 
-            s, o = exec_command.exec_command('echo "$BBB"', BBB='Hey', **kws)
+            s, o = exec_command.exec_command('echo "$BBB"', BBB='Hey', _BPXK_AUTOCVT='ON', **kws)
             assert_(s == 0)
             assert_(o == 'Hey')
 

--- a/numpy/fft/_pocketfft.c
+++ b/numpy/fft/_pocketfft.c
@@ -22,8 +22,15 @@
 #include "npy_config.h"
 #define restrict NPY_RESTRICT
 
+#ifdef __MVS__
+#define MAX(x,y) \
+    (((x) > (y)) ? (x) : (y))
+#define RALLOC(type,num) \
+  ((type *)malloc(MAX((1),(num)*sizeof(type))))
+#else
 #define RALLOC(type,num) \
   ((type *)malloc((num)*sizeof(type)))
+#endif
 #define DEALLOC(ptr) \
   do { free(ptr); (ptr)=NULL; } while(0)
 

--- a/numpy/linalg/lapack_lite/f2c.h
+++ b/numpy/linalg/lapack_lite/f2c.h
@@ -151,6 +151,15 @@ struct Namelist {
 	};
 typedef struct Namelist Namelist;
 
+#ifdef __MVS__
+#ifdef abs
+#undef abs
+#endif
+#ifdef dabs
+#undef dabs
+#endif
+#endif
+
 #ifndef abs
 #define abs(x) ((x) >= 0 ? (x) : -(x))
 #endif

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -25,6 +25,13 @@
 
 static const char* umath_linalg_version_string = "0.1.5";
 
+#ifdef __MVS__
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
+#define CKMALLOC(size) (malloc(MAX((1),size)))
+#else
+#define CKMALLOC(size) (malloc(size))
+#endif
+
 /*
  ****************************************************************************
  *                        Debugging support                                 *
@@ -1106,7 +1113,7 @@ static void
     safe_m = m;
     matrix_size = safe_m * safe_m * sizeof(@typ@);
     pivot_size = safe_m * sizeof(fortran_int);
-    tmp_buff = (npy_uint8 *)malloc(matrix_size + pivot_size);
+    tmp_buff = (npy_uint8 *)CKMALLOC(matrix_size + pivot_size);
 
     if (tmp_buff) {
         LINEARIZE_DATA_t lin_data;
@@ -1149,7 +1156,7 @@ static void
     safe_m = m;
     matrix_size = safe_m * safe_m * sizeof(@typ@);
     pivot_size = safe_m * sizeof(fortran_int);
-    tmp_buff = (npy_uint8 *)malloc(matrix_size + pivot_size);
+    tmp_buff = (npy_uint8 *)CKMALLOC(matrix_size + pivot_size);
 
     if (tmp_buff) {
         LINEARIZE_DATA_t lin_data;
@@ -2949,7 +2956,7 @@ init_@lapack_func@(GELSD_PARAMS_t *params,
     fortran_int lda = fortran_int_max(1, m);
     fortran_int ldb = fortran_int_max(1, fortran_int_max(m,n));
 
-    mem_buff = malloc(a_size + b_size + s_size);
+    mem_buff = CKMALLOC(a_size + b_size + s_size);
 
     if (!mem_buff)
         goto error;


### PR DESCRIPTION
This is a continuation on from https://github.com/numpy/numpy/pull/17655, which allowed Numpy to be built on z/OS. This PR is attempting to fix the various test failures that arise. If this PR is too big I can split it up as wanted. But here's a description of every fix for z/OS that's contained within this PR:

`numpy/core/getlimits.py`
- Swaps float128 to the fallback signature.

`numpy/core/setup_common.py`
- XL C/C++ V2.4.1 has issues with these builtins. It'll compile and link them fine but they won't run correctly, so we want to disable them on this platform.

`numpy/core/src/npymath/npy_math_internal.h.src`
- Some c99 functions are defined as macros and not actual functions on z/OS. These macros get undefined by numpy, which then causes aborts when the actual function is called. This change swaps it so that they only get undefined when actually being used.

`numpy/linalg/umath_linalg.c.src`
`numpy/fft/_pocketfft.c`
`numpy/core/src/npysort/heapsort.c.src`
 - Allocating 0 bytes within malloc gives a null pointer on z/OS, so this change makes it allocate minimum 1 byte.

`numpy/distutils/tests/test_exec_command.py`
- z/OS is by default an EBCDIC platform, not ASCII or UTF, and automatic conversion between the encodings is done through the filesystem/environment variable. By default this is set for z/OS - but `exec_command` will remove it if you specify an env. For this case, we just add it back.

`numpy/linalg/lapack_lite/f2c.h`
- z/OS has it's own abs/dabs that is included which does not work for floats. This undefines that so that it picks up the macros defined later on.