### PR TITLE
CI: Ensure that doc-build uses "main" as branch name

### DIFF
--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -44,7 +44,7 @@ def run(cmd, stdout=True):
 workdir = tempfile.mkdtemp()
 os.chdir(workdir)
 
-run(['git', 'init'])
+run(['git', 'init', '--initial-branch=main'])
 run(['git', 'remote', 'add', 'origin',  args.remote])
 run(['git', 'config', '--local', 'user.name', args.committer])
 run(['git', 'config', '--local', 'user.email', args.email])


### PR DESCRIPTION
The default of git is still "master", so we need to set
`--initial-branch=main` to ensure that we use the name `main`
that is used in the devdoc repository.

Closes gh-18568