### PR TITLE
BLD: add _2_24 to valid manylinux names

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -60,7 +60,7 @@ def get_manylinux(arch):
         default = '2014'
     ret = os.environ.get("MB_ML_VER", default)
     # XXX For PEP 600 this can be a glibc version
-    assert ret in ('1', '2010', '2014'), f'invalid MB_ML_VER {ret}'
+    assert ret in ('1', '2010', '2014', '_2_24'), f'invalid MB_ML_VER {ret}'
     return ret
 
 


### PR DESCRIPTION
`manylinux_2_24` is the first PEP 600 "perennial linux" version, based on glibc2.24. This might help get us past the [issues on ppc64le](https://github.com/numpy/numpy/issues?q=is%3Aissue+is%3Aopen+ppc64le)

xref MacPython/numpy-wheels#108 which uncovered the problem fixed here.