### PR TITLE
BUG: NameError in numpy.distutils.fcompiler.compaq

### DIFF
--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -80,8 +80,8 @@ class CompaqVisualFCompiler(FCompiler):
         except DistutilsPlatformError:
             pass
         except AttributeError as e:
-            if '_MSVCCompiler__root' in str(msg):
-                print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (msg))
+            if '_MSVCCompiler__root' in str(e):
+                print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (e))
             else:
                 raise
         except IOError as e:


### PR DESCRIPTION
Backport of #18539. 

Fix a simple mistake in commit da0497fdf35 which produces a NameError when building numpy in MinGW-w64/MSYS2.

(note: there are still other issues preventing me from achieving a successful installation in MinGW-w64/MSYS2, but the other problems are perhaps not as straightforward as this one so I'll be making an issue for them)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
