### PR TITLE
TST: Speed up the typing tests

### DIFF
--- a/numpy/typing/tests/data/mypy.ini
+++ b/numpy/typing/tests/data/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 plugins = numpy.typing.mypy_plugin
+show_absolute_path = True
 
 [mypy-numpy]
 ignore_errors = True

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -42,7 +42,6 @@ def run_mypy() -> None:
     if os.path.isdir(CACHE_DIR):
         shutil.rmtree(CACHE_DIR)
 
-    root = os.path.dirname(os.path.dirname(np.__file__))
     for directory in (PASS_DIR, REVEAL_DIR, FAIL_DIR):
         # Run mypy
         stdout, stderr, _ = api.run([
@@ -58,9 +57,7 @@ def run_mypy() -> None:
         # Parse the output
         key = lambda n: n.split(':', 1)[0]
         iterator = itertools.groupby(stdout.split("\n"), key=key)
-        OUTPUT_MYPY.update(
-            (os.path.join(root, k), list(v)) for k, v in iterator if k
-        )
+        OUTPUT_MYPY.update((k, list(v)) for k, v in iterator if k)
 
 
 def get_test_cases(directory):

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -58,7 +58,9 @@ def run_mypy() -> None:
         # Parse the output
         key = lambda n: n.split(':', 1)[0]
         iterator = itertools.groupby(stdout.split("\n"), key=key)
-        OUTPUT_MYPY.update((os.path.join(root, k), list(v)) for k, v in iterator)
+        OUTPUT_MYPY.update(
+            (os.path.join(root, k), list(v)) for k, v in iterator if k
+        )
 
 
 def get_test_cases(directory):
@@ -80,7 +82,9 @@ def get_test_cases(directory):
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
-    assert path not in OUTPUT_MYPY
+    # Alias `OUTPUT_MYPY` so that it appears in the local namespace
+    output_mypy = OUTPUT_MYPY
+    assert path not in output_mypy
 
 
 @pytest.mark.slow
@@ -93,8 +97,10 @@ def test_fail(path):
         lines = fin.readlines()
 
     errors = defaultdict(lambda: "")
-    assert path in OUTPUT_MYPY
-    for error_line in OUTPUT_MYPY[path]:
+
+    output_mypy = OUTPUT_MYPY
+    assert path in output_mypy
+    for error_line in output_mypy[path]:
         match = re.match(
             r"^.+\.py:(?P<lineno>\d+): (error|note): .+$",
             error_line,
@@ -219,8 +225,9 @@ def test_reveal(path):
     with open(path) as fin:
         lines = _parse_reveals(fin)
 
-    assert path in OUTPUT_MYPY
-    for error_line in OUTPUT_MYPY[path]:
+    output_mypy = OUTPUT_MYPY
+    assert path in output_mypy
+    for error_line in output_mypy[path]:
         match = re.match(
             r"^.+\.py:(?P<lineno>\d+): note: .+$",
             error_line,

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -25,14 +25,39 @@ REVEAL_DIR = os.path.join(DATA_DIR, "reveal")
 MYPY_INI = os.path.join(DATA_DIR, "mypy.ini")
 CACHE_DIR = os.path.join(DATA_DIR, ".mypy_cache")
 
+#: A dictionary with file names as keys and lists of the mypy stdout as values.
+#: To-be populated by `run_mypy`.
+OUTPUT_MYPY: Dict[str, List[str]] = {}
+
 
 @pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
-@pytest.fixture(scope="session", autouse=True)
-def clear_cache() -> None:
-    """Clears the mypy cache before running any of the typing tests."""
+@pytest.fixture(scope="module", autouse=True)
+def run_mypy() -> None:
+    """Clears the cache and run mypy before running any of the typing tests.
+
+    The mypy results are cached in `OUTPUT_MYPY` for further use.
+
+    """
     if os.path.isdir(CACHE_DIR):
         shutil.rmtree(CACHE_DIR)
+
+    for directory in (PASS_DIR, REVEAL_DIR, FAIL_DIR):
+        # Run mypy
+        stdout, stderr, _ = api.run([
+            "--config-file",
+            MYPY_INI,
+            "--cache-dir",
+            CACHE_DIR,
+            directory,
+        ])
+        assert not stderr, directory
+        stdout = stdout.replace('*', '')
+
+        # Parse the output
+        key = lambda n: n.split(':', 1)[0]
+        iterator = itertools.groupby(stdout.split("\n"), key=key)
+        OUTPUT_MYPY.update((os.path.abspath(k), list(v)) for k, v in iterator)
 
 
 def get_test_cases(directory):
@@ -54,15 +79,7 @@ def get_test_cases(directory):
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.mark.parametrize("path", get_test_cases(PASS_DIR))
 def test_success(path):
-    stdout, stderr, exitcode = api.run([
-        "--config-file",
-        MYPY_INI,
-        "--cache-dir",
-        CACHE_DIR,
-        path,
-    ])
-    assert exitcode == 0, stdout
-    assert re.match(r"Success: no issues found in \d+ source files?", stdout.strip())
+    assert path not in OUTPUT_MYPY
 
 
 @pytest.mark.slow
@@ -71,29 +88,12 @@ def test_success(path):
 def test_fail(path):
     __tracebackhide__ = True
 
-    stdout, stderr, exitcode = api.run([
-        "--config-file",
-        MYPY_INI,
-        "--cache-dir",
-        CACHE_DIR,
-        path,
-    ])
-    assert exitcode != 0
-
     with open(path) as fin:
         lines = fin.readlines()
 
     errors = defaultdict(lambda: "")
-    error_lines = stdout.rstrip("\n").split("\n")
-    assert re.match(
-        r"Found \d+ errors? in \d+ files? \(checked \d+ source files?\)",
-        error_lines[-1].strip(),
-    )
-    for error_line in error_lines[:-1]:
-        error_line = error_line.strip()
-        if not error_line:
-            continue
-
+    assert path in OUTPUT_MYPY
+    for error_line in OUTPUT_MYPY[path]:
         match = re.match(
             r"^.+\.py:(?P<lineno>\d+): (error|note): .+$",
             error_line,
@@ -215,23 +215,11 @@ def _parse_reveals(file: IO[str]) -> List[str]:
 def test_reveal(path):
     __tracebackhide__ = True
 
-    stdout, stderr, exitcode = api.run([
-        "--config-file",
-        MYPY_INI,
-        "--cache-dir",
-        CACHE_DIR,
-        path,
-    ])
-
     with open(path) as fin:
         lines = _parse_reveals(fin)
 
-    stdout_list = stdout.replace('*', '').split("\n")
-    for error_line in stdout_list:
-        error_line = error_line.strip()
-        if not error_line:
-            continue
-
+    assert path in OUTPUT_MYPY
+    for error_line in OUTPUT_MYPY[path]:
         match = re.match(
             r"^.+\.py:(?P<lineno>\d+): note: .+$",
             error_line,

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -42,6 +42,7 @@ def run_mypy() -> None:
     if os.path.isdir(CACHE_DIR):
         shutil.rmtree(CACHE_DIR)
 
+    root = os.path.dirname(os.path.dirname(np.__file__))
     for directory in (PASS_DIR, REVEAL_DIR, FAIL_DIR):
         # Run mypy
         stdout, stderr, _ = api.run([
@@ -57,7 +58,7 @@ def run_mypy() -> None:
         # Parse the output
         key = lambda n: n.split(':', 1)[0]
         iterator = itertools.groupby(stdout.split("\n"), key=key)
-        OUTPUT_MYPY.update((os.path.abspath(k), list(v)) for k, v in iterator)
+        OUTPUT_MYPY.update((os.path.join(root, k), list(v)) for k, v in iterator)
 
 
 def get_test_cases(directory):

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -30,6 +30,15 @@ CACHE_DIR = os.path.join(DATA_DIR, ".mypy_cache")
 OUTPUT_MYPY: Dict[str, List[str]] = {}
 
 
+def _key_func(key: str) -> str:
+    """Split at the first occurance of the ``:`` character.
+
+    Windows drive-letters (*e.g.* ``C:``) are ignored herein.
+    """
+    drive, tail = os.path.splitdrive(key)
+    return os.path.join(drive, tail.split(":", 1)[0])
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(NO_MYPY, reason="Mypy is not installed")
 @pytest.fixture(scope="module", autouse=True)
@@ -55,8 +64,7 @@ def run_mypy() -> None:
         stdout = stdout.replace('*', '')
 
         # Parse the output
-        key = lambda n: n.split(':', 1)[0]
-        iterator = itertools.groupby(stdout.split("\n"), key=key)
+        iterator = itertools.groupby(stdout.split("\n"), key=_key_func)
         OUTPUT_MYPY.update((k, list(v)) for k, v in iterator if k)
 
 


### PR DESCRIPTION
This PR attempts to speed up the typing tests by minimizing the number of mypy calls.

This is speedup is achieved with the help of a pytest fixture, the latter allowing us to run mypy only once 
(for each test directory) over the entire set of test files. The (cached) output is used afterwards for 
running the actual tests.

For reference: 
previously a local run of `python ./runtests.py -t numpy/typing/ --mode=full` would take about ~80 sec, 
now it takes only ~17.