### PR TITLE
BUG: Fix a MacOS build failure 

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -126,7 +126,7 @@ class GnuFCompiler(FCompiler):
                     target = '10.9'
                     s = f'Env. variable MACOSX_DEPLOYMENT_TARGET set to {target}'
                     warnings.warn(s, stacklevel=2)
-                os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
+                os.environ['MACOSX_DEPLOYMENT_TARGET'] = str(target)
             opt.extend(['-undefined', 'dynamic_lookup', '-bundle'])
         else:
             opt.append("-shared")


### PR DESCRIPTION
Backport of #17906. 

`numpy` fails to build on macOS Big Sur, on a Python 3.9.0 that was configured with `MACOSX_DEPLOYMENT_TARGET=11`:

```
    File "/private/var/folders/kf/25msxpx52j98k6qm2pgq11rh0000gn/T/pip-req-build-zkhrmwam/numpy/distutils/fcompiler/gnu.py", line 346, in get_flags_linker_so
      flags = GnuFCompiler.get_flags_linker_so(self)
    File "/private/var/folders/kf/25msxpx52j98k6qm2pgq11rh0000gn/T/pip-req-build-zkhrmwam/numpy/distutils/fcompiler/gnu.py", line 136, in get_flags_linker_so
      os.environ['MACOSX_DEPLOYMENT_TARGET'] = target
    File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/os.py", line 684, in __setitem__
      value = self.encodevalue(value)
    File "/usr/local/Cellar/python@3.9/3.9.0_4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/os.py", line 756, in encode
      raise TypeError("str expected, not %s" % type(value).__name__)
  TypeError: str expected, not int
```

On such a system, `sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')` will return `11` as an `int`, not as a `str`. And setting an environment variable to an `int` is not allowed, and fails as seen above.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
