### PR TITLE
DOC: Add sphinx-last-updated-by-git extension

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -84,6 +84,7 @@ extensions = [
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
     'sphinx.ext.imgmath',
+    'sphinx_last_updated_by_git',
 ]
 
 imgmath_image_format = 'svg'
@@ -171,7 +172,6 @@ html_additional_pages = {
 
 html_title = "%s v%s Manual" % (project, version)
 html_static_path = ['_static']
-html_last_updated_fmt = '%b %d, %Y'
 
 html_use_modindex = True
 html_copy_source = False

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -5,3 +5,4 @@ scipy
 matplotlib
 pandas
 pydata-sphinx-theme==0.4.3
+sphinx-last-updated-by-git


### PR DESCRIPTION
Currently, each page of the docs shows the same "last updated" date.
IMHO, that's of limited usefulness.

Using this extension (full disclosure: written by me) each page should get an individual date, based on the Git commit where it was last changed.

https://github.com/mgeier/sphinx-last-updated-by-git

I'm not sure though, how well that works on such a huge project, because `git` is called at least once for each page. I've never tried it on something of similar scope.

Sorry for using NumPy as guinea pig ...