### PR TITLE
ENH: Allow add_docstring to work under PyPy with -O0 -O

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -156,7 +156,7 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
 
     if not ARRAY_FUNCTION_ENABLED:
         def decorator(implementation):
-            if docs_from_dispatcher:
+            if docs_from_dispatcher and dispatcher.__doc__ is not None:
                 add_docstring(implementation, dispatcher.__doc__)
             if module is not None:
                 implementation.__module__ = module
@@ -167,7 +167,7 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         if verify:
             verify_matching_signatures(implementation, dispatcher)
 
-        if docs_from_dispatcher:
+        if docs_from_dispatcher and dispatcher.__doc__ is not None:
             add_docstring(implementation, dispatcher.__doc__)
 
         # Equivalently, we could define this function directly instead of using


### PR DESCRIPTION
Under PyPy, with `-O -O0`, we get a TypeError when the docstring is None. For some reason, CPython does not complain under `-O -O0`, but PyPy does and ironically, PyPY seems to have the correct behavior. The line of code causing the 

https://github.com/numpy/numpy/blob/v1.18.5/numpy/core/src/multiarray/compiled_base.c#L1451

The fix which works for both CPython and PyPy is to avoid sending in a None value to `add_docstring` where possible.
