### PR TITLE
ENH: Fast paths for richcompare

### DIFF
--- a/benchmarks/benchmarks/bench_scalar.py
+++ b/benchmarks/benchmarks/bench_scalar.py
@@ -1,3 +1,4 @@
+from random import randint
 from .common import Benchmark, TYPES1
 
 import numpy as np
@@ -31,3 +32,6 @@ class ScalarMath(Benchmark):
         n = self.num
         res = abs(abs(abs(abs(abs(abs(abs(abs(abs(abs(n))))))))))
 
+    def time_compare(self, typename):
+        n = self.num
+        res = [n == randint(-128, 127) for _ in range(10)]

--- a/benchmarks/benchmarks/bench_scalar.py
+++ b/benchmarks/benchmarks/bench_scalar.py
@@ -35,3 +35,9 @@ class ScalarMath(Benchmark):
     def time_compare(self, typename):
         n = self.num
         res = [n == randint(-128, 127) for _ in range(10)]
+
+    def time_compare_types(self, typename):
+        n1 = self.num
+        for type_lhs in TYPES1:
+            n2 = np.dtype(type_lhs).type(randint(-128, 127))
+            res = [n1 == n2 for _ in range(10)]

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -150,21 +150,6 @@ class CustomScalarFloorDivideInt(Benchmark):
         self.x // divisor
 
 
-class CustomScalarEqual(Benchmark):
-    params = (
-        [np.int8, np.int16, np.int32, np.int64,
-         np.uint8, np.uint16, np.uint32, np.uint64,
-         np.float32, np.float64])
-    param_names = ['dtype']
-
-    def setup(self, dtype):
-        self.scalar_x = dtype(np.random.randint(-128, 127))
-        self.scalar_y = np.random.randint(-128, 127)
-
-    def time_scalar_equality(self, dtype):
-        for i in range(10**6):
-            self.scalar_x == self.scalar_y
-
 class Scalar(Benchmark):
     def setup(self):
         self.x = np.asarray(1.0)

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -150,6 +150,21 @@ class CustomScalarFloorDivideInt(Benchmark):
         self.x // divisor
 
 
+class CustomScalarEqual(Benchmark):
+    params = (
+        [np.int8, np.int16, np.int32, np.int64,
+         np.uint8, np.uint16, np.uint32, np.uint64,
+         np.float32, np.float64])
+    param_names = ['dtype']
+
+    def setup(self, dtype):
+        self.scalar_x = dtype(np.random.randint(-128, 127))
+        self.scalar_y = np.random.randint(-128, 127)
+
+    def time_scalar_equality(self, dtype):
+        for i in range(10**6):
+            self.scalar_x == self.scalar_y
+
 class Scalar(Benchmark):
     def setup(self):
         self.x = np.asarray(1.0)

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -717,8 +717,8 @@ PyArray_CanCastScalar(PyTypeObject *from, PyTypeObject *to)
     int fromtype;
     int totype;
 
-    fromtype = _typenum_fromtypeobj((PyObject *)from, 0);
-    totype = _typenum_fromtypeobj((PyObject *)to, 0);
+    fromtype = PyArray_TypeNumFromNumPyScalarType((PyObject *)from, 0);
+    totype = PyArray_TypeNumFromNumPyScalarType((PyObject *)to, 0);
     if (fromtype == NPY_NOTYPE || totype == NPY_NOTYPE) {
         return NPY_FALSE;
     }

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -443,7 +443,7 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrFromTypeObject(PyObject *type)
 {
     /* if it's a builtin type, then use the typenumber */
-    int typenum = _typenum_fromtypeobj(type,1);
+    int typenum = PyArray_TypeNumFromNumPyScalarType(type,1);
     if (typenum != NPY_NOTYPE) {
         return PyArray_DescrFromType(typenum);
     }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -4144,7 +4144,7 @@ is_anyscalar_exact(PyObject *obj)
 }
 
 NPY_NO_EXPORT int
-_typenum_fromtypeobj(PyObject *type, int user)
+PyArray_TypeNumFromNumPyScalarType(PyObject *type, int user)
 {
     int typenum, i;
 

--- a/numpy/core/src/multiarray/scalartypes.h
+++ b/numpy/core/src/multiarray/scalartypes.h
@@ -26,7 +26,7 @@ NPY_NO_EXPORT int
 is_anyscalar_exact(PyObject *obj);
 
 NPY_NO_EXPORT int
-_typenum_fromtypeobj(PyObject *type, int user);
+PyArray_TypeNumFromNumPyScalarType(PyObject *type, int user);
 
 NPY_NO_EXPORT void *
 scalar_value(PyObject *scalar, PyArray_Descr *descr);

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -614,41 +614,44 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
 
 /**
  * This function attempts to compare NumPy or Python scalars
- * The operation is done by casting to array and getting `item`
- * which is then used to called the item's richcompare
+ * The operation is done by getting value of both scalars
+ * and calling richcompare on them.
  *
  * @param self The first object which will be converted to scalar item
  * @param other The second object to compare to
+ * @param other The value of comparison operator
  * @returns Py_False or Py_True if richcompare is successfull
- *          , otherwise NULL
+ *          , otherwise NULL.
  */
 static PyObject*
 do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
-    PyObject *arr, *item, *meth, *ret;
+    PyObject *item_self, *item_other, *ret;
+    PyArray_Descr *self_descr, *other_descr;
+    void *data_self, *data_other;
+    int pyscalar_self, pyscalar_other;
 
-    arr = PyArray_FromScalar(self, NULL);
-    if (arr == NULL) {
-        return NULL;
+    pyscalar_self = descr_from_basic_scalar(self, &self_descr);
+    pyscalar_other = descr_from_basic_scalar(other, &other_descr);
+
+    if (NPY_LIKELY(pyscalar_self > 0 && pyscalar_other > 0)) {
+        data_self = scalar_value(self, NULL);
+        data_other = scalar_value(other, NULL);
+
+        item_self = self_descr->f->getitem(data_self, NULL);
+        item_other = other_descr->f->getitem(data_other, NULL);
+
+        Py_DECREF(item_other);
+        Py_DECREF(item_self);
+
+        ret = PyObject_RichCompare(item_self, item_other, cmp_op);
+
+        Py_DECREF(self_descr);
+        Py_DECREF(other_descr);
+
+        return ret;
     }
 
-    meth = PyObject_GetAttrString(arr, "item");
-    if (meth == NULL) {
-        Py_DECREF(arr);
-        return NULL;
-    }
-
-    item = PyObject_CallObject(meth, NULL);
-    if (item == NULL) {
-        Py_DECREF(arr);
-        Py_DECREF(meth);
-        return NULL;
-    }
-
-    ret = PyObject_RichCompare(item, other, cmp_op);
-    Py_DECREF(arr);
-    Py_DECREF(meth);
-    Py_DECREF(item);
-    return ret;
+    return NULL;
 }
 
 
@@ -1343,8 +1346,8 @@ static PyObject*
 @name@_richcompare(PyObject *self, PyObject *other, int cmp_op)
 {
     npy_@name@ arg1, arg2;
-    int out=0, pyscalar=0;
-    PyArray_Descr *value_descr;
+    int out=0;
+    PyObject *ret;
 
     RICHCMP_GIVE_UP_IF_NEEDED(self, other);
 
@@ -1352,13 +1355,11 @@ static PyObject*
     case 0:
         break;
     case -1:
-        /* can't cast both safely.
-         * Try fastpath if `other` is not complex */
-        pyscalar = descr_from_basic_scalar(other, &value_descr);
-        if(NPY_LIKELY(pyscalar > 0)) {
-            if(value_descr->type_num < NPY_CFLOAT) {
-                return do_richcompare_on_scalars(self, other, cmp_op);
-            }
+        /* can't cast both safely to same type.
+         * Try fastpath else use ufuncs */
+        ret = do_richcompare_on_scalars(self, other, cmp_op);
+        if (ret != NULL) {
+            return ret;
         }
     case -2:
         /* use ufunc */

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -569,6 +569,47 @@ static void
 
 /*** END OF BASIC CODE **/
 
+/**
+ * Find the descriptor for a builtin or Python numerical scalar.
+ * This function should only be used for scalar math fast paths.
+ *
+ * @param obj The object for which to find the descriptor
+ * @param descr The descriptor that was found.
+ * @returns 1 if the other object is a Python type and thus must not
+ *          handle the operation, otherwise 0. -1 _without_ an error set
+ *          if no descriptor was found.
+ */
+static int
+descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
+{
+    /* TODO: We could try giving defined scalars a chance... */
+    int type_num = PyArray_TypeNumFromNumPyScalarType(
+            (PyObject *)Py_TYPE(obj), 0);
+    if (type_num != NPY_NOTYPE) {
+        *descr = PyArray_DescrFromType(type_num);
+        return 0;
+    }
+    else if (PyFloat_CheckExact(obj)) {
+        *descr = PyArray_DescrFromType(NPY_DOUBLE);
+        return 1;
+    }
+    else if (PyLong_CheckExact(obj)) {
+        int overflow;
+        if (PyLong_AsLongAndOverflow(obj, &overflow) < 0) {
+            /* overflow must have occurred */
+            assert(overflow != 0);
+            return -1;
+        }
+        *descr = PyArray_DescrFromType(NPY_LONG);
+        return 1;
+    }
+    else if (PyComplex_CheckExact(obj)) {
+        *descr = PyArray_DescrFromType(NPY_CDOUBLE);
+        return 1;
+    }
+    return -1;
+}
+
 
 /* The general strategy for commutative binary operators is to
  *

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -611,6 +611,46 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
 }
 
 
+/**
+ * This function attempts to compare NumPy or Python scalars
+ * The operation is done by casting to array and getting `item`
+ * which is then used to called the item's richcompare
+ *
+ * @param self The first object which will be converted to scalar item
+ * @param other The second object to compare to
+ * @returns Py_False or Py_True if richcompare is successfull
+ *          , otherwise NULL
+ */
+static PyObject*
+do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
+    PyObject *arr, *item, *meth, *ret;
+
+    arr = PyArray_FromScalar(self, NULL);
+    if (arr == NULL) {
+        return NULL;
+    }
+
+    meth = PyObject_GetAttrString(arr, "item");
+    if (meth == NULL) {
+        Py_DECREF(arr);
+        return NULL;
+    }
+
+    item = PyObject_CallObject(meth, NULL);
+    if (item == NULL) {
+        Py_DECREF(arr);
+        Py_DECREF(meth);
+        return NULL;
+    }
+
+    ret = PyObject_RichCompare(item, other, cmp_op);
+    Py_DECREF(arr);
+    Py_DECREF(meth);
+    Py_DECREF(item);
+    return ret;
+}
+
+
 /* The general strategy for commutative binary operators is to
  *
  * 1) Convert the types to the common type if both are scalars (0 return)
@@ -1302,7 +1342,8 @@ static PyObject*
 @name@_richcompare(PyObject *self, PyObject *other, int cmp_op)
 {
     npy_@name@ arg1, arg2;
-    int out=0;
+    int out=0, pyscalar=0;
+    PyArray_Descr *value_descr;
 
     RICHCMP_GIVE_UP_IF_NEEDED(self, other);
 
@@ -1311,6 +1352,12 @@ static PyObject*
         break;
     case -1:
         /* can't cast both safely use different add function */
+        pyscalar = descr_from_basic_scalar(other, &value_descr);
+        if(NPY_LIKELY(pyscalar > 0)) {
+            if(value_descr->type_num < NPY_CFLOAT) {
+                return do_richcompare_on_scalars(self, other, cmp_op);
+            }
+        }
     case -2:
         /* use ufunc */
         if (PyErr_Occurred()) {

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -15,6 +15,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
+#include "scalartypes.h"
 
 #include "npy_import.h"
 #include "npy_pycompat.h"
@@ -1351,7 +1352,8 @@ static PyObject*
     case 0:
         break;
     case -1:
-        /* can't cast both safely use different add function */
+        /* can't cast both safely.
+         * Try fastpath if `other` is not complex */
         pyscalar = descr_from_basic_scalar(other, &value_descr);
         if(NPY_LIKELY(pyscalar > 0)) {
             if(value_descr->type_num < NPY_CFLOAT) {

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -587,29 +587,38 @@ static void
 /**begin repeat
  * #name = byte, ubyte, short, ushort, int, uint,
  *         long, ulong, longlong, ulonglong,
- *         half, float, longdouble,
+ *         half, float, double, longdouble,
  *         cfloat, cdouble, clongdouble#
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_longdouble,
+ *         npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_cfloat, npy_cdouble, npy_clongdouble#
  * #Name = Byte, UByte, Short, UShort, Int, UInt,
  *         Long, ULong, LongLong, ULongLong,
- *         Half, Float, LongDouble,
+ *         Half, Float, Double, LongDouble,
  *         CFloat, CDouble, CLongDouble#
  * #TYPE = NPY_BYTE, NPY_UBYTE, NPY_SHORT, NPY_USHORT, NPY_INT, NPY_UINT,
  *         NPY_LONG, NPY_ULONG, NPY_LONGLONG, NPY_ULONGLONG,
- *         NPY_HALF, NPY_FLOAT, NPY_LONGDOUBLE,
+ *         NPY_HALF, NPY_FLOAT, NPY_DOUBLE, NPY_LONGDOUBLE,
  *         NPY_CFLOAT, NPY_CDOUBLE, NPY_CLONGDOUBLE#
  */
 
+#define _IS_@Name@
+
 static int
-_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
+_@name@_convert_to_ctype(PyObject *a, @type@ *arg)
 {
     PyObject *temp;
 
+#if defined(_IS_Double) || defined(_IS_LongDouble)
+    if (PyFloat_CheckExact(a)) {
+        *arg = (@type@)PyFloat_AS_DOUBLE(a);
+        return 0;
+    }
+#endif
+
     if (PyArray_IsScalar(a, @Name@)) {
-        *arg1 = PyArrayScalar_VAL(a, @Name@);
+        *arg = PyArrayScalar_VAL(a, @Name@);
         return 0;
     }
     else if (PyArray_IsScalar(a, Generic)) {
@@ -620,7 +629,7 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
         }
         descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
         if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
-            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
+            PyArray_CastScalarDirect(a, descr1, arg, @TYPE@);
             Py_DECREF(descr1);
             return 0;
         }
@@ -633,7 +642,7 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
         return -2;
     }
     else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
-        int retval = _@name@_convert_to_ctype(temp, arg1);
+        int retval = _@name@_convert_to_ctype(temp, arg);
 
         Py_DECREF(temp);
         return retval;
@@ -641,62 +650,7 @@ _@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
     return -2;
 }
 
-/**end repeat**/
-
-
-/* Same as above but added exact checks against known python types for speed */
-
-/**begin repeat
- * #name = double#
- * #type = npy_double#
- * #Name = Double#
- * #TYPE = NPY_DOUBLE#
- * #PYCHECKEXACT = PyFloat_CheckExact#
- * #PYEXTRACTCTYPE = PyFloat_AS_DOUBLE#
- */
-
-static int
-_@name@_convert_to_ctype(PyObject *a, @type@ *arg1)
-{
-    PyObject *temp;
-
-    if (@PYCHECKEXACT@(a)){
-        *arg1 = @PYEXTRACTCTYPE@(a);
-        return 0;
-    }
-
-    if (PyArray_IsScalar(a, @Name@)) {
-        *arg1 = PyArrayScalar_VAL(a, @Name@);
-        return 0;
-    }
-    else if (PyArray_IsScalar(a, Generic)) {
-        PyArray_Descr *descr1;
-
-        if (!PyArray_IsScalar(a, Number)) {
-            return -1;
-        }
-        descr1 = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(a));
-        if (PyArray_CanCastSafely(descr1->type_num, @TYPE@)) {
-            PyArray_CastScalarDirect(a, descr1, arg1, @TYPE@);
-            Py_DECREF(descr1);
-            return 0;
-        }
-        else {
-            Py_DECREF(descr1);
-            return -1;
-        }
-    }
-    else if (PyArray_GetPriority(a, NPY_PRIORITY) > NPY_PRIORITY) {
-        return -2;
-    }
-    else if ((temp = PyArray_ScalarFromObject(a)) != NULL) {
-        int retval = _@name@_convert_to_ctype(temp, arg1);
-
-        Py_DECREF(temp);
-        return retval;
-    }
-    return -2;
-}
+#undef _IS_@Name@
 
 /**end repeat**/
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -595,6 +595,10 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
         *descr = PyArray_DescrFromType(NPY_DOUBLE);
         return 1;
     }
+    else if (PyBool_Check(obj)) {
+        *descr = PyArray_DescrFromType(NPY_BOOL);
+        return 1;
+    }
     else if (PyLong_CheckExact(obj)) {
         if (PyLong_AsLong(obj) == -1 && PyErr_Occurred()) {
             PyErr_Clear();
@@ -610,6 +614,8 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
     return -1;
 }
 
+#define PyDescr_PythonCRepresentable(d) (d->type_num == NPY_LONGDOUBLE || \
+        d->type_num > NPY_CDOUBLE)
 
 /**
  * This function attempts to compare NumPy or Python scalars
@@ -618,37 +624,51 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
  *
  * @param self The first object which will be converted to scalar item
  * @param other The second object to compare to
- * @param other The value of comparison operator
+ * @param cmp_op The value of comparison operator
  * @returns Py_False or Py_True if richcompare is successfull
  *          , otherwise NULL.
  */
 static PyObject*
 do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
-    PyObject *item_self, *ret=NULL;
+    PyObject *cmp_item_self, *cmp_item_other, *ret=NULL;
     PyArray_Descr *self_descr=NULL, *other_descr=NULL;
-    void *data_self;
+    void *data_self, *data_other;
     int pyscalar_other, pyscalar_self;
-    int is_complex_operands, is_equality_operator;
+    int is_complex_operands, is_equality_operator, is_python_scalar;
 
     pyscalar_self = descr_from_basic_scalar(self, &self_descr);
     pyscalar_other = descr_from_basic_scalar(other, &other_descr);
 
     if (pyscalar_self >= 0 && pyscalar_other >= 0) {
         /*
-         * If either of the operands are complex AND the operator is not equality,
-         * python's built-in richcompare cannot be used as it is not supported
+         * If either of the operands are complex and operator is not equality,
+         * or the operands are not representable as a native type,
+         * python's built-in richcompare cannot be used as it is not supported.
          */
         is_complex_operands = (PyTypeNum_ISCOMPLEX(self_descr->type_num) ||
             PyTypeNum_ISCOMPLEX(other_descr->type_num));
         is_equality_operator = (cmp_op != Py_EQ && cmp_op != Py_NE);
+        is_python_scalar = PyDescr_PythonCRepresentable(self_descr) ||
+            PyDescr_PythonCRepresentable(other_descr);
 
-        if (!(is_complex_operands && is_equality_operator)) {
+        if (!(is_complex_operands && is_equality_operator) && !is_python_scalar) {
             data_self = scalar_value(self, NULL);
-            item_self = self_descr->f->getitem(data_self, NULL);
-            if (item_self != NULL) {
-                ret = PyObject_RichCompare(item_self, other, cmp_op);
+            data_other = scalar_value(other, NULL);
+            cmp_item_self = pyscalar_self == 0 ? self_descr->f->getitem(data_self, NULL):
+                self;
+            cmp_item_other = pyscalar_other == 0 ? other_descr->f->getitem(data_other, NULL):
+                other;
+
+            if (cmp_item_self != NULL && cmp_item_other != NULL) {
+                ret = PyObject_RichCompare(cmp_item_self, cmp_item_other, cmp_op);
             }
-            Py_XDECREF(item_self);
+
+            if (pyscalar_self == 0) {
+                Py_XDECREF(cmp_item_self);
+            }
+            if (pyscalar_other == 0) {
+                Py_XDECREF(cmp_item_other);
+            }
         }
     }
     Py_XDECREF(self_descr);

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -614,8 +614,8 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
     return -1;
 }
 
-#define PyDescr_PythonCRepresentable(d) (d->type_num == NPY_LONGDOUBLE || \
-        d->type_num > NPY_CDOUBLE)
+#define PyDescr_PythonRepresentable(d) (d->type_num < NPY_LONGDOUBLE || \
+        d->type_num == NPY_CFLOAT || d->type_num == NPY_CDOUBLE)
 
 /**
  * This function attempts to compare NumPy or Python scalars
@@ -634,7 +634,7 @@ do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
     PyArray_Descr *self_descr=NULL, *other_descr=NULL;
     void *data_self, *data_other;
     int pyscalar_other, pyscalar_self;
-    int is_complex_operands, is_equality_operator, is_python_scalar;
+    int is_complex_operands, is_equality_operator, is_python_representable;
 
     pyscalar_self = descr_from_basic_scalar(self, &self_descr);
     pyscalar_other = descr_from_basic_scalar(other, &other_descr);
@@ -648,10 +648,15 @@ do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
         is_complex_operands = (PyTypeNum_ISCOMPLEX(self_descr->type_num) ||
             PyTypeNum_ISCOMPLEX(other_descr->type_num));
         is_equality_operator = (cmp_op != Py_EQ && cmp_op != Py_NE);
-        is_python_scalar = PyDescr_PythonCRepresentable(self_descr) ||
-            PyDescr_PythonCRepresentable(other_descr);
+        is_python_representable = PyDescr_PythonRepresentable(self_descr) &&
+            PyDescr_PythonRepresentable(other_descr);
 
-        if (!(is_complex_operands && is_equality_operator) && !is_python_scalar) {
+        if (!(is_complex_operands && is_equality_operator) && is_python_representable) {
+            /*
+             * If the scalar is a python built-in, we can use the object as is.
+             * Else we need to obtain the value from the operand.
+             * Note: If we reach this point, one of the scalars must be built-in.
+             */
             data_self = scalar_value(self, NULL);
             data_other = scalar_value(other, NULL);
             cmp_item_self = pyscalar_self == 0 ? self_descr->f->getitem(data_self, NULL):

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -15,6 +15,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/arrayscalars.h"
+
 #include "scalartypes.h"
 
 #include "npy_import.h"
@@ -595,10 +596,8 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
         return 1;
     }
     else if (PyLong_CheckExact(obj)) {
-        int overflow;
-        if (PyLong_AsLongAndOverflow(obj, &overflow) < 0) {
-            /* overflow must have occurred */
-            assert(overflow != 0);
+        if (PyLong_AsLong(obj) == -1 && PyErr_Occurred()) {
+            PyErr_Clear();
             return -1;
         }
         *descr = PyArray_DescrFromType(NPY_LONG);
@@ -625,33 +624,37 @@ descr_from_basic_scalar(PyObject *obj, PyArray_Descr **descr)
  */
 static PyObject*
 do_richcompare_on_scalars(PyObject *self, PyObject *other, int cmp_op) {
-    PyObject *item_self, *item_other, *ret;
-    PyArray_Descr *self_descr, *other_descr;
-    void *data_self, *data_other;
-    int pyscalar_self, pyscalar_other;
+    PyObject *item_self, *ret=NULL;
+    PyArray_Descr *self_descr=NULL, *other_descr=NULL;
+    void *data_self;
+    int pyscalar_other, pyscalar_self;
+    int is_complex_operands, is_equality_operator;
 
     pyscalar_self = descr_from_basic_scalar(self, &self_descr);
     pyscalar_other = descr_from_basic_scalar(other, &other_descr);
 
-    if (NPY_LIKELY(pyscalar_self > 0 && pyscalar_other > 0)) {
-        data_self = scalar_value(self, NULL);
-        data_other = scalar_value(other, NULL);
+    if (pyscalar_self >= 0 && pyscalar_other >= 0) {
+        /*
+         * If either of the operands are complex AND the operator is not equality,
+         * python's built-in richcompare cannot be used as it is not supported
+         */
+        is_complex_operands = (PyTypeNum_ISCOMPLEX(self_descr->type_num) ||
+            PyTypeNum_ISCOMPLEX(other_descr->type_num));
+        is_equality_operator = (cmp_op != Py_EQ && cmp_op != Py_NE);
 
-        item_self = self_descr->f->getitem(data_self, NULL);
-        item_other = other_descr->f->getitem(data_other, NULL);
-
-        Py_DECREF(item_other);
-        Py_DECREF(item_self);
-
-        ret = PyObject_RichCompare(item_self, item_other, cmp_op);
-
-        Py_DECREF(self_descr);
-        Py_DECREF(other_descr);
-
-        return ret;
+        if (!(is_complex_operands && is_equality_operator)) {
+            data_self = scalar_value(self, NULL);
+            item_self = self_descr->f->getitem(data_self, NULL);
+            if (item_self != NULL) {
+                ret = PyObject_RichCompare(item_self, other, cmp_op);
+            }
+            Py_XDECREF(item_self);
+        }
     }
+    Py_XDECREF(self_descr);
+    Py_XDECREF(other_descr);
 
-    return NULL;
+    return ret;
 }
 
 

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -16,6 +16,8 @@ types = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
          np.int_, np.uint, np.longlong, np.ulonglong,
          np.single, np.double, np.longdouble, np.csingle,
          np.cdouble, np.clongdouble]
+all_numbers_dtypes = np.typecodes['AllInteger'] + np.typecodes['AllFloat'] +\
+        np.typecodes['Complex']
 
 floating_types = np.floating.__subclasses__()
 complex_floating_types = np.complexfloating.__subclasses__()
@@ -707,3 +709,13 @@ class TestBitShifts:
                 shift_arr = np.array([shift]*32, dtype=dt)
                 res_arr = op(val_arr, shift_arr)
                 assert_equal(res_arr, res_scl)
+
+class TestComparison:
+    @pytest.mark.parametrize('type_code_rhs', all_numbers_dtypes)
+    @pytest.mark.parametrize('type_code_lhs', all_numbers_dtypes)
+    def test_numbers_compare(self, type_code_rhs, type_code_lhs):
+        rand_num = np.random.randint(0, 127)
+        a = np.dtype(type_code_rhs).type(rand_num)
+        b = np.dtype(type_code_lhs).type(rand_num)
+
+        assert_almost_equal(a, b)


### PR DESCRIPTION
## Changes:
1. Added check to see if RHS is a python number and prevent the creation of array.
2. Added bench

## Benchmarks:
<details>
<summary>Benchmarks:</summary>

<pre>                                                                                                                   
********************************************************************************                                                                          
WARNING: you have uncommitted changes --- these will NOT be benchmarked!                                                                                  
********************************************************************************                                                                          
· Creating environments                                                      
· Discovering benchmarks                                                     
·· Uninstalling from virtualenv-py3.8-Cython                                 
·· Building 933620b4 <enh_14415_fast_compare> for virtualenv-py3.8-Cython..................................                                                                                                                                                                                                          
·· Installing 933620b4 <enh_14415_fast_compare> into virtualenv-py3.8-Cython.                                                                             
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)                                                                                  
[  0.00%] · For numpy commit 4d290795 <master> (round 1/2):                                                                                               
[  0.00%] ·· Building for virtualenv-py3.8-Cython.                                                                                                                                                                                                                                                                   
[  0.00%] ·· Benchmarking virtualenv-py3.8-Cython                                                                                                         
[ 25.00%] ··· Running (bench_ufunc.CustomScalarEqual.time_scalar_equality--).                                                                             
[ 25.00%] · For numpy commit 933620b4 <enh_14415_fast_compare> (round 1/2):                                                                               
[ 25.00%] ·· Building for virtualenv-py3.8-Cython.                                                                                                        
[ 25.00%] ·· Benchmarking virtualenv-py3.8-Cython                                                                                                         
[ 50.00%] ··· Running (bench_ufunc.CustomScalarEqual.time_scalar_equality--).                                                                             
[ 50.00%] · For numpy commit 933620b4 <enh_14415_fast_compare> (round 2/2):                                                                               
[ 50.00%] ·· Benchmarking virtualenv-py3.8-Cython                                                                                                         
[ 75.00%] ··· bench_ufunc.CustomScalarEqual.time_scalar_equality                                                                                                              ok                                                                                                                                     
[ 75.00%] ··· =============== ==========                                     
                   dtype                                                                                                                                  
              --------------- ----------                                     
                 numpy.int8    439±6ms                                       
                numpy.int16    445±8ms                                       
                numpy.int32    435±10ms                                      
                numpy.int64    147±2ms                                       
                numpy.uint8    427±10ms                                      
                numpy.uint16   444±8ms                                       
                numpy.uint32   437±10ms                                      
                numpy.uint64   447±4ms                                       
               numpy.float32   471±10ms                                      
               numpy.float64   180±4ms                                                                                                                    
              =============== ==========                                                                                                                  
                                                                             
[ 75.00%] · For numpy commit 4d290795 <master> (round 2/2):                                                                                               
[ 75.00%] ·· Building for virtualenv-py3.8-Cython.                                                                                                        
[ 75.00%] ·· Benchmarking virtualenv-py3.8-Cython                                                                                                         
[100.00%] ··· bench_ufunc.CustomScalarEqual.time_scalar_equality                                                                                                              ok                                                                                                                                     
[100.00%] ··· =============== ============                                   
                   dtype                                                     
              --------------- ------------                                   
                 numpy.int8     1.35±0s                                      
                numpy.int16    1.34±0.01s                                    
                numpy.int32    1.34±0.02s                                    
                numpy.int64     147±3ms                                      
                numpy.uint8     1.34±0s                                      
                numpy.uint16    1.36±0s                                      
                numpy.uint32    1.35±0s                                      
                numpy.uint64   1.54±0.01s                                    
               numpy.float32    1.54±0s                                      
               numpy.float64    184±4ms                                      
              =============== ============                                   

       before           after         ratio                                  
     [4d290795]       [933620b4]                                             
     <master>         <enh_14415_fast_compare>                                                                                                            
-      1.34±0.01s          445±8ms     0.33  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.int16'>)                                                                                                                                                                                               
-         1.36±0s          444±8ms     0.33  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.uint16'>)                                                                                                                                                                                              
-      1.34±0.02s         435±10ms     0.33  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.int32'>)                                                                                                                                                                                               
-         1.35±0s          439±6ms     0.33  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.int8'>)                                                                                                                                                                                                
-         1.35±0s         437±10ms     0.32  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.uint32'>)                                                                                                                                                                                              
-         1.34±0s         427±10ms     0.32  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.uint8'>)                                                                                                                                                                                               
-         1.54±0s         471±10ms     0.31  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.float32'>)                                                                                                                                                                                             
-      1.54±0.01s          447±4ms     0.29  bench_ufunc.CustomScalarEqual.time_scalar_equality(<class 'numpy.uint64'>)                                                                                                                                                                                              

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.                                  
PERFORMANCE INCREASED.                                                       

</pre>
</details>

resolves: #14415

cc: @seberg , @eric-wieser , @mattip 