### PR TITLE
BUG: Correct datetime64 missing type overload for datetime.date #18640

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2537,7 +2537,7 @@ class object_(generic):
 
 object0 = object_
 
-# The `datetime64` constructors requires an object with the three attributes below, 
+# The `datetime64` constructors requires an object with the three attributes below,
 # and thus supports datetime duck typing
 class _DatetimeScalar(Protocol):
     @property
@@ -2549,7 +2549,7 @@ class _DatetimeScalar(Protocol):
 
 
 class datetime64(generic):
-    @overload    
+    @overload
     def __init__(
         self,
         __value: Union[None, datetime64, _CharLike_co, _DatetimeScalar] = ...,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2549,8 +2549,6 @@ class _DatetimeScalar(Protocol):
 
 
 class datetime64(generic):
-    #Replaced dt.datetime with _DatetimeScalar per issue #18640 and
-    #BvB93s recommendation
     @overload    
     def __init__(
         self,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2537,8 +2537,8 @@ class object_(generic):
 
 object0 = object_
 
-#Added Protocol to typecheck for day, month, year property to be used in
-#datetime64 constructor per Issue #18640 and BvB93s recommendation
+# The `datetime64` constructors requires an object with the three attributes below, 
+# and thus supports datetime duck typing
 class _DatetimeScalar(Protocol):
     @property
     def day(self) -> int: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2537,11 +2537,24 @@ class object_(generic):
 
 object0 = object_
 
+#Added Protocol to typecheck for day, month, year property to be used in
+#datetime64 constructor per Issue #18640 and BvB93s recommendation
+class _DatetimeScalar(Protocol):
+    @property
+    def day(self) -> int: ...
+    @property
+    def month(self) -> int: ...
+    @property
+    def year(self) -> int: ...
+
+
 class datetime64(generic):
-    @overload
+    #Replaced dt.datetime with _DatetimeScalar per issue #18640 and
+    #BvB93s recommendation
+    @overload    
     def __init__(
         self,
-        __value: Union[None, datetime64, _CharLike_co, dt.datetime] = ...,
+        __value: Union[None, datetime64, _CharLike_co, _DatetimeScalar] = ...,
         __format: Union[_CharLike_co, Tuple[_CharLike_co, _IntLike_co]] = ...,
     ) -> None: ...
     @overload

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -84,6 +84,7 @@ np.datetime64(b"2019")
 np.datetime64("2019", "D")
 np.datetime64(np.datetime64())
 np.datetime64(dt.datetime(2000, 5, 3))
+np.datetime64(dt.date(2000, 5, 3))
 np.datetime64(None)
 np.datetime64(None, "D")
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
