### PR TITLE
DOC: add missing details to linalg.lstsq docstring

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2171,13 +2171,14 @@ def lstsq(a, b, rcond="warn"):
     r"""
     Return the least-squares solution to a linear matrix equation.
 
-    Computes the vector x that approximatively solves the equation
+    Computes the vector `x` that approximatively solves the equation
     ``a @ x = b``. The equation may be under-, well-, or over-determined
     (i.e., the number of linearly independent rows of `a` can be less than,
     equal to, or greater than its number of linearly independent columns).
     If `a` is square and of full rank, then `x` (but for round-off error)
     is the "exact" solution of the equation. Else, `x` minimizes the
-    Euclidean 2-norm :math:`|| b - a x ||`.
+    Euclidean 2-norm :math:`||b-ax||`. If there are multiple minimizing 
+    solutions, the one with the smallest 2-norm :math:`||x||` is returned.
 
     Parameters
     ----------

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2177,7 +2177,7 @@ def lstsq(a, b, rcond="warn"):
     equal to, or greater than its number of linearly independent columns).
     If `a` is square and of full rank, then `x` (but for round-off error)
     is the "exact" solution of the equation. Else, `x` minimizes the
-    Euclidean 2-norm :math:`||b-ax||`. If there are multiple minimizing 
+    Euclidean 2-norm :math:`||b - ax||`. If there are multiple minimizing 
     solutions, the one with the smallest 2-norm :math:`||x||` is returned.
 
     Parameters


### PR DESCRIPTION
It turns out that `linalg.lstsq` also minimizes the 2-norm of `x` when `a` is rank-deficient. I found that by searching [the documentation for the LAPACK library](https://www.netlib.org/lapack/lug/node27.html), which is the current implementation of `lstsq`.

This PR rewrites the docstring for `linalg.lstsq` such that it contains details for all cases.