### PR TITLE
ENH: Add annotations for the remaining `np.generic` aliases

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -335,7 +335,6 @@ bincount: Any
 bitwise_not: Any
 blackman: Any
 bmat: Any
-bool8: Any
 broadcast: Any
 broadcast_arrays: Any
 broadcast_to: Any
@@ -343,7 +342,6 @@ busday_count: Any
 busday_offset: Any
 busdaycalendar: Any
 byte_bounds: Any
-bytes0: Any
 c_: Any
 can_cast: Any
 cast: Any
@@ -351,7 +349,6 @@ chararray: Any
 column_stack: Any
 common_type: Any
 compare_chararrays: Any
-complex256: Any
 concatenate: Any
 conj: Any
 copy: Any
@@ -387,7 +384,6 @@ fix: Any
 flip: Any
 fliplr: Any
 flipud: Any
-float128: Any
 format_parser: Any
 frombuffer: Any
 fromfile: Any
@@ -471,7 +467,6 @@ nditer: Any
 nested_iters: Any
 newaxis: Any
 numarray: Any
-object0: Any
 ogrid: Any
 packbits: Any
 pad: Any
@@ -522,7 +517,6 @@ sinc: Any
 sort_complex: Any
 source: Any
 split: Any
-string_: Any
 take_along_axis: Any
 tile: Any
 trapz: Any
@@ -545,7 +539,6 @@ unwrap: Any
 vander: Any
 vdot: Any
 vectorize: Any
-void0: Any
 vsplit: Any
 where: Any
 who: Any
@@ -1667,12 +1660,16 @@ class bool_(generic):
     __gt__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
     __ge__: _ComparisonOp[_NumberLike_co, _ArrayLikeNumber_co]
 
+bool8 = bool_
+
 class object_(generic):
     def __init__(self, __value: object = ...) -> None: ...
     @property
     def real(self: _ArraySelf) -> _ArraySelf: ...
     @property
     def imag(self: _ArraySelf) -> _ArraySelf: ...
+
+object0 = object_
 
 class datetime64(generic):
     @overload
@@ -1869,6 +1866,7 @@ class floating(inexact[_NBit1]):
 float16 = floating[_16Bit]
 float32 = floating[_32Bit]
 float64 = floating[_64Bit]
+float128 = floating[_128Bit]
 
 half = floating[_NBitHalf]
 single = floating[_NBitSingle]
@@ -1903,6 +1901,7 @@ class complexfloating(inexact[_NBit1], Generic[_NBit1, _NBit2]):
 
 complex64 = complexfloating[_32Bit, _32Bit]
 complex128 = complexfloating[_64Bit, _64Bit]
+complex256 = complexfloating[_128Bit, _128Bit]
 
 csingle = complexfloating[_NBitSingle, _NBitSingle]
 singlecomplex = complexfloating[_NBitSingle, _NBitSingle]
@@ -1925,6 +1924,8 @@ class void(flexible):
         self, val: ArrayLike, dtype: DTypeLike, offset: int = ...
     ) -> None: ...
 
+void0 = void
+
 class character(flexible):  # type: ignore
     def __int__(self) -> int: ...
     def __float__(self) -> float: ...
@@ -1939,6 +1940,9 @@ class bytes_(character, bytes):
     def __init__(
         self, __value: str, encoding: str = ..., errors: str = ...
     ) -> None: ...
+
+string_ = bytes_
+bytes0 = bytes_
 
 class str_(character, str):
     @overload

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -166,6 +166,11 @@ c16.transpose()
 
 # Aliases
 np.str0()
+np.bool8()
+np.bytes0()
+np.string_()
+np.object0()
+np.void0(0)
 
 np.byte()
 np.short()

--- a/numpy/typing/tests/data/reveal/scalars.py
+++ b/numpy/typing/tests/data/reveal/scalars.py
@@ -30,6 +30,11 @@ reveal_type(np.str0('foo'))  # E: numpy.str_
 # Aliases
 reveal_type(np.unicode_())  # E: numpy.str_
 reveal_type(np.str0())  # E: numpy.str_
+reveal_type(np.bool8())  # E: numpy.bool_
+reveal_type(np.bytes0())  # E: numpy.bytes_
+reveal_type(np.string_())  # E: numpy.bytes_
+reveal_type(np.object0())  # E: numpy.object_
+reveal_type(np.void0(0))  # E: numpy.void
 
 reveal_type(np.byte())  # E: {byte}
 reveal_type(np.short())  # E: {short}


### PR DESCRIPTION
This PR adds annotations for all remaining `np.generic` aliases.

A number of aliases were already covered in https://github.com/numpy/numpy/pull/17479 and https://github.com/numpy/numpy/pull/17843; this PR takes care of most of the last ones (_e.g._ `bool8 = np.bool_`).

One thing that's still left to do is better handling of (platform-specific) extended precision `np.number`s,
but this is a task beyond the scope of this PR and one that, in all likeliness, will require an update of the mypy plugin.