### PR TITLE
DOC: __array__ accepts a dtype argument

### DIFF
--- a/doc/source/user/basics.dispatch.rst
+++ b/doc/source/user/basics.dispatch.rst
@@ -22,8 +22,8 @@ example that has rather narrow utility but illustrates the concepts involved.
 ...         self._i = value
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
-...     def __array__(self):
-...         return self._i * np.eye(self._N)
+...     def __array__(self, dtype=None):
+...         return self._i * np.eye(self._N, dtype=dtype)
 
 Our custom array can be instantiated like:
 
@@ -84,8 +84,8 @@ For this example we will only handle the method ``__call__``
 ...         self._i = value
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
-...     def __array__(self):
-...         return self._i * np.eye(self._N)
+...     def __array__(self, dtype=None):
+...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':
 ...             N = None
@@ -133,8 +133,8 @@ conveniently by inheriting from the mixin
 ...         self._i = value
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
-...     def __array__(self):
-...         return self._i * np.eye(self._N)
+...     def __array__(self, dtype=None):
+...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':
 ...             N = None
@@ -171,8 +171,8 @@ functions to our custom variants.
 ...         self._i = value
 ...     def __repr__(self):
 ...         return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
-...     def __array__(self):
-...         return self._i * np.eye(self._N)
+...     def __array__(self, dtype=None):
+...         return self._i * np.eye(self._N, dtype=dtype)
 ...     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
 ...         if method == '__call__':
 ...             N = None


### PR DESCRIPTION
The documentation for [writing custom array containers](https://numpy.org/devdocs/user/basics.dispatch.html) should indicate that the `__array__` interface accepts an optional dtype parameter.

In the present docs, the example class has a bug lurking:

```python
class DiagonalArray:
    def __init__(self, N, value):
        self._N = N
        self._i = value
    def __repr__(self):
        return f"{self.__class__.__name__}(N={self._N}, value={self._i})"
    def __array__(self):
        return self._i * np.eye(self._N)
```
```python
>>> arr = DiagonalArray(4, 2)
>>> np.asarray(arr, dtype=np.float32)
TypeError: __array__() takes 1 positional argument but 2 were given
```
 