### PR TITLE
BUG: Fix small issues found with pytest-leaks

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -902,8 +902,7 @@ PyArray_FindConcatenationDescriptor(
                     "The dtype `%R` is not a valid dtype for concatenation "
                     "since it is a subarray dtype (the subarray dimensions "
                     "would be added as array dimensions).", result);
-            Py_DECREF(result);
-            return NULL;
+            Py_SETREF(result, NULL);
         }
         goto finish;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2100,6 +2100,7 @@ array_fromstring(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
     array_function_result = array_implement_c_array_function_creation(
             "fromstring", args, keywds);
     if (array_function_result != Py_NotImplemented) {
+        Py_XDECREF(descr);
         return array_function_result;
     }
 

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -621,6 +621,7 @@ UMath_Tests_test_dispatch(PyObject *NPY_UNUSED(dummy), PyObject *NPY_UNUSED(dumm
         goto err;
     }
     NPY_CPU_DISPATCH_CALL_ALL(_umath_tests_dispatch_attach, (item));
+    Py_SETREF(item, NULL);
     if (PyErr_Occurred()) {
         goto err;
     }

--- a/numpy/core/src/umath/_umath_tests.dispatch.c
+++ b/numpy/core/src/umath/_umath_tests.dispatch.c
@@ -29,5 +29,6 @@ void NPY_CPU_DISPATCH_CURFX(_umath_tests_dispatch_attach)(PyObject *list)
     PyObject *item = PyUnicode_FromString(NPY_TOSTRING(NPY_CPU_DISPATCH_CURFX(func)));
     if (item) {
         PyList_Append(list, item);
+        Py_DECREF(item);
     }
 }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5495,6 +5495,7 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "first") < 0) {
+            Py_DECREF(tmp);
             return NULL;
         }
         ap1 = (PyArrayObject *) PyArray_FromObject(tmp, NPY_NOTYPE, 0, 0);
@@ -5514,6 +5515,7 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
         /* DEPRECATED 2020-05-13, NumPy 1.20 */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                 matrix_deprecation_msg, ufunc->name, "second") < 0) {
+            Py_DECREF(tmp);
             Py_DECREF(ap1);
             return NULL;
         }
@@ -5538,7 +5540,7 @@ ufunc_outer(PyUFuncObject *ufunc, PyObject *args, PyObject *kwds)
                 "maximum supported dimension for an ndarray is %d, but "
                 "`%s.outer()` result would have %d.",
                 NPY_MAXDIMS, ufunc->name, newdims.len);
-        return NPY_FAIL;
+        goto fail;
     }
     if (newdims.ptr == NULL) {
         goto fail;

--- a/numpy/core/tests/test_overrides.py
+++ b/numpy/core/tests/test_overrides.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+import os
 import tempfile
 from io import StringIO
 from unittest import mock
@@ -558,18 +559,19 @@ class TestArrayLike:
 
         data = np.random.random(5)
 
-        fname = tempfile.mkstemp()[1]
-        data.tofile(fname)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, "testfile")
+            data.tofile(fname)
 
-        array_like = np.fromfile(fname, like=ref)
-        if numpy_ref is True:
-            assert type(array_like) is np.ndarray
-            np_res = np.fromfile(fname, like=ref)
-            assert_equal(np_res, data)
-            assert_equal(array_like, np_res)
-        else:
-            assert type(array_like) is self.MyArray
-            assert array_like.function is self.MyArray.fromfile
+            array_like = np.fromfile(fname, like=ref)
+            if numpy_ref is True:
+                assert type(array_like) is np.ndarray
+                np_res = np.fromfile(fname, like=ref)
+                assert_equal(np_res, data)
+                assert_equal(array_like, np_res)
+            else:
+                assert type(array_like) is self.MyArray
+                assert array_like.function is self.MyArray.fromfile
 
     @requires_array_function
     def test_exception_handling(self):


### PR DESCRIPTION
Backport of gh-18670 (with two small differences)

None of these are particularly worrying as they either usually only
leak reference (and not memory) or appear in rare or almost impossible
error-paths, or are limited to the tests.

Unfortunately, this PR will not apply to 1.20.x, due to small changes
in the overrides.