### PR TITLE
BUG: Fixed command catching in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -248,9 +248,8 @@ def parse_setuppy_commands():
                      '--keywords', '--provides', '--requires', '--obsoletes',
                      'version',]
 
-    for command in info_commands:
-        if command in args:
-            return False
+    if args in info_commands:
+        return False
 
     # Note that 'alias', 'saveopts' and 'setopt' commands also seem to work
     # fine as they are, but are usually used together with one of the commands
@@ -260,13 +259,12 @@ def parse_setuppy_commands():
                      'bdist_wininst', 'bdist_msi', 'bdist_mpkg', 'build_src',
                      'bdist_egg')
 
-    for command in good_commands:
-        if command in args:
-            return True
+    if args in good_commands:
+        return True
 
     # The following commands are supported, but we need to show more
     # useful messages to the user
-    if 'install' in args:
+    if 'install' == args:
         print(textwrap.dedent("""
             Note: if you need reliable uninstall behavior, then install
             with pip instead of using `setup.py install`:
@@ -278,7 +276,7 @@ def parse_setuppy_commands():
             """))
         return True
 
-    if '--help' in args or '-h' in sys.argv[1]:
+    if args in ['-h', '--help']:
         print(textwrap.dedent("""
             NumPy-specific help
             -------------------
@@ -338,7 +336,7 @@ def parse_setuppy_commands():
         bad_commands[command] = "`setup.py %s` is not supported" % command
 
     for command in bad_commands.keys():
-        if command in args:
+        if command == args:
             print(textwrap.dedent(bad_commands[command]) +
                   "\nAdd `--force` to your command to use it anyway if you "
                   "must (unsupported).\n")
@@ -347,9 +345,8 @@ def parse_setuppy_commands():
     # Commands that do more than print info, but also don't need Cython and
     # template parsing.
     other_commands = ['egg_info', 'install_egg_info', 'rotate', 'dist_info']
-    for command in other_commands:
-        if command in args:
-            return False
+    if args in other_commands:
+        return False
 
     # If we got here, we didn't detect what setup.py command was given
     raise RuntimeError("Unrecognized setuptools command: {}".format(args))


### PR DESCRIPTION
Compound-words commands in `bad_commands` and `other_commands` like `install_lib` were caught by `install` command handler because of the use of `in` keyword in the equality check.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
