### PR TITLE
DOC: Ensure that we add documentation also as to the dict for types

### DIFF
--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1436,8 +1436,8 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
          * `__text_signature__` to the dict in the future.
          * The dictionary path is only necessary for heaptypes (currently not
          * used) and metaclasses.
-         * If `__doc__` as stored in `to_dict` is None, we assume this was
-         * filled in by `PyType_Read()` and should also be replaced.
+         * If `__doc__` as stored in `tp_dict` is None, we assume this was
+         * filled in by `PyType_Ready()` and should also be replaced.
          */
         PyTypeObject *new = (PyTypeObject *)obj;
         _ADDDOC(new->tp_doc, new->tp_name);


### PR DESCRIPTION
This ensures that `help(np.dtype)` produces a result.  I am not
exactly sure why it picks up `__doc__` from the dict instead of
`tp_doc` right now. It probably is due to the combination of
inheritance and the fact that the dict always includes `None`
and gets preference during inheritance.
(That probably makes a lot of sense to not inherit the `type`
docstring by default.)

Modifying the dictionary directly is not really good style, either,
but hopefully works.

Closes gh-18740
