### PR TITLE
CI: CircleCI seems to occasionally time out, increase the limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
 
       - run:
           name: build devdocs
+          no_output_timeout: 30m
           command: |
             . venv/bin/activate
             cd doc


### PR DESCRIPTION
Backport of #18349. 

CircleCI seems to default to a 10 minute timeout on no output,
simply increase it to 30 minutes to ensure the build should
succeed.
It seems the build does take 25+ minutes (maybe depending on the
machine it runs on). Technically, 30 minutes is probably more than
necessary, since there is a print in the middle, but that is
just a warning that could go away at some point.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
