### PR TITLE
DEP: Disable PyUFunc_GenericFunction and PyUFunc_SetUsesArraysAsData

### DIFF
--- a/doc/release/upcoming_changes/18697.expired.rst
+++ b/doc/release/upcoming_changes/18697.expired.rst
@@ -1,0 +1,5 @@
+* The function ``PyUFunc_GenericFunction`` has been disabled.
+  It was deprecated in NumPy 1.19.  Users should call the ufunc
+  directly using the Python API.
+* The function ``PyUFunc_SetUsesArraysAsData`` has been disabled.
+  It was deprecated in NumPy 1.19.

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -283,20 +283,6 @@ Functions
     signature is an array of data-type numbers indicating the inputs
     followed by the outputs assumed by the 1-d loop.
 
-.. c:function:: int PyUFunc_GenericFunction( \
-        PyUFuncObject* self, PyObject* args, PyObject* kwds, PyArrayObject** mps)
-
-    .. deprecated:: NumPy 1.19
-
-        Unless NumPy is made aware of an issue with this, this function
-        is scheduled for rapid removal without replacement.
-
-    Instead of this function ``PyObject_Call(ufunc, args, kwds)`` should be
-    used. The above function differs from this because it ignores support
-    for non-array, or array subclasses as inputs.
-    To ensure identical behaviour, it may be necessary to convert all inputs
-    using ``PyArray_FromAny(obj, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL)``.
-
 .. c:function:: int PyUFunc_checkfperr(int errmask, PyObject* errobj)
 
     A simple interface to the IEEE error-flag checking support. The

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -910,8 +910,6 @@ cdef extern from "numpy/ufuncobject.h":
           void **, char *, int, int, int, int, char *, char *, int)
     int PyUFunc_RegisterLoopForType(ufunc, int,
                                     PyUFuncGenericFunction, int *, void *)
-    int PyUFunc_GenericFunction \
-        (ufunc, PyObject *, PyObject *, PyArrayObject **)
     void PyUFunc_f_f_As_d_d \
          (char **, npy_intp *, npy_intp *, void *)
     void PyUFunc_d_d \

--- a/numpy/__init__.pxd
+++ b/numpy/__init__.pxd
@@ -868,8 +868,6 @@ cdef extern from "numpy/ufuncobject.h":
           void **, char *, int, int, int, int, char *, char *, int)
     int PyUFunc_RegisterLoopForType(ufunc, int,
                                     PyUFuncGenericFunction, int *, void *)
-    int PyUFunc_GenericFunction \
-        (ufunc, PyObject *, PyObject *, PyArrayObject **)
     void PyUFunc_f_f_As_d_d \
          (char **, npy_intp *, npy_intp *, void *)
     void PyUFunc_d_d \


### PR DESCRIPTION
Both functions have been deprecated in 1.19.x without complaints
(so far).  The first function is largely identical to a Python ufunc
call.  The second function had served internal NumPy purposes until
NumPy 1.6 (probably), and since then had a comment that it should
probably be removed (it was not documented).
