### PR TITLE
CI: CircleCI seems to occasionally time out, increase the limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
 
       - run:
           name: build devdocs
+          no_output_timeout: 30m
           command: |
             . venv/bin/activate
             cd doc


### PR DESCRIPTION
CircleCI seems to default to a 10 minute timeout on no output,
simply increase it to 30 minutes to ensure the build should
succeed.
This is assuming that the build time simply crawled up over 10
minutes just now.
