### PR TITLE
MAINT: Remove unnecessary variable iOuter from @TYPE@_matmul

### DIFF
--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -398,7 +398,6 @@ NPY_NO_EXPORT void
 @TYPE@_matmul(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     npy_intp dOuter = *dimensions++;
-    npy_intp iOuter;
     npy_intp s0 = *steps++;
     npy_intp s1 = *steps++;
     npy_intp s2 = *steps++;
@@ -429,8 +428,7 @@ NPY_NO_EXPORT void
                               is_blasable2d(is2_n, sz, dn, 1, sz));
 #endif
 
-    for (iOuter = 0; iOuter < dOuter; iOuter++,
-                         args[0] += s0, args[1] += s1, args[2] += s2) {
+    while (dOuter > 0) {
         void *ip1=args[0], *ip2=args[1], *op=args[2];
 #if @USEBLAS@ && defined(HAVE_CBLAS)
         /*
@@ -505,6 +503,10 @@ NPY_NO_EXPORT void
                                    op, os_m, os_p, dm, dn, dp);
 
 #endif
+        args[0] += s0;
+        args[1] += s1;
+        args[2] += s2;
+        dOuter--;
     }
 }
 


### PR DESCRIPTION
In my opinion, the code is easier to understand with these changes. However, there are performance implications as well: I confirmed that GCC does not automatically optimize out variables like `iOuter` even with `-O3` by inspecting the generated assembly code of the following two programs:

```
#include <stdio.h>

void matmul(const int *dimensions)
{
    int dOuter = *dimensions++;
    int iOuter;
    for (iOuter = 0; iOuter < dOuter; iOuter++)
    {
        puts("loop");
    }
}

int main(int argc, char **argv)
{
    matmul(&argc);
    return 0;
}
```

```
#include <stdio.h>

void matmul(const int *dimensions)
{
    int dOuter;
    for (dOuter = *dimensions++; dOuter > 0; dOuter--)
    {
        puts("loop");
    }
}

int main(int argc, char **argv)
{
    matmul(&argc);
    return 0;
}
```

The first results in 93 lines of x86_64 assembly code whereas the second results in only 86.