### PR TITLE
MAINT: defer the import of shutil

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -35,7 +35,6 @@ Example::
 
 """
 import os
-import shutil
 import io
 
 from numpy.core.overrides import set_module
@@ -257,6 +256,8 @@ class DataSource:
     def __del__(self):
         # Remove temp directories
         if hasattr(self, '_istmpdest') and self._istmpdest:
+            import shutil
+
             shutil.rmtree(self._destpath)
 
     def _iszip(self, filename):
@@ -319,8 +320,9 @@ class DataSource:
         Creates a copy of the file in the datasource cache.
 
         """
-        # We import these here because importing urllib is slow and
+        # We import these here because importing them is slow and
         # a significant fraction of numpy's total import time.
+        import shutil
         from urllib.request import urlopen
         from urllib.error import URLError
 


### PR DESCRIPTION
`numpy/lib/_datasource.py` is going through the hoops deferring the import of `lzma` and `bz2` until needed: 

https://github.com/numpy/numpy/blob/d5b6b41bcff0bd85e34f1f4afb6130fdec72ec7b/numpy/lib/_datasource.py#L70-L72

However the `lzma` and `bz2` modules were already loaded during `import shutil` earlier:

https://github.com/python/cpython/blob/49926cf2bcc8b44d9b8f148d81979ada191dd9d5/Lib/shutil.py#L21-L33

Also deferring the import of `shutil` reduces the initial numpy import time by almost 5% on my system.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
