### PR TITLE
ENH: Add __getitem__ __setitem__ to mixin

### DIFF
--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -174,3 +174,9 @@ class NDArrayOperatorsMixin:
     __pos__ = _unary_method(um.positive, 'pos')
     __abs__ = _unary_method(um.absolute, 'abs')
     __invert__ = _unary_method(um.invert, 'invert')
+
+    def __getitem__(self, *args, **kwargs):
+        return self.__array__().__getitem__(*args, **kwargs)
+
+    def __setitem__(self, *args, **kwargs):
+        return self.__array__().__setitem__(*args, **kwargs)


### PR DESCRIPTION
It seems to me that array containers (the target of the mixin class) should also provide `__getitem__` and `__setitem__`. Maybe an exception is sparse matrices (?). This PR is mostly to start a discussion. I'm sure my implementation is poor.