### PR TITLE
DOC: Simplifies Mandelbrot set plot in Quickstart guide

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1254,19 +1254,21 @@ set <https://en.wikipedia.org/wiki/Mandelbrot_set>`__:
 
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
-    >>> def mandelbrot(h, w, maxit=20):
+    >>> def mandelbrot(h, w, maxit=20, r=2):
     ...     """Returns an image of the Mandelbrot fractal of size (h,w)."""
-    ...     y, x = np.ogrid[-1.4:1.4:h*1j, -2:0.8:w*1j]
-    ...     c = x + y * 1j
-    ...     z = c
+    ...     x = np.linspace(-2.5, 1.5, 4*h+1)
+    ...     y = np.linspace(-1.5, 1.5, 3*w+1)
+    ...     A, B = np.meshgrid(x, y)
+    ...     C = A + B*1j
+    ...     z = np.zeros_like(C)
     ...     divtime = maxit + np.zeros(z.shape, dtype=int)
     ...
     ...     for i in range(maxit):
-    ...         z = z**2 + c
-    ...         diverge = z * np.conj(z) > 2**2       # who is diverging
+    ...         z = z**2 + C
+    ...         diverge = abs(z) > 2                    # who is diverging
     ...         div_now = diverge & (divtime == maxit)  # who is diverging now
     ...         divtime[div_now] = i                    # note when
-    ...         z[diverge] = 2                          # avoid diverging too much
+    ...         z[diverge] = r                          # avoid diverging too much
     ...
     ...     return divtime
     >>> plt.imshow(mandelbrot(400, 400))

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1265,7 +1265,7 @@ set <https://en.wikipedia.org/wiki/Mandelbrot_set>`__:
     ...
     ...     for i in range(maxit):
     ...         z = z**2 + C
-    ...         diverge = abs(z) > 2                    # who is diverging
+    ...         diverge = abs(z) > r                    # who is diverging
     ...         div_now = diverge & (divtime == maxit)  # who is diverging now
     ...         divtime[div_now] = i                    # note when
     ...         z[diverge] = r                          # avoid diverging too much


### PR DESCRIPTION
A slightly simpler example for the Quickstart guide. This is a compromise between the existing code and the suggested NumPy example in #18409.

Closes #18409 