### PR TITLE
DOC: update Steering Council membership and people on governance page

### DIFF
--- a/doc/source/dev/governance/people.rst
+++ b/doc/source/dev/governance/people.rst
@@ -7,59 +7,43 @@ Steering council
 ----------------
 
 * Sebastian Berg
-
-* Jaime Fernández del Río
-
 * Ralf Gommers
-
-* Allan Haldane
-
 * Charles Harris
-
 * Stephan Hoyer
-
+* Melissa Weber Mendonça
+* Inessa Pawson
 * Matti Picus
-
-* Nathaniel Smith
-
-* Julian Taylor
-
-* Pauli Virtanen
-
 * Stéfan van der Walt
-
 * Eric Wieser
-
 
 
 Emeritus members
 ----------------
 
 * Travis Oliphant -- project founder / emeritus leader (2005-2012)
-
 * Alex Griffing (2015-2017)
-
 * Marten van Kerkwijk (2017-2019)
+* Allan Haldane (2015-2021)
+* Nathaniel Smith (2012-2021)
+* Julian Taylor (2013-2021)
+* Pauli Virtanen (2008-2021)
+* Jaime Fernández del Río (2014-2021)
 
 
 NumFOCUS Subcommittee
 ---------------------
 
-* Chuck Harris
-
+* Charles Harris
 * Ralf Gommers
-
-* Jaime Fernández del Río
-
+* Melissa Weber Mendonça
 * Sebastian Berg
-
 * External member: Thomas Caswell
 
 
 Institutional Partners
 ----------------------
 
-* UC Berkeley (Stéfan van der Walt, Sebastian Berg, Warren Weckesser, Ross Barnowski)
+* UC Berkeley (Stéfan van der Walt, Sebastian Berg, Ross Barnowski)
 
-* Quansight (Ralf Gommers, Hameer Abbasi, Melissa Weber Mendonça, Mars Lee, Matti Picus)
+* Quansight (Ralf Gommers, Melissa Weber Mendonça, Mars Lee, Matti Picus, Pearu Peterson)
 


### PR DESCRIPTION
We welcome two new SC members, Melissa and Inessa.

The people moving to emeritus status have not been very active or not active at all for a while. They all still have commit rights, and if they get more active again their membership can be restored.

There are also a few changes to the NumFOCUS Subcommittee and Institutional Partners members, to reflect recent changes.

After this update, all listed people are currently actively contributing to NumPy. That does not only include technical contributions, but also participating in community meetings, mentoring newcomers, and many other activities across the project.

Cc'ing all the people whose name is added/changes/removed: @jaimefrio, @ahaldane, @melissawm, @InessaPawson, @njsmith, @juliantaylor, @pv, @WarrenWeckesser, @hameerabbasi, @pearu. 