### PR TITLE
CI: Use `towncrier build` explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             . venv/bin/activate
             pip install git+https://github.com/hawkowl/towncrier.git@master
             VERSION=$(python -c "import setup; print(setup.VERSION)")
-            towncrier --version $VERSION --yes
+            towncrier build --version $VERSION --yes
             ./tools/ci/test_all_newsfragments_used.py
 
       - run:

--- a/doc/release/upcoming_changes/README.rst
+++ b/doc/release/upcoming_changes/README.rst
@@ -50,7 +50,7 @@ and double-backticks for code.
 If you are unsure what pull request type to use, don't hesitate to ask in your
 PR.
 
-You can install ``towncrier`` and run ``towncrier --draft --version 1.18``
+You can install ``towncrier`` and run ``towncrier build --draft --version 1.18``
 if you want to get a preview of how your change will look in the final release
 notes.
 

--- a/tools/ci/test_all_newsfragments_used.py
+++ b/tools/ci/test_all_newsfragments_used.py
@@ -12,5 +12,5 @@ fragments.remove("template.rst")
 
 if fragments:
     print("The following files were not found by towncrier:")
-    print("    " + "    \n".join(fragments))
+    print("    " + "\n    ".join(fragments))
     sys.exit(1)


### PR DESCRIPTION
Without any argument towncrier defaults to `build`.  But towncrier
added a `--version` argument to just print the towncrier version.

NumPy relies on passing `--version` which collides.  Even if
towncrier might revert the change, using `towncrier build` explicitly
just doesn't hurt.

Closes gh-18788
