### PR TITLE
DOC: Misc numpydoc format fixes

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -538,7 +538,7 @@ def array2string(a, max_line_width=None, precision=None,
     separator : str, optional
         Inserted between elements.
     prefix : str, optional
-    suffix: str, optional
+    suffix : str, optional
         The length of the prefix and suffix strings are used to respectively
         align and wrap the output. An array is typically printed as::
 

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -327,7 +327,7 @@ def _greedy_path(input_sets, output_set, idx_dict, memory_limit):
         Set that represents the rhs side of the overall einsum subscript
     idx_dict : dictionary
         Dictionary of index sizes
-    memory_limit_limit : int
+    memory_limit : int
         The maximum number of elements in a temporary array
 
     Returns
@@ -1061,14 +1061,12 @@ def einsum(*operands, out=None, optimize=False, **kwargs):
     See Also
     --------
     einsum_path, dot, inner, outer, tensordot, linalg.multi_dot
-
-    einops:
+    einops :
         similar verbose interface is provided by
         `einops <https://github.com/arogozhnikov/einops>`_ package to cover
         additional operations: transpose, reshape/flatten, repeat/tile,
         squeeze/unsqueeze and reductions.
-
-    opt_einsum:
+    opt_einsum :
         `opt_einsum <https://optimized-einsum.readthedocs.io/en/stable/>`_
         optimizes contraction order for einsum-like expressions
         in backend-agnostic manner.

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1381,7 +1381,7 @@ def resize(a, new_shape):
     --------
     np.reshape : Reshape an array without changing the total size.
     np.pad : Enlarge and pad an array.
-    np.repeat: Repeat elements of an array.
+    np.repeat : Repeat elements of an array.
     ndarray.resize : resize an array in-place.
 
     Notes
@@ -2007,7 +2007,7 @@ def compress(condition, a, axis=None, out=None):
     --------
     take, choose, diag, diagonal, select
     ndarray.compress : Equivalent method in ndarray
-    extract: Equivalent method when working on 1-D arrays
+    extract : Equivalent method when working on 1-D arrays
     :ref:`ufuncs-output-type`
 
     Examples
@@ -2475,14 +2475,11 @@ def cumsum(a, axis=None, dtype=None, out=None):
         result has the same size as `a`, and the same shape as `a` if
         `axis` is not None or `a` is a 1-d array.
 
-
     See Also
     --------
     sum : Sum array elements.
-
     trapz : Integration of array values using the composite trapezoidal rule.
-
-    diff :  Calculate the n-th discrete difference along given axis.
+    diff : Calculate the n-th discrete difference along given axis.
 
     Notes
     -----

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -1441,7 +1441,7 @@ def is_busday(dates, weekmask=None, holidays=None, busdaycal=None, out=None):
 
     See Also
     --------
-    busdaycalendar: An object that specifies a custom set of valid days.
+    busdaycalendar : An object that specifies a custom set of valid days.
     busday_offset : Applies an offset counted in valid days.
     busday_count : Counts how many valid days are in a half-open date range.
 
@@ -1516,7 +1516,7 @@ def busday_offset(dates, offsets, roll=None, weekmask=None, holidays=None,
 
     See Also
     --------
-    busdaycalendar: An object that specifies a custom set of valid days.
+    busdaycalendar : An object that specifies a custom set of valid days.
     is_busday : Returns a boolean array indicating valid days.
     busday_count : Counts how many valid days are in a half-open date range.
 
@@ -1598,7 +1598,7 @@ def busday_count(begindates, enddates, weekmask=None, holidays=None,
 
     See Also
     --------
-    busdaycalendar: An object that specifies a custom set of valid days.
+    busdaycalendar : An object that specifies a custom set of valid days.
     is_busday : Returns a boolean array indicating valid days.
     busday_offset : Applies an offset counted in valid days.
 

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1427,12 +1427,11 @@ def moveaxis(a, source, destination):
 
     See Also
     --------
-    transpose: Permute the dimensions of an array.
-    swapaxes: Interchange two axes of an array.
+    transpose : Permute the dimensions of an array.
+    swapaxes : Interchange two axes of an array.
 
     Examples
     --------
-
     >>> x = np.zeros((3, 4, 5))
     >>> np.moveaxis(x, 0, -1).shape
     (4, 5, 3)

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -962,16 +962,16 @@ def array(obj, dtype=None, shape=None, offset=0, strides=None, formats=None,
 
     Parameters
     ----------
-    obj: any
+    obj : any
         Input object. See Notes for details on how various input types are
         treated.
-    dtype: data-type, optional
+    dtype : data-type, optional
         Valid dtype for array.
-    shape: int or tuple of ints, optional
+    shape : int or tuple of ints, optional
         Shape of each array.
-    offset: int, optional
+    offset : int, optional
         Position in the file or buffer to start reading from.
-    strides: tuple of ints, optional
+    strides : tuple of ints, optional
         Buffer (`buf`) is interpreted according to these strides (strides
         define how many bytes each array element, row, column, etc.
         occupy in memory).
@@ -979,7 +979,7 @@ def array(obj, dtype=None, shape=None, offset=0, strides=None, formats=None,
         If `dtype` is ``None``, these arguments are passed to
         `numpy.format_parser` to construct a dtype. See that function for
         detailed documentation.
-    copy: bool, optional
+    copy : bool, optional
         Whether to copy the input object (True), or to use a reference instead.
         This option only applies when the input is an ndarray or recarray.
         Defaults to True.

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -317,8 +317,8 @@ def pyod(filename):
     out : seq
         list of lines of od output
 
-    Note
-    ----
+    Notes
+    -----
     We only implement enough to get the necessary information for long double
     representation, this is not intended as a compatible replacement for od.
     """

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -607,7 +607,7 @@ def _block_info_recursion(arrays, max_depth, result_ndim, depth=0):
         The arrays to check
     max_depth : list of int
         The number of nested lists
-    result_ndim: int
+    result_ndim : int
         The number of dimensions in thefinal array.
 
     Returns


### PR DESCRIPTION
Via prototype docstring autoreformatter; and cherry-picked to mostly
include spacing issues around colons in parameters and see also.

When no space is present numpydoc tend to miss-parse those sections

A couple of typos are fixed as well.