### PR TITLE
DOC: Add a set of standard replies.

### DIFF
--- a/doc/source/dev/reviewer_guidelines.rst
+++ b/doc/source/dev/reviewer_guidelines.rst
@@ -37,9 +37,8 @@ Communication Guidelines
   style or grammar, consider merging the current PR when all important concerns
   are addressed. Then, either push a commit directly (if you are a maintainer)
   or open a follow-up PR yourself.
-- If you need help writing replies in reviews, check out some `Standard replies
-  for reviewing
-  <https://scikit-learn.org/stable/developers/tips.html#saved-replies>`_.
+- If you need help writing replies in reviews, check out some
+  :ref:`standard replies for reviewing<saved-replies>`.
 
 Reviewer Checklist
 ==================
@@ -115,5 +114,78 @@ the PR page.
 
 Assuming you have your :ref:`development environment<development-environment>`
 set up, you can now build the code and test it.
+
+.. _saved-replies:
+
+Standard replies for reviewing
+==============================
+
+It may be helpful to store some of these in GitHub's `saved
+replies <https://github.com/settings/replies/>`_ for reviewing:
+
+**Usage question**
+    ::
+
+        You are asking a usage question. The issue tracker is for bugs and new
+        features. I'm going to close this issue, feel free to ask for help via
+        our [help channels](https://numpy.org/gethelp/).
+
+**You’re welcome to update the docs**
+    ::
+
+        Please feel free to offer a pull request updating the documentation if
+        you feel it could be improved.
+
+**Self-contained example for bug**
+    ::
+
+        Please provide a [self-contained example code]
+        (https://stackoverflow.com/help/mcve), including imports and data
+        (if possible), so that other contributors can just run it and reproduce
+        your issue. Ideally your example code should be minimal.
+
+**Software versions**
+    ::
+
+        To help diagnose your issue, please paste the output of:
+        ```py
+        python -c 'import numpy; print(numpy.version.version)'
+        ```
+        Thanks.
+
+**Code blocks**
+    ::
+
+        Readability can be greatly improved if you
+        [format](https://help.github.com/articles/creating-and-highlighting-code-blocks/)
+        your code snippets and complete error messages appropriately.
+        You can edit your issue descriptions and comments at any time to
+        improve readability. This helps maintainers a lot. Thanks!
+
+**Linking to code**
+    ::
+
+        For clarity's sake, you can link to code like
+        [this](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/).
+
+**Better description and title**
+    ::
+
+        Please make the title of the PR more descriptive. The title will become
+        the commit message when this is merged. You should state what issue
+        (or PR) it fixes/resolves in the description using the syntax described
+        [here](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+
+**Regression test needed**
+    ::
+
+        Please add a [non-regression test](https://en.wikipedia.org/wiki/Non-regression_testing)
+        that would fail at main but pass in this PR.
+
+**Don’t change unrelated**
+    ::
+
+        Please do not change unrelated lines. It makes your contribution harder
+        to review and may introduce merge conflicts to other pull requests.
 
 .. include:: gitwash/git_links.inc

--- a/doc/source/dev/reviewer_guidelines.rst
+++ b/doc/source/dev/reviewer_guidelines.rst
@@ -124,24 +124,24 @@ It may be helpful to store some of these in GitHub's `saved
 replies <https://github.com/settings/replies/>`_ for reviewing:
 
 **Usage question**
-    ::
+    .. code-block:: md
 
         You are asking a usage question. The issue tracker is for bugs and new features.
         I'm going to close this issue, feel free to ask for help via our [help channels](https://numpy.org/gethelp/).
 
 **You’re welcome to update the docs**
-    ::
+    .. code-block:: md
 
         Please feel free to offer a pull request updating the documentation if you feel it could be improved.
 
 **Self-contained example for bug**
-    ::
+    .. code-block:: md
 
-        Please provide a [self-contained example code] (https://stackoverflow.com/help/mcve), including imports and data (if possible), so that other contributors can just run it and reproduce your issue.
+        Please provide a [self-contained example code](https://stackoverflow.com/help/mcve), including imports and data (if possible), so that other contributors can just run it and reproduce your issue.
         Ideally your example code should be minimal.
 
 **Software versions**
-    ::
+    .. code-block:: md
 
         To help diagnose your issue, please paste the output of:
         ```
@@ -150,31 +150,31 @@ replies <https://github.com/settings/replies/>`_ for reviewing:
         Thanks.
 
 **Code blocks**
-    ::
+    .. code-block:: md
 
         Readability can be greatly improved if you [format](https://help.github.com/articles/creating-and-highlighting-code-blocks/) your code snippets and complete error messages appropriately.
         You can edit your issue descriptions and comments at any time to improve readability.
         This helps maintainers a lot. Thanks!
 
 **Linking to code**
-    ::
+    .. code-block:: md
 
         For clarity's sake, you can link to code like [this](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/).
 
 **Better description and title**
-    ::
+    .. code-block:: md
 
         Please make the title of the PR more descriptive.
         The title will become the commit message when this is merged.
         You should state what issue (or PR) it fixes/resolves in the description using the syntax described [here](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 **Regression test needed**
-    ::
+    .. code-block:: md
 
         Please add a [non-regression test](https://en.wikipedia.org/wiki/Non-regression_testing) that would fail at main but pass in this PR.
 
 **Don’t change unrelated**
-    ::
+    .. code-block:: md
 
         Please do not change unrelated lines. It makes your contribution harder to review and may introduce merge conflicts to other pull requests.
 

--- a/doc/source/dev/reviewer_guidelines.rst
+++ b/doc/source/dev/reviewer_guidelines.rst
@@ -126,29 +126,25 @@ replies <https://github.com/settings/replies/>`_ for reviewing:
 **Usage question**
     ::
 
-        You are asking a usage question. The issue tracker is for bugs and new
-        features. I'm going to close this issue, feel free to ask for help via
-        our [help channels](https://numpy.org/gethelp/).
+        You are asking a usage question. The issue tracker is for bugs and new features.
+        I'm going to close this issue, feel free to ask for help via our [help channels](https://numpy.org/gethelp/).
 
 **You’re welcome to update the docs**
     ::
 
-        Please feel free to offer a pull request updating the documentation if
-        you feel it could be improved.
+        Please feel free to offer a pull request updating the documentation if you feel it could be improved.
 
 **Self-contained example for bug**
     ::
 
-        Please provide a [self-contained example code]
-        (https://stackoverflow.com/help/mcve), including imports and data
-        (if possible), so that other contributors can just run it and reproduce
-        your issue. Ideally your example code should be minimal.
+        Please provide a [self-contained example code] (https://stackoverflow.com/help/mcve), including imports and data (if possible), so that other contributors can just run it and reproduce your issue.
+        Ideally your example code should be minimal.
 
 **Software versions**
     ::
 
         To help diagnose your issue, please paste the output of:
-        ```py
+        ```
         python -c 'import numpy; print(numpy.version.version)'
         ```
         Thanks.
@@ -156,36 +152,30 @@ replies <https://github.com/settings/replies/>`_ for reviewing:
 **Code blocks**
     ::
 
-        Readability can be greatly improved if you
-        [format](https://help.github.com/articles/creating-and-highlighting-code-blocks/)
-        your code snippets and complete error messages appropriately.
-        You can edit your issue descriptions and comments at any time to
-        improve readability. This helps maintainers a lot. Thanks!
+        Readability can be greatly improved if you [format](https://help.github.com/articles/creating-and-highlighting-code-blocks/) your code snippets and complete error messages appropriately.
+        You can edit your issue descriptions and comments at any time to improve readability.
+        This helps maintainers a lot. Thanks!
 
 **Linking to code**
     ::
 
-        For clarity's sake, you can link to code like
-        [this](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/).
+        For clarity's sake, you can link to code like [this](https://help.github.com/articles/creating-a-permanent-link-to-a-code-snippet/).
 
 **Better description and title**
     ::
 
-        Please make the title of the PR more descriptive. The title will become
-        the commit message when this is merged. You should state what issue
-        (or PR) it fixes/resolves in the description using the syntax described
-        [here](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+        Please make the title of the PR more descriptive.
+        The title will become the commit message when this is merged.
+        You should state what issue (or PR) it fixes/resolves in the description using the syntax described [here](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 
 **Regression test needed**
     ::
 
-        Please add a [non-regression test](https://en.wikipedia.org/wiki/Non-regression_testing)
-        that would fail at main but pass in this PR.
+        Please add a [non-regression test](https://en.wikipedia.org/wiki/Non-regression_testing) that would fail at main but pass in this PR.
 
 **Don’t change unrelated**
     ::
 
-        Please do not change unrelated lines. It makes your contribution harder
-        to review and may introduce merge conflicts to other pull requests.
+        Please do not change unrelated lines. It makes your contribution harder to review and may introduce merge conflicts to other pull requests.
 
 .. include:: gitwash/git_links.inc


### PR DESCRIPTION
Dear numpy developers,
I'm Chiara, working for the [scikit-learn Consortium](https://scikit-learn.fondation-inria.fr/home/).
I really much enjoyed your [Communication guidelines](https://numpy.org/devdocs/dev/reviewer_guidelines.html#communication-guidelines) and I was planning to propose something similar for the scikit-learn documentation.
I saw you linked the scikit-learn standard replies and per this [comment](https://github.com/numpy/numpy/pull/17252#discussion_r485505394) in #17252, in this pull request I'm proposing some replies modified for numpy ... this is my effort to earn the right to copy your nice documentation... :)
I have skipped some replies for which I don't know numpy practices.
Thanks for considering it.