### PR TITLE
DOC: Emphasize distinctions between np.copy and ndarray.copy

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3114,7 +3114,18 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('copy',
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible. (Note that this function and :func:`numpy.copy` are very
         similar, but have different default values for their order=
-        arguments.)
+        arguments, and this function always passes sub-classes through.)
+
+    See also
+    --------
+    numpy.copy : Similar function with different default behavior
+    numpy.copyto
+
+    Notes
+    -----
+    This function is the preferred method for creating an array copy.  The
+    function :func:`numpy.copy` is similar, but it defaults to using order 'C',
+    and will not pass sub-classes through by default.
 
     See also
     --------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3127,11 +3127,6 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('copy',
     function :func:`numpy.copy` is similar, but it defaults to using order 'C',
     and will not pass sub-classes through by default.
 
-    See also
-    --------
-    numpy.copy
-    numpy.copyto
-
     Examples
     --------
     >>> x = np.array([[1,2,3],[4,5,6]], order='F')

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3113,7 +3113,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('copy',
         'F' means F-order, 'A' means 'F' if `a` is Fortran contiguous,
         'C' otherwise. 'K' means match the layout of `a` as closely
         as possible. (Note that this function and :func:`numpy.copy` are very
-        similar, but have different default values for their order=
+        similar but have different default values for their order=
         arguments, and this function always passes sub-classes through.)
 
     See also
@@ -3124,7 +3124,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('copy',
     Notes
     -----
     This function is the preferred method for creating an array copy.  The
-    function :func:`numpy.copy` is similar, but it defaults to using order 'C',
+    function :func:`numpy.copy` is similar, but it defaults to using order 'K',
     and will not pass sub-classes through by default.
 
     Examples


### PR DESCRIPTION
See #15570 and #15685.

@rossbar clarified the documentation for `numpy.copy`, but `ndarray.copy` was left unchanged.  This distinction recently [bit me](https://github.com/moble/quaternionic/issues/22) and one of my users again, which *might* have been avoided if the distinction were noted in both places.
