### PR TITLE
BUG: Fix tiny memory leaks when ``like=`` overrides are used

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1829,6 +1829,8 @@ array_empty(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     array_function_result = array_implement_c_array_function_creation(
             "empty", args, kwds);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(typecode);
+        npy_free_cache_dim_obj(shape);
         return array_function_result;
     }
 
@@ -2026,6 +2028,8 @@ array_zeros(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
     array_function_result = array_implement_c_array_function_creation(
             "zeros", args, kwds);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(typecode);
+        npy_free_cache_dim_obj(shape);
         return array_function_result;
     }
 
@@ -2139,11 +2143,13 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     array_function_result = array_implement_c_array_function_creation(
             "fromfile", args, keywds);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(type);
         return array_function_result;
     }
 
     file = NpyPath_PathlikeToFspath(file);
     if (file == NULL) {
+        Py_XDECREF(type);
         return NULL;
     }
 
@@ -2250,6 +2256,7 @@ array_frombuffer(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
     array_function_result = array_implement_c_array_function_creation(
             "frombuffer", args, keywds);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(type);
         return array_function_result;
     }
 


### PR DESCRIPTION
I thought I had fixed these leaks, but it appears I missed some.
We probably should backport this to 1.20.x (its simple), but the leaks
are also pretty harmless unless someone uses `like=` hundrets of
thousands of times in a running program (and its a new fetaure).

---

I was running valgrind checks again on master and noticed this, I think last time around I found these same leaks, but apparently did not fix them everywhere and then did not rerun the full test suit (It runs more than a day the way I run it).