### PR TITLE
DOC: Consistently use rng as variable name for random generators

### DIFF
--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -71,13 +71,13 @@ By default, `Generator.permuted` returns a copy.  To operate in-place with
 `Generator.permuted`, pass the same array as the first argument *and* as
 the value of the ``out`` parameter.  For example,
 
-    >>> rg = np.random.default_rng()
+    >>> rng = np.random.default_rng()
     >>> x = np.arange(0, 15).reshape(3, 5)
     >>> x
     array([[ 0,  1,  2,  3,  4],
            [ 5,  6,  7,  8,  9],
            [10, 11, 12, 13, 14]])
-    >>> y = rg.permuted(x, axis=1, out=x)
+    >>> y = rng.permuted(x, axis=1, out=x)
     >>> x
     array([[ 1,  0,  2,  4,  3],  # random
            [ 6,  7,  8,  9,  5],
@@ -97,13 +97,13 @@ which dimension of the input array to use as the sequence. In the case of a
 two-dimensional array, ``axis=0`` will, in effect, rearrange the rows of the
 array, and  ``axis=1`` will rearrange the columns.  For example
 
-    >>> rg = np.random.default_rng()
+    >>> rng = np.random.default_rng()
     >>> x = np.arange(0, 15).reshape(3, 5)
     >>> x
     array([[ 0,  1,  2,  3,  4],
            [ 5,  6,  7,  8,  9],
            [10, 11, 12, 13, 14]])
-    >>> rg.permutation(x, axis=1)
+    >>> rng.permutation(x, axis=1)
     array([[ 1,  3,  2,  0,  4],  # random
            [ 6,  8,  7,  5,  9],
            [11, 13, 12, 10, 14]])
@@ -116,7 +116,7 @@ how `numpy.sort` treats it.  Each slice along the given axis is shuffled
 independently of the others.  Compare the following example of the use of
 `Generator.permuted` to the above example of `Generator.permutation`:
 
-    >>> rg.permuted(x, axis=1)
+    >>> rng.permuted(x, axis=1)
     array([[ 1,  0,  2,  4,  3],  # random
            [ 5,  7,  6,  9,  8],
            [10, 14, 12, 13, 11]])
@@ -131,9 +131,9 @@ Shuffling non-NumPy sequences
 a sequence that is not a NumPy array, it shuffles that sequence in-place.
 For example,
 
-    >>> rg = np.random.default_rng()
+    >>> rng = np.random.default_rng()
     >>> a = ['A', 'B', 'C', 'D', 'E']
-    >>> rg.shuffle(a)  # shuffle the list in-place
+    >>> rng.shuffle(a)  # shuffle the list in-place
     >>> a
     ['B', 'D', 'A', 'E', 'C']  # random
 

--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -84,10 +84,10 @@ different
 .. code-block:: python
 
     try:
-        rg_integers = rg.integers
+        rng_integers = rng.integers
     except AttributeError:
-        rg_integers = rg.randint
-    a = rg_integers(1000)
+        rng_integers = rng.randint
+    a = rng_integers(1000)
 
 Seeds can be passed to any of the BitGenerators. The provided value is mixed
 via `SeedSequence` to spread a possible sequence of seeds across a wider
@@ -97,8 +97,8 @@ is wrapped with a `Generator`.
 .. code-block:: python
 
   from numpy.random import Generator, PCG64
-  rg = Generator(PCG64(12345))
-  rg.standard_normal()
+  rng = Generator(PCG64(12345))
+  rng.standard_normal()
   
 Here we use `default_rng` to create an instance of `Generator` to generate a 
 random float:
@@ -146,10 +146,10 @@ As a convenience NumPy  provides the `default_rng` function to hide these
 details:
   
 >>> from numpy.random import default_rng
->>> rg = default_rng(12345)
->>> print(rg)
+>>> rng = default_rng(12345)
+>>> print(rng)
 Generator(PCG64)
->>> print(rg.random())
+>>> print(rng.random())
 0.22733602246716966
   
 One can also instantiate `Generator` directly with a `BitGenerator` instance.
@@ -158,16 +158,16 @@ To use the default `PCG64` bit generator, one can instantiate it directly and
 pass it to `Generator`:
 
 >>> from numpy.random import Generator, PCG64
->>> rg = Generator(PCG64(12345))
->>> print(rg)
+>>> rng = Generator(PCG64(12345))
+>>> print(rng)
 Generator(PCG64)
 
 Similarly to use the older `MT19937` bit generator (not recommended), one can
 instantiate it directly and pass it to `Generator`:
 
 >>> from numpy.random import Generator, MT19937
->>> rg = Generator(MT19937(12345))
->>> print(rg)
+>>> rng = Generator(MT19937(12345))
+>>> print(rng)
 Generator(MT19937)
 
 What's New or Different

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -112,7 +112,7 @@ And in more detail:
 .. ipython:: python
 
   existing = np.zeros(4)
-  rg.random(out=existing[:2])
+  rng.random(out=existing[:2])
   print(existing)
 
 * Optional ``axis`` argument for methods like `~.Generator.choice`,

--- a/doc/source/reference/random/new-or-different.rst
+++ b/doc/source/reference/random/new-or-different.rst
@@ -58,18 +58,18 @@ And in more detail:
 
   from  numpy.random import Generator, PCG64
   import numpy.random
-  rg = Generator(PCG64())
-  %timeit -n 1 rg.standard_normal(100000)
+  rng = Generator(PCG64())
+  %timeit -n 1 rng.standard_normal(100000)
   %timeit -n 1 numpy.random.standard_normal(100000)
 
 .. ipython:: python
 
-  %timeit -n 1 rg.standard_exponential(100000)
+  %timeit -n 1 rng.standard_exponential(100000)
   %timeit -n 1 numpy.random.standard_exponential(100000)
 
 .. ipython:: python
 
-  %timeit -n 1 rg.standard_gamma(3.0, 100000)
+  %timeit -n 1 rng.standard_gamma(3.0, 100000)
   %timeit -n 1 numpy.random.standard_gamma(3.0, 100000)
 
 
@@ -94,9 +94,9 @@ And in more detail:
 
 .. ipython:: python
 
-  rg = Generator(PCG64(0))
-  rg.random(3, dtype='d')
-  rg.random(3, dtype='f')
+  rng = Generator(PCG64(0))
+  rng.random(3, dtype='d')
+  rng.random(3, dtype='f')
 
 * Optional ``out`` argument that allows existing arrays to be filled for
   select distributions
@@ -121,9 +121,9 @@ And in more detail:
 
 .. ipython:: python
 
-  rg = Generator(PCG64(123456789))
+  rng = Generator(PCG64(123456789))
   a = np.arange(12).reshape((3, 4))
   a
-  rg.choice(a, axis=1, size=5)
-  rg.shuffle(a, axis=1)        # Shuffle in-place
+  rng.choice(a, axis=1, size=5)
+  rng.shuffle(a, axis=1)        # Shuffle in-place
   a

--- a/doc/source/reference/routines.polynomials.rst
+++ b/doc/source/reference/routines.polynomials.rst
@@ -118,9 +118,9 @@ example, consider a simple linear fit to the following data:
 
 .. ipython:: python
 
-    rg = np.random.default_rng()
+    rng = np.random.default_rng()
     x = np.arange(10)
-    y = np.arange(10) + rg.standard_normal(10)
+    y = np.arange(10) + rng.standard_normal(10)
 
 With the legacy polynomial module, a linear fit (i.e. polynomial of degree 1)
 could be applied to these data with `~numpy.polyfit`:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -176,8 +176,8 @@ cdef class Generator:
     Examples
     --------
     >>> from numpy.random import Generator, PCG64
-    >>> rg = Generator(PCG64())
-    >>> rg.standard_normal()
+    >>> rng = Generator(PCG64())
+    >>> rng.standard_normal()
     -0.203  # random
 
     See Also
@@ -997,8 +997,8 @@ cdef class Generator:
         -----
         For random samples from :math:`N(\\mu, \\sigma^2)`, use one of::
 
-            mu + sigma * gen.standard_normal(size=...)
-            gen.normal(mu, sigma, size=...)
+            mu + sigma * rng.standard_normal(size=...)
+            rng.normal(mu, sigma, size=...)
 
         Examples
         --------


### PR DESCRIPTION
The naming in the docs switches back and forth between `rng` and `rg`.

I believe it's valuable to establish a standard naming for the generator, so that it becomes an idiom similar to how everybody knows what `np` is.

I've chosen to go with `rng` everywhere instead of `rg` because
- It's a little more distinct and thus easier to recognize. Also it's more likely that a user might use `rg` as some temporary local variable compared to `rng`. So we better avoid potential conflict.
- `rng` is the abbreviation used in `default_rng()`.
  Therefore `rng = np.random.default_rng()` reads better than `rg = np.random.default_rng()`.

Note: I only touched the occurrences in documentation. There are uses of `rg` in benchmarking and testing code that one could also adapt to extend the consistency from the end-user facing docs to internal usage.