### PR TITLE
CI: Use `git branch -m` instead of `--initial-branch=main`

### DIFF
--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -44,7 +44,8 @@ def run(cmd, stdout=True):
 workdir = tempfile.mkdtemp()
 os.chdir(workdir)
 
-run(['git', 'init', '--initial-branch=main'])
+run(['git', 'init'])
+run(['git', 'branch', '-m', 'master', 'main'])
 run(['git', 'remote', 'add', 'origin',  args.remote])
 run(['git', 'config', '--local', 'user.name', args.committer])
 run(['git', 'config', '--local', 'user.email', args.email])


### PR DESCRIPTION
It seems the git in the CircleCI environment does not have the
`--initial-branch` option that my local git has, hopefully
`git branch -m` works fine.

---

Is there a convenient way to test it? Locally the git repo is setup with the correct branch, so I assume it will work (but I did so for `--initial-branch=main` as well :)