### PR TITLE
DOC: Clarify docs for fliplr() / flipud()

### DIFF
--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -47,10 +47,11 @@ def _flip_dispatcher(m):
 @array_function_dispatch(_flip_dispatcher)
 def fliplr(m):
     """
-    Flip array in the left/right direction.
+    Reverse the order of elements along axis 1 (left/right).
 
-    Flip the entries in each row in the left/right direction.
-    Columns are preserved, but appear in a different order than before.
+    For a 2-D array, this flips the entries in each row in the left/right
+    direction. Columns are preserved, but appear in a different order than
+    before.
 
     Parameters
     ----------
@@ -66,11 +67,13 @@ def fliplr(m):
     See Also
     --------
     flipud : Flip array in the up/down direction.
+    flip : Flip array in one or more dimesions.
     rot90 : Rotate array counterclockwise.
 
     Notes
     -----
-    Equivalent to m[:,::-1]. Requires the array to be at least 2-D.
+    Equivalent to ``m[:,::-1]`` or ``np.flip(m, axis=1)``.
+    Requires the array to be at least 2-D.
 
     Examples
     --------
@@ -98,10 +101,10 @@ def fliplr(m):
 @array_function_dispatch(_flip_dispatcher)
 def flipud(m):
     """
-    Flip array in the up/down direction.
+    Reverse the order of elements along axis 0 (up/down).
 
-    Flip the entries in each column in the up/down direction.
-    Rows are preserved, but appear in a different order than before.
+    For a 2-D array, this flips the entries in each column in the up/down
+    direction. Rows are preserved, but appear in a different order than before.
 
     Parameters
     ----------
@@ -117,12 +120,13 @@ def flipud(m):
     See Also
     --------
     fliplr : Flip array in the left/right direction.
+    flip : Flip array in one or more dimesions.
     rot90 : Rotate array counterclockwise.
 
     Notes
     -----
-    Equivalent to ``m[::-1,...]``.
-    Does not require the array to be two-dimensional.
+    Equivalent to ``m[::-1, ...]`` or ``np.flip(m, axis=0)``.
+    Requires the array to be at least 1-D.
 
     Examples
     --------


### PR DESCRIPTION
I've two concerns with the existing summary lines ("Flip array in the up/down direction.")

- flip seems a bit colloquial and imprecise.
- up/down is great for 2-D, but quite unclear for other dimensions.

Motivation for the revised version:

- "Reverse the order of elements along axis 1." is exact. I've still added up/down in parenthesis to have the summary line pickup on the function name flip*ud*.
- The second paragraph then does the specialization for the common 2-D case, expanding on the up/down semantics.

I'm not 100% sure this is the best way. Generally, we have the discrepancy that these functions are named particularly with the 2-D case in mind, and are probably also used mostly for 2D, but their operation on other dim arrays must be described precisely as well. I've chosen to start with the exact technical definition and then explain the 2-D case. But I can also see the point if you want to have the intuitive 2-D description first and generalize afterwards.

