### PR TITLE
BUG: Fix <complex 0>^{non-zero}

### DIFF
--- a/doc/release/upcoming_changes/18535.improvement.rst
+++ b/doc/release/upcoming_changes/18535.improvement.rst
@@ -1,6 +1,6 @@
 Fix power of complex zero
 -------------------------
-``np.power`` now returns a IEEE 754-compliant result for ``0^{non-zero}``
+``np.power`` now returns a different result for ``0^{non-zero}``
 for complex numbers.  Note that the value is only defined when
 the real part of the exponent is larger than zero.
 Previously, NaN was returned unless the imaginary part was strictly

--- a/doc/release/upcoming_changes/18535.improvement.rst
+++ b/doc/release/upcoming_changes/18535.improvement.rst
@@ -4,5 +4,4 @@ Fix power of complex zero
 for complex numbers.  Note that the value is only defined when
 the real part of the exponent is larger than zero.
 Previously, NaN was returned unless the imaginary part was strictly
-zero.  Now a zero value is returned, with the sign bit
-set.  The return value is either ``0+0j`` or ``0-0j``.
+zero.  The return value is either ``0+0j`` or ``0-0j``.

--- a/doc/release/upcoming_changes/18535.improvement.rst
+++ b/doc/release/upcoming_changes/18535.improvement.rst
@@ -1,0 +1,3 @@
+Complex exponentiation bug fixed
+=================================
+Fixed #18378. ``np.power`` now returns the correct result for 0^{non-zero} complex numbers.

--- a/doc/release/upcoming_changes/18535.improvement.rst
+++ b/doc/release/upcoming_changes/18535.improvement.rst
@@ -1,3 +1,8 @@
-Complex exponentiation bug fixed
-=================================
-Fixed #18378. ``np.power`` now returns the correct result for 0^{non-zero} complex numbers.
+Fix power of complex zero
+-------------------------
+``np.power`` now returns the correct result for ``0^{non-zero}``
+for complex numbers.  Note that the value is only defined when
+the real part of the exponent is larger than zero.
+Previously, NaN was returned unless the imaginary part was strictly
+zero.  Now the correct zero value is returned, with the sign bit
+set.  The return value is either ``0+0j`` or ``0-0j``.

--- a/doc/release/upcoming_changes/18535.improvement.rst
+++ b/doc/release/upcoming_changes/18535.improvement.rst
@@ -1,8 +1,8 @@
 Fix power of complex zero
 -------------------------
-``np.power`` now returns the correct result for ``0^{non-zero}``
+``np.power`` now returns a IEEE 754-compliant result for ``0^{non-zero}``
 for complex numbers.  Note that the value is only defined when
 the real part of the exponent is larger than zero.
 Previously, NaN was returned unless the imaginary part was strictly
-zero.  Now the correct zero value is returned, with the sign bit
+zero.  Now a zero value is returned, with the sign bit
 set.  The return value is either ``0+0j`` or ``0-0j``.

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -446,7 +446,7 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     @ctype@ r;
 
     //Checking if in a^b, if b is zero.
-    //If a is not zero then by definition of logarithm a^0 is zero.
+    //If a is not zero then by definition of logarithm a^0 is one.
     //If a is also zero then as per IEEE 0^0 is best defined as 1.
     if(br == 0. && bi == 0.){
         return npy_cpack@c@(1.,0.);
@@ -460,6 +460,10 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
             return npy_cpack@c@(0.,0.);
         }
         else{
+            //Generating an invalid
+            volatile @type@ tmp=NPY_INFINITY@C@;
+            tmp-=NPY_INFINITY@C@;
+            ar=tmp;
             return npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
         }
     }

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -445,28 +445,22 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     @type@ bi = npy_cimag@c@(b);
     @ctype@ r;
 
-    if (br == 0. && bi == 0.) {
-        return npy_cpack@c@(1., 0.);
+    //Checking if in a^b, if b is zero.
+    //If a is not zero then by definition of logarithm a^0 is zero.
+    //If a is also zero then as per IEEE 0^0 is best defined as 1.
+    if(br == 0. && bi == 0.){
+        return npy_cpack@c@(1.,0.);
     }
-    if (ar == 0. && ai == 0.) {
-        if (br > 0 && bi == 0) {
-            return npy_cpack@c@(0., 0.);
+    //Here it is already tested that for a^b, b is not zero.
+    //So we are checking behaviour of a.
+    else if(ar == 0. && ai == 0.){
+        //Checking if real part of power is greater than zero then the result is zero.
+        //If not the result is undefined as it blows up or oscillates.
+        if(br > 0){
+            return npy_cpack@c@(0.,0.);
         }
-        else {
-            volatile @type@ tmp = NPY_INFINITY@C@;
-            /*
-             * NB: there are four complex zeros; c0 = (+-0, +-0), so that
-             * unlike for reals, c0**p, with `p` negative is in general
-             * ill-defined.
-             *
-             *     c0**z with z complex is also ill-defined.
-             */
-            r = npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
-
-            /* Raise invalid */
-            tmp -= NPY_INFINITY@C@;
-            ar = tmp;
-            return r;
+        else{
+            return npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
         }
     }
     if (bi == 0 && (n=(npy_intp)br) == br) {

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -445,17 +445,17 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     @type@ bi = npy_cimag@c@(b);
     @ctype@ r;
 
-    //Checking if in a^b, if b is zero.
-    //If a is not zero then by definition of logarithm a^0 is one.
-    //If a is also zero then as per IEEE 0^0 is best defined as 1.
+    /*Checking if in a^b, if b is zero.
+    If a is not zero then by definition of logarithm a^0 is one.
+    If a is also zero then as per IEEE 0^0 is best defined as 1.*/
     if(br == 0. && bi == 0.){
         return npy_cpack@c@(1.,0.);
     }
-    //Here it is already tested that for a^b, b is not zero.
-    //So we are checking behaviour of a.
+    /*Here it is already tested that for a^b, b is not zero.
+    So we are checking behaviour of a.*/
     else if(ar == 0. && ai == 0.){
-        //Checking if real part of power is greater than zero then the result is zero.
-        //If not the result is undefined as it blows up or oscillates.
+        /*Checking if real part of power is greater than zero then the result is zero.
+        If not the result is undefined as it blows up or oscillates.*/
         if(br > 0){
             return npy_cpack@c@(0.,0.);
         }

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -448,7 +448,7 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     /*
      * Checking if in a^b, if b is zero.
      * If a is not zero then by definition of logarithm a^0 is 1.
-     * If a is also zero then as per IEEE 754 0^0 is best defined as 1.
+     * If a is also zero then 0^0 is best defined as 1.
      */
     if (br == 0. && bi == 0.) {
         return npy_cpack@c@(1., 0.);

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -462,32 +462,26 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
      */
     else if (ar == 0. && ai == 0.) {
         /* 
-         * If br > 0 then result is 0 but contains sign opposite
-         * of bi.
-         * Else the result is undefined and we return (nan,nan)
+         * If the real part of b is positive (br>0) then this is
+         * the zero complex with positive sign on both the
+         * real and imaginary part.
          */
          if (br > 0) {
-             if (bi < 0) {
-                 return npy_cpack@c@(0., 0.);
-             }
-             else {
-                 return npy_cpack@c@(0., -0.);
-             }
-             
+             return npy_cpack@c@(0., 0.);
          }
-         else {
-             /* 
-              * Raising an invalid and returning
-              * (nan, nan)
-              */
-              volatile @type@ tmp = NPY_INFINITY@C@;
-              r = npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
-
-              /* Raise invalid */
-              tmp -= NPY_INFINITY@C@;
-              ar = tmp;
-              return r;
-         }
+        /* else we are in the case where the
+         * real part of b is negative (br<0).
+         * Here we should return a complex nan
+         * and raise FloatingPointError: invalid value...
+         */
+         
+         /* Raise invalid value by calling inf - inf*/
+          volatile @type@ tmp = NPY_INFINITY@C@;
+          tmp -= NPY_INFINITY@C@;
+          ar = tmp;
+          
+          r = npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
+          return r;
     }
     if (bi == 0 && (n=(npy_intp)br) == br) {
         if (n == 1) {

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -445,27 +445,46 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     @type@ bi = npy_cimag@c@(b);
     @ctype@ r;
 
-    /*Checking if in a^b, if b is zero.
-    If a is not zero then by definition of logarithm a^0 is one.
-    If a is also zero then as per IEEE 0^0 is best defined as 1.*/
-    if(br == 0. && bi == 0.){
-        return npy_cpack@c@(1.,0.);
+    /*
+     * Checking if in a^b, if b is zero.
+     * If a is not zero then by definition of logarithm a^0 is 1.
+     * If a is also zero then as per IEEE 0^0 is best defined as 1.
+     */
+    if (br == 0. && bi == 0.) {
+        return npy_cpack@c@(1., 0.);
     }
-    /*Here it is already tested that for a^b, b is not zero.
-    So we are checking behaviour of a.*/
-    else if(ar == 0. && ai == 0.){
-        /*Checking if real part of power is greater than zero then the result is zero.
-        If not the result is undefined as it blows up or oscillates.*/
-        if(br > 0){
-            return npy_cpack@c@(0.,0.);
-        }
-        else{
-            //Generating an invalid
-            volatile @type@ tmp=NPY_INFINITY@C@;
-            tmp-=NPY_INFINITY@C@;
-            ar=tmp;
-            return npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
-        }
+    /*
+     * If mantissa is zero, then result depends upon values of 
+     * br and bi. The result is either 0 (in magnitude) or 
+     * undefined ( or 1 for br=bi=0 and independent of ar and ai
+     * but that case is handled above).
+     */
+    else if (ar == 0. && ai == 0.) {
+        /* If br > 0 then result is 0 but contains sign opposite
+         * of bi.
+         * Else the result is undefined and we return (nan,nan)
+         */
+         if ( br > 0) {
+             if (bi < 0) {
+                 return npy_cpack@c@(0., 0.);
+             }
+             else {
+                 return npy_cpack@c@(0., -0.);
+             }
+             
+         }
+         else {
+             /* Raising an invalid and returning
+              * (nan, nan)
+              */
+              volatile @type@ tmp = NPY_INFINITY@C@;
+              r = npy_cpack@c@(NPY_NAN@C@, NPY_NAN@C@);
+
+              /* Raise invalid */
+              tmp -= NPY_INFINITY@C@;
+              ar = tmp;
+              return r;
+         }
     }
     if (bi == 0 && (n=(npy_intp)br) == br) {
         if (n == 1) {

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -448,7 +448,7 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     /*
      * Checking if in a^b, if b is zero.
      * If a is not zero then by definition of logarithm a^0 is 1.
-     * If a is also zero then as per IEEE 0^0 is best defined as 1.
+     * If a is also zero then as per IEEE 754 0^0 is best defined as 1.
      */
     if (br == 0. && bi == 0.) {
         return npy_cpack@c@(1., 0.);

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -460,11 +460,12 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
      * but that case is handled above).
      */
     else if (ar == 0. && ai == 0.) {
-        /* If br > 0 then result is 0 but contains sign opposite
+        /* 
+         * If br > 0 then result is 0 but contains sign opposite
          * of bi.
          * Else the result is undefined and we return (nan,nan)
          */
-         if ( br > 0) {
+         if (br > 0) {
              if (bi < 0) {
                  return npy_cpack@c@(0., 0.);
              }
@@ -474,7 +475,8 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
              
          }
          else {
-             /* Raising an invalid and returning
+             /* 
+              * Raising an invalid and returning
               * (nan, nan)
               */
               volatile @type@ tmp = NPY_INFINITY@C@;

--- a/numpy/core/src/npymath/npy_math_complex.c.src
+++ b/numpy/core/src/npymath/npy_math_complex.c.src
@@ -453,11 +453,12 @@ npy_cpow@c@ (@ctype@ a, @ctype@ b)
     if (br == 0. && bi == 0.) {
         return npy_cpack@c@(1., 0.);
     }
-    /*
-     * If mantissa is zero, then result depends upon values of 
-     * br and bi. The result is either 0 (in magnitude) or 
-     * undefined ( or 1 for br=bi=0 and independent of ar and ai
-     * but that case is handled above).
+    /* case 0^b
+     * If a is a complex zero (ai=ar=0), then the result depends 
+     * upon values of br and bi. The result is either:
+     * 0 (in magnitude), undefined or 1.
+     * The later case is for br=bi=0 and independent of ar and ai
+     * but is handled above).
      */
     else if (ar == 0. && ai == 0.) {
         /* 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -856,12 +856,13 @@ class TestPower:
         assert_complex_equal(np.power(zero, 1-1j), zero)
         #Complex powers will negative real part or 0 (provided imaginary 
         # part is not zero) will generate a NAN and hence a RUNTIME warning
-        with pytest.warns(expected_warning=RuntimeWarning):
+        with pytest.warns(expected_warning=RuntimeWarning) as r:
             assert_complex_equal(np.power(zero, -1+1j), cnan)
             assert_complex_equal(np.power(zero, -2-3j), cnan)
             assert_complex_equal(np.power(zero, -7+0j), cnan)
             assert_complex_equal(np.power(zero, 0+1j), cnan)
             assert_complex_equal(np.power(zero, 0-1j), cnan)
+        assert len(r) == 5
 
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -840,7 +840,7 @@ class TestPower:
 
     # Testing 0^{Non-zero} issue 18378
     def test_zero_power_nonzero(self):
-        zero = np.array([0j])
+        zero = np.array([0.0j])
         cnan = np.array([complex(np.nan, np.nan)])
 
         def assert_complex_equal(x, y):
@@ -850,11 +850,18 @@ class TestPower:
         #Complex powers with positive real part will not generate a warning
         assert_complex_equal(np.power(zero, 1+4j), zero)
         assert_complex_equal(np.power(zero, 2-3j), zero)
-        #Complex powers will negative real part will generate a NAN
-        #and hence a RUNTIME warning
+        #Testing zero values when real part is greater than zero
+        assert_complex_equal(np.power(zero, 1+1j), -zero)
+        assert_complex_equal(np.power(zero, 1+0j), -zero)
+        assert_complex_equal(np.power(zero, 1-1j), zero)
+        #Complex powers will negative real part or 0 (provided imaginary 
+        # part is not zero) will generate a NAN and hence a RUNTIME warning
         with pytest.warns(expected_warning=RuntimeWarning):
             assert_complex_equal(np.power(zero, -1+1j), cnan)
             assert_complex_equal(np.power(zero, -2-3j), cnan)
+            assert_complex_equal(np.power(zero, -7+0j), cnan)
+            assert_complex_equal(np.power(zero, 0+1j), cnan)
+            assert_complex_equal(np.power(zero, 0-1j), cnan)
 
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -847,28 +847,14 @@ class TestPower:
             assert_array_equal(x.real, y.real)
             assert_array_equal(x.imag, y.imag)
 
-        with pytest.warns(None) as record_pp:
-            #real part and imaginary part both greater than zero
-            #This case should not generate any warning
-            assert_complex_equal(np.power(zero,1+4j),zero)
-        assert len(record_pp)==0
-        with pytest.warns(None) as record_pn: 
-            #real part greater than zero imag part less than zero
-            #This case should not generate any warning
-            assert_complex_equal(np.power(zero,2-3j),zero)
-        assert len(record_pn)==0
-        with pytest.warns(None) as record_np:
-            #real part less than zero imag part greater than zero
-            #This case will generate a warning
+        #Complex powers with positive real part will not generate a warning
+        assert_complex_equal(np.power(zero,1+4j),zero)
+        assert_complex_equal(np.power(zero,2-3j),zero)
+        #Complex powers will negative real part will generate a NAN
+        #and hence a RUNTIME warning
+        with pytest.warns(expected_warning=RuntimeWarning):
             assert_complex_equal(np.power(zero,-1+1j),cnan)
-        assert len(record_np)==1
-        assert record_np[0].message.args[0]=="invalid value encountered in power"
-        with pytest.warns(None) as record_nn:
-            #real part less than zero imag part less than zero
-            #This case will generate a warning
             assert_complex_equal(np.power(zero,-2-3j),cnan)
-        assert len(record_nn)==1
-        assert record_nn[0].message.args[0]=="invalid value encountered in power"
 
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -841,20 +841,20 @@ class TestPower:
     # Testing 0^{Non-zero} issue 18378
     def test_zero_power_nonzero(self):
         zero = np.array([0j])
-        cnan = np.array([complex(np.nan,np.nan)])
+        cnan = np.array([complex(np.nan, np.nan)])
 
         def assert_complex_equal(x, y):
             assert_array_equal(x.real, y.real)
             assert_array_equal(x.imag, y.imag)
 
         #Complex powers with positive real part will not generate a warning
-        assert_complex_equal(np.power(zero,1+4j),zero)
-        assert_complex_equal(np.power(zero,2-3j),zero)
+        assert_complex_equal(np.power(zero, 1+4j), zero)
+        assert_complex_equal(np.power(zero, 2-3j), zero)
         #Complex powers will negative real part will generate a NAN
         #and hence a RUNTIME warning
         with pytest.warns(expected_warning=RuntimeWarning):
-            assert_complex_equal(np.power(zero,-1+1j),cnan)
-            assert_complex_equal(np.power(zero,-2-3j),cnan)
+            assert_complex_equal(np.power(zero, -1+1j), cnan)
+            assert_complex_equal(np.power(zero, -2-3j), cnan)
 
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -838,6 +838,25 @@ class TestPower:
                 assert_complex_equal(np.power(zero, -p), cnan)
             assert_complex_equal(np.power(zero, -1+0.2j), cnan)
 
+    # Testing 0^{Non-zero} issue 18378
+    def test_zero_power_nonzero(self):
+        zero = np.array([0j])
+        cnan = np.array([complex(np.nan,np.nan)])
+
+        def assert_complex_equal(x, y):
+            assert_array_equal(x.real, y.real)
+            assert_array_equal(x.imag, y.imag)
+
+        with np.errstate(invalid="ignore"):
+            #real part and imaginary part both greater than zero
+            assert_complex_equal(np.power(zero,1+4j),zero)
+            #real part greater than zero imag part less than zero
+            assert_complex_equal(np.power(zero,2-3j),zero)
+            #real part less than zero imag part greater than zero
+            assert_complex_equal(np.power(zero,-1+1j),cnan)
+            #real part less than zero imag part less than zero
+            assert_complex_equal(np.power(zero,-2-3j),cnan)
+
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)
         res = x**2.0

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -847,15 +847,28 @@ class TestPower:
             assert_array_equal(x.real, y.real)
             assert_array_equal(x.imag, y.imag)
 
-        with np.errstate(invalid="ignore"):
+        with pytest.warns(None) as record_pp:
             #real part and imaginary part both greater than zero
+            #This case should not generate any warning
             assert_complex_equal(np.power(zero,1+4j),zero)
+        assert len(record_pp)==0
+        with pytest.warns(None) as record_pn: 
             #real part greater than zero imag part less than zero
+            #This case should not generate any warning
             assert_complex_equal(np.power(zero,2-3j),zero)
+        assert len(record_pn)==0
+        with pytest.warns(None) as record_np:
             #real part less than zero imag part greater than zero
+            #This case will generate a warning
             assert_complex_equal(np.power(zero,-1+1j),cnan)
+        assert len(record_np)==1
+        assert record_np[0].message.args[0]=="invalid value encountered in power"
+        with pytest.warns(None) as record_nn:
             #real part less than zero imag part less than zero
+            #This case will generate a warning
             assert_complex_equal(np.power(zero,-2-3j),cnan)
+        assert len(record_nn)==1
+        assert record_nn[0].message.args[0]=="invalid value encountered in power"
 
     def test_fast_power(self):
         x = np.array([1, 2, 3], np.int16)

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -840,7 +840,7 @@ class TestPower:
 
     # Testing 0^{Non-zero} issue 18378
     def test_zero_power_nonzero(self):
-        zero = np.array([0.0j])
+        zero = np.array([0.0+0.0j])
         cnan = np.array([complex(np.nan, np.nan)])
 
         def assert_complex_equal(x, y):
@@ -851,8 +851,8 @@ class TestPower:
         assert_complex_equal(np.power(zero, 1+4j), zero)
         assert_complex_equal(np.power(zero, 2-3j), zero)
         #Testing zero values when real part is greater than zero
-        assert_complex_equal(np.power(zero, 1+1j), -zero)
-        assert_complex_equal(np.power(zero, 1+0j), -zero)
+        assert_complex_equal(np.power(zero, 1+1j), zero)
+        assert_complex_equal(np.power(zero, 1+0j), zero)
         assert_complex_equal(np.power(zero, 1-1j), zero)
         #Complex powers will negative real part or 0 (provided imaginary 
         # part is not zero) will generate a NAN and hence a RUNTIME warning


### PR DESCRIPTION
The IEEE standard 754 2008 is used in the development of floating-point libraries.  
The 0^0 case is discussed in [Wikipedia](https://en.wikipedia.org/wiki/Zero_to_the_power_of_zero#IEEE_floating-point_standard).
For the case of 0^non-zero, the result is the same as that of C99.  
Side note: C99 for negative real in complex powers generates inf + nan but we are generating nan + nan as  
it is consistent with our previous warning. 
Resolves #18378.