### PR TITLE
MAINT: einsum: Optimize the sub function two-operands by using SIMD.

### DIFF
--- a/numpy/core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/core/src/multiarray/einsum_sumprod.c.src
@@ -20,28 +20,6 @@
 #include "simd/simd.h"
 #include "common.h"
 
-#ifdef NPY_HAVE_SSE_INTRINSICS
-#define EINSUM_USE_SSE1 1
-#else
-#define EINSUM_USE_SSE1 0
-#endif
-
-#ifdef NPY_HAVE_SSE2_INTRINSICS
-#define EINSUM_USE_SSE2 1
-#else
-#define EINSUM_USE_SSE2 0
-#endif
-
-#if EINSUM_USE_SSE1
-#include <xmmintrin.h>
-#endif
-
-#if EINSUM_USE_SSE2
-#include <emmintrin.h>
-#endif
-
-#define EINSUM_IS_SSE_ALIGNED(x) ((((npy_intp)x)&0xf) == 0)
-
 // ARM/Neon don't have instructions for aligned memory access
 #ifdef NPY_HAVE_NEON
     #define EINSUM_IS_ALIGNED(x) 0
@@ -311,6 +289,77 @@ finish_after_unrolled_loop:
 
 #elif @nop@ == 2 && !@complex@
 
+// calculate the multiply and add operation such as dataout = data*scalar+dataout
+static NPY_GCC_OPT_3 void
+@name@_sum_of_products_muladd(@type@ *data, @type@ *data_out, @temptype@ scalar, npy_intp count)
+{
+#if @NPYV_CHK@ // NPYV check for @type@
+    /* Use aligned instructions if possible */
+    const int is_aligned = EINSUM_IS_ALIGNED(data) && EINSUM_IS_ALIGNED(data_out);
+    const int vstep = npyv_nlanes_@sfx@;
+    const npyv_@sfx@ v_scalar = npyv_setall_@sfx@(scalar);
+    /**begin repeat2
+     * #cond = if(is_aligned), else#
+     * #ld = loada, load#
+     * #st = storea, store#
+     */
+    @cond@ {
+        const npy_intp vstepx4 = vstep * 4;
+        for (; count >= vstepx4; count -= vstepx4, data += vstepx4, data_out += vstepx4) {
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@sfx@ b@i@ = npyv_@ld@_@sfx@(data + vstep * @i@);
+            npyv_@sfx@ c@i@ = npyv_@ld@_@sfx@(data_out + vstep * @i@);
+            /**end repeat3**/
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@sfx@ abc@i@ = npyv_muladd_@sfx@(v_scalar, b@i@, c@i@);
+            /**end repeat3**/
+            /**begin repeat3
+             * #i = 0, 1, 2, 3#
+             */
+            npyv_@st@_@sfx@(data_out + vstep * @i@, abc@i@);
+            /**end repeat3**/
+        }
+    }
+    /**end repeat2**/
+    for (; count > 0; count -= vstep, data += vstep, data_out += vstep) {
+        npyv_@sfx@ a = npyv_load_tillz_@sfx@(data, count);
+        npyv_@sfx@ b = npyv_load_tillz_@sfx@(data_out, count);
+        npyv_store_till_@sfx@(data_out, count, npyv_muladd_@sfx@(a, v_scalar, b));
+    }
+    npyv_cleanup();
+#else
+#ifndef NPY_DISABLE_OPTIMIZATION
+    for (; count >= 4; count -= 4, data += 4, data_out += 4) {
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        const @type@ b@i@ = @from@(data[@i@]);
+        const @type@ c@i@ = @from@(data_out[@i@]);
+        /**end repeat2**/
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        const @type@ abc@i@ = scalar * b@i@ + c@i@;
+        /**end repeat2**/
+        /**begin repeat2
+         * #i = 0, 1, 2, 3#
+         */
+        data_out[@i@] = @to@(abc@i@);
+        /**end repeat2**/
+    }
+#endif // !NPY_DISABLE_OPTIMIZATION
+    for (; count > 0; --count, ++data, ++data_out) {
+        const @type@ b = @from@(*data);
+        const @type@ c = @from@(*data_out);
+        *data_out = @to@(scalar * b + c);
+    }
+#endif // NPYV check for @type@
+}
+
 static void
 @name@_sum_of_products_contig_two(int nop, char **dataptr,
                                 npy_intp const *NPY_UNUSED(strides), npy_intp count)
@@ -403,242 +452,23 @@ static void
     @type@ *data1 = (@type@ *)dataptr[1];
     @type@ *data_out = (@type@ *)dataptr[2];
 
-#if EINSUM_USE_SSE1 && @float32@
-    __m128 a, b, value0_sse;
-#elif EINSUM_USE_SSE2 && @float64@
-    __m128d a, b, value0_sse;
-#endif
-
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_stride0_contig_outcontig_two (%d)\n",
                                                     (int)count);
-
-/* This is placed before the main loop to make small counts faster */
-finish_after_unrolled_loop:
-    switch (count) {
-/**begin repeat2
- * #i = 6, 5, 4, 3, 2, 1, 0#
- */
-        case @i@+1:
-            data_out[@i@] = @to@(value0 *
-                                 @from@(data1[@i@]) +
-                                 @from@(data_out[@i@]));
-/**end repeat2**/
-        case 0:
-            return;
-    }
-
-#if EINSUM_USE_SSE1 && @float32@
-    value0_sse = _mm_set_ps1(value0);
-
-    /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data1) && EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
-
-/**begin repeat2
- * #i = 0, 4#
- */
-            a = _mm_mul_ps(value0_sse, _mm_load_ps(data1+@i@));
-            b = _mm_add_ps(a, _mm_load_ps(data_out+@i@));
-            _mm_store_ps(data_out+@i@, b);
-/**end repeat2**/
-            data1 += 8;
-            data_out += 8;
-        }
-
-        /* Finish off the loop */
-        if (count > 0) {
-            goto finish_after_unrolled_loop;
-        }
-        else {
-            return;
-        }
-    }
-#elif EINSUM_USE_SSE2 && @float64@
-    value0_sse = _mm_set1_pd(value0);
-
-    /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data1) && EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
-
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-            a = _mm_mul_pd(value0_sse, _mm_load_pd(data1+@i@));
-            b = _mm_add_pd(a, _mm_load_pd(data_out+@i@));
-            _mm_store_pd(data_out+@i@, b);
-/**end repeat2**/
-            data1 += 8;
-            data_out += 8;
-        }
-
-        /* Finish off the loop */
-        if (count > 0) {
-            goto finish_after_unrolled_loop;
-        }
-        else {
-            return;
-        }
-    }
-#endif
-
-    /* Unroll the loop by 8 */
-    while (count >= 8) {
-        count -= 8;
-
-#if EINSUM_USE_SSE1 && @float32@
-/**begin repeat2
- * #i = 0, 4#
- */
-        a = _mm_mul_ps(value0_sse, _mm_loadu_ps(data1+@i@));
-        b = _mm_add_ps(a, _mm_loadu_ps(data_out+@i@));
-        _mm_storeu_ps(data_out+@i@, b);
-/**end repeat2**/
-#elif EINSUM_USE_SSE2 && @float64@
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-        a = _mm_mul_pd(value0_sse, _mm_loadu_pd(data1+@i@));
-        b = _mm_add_pd(a, _mm_loadu_pd(data_out+@i@));
-        _mm_storeu_pd(data_out+@i@, b);
-/**end repeat2**/
-#else
-/**begin repeat2
- * #i = 0, 1, 2, 3, 4, 5, 6, 7#
- */
-        data_out[@i@] = @to@(value0 *
-                             @from@(data1[@i@]) +
-                             @from@(data_out[@i@]));
-/**end repeat2**/
-#endif
-        data1 += 8;
-        data_out += 8;
-    }
-
-    /* Finish off the loop */
-    if (count > 0) {
-        goto finish_after_unrolled_loop;
-    }
+    @name@_sum_of_products_muladd(data1, data_out, value0, count);
+    
 }
 
 static void
 @name@_sum_of_products_contig_stride0_outcontig_two(int nop, char **dataptr,
                                 npy_intp const *NPY_UNUSED(strides), npy_intp count)
 {
-    @type@ *data0 = (@type@ *)dataptr[0];
     @temptype@ value1 = @from@(*(@type@ *)dataptr[1]);
+    @type@ *data0 = (@type@ *)dataptr[0];
     @type@ *data_out = (@type@ *)dataptr[2];
-
-#if EINSUM_USE_SSE1 && @float32@
-    __m128 a, b, value1_sse;
-#elif EINSUM_USE_SSE2 && @float64@
-    __m128d a, b, value1_sse;
-#endif
 
     NPY_EINSUM_DBG_PRINT1("@name@_sum_of_products_contig_stride0_outcontig_two (%d)\n",
                                                     (int)count);
-
-/* This is placed before the main loop to make small counts faster */
-finish_after_unrolled_loop:
-    switch (count) {
-/**begin repeat2
- * #i = 6, 5, 4, 3, 2, 1, 0#
- */
-        case @i@+1:
-            data_out[@i@] = @to@(@from@(data0[@i@])*
-                                 value1  +
-                                 @from@(data_out[@i@]));
-/**end repeat2**/
-        case 0:
-            return;
-    }
-
-#if EINSUM_USE_SSE1 && @float32@
-    value1_sse = _mm_set_ps1(value1);
-
-    /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
-
-/**begin repeat2
- * #i = 0, 4#
- */
-            a = _mm_mul_ps(_mm_load_ps(data0+@i@), value1_sse);
-            b = _mm_add_ps(a, _mm_load_ps(data_out+@i@));
-            _mm_store_ps(data_out+@i@, b);
-/**end repeat2**/
-            data0 += 8;
-            data_out += 8;
-        }
-
-        /* Finish off the loop */
-        goto finish_after_unrolled_loop;
-    }
-#elif EINSUM_USE_SSE2 && @float64@
-    value1_sse = _mm_set1_pd(value1);
-
-    /* Use aligned instructions if possible */
-    if (EINSUM_IS_SSE_ALIGNED(data0) && EINSUM_IS_SSE_ALIGNED(data_out)) {
-        /* Unroll the loop by 8 */
-        while (count >= 8) {
-            count -= 8;
-
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-            a = _mm_mul_pd(_mm_load_pd(data0+@i@), value1_sse);
-            b = _mm_add_pd(a, _mm_load_pd(data_out+@i@));
-            _mm_store_pd(data_out+@i@, b);
-/**end repeat2**/
-            data0 += 8;
-            data_out += 8;
-        }
-
-        /* Finish off the loop */
-        goto finish_after_unrolled_loop;
-    }
-#endif
-
-    /* Unroll the loop by 8 */
-    while (count >= 8) {
-        count -= 8;
-
-#if EINSUM_USE_SSE1 && @float32@
-/**begin repeat2
- * #i = 0, 4#
- */
-        a = _mm_mul_ps(_mm_loadu_ps(data0+@i@), value1_sse);
-        b = _mm_add_ps(a, _mm_loadu_ps(data_out+@i@));
-        _mm_storeu_ps(data_out+@i@, b);
-/**end repeat2**/
-#elif EINSUM_USE_SSE2 && @float64@
-/**begin repeat2
- * #i = 0, 2, 4, 6#
- */
-        a = _mm_mul_pd(_mm_loadu_pd(data0+@i@), value1_sse);
-        b = _mm_add_pd(a, _mm_loadu_pd(data_out+@i@));
-        _mm_storeu_pd(data_out+@i@, b);
-/**end repeat2**/
-#else
-/**begin repeat2
- * #i = 0, 1, 2, 3, 4, 5, 6, 7#
- */
-        data_out[@i@] = @to@(@from@(data0[@i@])*
-                             value1  +
-                             @from@(data_out[@i@]));
-/**end repeat2**/
-#endif
-        data0 += 8;
-        data_out += 8;
-    }
-
-    /* Finish off the loop */
-    goto finish_after_unrolled_loop;
+    @name@_sum_of_products_muladd(data0, data_out, value1, count);
 }
 
 static NPY_GCC_OPT_3 void


### PR DESCRIPTION
## Introduction

Here is the final part of #17049 , With code reduced by 69%, There has no impact on X86 platform and about 14%~49% increased performance in ARM. 

## Benchmark

Here is the ASV benchmark result.
<details>
<summary>SSE2 enabled</summary>
<pre><code>
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython
·· Building e4402bd8 <einsum-twooperands> for virtualenv-py3.7-Cython
·· Installing e4402bd8 <einsum-twooperands> into virtualenv-py3.7-Cython
· Running 28 total benchmarks (2 commits * 1 environments * 14 benchmarks)
[  0.00%] · For numpy commit 2908338b <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[  1.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 25.00%] · For numpy commit e4402bd8 <einsum-twooperands> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 26.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 50.00%] · For numpy commit e4402bd8 <einsum-twooperands> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 51.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                   ok
[ 51.79%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   139±2μs
               numpy.float64   240±5μs
              =============== =========

[ 53.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                               ok
[ 53.57%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   130±1μs
               numpy.float64   229±9μs
              =============== =========

[ 55.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                             ok
[ 55.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.40±0.05ms
               numpy.float64   2.74±0.03ms
              =============== =============

[ 57.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                        ok
[ 57.14%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   65.5±0.7μs
               numpy.float64    78.9±3μs
              =============== ============

[ 58.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                            ok
[ 58.93%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32    42.1±1μs
               numpy.float64   43.4±0.5μs
              =============== ============

[ 60.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                        ok
[ 60.71%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   32.0±0.7μs
               numpy.float64    33.0±2μs
              =============== ============

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                      ok
[ 62.50%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   39.6±2μs
               numpy.float64   46.3±3μs
              =============== ==========

[ 64.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                 ok
[ 64.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   67.9±3μs
               numpy.float64   78.3±4μs
              =============== ==========

[ 66.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                    ok
[ 66.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   10.7±0.1ms
               numpy.float64   21.8±0.3ms
              =============== ============

[ 67.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                  ok
[ 67.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   65.3±1μs
               numpy.float64   65.9±6μs
              =============== ==========

[ 69.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                 ok
[ 69.64%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   57.7±5μs
               numpy.float64   63.5±2μs
              =============== ==========

[ 71.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                           ok
[ 71.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   24.7±0.3ms
               numpy.float64   49.9±0.7ms
              =============== ============

[ 73.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                         ok
[ 73.21%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   55.7±2μs
               numpy.float64   59.5±3μs
              =============== ==========

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                        ok
[ 75.00%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   55.2±0.9μs
               numpy.float64    57.7±2μs
              =============== ============

[ 75.00%] · For numpy commit 2908338b <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 76.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                   ok
[ 76.79%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   149±7μs
               numpy.float64   237±4μs
              =============== =========

[ 78.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                               ok
[ 78.57%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   133±8μs
               numpy.float64   226±20μs
              =============== ==========

[ 80.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                             ok
[ 80.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.31±0.01ms
               numpy.float64   2.66±0.06ms
              =============== =============

[ 82.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                        ok
[ 82.14%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   65.6±4μs
               numpy.float64   79.2±4μs
              =============== ==========

[ 83.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                            ok
[ 83.93%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   42.2±1μs
               numpy.float64   44.8±3μs
              =============== ==========

[ 85.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                        ok
[ 85.71%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32    34.3±5μs
               numpy.float64   33.0±0.5μs
              =============== ============

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                      ok
[ 87.50%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   38.8±0.7μs
               numpy.float64    41.3±2μs
              =============== ============

[ 89.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                 ok
[ 89.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   67.8±3μs
               numpy.float64   78.2±4μs
              =============== ==========

[ 91.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                    ok
[ 91.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   10.8±0.2ms
               numpy.float64   22.1±0.2ms
              =============== ============

[ 92.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                  ok
[ 92.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   59.9±2μs
               numpy.float64   66.2±3μs
              =============== ==========

[ 94.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                 ok
[ 94.64%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   56.6±0.9μs
               numpy.float64    70.6±7μs
              =============== ============

[ 96.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                           ok
[ 96.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   24.5±0.6ms
               numpy.float64   49.2±0.9ms
              =============== ============

[ 98.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                         ok
[ 98.21%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   56.5±1μs
               numpy.float64   62.9±3μs
              =============== ==========

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                        ok
[100.00%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   55.1±0.8μs
               numpy.float64    62.3±5μs
              =============== ============


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
</code></pre>
</details>

<details>
<summary>AV2 enabled</summary>
<pre><code>
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython
·· Building e4402bd8 <einsum-twooperands> for virtualenv-py3.7-Cython
·· Installing e4402bd8 <einsum-twooperands> into virtualenv-py3.7-Cython
· Running 28 total benchmarks (2 commits * 1 environments * 14 benchmarks)
[  0.00%] · For numpy commit 2908338b <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[  1.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 25.00%] · For numpy commit e4402bd8 <einsum-twooperands> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 26.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 50.00%] · For numpy commit e4402bd8 <einsum-twooperands> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 51.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                   ok
[ 51.79%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   100±2μs
               numpy.float64   152±6μs
              =============== =========

[ 53.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                               ok
[ 53.57%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   146±10μs
               numpy.float64   244±2μs
              =============== ==========

[ 55.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                             ok
[ 55.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.41±0.02ms
               numpy.float64   2.66±0.03ms
              =============== =============

[ 57.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                        ok
[ 57.14%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   79.9±2μs
               numpy.float64   87.4±2μs
              =============== ==========

[ 58.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                            ok
[ 58.93%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32    42.6±2μs
               numpy.float64   41.6±0.6μs
              =============== ============

[ 60.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                        ok
[ 60.71%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   41.0±0.9μs
               numpy.float64   40.2±0.5μs
              =============== ============

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                      ok
[ 62.50%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   49.2±0.4μs
               numpy.float64    48.2±1μs
              =============== ============

[ 64.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                 ok
[ 64.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   76.7±2μs
               numpy.float64   83.3±2μs
              =============== ==========

[ 66.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                    ok
[ 66.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   10.4±0.1ms
               numpy.float64   21.9±0.4ms
              =============== ============

[ 67.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                  ok
[ 67.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   68.6±2μs
               numpy.float64   70.7±1μs
              =============== ==========

[ 69.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                 ok
[ 69.64%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   75.4±6μs
               numpy.float64   71.7±1μs
              =============== ==========

[ 71.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                           ok
[ 71.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   24.1±0.3ms
               numpy.float64   50.2±0.6ms
              =============== ============

[ 73.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                         ok
[ 73.21%] ··· =============== ===========
                   dtype
              --------------- -----------
               numpy.float32    67.5±2μs
               numpy.float64   71.0±10μs
              =============== ===========

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                        ok
[ 75.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   69.8±4μs
               numpy.float64   69.6±2μs
              =============== ==========

[ 75.00%] · For numpy commit 2908338b <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 76.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                                                                                                                   ok
[ 76.79%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   101±5μs
               numpy.float64   155±10μs
              =============== ==========

[ 78.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                                                                                                               ok
[ 78.57%] ··· =============== =========
                   dtype
              --------------- ---------
               numpy.float32   146±7μs
               numpy.float64   252±7μs
              =============== =========

[ 80.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                                                                                                             ok
[ 80.36%] ··· =============== =============
                   dtype
              --------------- -------------
               numpy.float32   1.39±0.09ms
               numpy.float64   2.63±0.04ms
              =============== =============

[ 82.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                                                                                                                        ok
[ 82.14%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   78.6±2μs
               numpy.float64   87.2±3μs
              =============== ==========

[ 83.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                                                                                                            ok
[ 83.93%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   47.4±5μs
               numpy.float64   53.9±9μs
              =============== ==========

[ 85.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                                                                                                                        ok
[ 85.71%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   40.2±2μs
               numpy.float64   41.6±4μs
              =============== ==========

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                                                                                                                      ok
[ 87.50%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   41.3±3μs
               numpy.float64   39.6±2μs
              =============== ==========

[ 89.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                                                                                                                 ok
[ 89.29%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   77.5±4μs
               numpy.float64   86.9±1μs
              =============== ==========

[ 91.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                                                                                                                    ok
[ 91.07%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   10.7±0.2ms
               numpy.float64   21.9±0.1ms
              =============== ============

[ 92.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                                                                                                                  ok
[ 92.86%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   67.9±3μs
               numpy.float64   70.6±2μs
              =============== ==========

[ 94.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                                                                                                                 ok
[ 94.64%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   68.3±1μs
               numpy.float64   69.7±1μs
              =============== ==========

[ 96.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                                                                                                                           ok
[ 96.43%] ··· =============== ============
                   dtype
              --------------- ------------
               numpy.float32   25.0±0.4ms
               numpy.float64   49.1±0.5ms
              =============== ============

[ 98.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                                                                                                                         ok
[ 98.21%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   70.0±3μs
               numpy.float64   69.2±7μs
              =============== ==========

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                                                                                                                        ok
[100.00%] ··· =============== ==========
                   dtype
              --------------- ----------
               numpy.float32   69.9±1μs
               numpy.float64   69.1±1μs
              =============== ==========


BENCHMARKS NOT SIGNIFICANTLY CHANGED.
</code></pre>
</details>

<details>
<summary>NEON enabled</summary>
<pre><code>
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.7-Cython.
·· Building ebfed05a <einsum-twooperands> for virtualenv-py3.7-Cython................................................
·· Installing ebfed05a <einsum-twooperands> into virtualenv-py3.7-Cython.
· Running 28 total benchmarks (2 commits * 1 environments * 14 benchmarks)
[  0.00%] · For numpy commit efaf210f <master> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.7-Cython..................................................
[  0.00%] ·· Benchmarking virtualenv-py3.7-Cython
[  1.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 25.00%] · For numpy commit ebfed05a <einsum-twooperands> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.7-Cython..
[ 25.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 26.79%] ··· Running (bench_linalg.Einsum.time_einsum_contig_contig--)..............
[ 50.00%] · For numpy commit ebfed05a <einsum-twooperands> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 51.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                       ok
[ 51.79%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   198±2μs 
               numpy.float64   353±5μs 
              =============== =========

[ 53.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                   ok
[ 53.57%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   224±2μs 
               numpy.float64   356±6μs 
              =============== =========

[ 55.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                 ok
[ 55.36%] ··· =============== ==========
                   dtype                
              --------------- ----------
               numpy.float32   487±10μs 
               numpy.float64   863±20μs 
              =============== ==========

[ 57.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                            ok
[ 57.14%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   115±0.5μs 
               numpy.float64    141±2μs  
              =============== ===========

[ 58.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                ok
[ 58.93%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   73.5±0.5μs 
               numpy.float64   74.0±0.7μs 
              =============== ============

[ 60.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                            ok
[ 60.71%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   59.6±0.2μs 
               numpy.float64   60.5±0.6μs 
              =============== ============

[ 62.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                          ok
[ 62.50%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   70.1±0.4μs 
               numpy.float64   72.0±0.5μs 
              =============== ============

[ 64.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                     ok
[ 64.29%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   115±2μs 
               numpy.float64   140±2μs 
              =============== =========

[ 66.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                        ok
[ 66.07%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   2.73±0.1ms 
               numpy.float64   6.22±0.2ms 
              =============== ============

[ 67.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                      ok
[ 67.86%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   99.3±0.4μs 
               numpy.float64   107±0.8μs  
              =============== ============

[ 69.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                     ok
[ 69.64%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   99.0±0.3μs 
               numpy.float64    107±1μs   
              =============== ============

[ 71.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                               ok
[ 71.43%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   10.8±0.4ms 
               numpy.float64   22.1±0.3ms 
              =============== ============

[ 73.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                             ok
[ 73.21%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   94.5±0.4μs 
               numpy.float64   98.1±0.3μs 
              =============== ============

[ 75.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                            ok
[ 75.00%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   94.3±0.7μs 
               numpy.float64   98.7±0.4μs 
              =============== ============

[ 75.00%] · For numpy commit efaf210f <master> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.7-Cython..
[ 75.00%] ·· Benchmarking virtualenv-py3.7-Cython
[ 76.79%] ··· bench_linalg.Einsum.time_einsum_contig_contig                                                       ok
[ 76.79%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   204±6μs 
               numpy.float64   355±5μs 
              =============== =========

[ 78.57%] ··· bench_linalg.Einsum.time_einsum_contig_outstride0                                                   ok
[ 78.57%] ··· =============== =========
                   dtype               
              --------------- ---------
               numpy.float32   226±6μs 
               numpy.float64   356±4μs 
              =============== =========

[ 80.36%] ··· bench_linalg.Einsum.time_einsum_mul                                                                 ok
[ 80.36%] ··· =============== =============
                   dtype                   
              --------------- -------------
               numpy.float32     789±30μs  
               numpy.float64   1.00±0.01ms 
              =============== =============

[ 82.14%] ··· bench_linalg.Einsum.time_einsum_multiply                                                            ok
[ 82.14%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   117±0.2μs 
               numpy.float64    145±3μs  
              =============== ===========

[ 83.93%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_contig                                                ok
[ 83.93%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   74.2±0.4μs 
               numpy.float64   76.0±0.6μs 
              =============== ============

[ 85.71%] ··· bench_linalg.Einsum.time_einsum_noncon_contig_outstride0                                            ok
[ 85.71%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   59.4±0.3μs 
               numpy.float64   60.5±0.3μs 
              =============== ============

[ 87.50%] ··· bench_linalg.Einsum.time_einsum_noncon_mul                                                          ok
[ 87.50%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   72.0±0.2μs 
               numpy.float64   72.9±0.2μs 
              =============== ============

[ 89.29%] ··· bench_linalg.Einsum.time_einsum_noncon_multiply                                                     ok
[ 89.29%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   115±0.5μs 
               numpy.float64   140±0.8μs 
              =============== ===========

[ 91.07%] ··· bench_linalg.Einsum.time_einsum_noncon_outer                                                        ok
[ 91.07%] ··· =============== =============
                   dtype                   
              --------------- -------------
               numpy.float32   5.35±0.07ms 
               numpy.float64    7.07±0.2ms 
              =============== =============

[ 92.86%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul                                                      ok
[ 92.86%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32   101±0.6μs 
               numpy.float64   109±0.5μs 
              =============== ===========

[ 94.64%] ··· bench_linalg.Einsum.time_einsum_noncon_sum_mul2                                                     ok
[ 94.64%] ··· =============== ===========
                   dtype                 
              --------------- -----------
               numpy.float32    101±1μs  
               numpy.float64   109±0.7μs 
              =============== ===========

[ 96.43%] ··· bench_linalg.Einsum.time_einsum_outer                                                               ok
[ 96.43%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   17.7±0.3ms 
               numpy.float64   25.8±0.5ms 
              =============== ============

[ 98.21%] ··· bench_linalg.Einsum.time_einsum_sum_mul                                                             ok
[ 98.21%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   95.5±0.5μs 
               numpy.float64   101±0.8μs  
              =============== ============

[100.00%] ··· bench_linalg.Einsum.time_einsum_sum_mul2                                                            ok
[100.00%] ··· =============== ============
                   dtype                  
              --------------- ------------
               numpy.float32   95.5±0.8μs 
               numpy.float64   98.8±0.5μs 
              =============== ============

       before           after         ratio
     [efaf210f]       [ebfed05a]
     <master>         <einsum-twooperands>
-     1.00±0.01ms         863±20μs     0.86  bench_linalg.Einsum.time_einsum_mul(<class 'numpy.float64'>)
-      25.8±0.5ms       22.1±0.3ms     0.86  bench_linalg.Einsum.time_einsum_outer(<class 'numpy.float64'>)
-        789±30μs         487±10μs     0.62  bench_linalg.Einsum.time_einsum_mul(<class 'numpy.float32'>)
-      17.7±0.3ms       10.8±0.4ms     0.61  bench_linalg.Einsum.time_einsum_outer(<class 'numpy.float32'>)
-     5.35±0.07ms       2.73±0.1ms     0.51  bench_linalg.Einsum.time_einsum_noncon_outer(<class 'numpy.float32'>)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
</code></pre>
</details>

## System Info

  | Arm | x86
-- | -- | --
Hardware | KunPeng |  
Processor | ARMv8 2.6GMHZ 8 processors | Intel(R) Xeon(R) Gold 6161 CPU @ 2.20GHz
OS | Linux ecs-9d50 4.19.36-vhulk1905.1.0.h276.eulerosv2r8.aarch64 | Windows Server 2008 R2 Enterprise
Compiler | gcc (GCC) 7.3.0 | MSVC14.06