### PR TITLE
CI: Pin docker image for Linux_Python_38_32bit_full_with_asserts test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,12 +63,11 @@ stages:
 
   - job: Linux_Python_38_32bit_full_with_asserts
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - script: |
-            docker pull quay.io/pypa/manylinux2010_i686
             docker run -v $(pwd):/numpy -e CFLAGS="-msse2 -std=c99 -UNDEBUG" \
-            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686 \
+            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686:2021-02-28-1f32361 \
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \


### PR DESCRIPTION
The azure-pipeline test Linux_Python_38_32bit_full_with_asserts has
been failing after the release of the latest manylinux2010. Pin
the docker image to `quay.io/pypa/manylinux2010_i686:2021-02-28-1f32361`
to fix this.

Closes #18553.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
