### PR TITLE
BUG, ENH: fix array2string rounding bug by adding min_digits option

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1053,9 +1053,10 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
         Pad the exponent with zeros until it contains at least this many digits.
         If omitted, the exponent will be at least 2 digits.
     min_digits : non-negative integer or None, optional
-        Minimum number of digits to print. This only has an effect for `unique=True`.
-        In that case more digits than necessary to uniquely identify the value may
-        be printed. The last additional digit is rounded unbiased.
+        Minimum number of digits to print. This only has an effect for
+        `unique=True`. In that case more digits than necessary to uniquely
+        identify the value may be printed and rounded unbiased.
+
 
     Returns
     -------

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1053,9 +1053,9 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
         Pad the exponent with zeros until it contains at least this many digits.
         If omitted, the exponent will be at least 2 digits.
     min_digits : non-negative integer or None, optional
-        Minimum number of digits to print. Only has an effect if `unique=True`
-        in which case additional digits past those necessary to uniquely
-        identify the value may be printed, rounding the last additional digit.
+        Minimum number of digits to print. This only has an effect for `unique=True`.
+        In that case more digits than necessary to uniquely identify the value may
+        be printed. The last additional digit is rounded unbiased.
 
     Returns
     -------

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1057,7 +1057,8 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
         `unique=True`. In that case more digits than necessary to uniquely
         identify the value may be printed and rounded unbiased.
 
-
+        -- versionadded:: 1.21.0
+        
     Returns
     -------
     rep : string
@@ -1142,6 +1143,8 @@ def format_float_positional(x, precision=None, unique=True,
         Minimum number of digits to print. Only has an effect if `unique=True`
         in which case additional digits past those necessary to uniquely
         identify the value may be printed, rounding the last additional digit.
+        
+        -- versionadded:: 1.21.0
 
     Returns
     -------

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -1030,7 +1030,7 @@ def format_float_scientific(x, precision=None, unique=True, trim='k',
         If `True`, use a digit-generation strategy which gives the shortest
         representation which uniquely identifies the floating-point number from
         other values of the same type, by judicious rounding. If `precision`
-        is given fewer digits than necessary can be printed, or if `min_digits`
+        is given fewer digits than necessary can be printed. If `min_digits`
         is given more can be printed, in which cases the last digit is rounded
         with unbiased rounding.
         If `False`, digits are generated as if printing an infinite-precision

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -103,6 +103,7 @@ def format_float_scientific(
     sign: bool = ...,
     pad_left: Optional[int] = ...,
     exp_digits: Optional[int] = ...,
+    min_digits: Optional[int] = ...,
 ) -> str: ...
 def format_float_positional(
     x: _FloatLike_co,
@@ -113,6 +114,7 @@ def format_float_positional(
     sign: bool = ...,
     pad_left: Optional[int] = ...,
     pad_right: Optional[int] = ...,
+    min_digits: Optional[int] = ...,
 ) -> str: ...
 def array_repr(
     arr: ndarray[Any, Any],

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -1130,8 +1130,9 @@ BigInt_ShiftLeft(BigInt *result, npy_uint32 shift)
  *   * exponent - value exponent in base 2
  *   * mantissaBit - index of the highest set mantissa bit
  *   * hasUnequalMargins - is the high margin twice as large as the low margin
- *   * cutoffMode - how to interpret cutoffNumber: fractional or total digits?
- *   * cutoffNumber - cut off printing after this many digits. -1 for no cutoff
+ *   * cutoffMode - how to interpret cutoff_*: fractional or total digits?
+ *   * cutoff_max - cut off printing after this many digits. -1 for no cutoff
+ *   * cutoff_min - print at least this many digits. -1 for no cutoff
  *   * pOutBuffer - buffer to output into
  *   * bufferSize - maximum characters that can be printed to pOutBuffer
  *   * pOutExponent - the base 10 exponent of the first digit
@@ -1142,7 +1143,7 @@ static npy_uint32
 Dragon4(BigInt *bigints, const npy_int32 exponent,
         const npy_uint32 mantissaBit, const npy_bool hasUnequalMargins,
         const DigitMode digitMode, const CutoffMode cutoffMode,
-        npy_int32 cutoffNumber, char *pOutBuffer,
+        npy_int32 cutoff_max, npy_int32 cutoff_min, char *pOutBuffer,
         npy_uint32 bufferSize, npy_int32 *pOutExponent)
 {
     char *curDigit = pOutBuffer;
@@ -1169,7 +1170,8 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
     BigInt *temp2 = &bigints[6];
 
     const npy_float64 log10_2 = 0.30102999566398119521373889472449;
-    npy_int32 digitExponent, cutoffExponent, hiBlock;
+    npy_int32 digitExponent, hiBlock;
+    npy_int32 cutoff_max_Exponent, cutoff_min_Exponent;
     npy_uint32 outputDigit;    /* current digit being output */
     npy_uint32 outputLen;
     npy_bool isEven = BigInt_IsEven(mantissa);
@@ -1294,9 +1296,9 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
      * increases the number. This will either correct digitExponent to an
      * accurate value or it will clamp it above the accurate value.
      */
-    if (cutoffNumber >= 0 && cutoffMode == CutoffMode_FractionLength &&
-            digitExponent <= -cutoffNumber) {
-        digitExponent = -cutoffNumber + 1;
+    if (cutoff_max >= 0 && cutoffMode == CutoffMode_FractionLength &&
+            digitExponent <= -cutoff_max) {
+        digitExponent = -cutoff_max + 1;
     }
 
 
@@ -1347,26 +1349,44 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
     }
 
     /*
-     * Compute the cutoff exponent (the exponent of the final digit to print).
-     * Default to the maximum size of the output buffer.
+     * Compute the cutoff_max exponent (the exponent of the final digit to
+     * print).  Default to the maximum size of the output buffer.
      */
-    cutoffExponent = digitExponent - bufferSize;
-    if (cutoffNumber >= 0) {
+    cutoff_max_Exponent = digitExponent - bufferSize;
+    if (cutoff_max >= 0) {
         npy_int32 desiredCutoffExponent;
 
         if (cutoffMode == CutoffMode_TotalLength) {
-            desiredCutoffExponent = digitExponent - cutoffNumber;
-            if (desiredCutoffExponent > cutoffExponent) {
-                cutoffExponent = desiredCutoffExponent;
+            desiredCutoffExponent = digitExponent - cutoff_max;
+            if (desiredCutoffExponent > cutoff_max_Exponent) {
+                cutoff_max_Exponent = desiredCutoffExponent;
             }
         }
-        /* Otherwise it's CutoffMode_FractionLength. Print cutoffNumber digits
+        /* Otherwise it's CutoffMode_FractionLength. Print cutoff_max digits
          * past the decimal point or until we reach the buffer size
          */
         else {
-            desiredCutoffExponent = -cutoffNumber;
-            if (desiredCutoffExponent > cutoffExponent) {
-                cutoffExponent = desiredCutoffExponent;
+            desiredCutoffExponent = -cutoff_max;
+            if (desiredCutoffExponent > cutoff_max_Exponent) {
+                cutoff_max_Exponent = desiredCutoffExponent;
+            }
+        }
+    }
+    /* Also compute the cutoff_min exponent. */
+    cutoff_min_Exponent = digitExponent;
+    if (cutoff_min >= 0) {
+        npy_int32 desiredCutoffExponent;
+
+        if (cutoffMode == CutoffMode_TotalLength) {
+            desiredCutoffExponent = digitExponent - cutoff_min;
+            if (desiredCutoffExponent < cutoff_min_Exponent) {
+                cutoff_min_Exponent = desiredCutoffExponent;
+            }
+        }
+        else {
+            desiredCutoffExponent = -cutoff_min;
+            if (desiredCutoffExponent < cutoff_min_Exponent) {
+                cutoff_min_Exponent = desiredCutoffExponent;
             }
         }
     }
@@ -1432,14 +1452,17 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
 
             /*
              * stop looping if we are far enough away from our neighboring
-             * values or if we have reached the cutoff digit
+             * values (and we have printed at least the requested minimum
+             * digits) or if we have reached the cutoff digit
              */
             cmp = BigInt_Compare(scaledValue, scaledMarginLow);
             low = isEven ? (cmp <= 0) : (cmp < 0);
             cmp = BigInt_Compare(scaledValueHigh, scale);
             high = isEven ? (cmp >= 0) : (cmp > 0);
-            if (low | high | (digitExponent == cutoffExponent))
+            if (((low | high) & (digitExponent <= cutoff_min_Exponent)) |
+                    (digitExponent == cutoff_max_Exponent)) {
                 break;
+            }
 
             /* store the output digit */
             *curDigit = (char)('0' + outputDigit);
@@ -1471,7 +1494,7 @@ Dragon4(BigInt *bigints, const npy_int32 exponent,
             DEBUG_ASSERT(outputDigit < 10);
 
             if ((scaledValue->length == 0) |
-                    (digitExponent == cutoffExponent)) {
+                    (digitExponent == cutoff_max_Exponent)) {
                 break;
             }
 
@@ -1589,6 +1612,7 @@ typedef struct Dragon4_Options {
     DigitMode digit_mode;
     CutoffMode cutoff_mode;
     npy_int32 precision;
+    npy_int32 min_digits;
     npy_bool sign;
     TrimMode trim_mode;
     npy_int32 digits_left;
@@ -1617,11 +1641,12 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
                  npy_int32 exponent, char signbit, npy_uint32 mantissaBit,
                  npy_bool hasUnequalMargins, DigitMode digit_mode,
                  CutoffMode cutoff_mode, npy_int32 precision,
-                 TrimMode trim_mode, npy_int32 digits_left,
-                 npy_int32 digits_right)
+                 npy_int32 min_digits, TrimMode trim_mode,
+                 npy_int32 digits_left, npy_int32 digits_right)
 {
     npy_int32 printExponent;
     npy_int32 numDigits, numWholeDigits=0, has_sign=0;
+    npy_int32 add_digits;
 
     npy_int32 maxPrintLen = (npy_int32)bufferSize - 1, pos = 0;
 
@@ -1644,8 +1669,9 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
     }
 
     numDigits = Dragon4(mantissa, exponent, mantissaBit, hasUnequalMargins,
-                        digit_mode, cutoff_mode, precision, buffer + has_sign,
-                        maxPrintLen - has_sign, &printExponent);
+                        digit_mode, cutoff_mode, precision, min_digits,
+                        buffer + has_sign, maxPrintLen - has_sign,
+                        &printExponent);
 
     DEBUG_ASSERT(numDigits > 0);
     DEBUG_ASSERT(numDigits <= bufferSize);
@@ -1744,9 +1770,10 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         buffer[pos++] = '.';
     }
 
-    desiredFractionalDigits = precision;
-    if (cutoff_mode == CutoffMode_TotalLength && precision >= 0) {
-        desiredFractionalDigits = precision - numWholeDigits;
+    add_digits = digit_mode == DigitMode_Unique ? min_digits : precision;
+    desiredFractionalDigits = add_digits < 0 ? 0 : add_digits;
+    if (cutoff_mode == CutoffMode_TotalLength) {
+        desiredFractionalDigits = add_digits - numWholeDigits;
     }
 
     if (trim_mode == TrimMode_LeaveOneZero) {
@@ -1757,10 +1784,9 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         }
     }
     else if (trim_mode == TrimMode_None &&
-             digit_mode != DigitMode_Unique &&
              desiredFractionalDigits > numFractionDigits &&
              pos < maxPrintLen) {
-        /* add trailing zeros up to precision length */
+        /* add trailing zeros up to add_digits length */
         /* compute the number of trailing zeros needed */
         npy_int32 count = desiredFractionalDigits - numFractionDigits;
         if (pos + count > maxPrintLen) {
@@ -1778,7 +1804,7 @@ FormatPositional(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
      * when rounding, we may still end up with trailing zeros. Remove them
      * depending on trim settings.
      */
-    if (precision >= 0 && trim_mode != TrimMode_None && numFractionDigits > 0) {
+    if (trim_mode != TrimMode_None && numFractionDigits > 0) {
         while (buffer[pos-1] == '0') {
             pos--;
             numFractionDigits--;
@@ -1852,7 +1878,7 @@ static npy_uint32
 FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
                   npy_int32 exponent, char signbit, npy_uint32 mantissaBit,
                   npy_bool hasUnequalMargins, DigitMode digit_mode,
-                  npy_int32 precision, TrimMode trim_mode,
+                  npy_int32 precision, npy_int32 min_digits, TrimMode trim_mode,
                   npy_int32 digits_left, npy_int32 exp_digits)
 {
     npy_int32 printExponent;
@@ -1860,11 +1886,11 @@ FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
     char *pCurOut;
     npy_int32 numFractionDigits;
     npy_int32 leftchars;
+    npy_int32 add_digits;
 
     if (digit_mode != DigitMode_Unique) {
         DEBUG_ASSERT(precision >= 0);
     }
-
 
     DEBUG_ASSERT(bufferSize > 0);
 
@@ -1893,7 +1919,9 @@ FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
     }
 
     numDigits = Dragon4(mantissa, exponent, mantissaBit, hasUnequalMargins,
-                        digit_mode, CutoffMode_TotalLength, precision + 1,
+                        digit_mode, CutoffMode_TotalLength,
+                        precision < 0 ? -1 : precision + 1,
+                        min_digits < 0 ? -1 : min_digits + 1,
                         pCurOut, bufferSize, &printExponent);
 
     DEBUG_ASSERT(numDigits > 0);
@@ -1928,6 +1956,8 @@ FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         --bufferSize;
     }
 
+    add_digits = digit_mode == DigitMode_Unique ? min_digits : precision;
+    add_digits = add_digits < 0 ? 0 : add_digits;
     if (trim_mode == TrimMode_LeaveOneZero) {
         /* if we didn't print any fractional digits, add the 0 */
         if (numFractionDigits == 0 && bufferSize > 1) {
@@ -1937,13 +1967,12 @@ FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
             ++numFractionDigits;
         }
     }
-    else if (trim_mode == TrimMode_None &&
-            digit_mode != DigitMode_Unique) {
-        /* add trailing zeros up to precision length */
-        if (precision > (npy_int32)numFractionDigits) {
+    else if (trim_mode == TrimMode_None) {
+        /* add trailing zeros up to add_digits length */
+        if (add_digits > (npy_int32)numFractionDigits) {
             char *pEnd;
             /* compute the number of trailing zeros needed */
-            npy_int32 numZeros = (precision - numFractionDigits);
+            npy_int32 numZeros = (add_digits - numFractionDigits);
 
             if (numZeros > (npy_int32)bufferSize - 1) {
                 numZeros = (npy_int32)bufferSize - 1;
@@ -1961,7 +1990,7 @@ FormatScientific (char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
      * when rounding, we may still end up with trailing zeros. Remove them
      * depending on trim settings.
      */
-    if (precision >= 0 && trim_mode != TrimMode_None && numFractionDigits > 0) {
+    if (trim_mode != TrimMode_None && numFractionDigits > 0) {
         --pCurOut;
         while (*pCurOut == '0') {
             --pCurOut;
@@ -2153,14 +2182,14 @@ Format_floatbits(char *buffer, npy_uint32 bufferSize, BigInt *mantissa,
         return FormatScientific(buffer, bufferSize, mantissa, exponent,
                                 signbit, mantissaBit, hasUnequalMargins,
                                 opt->digit_mode, opt->precision,
-                                opt->trim_mode, opt->digits_left,
-                                opt->exp_digits);
+                                opt->min_digits, opt->trim_mode,
+                                opt->digits_left, opt->exp_digits);
     }
     else {
         return FormatPositional(buffer, bufferSize, mantissa, exponent,
                                 signbit, mantissaBit, hasUnequalMargins,
                                 opt->digit_mode, opt->cutoff_mode,
-                                opt->precision, opt->trim_mode,
+                                opt->precision, opt->min_digits, opt->trim_mode,
                                 opt->digits_left, opt->digits_right);
     }
 }
@@ -3100,7 +3129,7 @@ Dragon4_Positional_##Type##_opt(npy_type *val, Dragon4_Options *opt)\
 \
 PyObject *\
 Dragon4_Positional_##Type(npy_type *val, DigitMode digit_mode,\
-                   CutoffMode cutoff_mode, int precision,\
+                   CutoffMode cutoff_mode, int precision, int min_digits, \
                    int sign, TrimMode trim, int pad_left, int pad_right)\
 {\
     Dragon4_Options opt;\
@@ -3109,6 +3138,7 @@ Dragon4_Positional_##Type(npy_type *val, DigitMode digit_mode,\
     opt.digit_mode = digit_mode;\
     opt.cutoff_mode = cutoff_mode;\
     opt.precision = precision;\
+    opt.min_digits = min_digits;\
     opt.sign = sign;\
     opt.trim_mode = trim;\
     opt.digits_left = pad_left;\
@@ -3136,7 +3166,8 @@ Dragon4_Scientific_##Type##_opt(npy_type *val, Dragon4_Options *opt)\
 }\
 PyObject *\
 Dragon4_Scientific_##Type(npy_type *val, DigitMode digit_mode, int precision,\
-                   int sign, TrimMode trim, int pad_left, int exp_digits)\
+                   int min_digits, int sign, TrimMode trim, int pad_left, \
+                   int exp_digits)\
 {\
     Dragon4_Options opt;\
 \
@@ -3144,6 +3175,7 @@ Dragon4_Scientific_##Type(npy_type *val, DigitMode digit_mode, int precision,\
     opt.digit_mode = digit_mode;\
     opt.cutoff_mode = CutoffMode_TotalLength;\
     opt.precision = precision;\
+    opt.min_digits = min_digits;\
     opt.sign = sign;\
     opt.trim_mode = trim;\
     opt.digits_left = pad_left;\
@@ -3166,8 +3198,8 @@ make_dragon4_typefuncs(LongDouble, npy_longdouble, NPY_LONGDOUBLE_BINFMT_NAME)
 
 PyObject *
 Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
-                   int precision, int sign, TrimMode trim, int pad_left,
-                   int pad_right)
+                   int precision, int min_digits, int sign, TrimMode trim,
+                   int pad_left, int pad_right)
 {
     npy_double val;
     Dragon4_Options opt;
@@ -3176,6 +3208,7 @@ Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
     opt.digit_mode = digit_mode;
     opt.cutoff_mode = cutoff_mode;
     opt.precision = precision;
+    opt.min_digits = min_digits;
     opt.sign = sign;
     opt.trim_mode = trim;
     opt.digits_left = pad_left;
@@ -3208,7 +3241,8 @@ Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
 
 PyObject *
 Dragon4_Scientific(PyObject *obj, DigitMode digit_mode, int precision,
-                   int sign, TrimMode trim, int pad_left, int exp_digits)
+                   int min_digits, int sign, TrimMode trim, int pad_left,
+                   int exp_digits)
 {
     npy_double val;
     Dragon4_Options opt;
@@ -3217,6 +3251,7 @@ Dragon4_Scientific(PyObject *obj, DigitMode digit_mode, int precision,
     opt.digit_mode = digit_mode;
     opt.cutoff_mode = CutoffMode_TotalLength;
     opt.precision = precision;
+    opt.min_digits = min_digits;
     opt.sign = sign;
     opt.trim_mode = trim;
     opt.digits_left = pad_left;

--- a/numpy/core/src/multiarray/dragon4.h
+++ b/numpy/core/src/multiarray/dragon4.h
@@ -112,12 +112,12 @@ typedef enum TrimMode
     PyObject *\
     Dragon4_Positional_##Type(npy_type *val, DigitMode digit_mode,\
                               CutoffMode cutoff_mode, int precision,\
-                              int sign, TrimMode trim, int pad_left,\
-                              int pad_right);\
+                              int min_digits, int sign, TrimMode trim, \
+                              int pad_left, int pad_right);\
     PyObject *\
     Dragon4_Scientific_##Type(npy_type *val, DigitMode digit_mode,\
-                              int precision, int sign, TrimMode trim,\
-                              int pad_left, int exp_digits);
+                              int precision, int min_digits, int sign, \
+                              TrimMode trim, int pad_left, int exp_digits);
 
 make_dragon4_typedecl(Half, npy_half)
 make_dragon4_typedecl(Float, npy_float)
@@ -128,12 +128,13 @@ make_dragon4_typedecl(LongDouble, npy_longdouble)
 
 PyObject *
 Dragon4_Positional(PyObject *obj, DigitMode digit_mode, CutoffMode cutoff_mode,
-                   int precision, int sign, TrimMode trim, int pad_left,
-                   int pad_right);
+                   int precision, int min_digits, int sign, TrimMode trim,
+                   int pad_left, int pad_right);
 
 PyObject *
 Dragon4_Scientific(PyObject *obj, DigitMode digit_mode, int precision,
-                   int sign, TrimMode trim, int pad_left, int exp_digits);
+                   int min_digits, int sign, TrimMode trim, int pad_left,
+                   int exp_digits);
 
 #endif
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3481,7 +3481,7 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyObject *obj;
-    int precision=-1, pad_left=-1, exp_digits=-1;
+    int precision=-1, pad_left=-1, exp_digits=-1, min_digits=-1;
     DigitMode digit_mode;
     TrimMode trim = TrimMode_None;
     int sign=0, unique=1;
@@ -3495,6 +3495,7 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy),
             "|trim", &trimmode_converter, &trim,
             "|pad_left", &PyArray_PythonPyIntFromInt, &pad_left,
             "|exp_digits", &PyArray_PythonPyIntFromInt, &exp_digits,
+            "|min_digits", &PyArray_PythonPyIntFromInt, &min_digits,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
@@ -3507,7 +3508,7 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy),
         return NULL;
     }
 
-    return Dragon4_Scientific(obj, digit_mode, precision, sign, trim,
+    return Dragon4_Scientific(obj, digit_mode, precision, min_digits, sign, trim,
                               pad_left, exp_digits);
 }
 
@@ -3522,7 +3523,7 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyObject *obj;
-    int precision=-1, pad_left=-1, pad_right=-1;
+    int precision=-1, pad_left=-1, pad_right=-1, min_digits=-1;
     CutoffMode cutoff_mode;
     DigitMode digit_mode;
     TrimMode trim = TrimMode_None;
@@ -3538,6 +3539,7 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy),
             "|trim", &trimmode_converter, &trim,
             "|pad_left", &PyArray_PythonPyIntFromInt, &pad_left,
             "|pad_right", &PyArray_PythonPyIntFromInt, &pad_right,
+            "|min_digits", &PyArray_PythonPyIntFromInt, &min_digits,
             NULL, NULL, NULL) < 0) {
         return NULL;
     }
@@ -3552,8 +3554,8 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy),
         return NULL;
     }
 
-    return Dragon4_Positional(obj, digit_mode, cutoff_mode, precision, sign,
-                              trim, pad_left, pad_right);
+    return Dragon4_Positional(obj, digit_mode, cutoff_mode, precision,
+                              min_digits, sign, trim, pad_left, pad_right);
 }
 
 static PyObject *
@@ -3572,7 +3574,7 @@ format_longfloat(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
                 "not a longfloat");
         return NULL;
     }
-    return Dragon4_Scientific(obj, DigitMode_Unique, precision, 0,
+    return Dragon4_Scientific(obj, DigitMode_Unique, precision, -1, 0,
                               TrimMode_LeaveOneZero, -1, -1);
 }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -331,13 +331,13 @@ format_@name@(@type@ val, npy_bool scientific,
 {
     if (scientific) {
         return Dragon4_Scientific_@Name@(&val,
-                        DigitMode_Unique, precision,
+                        DigitMode_Unique, precision, -1,
                         sign, trim, pad_left, exp_digits);
     }
     else {
         return Dragon4_Positional_@Name@(&val,
                         DigitMode_Unique, CutoffMode_TotalLength, precision,
-                        sign, trim, pad_left, pad_right);
+                        -1, sign, trim, pad_left, pad_right);
     }
 }
 

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -759,6 +759,10 @@ class TestPrintOptions:
         assert_equal(repr(c),
             "array([1.00000000+1.00000000j, 1.12345679+1.12345679j])")
 
+        # test unique special case (gh-18609)
+        a = np.float64.fromhex('-1p-97')
+        assert_equal(np.float64(np.array2string(a, floatmode='unique')), a)
+
     def test_legacy_mode_scalars(self):
         # in legacy mode, str of floats get truncated, and complex scalars
         # use * for non-finite imaginary part


### PR DESCRIPTION
Fixes #18609

This PR adds a new `min_digits` argument to the dragon4 float printing methods, such as `np.format_float_positional`. This kwd guarantees that at least the given number of digits will be printed, when printing in `unique=True` mode, even if the extra digits are unnecessary to uniquely specify the value. It is the counterpart to the `precision` argument which sets the maximum number of digits to be printed. (When `unique=False` fixed-precision mode, it has no effect, and the `precision` arg fixes the number of digits)

Using this new keyword, I then fix a bug in arrayprint ( #18609). The bug in the old code is that, in order to guarantee that all elements of an array print using the same number of digits, we turned off `unique=True` because we needed to use fixed-precision mode to fix the number of digits. However, unique mode rounds differently from fixed-precision mode, so the rounding was wrong. This PR instead now stays in unique mode to print the elements, but uses the `min_digits` and `precision` arguments to fix the number of output digits.

It looks like a lof of chages, but a lot of it is just introducing the `min_digits` arg into all the function signatures in dragon4 and in the user api.