### PR TITLE
MAINT: Fix version of wheel to support Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools<49.2.0",
-    "wheel<=0.35.1",
+    "wheel==0.36.2",
     "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 


### PR DESCRIPTION
The latest version of numpy is not installable from source code with Python 3.10. The reason is a bug (incompatibility) in the older versions of wheel package. For more info see this issue: https://github.com/pypa/wheel/issues/354

The problem is already fixed in the latest wheel release (0.36.2).
What happens when you try to install the latest numpy from the master branch with Python 3.10:
```
pip install .
Processing /home/lbalhar/Software/numpy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: numpy
  Building wheel for numpy (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
… more than 2000 lines of output …
  AssertionError: would build wheel with unsupported tag ('cp310', 'cp310', 'linux_x86_64')
```

With this patch it works like a charm:
```
pip install .
Processing /home/lbalhar/Software/numpy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: numpy
  Building wheel for numpy (PEP 517) ... done
  Created wheel for numpy: filename=numpy-1.21.0.dev0+722.gf6a71feac-cp310-cp310-linux_x86_64.whl size=19243966 sha256=02a8e24b3642ed0f5ae6d90984bb3f142a3f0089d0bd40d855ea644bf9f9d26e
  Stored in directory: /tmp/pip-ephem-wheel-cache-m_vxju0i/wheels/44/94/c3/357b79921baf29908a3c5fdcb200e26e772f557fb67941dcfc
Successfully built numpy
Installing collected packages: numpy
Successfully installed numpy-1.21.0.dev0+722.gf6a71feac

pip list
Package    Version
---------- --------------------------
Cython     0.29.21
numpy      1.21.0.dev0+722.gf6a71feac
pip        21.0.1
setuptools 53.0.0
wheel      0.36.2
```
