### PR TITLE
BUG: Fix f2py bugs when wrapping F90 subroutines.

### DIFF
--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -976,7 +976,7 @@ def is_free_format(file):
     with open(file, encoding='latin1') as f:
         line = f.readline()
         n = 10000 # the number of non-comment lines to scan for hints
-        if _has_f_header(line):
+        if _has_f_header(line) or _has_fix_header(line):
             n = 0
         elif _has_f90_header(line):
             n = 0

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -257,6 +257,7 @@ def ismodule(rout):
 def isfunction(rout):
     return 'block' in rout and 'function' == rout['block']
 
+
 def isfunction_wrap(rout):
     if isintent_c(rout):
         return 0
@@ -282,6 +283,10 @@ def hasassumedshape(rout):
                 rout['hasassumedshape'] = True
                 return True
     return False
+
+
+def requiresf90wrapper(rout):
+    return ismoduleroutine(rout) or hasassumedshape(rout)
 
 
 def isroutine(rout):

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3232,11 +3232,11 @@ def vars2fortran(block, vars, args, tab='', as_interface=False):
             outmess('vars2fortran: No definition for argument "%s".\n' % a)
             continue
         if a == block['name']:
-            if block['block'] == 'function':
-                if block.get('result'):
-                    # skip declaring function if its result is already declared
-                    continue
-            else:
+            if block['block'] != 'function' or block.get('result'):
+                # 1) skip declaring a variable that name matches with
+                #    subroutine name
+                # 2) skip declaring function when its type is
+                #    declared via `result` construction
                 continue
         if 'typespec' not in vars[a]:
             if 'attrspec' in vars[a] and 'external' in vars[a]['attrspec']:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3113,7 +3113,7 @@ def crack2fortrangen(block, tab='\n', as_interface=False):
         result = ' result (%s)' % block['result']
         if block['result'] not in argsl:
             argsl.append(block['result'])
-    body = crack2fortrangen(block['body'], tab + tabchar)
+    body = crack2fortrangen(block['body'], tab + tabchar, as_interface=as_interface)
     vars = vars2fortran(
         block, block['vars'], argsl, tab + tabchar, as_interface=as_interface)
     mess = ''
@@ -3231,8 +3231,13 @@ def vars2fortran(block, vars, args, tab='', as_interface=False):
             show(vars)
             outmess('vars2fortran: No definition for argument "%s".\n' % a)
             continue
-        if a == block['name'] and not block['block'] == 'function':
-            continue
+        if a == block['name']:
+            if block['block'] == 'function':
+                if block.get('result'):
+                    # skip declaring function if its result is already declared
+                    continue
+            else:
+                continue
         if 'typespec' not in vars[a]:
             if 'attrspec' in vars[a] and 'external' in vars[a]['attrspec']:
                 if a in args:

--- a/numpy/f2py/func2subr.py
+++ b/numpy/f2py/func2subr.py
@@ -130,7 +130,7 @@ def createfuncwrapper(rout, signature=0):
             l = l + ', ' + fortranname
     if need_interface:
         for line in rout['saved_interface'].split('\n'):
-            if line.lstrip().startswith('use '):
+            if line.lstrip().startswith('use ') and '__user__' not in line:
                 add(line)
 
     args = args[1:]
@@ -222,7 +222,7 @@ def createsubrwrapper(rout, signature=0):
 
     if need_interface:
         for line in rout['saved_interface'].split('\n'):
-            if line.lstrip().startswith('use '):
+            if line.lstrip().startswith('use ') and '__user__' not in line:
                 add(line)
 
     dumped_args = []
@@ -247,7 +247,10 @@ def createsubrwrapper(rout, signature=0):
             pass
         else:
             add('interface')
-            add(rout['saved_interface'].lstrip())
+            for line in rout['saved_interface'].split('\n'):
+                if line.lstrip().startswith('use ') and '__user__' in line:
+                    continue
+                add(line)
             add('end interface')
 
     sargs = ', '.join([a for a in args if a not in extra_args])

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1186,7 +1186,7 @@ def buildmodule(m, um):
         for nb in nb_list:
             api, wrap = buildapi(nb)
             if wrap:
-                if ismoduleroutine(nb):
+                if ismoduleroutine(nb) or issubroutine_wrap(nb):
                     funcwrappers2.append(wrap)
                 else:
                     funcwrappers.append(wrap)
@@ -1310,7 +1310,11 @@ def buildmodule(m, um):
                 '!     It contains Fortran 90 wrappers to fortran functions.\n')
             lines = []
             for l in ('\n\n'.join(funcwrappers2) + '\n').split('\n'):
-                if len(l) > 72 and l[0] == ' ':
+                i = l.find('!')
+                if i >= 0 and i < 72:
+                    # don't split comment lines
+                    lines.append(l + '\n')
+                elif len(l) > 72 and l[0] == ' ':
                     lines.append(l[:72] + '&\n     &')
                     l = l[72:]
                     while len(l) > 66:

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -73,7 +73,7 @@ from .auxfuncs import (
     issubroutine, issubroutine_wrap, isthreadsafe, isunsigned,
     isunsigned_char, isunsigned_chararray, isunsigned_long_long,
     isunsigned_long_longarray, isunsigned_short, isunsigned_shortarray,
-    l_and, l_not, l_or, outmess, replace, stripcomma,
+    l_and, l_not, l_or, outmess, replace, stripcomma, requiresf90wrapper
 )
 
 from . import capi_maps
@@ -1184,9 +1184,12 @@ def buildmodule(m, um):
                 nb1['args'] = a
                 nb_list.append(nb1)
         for nb in nb_list:
+            # requiresf90wrapper must be called before buildapi as it
+            # rewrites assumed shape arrays as automatic arrays.
+            isf90 = requiresf90wrapper(nb)
             api, wrap = buildapi(nb)
             if wrap:
-                if ismoduleroutine(nb) or issubroutine_wrap(nb):
+                if isf90:
                     funcwrappers2.append(wrap)
                 else:
                     funcwrappers.append(wrap)
@@ -1288,7 +1291,11 @@ def buildmodule(m, um):
                 'C     It contains Fortran 77 wrappers to fortran functions.\n')
             lines = []
             for l in ('\n\n'.join(funcwrappers) + '\n').split('\n'):
-                if l and l[0] == ' ':
+                i = l.find('!')
+                if i >= 0 and i < 66:
+                    # don't split comment lines
+                    lines.append(l + '\n')
+                elif l and l[0] == ' ':
                     while len(l) >= 66:
                         lines.append(l[:66] + '\n     &')
                         l = l[66:]

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1291,8 +1291,7 @@ def buildmodule(m, um):
                 'C     It contains Fortran 77 wrappers to fortran functions.\n')
             lines = []
             for l in ('\n\n'.join(funcwrappers) + '\n').split('\n'):
-                i = l.find('!')
-                if i >= 0 and i < 66:
+                if 0 <= l.find('!') < 66:
                     # don't split comment lines
                     lines.append(l + '\n')
                 elif l and l[0] == ' ':
@@ -1317,8 +1316,7 @@ def buildmodule(m, um):
                 '!     It contains Fortran 90 wrappers to fortran functions.\n')
             lines = []
             for l in ('\n\n'.join(funcwrappers2) + '\n').split('\n'):
-                i = l.find('!')
-                if i >= 0 and i < 72:
+                if 0 <= l.find('!') < 72:
                     # don't split comment lines
                     lines.append(l + '\n')
                 elif len(l) > 72 and l[0] == ' ':

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -217,7 +217,7 @@ class TestF90Callback(util.F2PyTest):
 
     suffix = '.f90'
 
-    code = """
+    code = textwrap.dedent("""
     function gh17797(f, y) result(r)
       external f
       integer(8) :: r, f
@@ -225,7 +225,7 @@ class TestF90Callback(util.F2PyTest):
       r = f(0)
       r = r + sum(y)
     end function gh17797
-    """
+    """)
 
     def test_gh17797(self):
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -211,3 +211,27 @@ class TestF77CallbackPythonTLS(TestF77Callback):
     compiler-provided
     """
     options = ["-DF2PY_USE_PYTHON_TLS"]
+
+
+class TestF90Callback(util.F2PyTest):
+
+    suffix = '.f90'
+
+    code = """
+function gh17797(f, y) result(r)
+  external f
+  integer(8) :: r, f
+  integer(8), dimension(:) :: y
+  r = f(0)
+  r = r + sum(y)
+end function gh17797
+    """
+
+    def test_gh17797(self):
+
+        def incr(x):
+            return x + 123
+
+        y = np.array([1, 2, 3], dtype=np.int64)
+        r = self.module.gh17797(incr, y)
+        assert r == 123 + 1 + 2 + 3

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -217,15 +217,16 @@ class TestF90Callback(util.F2PyTest):
 
     suffix = '.f90'
 
-    code = textwrap.dedent("""
-    function gh17797(f, y) result(r)
-      external f
-      integer(8) :: r, f
-      integer(8), dimension(:) :: y
-      r = f(0)
-      r = r + sum(y)
-    end function gh17797
-    """)
+    code = textwrap.dedent(
+        """
+        function gh17797(f, y) result(r)
+          external f
+          integer(8) :: r, f
+          integer(8), dimension(:) :: y
+          r = f(0)
+          r = r + sum(y)
+        end function gh17797
+        """)
 
     def test_gh17797(self):
 

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -218,13 +218,13 @@ class TestF90Callback(util.F2PyTest):
     suffix = '.f90'
 
     code = """
-function gh17797(f, y) result(r)
-  external f
-  integer(8) :: r, f
-  integer(8), dimension(:) :: y
-  r = f(0)
-  r = r + sum(y)
-end function gh17797
+    function gh17797(f, y) result(r)
+      external f
+      integer(8) :: r, f
+      integer(8), dimension(:) :: y
+      r = f(0)
+      r = r + sum(y)
+    end function gh17797
     """
 
     def test_gh17797(self):


### PR DESCRIPTION
This PR fixes the following bugs:
- Fortran sources in fixed format were incorrectly detected as free format sources
- f2py specific modules (with names containing `__user__`) must not be used in Fortran sources to be compiled
- Subroutines/functions using assumed shape array inputs were incorrectly treated as F77 codes. Closes #17797 
- Avoid splitting long comment lines

The PR supersedes #17800 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
