### PR TITLE
DOC: Move Sphinx numpy target in reference index.

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -1,14 +1,13 @@
 .. _reference:
 
+.. module:: numpy
+
 ###############
 NumPy Reference
 ###############
 
 :Release: |version|
 :Date: |today|
-
-
-.. module:: numpy
 
 This reference manual details functions, modules, and objects
 included in NumPy, describing what they are and what they do.


### PR DESCRIPTION
This is a possible improvement / step in the direction of a fix for #18844. However, this won't be a complete fix for that issue because the nav bar will still overlap the target location that is scrolled to in the body text.