### PR TITLE
MAINT: random: Use 'from exc' when raising a ValueError in choice.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -694,21 +694,23 @@ cdef class Generator:
         cdef uint64_t set_size, mask
         cdef uint64_t[::1] hash_set
         # Format and Verify input
+        a_original = a
         a = np.array(a, copy=False)
         if a.ndim == 0:
             try:
                 # __index__ must return an integer by python rules.
                 pop_size = operator.index(a.item())
             except TypeError:
-                raise ValueError("a must an array or an integer")
+                raise ValueError("a must be an array or an integer, "
+                                 f"not {type(a_original)}") from None
             if pop_size <= 0 and np.prod(size) != 0:
                 raise ValueError("a must be a positive integer unless no"
-                                 "samples are taken")
+                                 " samples are taken")
         else:
             pop_size = a.shape[axis]
             if pop_size == 0 and np.prod(size) != 0:
                 raise ValueError("a cannot be empty unless no samples are"
-                                 "taken")
+                                 " taken")
 
         if p is not None:
             d = len(p)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -700,17 +700,17 @@ cdef class Generator:
             try:
                 # __index__ must return an integer by python rules.
                 pop_size = operator.index(a.item())
-            except TypeError:
-                raise ValueError("a must be an array or an integer, "
-                                 f"not {type(a_original)}") from None
+            except TypeError as exc:
+                raise ValueError("a must be a sequence or an integer, "
+                                 f"not {type(a_original)}") from exc
             if pop_size <= 0 and np.prod(size) != 0:
-                raise ValueError("a must be a positive integer unless no"
-                                 " samples are taken")
+                raise ValueError("a must be a positive integer unless no "
+                                 "samples are taken")
         else:
             pop_size = a.shape[axis]
             if pop_size == 0 and np.prod(size) != 0:
-                raise ValueError("a cannot be empty unless no samples are"
-                                 " taken")
+                raise ValueError("a cannot be empty unless no samples are "
+                                 "taken")
 
         if p is not None:
             d = len(p)


### PR DESCRIPTION
Use 'from exc' when the ValueError is raised when the first argument to
`choice` is not an array and not an integer.

Also fix the error message for the ValueError.
