### PR TITLE
BUG:  ``diagflat`` could overflow on windows or 32-bit platforms

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -5,8 +5,8 @@ import functools
 
 from numpy.core.numeric import (
     asanyarray, arange, zeros, greater_equal, multiply, ones,
-    asarray, where, int8, int16, int32, int64, empty, promote_types, diagonal,
-    nonzero, indices
+    asarray, where, int8, int16, int32, int64, intp, empty, promote_types,
+    diagonal, nonzero, indices
     )
 from numpy.core.overrides import set_array_function_like_doc, set_module
 from numpy.core import overrides
@@ -348,10 +348,10 @@ def diagflat(v, k=0):
     n = s + abs(k)
     res = zeros((n, n), v.dtype)
     if (k >= 0):
-        i = arange(0, n-k)
+        i = arange(0, n-k, dtype=intp)
         fi = i+k+i*n
     else:
-        i = arange(0, n+k)
+        i = arange(0, n+k, dtype=intp)
         fi = i+(i-k)*n
     res.flat[fi] = v
     if not wrap:


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/18449.

For particularly large input arrays the `np.diagflat` function could yield non-zero diagonal elements due to integer overflow,
the latter facilitated by the default `np.arange` integer-dtype being `np.int32` on windows.

This PR fixes aforementioned issue by explicitly setting the dtype to `np.intp`.