### PR TITLE
DOC: Adjust polyfit doc to clarify the meaning of w

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -489,8 +489,8 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (M,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared residual
+        ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are chosen so
         that the errors of the products ``w[i]*y[i]`` all have the same
         variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -489,16 +489,20 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (M,), optional
-        Weights to apply to the y-coordinates of the sample points. For
-        gaussian uncertainties, use 1/sigma (not 1/sigma**2).
+        Weights to apply to the unsquared residual of each point.  When these
+        correspond to weighting by Gaussian uncertainties, use w = 1/sigma.
+        Note that w here is the sqrt of the more typical definition of the
+        weights in weighted least squares, which generally uses
+        W = w**2 = 1/sigma**2 (or more generally 1/var) to weight the squared
+        residual of each point.
     cov : bool or str, optional
         If given and not `False`, return not just the estimate but also its
         covariance matrix. By default, the covariance are scaled by
-        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed
-        to be unreliable except in a relative sense and everything is scaled
-        such that the reduced chi2 is unity. This scaling is omitted if
-        ``cov='unscaled'``, as is relevant for the case that the weights are
-        1/sigma**2, with sigma known to be a reliable estimate of the
+        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed 
+        to be unreliable except in a relative sense and everything is scaled 
+        such that the reduced chi2 is unity. This scaling is omitted if 
+        ``cov='unscaled'``, as is relevant for the case that the weights are 
+        w**2 = 1/sigma**2, with sigma known to be a reliable estimate of the
         uncertainty.
 
     Returns

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -489,18 +489,18 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (M,), optional
-        Weights. If not None, the weight ``w[i]`` applies to the unsquared residual
-        ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
     cov : bool or str, optional
         If given and not `False`, return not just the estimate but also its
         covariance matrix. By default, the covariance are scaled by
-        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed 
-        to be unreliable except in a relative sense and everything is scaled 
-        such that the reduced chi2 is unity. This scaling is omitted if 
-        ``cov='unscaled'``, as is relevant for the case that the weights are 
+        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed
+        to be unreliable except in a relative sense and everything is scaled
+        such that the reduced chi2 is unity. This scaling is omitted if
+        ``cov='unscaled'``, as is relevant for the case that the weights are
         w = 1/sigma, with sigma known to be a reliable estimate of the
         uncertainty.
 

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -489,10 +489,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (M,), optional
-        Weights. If not None, the contribution of each point (x[i],y[i]) to
-        the fit is weighted by w[i]. Ideally the weights are chosen so that
-        the errors of the products w[i]*y[i] all have the same variance.
-        The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
     cov : bool or str, optional
         If given and not `False`, return not just the estimate but also its
         covariance matrix. By default, the covariance are scaled by

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -489,12 +489,10 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (M,), optional
-        Weights to apply to the unsquared residual of each point.  When these
-        correspond to weighting by Gaussian uncertainties, use w = 1/sigma.
-        Note that w here is the sqrt of the more typical definition of the
-        weights in weighted least squares, which generally uses
-        W = w**2 = 1/sigma**2 (or more generally 1/var) to weight the squared
-        residual of each point.
+        Weights. If not None, the contribution of each point (x[i],y[i]) to
+        the fit is weighted by w[i]. Ideally the weights are chosen so that
+        the errors of the products w[i]*y[i] all have the same variance.
+        The default value is None.
     cov : bool or str, optional
         If given and not `False`, return not just the estimate but also its
         covariance matrix. By default, the covariance are scaled by
@@ -502,7 +500,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         to be unreliable except in a relative sense and everything is scaled 
         such that the reduced chi2 is unity. This scaling is omitted if 
         ``cov='unscaled'``, as is relevant for the case that the weights are 
-        w**2 = 1/sigma**2, with sigma known to be a reliable estimate of the
+        w = 1/sigma, with sigma known to be a reliable estimate of the
         uncertainty.
 
     Returns

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -938,8 +938,8 @@ class ABCPolyBase(abc.ABC):
         w : array_like, shape (M,), optional
             Weights. If not None, the weight ``w[i]`` applies to the unsquared
             residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
-            chosen so that the errors of the products ``w[i]*y[i]`` all have the
-            same variance.  When using inverse-variance weighting, use
+            chosen so that the errors of the products ``w[i]*y[i]`` all have
+            the same variance.  When using inverse-variance weighting, use
             ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
             .. versionadded:: 1.5.0

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -936,10 +936,10 @@ class ABCPolyBase(abc.ABC):
             diagnostic information from the singular value decomposition is
             also returned.
         w : array_like, shape (M,), optional
-            Weights. If not None, the weight to apply to the unsquared residual
-            at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-            that the errors of the products ``w[i]*y[i]`` all have the same
-            variance.  When using inverse-variance weighting, use
+            Weights. If not None, the weight ``w[i]`` applies to the unsquared
+            residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+            chosen so that the errors of the products ``w[i]*y[i]`` all have the
+            same variance.  When using inverse-variance weighting, use
             ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
             .. versionadded:: 1.5.0

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -936,11 +936,11 @@ class ABCPolyBase(abc.ABC):
             diagnostic information from the singular value decomposition is
             also returned.
         w : array_like, shape (M,), optional
-            Weights. If not None the contribution of each point
-            ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-            weights are chosen so that the errors of the products
-            ``w[i]*y[i]`` all have the same variance.  The default value is
-            None.
+            Weights. If not None, the weight to apply to the unsquared residual
+            at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+            that the errors of the products ``w[i]*y[i]`` all have the same
+            variance.  When using inverse-variance weighting, use
+            ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
             .. versionadded:: 1.5.0
         window : {[beg, end]}, optional

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1582,10 +1582,11 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -1582,10 +1582,10 @@ def chebfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1310,10 +1310,10 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -1310,10 +1310,11 @@ def hermfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns
     -------

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1301,10 +1301,11 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns
     -------

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -1301,10 +1301,10 @@ def hermefit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1307,10 +1307,10 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -1307,10 +1307,11 @@ def lagfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
     Returns
     -------

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1321,10 +1321,11 @@ def legfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0
 

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -1321,10 +1321,10 @@ def legfit(x, y, deg, rcond=None, full=False, w=None):
         default) just the coefficients are returned, when True diagnostic
         information from the singular value decomposition is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1252,10 +1252,10 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
         diagnostic information from the singular value decomposition (used
         to solve the fit's matrix equation) is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the weight to apply to the unsquared residual
-        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
-        that the errors of the products ``w[i]*y[i]`` all have the same
-        variance.  When using inverse-variance weighting, use
+        Weights. If not None, the weight ``w[i]`` applies to the unsquared
+        residual ``y[i] - y_hat[i]`` at ``x[i]``. Ideally the weights are
+        chosen so that the errors of the products ``w[i]*y[i]`` all have the
+        same variance.  When using inverse-variance weighting, use
         ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1252,10 +1252,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
         diagnostic information from the singular value decomposition (used
         to solve the fit's matrix equation) is also returned.
     w : array_like, shape (`M`,), optional
-        Weights. If not None, the contribution of each point
-        ``(x[i],y[i])`` to the fit is weighted by ``w[i]``. Ideally the
-        weights are chosen so that the errors of the products ``w[i]*y[i]``
-        all have the same variance.  The default value is None.
+        Weights. If not None, the weight to apply to the unsquared residual
+        at each point ``(x[i], y[i])``. Ideally the weights are chosen so
+        that the errors of the products ``w[i]*y[i]`` all have the same
+        variance.  When using inverse-variance weighting, use
+        ``w[i] = 1/sigma(y[i])``.  The default value is None.
 
         .. versionadded:: 1.5.0
 


### PR DESCRIPTION
This fixes some confusing and arguably erroneous parts of the doc string to `np.polyfit` with respect to the definition of the weight, w.

`cov='unscaled'`, in particular, had inconsistently referred to a weight of `1/sigma**2`, while the doc for `w` says it should be equal to 1/sigma. This change clarifies the definition of w to comport with more typical meanings of weights in weighted least squares (namely that they usually refer to `W = w**2` as "the weight"), and makes clear that `cov='unscaled'` is appropriate when the weight, `w**2 = 1/sigma**2`.

cf. Issue #5261
