### PR TITLE
BUG: Correct shuffling of objects in 1-d array likes

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4437,9 +4437,9 @@ cdef class Generator:
                     if i == j:
                         # i == j is not needed and memcpy is undefined.
                         continue
-                    buf[...] = x[j]
-                    x[j] = x[i]
-                    x[i] = buf
+                    buf[...] = x[j, ...]
+                    x[j, ...] = x[i, ...]
+                    x[i, ...] = buf
         else:
             # Untyped path.
             if not isinstance(x, Sequence):

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4462,6 +4462,17 @@ cdef class RandomState:
                 # shuffling is a no-op
                 return
 
+            if x.ndim == 1 and x.dtype.type is np.object_:
+                warnings.warn(
+                        "Shuffling a one dimensional array subclass containing "
+                        "objects gives incorrect results for most array "
+                        "subclasses.  "
+                        "Please us the new random number API instead: "
+                        "https://numpy.org/doc/stable/reference/random/index.html\n"
+                        "The new API fixes this issue. This version will not "
+                        "be fixed due to stability guarantees of the API.",
+                        UserWarning, stacklevel=1)  # Cython adds no stacklevel
+
             buf = np.empty_like(x[0, ...])
             with self.lock:
                 for i in reversed(range(1, n)):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -529,7 +529,9 @@ class TestRandomDist:
         class MyArr(np.ndarray):
             pass
 
-        items = [None, np.array([3]), np.float64(3), np.array(10), np.float64(7)]
+        items = [None, np.array([3]), np.float64(3), np.array(10),
+                 np.float64(7)
+                ]
         arr = np.array(items, dtype=object)
         item_ids = {id(i) for i in items}
         if use_array_like:

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -529,9 +529,9 @@ class TestRandomDist:
         class MyArr(np.ndarray):
             pass
 
-        items = [None, np.array([3]), np.float64(3), np.array(10),
-                 np.float64(7)
-                ]
+        items = [
+            None, np.array([3]), np.float64(3), np.array(10), np.float64(7)
+        ]
         arr = np.array(items, dtype=object)
         item_ids = {id(i) for i in items}
         if use_array_like:

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -522,6 +522,31 @@ class TestRandomDist:
             random.shuffle(values)
         assert "test_random" in rec[0].filename
 
+    @pytest.mark.parametrize("random",
+        [np.random, np.random.RandomState(), np.random.default_rng()])
+    @pytest.mark.parametrize("use_array_like", [True, False])
+    def test_shuffle_no_object_unpacking(self, random, use_array_like):
+        class MyArr(np.ndarray):
+            pass
+
+        items = [None, np.array([3]), np.float64(3), np.array(10), np.float64(7)]
+        arr = np.array(items, dtype=object)
+        item_ids = {id(i) for i in items}
+        if use_array_like:
+            arr = arr.view(MyArr)
+
+        # The array was created fine, and did not modify any objects:
+        assert all(id(i) in item_ids for i in arr)
+
+        if use_array_like and not isinstance(random, np.random.Generator):
+            # The old API gives incorrect results, but warns about it.
+            with pytest.warns(UserWarning,
+                    match="Shuffling a one dimensional array.*"):
+                random.shuffle(arr)
+        else:
+            random.shuffle(arr)
+            assert all(id(i) in item_ids for i in arr)
+
     def test_shuffle_memoryview(self):
         # gh-18273
         # allow graceful handling of memoryviews


### PR DESCRIPTION
While introducing the buffer fixed the in-place problem years ago,
running valgrind (and masked arrays) pointed out to me that without
the additional `...` NumPy will unpack and repack objects leading
to slightly incorrect results.

---

This is extremely subtle, and although I can't think of anything, maybe tricky enough that I don't think there is much reason to backport.