### PR TITLE
DEV: add a conda environment.yml with all development dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,16 +4,17 @@
 # data, etc files to distribution (*for installation*).
 # Avoid using MANIFEST.in for that.
 #
-include MANIFEST.in
-include pyproject.toml
-include pytest.ini
-include *.txt
-include README.md
-include site.cfg.example
-include runtests.py
-include tox.ini
-include .coveragerc
-include test_requirements.txt
+# Files in top-level directory:
+include *.*
+# Exclude license file that we append to the main license when running
+# `python setup.py sdist`.  And exclude generated files in repo root.
+exclude LICENSES_bundled.txt
+exclude .*
+exclude azure-*.yml
+exclude shippable.yml
+
+# Sub-directories. Included are: numpy/, doc/, benchmarks/, tools/
+include numpy/_version.py
 recursive-include numpy/random *.pyx *.pxd *.pyx.in *.pxd.in
 include numpy/py.typed
 include numpy/random/include/*
@@ -45,8 +46,3 @@ prune benchmarks/numpy
 # Exclude generated files
 prune */__pycache__
 global-exclude *.pyc *.pyo *.pyd *.swp *.bak *~
-# Exclude license file that we append to the main license when running
-# `python setup.py sdist`
-exclude LICENSES_bundled.txt
-include versioneer.py
-include numpy/_version.py

--- a/doc/source/dev/development_environment.rst
+++ b/doc/source/dev/development_environment.rst
@@ -57,7 +57,8 @@ When using pytest as a target (the default), you can
 
 Using ``runtests.py`` is the recommended approach to running tests.
 There are also a number of alternatives to it, for example in-place
-build or installing to a virtualenv. See the FAQ below for details.
+build or installing to a virtualenv or a conda environment. See the FAQ below
+for details.
 
 .. note::
 
@@ -130,17 +131,27 @@ to see this output, you can run the ``build_src`` stage verbosely::
 
     $ python build build_src -v
 
-Using virtualenvs
------------------
+Using virtual environments
+--------------------------
 
 A frequently asked question is "How do I set up a development version of NumPy
 in parallel to a released version that I use to do my job/research?".
 
 One simple way to achieve this is to install the released version in
-site-packages, by using a binary installer or pip for example, and set
-up the development version in a virtualenv.  First install
+site-packages, by using pip or conda for example, and set
+up the development version in a virtual environment.
+
+If you use conda, we recommend creating a separate virtual environment for
+numpy development using the ``environment.yml`` file in the root of the repo
+(this will create the environment and install all development dependencies at
+once)::
+
+    $ conda env create -f environment.yml  # `mamba` works too for this command
+    $ conda activate numpy-dev
+
+If you installed Python some other way than conda, first install
 `virtualenv`_ (optionally use `virtualenvwrapper`_), then create your
-virtualenv (named numpy-dev here) with::
+virtualenv (named ``numpy-dev`` here) with::
 
     $ virtualenv numpy-dev
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,33 @@
+# To use:
+#   $ conda env create -f environment.yml  # `mamba` works too for this command
+#   $ conda activate numpy-dev
+name: numpy-dev
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - cython
+  - compilers
+  - openblas
+  # For testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - hypothesis
+  # For type annotations 
+  - mypy=0.812
+  - typing_extensions
+  # For building docs
+  - sphinx=3.5.2
+  - numpydoc=1.1.0
+  - ipython
+  - scipy
+  - pandas
+  - matplotlib
+  - pydata-sphinx-theme
+  # For linting
+  - pycodestyle=2.7.0
+  - gitpython
+  # Used in some tests
+  - cffi
+  - pytz


### PR DESCRIPTION
There are enough dependencies now that it's too hard to remember. This set is comprehensive, so a single
`conda env create -f environment.yml` gives you everything in a fresh environment named `numpy-dev`.