### PR TITLE
BUG: Fix non-versioneer uses of numpy.distutils

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -1970,7 +1970,7 @@ class Configuration:
                 try:
                     version = version_module.get_versions()['version']
                 except AttributeError:
-                    version = None
+                    pass
 
                 if version is not None:
                     break


### PR DESCRIPTION
See https://github.com/scipy/scipy/issues/13609. SciPy doesn't use `versioneer`. The current code in `master` of NumPy tries to get a version based on the passed in `version_file`, but then proceeds to completely ignore it -- the `master` code will overwrite the `version` variable no matter what it was when it tries to get one using `versioneer`. This PR makes it respect the `version` that was obtained by the file-based checks, and only overwrite the `version` variable if the `versioneer` function exists.