### PR TITLE
CI: Use informational mode for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,8 +6,9 @@ coverage:
   status:
     project:
       default:
-        # Require 1% coverage, i.e., always succeed
-        target: 1
-    patch: true
+        informational: true
+    patch:
+      default:
+        informational: true
     changes: false
 comment: off


### PR DESCRIPTION
Small teaks for codecov, should close gh-18747 (although I somewhat expect the problem there is rebase related as well).