### PR TITLE
DEP: doc-deprecate BLAS_SRC/LAPACK_SRC

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -1549,6 +1549,9 @@ class lapack_info(system_info):
 
 
 class lapack_src_info(system_info):
+    # LAPACK_SRC is deprecated, please do not use this!
+    # Build or install a BLAS library via your package manager or from
+    # source separately.
     section = 'lapack_src'
     dir_env_var = 'LAPACK_SRC'
     notfounderror = LapackSrcNotFoundError
@@ -2468,6 +2471,9 @@ class accelerate_info(system_info):
         return
 
 class blas_src_info(system_info):
+    # BLAS_SRC is deprecated, please do not use this!
+    # Build or install a BLAS library via your package manager or from
+    # source separately.
     section = 'blas_src'
     dir_env_var = 'BLAS_SRC'
     notfounderror = BlasSrcNotFoundError

--- a/site.cfg.example
+++ b/site.cfg.example
@@ -28,7 +28,7 @@
 #       extensions with this dependency. Use the character given by os.pathsep
 #       to separate the items in the list. Note that this character is known to
 #       vary on some unix-like systems; if a colon does not work, try a comma.
-#       This also applies to include_dirs and src_dirs (see below).
+#       This also applies to include_dirs.
 #       On UN*X-type systems (OS X, most BSD and Linux systems):
 #           library_dirs = /usr/lib:/usr/local/lib
 #       On Windows:
@@ -39,15 +39,6 @@
 #   include_dirs
 #       List of directories to add to the header file search path.
 #           include_dirs = /usr/include:/usr/local/include
-#
-#   src_dirs
-#       List of directories that contain extracted source code for the
-#       dependency. For some dependencies, numpy.distutils will be able to build
-#       them from source if binaries cannot be found. The FORTRAN BLAS and
-#       LAPACK libraries are one example. However, most dependencies are more
-#       complicated and require actual installation that you need to do
-#       yourself.
-#           src_dirs = /home/username/src/BLAS_SRC:/home/username/src/LAPACK_SRC
 #
 #   search_static_first
 #       Boolean (one of (0, false, no, off) for False or (1, true, yes, on) for


### PR DESCRIPTION
Building BLAS and LAPACK from sources in a NumPy build makes very little sense in 2021. Therefore remove the documentation for this from `site.cfg.example`, and doc-deprecate it in `distutils/system_info.py`.

It's hard to properly deprecate and not worth doing, just de-emphasizing is enough.

`[ci skip]`

xref https://github.com/scipy/scipy/issues/4518, where a user was struggling with this.
