### PR TITLE
DOC: update random and asserts in test guidelines

### DIFF
--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -351,8 +351,7 @@ new bugs or regressions, a test that passes most of the time but fails
 occasionally with no code changes is not helpful. Make the random data
 deterministic by setting the random number seed before generating it.  Use
 either Python's ``random.seed(some_number)`` or NumPy's
-``rng = np.random.default_rng(some_number)``, depending on the source of
-random numbers.
+``numpy.random.seed(some_number)``, depending on the source of random numbers.
 
 Alternatively, you can use `Hypothesis`_ to generate arbitrary data.
 Hypothesis manages both Python's and Numpy's random seeds for you, and

--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -59,7 +59,7 @@ that are run; but if it is greater than 1, then the tests will also provide
 warnings on missing tests. So if you want to run every test and get
 messages about which modules don't have tests::
 
-  >>> numpy.test(label='full', verbose=2) # or numpy.test('full', 2)
+  >>> numpy.test(label='full', verbose=2)  # or numpy.test('full', 2)
 
 Finally, if you are only interested in testing a subset of NumPy, for
 example, the ``core`` module, use the following::
@@ -101,27 +101,25 @@ module called ``test_yyy.py``.  If you only need to test one aspect of
 ``zzz``, you can simply add a test function::
 
   def test_zzz():
-      assert_(zzz() == 'Hello from zzz')
+      assert zzz() == 'Hello from zzz'
 
 More often, we need to group a number of tests together, so we create
 a test class::
 
-  from numpy.testing import assert_, assert_raises
-
   # import xxx symbols
   from numpy.xxx.yyy import zzz
+  import pytest
 
   class TestZzz:
       def test_simple(self):
-          assert_(zzz() == 'Hello from zzz')
+          assert zzz() == 'Hello from zzz'
 
       def test_invalid_parameter(self):
-          assert_raises(...)
+          with pytest.raises(xxxError, match='expected error message'):
+              ...
 
-Within these test methods, ``assert_()`` and related functions are used to test
+Within these test methods, ``assert`` and related functions are used to test
 whether a certain assumption is valid. If the assertion fails, the test fails.
-Note that the Python builtin ``assert`` should not be used, because it is
-stripped during compilation with ``-O``.
 
 Note that ``test_`` functions or methods should not have a docstring, because
 that makes it hard to identify the test from the output of running the test
@@ -282,12 +280,12 @@ from one in `numpy/linalg/tests/test_linalg.py
 
   class LinalgTestCase:
       def test_single(self):
-          a = array([[1.,2.], [3.,4.]], dtype=single)
+          a = array([[1., 2.], [3., 4.]], dtype=single)
           b = array([2., 1.], dtype=single)
           self.do(a, b)
 
       def test_double(self):
-          a = array([[1.,2.], [3.,4.]], dtype=double)
+          a = array([[1., 2.], [3., 4.]], dtype=double)
           b = array([2., 1.], dtype=double)
           self.do(a, b)
 
@@ -296,14 +294,14 @@ from one in `numpy/linalg/tests/test_linalg.py
   class TestSolve(LinalgTestCase):
       def do(self, a, b):
           x = linalg.solve(a, b)
-          assert_almost_equal(b, dot(a, x))
-          assert_(imply(isinstance(b, matrix), isinstance(x, matrix)))
+          assert_allclose(b, dot(a, x))
+          assert imply(isinstance(b, matrix), isinstance(x, matrix))
 
   class TestInv(LinalgTestCase):
       def do(self, a, b):
           a_inv = linalg.inv(a)
-          assert_almost_equal(dot(a, a_inv), identity(asarray(a).shape[0]))
-          assert_(imply(isinstance(a, matrix), isinstance(a_inv, matrix)))
+          assert_allclose(dot(a, a_inv), identity(asarray(a).shape[0]))
+          assert imply(isinstance(a, matrix), isinstance(a_inv, matrix))
 
 In this case, we wanted to test solving a linear algebra problem using
 matrices of several data types, using ``linalg.solve`` and
@@ -353,7 +351,8 @@ new bugs or regressions, a test that passes most of the time but fails
 occasionally with no code changes is not helpful. Make the random data
 deterministic by setting the random number seed before generating it.  Use
 either Python's ``random.seed(some_number)`` or NumPy's
-``numpy.random.seed(some_number)``, depending on the source of random numbers.
+``rng = np.random.default_rng(some_number)``, depending on the source of
+random numbers.
 
 Alternatively, you can use `Hypothesis`_ to generate arbitrary data.
 Hypothesis manages both Python's and Numpy's random seeds for you, and

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -29,9 +29,14 @@ Asserts
    assert_warns
    assert_string_equal
 
+Asserts (not recommanded)
+-------------------------
+It is recommended to use one of `assert_allclose`,
+`assert_array_almost_equal_nulp` or `assert_array_max_ulp` instead of these
+functions for more consistent floating point comparisons.
+
 .. autosummary::
    :toctree: generated/
-   :hidden:
 
    assert_almost_equal
    assert_approx_equal

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -29,7 +29,7 @@ Asserts
    assert_warns
    assert_string_equal
 
-Asserts (not recommanded)
+Asserts (not recommended)
 -------------------------
 It is recommended to use one of `assert_allclose`,
 `assert_array_almost_equal_nulp` or `assert_array_max_ulp` instead of these

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -18,9 +18,6 @@ Asserts
 .. autosummary::
    :toctree: generated/
 
-   assert_almost_equal
-   assert_approx_equal
-   assert_array_almost_equal
    assert_allclose
    assert_array_almost_equal_nulp
    assert_array_max_ulp
@@ -31,6 +28,14 @@ Asserts
    assert_raises_regex
    assert_warns
    assert_string_equal
+
+.. autosummary::
+   :toctree: generated/
+   :hidden:
+
+   assert_almost_equal
+   assert_approx_equal
+   assert_array_almost_equal
 
 Decorators
 ----------


### PR DESCRIPTION
I propose to update the testing guide.

* ~Change `np.random.seed` to using `np.random. default_rng.~
* Change `assert_` to plain `assert` as the statement about python stripping them out is not relevant in this context.
* Hide sections about `assert_almost_equal` and alike as better alternative are recommended.

There was a discussion over at SciPy which suggested that this guide needed updates.
xref https://github.com/scipy/scipy/issues/8583