### PR TITLE
CI: Use Ubuntu 18.04 to run "full" test.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,7 +80,7 @@ jobs:
 
   full:
     needs: smoke_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       USE_WHEEL: 1
       RUN_FULL_TESTS: 1


### PR DESCRIPTION
NumPy does not build using the `--coverage` flag on Ubuntu 20.04, the problem seems to be gcc 9.3.0-17. Work around that by running on Ubuntu 18.04 instead.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
