### PR TITLE
BUG: Fix ma coercion list-of-ma-arrays if they do not cast to bool

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2859,8 +2859,9 @@ class MaskedArray(ndarray):
             elif isinstance(data, (tuple, list)):
                 try:
                     # If data is a sequence of masked array
-                    mask = np.array([getmaskarray(np.asanyarray(m, dtype=mdtype))
-                                                    for m in data], dtype=mdtype)
+                    mask = np.array(
+                        [getmaskarray(np.asanyarray(m, dtype=_data.dtype))
+                         for m in data], dtype=mdtype)
                 except ValueError:
                     # If data is nested
                     mask = nomask

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -238,6 +238,25 @@ class TestMaskedArray:
         assert_equal(data, [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
         assert_(data.mask is nomask)
 
+    def test_creation_with_list_of_maskedarrays_no_bool_cast(self):
+        # Tests the regression in gh-18551
+        masked_str = np.ma.masked_array(['a', 'b'], mask=[True, False])
+        normal_int = np.arange(2)
+        res = np.ma.asarray([masked_str, normal_int])
+        assert_array_equal(res.mask, [[True, False], [False, False]])
+        # Te above only failed due a long chain of oddity, try also with
+        # an object array that cannot be converted to bool always:
+        class NotBool():
+            def __bool__(self):
+                raise ValueError("not a bool!")
+        masked_obj = np.ma.masked_array([NotBool(), 'b'], mask=[True, False])
+        # Check that the NotBool actually fails like we would expect:
+        with pytest.raises(ValueError, match="not a bool!"):
+            np.asarray([masked_obj], dtype=bool)
+
+        res = np.ma.asarray([masked_obj, normal_int])
+        assert_array_equal(res.mask, [[True, False], [False, False]])
+
     def test_creation_from_ndarray_with_padding(self):
         x = np.array([('A', 0)], dtype={'names':['f0','f1'],
                                         'formats':['S4','i8'],

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -242,7 +242,7 @@ class TestMaskedArray:
         # Tests the regression in gh-18551
         masked_str = np.ma.masked_array(['a', 'b'], mask=[True, False])
         normal_int = np.arange(2)
-        res = np.ma.asarray([masked_str, normal_int])
+        res = np.ma.asarray([masked_str, normal_int], dtype="U21")
         assert_array_equal(res.mask, [[True, False], [False, False]])
 
         # The above only failed due a long chain of oddity, try also with

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -244,7 +244,8 @@ class TestMaskedArray:
         normal_int = np.arange(2)
         res = np.ma.asarray([masked_str, normal_int])
         assert_array_equal(res.mask, [[True, False], [False, False]])
-        # Te above only failed due a long chain of oddity, try also with
+
+        # The above only failed due a long chain of oddity, try also with
         # an object array that cannot be converted to bool always:
         class NotBool():
             def __bool__(self):


### PR DESCRIPTION
Backport of #18605. 

There was a regression here due to force casting to bool, but if that
happens to fail (it does, but should not for strings). The mask
would just be dropped.

Of course masked arrays are held together by faith here, but its
a regression.

Closes gh-18551

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
