### PR TITLE
BUG:  Use C linkage for random distributions

### DIFF
--- a/numpy/core/include/numpy/random/distributions.h
+++ b/numpy/core/include/numpy/random/distributions.h
@@ -1,6 +1,10 @@
 #ifndef _RANDOMDGEN__DISTRIBUTIONS_H_
 #define _RANDOMDGEN__DISTRIBUTIONS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "Python.h"
 #include "numpy/npy_common.h"
 #include <stddef.h>
@@ -196,5 +200,9 @@ double random_loggam(double x);
 static NPY_INLINE double next_double(bitgen_t *bitgen_state) {
     return bitgen_state->next_double(bitgen_state->state);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/numpy/random/_examples/cffi/parse.py
+++ b/numpy/random/_examples/cffi/parse.py
@@ -17,11 +17,20 @@ def parse_distributions_h(ffi, inc_dir):
                 continue
             s.append(line)
         ffi.cdef('\n'.join(s))
-            
+
     with open(os.path.join(inc_dir, 'random', 'distributions.h')) as fid:
         s = []
         in_skip = 0
+        ignoring = False
         for line in fid:
+            # check for and remove extern "C" guards
+            if ignoring:
+                if line.strip().startswith('#endif'):
+                    ignoring = False
+                continue
+            if line.strip().startswith('#ifdef __cplusplus'):
+                ignoring = True
+            
             # massage the include file
             if line.strip().startswith('#'):
                 continue


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

When using the numpy.random C API with Cython as described in [examples](https://numpy.org/devdocs/reference/random/extending.html#cython) with C++ sources instead of C sources, C++ name mangling will prevent correctly linking to symbols in the `npyrandom` static library which has C linkage.  A work-around is described [here](https://github.com/mdhaber/scipy/pull/56#discussion_r567335898), but it seems like adding some `extern "C"` declarations should do the trick.  These are found in nearly all other numpy header files, e.g. [npy_math.h](https://github.com/numpy/numpy/blob/48808e1a6a775283b2d482d65f93390ddeb534af/numpy/core/include/numpy/npy_math.h#L4).

Someone else may need to comment on why `cffi` extending tests are failing, I am unfamiliar with `cffi`. _EDIT: filtering out `extern "C"` statements was enough to get the tests working_