### PR TITLE
DOC: cleanup of numpy/polynomial.

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -757,9 +757,6 @@ class ABCPolyBase(abc.ABC):
         Conversion between domains and class types can result in
         numerically ill defined series.
 
-        Examples
-        --------
-
         """
         if kind is None:
             kind = self.__class__

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1149,9 +1149,6 @@ def chebval(x, c, tensor=True):
     -----
     The evaluation uses Clenshaw recursion, aka synthetic division.
 
-    Examples
-    --------
-
     """
     c = np.array(c, ndmin=1, copy=True)
     if c.dtype.char in '?bBhHiIlLqQpP':

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -605,9 +605,6 @@ def legpow(c, pow, maxpower=16):
     --------
     legadd, legsub, legmulx, legmul, legdiv
 
-    Examples
-    --------
-
     """
     return pu._pow(legmul, c, pow, maxpower)
 
@@ -889,9 +886,6 @@ def legval(x, c, tensor=True):
     Notes
     -----
     The evaluation uses Clenshaw recursion, aka synthetic division.
-
-    Examples
-    --------
 
     """
     c = np.array(c, ndmin=1, copy=False)

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -509,7 +509,7 @@ def _fromroots(line_f, mul_f, roots):
         The ``<type>line`` function, such as ``polyline``
     mul_f : function(array_like, array_like) -> ndarray
         The ``<type>mul`` function, such as ``polymul``
-    roots :
+    roots
         See the ``<type>fromroots`` functions for more detail
     """
     if len(roots) == 0:
@@ -537,7 +537,7 @@ def _valnd(val_f, c, *args):
     ----------
     val_f : function(array_like, array_like, tensor: bool) -> array_like
         The ``<type>val`` function, such as ``polyval``
-    c, args :
+    c, args
         See the ``<type>val<n>d`` functions for more detail
     """
     args = [np.asanyarray(a) for a in args]
@@ -567,7 +567,7 @@ def _gridnd(val_f, c, *args):
     ----------
     val_f : function(array_like, array_like, tensor: bool) -> array_like
         The ``<type>val`` function, such as ``polyval``
-    c, args :
+    c, args
         See the ``<type>grid<n>d`` functions for more detail
     """
     for xi in args:
@@ -586,7 +586,7 @@ def _div(mul_f, c1, c2):
     ----------
     mul_f : function(array_like, array_like) -> array_like
         The ``<type>mul`` function, such as ``polymul``
-    c1, c2 :
+    c1, c2
         See the ``<type>div`` functions for more detail
     """
     # c1, c2 are trimmed copies
@@ -646,7 +646,7 @@ def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
     ----------
     vander_f : function(array_like, int) -> ndarray
         The 1d vander function, such as ``polyvander``
-    c1, c2 :
+    c1, c2
         See the ``<type>fit`` functions for more detail
     """
     x = np.asarray(x) + 0.0
@@ -732,12 +732,12 @@ def _pow(mul_f, c, pow, maxpower):
 
     Parameters
     ----------
-    vander_f : function(array_like, int) -> ndarray
-        The 1d vander function, such as ``polyvander``
-    pow, maxpower :
-        See the ``<type>pow`` functions for more detail
     mul_f : function(array_like, array_like) -> ndarray
         The ``<type>mul`` function, such as ``polymul``
+    c : array_like
+        1-D array of array of series coefficients
+    pow, maxpower
+        See the ``<type>pow`` functions for more detail
     """
     # c is a trimmed copy
     [c] = as_series([c])


### PR DESCRIPTION
Numpydoc format says that the colon need o be omitted if there is no
type, there were also some empty Examples Sections.

I was unsure if those should be fixed (arguably I see how one could decide to amend the numpydoc format guide to always requires `:`, to be simpler, and I know that empty sections can be used to dynamically insert examples but it did not appear to be the case here. 

Note that one of the parameter of `_pow` was named `vander_f`, which was non existent, I tried to fix that with the best of my understanding of that piece of code.