### PR TITLE
MAINT: Fix azure linter problems with pip 21.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,10 @@ stages:
         addToPath: true
         architecture: 'x64'
     - script: >-
-        python -m pip --disable-pip-version-check install -r linter_requirements.txt
+        python -m pip install -r linter_requirements.txt
       displayName: 'Install tools'
-      failOnStderr: true
+      # pip 21.1 emits a pile of garbage messages to annoy users :)
+      #      failOnStderr: true
     - script: |
         python tools/linter.py --branch origin/$(System.PullRequest.TargetBranch)
       displayName: 'Run Lint Checks'


### PR DESCRIPTION
The default Python 3.8  pip version seems to have been upgraded, leading
to a large number of harmless messages being printed during package
installation. This PR fixes the linter script to ignore the messages.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
