### PR TITLE
BLD: update OpenBLAS to af2b0d02

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,7 +13,7 @@ from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
 OPENBLAS_V = '0.3.13'
-OPENBLAS_LONG = 'v0.3.13'
+OPENBLAS_LONG = 'v0.3.13-62-gaf2b0d02'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 ARCHITECTURES = ['', 'windows', 'darwin', 'aarch64', 'x86_64',


### PR DESCRIPTION
This picks up xianyi/OpenBLAS#3066 which fixes gh-18141 (percolates BUFFERSIZE into the Makefiles) and xianyi/OpenBLAS#3060 which might fix gh-18131 (segfault on Jetson hardware).

@charris assuming this works, do you want to backport to 1.20 or is it too late?