### PR TITLE
MAINT: Use explicit reexports for numpy.typing objects

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -217,9 +217,9 @@ from ._scalars import (
     _ScalarLike,
     _VoidLike,
 )
-from ._array_like import _SupportsArray, ArrayLike
+from ._array_like import _SupportsArray, ArrayLike as ArrayLike
 from ._shape import _Shape, _ShapeLike
-from ._dtype_like import _SupportsDType, _VoidDTypeLike, DTypeLike
+from ._dtype_like import _SupportsDType, _VoidDTypeLike, DTypeLike as DTypeLike
 
 if __doc__ is not None:
     from ._add_docstring import _docstrings


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/18191.

`mypy --strict` is disabling `implicit_reexport`.  Consequently, when we try to
 import `ArrayLike` and `DTypeLike` from `numpy.typing`, mypy throws an error.

With this commit we add explicit "reexports" for these two objects.
