### PR TITLE
ENH: Improve performance of tril_indices and triu_indices

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -93,6 +93,12 @@ class Core(Benchmark):
     def time_tril_l10x10(self):
         np.tril(self.l10x10)
 
+    def time_triu_indices_500(self):
+        np.triu_indices(500)
+
+    def time_tril_indices_500(self):
+        np.tril_indices(500)
+
 
 class Temporaries(Benchmark):
     def setup(self):

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -894,7 +894,10 @@ def tril_indices(n, k=0, m=None):
            [-10, -10, -10, -10]])
 
     """
-    return nonzero(tri(n, m, k=k, dtype=bool))
+    tri = np.tri(n, m=m, k=k, dtype=bool)
+
+    return tuple(np.broadcast_to(inds, tri.shape)[tri]
+                 for inds in np.indices(tri.shape, sparse=True))
 
 
 def _trilu_indices_form_dispatcher(arr, k=None):
@@ -1010,7 +1013,10 @@ def triu_indices(n, k=0, m=None):
            [ 12,  13,  14,  -1]])
 
     """
-    return nonzero(~tri(n, m, k=k-1, dtype=bool))
+    tri = ~np.tri(n, m, k=k - 1, dtype=bool)
+
+    return tuple(np.broadcast_to(inds, tri.shape)[tri]
+                 for inds in np.indices(tri.shape, sparse=True))
 
 
 @array_function_dispatch(_trilu_indices_form_dispatcher)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -6,11 +6,12 @@ import functools
 from numpy.core.numeric import (
     asanyarray, arange, zeros, greater_equal, multiply, ones,
     asarray, where, int8, int16, int32, int64, empty, promote_types, diagonal,
-    nonzero
+    nonzero, indices
     )
 from numpy.core.overrides import set_array_function_like_doc, set_module
 from numpy.core import overrides
 from numpy.core import iinfo
+from numpy.lib.stride_tricks import broadcast_to
 
 
 __all__ = [
@@ -894,10 +895,10 @@ def tril_indices(n, k=0, m=None):
            [-10, -10, -10, -10]])
 
     """
-    tri = np.tri(n, m, k=k, dtype=bool)
+    tri_ = tri(n, m, k=k, dtype=bool)
 
-    return tuple(np.broadcast_to(inds, tri.shape)[tri]
-                 for inds in np.indices(tri.shape, sparse=True))
+    return tuple(broadcast_to(inds, tri_.shape)[tri_]
+                 for inds in indices(tri_.shape, sparse=True))
 
 
 def _trilu_indices_form_dispatcher(arr, k=None):
@@ -1013,10 +1014,10 @@ def triu_indices(n, k=0, m=None):
            [ 12,  13,  14,  -1]])
 
     """
-    tri = ~np.tri(n, m, k=k - 1, dtype=bool)
+    tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 
-    return tuple(np.broadcast_to(inds, tri.shape)[tri]
-                 for inds in np.indices(tri.shape, sparse=True))
+    return tuple(broadcast_to(inds, tri_.shape)[tri_]
+                 for inds in indices(tri_.shape, sparse=True))
 
 
 @array_function_dispatch(_trilu_indices_form_dispatcher)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -894,7 +894,7 @@ def tril_indices(n, k=0, m=None):
            [-10, -10, -10, -10]])
 
     """
-    tri = np.tri(n, m=m, k=k, dtype=bool)
+    tri = np.tri(n, m, k=k, dtype=bool)
 
     return tuple(np.broadcast_to(inds, tri.shape)[tri]
                  for inds in np.indices(tri.shape, sparse=True))


### PR DESCRIPTION
`np.nonzero` seems slow compared to other methods. Use `np.indices` and `np.broadcast_to` to speed it up.

Closes #18153.

Performance comparison:
```python
import numpy as np


def tril_indices(n, k=0, m=None):
    tri = np.tri(n, m, k=k, dtype=bool)

    return tuple(np.broadcast_to(inds, tri.shape)[tri]
                 for inds in np.indices(tri.shape, sparse=True))


def triu_indices(n, k=0, m=None):
    tri = ~np.tri(n, m, k=k - 1, dtype=bool)

    return tuple(np.broadcast_to(inds, tri.shape)[tri]
                 for inds in np.indices(tri.shape, sparse=True))

# Original numpy implementation with nonzero:
%timeit np.tril_indices(500)
2.14 ms ± 52.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# New implementation:
%timeit tril_indices(500)
684 µs ± 60.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```