### PR TITLE
STY: Use explicit reexports for numpy.typing objects

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -295,9 +295,9 @@ from ._scalars import (
     _VoidLike,
 )
 from ._shape import _Shape, _ShapeLike
-from ._dtype_like import _SupportsDType, _VoidDTypeLike, DTypeLike
+from ._dtype_like import _SupportsDType, _VoidDTypeLike, DTypeLike as DTypeLike
 from ._array_like import (
-    ArrayLike,
+    ArrayLike as ArrayLike,
     _ArrayLike,
     _NestedSequence,
     _SupportsArray,


### PR DESCRIPTION
`mypy --strict` is disabling `implicit_reexport`.  Consequently, when we try to
 import `ArrayLike` and `DTypeLike` from `numpy.typing`, mypy throws an error.

With this commit we add explicit "reexports" for these two objects.

Fixes #18190