### PR TITLE
MAINT: Add dist_info to "other" setup.py commands.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,8 @@ def parse_setuppy_commands():
                      '--maintainer', '--maintainer-email', '--contact',
                      '--contact-email', '--url', '--license', '--description',
                      '--long-description', '--platforms', '--classifiers',
-                     '--keywords', '--provides', '--requires', '--obsoletes']
+                     '--keywords', '--provides', '--requires', '--obsoletes',
+                     'version',]
 
     for command in info_commands:
         if command in args:
@@ -251,8 +252,7 @@ def parse_setuppy_commands():
     # below and not standalone.  Hence they're not added to good_commands.
     good_commands = ('develop', 'sdist', 'build', 'build_ext', 'build_py',
                      'build_clib', 'build_scripts', 'bdist_wheel', 'bdist_rpm',
-                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg', 'build_src',
-                     'version')
+                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg', 'build_src',)
 
     for command in good_commands:
         if command in args:
@@ -340,17 +340,13 @@ def parse_setuppy_commands():
 
     # Commands that do more than print info, but also don't need Cython and
     # template parsing.
-    other_commands = ['egg_info', 'install_egg_info', 'rotate']
+    other_commands = ['egg_info', 'install_egg_info', 'rotate', 'dist_info']
     for command in other_commands:
         if command in args:
             return False
 
     # If we got here, we didn't detect what setup.py command was given
-    import warnings
-    warnings.warn("Unrecognized setuptools command, proceeding with "
-                  "generating Cython sources and expanding templates",
-                  stacklevel=2)
-    return True
+    raise RuntimeError("Unrecognized setuptools command: {}".format(args))
 
 
 def get_docs_url():
@@ -416,7 +412,7 @@ def setup_package():
         # Raise errors for unsupported commands, improve help output, etc.
         run_build = parse_setuppy_commands()
 
-    if run_build and 'version' not in sys.argv:
+    if run_build:
         # patches distutils, even though we don't use it
         #from setuptools import setup
         from numpy.distutils.core import setup


### PR DESCRIPTION
The following changes are made to 'setup.py'.
    
- Add `dist_info` to the valid `setup.py` commands. The `dist_info` command was added to setuptools in 2017 and we were 
following the unrecognized command path in `setup.py` which raised a warning.
- Add `version` to the recognized information commands, it came in with the move to versioneer.
- Include the arguments passed to `setup.py` when the unrecognized command warning is raised. This will aid in maintaining the command checks in the future.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
