### PR TITLE
DOC: remove pygments_style from conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -138,9 +138,6 @@ add_function_parentheses = False
 # output. They are ignored by default.
 #show_authors = False
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
 def setup(app):
     # add a config value for `ifconfig` directives
     app.add_config_value('python_version_major', str(sys.version_info.major), 'env')


### PR DESCRIPTION
The current HTML theme ignores the Pygments background color, so this change will not really have a visual effect.

But anyway, the Pygments style should be chosen by the HTML theme unless there is a desire to use a different one.