### PR TITLE
MAINT: Fix typo in docstring example

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1092,7 +1092,7 @@ cdef class Generator:
         0.0  # may vary
 
         >>> abs(sigma - np.std(s, ddof=1))
-        0.1  # may vary
+        0.0  # may vary
 
         Display the histogram of the samples, along with
         the probability density function:


### PR DESCRIPTION
Hello, I think that an error of 0.1 on the estimated std is not a good thing when the desired std was 0.1 :)

I think it is a typo. Locally, I obtained an error of around 0.002 for both the mean and the std, so I think it would make more sense to write 0.0 as an ideal value, as it is done for the mean.