### PR TITLE
Fix the numpy Apple M1 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
+    "packaging==20.5",
     "setuptools<49.2.0",
     "wheel==0.36.2",
     "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "packaging==20.5",
+    "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools<49.2.0",
     "wheel==0.36.2",
     "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
@@ -74,4 +74,3 @@ requires = [
         directory = "change"
         name = "Changes"
         showcontent = true
-


### PR DESCRIPTION
There was a build issue on numpy with M1:
AssertionError: would build wheel with unsupported tag ('cp39', 'cp39', 'macosx_11_0_universal2')

The issue was fixed in the packaging 20.5 and onwards, but that was not
getting picked by setuptools. So explicitly adding this dependency in
the toml file. The change was tested with:

```
python3 -m pip install --force-reinstall .
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
