### PR TITLE
BLD: remove /usr/include from default include dirs

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -314,7 +314,7 @@ else:
                                  '/opt/local/lib', '/sw/lib'], platform_bits)
     default_runtime_dirs = []
     default_include_dirs = ['/usr/local/include',
-                            '/opt/include', '/usr/include',
+                            '/opt/include',
                             # path of umfpack under macports
                             '/opt/local/include/ufsparse',
                             '/opt/local/include', '/sw/include',
@@ -323,8 +323,7 @@ else:
 
     default_x11_lib_dirs = libpaths(['/usr/X11R6/lib', '/usr/X11/lib',
                                      '/usr/lib'], platform_bits)
-    default_x11_include_dirs = ['/usr/X11R6/include', '/usr/X11/include',
-                                '/usr/include']
+    default_x11_include_dirs = ['/usr/X11R6/include', '/usr/X11/include']
 
     if os.path.exists('/usr/lib/X11'):
         globbed_x11_dir = glob('/usr/lib/*/libX11.so')


### PR DESCRIPTION
Including this directory is painful for cross-compiling, see gh-14980 and gh-13280. Removing this directory fixes the following build failure:
```
gcc: numpy/core/src/common/numpyos.c
In file included from numpy/core/src/common/numpyos.c:23:
/usr/include/xlocale.h:27:16: error: redefinition of ‘struct __locale_struct’
   27 | typedef struct __locale_struct
```
This error also shows up in various other build issues outside of the NumPy issue tracker.

Compilers normally always include this path, so this shouldn't break anything. The default include paths for the compiler can be checked, e.g. for gcc with `cpp -v`. That will typically have /usr/include last.

In case this breaks something for a nonstandard compiler, that can be worked around via a site.cfg file in the root of the repo (or equivalently, `~/numpy-site.cfg`) containing:
```
[DEFAULT]
include_dirs = /usr/include
```

The same principle should apply to `/usr/lib`. The `/usr/lib` change is made in a separate commit, because the failure mode for that will be different (may be useful in case this breaks something else).

EDIT: to clarify: it is not possible to fix this with an extra `ifdef` in `numpyos.c`, the problem is that there's a mix between `locale.h` and `xlocale.h` that both exist but are not compatible. For example, a really new `locale.h` in `/usr/include` on Arch Linux, combined with an old `xlocale.h` shipped with conda.

EDIT2: currently it's really easy to reproduce the `xlocale.h` failure:
- On Arch Linux, create a fresh conda environment with the `environment.yml` in gh-18659
- Activate the environment and run `python setup.py build_ext -i`.