### PR TITLE
MAINT: Explicitly mark text files in .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,10 @@
-# Numerical data files
-numpy/lib/tests/data/*.npy binary
-
-# Release notes, reduce number of conflicts.
-doc/release/*.rst merge=union
-
 # Highlight our custom templating language as C, since it's hopefully better
 # than nothing. This also affects repo statistics.
-*.c.src linguist-language=C
-*.inc.src linguist-language=C
-*.h.src linguist-language=C
+*.c.src   text linguist-language=C
+*.inc.src text linguist-language=C
+*.h.src   text linguist-language=C
+*.pyx.in  text linguist-language=Python
+*.pxd.in  text linguist-language=Python
 
 # Mark some files as vendored
 numpy/linalg/lapack_lite/f2c.c linguist-vendored
@@ -19,5 +15,95 @@ numpy/core/include/numpy/libdivide/* linguist-vendored
 # Mark some files as generated
 numpy/linalg/lapack_lite/f2c_*.c linguist-generated
 numpy/linalg/lapack_lite/lapack_lite_names.h linguist-generated
-
 numpy/_version.py export-subst
+
+# Configuration files
+*.ini text
+*.cfg text
+./MANIFEST.in text
+./numpy/core/npymath.ini.in text
+./numpy/core/mlib.ini.in text
+./site.cfg.example text
+
+# Python sources
+*.py    text diff=python
+*.pxd   text diff=python
+*.pyx   text diff=python
+*.pyi   text diff=python
+
+# C/C++ sources
+*.c     text diff=c
+*.h     text diff=c
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.hpp   text diff=cpp
+*.hh    text diff=cpp
+
+# Fortran sources
+*.f     text diff=fortran
+*.for   text diff=fortran
+*.f90   text diff=fortran
+*.f95   text diff=fortran
+*.f03   text diff=fortran
+
+# JavaScript
+*.js    text
+
+# F2py
+./doc/source/f2py/*.pyf text
+./doc/source/f2py/*.dat text
+./numpy/f2py/tests/src/module_data/mod.mod binary
+
+# Documents
+*.md    text diff=markdown
+*.txt   text
+*.rst   text
+*.pdf   binary
+*.css   text diff=css
+*.html  text diff=html
+
+# Graphics
+*.png   binary
+*.ico   binary
+*.dia   binary
+*.gif   binary
+*.odg   binary
+*.fig   text
+*.svg   text
+# SVG is treated as an asset (binary) by default. If you want
+# to treat it as binary, use the following line instead.
+# *.svg    binary
+
+# Scripts
+*.sh    text eol=lf
+*.sed   text
+# These are explicitly windows files and should use crlf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# Serialisation
+*.json  text
+*.toml  text
+*.xml   text
+*.yaml  text
+*.yml   text
+
+# Data files
+*.csv   text
+*.pkl   binary
+*.fits  binary
+*.npy   binary
+*.npz   binary
+
+# Misc.
+*.swg   text
+*.patch text
+./doc/neps/index.rst.tmpl text
+./benchmarks/asv_compare.conf.json.tpl text
+./tools/swig/test/*.i text
+./tools/gitpod/gitpod.Dockerfile text
+./doc/source/dev/gitwash/git_links.inc text
+./doc/source/reference/simd/*.inc text
+./numpy/core/src/_simd/*.inc text diff=c
+


### PR DESCRIPTION
Marking files as text will ensure the line endings are normalized to lf
on checkin. The line endings in the working tree may be controlled by
setting the eol variable in the .gitconfig file.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
