### PR TITLE
BUG, SIMD: Fix _simd module build for 64bit Arm/neon clang

### DIFF
--- a/numpy/core/src/_simd/_simd_easyintrin.inc
+++ b/numpy/core/src/_simd/_simd_easyintrin.inc
@@ -87,10 +87,10 @@
             simd_arg_converter, &arg1,                    \
             simd_arg_converter, &arg2                     \
         )) return NULL;                                   \
-        simd_data data;                                   \
+        simd_data data = {.u64 = 0};                      \
         data.RET = NPY_CAT(SIMD__IMPL_COUNT_, CONST_RNG)( \
             SIMD__REPEAT_2IMM, NAME, IN0                  \
-        ) npyv_##NAME(arg1.data.IN0, 0);                  \
+        ) data.RET;                                       \
         simd_arg_free(&arg1);                             \
         simd_arg ret = {                                  \
             .data = data, .dtype = simd_data_##RET        \

--- a/numpy/core/src/common/simd/neon/operators.h
+++ b/numpy/core/src/common/simd/neon/operators.h
@@ -34,12 +34,12 @@
 #define npyv_shr_s64(A, C) vshlq_s64(A, npyv_setall_s64(-(C)))
 
 // right by an immediate constant
-#define npyv_shri_u16(VEC, C) ((C) == 0 ? VEC : vshrq_n_u16(VEC, C))
-#define npyv_shri_s16(VEC, C) ((C) == 0 ? VEC : vshrq_n_s16(VEC, C))
-#define npyv_shri_u32(VEC, C) ((C) == 0 ? VEC : vshrq_n_u32(VEC, C))
-#define npyv_shri_s32(VEC, C) ((C) == 0 ? VEC : vshrq_n_s32(VEC, C))
-#define npyv_shri_u64(VEC, C) ((C) == 0 ? VEC : vshrq_n_u64(VEC, C))
-#define npyv_shri_s64(VEC, C) ((C) == 0 ? VEC : vshrq_n_s64(VEC, C))
+#define npyv_shri_u16 vshrq_n_u16
+#define npyv_shri_s16 vshrq_n_s16
+#define npyv_shri_u32 vshrq_n_u32
+#define npyv_shri_s32 vshrq_n_s32
+#define npyv_shri_u64 vshrq_n_u64
+#define npyv_shri_s64 vshrq_n_s64
 
 /***************************
  * Logical

--- a/numpy/core/tests/test_simd.py
+++ b/numpy/core/tests/test_simd.py
@@ -173,14 +173,21 @@ class _SIMD_INT(_Test_Utility):
             # left shift
             shl = self.shl(vdata_a, count)
             assert shl == data_shl_a
-            # left shift by an immediate constant
-            shli = self.shli(vdata_a, count)
-            assert shli == data_shl_a
             # load to cast
             data_shr_a = self.load([a >> count for a in data_a])
             # right shift
             shr = self.shr(vdata_a, count)
             assert shr == data_shr_a
+
+        # shift by zero or max or out-range immediate constant is not applicable and illogical
+        for count in range(1, self._scalar_size()):
+            # load to cast
+            data_shl_a = self.load([a << count for a in data_a])
+            # left shift by an immediate constant
+            shli = self.shli(vdata_a, count)
+            assert shli == data_shl_a
+            # load to cast
+            data_shr_a = self.load([a >> count for a in data_a])
             # right shift by an immediate constant
             shri = self.shri(vdata_a, count)
             assert shri == data_shr_a


### PR DESCRIPTION
#### Fix _simd module build for 64bit Arm/neon clang

related to #17964, closes #18105

##### Steps to reproduce
build NumPy 1.20/master on aarch64/arm64 clang e.g. m1 platform

<details>
<summary>Error log</summary>

```Bash
compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd -Inumpy/core/include -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/include/numpy -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/Users/*/miniforge3/include/python3.9 -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/common -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/npymath -c'
extra options: '-Werror'
clang: build/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd/_simd.dispatch.c
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 16]
SIMD_IMPL_INTRIN_2IMM(shri_u16, vu16, vu16, 16)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:152:1: note: expanded from here
npyv_shri_u16
^
numpy/core/src/common/simd/neon/operators.h:37:49: note: expanded from macro 'npyv_shri_u16'
#define npyv_shri_u16(VEC, C) ((C) == 0 ? VEC : vshrq_n_u16(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:24005:24: note: expanded from macro 'vshrq_n_u16'
  __ret = (uint16x8_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 49); \
                       ^                                         ~~~~
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 16]
SIMD_IMPL_INTRIN_2IMM(shri_s16, vs16, vs16, 16)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:79:1: note: expanded from here
npyv_shri_s16
^
numpy/core/src/common/simd/neon/operators.h:38:49: note: expanded from macro 'npyv_shri_s16'
#define npyv_shri_s16(VEC, C) ((C) == 0 ? VEC : vshrq_n_s16(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:24077:23: note: expanded from macro 'vshrq_n_s16'
  __ret = (int16x8_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 33); \
                      ^                                         ~~~~
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 32]
SIMD_IMPL_INTRIN_2IMM(shri_u32, vu32, vu32, 32)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:32:1: note: expanded from here
npyv_shri_u32
^
numpy/core/src/common/simd/neon/operators.h:39:49: note: expanded from macro 'npyv_shri_u32'
#define npyv_shri_u32(VEC, C) ((C) == 0 ? VEC : vshrq_n_u32(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:23969:24: note: expanded from macro 'vshrq_n_u32'
  __ret = (uint32x4_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 50); \
                       ^                                         ~~~~
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 32]
SIMD_IMPL_INTRIN_2IMM(shri_s32, vs32, vs32, 32)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:189:1: note: expanded from here
npyv_shri_s32
^
numpy/core/src/common/simd/neon/operators.h:40:49: note: expanded from macro 'npyv_shri_s32'
#define npyv_shri_s32(VEC, C) ((C) == 0 ? VEC : vshrq_n_s32(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:24041:23: note: expanded from macro 'vshrq_n_s32'
  __ret = (int32x4_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 34); \
                      ^                                         ~~~~
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 64]
SIMD_IMPL_INTRIN_2IMM(shri_u64, vu64, vu64, 64)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:200:1: note: expanded from here
npyv_shri_u64
^
numpy/core/src/common/simd/neon/operators.h:41:49: note: expanded from macro 'npyv_shri_u64'
#define npyv_shri_u64(VEC, C) ((C) == 0 ? VEC : vshrq_n_u64(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:23987:24: note: expanded from macro 'vshrq_n_u64'
  __ret = (uint64x2_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 51); \
                       ^                                         ~~~~
numpy/core/src/_simd/_simd.dispatch.c.src:306:1: error: argument value 0 is outside the valid range [1, 64]
SIMD_IMPL_INTRIN_2IMM(shri_s64, vs64, vs64, 64)
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
numpy/core/src/_simd/_simd_easyintrin.inc:93:11: note: expanded from macro 'SIMD_IMPL_INTRIN_2IMM'
        ) npyv_##NAME(arg1.data.IN0, 0);                  \
          ^                          ~
<scratch space>:185:1: note: expanded from here
npyv_shri_s64
^
numpy/core/src/common/simd/neon/operators.h:42:49: note: expanded from macro 'npyv_shri_s64'
#define npyv_shri_s64(VEC, C) ((C) == 0 ? VEC : vshrq_n_s64(VEC, C))
                                                ^                ~
/Library/Developer/CommandLineTools/usr/lib/clang/12.0.0/include/arm_neon.h:24059:23: note: expanded from macro 'vshrq_n_s64'
  __ret = (int64x2_t) __builtin_neon_vshrq_n_v((int8x16_t)__s0, __p1, 35); \
                      ^                                         ~~~~
6 errors generated.
error: Command "clang -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /Users/*/miniforge3/include -arch arm64 -fPIC -O2 -isystem /Users/*/miniforge3/include -arch arm64 -DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd -Inumpy/core/include -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/include/numpy -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/Users/*/miniforge3/include/python3.9 -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/common -Ibuild/src.macosx-11.0-arm64-3.9/numpy/core/src/npymath -c build/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd/_simd.dispatch.c -o build/temp.macosx-11.0-arm64-3.9/build/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd/_simd.dispatch.o -MMD -MF build/temp.macosx-11.0-arm64-3.9/build/src.macosx-11.0-arm64-3.9/numpy/core/src/_simd/_simd.dispatch.o.d -Werror" failed with exit status 1

````

</details>