### PR TITLE
[DOC] np.kron use double backticks for non-references

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -1088,8 +1088,8 @@ def kron(a, b):
     -----
     The function assumes that the number of dimensions of `a` and `b`
     are the same, if necessary prepending the smallest with ones.
-    If `a.shape = (r0,r1,..,rN)` and `b.shape = (s0,s1,...,sN)`,
-    the Kronecker product has shape `(r0*s0, r1*s1, ..., rN*SN)`.
+    If ``a.shape = (r0,r1,..,rN)`` and ``b.shape = (s0,s1,...,sN)``,
+    the Kronecker product has shape ``(r0*s0, r1*s1, ..., rN*SN)``.
     The elements are products of elements from `a` and `b`, organized
     explicitly by::
 


### PR DESCRIPTION
Some part of the docstring were between simple backticks which are
therefore marked as cross-reference, while I beleive the intended role is
likely verbatim.

---

And apologies for the few PRs I'm working on a side project about documentation and use numpy as a guinea pig; if you find those PRs annoying or that I'm nitpicking too much; I'm happy to just left those be...