### PR TITLE
ENH: Add annotations for `np.core.arrayprint`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -174,6 +174,18 @@ from numpy.core._ufunc_config import (
     _ErrDictOptional,
 )
 
+from numpy.core.arrayprint import (
+    set_printoptions as set_printoptions,
+    get_printoptions as get_printoptions,
+    array2string as array2string,
+    format_float_scientific as format_float_scientific,
+    format_float_positional as format_float_positional,
+    array_repr as array_repr,
+    array_str as array_str,
+    set_string_function as set_string_function,
+    printoptions as printoptions,
+)
+
 from numpy.core.numeric import (
     zeros_like as zeros_like,
     ones as ones,
@@ -281,10 +293,7 @@ append: Any
 apply_along_axis: Any
 apply_over_axes: Any
 arange: Any
-array2string: Any
-array_repr: Any
 array_split: Any
-array_str: Any
 asarray_chkfinite: Any
 asfarray: Any
 asmatrix: Any
@@ -357,8 +366,6 @@ fliplr: Any
 flipud: Any
 float128: Any
 float_: Any
-format_float_positional: Any
-format_float_scientific: Any
 format_parser: Any
 frombuffer: Any
 fromfile: Any
@@ -368,7 +375,6 @@ fromregex: Any
 fromstring: Any
 genfromtxt: Any
 get_include: Any
-get_printoptions: Any
 geterrobj: Any
 gradient: Any
 half: Any
@@ -469,7 +475,6 @@ polyint: Any
 polymul: Any
 polysub: Any
 polyval: Any
-printoptions: Any
 product: Any
 promote_types: Any
 put_along_axis: Any
@@ -495,8 +500,6 @@ savetxt: Any
 savez: Any
 savez_compressed: Any
 select: Any
-set_printoptions: Any
-set_string_function: Any
 setdiff1d: Any
 seterrobj: Any
 setxor1d: Any

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -524,7 +524,7 @@ def array2string(a, max_line_width=None, precision=None,
 
     Parameters
     ----------
-    a : array_like
+    a : ndarray
         Input array.
     max_line_width : int, optional
         Inserts newlines if text is longer than `max_line_width`.

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -146,7 +146,6 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         - 'longcomplexfloat' : composed of two 128-bit floats
         - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
         - 'object' : `np.object_` arrays
-        - 'str' : all other strings
 
         Other keys that can be used to set a group of types at once are:
 
@@ -154,7 +153,7 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         - 'int_kind' : sets 'int'
         - 'float_kind' : sets 'float' and 'longfloat'
         - 'complex_kind' : sets 'complexfloat' and 'longcomplexfloat'
-        - 'str_kind' : sets 'str' and 'numpystr'
+        - 'str_kind' : sets 'numpystr'
     floatmode : str, optional
         Controls the interpretation of the `precision` option for
         floating-point types. Can take the following values
@@ -375,8 +374,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
         'timedelta': lambda: TimedeltaFormat(data),
         'object': lambda: _object_format,
         'void': lambda: str_format,
-        'numpystr': lambda: repr_format,
-        'str': lambda: str}
+        'numpystr': lambda: repr_format}
 
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
@@ -398,8 +396,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
             for key in ['complexfloat', 'longcomplexfloat']:
                 formatdict[key] = indirect(formatter['complex_kind'])
         if 'str_kind' in fkeys:
-            for key in ['numpystr', 'str']:
-                formatdict[key] = indirect(formatter['str_kind'])
+            formatdict['numpystr'] = indirect(formatter['str_kind'])
         for key in formatdict.keys():
             if key in fkeys:
                 formatdict[key] = indirect(formatter[key])
@@ -572,7 +569,6 @@ def array2string(a, max_line_width=None, precision=None,
         - 'longcomplexfloat' : composed of two 128-bit floats
         - 'void' : type `numpy.void`
         - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
-        - 'str' : all other strings
 
         Other keys that can be used to set a group of types at once are:
 
@@ -580,7 +576,7 @@ def array2string(a, max_line_width=None, precision=None,
         - 'int_kind' : sets 'int'
         - 'float_kind' : sets 'float' and 'longfloat'
         - 'complex_kind' : sets 'complexfloat' and 'longcomplexfloat'
-        - 'str_kind' : sets 'str' and 'numpystr'
+        - 'str_kind' : sets 'numpystr'
     threshold : int, optional
         Total number of array elements which trigger summarization
         rather than full repr.

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -28,6 +28,8 @@ if sys.version_info > (3, 8):
 else:
     from typing_extensions import Literal, TypedDict
 
+_FloatMode = Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+
 class _FormatDict(TypedDict, total=False):
     bool: Callable[[bool_], str]
     int: Callable[[integer[Any]], str]
@@ -56,7 +58,7 @@ class _FormatOptions(TypedDict):
     infstr: str
     formatter: Optional[_FormatDict]
     sign: Literal["-", "+", " "]
-    floatmode: Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+    floatmode: _FloatMode
     legacy: Literal[False, "1.13"]
 
 def set_printoptions(
@@ -69,9 +71,7 @@ def set_printoptions(
     infstr: Optional[str] = ...,
     formatter: Optional[_FormatDict] = ...,
     sign: Optional[Literal["-", "+", " "]] = ...,
-    floatmode: Optional[
-        Literal["fixed", "unique", "maxprec", "maxprec_equal"]
-    ] = ...,
+    floatmode: Optional[_FloatMode] = ...,
     *,
     legacy: Optional[Literal[False, "1.13"]] = ...
 ) -> None: ...
@@ -83,7 +83,7 @@ def array2string(
     suppress_small: Optional[bool] = ...,
     separator: str = ...,
     prefix: str = ...,
-    # NOTE With the `style` argument being deprecated,
+    # NOTE: With the `style` argument being deprecated,
     # all arguments between `formatter` and `suffix` are de facto
     # keyworld-only arguments
     *,
@@ -91,7 +91,7 @@ def array2string(
     threshold: Optional[int] = ...,
     edgeitems: Optional[int] = ...,
     sign: Optional[Literal["-", "+", " "]] = ...,
-    floatmode: Optional[Literal["fixed", "unique", "maxprec", "maxprec_equal"]] = ...,
+    floatmode: Optional[_FloatMode] = ...,
     suffix: str = ...,
     legacy: Optional[Literal[False, "1.13"]] = ...,
 ) -> str: ...
@@ -139,9 +139,7 @@ def printoptions(
     infstr: Optional[str] = ...,
     formatter: Optional[_FormatDict] = ...,
     sign: Optional[Literal["-", "+", " "]] = ...,
-    floatmode: Optional[
-        Literal["fixed", "unique", "maxprec", "maxprec_equal"]
-    ] = ...,
+    floatmode: Optional[_FloatMode] = ...,
     *,
     legacy: Optional[Literal[False, "1.13"]] = ...
 ) -> _GeneratorContextManager[_FormatOptions]: ...

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -1,0 +1,148 @@
+import sys
+from types import TracebackType
+from typing import Any, Optional, Callable, Union, Type
+
+# Using a private class is by no means ideal, but it is simply a consquence
+# of a `contextlib.context` returning an instance of aformentioned class
+from contextlib import _GeneratorContextManager
+
+from numpy import (
+    ndarray,
+    generic,
+    bool_,
+    integer,
+    timedelta64,
+    datetime64,
+    floating,
+    complexfloating,
+    void,
+    str_,
+    bytes_,
+    longdouble,
+    clongdouble,
+)
+from numpy.typing import ArrayLike, _CharLike, _FloatLike
+
+if sys.version_info > (3, 8):
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal, TypedDict
+
+class _FormatDict(TypedDict, total=False):
+    bool: Callable[[bool_], str]
+    int: Callable[[integer[Any]], str]
+    timedelta: Callable[[timedelta64], str]
+    datetime: Callable[[datetime64], str]
+    float: Callable[[floating[Any]], str]
+    longfloat: Callable[[longdouble], str]
+    complexfloat: Callable[[complexfloating[Any, Any]], str]
+    longcomplexfloat: Callable[[clongdouble], str]
+    void: Callable[[void], str]
+    numpystr: Callable[[_CharLike], str]
+    object: Callable[[object], str]
+    str: Callable[[Any], str]  # Unused but still present?
+    all: Callable[[object], str]
+    int_kind: Callable[[integer[Any]], str]
+    float_kind: Callable[[floating[Any]], str]
+    complex_kind: Callable[[complexfloating[Any, Any]], str]
+    str_kind: Callable[[_CharLike], str]
+
+class _FormatOptions(TypedDict):
+    precision: int
+    threshold: int
+    edgeitems: int
+    linewidth: int
+    suppress: bool
+    nanstr: str
+    infstr: str
+    formatter: Optional[_FormatDict]
+    sign: Literal["-", "+", " "]
+    floatmode: Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+    legacy: Literal[False, "1.13"]
+
+def set_printoptions(
+    precision: Optional[int] = ...,
+    threshold: Optional[int] = ...,
+    edgeitems: Optional[int] = ...,
+    linewidth: Optional[int] = ...,
+    suppress: Optional[bool] = ...,
+    nanstr: Optional[str] = ...,
+    infstr: Optional[str] = ...,
+    formatter: Optional[_FormatDict] = ...,
+    sign: Optional[Literal["-", "+", " "]] = ...,
+    floatmode: Optional[
+        Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+    ] = ...,
+    *,
+    legacy: Optional[Literal[False, "1.13"]] = ...
+) -> None: ...
+def get_printoptions() -> _FormatOptions: ...
+def array2string(
+    a: ndarray[Any, Any],
+    max_line_width: Optional[int] = ...,
+    precision: Optional[int] = ...,
+    suppress_small: Optional[bool] = ...,
+    separator: str = ...,
+    prefix: str = ...,
+    # NOTE With the `style` argument being deprecated,
+    # all arguments between `formatter` and `suffix` are de facto
+    # keyworld-only arguments
+    *,
+    formatter: Optional[_FormatDict] = ...,
+    threshold: Optional[int] = ...,
+    edgeitems: Optional[int] = ...,
+    sign: Optional[Literal["-", "+", " "]] = ...,
+    floatmode: Optional[Literal["fixed", "unique", "maxprec", "maxprec_equal"]] = ...,
+    suffix: str = ...,
+    legacy: Optional[Literal[False, "1.13"]] = ...,
+) -> str: ...
+def format_float_scientific(
+    x: _FloatLike,
+    precision: Optional[int] = ...,
+    unique: bool = ...,
+    trim: Literal["k", ".", "0", "-"] = ...,
+    sign: bool = ...,
+    pad_left: Optional[int] = ...,
+    exp_digits: Optional[int] = ...,
+) -> str: ...
+def format_float_positional(
+    x: _FloatLike,
+    precision: Optional[int] = ...,
+    unique: bool = ...,
+    fractional: bool = ...,
+    trim: Literal["k", ".", "0", "-"] = ...,
+    sign: bool = ...,
+    pad_left: Optional[int] = ...,
+    pad_right: Optional[int] = ...,
+) -> str: ...
+def array_repr(
+    arr: ndarray[Any, Any],
+    max_line_width: Optional[int] = ...,
+    precision: Optional[int] = ...,
+    suppress_small: Optional[bool] = ...,
+) -> str: ...
+def array_str(
+    a: ndarray[Any, Any],
+    max_line_width: Optional[int] = ...,
+    precision: Optional[int] = ...,
+    suppress_small: Optional[bool] = ...,
+) -> str: ...
+def set_string_function(
+    f: Optional[Callable[[ndarray[Any, Any]], str]], repr: bool = ...
+) -> None: ...
+def printoptions(
+    precision: Optional[int] = ...,
+    threshold: Optional[int] = ...,
+    edgeitems: Optional[int] = ...,
+    linewidth: Optional[int] = ...,
+    suppress: Optional[bool] = ...,
+    nanstr: Optional[str] = ...,
+    infstr: Optional[str] = ...,
+    formatter: Optional[_FormatDict] = ...,
+    sign: Optional[Literal["-", "+", " "]] = ...,
+    floatmode: Optional[
+        Literal["fixed", "unique", "maxprec", "maxprec_equal"]
+    ] = ...,
+    *,
+    legacy: Optional[Literal[False, "1.13"]] = ...
+) -> _GeneratorContextManager[_FormatOptions]: ...

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -40,7 +40,6 @@ class _FormatDict(TypedDict, total=False):
     void: Callable[[void], str]
     numpystr: Callable[[_CharLike], str]
     object: Callable[[object], str]
-    str: Callable[[Any], str]  # Unused but still present?
     all: Callable[[object], str]
     int_kind: Callable[[integer[Any]], str]
     float_kind: Callable[[floating[Any]], str]

--- a/numpy/typing/tests/data/fail/arrayprint.py
+++ b/numpy/typing/tests/data/fail/arrayprint.py
@@ -1,0 +1,13 @@
+from typing import Callable, Any
+import numpy as np
+
+AR: np.ndarray
+func1: Callable[[Any], str]
+func2: Callable[[np.integer[Any]], str]
+
+np.array2string(AR, style=None)  # E: Unexpected keyword argument
+np.array2string(AR, legacy="1.14")  # E: incompatible type
+np.array2string(AR, sign="*")  # E: incompatible type
+np.array2string(AR, floatmode="default")  # E: incompatible type
+np.array2string(AR, formatter={"A": func1})  # E: incompatible type
+np.array2string(AR, formatter={"float": func2})  # E: Incompatible types

--- a/numpy/typing/tests/data/pass/arrayprint.py
+++ b/numpy/typing/tests/data/pass/arrayprint.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+AR = np.arange(10)
+AR.setflags(write=False)
+
+with np.printoptions():
+    np.set_printoptions(
+        precision=1,
+        threshold=2,
+        edgeitems=3,
+        linewidth=4,
+        suppress=False,
+        nanstr="Bob",
+        infstr="Bill",
+        formatter={},
+        sign="+",
+        floatmode="unique",
+    )
+    np.get_printoptions()
+    str(AR)
+
+    np.array2string(
+        AR,
+        max_line_width=5,
+        precision=2,
+        suppress_small=True,
+        separator=";",
+        prefix="test",
+        threshold=5,
+        floatmode="fixed",
+        suffix="?",
+        legacy="1.13",
+    )
+    np.format_float_scientific(1, precision=5)
+    np.format_float_positional(1, trim="k")
+    np.array_repr(AR)
+    np.array_str(AR)

--- a/numpy/typing/tests/data/reveal/arrayprint.py
+++ b/numpy/typing/tests/data/reveal/arrayprint.py
@@ -1,0 +1,19 @@
+from typing import Any, Callable
+import numpy as np
+
+AR: np.ndarray[Any, Any]
+func_float: Callable[[np.floating[Any]], str]
+func_int: Callable[[np.integer[Any]], str]
+
+reveal_type(np.get_printoptions())  # E: TypedDict
+reveal_type(np.array2string(  # E: str
+    AR, formatter={'float_kind': func_float, 'int_kind': func_int}
+))
+reveal_type(np.format_float_scientific(1.0))  # E: str
+reveal_type(np.format_float_positional(1))  # E: str
+reveal_type(np.array_repr(AR))  # E: str
+reveal_type(np.array_str(AR))  # E: str
+
+reveal_type(np.printoptions())  # E: contextlib._GeneratorContextManager
+with np.printoptions() as dct:
+    reveal_type(dct)  # E: TypedDict


### PR DESCRIPTION
Per the title: this PR adds annotations for all array-printing-related functions in `np.core.arrayprint`.

@charris continuing from https://github.com/numpy/numpy/pull/7859#issuecomment-747588637: 
The signature of `np.set_printoptions` can quite easily be annotated as it turns out,
so annotations can definitely help here with aforementioned issue.
