### PR TITLE
SIMD, TEST: Workaround for misaligned stack GCC BUG ABI on WIN64

### DIFF
--- a/numpy/core/src/_simd/_simd_vector.inc
+++ b/numpy/core/src/_simd/_simd_vector.inc
@@ -86,7 +86,22 @@ static PyTypeObject PySIMDVectorType = {
 /************************************
  ** Protected Definitions
  ************************************/
-static PySIMDVectorObject *
+/*
+ * Force inlining the following functions on CYGWIN to avoid spilling vector
+ * registers into the stack to workaround GCC/WIN64 bug that performs
+ * miss-align load variable of 256/512-bit vector from non-aligned
+ * 256/512-bit stack pointer.
+ *
+ * check the following links for more clearification:
+ * https://github.com/numpy/numpy/pull/18330#issuecomment-821539919
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001
+ */
+#if defined(__CYGWIN__) || (defined(__GNUC__) && defined(_WIN64))
+    #define CYG_FINLINE NPY_FINLINE
+#else
+    #define CYG_FINLINE static
+#endif
+CYG_FINLINE PySIMDVectorObject *
 PySIMDVector_FromData(simd_data data, simd_data_type dtype)
 {
     const simd_data_info *info = simd_data_getinfo(dtype);
@@ -118,7 +133,7 @@ PySIMDVector_FromData(simd_data data, simd_data_type dtype)
     return vec;
 }
 
-static simd_data
+CYG_FINLINE simd_data
 PySIMDVector_AsData(PySIMDVectorObject *vec, simd_data_type dtype)
 {
     const simd_data_info *info = simd_data_getinfo(dtype);


### PR DESCRIPTION
related to #18330

This patch fixes the segfault error for GCC SIMD module builds on WIN64,
the problem occurs when GCC aligned load the AVX registers from stack pointer with 128-bit alignment.

Error log:
```Bash
2021-04-15T22:12:46.9466187Z Fatal Python error: Segmentation fault
2021-04-15T22:12:46.9466732Z 
2021-04-15T22:12:46.9467298Z Current thread 0x0000000800000010 (most recent call first):
2021-04-15T22:12:46.9468593Z   File "/usr/lib/python3.7/site-packages/numpy/core/tests/test_simd.py", line 122 in _load_b
2021-04-15T22:12:46.9470318Z   File "/usr/lib/python3.7/site-packages/numpy/core/tests/test_simd.py", line 132 in test_operators_logical
2021-04-15T22:12:46.9472364Z   File "/usr/lib/python3.7/site-packages/_pytest/python.py", line 183 in pytest_pyfunc_call
2021-04-15T22:12:46.9474373Z   File "/usr/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
2021-04-15T22:12:46.9475619Z   File "/usr/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
2021-04-15T22:12:46.9477491Z   File "/usr/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
2021-04-15T22:12:46.9478966Z   File "/usr/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
2021-04-15T22:12:46.9480639Z   File "/usr/lib/python3.7/site-packages/_pytest/python.py", line 1641 in runtest
2021-04-15T22:12:46.9482799Z   File "/usr/lib/python3.7/site-packages/_pytest/runner.py", line 162 in pytest_runtest_call
2021-04-15T22:12:46.9484519Z   File "/usr/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
2021-04-15T22:12:46.9486606Z   File "/usr/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
2021-04-15T22:12:46.9488076Z   File "/usr/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
```