### PR TITLE
MAINT: OrderedDict is no longer necessary from Python 3.7

### DIFF
--- a/doc/source/reference/random/performance.py
+++ b/doc/source/reference/random/performance.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from timeit import repeat
 
 import pandas as pd
@@ -8,7 +7,7 @@ from numpy.random import MT19937, PCG64, Philox, SFC64
 
 PRNGS = [MT19937, PCG64, Philox, SFC64]
 
-funcs = OrderedDict()
+funcs = {}
 integers = 'integers(0, 2**{bits},size=1000000, dtype="uint{bits}")'
 funcs['32-bit Unsigned Ints'] = integers.format(bits=32)
 funcs['64-bit Unsigned Ints'] = integers.format(bits=64)
@@ -26,10 +25,10 @@ rg = Generator({prng}())
 """
 
 test = "rg.{func}"
-table = OrderedDict()
+table = {}
 for prng in PRNGS:
     print(prng)
-    col = OrderedDict()
+    col = {}
     for key in funcs:
         t = repeat(test.format(func=funcs[key]),
                    setup.format(prng=prng().__class__.__name__),
@@ -38,7 +37,7 @@ for prng in PRNGS:
     col = pd.Series(col)
     table[prng().__class__.__name__] = col
 
-npfuncs = OrderedDict()
+npfuncs = {}
 npfuncs.update(funcs)
 npfuncs['32-bit Unsigned Ints'] = 'randint(2**32,dtype="uint32",size=1000000)'
 npfuncs['64-bit Unsigned Ints'] = 'randint(2**64,dtype="uint64",size=1000000)'

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -98,10 +98,9 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
       File "<stdin>", line 1, in <module>
     FloatingPointError: overflow encountered in short_scalars
 
-    >>> from collections import OrderedDict
     >>> old_settings = np.seterr(all='print')
-    >>> OrderedDict(np.geterr())
-    OrderedDict([('divide', 'print'), ('over', 'print'), ('under', 'print'), ('invalid', 'print')])
+    >>> np.geterr()
+    {'divide': 'print', 'over': 'print', 'under': 'print', 'invalid': 'print'}
     >>> np.int16(32000) * np.int16(3)
     30464
 
@@ -153,15 +152,14 @@ def geterr():
 
     Examples
     --------
-    >>> from collections import OrderedDict
-    >>> sorted(np.geterr().items())
-    [('divide', 'warn'), ('invalid', 'warn'), ('over', 'warn'), ('under', 'ignore')]
+    >>> np.geterr()
+    {'divide': 'warn', 'over': 'warn', 'under': 'ignore', 'invalid': 'warn'}
     >>> np.arange(3.) / np.arange(3.)
     array([nan,  1.,  1.])
 
     >>> oldsettings = np.seterr(all='warn', over='raise')
-    >>> OrderedDict(sorted(np.geterr().items()))
-    OrderedDict([('divide', 'warn'), ('invalid', 'warn'), ('over', 'raise'), ('under', 'warn')])
+    >>> np.geterr()
+    {'divide': 'warn', 'over': 'raise', 'under': 'warn', 'invalid': 'warn'}
     >>> np.arange(3.) / np.arange(3.)
     array([nan,  1.,  1.])
 
@@ -270,7 +268,6 @@ def seterrcall(func):
 
     >>> saved_handler = np.seterrcall(err_handler)
     >>> save_err = np.seterr(all='call')
-    >>> from collections import OrderedDict
 
     >>> np.array([1, 2, 3]) / 0.0
     Floating point error (divide by zero), with flag 1
@@ -278,8 +275,8 @@ def seterrcall(func):
 
     >>> np.seterrcall(saved_handler)
     <function err_handler at 0x...>
-    >>> OrderedDict(sorted(np.seterr(**save_err).items()))
-    OrderedDict([('divide', 'call'), ('invalid', 'call'), ('over', 'call'), ('under', 'call')])
+    >>> np.seterr(**save_err)
+    {'divide': 'call', 'over': 'call', 'under': 'call', 'invalid': 'call'}
 
     Log error message:
 
@@ -298,8 +295,8 @@ def seterrcall(func):
 
     >>> np.seterrcall(saved_handler)
     <numpy.core.numeric.Log object at 0x...>
-    >>> OrderedDict(sorted(np.seterr(**save_err).items()))
-    OrderedDict([('divide', 'log'), ('invalid', 'log'), ('over', 'log'), ('under', 'log')])
+    >>> np.seterr(**save_err)
+    {'divide': 'log', 'over': 'log', 'under': 'log', 'invalid': 'log'}
 
     """
     if func is not None and not isinstance(func, collections.abc.Callable):
@@ -402,7 +399,6 @@ class errstate(contextlib.ContextDecorator):
 
     Examples
     --------
-    >>> from collections import OrderedDict
     >>> olderr = np.seterr(all='ignore')  # Set error handling to known state.
 
     >>> np.arange(3) / 0.
@@ -421,8 +417,8 @@ class errstate(contextlib.ContextDecorator):
 
     Outside the context the error handling behavior has not changed:
 
-    >>> OrderedDict(sorted(np.geterr().items()))
-    OrderedDict([('divide', 'ignore'), ('invalid', 'ignore'), ('over', 'ignore'), ('under', 'ignore')])
+    >>> np.geterr()
+    {'divide': 'ignore', 'over': 'ignore', 'under': 'ignore', 'invalid': 'ignore'}
 
     """
 

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -35,7 +35,7 @@ Record arrays allow us to access fields as properties::
 """
 import os
 import warnings
-from collections import Counter, OrderedDict
+from collections import Counter
 from contextlib import nullcontext
 
 from . import numeric as sb
@@ -75,23 +75,12 @@ _byteorderconv = {'b':'>',
 
 numfmt = nt.typeDict
 
-# taken from OrderedDict recipes in the Python documentation
-# https://docs.python.org/3.3/library/collections.html#ordereddict-examples-and-recipes
-class _OrderedCounter(Counter, OrderedDict):
-    """Counter that remembers the order elements are first encountered"""
-
-    def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, OrderedDict(self))
-
-    def __reduce__(self):
-        return self.__class__, (OrderedDict(self),)
-
 
 def find_duplicate(list):
     """Find duplication in a list, return a list of duplicated elements"""
     return [
         item
-        for item, counts in _OrderedCounter(list).items()
+        for item, counts in Counter(list).items()
         if counts > 1
     ]
 

--- a/numpy/testing/_private/parameterized.py
+++ b/numpy/testing/_private/parameterized.py
@@ -37,11 +37,6 @@ from functools import wraps
 from types import MethodType
 from collections import namedtuple
 
-try:
-    from collections import OrderedDict as MaybeOrderedDict
-except ImportError:
-    MaybeOrderedDict = dict
-
 from unittest import TestCase
 
 _param = namedtuple("param", "args kwargs")
@@ -113,13 +108,6 @@ class param(_param):
         return "param(*%r, **%r)" %self
 
 
-class QuietOrderedDict(MaybeOrderedDict):
-    """ When OrderedDict is available, use it to make sure that the kwargs in
-        doc strings are consistently ordered. """
-    __str__ = dict.__str__
-    __repr__ = dict.__repr__
-
-
 def parameterized_argument_value_pairs(func, p):
     """Return tuples of parameterized arguments and their values.
 
@@ -165,7 +153,7 @@ def parameterized_argument_value_pairs(func, p):
     ])
 
     seen_arg_names = {n for (n, _) in result}
-    keywords = QuietOrderedDict(sorted([
+    keywords = dict(sorted([
         (name, p.kwargs[name])
         for name in p.kwargs
         if name not in seen_arg_names


### PR DESCRIPTION
Since Python 3.7, [`OrderedDict`](https://docs.python.org/3.7/library/collections.html#ordereddict-objects) has largely been superseded by the `dict` built-in. This PR removes the need for `OrderedDict` in NumPy, including a few custom derived classes.

In `numpy/core/records.py`, a class `_OrderedCounter` is borrowed from a [Python 3.3 recipe](https://docs.python.org/3.3/library/collections.html#ordereddict-examples-and-recipes), which has been removed for Python 3.7. A quick verification shows that Python 3.7's `Counter` natively preserves insertion order, so there is no further need for this extended class based on `OrderedDict`.