### PR TITLE
DOC: remove layout overrides for headers

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -18,14 +18,8 @@ pre, code {
 }
 
 h1 {
-  font-style: "Lato", sans-serif;
+  font-family: "Lato", sans-serif;
   color: #013243; /* warm black */
-  font-weight: 700;
-  letter-spacing: -.04em;
-  text-align: right;
-  margin-top: 3rem;
-  margin-bottom: 4rem;
-  font-size: 3rem;
 }
 
 


### PR DESCRIPTION
Addresses gh-18321.

Also fixes a typo where `font-style` instead of `font-family` was used. Since the font boldness and letter-spacing choices were built on top of this mistake, they were removed too.

If someone feels the pydata-sphinx-theme would look nicer with some layout tweaks, I would strongly encourage them to adjust the theme itself upstream.

Before:

![image](https://user-images.githubusercontent.com/425260/107975604-4192d080-6fb0-11eb-958c-0af1ff7ad7aa.png)


After:

![image](https://user-images.githubusercontent.com/425260/107975561-32ac1e00-6fb0-11eb-956b-4d738974f5a4.png)



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
