### PR TITLE
ENH, DOC: Build notes and fixes for Cygwin.

### DIFF
--- a/numpy/core/tests/test_cpu_features.py
+++ b/numpy/core/tests/test_cpu_features.py
@@ -104,9 +104,12 @@ class AbstractTest:
                 )
 
 is_linux = sys.platform.startswith('linux')
+is_cygwin = sys.platform.startswith('cygwin')
 machine  = platform.machine()
 is_x86   = re.match("^(amd64|x86|i386|i686)", machine, re.IGNORECASE)
-@pytest.mark.skipif(not is_linux or not is_x86, reason="Only for Linux and x86")
+@pytest.mark.skipif(
+    not (is_linux or is_cygwin) or not is_x86, reason="Only for Linux and x86"
+)
 class Test_X86_Features(AbstractTest):
     features = [
         "MMX", "SSE", "SSE2", "SSE3", "SSSE3", "SSE41", "POPCNT", "SSE42",

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -637,62 +637,65 @@ class TestFloatExceptions:
         self.assert_raises_fpe(fpeerr, flop, sc1, sc2[()])
         self.assert_raises_fpe(fpeerr, flop, sc1[()], sc2[()])
 
-    def test_floating_exceptions(self):
+    # Test for all real and complex float types
+    @pytest.mark.parametrize("typecode", np.typecodes["AllFloat"])
+    def test_floating_exceptions(self, typecode):
         # Test basic arithmetic function errors
         with np.errstate(all='raise'):
-            # Test for all real and complex float types
-            for typecode in np.typecodes['AllFloat']:
-                ftype = np.obj2sctype(typecode)
-                if np.dtype(ftype).kind == 'f':
-                    # Get some extreme values for the type
-                    fi = np.finfo(ftype)
-                    ft_tiny = fi.machar.tiny
-                    ft_max = fi.max
-                    ft_eps = fi.eps
-                    underflow = 'underflow'
-                    divbyzero = 'divide by zero'
-                else:
-                    # 'c', complex, corresponding real dtype
-                    rtype = type(ftype(0).real)
-                    fi = np.finfo(rtype)
-                    ft_tiny = ftype(fi.machar.tiny)
-                    ft_max = ftype(fi.max)
-                    ft_eps = ftype(fi.eps)
-                    # The complex types raise different exceptions
-                    underflow = ''
-                    divbyzero = ''
-                overflow = 'overflow'
-                invalid = 'invalid'
+            ftype = np.obj2sctype(typecode)
+            if np.dtype(ftype).kind == 'f':
+                # Get some extreme values for the type
+                fi = np.finfo(ftype)
+                ft_tiny = fi.machar.tiny
+                ft_max = fi.max
+                ft_eps = fi.eps
+                underflow = 'underflow'
+                divbyzero = 'divide by zero'
+            else:
+                # 'c', complex, corresponding real dtype
+                rtype = type(ftype(0).real)
+                fi = np.finfo(rtype)
+                ft_tiny = ftype(fi.machar.tiny)
+                ft_max = ftype(fi.max)
+                ft_eps = ftype(fi.eps)
+                # The complex types raise different exceptions
+                underflow = ''
+                divbyzero = ''
+            overflow = 'overflow'
+            invalid = 'invalid'
 
-                # The value of tiny for double double is NaN, so we need to
-                # pass the assert
-                if not np.isnan(ft_tiny):
-                    self.assert_raises_fpe(underflow,
-                                        lambda a, b: a/b, ft_tiny, ft_max)
-                    self.assert_raises_fpe(underflow,
-                                        lambda a, b: a*b, ft_tiny, ft_tiny)
-                self.assert_raises_fpe(overflow,
-                                       lambda a, b: a*b, ft_max, ftype(2))
-                self.assert_raises_fpe(overflow,
-                                       lambda a, b: a/b, ft_max, ftype(0.5))
-                self.assert_raises_fpe(overflow,
-                                       lambda a, b: a+b, ft_max, ft_max*ft_eps)
-                self.assert_raises_fpe(overflow,
-                                       lambda a, b: a-b, -ft_max, ft_max*ft_eps)
-                self.assert_raises_fpe(overflow,
-                                       np.power, ftype(2), ftype(2**fi.nexp))
-                self.assert_raises_fpe(divbyzero,
-                                       lambda a, b: a/b, ftype(1), ftype(0))
-                self.assert_raises_fpe(invalid,
-                                       lambda a, b: a/b, ftype(np.inf), ftype(np.inf))
-                self.assert_raises_fpe(invalid,
-                                       lambda a, b: a/b, ftype(0), ftype(0))
-                self.assert_raises_fpe(invalid,
-                                       lambda a, b: a-b, ftype(np.inf), ftype(np.inf))
-                self.assert_raises_fpe(invalid,
-                                       lambda a, b: a+b, ftype(np.inf), ftype(-np.inf))
-                self.assert_raises_fpe(invalid,
-                                       lambda a, b: a*b, ftype(0), ftype(np.inf))
+            # The value of tiny for double double is NaN, so we need to
+            # pass the assert
+            if not np.isnan(ft_tiny):
+                self.assert_raises_fpe(underflow,
+                                    lambda a, b: a/b, ft_tiny, ft_max)
+                self.assert_raises_fpe(underflow,
+                                    lambda a, b: a*b, ft_tiny, ft_tiny)
+            self.assert_raises_fpe(overflow,
+                                   lambda a, b: a*b, ft_max, ftype(2))
+            self.assert_raises_fpe(overflow,
+                                   lambda a, b: a/b, ft_max, ftype(0.5))
+            self.assert_raises_fpe(overflow,
+                                   lambda a, b: a+b, ft_max, ft_max*ft_eps)
+            self.assert_raises_fpe(overflow,
+                                   lambda a, b: a-b, -ft_max, ft_max*ft_eps)
+            self.assert_raises_fpe(overflow,
+                                   np.power, ftype(2), ftype(2**fi.nexp))
+            self.assert_raises_fpe(divbyzero,
+                                   lambda a, b: a/b, ftype(1), ftype(0))
+            self.assert_raises_fpe(
+                invalid, lambda a, b: a/b, ftype(np.inf), ftype(np.inf)
+            )
+            self.assert_raises_fpe(invalid,
+                                   lambda a, b: a/b, ftype(0), ftype(0))
+            self.assert_raises_fpe(
+                invalid, lambda a, b: a-b, ftype(np.inf), ftype(np.inf)
+            )
+            self.assert_raises_fpe(
+                invalid, lambda a, b: a+b, ftype(np.inf), ftype(-np.inf)
+            )
+            self.assert_raises_fpe(invalid,
+                                   lambda a, b: a*b, ftype(0), ftype(np.inf))
 
     def test_warnings(self):
         # test warning code path

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -870,20 +870,20 @@ class TestFloat_power:
 
 
 class TestLog2:
-    def test_log2_values(self):
+    @pytest.mark.parametrize('dt', ['f', 'd', 'g'])
+    def test_log2_values(self, dt):
         x = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
         y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        for dt in ['f', 'd', 'g']:
-            xf = np.array(x, dtype=dt)
-            yf = np.array(y, dtype=dt)
-            assert_almost_equal(np.log2(xf), yf)
+        xf = np.array(x, dtype=dt)
+        yf = np.array(y, dtype=dt)
+        assert_almost_equal(np.log2(xf), yf)
 
-    def test_log2_ints(self):
+    @pytest.mark.parametrize("i", range(1, 65))
+    def test_log2_ints(self, i):
         # a good log2 implementation should provide this,
         # might fail on OS with bad libm
-        for i in range(1, 65):
-            v = np.log2(2.**i)
-            assert_equal(v, float(i), err_msg='at exponent %d' % i)
+        v = np.log2(2.**i)
+        assert_equal(v, float(i), err_msg='at exponent %d' % i)
 
     def test_log2_special(self):
         assert_equal(np.log2(1.), 0.)
@@ -1069,18 +1069,19 @@ class TestSpecialFloats:
             assert_raises(FloatingPointError, np.cos, np.float32(-np.inf))
             assert_raises(FloatingPointError, np.cos, np.float32(np.inf))
 
-    def test_sqrt_values(self):
+    @pytest.mark.parametrize('dt', ['f', 'd', 'g'])
+    def test_sqrt_values(self, dt):
         with np.errstate(all='ignore'):
             x = [np.nan,  np.nan, np.inf, np.nan, 0.]
             y = [np.nan, -np.nan, np.inf, -np.inf, 0.]
-            for dt in ['f', 'd', 'g']:
-                xf = np.array(x, dtype=dt)
-                yf = np.array(y, dtype=dt)
-                assert_equal(np.sqrt(yf), xf)
+            xf = np.array(x, dtype=dt)
+            yf = np.array(y, dtype=dt)
+            assert_equal(np.sqrt(yf), xf)
 
-        #with np.errstate(invalid='raise'):
-        #    for dt in ['f', 'd', 'g']:
-        #        assert_raises(FloatingPointError, np.sqrt, np.array(-100., dtype=dt))
+        # with np.errstate(invalid='raise'):
+        #     assert_raises(
+        #         FloatingPointError, np.sqrt, np.array(-100., dtype=dt)
+        #     )
 
     def test_abs_values(self):
         x = [np.nan,  np.nan, np.inf, np.inf, 0., 0., 1.0, 1.0]

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -247,7 +247,7 @@ class GnuFCompiler(FCompiler):
         return []
 
     def runtime_library_dir_option(self, dir):
-        if sys.platform == 'win32':
+        if sys.platform == 'win32' or sys.platform == 'cygwin':
             # Linux/Solaris/Unix support RPATH, Windows does not
             raise NotImplementedError
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -377,9 +377,40 @@ def blue_text(s):
 #########################
 
 def cyg2win32(path):
-    if sys.platform=='cygwin' and path.startswith('/cygdrive'):
-        path = path[10] + ':' + os.path.normcase(path[11:])
-    return path
+    """Convert a path from Cygwin-native to Windows-native.
+
+    Uses the builting cygpath script to do the actual conversion.
+    Falls back to returning the original path if this fails.
+
+    Handles the default "/cygdrive" prefix as well as "/proc/cygdrive"
+    portable prefix and custom cygdrive prefixes such as "/" or "/mnt".
+
+    Parameters
+    ----------
+    path : str
+       The path to convert
+
+    Returns
+    -------
+    converted_path : str
+        The converted path
+
+    Notes
+    -----
+    Documentation for cygpath utility:
+    https://cygwin.com/cygwin-ug-net/cygpath.html
+    Documentation for the C function it wraps:
+    https://cygwin.com/cygwin-api/func-cygwin-conv-path.html
+
+    """
+    if sys.platform != "cygwin":
+        return path
+    try:
+        return subprocess.check_output(
+            ["/usr/bin/cygpath", "--windows", path], universal_newlines=True
+        )
+    except subprocess.CalledProcessError:
+        return path
 
 def mingw32():
     """Return true when using mingw32 environment.


### PR DESCRIPTION
Teach the NumPy build system about Cygwin.

Someone seems to have fixed a number of failing tests, so thank you to whomever that might be.

There are twelve tests that still fail.  

- Four appear to be due to the reference implementation of `np.abs(np.complex256(+-inf+nanj))` giving `inf` while the system `cabsl(INFINITY + NAN * _IMAGINARY_I)` gives `nan`.  
- Two more are complaining that `np.abs(np.complex256(1.7e4932))` should not be `inf`.  The system `cabsl(1.1e4932 + 0j)  == inf`; larger numbers give me compiler warnings about the literal not fitting in a `long double`. 
-  I think another two are related to `csqrt{f,}` not using the sign of zero for branch cuts.  
- Three involve zero-division warnings in `numpy/core/tests/test_umath.py:TestComplexFunctions.test_loss_of_precision:check`, and the divisor there is `np.arcsinh(z).real`.  The system `arcsinhl(1e-20+0j) == 0+0j`
- The last is `np.power(np.complex256(2+0j), 32768+0j)` not raising an overflow FPE.  I don't know how to check that one.

I can include the tests, written in C, if anyone wants to see those.

Update of #18102, #16246.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
