### PR TITLE
BUG: Fix unique handling of nan entries.

### DIFF
--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -53,6 +53,7 @@ class Pad(Benchmark):
     def time_pad(self, shape, pad_width, mode):
         np.pad(self.array, pad_width, mode)
 
+
 class Nan(Benchmark):
     """Benchmarks for nan functions"""
 
@@ -113,3 +114,26 @@ class Nan(Benchmark):
 
     def time_nanpercentile(self, array_size, percent_nans):
         np.nanpercentile(self.arr, q=50)
+
+
+class Unique(Benchmark):
+    """Benchmark for np.unique with np.nan values."""
+
+    param_names = ["array_size", "percent_nans"]
+    params = [
+        # sizes of the 1D arrays
+        [200, int(2e5)],
+        # percent of np.nan in arrays
+        [0, 0.1, 2., 50., 90.],
+    ]
+
+    def setup(self, array_size, percent_nans):
+        np.random.seed(123)
+        # produce a randomly shuffled array with the
+        # approximate desired percentage np.nan content
+        base_array = np.random.uniform(size=array_size)
+        base_array[base_array < percent_nans / 100.] = np.nan
+        self.arr = base_array
+
+    def time_unique(self, array_size, percent_nans):
+        np.unique(self.arr)

--- a/doc/release/upcoming_changes/18070.improvement.rst
+++ b/doc/release/upcoming_changes/18070.improvement.rst
@@ -4,3 +4,9 @@ When ``np.unique`` operated on an array with multiple ``NaN`` entries,
 its return included a ``NaN`` for each entry that was ``NaN`` in the original array.
 This is now improved such that the returned array contains just one ``NaN`` as the
 last element.
+
+Also for complex arrays all ``NaN`` values are considered equivalent
+(no matter whether the ``NaN`` is in the real or imaginary part). As the
+representant for the returned array the smallest one in the
+lexicographical order is chosen - see ``np.sort`` for how the lexicographical
+order is defined for complex arrays.

--- a/doc/release/upcoming_changes/18070.improvement.rst
+++ b/doc/release/upcoming_changes/18070.improvement.rst
@@ -1,0 +1,6 @@
+``np.unique`` now returns single ``NaN``
+----------------------------------------
+When ``np.unique`` operated on an array with multiple ``NaN`` entries,
+its return included a ``NaN`` for each entry that was ``NaN`` in the original array.
+This is now improved such that the returned array contains just one ``NaN`` as the
+last element.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -327,7 +327,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask[:1] = True
     if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
         # Ensure that `NaT` is used for time-like dtypes
-        nan = np.array(np.nan, dtype=aux.dtype)
+        nan = np.full(shape=1, fill_value=np.nan, dtype=aux.dtype)[0]
         aux_firstnan = np.searchsorted(aux, nan, side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -327,7 +327,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask[:1] = True
     if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
         # Ensure that `NaT` is used for time-like dtypes
-        nan = np.full(shape=1, fill_value=np.nan, dtype=aux.dtype)[0]
+        nan = np.array(np.nan).astype(aux.dtype)
         aux_firstnan = np.searchsorted(aux, nan, side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -207,7 +207,7 @@ def unique(ar, return_index=False, return_inverse=False,
     effect that we end up with a 1-D array of structured types that can be
     treated in the same way as any other 1-D array. The result is that the
     flattened subarrays are sorted in lexicographic order starting with the
-    first element. If nan values are in the input array, singe nan is put
+    first element. If nan values are in the input array, a single nan is put
     to the end of the sorted unique values.
 
     Examples

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -207,8 +207,11 @@ def unique(ar, return_index=False, return_inverse=False,
     effect that we end up with a 1-D array of structured types that can be
     treated in the same way as any other 1-D array. The result is that the
     flattened subarrays are sorted in lexicographic order starting with the
-    first element. If nan values are in the input array, a single nan is put
-    to the end of the sorted unique values.
+    first element.
+
+    .. versionchanged: NumPy 1.21
+        If nan values are in the input array, a single nan is put
+        to the end of the sorted unique values.
 
     Examples
     --------
@@ -326,9 +329,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
     if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
-        # Ensure that `NaT` is used for time-like dtypes
-        nan = np.array(np.nan).astype(aux.dtype)
-        aux_firstnan = np.searchsorted(aux, nan, side='left')
+        aux_firstnan = np.searchsorted(aux, aux[-1], side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True
         mask[aux_firstnan + 1:] = False

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -207,7 +207,8 @@ def unique(ar, return_index=False, return_inverse=False,
     effect that we end up with a 1-D array of structured types that can be
     treated in the same way as any other 1-D array. The result is that the
     flattened subarrays are sorted in lexicographic order starting with the
-    first element.
+    first element. If nan values are in the input array, singe nan is put
+    to the end of the sorted unique values.
 
     Examples
     --------
@@ -325,7 +326,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
     floats = (float, np.float16, np.float32, np.float64)
-    if (aux.shape[0] > 0 and isinstance(aux[-1], floats) and np.isnan(aux[-1])):
+    if aux.shape[0] > 0 and isinstance(aux[-1], floats) and np.isnan(aux[-1]):
         aux_firstnan = np.searchsorted(aux, np.nan, side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -324,7 +324,14 @@ def _unique1d(ar, return_index=False, return_inverse=False,
         aux = ar
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
-    mask[1:] = aux[1:] != aux[:-1]
+    floats = (float, np.float16, np.float32, np.float64)
+    if (aux.shape[0] > 0 and isinstance(aux[-1], floats) and np.isnan(aux[-1])):
+        aux_firstnan = np.searchsorted(aux, np.nan, side='left')
+        mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
+        mask[aux_firstnan] = True
+        mask[aux_firstnan + 1:] = False
+    else:
+        mask[1:] = aux[1:] != aux[:-1]
 
     ret = (aux[mask],)
     if return_index:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -325,9 +325,10 @@ def _unique1d(ar, return_index=False, return_inverse=False,
         aux = ar
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
-    floats = (float, np.float16, np.float32, np.float64)
-    if aux.shape[0] > 0 and isinstance(aux[-1], floats) and np.isnan(aux[-1]):
-        aux_firstnan = np.searchsorted(aux, np.nan, side='left')
+    if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
+        # Ensure that `NaT` is used for time-like dtypes
+        nan = np.array(np.nan, dtype=aux.dtype)
+        aux_firstnan = np.searchsorted(aux, nan, side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True
         mask[aux_firstnan + 1:] = False

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -213,6 +213,12 @@ def unique(ar, return_index=False, return_inverse=False,
         If nan values are in the input array, a single nan is put
         to the end of the sorted unique values.
 
+        Also for complex arrays all NaN values are considered equivalent
+        (no matter whether the NaN is in the real or imaginary part).
+        As the representant for the returned array the smallest one in the
+        lexicographical order is chosen - see np.sort for how the lexicographical
+        order is defined for complex arrays.
+
     Examples
     --------
     >>> np.unique([1, 1, 2, 2, 3, 3])
@@ -329,7 +335,10 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
     if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
-        aux_firstnan = np.searchsorted(aux, aux[-1], side='left')
+        if aux.dtype.kind == "c":  # for complex all NaNs are considered equivalent
+            aux_firstnan = np.searchsorted(np.isnan(aux), True, side='left')
+        else:
+            aux_firstnan = np.searchsorted(aux, aux[-1], side='left')
         mask[1:aux_firstnan] = (aux[1:aux_firstnan] != aux[:aux_firstnan - 1])
         mask[aux_firstnan] = True
         mask[aux_firstnan + 1:] = False

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -542,6 +542,17 @@ class TestUnique:
         assert_equal(np.unique(a, return_inverse=True), (ua, ua_inv))
         assert_equal(np.unique(a, return_counts=True), (ua, ua_cnt))
 
+        # test for ticket 2111 - complex
+        a = [2.0-1j, np.nan, 1.0+1j, complex(0.0, np.nan), complex(1.0, np.nan)]
+        ua = [1.0+1j, 2.0-1j, complex(0.0, np.nan)]
+        ua_idx = [2, 0, 3]
+        ua_inv = [1, 2, 0, 2, 2]
+        ua_cnt = [1, 1, 3]
+        assert_equal(np.unique(a), ua)
+        assert_equal(np.unique(a, return_index=True), (ua, ua_idx))
+        assert_equal(np.unique(a, return_inverse=True), (ua, ua_inv))
+        assert_equal(np.unique(a, return_counts=True), (ua, ua_cnt))
+
         # test for ticket 2111 - datetime64
         nat = np.datetime64('nat')
         a = [np.datetime64('2020-12-26'), nat, np.datetime64('2020-12-24'), nat]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -531,9 +531,33 @@ class TestUnique:
         assert_equal(a3_idx.dtype, np.intp)
         assert_equal(a3_inv.dtype, np.intp)
 
-        # test for ticket 2111
-        a = [2, np.nan, 1, np.nan]
-        ua = [1, 2, np.nan]
+        # test for ticket 2111 - float
+        a = [2.0, np.nan, 1.0, np.nan]
+        ua = [1.0, 2.0, np.nan]
+        ua_idx = [2, 0, 1]
+        ua_inv = [1, 2, 0, 2]
+        ua_cnt = [1, 1, 2]
+        assert_equal(np.unique(a), ua)
+        assert_equal(np.unique(a, return_index=True), (ua, ua_idx))
+        assert_equal(np.unique(a, return_inverse=True), (ua, ua_inv))
+        assert_equal(np.unique(a, return_counts=True), (ua, ua_cnt))
+
+        # test for ticket 2111 - datetime64
+        nat = np.datetime64('nat')
+        a = [np.datetime64('2020-12-26'), nat, np.datetime64('2020-12-24'), nat]
+        ua = [np.datetime64('2020-12-24'), np.datetime64('2020-12-26'), nat]
+        ua_idx = [2, 0, 1]
+        ua_inv = [1, 2, 0, 2]
+        ua_cnt = [1, 1, 2]
+        assert_equal(np.unique(a), ua)
+        assert_equal(np.unique(a, return_index=True), (ua, ua_idx))
+        assert_equal(np.unique(a, return_inverse=True), (ua, ua_inv))
+        assert_equal(np.unique(a, return_counts=True), (ua, ua_cnt))
+
+        # test for ticket 2111 - timedelta
+        nat = np.timedelta64('nat')
+        a = [np.timedelta64(1, 'D'), nat, np.timedelta64(1, 'h'), nat]
+        ua = [np.timedelta64(1, 'h'), np.timedelta64(1, 'D'), nat]
         ua_idx = [2, 0, 1]
         ua_inv = [1, 2, 0, 2]
         ua_cnt = [1, 1, 2]

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -531,6 +531,10 @@ class TestUnique:
         assert_equal(a3_idx.dtype, np.intp)
         assert_equal(a3_inv.dtype, np.intp)
 
+        # test for ticket 2111
+        a = [2, np.nan, 1, np.nan]
+        assert_array_equal(np.unique(a), [1, 2, np.nan, np.nan])
+
     def test_unique_axis_errors(self):
         assert_raises(TypeError, self._run_axis_tests, object)
         assert_raises(TypeError, self._run_axis_tests,

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -533,7 +533,7 @@ class TestUnique:
 
         # test for ticket 2111
         a = [2, np.nan, 1, np.nan]
-        assert_array_equal(np.unique(a), [1, 2, np.nan, np.nan])
+        assert_array_equal(np.unique(a), [1, 2, np.nan])
 
     def test_unique_axis_errors(self):
         assert_raises(TypeError, self._run_axis_tests, object)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -533,7 +533,14 @@ class TestUnique:
 
         # test for ticket 2111
         a = [2, np.nan, 1, np.nan]
-        assert_array_equal(np.unique(a), [1, 2, np.nan])
+        ua = [1, 2, np.nan]
+        ua_idx = [2, 0, 1]
+        ua_inv = [1, 2, 0, 2]
+        ua_cnt = [1, 1, 2]
+        assert_equal(np.unique(a), ua)
+        assert_equal(np.unique(a, return_index=True), (ua, ua_idx))
+        assert_equal(np.unique(a, return_inverse=True), (ua, ua_inv))
+        assert_equal(np.unique(a, return_counts=True), (ua, ua_cnt))
 
     def test_unique_axis_errors(self):
         assert_raises(TypeError, self._run_axis_tests, object)


### PR DESCRIPTION
BUG: Unique and nan entries (closes #2111)

When unique operates on an array with multiple NaN entries its return includes a NaN for each entry that was NaN in the original array.

This is my first PR in an open-source project, so please apology any mistakes. In this fix, I used the code suggested by [ufmayer](https://github.com/numpy/numpy/issues/2111#issuecomment-639957194). It works correctly. I have added unit tests as well.

The performance impact is negligible as shown by the benchmark I have created.
`python runtests.py --bench bench_lib.Unique`
Before change:
```
[100.00%] ··· ============ ============= ============ ============= ============= =============
              --                                       percent_nans
              ------------ --------------------------------------------------------------------
               array_size        0           0.1           2.0           50.0          90.0
              ============ ============= ============ ============= ============= =============
                  200        7.47±0.2μs   7.58±0.1μs   7.24±0.08μs    7.27±0.2μs    7.14±0.7μs
                 200000     13.2±0.09ms   13.2±0.4ms    13.2±0.3ms   9.63±0.07ms   4.72±0.08ms
              ============ ============= ============ ============= ============= =============
```
After change:
```
[100.00%] ··· ============ ============ ============= ============ ============ =============
              --                                      percent_nans
              ------------ ------------------------------------------------------------------
               array_size       0            0.1          2.0          50.0          90.0
              ============ ============ ============= ============ ============ =============
                  200       9.81±0.1μs    9.85±0.2μs   13.4±0.2μs   13.3±0.2μs     13.2±1μs
                 200000     13.1±0.2ms   13.2±0.06ms   13.3±0.1ms   9.68±0.1ms   4.56±0.04ms
              ============ ============ ============= ============ ============ =============
```
