### PR TITLE
MAINT: Remove redundant null check before free

### DIFF
--- a/numpy/core/src/npysort/timsort.c.src
+++ b/numpy/core/src/npysort/timsort.c.src
@@ -507,9 +507,7 @@ timsort_@suff@(void *start, npy_intp num, void *NPY_UNUSED(varr))
     ret = 0;
 cleanup:
 
-    if (buffer.pw != NULL) {
-        free(buffer.pw);
-    }
+    free(buffer.pw);
 
     return ret;
 }


### PR DESCRIPTION
`free(NULL)` is guaranteed to do nothing in C.