### PR TITLE
MAINT: gracefully shuffle memoryviews

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4394,6 +4394,9 @@ cdef class Generator:
             char* x_ptr
             char* buf_ptr
 
+        if isinstance(x, memoryview):
+            x = np.asarray(x)
+
         axis = normalize_axis_index(axis, np.ndim(x))
 
         if type(x) is np.ndarray and x.ndim == 1 and x.size:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2,7 +2,7 @@
 #cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3
 import operator
 import warnings
-from collections.abc import MutableSequence
+from collections.abc import Sequence
 
 from cpython.pycapsule cimport PyCapsule_IsValid, PyCapsule_GetPointer
 from cpython cimport (Py_INCREF, PyFloat_AsDouble)
@@ -4394,9 +4394,6 @@ cdef class Generator:
             char* x_ptr
             char* buf_ptr
 
-        if isinstance(x, memoryview):
-            x = np.asarray(x)
-
         axis = normalize_axis_index(axis, np.ndim(x))
 
         if type(x) is np.ndarray and x.ndim == 1 and x.size:
@@ -4439,7 +4436,7 @@ cdef class Generator:
                     x[i] = buf
         else:
             # Untyped path.
-            if not isinstance(x, MutableSequence):
+            if not isinstance(x, Sequence):
                 # See gh-18206. We may decide to deprecate here in the future.
                 warnings.warn(
                     "`x` isn't a recognized object; `shuffle` is not guaranteed "

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4436,6 +4436,9 @@ cdef class RandomState:
             char* x_ptr
             char* buf_ptr
 
+        if isinstance(x, memoryview):
+            x = np.asarray(x)
+
         if type(x) is np.ndarray and x.ndim == 1 and x.size:
             # Fast, statically typed path: shuffle the underlying buffer.
             # Only for non-empty, 1d objects of class ndarray (subclasses such

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -2,7 +2,7 @@
 #cython: wraparound=False, nonecheck=False, boundscheck=False, cdivision=True, language_level=3
 import operator
 import warnings
-from collections.abc import MutableSequence
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -4436,9 +4436,6 @@ cdef class RandomState:
             char* x_ptr
             char* buf_ptr
 
-        if isinstance(x, memoryview):
-            x = np.asarray(x)
-
         if type(x) is np.ndarray and x.ndim == 1 and x.size:
             # Fast, statically typed path: shuffle the underlying buffer.
             # Only for non-empty, 1d objects of class ndarray (subclasses such
@@ -4476,7 +4473,7 @@ cdef class RandomState:
                     x[i] = buf
         else:
             # Untyped path.
-            if not isinstance(x, MutableSequence):
+            if not isinstance(x, Sequence):
                 # See gh-18206. We may decide to deprecate here in the future.
                 warnings.warn(
                     "`x` isn't a recognized object; `shuffle` is not guaranteed "

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -510,6 +510,21 @@ class TestRandomDist:
             assert_equal(
                 sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
 
+    def test_shuffle_memoryview(self):
+        # gh-18273
+        # allow graceful handling of memoryviews
+        # (treat the same as arrays)
+        np.random.seed(self.seed)
+        a = np.arange(5).data
+        np.random.shuffle(a)
+        assert_equal(np.asarray(a), [0, 1, 4, 3, 2])
+        rng = np.random.RandomState(self.seed)
+        rng.shuffle(a)
+        assert_equal(np.asarray(a), [0, 1, 2, 3, 4])
+        rng = np.random.default_rng(self.seed)
+        rng.shuffle(a)
+        assert_equal(np.asarray(a), [4, 1, 0, 3, 2])
+
     def test_beta(self):
         np.random.seed(self.seed)
         actual = np.random.beta(.1, .9, size=(3, 2))


### PR DESCRIPTION
Backport of #18282. 

Fixes gh-18273

* allow graceful shuffling of memoryviews, with
same behavior as arrays, instead of producing
a warning on `memoryview` shuffle

There's certainly some contention that me doing this downstream was sub-optimal anyway, but I don't think there's any claim that it should be disallowed/considered a bug to shuffle a memoryview.

I was originally going to special case 1-D C-contiguous memoryviews, but the discussion in the matching issue seems to suggest that just using `asarray()` without fancy special casing might be the way to go?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
