### PR TITLE
TST: use setup-python action for pypy, disable win64 pypy

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -182,21 +182,9 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-    - name: get_pypy
-      run: |
-        wget -q https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2 -O pypy.tar.bz2
-        mkdir -p pypy3
-        (cd pypy3; tar --strip-components=1 -xf ../pypy.tar.bz2)
-        pypy3/bin/pypy3 -mensurepip
-        pypy3/bin/pypy3 -m pip install --upgrade pip wheel
-        if [ ! -e pypy3/bin/python ]
-        then
-            pushd pypy3/bin
-            ln -s pypy3 python
-            popd
-        fi
-        echo $PWD/pypy3/bin >> $GITHUB_PATH
-
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy-3.7
     - uses: ./.github/actions
 
   sdist:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,11 +230,11 @@ stages:
             PYTHON_ARCH: 'x64'
             TEST_MODE: full
             BITS: 64
-          PyPy37-64bit-full:
-            PYTHON_VERSION: 'PyPy3.7'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: fast
-            BITS: 64
+          #PyPy37-64bit-full:
+          #  PYTHON_VERSION: 'PyPy3.7'
+          #  PYTHON_ARCH: 'x64'
+          #  TEST_MODE: fast
+          #  BITS: 64
           Python38-32bit-fast:
             PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'


### PR DESCRIPTION
The pre-release pypy win64 build has been flaky - disable it until there is an official release.

At the same time, use the best-practices way to install pypy3.7 on github actions via a setup-python action.