### PR TITLE
BUG: NameError in numpy.distutils.fcompiler.compaq

### DIFF
--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -80,8 +80,8 @@ class CompaqVisualFCompiler(FCompiler):
         except DistutilsPlatformError:
             pass
         except AttributeError as e:
-            if '_MSVCCompiler__root' in str(msg):
-                print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (msg))
+            if '_MSVCCompiler__root' in str(e):
+                print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (e))
             else:
                 raise
         except IOError as e:


### PR DESCRIPTION
Fix a simple mistake in commit da0497fdf35 which produces a NameError when building numpy in MinGW-w64/MSYS2.

(note: there are still other issues preventing me from achieving a successful installation in MinGW-w64/MSYS2, but the other problems are perhaps not as straightforward as this one so I'll be making an issue for them)