### PR TITLE
ENH: libdivide for unsigned integers

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -135,10 +135,10 @@ class CustomScalar(Benchmark):
 
 
 class CustomScalarFloorDivideInt(Benchmark):
-    params = ([np.int8, np.int16, np.int32, np.int64], [8, -8, 43, -43, 0])
+    params = ([*np.sctypes['int'], *np.sctypes['uint']], [8, -8, 43, -43, 0])
     param_names = ['dtype', 'divisors']
-    max_value = 10**7
-    min_value = -10**7
+    max_value = 10**2
+    min_value = -10**2
 
     def setup(self, dtype, divisor):
         iinfo = np.iinfo(dtype)

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -997,9 +997,10 @@ NPY_NO_EXPORT void
 /**end repeat**/
 
 /**begin repeat
- * #TYPE = UBYTE, USHORT, UINT, ULONG, ULONGLONG#
- * #type = npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong#
- * #c    = u,u,u,ul,ull#
+ * #TYPE  = UBYTE, USHORT, UINT, ULONG, ULONGLONG#
+ * #TYPE2 = BYTE, SHORT, INT, LONG, LONGLONG#
+ * #type  = npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong#
+ * #c     = u,u,u,ul,ull#
  */
 
 NPY_NO_EXPORT NPY_GCC_OPT_3 void
@@ -1014,18 +1015,57 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 void
     UNARY_LOOP_FAST(@type@, @type@, *out = in > 0 ? 1 : 0);
 }
 
+/* Libdivide only supports 32 and 64 bit types
+ * We try to pick the best possible one */
+#if NPY_BITSOF_@TYPE2@ <= 32
+#define libdivide_@type@_t libdivide_u32_t
+#define libdivide_@type@_gen libdivide_u32_gen
+#define libdivide_@type@_do libdivide_u32_do
+#else
+#define libdivide_@type@_t libdivide_u64_t
+#define libdivide_@type@_gen libdivide_u64_gen
+#define libdivide_@type@_do libdivide_u64_do
+#endif
 NPY_NO_EXPORT void
 @TYPE@_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
+    BINARY_DEFS
+
+    /* When the divisor is a constant, use libdivide for faster division */
+    if (steps[1] == 0) {
+        /* In case of empty array, just return */
+        if (n == 0) {
+            return;
+        }
+
         const @type@ in2 = *(@type@ *)ip2;
+
+        /* If divisor is 0, we need not compute anything */
         if (in2 == 0) {
             npy_set_floatstatus_divbyzero();
-            *((@type@ *)op1) = 0;
+            BINARY_LOOP_SLIDING {
+                *((@type@ *)op1) = 0;
+            }
         }
         else {
-            *((@type@ *)op1)= in1/in2;
+            struct libdivide_@type@_t fast_d = libdivide_@type@_gen(in2);
+            BINARY_LOOP_SLIDING {
+                const @type@ in1 = *(@type@ *)ip1;
+                *((@type@ *)op1) = libdivide_@type@_do(in1, &fast_d);
+            }
+        }
+    }
+    else {
+        BINARY_LOOP_SLIDING {
+            const @type@ in1 = *(@type@ *)ip1;
+            const @type@ in2 = *(@type@ *)ip2;
+            if (in2 == 0) {
+                npy_set_floatstatus_divbyzero();
+                *((@type@ *)op1) = 0;
+            }
+            else {
+                *((@type@ *)op1)= in1/in2;
+            }
         }
     }
 }

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -250,13 +250,18 @@ class TestDivision:
         assert_equal(x % 100, [5, 10, 90, 0, 95, 90, 10, 0, 80])
 
     @pytest.mark.parametrize("input_dtype",
-            [np.int8, np.int16, np.int32, np.int64])
+            [*np.sctypes['int'], *np.sctypes['uint']])
     def test_division_int_boundary(self, input_dtype):
         iinfo = np.iinfo(input_dtype)
 
-        # Create list with min, 25th percentile, 0, 75th percentile, max
-        lst = [iinfo.min, iinfo.min//2, 0, iinfo.max//2, iinfo.max]
-        divisors = [iinfo.min, iinfo.min//2, iinfo.max//2, iinfo.max]
+        # Unsigned: Create list with 0, 25th, 50th, 75th percentile and max
+        if iinfo.min == 0:
+            lst = [0, iinfo.max//4, iinfo.max//2, int(iinfo.max/1.33), iinfo.max]
+            divisors = [iinfo.max//4, iinfo.max//2, int(iinfo.max/1.33), iinfo.max]
+        # Signed: Create list with min, 25th percentile, 0, 75th percentile, max
+        else:
+            lst = [iinfo.min, iinfo.min//2, 0, iinfo.max//2, iinfo.max]
+            divisors = [iinfo.min, iinfo.min//2, iinfo.max//2, iinfo.max]
         a = np.array(lst, dtype=input_dtype)
 
         for divisor in divisors:
@@ -926,7 +931,7 @@ class TestSpecialFloats:
             assert_raises(FloatingPointError, np.log, np.float32(-np.inf))
             assert_raises(FloatingPointError, np.log, np.float32(-1.0))
 
-        # See https://github.com/numpy/numpy/issues/18005 
+        # See https://github.com/numpy/numpy/issues/18005
         with assert_no_warnings():
             a = np.array(1e9, dtype='float32')
             np.log(a)


### PR DESCRIPTION
## Changes:
1. Added libdivide for unsinged types
2. Added bench and UT for above

## Benchmarks:
<details>
<summary>Benchmarks:</summary>

<pre> 
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython
·· Installing e1cb8503 <enh_libdivide_uints> into virtualenv-py3.7-Cython
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For numpy commit 11cba182 <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 25.00%] ··· Running (bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int--).
[ 25.00%] · For numpy commit e1cb8503 <enh_libdivide_uints> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 50.00%] ··· Running (bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int--).
[ 50.00%] · For numpy commit e1cb8503 <enh_libdivide_uints> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 75.00%] ··· ...omScalarFloorDivideInt.time_floor_divide_int                 ok
[ 75.00%] ··· ============== ========== =============
                  dtype       divisors               
              -------------- ---------- -------------
                numpy.int8       8       1.54±0.01μs 
                numpy.int8       -8        1.52±0μs  
                numpy.int8       43      1.68±0.01μs 
                numpy.int8      -43      1.67±0.01μs 
                numpy.int8       0       2.28±0.02μs 
               numpy.int16       8       1.60±0.01μs 
               numpy.int16       -8      1.58±0.02μs 
               numpy.int16       43      1.66±0.02μs 
               numpy.int16      -43      1.69±0.05μs 
               numpy.int16       0       2.38±0.04μs 
               numpy.int32       8       1.60±0.01μs 
               numpy.int32       -8      1.61±0.01μs 
               numpy.int32       43      1.69±0.01μs 
               numpy.int32      -43      1.71±0.01μs 
               numpy.int32       0       2.42±0.01μs 
               numpy.int64       8       1.53±0.01μs 
               numpy.int64       -8      1.52±0.01μs 
               numpy.int64       43      1.59±0.02μs 
               numpy.int64      -43      1.59±0.01μs 
               numpy.int64       0       2.29±0.02μs 
               numpy.uint8       8       1.32±0.01μs 
               numpy.uint8       -8      1.72±0.01μs 
               numpy.uint8       43      1.33±0.02μs 
               numpy.uint8      -43      1.78±0.05μs 
               numpy.uint8       0       2.29±0.04μs 
               numpy.uint16      8       1.37±0.03μs 
               numpy.uint16      -8      1.74±0.02μs 
               numpy.uint16      43      1.37±0.02μs 
               numpy.uint16     -43      1.82±0.02μs 
               numpy.uint16      0       2.35±0.06μs 
               numpy.uint32      8       1.43±0.03μs 
               numpy.uint32      -8      1.65±0.03μs 
               numpy.uint32      43      1.44±0.03μs 
               numpy.uint32     -43      1.69±0.03μs 
               numpy.uint32      0       2.44±0.04μs 
               numpy.uint64      8       1.47±0.03μs 
               numpy.uint64      -8      3.04±0.03μs 
               numpy.uint64      43      1.49±0.01μs 
               numpy.uint64     -43      2.81±0.03μs 
               numpy.uint64      0       2.45±0.05μs 
              ============== ========== =============

[ 75.00%] ···· For parameters: <class 'numpy.int8'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int16'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int32'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int64'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint8'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint16'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint32'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint64'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor

[ 75.00%] · For numpy commit 11cba182 <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[100.00%] ··· ...omScalarFloorDivideInt.time_floor_divide_int                 ok
[100.00%] ··· ============== ========== =============
                  dtype       divisors               
              -------------- ---------- -------------
                numpy.int8       8         1.53±0μs  
                numpy.int8       -8      1.54±0.02μs 
                numpy.int8       43      1.65±0.01μs 
                numpy.int8      -43      1.66±0.01μs 
                numpy.int8       0       2.26±0.04μs 
               numpy.int16       8       1.59±0.01μs 
               numpy.int16       -8      1.62±0.01μs 
               numpy.int16       43      1.61±0.03μs 
               numpy.int16      -43      1.68±0.02μs 
               numpy.int16       0       2.36±0.04μs 
               numpy.int32       8       1.63±0.02μs 
               numpy.int32       -8      1.61±0.01μs 
               numpy.int32       43        1.68±0μs  
               numpy.int32      -43      1.70±0.01μs 
               numpy.int32       0       2.42±0.05μs 
               numpy.int64       8       1.51±0.02μs 
               numpy.int64       -8      1.49±0.01μs 
               numpy.int64       43      1.58±0.01μs 
               numpy.int64      -43      1.58±0.02μs 
               numpy.int64       0       2.27±0.02μs 
               numpy.uint8       8       1.51±0.02μs 
               numpy.uint8       -8        1.73±0μs  
               numpy.uint8       43      1.51±0.04μs 
               numpy.uint8      -43      1.80±0.01μs 
               numpy.uint8       0       2.44±0.02μs 
               numpy.uint16      8       1.62±0.02μs 
               numpy.uint16      -8      1.77±0.03μs 
               numpy.uint16      43      1.60±0.01μs 
               numpy.uint16     -43        1.84±0μs  
               numpy.uint16      0       2.48±0.02μs 
               numpy.uint32      8       1.64±0.01μs 
               numpy.uint32      -8      1.63±0.02μs 
               numpy.uint32      43      1.64±0.02μs 
               numpy.uint32     -43      1.69±0.01μs 
               numpy.uint32      0       2.51±0.01μs 
               numpy.uint64      8       1.68±0.02μs 
               numpy.uint64      -8      3.01±0.05μs 
               numpy.uint64      43      1.68±0.01μs 
               numpy.uint64     -43      2.82±0.02μs 
               numpy.uint64      0       2.57±0.01μs 
              ============== ========== =============

[100.00%] ···· For parameters: <class 'numpy.int8'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int16'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int32'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.int64'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint8'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint16'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint32'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor
               
               For parameters: <class 'numpy.uint64'>, 0
               /home/ganesh/open-source/numpy/benchmarks/benchmarks/bench_ufunc.py:150: RuntimeWarning: divide by zero encountered in floor_divide
                 self.x // divisor

       before           after         ratio
     [11cba182]       [e1cb8503]
     <master>         <enh_libdivide_uints>
-     2.48±0.02μs      2.35±0.06μs     0.95  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint16'>, 0)
-     2.44±0.02μs      2.29±0.04μs     0.94  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint8'>, 0)
-     1.68±0.01μs      1.49±0.01μs     0.88  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint64'>, 43)
-     1.64±0.02μs      1.44±0.03μs     0.88  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint32'>, 43)
-     1.51±0.04μs      1.33±0.02μs     0.88  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint8'>, 43)
-     1.68±0.02μs      1.47±0.03μs     0.88  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint64'>, 8)
-     1.51±0.02μs      1.32±0.01μs     0.87  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint8'>, 8)
-     1.64±0.01μs      1.43±0.03μs     0.87  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint32'>, 8)
-     1.60±0.01μs      1.37±0.02μs     0.85  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint16'>, 43)
-     1.62±0.02μs      1.37±0.03μs     0.85  bench_ufunc.CustomScalarFloorDivideInt.time_floor_divide_int(<class 'numpy.uint16'>, 8)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
********************************************************************************
WARNING: you have uncommitted changes --- these will NOT be benchmarked!
********************************************************************************
</pre>
</details>

Note: I saw unsigned ints was missed when I was working on scalar fastpaths, so added it here.

Continues: #17727