### PR TITLE
BUG: Fix typo in ``numpy.__init__.py``

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -212,8 +212,8 @@ else:
                     extended_msg=_int_extended_msg.format("long")))
 
     __deprecated_attrs__["unicode"] = (
-        getattr(compat, "long"),
-        _msg.format(n="unciode", n2="str",
+        getattr(compat, "unicode"),
+        _msg.format(n="unicode", n2="str",
                     extended_msg=_specific_msg.format("str_")))
 
     del _msg, _specific_msg, _int_extended_msg, _type_info, _builtins

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -687,16 +687,16 @@ class TestDeprecatedGlobals(_DeprecationTestCase):
         reason='module-level __getattr__ not supported')
     def test_type_aliases(self):
         # from builtins
-        self.assert_deprecated(lambda: np.bool)
-        self.assert_deprecated(lambda: np.int)
-        self.assert_deprecated(lambda: np.float)
-        self.assert_deprecated(lambda: np.complex)
-        self.assert_deprecated(lambda: np.object)
-        self.assert_deprecated(lambda: np.str)
+        self.assert_deprecated(lambda: np.bool(True))
+        self.assert_deprecated(lambda: np.int(1))
+        self.assert_deprecated(lambda: np.float(1))
+        self.assert_deprecated(lambda: np.complex(1))
+        self.assert_deprecated(lambda: np.object())
+        self.assert_deprecated(lambda: np.str('abc'))
 
         # from np.compat
-        self.assert_deprecated(lambda: np.long)
-        self.assert_deprecated(lambda: np.unicode)
+        self.assert_deprecated(lambda: np.long(1))
+        self.assert_deprecated(lambda: np.unicode('abc'))
 
 
 class TestMatrixInOuter(_DeprecationTestCase):


### PR DESCRIPTION
Fix use of "long" when "unicode" was intended. Also fix
spelling of "unicode".

Closes #18287

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
