### PR TITLE
DEV: Pin pydata-sphinx-theme to 0.5.2.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - scipy
   - pandas
   - matplotlib
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme=0.5.2
   # For linting
   - pycodestyle=2.7.0
   - gitpython


### PR DESCRIPTION
Pin pydata-sphinx-theme until pydata/pydata-sphinx-theme#381 is resolved.

Since the `environment.yml` is used to build the gitpod instance, doc builds in gitpod are currently extremely slow.