### PR TITLE
MAINT: Generalize and shorten the ufunc "trivially iterable" path

### DIFF
--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -647,25 +647,6 @@ npy_bswap8_unaligned(char * x)
  *          // Create iterator, etc...
  *      }
  *
- * Here is example code for a pair of arrays:
- *
- *      if (PyArray_TRIVIALLY_ITERABLE_PAIR(a1, a2)) {
- *          char *data1, *data2;
- *          npy_intp count, stride1, stride2;
- *
- *          PyArray_PREPARE_TRIVIAL_PAIR_ITERATION(a1, a2, count,
- *                                  data1, data2, stride1, stride2);
- *
- *          while (count--) {
- *              // Use the data1 and data2 pointers
- *
- *              data1 += stride1;
- *              data2 += stride2;
- *          }
- *      }
- *      else {
- *          // Create iterator, etc...
- *      }
  */
 
 /*
@@ -776,16 +757,6 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
                                             PyArray_STRIDE(arr, 0) : \
                                             PyArray_ITEMSIZE(arr)));
 
-#define PyArray_TRIVIALLY_ITERABLE_PAIR(arr1, arr2, arr1_read, arr2_read) (   \
-                    PyArray_TRIVIALLY_ITERABLE(arr1) && \
-                        (PyArray_NDIM(arr2) == 0 || \
-                         PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) ||  \
-                         (PyArray_NDIM(arr1) == 0 && \
-                             PyArray_TRIVIALLY_ITERABLE(arr2) \
-                         ) \
-                        ) && \
-                        PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr2, arr1_read, arr2_read) \
-                        )
 #define PyArray_PREPARE_TRIVIAL_PAIR_ITERATION(arr1, arr2, \
                                         count, \
                                         data1, data2, \
@@ -797,47 +768,6 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
                     data2 = PyArray_BYTES(arr2); \
                     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
                     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
-                }
-
-#define PyArray_TRIVIALLY_ITERABLE_TRIPLE(arr1, arr2, arr3, arr1_read, arr2_read, arr3_read) ( \
-                PyArray_TRIVIALLY_ITERABLE(arr1) && \
-                    ((PyArray_NDIM(arr2) == 0 && \
-                        (PyArray_NDIM(arr3) == 0 || \
-                            PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr3) \
-                        ) \
-                     ) || \
-                     (PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr2) && \
-                        (PyArray_NDIM(arr3) == 0 || \
-                            PyArray_EQUIVALENTLY_ITERABLE_BASE(arr1, arr3) \
-                        ) \
-                     ) || \
-                     (PyArray_NDIM(arr1) == 0 && \
-                        PyArray_TRIVIALLY_ITERABLE(arr2) && \
-                            (PyArray_NDIM(arr3) == 0 || \
-                                PyArray_EQUIVALENTLY_ITERABLE_BASE(arr2, arr3) \
-                            ) \
-                     ) \
-                    ) && \
-                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr2, arr1_read, arr2_read) && \
-                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr1, arr3, arr1_read, arr3_read) && \
-                    PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(arr2, arr3, arr2_read, arr3_read) \
-                )
-
-#define PyArray_PREPARE_TRIVIAL_TRIPLE_ITERATION(arr1, arr2, arr3, \
-                                        count, \
-                                        data1, data2, data3, \
-                                        stride1, stride2, stride3) { \
-                    npy_intp size1 = PyArray_SIZE(arr1); \
-                    npy_intp size2 = PyArray_SIZE(arr2); \
-                    npy_intp size3 = PyArray_SIZE(arr3); \
-                    count = ((size1 > size2) || size1 == 0) ? size1 : size2; \
-                    count = ((size3 > count) || size3 == 0) ? size3 : count; \
-                    data1 = PyArray_BYTES(arr1); \
-                    data2 = PyArray_BYTES(arr2); \
-                    data3 = PyArray_BYTES(arr3); \
-                    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
-                    stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
-                    stride3 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size3, arr3); \
                 }
 
 #endif

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1212,6 +1212,12 @@ try_trivial_single_output_loop(PyUFuncObject *ufunc,
                 return -2;
             }
         }
+        /* Check self-overlap (non 1-D are contiguous, perfect overlap is OK) */
+        if (operation_ndim == 1 &&
+                PyArray_STRIDES(op[nin])[0] < PyArray_ITEMSIZE(op[nin]) &&
+                PyArray_STRIDES(op[nin])[0] != 0) {
+            return -2;
+        }
     }
 
     /* Call the __prepare_array__ if necessary */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1113,7 +1113,7 @@ prepare_ufunc_output(PyUFuncObject *ufunc,
  * is possible.
  *
  * This function only supports a single output (due to the overlap check).
- * It always accepts 0-D arrays and will broadcast them.  The function will
+ * It always accepts 0-D arrays and will broadcast them.  The function
  * cannot broadcast any other array (as it requires a single stride).
  * The function accepts all 1-D arrays, and N-D arrays that are either all
  * C- or all F-contiguous.

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -792,7 +792,7 @@ class TestUFunc:
         check(np.add, a, ind, a[25:75])
 
     def test_unary_ufunc_1d_manual(self):
-        # Exercise branches in PyArray_EQUIVALENTLY_ITERABLE
+        # Exercise ufunc fast-paths (that avoid creation of an `np.nditer`)
 
         def check(a, b):
             a_orig = a.copy()

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -666,6 +666,11 @@ class TestUFunc:
     def test_unary_ufunc_call_fuzz(self):
         self.check_unary_fuzz(np.invert, None, np.int16)
 
+    @pytest.mark.slow
+    def test_unary_ufunc_call_complex_fuzz(self):
+        # Complex typically has a smaller alignment than itemsize
+        self.check_unary_fuzz(np.negative, None, np.complex128, count=500)
+
     def test_binary_ufunc_accumulate_fuzz(self):
         def get_out_axis_size(a, b, axis):
             if axis is None:


### PR DESCRIPTION
This avoids the large macros designed for specific number of
arguments and generalizes it to all ufuncs with a single output
(Instead of only 1 and 2 operand input ufuncs.)

That is not a big generalization, but the code actually shortens
and while it is slightly more complex in umath itself, it avoids
the fairly complex macros as well.

---

This code is very slightly useful to me, because I have to push the `innerloop` resolution down until after `fixed_strides` is defined.  Which currently happens in two spots (for 1 or 2 input ufuncs).  For a bit I thought there was more to it, so this fell out.

I currently slightly prefer it though, and think it is probably easier to understand then `PyArray_TRIVIALLY_ITERABLE_TRIPLE`... So would like to continue my work based off this (and this being merged soon :crossed_fingers:).