### PR TITLE
CI: Do not fail CI on lint error

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,6 +22,7 @@ jobs:
   lint:
     if: "github.repository == 'numpy/numpy' && github.ref != 'refs/heads/main' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
### Changes:
1. Added continue-on-error to unblock workflow.

Sample run showing solution: https://github.com/numpy/numpy/actions/runs/643660439

![image](https://user-images.githubusercontent.com/20969920/110835666-1b1d3800-82c5-11eb-8345-8462c6930435.png)


resolves: #18587 

~~*Note: There is one tmp commit to check, I'll remove, if it works*~~