### PR TITLE
CI: fix when GitHub Actions builds trigger, and allow ci skips

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,14 @@
 name: Build_Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - maintenance/**
+  pull_request:
+    branches:
+      - master
+      - maintenance/**
 
 defaults:
   run:
@@ -12,6 +20,7 @@ env:
 
 jobs:
   smoke_test:
+    if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Similar to what SciPy does. Right now, it triggers even on pushes to branches on forks, which is useless and generates lots of notifications on failures and wasted resources if no failures.