### PR TITLE
MAINT: Update test_requirements and release_requirements.

### DIFF
--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -14,4 +14,4 @@ twine
 
 # building and notes
 Paver
-towncrier
+git+https://github.com/hawkowl/towncrier.git@master

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 cython==0.29.21
-wheel
+wheel<=0.35.1
 setuptools<49.2.0
 hypothesis==5.41.5
 pytest==6.0.2


### PR DESCRIPTION
Very minor changes so that `python -mpip install -r <reguirement.txt>` installs the correct versions of wheel and towncrier. We could probably update the wheel version, 0.36.1 came out Dec 4.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
