### PR TITLE
DOC: Clarify isreal docstring 

### DIFF
--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -252,8 +252,9 @@ def isreal(x):
     If element has complex type with zero complex part, the return value
     for that element is True.
 
-    .. note:: Returns all True for input elements which are not of complex
-    type.
+    .. note::
+
+    Returns all True for input elements which are not of complex type.
 
     Parameters
     ----------
@@ -266,7 +267,7 @@ def isreal(x):
         Boolean array of same shape as `x`.
 
     Notes
-    --------
+    -----
     Returns all True for non-complex array.
 
     See Also
@@ -280,6 +281,7 @@ def isreal(x):
     array([False,  True,  True,  True,  True, False])
     
     Returns True for all elements in input array which are not of complex type. 
+
     >>> np.isreal([None, False, "imaginary", complex])
     array([True, True, True, True])
 

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -273,7 +273,8 @@ def isreal(x):
 
     Examples
     --------
-    >>> np.isreal([1+1j, 1+0j, 4.5, 3, 2, 2j])
+    >>> a = np.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype=complex)
+    >>> np.isreal(a)
     array([False,  True,  True,  True,  True, False])
     
     The function does not work on string arrays.

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -264,8 +264,7 @@ def isreal(x):
 
     Notes
     -----
-    Returns all True for non-complex array.
-
+    `isreal` may behave unexpectedly for string or object arrays (see examples)
     See Also
     --------
     iscomplex

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -252,7 +252,8 @@ def isreal(x):
     If element has complex type with zero complex part, the return value
     for that element is True.
 
-    .. note:: Returns all True for input elements which are not of complex type.
+    .. note:: Returns all True for input elements which are not of complex
+    type.
 
     Parameters
     ----------

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -275,8 +275,6 @@ def isreal(x):
     >>> np.isreal([1+1j, 1+0j, 4.5, 3, 2, 2j])
     array([False,  True,  True,  True,  True, False])
     
-    .. note::
-    
     The function does not work on string arrays.
 
     >>> np.isreal([2j, "a"])

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -252,10 +252,6 @@ def isreal(x):
     If element has complex type with zero complex part, the return value
     for that element is True.
 
-    .. note::
-
-    Returns all True for input elements which are not of complex type.
-
     Parameters
     ----------
     x : array_like
@@ -280,10 +276,18 @@ def isreal(x):
     >>> np.isreal([1+1j, 1+0j, 4.5, 3, 2, 2j])
     array([False,  True,  True,  True,  True, False])
     
-    Returns True for all elements in input array which are not of complex type. 
+    .. note::
+    
+    The function does not work on string arrays.
 
-    >>> np.isreal([None, False, "imaginary", complex])
-    array([True, True, True, True])
+    >>> np.isreal([2j, "a"])
+    False
+    
+    Returns True for all elements in input array of `dtype=object` even if 
+    any of the elements is complex.
+
+    >>> np.array([1+2j, ...], dtype=object)
+    array([True,  True])
 
     """
     return imag(x) == 0

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -252,6 +252,10 @@ def isreal(x):
     If element has complex type with zero complex part, the return value
     for that element is True.
 
+    Returns True for non-numeric input elements, since the input is
+    interpreted to be an object array for which imaginary units of a complex 
+    number is not defined.
+
     Parameters
     ----------
     x : array_like
@@ -271,6 +275,8 @@ def isreal(x):
     --------
     >>> np.isreal([1+1j, 1+0j, 4.5, 3, 2, 2j])
     array([False,  True,  True,  True,  True, False])
+    >>> np.isreal(None, False, "imaginary", complex])
+    array([True, True, True, True])
 
     """
     return imag(x) == 0

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -286,8 +286,15 @@ def isreal(x):
     Returns True for all elements in input array of `dtype=object` even if 
     any of the elements is complex.
 
-    >>> np.array([1+2j, ...], dtype=object)
-    array([True,  True])
+    >>> a = np.array([1, "2", 3+4j], dtype=object)
+    >>> np.isreal(a)
+    array([ True,  True,  True])
+    
+    isreal should not be used with object arrays
+    
+    >>> a = np.array([1+2j, 2+1j], dtype=object)
+    >>> np.isreal(a)
+    array([ True,  True])
 
     """
     return imag(x) == 0

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -283,7 +283,7 @@ def isreal(x):
     >>> np.isreal(a)  # Warns about non-elementwise comparison
     False
     
-    Returns True for all elements in input array of `dtype=object` even if 
+    Returns True for all elements in input array of ``dtype=object`` even if
     any of the elements is complex.
 
     >>> a = np.array([1, "2", 3+4j], dtype=object)

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -265,6 +265,7 @@ def isreal(x):
     Notes
     -----
     `isreal` may behave unexpectedly for string or object arrays (see examples)
+
     See Also
     --------
     iscomplex
@@ -277,7 +278,8 @@ def isreal(x):
     
     The function does not work on string arrays.
 
-    >>> np.isreal([2j, "a"])
+    >>> a = np.array([2j, "a"], dtype="U")
+    >>> np.isreal(a)  # Warns about non-elementwise comparison
     False
     
     Returns True for all elements in input array of `dtype=object` even if 


### PR DESCRIPTION
Add a clarification to docstring of `isreal` method. Raised in #18814, `isreal` returns `True` for non-numeric inputs like `None`.

Closes #18814
