### PR TITLE
DOC: add docstring for TooHardError

### DIFF
--- a/numpy/core/_exceptions.py
+++ b/numpy/core/_exceptions.py
@@ -117,7 +117,8 @@ class _UFuncOutputCastingError(_UFuncCastingError):
 # Exception used in shares_memory()
 @set_module('numpy')
 class TooHardError(RuntimeError):
-    pass
+    def __str__(self):
+        return ("max_work Exceeded")
 
 
 @set_module('numpy')


### PR DESCRIPTION
xref gh-10106

Added DocString function in TooHardError. Please let me know if changes are required. Since it's my first contribution.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
