### PR TITLE
DOC: add release note for removal of /usr/include from include paths

### DIFF
--- a/doc/release/upcoming_changes/18658.compatibility.rst
+++ b/doc/release/upcoming_changes/18658.compatibility.rst
@@ -1,0 +1,6 @@
+``/usr/include`` removed from default include paths
+---------------------------------------------------
+The default include paths when building a package with ``numpy.distutils`` no
+longer include ``/usr/include``. This path is normally added by the compiler,
+and hardcoding it can be problematic. In case this causes a problem, please
+open an issue. A workaround is documented in PR 18658.


### PR DESCRIPTION
Follow-up to gh-18658