### PR TITLE
MAINT: Remove obsolete workaround to set ndarray.__hash__ = None

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1754,10 +1754,6 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     .tp_as_number = &array_as_number,
     .tp_as_sequence = &array_as_sequence,
     .tp_as_mapping = &array_as_mapping,
-    /*
-     * The tp_hash slot will be set PyObject_HashNotImplemented when the
-     * module is loaded.
-     */
     .tp_str = (reprfunc)array_str,
     .tp_as_buffer = &array_as_buffer,
     .tp_flags =(Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE),

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4556,13 +4556,6 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
-    /*
-     * Before calling PyType_Ready, initialize the tp_hash slot in
-     * PyArray_Type to work around mingw32 not being able initialize
-     * static structure slots with functions from the Python C_API.
-     */
-    PyArray_Type.tp_hash = PyObject_HashNotImplemented;
-
     if (PyType_Ready(&PyUFunc_Type) < 0) {
         goto err;
     }


### PR DESCRIPTION
In Python 3, a type that sets tp_richcompare but leaves tp_hash null is
always unhashable. In Python 2, such types used to inherit tp_hash from
their bases.
