### PR TITLE
DOC: Parameter name typo axes -> axis in numpy.fft._pocketfft.

### DIFF
--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -160,7 +160,7 @@ def fft(a, n=None, axis=-1, norm=None):
     Raises
     ------
     IndexError
-        if `axes` is larger than the last axis of `a`.
+        If `axis` is not a valid axis of `a`.
 
     See Also
     --------
@@ -272,7 +272,7 @@ def ifft(a, n=None, axis=-1, norm=None):
     Raises
     ------
     IndexError
-        If `axes` is larger than the last axis of `a`.
+        If `axis` is not a valid axis of `a`.
 
     See Also
     --------
@@ -358,7 +358,7 @@ def rfft(a, n=None, axis=-1, norm=None):
     Raises
     ------
     IndexError
-        If `axis` is larger than the last axis of `a`.
+        If `axis` is not a valid axis of `a`.
 
     See Also
     --------
@@ -461,7 +461,7 @@ def irfft(a, n=None, axis=-1, norm=None):
     Raises
     ------
     IndexError
-        If `axis` is larger than the last axis of `a`.
+        If `axis` is not a valid axis of `a`.
 
     See Also
     --------
@@ -556,7 +556,7 @@ def hfft(a, n=None, axis=-1, norm=None):
     Raises
     ------
     IndexError
-        If `axis` is larger than the last axis of `a`.
+        If `axis` is not a valid axis of `a`.
 
     See also
     --------


### PR DESCRIPTION
The parameter name seem to have a typo in both those case and reference
axis (and not axes), this is likely due to copy past as some other
functions in this modules use axes (when several indices are required),
but other also use `axis` and have the correct spelling.

From review it also seem like previous phrasing is unclear so update
all similar entries to reflect the new phrasing.