### PR TITLE
MAINT: Use towncrier build explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       -  run:
           name: deploy devdocs
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
               touch doc/build/html/.nojekyll
 
               ./tools/ci/push_docs_to_repo.py doc/build/html \
@@ -101,7 +101,7 @@ jobs:
                   --message "Docs build of $CIRCLE_SHA1" \
                   --force
             else
-              echo "Not on the master branch; skipping deployment"
+              echo "Not on the main branch; skipping deployment"
             fi
 
       - add_ssh_keys:
@@ -120,7 +120,7 @@ jobs:
       -  run:
           name: deploy neps
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
               touch doc/neps/_build/html/.nojekyll
 
               ./tools/ci/push_docs_to_repo.py doc/neps/_build/html \
@@ -130,5 +130,5 @@ jobs:
                   --message "Docs build of $CIRCLE_SHA1" \
                   --force
             else
-              echo "Not on the master branch; skipping deployment"
+              echo "Not on the main branch; skipping deployment"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             . venv/bin/activate
             pip install git+https://github.com/hawkowl/towncrier.git@master
             VERSION=$(python -c "import setup; print(setup.VERSION)")
-            towncrier --version $VERSION --yes
+            towncrier build --version $VERSION --yes
             ./tools/ci/test_all_newsfragments_used.py
 
       - run:

--- a/doc/HOWTO_RELEASE.rst.txt
+++ b/doc/HOWTO_RELEASE.rst.txt
@@ -18,7 +18,7 @@ Source tree
 
 NumPy Docs
 ----------
-- https://github.com/numpy/numpy/blob/master/doc/HOWTO_RELEASE.rst.txt
+- https://github.com/numpy/numpy/blob/main/doc/HOWTO_RELEASE.rst.txt
 
 
 SciPy.org wiki
@@ -35,7 +35,7 @@ Supported platforms and versions
 ================================
 :ref:`NEP 29 <NEP29>` outlines which Python versions
 are supported; For the first half of 2020, this will be Python >= 3.6. We test
-NumPy against all these versions every time we merge code to master.  Binary
+NumPy against all these versions every time we merge code to main.  Binary
 installers may be available for a subset of these versions (see below).
 
 OS X
@@ -185,7 +185,7 @@ A typical release schedule is one beta, two release candidates and a final
 release.  It's best to discuss the timing on the mailing list first, in order
 for people to get their commits in on time, get doc wiki edits merged, etc.
 After a date is set, create a new maintenance/x.y.z branch, add new empty
-release notes for the next version in the master branch and update the Trac
+release notes for the next version in the main branch and update the Trac
 Milestones.
 
 
@@ -336,8 +336,8 @@ to public keyservers, with a command such as::
     gpg --send-keys <yourkeyid>
 
 
-Update the version of the master branch
----------------------------------------
+Update the version of the main branch
+-------------------------------------
 Increment the release number in setup.py. Release candidates should have "rc1"
 (or "rc2", "rcN") appended to the X.Y.Z format.
 
@@ -460,6 +460,15 @@ The scipy.org should be a PR at https://github.com/scipy/scipy.org. The file
 that needs modification is ``www/index.rst``. Search for ``News``.
 
 
+Update oldest-supported-numpy
+-----------------------------
+If this release is the first one to support a new Python version, or the first
+to provide wheels for a new platform or PyPy version, the version pinnings
+in https://github.com/scipy/oldest-supported-numpy should be updated.
+Either submit a PR with changes to ``setup.cfg`` there, or open an issue with
+info on needed changes.
+
+
 Announce to the lists
 ---------------------
 The release should be announced on the mailing lists of
@@ -483,5 +492,5 @@ After the final release is announced, a few administrative tasks are left to be
 done:
 
   - Forward port changes in the release branch to release notes and release
-    scripts, if any, to master branch.
+    scripts, if any, to main branch.
   - Update the Milestones in Trac.

--- a/doc/release/upcoming_changes/README.rst
+++ b/doc/release/upcoming_changes/README.rst
@@ -50,7 +50,7 @@ and double-backticks for code.
 If you are unsure what pull request type to use, don't hesitate to ask in your
 PR.
 
-You can install ``towncrier`` and run ``towncrier --draft --version 1.18``
+You can install ``towncrier`` and run ``towncrier build --draft --version 1.18``
 if you want to get a preview of how your change will look in the final release
 notes.
 

--- a/release_requirements.txt
+++ b/release_requirements.txt
@@ -14,4 +14,4 @@ twine
 
 # building and notes
 Paver
-towncrier
+git+https://github.com/hawkowl/towncrier.git@master

--- a/tools/ci/test_all_newsfragments_used.py
+++ b/tools/ci/test_all_newsfragments_used.py
@@ -12,5 +12,5 @@ fragments.remove("template.rst")
 
 if fragments:
     print("The following files were not found by towncrier:")
-    print("    " + "    \n".join(fragments))
+    print("    " + "\n    ".join(fragments))
     sys.exit(1)


### PR DESCRIPTION
Backport of #18790 and #18792.

Without any argument towncrier defaults to build. But towncrier
added a --version argument to just print the towncrier version.

NumPy relies on passing --version which collides. Even if
towncrier might revert the change, using towncrier build explicitly
just doesn't hurt.

Also use recent release of towncrier on PyPI instead of building
from the master branch.

Closes gh-18788
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
