### PR TITLE
DOC: Double backticks for inline code example.

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -299,7 +299,7 @@ def full(shape, fill_value, dtype=None, order='C', *, like=None):
         Fill value.
     dtype : data-type, optional
         The desired data-type for the array  The default, None, means
-         `np.array(fill_value).dtype`.
+         ``np.array(fill_value).dtype``.
     order : {'C', 'F'}, optional
         Whether to store multidimensional data in C- or Fortran-contiguous
         (row- or column-wise) order in memory.


### PR DESCRIPTION
Single backticks are supposed to be use for reference to other object,
In this context double backticks (verbatim) appear to be better suited.