### PR TITLE
TST: Allow mypy output types to be specified via aliases

### DIFF
--- a/numpy/typing/tests/data/reveal/arithmetic.py
+++ b/numpy/typing/tests/data/reveal/arithmetic.py
@@ -25,36 +25,36 @@ AR.setflags(write=False)
 
 # unary ops
 
-reveal_type(-c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(-c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(-f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(-f4)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(-i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(-i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(-u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(-u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(-c16)  # E: {complex128}
+reveal_type(-c8)  # E: {complex64}
+reveal_type(-f8)  # E: {float64}
+reveal_type(-f4)  # E: {float32}
+reveal_type(-i8)  # E: {int64}
+reveal_type(-i4)  # E: {int32}
+reveal_type(-u8)  # E: {uint64}
+reveal_type(-u4)  # E: {uint32}
 reveal_type(-td)  # E: numpy.timedelta64
 reveal_type(-AR)  # E: Any
 
-reveal_type(+c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(+c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(+f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(+f4)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(+i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(+i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(+u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(+u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(+c16)  # E: {complex128}
+reveal_type(+c8)  # E: {complex64}
+reveal_type(+f8)  # E: {float64}
+reveal_type(+f4)  # E: {float32}
+reveal_type(+i8)  # E: {int64}
+reveal_type(+i4)  # E: {int32}
+reveal_type(+u8)  # E: {uint64}
+reveal_type(+u4)  # E: {uint32}
 reveal_type(+td)  # E: numpy.timedelta64
 reveal_type(+AR)  # E: Any
 
-reveal_type(abs(c16))  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(abs(c8))  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(abs(f8))  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(abs(f4))  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(abs(i8))  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(abs(i4))  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(abs(u8))  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(abs(u4))  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(abs(c16))  # E: {float64}
+reveal_type(abs(c8))  # E: {float32}
+reveal_type(abs(f8))  # E: {float64}
+reveal_type(abs(f4))  # E: {float32}
+reveal_type(abs(i8))  # E: {int64}
+reveal_type(abs(i4))  # E: {int32}
+reveal_type(abs(u8))  # E: {uint64}
+reveal_type(abs(u4))  # E: {uint32}
 reveal_type(abs(td))  # E: numpy.timedelta64
 reveal_type(abs(b_))  # E: numpy.bool_
 reveal_type(abs(AR))  # E: Any
@@ -81,214 +81,212 @@ reveal_type(td - i8)  # E: numpy.timedelta64
 reveal_type(td / f)  # E: numpy.timedelta64
 reveal_type(td / f4)  # E: numpy.timedelta64
 reveal_type(td / f8)  # E: numpy.timedelta64
-reveal_type(td / td)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(td // td)  # E: numpy.signedinteger[numpy.typing._64Bit]
+reveal_type(td / td)  # E: {float64}
+reveal_type(td // td)  # E: {int64}
 
 # boolean
 
-reveal_type(b_ / b)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / i)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / i4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / u8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / u4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / f4)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(b_ / c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(b_ / c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(b_ / c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
+reveal_type(b_ / b)  # E: {float64}
+reveal_type(b_ / b_)  # E: {float64}
+reveal_type(b_ / i)  # E: {float64}
+reveal_type(b_ / i8)  # E: {float64}
+reveal_type(b_ / i4)  # E: {float64}
+reveal_type(b_ / u8)  # E: {float64}
+reveal_type(b_ / u4)  # E: {float64}
+reveal_type(b_ / f)  # E: {float64}
+reveal_type(b_ / f8)  # E: {float64}
+reveal_type(b_ / f4)  # E: {float32}
+reveal_type(b_ / c)  # E: {complex128}
+reveal_type(b_ / c16)  # E: {complex128}
+reveal_type(b_ / c8)  # E: {complex64}
 
-reveal_type(b / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i4 / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(u8 / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(u4 / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 / b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 / b_)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(c / b_)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 / b_)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 / b_)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
+reveal_type(b / b_)  # E: {float64}
+reveal_type(b_ / b_)  # E: {float64}
+reveal_type(i / b_)  # E: {float64}
+reveal_type(i8 / b_)  # E: {float64}
+reveal_type(i4 / b_)  # E: {float64}
+reveal_type(u8 / b_)  # E: {float64}
+reveal_type(u4 / b_)  # E: {float64}
+reveal_type(f / b_)  # E: {float64}
+reveal_type(f8 / b_)  # E: {float64}
+reveal_type(f4 / b_)  # E: {float32}
+reveal_type(c / b_)  # E: {complex128}
+reveal_type(c16 / b_)  # E: {complex128}
+reveal_type(c8 / b_)  # E: {complex64}
 
 # Complex
 
-reveal_type(c16 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + f8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + i8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + f4)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + i4)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + b_)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + b)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c16 + f)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
+reveal_type(c16 + c16)  # E: {complex128}
+reveal_type(c16 + f8)  # E: {complex128}
+reveal_type(c16 + i8)  # E: {complex128}
+reveal_type(c16 + c8)  # E: {complex128}
+reveal_type(c16 + f4)  # E: {complex128}
+reveal_type(c16 + i4)  # E: {complex128}
+reveal_type(c16 + b_)  # E: {complex128}
+reveal_type(c16 + b)  # E: {complex128}
+reveal_type(c16 + c)  # E: {complex128}
+reveal_type(c16 + f)  # E: {complex128}
 
-# note this comment is deliberate truncated as the result varies by platform,
-# and the numpy `reveal` tests use substring matching
-reveal_type(c16 + i)  # E: numpy.complexfloating[numpy.typing._
+reveal_type(c16 + i)  # E: {complex128}
 reveal_type(c16 + AR)  # E: Any
 
-reveal_type(c16 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f8 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i8 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f4 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i4 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(b_ + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(b + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i + c16)  # E: numpy.complexfloating[numpy.typing._
+reveal_type(c16 + c16)  # E: {complex128}
+reveal_type(f8 + c16)  # E: {complex128}
+reveal_type(i8 + c16)  # E: {complex128}
+reveal_type(c8 + c16)  # E: {complex128}
+reveal_type(f4 + c16)  # E: {complex128}
+reveal_type(i4 + c16)  # E: {complex128}
+reveal_type(b_ + c16)  # E: {complex128}
+reveal_type(b + c16)  # E: {complex128}
+reveal_type(c + c16)  # E: {complex128}
+reveal_type(f + c16)  # E: {complex128}
+reveal_type(i + c16)  # E: {complex128}
 reveal_type(AR + c16)  # E: Any
 
-reveal_type(c8 + c16)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + f8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + i8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c8 + f4)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c8 + i4)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c8 + b_)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c8 + b)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c8 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + f)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + i)  # E: numpy.complexfloating[numpy.typing._
+reveal_type(c8 + c16)  # E: {complex128}
+reveal_type(c8 + f8)  # E: {complex128}
+reveal_type(c8 + i8)  # E: {complex128}
+reveal_type(c8 + c8)  # E: {complex64}
+reveal_type(c8 + f4)  # E: {complex64}
+reveal_type(c8 + i4)  # E: {complex64}
+reveal_type(c8 + b_)  # E: {complex64}
+reveal_type(c8 + b)  # E: {complex64}
+reveal_type(c8 + c)  # E: {complex128}
+reveal_type(c8 + f)  # E: {complex128}
+reveal_type(c8 + i)  # E: numpy.complexfloating[{_NBitInt}, {_NBitInt}]
 reveal_type(c8 + AR)  # E: Any
 
-reveal_type(c16 + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f8 + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i8 + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(c8 + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(f4 + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(i4 + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(b_ + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(b + c8)  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(c + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + c8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i + c8)  # E: numpy.complexfloating[numpy.typing._
+reveal_type(c16 + c8)  # E: {complex128}
+reveal_type(f8 + c8)  # E: {complex128}
+reveal_type(i8 + c8)  # E: {complex128}
+reveal_type(c8 + c8)  # E: {complex64}
+reveal_type(f4 + c8)  # E: {complex64}
+reveal_type(i4 + c8)  # E: {complex64}
+reveal_type(b_ + c8)  # E: {complex64}
+reveal_type(b + c8)  # E: {complex64}
+reveal_type(c + c8)  # E: {complex128}
+reveal_type(f + c8)  # E: {complex128}
+reveal_type(i + c8)  # E: numpy.complexfloating[{_NBitInt}, {_NBitInt}]
 reveal_type(AR + c8)  # E: Any
 
 # Float
 
-reveal_type(f8 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + f4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + i4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + b)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f8 + f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 + i)  # E: numpy.floating[numpy.typing._
+reveal_type(f8 + f8)  # E: {float64}
+reveal_type(f8 + i8)  # E: {float64}
+reveal_type(f8 + f4)  # E: {float64}
+reveal_type(f8 + i4)  # E: {float64}
+reveal_type(f8 + b_)  # E: {float64}
+reveal_type(f8 + b)  # E: {float64}
+reveal_type(f8 + c)  # E: {complex128}
+reveal_type(f8 + f)  # E: {float64}
+reveal_type(f8 + i)  # E: {float64}
 reveal_type(f8 + AR)  # E: Any
 
-reveal_type(f8 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i4 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(c + f8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i + f8)  # E: numpy.floating[numpy.typing._
+reveal_type(f8 + f8)  # E: {float64}
+reveal_type(i8 + f8)  # E: {float64}
+reveal_type(f4 + f8)  # E: {float64}
+reveal_type(i4 + f8)  # E: {float64}
+reveal_type(b_ + f8)  # E: {float64}
+reveal_type(b + f8)  # E: {float64}
+reveal_type(c + f8)  # E: {complex128}
+reveal_type(f + f8)  # E: {float64}
+reveal_type(i + f8)  # E: {float64}
 reveal_type(AR + f8)  # E: Any
 
-reveal_type(f4 + f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 + i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 + f4)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(f4 + i4)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(f4 + b_)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(f4 + b)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(f4 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f4 + f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 + i)  # E: numpy.floating[numpy.typing._
+reveal_type(f4 + f8)  # E: {float64}
+reveal_type(f4 + i8)  # E: {float64}
+reveal_type(f4 + f4)  # E: {float32}
+reveal_type(f4 + i4)  # E: {float32}
+reveal_type(f4 + b_)  # E: {float32}
+reveal_type(f4 + b)  # E: {float32}
+reveal_type(f4 + c)  # E: {complex128}
+reveal_type(f4 + f)  # E: {float64}
+reveal_type(f4 + i)  # E: numpy.floating[{_NBitInt}]
 reveal_type(f4 + AR)  # E: Any
 
-reveal_type(f8 + f4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 + f4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 + f4)  # E: umpy.floating[numpy.typing._32Bit]
-reveal_type(i4 + f4)  # E: umpy.floating[numpy.typing._32Bit]
-reveal_type(b_ + f4)  # E: umpy.floating[numpy.typing._32Bit]
-reveal_type(b + f4)  # E: umpy.floating[numpy.typing._32Bit]
-reveal_type(c + f4)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + f4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i + f4)  # E: numpy.floating[numpy.typing._
+reveal_type(f8 + f4)  # E: {float64}
+reveal_type(i8 + f4)  # E: {float64}
+reveal_type(f4 + f4)  # E: {float32}
+reveal_type(i4 + f4)  # E: {float32}
+reveal_type(b_ + f4)  # E: {float32}
+reveal_type(b + f4)  # E: {float32}
+reveal_type(c + f4)  # E: {complex128}
+reveal_type(f + f4)  # E: {float64}
+reveal_type(i + f4)  # E: numpy.floating[{_NBitInt}]
 reveal_type(AR + f4)  # E: Any
 
 # Int
 
-reveal_type(i8 + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 + u8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(i8 + i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 + u4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(i8 + b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 + b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(i8 + f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 + i)  # E: numpy.signedinteger[numpy.typing._
+reveal_type(i8 + i8)  # E: {int64}
+reveal_type(i8 + u8)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(i8 + i4)  # E: {int64}
+reveal_type(i8 + u4)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(i8 + b_)  # E: {int64}
+reveal_type(i8 + b)  # E: {int64}
+reveal_type(i8 + c)  # E: {complex128}
+reveal_type(i8 + f)  # E: {float64}
+reveal_type(i8 + i)  # E: {int64}
 reveal_type(i8 + AR)  # E: Any
 
-reveal_type(u8 + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 + i4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u8 + u4)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 + b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 + b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 + c)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(u8 + f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(u8 + i)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
+reveal_type(u8 + u8)  # E: {uint64}
+reveal_type(u8 + i4)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u8 + u4)  # E: {uint64}
+reveal_type(u8 + b_)  # E: {uint64}
+reveal_type(u8 + b)  # E: {uint64}
+reveal_type(u8 + c)  # E: {complex128}
+reveal_type(u8 + f)  # E: {float64}
+reveal_type(u8 + i)  # E: Union[numpy.signedinteger[Any], {float64}]
 reveal_type(u8 + AR)  # E: Any
 
-reveal_type(i8 + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(u8 + i8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(i4 + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(u4 + i8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(b_ + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(b + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(c + i8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i + i8)  # E: numpy.signedinteger[numpy.typing._
+reveal_type(i8 + i8)  # E: {int64}
+reveal_type(u8 + i8)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(i4 + i8)  # E: {int64}
+reveal_type(u4 + i8)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(b_ + i8)  # E: {int64}
+reveal_type(b + i8)  # E: {int64}
+reveal_type(c + i8)  # E: {complex128}
+reveal_type(f + i8)  # E: {float64}
+reveal_type(i + i8)  # E: {int64}
 reveal_type(AR + i8)  # E: Any
 
-reveal_type(u8 + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(i4 + u8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u4 + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(b_ + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(b + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(c + u8)  # E: numpy.complexfloating[numpy.typing._64Bit, numpy.typing._64Bit]
-reveal_type(f + u8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i + u8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
+reveal_type(u8 + u8)  # E: {uint64}
+reveal_type(i4 + u8)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u4 + u8)  # E: {uint64}
+reveal_type(b_ + u8)  # E: {uint64}
+reveal_type(b + u8)  # E: {uint64}
+reveal_type(c + u8)  # E: {complex128}
+reveal_type(f + u8)  # E: {float64}
+reveal_type(i + u8)  # E: Union[numpy.signedinteger[Any], {float64}]
 reveal_type(AR + u8)  # E: Any
 
-reveal_type(i4 + i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i4 + i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 + i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i4 + b_)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 + b)  # E: numpy.signedinteger[numpy.typing._32Bit]
+reveal_type(i4 + i8)  # E: {int64}
+reveal_type(i4 + i4)  # E: {int32}
+reveal_type(i4 + i)  # E: {int_}
+reveal_type(i4 + b_)  # E: {int32}
+reveal_type(i4 + b)  # E: {int32}
 reveal_type(i4 + AR)  # E: Any
 
-reveal_type(u4 + i8)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u4 + i4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u4 + u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u4 + u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 + i)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u4 + b_)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 + b)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(u4 + i8)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u4 + i4)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u4 + u8)  # E: {uint64}
+reveal_type(u4 + u4)  # E: {uint32}
+reveal_type(u4 + i)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u4 + b_)  # E: {uint32}
+reveal_type(u4 + b)  # E: {uint32}
 reveal_type(u4 + AR)  # E: Any
 
-reveal_type(i8 + i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i4 + i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i + i4)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ + i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(b + i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
+reveal_type(i8 + i4)  # E: {int64}
+reveal_type(i4 + i4)  # E: {int32}
+reveal_type(i + i4)  # E: {int_}
+reveal_type(b_ + i4)  # E: {int32}
+reveal_type(b + i4)  # E: {int32}
 reveal_type(AR + i4)  # E: Any
 
-reveal_type(i8 + u4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(i4 + u4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
-reveal_type(u8 + u4)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u4 + u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(b_ + u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(b + u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(i + u4)  # E: Union[numpy.signedinteger[Any], numpy.floating[numpy.typing._64Bit]]
+reveal_type(i8 + u4)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(i4 + u4)  # E: Union[numpy.signedinteger[Any], {float64}]
+reveal_type(u8 + u4)  # E: {uint64}
+reveal_type(u4 + u4)  # E: {uint32}
+reveal_type(b_ + u4)  # E: {uint32}
+reveal_type(b + u4)  # E: {uint32}
+reveal_type(i + u4)  # E: Union[numpy.signedinteger[Any], {float64}]
 reveal_type(AR + u4)  # E: Any

--- a/numpy/typing/tests/data/reveal/bitwise_ops.py
+++ b/numpy/typing/tests/data/reveal/bitwise_ops.py
@@ -15,11 +15,11 @@ AR = np.array([0, 1, 2], dtype=np.int32)
 AR.setflags(write=False)
 
 
-reveal_type(i8 << i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 >> i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 | i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 ^ i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 & i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
+reveal_type(i8 << i8)  # E: {int64}
+reveal_type(i8 >> i8)  # E: {int64}
+reveal_type(i8 | i8)  # E: {int64}
+reveal_type(i8 ^ i8)  # E: {int64}
+reveal_type(i8 & i8)  # E: {int64}
 
 reveal_type(i8 << AR)  # E: Any
 reveal_type(i8 >> AR)  # E: Any
@@ -27,41 +27,41 @@ reveal_type(i8 | AR)  # E: Any
 reveal_type(i8 ^ AR)  # E: Any
 reveal_type(i8 & AR)  # E: Any
 
-reveal_type(i4 << i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 >> i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 | i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 ^ i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 & i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
+reveal_type(i4 << i4)  # E: {int32}
+reveal_type(i4 >> i4)  # E: {int32}
+reveal_type(i4 | i4)  # E: {int32}
+reveal_type(i4 ^ i4)  # E: {int32}
+reveal_type(i4 & i4)  # E: {int32}
 
-reveal_type(i8 << i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 >> i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 | i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 ^ i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 & i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
+reveal_type(i8 << i4)  # E: {int64}
+reveal_type(i8 >> i4)  # E: {int64}
+reveal_type(i8 | i4)  # E: {int64}
+reveal_type(i8 ^ i4)  # E: {int64}
+reveal_type(i8 & i4)  # E: {int64}
 
-reveal_type(i8 << i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i8 >> i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i8 | i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i8 ^ i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i8 & i)  # E: numpy.signedinteger[numpy.typing._
+reveal_type(i8 << i)  # E: {int64}
+reveal_type(i8 >> i)  # E: {int64}
+reveal_type(i8 | i)  # E: {int64}
+reveal_type(i8 ^ i)  # E: {int64}
+reveal_type(i8 & i)  # E: {int64}
 
-reveal_type(i8 << b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 >> b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 | b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 ^ b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 & b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
+reveal_type(i8 << b_)  # E: {int64}
+reveal_type(i8 >> b_)  # E: {int64}
+reveal_type(i8 | b_)  # E: {int64}
+reveal_type(i8 ^ b_)  # E: {int64}
+reveal_type(i8 & b_)  # E: {int64}
 
-reveal_type(i8 << b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 >> b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 | b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 ^ b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 & b)  # E: numpy.signedinteger[numpy.typing._64Bit]
+reveal_type(i8 << b)  # E: {int64}
+reveal_type(i8 >> b)  # E: {int64}
+reveal_type(i8 | b)  # E: {int64}
+reveal_type(i8 ^ b)  # E: {int64}
+reveal_type(i8 & b)  # E: {int64}
 
-reveal_type(u8 << u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 >> u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 | u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 ^ u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 & u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
+reveal_type(u8 << u8)  # E: {uint64}
+reveal_type(u8 >> u8)  # E: {uint64}
+reveal_type(u8 | u8)  # E: {uint64}
+reveal_type(u8 ^ u8)  # E: {uint64}
+reveal_type(u8 & u8)  # E: {uint64}
 
 reveal_type(u8 << AR)  # E: Any
 reveal_type(u8 >> AR)  # E: Any
@@ -69,11 +69,11 @@ reveal_type(u8 | AR)  # E: Any
 reveal_type(u8 ^ AR)  # E: Any
 reveal_type(u8 & AR)  # E: Any
 
-reveal_type(u4 << u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 >> u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 | u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 ^ u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
-reveal_type(u4 & u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(u4 << u4)  # E: {uint32}
+reveal_type(u4 >> u4)  # E: {uint32}
+reveal_type(u4 | u4)  # E: {uint32}
+reveal_type(u4 ^ u4)  # E: {uint32}
+reveal_type(u4 & u4)  # E: {uint32}
 
 reveal_type(u4 << i4)  # E: numpy.signedinteger[Any]
 reveal_type(u4 >> i4)  # E: numpy.signedinteger[Any]
@@ -87,20 +87,20 @@ reveal_type(u4 | i)  # E: numpy.signedinteger[Any]
 reveal_type(u4 ^ i)  # E: numpy.signedinteger[Any]
 reveal_type(u4 & i)  # E: numpy.signedinteger[Any]
 
-reveal_type(u8 << b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 >> b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 | b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 ^ b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 & b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
+reveal_type(u8 << b_)  # E: {uint64}
+reveal_type(u8 >> b_)  # E: {uint64}
+reveal_type(u8 | b_)  # E: {uint64}
+reveal_type(u8 ^ b_)  # E: {uint64}
+reveal_type(u8 & b_)  # E: {uint64}
 
-reveal_type(u8 << b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 >> b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 | b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 ^ b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(u8 & b)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
+reveal_type(u8 << b)  # E: {uint64}
+reveal_type(u8 >> b)  # E: {uint64}
+reveal_type(u8 | b)  # E: {uint64}
+reveal_type(u8 ^ b)  # E: {uint64}
+reveal_type(u8 & b)  # E: {uint64}
 
-reveal_type(b_ << b_)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(b_ >> b_)  # E: numpy.signedinteger[numpy.typing._8Bit]
+reveal_type(b_ << b_)  # E: {int8}
+reveal_type(b_ >> b_)  # E: {int8}
 reveal_type(b_ | b_)  # E: numpy.bool_
 reveal_type(b_ ^ b_)  # E: numpy.bool_
 reveal_type(b_ & b_)  # E: numpy.bool_
@@ -111,21 +111,21 @@ reveal_type(b_ | AR)  # E: Any
 reveal_type(b_ ^ AR)  # E: Any
 reveal_type(b_ & AR)  # E: Any
 
-reveal_type(b_ << b)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(b_ >> b)  # E: numpy.signedinteger[numpy.typing._8Bit]
+reveal_type(b_ << b)  # E: {int8}
+reveal_type(b_ >> b)  # E: {int8}
 reveal_type(b_ | b)  # E: numpy.bool_
 reveal_type(b_ ^ b)  # E: numpy.bool_
 reveal_type(b_ & b)  # E: numpy.bool_
 
-reveal_type(b_ << i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ >> i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ | i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ ^ i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ & i)  # E: numpy.signedinteger[numpy.typing._
+reveal_type(b_ << i)  # E: {int_}
+reveal_type(b_ >> i)  # E: {int_}
+reveal_type(b_ | i)  # E: {int_}
+reveal_type(b_ ^ i)  # E: {int_}
+reveal_type(b_ & i)  # E: {int_}
 
-reveal_type(~i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(~i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(~u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(~u4)  # E: numpy.unsignedinteger[numpy.typing._32Bit]
+reveal_type(~i8)  # E: {int64}
+reveal_type(~i4)  # E: {int32}
+reveal_type(~u8)  # E: {uint64}
+reveal_type(~u4)  # E: {uint32}
 reveal_type(~b_)  # E: numpy.bool_
 reveal_type(~AR)  # E: Any

--- a/numpy/typing/tests/data/reveal/dtype.py
+++ b/numpy/typing/tests/data/reveal/dtype.py
@@ -2,31 +2,31 @@ import numpy as np
 
 dtype_obj: np.dtype[np.str_]
 
-reveal_type(np.dtype(np.float64))  # E: numpy.dtype[numpy.floating[numpy.typing._64Bit]]
-reveal_type(np.dtype(np.int64))  # E: numpy.dtype[numpy.signedinteger[numpy.typing._64Bit]]
+reveal_type(np.dtype(np.float64))  # E: numpy.dtype[{float64}]
+reveal_type(np.dtype(np.int64))  # E: numpy.dtype[{int64}]
 
 # String aliases
-reveal_type(np.dtype("float64"))  # E: numpy.dtype[numpy.floating[numpy.typing._64Bit]]
-reveal_type(np.dtype("float32"))  # E: numpy.dtype[numpy.floating[numpy.typing._32Bit]]
-reveal_type(np.dtype("int64"))  # E: numpy.dtype[numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(np.dtype("int32"))  # E: numpy.dtype[numpy.signedinteger[numpy.typing._32Bit]]
+reveal_type(np.dtype("float64"))  # E: numpy.dtype[{float64}]
+reveal_type(np.dtype("float32"))  # E: numpy.dtype[{float32}]
+reveal_type(np.dtype("int64"))  # E: numpy.dtype[{int64}]
+reveal_type(np.dtype("int32"))  # E: numpy.dtype[{int32}]
 reveal_type(np.dtype("bool"))  # E: numpy.dtype[numpy.bool_]
 reveal_type(np.dtype("bytes"))  # E: numpy.dtype[numpy.bytes_]
 reveal_type(np.dtype("str"))  # E: numpy.dtype[numpy.str_]
 
 # Python types
-reveal_type(np.dtype(complex))  # E: numpy.dtype[numpy.complexfloating[numpy.typing._
-reveal_type(np.dtype(float))  # E: numpy.dtype[numpy.floating[numpy.typing._
-reveal_type(np.dtype(int))  # E: numpy.dtype[numpy.signedinteger[numpy.typing._
+reveal_type(np.dtype(complex))  # E: numpy.dtype[{cdouble}]
+reveal_type(np.dtype(float))  # E: numpy.dtype[{double}]
+reveal_type(np.dtype(int))  # E: numpy.dtype[{int_}]
 reveal_type(np.dtype(bool))  # E: numpy.dtype[numpy.bool_]
 reveal_type(np.dtype(str))  # E: numpy.dtype[numpy.str_]
 reveal_type(np.dtype(bytes))  # E: numpy.dtype[numpy.bytes_]
 
 # Special case for None
-reveal_type(np.dtype(None))  # E: numpy.dtype[numpy.floating[numpy.typing._
+reveal_type(np.dtype(None))  # E: numpy.dtype[{double}]
 
 # Dtypes of dtypes
-reveal_type(np.dtype(np.dtype(np.float64)))  # E: numpy.dtype[numpy.floating[numpy.typing._64Bit]]
+reveal_type(np.dtype(np.dtype(np.float64)))  # E: numpy.dtype[{float64}]
 
 # Parameterized dtypes
 reveal_type(np.dtype("S8"))  # E: numpy.dtype

--- a/numpy/typing/tests/data/reveal/fromnumeric.py
+++ b/numpy/typing/tests/data/reveal/fromnumeric.py
@@ -13,7 +13,7 @@ c = 1.0
 d = np.array(1.0, dtype=np.float32)  # writeable
 
 reveal_type(np.take(a, 0))  # E: numpy.bool_
-reveal_type(np.take(b, 0))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.take(b, 0))  # E: {float32}
 reveal_type(
     np.take(c, 0)  # E: Union[numpy.generic, datetime.datetime, datetime.timedelta]
 )
@@ -66,8 +66,8 @@ reveal_type(np.partition(c, 0, axis=None))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.partition(A, 0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.partition(B, 0))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.argpartition(a, 0))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.argpartition(b, 0))  # E: numpy.signedinteger[numpy.typing._
+reveal_type(np.argpartition(a, 0))  # E: {intp}
+reveal_type(np.argpartition(b, 0))  # E: {intp}
 reveal_type(np.argpartition(c, 0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.argpartition(A, 0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.argpartition(B, 0))  # E: numpy.ndarray[Any, Any]
@@ -78,18 +78,18 @@ reveal_type(np.sort(B, 0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.argsort(A, 0))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.argsort(B, 0))  # E: numpy.ndarray[Any, Any]
 
-reveal_type(np.argmax(A))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.argmax(B))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.argmax(A, axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
-reveal_type(np.argmax(B, axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
+reveal_type(np.argmax(A))  # E: {intp}
+reveal_type(np.argmax(B))  # E: {intp}
+reveal_type(np.argmax(A, axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
+reveal_type(np.argmax(B, axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
 
-reveal_type(np.argmin(A))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.argmin(B))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.argmin(A, axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
-reveal_type(np.argmin(B, axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
+reveal_type(np.argmin(A))  # E: {intp}
+reveal_type(np.argmin(B))  # E: {intp}
+reveal_type(np.argmin(A, axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
+reveal_type(np.argmin(B, axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
 
-reveal_type(np.searchsorted(A[0], 0))  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.searchsorted(B[0], 0))  # E: numpy.signedinteger[numpy.typing._
+reveal_type(np.searchsorted(A[0], 0))  # E: {intp}
+reveal_type(np.searchsorted(B[0], 0))  # E: {intp}
 reveal_type(np.searchsorted(A[0], [0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.searchsorted(B[0], [0]))  # E: numpy.ndarray[Any, Any]
 
@@ -100,7 +100,7 @@ reveal_type(np.resize(A, (5, 5)))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.resize(B, (5, 5)))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.squeeze(a))  # E: numpy.bool_
-reveal_type(np.squeeze(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.squeeze(b))  # E: {float32}
 reveal_type(np.squeeze(c))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.squeeze(A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.squeeze(B))  # E: numpy.ndarray[Any, Any]
@@ -136,13 +136,13 @@ reveal_type(np.compress([True], A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.compress([True], B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.clip(a, 0, 1.0))  # E: numpy.number[Any]
-reveal_type(np.clip(b, -1, 1))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.clip(b, -1, 1))  # E: {float32}
 reveal_type(np.clip(c, 0, 1))  # E: numpy.number[Any]
 reveal_type(np.clip(A, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(np.clip(B, 0, 1))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.sum(a))  # E: numpy.number[Any]
-reveal_type(np.sum(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.sum(b))  # E: {float32}
 reveal_type(np.sum(c))  # E: numpy.number[Any]
 reveal_type(np.sum(A))  # E: numpy.number[Any]
 reveal_type(np.sum(B))  # E: numpy.number[Any]
@@ -176,7 +176,7 @@ reveal_type(np.cumsum(A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.cumsum(B))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.ptp(a))  # E: numpy.number[Any]
-reveal_type(np.ptp(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.ptp(b))  # E: {float32}
 reveal_type(np.ptp(c))  # E: numpy.number[Any]
 reveal_type(np.ptp(A))  # E: numpy.number[Any]
 reveal_type(np.ptp(B))  # E: numpy.number[Any]
@@ -186,7 +186,7 @@ reveal_type(np.ptp(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarr
 reveal_type(np.ptp(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.amax(a))  # E: numpy.number[Any]
-reveal_type(np.amax(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.amax(b))  # E: {float32}
 reveal_type(np.amax(c))  # E: numpy.number[Any]
 reveal_type(np.amax(A))  # E: numpy.number[Any]
 reveal_type(np.amax(B))  # E: numpy.number[Any]
@@ -196,7 +196,7 @@ reveal_type(np.amax(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndar
 reveal_type(np.amax(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.amin(a))  # E: numpy.number[Any]
-reveal_type(np.amin(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.amin(b))  # E: {float32}
 reveal_type(np.amin(c))  # E: numpy.number[Any]
 reveal_type(np.amin(A))  # E: numpy.number[Any]
 reveal_type(np.amin(B))  # E: numpy.number[Any]
@@ -206,7 +206,7 @@ reveal_type(np.amin(A, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndar
 reveal_type(np.amin(B, keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 
 reveal_type(np.prod(a))  # E: numpy.number[Any]
-reveal_type(np.prod(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.prod(b))  # E: {float32}
 reveal_type(np.prod(c))  # E: numpy.number[Any]
 reveal_type(np.prod(A))  # E: numpy.number[Any]
 reveal_type(np.prod(B))  # E: numpy.number[Any]
@@ -236,7 +236,7 @@ reveal_type(np.size(A))  # E: int
 reveal_type(np.size(B))  # E: int
 
 reveal_type(np.around(a))  # E: numpy.number[Any]
-reveal_type(np.around(b))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(np.around(b))  # E: {float32}
 reveal_type(np.around(c))  # E: numpy.number[Any]
 reveal_type(np.around(A))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.around(B))  # E: numpy.ndarray[Any, Any]

--- a/numpy/typing/tests/data/reveal/mod.py
+++ b/numpy/typing/tests/data/reveal/mod.py
@@ -27,123 +27,123 @@ reveal_type(td % td)  # E: numpy.timedelta64
 reveal_type(AR2 % td)  # E: Any
 reveal_type(td % AR2)  # E: Any
 
-reveal_type(divmod(td, td))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.timedelta64]
+reveal_type(divmod(td, td))  # E: Tuple[{int64}, numpy.timedelta64]
 reveal_type(divmod(AR2, td))  # E: Tuple[Any, Any]
 reveal_type(divmod(td, AR2))  # E: Tuple[Any, Any]
 
 # Bool
 
-reveal_type(b_ % b)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(b_ % i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(b_ % f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ % b_)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(b_ % i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(b_ % u8)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(b_ % f8)  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(b_ % b)  # E: {int8}
+reveal_type(b_ % i)  # E: {int_}
+reveal_type(b_ % f)  # E: {float64}
+reveal_type(b_ % b_)  # E: {int8}
+reveal_type(b_ % i8)  # E: {int64}
+reveal_type(b_ % u8)  # E: {uint64}
+reveal_type(b_ % f8)  # E: {float64}
 reveal_type(b_ % AR)  # E: Any
 
-reveal_type(divmod(b_, b))  # E: Tuple[numpy.signedinteger[numpy.typing._8Bit], numpy.signedinteger[numpy.typing._8Bit]]
-reveal_type(divmod(b_, i))  # E: Tuple[numpy.signedinteger[numpy.typing._
-reveal_type(divmod(b_, f))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(b_, b_))  # E: Tuple[numpy.signedinteger[numpy.typing._8Bit], numpy.signedinteger[numpy.typing._8Bit]]
-reveal_type(divmod(b_, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(b_, u8))  # E: Tuple[numpy.unsignedinteger[numpy.typing._64Bit], numpy.unsignedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(b_, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
+reveal_type(divmod(b_, b))  # E: Tuple[{int8}, {int8}]
+reveal_type(divmod(b_, i))  # E: Tuple[{int_}, {int_}]
+reveal_type(divmod(b_, f))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(b_, b_))  # E: Tuple[{int8}, {int8}]
+reveal_type(divmod(b_, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(b_, u8))  # E: Tuple[{uint64}, {uint64}]
+reveal_type(divmod(b_, f8))  # E: Tuple[{float64}, {float64}]
 reveal_type(divmod(b_, AR))  # E: Tuple[Any, Any]
 
-reveal_type(b % b_)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(i % b_)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(f % b_)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(b_ % b_)  # E: numpy.signedinteger[numpy.typing._8Bit]
-reveal_type(i8 % b_)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(u8 % b_)  # E: numpy.unsignedinteger[numpy.typing._64Bit]
-reveal_type(f8 % b_)  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(b % b_)  # E: {int8}
+reveal_type(i % b_)  # E: {int_}
+reveal_type(f % b_)  # E: {float64}
+reveal_type(b_ % b_)  # E: {int8}
+reveal_type(i8 % b_)  # E: {int64}
+reveal_type(u8 % b_)  # E: {uint64}
+reveal_type(f8 % b_)  # E: {float64}
 reveal_type(AR % b_)  # E: Any
 
-reveal_type(divmod(b, b_))  # E: Tuple[numpy.signedinteger[numpy.typing._8Bit], numpy.signedinteger[numpy.typing._8Bit]]
-reveal_type(divmod(i, b_))  # E: Tuple[numpy.signedinteger[numpy.typing._
-reveal_type(divmod(f, b_))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(b_, b_))  # E: Tuple[numpy.signedinteger[numpy.typing._8Bit], numpy.signedinteger[numpy.typing._8Bit]]
-reveal_type(divmod(i8, b_))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(u8, b_))  # E: Tuple[numpy.unsignedinteger[numpy.typing._64Bit], numpy.unsignedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(f8, b_))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
+reveal_type(divmod(b, b_))  # E: Tuple[{int8}, {int8}]
+reveal_type(divmod(i, b_))  # E: Tuple[{int_}, {int_}]
+reveal_type(divmod(f, b_))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(b_, b_))  # E: Tuple[{int8}, {int8}]
+reveal_type(divmod(i8, b_))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(u8, b_))  # E: Tuple[{uint64}, {uint64}]
+reveal_type(divmod(f8, b_))  # E: Tuple[{float64}, {float64}]
 reveal_type(divmod(AR, b_))  # E: Tuple[Any, Any]
 
 # int
 
-reveal_type(i8 % b)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 % i)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(i8 % f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 % i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i8 % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i4 % i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i4 % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i4 % i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(i4 % f4)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(i8 % b)  # E: {int64}
+reveal_type(i8 % i)  # E: {int64}
+reveal_type(i8 % f)  # E: {float64}
+reveal_type(i8 % i8)  # E: {int64}
+reveal_type(i8 % f8)  # E: {float64}
+reveal_type(i4 % i8)  # E: {int64}
+reveal_type(i4 % f8)  # E: {float64}
+reveal_type(i4 % i4)  # E: {int32}
+reveal_type(i4 % f4)  # E: {float32}
 reveal_type(i8 % AR)  # E: Any
 
-reveal_type(divmod(i8, b))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(i8, i))  # E: Tuple[numpy.signedinteger[numpy.typing._
-reveal_type(divmod(i8, f))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i8, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(i8, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i8, i4))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(i8, f4))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i4, i4))  # E: Tuple[numpy.signedinteger[numpy.typing._32Bit], numpy.signedinteger[numpy.typing._32Bit]]
-reveal_type(divmod(i4, f4))  # E: Tuple[numpy.floating[numpy.typing._32Bit], numpy.floating[numpy.typing._32Bit]]
+reveal_type(divmod(i8, b))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(i8, i))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(i8, f))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i8, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(i8, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i8, i4))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(i8, f4))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i4, i4))  # E: Tuple[{int32}, {int32}]
+reveal_type(divmod(i4, f4))  # E: Tuple[{float32}, {float32}]
 reveal_type(divmod(i8, AR))  # E: Tuple[Any, Any]
 
-reveal_type(b % i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(i % i8)  # E: numpy.signedinteger[numpy.typing._
-reveal_type(f % i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 % i8)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(f8 % i8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 % i4)  # E: numpy.signedinteger[numpy.typing._64Bit]
-reveal_type(f8 % i4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i4 % i4)  # E: numpy.signedinteger[numpy.typing._32Bit]
-reveal_type(f4 % i4)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(b % i8)  # E: {int64}
+reveal_type(i % i8)  # E: {int64}
+reveal_type(f % i8)  # E: {float64}
+reveal_type(i8 % i8)  # E: {int64}
+reveal_type(f8 % i8)  # E: {float64}
+reveal_type(i8 % i4)  # E: {int64}
+reveal_type(f8 % i4)  # E: {float64}
+reveal_type(i4 % i4)  # E: {int32}
+reveal_type(f4 % i4)  # E: {float32}
 reveal_type(AR % i8)  # E: Any
 
-reveal_type(divmod(b, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(i, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._
-reveal_type(divmod(f, i8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i8, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(f8, i8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i4, i8))  # E: Tuple[numpy.signedinteger[numpy.typing._64Bit], numpy.signedinteger[numpy.typing._64Bit]]
-reveal_type(divmod(f4, i8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i4, i4))  # E: Tuple[numpy.signedinteger[numpy.typing._32Bit], numpy.signedinteger[numpy.typing._32Bit]]
-reveal_type(divmod(f4, i4))  # E: Tuple[numpy.floating[numpy.typing._32Bit], numpy.floating[numpy.typing._32Bit]]
+reveal_type(divmod(b, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(i, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(f, i8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i8, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(f8, i8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i4, i8))  # E: Tuple[{int64}, {int64}]
+reveal_type(divmod(f4, i8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i4, i4))  # E: Tuple[{int32}, {int32}]
+reveal_type(divmod(f4, i4))  # E: Tuple[{float32}, {float32}]
 reveal_type(divmod(AR, i8))  # E: Tuple[Any, Any]
 
 # float
 
-reveal_type(f8 % b)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 % i)  # E: numpy.floating[numpy.typing._
-reveal_type(f8 % f)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i8 % f4)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 % f4)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(f8 % b)  # E: {float64}
+reveal_type(f8 % i)  # E: {float64}
+reveal_type(f8 % f)  # E: {float64}
+reveal_type(i8 % f4)  # E: {float64}
+reveal_type(f4 % f4)  # E: {float32}
 reveal_type(f8 % AR)  # E: Any
 
-reveal_type(divmod(f8, b))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f8, i))  # E: Tuple[numpy.floating[numpy.typing._
-reveal_type(divmod(f8, f))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f8, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f8, f4))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f4, f4))  # E: Tuple[numpy.floating[numpy.typing._32Bit], numpy.floating[numpy.typing._32Bit]]
+reveal_type(divmod(f8, b))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f8, i))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f8, f))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f8, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f8, f4))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f4, f4))  # E: Tuple[{float32}, {float32}]
 reveal_type(divmod(f8, AR))  # E: Tuple[Any, Any]
 
-reveal_type(b % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(i % f8)  # E: numpy.floating[numpy.typing._
-reveal_type(f % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f8 % f8)  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(f4 % f4)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(b % f8)  # E: {float64}
+reveal_type(i % f8)  # E: {float64}
+reveal_type(f % f8)  # E: {float64}
+reveal_type(f8 % f8)  # E: {float64}
+reveal_type(f8 % f8)  # E: {float64}
+reveal_type(f4 % f4)  # E: {float32}
 reveal_type(AR % f8)  # E: Any
 
-reveal_type(divmod(b, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(i, f8))  # E: Tuple[numpy.floating[numpy.typing._
-reveal_type(divmod(f, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f8, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f4, f8))  # E: Tuple[numpy.floating[numpy.typing._64Bit], numpy.floating[numpy.typing._64Bit]]
-reveal_type(divmod(f4, f4))  # E: Tuple[numpy.floating[numpy.typing._32Bit], numpy.floating[numpy.typing._32Bit]]
+reveal_type(divmod(b, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(i, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f8, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f4, f8))  # E: Tuple[{float64}, {float64}]
+reveal_type(divmod(f4, f4))  # E: Tuple[{float32}, {float32}]
 reveal_type(divmod(AR, f8))  # E: Tuple[Any, Any]

--- a/numpy/typing/tests/data/reveal/nbit_base_example.py
+++ b/numpy/typing/tests/data/reveal/nbit_base_example.py
@@ -12,7 +12,7 @@ i4: np.int32
 f8: np.float64
 f4: np.float32
 
-reveal_type(add(f8, i8))  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(add(f4, i8))  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(add(f8, i4))  # E: numpy.floating[numpy.typing._64Bit]
-reveal_type(add(f4, i4))  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(add(f8, i8))  # E: {float64}
+reveal_type(add(f4, i8))  # E: {float64}
+reveal_type(add(f8, i4))  # E: {float64}
+reveal_type(add(f4, i4))  # E: {float32}

--- a/numpy/typing/tests/data/reveal/ndarray_misc.py
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.py
@@ -26,14 +26,14 @@ reveal_type(A.any(axis=0))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 reveal_type(A.any(keepdims=True))  # E: Union[numpy.bool_, numpy.ndarray[Any, Any]]
 reveal_type(A.any(out=B))  # E: SubClass
 
-reveal_type(f8.argmax())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(A.argmax())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(A.argmax(axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
+reveal_type(f8.argmax())  # E: {intp}
+reveal_type(A.argmax())  # E: {intp}
+reveal_type(A.argmax(axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
 reveal_type(A.argmax(out=B))  # E: SubClass
 
-reveal_type(f8.argmin())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(A.argmin())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(A.argmin(axis=0))  # E: Union[numpy.ndarray[Any, Any], numpy.signedinteger[numpy.typing._
+reveal_type(f8.argmin())  # E: {intp}
+reveal_type(A.argmin())  # E: {intp}
+reveal_type(A.argmin(axis=0))  # E: Union[numpy.ndarray[Any, Any], {intp}]
 reveal_type(A.argmin(out=B))  # E: SubClass
 
 reveal_type(f8.argsort())  # E: numpy.ndarray[Any, Any]
@@ -53,11 +53,11 @@ reveal_type(f8.compress([0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(A.compress([0]))  # E: numpy.ndarray[Any, Any]
 reveal_type(A.compress([0], out=B))  # E: SubClass
 
-reveal_type(f8.conj())  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(f8.conj())  # E: {float64}
 reveal_type(A.conj())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.conj())  # E: SubClass
 
-reveal_type(f8.conjugate())  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(f8.conjugate())  # E: {float64}
 reveal_type(A.conjugate())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.conjugate())  # E: SubClass
 
@@ -87,7 +87,7 @@ reveal_type(A.min(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any
 reveal_type(A.min(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.min(out=B))  # E: SubClass
 
-reveal_type(f8.newbyteorder())  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(f8.newbyteorder())  # E: {float64}
 reveal_type(A.newbyteorder())  # E: numpy.ndarray[Any, Any]
 reveal_type(B.newbyteorder('|'))  # E: SubClass
 
@@ -103,7 +103,7 @@ reveal_type(A.ptp(axis=0))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any
 reveal_type(A.ptp(keepdims=True))  # E: Union[numpy.number[Any], numpy.ndarray[Any, Any]]
 reveal_type(A.ptp(out=B))  # E: SubClass
 
-reveal_type(f8.round())  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(f8.round())  # E: {float64}
 reveal_type(A.round())  # E: numpy.ndarray[Any, Any]
 reveal_type(A.round(out=B))  # E: SubClass
 

--- a/numpy/typing/tests/data/reveal/scalars.py
+++ b/numpy/typing/tests/data/reveal/scalars.py
@@ -2,11 +2,11 @@ import numpy as np
 
 x = np.complex64(3 + 2j)
 
-reveal_type(x.real)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(x.imag)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(x.real)  # E: {float32}
+reveal_type(x.imag)  # E: {float32}
 
-reveal_type(x.real.real)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(x.real.imag)  # E: numpy.floating[numpy.typing._32Bit]
+reveal_type(x.real.real)  # E: {float32}
+reveal_type(x.real.imag)  # E: {float32}
 
 reveal_type(x.itemsize)  # E: int
 reveal_type(x.shape)  # E: Tuple[]
@@ -15,14 +15,14 @@ reveal_type(x.strides)  # E: Tuple[]
 reveal_type(x.ndim)  # E: Literal[0]
 reveal_type(x.size)  # E: Literal[1]
 
-reveal_type(x.squeeze())  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(x.byteswap())  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
-reveal_type(x.transpose())  # E: numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]
+reveal_type(x.squeeze())  # E: {complex64}
+reveal_type(x.byteswap())  # E: {complex64}
+reveal_type(x.transpose())  # E: {complex64}
 
-reveal_type(x.dtype)  # E: numpy.dtype[numpy.complexfloating[numpy.typing._32Bit, numpy.typing._32Bit]]
+reveal_type(x.dtype)  # E: numpy.dtype[{complex64}]
 
-reveal_type(np.complex64().real)  # E: numpy.floating[numpy.typing._32Bit]
-reveal_type(np.complex128().imag)  # E: numpy.floating[numpy.typing._64Bit]
+reveal_type(np.complex64().real)  # E: {float32}
+reveal_type(np.complex128().imag)  # E: {float64}
 
 reveal_type(np.unicode_('foo'))  # E: numpy.str_
 reveal_type(np.str0('foo'))  # E: numpy.str_
@@ -31,34 +31,34 @@ reveal_type(np.str0('foo'))  # E: numpy.str_
 reveal_type(np.unicode_())  # E: numpy.str_
 reveal_type(np.str0())  # E: numpy.str_
 
-reveal_type(np.byte())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.short())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.intc())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.intp())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.int0())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.int_())  # E: numpy.signedinteger[numpy.typing._
-reveal_type(np.longlong())  # E: numpy.signedinteger[numpy.typing._
+reveal_type(np.byte())  # E: {byte}
+reveal_type(np.short())  # E: {short}
+reveal_type(np.intc())  # E: {intc}
+reveal_type(np.intp())  # E: {intp}
+reveal_type(np.int0())  # E: {intp}
+reveal_type(np.int_())  # E: {int_}
+reveal_type(np.longlong())  # E: {longlong}
 
-reveal_type(np.ubyte())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.ushort())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.uintc())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.uintp())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.uint0())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.uint())  # E: numpy.unsignedinteger[numpy.typing._
-reveal_type(np.ulonglong())  # E: numpy.unsignedinteger[numpy.typing._
+reveal_type(np.ubyte())  # E: {ubyte}
+reveal_type(np.ushort())  # E: {ushort}
+reveal_type(np.uintc())  # E: {uintc}
+reveal_type(np.uintp())  # E: {uintp}
+reveal_type(np.uint0())  # E: {uintp}
+reveal_type(np.uint())  # E: {uint}
+reveal_type(np.ulonglong())  # E: {ulonglong}
 
-reveal_type(np.half())  # E: numpy.floating[numpy.typing._
-reveal_type(np.single())  # E: numpy.floating[numpy.typing._
-reveal_type(np.double())  # E: numpy.floating[numpy.typing._
-reveal_type(np.float_())  # E: numpy.floating[numpy.typing._
-reveal_type(np.longdouble())  # E: numpy.floating[numpy.typing._
-reveal_type(np.longfloat())  # E: numpy.floating[numpy.typing._
+reveal_type(np.half())  # E: {half}
+reveal_type(np.single())  # E: {single}
+reveal_type(np.double())  # E: {double}
+reveal_type(np.float_())  # E: {double}
+reveal_type(np.longdouble())  # E: {longdouble}
+reveal_type(np.longfloat())  # E: {longdouble}
 
-reveal_type(np.csingle())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.singlecomplex())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.cdouble())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.complex_())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.cfloat())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.clongdouble())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.clongfloat())  # E: numpy.complexfloating[numpy.typing._
-reveal_type(np.longcomplex())  # E: numpy.complexfloating[numpy.typing._
+reveal_type(np.csingle())  # E: {csingle}
+reveal_type(np.singlecomplex())  # E: {csingle}
+reveal_type(np.cdouble())  # E: {cdouble}
+reveal_type(np.complex_())  # E: {cdouble}
+reveal_type(np.cfloat())  # E: {cdouble}
+reveal_type(np.clongdouble())  # E: {clongdouble}
+reveal_type(np.clongfloat())  # E: {clongdouble}
+reveal_type(np.longcomplex())  # E: {clongdouble}


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/17617

This PR allows one to use aliases for output types in the mypy `reveal` tests, thus allowing one to, 
for example, express `numpy.signedinteger[numpy.typing._64Bit]]` as the formatable string `{int64}`.

The purpose of this change is two fold:
1. It significantly cuts down on the verbosity.
2. It allows us to test platform-specific precisions, something we previously couldn't properly do. For example,  `np.int_` can map to either `numpy.signedinteger[numpy.typing._64Bit]]` or `numpy.signedinteger[numpy.typing._32Bit]]`. Since the output types are specified via normal python comments, the best we could do before this PR was to describe it via a common substring: `numpy.signedinteger[numpy.typing._`.