### PR TITLE
MAINT: Remove useless declarations in `bad_commands`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,8 +313,6 @@ def parse_setuppy_commands():
             Instead, build what you want to upload and upload those files
             with `twine upload -s <filenames>` instead.
             """,
-        upload_docs="`setup.py upload_docs` is not supported",
-        easy_install="`setup.py easy_install` is not supported",
         clean="""
             `setup.py clean` is not supported, use one of the following instead:
 
@@ -322,10 +320,6 @@ def parse_setuppy_commands():
               - `git clean -Xdf` (cleans all versioned files, doesn't touch
                                   files that aren't checked into the git repo)
             """,
-        check="`setup.py check` is not supported",
-        register="`setup.py register` is not supported",
-        bdist_dumb="`setup.py bdist_dumb` is not supported",
-        bdist="`setup.py bdist` is not supported",
         build_sphinx="""
             `setup.py build_sphinx` is not supported, use the
             Makefile under doc/""",


### PR DESCRIPTION
When creating the `bad_commands` dictionary it is useless to declare commands that are already set with a default message in the 329th line's for loop

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
