### PR TITLE
DEP: Deprecate promotion of numbers and bool to string

### DIFF
--- a/doc/release/upcoming_changes/18116.future.rst
+++ b/doc/release/upcoming_changes/18116.future.rst
@@ -1,0 +1,29 @@
+Promotion of strings with numbers and bools is deprecated
+---------------------------------------------------------
+Any promotion of numbers and strings is deprecated and will
+give a ``FutureWarning`` the main affected functionalities
+are:
+
+* `numpy.promote_types` and `numpy.result_type` which will raise
+  an error in this case in the future.
+* `numpy.concatenate` will raise an error when concatenating a string
+  and numeric array. You can use ``dtype="S"`` to explicitly request
+  a string result.
+* `numpy.array` and related functions will start returning ``object``
+  arrays because these functions use ``object`` as a fallback when
+  no common dtype can be found. (In this case setting the
+  ``FutureWarning`` to be raised will unfortunately lead to the new
+  behaviour)
+
+This will mainly affect code such as::
+
+    np.asarray(['string', 0])
+
+and::
+
+    np.concatenate((['string'], [0]))
+
+in both cases adding ``dtype="U"`` or ``dtype="S"`` will give the
+previous (string) result.
+
+Comparisons, universal functions, and casting are not affected by this.

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -407,6 +407,19 @@ string_unicode_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         Py_INCREF(Py_NotImplemented);
         return (PyArray_DTypeMeta *)Py_NotImplemented;
     }
+    if (other->type_num != NPY_STRING && other->type_num != NPY_UNICODE) {
+        /* Deprecated 2020-12-19, NumPy 1.21. */
+        if (DEPRECATE_FUTUREWARNING(
+                "Promotion of numbers and bools to strings is deprecated. "
+                "In the future, code such as `np.concatenate((['string'], [0]))` "
+                "will raise an error, while `np.asarray(['string', 0])` will "
+                "return an array with `dtype=object`.  To avoid the warning "
+                "while retaining a string result use `dtype='U'` (or 'S').  "
+                "To get an array of Python objects use `dtype=object`. "
+                "(Warning added in NumPy 1.21)") < 0) {
+            return NULL;
+        }
+    }
     /*
      * The builtin types are ordered by complexity (aside from object) here.
      * Arguably, we should not consider numbers and strings "common", but

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -234,6 +234,7 @@ class TestScalarDiscovery:
 
     # Additionally to string this test also runs into a corner case
     # with datetime promotion (the difference is the promotion order).
+    @pytest.mark.filterwarnings("ignore:Promotion of numbers:FutureWarning")
     def test_scalar_promotion(self):
         for sc1, sc2 in product(scalar_instances(), scalar_instances()):
             sc1, sc2 = sc1.values[0], sc2.values[0]

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -71,8 +71,10 @@ class TestHalf:
     def test_half_conversion_to_string(self, string_dt):
         # Currently uses S/U32 (which is sufficient for float32)
         expected_dt = np.dtype(f"{string_dt}32")
-        assert np.promote_types(np.float16, string_dt) == expected_dt
-        assert np.promote_types(string_dt, np.float16) == expected_dt
+        with pytest.warns(FutureWarning):
+            assert np.promote_types(np.float16, string_dt) == expected_dt
+        with pytest.warns(FutureWarning):
+            assert np.promote_types(string_dt, np.float16) == expected_dt
 
         arr = np.ones(3, dtype=np.float16).astype(string_dt)
         assert arr.dtype == expected_dt

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -847,10 +847,12 @@ class TestTypes:
         assert_equal(np.promote_types('<i8', '<i8'), np.dtype('i8'))
         assert_equal(np.promote_types('>i8', '>i8'), np.dtype('i8'))
 
-        assert_equal(np.promote_types('>i8', '>U16'), np.dtype('U21'))
-        assert_equal(np.promote_types('<i8', '<U16'), np.dtype('U21'))
-        assert_equal(np.promote_types('>U16', '>i8'), np.dtype('U21'))
-        assert_equal(np.promote_types('<U16', '<i8'), np.dtype('U21'))
+        with pytest.warns(FutureWarning,
+                match="Promotion of numbers and bools to strings"):
+            assert_equal(np.promote_types('>i8', '>U16'), np.dtype('U21'))
+            assert_equal(np.promote_types('<i8', '<U16'), np.dtype('U21'))
+            assert_equal(np.promote_types('>U16', '>i8'), np.dtype('U21'))
+            assert_equal(np.promote_types('<U16', '<i8'), np.dtype('U21'))
 
         assert_equal(np.promote_types('<S5', '<U8'), np.dtype('U8'))
         assert_equal(np.promote_types('>S5', '>U8'), np.dtype('U8'))
@@ -897,32 +899,38 @@ class TestTypes:
             promote_types = np.promote_types
 
         S = string_dtype
-        # Promote numeric with unsized string:
-        assert_equal(promote_types('bool', S), np.dtype(S+'5'))
-        assert_equal(promote_types('b', S), np.dtype(S+'4'))
-        assert_equal(promote_types('u1', S), np.dtype(S+'3'))
-        assert_equal(promote_types('u2', S), np.dtype(S+'5'))
-        assert_equal(promote_types('u4', S), np.dtype(S+'10'))
-        assert_equal(promote_types('u8', S), np.dtype(S+'20'))
-        assert_equal(promote_types('i1', S), np.dtype(S+'4'))
-        assert_equal(promote_types('i2', S), np.dtype(S+'6'))
-        assert_equal(promote_types('i4', S), np.dtype(S+'11'))
-        assert_equal(promote_types('i8', S), np.dtype(S+'21'))
-        # Promote numeric with sized string:
-        assert_equal(promote_types('bool', S+'1'), np.dtype(S+'5'))
-        assert_equal(promote_types('bool', S+'30'), np.dtype(S+'30'))
-        assert_equal(promote_types('b', S+'1'), np.dtype(S+'4'))
-        assert_equal(promote_types('b', S+'30'), np.dtype(S+'30'))
-        assert_equal(promote_types('u1', S+'1'), np.dtype(S+'3'))
-        assert_equal(promote_types('u1', S+'30'), np.dtype(S+'30'))
-        assert_equal(promote_types('u2', S+'1'), np.dtype(S+'5'))
-        assert_equal(promote_types('u2', S+'30'), np.dtype(S+'30'))
-        assert_equal(promote_types('u4', S+'1'), np.dtype(S+'10'))
-        assert_equal(promote_types('u4', S+'30'), np.dtype(S+'30'))
-        assert_equal(promote_types('u8', S+'1'), np.dtype(S+'20'))
-        assert_equal(promote_types('u8', S+'30'), np.dtype(S+'30'))
-        # Promote with object:
-        assert_equal(promote_types('O', S+'30'), np.dtype('O'))
+        
+        with pytest.warns(FutureWarning,
+                match="Promotion of numbers and bools to strings") as record:
+            # Promote numeric with unsized string:
+            assert_equal(promote_types('bool', S), np.dtype(S+'5'))
+            assert_equal(promote_types('b', S), np.dtype(S+'4'))
+            assert_equal(promote_types('u1', S), np.dtype(S+'3'))
+            assert_equal(promote_types('u2', S), np.dtype(S+'5'))
+            assert_equal(promote_types('u4', S), np.dtype(S+'10'))
+            assert_equal(promote_types('u8', S), np.dtype(S+'20'))
+            assert_equal(promote_types('i1', S), np.dtype(S+'4'))
+            assert_equal(promote_types('i2', S), np.dtype(S+'6'))
+            assert_equal(promote_types('i4', S), np.dtype(S+'11'))
+            assert_equal(promote_types('i8', S), np.dtype(S+'21'))
+            # Promote numeric with sized string:
+            assert_equal(promote_types('bool', S+'1'), np.dtype(S+'5'))
+            assert_equal(promote_types('bool', S+'30'), np.dtype(S+'30'))
+            assert_equal(promote_types('b', S+'1'), np.dtype(S+'4'))
+            assert_equal(promote_types('b', S+'30'), np.dtype(S+'30'))
+            assert_equal(promote_types('u1', S+'1'), np.dtype(S+'3'))
+            assert_equal(promote_types('u1', S+'30'), np.dtype(S+'30'))
+            assert_equal(promote_types('u2', S+'1'), np.dtype(S+'5'))
+            assert_equal(promote_types('u2', S+'30'), np.dtype(S+'30'))
+            assert_equal(promote_types('u4', S+'1'), np.dtype(S+'10'))
+            assert_equal(promote_types('u4', S+'30'), np.dtype(S+'30'))
+            assert_equal(promote_types('u8', S+'1'), np.dtype(S+'20'))
+            assert_equal(promote_types('u8', S+'30'), np.dtype(S+'30'))
+            # Promote with object:
+            assert_equal(promote_types('O', S+'30'), np.dtype('O'))
+
+        assert len(record) == 22  # each string promotion gave one warning
+
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
             [[np.dtype("V6"), np.dtype("V10")],
@@ -972,6 +980,7 @@ class TestTypes:
             assert res.isnative
 
     @pytest.mark.slow
+    @pytest.mark.filterwarnings('ignore:Promotion of numbers:FutureWarning')
     @pytest.mark.parametrize(["dtype1", "dtype2"],
             itertools.product(
                 list(np.typecodes["All"]) +

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -782,7 +782,9 @@ class TestRegression:
         # Ticket #514
         s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         t = []
-        np.hstack((t, s))
+        with pytest.warns(FutureWarning,
+                match="Promotion of numbers and bools to strings"):
+            np.hstack((t, s))
 
     def test_arr_transpose(self):
         # Ticket #516

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -256,7 +256,7 @@ class TestConcatenate:
         r = np.concatenate((a, b), axis=None)
         assert_equal(r.size, a.size + len(b))
         assert_equal(r.dtype, a.dtype)
-        r = np.concatenate((a, b, c), axis=None)
+        r = np.concatenate((a, b, c), axis=None, dtype="U")
         d = array(['0.0', '1.0', '2.0', '3.0',
                    '0', '1', '2', 'x'])
         assert_array_equal(r, d)
@@ -377,7 +377,8 @@ class TestConcatenate:
         # Note that U0 and S0 should be deprecated eventually and changed to
         # actually give the empty string result (together with `np.array`)
         res = np.concatenate(arrs, axis=axis, dtype=string_dt, casting="unsafe")
-        assert res.dtype == np.promote_types("d", string_dt)
+        # The actual dtype should be identical to a cast (of a double array):
+        assert res.dtype == np.array(1.).astype(string_dt).dtype
 
     @pytest.mark.parametrize("axis", [None, 0])
     def test_string_dtype_does_not_inspect(self, axis):

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -1,3 +1,5 @@
+import pytest
+
 import os
 
 import numpy as np
@@ -62,7 +64,8 @@ class TestRegression:
     def test_mem_string_concat(self):
         # Ticket #469
         x = np.array([])
-        np.append(x, 'asdasd\tasdasd')
+        with pytest.warns(FutureWarning):
+            np.append(x, 'asdasd\tasdasd')
 
     def test_poly_div(self):
         # Ticket #553


### PR DESCRIPTION
This deprecates promotion of strings and numbers (and bool). This an absolutely necessary step to make things sane at some point...  (marking as draft for now, as it is based off the fix for promotion with half precision and string).

Some notes:
* Promotion to string is, quite frankly, nonsense. It is so bad that pandas has to work around our behaviour (they don't even notice this change because of that, as far as I am aware).  I think `safe` casting to string is *also* weird, but most places where we use "safe casting" as logic (i.e. ufuncs) *should be using promotion* instead, so I just don't care much anymore how we define "safe" casting.  (Safe casting is just another casting level, and not a fundamental operator used for any logic.)
* FutureWarning isn't ideal, as DeprecationWarning would be nicer, but I am not sure I want yet another special case to work around the fact that it is defined in one place and `np.array` uses a `try/except`.
* I did add a work-around for ufunc type resolution so no warning is given there (since that will error anyway).  That might turn out aannoying to keep. But probably I have to keep a similar hack in place in any case, since the alternative would be to shorten the deprecation period.  (The could become akward when we start adding ufunc loops for strings, which we want to)