### PR TITLE
BUG: np.in1d bug on the object array (issue 17923)

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -565,6 +565,10 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     ar1 = np.asarray(ar1).ravel()
     ar2 = np.asarray(ar2).ravel()
 
+    # Ensure that iteration through object arrays yields size-1 arrays
+    if ar2.dtype == object:
+        ar2 = ar2.reshape(-1, 1)
+
     # Check if one of the arrays may contain arbitrary objects
     contains_object = ar1.dtype.hasobject or ar2.dtype.hasobject
 
@@ -575,28 +579,12 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     if len(ar2) < 10 * len(ar1) ** 0.145 or contains_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
-            # If ar2.dtype is object, store is used to wrap the a value
-            # in an array to prevent tuples from being unpacked before the comparison
-            if ar2.dtype == object:
-                store = np.empty(shape=1, dtype=object)
-                for a in ar2:
-                    store[0] = a
-                    mask &= (ar1 != store)
-            else:
-                for a in ar2:
-                    mask &= (ar1 != a)
+            for a in ar2:
+                mask &= (ar1 != a)
         else:
             mask = np.zeros(len(ar1), dtype=bool)
-            # If ar2.dtype is object, store is used to wrap the a value
-            # in an array to prevent tuples from being unpacked before the comparison
-            if ar2.dtype == object:
-                store = np.empty(shape=1, dtype=object)
-                for a in ar2:
-                    store[0] = a
-                    mask |= (ar1 == store)
-            else:
-                for a in ar2:
-                    mask |= (ar1 == a)
+            for a in ar2:
+                mask |= (ar1 == a)
         return mask
 
     # Otherwise use sorting

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -575,12 +575,28 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     if len(ar2) < 10 * len(ar1) ** 0.145 or contains_object:
         if invert:
             mask = np.ones(len(ar1), dtype=bool)
-            for a in ar2:
-                mask &= (ar1 != a)
+            # If ar2.dtype is object, store is used to wrap the a value
+            # in an array to prevent tuples from being unpacked before the comparison
+            if ar2.dtype == object:
+                store = np.empty(shape=1, dtype=object)
+                for a in ar2:
+                    store[0] = a
+                    mask &= (ar1 != store)
+            else:
+                for a in ar2:
+                    mask &= (ar1 != a)
         else:
             mask = np.zeros(len(ar1), dtype=bool)
-            for a in ar2:
-                mask |= (ar1 == a)
+            # If ar2.dtype is object, store is used to wrap the a value
+            # in an array to prevent tuples from being unpacked before the comparison
+            if ar2.dtype == object:
+                store = np.empty(shape=1, dtype=object)
+                for a in ar2:
+                    store[0] = a
+                    mask |= (ar1 == store)
+            else:
+                for a in ar2:
+                    mask |= (ar1 == a)
         return mask
 
     # Otherwise use sorting

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -358,6 +358,39 @@ class TestSetOps:
         result = np.in1d(ar1, ar2)
         assert_array_equal(result, expected)
 
+    def test_in1d_with_arrays_containing_tuples(self):
+        ar1 = np.array([(1,), 2], dtype=object)
+        ar2 = np.array([(1,), 2], dtype=object)
+        expected = np.array([True, True])
+        result = np.in1d(ar1, ar2)
+        assert_array_equal(result, expected)
+        result = np.in1d(ar1, ar2, invert=True)
+        assert_array_equal(result, np.invert(expected))
+
+        # An integer is added at the end of the array to make sure
+        # that the array builder will create the array with tuples
+        # and after it's created the integer is removed.
+        # There's a bug in the array constructor that doesn't handle
+        # tuples properly and adding the integer fixes that.
+        ar1 = np.array([(1,), (2, 1), 1], dtype=object)
+        ar1 = ar1[:-1]
+        ar2 = np.array([(1,), (2, 1), 1], dtype=object)
+        ar2 = ar2[:-1]
+        expected = np.array([True, True])
+        result = np.in1d(ar1, ar2)
+        assert_array_equal(result, expected)
+        result = np.in1d(ar1, ar2, invert=True)
+        assert_array_equal(result, np.invert(expected))
+
+        ar1 = np.array([(1,), (2, 3), 1], dtype=object)
+        ar1 = ar1[:-1]
+        ar2 = np.array([(1,), 2], dtype=object)
+        expected = np.array([True, False])
+        result = np.in1d(ar1, ar2)
+        assert_array_equal(result, expected)
+        result = np.in1d(ar1, ar2, invert=True)
+        assert_array_equal(result, np.invert(expected))
+
     def test_union1d(self):
         a = np.array([5, 4, 7, 1, 2])
         b = np.array([2, 4, 3, 3, 2, 1, 5])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
BUG: np.in1d bug on the object array (closes #17923)

When calling `np.in1d()` method with array that contains tuples the comparison didn't work properly due to an underling issue with the unpacking of those tuples. To prevent this, and following the approach suggested by @tylerjereddy I changed the way the comparison is made for arrays of objects, adding a wrapper to those objects preventing tuples from being unpacked.

Unit tests for the failing cases mentioned in the issue were also added.