### PR TITLE
DOC: Discussion on the @ operator and the matrix class

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -330,6 +330,8 @@ NumPy provides several hooks that classes can customize:
    returned by :func:`__array__`. This practice will return ``TypeError``.
 
 
+.. _matrix-objects:
+
 Matrix objects
 ==============
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -567,10 +567,8 @@ Matrix Multiplication:
 .. note::
 
    Matrix operators ``@`` and ``@=`` were introduced in Python 3.5
-   following PEP465_ and are available since NumPy 1.10.0. Further
+   following :pep:`465` and are available since NumPy 1.10.0. Further
    information can be found in the :func:`matmul` documentation.
-
-.. _PEP465: https://www.python.org/dev/peps/pep-0465/
 
 Special methods
 ===============

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -567,10 +567,10 @@ Matrix Multiplication:
 .. note::
 
    Matrix operators ``@`` and ``@=`` were introduced in Python 3.5
-   following PEP465. NumPy 1.10.0 has a preliminary implementation of ``@``
-   for testing purposes. Further documentation can be found in the
-   :func:`matmul` documentation.
+   following PEP465_ and are available since NumPy 1.10.0. Further
+   information can be found in the :func:`matmul` documentation.
 
+.. _PEP465: https://www.python.org/dev/peps/pep-0465/
 
 Special methods
 ===============

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -567,8 +567,8 @@ Matrix Multiplication:
 .. note::
 
    Matrix operators ``@`` and ``@=`` were introduced in Python 3.5
-   following :pep:`465` and are available since NumPy 1.10.0. Further
-   information can be found in the :func:`matmul` documentation.
+   following :pep:`465`, and the ``@`` operator has been introduced in NumPy
+   1.10.0. Further information can be found in the :func:`matmul` documentation.
 
 Special methods
 ===============

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -30,10 +30,26 @@ flexible broadcasting options.  For example, `numpy.linalg.solve` can handle
 "stacked" arrays, while `scipy.linalg.solve` accepts only a single square
 array as its first argument.
 
+.. note::
+
+   The term *matrix* as it is used on this page indicates a 2d `numpy.array`
+   object, and *not* a `numpy.matrix` object. The latter is no longer
+   recommended, even for linear algebra. See
+   :ref:`the matrix object documentation<matrix-objects>` for
+   more information.
+
+The ``@`` operator
+------------------
+
+Introduced in NumPy 1.10.0, the ``@`` and ``@=`` operators are preferable to
+other methods when computing the matrix product between 2d arrays. The
+:func:`numpy.matmul` function implements the semantics of the ``@`` operator.
+
 .. currentmodule:: numpy
 
 Matrix and vector products
 --------------------------
+
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -41,7 +41,7 @@ array as its first argument.
 The ``@`` operator
 ------------------
 
-Introduced in NumPy 1.10.0, the ``@`` and ``@=`` operators are preferable to
+Introduced in NumPy 1.10.0, the ``@`` operator is preferable to
 other methods when computing the matrix product between 2d arrays. The
 :func:`numpy.matmul` function implements the ``@`` operator.
 

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -43,7 +43,7 @@ The ``@`` operator
 
 Introduced in NumPy 1.10.0, the ``@`` and ``@=`` operators are preferable to
 other methods when computing the matrix product between 2d arrays. The
-:func:`numpy.matmul` function implements the semantics of the ``@`` operator.
+:func:`numpy.matmul` function implements the ``@`` operator.
 
 .. currentmodule:: numpy
 

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2809,7 +2809,7 @@ add_newdoc('numpy.core.umath', 'matmul',
       >>> # n is 7, k is 4, m is 3
 
     The matmul function implements the semantics of the ``@`` operator introduced
-    in Python 3.5 following PEP465.
+    in Python 3.5 following :pep:`465`.
 
     Examples
     --------

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2808,7 +2808,7 @@ add_newdoc('numpy.core.umath', 'matmul',
       (9, 5, 7, 3)
       >>> # n is 7, k is 4, m is 3
 
-    The matmul function implements the semantics of the `@` operator introduced
+    The matmul function implements the semantics of the ``@`` operator introduced
     in Python 3.5 following PEP465.
 
     Examples


### PR DESCRIPTION
Fixes #9419.

What may be missing is moving the `np.matrix` docs to a deprecated section. Let me know if you have ideas for that.