### PR TITLE
DOC: Avoid using "set of" when talking about an ordered list.

### DIFF
--- a/benchmarks/benchmarks/bench_app.py
+++ b/benchmarks/benchmarks/bench_app.py
@@ -70,8 +70,8 @@ class MaxesOfDots(Benchmark):
 
         Arrays must agree only on the first dimension.
 
-        For numpy it a join benchmark of dot products and max()
-        on a set of arrays.
+        Numpy uses this as a simultaneous benchmark of 1) dot products
+        and 2) max(<array>, axis=<int>).
         """
         feature_scores = ([0] * len(arrays))
         for (i, sd) in enumerate(arrays):

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -14,7 +14,7 @@ nx, ny = 1000, 1000
 # time-consuming functions (ufunc, linalg, etc)
 nxs, nys = 100, 100
 
-# a set of interesting types to test
+# a list of interesting types to test
 TYPES1 = [
     'int16', 'float16',
     'int32', 'float32',

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -308,7 +308,7 @@ def _choose_dispatcher(a, choices, out=None, mode=None):
 @array_function_dispatch(_choose_dispatcher)
 def choose(a, choices, out=None, mode='raise'):
     """
-    Construct an array from an index array and a set of arrays to choose from.
+    Construct an array from an index array and a list of arrays to choose from.
 
     First of all, if confused or uncertain, definitely look at the Examples -
     in its full generality, this function is less simple than it might

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1019,7 +1019,7 @@ array_getarray(PyArrayObject *self, PyObject *args)
 }
 
 /*
- * Check whether any of a set of input and output args have a non-default
+ * Check whether any of the input and output args have a non-default
  * __array_ufunc__ method. Return 1 if so, 0 if not, and -1 on error.
  *
  * This function primarily exists to help ndarray.__array_ufunc__ determine

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -846,7 +846,7 @@ def gradient(f, *varargs, axis=None, edge_order=1):
     Returns
     -------
     gradient : ndarray or list of ndarray
-        A set of ndarrays (or a single ndarray if there is only one dimension)
+        A list of ndarrays (or a single ndarray if there is only one dimension)
         corresponding to the derivatives of f with respect to each dimension.
         Each derivative has the same shape as f.
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -678,7 +678,7 @@ def _histogram_dispatcher(
 def histogram(a, bins=10, range=None, normed=None, weights=None,
               density=None):
     r"""
-    Compute the histogram of a set of data.
+    Compute the histogram of a dataset.
 
     Parameters
     ----------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -7339,9 +7339,9 @@ def where(condition, x=_NoValue, y=_NoValue):
 
 def choose(indices, choices, out=None, mode='raise'):
     """
-    Use an index array to construct a new array from a set of choices.
+    Use an index array to construct a new array from a list of choices.
 
-    Given an array of integers and a set of n choice arrays, this method
+    Given an array of integers and a list of n choice arrays, this method
     will create a new array that merges each of the choice arrays.  Where a
     value in `a` is i, the new array will have the value that choices[i]
     contains in the same place.

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1322,7 +1322,7 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
         observation of all those variables. Also see `rowvar` below.
     y : array_like, optional
         An additional set of variables and observations. `y` has the same
-        form as `x`.
+        shape as `x`.
     rowvar : bool, optional
         If `rowvar` is True (default), then each row represents a
         variable, with observations in the columns. Otherwise, the relationship

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -694,7 +694,7 @@ class ABCPolyBase(abc.ABC):
         Returns
         -------
         new_series : series
-            Contains the new set of coefficients.
+            New instance of series with trimmed coefficients.
 
         """
         coef = pu.trimcoef(self.coef, tol)

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -339,7 +339,7 @@ class parameterized:
                             "'@parameterized.expand' instead.")
 
     def _terrible_magic_get_defining_classes(self):
-        """ Returns the set of parent classes of the class currently being defined.
+        """ Returns the list of parent classes of the class currently being defined.
             Will likely only work if called from the ``parameterized`` decorator.
             This function is entirely @brandon_rhodes's fault, as he suggested
             the implementation: http://stackoverflow.com/a/8793684/71522

--- a/tools/npy_tempita/__init__.py
+++ b/tools/npy_tempita/__init__.py
@@ -705,7 +705,7 @@ lead_whitespace_re = re.compile(r'^[\t ]*\n')
 
 def trim_lex(tokens):
     r"""
-    Takes a lexed set of tokens, and removes whitespace when there is
+    Takes a lexed list of tokens, and removes whitespace when there is
     a directive on a line by itself:
 
        >>> tokens = lex('{{if x}}\nx\n{{endif}}\ny', trim_whitespace=False)

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -305,7 +305,7 @@ def compare(all_dict, others, names, module_name):
         List of non deprecated sub modules for module_name
     others : list
         List of sub modules for module_name
-    names :  set
+    names : set
         Set of function names or special directives present in
         docstring of module_name
     module_name : ModuleType
@@ -780,7 +780,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
 
     Parameters
     ----------
-    tests: list
+    tests : list
 
     full_name : str
 


### PR DESCRIPTION
... or when the input isn't/cannot be a set.  I left a few usages, e.g.
in random sampling, where "set" is reasonable as informal description of
an array as the order doesn't matter; however, for e.g. np.gradient the
order of the returned list is clearly important, so "set" is wrong.

Also some other minor doc edits noticed during the grepping: using
`shape` instead of `form` in `cov` is consistent with most other places;
the wording in `Polynomial.trim` now matches other methods on the same
class.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
