### PR TITLE
TST: Pin `typing_extensions` to the latest version

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -153,9 +153,7 @@ from typing import (
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, SupportsIndex, Final
 else:
-    from typing_extensions import Literal, Protocol, Final
-    class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...
+    from typing_extensions import Literal, Protocol, SupportsIndex, Final
 
 # Ensures that the stubs are picked up
 from numpy import (

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -7,10 +7,7 @@ from numpy.typing import ArrayLike, DTypeLike, _SupportsArray, _NumberLike_co
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex, Literal
 else:
-    from typing_extensions import Literal, Protocol
-
-    class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...
+    from typing_extensions import SupportsIndex, Literal
 
 # TODO: wait for support for recursive types
 _ArrayLikeNested = Sequence[Sequence[Any]]

--- a/numpy/core/shape_base.pyi
+++ b/numpy/core/shape_base.pyi
@@ -7,9 +7,7 @@ from numpy.typing import ArrayLike
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex
 else:
-    from typing_extensions import Protocol
-    class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...
+    from typing_extensions import SupportsIndex
 
 _ArrayType = TypeVar("_ArrayType", bound=ndarray)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,5 +11,6 @@ cffi
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # - Mypy doesn't currently work on Python 3.9
+# - There is no point in installing typing_extensions without mypy
 mypy==0.800; platform_python_implementation != "PyPy"
-typing_extensions
+typing_extensions==3.7.4.3; platform_python_implementation != "PyPy"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,6 @@ pickle5; python_version == '3.7' and platform_python_implementation != 'PyPy'
 cffi
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
-# - Mypy doesn't currently work on Python 3.9
 # - There is no point in installing typing_extensions without mypy
 mypy==0.800; platform_python_implementation != "PyPy"
 typing_extensions==3.7.4.3; platform_python_implementation != "PyPy"


### PR DESCRIPTION
This PR pins the `typing_extensions` extension, something probably should have been done from the very begining, but somehow slipped through the cracks.

As a side note: is it correct that `typing_extensions` will now be automatically managed by @dependabot-preview?