### PR TITLE
BUG: Fixed ``where`` keyword for ``np.mean`` & ``np.var`` methods

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -165,7 +165,8 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     is_float16_result = False
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
-    if (where is True and rcount == 0) or (where is not True and _any(rcount == 0)):
+    if (where is True and rcount == 0) or \
+            (where is not True and umr_any(rcount == 0, axis=None)):
         warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
 
     # Cast bool, unsigned int, and int to float64 by default
@@ -198,7 +199,8 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
     # Make this warning show up on top.
-    if (where is True and ddof >= rcount) or (where is not True and _any(ddof >= rcount)):
+    if (where is True and ddof >= rcount) or \
+            (where is not True and umr_any(ddof >= rcount, axis=None)):
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning,
                       stacklevel=2)
 

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -165,7 +165,7 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     is_float16_result = False
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
-    if rcount == 0 if where is True else umr_any(rcount == 0):
+    if (where is True and rcount == 0) or (where is not True and _any(rcount == 0)):
         warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
 
     # Cast bool, unsigned int, and int to float64 by default
@@ -198,7 +198,7 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
     # Make this warning show up on top.
-    if ddof >= rcount if where is True else umr_any(ddof >= rcount):
+    if (where is True and ddof >= rcount) or (where is not True and _any(ddof >= rcount)):
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning,
                       stacklevel=2)
 

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -165,8 +165,7 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     is_float16_result = False
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
-    if (where is True and rcount == 0) or \
-            (where is not True and umr_any(rcount == 0, axis=None)):
+    if rcount == 0 if where is True else umr_any(rcount == 0, axis=None):
         warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
 
     # Cast bool, unsigned int, and int to float64 by default
@@ -199,8 +198,7 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
     # Make this warning show up on top.
-    if (where is True and ddof >= rcount) or \
-            (where is not True and umr_any(ddof >= rcount, axis=None)):
+    if ddof >= rcount if where is True else umr_any(ddof >= rcount, axis=None):
         warnings.warn("Degrees of freedom <= 0 for slice", RuntimeWarning,
                       stacklevel=2)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5720,6 +5720,15 @@ class TestStats:
                             np.array(_res))
             assert_allclose(np.mean(a, axis=_ax, where=_wh),
                             np.array(_res))
+
+        a3d = np.arange(16).reshape((2, 2, 4))
+        _wh_partial = np.array([False, True, True, False])
+        _res = [[1.5, 5.5], [9.5, 13.5]]
+        assert_allclose(a3d.mean(axis=2, where=_wh_partial),
+                        np.array(_res))
+        assert_allclose(np.mean(a3d, axis=2, where=_wh_partial),
+                        np.array(_res))
+
         with pytest.warns(RuntimeWarning) as w:
             assert_allclose(a.mean(axis=1, where=wh_partial),
                             np.array([np.nan, 5.5, 9.5, np.nan]))

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5804,6 +5804,15 @@ class TestStats:
                             np.array(_res))
             assert_allclose(np.var(a, axis=_ax, where=_wh),
                             np.array(_res))
+
+        a3d = np.arange(16).reshape((2, 2, 4))
+        _wh_partial = np.array([False, True, True, False])
+        _res = [[0.25, 0.25], [0.25, 0.25]]
+        assert_allclose(a3d.var(axis=2, where=_wh_partial),
+                        np.array(_res))
+        assert_allclose(np.var(a3d, axis=2, where=_wh_partial),
+                        np.array(_res))
+
         assert_allclose(np.var(a, axis=1, where=wh_full),
                         np.var(a[wh_full].reshape((5, 3)), axis=1))
         assert_allclose(np.var(a, axis=0, where=wh_partial),
@@ -5842,6 +5851,14 @@ class TestStats:
         for _ax, _wh, _res in _cases:
             assert_allclose(a.std(axis=_ax, where=_wh), _res)
             assert_allclose(np.std(a, axis=_ax, where=_wh), _res)
+
+        a3d = np.arange(16).reshape((2, 2, 4))
+        _wh_partial = np.array([False, True, True, False])
+        _res = [[0.5, 0.5], [0.5, 0.5]]
+        assert_allclose(a3d.std(axis=2, where=_wh_partial),
+                        np.array(_res))
+        assert_allclose(np.std(a3d, axis=2, where=_wh_partial),
+                        np.array(_res))
 
         assert_allclose(a.std(axis=1, where=whf),
                         np.std(a[whf].reshape((5,3)), axis=1))


### PR DESCRIPTION
Addresses #18552 

Hi @seberg!

I've managed to fix `where` keyword issue by refactoring those if statements.

So the `rcount` is a scalar when `where` is not provided as we reduce equal number of elements for given axis (or axes). So the first `and` statement prevents from illegal comparison of array to 0 value that caused original error. If the `where` clause is provided and `rcount` is an array (as we might want to reduce different number of elements along axis due to masking) then we check second `and` statement if any of those reduce groups are zero. I also maintained this micro-optimization to avoid calling `_any(rcount == 0)` when `where is True` and not zero.

Is this correct?

Also I had to change `umr_any` to `_any` as I think there is another bug there (or `umr_any` shouldn't be used there). `np.any` without `axis` parameter evaluates to scalar value (that can be used in `if` statement). But `umr_any` does not behave that way - it only reduces one dimension. Here's code for reproducing:

```python
import numpy as np
from numpy.core import umath as um
a = np.ones((3,4))

# used in numpy/core/_methods.py
umr_any = um.logical_or.reduce

# np.any works as expected
if np.any(a == 0):
    pass

# but umr_any can't be used in if statement as here in `_mean`
if umr_any(a == 0):
    pass
```

Here's a colab reproduction: https://colab.research.google.com/drive/1UJi6E50zzaLu2nZQWMEFHPLZnq2v6pzT?usp=sharing

Thank you for any help!