### PR TITLE
MAINT: Add missing placeholder annotations

### DIFF
--- a/numpy/char.pyi
+++ b/numpy/char.pyi
@@ -53,3 +53,4 @@ isnumeric: Any
 isdecimal: Any
 array: Any
 asarray: Any
+chararray: Any

--- a/numpy/char.pyi
+++ b/numpy/char.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 equal: Any
 not_equal: Any

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -75,7 +75,7 @@ from . import fromnumeric
 from .fromnumeric import *
 from . import defchararray as char
 from . import records as rec
-from .records import *
+from .records import record, recarray, format_parser
 from .memmap import *
 from .defchararray import chararray
 from . import function_base
@@ -106,7 +106,7 @@ from . import _methods
 __all__ = ['char', 'rec', 'memmap']
 __all__ += numeric.__all__
 __all__ += fromnumeric.__all__
-__all__ += rec.__all__
+__all__ += ['record', 'recarray', 'format_parser']
 __all__ += ['chararray']
 __all__ += function_base.__all__
 __all__ += machar.__all__

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -45,7 +45,10 @@ from numpy.core.overrides import set_module
 from .arrayprint import get_printoptions
 
 # All of the functions allow formats to be a dtype
-__all__ = ['record', 'recarray', 'format_parser']
+__all__ = [
+    'record', 'recarray', 'format_parser',
+    'fromarrays', 'fromrecords', 'fromstring', 'fromfile', 'array',
+]
 
 
 ndarray = sb.ndarray

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -49,7 +49,8 @@ Then, we're ready to call ``foo_func``:
 >>> _lib.foo_func(out, len(out))                #doctest: +SKIP
 
 """
-__all__ = ['load_library', 'ndpointer', 'c_intp', 'as_ctypes', 'as_array']
+__all__ = ['load_library', 'ndpointer', 'c_intp', 'as_ctypes', 'as_array',
+           'as_ctypes_type']
 
 import os
 from numpy import (

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 load_library: Any
 ndpointer: Any

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -7,3 +7,4 @@ ndpointer: Any
 c_intp: Any
 as_ctypes: Any
 as_array: Any
+as_ctypes_type: Any

--- a/numpy/emath.pyi
+++ b/numpy/emath.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 sqrt: Any
 log: Any

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 run_main: Any
 compile: Any

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 emath: Any
 math: Any

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -177,3 +177,4 @@ nanquantile: Any
 histogram: Any
 histogramdd: Any
 histogram_bin_edges: Any
+NumpyVersion: Any

--- a/numpy/ma/__init__.pyi
+++ b/numpy/ma/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 core: Any
 extras: Any

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 matrix: Any
 bmat: Any

--- a/numpy/random/__init__.pyi
+++ b/numpy/random/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 beta: Any
 binomial: Any

--- a/numpy/rec.pyi
+++ b/numpy/rec.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 record: Any
 recarray: Any

--- a/numpy/rec.pyi
+++ b/numpy/rec.pyi
@@ -5,3 +5,8 @@ __all__: List[str]
 record: Any
 recarray: Any
 format_parser: Any
+fromarrays: Any
+fromrecords: Any
+fromstring: Any
+fromfile: Any
+array: Any

--- a/numpy/testing/__init__.pyi
+++ b/numpy/testing/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 assert_equal: Any
 assert_almost_equal: Any

--- a/numpy/typing/tests/data/pass/modules.py
+++ b/numpy/typing/tests/data/pass/modules.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy import f2py
 
 np.char
 np.ctypeslib
@@ -14,7 +15,17 @@ np.rec
 np.testing
 np.version
 
-np.__all__
 np.__path__
 np.__version__
 np.__git_version__
+
+np.__all__
+np.char.__all__
+np.ctypeslib.__all__
+np.emath.__all__
+np.lib.__all__
+np.ma.__all__
+np.random.__all__
+np.rec.__all__
+np.testing.__all__
+f2py.__all__

--- a/numpy/typing/tests/data/reveal/modules.py
+++ b/numpy/typing/tests/data/reveal/modules.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy import f2py
 
 reveal_type(np)  # E: ModuleType
 
@@ -19,7 +20,17 @@ reveal_type(np.version)  # E: ModuleType
 # TODO: Remove when annotations have been added to `np.testing.assert_equal`
 reveal_type(np.testing.assert_equal)  # E: Any
 
-reveal_type(np.__all__)  # E: list[builtins.str]
 reveal_type(np.__path__)  # E: list[builtins.str]
 reveal_type(np.__version__)  # E: str
 reveal_type(np.__git_version__)  # E: str
+
+reveal_type(np.__all__)  # E: list[builtins.str]
+reveal_type(np.char.__all__)  # E: list[builtins.str]
+reveal_type(np.ctypeslib.__all__)  # E: list[builtins.str]
+reveal_type(np.emath.__all__)  # E: list[builtins.str]
+reveal_type(np.lib.__all__)  # E: list[builtins.str]
+reveal_type(np.ma.__all__)  # E: list[builtins.str]
+reveal_type(np.random.__all__)  # E: list[builtins.str]
+reveal_type(np.rec.__all__)  # E: list[builtins.str]
+reveal_type(np.testing.__all__)  # E: list[builtins.str]
+reveal_type(f2py.__all__)  # E: list[builtins.str]


### PR DESCRIPTION
This PR adds (placeholder) annotations for a few objects that were missed in https://github.com/numpy/numpy/pull/17104.

In the wake of https://github.com/numpy/numpy/issues/18270 I did a double check of all placeholder annotations and identified a few 
that were previously missing, mostly module-level `__all__` attributes. 

In addition there were two groups of public functions that were missing from their module's `__all__`.
This has now been rectified:
* `np.ctypeslib.as_ctypes_type`
* Five functions in `np.rec`.