### PR TITLE
ENH: Add annotations for `np.lib.ufunclike`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -332,6 +332,12 @@ from numpy.core.shape_base import (
     vstack as vstack,
 )
 
+from numpy.lib.ufunclike import (
+    fix as fix,
+    isposinf as isposinf,
+    isneginf as isneginf,
+)
+
 __all__: List[str]
 __path__: List[str]
 __version__: str
@@ -401,7 +407,6 @@ extract: Any
 eye: Any
 fill_diagonal: Any
 finfo: Any
-fix: Any
 flip: Any
 fliplr: Any
 flipud: Any
@@ -437,8 +442,6 @@ is_busday: Any
 iscomplex: Any
 iscomplexobj: Any
 isin: Any
-isneginf: Any
-isposinf: Any
 isreal: Any
 isrealobj: Any
 iterable: Any

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -1,5 +1,11 @@
 from typing import Any, List
 
+from numpy.lib.ufunclike import (
+    fix as fix,
+    isposinf as isposinf,
+    isneginf as isneginf,
+)
+
 __all__: List[str]
 
 emath: Any
@@ -108,9 +114,6 @@ tril_indices: Any
 tril_indices_from: Any
 triu_indices: Any
 triu_indices_from: Any
-fix: Any
-isneginf: Any
-isposinf: Any
 pad: Any
 poly: Any
 roots: Any

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -189,7 +189,8 @@ def isposinf(x, out=None):
     try:
         signbit = ~nx.signbit(x)
     except TypeError as e:
-        raise TypeError('This operation is not supported for complex values '
+        dtype = nx.asanyarray(x).dtype
+        raise TypeError(f'This operation is not supported for {dtype} values '
                         'because it would be ambiguous.') from e
     else:
         return nx.logical_and(is_inf, signbit, out)
@@ -260,7 +261,8 @@ def isneginf(x, out=None):
     try:
         signbit = nx.signbit(x)
     except TypeError as e:
-        raise TypeError('This operation is not supported for complex values '
+        dtype = nx.asanyarray(x).dtype
+        raise TypeError(f'This operation is not supported for {dtype} values '
                         'because it would be ambiguous.') from e
     else:
         return nx.logical_and(is_inf, signbit, out)

--- a/numpy/lib/ufunclike.pyi
+++ b/numpy/lib/ufunclike.pyi
@@ -1,0 +1,50 @@
+from typing import Any, overload, TypeVar, List, Union
+
+from numpy import floating, bool_, ndarray
+from numpy.typing import (
+    _ArrayLikeFloat_co,
+    _ArrayLikeObject_co,
+    _ArrayOrScalar,
+)
+
+_ArrayType = TypeVar("_ArrayType", bound=ndarray[Any, Any])
+
+__all__: List[str]
+
+@overload
+def fix(
+    x: _ArrayLikeFloat_co,
+    out: None = ...,
+) -> _ArrayOrScalar[floating[Any]]: ...
+@overload
+def fix(
+    x: _ArrayLikeObject_co,
+    out: None = ...,
+) -> Any: ...
+@overload
+def fix(
+    x: Union[_ArrayLikeFloat_co, _ArrayLikeObject_co],
+    out: _ArrayType,
+) -> _ArrayType: ...
+
+@overload
+def isposinf(
+    x: _ArrayLikeFloat_co,
+    out: None = ...,
+) -> _ArrayOrScalar[bool_]: ...
+@overload
+def isposinf(
+    x: _ArrayLikeFloat_co,
+    out: _ArrayType,
+) -> _ArrayType: ...
+
+@overload
+def isneginf(
+    x: _ArrayLikeFloat_co,
+    out: None = ...,
+) -> _ArrayOrScalar[bool_]: ...
+@overload
+def isneginf(
+    x: _ArrayLikeFloat_co,
+    out: _ArrayType,
+) -> _ArrayType: ...

--- a/numpy/typing/tests/data/fail/ufunclike.py
+++ b/numpy/typing/tests/data/fail/ufunclike.py
@@ -1,0 +1,21 @@
+from typing import List, Any
+import numpy as np
+
+AR_c: np.ndarray[Any, np.dtype[np.complex128]]
+AR_m: np.ndarray[Any, np.dtype[np.timedelta64]]
+AR_M: np.ndarray[Any, np.dtype[np.datetime64]]
+AR_O: np.ndarray[Any, np.dtype[np.object_]]
+
+np.fix(AR_c)  # E: incompatible type
+np.fix(AR_m)  # E: incompatible type
+np.fix(AR_M)  # E: incompatible type
+
+np.isposinf(AR_c)  # E: incompatible type
+np.isposinf(AR_m)  # E: incompatible type
+np.isposinf(AR_M)  # E: incompatible type
+np.isposinf(AR_O)  # E: incompatible type
+
+np.isneginf(AR_c)  # E: incompatible type
+np.isneginf(AR_m)  # E: incompatible type
+np.isneginf(AR_M)  # E: incompatible type
+np.isneginf(AR_O)  # E: incompatible type

--- a/numpy/typing/tests/data/pass/ufunclike.py
+++ b/numpy/typing/tests/data/pass/ufunclike.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from typing import Any
+import numpy as np
+
+
+class Object:
+    def __ceil__(self) -> Object:
+        return self
+
+    def __floor__(self) -> Object:
+        return self
+
+    def __ge__(self, value: object) -> bool:
+        return True
+
+    def __array__(
+        self, dtype: None = None
+    ) -> np.ndarray[Any, np.dtype[np.object_]]:
+        ret = np.empty((), dtype=object)
+        ret[()] = self
+        return ret
+
+
+AR_LIKE_b = [True, True, False]
+AR_LIKE_u = [np.uint32(1), np.uint32(2), np.uint32(3)]
+AR_LIKE_i = [1, 2, 3]
+AR_LIKE_f = [1.0, 2.0, 3.0]
+AR_LIKE_O = [Object(), Object(), Object()]
+AR_U: np.ndarray[Any, np.dtype[np.str_]] = np.zeros(3, dtype="U5")
+
+np.fix(AR_LIKE_b)
+np.fix(AR_LIKE_u)
+np.fix(AR_LIKE_i)
+np.fix(AR_LIKE_f)
+np.fix(AR_LIKE_O)
+np.fix(AR_LIKE_f, out=AR_U)
+
+np.isposinf(AR_LIKE_b)
+np.isposinf(AR_LIKE_u)
+np.isposinf(AR_LIKE_i)
+np.isposinf(AR_LIKE_f)
+np.isposinf(AR_LIKE_f, out=AR_U)
+
+np.isneginf(AR_LIKE_b)
+np.isneginf(AR_LIKE_u)
+np.isneginf(AR_LIKE_i)
+np.isneginf(AR_LIKE_f)
+np.isneginf(AR_LIKE_f, out=AR_U)

--- a/numpy/typing/tests/data/reveal/ufunclike.py
+++ b/numpy/typing/tests/data/reveal/ufunclike.py
@@ -1,0 +1,29 @@
+from typing import List, Any
+import numpy as np
+
+AR_LIKE_b: List[bool]
+AR_LIKE_u: List[np.uint32]
+AR_LIKE_i: List[int]
+AR_LIKE_f: List[float]
+AR_LIKE_O: List[np.object_]
+
+AR_U: np.ndarray[Any, np.dtype[np.str_]]
+
+reveal_type(np.fix(AR_LIKE_b))  # E: Union[numpy.floating[Any], numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]]
+reveal_type(np.fix(AR_LIKE_u))  # E: Union[numpy.floating[Any], numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]]
+reveal_type(np.fix(AR_LIKE_i))  # E: Union[numpy.floating[Any], numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]]
+reveal_type(np.fix(AR_LIKE_f))  # E: Union[numpy.floating[Any], numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]]
+reveal_type(np.fix(AR_LIKE_O))  # E: Any
+reveal_type(np.fix(AR_LIKE_f, out=AR_U))  # E: numpy.ndarray[Any, numpy.dtype[numpy.str_]]
+
+reveal_type(np.isposinf(AR_LIKE_b))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isposinf(AR_LIKE_u))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isposinf(AR_LIKE_i))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isposinf(AR_LIKE_f))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isposinf(AR_LIKE_f, out=AR_U))  # E: numpy.ndarray[Any, numpy.dtype[numpy.str_]]
+
+reveal_type(np.isneginf(AR_LIKE_b))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isneginf(AR_LIKE_u))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isneginf(AR_LIKE_i))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isneginf(AR_LIKE_f))  # E: Union[numpy.bool_, numpy.ndarray[Any, numpy.dtype[numpy.bool_]]]
+reveal_type(np.isneginf(AR_LIKE_f, out=AR_U))  # E: numpy.ndarray[Any, numpy.dtype[numpy.str_]]


### PR DESCRIPTION
Per the title: this PR adds annotations for `np.lib.ufunclike`.

DType support also turned out to be fairly straightforward to implement here, so that was definitely a plus.