### PR TITLE
BLD: Negative zero handling with ifort

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -59,7 +59,8 @@ class IntelFCompiler(BaseIntelFCompiler):
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-fp-model', 'strict', '-O1', '-assume', 'minus0', '-{}'.format(mpopt)]
+        return ['-fp-model', 'strict', '-O1',
+                '-assume', 'minus0', '-{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return []

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -59,7 +59,7 @@ class IntelFCompiler(BaseIntelFCompiler):
     def get_flags_opt(self):  # Scipy test failures with -O2
         v = self.get_version()
         mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-fp-model', 'strict', '-O1', '-{}'.format(mpopt)]
+        return ['-fp-model', 'strict', '-O1', '-assume', 'minus0', '-{}'.format(mpopt)]
 
     def get_flags_arch(self):
         return []
@@ -119,17 +119,6 @@ class IntelEM64TFCompiler(IntelFCompiler):
         'ranlib'       : ["ranlib"]
         }
 
-    def get_flags(self):
-        return ['-fPIC']
-
-    def get_flags_opt(self):  # Scipy test failures with -O2
-        v = self.get_version()
-        mpopt = 'openmp' if v and v < '15' else 'qopenmp'
-        return ['-fp-model', 'strict', '-O1', '-{}'.format(mpopt)]
-
-    def get_flags_arch(self):
-        return []
-
 # Is there no difference in the version string between the above compilers
 # and the Visual compilers?
 
@@ -174,7 +163,7 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
         return ['/4Yb', '/d2']
 
     def get_flags_opt(self):
-        return ['/O1']  # Scipy test failures with /O2
+        return ['/O1', '/assume:minus0']  # Scipy test failures with /O2
 
     def get_flags_arch(self):
         return ["/arch:IA32", "/QaxSSE3"]


### PR DESCRIPTION
Fixes https://github.com/scipy/scipy/issues/11339

**What does this implement/fix?**

NumPy/SciPy compiled with Intel Fortran compiler using default flags treat both -0.0 and +0.0 as 0.0, however it is not IEEE 754 compliant and some SciPy logic relies on this -0.0 and +0.0 differentiation.
