### PR TITLE
MAINT: Use normal release version of towncrier and update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           name: create release notes
           command: |
             . venv/bin/activate
-            pip install git+https://github.com/hawkowl/towncrier.git@master
+            pip install towncrier
             VERSION=$(python -c "import setup; print(setup.VERSION)")
             towncrier build --version $VERSION --yes
             ./tools/ci/test_all_newsfragments_used.py

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -258,10 +258,8 @@ Check the release notes
 Use `towncrier`_ to build the release note and
 commit the changes. This will remove all the fragments from
 ``doc/release/upcoming_changes`` and add ``doc/release/<version>-note.rst``.
-Note that currently towncrier must be installed from its master branch as the
-last release (19.2.0) is outdated.
 
-    towncrier --version "<version>"
+    towncrier build --version "<version>"
     git commit -m"Create release note"
 
 Check that the release notes are up-to-date.
@@ -275,7 +273,7 @@ following:
   - for SciPy, supported NumPy version(s)
   - outlook for the near future
 
-.. _towncrier: https://github.com/hawkowl/towncrier
+.. _towncrier: https://pypi.org/project/towncrier/
 
 
 Update the release status and create a release "tag"

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -14,4 +14,4 @@ twine
 
 # building and notes
 Paver
-git+https://github.com/hawkowl/towncrier.git@master
+towncrier


### PR DESCRIPTION
Just "updates" to the release version of towncrier (and fixes one "build" that I missed).