### PR TITLE
MAINT: Fix annotations warning.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -176,7 +176,7 @@ jobs:
 
   pypy37:
     needs: smoke_test
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -176,7 +176,7 @@ jobs:
 
   pypy37:
     needs: smoke_test
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
To clear the annotations warning in workflow, I would like to suggest this change.
(Initial Warning obtained in summary part of workflow actions : Ubuntu-latest workflows will use Ubuntu-20.04 soon)

Changed runs-on in build_test.yml from ubuntu-latest to Ubuntu-20.04