### PR TITLE
TST: add a pypy37 windows 64-bit build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,11 @@ stages:
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64
+          PyPy37-64bit-full:
+            PYTHON_VERSION: 'PyPy3.7'
+            PYTHON_ARCH: 'x64'
+            TEST_MODE: full
+            BITS: 64
           Python38-32bit-fast:
             PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ stages:
           PyPy37-64bit-full:
             PYTHON_VERSION: 'PyPy3.7'
             PYTHON_ARCH: 'x64'
-            TEST_MODE: full
+            TEST_MODE: fast
             BITS: 64
           Python38-32bit-fast:
             PYTHON_VERSION: '3.8'

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -6,7 +6,7 @@ steps:
     architecture: $(PYTHON_ARCH)
   condition: not(contains(variables['PYTHON_VERSION'], 'PyPy'))
 - powershell: |
-    $url = "http://buildbot.pypy.org/nightly/py3.6/pypy-c-jit-latest-win32.zip"
+    $url = "http://buildbot.pypy.org/nightly/py3.7/pypy-c-jit-latest-win64.zip"
     $output = "pypy.zip"
     $wc = New-Object System.Net.WebClient
     $wc.DownloadFile($url, $output)


### PR DESCRIPTION
PyPy now has an 64-bit windows build. Locally tests pass. 