### PR TITLE
BUG, SIMD: Fix direactive check for AVX512BW of intrinsics npyv_tobits_*

### DIFF
--- a/numpy/core/src/common/simd/avx512/conversion.h
+++ b/numpy/core/src/common/simd/avx512/conversion.h
@@ -56,7 +56,7 @@ NPY_FINLINE npy_uint64 npyv_tobits_b8(npyv_b8 a)
 {
 #ifdef NPY_HAVE_AVX512BW_MASK
     return (npy_uint64)_cvtmask64_u64(a);
-#elif NPY_HAVE_AVX512BW
+#elif defined(NPY_HAVE_AVX512BW)
     return (npy_uint64)a;
 #else
     int mask_lo = _mm256_movemask_epi8(npyv512_lower_si256(a));
@@ -68,7 +68,7 @@ NPY_FINLINE npy_uint64 npyv_tobits_b16(npyv_b16 a)
 {
 #ifdef NPY_HAVE_AVX512BW_MASK
     return (npy_uint32)_cvtmask32_u32(a);
-#elif NPY_HAVE_AVX512BW
+#elif defined(NPY_HAVE_AVX512BW)
     return (npy_uint32)a;
 #else
     __m256i pack = _mm256_packs_epi16(


### PR DESCRIPTION
closes #17969, related to #17789 