### PR TITLE
DOC: Fix links to landing page

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,7 +94,7 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-master_doc = 'contents'
+master_doc = 'index'
 
 # General substitutions.
 project = 'NumPy'

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,6 +6,7 @@ NumPy Documentation
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    User Guide <user/index>
    API reference <reference/index>


### PR DESCRIPTION
Currenlty, the `master_doc` points to `contents.rst`, the purpose of which is to specify the top-level toctree to set up the navbar correctly in the `pydata-sphinx-theme`. However, the rendered `contents.html` document doesn't have any useful info in it, and is linked to by e.g. clicking on the numpy logo in the upper-left corner of the docs.

This PR fixes that by moving the toctree meta-info to `index.rst`. The info in the rst file is used to properly set up the navbar, while the rendered index page is still drawn from `_templates/indexcontent.html`. This means that any references back to `numpy_docs_mainpage` now point to the landing page rather than the `contents` file, which only contained a toctree.