### PR TITLE
DOC: Fix whitespace before "last updated" on overview page

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -7,7 +7,7 @@
 <h1>{{ docstitle|e }}</h1>
 <p>
   Welcome! This is the documentation for NumPy {{ release|e }}
-  {% if last_updated %}, last updated {{ last_updated|e }}{% endif %}.
+  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}.
 </p>
 <p><strong>For users:</strong></p>
 <table class="contentstable" align="center"><tr>


### PR DESCRIPTION
The display of the "last updated" date on the `index.html` page will vanish anyway if and when #18268 is merged, but until then, this should take care of the stray whitespace.

And after that, it will still be useful in avoiding whitespace before the period.