### PR TITLE
MAINT: regex char class improve

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -1770,7 +1770,7 @@ class _Parse:
         tokens = tokens[start_pos:end_pos]
         return self._parse_target_tokens(tokens)
 
-    _parse_regex_arg = re.compile(r'\s|[,]|([+-])')
+    _parse_regex_arg = re.compile(r'\s|,|([+-])')
     def _parse_arg_features(self, arg_name, req_features):
         if not isinstance(req_features, str):
             self.dist_fatal("expected a string in '%s'" % arg_name)

--- a/numpy/distutils/command/build_src.py
+++ b/numpy/distutils/command/build_src.py
@@ -715,14 +715,14 @@ class build_src(build_ext.build_ext):
 
         return new_sources + py_files
 
-_f_pyf_ext_match = re.compile(r'.*[.](f90|f95|f77|for|ftn|f|pyf)\Z', re.I).match
-_header_ext_match = re.compile(r'.*[.](inc|h|hpp)\Z', re.I).match
+_f_pyf_ext_match = re.compile(r'.*\.(f90|f95|f77|for|ftn|f|pyf)\Z', re.I).match
+_header_ext_match = re.compile(r'.*\.(inc|h|hpp)\Z', re.I).match
 
 #### SWIG related auxiliary functions ####
 _swig_module_name_match = re.compile(r'\s*%module\s*(.*\(\s*package\s*=\s*"(?P<package>[\w_]+)".*\)|)\s*(?P<name>[\w_]+)',
                                      re.I).match
-_has_c_header = re.compile(r'-[*]-\s*c\s*-[*]-', re.I).search
-_has_cpp_header = re.compile(r'-[*]-\s*c[+][+]\s*-[*]-', re.I).search
+_has_c_header = re.compile(r'-\*-\s*c\s*-\*-', re.I).search
+_has_cpp_header = re.compile(r'-\*-\s*c\+\+\s*-\*-', re.I).search
 
 def get_swig_target(source):
     with open(source, 'r') as f:

--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -137,7 +137,7 @@ def paren_repl(obj):
     numrep = obj.group(2)
     return ','.join([torep]*int(numrep))
 
-parenrep = re.compile(r"[(]([^)]*)[)]\*(\d+)")
+parenrep = re.compile(r"\(([^)]*)\)\*(\d+)")
 plainrep = re.compile(r"([^*]+)\*(\d+)")
 def parse_values(astr):
     # replaces all occurrences of '(a,b,c)*4' in astr
@@ -207,7 +207,7 @@ def parse_loop_header(loophead) :
         dlist.append(tmp)
     return dlist
 
-replace_re = re.compile(r"@([\w]+)@")
+replace_re = re.compile(r"@(\w+)@")
 def parse_string(astr, env, level, line) :
     lineno = "#line %d\n" % line
 

--- a/numpy/distutils/extension.py
+++ b/numpy/distutils/extension.py
@@ -10,8 +10,8 @@ import re
 from distutils.extension import Extension as old_Extension
 
 
-cxx_ext_re = re.compile(r'.*[.](cpp|cxx|cc)\Z', re.I).match
-fortran_pyf_ext_re = re.compile(r'.*[.](f90|f95|f77|for|ftn|f|pyf)\Z', re.I).match
+cxx_ext_re = re.compile(r'.*\.(cpp|cxx|cc)\Z', re.I).match
+fortran_pyf_ext_re = re.compile(r'.*\.(f90|f95|f77|for|ftn|f|pyf)\Z', re.I).match
 
 
 class Extension(old_Extension):

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -962,10 +962,10 @@ def dummy_fortran_file():
     return name[:-2]
 
 
-is_f_file = re.compile(r'.*[.](for|ftn|f77|f)\Z', re.I).match
-_has_f_header = re.compile(r'-[*]-\s*fortran\s*-[*]-', re.I).search
-_has_f90_header = re.compile(r'-[*]-\s*f90\s*-[*]-', re.I).search
-_has_fix_header = re.compile(r'-[*]-\s*fix\s*-[*]-', re.I).search
+is_f_file = re.compile(r'.*\.(for|ftn|f77|f)\Z', re.I).match
+_has_f_header = re.compile(r'-\*-\s*fortran\s*-\*-', re.I).search
+_has_f90_header = re.compile(r'-\*-\s*f90\s*-\*-', re.I).search
+_has_fix_header = re.compile(r'-\*-\s*fix\s*-\*-', re.I).search
 _free_f90_start = re.compile(r'[^c*!]\s*[^\s\d\t]', re.I).match
 
 def is_free_format(file):

--- a/numpy/distutils/fcompiler/ibm.py
+++ b/numpy/distutils/fcompiler/ibm.py
@@ -77,7 +77,7 @@ class IBMFCompiler(FCompiler):
             fo, new_cfg = make_temp_file(suffix='_xlf.cfg')
             log.info('Creating '+new_cfg)
             with open(xlf_cfg, 'r') as fi:
-                crt1_match = re.compile(r'\s*crt\s*[=]\s*(?P<path>.*)/crt1.o').match
+                crt1_match = re.compile(r'\s*crt\s*=\s*(?P<path>.*)/crt1.o').match
                 for line in fi:
                     m = crt1_match(line)
                     if m:

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -206,7 +206,7 @@ def process_str(allstr):
 
     return writestr
 
-include_src_re = re.compile(r"(\n|\A)\s*include\s*['\"](?P<name>[\w\d./\\]+[.]src)['\"]", re.I)
+include_src_re = re.compile(r"(\n|\A)\s*include\s*['\"](?P<name>[\w\d./\\]+\.src)['\"]", re.I)
 
 def resolve_includes(source):
     d = os.path.dirname(source)

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -428,9 +428,9 @@ def msvc_runtime_major():
 #########################
 
 #XXX need support for .C that is also C++
-cxx_ext_match = re.compile(r'.*[.](cpp|cxx|cc)\Z', re.I).match
-fortran_ext_match = re.compile(r'.*[.](f90|f95|f77|for|ftn|f)\Z', re.I).match
-f90_ext_match = re.compile(r'.*[.](f90|f95)\Z', re.I).match
+cxx_ext_match = re.compile(r'.*\.(cpp|cxx|cc)\Z', re.I).match
+fortran_ext_match = re.compile(r'.*\.(f90|f95|f77|for|ftn|f)\Z', re.I).match
+f90_ext_match = re.compile(r'.*\.(f90|f95)\Z', re.I).match
 f90_module_name_match = re.compile(r'\s*module\s*(?P<name>[\w_]+)', re.I).match
 def _get_f90_modules(source):
     """Return a list of Fortran f90 module names that

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -294,10 +294,10 @@ def getextension(name):
         return ''
     return name[i + 1:]
 
-is_f_file = re.compile(r'.*[.](for|ftn|f77|f)\Z', re.I).match
-_has_f_header = re.compile(r'-[*]-\s*fortran\s*-[*]-', re.I).search
-_has_f90_header = re.compile(r'-[*]-\s*f90\s*-[*]-', re.I).search
-_has_fix_header = re.compile(r'-[*]-\s*fix\s*-[*]-', re.I).search
+is_f_file = re.compile(r'.*\.(for|ftn|f77|f)\Z', re.I).match
+_has_f_header = re.compile(r'-\*-\s*fortran\s*-\*-', re.I).search
+_has_f90_header = re.compile(r'-\*-\s*f90\s*-\*-', re.I).search
+_has_fix_header = re.compile(r'-\*-\s*fix\s*-\*-', re.I).search
 _free_f90_start = re.compile(r'[^c*]\s*[^\s\d\t]', re.I).match
 
 
@@ -1482,7 +1482,7 @@ def cracktypespec0(typespec, ll):
         ll = ll[i + 2:]
     return typespec, selector, attr, ll
 #####
-namepattern = re.compile(r'\s*(?P<name>\b[\w]+\b)\s*(?P<after>.*)\s*\Z', re.I)
+namepattern = re.compile(r'\s*(?P<name>\b\w+\b)\s*(?P<after>.*)\s*\Z', re.I)
 kindselector = re.compile(
     r'\s*(\(\s*(kind\s*=)?\s*(?P<kind>.*)\s*\)|[*]\s*(?P<kind2>.*?))\s*\Z', re.I)
 charselector = re.compile(

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -511,7 +511,7 @@ def run_compile():
         remove_build_dir = 1
         build_dir = tempfile.mkdtemp()
 
-    _reg1 = re.compile(r'[-][-]link[-]')
+    _reg1 = re.compile(r'--link-')
     sysinfo_flags = [_m for _m in sys.argv[1:] if _reg1.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in sysinfo_flags]
     if sysinfo_flags:
@@ -569,7 +569,7 @@ def run_compile():
             del flib_flags[i]
         assert len(flib_flags) <= 2, repr(flib_flags)
 
-    _reg5 = re.compile(r'[-][-](verbose)')
+    _reg5 = re.compile(r'--(verbose)')
     setup_flags = [_m for _m in sys.argv[1:] if _reg5.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in setup_flags]
 

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -1037,7 +1037,7 @@ def polydiv(u, v):
         return poly1d(q), poly1d(r)
     return q, r
 
-_poly_mat = re.compile(r"[*][*]([0-9]*)")
+_poly_mat = re.compile(r"\*\*([0-9]*)")
 def _raise_power(astr, wrap=70):
     n = 0
     line1 = ''

--- a/tools/commitstats.py
+++ b/tools/commitstats.py
@@ -4,7 +4,7 @@ import re
 import numpy as np
 import os
 
-names = re.compile(r'r\d+\s[|]\s(.*)\s[|]\s200')
+names = re.compile(r'r\d+\s\|\s(.*)\s\|\s200')
 
 def get_count(filename, repo):
     mystr = open(filename).read()


### PR DESCRIPTION
* replace superfluous single-character regex character
classes with their literal string equivalents; this
avoids the overhead associated with a character class
when there's only a single character enclosed (so there's
no benefit to the class overhead)--i.e., not a purely cosmetic
change

* for more information see:
Chapter 6 of:
Friedl, Jeffrey. Mastering Regular Expressions. 3rd ed.,
O’Reilly Media, 2009.

* on the topic of using classes to escape metacharacters, which is slightly more justified, the author notes `...it's probably because the author didn't know about escaping...` While that may be a little harsh, avoiding the overhead still makes sense to me.

* I probably didn't catch cases where `re.compile(..` spans multiple lines or is interpolated from constituent variables, but it is a start--the [scraping code](https://github.com/tylerjereddy/regex-improve) may eventually be augmented I suppose..