### PR TITLE
MAINT: Threading and Unicode strings

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -26,10 +26,8 @@ from numpy.distutils.misc_util import cyg2win32, is_sequence, mingw32, \
                                       _commandline_dep_string
 
 # globals for parallel build management
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+import threading
+
 _job_semaphore = None
 _global_lock = threading.Lock()
 _processing_files = set()

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -10,13 +10,10 @@ import shutil
 import multiprocessing
 import textwrap
 import importlib.util
+from threading import local as tlocal
 
 import distutils
 from distutils.errors import DistutilsError
-try:
-    from threading import local as tlocal
-except ImportError:
-    from dummy_threading import local as tlocal
 
 # stores temporary directory of each thread to only create one per thread
 _tdata = tlocal()

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -25,11 +25,11 @@ cdef uint64_t MAXSIZE = <uint64_t>sys.maxsize
 cdef object benchmark(bitgen_t *bitgen, object lock, Py_ssize_t cnt, object method):
     """Benchmark command used by BitGenerator"""
     cdef Py_ssize_t i
-    if method==u'uint64':
+    if method=='uint64':
         with lock, nogil:
             for i in range(cnt):
                 bitgen.next_uint64(bitgen.state)
-    elif method==u'double':
+    elif method=='double':
         with lock, nogil:
             for i in range(cnt):
                 bitgen.next_double(bitgen.state)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -386,7 +386,7 @@ cdef class Generator:
                     0.0, '', CONS_NONE,
                     None)
 
-    def standard_exponential(self, size=None, dtype=np.float64, method=u'zig', out=None):
+    def standard_exponential(self, size=None, dtype=np.float64, method='zig', out=None):
         """
         standard_exponential(size=None, dtype=np.float64, method='zig', out=None)
 
@@ -426,12 +426,12 @@ cdef class Generator:
         """
         _dtype = np.dtype(dtype)
         if _dtype == np.float64:
-            if method == u'zig':
+            if method == 'zig':
                 return double_fill(&random_standard_exponential_fill, &self._bitgen, size, self.lock, out)
             else:
                 return double_fill(&random_standard_exponential_inv_fill, &self._bitgen, size, self.lock, out)
         elif _dtype == np.float32:
-            if method == u'zig':
+            if method == 'zig':
                 return float_fill(&random_standard_exponential_fill_f, &self._bitgen, size, self.lock, out)
             else:
                 return float_fill(&random_standard_exponential_inv_fill_f, &self._bitgen, size, self.lock, out)

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -1,10 +1,5 @@
 from cpython.pycapsule cimport PyCapsule_New
 
-try:
-    from threading import Lock
-except ImportError:
-    from dummy_threading import Lock
-
 import numpy as np
 cimport numpy as np
 

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -584,8 +584,8 @@ cdef class BitGenerator():
         """
         return random_raw(&self._bitgen, self.lock, size, output)
 
-    def _benchmark(self, Py_ssize_t cnt, method=u'uint64'):
-        '''Used in tests'''
+    def _benchmark(self, Py_ssize_t cnt, method='uint64'):
+        """Used in tests"""
         return benchmark(&self._bitgen, self.lock, cnt, method)
 
     @property

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -43,10 +43,7 @@ except ImportError:
     from random import SystemRandom
     randbits = SystemRandom().getrandbits
 
-try:
-    from threading import Lock
-except ImportError:
-    from dummy_threading import Lock
+from threading import Lock
 
 from cpython.pycapsule cimport PyCapsule_New
 


### PR DESCRIPTION
Small clean-up of threading and unicode strings in random

* Remove dummy_threading which is not needed for Python >= 3.7
* Remove unnecessary u"" markers from random

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
