### PR TITLE
API, DEP: Move ufunc signature parsing to the start

### DIFF
--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -150,6 +150,11 @@ The masked type resolvers specifically will *not* remain supported, but
 has no known users (including NumPy itself, which only uses the default
 version).
 
+Further, no compatibility attempt will be made for *calling* as opposed
+to providing either the normal or the masked type resolver.  As NumPy
+will use it only as a fallback.  There are no known users of this
+(undocumented) possibility.
+
 While the above changes potentially break some workflows,
 we believe that the long-term improvements vastly outweigh this.
 Further, packages such as astropy and Numba are capable of adapting so that

--- a/doc/release/upcoming_changes/18718.c_api.rst
+++ b/doc/release/upcoming_changes/18718.c_api.rst
@@ -1,0 +1,13 @@
+Use of ``ufunc->type_resolver`` and "type tuple"
+------------------------------------------------
+NumPy now normalizes the "type tuple" argument to the
+type resolver functions before calling it.  Note that in
+the use of this type resolver is legacy behaviour and NumPy
+will not do so when possible.
+Calling ``ufunc->type_resolver`` or ``PyUFunc_DefaultTypeResolver``
+is strongly discouraged and will now enforce a normalized
+type tuple if done.
+Note that this does not affect providing a type resolver, which
+is expected to keep working in most circumstances.
+If you have an unexpected use-case for calling the type resolver,
+please inform the NumPy developers so that a solution can be found.

--- a/doc/release/upcoming_changes/18718.compatibility.rst
+++ b/doc/release/upcoming_changes/18718.compatibility.rst
@@ -1,0 +1,53 @@
+Changes to comparisons with ``dtype=...``
+-----------------------------------------
+When the ``dtype=`` (or ``signature``) arguments to comparison
+ufuncs (``equal``, ``less``, etc.) is used, this will denote
+the desired output dtype in the future.
+This means that:
+
+    np.equal(2, 3, dtype=object)
+
+will give a ``FutureWarning`` that it will return an ``object``
+array in the future, which currently happens for:
+
+    np.equal(None, None, dtype=object)
+
+due to the fact that ``np.array(None)`` is already an object
+array. (This also happens for some other dtypes.)
+
+Since comparisons normally only return boolean arrays, providing
+any other dtype will always raise an error in the future and
+give a ``DeprecationWarning`` now.
+
+
+Changes to ``dtype`` and ``signature`` arguments in ufuncs
+----------------------------------------------------------
+The universal function arguments ``dtype`` and ``signature``
+which are also valid for reduction such as ``np.add.reduce``
+(which is the implementation for ``np.sum``) will now issue
+a warning when the ``dtype`` provided is not a "basic" dtype.
+
+NumPy almost always ignored metadata, byteorder or time units
+on these inputs.  NumPy will now always ignore it and issue
+a warning if byteorder or time unit changed.
+The following are the most important examples of changes which
+will issue the warning and in some cases previously returned
+different results::
+
+    # The following will now warn on most systems (unchanged result):
+    np.add(3, 5, dtype=">i32")
+
+    # The biggest impact is for timedelta or datetimes:
+    arr = np.arange(10, dtype="m8[s]")
+    # The examples always ignored the time unit "ns" (using the
+    # unit of `arr`.  They now issue a warning:
+    np.add(arr, arr, dtype="m8[ns]")
+    np.maximum.reduce(arr, dtype="m8[ns]")
+
+    # The following issue a warning but previously did return
+    # a "ns" result.
+    np.add(3, 5, dtype="m8[ns]")  # Now return generic time units
+    np.maximum(arr, arr, dtype="m8[ns]")  # Now returns "s" (from `arr`)
+
+The same applies for functions like ``np.sum`` which use these internally.
+This change is necessary to achieve consistent handling within NumPy.

--- a/doc/release/upcoming_changes/18718.compatibility.rst
+++ b/doc/release/upcoming_changes/18718.compatibility.rst
@@ -28,26 +28,32 @@ which are also valid for reduction such as ``np.add.reduce``
 a warning when the ``dtype`` provided is not a "basic" dtype.
 
 NumPy almost always ignored metadata, byteorder or time units
-on these inputs.  NumPy will now always ignore it and issue
-a warning if byteorder or time unit changed.
+on these inputs.  NumPy will now always ignore it and raise an
+error if byteorder or time unit changed.
 The following are the most important examples of changes which
-will issue the warning and in some cases previously returned
-different results::
+will give the error.  In some cases previously the information
+stored was not ignored, in all of these an error is now raised::
 
-    # The following will now warn on most systems (unchanged result):
+    # Previously ignored the byte-order (affect if non-native)
     np.add(3, 5, dtype=">i32")
 
     # The biggest impact is for timedelta or datetimes:
     arr = np.arange(10, dtype="m8[s]")
-    # The examples always ignored the time unit "ns" (using the
-    # unit of `arr`.  They now issue a warning:
+    # The examples always ignored the time unit "ns":
     np.add(arr, arr, dtype="m8[ns]")
     np.maximum.reduce(arr, dtype="m8[ns]")
 
-    # The following issue a warning but previously did return
-    # a "ns" result.
+    # The following previously did use "ns" (as opposed to `arr.dtype`)
     np.add(3, 5, dtype="m8[ns]")  # Now return generic time units
     np.maximum(arr, arr, dtype="m8[ns]")  # Now returns "s" (from `arr`)
 
 The same applies for functions like ``np.sum`` which use these internally.
 This change is necessary to achieve consistent handling within NumPy.
+
+If you run into these, in most cases pass for example ``dtype=np.timedelta64``
+which clearly denotes a general ``timedelta64`` without any unit or byte-order
+defined.  If you need to specify the output dtype precisely, you may do so
+by either casting the inputs or providing an output array using `out=`.
+
+NumPy may choose to allow providing an exact output ``dtype`` here in the
+future, which would be preceded by a ``FutureWarning``.

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -47,6 +47,7 @@
 #include "npy_import.h"
 #include "extobj.h"
 #include "common.h"
+#include "dtypemeta.h"
 #include "numpyos.h"
 
 /********** PRINTF DEBUG TRACING **************/
@@ -2682,7 +2683,6 @@ PyUFunc_GenericFunctionInternal(PyUFuncObject *ufunc, PyArrayObject **op,
 
     int trivial_loop_ok = 0;
 
-
     nin = ufunc->nin;
     nout = ufunc->nout;
     nop = nin + nout;
@@ -4033,6 +4033,10 @@ _not_NoValue(PyObject *obj, PyObject **out)
     return 1;
 }
 
+
+/* forward declaration */
+static PyArray_DTypeMeta * _get_dtype(PyObject *dtype_obj);
+
 /*
  * This code handles reduce, reduceat, and accumulate
  * (accumulate and reduce are special cases of the more general reduceat
@@ -4192,8 +4196,14 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
-    if (otype_obj && !PyArray_DescrConverter2(otype_obj, &otype)) {
-        goto fail;
+    if (otype_obj && otype_obj != Py_None) {
+        /* Use `_get_dtype` because `dtype` is a DType and not the instance */
+        PyArray_DTypeMeta *dtype = _get_dtype(otype_obj);
+        if (dtype == NULL) {
+            goto fail;
+        }
+        Py_INCREF(dtype->singleton);
+        otype = dtype->singleton;
     }
     if (out_obj && !PyArray_OutputConverter(out_obj, &out)) {
         goto fail;
@@ -4396,35 +4406,42 @@ fail:
 
 
 /*
- * Sets typetup to a new reference to the passed in dtype information
- * tuple or NULL. Returns -1 on failure.
+ * Perform a basic check on `dtype`, `sig`, and `signature` since only one
+ * may be set.  If `sig` is used, writes it into `out_signature` (which should
+ * be set to `signature_obj` so that following code only requires to handle
+ * `signature_obj`).
+ *
+ * Does NOT incref the output!  This only copies the borrowed references
+ * gotten during the argument parsing.
+ *
+ * This function does not do any normalization of the input dtype tuples,
+ * this happens after the array-ufunc override check currently.
  */
 static int
-_get_typetup(PyObject *sig_obj, PyObject *signature_obj, PyObject *dtype,
-        PyObject **out_typetup)
+_check_and_copy_sig_to_signature(
+        PyObject *sig_obj, PyObject *signature_obj, PyObject *dtype,
+        PyObject **out_signature)
 {
-    *out_typetup = NULL;
+    *out_signature = NULL;
     if (signature_obj != NULL) {
-        Py_INCREF(signature_obj);
-        *out_typetup = signature_obj;
+        *out_signature = signature_obj;
     }
 
     if (sig_obj != NULL) {
-        if (*out_typetup != NULL) {
+        if (*out_signature != NULL) {
             PyErr_SetString(PyExc_TypeError,
                     "cannot specify both 'sig' and 'signature'");
-            Py_SETREF(*out_typetup, NULL);
+            *out_signature = NULL;
             return -1;
         }
         Py_INCREF(sig_obj);
-        *out_typetup = sig_obj;
+        *out_signature = sig_obj;
     }
 
     if (dtype != NULL) {
-        if (*out_typetup != NULL) {
+        if (*out_signature != NULL) {
             PyErr_SetString(PyExc_TypeError,
                     "cannot specify both 'signature' and 'dtype'");
-            Py_SETREF(*out_typetup, NULL);
             return -1;
         }
         /* dtype needs to be converted, delay after the override check */
@@ -4432,32 +4449,264 @@ _get_typetup(PyObject *sig_obj, PyObject *signature_obj, PyObject *dtype,
     return 0;
 }
 
+
 /*
- * Finish conversion parsing of the type tuple. This is currenlty only
- * conversion of the `dtype` argument, but should do more in the future.
+ * Note: This function currently lets DType classes pass, but in general
+ * the class (not the descriptor instance) is the preferred input, so the
+ * parsing should eventually be adapted to prefer classes and possible
+ * deprecated instances. (Users should not notice that much, since `np.float64`
+ * or "float64" usually denotes the DType class rather than the instance.)
+ */
+static PyArray_DTypeMeta *
+_get_dtype(PyObject *dtype_obj) {
+    if (PyObject_TypeCheck(dtype_obj, &PyArrayDTypeMeta_Type)) {
+        Py_INCREF(dtype_obj);
+        return (PyArray_DTypeMeta *)dtype_obj;
+    }
+    else {
+        PyArray_Descr *descr = NULL;
+        if (!PyArray_DescrConverter(dtype_obj, &descr)) {
+            return NULL;
+        }
+        PyArray_DTypeMeta *out = NPY_DTYPE(descr);
+        if (NPY_UNLIKELY(!out->legacy)) {
+            /* TODO: this path was unreachable when added. */
+            PyErr_SetString(PyExc_TypeError,
+                    "Cannot pass a new user DType instance to the `dtype` or "
+                    "`signature` arguments of ufuncs. Pass the DType class "
+                    "instead.");
+            Py_DECREF(descr);
+            return NULL;
+        }
+        else if (NPY_UNLIKELY(out->singleton != descr)) {
+            /* This does not warn about `metadata`, but units is important. */
+            if (!PyArray_EquivTypes(out->singleton, descr)) {
+                if (PyErr_WarnFormat(PyExc_UserWarning, 1,
+                        "The `dtype` and `signature` arguments to "
+                        "ufuncs only select the general DType and not details "
+                        "such as the byte order or time unit. "
+                        "In very rare cases NumPy <1.21 may have preserved the "
+                        "time unit for `dtype=`.  The cases are mainly "
+                        "`np.minimum(arr1, arr2, dtype='m8[ms]')` and when the "
+                        "output is timedelta, but the input is integer. "
+                        "(See NumPy 1.21.0 release notes for details.)\n"
+                        "If you wish to set an exact output dtype, you must "
+                        "currently pass `out=` instead.") < 0) {
+                    Py_DECREF(descr);
+                    return NULL;
+                }
+            }
+        }
+        Py_INCREF(out);
+        Py_DECREF(descr);
+        return out;
+    }
+}
+
+
+static int
+_make_new_typetup(
+        int nop, PyArray_DTypeMeta *signature[], PyObject **out_typetup) {
+    *out_typetup = PyTuple_New(nop);
+    if (*out_typetup == NULL) {
+        return -1;
+    }
+    for (int i = 0; i < nop; i++) {
+        PyObject *item;
+        if (signature[i] == NULL) {
+            item = Py_None;
+        }
+        else {
+            if (!signature[i]->legacy || signature[i]->abstract) {
+                /*
+                 * The legacy type resolution can't deal with these.
+                 * This path will return `None` or so in the future to
+                 * set an error later if the legacy type resolution is used.
+                 */
+                PyErr_SetString(PyExc_RuntimeError,
+                        "Internal NumPy error: new DType in signature not yet "
+                        "supported. (This should be unreachable code!)");
+                Py_SETREF(*out_typetup, NULL);
+                return -1;
+            }
+            item = (PyObject *)signature[i]->singleton;
+        }
+        Py_INCREF(item);
+        PyTuple_SET_ITEM(*out_typetup, i, item);
+    }
+    return 0;
+}
+
+
+/*
+ * Finish conversion parsing of the type tuple.  NumPy always only honored
+ * the type number for passed in descriptors/dtypes.
+ * The `dtype` argument is interpreted as the first output DType (not
+ * descriptor).
+ * Unlike the dtype of an `out` array, it influences loop selection!
  *
- * TODO: The parsing of the typetup should be moved here (followup cleanup).
+ * NOTE: This function replaces the type tuple if passed in (it steals
+ *       the original reference and returns a new object and reference)!
+ *       The caller must XDECREF the type tuple both on error or success.
+ *
+ * The function returns a new, normalized type-tuple.
  */
 static int
-_convert_typetup(PyObject *dtype_obj, PyObject **out_typetup)
+_get_normalized_typetup(PyUFuncObject *ufunc,
+        PyObject *dtype_obj, PyObject *signature_obj, PyObject **out_typetup)
 {
+    if (dtype_obj == NULL && signature_obj == NULL) {
+        return 0;
+    }
+
+    int res = -1;
+    int nin = ufunc->nin, nout = ufunc->nout, nop = nin + nout;
+    /*
+     * TODO: `signature` will be the main result in the future and
+     *       not the typetup. (Type tuple construction can be deffered to when
+     *       the legacy fallback is used).
+     */
+    PyArray_DTypeMeta *signature[NPY_MAXARGS];
+    memset(signature, '\0', sizeof(*signature) * nop);
+
     if (dtype_obj != NULL) {
-        PyArray_Descr *dtype = NULL;
-        if (!PyArray_DescrConverter2(dtype_obj, &dtype)) {
-            return -1;
-        }
-        if (dtype == NULL) {
-            /* dtype=None, no need to set typetup. */
+        if (dtype_obj == Py_None) {
+            /* If `dtype=None` is passed, no need to do anything */
+            assert(*out_typetup == NULL);
             return 0;
         }
-        *out_typetup = PyTuple_Pack(1, (PyObject *)dtype);
-        Py_DECREF(dtype);
-        if (*out_typetup == NULL) {
+        if (nout == 0) {
+            /* This may be allowed (NumPy does not do this)? */
+            PyErr_SetString(PyExc_TypeError,
+                    "Cannot provide `dtype` when a ufunc has no outputs");
             return -1;
         }
+        signature[nin] = _get_dtype(dtype_obj);
+        if (signature[nin] == NULL) {
+            return -1;
+        }
+        res = _make_new_typetup(nop, signature, out_typetup);
+        goto finish;
     }
-    /* sig and signature are not converted here right now. */
-    return 0;
+
+    assert(signature_obj != NULL);
+    /* Fill in specified_types from the tuple or string (signature_obj) */
+    if (PyTuple_Check(signature_obj)) {
+        int nonecount = 0;
+        Py_ssize_t n = PyTuple_GET_SIZE(signature_obj);
+        if (n == 1 && nop != 1) {
+            /*
+             * Special handling, because we deprecate this path.  The path
+             * probably mainly existed since the `dtype=obj` was passed through
+             * as `(obj,)` and parsed later.
+             */
+            if (PyTuple_GET_ITEM(signature_obj, 0) == Py_None) {
+                PyErr_SetString(PyExc_TypeError,
+                        "a single item type tuple cannot contain None.");
+                goto finish;
+            }
+            if (DEPRECATE("The use of a length 1 tuple for the ufunc "
+                          "`signature` is deprecated. Use `dtype` or  fill the"
+                          "tuple with `None`s.") < 0) {
+                goto finish;
+            }
+            /* Use the same logic as for `dtype=` */
+            res = _get_normalized_typetup(ufunc,
+                    PyTuple_GET_ITEM(signature_obj, 0), NULL, out_typetup);
+            goto finish;
+        }
+        if (n != nop) {
+            PyErr_Format(PyExc_ValueError,
+                    "a type-tuple must be specified of length %d for ufunc '%s'",
+                    nop, ufunc_get_name_cstr(ufunc));
+            goto finish;
+        }
+        for (int i = 0; i < nop; ++i) {
+            PyObject *item = PyTuple_GET_ITEM(signature_obj, i);
+            if (item == Py_None) {
+                ++nonecount;
+            }
+            else {
+                signature[i] = _get_dtype(item);
+                if (signature[i] == NULL) {
+                    goto finish;
+                }
+            }
+        }
+        if (nonecount == n) {
+            PyErr_SetString(PyExc_ValueError,
+                    "the type-tuple provided to the ufunc "
+                    "must specify at least one none-None dtype");
+            goto finish;
+        }
+    }
+    else if (PyBytes_Check(signature_obj) || PyUnicode_Check(signature_obj)) {
+        PyObject *str_object = NULL;
+
+        if (PyBytes_Check(signature_obj)) {
+            str_object = PyUnicode_FromEncodedObject(signature_obj, NULL, NULL);
+            if (str_object == NULL) {
+                goto finish;
+            }
+        }
+        else {
+            Py_INCREF(signature_obj);
+            str_object = signature_obj;
+        }
+
+        Py_ssize_t length;
+        const char *str = PyUnicode_AsUTF8AndSize(str_object, &length);
+        if (str == NULL) {
+            Py_DECREF(str_object);
+            goto finish;
+        }
+
+        if (length != 1 && (length != nin+nout + 2 ||
+                            str[nin] != '-' || str[nin+1] != '>')) {
+            PyErr_Format(PyExc_ValueError,
+                    "a type-string for %s, %d typecode(s) before and %d after "
+                    "the -> sign", ufunc_get_name_cstr(ufunc), nin, nout);
+            Py_DECREF(str_object);
+            goto finish;
+        }
+        if (length == 1 && nin+nout != 1) {
+            Py_DECREF(str_object);
+            if (DEPRECATE("The use of a length 1 string for the ufunc "
+                          "`signature` is deprecated. Use `dtype` attribute or "
+                          "pass a tuple with `None`s.") < 0) {
+                goto finish;
+            }
+            /* `signature="l"` is the same as `dtype="l"` */
+            res = _get_normalized_typetup(ufunc, str_object, NULL, out_typetup);
+            goto finish;
+        }
+        else {
+            for (int i = 0; i < nin+nout; ++i) {
+                npy_intp istr = i < nin ? i : i+2;
+                PyArray_Descr *descr = PyArray_DescrFromType(str[istr]);
+                if (descr == NULL) {
+                    Py_DECREF(str_object);
+                    goto finish;
+                }
+                signature[i] = NPY_DTYPE(descr);
+                Py_INCREF(signature[i]);
+                Py_DECREF(descr);
+            }
+            Py_DECREF(str_object);
+        }
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "The signature object to ufunc must be a string or a tuple.");
+        goto finish;
+    }
+    res = _make_new_typetup(nop, signature, out_typetup);
+
+  finish:
+    for (int i =0; i < nop; i++) {
+        Py_XDECREF(signature[i]);
+    }
+    return res;
 }
 
 
@@ -4613,9 +4862,13 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
                 goto fail;
             }
         }
-
-        /* Only one of signature, sig, and dtype should be passed */
-        if (_get_typetup(sig_obj, signature_obj, dtype_obj, &typetup) < 0) {
+        /*
+         * Only one of signature, sig, and dtype should be passed. If `sig`
+         * was passed, this puts it into `signature_obj` instead (these
+         * are borrowed references).
+         */
+        if (_check_and_copy_sig_to_signature(
+                sig_obj, signature_obj, dtype_obj, &signature_obj) < 0) {
             goto fail;
         }
     }
@@ -4635,7 +4888,6 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
         goto fail;
     }
     else if (override) {
-        Py_XDECREF(typetup);
         Py_DECREF(full_args.in);
         Py_XDECREF(full_args.out);
         return override;
@@ -4650,8 +4902,11 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
         Py_SETREF(full_args.in, new_in);
     }
 
-    /* Finish argument parsing/converting for the dtype and all others */
-    if (_convert_typetup(dtype_obj, &typetup) < 0) {
+    /*
+     * Parse the passed `dtype` or `signature` into an array containing
+     * PyArray_DTypeMeta and/or None.
+     */
+    if (_get_normalized_typetup(ufunc, dtype_obj, signature_obj, &typetup) < 0) {
         goto fail;
     }
 
@@ -4734,7 +4989,6 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     Py_XDECREF(typetup);
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
-
     if (ufunc->nout == 1) {
         return retobj[0];
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4480,20 +4480,19 @@ _get_dtype(PyObject *dtype_obj) {
         else if (NPY_UNLIKELY(out->singleton != descr)) {
             /* This does not warn about `metadata`, but units is important. */
             if (!PyArray_EquivTypes(out->singleton, descr)) {
-                if (PyErr_WarnFormat(PyExc_UserWarning, 1,
+                PyErr_Format(PyExc_TypeError,
                         "The `dtype` and `signature` arguments to "
                         "ufuncs only select the general DType and not details "
-                        "such as the byte order or time unit. "
-                        "In very rare cases NumPy <1.21 may have preserved the "
-                        "time unit for `dtype=`.  The cases are mainly "
-                        "`np.minimum(arr1, arr2, dtype='m8[ms]')` and when the "
-                        "output is timedelta, but the input is integer. "
-                        "(See NumPy 1.21.0 release notes for details.)\n"
-                        "If you wish to set an exact output dtype, you must "
-                        "currently pass `out=` instead.") < 0) {
-                    Py_DECREF(descr);
-                    return NULL;
-                }
+                        "such as the byte order or time unit (with rare "
+                        "exceptions see release notes).  To avoid this warning "
+                        "please use the scalar types `np.float64`, or string "
+                        "notation.\n"
+                        "In rare cases where the time unit was preserved, "
+                        "either cast the inputs or provide an output array. "
+                        "In the future NumPy may transition to allow providing "
+                        "`dtype=` to denote the outputs `dtype` as well");
+                Py_DECREF(descr);
+                return NULL;
             }
         }
         Py_INCREF(out);

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -563,12 +563,12 @@ PyUFunc_SimpleUniformOperationTypeResolver(
                     continue;
                 }
                 if (!PyArray_DescrCheck(item)) {
-                    /* bad type tuple (maybe not normalized correctly?) */
+                    /* Defer to default resolver (will raise an error there) */
                     descr = NULL;
                     break;
                 }
                 if (descr != NULL && descr != (PyArray_Descr *)item) {
-                    /* descriptor mismatch, probably a bad signature. */
+                    /* Descriptor mismatch: try with default (probable error) */
                     descr = NULL;
                     break;
                 }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1141,3 +1141,37 @@ class TestStringPromotion(_DeprecationTestCase):
         # np.equal uses a different type resolver:
         with pytest.raises(TypeError):
             self.assert_not_deprecated(lambda: np.equal(arr1, arr2))
+
+
+class TestSingleElementSignature(_DeprecationTestCase):
+    # Deprecated 2021-04-01, NumPy 1.21
+    message = r"The use of a length 1"
+
+    def test_deprecated(self):
+        self.assert_deprecated(lambda: np.add(1, 2, signature="d"))
+        self.assert_deprecated(lambda: np.add(1, 2, sig=(np.dtype("l"),)))
+
+
+class TestComparisonBadDType(_DeprecationTestCase):
+    # Deprecated 2021-04-01, NumPy 1.21
+    message = r"using `dtype=` in comparisons is only useful for"
+
+    def test_deprecated(self):
+        self.assert_deprecated(lambda: np.equal(1, 1, dtype=np.int64))
+        # Not an error only for the transition
+        self.assert_deprecated(lambda: np.equal(1, 1, sig=(None, None, "l")))
+
+    def test_not_deprecated(self):
+        np.equal(True, False, dtype=bool)
+        np.equal(3, 5, dtype=bool, casting="unsafe")
+        np.equal([None], [4], dtype=object)
+
+class TestComparisonBadObjectDType(_DeprecationTestCase):
+    # Deprecated 2021-04-01, NumPy 1.21  (different branch of the above one)
+    message = r"using `dtype=object` \(or equivalent signature\) will"
+    warning_cls = FutureWarning
+
+    def test_deprecated(self):
+        self.assert_deprecated(lambda: np.equal(1, 1, dtype=object))
+        self.assert_deprecated(
+                lambda: np.equal(1, 1, sig=(None, None, object)))

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -467,6 +467,12 @@ class TestUfunc:
             np.add(3, 4, signature="%^->#")
 
         with pytest.raises(ValueError):
+            np.add(3, 4, signature=b"ii-i")  # incomplete and byte string
+
+        with pytest.raises(ValueError):
+            np.add(3, 4, signature="ii>i")  # incomplete string
+
+        with pytest.raises(ValueError):
             np.add(3, 4, signature=(None, "f8"))  # bad length
 
         with pytest.raises(UnicodeDecodeError):

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -498,23 +498,17 @@ class TestUfunc:
         np.add(3, 4, dtype=int64_2)
 
         arr = np.arange(10, dtype="m8[s]")
-        with pytest.warns(UserWarning,
-                match="The `dtype` and `signature` arguments to") as rec:
+        msg = "The `dtype` and `signature` arguments to ufuncs only select the"
+        with pytest.raises(TypeError, match=msg):
             np.add(3, 5, dtype=int64.newbyteorder())
+        with pytest.raises(TypeError, match=msg):
             np.add(3, 5, dtype="m8[ns]")  # previously used the "ns"
+        with pytest.raises(TypeError, match=msg):
             np.add(arr, arr, dtype="m8[ns]")  # never preserved the "ns"
+        with pytest.raises(TypeError, match=msg):
             np.maximum(arr, arr, dtype="m8[ns]")  # previously used the "ns"
+        with pytest.raises(TypeError, match=msg):
             np.maximum.reduce(arr, dtype="m8[ns]")  # never preserved the "ns"
-
-        assert len(rec) == 5  # each of the above call should cause one
-
-        # Also check the error paths:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning):
-                np.add(3, 5, dtype="m8[ns]")
-            with pytest.raises(UserWarning):
-                np.maximum.reduce(arr, dtype="m8[ns]")
 
     def test_true_divide(self):
         a = np.array(10)

--- a/numpy/typing/tests/data/pass/ufuncs.py
+++ b/numpy/typing/tests/data/pass/ufuncs.py
@@ -4,7 +4,7 @@ np.sin(1)
 np.sin([1, 2, 3])
 np.sin(1, out=np.empty(1))
 np.matmul(np.ones((2, 2, 2)), np.ones((2, 2, 2)), axes=[(0, 1), (0, 1), (0, 1)])
-np.sin(1, signature="D")
+np.sin(1, signature="D->D")
 np.sin(1, extobj=[16, 1, lambda: None])
 # NOTE: `np.generic` subclasses are not guaranteed to support addition;
 # re-enable this we can infer the exact return type of `np.sin(...)`.


### PR DESCRIPTION
This may have slight affects on users, see release notes.

Mainly, we have to parse the type tuple up-front (because we need
to replace the current type resolution).  Since we _must_ de-facto
replace the current type resolution, I do not see why we should
duplicate code for the odd possibility of someone actually calling
`ufunc.type_resolver()` with a `typetup` that is not a actually a
type tuple.

This commit also deprecates `signature="l"` as meaning (normally)
the same as `dtype="l"`.
