### PR TITLE
MAINT: Disable pip version check for azure lint check.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ stages:
         addToPath: true
         architecture: 'x64'
     - script: >-
-        python -m pip install -r linter_requirements.txt
+        python -m pip --disable-pip-version-check install -r linter_requirements.txt
       displayName: 'Install tools'
       failOnStderr: true
     - script: |


### PR DESCRIPTION
If the installed version is not up to date, the terminal notification of such is treated as an error. Unfortunately, pip 21.0.0 released 04/24/2021 has a number new warnings, so upgrading is not a solution. The option taken here is to disable the pip version check.

The reason the pip warnings cause problems is the setting `failOnStderr: true`. We could instead
disable that for the dependency installs.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
