### PR TITLE
BLD: introduce use of BLAS_LIBS and LAPACK_LIBS in distutils/system_info

### DIFF
--- a/doc/release/upcoming_changes/18737.new_feature.rst
+++ b/doc/release/upcoming_changes/18737.new_feature.rst
@@ -1,0 +1,9 @@
+generic optimized BLAS and LAPACK via NPY_BLAS_LIBS etal.
+---------------------------------------------------------
+There is a generic choice for BLAS and LAPACK during build that
+is activated by defining NPY_BLAS_LIBS, NPY_CBLAS_LIBS,  and
+NPYLAPACK_LIBS in the environment of setup.py to the respective
+linker flags. This shortcuts any automatic guessing and allows
+simple controlled linkage of BLAS/LAPACK in automated builds,
+also possibly to replace the actual implementation at runtime
+via stub library links.

--- a/doc/release/upcoming_changes/18737.new_feature.rst
+++ b/doc/release/upcoming_changes/18737.new_feature.rst
@@ -1,9 +1,12 @@
-generic optimized BLAS and LAPACK via NPY_BLAS_LIBS etal.
----------------------------------------------------------
-There is a generic choice for BLAS and LAPACK during build that
-is activated by defining NPY_BLAS_LIBS, NPY_CBLAS_LIBS,  and
-NPYLAPACK_LIBS in the environment of setup.py to the respective
-linker flags. This shortcuts any automatic guessing and allows
-simple controlled linkage of BLAS/LAPACK in automated builds,
-also possibly to replace the actual implementation at runtime
-via stub library links.
+BLAS and LAPACK configuration via environment variables
+-------------------------------------------------------
+Autodetection of installed BLAS and LAPACK libraries can be bypassed by using
+the ``NPY_BLAS_LIBS`` and ``NPY_LAPACK_LIBS`` environment variables. Instead,
+the link flags in these environment variables will be used directly, and the
+language is assumed to be F77.  This is especially useful in automated builds
+where the BLAS and LAPACK that are installed are known exactly.  A use case is
+replacing the actual implementation at runtime via stub library links.
+
+If ``NPY_CBLAS_LIBS`` is set (optional in addition to ``NPY_BLAS_LIBS``), this
+will be used as well, by defining ``HAVE_CBLAS`` and appending the environment
+variable content to the link flags.

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -6,7 +6,7 @@ Building from source
 A general overview of building NumPy from source is given here, with detailed
 instructions for specific platforms given separately.
 
-.. 
+..
   This page is referenced from numpy/numpy/__init__.py. Please keep its
   location in sync with the link there.
 
@@ -128,12 +128,17 @@ optimized build of NumPy.
 
 The default order for the libraries are:
 
-1. generic (NPY_BLAS_LIBS and NPY_CBLAS_LIBS from environment)
-2. MKL
-3. BLIS
-4. OpenBLAS
-5. ATLAS
-6. BLAS (NetLIB)
+1. MKL
+2. BLIS
+3. OpenBLAS
+4. ATLAS
+5. BLAS (NetLIB)
+
+The detection of BLAS libraries may be bypassed by defining the environment
+variable ``NPY_BLAS_LIBS`` , which should contain the exact linker flags you
+want to use (interface is assumed to be Fortran 77).  Also define
+``NPY_CBLAS_LIBS`` (even empty if CBLAS is contained in your BLAS library) to
+trigger use of CBLAS and avoid slow fallback code for matrix calculations.
 
 If you wish to build against OpenBLAS but you also have BLIS available one
 may predefine the order of searching via the environment variable
@@ -156,30 +161,20 @@ list is retained.
 One cannot mix negation and positives, nor have multiple negations, such cases will
 raise an error.
 
-The generic option shortcuts any automatic library checks if NPY_BLAS_LIBS
-is defined in the environment. NPY_BLAS_LIBS is supposed to contain all
-linker flags to link to a standard BLAS library that offers the Fortran
-interface. Also define NPY_CBLAS_LIBS (even empty if CBLAS is contained
-in your BLAS library) to trigger use of CBLAS and avoid slow fallback
-code for matrix calculations.
-
-You can use the generic mechanism to ensure that the build is agnostic
-to the actual BLAS implementation.  This is also the first in the list
-to enable the not uncommon behaviour of using NPY_BLAS_LIBS from the
-environment and only guessing if it is not set.
-
 LAPACK
 ~~~~~~
 
 The default order for the libraries are:
 
-1. generic (NPY_LAPACK_LIBS from environment)
-2. MKL
-3. OpenBLAS
-4. libFLAME
-5. ATLAS
-6. LAPACK (NetLIB)
+1. MKL
+2. OpenBLAS
+3. libFLAME
+4. ATLAS
+5. LAPACK (NetLIB)
 
+The detection of LAPACK libraries may be bypassed by defining the environment
+variable ``NPY_LAPACK_LIBS``, which should contain the exact linker flags you
+want to use (language is assumed to be Fortran 77).
 
 If you wish to build against OpenBLAS but you also have MKL available one
 may predefine the order of searching via the environment variable
@@ -201,14 +196,6 @@ list is retained.
 
 One cannot mix negation and positives, nor have multiple negations, such cases will
 raise an error.
-
-The generic option shortcuts any automatic library checks if NPY_LAPACK_LIBS
-is defined in the environment. NPY_LAPACK_LIBS is supposed to contain
-all linker flags to link to a standard LAPACK library that offers the
-Fortran interface.  You can use this mechanism to ensure that the build
-is agnostic to the actual LAPACK implementation. This is also the first
-in the list to enable the not uncommon behaviour of using NPY_LAPACK_LIBS
-from the environment and only guessing if it is not set.
 
 .. deprecated:: 1.20
   The native libraries on macOS, provided by Accelerate, are not fit for use

--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -123,13 +123,17 @@ in the ``site.cfg.example`` file.
 BLAS
 ~~~~
 
+Note that both BLAS and CBLAS interfaces are needed for a properly
+optimized build of NumPy.
+
 The default order for the libraries are:
 
-1. MKL
-2. BLIS
-3. OpenBLAS
-4. ATLAS
-5. BLAS (NetLIB)
+1. generic (NPY_BLAS_LIBS and NPY_CBLAS_LIBS from environment)
+2. MKL
+3. BLIS
+4. OpenBLAS
+5. ATLAS
+6. BLAS (NetLIB)
 
 If you wish to build against OpenBLAS but you also have BLIS available one
 may predefine the order of searching via the environment variable
@@ -152,16 +156,29 @@ list is retained.
 One cannot mix negation and positives, nor have multiple negations, such cases will
 raise an error.
 
+The generic option shortcuts any automatic library checks if NPY_BLAS_LIBS
+is defined in the environment. NPY_BLAS_LIBS is supposed to contain all
+linker flags to link to a standard BLAS library that offers the Fortran
+interface. Also define NPY_CBLAS_LIBS (even empty if CBLAS is contained
+in your BLAS library) to trigger use of CBLAS and avoid slow fallback
+code for matrix calculations.
+
+You can use the generic mechanism to ensure that the build is agnostic
+to the actual BLAS implementation.  This is also the first in the list
+to enable the not uncommon behaviour of using NPY_BLAS_LIBS from the
+environment and only guessing if it is not set.
+
 LAPACK
 ~~~~~~
 
 The default order for the libraries are:
 
-1. MKL
-2. OpenBLAS
-3. libFLAME
-4. ATLAS
-5. LAPACK (NetLIB)
+1. generic (NPY_LAPACK_LIBS from environment)
+2. MKL
+3. OpenBLAS
+4. libFLAME
+5. ATLAS
+6. LAPACK (NetLIB)
 
 
 If you wish to build against OpenBLAS but you also have MKL available one
@@ -185,6 +202,13 @@ list is retained.
 One cannot mix negation and positives, nor have multiple negations, such cases will
 raise an error.
 
+The generic option shortcuts any automatic library checks if NPY_LAPACK_LIBS
+is defined in the environment. NPY_LAPACK_LIBS is supposed to contain
+all linker flags to link to a standard LAPACK library that offers the
+Fortran interface.  You can use this mechanism to ensure that the build
+is agnostic to the actual LAPACK implementation. This is also the first
+in the list to enable the not uncommon behaviour of using NPY_LAPACK_LIBS
+from the environment and only guessing if it is not set.
 
 .. deprecated:: 1.20
   The native libraries on macOS, provided by Accelerate, are not fit for use

--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -122,7 +122,7 @@ This search (or autodetection) can be bypassed by defining the environment
 variables NPY_BLAS_LIBS and NPY_LAPACK_LIBS, which should then contain the
 exact linker flags to use (language will be set to F77). Building against
 Netlib BLAS/LAPACK or stub files, in order to be able to switch BLAS and LAPACK
-implementations at runtime If using this to build NumPy itself, it is
+implementations at runtime. If using this to build NumPy itself, it is
 recommended to also define NPY_CBLAS_LIBS (assuming your BLAS library has a
 CBLAS interface) to enable CBLAS usage for matrix multiplication (unoptimized
 otherwise).


### PR DESCRIPTION
This enables the behaviour of the build honouring the environment
variables BLAS_LIBS and LAPACK_LIBS to select any standard-conforming
implementation of the f77 interfaces.

This is needed to sanely have automated builds provide BLAS libs
in a way common to multiple packages (using some environment variable,
BLAS_LIBS being canonical, but variants exist). Hacking a site.cfg
is fine for a single user, but does not scale well. As example,
pkgsrc, the NetBSD packages collection, offers differing builds
of Netlib or OpenBLAS, the latter in variables openblas,
openblas_openmp, and openblas_pthread. With this patch, differing
builds can just use different variable values like

BLAS_LIBS=-lblas LAPACK_LIBS='-lapack -lblas' \
  python setup.py build

BLAS_LIBS=-lopenblas_pthread LAPACK_LIBS='-lopenblas_pthread' \
  python setup.py build

(LAPACK_LIBS contains reference to BLAS, too, for packages that only
use LAPACK and would miss underlying BLAS otherwise for static linking.)

EDIT: this part was removed from the PR:
~To ensure the generic BLAS being used, pkgsrc also sets~

  ~NPY_BLAS_ORDER=generic NPY_LAPACK_ORDER=generic~

~but I do think it makes sense to keep it first in line to enable the above simple usage that matches other scientific software with less sophisticated build systems.~
