### PR TITLE
MAINT: Allow more recursion depth for scalar tests.

### DIFF
--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -737,7 +737,7 @@ reasonable_operators_for_scalars = [
 @settings(verbosity=Verbosity.verbose)
 def test_operator_object_left(o, op, type_):
     try:
-        with recursionlimit(100):
+        with recursionlimit(200):
             op(o, type_(1))
     except TypeError:
         pass
@@ -748,7 +748,7 @@ def test_operator_object_left(o, op, type_):
        sampled_from(types))
 def test_operator_object_right(o, op, type_):
     try:
-        with recursionlimit(100):
+        with recursionlimit(200):
             op(type_(1), o)
     except TypeError:
         pass


### PR DESCRIPTION
The test_operator_object_left and test_operator_object_right tests in
test_scalarmath.py set a maximum recursion depth of 100 that caused an
error in gitpod because it was too close to the starting depth of 75.
The fix here is to raise the maximum depth to 200.

Closes #18749

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
