### PR TITLE
ENH: Avoid calling add_docstring if __doc__ is None

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -177,7 +177,7 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
 
     if not ARRAY_FUNCTION_ENABLED:
         def decorator(implementation):
-            if docs_from_dispatcher:
+            if docs_from_dispatcher and dispatcher.__doc__ is not None:
                 add_docstring(implementation, dispatcher.__doc__)
             if module is not None:
                 implementation.__module__ = module
@@ -188,7 +188,7 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         if verify:
             verify_matching_signatures(implementation, dispatcher)
 
-        if docs_from_dispatcher:
+        if docs_from_dispatcher and dispatcher.__doc__ is not None:
             add_docstring(implementation, dispatcher.__doc__)
 
         # Equivalently, we could define this function directly instead of using


### PR DESCRIPTION
Under PyPy, with `-O -OO`, we get a `TypeError` when the docstring is `None`. For some reason, CPython does not complain, but PyPy does and ironically, PyPY seems to have the correct behavior. The line of code causing the problem is here:

https://github.com/numpy/numpy/blob/v1.18.5/numpy/core/src/multiarray/compiled_base.c#L1451

The fix which works for both CPython and PyPy is to avoid sending in a None value to add_docstring where possible.

I have confirmed this problem still exists in numpy from pip (was unable to build numpy master for my version of pypy).