### PR TITLE
BUG: Raise ValueError on strings with smaller than expected byte-size

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -658,6 +658,10 @@ fprintf(stderr,\"string_from_pyobj(str='%s',len=%d,inistr='%s',obj=%p)\\n\",(cha
         }
         if (*len == -1)
             *len = (PyArray_ITEMSIZE(arr))*PyArray_SIZE(arr);
+        if ((PyArray_ITEMSIZE(arr))*PyArray_SIZE(arr) < *len) {
+            PyErr_SetString(PyExc_ValueError,\"string input has smaller byte-size than expected.\");
+            goto capi_fail;
+        }
         STRINGMALLOC(*str,*len);
         STRINGCOPYN(*str,PyArray_DATA(arr),*len+1);
         return 1;

--- a/numpy/f2py/tests/src/string/char.f90
+++ b/numpy/f2py/tests/src/string/char.f90
@@ -5,7 +5,6 @@ CONTAINS
 SUBROUTINE change_strings(strings, n_strs, out_strings)
     IMPLICIT NONE
 
-    ! Inputs
     INTEGER, INTENT(IN) :: n_strs
     CHARACTER, INTENT(IN), DIMENSION(2,n_strs) :: strings
     CHARACTER, INTENT(OUT), DIMENSION(2,n_strs) :: out_strings
@@ -14,9 +13,7 @@ SUBROUTINE change_strings(strings, n_strs, out_strings)
 !f2py CHARACTER, INTENT(IN), DIMENSION(2,n_strs) :: strings
 !f2py CHARACTER, INTENT(OUT), DIMENSION(2,n_strs) :: strings
 
-    ! Misc.
     INTEGER*4 :: j
-
 
     DO j=1, n_strs
         out_strings(1,j) = strings(1,j)
@@ -25,14 +22,78 @@ SUBROUTINE change_strings(strings, n_strs, out_strings)
 
 END SUBROUTINE change_strings
 
-SUBROUTINE string_size(string)
+SUBROUTINE string_size_inout(a)
     IMPLICIT NONE
 
-    CHARACTER(len=4), intent(inout) :: string
+    CHARACTER(len=4), intent(inout) :: a
 
-    string(1:1) = 'A'
+    a(1:1) = 'A'
 
-END SUBROUTINE string_size
+END SUBROUTINE string_size_inout
+
+SUBROUTINE string_size_cache(a)
+    IMPLICIT NONE
+
+    CHARACTER(len=4) :: a
+!f2py intent(cache) :: a
+
+    a(1:1) = 'A'
+
+END SUBROUTINE string_size_cache
+
+SUBROUTINE string_size_overwrite(a)
+    IMPLICIT NONE
+
+    CHARACTER(len=4) :: a
+!f2py intent(in, overwrite) :: a
+
+    a(1:1) = 'A'
+
+END SUBROUTINE string_size_overwrite
+
+SUBROUTINE string_size_in(a, b)
+    IMPLICIT NONE
+
+    CHARACTER(len=4), intent(in) :: a
+    CHARACTER(len=4), intent(out) :: b
+
+    b(1:1) = 'A'
+    b(2:4) = a(2:4)
+
+END SUBROUTINE string_size_in
+
+SUBROUTINE string_size_copy(a, b)
+    IMPLICIT NONE
+
+    CHARACTER(len=4) :: a
+!f2py intent(in, copy) :: a
+
+    CHARACTER(len=4), intent(out) :: b
+
+    a(1:1) = 'A'
+    b(1:4) = a(1:4)
+
+END SUBROUTINE string_size_copy
+
+SUBROUTINE string_size_inplace(a)
+    IMPLICIT NONE
+
+    CHARACTER(len=4) :: a
+!f2py intent(inplace) :: a
+
+    a(1:1) = 'A'
+
+END SUBROUTINE string_size_inplace
+
+SUBROUTINE string_size_out(a)
+    IMPLICIT NONE
+
+    CHARACTER(len=4) :: a
+!f2py intent(in, out) :: a
+
+    a(1:1) = 'A'
+
+END SUBROUTINE string_size_out
 
 END MODULE char_test
 

--- a/numpy/f2py/tests/src/string/char.f90
+++ b/numpy/f2py/tests/src/string/char.f90
@@ -25,5 +25,14 @@ SUBROUTINE change_strings(strings, n_strs, out_strings)
 
 END SUBROUTINE change_strings
 
+SUBROUTINE string_size(string)
+    IMPLICIT NONE
+
+    CHARACTER(len=4), intent(inout) :: string
+
+    string(1:1) = 'A'
+
+END SUBROUTINE string_size
+
 END MODULE char_test
 

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -27,7 +27,8 @@ class TestString(util.F2PyTest):
     @pytest.mark.slow
     def test_char(self):
         strings = np.array(['ab', 'cd', 'ef'], dtype='c').T
-        inp, out = self.module.char_test.change_strings(strings, strings.shape[1])
+        inp, out = self.module.char_test.change_strings(strings,
+                                                        strings.shape[1])
         assert_array_equal(inp, strings)
         expected = strings.copy()
         expected[1, :] = 'AAA'
@@ -40,7 +41,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(string, np.array(b'A234'))
 
     def test_char_intent_inout_toosmall(self, toosmall):
-        assert_raises(ValueError, self.module.char_test.string_size_inout, toosmall)
+        assert_raises(ValueError, self.module.char_test.string_size_inout,
+                      toosmall)
 
     def test_char_intent_inout_toolarge(self, toolarge):
         self.module.char_test.string_size_inout(toolarge)
@@ -51,7 +53,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(string, np.array(b'1234'))
 
     def test_char_intent_cache_toosmall(self, toosmall):
-        assert_raises(ValueError, self.module.char_test.string_size_cache, toosmall)
+        assert_raises(ValueError, self.module.char_test.string_size_cache,
+                      toosmall)
 
     def test_char_intent_cache_toolarge(self, toolarge):
         self.module.char_test.string_size_cache(toolarge)
@@ -65,7 +68,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(string, np.array(b'A234'))
 
     def test_char_intent_overwrite_toosmall(self, toosmall):
-        assert_raises(ValueError, self.module.char_test.string_size_overwrite, toosmall)
+        assert_raises(ValueError, self.module.char_test.string_size_overwrite,
+                      toosmall)
 
     @pytest.mark.xfail
     # string is unchanged even with intent(in, overwrite)
@@ -80,7 +84,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(result, np.array(b'A234'))
 
     @pytest.mark.xfail
-    # Raises value error but should create a temporary variable with appropriate size
+    # Raises value error but should create a temporary variable with appropriate
+    # size
     def test_char_intent_copy_toosmall(self, toosmall):
         result = self.module.char_test.string_size_copy(toosmall)
         assert_array_equal(toosmall, np.array(b'123'))
@@ -99,7 +104,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(string, np.array(b'A234'))
 
     @pytest.mark.xfail
-    # Raises value error but should create a temporary variable with appropriate size
+    # Raises value error but should create a temporary variable with appropriate
+    # size
     def test_char_intent_inplace_toosmall(self, toosmall):
         self.module.char_test.string_size_inplace(toosmall)
         assert_array_equal(toosmall, np.array(b'A23'))
@@ -117,7 +123,8 @@ class TestString(util.F2PyTest):
         assert_array_equal(result, np.array(b'A234'))
 
     @pytest.mark.xfail
-    # Raises value error but should create a temporary variable with appropriate size
+    # Raises value error but should create a temporary variable with appropriate
+    # size
     def test_char_intent_out_toosmall(self, toosmall):
         result = self.module.char_test.string_size_out(toosmall)
         assert_array_equal(toosmall, np.array(b'123'))

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -9,6 +9,18 @@ from . import util
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
 
+@pytest.fixture
+def string():
+    return np.array(b'1234')
+
+@pytest.fixture
+def toolarge():
+    return np.array(b'12345')
+
+@pytest.fixture
+def toosmall():
+    return np.array(b'123')
+
 class TestString(util.F2PyTest):
     sources = [_path('src', 'string', 'char.f90')]
 
@@ -21,10 +33,97 @@ class TestString(util.F2PyTest):
         expected[1, :] = 'AAA'
         assert_array_equal(out, expected)
 
-    def test_char_bytesize(self):
-        a = np.array(b'123')
-        b = np.array(b'12345')
-        self.module.char_test.string_size(b)
-        assert_raises(ValueError, self.module.char_test.string_size, a)
-        assert_array_equal(b, np.array(b'A234'))
+    @pytest.mark.xfail
+    # Returns on less character than expected - see gh-18431
+    def test_char_intent_inout(self, string):
+        self.module.char_test.string_size_inout(string)
+        assert_array_equal(string, np.array(b'A234'))
 
+    def test_char_intent_inout_toosmall(self, toosmall):
+        assert_raises(ValueError, self.module.char_test.string_size_inout, toosmall)
+
+    def test_char_intent_inout_toolarge(self, toolarge):
+        self.module.char_test.string_size_inout(toolarge)
+        assert_array_equal(toolarge, np.array(b'A234'))
+
+    def test_char_intent_cache(self, string):
+        self.module.char_test.string_size_cache(string)
+        assert_array_equal(string, np.array(b'1234'))
+
+    def test_char_intent_cache_toosmall(self, toosmall):
+        assert_raises(ValueError, self.module.char_test.string_size_cache, toosmall)
+
+    def test_char_intent_cache_toolarge(self, toolarge):
+        self.module.char_test.string_size_cache(toolarge)
+        assert_array_equal(toolarge, np.array(b'12345'))
+
+    @pytest.mark.xfail
+    # string is unchanged even with intent(in, overwrite)
+    # this may be expected?
+    def test_char_intent_overwrite(self, string):
+        self.module.char_test.string_size_overwrite(string)
+        assert_array_equal(string, np.array(b'A234'))
+
+    def test_char_intent_overwrite_toosmall(self, toosmall):
+        assert_raises(ValueError, self.module.char_test.string_size_overwrite, toosmall)
+
+    @pytest.mark.xfail
+    # string is unchanged even with intent(in, overwrite)
+    # this may be expected?
+    def test_char_intent_overwrite_toolarge(self, toolarge):
+        self.module.char_test.string_size_overwrite(toolarge)
+        assert_array_equal(toolarge, np.array(b'A234'))
+
+    def test_char_intent_copy(self, string):
+        result = self.module.char_test.string_size_copy(string)
+        assert_array_equal(string, np.array(b'1234'))
+        assert_array_equal(result, np.array(b'A234'))
+
+    @pytest.mark.xfail
+    # Raises value error but should create a temporary variable with appropriate size
+    def test_char_intent_copy_toosmall(self, toosmall):
+        result = self.module.char_test.string_size_copy(toosmall)
+        assert_array_equal(toosmall, np.array(b'123'))
+        assert_array_equal(result, np.array(b'A23'))
+
+    def test_char_intent_copy_toolarge(self, toolarge):
+        result = self.module.char_test.string_size_copy(toolarge)
+        assert_array_equal(toolarge, np.array(b'12345'))
+        assert_array_equal(result, np.array(b'A234'))
+
+    @pytest.mark.xfail
+    # string is unchanged even with intent(inplace)
+    # this may be expected?
+    def test_char_intent_inplace(self, string):
+        self.module.char_test.string_size_inplace(string)
+        assert_array_equal(string, np.array(b'A234'))
+
+    @pytest.mark.xfail
+    # Raises value error but should create a temporary variable with appropriate size
+    def test_char_intent_inplace_toosmall(self, toosmall):
+        self.module.char_test.string_size_inplace(toosmall)
+        assert_array_equal(toosmall, np.array(b'A23'))
+
+    @pytest.mark.xfail
+    # string is unchanged even with intent(inplace)
+    # this may be expected?
+    def test_char_intent_inplace_toolarge(self, toolarge):
+        self.module.char_test.string_size_inplace(toolarge)
+        assert_array_equal(toolarge, np.array(b'A234'))
+
+    def test_char_intent_out(self, string):
+        result = self.module.char_test.string_size_out(string)
+        assert_array_equal(string, np.array(b'1234'))
+        assert_array_equal(result, np.array(b'A234'))
+
+    @pytest.mark.xfail
+    # Raises value error but should create a temporary variable with appropriate size
+    def test_char_intent_out_toosmall(self, toosmall):
+        result = self.module.char_test.string_size_out(toosmall)
+        assert_array_equal(toosmall, np.array(b'123'))
+        assert_array_equal(result, np.array(b'A23'))
+
+    def test_char_intent_out_toolarge(self, toolarge):
+        result = self.module.char_test.string_size_out(toolarge)
+        assert_array_equal(toolarge, np.array(b'12345'))
+        assert_array_equal(result, np.array(b'A234'))

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_raises
 import numpy as np
 from . import util
 
@@ -20,3 +20,11 @@ class TestString(util.F2PyTest):
         expected = strings.copy()
         expected[1, :] = 'AAA'
         assert_array_equal(out, expected)
+
+    def test_char_bytesize(self):
+        a = np.array(b'123')
+        b = np.array(b'12345')
+        self.module.char_test.string_size(b)
+        assert_raises(ValueError, self.module.char_test.string_size, a)
+        assert_array_equal(b, np.array(b'A234'))
+


### PR DESCRIPTION
This is an attempt at fixing #15311.

This raises a ValueError if the input array has byte-size smaller than expected, but the string is truncated if it is larger than expected (which is consistent with the [current docs](https://numpy.org/devdocs/f2py/python-usage.html#string-arguments)).

Feedback is appreciated!

Closes #15311


