### PR TITLE
BUG: fix stacklevel in warning within random.shuffle

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -4445,11 +4445,12 @@ cdef class Generator:
             if not isinstance(x, Sequence):
                 # See gh-18206. We may decide to deprecate here in the future.
                 warnings.warn(
-                    "`x` isn't a recognized object; `shuffle` is not guaranteed "
-                    "to behave correctly. E.g., non-numpy array/tensor objects "
-                    "with view semantics may contain duplicates after shuffling.",
-                    UserWarning, stacklevel=2
-                )
+                    f"you are shuffling a '{type(x).__name__}' object "
+                    "which is not a subclass of 'Sequence'; "
+                    "`shuffle` is not guaranteed to behave correctly. "
+                    "E.g., non-numpy array/tensor objects with view semantics "
+                    "may contain duplicates after shuffling.",
+                    UserWarning, stacklevel=1)  # Cython does not add a level
 
             if axis != 0:
                 raise NotImplementedError("Axis argument is only supported "

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4476,11 +4476,12 @@ cdef class RandomState:
             if not isinstance(x, Sequence):
                 # See gh-18206. We may decide to deprecate here in the future.
                 warnings.warn(
-                    "`x` isn't a recognized object; `shuffle` is not guaranteed "
-                    "to behave correctly. E.g., non-numpy array/tensor objects "
-                    "with view semantics may contain duplicates after shuffling.",
-                    UserWarning, stacklevel=2
-                )
+                    f"you are shuffling a '{type(x).__name__}' object "
+                    "which is not a subclass of 'Sequence'; "
+                    "`shuffle` is not guaranteed to behave correctly. "
+                    "E.g., non-numpy array/tensor objects with view semantics "
+                    "may contain duplicates after shuffling.",
+                    UserWarning, stacklevel=1)  # Cython does not add a level
 
             with self.lock:
                 for i in reversed(range(1, n)):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pytest
+
 import numpy as np
 from numpy.testing import (
         assert_, assert_raises, assert_equal, assert_warns,
@@ -509,6 +511,16 @@ class TestRandomDist:
             np.random.shuffle(b)
             assert_equal(
                 sorted(b.data[~b.mask]), sorted(b_orig.data[~b_orig.mask]))
+
+    @pytest.mark.parametrize("random",
+            [np.random, np.random.RandomState(), np.random.default_rng()])
+    def test_shuffle_untyped_warning(self, random):
+        # Create a dict works like a sequence but isn't one
+        values = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6}
+        with pytest.warns(UserWarning,
+                match="you are shuffling a 'dict' object") as rec:
+            random.shuffle(values)
+        assert "test_random" in rec[0].filename
 
     def test_shuffle_memoryview(self):
         # gh-18273


### PR DESCRIPTION
Cython does _not_ add a new stacklevel (at least at this time),
so `stacklevel=1` (or ommiting it) is, maybe surprisingly, correct.

The second commit adds a test for the warning, with an assert for the filename (which by proxy tests the stacklevel).  I am not quite sure how safe that test is, so if we want to backport we could omit it, I guess.