### PR TITLE
BLD,DOC: pin sphinx to 3.3.1

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.2
+sphinx==3.3.1
 numpydoc==1.1.0
 ipython
 scipy


### PR DESCRIPTION
Fixes gh-18043

It seems sphinx 3.4.0, released yesterday, broke our use of autosummary. We get lots of errors like
```
/home/matti/miniconda3/envs/test/lib/python3.8/site-packages/numpy/__init__.py:docstring of numpy.bool_.rst:62:  \
    WARNING: autosummary: failed to import astype
```