### PR TITLE
BUG: Correct `datetime64` missing type overload for `datetime.date` #18640

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1758,11 +1758,21 @@ class object_(generic):
     @property
     def imag(self: _ArraySelf) -> _ArraySelf: ...
 
+# The `datetime64` constructors requires an object with the three attributes below,
+# and thus supports datetime duck typing
+class _DatetimeScalar(Protocol):
+    @property
+    def day(self) -> int: ...
+    @property
+    def month(self) -> int: ...
+    @property
+    def year(self) -> int: ...
+
 class datetime64(generic):
     @overload
     def __init__(
         self,
-        __value: Union[None, datetime64, _CharLike, dt.datetime] = ...,
+        __value: Union[None, datetime64, _CharLike, _DatetimeScalar] = ...,
         __format: Union[_CharLike, Tuple[_CharLike, _IntLike]] = ...,
     ) -> None: ...
     @overload

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -85,6 +85,7 @@ np.datetime64("2019", "D")
 np.datetime64(np.datetime64())
 np.datetime64(dt.datetime(2000, 5, 3))
 np.datetime64(None)
+np.datetime64(dt.date(2000, 5, 3))
 np.datetime64(None, "D")
 
 np.timedelta64()


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/18690.

The `np.datetime64` can in fact take any object with the `day`, `month` and `year` properties (_e.g._ `dt.date`) and not just `dt.datetime`.