### PR TITLE
DOC: add note to numpy.rint() docstrings

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3489,6 +3489,12 @@ add_newdoc('numpy.core.umath', 'rint',
     --------
     fix, ceil, floor, trunc
 
+    Notes
+    -----
+    For values exactly halfway between rounded decimal values, NumPy
+    rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0,
+    -0.5 and 0.5 round to 0.0, etc.
+
     Examples
     --------
     >>> a = np.array([-1.7, -1.5, -0.2, 0.2, 1.5, 1.7, 2.0])


### PR DESCRIPTION
**DOC: add note to numpy.rint() docstrings**

Closes #18556.

Adds a note to `numpy.rint()` docstrings explaining that for values exactly halfway between rounded decimal values, the function rounds to the nearest even value. The note is identical to that of `numpy.around()` for consistency.