### PR TITLE
BUG: Fix small valgrind-found issues

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -748,6 +748,7 @@ find_descriptor_from_array(
                     NULL, DType, &flags, item_DType) < 0) {
                 Py_DECREF(iter);
                 Py_DECREF(elem);
+                Py_XDECREF(*out_descr);
                 Py_XDECREF(item_DType);
                 return -1;
             }

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -878,6 +878,7 @@ void_getbuffer(PyObject *self, Py_buffer *view, int flags)
      */
     _buffer_info_t *info = _buffer_get_info(&scalar->_buffer_info, self, flags);
     if (info == NULL) {
+        Py_DECREF(self);
         return -1;
     }
     view->format = info->format;

--- a/numpy/core/src/multiarray/legacy_dtype_implementation.c
+++ b/numpy/core/src/multiarray/legacy_dtype_implementation.c
@@ -161,10 +161,12 @@ PyArray_LegacyCanCastSafely(int fromtype, int totype)
 
         while (*curtype != NPY_NOTYPE) {
             if (*curtype++ == totype) {
+                Py_DECREF(from);
                 return 1;
             }
         }
     }
+    Py_DECREF(from);
     return 0;
 }
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -603,19 +603,20 @@ UMath_Tests_test_dispatch(PyObject *NPY_UNUSED(dummy), PyObject *NPY_UNUSED(dumm
     NPY_CPU_DISPATCH_CALL_XB(highest_func_xb = _umath_tests_dispatch_func, ());
     NPY_CPU_DISPATCH_CALL_XB(highest_var_xb  = _umath_tests_dispatch_var);
 
-    PyObject *dict = PyDict_New(), *item = NULL;
+    PyObject *dict = PyDict_New(), *item;
     if (dict == NULL) {
         return NULL;
     }
     /**begin repeat
      * #str = func, var, func_xb, var_xb#
     */
-    Py_XSETREF(item, PyUnicode_FromString(highest_@str@));
+    item = PyUnicode_FromString(highest_@str@);
     if (item == NULL || PyDict_SetItemString(dict, "@str@", item) < 0) {
         goto err;
     }
+    Py_DECREF(item);
     /**end repeat**/
-    Py_SETREF(item, PyList_New(0));
+    item = PyList_New(0);
     if (item == NULL || PyDict_SetItemString(dict, "all", item) < 0) {
         goto err;
     }

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -603,19 +603,19 @@ UMath_Tests_test_dispatch(PyObject *NPY_UNUSED(dummy), PyObject *NPY_UNUSED(dumm
     NPY_CPU_DISPATCH_CALL_XB(highest_func_xb = _umath_tests_dispatch_func, ());
     NPY_CPU_DISPATCH_CALL_XB(highest_var_xb  = _umath_tests_dispatch_var);
 
-    PyObject *dict = PyDict_New(), *item;
+    PyObject *dict = PyDict_New(), *item = NULL;
     if (dict == NULL) {
         return NULL;
     }
     /**begin repeat
      * #str = func, var, func_xb, var_xb#
     */
-    item = PyUnicode_FromString(highest_@str@);
+    Py_XSETREF(item, PyUnicode_FromString(highest_@str@));
     if (item == NULL || PyDict_SetItemString(dict, "@str@", item) < 0) {
         goto err;
     }
     /**end repeat**/
-    item = PyList_New(0);
+    Py_SETREF(item, PyList_New(0));
     if (item == NULL || PyDict_SetItemString(dict, "all", item) < 0) {
         goto err;
     }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7486,7 +7486,7 @@ class TestNewBufferProtocol:
             memoryview(arr)
 
     def test_max_dims(self):
-        a = np.empty((1,) * 32)
+        a = np.ones((1,) * 32)
         self._check_roundtrip(a)
 
     @pytest.mark.slow


### PR DESCRIPTION
This should be backportable. There was at least one that I could
not reproduce when running the tests again. And the new random-shuffle
tests give false-positives (which is just slightly annoying, considering
that we are very close to almost only "longdouble" related
false-positives)

---

I don't think this touches any code modified in the main branch. So it should be backported to 1.20.  I may have to run pytest-leaks... (although leaks found there but not with valgrind are unlikely to cause much trouble in the wild...)