### PR TITLE
DOC: Improve doc for numpy.random.Generator.choice

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -665,6 +665,13 @@ cdef class Generator:
         array([3,1,0]) # random
         >>> #This is equivalent to rng.permutation(np.arange(5))[:3]
 
+        Generate a uniform random sample from a 2-D array, without
+        replacement:
+
+        >>> rng.choice([[0, 1, 2], [3, 4, 5], [6, 7, 8]], 2, replace=False)
+        array([[3, 4, 5],
+               [0, 1, 2]])
+
         Generate a non-uniform random sample from np.arange(5) of size
         3 without replacement:
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -665,8 +665,8 @@ cdef class Generator:
         array([3,1,0]) # random
         >>> #This is equivalent to rng.permutation(np.arange(5))[:3]
 
-        Generate a uniform random sample from a 2-D array, without
-        replacement:
+        Generate a uniform random sample from a 2-D array along the first
+        axis (the default), without replacement:
 
         >>> rng.choice([[0, 1, 2], [3, 4, 5], [6, 7, 8]], 2, replace=False)
         array([[3, 4, 5], # random

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -599,7 +599,7 @@ cdef class Generator:
         """
         choice(a, size=None, replace=True, p=None, axis=0, shuffle=True)
 
-        Generates a random sample from a given 1-D array
+        Generates a random sample from a given array
 
         Parameters
         ----------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -669,7 +669,7 @@ cdef class Generator:
         replacement:
 
         >>> rng.choice([[0, 1, 2], [3, 4, 5], [6, 7, 8]], 2, replace=False)
-        array([[3, 4, 5],
+        array([[3, 4, 5], # random
                [0, 1, 2]])
 
         Generate a non-uniform random sample from np.arange(5) of size


### PR DESCRIPTION
The summary of `numpy.random.Generator.choice()` suggests that the function is restricted to 1-D inputs, but this is not the case.

This PR removes the "1-D" qualifier from the summary and adds an example demonstrating use of this function for sampling from an array of dimension greater than one.