### PR TITLE
TST: Remove the `einsum` typing tests reliance on issuing a `ComplexWarning`

### DIFF
--- a/numpy/typing/tests/data/pass/einsumfunc.py
+++ b/numpy/typing/tests/data/pass/einsumfunc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import List, Any
 
-import pytest
 import numpy as np
 
 AR_LIKE_b = [True, True, True]
@@ -12,6 +11,7 @@ AR_LIKE_f = [1.0, 2.0, 3.0]
 AR_LIKE_c = [1j, 2j, 3j]
 AR_LIKE_U = ["1", "2", "3"]
 
+OUT_f: np.ndarray[Any, np.dtype[np.float64]] = np.empty(3, dtype=np.float64)
 OUT_c: np.ndarray[Any, np.dtype[np.complex128]] = np.empty(3, dtype=np.complex128)
 
 np.einsum("i,i->i", AR_LIKE_b, AR_LIKE_b)
@@ -25,8 +25,7 @@ np.einsum("i,i,i,i->i", AR_LIKE_b, AR_LIKE_u, AR_LIKE_i, AR_LIKE_c)
 np.einsum("i,i->i", AR_LIKE_f, AR_LIKE_f, dtype="c16")
 np.einsum("i,i->i", AR_LIKE_U, AR_LIKE_U, dtype=bool, casting="unsafe")
 np.einsum("i,i->i", AR_LIKE_f, AR_LIKE_f, out=OUT_c)
-with pytest.raises(np.ComplexWarning):
-    np.einsum("i,i->i", AR_LIKE_U, AR_LIKE_U, dtype=float, casting="unsafe", out=OUT_c)
+np.einsum("i,i->i", AR_LIKE_U, AR_LIKE_U, dtype=int, casting="unsafe", out=OUT_f)
 
 np.einsum_path("i,i->i", AR_LIKE_b, AR_LIKE_b)
 np.einsum_path("i,i->i", AR_LIKE_u, AR_LIKE_u)


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/18496.

As was noted in aforementioned issue: `ComplexWarning`s were not issued reliably on all platforms.
