### PR TITLE
MAINT: Fixed chain exception for array_split func

### DIFF
--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -775,7 +775,7 @@ def array_split(ary, indices_or_sections, axis=0):
         # indices_or_sections is a scalar, not an array.
         Nsections = int(indices_or_sections)
         if Nsections <= 0:
-            raise ValueError('number sections must be larger than 0.')
+            raise ValueError('number sections must be larger than 0.') from None
         Neach_section, extras = divmod(Ntotal, Nsections)
         section_sizes = ([0] +
                          extras * [Neach_section+1] +


### PR DESCRIPTION
This update is related to #15986.
@eric-wieser please review this PR.

Before:

```
>>> import numpy as np
>>> x = np.arange(8.0)
>>> np.array_split(x, 0)
Traceback (most recent call last):
  File "/home/fruity/Desktop/venv/lib/python3.8/site-packages/numpy/lib/shape_base.py", line 772, in array_split
    Nsections = len(indices_or_sections) + 1
TypeError: object of type 'int' has no len()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 5, in array_split
  File "/home/fruity/Desktop/venv/lib/python3.8/site-packages/numpy/lib/shape_base.py", line 778, in array_split
    raise ValueError('number sections must be larger than 0.') from None
ValueError: number sections must be larger than 0.
```

After:

```
>>> import numpy as np
>>> x = np.arange(8.0)
>>> np.array_split(x, 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<__array_function__ internals>", line 5, in array_split
  File "/home/fruity/Desktop/venv/lib/python3.8/site-packages/numpy/lib/shape_base.py", line 778, in array_split
    raise ValueError('number sections must be larger than 0.') from None
ValueError: number sections must be larger than 0.
```

Thank you.