### PR TITLE
BLD, TST: use pypy nightly to work around bug

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -211,7 +211,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: pypy-3.7
+        python-version: pypy-3.7-nightly
     - uses: ./.github/actions
 
   sdist:


### PR DESCRIPTION
PR gh-18439 exposed a bug in PyPy that was fixed. Use a nightly PyPy release until the next official one.