### PR TITLE
MAINT: Remove dead codepath in generalized ufuncs

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2457,7 +2457,7 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc, PyArrayObject **op,
     /* Fill in any allocated outputs */
     {
         PyArrayObject **operands = NpyIter_GetOperandArray(iter);
-        for (i = 0; i < nop; ++i) {
+        for (i = nin; i < nop; ++i) {
             if (op[i] == NULL) {
                 op[i] = operands[i];
                 Py_INCREF(op[i]);
@@ -2592,34 +2592,6 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc, PyArrayObject **op,
         if (!needs_api && !NpyIter_IterationNeedsAPI(iter)) {
             NPY_END_THREADS;
         }
-    } else {
-        /**
-         * For each output operand, check if it has non-zero size,
-         * and assign the identity if it does. For example, a dot
-         * product of two zero-length arrays will be a scalar,
-         * which has size one.
-         */
-        npy_bool reorderable;
-        PyObject *identity = _get_identity(ufunc, &reorderable);
-        if (identity == NULL) {
-            retval = -1;
-            goto fail;
-        }
-
-        for (i = nin; i < nop; ++i) {
-            if (PyArray_SIZE(op[i]) != 0) {
-                if (identity == Py_None) {
-                    PyErr_Format(PyExc_ValueError,
-                            "ufunc %s ",
-                            ufunc_name);
-                    Py_DECREF(identity);
-                    retval = -1;
-                    goto fail;
-                }
-                PyArray_FillWithScalar(op[i], identity);
-            }
-        }
-        Py_DECREF(identity);
     }
 
     /* Check whether any errors occurred during the loop */

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6446,6 +6446,16 @@ class TestMatmul(MatmulCommon):
             c = c.astype(tgt.dtype)
         assert_array_equal(c, tgt)
 
+    def test_empty_out(self):
+        # Check that the output cannot be broadcast, so that it cannot be
+        # size zero when the outer dimensions (iterator size) has size zero.
+        arr = np.ones((0, 1, 1))
+        out = np.ones((1, 1, 1))
+        assert self.matmul(arr, arr).shape == (0, 1, 1)
+
+        with pytest.raises(ValueError, match=r"non-broadcastable"):
+            self.matmul(arr, arr, out=out)
+
     def test_out_contiguous(self):
         a = np.ones((5, 2), dtype=float)
         b = np.array([[1, 3], [5, 7]], dtype=float)


### PR DESCRIPTION
If the iterator has size zero, then that means that the outer
iteration has size.  Since the outer iteration is unaffected by
core dimensions, in that case the output always has size zero
and the code does nothing but unnecessary checking the array sizes.

---

@rossbar this is a short PR you will like ;).