### PR TITLE
DOC: Fix a couple of reference to verbatim and vice versa

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -185,7 +185,7 @@ add_newdoc('numpy.core.umath', 'arccos',
     Notes
     -----
     `arccos` is a multivalued function: for each `x` there are infinitely
-    many numbers `z` such that `cos(z) = x`. The convention is to return
+    many numbers `z` such that ``cos(z) = x``. The convention is to return
     the angle `z` whose real part lies in `[0, pi]`.
 
     For real-valued input data types, `arccos` always returns real output.
@@ -193,7 +193,7 @@ add_newdoc('numpy.core.umath', 'arccos',
     it yields ``nan`` and sets the `invalid` floating point error flag.
 
     For complex-valued input, `arccos` is a complex analytic function that
-    has branch cuts `[-inf, -1]` and `[1, inf]` and is continuous from
+    has branch cuts ``[-inf, -1]`` and `[1, inf]` and is continuous from
     above on the former and from below on the latter.
 
     The inverse `cos` is also known as `acos` or cos^-1.
@@ -245,7 +245,7 @@ add_newdoc('numpy.core.umath', 'arccosh',
     -----
     `arccosh` is a multivalued function: for each `x` there are infinitely
     many numbers `z` such that `cosh(z) = x`. The convention is to return the
-    `z` whose imaginary part lies in `[-pi, pi]` and the real part in
+    `z` whose imaginary part lies in ``[-pi, pi]`` and the real part in
     ``[0, inf]``.
 
     For real-valued input data types, `arccosh` always returns real output.
@@ -406,7 +406,7 @@ add_newdoc('numpy.core.umath', 'arctan',
     it yields ``nan`` and sets the `invalid` floating point error flag.
 
     For complex-valued input, `arctan` is a complex analytic function that
-    has [`1j, infj`] and [`-1j, -infj`] as branch cuts, and is continuous
+    has [``1j, infj``] and [``-1j, -infj``] as branch cuts, and is continuous
     from the left on the former and from the right on the latter.
 
     The inverse tangent is also known as `atan` or tan^{-1}.
@@ -544,7 +544,7 @@ add_newdoc('numpy.core.umath', 'arctanh',
     Notes
     -----
     `arctanh` is a multivalued function: for each `x` there are infinitely
-    many numbers `z` such that `tanh(z) = x`. The convention is to return
+    many numbers `z` such that ``tanh(z) = x``. The convention is to return
     the `z` whose imaginary part lies in `[-pi/2, pi/2]`.
 
     For real-valued input data types, `arctanh` always returns real output.
@@ -765,7 +765,7 @@ add_newdoc('numpy.core.umath', 'ceil',
     Return the ceiling of the input, element-wise.
 
     The ceil of the scalar `x` is the smallest integer `i`, such that
-    `i >= x`.  It is often denoted as :math:`\\lceil x \\rceil`.
+    ``i >= x``.  It is often denoted as :math:`\\lceil x \\rceil`.
 
     Parameters
     ----------

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -708,8 +708,8 @@ def polyval(p, x):
 
         ``p[0]*x**(N-1) + p[1]*x**(N-2) + ... + p[N-2]*x + p[N-1]``
 
-    If `x` is a sequence, then `p(x)` is returned for each element of `x`.
-    If `x` is another polynomial then the composite polynomial `p(x(t))`
+    If `x` is a sequence, then ``p(x)`` is returned for each element of ``x``.
+    If `x` is another polynomial then the composite polynomial ``p(x(t))``
     is returned.
 
     Parameters

--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -572,10 +572,10 @@ def arctanh(x):
     Compute the inverse hyperbolic tangent of `x`.
 
     Return the "principal value" (for a description of this, see
-    `numpy.arctanh`) of `arctanh(x)`. For real `x` such that
-    `abs(x) < 1`, this is a real number.  If `abs(x) > 1`, or if `x` is
+    `numpy.arctanh`) of ``arctanh(x)``. For real `x` such that
+    ``abs(x) < 1``, this is a real number.  If `abs(x) > 1`, or if `x` is
     complex, the result is complex. Finally, `x = 1` returns``inf`` and
-    `x=-1` returns ``-inf``.
+    ``x=-1`` returns ``-inf``.
 
     Parameters
     ----------
@@ -597,7 +597,7 @@ def arctanh(x):
     -----
     For an arctanh() that returns ``NAN`` when real `x` is not in the
     interval ``(-1,1)``, use `numpy.arctanh` (this latter, however, does
-    return +/-inf for `x = +/-1`).
+    return +/-inf for ``x = +/-1``).
 
     Examples
     --------

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -156,7 +156,7 @@ def polyfromroots(roots):
 
     .. math:: p(x) = (x - r_0) * (x - r_1) * ... * (x - r_n),
 
-    where the `r_n` are the roots specified in `roots`.  If a zero has
+    where the ``r_n`` are the roots specified in `roots`.  If a zero has
     multiplicity n, then it must appear in `roots` n times. For instance,
     if 2 is a root of multiplicity three and 3 is a root of multiplicity 2,
     then `roots` looks something like [2, 2, 2, 3, 3]. The roots can appear
@@ -192,11 +192,11 @@ def polyfromroots(roots):
     Notes
     -----
     The coefficients are determined by multiplying together linear factors
-    of the form `(x - r_i)`, i.e.
+    of the form ``(x - r_i)``, i.e.
 
     .. math:: p(x) = (x - r_0) (x - r_1) ... (x - r_n)
 
-    where ``n == len(roots) - 1``; note that this implies that `1` is always
+    where ``n == len(roots) - 1``; note that this implies that ``1`` is always
     returned for :math:`a_n`.
 
     Examples

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -481,7 +481,7 @@ def assert_almost_equal(actual,desired,decimal=7,err_msg='',verbose=True):
               instead of this function for more consistent floating point
               comparisons.
 
-    The test verifies that the elements of ``actual`` and ``desired`` satisfy.
+    The test verifies that the elements of `actual` and `desired` satisfy.
 
         ``abs(desired-actual) < 1.5 * 10**(-decimal)``
 


### PR DESCRIPTION
This update a couple of references (single backticks) that actually are not to
verbatim/code (double backticks); and a couple of verbatim to reference
when they do actually exists and can be resolved in context.

    I probably missed other; and stayed simple but spoted a few other
    inconsistencies that I did not fix:

      - some ``...`` could actually be :math:`...` but not always clear if
      it would be better.
      - some intervals are [``...``], other are ``[...]``

    I guess they could be discussed individually; it was mostly the failing
    references that bothered me.


--- 

Apologies I'm over-indenting the PR description as otherwise github interprets the backtick in it and it does not make much sense anymore.