### PR TITLE
BUG: don't mutate list of fake libraries while iterating over it

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -569,7 +569,10 @@ class build_ext (old_build_ext):
         objects = list(objects)
         unlinkable_fobjects = list(unlinkable_fobjects)
 
-        # Expand possible fake static libraries to objects
+        # Expand possible fake static libraries to objects;
+        # make sure to iterate over a copy of the list as
+        # "fake" libraries will be removed as they are
+        # enountered
         for lib in libraries[:]:
             for libdir in library_dirs:
                 fake_lib = os.path.join(libdir, lib + '.fobjects')

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -570,13 +570,12 @@ class build_ext (old_build_ext):
         unlinkable_fobjects = list(unlinkable_fobjects)
 
         # Expand possible fake static libraries to objects
-        to_remove = []
-        for lib in libraries:
+        for lib in libraries[:]:
             for libdir in library_dirs:
                 fake_lib = os.path.join(libdir, lib + '.fobjects')
                 if os.path.isfile(fake_lib):
                     # Replace fake static library
-                    to_remove.append(lib)
+                    libraries.remove(lib)
                     with open(fake_lib, 'r') as f:
                         unlinkable_fobjects.extend(f.read().splitlines())
 
@@ -584,9 +583,6 @@ class build_ext (old_build_ext):
                     c_lib = os.path.join(libdir, lib + '.cobjects')
                     with open(c_lib, 'r') as f:
                         objects.extend(f.read().splitlines())
-
-        for lib in to_remove:
-            libraries.remove(lib)
 
         # Wrap unlinkable objects to a linkable one
         if unlinkable_fobjects:

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -570,12 +570,13 @@ class build_ext (old_build_ext):
         unlinkable_fobjects = list(unlinkable_fobjects)
 
         # Expand possible fake static libraries to objects
+        to_remove = []
         for lib in libraries:
             for libdir in library_dirs:
                 fake_lib = os.path.join(libdir, lib + '.fobjects')
                 if os.path.isfile(fake_lib):
                     # Replace fake static library
-                    libraries.remove(lib)
+                    to_remove.append(lib)
                     with open(fake_lib, 'r') as f:
                         unlinkable_fobjects.extend(f.read().splitlines())
 
@@ -583,6 +584,9 @@ class build_ext (old_build_ext):
                     c_lib = os.path.join(libdir, lib + '.cobjects')
                     with open(c_lib, 'r') as f:
                         objects.extend(f.read().splitlines())
+
+        for lib in to_remove:
+            libraries.remove(lib)
 
         # Wrap unlinkable objects to a linkable one
         if unlinkable_fobjects:

--- a/numpy/distutils/tests/test_build_ext.py
+++ b/numpy/distutils/tests/test_build_ext.py
@@ -1,7 +1,6 @@
 '''Tests for numpy.distutils.build_ext.'''
 
 import os
-import shutil
 import subprocess
 import sys
 from textwrap import indent, dedent
@@ -13,6 +12,14 @@ def test_multi_fortran_libs_link(tmp_path):
     Ensures multiple "fake" static libraries are correctly linked.
     see gh-18295
     '''
+
+    # We need to make sure we actually have an f77 compiler.
+    # This is nontrivial, so we'll borrow the utilities
+    # from f2py tests:
+    from numpy.f2py.tests.util import has_f77_compiler
+    if not has_f77_compiler():
+        pytest.skip('No F77 compiler found')
+
     # make some dummy sources
     with open(tmp_path / '_dummy1.f', 'w') as fid:
         fid.write(indent(dedent('''\

--- a/numpy/distutils/tests/test_build_ext.py
+++ b/numpy/distutils/tests/test_build_ext.py
@@ -1,0 +1,65 @@
+'''Tests for numpy.distutils.build_ext.'''
+
+import os
+import shutil
+import subprocess
+import sys
+from textwrap import indent, dedent
+import pytest
+
+@pytest.mark.slow
+def test_multi_fortran_libs_link(tmp_path):
+    '''
+    Ensures multiple "fake" static libraries are correctly linked.
+    see gh-18295
+    '''
+    # make some dummy sources
+    with open(tmp_path / '_dummy1.f', 'w') as fid:
+        fid.write(indent(dedent('''\
+            FUNCTION dummy_one()
+            RETURN
+            END FUNCTION'''), prefix=' '*6))
+    with open(tmp_path / '_dummy2.f', 'w') as fid:
+        fid.write(indent(dedent('''\
+            FUNCTION dummy_two()
+            RETURN
+            END FUNCTION'''), prefix=' '*6))
+    with open(tmp_path / '_dummy.c', 'w') as fid:
+        # doesn't need to load - just needs to exist
+        fid.write('int PyInit_dummyext;')
+
+    # make a setup file
+    with open(tmp_path / 'setup.py', 'w') as fid:
+        srctree = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+        fid.write(dedent(f'''\
+            def configuration(parent_package="", top_path=None):
+                from numpy.distutils.misc_util import Configuration
+                config = Configuration("", parent_package, top_path)
+                config.add_library("dummy1", sources=["_dummy1.f"])
+                config.add_library("dummy2", sources=["_dummy2.f"])
+                config.add_extension("dummyext", sources=["_dummy.c"], libraries=["dummy1", "dummy2"])
+                return config
+
+
+            if __name__ == "__main__":
+                import sys
+                sys.path.insert(0, r"{srctree}")
+                from numpy.distutils.core import setup
+                setup(**configuration(top_path="").todict())'''))
+
+    # build the test extensino and "install" into a temporary directory
+    build_dir = tmp_path
+    subprocess.check_call([sys.executable, 'setup.py', 'build', 'install',
+                           '--prefix', str(tmp_path / 'installdir'),
+                           '--record', str(tmp_path / 'tmp_install_log.txt'),
+                          ],
+                          cwd=str(build_dir),
+                      )
+    # get the path to the so
+    so = None
+    with open(tmp_path /'tmp_install_log.txt') as fid:
+        for line in fid:
+            if 'dummyext' in line:
+                so = line.strip()
+                break
+    assert so is not None


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

- Fixes regression causing Fortran static libraries in SciPy to not be found and linked on Windows 10 using MinGW-W64 (see https://github.com/scipy/scipy/issues/13072)
- not sure why this is causing an issue now (worked with previous versions), but with v1.20.0 it's not playing nicely with multiple Fortran libraries (_EDIT: might be due to gh-17052, this patch is good anyways because it makes it obvious what needs to happen rather than a list copy that looks unnecessary_)
- [simple bug reproducer](https://github.com/scipy/scipy/issues/13072#issuecomment-771327204)