### PR TITLE
MAINT: ssize_t -> Py_ssize_t and other fixes for Python v3.10.0

### DIFF
--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -251,7 +251,7 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     if (ret == NULL) {
         return NULL;
     }
-    fd2 = PyNumber_AsSsize_t(ret, NULL);
+    fd2 = (int)PyNumber_AsSsize_t(ret, NULL);
     Py_DECREF(ret);
 
     /* Convert to FILE* handle */

--- a/numpy/core/include/numpy/npy_3kcompat.h
+++ b/numpy/core/include/numpy/npy_3kcompat.h
@@ -216,6 +216,7 @@ static NPY_INLINE FILE*
 npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
 {
     int fd, fd2, unbuf;
+    Py_ssize_t fd2_tmp;
     PyObject *ret, *os, *io, *io_raw;
     npy_off_t pos;
     FILE *handle;
@@ -251,8 +252,17 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     if (ret == NULL) {
         return NULL;
     }
-    fd2 = (int)PyNumber_AsSsize_t(ret, NULL);
+    fd2_tmp = PyNumber_AsSsize_t(ret, PyExc_IOError);
     Py_DECREF(ret);
+    if (fd2_tmp == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+    if (fd2_tmp < INT_MIN || fd2_tmp > INT_MAX) {
+        PyErr_SetString(PyExc_IOError,
+                        "Getting an 'int' from os.dup() failed");
+        return NULL;
+    }
+    fd2 = (int)fd2_tmp;
 
     /* Convert to FILE* handle */
 #ifdef _WIN32

--- a/numpy/core/src/common/npy_argparse.c
+++ b/numpy/core/src/common/npy_argparse.c
@@ -338,7 +338,7 @@ _npy_parse_arguments(const char *funcname,
                 }
             }
 
-             ssize_t param_pos = (
+             Py_ssize_t param_pos = (
                     (name - cache->kw_strings) + cache->npositional_only);
 
             /* There could be an identical positional argument */

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -422,7 +422,7 @@ PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
         return NULL;
     }
 
-    ssize_t length = strlen(spec->name);
+    Py_ssize_t length = strlen(spec->name);
     res->method->name = PyMem_Malloc(length + 1);
     if (res->method->name == NULL) {
         Py_DECREF(res);
@@ -625,7 +625,7 @@ boundarraymethod__simple_strided_call(
     PyArrayObject *arrays[NPY_MAXARGS];
     PyArray_Descr *descrs[NPY_MAXARGS];
     PyArray_Descr *out_descrs[NPY_MAXARGS];
-    ssize_t length = -1;
+    Py_ssize_t length = -1;
     int aligned = 1;
     char *args[NPY_MAXARGS];
     npy_intp strides[NPY_MAXARGS];

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -209,7 +209,7 @@ npy_is_aligned(const void * p, const npy_uintp alignment)
 }
 
 /* Get equivalent "uint" alignment given an itemsize, for use in copy code */
-static NPY_INLINE int
+static NPY_INLINE npy_uintp
 npy_uint_alignment(int itemsize)
 {
     npy_uintp alignment = 0; /* return value of 0 means unaligned */

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2281,7 +2281,9 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
 {
     PyObject *key, *tup, *title;
     PyArray_Descr *src_fld_dtype, *dst_fld_dtype;
-    npy_int i, field_count, structsize;
+    npy_int i;
+    size_t structsize;
+    Py_ssize_t field_count;
     int src_offset, dst_offset;
     _field_transfer_data *data;
 
@@ -2468,7 +2470,8 @@ get_decref_fields_transfer_function(int NPY_UNUSED(aligned),
 {
     PyObject *names, *key, *tup, *title;
     PyArray_Descr *src_fld_dtype;
-    npy_int i, field_count, structsize;
+    npy_int i, structsize;
+    Py_ssize_t field_count;
     int src_offset;
 
     names = src_dtype->names;
@@ -2831,17 +2834,17 @@ static NpyAuxData *
 _multistep_cast_auxdata_clone_int(_multistep_castdata *castdata, int move_info)
 {
     /* Round up the structure size to 16-byte boundary for the buffers */
-    ssize_t datasize = (sizeof(_multistep_castdata) + 15) & ~0xf;
+    Py_ssize_t datasize = (sizeof(_multistep_castdata) + 15) & ~0xf;
 
-    ssize_t from_buffer_offset = datasize;
+    Py_ssize_t from_buffer_offset = datasize;
     if (castdata->from.func != NULL) {
-        ssize_t src_itemsize = castdata->main.context.descriptors[0]->elsize;
+        Py_ssize_t src_itemsize = castdata->main.context.descriptors[0]->elsize;
         datasize += NPY_LOWLEVEL_BUFFER_BLOCKSIZE * src_itemsize;
         datasize = (datasize + 15) & ~0xf;
     }
-    ssize_t to_buffer_offset = datasize;
+    Py_ssize_t to_buffer_offset = datasize;
     if (castdata->to.func != NULL) {
-        ssize_t dst_itemsize = castdata->main.context.descriptors[1]->elsize;
+        Py_ssize_t dst_itemsize = castdata->main.context.descriptors[1]->elsize;
         datasize += NPY_LOWLEVEL_BUFFER_BLOCKSIZE * dst_itemsize;
     }
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -539,7 +539,7 @@ dtypemeta_wrap_legacy_descriptor(PyArray_Descr *descr)
     if (dot) {
         scalar_name = dot + 1;
     }
-    ssize_t name_length = strlen(scalar_name) + 14;
+    Py_ssize_t name_length = strlen(scalar_name) + 14;
 
     char *tp_name = malloc(name_length);
     if (tp_name == NULL) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5052,7 +5052,7 @@ class TestIO:
             return 'abc'
 
         def dup_bigint(fd):
-            return 2*68
+            return 2**68
 
         old_dup = os.dup
         try:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5047,6 +5047,7 @@ class TestIO:
                     np.fromfile, self.filename, dtype=self.dtype,
                     sep=",", offset=1)
 
+    @pytest.mark.skipif(IS_PYPY, reason="bug in PyPy's PyNumber_AsSsize_t")
     def test_fromfile_bad_dup(self):
         def dup_str(fd):
             return 'abc'

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5055,10 +5055,14 @@ class TestIO:
             return 2*68
         
         old_dup = os.dup
-        with open(self.filename, 'wb') as f:
-            self.x.tofile(f)
-            for dup in (dup_str, dup_bigint):
-                assert_raises(OSError, np.fromfile, f)
+        try:
+            with open(self.filename, 'wb') as f:
+                self.x.tofile(f)
+                for dup in (dup_str, dup_bigint):
+                    os.dup = dup
+                    assert_raises(OSError, np.fromfile, f)
+        finally:
+            os.dup = old_dup
  
     def _check_from(self, s, value, **kw):
         if 'sep' not in kw:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5053,17 +5053,17 @@ class TestIO:
 
         def dup_bigint(fd):
             return 2*68
-        
+
         old_dup = os.dup
         try:
             with open(self.filename, 'wb') as f:
                 self.x.tofile(f)
-                for dup in (dup_str, dup_bigint):
+                for dup, exc in ((dup_str, TypeError), (dup_bigint, OSError)):
                     os.dup = dup
-                    assert_raises(OSError, np.fromfile, f)
+                    assert_raises(exc, np.fromfile, f)
         finally:
             os.dup = old_dup
- 
+
     def _check_from(self, s, value, **kw):
         if 'sep' not in kw:
             y = np.frombuffer(s, **kw)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5047,6 +5047,19 @@ class TestIO:
                     np.fromfile, self.filename, dtype=self.dtype,
                     sep=",", offset=1)
 
+    def test_fromfile_bad_dup(self):
+        def dup_str(fd):
+            return 'abc'
+
+        def dup_bigint(fd):
+            return 2*68
+        
+        old_dup = os.dup
+        with open(self.filename, 'wb') as f:
+            self.x.tofile(f)
+            for dup in (dup_str, dup_bigint):
+                assert_raises(OSError, np.fromfile, f)
+ 
     def _check_from(self, s, value, **kw):
         if 'sep' not in kw:
             y = np.frombuffer(s, **kw)


### PR DESCRIPTION
Fixes #18888 

It would be good to get a CI run with the 3.10.0a7 candidate. It seems the easiest way to do that is via the github action setup-python, but all our windows CI runs are on azure pipelines.