### PR TITLE
DOC: Clarify the type alias deprecation message

### DIFF
--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -75,32 +75,59 @@ Using the aliases of builtin types like ``np.int`` is deprecated
 ----------------------------------------------------------------
 
 For a long time, ``np.int`` has been an alias of the builtin ``int``. This is
-repeatedly a cause of confusion for newcomers, and is also simply not useful.
+repeatedly a cause of confusion for newcomers, and existed mainly for historic
+reasons.
 
 These aliases have been deprecated. The table below shows the full list of
 deprecated aliases, along with their exact meaning. Replacing uses of items in
 the first column with the contents of the second column will work identically
 and silence the deprecation warning.
 
-In many cases, it may have been intended to use the types from the third column.
-Be aware that use of these types may result in subtle but desirable behavior
-changes.
+The third column lists alternative NumPy names which may occasionally be
+preferential. See also :doc:`user/basics.types` for additional details.
 
-==================  =================================  ==================================================================
-Deprecated name     Identical to                       Possibly intended numpy type
-==================  =================================  ==================================================================
-``numpy.bool``      ``bool``                           `numpy.bool_`
-``numpy.int``       ``int``                            `numpy.int_` (default int dtype), `numpy.cint` (C ``int``)
-``numpy.float``     ``float``                          `numpy.float_`, `numpy.double` (equivalent)
-``numpy.complex``   ``complex``                        `numpy.complex_`, `numpy.cdouble` (equivalent)
-``numpy.object``    ``object``                         `numpy.object_`
-``numpy.str``       ``str``                            `numpy.str_`
-``numpy.long``      ``int`` (``long`` on Python 2)     `numpy.int_` (C ``long``), `numpy.longlong` (largest integer type)
-``numpy.unicode``   ``str`` (``unicode`` on Python 2)  `numpy.unicode_`
-==================  =================================  ==================================================================
+=================  ============  ==================================================================
+Deprecated name    Identical to  NumPy scalar type names
+=================  ============  ==================================================================
+``numpy.bool``     ``bool``      `numpy.bool_`
+``numpy.int``      ``int``       `numpy.int_` (default), ``numpy.int64``, or ``numpy.int32``
+``numpy.float``    ``float``     `numpy.float64`, `numpy.float_`, `numpy.double` (equivalent)
+``numpy.complex``  ``complex``   `numpy.complex128`, `numpy.complex_`, `numpy.cdouble` (equivalent)
+``numpy.object``   ``object``    `numpy.object_`
+``numpy.str``      ``str``       `numpy.str_`
+``numpy.long``     ``int``       `numpy.int_` (C ``long``), `numpy.longlong` (largest integer type)
+``numpy.unicode``  ``str``       `numpy.unicode_`
+=================  ============  ==================================================================
 
-Note that for technical reasons these deprecation warnings will only be emitted
-on Python 3.7 and above.
+To give a clear guideline for the vast majority of cases, for the types
+``bool``, ``object``, ``str`` (and ``unicode``) using the plain version
+is shorter and clear, and generally a good replacement.
+For ``float`` and ``complex`` you can use ``float64`` and ``complex128``
+if you wish to be more explicit about the precision.
+
+For ``np.int`` a direct replacement with ``np.int_`` or ``int`` is also
+good, but the precision depends on the computer and operating system.
+If you want to be more explicit and review the current use, you have the
+following alternatives:
+
+* ``np.int64`` or ``np.int32`` to specify the precision exactly.
+  This ensures that results cannot depend on the computer or operating system.
+* ``np.int_`` or ``int`` (the default), but be aware that it depends on
+  the computer and operating system.
+* The C types: ``np.cint`` (int), ``np.int_`` (long), ``np.longlong``,
+* ``np.intp`` which is 32bit on 32bit machines 64bit on 64bit machines.
+  This can be the best type to use for indexing.
+
+When used with ``np.dtype(...)`` or ``dtype=...`` changing it to the
+NumPy name as mentioned above will have no effect on the output.
+If used as a scalar with::
+
+    np.float(123)
+
+changing it can subtly change the result.  In this case, the Python version
+``float(123)`` or ``int(12.)`` is normally preferable, although the NumPy
+version may be useful for consistency with NumPy arrays. For example, since
+NumPy behaves differently for things like division by zero.
 
 (`gh-14882 <https://github.com/numpy/numpy/pull/14882>`__)
 

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -106,7 +106,8 @@ For ``float`` and ``complex`` you can use ``float64`` and ``complex128``
 if you wish to be more explicit about the precision.
 
 For ``np.int`` a direct replacement with ``np.int_`` or ``int`` is also
-good, but the precision depends on the computer and operating system.
+good and will not change behavior, but the precision will continue to depend
+on the computer and operating system.
 If you want to be more explicit and review the current use, you have the
 following alternatives:
 
@@ -998,6 +999,5 @@ The former result can still be obtained with::
     array([-3, -2, -1, -1,  0,  0,  0,  1])
 
 (`gh-16841 <https://github.com/numpy/numpy/pull/16841>`__)
-
 
 

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -84,7 +84,7 @@ the first column with the contents of the second column will work identically
 and silence the deprecation warning.
 
 The third column lists alternative NumPy names which may occasionally be
-preferential. See also :doc:`user/basics.types` for additional details.
+preferential. See also :ref:`basics.types` for additional details.
 
 =================  ============  ==================================================================
 Deprecated name    Identical to  NumPy scalar type names

--- a/doc/source/release/1.20.0-notes.rst
+++ b/doc/source/release/1.20.0-notes.rst
@@ -115,7 +115,7 @@ following alternatives:
   This ensures that results cannot depend on the computer or operating system.
 * ``np.int_`` or ``int`` (the default), but be aware that it depends on
   the computer and operating system.
-* The C types: ``np.cint`` (int), ``np.int_`` (long), ``np.longlong``,
+* The C types: ``np.cint`` (int), ``np.int_`` (long), ``np.longlong``.
 * ``np.intp`` which is 32bit on 32bit machines 64bit on 64bit machines.
   This can be the best type to use for indexing.
 
@@ -127,8 +127,8 @@ If used as a scalar with::
 
 changing it can subtly change the result.  In this case, the Python version
 ``float(123)`` or ``int(12.)`` is normally preferable, although the NumPy
-version may be useful for consistency with NumPy arrays. For example, since
-NumPy behaves differently for things like division by zero.
+version may be useful for consistency with NumPy arrays (for example,
+NumPy behaves differently for things like division by zero).
 
 (`gh-14882 <https://github.com/numpy/numpy/pull/14882>`__)
 
@@ -999,5 +999,4 @@ The former result can still be obtained with::
     array([-3, -2, -1, -1,  0,  0,  0,  1])
 
 (`gh-16841 <https://github.com/numpy/numpy/pull/16841>`__)
-
 

--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -1,3 +1,5 @@
+.. _basics.types:
+
 **********
 Data types
 **********

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -190,11 +190,10 @@ else:
         ("str", _specific_msg.format("str_")),
         ("int", _int_extended_msg.format("int"))]
 
-    for n, extended_msg in _type_info:
-        __deprecated_attrs__[n] = (getattr(_builtins, n),
-                                   _msg.format(n=n, extended_msg=extended_msg))
-
-    del n, extended_msg
+    __deprecated_attrs__.update({
+        n: (getattr(_builtins, n), _msg.format(n=n, extended_msg=extended_msg))
+        for n, extended_msg in _type_info
+    })
 
     _msg = (
         "`np.{n}` is a deprecated alias for `np.compat.{n}`. "
@@ -422,4 +421,3 @@ else:
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -179,7 +179,7 @@ else:
     _int_extended_msg = (
         "When replacing `np.{}`, you may wish to use e.g. `np.int64` "
         "or `np.int32` to specify the precision. If you wish to review "
-        "your current use check the release note link for "
+        "your current use, check the release note link for "
         "additional information.")
 
     _type_info = [

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -165,33 +165,58 @@ else:
 
     # Deprecations introduced in NumPy 1.20.0, 2020-06-06
     import builtins as _builtins
-    __deprecated_attrs__.update({
-        n: (
-            getattr(_builtins, n),
-            "`np.{n}` is a deprecated alias for the builtin `{n}`. "
-            "Use `{n}` by itself, which is identical in behavior, to silence "
-            "this warning. "
-            "If you specifically wanted the numpy scalar type, use `np.{n}_` "
-            "here."
-            .format(n=n)
-        )
-        for n in ["bool", "int", "float", "complex", "object", "str"]
-    })
-    __deprecated_attrs__.update({
-        n: (
-            getattr(compat, n),
-            "`np.{n}` is a deprecated alias for `np.compat.{n}`. "
-            "Use `np.compat.{n}` by itself, which is identical in behavior, "
-            "to silence this warning. "
-            "In the likely event your code does not need to work on Python 2 "
-            "you can use the builtin ``{n2}`` for which ``np.compat.{n}`` is "
-            "itself an alias. "
-            "If you specifically wanted the numpy scalar type, use `np.{n2}_` "
-            "here."
-            .format(n=n, n2=n2)
-        )
-        for n, n2 in [("long", "int"), ("unicode", "str")]
-    })
+
+    _msg = (
+        "`np.{n}` is a deprecated alias for the builtin `{n}`. "
+        "To silence this warning, use `{n}` by itself. Doing this will not "
+        "modify any behavior and is safe. {extended_msg}\n"
+        "Deprecated in NumPy 1.20; for more details and guidance: "
+        "https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations")
+
+    _specific_msg = (
+        "If you specifically wanted the numpy scalar type, use `np.{}` here.")
+
+    _int_extended_msg = (
+        "When replacing `np.{}`, you may wish to use e.g. `np.int64` "
+        "or `np.int32` to specify the precision. If you wish to review "
+        "your current use check the release note link for "
+        "additional information.")
+
+    _type_info = [
+        ("object", ""),  # The NumPy scalar only exists by name.
+        ("bool", _specific_msg.format("bool_")),
+        ("float", _specific_msg.format("float64")),
+        ("complex", _specific_msg.format("complex128")),
+        ("str", _specific_msg.format("str_")),
+        ("int", _int_extended_msg.format("int"))]
+
+    for n, extended_msg in _type_info:
+        __deprecated_attrs__[n] = (getattr(_builtins, n),
+                                   _msg.format(n=n, extended_msg=extended_msg))
+
+    del n, extended_msg
+
+    _msg = (
+        "`np.{n}` is a deprecated alias for `np.compat.{n}`. "
+        "To silence this warning, use `np.compat.{n}` by itself. "
+        "In the likely event your code does not need to work on Python 2 "
+        "you can use the builtin `{n2}` for which `np.compat.{n}` is itself "
+        "an alias. Doing this will not modify any behaviour and is safe. "
+        "{extended_msg}\n"
+        "Deprecated in NumPy 1.20; for more details and guidance: "
+        "https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations")
+
+    __deprecated_attrs__["long"] = (
+        getattr(compat, "long"),
+        _msg.format(n="long", n2="int",
+                    extended_msg=_int_extended_msg.format("long")))
+
+    __deprecated_attrs__["unicode"] = (
+        getattr(compat, "long"),
+        _msg.format(n="unciode", n2="str",
+                    extended_msg=_specific_msg.format("str_")))
+
+    del _msg, _specific_msg, _int_extended_msg, _type_info, _builtins
 
     from .core import round, abs, max, min
     # now that numpy modules are imported, can initialize limits


### PR DESCRIPTION
This tries to clarify the type alias deprecation message slightly
to give more guidance on how to review the replacement (if desired).

---

<details> <summary> The new messages are as follows: </summary>

```
In [1]: np.bool                                                                                                                                             
<ipython-input-1-190120470286>:1: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.bool
Out[1]: bool

In [2]: np.object                                                                                                                                           
<ipython-input-2-4921af820668>:1: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. To silence this warning, use `object` by itself. Doing this will not modify any behavior and is safe. 
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.object
Out[2]: object

In [3]: np.str                                                                                                                                              
<ipython-input-3-15a72efb409b>:1: DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.str
Out[3]: str

In [4]: np.float                                                                                                                                            
<ipython-input-4-b3b46df38e48>:1: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.float
Out[4]: float

In [5]: np.complex                                                                                                                                          
<ipython-input-5-087dad13a955>:1: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.complex
Out[5]: complex

In [6]: np.int                                                                                                                                              
<ipython-input-6-5dcbb6b27796>:1: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.int
Out[6]: int

In [7]: np.long                                                                                                                                             
<ipython-input-7-2567cec2f44b>:1: DeprecationWarning: `np.long` is a deprecated alias for `np.compat.long`. To silence this warning, use `np.compat.long` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `int` for which `np.compat.long` is itself an alias. Doing this will not modify any behaviour and is safe. When replacing `np.long`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.long
Out[7]: int

In [8]: np.unicode                                                                                                                                          
<ipython-input-8-a16bff60575c>:1: DeprecationWarning: `np.unciode` is a deprecated alias for `np.compat.unciode`. To silence this warning, use `np.compat.unciode` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `str` for which `np.compat.unciode` is itself an alias. Doing this will not modify any behaviour and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  np.unicode
```