### PR TITLE
DOC: Numpydoc format space before `:` in Parameters

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -613,7 +613,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue):
     --------
     numpy.sum : Sum across array propagating NaNs.
     isnan : Show which elements are NaN.
-    isfinite: Show which elements are not NaN or +/-inf.
+    isfinite : Show which elements are not NaN or +/-inf.
 
     Notes
     -----

--- a/numpy/random/_pickle.py
+++ b/numpy/random/_pickle.py
@@ -19,7 +19,7 @@ def __generator_ctor(bit_generator_name='MT19937'):
 
     Parameters
     ----------
-    bit_generator_name: str
+    bit_generator_name : str
         String containing the core BitGenerator
 
     Returns
@@ -42,7 +42,7 @@ def __bit_generator_ctor(bit_generator_name='MT19937'):
 
     Parameters
     ----------
-    bit_generator_name: str
+    bit_generator_name : str
         String containing the name of the BitGenerator
 
     Returns
@@ -65,7 +65,7 @@ def __randomstate_ctor(bit_generator_name='MT19937'):
 
     Parameters
     ----------
-    bit_generator_name: str
+    bit_generator_name : str
         String containing the core BitGenerator
 
     Returns

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -166,9 +166,8 @@ def short_path(path, cwd=None):
 
     Parameters
     ----------
-    path: str or None
-
-    cwd: str or None
+    path : str or None
+    cwd : str or None
 
     Returns
     -------
@@ -344,8 +343,8 @@ def is_deprecated(f):
     """
     Check if module `f` is deprecated
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     f : ModuleType
 
     Returns
@@ -785,8 +784,7 @@ def _run_doctests(tests, full_name, verbose, doctest_warnings):
     full_name : str
 
     verbose : bool
-
-    doctest_warning : bool
+    doctest_warnings : bool
 
     Returns
     -------


### PR DESCRIPTION
Also missing `s` in two spellings.
