### PR TITLE
BUG: Allow pickling all relevant DType types/classes

### DIFF
--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1019,7 +1019,12 @@ class TestPickling:
 
     def check_pickling(self, dtype):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            pickled = pickle.loads(pickle.dumps(dtype, proto))
+            buf = pickle.dumps(dtype, proto)
+            # The dtype pickling itself pickles `np.dtype` if it is pickled
+            # as a singleton `dtype` should be stored in the buffer:
+            assert b"_DType_reconstruct" not in buf
+            assert b"dtype" in buf
+            pickled = pickle.loads(buf)
             assert_equal(pickled, dtype)
             assert_equal(pickled.descr, dtype.descr)
             if dtype.metadata is not None:
@@ -1074,6 +1079,15 @@ class TestPickling:
     def test_metadata(self):
         dt = np.dtype(int, metadata={'datum': 1})
         self.check_pickling(dt)
+
+    @pytest.mark.parametrize("DType",
+        [type(np.dtype(t)) for t in np.typecodes['All']] +
+        [np.dtype(rational), np.dtype])
+    def test_pickle_types(self, DType):
+        # Check that DTypes (the classes/types) roundtrip when pickling
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            roundtrip_DType = pickle.loads(pickle.dumps(DType, proto))
+            assert roundtrip_DType is DType
 
 
 def test_rational_dtype():


### PR DESCRIPTION
Introducing the metaclass without a canonical top-level name broke
pickling of `type(np.dtype(...))` (which was always just `np.dtype`).

While a better solution will likely be possible by making the
DTypes HeapTypes and this solution may not work for all imaginable
cases (i.e. it is plausible for a dtype to not have a scalar type
associated), using a `copyreg` registration for the metaclass
surprisingly works without any issues and seems like the simplest
solution right now.

Closes gh-16692, gh-18325