### PR TITLE
DOC: remove "last updated" date from generated HTML pages

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -171,7 +171,6 @@ html_additional_pages = {
 
 html_title = "%s v%s Manual" % (project, version)
 html_static_path = ['_static']
-html_last_updated_fmt = '%b %d, %Y'
 
 html_use_modindex = True
 html_copy_source = False


### PR DESCRIPTION
Alternative to #18268, which just removes the "last updated" date instead of trying to make it more accurate.