### PR TITLE
ENH: Allow longdouble probabilities

### DIFF
--- a/numpy/random/_common.pxd
+++ b/numpy/random/_common.pxd
@@ -67,6 +67,8 @@ cdef double kahan_sum(double *darr, np.npy_intp n)
 cdef inline double uint64_to_double(uint64_t rnd) nogil:
     return (rnd >> 11) * (1.0 / 9007199254740992.0)
 
+cdef np.ndarray convert_floating(object prob)
+
 cdef object double_fill(void *func, bitgen_t *state, object size, object lock, object out)
 
 cdef object float_fill(void *func, bitgen_t *state, object size, object lock, object out)

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -272,6 +272,31 @@ cdef check_output(object out, object dtype, object size, bint require_c_array):
             raise ValueError('size must match out.shape when used together')
 
 
+cdef np.ndarray convert_floating(object prob):
+    """
+    Convert array-like floating to float64 
+    
+    Parameters
+    ----------
+    prob : array_like
+        Probabilities to convert
+
+    Returns
+    -------
+    prob_arr : ndarray
+        An double array that is aligned and c-contiguous. If prob is an
+        ndarray with a longdouble dtype, force casts to double. Otherwise
+        uses safe casting.
+    """
+    cdef int requirements = np.NPY_ARRAY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS
+
+    if np.PyArray_Check(prob) and np.issubdtype(prob.dtype, np.longdouble):
+        # Force cast to allow longdouble, others are safe
+        requirements |= np.NPY_ARRAY_FORCECAST
+
+    return <np.ndarray>np.PyArray_FROM_OTF(prob, np.NPY_DOUBLE, requirements)
+
+
 cdef object double_fill(void *func, bitgen_t *state, object size, object lock, object out):
     cdef random_double_fill random_func = (<random_double_fill>func)
     cdef double out_val

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -23,7 +23,7 @@ from ._common cimport (POISSON_LAM_MAX, CONS_POSITIVE, CONS_NONE,
             CONS_GT_1, LEGACY_CONS_POISSON,
             double_fill, cont, kahan_sum, cont_broadcast_3,
             check_array_constraint, check_constraint, disc, discrete_broadcast_iii,
-            validate_output_shape
+            validate_output_shape, convert_floating
         )
 
 cdef extern from "numpy/random/distributions.h":
@@ -922,8 +922,7 @@ cdef class RandomState:
                 if np.issubdtype(p.dtype, np.floating):
                     atol = max(atol, np.sqrt(np.finfo(p.dtype).eps))
 
-            p = <np.ndarray>np.PyArray_FROM_OTF(
-                p, np.NPY_DOUBLE, np.NPY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
+            p = <np.ndarray>convert_floating(p)
             pix = <double*>np.PyArray_DATA(p)
 
             if p.ndim != 1:
@@ -3377,7 +3376,7 @@ cdef class RandomState:
         cdef long *randoms_data
         cdef np.broadcast it
 
-        p_arr = <np.ndarray>np.PyArray_FROM_OTF(p, np.NPY_DOUBLE, np.NPY_ALIGNED)
+        p_arr = <np.ndarray>convert_floating(p)
         is_scalar = is_scalar and np.PyArray_NDIM(p_arr) == 0
         n_arr = <np.ndarray>np.PyArray_FROM_OTF(n, np.NPY_LONG, np.NPY_ALIGNED)
         is_scalar = is_scalar and np.PyArray_NDIM(n_arr) == 0
@@ -4229,8 +4228,9 @@ cdef class RandomState:
         cdef long ni
 
         d = len(pvals)
-        parr = <np.ndarray>np.PyArray_FROMANY(
-            pvals, np.NPY_DOUBLE, 1, 1, np.NPY_ARRAY_ALIGNED | np.NPY_ARRAY_C_CONTIGUOUS)
+        parr = <np.ndarray>convert_floating(pvals)
+        if np.PyArray_NDIM(parr) != 1:
+            raise ValueError("pvals must be a 1d array")
         pix = <double*>np.PyArray_DATA(parr)
         check_array_constraint(parr, 'pvals', CONS_BOUNDED_0_1)
         if kahan_sum(pix, d-1) > (1.0 + 1e-12):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -921,6 +921,17 @@ class TestRandomDist:
         res = hashlib.sha256(actual.view(np.int8)).hexdigest()
         assert_(choice_hash == res)
 
+    def test_choice_longdouble(self):
+        random = Generator(MT19937(self.seed))
+        p = np.array([.4, .4, .2])
+        actual = random.choice([0, 1, 2], size=2, p=p)
+
+        random = Generator(MT19937(self.seed))
+        p = np.array([.4, .4, .2], dtype=np.longdouble)
+        actual_128 = random.choice([0, 1, 2], size=2, p=p)
+
+        assert_equal(actual, actual_128)
+
     def test_bytes(self):
         random = Generator(MT19937(self.seed))
         actual = random.bytes(10)

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -660,6 +660,17 @@ class TestRandomDist:
         contig = random.choice(5, 3, p=np.ascontiguousarray(p[::2]))
         assert_array_equal(non_contig, contig)
 
+    def test_choice_longdouble(self):
+        random.seed(self.seed)
+        p = np.array([.4, .4, .2])
+        actual = random.choice([0, 1, 2], size=2, p=p)
+        
+        random.seed(self.seed)
+        p = np.array([.4, .4, .2], dtype=np.longdouble)
+        actual_128 = random.choice([0, 1, 2], size=2, p=p)
+        
+        assert_equal(actual, actual_128)
+
     def test_bytes(self):
         random.seed(self.seed)
         actual = random.bytes(10)


### PR DESCRIPTION
Force cast floating to 64-bit floats to allow 128bit floats

closes #6132

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
