### PR TITLE
DOC: remove explanations from TOC - See #17845

### DIFF
--- a/doc/source/user/explanations_index.rst
+++ b/doc/source/user/explanations_index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _explanations:
 
 ################
@@ -9,6 +11,7 @@ used in NumPy. For the reference documentation of the functions and classes
 contained in the package, see the :ref:`API reference <reference>`.
 
 .. toctree::
-   :maxdepth: 1
+    :hidden:
+    :maxdepth: 1
 
-   basics.broadcasting
+    basics.broadcasting


### PR DESCRIPTION
Please let me know if I did this correctly as I'm not familiar with Sphinx. I added orphan to the top of the explanations file as well as adding hidden to the toctree. I might be way off, but would be happy to correct it if this isn't right!