### PR TITLE
DOC: replace 'this platform' with the actual platform in the scalar type documentation

### DIFF
--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -6,6 +6,7 @@ platform-dependent information.
 from numpy.core import dtype
 from numpy.core import numerictypes as _numerictypes
 from numpy.core.function_base import add_newdoc
+import platform
 
 ##############################################################################
 #
@@ -56,7 +57,7 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     character_code = dtype(o).char
     canonical_name_doc = "" if obj == o.__name__ else ":Canonical name: `numpy.{}`\n    ".format(obj)
     alias_doc = ''.join(":Alias: `numpy.{}`\n    ".format(alias) for alias in fixed_aliases)
-    alias_doc += ''.join(":Alias on this platform: `numpy.{}`: {}.\n    ".format(alias, doc)
+    alias_doc += ''.join(":Alias on {} ({}): `numpy.{}`: {}.\n    ".format(platform.system(), platform.machine(), alias, doc)
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
     docstring = """
     {doc}

--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -50,6 +50,8 @@ possible_aliases = numeric_type_aliases([
     ])
 
 
+
+
 def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     # note: `:field: value` is rST syntax which renders as field lists.
     o = getattr(_numerictypes, obj)
@@ -57,7 +59,7 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     character_code = dtype(o).char
     canonical_name_doc = "" if obj == o.__name__ else ":Canonical name: `numpy.{}`\n    ".format(obj)
     alias_doc = ''.join(":Alias: `numpy.{}`\n    ".format(alias) for alias in fixed_aliases)
-    alias_doc += ''.join(":Alias on {} ({}): `numpy.{}`: {}.\n    ".format(platform.system(), platform.machine(), alias, doc)
+    alias_doc += ''.join(":Alias on this platform ({} {}): `numpy.{}`: {}.\n    ".format(platform.system(), platform.machine(), alias, doc)
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
     docstring = """
     {doc}


### PR DESCRIPTION
This pull changes the wording of the scalar type documentation so that it uses information from python's `platform` module (specifically `{platform.system()} ({platform.machine()}`) instead of the phrase 'this platform', which does not make it obvious that 'this platform' refers to the platform the documentation was built on, as well as which platform that is.