### PR TITLE
CI: fix the GitHub Actions trigger in docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - main
     paths:
-      - './environment.yml'
-    tags:
-      - '*'
-      
+      - 'environment.yml'
+
 jobs: 
   build:
     name: Build base Docker image 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,8 @@
 # To use:
+#
 #   $ conda env create -f environment.yml  # `mamba` works too for this command
 #   $ conda activate numpy-dev
+#
 name: numpy-dev
 channels:
   - conda-forge


### PR DESCRIPTION
Also remove `tags: *`, this is unnecessary. This mirrors the fix in SciPy, so should work. Somehow GitHub Actions no longer likes `./` at the start of a path.