### PR TITLE
MAINT: Remove redundant Python2 float/int conversions

### DIFF
--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -1316,13 +1316,13 @@ class TestDateTime:
             assert_equal(tda / 0.5, tdc)
             assert_equal((tda / 0.5).dtype, np.dtype('m8[h]'))
             # m8 / m8
-            assert_equal(tda / tdb, 6.0 / 9.0)
-            assert_equal(np.divide(tda, tdb), 6.0 / 9.0)
-            assert_equal(np.true_divide(tda, tdb), 6.0 / 9.0)
-            assert_equal(tdb / tda, 9.0 / 6.0)
+            assert_equal(tda / tdb, 6 / 9)
+            assert_equal(np.divide(tda, tdb), 6 / 9)
+            assert_equal(np.true_divide(tda, tdb), 6 / 9)
+            assert_equal(tdb / tda, 9 / 6)
             assert_equal((tda / tdb).dtype, np.dtype('f8'))
-            assert_equal(tda / tdd, 60.0)
-            assert_equal(tdd / tda, 1.0 / 60.0)
+            assert_equal(tda / tdd, 60)
+            assert_equal(tdd / tda, 1 / 60)
 
             # int / m8
             assert_raises(TypeError, np.divide, 2, tdb)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2585,15 +2585,15 @@ class TestStdVar:
 
     def test_ddof1(self):
         assert_almost_equal(np.var(self.A, ddof=1),
-                            self.real_var*len(self.A)/float(len(self.A)-1))
+                            self.real_var * len(self.A) / (len(self.A) - 1))
         assert_almost_equal(np.std(self.A, ddof=1)**2,
-                            self.real_var*len(self.A)/float(len(self.A)-1))
+                            self.real_var*len(self.A) / (len(self.A) - 1))
 
     def test_ddof2(self):
         assert_almost_equal(np.var(self.A, ddof=2),
-                            self.real_var*len(self.A)/float(len(self.A)-2))
+                            self.real_var * len(self.A) / (len(self.A) - 2))
         assert_almost_equal(np.std(self.A, ddof=2)**2,
-                            self.real_var*len(self.A)/float(len(self.A)-2))
+                            self.real_var * len(self.A) / (len(self.A) - 2))
 
     def test_out_scalar(self):
         d = np.arange(10)

--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -10,7 +10,7 @@ import queue
 
 def fft1(x):
     L = len(x)
-    phase = -2j*np.pi*(np.arange(L)/float(L))
+    phase = -2j * np.pi * (np.arange(L) / L)
     phase = np.arange(L).reshape(-1, 1) * phase
     return np.sum(x*np.exp(phase), axis=1)
 

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -159,8 +159,7 @@ class nd_grid:
                     size.append(int(abs(step)))
                     typ = float
                 else:
-                    size.append(
-                        int(math.ceil((key[k].stop - start)/(step*1.0))))
+                    size.append(math.ceil((key[k].stop - start) / step))
                 if (isinstance(step, (_nx.floating, float)) or
                         isinstance(start, (_nx.floating, float)) or
                         isinstance(key[k].stop, (_nx.floating, float))):
@@ -180,7 +179,7 @@ class nd_grid:
                 if isinstance(step, (_nx.complexfloating, complex)):
                     step = int(abs(step))
                     if step != 1:
-                        step = (key[k].stop - start)/float(step-1)
+                        step = (key[k].stop - start) / (step - 1)
                 nn[k] = (nn[k]*step+start)
             if self.sparse:
                 slobj = [_nx.newaxis]*len(size)
@@ -199,7 +198,7 @@ class nd_grid:
                 step = abs(step)
                 length = int(step)
                 if step != 1:
-                    step = (key.stop-start)/float(step-1)
+                    step = (key.stop - start) / (step - 1)
                 stop = key.stop + step
                 return _nx.arange(0, length, 1, float)*step + start
             else:

--- a/numpy/random/tests/test_generator_mt19937_regressions.py
+++ b/numpy/random/tests/test_generator_mt19937_regressions.py
@@ -32,11 +32,11 @@ class TestRegression:
         # these two frequency counts should be close to theoretical
         # numbers with this large sample
         # theoretical large N result is 0.49706795
-        freq = np.sum(rvsn == 1) / float(N)
+        freq = np.sum(rvsn == 1) / N
         msg = f'Frequency was {freq:f}, should be > 0.45'
         assert_(freq > 0.45, msg)
         # theoretical large N result is 0.19882718
-        freq = np.sum(rvsn == 2) / float(N)
+        freq = np.sum(rvsn == 2) / N
         msg = f'Frequency was {freq:f}, should be < 0.23'
         assert_(freq < 0.23, msg)
 

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -43,11 +43,11 @@ class TestRegression:
         # these two frequency counts should be close to theoretical
         # numbers with this large sample
         # theoretical large N result is 0.49706795
-        freq = np.sum(rvsn == 1) / float(N)
+        freq = np.sum(rvsn == 1) / N
         msg = f'Frequency was {freq:f}, should be > 0.45'
         assert_(freq > 0.45, msg)
         # theoretical large N result is 0.19882718
-        freq = np.sum(rvsn == 2) / float(N)
+        freq = np.sum(rvsn == 2) / N
         msg = f'Frequency was {freq:f}, should be < 0.23'
         assert_(freq < 0.23, msg)
 

--- a/numpy/random/tests/test_regression.py
+++ b/numpy/random/tests/test_regression.py
@@ -39,11 +39,11 @@ class TestRegression:
         # these two frequency counts should be close to theoretical
         # numbers with this large sample
         # theoretical large N result is 0.49706795
-        freq = np.sum(rvsn == 1) / float(N)
+        freq = np.sum(rvsn == 1) / N
         msg = f'Frequency was {freq:f}, should be > 0.45'
         assert_(freq > 0.45, msg)
         # theoretical large N result is 0.19882718
-        freq = np.sum(rvsn == 2) / float(N)
+        freq = np.sum(rvsn == 2) / N
         msg = f'Frequency was {freq:f}, should be < 0.23'
         assert_(freq < 0.23, msg)
 


### PR DESCRIPTION
Remove `int(` or `float(` that were necessary hacks in Python2, but are now redundant in Python3.

I have also changed a few literals, such as `6.0 / 9.0` to `6 / 9` because that converts to `float` in Python 3 anyway.