### PR TITLE
MAINT: Relax the integer-type-constraint of `npt._ShapeLike`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1375,7 +1375,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     def imag(self, value: ArrayLike) -> None: ...
     def __new__(
         cls: Type[_ArraySelf],
-        shape: Sequence[int],
+        shape: _ShapeLike,
         dtype: DTypeLike = ...,
         buffer: _BufferType = ...,
         offset: int = ...,

--- a/numpy/typing/_shape.py
+++ b/numpy/typing/_shape.py
@@ -1,6 +1,15 @@
+import sys
 from typing import Sequence, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from typing import SupportsIndex
+else:
+    try:
+        from typing_extensions import SupportsIndex
+    except ImportError:
+        SupportsIndex = NotImplemented
 
 _Shape = Tuple[int, ...]
 
 # Anything that can be coerced to a shape tuple
-_ShapeLike = Union[int, Sequence[int]]
+_ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]

--- a/numpy/typing/tests/data/pass/array_constructors.py
+++ b/numpy/typing/tests/data/pass/array_constructors.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Any
 import numpy as np
 
@@ -22,8 +23,9 @@ B = A.view(SubClass).copy()
 B_stack = np.array([[1], [1]]).view(SubClass)
 C = [1]
 
-np.ndarray(Index())
-np.ndarray([Index()])
+if sys.version_info >= (3, 8):
+    np.ndarray(Index())
+    np.ndarray([Index()])
 
 np.array(1, dtype=float)
 np.array(1, copy=False)

--- a/numpy/typing/tests/data/pass/array_constructors.py
+++ b/numpy/typing/tests/data/pass/array_constructors.py
@@ -17,6 +17,9 @@ C = [1]
 def func(i: int, j: int, **kwargs: Any) -> SubClass:
     return B
 
+np.ndarray(Index())
+np.ndarray([Index()])
+
 np.array(1, dtype=float)
 np.array(1, copy=False)
 np.array(1, order='F')

--- a/numpy/typing/tests/data/pass/array_constructors.py
+++ b/numpy/typing/tests/data/pass/array_constructors.py
@@ -1,11 +1,19 @@
 from typing import List, Any
 import numpy as np
 
+
 class Index:
     def __index__(self) -> int:
         return 0
 
-class SubClass(np.ndarray): ...
+
+class SubClass(np.ndarray):
+    pass
+
+
+def func(i: int, j: int, **kwargs: Any) -> SubClass:
+    return B
+
 
 i8 = np.int64(1)
 
@@ -13,9 +21,6 @@ A = np.array([1])
 B = A.view(SubClass).copy()
 B_stack = np.array([[1], [1]]).view(SubClass)
 C = [1]
-
-def func(i: int, j: int, **kwargs: Any) -> SubClass:
-    return B
 
 np.ndarray(Index())
 np.ndarray([Index()])


### PR DESCRIPTION
As was noted in https://github.com/scipy/scipy/pull/13833#discussion_r613452952 the definition of `npt._ShapeLike` prior to this PR is too strict. 

The latter currently demands a `builtins.int` (or sequence thereof) while the likes of `np.integer` or, 
more generally, objects implementing the `__index__` protocol are generally suitable alternatives.