### PR TITLE
DOC: lib/shape_base numpydoc formatting.

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -69,13 +69,13 @@ def take_along_axis(arr, indices, axis):
 
     Parameters
     ----------
-    arr: ndarray (Ni..., M, Nk...)
+    arr : ndarray (Ni..., M, Nk...)
         Source array
-    indices: ndarray (Ni..., J, Nk...)
+    indices : ndarray (Ni..., J, Nk...)
         Indices to take along each 1d slice of `arr`. This must match the
         dimension of arr, but dimensions Ni and Nj only need to broadcast
         against `arr`.
-    axis: int
+    axis : int
         The axis to take 1d slices along. If axis is None, the input array is
         treated as if it had first been flattened to 1d, for consistency with
         `sort` and `argsort`.
@@ -190,16 +190,16 @@ def put_along_axis(arr, indices, values, axis):
 
     Parameters
     ----------
-    arr: ndarray (Ni..., M, Nk...)
+    arr : ndarray (Ni..., M, Nk...)
         Destination array.
-    indices: ndarray (Ni..., J, Nk...)
+    indices : ndarray (Ni..., J, Nk...)
         Indices to change along each 1d slice of `arr`. This must match the
         dimension of arr, but dimensions in Ni and Nj may be 1 to broadcast
         against `arr`.
-    values: array_like (Ni..., J, Nk...)
+    values : array_like (Ni..., J, Nk...)
         values to insert at those indices. Its shape and dimension are
         broadcast to match that of `indices`.
-    axis: int
+    axis : int
         The axis to take 1d slices along. If axis is None, the destination
         array is treated as if a flattened 1d view had been created of it.
 


### PR DESCRIPTION
Numpydoc parses parameter different depending on whether there is a space
before the colon, for it to be properly interpreted as names and types;
spaces need to be put on each side.
