### PR TITLE
TST: Ensure tests are not sensitive to execution order

### DIFF
--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -430,25 +430,27 @@ class TestNumPyFunctions:
 
 
 class TestArrayLike:
+    def setup(self):
+        class MyArray():
+            def __init__(self, function=None):
+                self.function = function
 
-    class MyArray():
+            def __array_function__(self, func, types, args, kwargs):
+                try:
+                    my_func = getattr(self, func.__name__)
+                except AttributeError:
+                    return NotImplemented
+                return my_func(*args, **kwargs)
 
-        def __init__(self, function=None):
-            self.function = function
+        self.MyArray = MyArray
 
-        def __array_function__(self, func, types, args, kwargs):
-            try:
-                my_func = getattr(TestArrayLike.MyArray, func.__name__)
-            except AttributeError:
-                return NotImplemented
-            return my_func(*args, **kwargs)
+        class MyNoArrayFunctionArray():
+            def __init__(self, function=None):
+                self.function = function
 
-    class MyNoArrayFunctionArray():
+        self.MyNoArrayFunctionArray = MyNoArrayFunctionArray
 
-        def __init__(self, function=None):
-            self.function = function
-
-    def add_method(name, arr_class, enable_value_error=False):
+    def add_method(self, name, arr_class, enable_value_error=False):
         def _definition(*args, **kwargs):
             # Check that `like=` isn't propagated downstream
             assert 'like' not in kwargs
@@ -464,9 +466,9 @@ class TestArrayLike:
 
     @requires_array_function
     def test_array_like_not_implemented(self):
-        TestArrayLike.add_method('array', TestArrayLike.MyArray)
+        self.add_method('array', self.MyArray)
 
-        ref = TestArrayLike.MyArray.array()
+        ref = self.MyArray.array()
 
         with assert_raises_regex(TypeError, 'no implementation found'):
             array_like = np.asarray(1, like=ref)
@@ -497,15 +499,15 @@ class TestArrayLike:
     @pytest.mark.parametrize('numpy_ref', [True, False])
     @requires_array_function
     def test_array_like(self, function, args, kwargs, numpy_ref):
-        TestArrayLike.add_method('array', TestArrayLike.MyArray)
-        TestArrayLike.add_method(function, TestArrayLike.MyArray)
+        self.add_method('array', self.MyArray)
+        self.add_method(function, self.MyArray)
         np_func = getattr(np, function)
-        my_func = getattr(TestArrayLike.MyArray, function)
+        my_func = getattr(self.MyArray, function)
 
         if numpy_ref is True:
             ref = np.array(1)
         else:
-            ref = TestArrayLike.MyArray.array()
+            ref = self.MyArray.array()
 
         like_args = tuple(a() if callable(a) else a for a in args)
         array_like = np_func(*like_args, **kwargs, like=ref)
@@ -523,20 +525,20 @@ class TestArrayLike:
 
             assert_equal(array_like, np_arr)
         else:
-            assert type(array_like) is TestArrayLike.MyArray
+            assert type(array_like) is self.MyArray
             assert array_like.function is my_func
 
     @pytest.mark.parametrize('function, args, kwargs', _array_tests)
-    @pytest.mark.parametrize('ref', [1, [1], MyNoArrayFunctionArray])
+    @pytest.mark.parametrize('ref', [1, [1], "MyNoArrayFunctionArray"])
     @requires_array_function
     def test_no_array_function_like(self, function, args, kwargs, ref):
-        TestArrayLike.add_method('array', TestArrayLike.MyNoArrayFunctionArray)
-        TestArrayLike.add_method(function, TestArrayLike.MyNoArrayFunctionArray)
+        self.add_method('array', self.MyNoArrayFunctionArray)
+        self.add_method(function, self.MyNoArrayFunctionArray)
         np_func = getattr(np, function)
 
         # Instantiate ref if it's the MyNoArrayFunctionArray class
-        if ref is TestArrayLike.MyNoArrayFunctionArray:
-            ref = ref.array()
+        if ref == "MyNoArrayFunctionArray":
+            ref = self.MyNoArrayFunctionArray.array()
 
         like_args = tuple(a() if callable(a) else a for a in args)
 
@@ -546,13 +548,13 @@ class TestArrayLike:
 
     @pytest.mark.parametrize('numpy_ref', [True, False])
     def test_array_like_fromfile(self, numpy_ref):
-        TestArrayLike.add_method('array', TestArrayLike.MyArray)
-        TestArrayLike.add_method("fromfile", TestArrayLike.MyArray)
+        self.add_method('array', self.MyArray)
+        self.add_method("fromfile", self.MyArray)
 
         if numpy_ref is True:
             ref = np.array(1)
         else:
-            ref = TestArrayLike.MyArray.array()
+            ref = self.MyArray.array()
 
         data = np.random.random(5)
 
@@ -566,18 +568,14 @@ class TestArrayLike:
             assert_equal(np_res, data)
             assert_equal(array_like, np_res)
         else:
-            assert type(array_like) is TestArrayLike.MyArray
-            assert array_like.function is TestArrayLike.MyArray.fromfile
+            assert type(array_like) is self.MyArray
+            assert array_like.function is self.MyArray.fromfile
 
     @requires_array_function
     def test_exception_handling(self):
-        TestArrayLike.add_method(
-            'array',
-            TestArrayLike.MyArray,
-            enable_value_error=True,
-        )
+        self.add_method('array', self.MyArray, enable_value_error=True)
 
-        ref = TestArrayLike.MyArray.array()
+        ref = self.MyArray.array()
 
         with assert_raises(ValueError):
             np.array(1, value_error=True, like=ref)

--- a/numpy/ma/timer_comparison.py
+++ b/numpy/ma/timer_comparison.py
@@ -7,11 +7,8 @@ import numpy.core.fromnumeric as fromnumeric
 
 from numpy.testing import build_err_msg
 
-# Fixme: this does not look right.
-np.seterr(all='ignore')
 
 pi = np.pi
-
 
 class ModuleTester:
     def __init__(self, module):
@@ -111,6 +108,7 @@ class ModuleTester:
         self.assert_array_compare(self.equal, x, y, err_msg=err_msg,
                                   header='Arrays are not equal')
 
+    @np.errstate(all='ignore')
     def test_0(self):
         """
         Tests creation
@@ -121,6 +119,7 @@ class ModuleTester:
         xm = self.masked_array(x, mask=m)
         xm[0]
 
+    @np.errstate(all='ignore')
     def test_1(self):
         """
         Tests creation
@@ -148,6 +147,7 @@ class ModuleTester:
             xf.shape = s
             assert(self.count(xm) == len(m1) - reduce(lambda x, y:x+y, m1))
 
+    @np.errstate(all='ignore')
     def test_2(self):
         """
         Tests conversions and indexing.
@@ -190,6 +190,7 @@ class ModuleTester:
         m3 = self.make_mask(m, copy=1)
         assert(m is not m3)
 
+    @np.errstate(all='ignore')
     def test_3(self):
         """
         Tests resize/repeat
@@ -209,6 +210,7 @@ class ModuleTester:
         y8 = x4.repeat(2, 0)
         assert self.allequal(y5, y8)
 
+    @np.errstate(all='ignore')
     def test_4(self):
         """
         Test of take, transpose, inner, outer products.
@@ -232,6 +234,7 @@ class ModuleTester:
         assert t[1] == 2
         assert t[2] == 3
 
+    @np.errstate(all='ignore')
     def test_5(self):
         """
         Tests inplace w/ scalar
@@ -284,6 +287,7 @@ class ModuleTester:
         x += 1.
         assert self.allequal(x, y + 1.)
 
+    @np.errstate(all='ignore')
     def test_6(self):
         """
         Tests inplace w/ array
@@ -335,6 +339,7 @@ class ModuleTester:
         x /= a
         xm /= a
 
+    @np.errstate(all='ignore')
     def test_7(self):
         "Tests ufunc"
         d = (self.array([1.0, 0, -1, pi/2]*2, mask=[0, 1]+[0]*6),
@@ -369,6 +374,7 @@ class ModuleTester:
             self.assert_array_equal(ur.filled(0), mr.filled(0), f)
             self.assert_array_equal(ur._mask, mr._mask)
 
+    @np.errstate(all='ignore')
     def test_99(self):
         # test average
         ott = self.array([0., 1., 2., 3.], mask=[1, 0, 0, 0])
@@ -414,6 +420,7 @@ class ModuleTester:
         self.assert_array_equal(self.average(z, axis=1), [2.5, 5.0])
         self.assert_array_equal(self.average(z, axis=0, weights=w2), [0., 1., 99., 99., 4.0, 10.0])
 
+    @np.errstate(all='ignore')
     def test_A(self):
         x = self.arange(24)
         x[5:6] = self.masked


### PR DESCRIPTION
This moves class creation into a `setup` function and uses `self`
instead of the test class all over.  There are probably nicer
ways to fix (and improve) it, but this seemed nice minimal.

---

Should be backported to 1.20 probably to ensure that `pytest-randomly` doesn't disturb the result. There is at least one further such things, but that might not require backport.