### PR TITLE
TST: Fix some uninitialized memory in the tests

### DIFF
--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2104,7 +2104,8 @@ class TestRegression:
         assert_raises(TypeError, np.searchsorted, a, 1.2)
         # Ticket #2066, similar problem:
         dtype = np.format_parser(['i4', 'i4'], [], [])
-        a = np.recarray((2, ), dtype)
+        a = np.recarray((2,), dtype)
+        a[...] = [(1, 2), (3, 4)]
         assert_raises(TypeError, np.searchsorted, a, 1)
 
     def test_complex64_alignment(self):

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1952,7 +1952,7 @@ class TestSpecialMethods:
             _wrap_args = None
             _prepare_args = None
             def __new__(cls):
-                return np.empty(()).view(cls)
+                return np.zeros(()).view(cls)
             def __array_wrap__(self, obj, context):
                 self._wrap_args = context[1]
                 return obj


### PR DESCRIPTION
This adds a flag to allow disabling of caches. It is not very useful,
so I do not care too much about it; My initial intention was to compile
more things useful when running with valgrind.

It will be occasionally useful (since it can clarify where a leak is),
but overall, I am also fine with not including it at all.

---

Happy to not put this in, but it seemed like a harmless little addition, which might just be useful occasionally (I used it now, but I am not sure it made a difference really).