### PR TITLE
ENH: Use buffered space in linalg.matrix_power

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -651,17 +651,19 @@ def matrix_power(a, n):
         return fmatmul(a, a)
 
     elif n == 3:
-        return fmatmul(fmatmul(a, a), a)
+        # create and use buffered space
+        buffer = fmatmul(a, a)
+        return fmatmul(buffer, a, out=buffer)
 
     # Use binary decomposition to reduce the number of matrix multiplications.
     # Here, we iterate over the bits of n, from LSB to MSB, raise `a` to
     # increasing powers of 2, and multiply into the result as needed.
     z = result = None
     while n > 0:
-        z = a if z is None else fmatmul(z, z)
+        z = a.copy() if z is None else fmatmul(z, z, out=z)
         n, bit = divmod(n, 2)
         if bit:
-            result = z if result is None else fmatmul(result, z)
+            result = z.copy() if result is None else fmatmul(result, z, out=result)
 
     return result
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1039,6 +1039,18 @@ class TestMatrixPower:
             if dt != object:
                 tz(self.stacked.astype(dt))
 
+    def test_power_is_three(self, dt):
+        def tz(mat):
+            mz = matrix_power(mat, 3)
+            mmul = matmul if mat.dtype != object else dot
+            assert_equal(mz, mmul(mat, mmul(mat, mat)))
+            assert_equal(mz.dtype, mat.dtype)
+
+        for mat in self.rshft_all:
+            tz(mat.astype(dt))
+            if dt != object:
+                tz(self.stacked.astype(dt))
+
     def test_power_is_minus_one(self, dt):
         def tz(mat):
             invmat = matrix_power(mat, -1)


### PR DESCRIPTION
The linalg.matrix_power function allocates new space
for each matrix multiplication that it performs.
For large matrices, creating and using a buffer
can lead to performance benefits.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
