### PR TITLE
BUG: don't mutate list of fake libraries while iterating over it.

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -569,8 +569,11 @@ class build_ext (old_build_ext):
         objects = list(objects)
         unlinkable_fobjects = list(unlinkable_fobjects)
 
-        # Expand possible fake static libraries to objects
-        for lib in libraries:
+        # Expand possible fake static libraries to objects;
+        # make sure to iterate over a copy of the list as
+        # "fake" libraries will be removed as they are
+        # enountered
+        for lib in libraries[:]:
             for libdir in library_dirs:
                 fake_lib = os.path.join(libdir, lib + '.fobjects')
                 if os.path.isfile(fake_lib):

--- a/numpy/distutils/tests/test_build_ext.py
+++ b/numpy/distutils/tests/test_build_ext.py
@@ -1,0 +1,72 @@
+'''Tests for numpy.distutils.build_ext.'''
+
+import os
+import subprocess
+import sys
+from textwrap import indent, dedent
+import pytest
+
+@pytest.mark.slow
+def test_multi_fortran_libs_link(tmp_path):
+    '''
+    Ensures multiple "fake" static libraries are correctly linked.
+    see gh-18295
+    '''
+
+    # We need to make sure we actually have an f77 compiler.
+    # This is nontrivial, so we'll borrow the utilities
+    # from f2py tests:
+    from numpy.f2py.tests.util import has_f77_compiler
+    if not has_f77_compiler():
+        pytest.skip('No F77 compiler found')
+
+    # make some dummy sources
+    with open(tmp_path / '_dummy1.f', 'w') as fid:
+        fid.write(indent(dedent('''\
+            FUNCTION dummy_one()
+            RETURN
+            END FUNCTION'''), prefix=' '*6))
+    with open(tmp_path / '_dummy2.f', 'w') as fid:
+        fid.write(indent(dedent('''\
+            FUNCTION dummy_two()
+            RETURN
+            END FUNCTION'''), prefix=' '*6))
+    with open(tmp_path / '_dummy.c', 'w') as fid:
+        # doesn't need to load - just needs to exist
+        fid.write('int PyInit_dummyext;')
+
+    # make a setup file
+    with open(tmp_path / 'setup.py', 'w') as fid:
+        srctree = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+        fid.write(dedent(f'''\
+            def configuration(parent_package="", top_path=None):
+                from numpy.distutils.misc_util import Configuration
+                config = Configuration("", parent_package, top_path)
+                config.add_library("dummy1", sources=["_dummy1.f"])
+                config.add_library("dummy2", sources=["_dummy2.f"])
+                config.add_extension("dummyext", sources=["_dummy.c"], libraries=["dummy1", "dummy2"])
+                return config
+
+
+            if __name__ == "__main__":
+                import sys
+                sys.path.insert(0, r"{srctree}")
+                from numpy.distutils.core import setup
+                setup(**configuration(top_path="").todict())'''))
+
+    # build the test extensino and "install" into a temporary directory
+    build_dir = tmp_path
+    subprocess.check_call([sys.executable, 'setup.py', 'build', 'install',
+                           '--prefix', str(tmp_path / 'installdir'),
+                           '--record', str(tmp_path / 'tmp_install_log.txt'),
+                          ],
+                          cwd=str(build_dir),
+                      )
+    # get the path to the so
+    so = None
+    with open(tmp_path /'tmp_install_log.txt') as fid:
+        for line in fid:
+            if 'dummyext' in line:
+                so = line.strip()
+                break
+    assert so is not None


### PR DESCRIPTION
Backport of #18295. 

* BUG: don't mutate list of fake libraries while iterating over it

* BUG: iterate over copy of list

* TST: add build test for build_ext fix (#1)

* TST: add build test for build_ext fix

* TST: clearer test name

* STY: use triple quotes instead of lists of strings

* FIX: check for f77 compiler before test is run

* DOC: add comment explaining that a list copy is necessary

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
