### PR TITLE
TST: pin pypy version to 7.3.4rc1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -212,7 +212,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: pypy-3.7-nightly
+        python-version: pypy-3.7-v7.3.4rc1
     - uses: ./.github/actions
 
   sdist:


### PR DESCRIPTION
Originally we moved to a nightly build in #18439 to avoid a PyPy bug. But the nightly builds can be flaky. Now that there is a 7.3.4rc1 release candidate, use that instead