### PR TITLE
NEP: mark NEP 28 on website redesign as final

### DIFF
--- a/doc/neps/nep-0028-website-redesign.rst
+++ b/doc/neps/nep-0028-website-redesign.rst
@@ -7,7 +7,7 @@ NEP 28 — numpy.org website redesign
 :Author: Ralf Gommers <ralf.gommers@gmail.com>
 :Author: Joe LaChance <joe@boldmetrics.com>
 :Author: Shekhar Rajak <shekharrajak.1994@gmail.com>
-:Status: Accepted
+:Status: Final
 :Type: Informational
 :Created: 2019-07-16
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2019-August/079889.html
@@ -323,7 +323,9 @@ Alternatives we considered for the overall design of the website:
 Discussion
 ----------
 
-Mailing list thread discussing this NEP: TODO
+- Pull request for this NEP (with a good amount of discussion): https://github.com/numpy/numpy/pull/14032
+- Email about NEP for review: https://mail.python.org/pipermail/numpy-discussion/2019-July/079856.html
+- Proposal to accept this NEP: https://mail.python.org/pipermail/numpy-discussion/2019-August/079889.html
 
 
 References and Footnotes


### PR DESCRIPTION
There will always be more work to do on the website, but this NEP was implemented and numpy.org has been live for over half a year. So time to mark this NEP as final.

`[ci skip]`

