### PR TITLE
CI: Backport CI fixes from main.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -80,7 +80,7 @@ jobs:
 
   full:
     needs: smoke_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       USE_WHEEL: 1
       RUN_FULL_TESTS: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,12 +39,11 @@ stages:
 
   - job: Linux_Python_38_32bit_full_with_asserts
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
     - script: |
-            docker pull quay.io/pypa/manylinux2010_i686
             docker run -v $(pwd):/numpy -e CFLAGS="-msse2 -std=c99 -UNDEBUG" \
-            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686 \
+            -e F77=gfortran-5 -e F90=gfortran-5 quay.io/pypa/manylinux2010_i686:2021-02-28-1f32361 \
             /bin/bash -xc "cd numpy && \
             /opt/python/cp38-cp38/bin/python -mvenv venv &&\
             source venv/bin/activate && \


### PR DESCRIPTION
Backport CI fixes from main.

- #18554: The azure-pipeline test Linux_Python_38_32bit_full_with_asserts has
been failing after the release of the latest manylinux2010. Pin
the docker image to quay.io/pypa/manylinux2010_i686:2021-02-28-1f32361
to fix this.
- #18531: NumPy does not build using the --coverage flag on Ubuntu 20.04, the problem seems to be gcc 9.3.0-17. Work around that by running on Ubuntu 18.04 instead.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
