### PR TITLE
TST: Branch coverage improvement for `np.polynomial`

### DIFF
--- a/numpy/polynomial/tests/test_legendre.py
+++ b/numpy/polynomial/tests/test_legendre.py
@@ -305,6 +305,9 @@ class TestIntegral:
         res = leg.legint(c2d, k=3, axis=1)
         assert_almost_equal(res, tgt)
 
+    def test_legint_zerointord(self):
+        assert_equal(leg.legint((1, 2, 3), 0), (1, 2, 3))
+
 
 class TestDerivative:
 
@@ -345,6 +348,9 @@ class TestDerivative:
         res = leg.legder(c2d, axis=1)
         assert_almost_equal(res, tgt)
 
+    def test_legder_orderhigherthancoeff(self):
+        c = (1, 2, 3, 4)
+        assert_equal(leg.legder(c, 4), [0])
 
 class TestVander:
     # some random values in [-1, 1)
@@ -392,6 +398,9 @@ class TestVander:
         # check shape
         van = leg.legvander3d([x1], [x2], [x3], [1, 2, 3])
         assert_(van.shape == (1, 5, 24))
+
+    def test_legvander_negdeg(self):
+        assert_raises(ValueError, leg.legvander, (1, 2, 3), -1)
 
 
 class TestFitting:
@@ -540,6 +549,9 @@ class TestMisc:
 
     def test_legline(self):
         assert_equal(leg.legline(3, 4), [3, 4])
+
+    def test_legline_zeroscl(self):
+        assert_equal(leg.legline(3, 0), [3])
 
     def test_leg2poly(self):
         for i in range(10):

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -473,6 +473,10 @@ class TestVander:
         van = poly.polyvander3d([x1], [x2], [x3], [1, 2, 3])
         assert_(van.shape == (1, 5, 24))
 
+    def test_polyvandernegdeg(self):
+        x = np.arange(3)
+        assert_raises(ValueError, poly.polyvander, x, -1)
+
 
 class TestCompanion:
 
@@ -591,3 +595,6 @@ class TestMisc:
 
     def test_polyline(self):
         assert_equal(poly.polyline(3, 4), [3, 4])
+
+    def test_polyline_zero(self):
+        assert_equal(poly.polyline(3, 0), [3])

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -40,6 +40,21 @@ class TestMisc:
         assert_equal(pu.trimcoef(coef, 1), coef[:-3])
         assert_equal(pu.trimcoef(coef, 2), [0])
 
+    def test_vander_nd_exception(self):
+        # n_dims != len(points)
+        assert_raises(ValueError, pu._vander_nd, (), (1, 2, 3), [90])
+        # n_dims != len(degrees)
+        assert_raises(ValueError, pu._vander_nd, (), (), [90.65])
+        # n_dims == 0
+        assert_raises(ValueError, pu._vander_nd, (), (), [])
+
+    def test_div_zerodiv(self):
+        # c2[-1] == 0
+        assert_raises(ZeroDivisionError, pu._div, pu._div, (1, 2, 3), [0])
+
+    def test_pow_tolargepow(self):
+        # power > maxpower
+        assert_raises(ValueError, pu._pow, (), [1, 2, 3], 5, 4)
 
 class TestDomain:
 

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -52,7 +52,7 @@ class TestMisc:
         # c2[-1] == 0
         assert_raises(ZeroDivisionError, pu._div, pu._div, (1, 2, 3), [0])
 
-    def test_pow_tolargepow(self):
+    def test_pow_too_large(self):
         # power > maxpower
         assert_raises(ValueError, pu._pow, (), [1, 2, 3], 5, 4)
 


### PR DESCRIPTION
Hello Numpy!

This pull request contains added tests for the classes legendre.py, polynomial.py and polyutils.py. The purpose with the tests is to improve branch coverage.

We have run the test suit and all of the tests seems to work and we have checked that we do improve branch coverage. We used the tool coverage.py.

Legendre Branch Coverage improved by 2 %. From 5 branches missing to 1.

Polynomial Branch Coverage improved by 2 %. From 4 branches missing to 2.

Polyutils Branch Coverage improved by 2 %. From 10 branches missing to 5.

Some thoughts that we are uncertain about is if we put the tests in correct test for each respective test class, and if the names of the tests are sufficient. 

Feel free to send any feedback.

We set the wrong commit message "enhance" instead of "ENH" and we have tried solve it with git --amend but we have run in to branch problems so haven't managed to push the change yet. Tell us if we have to fix this or if it is OK.

Cheers
