### PR TITLE
WIP: Make .item() and .astype(object) return NumPy scalars for datetime and timedelta

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1007,48 +1007,14 @@ VOID_setitem(PyObject *op, void *input, void *vap)
 static PyObject *
 DATETIME_getitem(void *ip, void *vap)
 {
-    PyArrayObject *ap = vap;
-    npy_datetime dt;
-    PyArray_DatetimeMetaData *meta = NULL;
-
-    /* Get the datetime units metadata */
-    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
-    if (meta == NULL) {
-        return NULL;
-    }
-
-    if ((ap == NULL) || PyArray_ISBEHAVED_RO(ap)) {
-        dt = *((npy_datetime *)ip);
-    }
-    else {
-        PyArray_DESCR(ap)->f->copyswap(&dt, ip, PyArray_ISBYTESWAPPED(ap), ap);
-    }
-
-    return convert_datetime_to_pyobject(dt, meta);
+    return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
 }
 
 
 static PyObject *
 TIMEDELTA_getitem(void *ip, void *vap)
 {
-    PyArrayObject *ap = vap;
-    npy_timedelta td;
-    PyArray_DatetimeMetaData *meta = NULL;
-
-    /* Get the datetime units metadata */
-    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
-    if (meta == NULL) {
-        return NULL;
-    }
-
-    if ((ap == NULL) || PyArray_ISBEHAVED_RO(ap)) {
-        td = *((npy_timedelta *)ip);
-    }
-    else {
-        PyArray_DESCR(ap)->f->copyswap(&td, ip, PyArray_ISBYTESWAPPED(ap), ap);
-    }
-
-    return convert_timedelta_to_pyobject(td, meta);
+    return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
 }
 
 static int

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1007,14 +1007,58 @@ VOID_setitem(PyObject *op, void *input, void *vap)
 static PyObject *
 DATETIME_getitem(void *ip, void *vap)
 {
-    return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
+    PyArrayObject *ap = vap;
+    npy_datetime dt;
+    PyArray_DatetimeMetaData *meta = NULL;
+
+    /* Get the datetime units metadata */
+    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
+    if (meta == NULL) {
+        return NULL;
+    }
+
+    if ((ap == NULL) || PyArray_ISBEHAVED_RO(ap)) {
+        dt = *((npy_datetime *)ip);
+    }
+    else {
+        PyArray_DESCR(ap)->f->copyswap(&dt, ip, PyArray_ISBYTESWAPPED(ap), ap);
+    }
+
+    // See https://github.com/numpy/numpy/issues/12550
+    if (PyLong_Check(convert_datetime_to_pyobject(dt, meta))) {
+        return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
+    }
+
+    return convert_datetime_to_pyobject(dt, meta);
 }
 
 
 static PyObject *
 TIMEDELTA_getitem(void *ip, void *vap)
 {
-    return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
+    PyArrayObject *ap = vap;
+    npy_timedelta td;
+    PyArray_DatetimeMetaData *meta = NULL;
+
+    /* Get the datetime units metadata */
+    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
+    if (meta == NULL) {
+        return NULL;
+    }
+
+    if ((ap == NULL) || PyArray_ISBEHAVED_RO(ap)) {
+        td = *((npy_timedelta *)ip);
+    }
+    else {
+        PyArray_DESCR(ap)->f->copyswap(&td, ip, PyArray_ISBYTESWAPPED(ap), ap);
+    }
+
+    // See https://github.com/numpy/numpy/issues/12550
+    if (PyLong_Check(convert_timedelta_to_pyobject(td, meta))) {
+        return PyArray_Scalar(ip, PyArray_DESCR((PyArrayObject *)vap), NULL);
+    }
+
+    return convert_timedelta_to_pyobject(td, meta);
 }
 
 static int

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -109,9 +109,9 @@ run_test()
 
   if [ -n "$RUN_FULL_TESTS" ]; then
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
-    $PYTHON -b ../runtests.py -n -v --mode=full $DURATIONS_FLAG $COVERAGE_FLAG
+    $PYTHON -b ../runtests.py -n -vv --mode=full $DURATIONS_FLAG $COVERAGE_FLAG
   else
-    $PYTHON ../runtests.py -n -v $DURATIONS_FLAG -- -rs
+    $PYTHON ../runtests.py -n -vv $DURATIONS_FLAG -- -rs
   fi
 
   if [ -n "$RUN_COVERAGE" ]; then


### PR DESCRIPTION
This is to avoid implicitly casting e.g. datetime64 to (python-)datetimes when
using operations - like `.astype(object)` - that are expected not to change the
type. Fixes #12550.

Co-Authored-By: Sebastian Berg <sebastian@sipsolutions.net>

--------------

The diff was [provided](https://github.com/numpy/numpy/issues/12550#issuecomment-780203343) by @seberg, but is likely incomplete (see link). Opening this PR to hopefully start iterating towards completion. Help welcome - I'll happily give push access to my fork for those who want to contribute. 

CC @jbrockmendel 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
