### PR TITLE
ENH: Add `__all__` to a number of public modules

### DIFF
--- a/numpy/fft/__init__.py
+++ b/numpy/fft/__init__.py
@@ -200,8 +200,12 @@ For examples, see the various functions.
 
 """
 
+from . import _pocketfft, helper
 from ._pocketfft import *
 from .helper import *
+
+__all__ = _pocketfft.__all__.copy()
+__all__ += helper.__all__
 
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)

--- a/numpy/fft/__init__.pyi
+++ b/numpy/fft/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 fft: Any
 ifft: Any

--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -70,7 +70,10 @@ Exceptions
 
 """
 # To get sub-modules
+from . import linalg
 from .linalg import *
+
+__all__ = linalg.__all__.copy()
 
 from numpy._pytesttester import PytestTester
 test = PytestTester(__name__)

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, List
+
+__all__: List[str]
 
 matrix_power: Any
 solve: Any

--- a/numpy/polynomial/__init__.py
+++ b/numpy/polynomial/__init__.py
@@ -37,13 +37,13 @@ This eliminates the need to navigate to the corresponding submodules, e.g.
 The classes provide a more consistent and concise interface than the
 type-specific functions defined in the submodules for each type of polynomial.
 For example, to fit a Chebyshev polynomial with degree ``1`` to data given
-by arrays ``xdata`` and ``ydata``, the 
+by arrays ``xdata`` and ``ydata``, the
 `~chebyshev.Chebyshev.fit` class method::
 
     >>> from numpy.polynomial import Chebyshev
     >>> c = Chebyshev.fit(xdata, ydata, deg=1)
 
-is preferred over the `chebyshev.chebfit` function from the 
+is preferred over the `chebyshev.chebfit` function from the
 ``np.polynomial.chebyshev`` module::
 
     >>> from numpy.polynomial.chebyshev import chebfit
@@ -76,7 +76,7 @@ Methods for creating polynomial instances.
 
 - ``Poly.basis(degree)``    -- Basis polynomial of given degree
 - ``Poly.identity()``       -- ``p`` where ``p(x) = x`` for all ``x``
-- ``Poly.fit(x, y, deg)``   -- ``p`` of degree ``deg`` with coefficients 
+- ``Poly.fit(x, y, deg)``   -- ``p`` of degree ``deg`` with coefficients
   determined by the least-squares fit to the data ``x``, ``y``
 - ``Poly.fromroots(roots)`` -- ``p`` with specified roots
 - ``p.copy()``              -- Create a copy of ``p``
@@ -119,6 +119,16 @@ from .legendre import Legendre
 from .hermite import Hermite
 from .hermite_e import HermiteE
 from .laguerre import Laguerre
+
+__all__ = [
+    "set_default_printstyle",
+    "polynomial", "Polynomial",
+    "chebyshev", "Chebyshev",
+    "legendre", "Legendre",
+    "hermite", "Hermite",
+    "hermite_e", "HermiteE",
+    "laguerre", "Laguerre",
+]
 
 
 def set_default_printstyle(style):

--- a/numpy/polynomial/__init__.pyi
+++ b/numpy/polynomial/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from numpy.polynomial import (
     chebyshev as chebyshev,
@@ -8,6 +8,8 @@ from numpy.polynomial import (
     legendre as legendre,
     polynomial as polynomial,
 )
+
+__all__: List[str]
 
 Polynomial: Any
 Chebyshev: Any


### PR DESCRIPTION
A number of public modules were still missing an `__all__`.

This PR addresses aforementioned issue for the following modules:
* `np.fft`
* `np.linalg`
* `np.polynomial`