### PR TITLE
MAINT: Disable TravisCI git clone depth.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
       # Speedup builds, particularly when USE_CHROOT=1
       - eatmydata
 
+# Disable clone depth
+git:
+  depth: false
+
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
The default clone depth of TravisCI is 50, which is insufficient to make
the most recent annotated tag visible to versioneer now that master is
has grown to 689 commits past the tag. Disabling the clone depth as
suggested at https://docs.travis-ci.com/user/customizing-the-build/
appears to solve the problem.

Closes #18365 .
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
