### PR TITLE
MAINT: CPUs that support unaligned access.

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -10,14 +10,6 @@
 #include <npy_config.h>
 #endif
 
-// int*, int64* should be propertly aligned on ARMv7 to avoid bus error
-#if !defined(NPY_STRONG_ALIGNMENT) && defined(__arm__) && !(defined(__aarch64__) || defined(_M_ARM64))
-#define NPY_STRONG_ALIGNMENT 1
-#endif
-#if !defined(NPY_STRONG_ALIGNMENT)
-#define NPY_STRONG_ALIGNMENT 0
-#endif
-
 // compile time environment variables
 #ifndef NPY_RELAXED_STRIDES_CHECKING
     #define NPY_RELAXED_STRIDES_CHECKING 0

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -109,41 +109,17 @@
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)
 #endif
-/*
-Unaligned memory accesses occur when you try to read N bytes of data starting
-from an address that is not evenly divisible by N (i.e. addr % N != 0).
-For example, reading 4 bytes of data from address 0x10004 is fine, but
-reading 4 bytes of data from address 0x10005 would be an unaligned memory
-access.In reality, only a few architectures supports unaligned memory access.
-The effects of performing an unaligned memory access vary from architecture
-to architecture. It would be easy to write a whole document on the differences
-here; a summary of the common scenarios is presented below:
 
- 1. Some architectures are able to perform unaligned memory accesses
-   transparently, but there is usually a significant performance cost.
-   (eg:X86, AMD64, ARM64, powerpc64)
- 2. Some architectures raise processor exceptions when unaligned accesses
-   happen. The exception handler is able to correct the unaligned access,
-   at significant cost to performance.
-   (eg:ARM32, Alpha)
- 3. Some architectures raise processor exceptions when unaligned accesses
-   happen, but the exceptions do not contain enough information for the
-   unaligned access to be corrected.
-   (eg:MIPS, Sparc)
- 4. Some architectures are not capable of unaligned memory access, but will
-   silently perform a different memory access to the one that was requested,
-   resulting in a subtle code bug that is hard to detect!
-   (eg:RISCV, ia64)
-It should be obvious from the above that strong alignment should defined in
-all situations except No.1.
-
-NOTE: in x86 platform this flag can only be enabled if autovectorization is disabled.
+/* 
+ * Except for the following architectures, memory access is limited to the natural
+ * alignment of data types otherwise it may lead to bus error or performance regression.
+ * For more details about unaligned access, see https://www.kernel.org/doc/Documentation/unaligned-memory-access.txt.
 */
 #if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64) || defined(__aarch64__) || defined(__powerpc64__)
-    #define NPY_STRONG_ALIGNMENT_REQUIRED 0
+    #define NPY_ALIGNMENT_REQUIRED 0
 #endif
-#ifndef NPY_STRONG_ALIGNMENT_REQUIRED
-    #define NPY_STRONG_ALIGNMENT_REQUIRED 1
+#ifndef NPY_ALIGNMENT_REQUIRED
+    #define NPY_ALIGNMENT_REQUIRED 1
 #endif
 
 #endif

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -109,12 +109,41 @@
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)
 #endif
+/*
+Unaligned memory accesses occur when you try to read N bytes of data starting
+from an address that is not evenly divisible by N (i.e. addr % N != 0).
+For example, reading 4 bytes of data from address 0x10004 is fine, but
+reading 4 bytes of data from address 0x10005 would be an unaligned memory
+access.In reality, only a few architectures supports unaligned memory access.
+The effects of performing an unaligned memory access vary from architecture
+to architecture. It would be easy to write a whole document on the differences
+here; a summary of the common scenarios is presented below:
 
+ 1. Some architectures are able to perform unaligned memory accesses
+   transparently, but there is usually a significant performance cost.
+   (eg:X86, AMD64, ARM64, powerpc64)
+ 2. Some architectures raise processor exceptions when unaligned accesses
+   happen. The exception handler is able to correct the unaligned access,
+   at significant cost to performance.
+   (eg:ARM32, Alpha)
+ 3. Some architectures raise processor exceptions when unaligned accesses
+   happen, but the exceptions do not contain enough information for the
+   unaligned access to be corrected.
+   (eg:MIPS, Sparc)
+ 4. Some architectures are not capable of unaligned memory access, but will
+   silently perform a different memory access to the one that was requested,
+   resulting in a subtle code bug that is hard to detect!
+   (eg:RISCV, ia64)
+It should be obvious from the above that strong alignment should defined in
+all situations except No.1.
+
+NOTE: in x86 platform this flag can only be enabled if autovectorization is disabled.
+*/
 #if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64) || defined(__aarch64__) || defined(__powerpc64__)
-    #define NPY_STRONG_ALIGNMENT 0
+    #define NPY_STRONG_ALIGNMENT_REQUIRED 0
 #endif
-#ifndef NPY_STRONG_ALIGNMENT
-    #define NPY_STRONG_ALIGNMENT 1
+#ifndef NPY_STRONG_ALIGNMENT_REQUIRED
+    #define NPY_STRONG_ALIGNMENT_REQUIRED 1
 #endif
 
 #endif

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -110,10 +110,11 @@
     information about your platform (OS, CPU and compiler)
 #endif
 
-#if (defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64))
-#define NPY_CPU_HAVE_UNALIGNED_ACCESS 1
-#else
+// int*, int64* should be propertly aligned on ARMv7 to avoid bus error
+#if defined(__arm__) && !(defined(__aarch64__) || defined(_M_ARM64))
 #define NPY_CPU_HAVE_UNALIGNED_ACCESS 0
+#else
+#define NPY_CPU_HAVE_UNALIGNED_ACCESS 1
 #endif
 
 #endif

--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -110,11 +110,11 @@
     information about your platform (OS, CPU and compiler)
 #endif
 
-// int*, int64* should be propertly aligned on ARMv7 to avoid bus error
-#if defined(__arm__) && !(defined(__aarch64__) || defined(_M_ARM64))
-#define NPY_CPU_HAVE_UNALIGNED_ACCESS 0
-#else
-#define NPY_CPU_HAVE_UNALIGNED_ACCESS 1
+#if defined(NPY_CPU_X86) || defined(NPY_CPU_AMD64) || defined(__aarch64__) || defined(__powerpc64__)
+    #define NPY_STRONG_ALIGNMENT 0
+#endif
+#ifndef NPY_STRONG_ALIGNMENT
+    #define NPY_STRONG_ALIGNMENT 1
 #endif
 
 #endif

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -267,7 +267,7 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-        if (!NPY_STRONG_ALIGNMENT && needle == 0 && stride == 1) {
+        if (!NPY_STRONG_ALIGNMENT_REQUIRED && needle == 0 && stride == 1) {
             /* iterate until last multiple of 4 */
             char * block_end = haystack + size - (size % sizeof(unsigned int));
             while (p < block_end) {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -267,7 +267,7 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-        if (!NPY_STRONG_ALIGNMENT_REQUIRED && needle == 0 && stride == 1) {
+        if (!NPY_ALIGNMENT_REQUIRED && needle == 0 && stride == 1) {
             /* iterate until last multiple of 4 */
             char * block_end = haystack + size - (size % sizeof(unsigned int));
             while (p < block_end) {

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -267,7 +267,7 @@ npy_memchr(char * haystack, char needle,
     }
     else {
         /* usually find elements to skip path */
-        if (NPY_CPU_HAVE_UNALIGNED_ACCESS && needle == 0 && stride == 1) {
+        if (!NPY_STRONG_ALIGNMENT && needle == 0 && stride == 1) {
             /* iterate until last multiple of 4 */
             char * block_end = haystack + size - (size % sizeof(unsigned int));
             while (p < block_end) {

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1521,7 +1521,7 @@ pack_inner(const char *inptr,
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
             if(out_stride == 1 && 
-                (!NPY_STRONG_ALIGNMENT_REQUIRED || isAligned)) {
+                (!NPY_ALIGNMENT_REQUIRED || isAligned)) {
                 npy_uint64 *ptr64 = (npy_uint64*)outptr;
             #if NPY_SIMD_WIDTH == 16
                 npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1521,7 +1521,7 @@ pack_inner(const char *inptr,
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
             if(out_stride == 1 && 
-                (!NPY_STRONG_ALIGNMENT || isAligned)) {
+                (!NPY_STRONG_ALIGNMENT_REQUIRED || isAligned)) {
                 npy_uint64 *ptr64 = (npy_uint64*)outptr;
             #if NPY_SIMD_WIDTH == 16
                 npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1521,7 +1521,7 @@ pack_inner(const char *inptr,
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
             if(out_stride == 1 && 
-                (!NPY_STRONG_ALIGNMENT || isAligned)) {
+                (NPY_CPU_HAVE_UNALIGNED_ACCESS || isAligned)) {
                 npy_uint64 *ptr64 = (npy_uint64*)outptr;
             #if NPY_SIMD_WIDTH == 16
                 npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1521,7 +1521,7 @@ pack_inner(const char *inptr,
             bb[2] = npyv_tobits_b8(npyv_cmpneq_u8(v2, v_zero));
             bb[3] = npyv_tobits_b8(npyv_cmpneq_u8(v3, v_zero));
             if(out_stride == 1 && 
-                (NPY_CPU_HAVE_UNALIGNED_ACCESS || isAligned)) {
+                (!NPY_STRONG_ALIGNMENT || isAligned)) {
                 npy_uint64 *ptr64 = (npy_uint64*)outptr;
             #if NPY_SIMD_WIDTH == 16
                 npy_uint64 bcomp = bb[0] | (bb[1] << 16) | (bb[2] << 32) | (bb[3] << 48);

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2245,7 +2245,7 @@ count_boolean_trues(int ndim, char *data, npy_intp const *ashape, npy_intp const
             count += count_nonzero_bytes((const npy_uint8 *)d, stride);
             d += stride;
 #else
-            if (!NPY_STRONG_ALIGNMENT ||
+            if (!NPY_STRONG_ALIGNMENT_REQUIRED ||
                     npy_is_aligned(d, sizeof(npy_uint64))) {
                 npy_uintp stride = 6 * sizeof(npy_uint64);
                 for (; d < e - (shape[0] % stride); d += stride) {

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2245,7 +2245,7 @@ count_boolean_trues(int ndim, char *data, npy_intp const *ashape, npy_intp const
             count += count_nonzero_bytes((const npy_uint8 *)d, stride);
             d += stride;
 #else
-            if (NPY_CPU_HAVE_UNALIGNED_ACCESS ||
+            if (!NPY_STRONG_ALIGNMENT ||
                     npy_is_aligned(d, sizeof(npy_uint64))) {
                 npy_uintp stride = 6 * sizeof(npy_uint64);
                 for (; d < e - (shape[0] % stride); d += stride) {

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -2245,7 +2245,7 @@ count_boolean_trues(int ndim, char *data, npy_intp const *ashape, npy_intp const
             count += count_nonzero_bytes((const npy_uint8 *)d, stride);
             d += stride;
 #else
-            if (!NPY_STRONG_ALIGNMENT_REQUIRED ||
+            if (!NPY_ALIGNMENT_REQUIRED ||
                     npy_is_aligned(d, sizeof(npy_uint64))) {
                 npy_uintp stride = 6 * sizeof(npy_uint64);
                 for (; d < e - (shape[0] % stride); d += stride) {

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -29,7 +29,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if NPY_CPU_HAVE_UNALIGNED_ACCESS
+#if NPY_STRONG_ALIGNMENT
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -29,7 +29,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if NPY_STRONG_ALIGNMENT
+#if NPY_STRONG_ALIGNMENT_REQUIRED
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -29,7 +29,7 @@
  * instructions (16 byte).
  * So this flag can only be enabled if autovectorization is disabled.
  */
-#if NPY_STRONG_ALIGNMENT_REQUIRED
+#if NPY_ALIGNMENT_REQUIRED
 #  define NPY_USE_UNALIGNED_ACCESS 0
 #else
 #  define NPY_USE_UNALIGNED_ACCESS 0


### PR DESCRIPTION
Currently two aligned strategy is defined in the code base, `NPY_CPU_HAVE_UNALIGNED_ACCESS` points out `X86` and `AMD64` supports unaligned access, while `NPY_STRONG_ALIGNMENT` points out ARMV7 needs aligned access, This PR try to integrate two macros into one.