### PR TITLE
DOC: Fix command in "Writing custom array containers" guide

### DIFF
--- a/doc/source/user/basics.dispatch.rst
+++ b/doc/source/user/basics.dispatch.rst
@@ -56,7 +56,7 @@ array([[2., 0., 0., 0., 0.],
 
 Notice that the return type is a standard ``numpy.ndarray``.
 
->>> type(arr)
+>>> type(np.multiply(arr, 2))
 numpy.ndarray
 
 How can we pass our custom array type through this function? Numpy allows a


### PR DESCRIPTION
This is a minor doc fix: the `arr` object is of type `DiagonalArray`, not `ndarray`.
I believe the point of this section is to illustrate that `type(np.multiply(arr, 2)) == np.ndarray`