### PR TITLE
BUG: fix nanpercentile returns incorrect shape when input empty array

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1363,7 +1363,8 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # apply_along_axis in _nanpercentile doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
-        return np.nanmean(a, axis, out=out, keepdims=keepdims)
+        r = np.nanmean(a, axis, out=out, keepdims=keepdims)
+        return np.broadcast_to(r, q.shape + r.shape)
 
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1363,8 +1363,14 @@ def _nanquantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
     # apply_along_axis in _nanpercentile doesn't handle empty arrays well,
     # so deal them upfront
     if a.size == 0:
-        r = np.nanmean(a, axis, out=out, keepdims=keepdims)
-        return np.broadcast_to(r, q.shape + r.shape)
+        if np.isscalar(q):
+            return np.nanmean(a, axis, out=out, keepdims=keepdims)
+        else:
+            r = np.nanmean(a, axis, keepdims=keepdims)
+            result = np.broadcast_to(r, q.shape + r.shape)
+            if out is not None:
+                np.copyto(out, result)
+            return result
 
     r, k = function_base._ureduce(
         a, func=_nanquantile_ureduce_func, q=q, axis=axis, out=out,

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -850,12 +850,22 @@ class TestNanFunctions_Percentile:
                 assert_(len(w) == 0)
 
     # gh-18158
-    def test_empty_shape(self):
+    def test_shape_from_empty_array(self):
         mat = np.zeros((0, 1))
         with suppress_warnings() as sup:
             sup.filter(RuntimeWarning)
             res = np.nanpercentile(mat, [50, 99], axis=1)
             assert_equal(res.shape, (2, 0))
+
+    # gh-18746
+    def test_out_with_keepdims(self):
+        mat = np.zeros((3, 4, 2))
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            res = np.nanpercentile(mat, [50, 99], axis=0, keepdims=True)
+            resout = np.zeros(res.shape)
+            np.nanpercentile(mat, [50, 99], axis=0, keepdims=True, out=resout)
+            assert_almost_equal(res, resout)
 
     def test_scalar(self):
         assert_equal(np.nanpercentile(0., 100), 0.)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -849,6 +849,14 @@ class TestNanFunctions_Percentile:
                 assert_equal(np.nanpercentile(mat, 40, axis=axis), np.zeros([]))
                 assert_(len(w) == 0)
 
+    # gh-18158
+    def test_empty_shape(self):
+        mat = np.zeros((0, 1))
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            res = np.nanpercentile(mat, [50, 99], axis=1)
+            assert_equal(res.shape, (2, 0))
+
     def test_scalar(self):
         assert_equal(np.nanpercentile(0., 100), 0.)
         a = np.arange(6)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Here tries to fix the shape bug mentioned within gh-18158

> When the size of the first input (`a`) array is nonzero, the first dimension of the output always has length equal to that of the second input (`q`) , but that breaks down when the size of `a` is zero.

However this PR does not resolve 18158 yet, if there is a conclusion for Error vs NaN, I would try to do it in another PR

PS. here also fix another bug described in gh-18746