### PR TITLE
DOC: Fix and extend the docstring for np.inner

### DIFF
--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -259,10 +259,10 @@ def inner(a, b):
     Returns
     -------
     out : ndarray
-        Returns the inner product of `a` and `b`. If `a` and `b` are both
+        If `a` and `b` are both
         scalars or both 1-D arrays then a scalar is returned; otherwise
         an array is returned.
-        `out.shape = (*a.shape[:-1], *b.shape[:-1])`
+        ``out.shape = (*a.shape[:-1], *b.shape[:-1])``
 
     Raises
     ------

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -304,7 +304,7 @@ def inner(a, b):
     >>> np.inner(a, b)
     2
 
-    A multidimensional examples:
+    Some multidimensional examples:
 
     >>> a = np.arange(24).reshape((2,3,4))
     >>> b = np.arange(4)

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -284,8 +284,8 @@ def inner(a, b):
 
     or explicitly::
 
-        np.inner(a, b)[i0,...,ir-1,j0,...,js-1]
-             = sum(a[i0,...,ir-1,:]*b[j0,...,js-1,:])
+        np.inner(a, b)[i0,...,ir-2,j0,...,js-2]
+             = sum(a[i0,...,ir-2,:]*b[j0,...,js-2,:])
 
     In addition `a` or `b` may be scalars, in which case::
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -259,12 +259,16 @@ def inner(a, b):
     Returns
     -------
     out : ndarray
-        `out.shape = a.shape[:-1] + b.shape[:-1]`
+        Returns the inner product of `a` and `b`. If `a` and `b` are both
+        scalars or both 1-D arrays then a scalar is returned; otherwise
+        an array is returned.
+        `out.shape = (*a.shape[:-1], *b.shape[:-1])`
 
     Raises
     ------
     ValueError
-        If the last dimension of `a` and `b` has different size.
+        If both `a` and `b` are nonscalar and their last dimensions have
+        different sizes.
 
     See Also
     --------
@@ -300,13 +304,24 @@ def inner(a, b):
     >>> np.inner(a, b)
     2
 
-    A multidimensional example:
+    A multidimensional examples:
 
     >>> a = np.arange(24).reshape((2,3,4))
     >>> b = np.arange(4)
-    >>> np.inner(a, b)
+    >>> c = np.inner(a, b)
+    >>> c.shape
+    (2, 3)
+    >>> c
     array([[ 14,  38,  62],
            [ 86, 110, 134]])
+
+    >>> a = np.arange(2).reshape((1,1,2))
+    >>> b = np.arange(6).reshape((3,2))
+    >>> c = np.inner(a, b)
+    >>> c.shape
+    (1, 1, 3)
+    >>> c
+    array([[[1, 3, 5]]])
 
     An example where `b` is a scalar:
 


### PR DESCRIPTION
This PR fixes a mistake in the description of `np.inner` function:
> More generally, if _ndim(a) = r > 0_ and _ndim(b) = s > 0_:
> ...
> ```
> np.inner(a, b)[i0,...,ir-1,j0,...,js-1]
>      = sum(a[i0,...,ir-1,:]*b[j0,...,js-1,:])
> ```
In this case, the result of `np.inner(a,b)` is a `r+s-2`-dimensional array and indexing it with `r+s` indices will raise the `IndexError`.

For further clarification I have expanded the description and added one more example.