### PR TITLE
CI: Set git default branch to "main" in CircleCI.

### DIFF
--- a/tools/ci/push_docs_to_repo.py
+++ b/tools/ci/push_docs_to_repo.py
@@ -45,7 +45,9 @@ workdir = tempfile.mkdtemp()
 os.chdir(workdir)
 
 run(['git', 'init'])
-run(['git', 'branch', '-m', 'master', 'main'])
+# ensure the working branch is called "main"
+# (`--initial-branch=main` appared to have failed on older git versions):
+run(['git', 'checkout', '-b', 'main'])
 run(['git', 'remote', 'add', 'origin',  args.remote])
 run(['git', 'config', '--local', 'user.name', args.committer])
 run(['git', 'config', '--local', 'user.email', args.email])


### PR DESCRIPTION
Should fix the current failure that "master" does not exist.
I am a bit curious why master does not exist, maybe the CircleCI
git is set up to use some other default?

---

I am starting to get confused, I just hope the branch name was actually at the core of the issue :) (although the error message does indicate so).