### PR TITLE
BLD, BUG: Fix compiler optimization log AttributeError

### DIFF
--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -132,12 +132,12 @@ class build_clib(old_build_clib):
                 log.info("Detected changes on compiler optimizations, force rebuilding")
                 self.force = True
 
-            import atexit
-            def report():
+            def report(copt):
                 log.info("\n########### CLIB COMPILER OPTIMIZATION ###########")
-                log.info(self.compiler_opt.report(full=True))
+                log.info(copt.report(full=True))
 
-            atexit.register(report)
+            import atexit
+            atexit.register(report, self.compiler_opt)
 
         if self.have_f_sources():
             from numpy.distutils.fcompiler import new_fcompiler

--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -160,11 +160,12 @@ class build_ext (old_build_ext):
                 log.info("Detected changes on compiler optimizations, force rebuilding")
                 self.force = True
 
-            import atexit
-            def report():
+            def report(copt):
                 log.info("\n########### EXT COMPILER OPTIMIZATION ###########")
-                log.info(self.compiler_opt.report(full=True))
-            atexit.register(report)
+                log.info(copt.report(full=True))
+
+            import atexit
+            atexit.register(report, self.compiler_opt)
 
         # Setup directory for storing generated extra DLL files on Windows
         self.extra_dll_dir = os.path.join(self.build_temp, '.libs')


### PR DESCRIPTION
related to #18892

  The error appears when option `build` is represented
  before `bdist_wheel`.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
