### PR TITLE
BLD: fix issue with `bdist_egg`, which made `make dist` in doc/ fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,8 @@ def parse_setuppy_commands():
     # below and not standalone.  Hence they're not added to good_commands.
     good_commands = ('develop', 'sdist', 'build', 'build_ext', 'build_py',
                      'build_clib', 'build_scripts', 'bdist_wheel', 'bdist_rpm',
-                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg', 'build_src',)
+                     'bdist_wininst', 'bdist_msi', 'bdist_mpkg', 'build_src',
+                     'bdist_egg')
 
     for command in good_commands:
         if command in args:


### PR DESCRIPTION
This issue came in because of commit 9b3f65096e a month ago. `bdist_egg` has always been missing from the command list, but
that wasn't a problem because missing commands were simply ignored by the validation. After that commit we started raising a `RuntimeError` instead.
