### PR TITLE
DOC: Remove unfinished Linear Algebra section from Quickstart tutorial

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1394,53 +1394,7 @@ See :ref:`structured_arrays`.
 Linear Algebra
 ==============
 
-Work in progress. Basic linear algebra to be included here.
-
-Simple Array Operations
------------------------
-
-See linalg.py in numpy folder for more.
-
-::
-
-    >>> import numpy as np
-    >>> a = np.array([[1.0, 2.0], [3.0, 4.0]])
-    >>> print(a)
-    [[1. 2.]
-     [3. 4.]]
-    >>> a.transpose()
-    array([[1., 3.],
-           [2., 4.]])
-    >>> np.linalg.inv(a)
-    array([[-2. ,  1. ],
-           [ 1.5, -0.5]])
-    >>> u = np.eye(2)  # unit 2x2 matrix; "eye" represents "I"
-    >>> u
-    array([[1., 0.],
-           [0., 1.]])
-    >>> j = np.array([[0.0, -1.0], [1.0, 0.0]])
-    >>> j @ j  # matrix product
-    array([[-1.,  0.],
-           [ 0., -1.]])
-    >>> np.trace(u)  # trace
-    2.0
-    >>> y = np.array([[5.], [7.]])
-    >>> np.linalg.solve(a, y)
-    array([[-3.],
-           [ 4.]])
-    >>> np.linalg.eig(j)
-    (array([0.+1.j, 0.-1.j]), array([[0.70710678+0.j        , 0.70710678-0.j        ],
-           [0.        -0.70710678j, 0.        +0.70710678j]]))
-
-::
-
-    Parameters:
-        square matrix
-    Returns
-        The eigenvalues, each repeated according to its multiplicity.
-        The normalized (unit "length") eigenvectors, such that the
-        column ``v[:, i]`` is the eigenvector corresponding to the
-        eigenvalue ``w[i]`` .
+See :doc:`tutorial-svd`
 
 Tricks and Tips
 ===============

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -20,8 +20,7 @@ in addition to NumPy.
 
 **Learner profile**
 
-This is a quick overview of
-algebra and arrays in NumPy. It demonstrates how n-dimensional
+This is a quick overview of arrays in NumPy. It demonstrates how n-dimensional
 (:math:`n>=2`) arrays are represented and can be manipulated. In particular, if
 you don't know how to apply common functions to n-dimensional arrays (without
 using for-loops), or if you want to understand axis and shape properties for
@@ -1391,11 +1390,6 @@ Indexing with strings
 
 See :ref:`structured_arrays`.
 
-Linear Algebra
-==============
-
-See :doc:`tutorial-svd`
-
 Tricks and Tips
 ===============
 
@@ -1484,3 +1478,4 @@ Further reading
 -  `SciPy Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`__
 -  `SciPy Lecture Notes <https://scipy-lectures.org>`__
 -  A `matlab, R, IDL, NumPy/SciPy dictionary <http://mathesaurus.sf.net/>`__
+-  :doc:`tutorial-svd`


### PR DESCRIPTION
The Quickstart tutorial has an [incomplete Linear Algebra section](https://numpy.org/devdocs/user/quickstart.html#linear-algebra) that has been marked as a WIP since [at least 1.13](https://numpy.org/doc/1.13/user/quickstart.html#linear-algebra). This PR suggests replacing this section with a link to the [svd tutorial](https://numpy.org/devdocs/user/tutorial-svd.html) which is much more complete and covers a lot of the same material. 

Alternatively, this section (or at the very least the sentence about being a WIP) could be removed entirely so it no longer stands out as incomplete.