### PR TITLE
API: make piecewise subclass safe using use zeros_like.

### DIFF
--- a/doc/release/upcoming_changes/18110.change.rst
+++ b/doc/release/upcoming_changes/18110.change.rst
@@ -1,0 +1,5 @@
+`numpy.piecewise` output class now matches the input class
+----------------------------------------------------------
+When `numpy.ndarray` subclasses are used on input to `numpy.piecewise`,
+they are passed on to the functions. The output will now be of the
+same subclass as well.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.core.numeric as _nx
 from numpy.core import transpose
 from numpy.core.numeric import (
-    ones, zeros, arange, concatenate, array, asarray, asanyarray, empty,
+    ones, zeros_like, arange, concatenate, array, asarray, asanyarray, empty,
     ndarray, around, floor, ceil, take, dot, where, intp,
     integer, isscalar, absolute
     )
@@ -606,7 +606,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
             .format(n, n, n+1)
         )
 
-    y = zeros(x.shape, x.dtype)
+    y = zeros_like(x)
     for cond, func in zip(condlist, funclist):
         if not isinstance(func, collections.abc.Callable):
             y[cond] = func

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2399,6 +2399,14 @@ class TestPiecewise:
         assert_array_equal(y, np.array([[-1., -1., -1.],
                                         [3., 3., 1.]]))
 
+    def test_subclasses(self):
+        class subclass(np.ndarray):
+            pass
+        x = np.arange(5.).view(subclass)
+        r = piecewise(x, [x<2., x>=4], [-1., 1., 0.])
+        assert_equal(type(r), subclass)
+        assert_equal(r, [-1., -1., 0., 0., 1.])
+
 
 class TestBincount:
 


### PR DESCRIPTION
Arguably more logical and makes the otherwise very subclass-aware code subclass safe.

Mostly because as I am implementing [a new `Masked` class](https://github.com/astropy/astropy/pull/11127) that can handle subclasses properly, I found that for my `__array_function__` helpers I had to copy the whole `piecewise` implementation to just make this single change.