### PR TITLE
DOC: Rename "Ones and zeros" section in array-creation documentation.

### DIFF
--- a/doc/source/reference/routines.array-creation.rst
+++ b/doc/source/reference/routines.array-creation.rst
@@ -7,8 +7,8 @@ Array creation routines
 
 .. currentmodule:: numpy
 
-Ones and zeros
---------------
+From shape or value
+-------------------
 .. autosummary::
    :toctree: generated/
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Implements the change recommended by @melissawm in the discussion of issue #7408. The "Ones and zeros" section is renamed "From shape or value". Closes #7408.