### PR TITLE
Improve numpy.zeros() performance.

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2818,15 +2818,14 @@ PyArray_Zeros(int nd, npy_intp const *dims, PyArray_Descr *type, int is_f_order)
      * but we need to look at type later.
      * */
     Py_INCREF(type);
-
-    PyObject *zero = PyLong_FromLong(0);
     
-    ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type,
-                                                type, nd, dims,
-                                                NULL, NULL,
-                                                is_f_order, zero);
+    ret = (PyArrayObject *)PyArray_NewFromDescr_int(
+            &PyArray_Type, type,
+            nd, dims, NULL, NULL,
+            is_f_order, NULL, NULL,
+            1, 0);
     if (ret != NULL && PyDataType_REFCHK(type)) {
-        PyArray_FillObjectArray(ret, zero);
+        PyArray_FillObjectArray(ret, PyLong_FromLong(0));
         if (PyErr_Occurred()) {
             Py_DECREF(ret);
             Py_DECREF(type);

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -144,8 +144,8 @@ def zeros(shape, dtype=None, order='C'):
     matrix([[0.,  0.]])
 
     """
-    a = ndarray.__new__(matrix, shape, dtype, order=order)
-    a.fill(0)
+    a = empty(shape, dtype=dtype, order=order)
+    a *= 0
     return a
 
 def identity(n,dtype=None):


### PR DESCRIPTION
Hi,

I have noticed that the performance of zeros() method could be improved when initialising the array with empty() and then multiply its values by zero.

![image](https://user-images.githubusercontent.com/26169771/102007254-ba16b000-3d27-11eb-85ce-2bab4a5003a8.png)


Hope it helps!


Regards,
Miguel

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
