### PR TITLE
BLD: Fixes for versioneer and setup.py sdist.

### DIFF
--- a/numpy/_version.py
+++ b/numpy/_version.py
@@ -236,7 +236,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty=",
                                           "--always", "--long",
                                           "--match", "%s*" % tag_prefix],
                                    cwd=root)

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,10 @@ if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
 # We need to import setuptools here in order for it to persist in sys.modules.
-# Its presence/absence is used in subclassing setup in numpy/distutils/core.py,
-# which may not be the most robust design.
+# Its presence/absence is used in subclassing setup in numpy/distutils/core.py.
+# However, we need to run the distutils version of sdist, so import that first
+# so that it is in sys.modules
+import numpy.distutils.command.sdist
 import setuptools
 
 # Initialize cmdclass from versioneer
@@ -158,13 +160,14 @@ class concat_license_files():
             f.write(self.bsd_text)
 
 
-sdist_class = cmdclass['sdist']
-class sdist_checked(sdist_class):
+# Need to inherit from versioneer version of sdist to get the encoded
+# version information.
+class sdist_checked(cmdclass['sdist']):
     """ check submodules on sdist to prevent incomplete tarballs """
     def run(self):
         check_submodules()
         with concat_license_files():
-            sdist_class.run(self)
+            super().run()
 
 
 def get_build_overrides():

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ if sys.version_info[:2] < (3, 7):
 
 # The first version not in the `Programming Language :: Python :: ...` classifiers above
 if sys.version_info >= (3, 10):
+    fmt = "NumPy {} may not yet support Python {}.{}."
     warnings.warn(
-        f"NumPy {VERSION} may not yet support Python "
-        f"{sys.version_info.major}.{sys.version_info.minor}.",
-        RuntimeWarning,
-    )
+        fmt.format(VERSION, *sys.version_info[:2]),
+        RuntimeWarning)
+    del fmt
 
 # BEFORE importing setuptools, remove MANIFEST. Otherwise it may not be
 # properly updated when the contents of directories change (true for distutils,

--- a/versioneer.py
+++ b/versioneer.py
@@ -647,7 +647,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty=",
                                           "--always", "--long",
                                           "--match", "%%s*" %% tag_prefix],
                                    cwd=root)
@@ -1046,7 +1046,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty=",
                                           "--always", "--long",
                                           "--match", "%s*" % tag_prefix],
                                    cwd=root)


### PR DESCRIPTION
Two fixes needed after the transition to versioneer.

1. We patch the LICENSE file for both sdist and wheel releases, making them
all "dirty", i.e., containing files that have not been committed. Having
"dirty" in the product name is bad marketing and the versioneer tool
does not have an option or style that will omit that bit of information,
so patch the versioneer files to make that tag an empty string.

2. Numpy sdist has two versions depending on whether or not `sys.modules` contains
setuptools. We need to avoid the setuptools version, see gh-7131 for details. That got
lost in the transition to versioneer, so fix that.

This also fixes an f-string in setup.py, closes  #17984.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
