### PR TITLE
MAINT: Move transferdata into buffer-wise struct

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -1557,6 +1557,8 @@ NpyIter_DebugPrint(NpyIter *iter)
 
     if (itflags&NPY_ITFLAG_BUFFER) {
         NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
+        NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
+
         printf("| BufferData:\n");
         printf("|   BufferSize: %d\n", (int)NBF_BUFFERSIZE(bufferdata));
         printf("|   Size: %d\n", (int)NBF_SIZE(bufferdata));
@@ -1598,19 +1600,19 @@ NpyIter_DebugPrint(NpyIter *iter)
         }
         printf("|   ReadTransferFn: ");
         for (iop = 0; iop < nop; ++iop)
-            printf("%p ", (void *)NBF_READTRANSFERFN(bufferdata)[iop]);
+            printf("%p ", (void *)transferinfo[iop].read.func);
         printf("\n");
         printf("|   ReadTransferData: ");
         for (iop = 0; iop < nop; ++iop)
-            printf("%p ", (void *)NBF_READTRANSFERDATA(bufferdata)[iop]);
+            printf("%p ", (void *)transferinfo[iop].read.auxdata);
         printf("\n");
         printf("|   WriteTransferFn: ");
         for (iop = 0; iop < nop; ++iop)
-            printf("%p ", (void *)NBF_WRITETRANSFERFN(bufferdata)[iop]);
+            printf("%p ", (void *)transferinfo[iop].write.func);
         printf("\n");
         printf("|   WriteTransferData: ");
         for (iop = 0; iop < nop; ++iop)
-            printf("%p ", (void *)NBF_WRITETRANSFERDATA(bufferdata)[iop]);
+            printf("%p ", (void *)transferinfo[iop].write.auxdata);
         printf("\n");
         printf("|   Buffers: ");
         for (iop = 0; iop < nop; ++iop)
@@ -1889,9 +1891,6 @@ npyiter_copy_from_buffers(NpyIter *iter)
     npy_intp reduce_outerdim = 0;
     npy_intp *reduce_outerstrides = NULL;
 
-    PyArray_StridedUnaryOp *stransfer = NULL;
-    NpyAuxData *transferdata = NULL;
-
     npy_intp axisdata_incr = NIT_AXISDATA_SIZEOF(itflags, ndim, nop) /
                                 NPY_SIZEOF_INTP;
 
@@ -1909,9 +1908,8 @@ npyiter_copy_from_buffers(NpyIter *iter)
         transfersize *= NBF_REDUCE_OUTERSIZE(bufferdata);
     }
 
+    NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
     for (iop = 0; iop < nop; ++iop) {
-        stransfer = NBF_WRITETRANSFERFN(bufferdata)[iop];
-        transferdata = NBF_WRITETRANSFERDATA(bufferdata)[iop];
         buffer = buffers[iop];
         /*
          * Copy the data back to the arrays.  If the type has refs,
@@ -1920,7 +1918,7 @@ npyiter_copy_from_buffers(NpyIter *iter)
          * The flag USINGBUFFER is set when the buffer was used, so
          * only copy back when this flag is on.
          */
-        if ((stransfer != NULL) &&
+        if ((transferinfo[iop].write.func != NULL) &&
                (op_itflags[iop]&(NPY_OP_ITFLAG_WRITE|NPY_OP_ITFLAG_USINGBUFFER))
                         == (NPY_OP_ITFLAG_WRITE|NPY_OP_ITFLAG_USINGBUFFER)) {
             npy_intp op_transfersize;
@@ -2011,8 +2009,8 @@ npyiter_copy_from_buffers(NpyIter *iter)
                         dst_coords, axisdata_incr,
                         dst_shape, axisdata_incr,
                         op_transfersize, dtypes[iop]->elsize,
-                        (PyArray_MaskedStridedUnaryOp *)stransfer,
-                        transferdata) < 0) {
+                        (PyArray_MaskedStridedUnaryOp *)transferinfo[iop].write.func,
+                        transferinfo[iop].write.auxdata) < 0) {
                     return -1;
                 }
             }
@@ -2024,8 +2022,8 @@ npyiter_copy_from_buffers(NpyIter *iter)
                         dst_coords, axisdata_incr,
                         dst_shape, axisdata_incr,
                         op_transfersize, dtypes[iop]->elsize,
-                        stransfer,
-                        transferdata) < 0) {
+                        transferinfo[iop].write.func,
+                        transferinfo[iop].write.auxdata) < 0) {
                     return -1;
                 }
             }
@@ -2037,14 +2035,15 @@ npyiter_copy_from_buffers(NpyIter *iter)
          * The flag USINGBUFFER is set when the buffer was used, so
          * only decrement refs when this flag is on.
          */
-        else if (stransfer != NULL &&
+        else if (transferinfo[iop].write.func != NULL &&
                        (op_itflags[iop]&NPY_OP_ITFLAG_USINGBUFFER) != 0) {
             NPY_IT_DBG_PRINT1("Iterator: Freeing refs and zeroing buffer "
                                 "of operand %d\n", (int)iop);
             /* Decrement refs */
-            if (stransfer(NULL, 0, buffer, dtypes[iop]->elsize,
-                          transfersize, dtypes[iop]->elsize,
-                          transferdata) < 0) {
+            if (transferinfo[iop].write.func(
+                    NULL, 0, buffer, dtypes[iop]->elsize,
+                    transfersize, dtypes[iop]->elsize,
+                    transferinfo[iop].write.auxdata) < 0) {
                 /* Since this should only decrement, it should never error */
                 assert(0);
                 return -1;
@@ -2093,9 +2092,6 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
 
     npy_intp *reduce_outerstrides = NULL;
     char **reduce_outerptrs = NULL;
-
-    PyArray_StridedUnaryOp *stransfer = NULL;
-    NpyAuxData *transferdata = NULL;
 
     /*
      * Have to get this flag before npyiter_checkreducesize sets
@@ -2207,13 +2203,14 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
         is_onestride = 1;
     }
 
+    NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
     for (iop = 0; iop < nop; ++iop) {
         /*
          * If the buffer is write-only, these two are NULL, and the buffer
          * pointers will be set up but the read copy won't be done
          */
-        stransfer = NBF_READTRANSFERFN(bufferdata)[iop];
-        transferdata = NBF_READTRANSFERDATA(bufferdata)[iop];
+        PyArray_StridedUnaryOp *stransfer = transferinfo[iop].read.func;
+
         switch (op_itflags[iop]&
                         (NPY_OP_ITFLAG_BUFNEVER|
                          NPY_OP_ITFLAG_CAST|
@@ -2554,12 +2551,12 @@ npyiter_copy_to_buffers(NpyIter *iter, char **prev_dataptrs)
                                 (int)iop, (int)op_transfersize);
 
                 if (PyArray_TransferNDimToStrided(
-                                ndim_transfer, ptrs[iop], dst_stride,
-                                ad_ptrs[iop], src_strides, axisdata_incr,
-                                src_coords, axisdata_incr,
-                                src_shape, axisdata_incr,
-                                op_transfersize, src_itemsize,
-                                stransfer, transferdata) < 0) {
+                        ndim_transfer, ptrs[iop], dst_stride,
+                        ad_ptrs[iop], src_strides, axisdata_incr,
+                        src_coords, axisdata_incr,
+                        src_shape, axisdata_incr,
+                        op_transfersize, src_itemsize,
+                        stransfer, transferinfo[iop].read.auxdata) < 0) {
                     return -1;
                 }
             }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -235,8 +235,8 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
         NBF_SIZE(bufferdata) = 0;
         memset(NBF_BUFFERS(bufferdata), 0, nop*NPY_SIZEOF_INTP);
         memset(NBF_PTRS(bufferdata), 0, nop*NPY_SIZEOF_INTP);
-        memset(NBF_READTRANSFERDATA(bufferdata), 0, nop*NPY_SIZEOF_INTP);
-        memset(NBF_WRITETRANSFERDATA(bufferdata), 0, nop*NPY_SIZEOF_INTP);
+        /* Ensure that the transferdata/auxdata is NULLed */
+        memset(NBF_TRANSFERINFO(bufferdata), 0, nop * sizeof(NpyIter_TransferInfo));
     }
 
     /* Fill in the AXISDATA arrays and set the ITERSIZE field */
@@ -577,13 +577,11 @@ NpyIter_Copy(NpyIter *iter)
         NpyIter_BufferData *bufferdata;
         npy_intp buffersize, itemsize;
         char **buffers;
-        NpyAuxData **readtransferdata, **writetransferdata;
 
         bufferdata = NIT_BUFFERDATA(newiter);
         buffers = NBF_BUFFERS(bufferdata);
-        readtransferdata = NBF_READTRANSFERDATA(bufferdata);
-        writetransferdata = NBF_WRITETRANSFERDATA(bufferdata);
         buffersize = NBF_BUFFERSIZE(bufferdata);
+        NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
 
         for (iop = 0; iop < nop; ++iop) {
             if (buffers[iop] != NULL) {
@@ -599,27 +597,27 @@ NpyIter_Copy(NpyIter *iter)
                 }
             }
 
-            if (readtransferdata[iop] != NULL) {
+            if (transferinfo[iop].read.auxdata != NULL) {
                 if (out_of_memory) {
-                    readtransferdata[iop] = NULL;
+                    transferinfo[iop].read.auxdata = NULL;
                 }
                 else {
-                    readtransferdata[iop] =
-                          NPY_AUXDATA_CLONE(readtransferdata[iop]);
-                    if (readtransferdata[iop] == NULL) {
+                    transferinfo[iop].read.auxdata =
+                          NPY_AUXDATA_CLONE(transferinfo[iop].read.auxdata);
+                    if (transferinfo[iop].read.auxdata == NULL) {
                         out_of_memory = 1;
                     }
                 }
             }
 
-            if (writetransferdata[iop] != NULL) {
+            if (transferinfo[iop].write.auxdata != NULL) {
                 if (out_of_memory) {
-                    writetransferdata[iop] = NULL;
+                    transferinfo[iop].write.auxdata = NULL;
                 }
                 else {
-                    writetransferdata[iop] =
-                          NPY_AUXDATA_CLONE(writetransferdata[iop]);
-                    if (writetransferdata[iop] == NULL) {
+                    transferinfo[iop].write.auxdata =
+                          NPY_AUXDATA_CLONE(transferinfo[iop].write.auxdata);
+                    if (transferinfo[iop].write.auxdata == NULL) {
                         out_of_memory = 1;
                     }
                 }
@@ -688,25 +686,21 @@ NpyIter_Deallocate(NpyIter *iter)
 
         NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
         char **buffers;
-        NpyAuxData **transferdata;
 
         /* buffers */
         buffers = NBF_BUFFERS(bufferdata);
         for (iop = 0; iop < nop; ++iop, ++buffers) {
             PyArray_free(*buffers);
         }
+
+        NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
         /* read bufferdata */
-        transferdata = NBF_READTRANSFERDATA(bufferdata);
-        for(iop = 0; iop < nop; ++iop, ++transferdata) {
-            if (*transferdata) {
-                NPY_AUXDATA_FREE(*transferdata);
+        for (iop = 0; iop < nop; ++iop, ++transferinfo) {
+            if (transferinfo->read.auxdata) {
+                NPY_AUXDATA_FREE(transferinfo->read.auxdata);
             }
-        }
-        /* write bufferdata */
-        transferdata = NBF_WRITETRANSFERDATA(bufferdata);
-        for(iop = 0; iop < nop; ++iop, ++transferdata) {
-            if (*transferdata) {
-                NPY_AUXDATA_FREE(*transferdata);
+            if (transferinfo->write.auxdata) {
+                NPY_AUXDATA_FREE(transferinfo->write.auxdata);
             }
         }
     }
@@ -3142,13 +3136,8 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
     PyArrayObject **op = NIT_OPERANDS(iter);
     PyArray_Descr **op_dtype = NIT_DTYPES(iter);
     npy_intp *strides = NAD_STRIDES(axisdata), op_stride;
-    PyArray_StridedUnaryOp **readtransferfn = NBF_READTRANSFERFN(bufferdata),
-                        **writetransferfn = NBF_WRITETRANSFERFN(bufferdata);
-    NpyAuxData **readtransferdata = NBF_READTRANSFERDATA(bufferdata),
-               **writetransferdata = NBF_WRITETRANSFERDATA(bufferdata);
+    NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);
 
-    PyArray_StridedUnaryOp *stransfer = NULL;
-    NpyAuxData *transferdata = NULL;
     int needs_api = 0;
 
     for (iop = 0; iop < nop; ++iop) {
@@ -3174,17 +3163,15 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
                                         PyArray_DESCR(op[iop]),
                                         op_dtype[iop],
                                         move_references,
-                                        &stransfer,
-                                        &transferdata,
+                                        &transferinfo[iop].read.func,
+                                        &transferinfo[iop].read.auxdata,
                                         &needs_api) != NPY_SUCCEED) {
                     iop -= 1;  /* This one cannot be cleaned up yet. */
                     goto fail;
                 }
-                readtransferfn[iop] = stransfer;
-                readtransferdata[iop] = transferdata;
             }
             else {
-                readtransferfn[iop] = NULL;
+                transferinfo[iop].read.func = NULL;
             }
             if (flags & NPY_OP_ITFLAG_WRITE) {
                 int move_references = 1;
@@ -3200,38 +3187,35 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
                      * could be inconsistent.
                      */
                     if (PyArray_GetMaskedDTypeTransferFunction(
-                                (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
-                                op_dtype[iop]->elsize,
-                                op_stride,
-                                (strides[maskop] == mask_dtype->elsize) ?
-                                                mask_dtype->elsize :
-                                                NPY_MAX_INTP,
-                                op_dtype[iop],
-                                PyArray_DESCR(op[iop]),
-                                mask_dtype,
-                                move_references,
-                                (PyArray_MaskedStridedUnaryOp **)&stransfer,
-                                &transferdata,
-                                &needs_api) != NPY_SUCCEED) {
+                            (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
+                            op_dtype[iop]->elsize,
+                            op_stride,
+                            (strides[maskop] == mask_dtype->elsize) ?
+                                mask_dtype->elsize : NPY_MAX_INTP,
+                            op_dtype[iop],
+                            PyArray_DESCR(op[iop]),
+                            mask_dtype,
+                            move_references,
+                            (PyArray_MaskedStridedUnaryOp **)&transferinfo[iop].write.func,
+                            &transferinfo[iop].write.auxdata,
+                            &needs_api) != NPY_SUCCEED) {
                         goto fail;
                     }
                 }
                 else {
                     if (PyArray_GetDTypeTransferFunction(
-                                        (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
-                                        op_dtype[iop]->elsize,
-                                        op_stride,
-                                        op_dtype[iop],
-                                        PyArray_DESCR(op[iop]),
-                                        move_references,
-                                        &stransfer,
-                                        &transferdata,
-                                        &needs_api) != NPY_SUCCEED) {
+                            (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
+                            op_dtype[iop]->elsize,
+                            op_stride,
+                            op_dtype[iop],
+                            PyArray_DESCR(op[iop]),
+                            move_references,
+                            &transferinfo[iop].write.func,
+                            &transferinfo[iop].write.auxdata,
+                            &needs_api) != NPY_SUCCEED) {
                         goto fail;
                     }
                 }
-                writetransferfn[iop] = stransfer;
-                writetransferdata[iop] = transferdata;
             }
             /* If no write back but there are references make a decref fn */
             else if (PyDataType_REFCHK(op_dtype[iop])) {
@@ -3241,25 +3225,23 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
                  * src references.
                  */
                 if (PyArray_GetDTypeTransferFunction(
-                                        (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
-                                        op_dtype[iop]->elsize, 0,
-                                        op_dtype[iop], NULL,
-                                        1,
-                                        &stransfer,
-                                        &transferdata,
-                                        &needs_api) != NPY_SUCCEED) {
+                        (flags & NPY_OP_ITFLAG_ALIGNED) != 0,
+                        op_dtype[iop]->elsize, 0,
+                        op_dtype[iop], NULL,
+                        1,
+                        &transferinfo[iop].write.func,
+                        &transferinfo[iop].write.auxdata,
+                        &needs_api) != NPY_SUCCEED) {
                     goto fail;
                 }
-                writetransferfn[iop] = stransfer;
-                writetransferdata[iop] = transferdata;
             }
             else {
-                writetransferfn[iop] = NULL;
+                transferinfo[iop].write.func = NULL;
             }
         }
         else {
-            readtransferfn[iop] = NULL;
-            writetransferfn[iop] = NULL;
+            transferinfo[iop].read.func = NULL;
+            transferinfo[iop].write.func = NULL;
         }
     }
 
@@ -3272,13 +3254,13 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
 
 fail:
     for (i = 0; i < iop+1; ++i) {
-        if (readtransferdata[iop] != NULL) {
-            NPY_AUXDATA_FREE(readtransferdata[iop]);
-            readtransferdata[iop] = NULL;
+        if (transferinfo[iop].read.auxdata != NULL) {
+            NPY_AUXDATA_FREE(transferinfo[iop].read.auxdata);
+            transferinfo[iop].read.auxdata = NULL;
         }
-        if (writetransferdata[iop] != NULL) {
-            NPY_AUXDATA_FREE(writetransferdata[iop]);
-            writetransferdata[iop] = NULL;
+        if (transferinfo[iop].write.auxdata != NULL) {
+            NPY_AUXDATA_FREE(transferinfo[iop].write.auxdata);
+            transferinfo[iop].write.auxdata = NULL;
         }
     }
     return 0;

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -239,6 +239,8 @@ struct _transferdata {
 struct NpyIter_TransferInfo_tag {
     struct _transferdata read;
     struct _transferdata write;
+    /* Probably unnecessary, but make sure what follows is intp aligned: */
+    npy_intp _unused_ensure_alignment[];
 };
 
 struct NpyIter_BufferData_tag {
@@ -263,7 +265,6 @@ struct NpyIter_BufferData_tag {
         (&(bufferdata)->bd_flexdata + 3*(nop)))
 #define NBF_BUFFERS(bufferdata) ((char **) \
         (&(bufferdata)->bd_flexdata + 4*(nop)))
-/* NOTE: We assume that transferdata is a multiple of npy_intp in size. */
 #define NBF_TRANSFERINFO(bufferdata) ((NpyIter_TransferInfo *) \
         (&(bufferdata)->bd_flexdata + 5*(nop)))
 

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -148,8 +148,9 @@ struct NpyIter_InternalOnly {
     char iter_flexdata;
 };
 
-typedef struct NpyIter_AD NpyIter_AxisData;
-typedef struct NpyIter_BD NpyIter_BufferData;
+typedef struct NpyIter_AxisData_tag NpyIter_AxisData;
+typedef struct NpyIter_TransferInfo_tag NpyIter_TransferInfo;
+typedef struct NpyIter_BufferData_tag NpyIter_BufferData;
 
 typedef npy_int16 npyiter_opitflags;
 
@@ -167,7 +168,8 @@ typedef npy_int16 npyiter_opitflags;
 #define NIT_OPITFLAGS_SIZEOF(itflags, ndim, nop) \
         (NPY_INTP_ALIGNED(sizeof(npyiter_opitflags) * nop))
 #define NIT_BUFFERDATA_SIZEOF(itflags, ndim, nop) \
-        ((itflags&NPY_ITFLAG_BUFFER) ? ((NPY_SIZEOF_INTP)*(6 + 9*nop)) : 0)
+        ((itflags&NPY_ITFLAG_BUFFER) ? ( \
+            (NPY_SIZEOF_INTP)*(6 + 5*nop) + sizeof(NpyIter_TransferInfo) * nop) : 0)
 
 /* Byte offsets of the iterator members starting from iter->iter_flexdata */
 #define NIT_PERM_OFFSET() \
@@ -229,11 +231,22 @@ typedef npy_int16 npyiter_opitflags;
         &(iter)->iter_flexdata + NIT_AXISDATA_OFFSET(itflags, ndim, nop)))
 
 /* Internal-only BUFFERDATA MEMBER ACCESS */
-struct NpyIter_BD {
+struct _transferdata {
+    PyArray_StridedUnaryOp *func;
+    NpyAuxData *auxdata;
+};
+
+struct NpyIter_TransferInfo_tag {
+    struct _transferdata read;
+    struct _transferdata write;
+};
+
+struct NpyIter_BufferData_tag {
     npy_intp buffersize, size, bufiterend,
              reduce_pos, reduce_outersize, reduce_outerdim;
     npy_intp bd_flexdata;
 };
+
 #define NBF_BUFFERSIZE(bufferdata) ((bufferdata)->buffersize)
 #define NBF_SIZE(bufferdata) ((bufferdata)->size)
 #define NBF_BUFITEREND(bufferdata) ((bufferdata)->bufiterend)
@@ -248,19 +261,14 @@ struct NpyIter_BD {
         (&(bufferdata)->bd_flexdata + 2*(nop)))
 #define NBF_REDUCE_OUTERPTRS(bufferdata) ((char **) \
         (&(bufferdata)->bd_flexdata + 3*(nop)))
-#define NBF_READTRANSFERFN(bufferdata) ((PyArray_StridedUnaryOp **) \
-        (&(bufferdata)->bd_flexdata + 4*(nop)))
-#define NBF_READTRANSFERDATA(bufferdata) ((NpyAuxData **) \
-        (&(bufferdata)->bd_flexdata + 5*(nop)))
-#define NBF_WRITETRANSFERFN(bufferdata) ((PyArray_StridedUnaryOp **) \
-        (&(bufferdata)->bd_flexdata + 6*(nop)))
-#define NBF_WRITETRANSFERDATA(bufferdata) ((NpyAuxData **) \
-        (&(bufferdata)->bd_flexdata + 7*(nop)))
 #define NBF_BUFFERS(bufferdata) ((char **) \
-        (&(bufferdata)->bd_flexdata + 8*(nop)))
+        (&(bufferdata)->bd_flexdata + 4*(nop)))
+/* NOTE: We assume that transferdata is a multiple of npy_intp in size. */
+#define NBF_TRANSFERINFO(bufferdata) ((NpyIter_TransferInfo *) \
+        (&(bufferdata)->bd_flexdata + 5*(nop)))
 
 /* Internal-only AXISDATA MEMBER ACCESS. */
-struct NpyIter_AD {
+struct NpyIter_AxisData_tag {
     npy_intp shape, index;
     npy_intp ad_flexdata;
 };

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1134,6 +1134,9 @@ static void
 npyiter_dealloc(NewNpyArrayIterObject *self)
 {
     if (self->iter) {
+        /* Store error, so that WriteUnraisable cannot clear an existing one */
+        PyObject *exc, *val, *tb;
+        PyErr_Fetch(&exc, &val, &tb);
         if (npyiter_has_writeback(self->iter)) {
             if (PyErr_WarnEx(PyExc_RuntimeWarning,
                     "Temporary data has not been written back to one of the "
@@ -1152,10 +1155,13 @@ npyiter_dealloc(NewNpyArrayIterObject *self)
                 }
             }
         }
-        NpyIter_Deallocate(self->iter);
+        if (!NpyIter_Deallocate(self->iter)) {
+            PyErr_WriteUnraisable(Py_None);
+        }
         self->iter = NULL;
         Py_XDECREF(self->nested_child);
         self->nested_child = NULL;
+        PyErr_Restore(exc, val, tb);
     }
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -2320,7 +2326,7 @@ npyiter_close(NewNpyArrayIterObject *self)
     self->iter = NULL;
     Py_XDECREF(self->nested_child);
     self->nested_child = NULL;
-    if (ret < 0) {
+    if (ret != NPY_SUCCEED) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1,6 +1,8 @@
 import sys
 import pytest
 
+import subprocess, textwrap, re
+
 import numpy as np
 import numpy.core._multiarray_tests as _multiarray_tests
 from numpy import array, arange, nditer, all
@@ -3014,3 +3016,86 @@ def test_partial_iteration_error(in_dtype, buf_dtype):
         it.iternext()
 
     assert count == sys.getrefcount(value)
+
+
+def test_debug_print():
+    """
+    Matches the expected output of a debug print with the actual output.
+    Note that the iterator dump should not be considered stable API,
+    this test is mainly to ensure the print does not crash.
+
+    Currently uses a subprocess to avoid dealing with the C level `printf`s.
+    """
+    # the expected output with all addresses and sizes stripped (they vary
+    # and/or are platform dependend).
+    expected = textwrap.dedent("""
+    ------ BEGIN ITERATOR DUMP ------
+    | Iterator Address:
+    | ItFlags: BUFFER REDUCE REUSE_REDUCE_LOOPS
+    | NDim: 2
+    | NOp: 2
+    | IterSize: 50
+    | IterStart: 0
+    | IterEnd: 50
+    | IterIndex: 0
+    | Iterator SizeOf:
+    | BufferData SizeOf:
+    | AxisData SizeOf:
+    |
+    | Perm: 0 1
+    | DTypes:
+    | DTypes: dtype('float64') dtype('int32')
+    | InitDataPtrs:
+    | BaseOffsets: 0 0
+    | Operands:
+    | Operand DTypes: dtype('int64') dtype('float64')
+    | OpItFlags:
+    |   Flags[0]: READ CAST ALIGNED
+    |   Flags[1]: READ WRITE CAST ALIGNED REDUCE
+    |
+    | BufferData:
+    |   BufferSize: 50
+    |   Size: 5
+    |   BufIterEnd: 5
+    |   REDUCE Pos: 0
+    |   REDUCE OuterSize: 10
+    |   REDUCE OuterDim: 1
+    |   Strides: 8 4
+    |   Ptrs:
+    |   REDUCE Outer Strides: 40 0
+    |   REDUCE Outer Ptrs:
+    |   ReadTransferFn:
+    |   ReadTransferData: (nil) (nil)
+    |   WriteTransferFn: (nil)
+    |   WriteTransferData: (nil) (nil)
+    |   Buffers:
+    |
+    | AxisData[0]:
+    |   Shape: 5
+    |   Index: 0
+    |   Strides: 16 8
+    |   Ptrs:
+    | AxisData[1]:
+    |   Shape: 10
+    |   Index: 0
+    |   Strides: 80 0
+    |   Ptrs:
+    ------- END ITERATOR DUMP -------
+    """).strip()
+
+    code = textwrap.dedent("""
+        import numpy as np
+        arr1 = np.arange(100, dtype=np.int64).reshape(10, 10)[:, ::2]
+        arr2 = np.arange(5.)
+        it = np.nditer((arr1, arr2), op_dtypes=["d", "i4"], casting="unsafe",
+                       flags=["reduce_ok", "buffered"],
+                       op_flags=[["readonly"], ["readwrite"]])
+        it.debug_print()
+        """)
+    res = subprocess.check_output([sys.executable, "-c", code], text=True)
+    res = res.strip()
+
+    for res_line, expected_line in zip(res.splitlines(), expected.splitlines()):
+        # The actual output may have additional pointers listed that are
+        # stripped from the example output:
+        assert res_line.startswith(expected_line)

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -3100,9 +3100,9 @@ def test_debug_print(capfd):
     |   REDUCE Outer Strides: 40 0
     |   REDUCE Outer Ptrs:
     |   ReadTransferFn:
-    |   ReadTransferData: (nil) (nil)
-    |   WriteTransferFn: (nil)
-    |   WriteTransferData: (nil) (nil)
+    |   ReadTransferData:
+    |   WriteTransferFn:
+    |   WriteTransferData:
     |   Buffers:
     |
     | AxisData[0]:

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1958,6 +1958,8 @@ def test_iter_buffered_cast_structured_type():
                  [np.array((1, 2, 3), dtype=sdt2),
                   np.array((4, 5, 6), dtype=sdt2)])
 
+
+def test_iter_buffered_cast_structured_type_failure_with_cleanup():
     # make sure struct type -> struct type with different
     # number of fields fails
     sdt1 = [('a', 'f4'), ('b', 'i8'), ('d', 'O')]
@@ -1967,12 +1969,13 @@ def test_iter_buffered_cast_structured_type():
     for intent in ["readwrite", "readonly", "writeonly"]:
         # If the following assert fails, the place where the error is raised
         # within nditer may change. That is fine, but it may make sense for
-        # a new (hard to design) test to replace it:
+        # a new (hard to design) test to replace it. The `simple_arr` is
+        # designed to require a multi-step cast (due to having fields).
         assert np.can_cast(a.dtype, sdt2, casting="unsafe")
-        simple_arr = np.array([1, 2], dtype="i")  # succeeds but needs clean up
+        simple_arr = np.array([1, 2], dtype="i,i")  # requires clean up
         with pytest.raises(ValueError):
             nditer((simple_arr, a), ['buffered', 'refs_ok'], [intent, intent],
-                   casting='unsafe', op_dtypes=["f", sdt2])
+                   casting='unsafe', op_dtypes=["f,f", sdt2])
 
 
 def test_buffered_cast_error_paths():


### PR DESCRIPTION
This hopefully slightly simplifies the NpyIter struct in order
to be able to add a new "Context" more easily.

---

Splitting it out for easier discussion.  I need to add a second piece of info if we go ahead with signatures proposed in NEP 43. Adding two more fields (write and read) and macros for both seemed not great either, so I thought I would propose consolidating it into a struct instead.
I first wanted to consolidate even more, but at least `strides` and `ptr` are directly exposed as arrays of intp, probably leaving only `buffers` (the base pointer holding the memory). So instead, just consolidated all the "transferinfo" needed to do the actual casting.