### PR TITLE
TST: Turn some tests with loops into parametrized tests.

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8577,22 +8577,15 @@ def test_equal_override():
 
 
 @pytest.mark.parametrize(
-    ["fun", "npfun", "x", "y", "test_dtype"],
+    ["fun", "npfun"],
     [
-        pytest.param(
-            fun, npfun, x, y, test_dtype
-        )
-        for (fun, npfun), x, y, test_dtype in itertools.product(
-                [
-                    (_multiarray_tests.npy_cabs, np.absolute),
-                    (_multiarray_tests.npy_carg, np.angle),
-                ],
-                [1, np.inf, -np.inf, np.nan],
-                [1, np.inf, -np.inf, np.nan],
-                [np.complex64, np.complex128, np.clongdouble],
-        )
-    ],
+        (_multiarray_tests.npy_cabs, np.absolute),
+        (_multiarray_tests.npy_carg, np.angle)
+    ]
 )
+@pytest.mark.parametrize("x", [1, np.inf, -np.inf, np.nan])
+@pytest.mark.parametrize("y", [1, np.inf, -np.inf, np.nan])
+@pytest.mark.parametrize("test_dtype", np.complexfloating.__subclasses__())
 def test_npymath_complex(fun, npfun, x, y, test_dtype):
     # Smoketest npymath functions
     z = test_dtype(complex(x, y))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -8576,23 +8576,29 @@ def test_equal_override():
         assert_equal(array != my_always_equal, 'ne')
 
 
-def test_npymath_complex():
+@pytest.mark.parametrize(
+    ["fun", "npfun", "x", "y", "test_dtype"],
+    [
+        pytest.param(
+            fun, npfun, x, y, test_dtype
+        )
+        for (fun, npfun), x, y, test_dtype in itertools.product(
+                [
+                    (_multiarray_tests.npy_cabs, np.absolute),
+                    (_multiarray_tests.npy_carg, np.angle),
+                ],
+                [1, np.inf, -np.inf, np.nan],
+                [1, np.inf, -np.inf, np.nan],
+                [np.complex64, np.complex128, np.clongdouble],
+        )
+    ],
+)
+def test_npymath_complex(fun, npfun, x, y, test_dtype):
     # Smoketest npymath functions
-    from numpy.core._multiarray_tests import (
-        npy_cabs, npy_carg)
-
-    funcs = {npy_cabs: np.absolute,
-             npy_carg: np.angle}
-    vals = (1, np.inf, -np.inf, np.nan)
-    types = (np.complex64, np.complex128, np.clongdouble)
-
-    for fun, npfun in funcs.items():
-        for x, y in itertools.product(vals, vals):
-            for t in types:
-                z = t(complex(x, y))
-                got = fun(z)
-                expected = npfun(z)
-                assert_allclose(got, expected)
+    z = test_dtype(complex(x, y))
+    got = fun(z)
+    expected = npfun(z)
+    assert_allclose(got, expected)
 
 
 def test_npymath_real():

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -673,23 +673,11 @@ class TestAbs:
         x = test_dtype(np.finfo(test_dtype).min)
         assert_equal(absfunc(x), -x.real)
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            pytest.param(dtype)
-            for dtype in floating_types + complex_floating_types
-        ],
-    )
+    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_builtin_abs(self, dtype):
         self._test_abs_func(abs, dtype)
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            pytest.param(dtype)
-            for dtype in floating_types + complex_floating_types
-        ],
-    )
+    @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_numpy_abs(self, dtype):
         self._test_abs_func(np.abs, dtype)
 

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -653,33 +653,45 @@ class TestSubtract:
 
 
 class TestAbs:
-    def _test_abs_func(self, absfunc):
-        for tp in floating_types + complex_floating_types:
-            x = tp(-1.5)
-            assert_equal(absfunc(x), 1.5)
-            x = tp(0.0)
-            res = absfunc(x)
-            # assert_equal() checks zero signedness
-            assert_equal(res, 0.0)
-            x = tp(-0.0)
-            res = absfunc(x)
-            assert_equal(res, 0.0)
+    def _test_abs_func(self, absfunc, test_dtype):
+        x = test_dtype(-1.5)
+        assert_equal(absfunc(x), 1.5)
+        x = test_dtype(0.0)
+        res = absfunc(x)
+        # assert_equal() checks zero signedness
+        assert_equal(res, 0.0)
+        x = test_dtype(-0.0)
+        res = absfunc(x)
+        assert_equal(res, 0.0)
 
-            x = tp(np.finfo(tp).max)
-            assert_equal(absfunc(x), x.real)
+        x = test_dtype(np.finfo(test_dtype).max)
+        assert_equal(absfunc(x), x.real)
 
-            x = tp(np.finfo(tp).tiny)
-            assert_equal(absfunc(x), x.real)
+        x = test_dtype(np.finfo(test_dtype).tiny)
+        assert_equal(absfunc(x), x.real)
 
-            x = tp(np.finfo(tp).min)
-            assert_equal(absfunc(x), -x.real)
+        x = test_dtype(np.finfo(test_dtype).min)
+        assert_equal(absfunc(x), -x.real)
 
-    def test_builtin_abs(self):
-        self._test_abs_func(abs)
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            pytest.param(dtype)
+            for dtype in floating_types + complex_floating_types
+        ],
+    )
+    def test_builtin_abs(self, dtype):
+        self._test_abs_func(abs, dtype)
 
-    def test_numpy_abs(self):
-        self._test_abs_func(np.abs)
-
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            pytest.param(dtype)
+            for dtype in floating_types + complex_floating_types
+        ],
+    )
+    def test_numpy_abs(self, dtype):
+        self._test_abs_func(np.abs, dtype)
 
 class TestBitShifts:
 


### PR DESCRIPTION
I wanted to mark only some parts of the loops as xfail for another PR.  That part of the PR probably won't make it into numpy, but parametrized tests give better information on failure than tests with loops do, especially if the test segfaults during execution, so I'm submitting these here.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
