### PR TITLE
DOC: point intersphinx to matplotlib/stable...

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -285,7 +285,7 @@ intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/dev', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'matplotlib': ('https://matplotlib.org', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
     'skimage': ('https://scikit-image.org/docs/stable', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),


### PR DESCRIPTION
matplotlib canonical docs are now  https://matplotlib.org/stable

https://discourse.matplotlib.org/t/canonical-documentation-have-moved/21863