### PR TITLE
ENH: add support for array-likes in polynomial evaluation

### DIFF
--- a/doc/release/upcoming_changes/18662.new_feature.rst
+++ b/doc/release/upcoming_changes/18662.new_feature.rst
@@ -1,0 +1,5 @@
+Add support for array-likes in polynomial evaluation
+----------------------------------------------------------------------------
+
+Polynomial evaluation now accepts array-likes (e.g. lists) as its
+input argument, in addition to NumPy arrays.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -479,6 +479,7 @@ class ABCPolyBase(abc.ABC):
 
     def __call__(self, arg):
         off, scl = pu.mapparms(self.domain, self.window)
+        arg = np.asarray(arg)
         arg = off + scl*arg
         return self._val(arg, self.coef)
 


### PR DESCRIPTION
**ENH: add support for array-likes in polynomial evaluation**

Closes #17949.

Adds an `asarray()` call in the polybase `__call__` method so that evaluation works with array-likes too. See #17949 for the initial reproduced code example; after the above change, evaluation works as expected:

```python
import numpy as np
>>> np.polynomial.Polynomial([1, 2])(np.array([3, 4]))
array([7., 9.])
>>> np.polynomial.Polynomial([1, 2])([3, 4])
array([7., 9.])
```