### PR TITLE
TST: Avoid changing odd tempfile names in tests' site.cfg

### DIFF
--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -269,7 +269,7 @@ class TestSystemInfoReading:
             # But if we copy the values to a '[mkl]' section the value
             # is correct
             with open(cfg, 'r') as fid:
-                mkl = fid.read().replace('ALL', 'mkl')
+                mkl = fid.read().replace('[ALL]', '[mkl]', 1)
             with open(cfg, 'w') as fid:
                 fid.write(mkl)
             info = mkl_info()
@@ -277,7 +277,7 @@ class TestSystemInfoReading:
 
             # Also, the values will be taken from a section named '[DEFAULT]'
             with open(cfg, 'r') as fid:
-                dflt = fid.read().replace('mkl', 'DEFAULT')
+                dflt = fid.read().replace('[mkl]', '[DEFAULT]', 1)
             with open(cfg, 'w') as fid:
                 fid.write(dflt)
             info = mkl_info()


### PR DESCRIPTION
CI once produced a tempfile name with the string 'mkl' embedded.  The
old code changed this as well as the section name.  This should ensure
only section names get changed, and the restriction on the number of
replacements should catch any weird corner cases, since I think the
sections came first.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
