### PR TITLE
TST: Fix crosstalk issues with polynomial str tests.

### DIFF
--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -85,7 +85,7 @@ class TestStrUnicodeSuperSubscripts:
 class TestStrAscii:
 
     @pytest.fixture(scope='class', autouse=True)
-    def use_unicode(self):
+    def use_ascii(self):
         poly.set_default_printstyle('ascii')
 
     @pytest.mark.parametrize(('inp', 'tgt'), (
@@ -161,7 +161,10 @@ class TestStrAscii:
 
 
 class TestLinebreaking:
-    poly.set_default_printstyle('ascii')
+
+    @pytest.fixture(scope='class', autouse=True)
+    def use_ascii(self):
+        poly.set_default_printstyle('ascii')
 
     def test_single_line_one_less(self):
         # With 'ascii' style, len(str(p)) is default linewidth - 1 (i.e. 74)
@@ -283,19 +286,19 @@ def test_nonnumeric_object_coefficients(coefs, tgt):
 
 class TestFormat:
     def test_format_unicode(self):
-        poly.Polynomial._use_unicode = False
+        poly.set_default_printstyle('ascii')
         p = poly.Polynomial([1, 2, 0, -1])
         assert_equal(format(p, 'unicode'), "1.0 + 2.0·x¹ + 0.0·x² - 1.0·x³")
 
     def test_format_ascii(self):
-        poly.Polynomial._use_unicode = True
+        poly.set_default_printstyle('unicode')
         p = poly.Polynomial([1, 2, 0, -1])
         assert_equal(
             format(p, 'ascii'), "1.0 + 2.0 x**1 + 0.0 x**2 - 1.0 x**3"
         )
 
     def test_empty_formatstr(self):
-        poly.Polynomial._use_unicode = False
+        poly.set_default_printstyle('ascii')
         p = poly.Polynomial([1, 2, 3])
         assert_equal(format(p), "1.0 + 2.0 x**1 + 3.0 x**2")
         assert_equal(f"{p}", "1.0 + 2.0 x**1 + 3.0 x**2")


### PR DESCRIPTION
Backport of #17957. 

Polynomial printing tests implicitly depended on calling
order, causing the test suite to fail when the test ordering was
randomized with the pytest-random plugin (gh-17954).

Two factors contributed to this:
 * Improper setting of class-level test config and
 * Poorly designed test that overrode an inherited class
   variable.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
