### PR TITLE
BUG: Fix refcount leak in f2py ``complex_double_from_pyobj``.

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1023,6 +1023,7 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
         }
         (*v).r = ((npy_cdouble *)PyArray_DATA(arr))->real;
         (*v).i = ((npy_cdouble *)PyArray_DATA(arr))->imag;
+        Py_DECREF(arr);
         return 1;
     }
     /* Python does not provide PyNumber_Complex function :-( */


### PR DESCRIPTION
Backport of #18437. 

The nice thing is, that over time or with the last few big changes, it might just be that with this and gh-18431 the f2py tests will be happy running in valgrind.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
