### PR TITLE
BUG: Fix refcount leak in f2py `complex_double_from_pyobj`

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1023,6 +1023,7 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
         }
         (*v).r = ((npy_cdouble *)PyArray_DATA(arr))->real;
         (*v).i = ((npy_cdouble *)PyArray_DATA(arr))->imag;
+        Py_DECREF(arr);
         return 1;
     }
     /* Python does not provide PyNumber_Complex function :-( */


### PR DESCRIPTION
The nice thing is, that over time or with the last few big changes, it might just be that with this and gh-18431 the f2py tests will be happy running in valgrind.