### PR TITLE
DOC: Misc Numpydoc and formatting for proper parsing.

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3936,7 +3936,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('sort',
         actual implementation will vary with datatype. The 'mergesort' option
         is retained for backwards compatibility.
 
-        .. versionchanged:: 1.15.0.
+        .. versionchanged:: 1.15.0
            The 'stable' option was added.
 
     order : str or list of str, optional

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1019,6 +1019,7 @@ def _median_nancheck(data, result, axis, out):
         Axis along which the median was computed.
     out : ndarray, optional
         Output array in which to place the result.
+
     Returns
     -------
     median : scalar or ndarray


### PR DESCRIPTION
The version changed is the only with a trailing dot, and the blank line is necessary for Numpydoc to see the "Return" section.