### PR TITLE
ENH: Add placeholder annotations for two missing `np.testing` objects

### DIFF
--- a/numpy/testing/__init__.pyi
+++ b/numpy/testing/__init__.pyi
@@ -7,11 +7,17 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Final
 
+from unittest import (
+    TestCase as TestCase,
+)
+
 from unittest.case import (
     SkipTest as SkipTest,
 )
 
 __all__: List[str]
+
+def run_module_suite(file_to_run=..., argv=...): ...
 
 class KnownFailureException(Exception): ...
 class IgnoreException(Exception): ...


### PR DESCRIPTION
Xref https://github.com/scipy/scipy/pull/13992.

Add placeholders for two `np.testing` objects previously missed in https://github.com/numpy/numpy/pull/18842.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
