### PR TITLE
BUG: incorrect error fallthrough in nditer

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3525,7 +3525,7 @@ reduce_loop(NpyIter *iter, char **dataptrs, npy_intp const *strides,
                         strides_copy, innerloopdata);
 
             if (needs_api && PyErr_Occurred()) {
-                break;
+                goto finish_loop;
             }
 
             /* Jump to the faster loop when skipping is done */
@@ -3539,6 +3539,11 @@ reduce_loop(NpyIter *iter, char **dataptrs, npy_intp const *strides,
             }
         } while (iternext(iter));
     }
+
+    if (needs_api && PyErr_Occurred()) {
+        goto finish_loop;
+    }
+
     do {
         /* Turn the two items into three for the inner loop */
         dataptrs_copy[0] = dataptrs[0];

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2883,6 +2883,14 @@ def test_object_iter_cleanup():
     oarr[:, -1] = None
     assert_raises(TypeError, lambda: np.add(oarr[:, ::-1], arr[:, ::-1]))
 
+    # followup: this tests for a bug introduced in the first pass of gh-18450,
+    # caused by an incorrect fallthrough of the TypeError
+    class T:
+        def __bool__(self):
+            raise TypeError("Ambiguous")
+    assert_raises(TypeError, np.logical_or.reduce, 
+                             np.array([T(), T()], dtype='O'))
+
 def test_iter_too_large():
     # The total size of the iterator must not exceed the maximum intp due
     # to broadcasting. Dividing by 1024 will keep it small enough to


### PR DESCRIPTION
Fixup to #18450, to fix bug introduced which triggered downstream bug: xref: pandas-dev/pandas#40158
