### PR TITLE
BUG: Make changelog recognize ``gh-`` as a PR number prefix.

### DIFF
--- a/doc/changelog/1.17.0-changelog.rst
+++ b/doc/changelog/1.17.0-changelog.rst
@@ -159,7 +159,7 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 531 pull requests were merged for this release.
+A total of 532 pull requests were merged for this release.
 
 * `#4808 <https://github.com/numpy/numpy/pull/4808>`__: ENH: Make the `mode` parameter of np.pad default to 'constant'
 * `#8131 <https://github.com/numpy/numpy/pull/8131>`__: BUG: Fix help() formatting for deprecated functions.
@@ -174,6 +174,7 @@ A total of 531 pull requests were merged for this release.
 * `#10855 <https://github.com/numpy/numpy/pull/10855>`__: ENH: Adding a count parameter to np.unpackbits
 * `#11230 <https://github.com/numpy/numpy/pull/11230>`__: MAINT: More cleanup of einsum
 * `#11233 <https://github.com/numpy/numpy/pull/11233>`__: BUG: ensure i0 does not change the shape.
+* `#11358 <https://github.com/numpy/numpy/pull/11358>`__: MAINT: Rewrite numpy.pad without concatenate
 * `#11684 <https://github.com/numpy/numpy/pull/11684>`__: BUG: Raise when unravel_index, ravel_multi_index are given empty...
 * `#11689 <https://github.com/numpy/numpy/pull/11689>`__: DOC: Add ref docs for C generic types.
 * `#11721 <https://github.com/numpy/numpy/pull/11721>`__: BUG: Make `arr.ctypes.data` hold onto a reference to the underlying...

--- a/doc/changelog/1.18.0-changelog.rst
+++ b/doc/changelog/1.18.0-changelog.rst
@@ -123,20 +123,20 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 406 pull requests were merged for this release.
+A total of 413 pull requests were merged for this release.
 
 * `#9301 <https://github.com/numpy/numpy/pull/9301>`__: DOC: added note to docstring of numpy.savez
 * `#10151 <https://github.com/numpy/numpy/pull/10151>`__: BUG: Numpy scalar types sometimes have the same name
 * `#12129 <https://github.com/numpy/numpy/pull/12129>`__: DOC: Improve axes shift description and example in np.tensordot
-* `#12205 <https://github.com/numpy/numpy/pull/12205>`__: MAINT: avoid relying on `np.generic.__name__` in `np.dtype.name`
+* `#12205 <https://github.com/numpy/numpy/pull/12205>`__: MAINT: avoid relying on ``np.generic.__name__`` in ``np.dtype.name``
 * `#12284 <https://github.com/numpy/numpy/pull/12284>`__: ENH: supply our version of numpy.pxd, requires cython>=0.29
 * `#12633 <https://github.com/numpy/numpy/pull/12633>`__: BUG: General fixes to f2py reference counts (dereferencing)
 * `#12658 <https://github.com/numpy/numpy/pull/12658>`__: BUG: NaT now sorts to ends of arrays
 * `#12828 <https://github.com/numpy/numpy/pull/12828>`__: DOC: Updates to nditer usage instructions
-* `#13003 <https://github.com/numpy/numpy/pull/13003>`__: BUG: Do not crash on recursive `.dtype` attribute lookup.
+* `#13003 <https://github.com/numpy/numpy/pull/13003>`__: BUG: Do not crash on recursive ``.dtype`` attribute lookup.
 * `#13368 <https://github.com/numpy/numpy/pull/13368>`__: ENH: Use AVX for float32 implementation of np.sin & np.cos
 * `#13605 <https://github.com/numpy/numpy/pull/13605>`__: DEP: Deprecate silent ignoring of bad data in fromfile/fromstring
-* `#13610 <https://github.com/numpy/numpy/pull/13610>`__: ENH: Always produce a consistent shape in the result of `argwhere`
+* `#13610 <https://github.com/numpy/numpy/pull/13610>`__: ENH: Always produce a consistent shape in the result of ``argwhere``
 * `#13673 <https://github.com/numpy/numpy/pull/13673>`__: DOC: array(obj, dtype=dt) can downcast
 * `#13698 <https://github.com/numpy/numpy/pull/13698>`__: DOC: Document ma.filled behavior with non-scalar fill_value
 * `#13710 <https://github.com/numpy/numpy/pull/13710>`__: DOC: Add note to irfft-like functions about the default sizes
@@ -144,6 +144,7 @@ A total of 406 pull requests were merged for this release.
 * `#13766 <https://github.com/numpy/numpy/pull/13766>`__: MAINT: Update NEP template.
 * `#13794 <https://github.com/numpy/numpy/pull/13794>`__: ENH: random: Add the multivariate hypergeometric distribution.
 * `#13799 <https://github.com/numpy/numpy/pull/13799>`__: DOC: Fix unrendered links
+* `#13802 <https://github.com/numpy/numpy/pull/13802>`__: BUG: Fixed maximum relative error reporting in assert_allclose
 * `#13812 <https://github.com/numpy/numpy/pull/13812>`__: MAINT: Rewrite Floyd algorithm
 * `#13825 <https://github.com/numpy/numpy/pull/13825>`__: DOC: Add missing macros to C-API documentation
 * `#13829 <https://github.com/numpy/numpy/pull/13829>`__: ENH: Add axis argument to random.permutation and random.shuffle
@@ -162,6 +163,7 @@ A total of 406 pull requests were merged for this release.
 * `#13892 <https://github.com/numpy/numpy/pull/13892>`__: DOC : Refactor Array API documentation -- Array Structure and...
 * `#13895 <https://github.com/numpy/numpy/pull/13895>`__: DOC: Fix typo in "make_mask" documentation
 * `#13896 <https://github.com/numpy/numpy/pull/13896>`__: MAINT: Delete unused _aliased_types.py
+* `#13899 <https://github.com/numpy/numpy/pull/13899>`__: MAINT: Change the type of error raised in set_printoptions
 * `#13901 <https://github.com/numpy/numpy/pull/13901>`__: BLD: Remove Trusty dist in Travis CI build
 * `#13907 <https://github.com/numpy/numpy/pull/13907>`__: BUG: Handle weird bytestrings in dtype()
 * `#13908 <https://github.com/numpy/numpy/pull/13908>`__: ENH: use towncrier to build the release note
@@ -174,7 +176,7 @@ A total of 406 pull requests were merged for this release.
 * `#13926 <https://github.com/numpy/numpy/pull/13926>`__: DOC: Remove explicit .next method calls with built-in next function...
 * `#13928 <https://github.com/numpy/numpy/pull/13928>`__: DOC: Don't override MaskedArray.view documentation with the one...
 * `#13930 <https://github.com/numpy/numpy/pull/13930>`__: BUG: Fix incorrect GIL release in array.nonzero
-* `#13935 <https://github.com/numpy/numpy/pull/13935>`__: MAINT: Warn if `_add_newdocs.py` is used to add docstrings to...
+* `#13935 <https://github.com/numpy/numpy/pull/13935>`__: MAINT: Warn if ``_add_newdocs.py`` is used to add docstrings to...
 * `#13943 <https://github.com/numpy/numpy/pull/13943>`__: MAINT: Revert #13876, "MAINT,BUG,DOC: Fix errors in _add_newdocs"
 * `#13944 <https://github.com/numpy/numpy/pull/13944>`__: MAINT,BUG,DOC: Fix errors in _add_newdocs
 * `#13945 <https://github.com/numpy/numpy/pull/13945>`__: DOC, MAINT: emphasize random API changes, remove Generator.randint
@@ -184,7 +186,7 @@ A total of 406 pull requests were merged for this release.
 * `#13950 <https://github.com/numpy/numpy/pull/13950>`__: Fixing failure on Python 2.7 on Windows 7
 * `#13952 <https://github.com/numpy/numpy/pull/13952>`__: Fix a typo related to the range of indices
 * `#13959 <https://github.com/numpy/numpy/pull/13959>`__: DOC: add space between words across lines
-* `#13964 <https://github.com/numpy/numpy/pull/13964>`__: BUG, DOC: add new recfunctions to `__all__`
+* `#13964 <https://github.com/numpy/numpy/pull/13964>`__: BUG, DOC: add new recfunctions to ``__all__``
 * `#13967 <https://github.com/numpy/numpy/pull/13967>`__: DOC: Change (old) range() to np.arange()
 * `#13968 <https://github.com/numpy/numpy/pull/13968>`__: DOC: improve np.sort docstring
 * `#13970 <https://github.com/numpy/numpy/pull/13970>`__: DOC: spellcheck numpy/doc/broadcasting.py
@@ -226,7 +228,7 @@ A total of 406 pull requests were merged for this release.
 * `#14076 <https://github.com/numpy/numpy/pull/14076>`__: TST: Add 3.8-dev to travisCI testing.
 * `#14085 <https://github.com/numpy/numpy/pull/14085>`__: DOC: Add blank line above doctest for intersect1d
 * `#14086 <https://github.com/numpy/numpy/pull/14086>`__: ENH: Propose standard policy for dropping support of old Python...
-* `#14089 <https://github.com/numpy/numpy/pull/14089>`__: DOC: Use `pip install .` where possible instead of calling setup.py
+* `#14089 <https://github.com/numpy/numpy/pull/14089>`__: DOC: Use ``pip install .`` where possible instead of calling setup.py
 * `#14091 <https://github.com/numpy/numpy/pull/14091>`__: MAINT: adjustments to test_ufunc_noncontigous
 * `#14092 <https://github.com/numpy/numpy/pull/14092>`__: MAINT: Improve NEP template
 * `#14096 <https://github.com/numpy/numpy/pull/14096>`__: DOC: fix documentation of i and j for tri.
@@ -236,6 +238,7 @@ A total of 406 pull requests were merged for this release.
 * `#14106 <https://github.com/numpy/numpy/pull/14106>`__: MAINT: remove duplicate variable assignments
 * `#14108 <https://github.com/numpy/numpy/pull/14108>`__: BUG: initialize variable that is passed by pointer
 * `#14110 <https://github.com/numpy/numpy/pull/14110>`__: DOC: fix typo in c-api/array.rst doc
+* `#14115 <https://github.com/numpy/numpy/pull/14115>`__: DOC: fix markup of news fragment readme
 * `#14121 <https://github.com/numpy/numpy/pull/14121>`__: BUG: Add gcd/lcm definitions to npy_math.h
 * `#14122 <https://github.com/numpy/numpy/pull/14122>`__: MAINT: Mark umath accuracy test xfail.
 * `#14124 <https://github.com/numpy/numpy/pull/14124>`__: MAINT: Use equality instead of identity check with literal
@@ -249,36 +252,39 @@ A total of 406 pull requests were merged for this release.
 * `#14153 <https://github.com/numpy/numpy/pull/14153>`__: TST: Allow fuss in testing strided/non-strided exp/log loops
 * `#14170 <https://github.com/numpy/numpy/pull/14170>`__: NEP: Proposal for __duckarray__ protocol
 * `#14171 <https://github.com/numpy/numpy/pull/14171>`__: BUG: Make advanced indexing result on read-only subclass writeable
+* `#14174 <https://github.com/numpy/numpy/pull/14174>`__: BUG: Check for existence of ``fromstr`` which used in ``fromstr_next_element``
 * `#14178 <https://github.com/numpy/numpy/pull/14178>`__: TST: Clean up of test_pocketfft.py
 * `#14181 <https://github.com/numpy/numpy/pull/14181>`__: DEP: Deprecate np.alen
+* `#14183 <https://github.com/numpy/numpy/pull/14183>`__: DOC: Fix misleading ``allclose`` docstring for ``equal_nan``
 * `#14185 <https://github.com/numpy/numpy/pull/14185>`__: MAINT: Workaround for Intel compiler bug leading to failing test
-* `#14190 <https://github.com/numpy/numpy/pull/14190>`__: DOC: Fix hermitian argument docs in `svd`
+* `#14190 <https://github.com/numpy/numpy/pull/14190>`__: DOC: Fix hermitian argument docs in ``svd``
 * `#14195 <https://github.com/numpy/numpy/pull/14195>`__: MAINT: Fix a docstring typo.
-* `#14196 <https://github.com/numpy/numpy/pull/14196>`__: DOC: Fix links in `/.github/CONTRIBUTING.md`.
+* `#14196 <https://github.com/numpy/numpy/pull/14196>`__: DOC: Fix links in ``/.github/CONTRIBUTING.md``.
 * `#14197 <https://github.com/numpy/numpy/pull/14197>`__: ENH: Multivariate normal speedups
 * `#14203 <https://github.com/numpy/numpy/pull/14203>`__: MAINT: Improve mismatch message of np.testing.assert_array_equal
 * `#14204 <https://github.com/numpy/numpy/pull/14204>`__: DOC,MAINT: Move towncrier files and fixup categories
 * `#14207 <https://github.com/numpy/numpy/pull/14207>`__: BUG: Fixed default BitGenerator name
 * `#14209 <https://github.com/numpy/numpy/pull/14209>`__: BUG: Fix uint-overflow if padding with linear_ramp and negative...
 * `#14216 <https://github.com/numpy/numpy/pull/14216>`__: ENH: Enable huge pages in all Linux builds
-* `#14217 <https://github.com/numpy/numpy/pull/14217>`__: BUG: Fix leak in the f2py-generated module init and `PyMem_Del`...
+* `#14217 <https://github.com/numpy/numpy/pull/14217>`__: BUG: Fix leak in the f2py-generated module init and ``PyMem_Del``...
 * `#14219 <https://github.com/numpy/numpy/pull/14219>`__: DOC: new nan_to_num keywords are from 1.17 onwards
 * `#14223 <https://github.com/numpy/numpy/pull/14223>`__: TST: Add tests for deprecated C functions (PyArray_As1D, PyArray_As1D)
-* `#14224 <https://github.com/numpy/numpy/pull/14224>`__: DOC: mention `take_along_axis` in `choose`
+* `#14224 <https://github.com/numpy/numpy/pull/14224>`__: DOC: mention ``take_along_axis`` in ``choose``
 * `#14227 <https://github.com/numpy/numpy/pull/14227>`__: ENH: Parse complex number from string
 * `#14231 <https://github.com/numpy/numpy/pull/14231>`__: DOC: update or remove outdated sourceforge links
 * `#14234 <https://github.com/numpy/numpy/pull/14234>`__: MAINT: Better error message for norm
 * `#14235 <https://github.com/numpy/numpy/pull/14235>`__: DOC: add backlinks to numpy.org
 * `#14240 <https://github.com/numpy/numpy/pull/14240>`__: BUG: Don't fail when lexsorting some empty arrays.
-* `#14241 <https://github.com/numpy/numpy/pull/14241>`__: BUG: Fix segfault in `random.permutation(x)` when x is a string.
+* `#14241 <https://github.com/numpy/numpy/pull/14241>`__: BUG: Fix segfault in ``random.permutation(x)`` when x is a string.
 * `#14245 <https://github.com/numpy/numpy/pull/14245>`__: Doc: fix a typo in NEP21
 * `#14249 <https://github.com/numpy/numpy/pull/14249>`__: DOC: set status of NEP 28 (website redesign) to Accepted
 * `#14250 <https://github.com/numpy/numpy/pull/14250>`__: BLD: MAINT: change default behavior of build flag appending.
 * `#14252 <https://github.com/numpy/numpy/pull/14252>`__: BUG: Fixes StopIteration error from 'np.genfromtext' for empty...
-* `#14255 <https://github.com/numpy/numpy/pull/14255>`__: BUG: fix inconsistent axes ordering for axis in function `unique`
+* `#14255 <https://github.com/numpy/numpy/pull/14255>`__: BUG: fix inconsistent axes ordering for axis in function ``unique``
 * `#14256 <https://github.com/numpy/numpy/pull/14256>`__: DEP: Deprecate load/dump functions in favour of pickle methods
 * `#14257 <https://github.com/numpy/numpy/pull/14257>`__: MAINT: Update NEP-30
 * `#14259 <https://github.com/numpy/numpy/pull/14259>`__: DEP: Deprecate arrayprint formatting functions
+* `#14263 <https://github.com/numpy/numpy/pull/14263>`__: DOC: Make Py3K docs C code snippets RST literal blocks
 * `#14266 <https://github.com/numpy/numpy/pull/14266>`__: DOC: remove scipy.org from the breadcrumb formattiong
 * `#14270 <https://github.com/numpy/numpy/pull/14270>`__: BUG: Fix formatting error in exception message
 * `#14272 <https://github.com/numpy/numpy/pull/14272>`__: DOC: Address typos in dispatch docs
@@ -293,9 +299,9 @@ A total of 406 pull requests were merged for this release.
 * `#14313 <https://github.com/numpy/numpy/pull/14313>`__: DOC: Clarify rules about broadcasting when empty arrays are involved.
 * `#14321 <https://github.com/numpy/numpy/pull/14321>`__: TST, MAINT: bump to OpenBLAS 0.3.7 stable
 * `#14325 <https://github.com/numpy/numpy/pull/14325>`__: DEP: numpy.testing.rand
-* `#14335 <https://github.com/numpy/numpy/pull/14335>`__: DEP: Deprecate class `SafeEval`
+* `#14335 <https://github.com/numpy/numpy/pull/14335>`__: DEP: Deprecate class ``SafeEval``
 * `#14341 <https://github.com/numpy/numpy/pull/14341>`__: BUG: revert detecting and raising error on ragged arrays
-* `#14342 <https://github.com/numpy/numpy/pull/14342>`__: DOC: Improve documentation of `isscalar`.
+* `#14342 <https://github.com/numpy/numpy/pull/14342>`__: DOC: Improve documentation of ``isscalar``.
 * `#14349 <https://github.com/numpy/numpy/pull/14349>`__: MAINT: Fix bloated mismatch error percentage in array comparisons.
 * `#14351 <https://github.com/numpy/numpy/pull/14351>`__: DOC: Fix a minor typo in dispatch documentation.
 * `#14352 <https://github.com/numpy/numpy/pull/14352>`__: MAINT: Remove redundant deprecation checks
@@ -344,7 +350,7 @@ A total of 406 pull requests were merged for this release.
 * `#14475 <https://github.com/numpy/numpy/pull/14475>`__: DOC: add timedelta64 signature
 * `#14477 <https://github.com/numpy/numpy/pull/14477>`__: MAINT: Extract raising of MemoryError to a helper function
 * `#14483 <https://github.com/numpy/numpy/pull/14483>`__: BUG,MAINT: Some fixes and minor cleanup based on clang analysis
-* `#14484 <https://github.com/numpy/numpy/pull/14484>`__: MAINT: Add `NPY_UNUSED` and `const` qualified suggested by clang
+* `#14484 <https://github.com/numpy/numpy/pull/14484>`__: MAINT: Add ``NPY_UNUSED`` and ``const`` qualified suggested by clang
 * `#14485 <https://github.com/numpy/numpy/pull/14485>`__: MAINT: Silence integer comparison build warnings in assert statements
 * `#14486 <https://github.com/numpy/numpy/pull/14486>`__: MAINT: distutils: Add newline at the end of printed warnings.
 * `#14490 <https://github.com/numpy/numpy/pull/14490>`__: BUG: random: Revert gh-14458 and refix gh-14557.
@@ -383,7 +389,7 @@ A total of 406 pull requests were merged for this release.
 * `#14567 <https://github.com/numpy/numpy/pull/14567>`__: DEP: remove deprecated (and private) numpy.testing submodules.
 * `#14568 <https://github.com/numpy/numpy/pull/14568>`__: BLD, DOC: fix gh-14518, add release note
 * `#14570 <https://github.com/numpy/numpy/pull/14570>`__: BUG: importing build_src breaks setuptools monkeypatch for msvc14
-* `#14572 <https://github.com/numpy/numpy/pull/14572>`__: DOC: Note runtests.py `-- -s` method to use pytests `-s`
+* `#14572 <https://github.com/numpy/numpy/pull/14572>`__: DOC: Note runtests.py ``-- -s`` method to use pytests ``-s``
 * `#14573 <https://github.com/numpy/numpy/pull/14573>`__: DOC: update submodule docstrings, remove info.py files
 * `#14576 <https://github.com/numpy/numpy/pull/14576>`__: DOC: Document the NPY_SCALARKIND values as C variables.
 * `#14582 <https://github.com/numpy/numpy/pull/14582>`__: MAINT: Bump pytest from 5.1.2 to 5.1.3
@@ -405,30 +411,31 @@ A total of 406 pull requests were merged for this release.
 * `#14614 <https://github.com/numpy/numpy/pull/14614>`__: MAINT: Bump pytest from 5.1.3 to 5.2.0
 * `#14615 <https://github.com/numpy/numpy/pull/14615>`__: MAINT: Add "MAINT" tag to dependabot commit msg
 * `#14616 <https://github.com/numpy/numpy/pull/14616>`__: DOC: Updated sphinx directive formatting
-* `#14620 <https://github.com/numpy/numpy/pull/14620>`__: DEP: Finish deprecation of non-integer `num` in linspace
+* `#14620 <https://github.com/numpy/numpy/pull/14620>`__: DEP: Finish deprecation of non-integer ``num`` in linspace
 * `#14621 <https://github.com/numpy/numpy/pull/14621>`__: DOC: s/OR/AND/ in np.logical_and docstring
 * `#14623 <https://github.com/numpy/numpy/pull/14623>`__: DOC: misleading np.sinc() documentation
 * `#14629 <https://github.com/numpy/numpy/pull/14629>`__: DOC: clarify residual in np.polyfit
 * `#14630 <https://github.com/numpy/numpy/pull/14630>`__: BUILD: change to build_src --verbose-cfg, runtests.py --debug-info
 * `#14631 <https://github.com/numpy/numpy/pull/14631>`__: BUG: always free clean_sep
-* `#14634 <https://github.com/numpy/numpy/pull/14634>`__: DOC: Create `class Extension` docstring and add it to documentation.
-* `#14636 <https://github.com/numpy/numpy/pull/14636>`__: DOC: add `printoptions` as a context manager to `set_printoptions`
+* `#14634 <https://github.com/numpy/numpy/pull/14634>`__: DOC: Create ``class Extension`` docstring and add it to documentation.
+* `#14636 <https://github.com/numpy/numpy/pull/14636>`__: DOC: add ``printoptions`` as a context manager to ``set_printoptions``
 * `#14639 <https://github.com/numpy/numpy/pull/14639>`__: DOC: Fix typo in NEP 29
 * `#14643 <https://github.com/numpy/numpy/pull/14643>`__: MAINT: Use scalar math power function directly
 * `#14649 <https://github.com/numpy/numpy/pull/14649>`__: DOC: Add IPython to dependencies needed to build docs.
 * `#14652 <https://github.com/numpy/numpy/pull/14652>`__: MAINT: Bump pytest-cov from 2.7.1 to 2.8.1
 * `#14653 <https://github.com/numpy/numpy/pull/14653>`__: MAINT: Bump pytest from 5.2.0 to 5.2.1
 * `#14654 <https://github.com/numpy/numpy/pull/14654>`__: MAINT: Bump pytz from 2019.2 to 2019.3
-* `#14656 <https://github.com/numpy/numpy/pull/14656>`__: MAINT: Use `extract_unit` throughout datetime
+* `#14656 <https://github.com/numpy/numpy/pull/14656>`__: MAINT: Use ``extract_unit`` throughout datetime
 * `#14657 <https://github.com/numpy/numpy/pull/14657>`__: BUG: fix fromfile behavior when reading sub-array dtypes
 * `#14662 <https://github.com/numpy/numpy/pull/14662>`__: BUG: random: Use correct length when axis is given to shuffle.
 * `#14669 <https://github.com/numpy/numpy/pull/14669>`__: BUG: Do not rely on undefined behaviour to cast from float to...
 * `#14674 <https://github.com/numpy/numpy/pull/14674>`__: NEP: add default-dtype-object-deprecation nep 34
 * `#14681 <https://github.com/numpy/numpy/pull/14681>`__: MAINT: Remove unused boolean negative/subtract loops
-* `#14682 <https://github.com/numpy/numpy/pull/14682>`__: DEP: ufunc `out` argument must be a tuple for multiple outputs
-* `#14693 <https://github.com/numpy/numpy/pull/14693>`__: BUG: Fix `np.einsum` errors on Power9 Linux and z/Linux
+* `#14682 <https://github.com/numpy/numpy/pull/14682>`__: DEP: ufunc ``out`` argument must be a tuple for multiple outputs
+* `#14693 <https://github.com/numpy/numpy/pull/14693>`__: BUG: Fix ``np.einsum`` errors on Power9 Linux and z/Linux
 * `#14696 <https://github.com/numpy/numpy/pull/14696>`__: DOC: Note release notes process changes on devdocs start page
 * `#14699 <https://github.com/numpy/numpy/pull/14699>`__: Doc warnings
+* `#14703 <https://github.com/numpy/numpy/pull/14703>`__: TST: Adding CI stages, with one initial job to the Travis CI
 * `#14705 <https://github.com/numpy/numpy/pull/14705>`__: DOC: Switch Markdown link to RST in NEP 29
 * `#14709 <https://github.com/numpy/numpy/pull/14709>`__: TST: Divide Azure CI Pipelines into stages.
 * `#14710 <https://github.com/numpy/numpy/pull/14710>`__: DEP: Finish the out kwarg deprecation for ufunc calls
@@ -526,7 +533,7 @@ A total of 406 pull requests were merged for this release.
 * `#15058 <https://github.com/numpy/numpy/pull/15058>`__: API, DOC: change names to multivariate_hypergeometric, improve docs
 * `#15059 <https://github.com/numpy/numpy/pull/15059>`__: REL: Prepare for NumPy 1.18.0 release.
 * `#15109 <https://github.com/numpy/numpy/pull/15109>`__: TST: Check requires_memory immediately before the test
-* `#15111 <https://github.com/numpy/numpy/pull/15111>`__: ENH: Add support to sort timedelta64 `NaT` to end of the array
+* `#15111 <https://github.com/numpy/numpy/pull/15111>`__: ENH: Add support to sort timedelta64 ``NaT`` to end of the array
 * `#15112 <https://github.com/numpy/numpy/pull/15112>`__: MAINT: follow-up cleanup for blas64 PR
 * `#15113 <https://github.com/numpy/numpy/pull/15113>`__: ENH: f2py: add --f2cmap option for specifying the name of .f2py_f2cmap
 * `#15114 <https://github.com/numpy/numpy/pull/15114>`__: ENH: add support for ILP64 OpenBLAS (without symbol suffix)

--- a/doc/changelog/1.19.0-changelog.rst
+++ b/doc/changelog/1.19.0-changelog.rst
@@ -136,25 +136,28 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 452 pull requests were merged for this release.
+A total of 488 pull requests were merged for this release.
 
 * `#8255 <https://github.com/numpy/numpy/pull/8255>`__: ENH: add identity kwarg to frompyfunc
+* `#10600 <https://github.com/numpy/numpy/pull/10600>`__: DOC: Do not complain about contiguity when mutating ``ndarray.shape``
 * `#12646 <https://github.com/numpy/numpy/pull/12646>`__: TST: check exception details in refguide_check.py
 * `#13421 <https://github.com/numpy/numpy/pull/13421>`__: ENH: improve runtime detection of CPU features
 * `#14326 <https://github.com/numpy/numpy/pull/14326>`__: TST: Add assert_array_equal test for big integer arrays.
 * `#14376 <https://github.com/numpy/numpy/pull/14376>`__: MAINT: Remove unnecessary 'from __future__ import ...' statements
 * `#14530 <https://github.com/numpy/numpy/pull/14530>`__: MAINT: Fix typos and copy edit NEP-0030.
 * `#14546 <https://github.com/numpy/numpy/pull/14546>`__: DOC: NumPy for absolute beginners tutorial
-* `#14715 <https://github.com/numpy/numpy/pull/14715>`__: NEP: Proposal for array creation dispatching with `__array_function__`
+* `#14715 <https://github.com/numpy/numpy/pull/14715>`__: NEP: Proposal for array creation dispatching with ``__array_function__``
 * `#14867 <https://github.com/numpy/numpy/pull/14867>`__: ENH: Use AVX-512F for np.maximum and np.minimum
 * `#14924 <https://github.com/numpy/numpy/pull/14924>`__: BUG: Fix numpy.random.dirichlet returns NaN for small 'alpha'...
-* `#14933 <https://github.com/numpy/numpy/pull/14933>`__: API: Use `ResultType` in `PyArray_ConvertToCommonType`
+* `#14933 <https://github.com/numpy/numpy/pull/14933>`__: API: Use ``ResultType`` in ``PyArray_ConvertToCommonType``
+* `#14940 <https://github.com/numpy/numpy/pull/14940>`__: BUG: pickle the content of a scalar containing objects, not the...
 * `#14942 <https://github.com/numpy/numpy/pull/14942>`__: MAINT,API: ignore and NULL fasttake/fastputmask ArrFuncs slots
 * `#14981 <https://github.com/numpy/numpy/pull/14981>`__: BUG: Make ``ediff1d`` kwarg casting consistent
 * `#14988 <https://github.com/numpy/numpy/pull/14988>`__: DOC: linalg: Include information about scipy.linalg.
 * `#14995 <https://github.com/numpy/numpy/pull/14995>`__: BUG: Use ``__array__`` during dimension discovery
 * `#15011 <https://github.com/numpy/numpy/pull/15011>`__: MAINT: cleanup compat.py3k.py
 * `#15022 <https://github.com/numpy/numpy/pull/15022>`__: ENH: f2py: improve error messages
+* `#15024 <https://github.com/numpy/numpy/pull/15024>`__: DOC: clarify documentation for transpose()
 * `#15028 <https://github.com/numpy/numpy/pull/15028>`__: [DOC] LaTeX: fix preamble (closes #15026)
 * `#15035 <https://github.com/numpy/numpy/pull/15035>`__: BUG: add endfunction, endsubroutine to valid fortran end words
 * `#15040 <https://github.com/numpy/numpy/pull/15040>`__: TST: Add test for object method (and general unary) loops
@@ -165,6 +168,7 @@ A total of 452 pull requests were merged for this release.
 * `#15052 <https://github.com/numpy/numpy/pull/15052>`__: MAINT: follow-up cleanup for blas64 PR
 * `#15054 <https://github.com/numpy/numpy/pull/15054>`__: DOC: add docstrings to refguide-check
 * `#15066 <https://github.com/numpy/numpy/pull/15066>`__: Revert "DEP: issue deprecation warning when creating ragged array...
+* `#15068 <https://github.com/numpy/numpy/pull/15068>`__: ENH: Add support to sort timedelta64 ``NaT`` to end of the array
 * `#15069 <https://github.com/numpy/numpy/pull/15069>`__: ENH: add support for ILP64 OpenBLAS (without symbol suffix)
 * `#15070 <https://github.com/numpy/numpy/pull/15070>`__: DOC: correct version for NaT sort
 * `#15072 <https://github.com/numpy/numpy/pull/15072>`__: TST: Check requires_memory immediately before the test
@@ -201,6 +205,7 @@ A total of 452 pull requests were merged for this release.
 * `#15187 <https://github.com/numpy/numpy/pull/15187>`__: MAINT: unskip test on win32
 * `#15189 <https://github.com/numpy/numpy/pull/15189>`__: ENH: Add property-based tests using Hypothesis
 * `#15194 <https://github.com/numpy/numpy/pull/15194>`__: BUG: test, fix for c++ compilation
+* `#15195 <https://github.com/numpy/numpy/pull/15195>`__: MAINT: refactoring in np.core.records
 * `#15196 <https://github.com/numpy/numpy/pull/15196>`__: DOC: Adding instructions for building documentation to developer...
 * `#15197 <https://github.com/numpy/numpy/pull/15197>`__: DOC: NEP 37: A dispatch protocol for NumPy-like modules
 * `#15203 <https://github.com/numpy/numpy/pull/15203>`__: MAINT: Do not use private Python function in testing
@@ -215,6 +220,8 @@ A total of 452 pull requests were merged for this release.
 * `#15227 <https://github.com/numpy/numpy/pull/15227>`__: DOC: typo in release.rst
 * `#15228 <https://github.com/numpy/numpy/pull/15228>`__: NEP: universal SIMD NEP 38
 * `#15229 <https://github.com/numpy/numpy/pull/15229>`__: MAINT: Remove unused int_asbuffer
+* `#15230 <https://github.com/numpy/numpy/pull/15230>`__: BUG: do not emit warnings for np.sign, np.equal when using nan
+* `#15231 <https://github.com/numpy/numpy/pull/15231>`__: MAINT: Remove Python2 specific C module setup [part2]
 * `#15232 <https://github.com/numpy/numpy/pull/15232>`__: MAINT: Cleaning up PY_MAJOR_VERSION/PY_VERSION_HEX
 * `#15233 <https://github.com/numpy/numpy/pull/15233>`__: MAINT: Clean up more PY_VERSION_HEX
 * `#15236 <https://github.com/numpy/numpy/pull/15236>`__: MAINT: Remove implicit inheritance from object class
@@ -224,14 +231,14 @@ A total of 452 pull requests were merged for this release.
 * `#15241 <https://github.com/numpy/numpy/pull/15241>`__: MAINT: Remove references to non-existent sys.exc_clear()
 * `#15242 <https://github.com/numpy/numpy/pull/15242>`__: DOC: Update HOWTO_RELEASE.rst
 * `#15248 <https://github.com/numpy/numpy/pull/15248>`__: MAINT: cleanup use of sys.exc_info
-* `#15249 <https://github.com/numpy/numpy/pull/15249>`__: MAINT: Eliminate some calls to `eval`
+* `#15249 <https://github.com/numpy/numpy/pull/15249>`__: MAINT: Eliminate some calls to ``eval``
 * `#15251 <https://github.com/numpy/numpy/pull/15251>`__: MAINT: Improve const-correctness of shapes and strides
 * `#15253 <https://github.com/numpy/numpy/pull/15253>`__: DOC: clarify the effect of None parameters passed to ndarray.view
 * `#15254 <https://github.com/numpy/numpy/pull/15254>`__: MAINT: Improve const-correctness of string arguments
 * `#15255 <https://github.com/numpy/numpy/pull/15255>`__: MAINT: Delete numpy.distutils.compat
 * `#15256 <https://github.com/numpy/numpy/pull/15256>`__: MAINT: Implement keyword-only arguments as syntax
 * `#15260 <https://github.com/numpy/numpy/pull/15260>`__: MAINT: Remove FIXME comments introduced in the previous commit
-* `#15261 <https://github.com/numpy/numpy/pull/15261>`__: MAINT: Work with unicode strings in `dtype('i8,i8')`
+* `#15261 <https://github.com/numpy/numpy/pull/15261>`__: MAINT: Work with unicode strings in ``dtype('i8,i8')``
 * `#15262 <https://github.com/numpy/numpy/pull/15262>`__: BUG: Use PyDict_GetItemWithError() instead of PyDict_GetItem()
 * `#15263 <https://github.com/numpy/numpy/pull/15263>`__: MAINT: Remove python2 array_{get,set}slice
 * `#15264 <https://github.com/numpy/numpy/pull/15264>`__: DOC: Add some missing functions in the list of available ufuncs.
@@ -248,8 +255,9 @@ A total of 452 pull requests were merged for this release.
 * `#15280 <https://github.com/numpy/numpy/pull/15280>`__: BENCH: Add basic benchmarks for take and putmask
 * `#15281 <https://github.com/numpy/numpy/pull/15281>`__: MAINT: Cleanup most PY3K #ifdef guards
 * `#15282 <https://github.com/numpy/numpy/pull/15282>`__: DOC: BLD: add empty release notes for 1.19.0 to fix doc build...
+* `#15283 <https://github.com/numpy/numpy/pull/15283>`__: MAINT: Cleanup more NPY_PY3K
 * `#15284 <https://github.com/numpy/numpy/pull/15284>`__: MAINT: Use a simpler return convention for internal functions
-* `#15285 <https://github.com/numpy/numpy/pull/15285>`__: MAINT: Simplify np.int_ inheritance
+* `#15285 <https://github.com/numpy/numpy/pull/15285>`__: MAINT: Simplify ``np.int_`` inheritance
 * `#15286 <https://github.com/numpy/numpy/pull/15286>`__: DOC" Update np.full docstring.
 * `#15287 <https://github.com/numpy/numpy/pull/15287>`__: MAINT: Express PyArray_DescrAlignConverter in terms of _convert_from_any
 * `#15288 <https://github.com/numpy/numpy/pull/15288>`__: MAINT: Push down declarations in _convert_from_*
@@ -261,7 +269,7 @@ A total of 452 pull requests were merged for this release.
 * `#15304 <https://github.com/numpy/numpy/pull/15304>`__: MAINT: Remove NPY_PY3K constant
 * `#15305 <https://github.com/numpy/numpy/pull/15305>`__: MAINT: Remove sys.version checks in tests
 * `#15307 <https://github.com/numpy/numpy/pull/15307>`__: MAINT: cleanup sys.version dependant code
-* `#15310 <https://github.com/numpy/numpy/pull/15310>`__: MAINT: Ensure `_convert_from_*` functions set errors
+* `#15310 <https://github.com/numpy/numpy/pull/15310>`__: MAINT: Ensure ``_convert_from_*`` functions set errors
 * `#15312 <https://github.com/numpy/numpy/pull/15312>`__: MAINT: Avoid escaping unicode in error messages
 * `#15315 <https://github.com/numpy/numpy/pull/15315>`__: MAINT: Change file extension of ma README to rst.
 * `#15319 <https://github.com/numpy/numpy/pull/15319>`__: BUG: fix NameError in clip nan propagation tests
@@ -271,22 +279,25 @@ A total of 452 pull requests were merged for this release.
 * `#15329 <https://github.com/numpy/numpy/pull/15329>`__: TST: move _no_tracing to testing._private, remove testing.support
 * `#15333 <https://github.com/numpy/numpy/pull/15333>`__: BUG: Add some missing C error handling
 * `#15335 <https://github.com/numpy/numpy/pull/15335>`__: MAINT: Remove sys.version checks
-* `#15336 <https://github.com/numpy/numpy/pull/15336>`__: DEP: Deprecate `->f->fastclip` at registration time
+* `#15336 <https://github.com/numpy/numpy/pull/15336>`__: DEP: Deprecate ``->f->fastclip`` at registration time
 * `#15338 <https://github.com/numpy/numpy/pull/15338>`__: DOC: document site.cfg.example
 * `#15350 <https://github.com/numpy/numpy/pull/15350>`__: MAINT: Fix mistype in histogramdd docstring
 * `#15351 <https://github.com/numpy/numpy/pull/15351>`__: DOC, BLD: reword release note, upgrade sphinx version
 * `#15353 <https://github.com/numpy/numpy/pull/15353>`__: MAINT: Remove unnecessary calls to PyArray_DATA from binomial...
 * `#15354 <https://github.com/numpy/numpy/pull/15354>`__: MAINT: Bump pytest from 5.3.2 to 5.3.3
+* `#15355 <https://github.com/numpy/numpy/pull/15355>`__: MAINT: Const qualify UFunc inner loops
 * `#15358 <https://github.com/numpy/numpy/pull/15358>`__: MAINT: Remove six
 * `#15361 <https://github.com/numpy/numpy/pull/15361>`__: MAINT: Revise imports from collections.abc module
 * `#15362 <https://github.com/numpy/numpy/pull/15362>`__: MAINT: remove internal functions required to handle Python2/3...
 * `#15364 <https://github.com/numpy/numpy/pull/15364>`__: MAINT: Remove other uses of six module
 * `#15366 <https://github.com/numpy/numpy/pull/15366>`__: MAINT: resolve pyflake F403 'from module import *' used
+* `#15367 <https://github.com/numpy/numpy/pull/15367>`__: DOC: Fix Multithreaded Generation example docs
 * `#15368 <https://github.com/numpy/numpy/pull/15368>`__: MAINT: Update tox for supported Python versions
 * `#15369 <https://github.com/numpy/numpy/pull/15369>`__: MAINT: simd: Avoid signed comparison warning
-* `#15370 <https://github.com/numpy/numpy/pull/15370>`__: DOC: Updating Chararry Buffer datatypes #15360
+* `#15370 <https://github.com/numpy/numpy/pull/15370>`__: DOC: Updating Chararry Buffer datatypes
+* `#15373 <https://github.com/numpy/numpy/pull/15373>`__: MAINT: Remove sys.version checks
 * `#15374 <https://github.com/numpy/numpy/pull/15374>`__: TST: Simplify unicode test
-* `#15375 <https://github.com/numpy/numpy/pull/15375>`__: MAINT: Use `with open` when possible
+* `#15375 <https://github.com/numpy/numpy/pull/15375>`__: MAINT: Use ``with open`` when possible
 * `#15377 <https://github.com/numpy/numpy/pull/15377>`__: MAINT: Cleanup python2 references
 * `#15379 <https://github.com/numpy/numpy/pull/15379>`__: MAINT: Python2 Cleanups
 * `#15381 <https://github.com/numpy/numpy/pull/15381>`__: DEP: add PendingDeprecation to matlib.py funky namespace
@@ -303,11 +314,14 @@ A total of 452 pull requests were merged for this release.
 * `#15407 <https://github.com/numpy/numpy/pull/15407>`__: MAINT: Replace basestring with str.
 * `#15408 <https://github.com/numpy/numpy/pull/15408>`__: ENH: Use AVX-512F for complex number arithmetic, absolute, square...
 * `#15414 <https://github.com/numpy/numpy/pull/15414>`__: MAINT: Remove Python2 workarounds
+* `#15415 <https://github.com/numpy/numpy/pull/15415>`__: MAINT: Revert f2py Python 2.6 workaround
 * `#15417 <https://github.com/numpy/numpy/pull/15417>`__: MAINT: Cleanup references to python2
 * `#15418 <https://github.com/numpy/numpy/pull/15418>`__: MAINT, DOC: Remove use of old Python __builtin__, now known as...
 * `#15421 <https://github.com/numpy/numpy/pull/15421>`__: ENH: Make use of ExitStack in npyio.py
 * `#15422 <https://github.com/numpy/numpy/pull/15422>`__: MAINT: Inline gentype_getreadbuf
 * `#15423 <https://github.com/numpy/numpy/pull/15423>`__: MAINT: Use f-strings for clarity.
+* `#15425 <https://github.com/numpy/numpy/pull/15425>`__: MAINT: dir(numpy) returns duplicate "testing"
+* `#15426 <https://github.com/numpy/numpy/pull/15426>`__: MAINT: Use the PyArrayScalar_VAL macro where possible
 * `#15427 <https://github.com/numpy/numpy/pull/15427>`__: DEP: Schedule unused C-API functions for removal/disabling
 * `#15428 <https://github.com/numpy/numpy/pull/15428>`__: DOC: Improve ndarray.ctypes example
 * `#15429 <https://github.com/numpy/numpy/pull/15429>`__: DOC: distutils: Add a docstring to show_config().
@@ -315,14 +329,15 @@ A total of 452 pull requests were merged for this release.
 * `#15434 <https://github.com/numpy/numpy/pull/15434>`__: MAINT: Updated polynomial to use fstrings
 * `#15435 <https://github.com/numpy/numpy/pull/15435>`__: DOC: Fix Incorrect document in Beginner Docs
 * `#15436 <https://github.com/numpy/numpy/pull/15436>`__: MAINT: Update core.py with fstrings (issue #15420)
-* `#15439 <https://github.com/numpy/numpy/pull/15439>`__: DOC: fix docstrings so `python tools/refguide-check --rst <file>...
+* `#15439 <https://github.com/numpy/numpy/pull/15439>`__: DOC: fix docstrings so ``python tools/refguide-check --rst <file>``...
 * `#15441 <https://github.com/numpy/numpy/pull/15441>`__: MAINT: Tidy macros in scalar_new
 * `#15444 <https://github.com/numpy/numpy/pull/15444>`__: MAINT: use 'yield from <expr>' for simple cases
 * `#15445 <https://github.com/numpy/numpy/pull/15445>`__: MAINT: Bump pytest from 5.3.3 to 5.3.4
 * `#15446 <https://github.com/numpy/numpy/pull/15446>`__: BUG: Reject nonsense arguments to scalar constructors
 * `#15449 <https://github.com/numpy/numpy/pull/15449>`__: DOC: Update refguide_check note on how to skip code
-* `#15451 <https://github.com/numpy/numpy/pull/15451>`__: MAINT: Simplify `np.object_.__new__`
+* `#15451 <https://github.com/numpy/numpy/pull/15451>`__: MAINT: Simplify ``np.object_.__new__``
 * `#15452 <https://github.com/numpy/numpy/pull/15452>`__: STY,MAINT: avoid 'multiple imports on one line'
+* `#15463 <https://github.com/numpy/numpy/pull/15463>`__: ENH: expose ``bit_generator`` and random C-API to cython
 * `#15464 <https://github.com/numpy/numpy/pull/15464>`__: MAINT: Cleanup duplicate line in refguide_check
 * `#15465 <https://github.com/numpy/numpy/pull/15465>`__: MAINT: cleanup unused imports; avoid redefinition of imports
 * `#15468 <https://github.com/numpy/numpy/pull/15468>`__: BUG: Fix for SVD not always sorted with hermitian=True
@@ -330,21 +345,22 @@ A total of 452 pull requests were merged for this release.
 * `#15474 <https://github.com/numpy/numpy/pull/15474>`__: MAINT: Eliminate messy _WORK macro
 * `#15476 <https://github.com/numpy/numpy/pull/15476>`__: update result of rng.random(3) to current rng output
 * `#15480 <https://github.com/numpy/numpy/pull/15480>`__: DOC: Correct get_state doc
-* `#15482 <https://github.com/numpy/numpy/pull/15482>`__: MAINT: Use `.identifier = val` to fill type structs
+* `#15482 <https://github.com/numpy/numpy/pull/15482>`__: MAINT: Use ``.identifier = val`` to fill type structs
 * `#15483 <https://github.com/numpy/numpy/pull/15483>`__: [DOC] Mention behaviour of np.squeeze with one element
 * `#15484 <https://github.com/numpy/numpy/pull/15484>`__: ENH: fixing generic error messages to be more specific in multiarray/descriptor.c
 * `#15487 <https://github.com/numpy/numpy/pull/15487>`__: BUG: Fixing result of np quantile edge case
 * `#15491 <https://github.com/numpy/numpy/pull/15491>`__: TST: mark the top 3 slowest tests to save ~10 seconds
 * `#15493 <https://github.com/numpy/numpy/pull/15493>`__: MAINT: Bump pytest from 5.3.4 to 5.3.5
 * `#15500 <https://github.com/numpy/numpy/pull/15500>`__: MAINT: Use True/False instead of 1/0 in np.dtype.__reduce__
-* `#15503 <https://github.com/numpy/numpy/pull/15503>`__: MAINT: Do not allow `copyswap` and friends to fail silently
+* `#15503 <https://github.com/numpy/numpy/pull/15503>`__: MAINT: Do not allow ``copyswap`` and friends to fail silently
 * `#15504 <https://github.com/numpy/numpy/pull/15504>`__: DOC: Remove duplicated code in true_divide docstring
 * `#15505 <https://github.com/numpy/numpy/pull/15505>`__: NEP 40: Informational NEP about current DTypes
+* `#15506 <https://github.com/numpy/numpy/pull/15506>`__: NEP 41: First steps towards improved Datatype Support
 * `#15510 <https://github.com/numpy/numpy/pull/15510>`__: DOC: Update unique docstring example
 * `#15511 <https://github.com/numpy/numpy/pull/15511>`__: MAINT: Large overhead in some random functions
 * `#15516 <https://github.com/numpy/numpy/pull/15516>`__: TST: Fix missing output in refguide-check
 * `#15521 <https://github.com/numpy/numpy/pull/15521>`__: MAINT: Simplify arraydescr_richcompare
-* `#15522 <https://github.com/numpy/numpy/pull/15522>`__: MAINT: Fix internal misuses of `NPY_TITLE_KEY`
+* `#15522 <https://github.com/numpy/numpy/pull/15522>`__: MAINT: Fix internal misuses of ``NPY_TITLE_KEY``
 * `#15524 <https://github.com/numpy/numpy/pull/15524>`__: DOC: Update instructions for building/archiving docs.
 * `#15526 <https://github.com/numpy/numpy/pull/15526>`__: BUG: Fix inline assembly that detects cpu features on x86(32bit)
 * `#15532 <https://github.com/numpy/numpy/pull/15532>`__: update doctests, small bugs and changes of repr
@@ -354,13 +370,15 @@ A total of 452 pull requests were merged for this release.
 * `#15543 <https://github.com/numpy/numpy/pull/15543>`__: NEP: edit and move NEP 38 to accepted status
 * `#15547 <https://github.com/numpy/numpy/pull/15547>`__: MAINT: Refresh Doxyfile and modernize numpyfilter.py
 * `#15549 <https://github.com/numpy/numpy/pull/15549>`__: TST: Accuracy test float32 sin/cos/exp/log for AVX platforms
-* `#15550 <https://github.com/numpy/numpy/pull/15550>`__: DOC: Improve the `numpy.linalg.eig` docstring.
+* `#15550 <https://github.com/numpy/numpy/pull/15550>`__: DOC: Improve the ``numpy.linalg.eig`` docstring.
+* `#15553 <https://github.com/numpy/numpy/pull/15553>`__: BUG: Added missing error check in ``ndarray.__contains__``
 * `#15554 <https://github.com/numpy/numpy/pull/15554>`__: NEP 44 - Restructuring the NumPy Documentation
 * `#15556 <https://github.com/numpy/numpy/pull/15556>`__: TST: (Travis CI) Use full python3-dbg path for virtual env creation
 * `#15560 <https://github.com/numpy/numpy/pull/15560>`__: BUG, DOC: restore missing import
 * `#15566 <https://github.com/numpy/numpy/pull/15566>`__: DOC: Removing bad practices from quick start + some PEP8
 * `#15574 <https://github.com/numpy/numpy/pull/15574>`__: TST: Do not create symbolic link named gfortran.
 * `#15575 <https://github.com/numpy/numpy/pull/15575>`__: DOC: Document caveat in random.uniform
+* `#15577 <https://github.com/numpy/numpy/pull/15577>`__: TST: Test division by zero both with scalar and with array
 * `#15579 <https://github.com/numpy/numpy/pull/15579>`__: DOC: numpy.clip is equivalent to minimum(..., maximum(...))
 * `#15582 <https://github.com/numpy/numpy/pull/15582>`__: MAINT: Bump cython from 0.29.14 to 0.29.15
 * `#15583 <https://github.com/numpy/numpy/pull/15583>`__: MAINT: Bump hypothesis from 5.3.0 to 5.5.4
@@ -369,6 +387,7 @@ A total of 452 pull requests were merged for this release.
 * `#15600 <https://github.com/numpy/numpy/pull/15600>`__: TST: use manylinux2010 docker instead of ubuntu
 * `#15610 <https://github.com/numpy/numpy/pull/15610>`__: TST: mask DeprecationWarning in xfailed test
 * `#15612 <https://github.com/numpy/numpy/pull/15612>`__: BUG: Fix bug in AVX-512F np.maximum and np.minimum
+* `#15614 <https://github.com/numpy/numpy/pull/15614>`__: DOC: Reword docstring for assert_equal
 * `#15615 <https://github.com/numpy/numpy/pull/15615>`__: BUG: Remove check requiring natural alignment of float/double...
 * `#15616 <https://github.com/numpy/numpy/pull/15616>`__: DOC: Add missing imports, definitions and dummy file
 * `#15619 <https://github.com/numpy/numpy/pull/15619>`__: DOC: Fix documentation for apply_along_axis
@@ -376,9 +395,10 @@ A total of 452 pull requests were merged for this release.
 * `#15631 <https://github.com/numpy/numpy/pull/15631>`__: MAINT: Pull identical line out of conditional.
 * `#15633 <https://github.com/numpy/numpy/pull/15633>`__: DOC: remove broken link in f2py tutorial
 * `#15639 <https://github.com/numpy/numpy/pull/15639>`__: BLD: update openblas download to new location, use manylinux2010-base
+* `#15644 <https://github.com/numpy/numpy/pull/15644>`__: DOC: Update to clarify actual behavior real_if_(all elements)_close
 * `#15648 <https://github.com/numpy/numpy/pull/15648>`__: MAINT: AVX512 implementation with intrinsic for float64 input...
 * `#15653 <https://github.com/numpy/numpy/pull/15653>`__: BLD: update OpenBLAS to pre-0.3.9 version
-* `#15662 <https://github.com/numpy/numpy/pull/15662>`__: DOC: Refactor `np.polynomial` docs using `automodule`
+* `#15662 <https://github.com/numpy/numpy/pull/15662>`__: DOC: Refactor ``np.polynomial`` docs using ``automodule``
 * `#15665 <https://github.com/numpy/numpy/pull/15665>`__: BUG: fix doctest exception messages
 * `#15672 <https://github.com/numpy/numpy/pull/15672>`__: MAINT: Added comment pointing FIXME to relevant PR.
 * `#15673 <https://github.com/numpy/numpy/pull/15673>`__: DOC: Make extension module wording more clear
@@ -386,16 +406,18 @@ A total of 452 pull requests were merged for this release.
 * `#15680 <https://github.com/numpy/numpy/pull/15680>`__: DOC: Improve Benchmark README with environment setup and more...
 * `#15682 <https://github.com/numpy/numpy/pull/15682>`__: MAINT: Bump hypothesis from 5.5.4 to 5.6.0
 * `#15683 <https://github.com/numpy/numpy/pull/15683>`__: NEP: move NEP 44 to accepted status
+* `#15685 <https://github.com/numpy/numpy/pull/15685>`__: ENH: Add ``subok`` parameter to np.copy function (cf. #6509)
 * `#15694 <https://github.com/numpy/numpy/pull/15694>`__: DOC: Fix indexing docs to pass refguide
 * `#15695 <https://github.com/numpy/numpy/pull/15695>`__: MAINT: Test during import to detect bugs with Accelerate(MacOS)...
 * `#15696 <https://github.com/numpy/numpy/pull/15696>`__: MAINT: Add a fast path to var for complex input
 * `#15701 <https://github.com/numpy/numpy/pull/15701>`__: MAINT: Convert shebang from python to python3 (#15687)
 * `#15702 <https://github.com/numpy/numpy/pull/15702>`__: MAINT: replace optparse with argparse for 'doc' and 'tools' scripts
 * `#15703 <https://github.com/numpy/numpy/pull/15703>`__: DOC: Fix quickstart doc to pass refguide
+* `#15705 <https://github.com/numpy/numpy/pull/15705>`__: DOC: Change list to tuple in example description.
 * `#15706 <https://github.com/numpy/numpy/pull/15706>`__: MAINT: Fixing typos in f2py comments and code.
 * `#15710 <https://github.com/numpy/numpy/pull/15710>`__: DOC: fix SVD tutorial to pass refguide
 * `#15714 <https://github.com/numpy/numpy/pull/15714>`__: MAINT: use list-based APIs to call subprocesses
-* `#15715 <https://github.com/numpy/numpy/pull/15715>`__: ENH: update numpy.linalg.multi_dot to accept an `out` argument
+* `#15715 <https://github.com/numpy/numpy/pull/15715>`__: ENH: update numpy.linalg.multi_dot to accept an ``out`` argument
 * `#15716 <https://github.com/numpy/numpy/pull/15716>`__: TST: always use 'python -mpip' not 'pip'
 * `#15717 <https://github.com/numpy/numpy/pull/15717>`__: DOC: update datetime reference to pass refguide
 * `#15718 <https://github.com/numpy/numpy/pull/15718>`__: DOC: Fix coremath.rst to fix refguide_check
@@ -403,6 +425,7 @@ A total of 452 pull requests were merged for this release.
 * `#15723 <https://github.com/numpy/numpy/pull/15723>`__: BUG: fix logic error when nm fails on 32-bit
 * `#15724 <https://github.com/numpy/numpy/pull/15724>`__: TST: Remove nose from the test_requirements.txt file.
 * `#15733 <https://github.com/numpy/numpy/pull/15733>`__: DOC: Allow NEPs to link to python, numpy, scipy, and matplotlib...
+* `#15735 <https://github.com/numpy/numpy/pull/15735>`__: DOC: LICENSE 2019 -> 2020
 * `#15736 <https://github.com/numpy/numpy/pull/15736>`__: BUG: Guarantee array is in valid state after memory error occurs...
 * `#15738 <https://github.com/numpy/numpy/pull/15738>`__: MAINT: Remove non-native byte order from _var check.
 * `#15740 <https://github.com/numpy/numpy/pull/15740>`__: MAINT: Add better error handling in linalg.norm for vectors and...
@@ -418,28 +441,30 @@ A total of 452 pull requests were merged for this release.
 * `#15769 <https://github.com/numpy/numpy/pull/15769>`__: ENH: Allow toggling madvise hugepage and fix default
 * `#15771 <https://github.com/numpy/numpy/pull/15771>`__: DOC: Fix runtests example in developer docs
 * `#15773 <https://github.com/numpy/numpy/pull/15773>`__: DEP: Make issubdtype consistent for types and dtypes
-* `#15774 <https://github.com/numpy/numpy/pull/15774>`__: MAINT: remove useless `global` statements
+* `#15774 <https://github.com/numpy/numpy/pull/15774>`__: MAINT: remove useless ``global`` statements
 * `#15778 <https://github.com/numpy/numpy/pull/15778>`__: BLD: Add requirements.txt file for building docs
 * `#15781 <https://github.com/numpy/numpy/pull/15781>`__: BUG: don't add 'public' or 'private' if the other one exists
-* `#15784 <https://github.com/numpy/numpy/pull/15784>`__: ENH: Use TypeError in `np.array` for python consistency
+* `#15784 <https://github.com/numpy/numpy/pull/15784>`__: ENH: Use TypeError in ``np.array`` for python consistency
 * `#15794 <https://github.com/numpy/numpy/pull/15794>`__: BUG: Add basic __format__ for masked element to fix incorrect...
 * `#15797 <https://github.com/numpy/numpy/pull/15797>`__: TST: Add unit test for out=None of np.einsum
 * `#15799 <https://github.com/numpy/numpy/pull/15799>`__: MAINT: Cleanups to np.insert and np.delete
 * `#15800 <https://github.com/numpy/numpy/pull/15800>`__: BUG: Add error-checking versions of strided casts.
-* `#15802 <https://github.com/numpy/numpy/pull/15802>`__: DEP: Make `np.insert` and `np.delete` on 0d arrays with an axis...
-* `#15803 <https://github.com/numpy/numpy/pull/15803>`__: DOC: correct possible list lengths for `extobj` in ufunc calls
+* `#15802 <https://github.com/numpy/numpy/pull/15802>`__: DEP: Make ``np.insert`` and ``np.delete`` on 0d arrays with an axis...
+* `#15803 <https://github.com/numpy/numpy/pull/15803>`__: DOC: correct possible list lengths for ``extobj`` in ufunc calls
 * `#15804 <https://github.com/numpy/numpy/pull/15804>`__: DEP: Make np.delete on out-of-bounds indices an error
-* `#15805 <https://github.com/numpy/numpy/pull/15805>`__: DEP: Forbid passing non-integral index arrays to `insert` and...
+* `#15805 <https://github.com/numpy/numpy/pull/15805>`__: DEP: Forbid passing non-integral index arrays to ``insert`` and...
 * `#15806 <https://github.com/numpy/numpy/pull/15806>`__: TST: Parametrize sort test
 * `#15809 <https://github.com/numpy/numpy/pull/15809>`__: TST: switch PyPy job with CPython
 * `#15812 <https://github.com/numpy/numpy/pull/15812>`__: TST: Remove code that is not supposed to warn out of warning...
 * `#15815 <https://github.com/numpy/numpy/pull/15815>`__: DEP: Do not cast boolean indices to integers in np.delete
 * `#15816 <https://github.com/numpy/numpy/pull/15816>`__: MAINT: simplify code that assumes str/unicode and int/long are...
+* `#15827 <https://github.com/numpy/numpy/pull/15827>`__: BUG: Break on all errors when performing strided casts.
 * `#15830 <https://github.com/numpy/numpy/pull/15830>`__: MAINT: pathlib and hashlib are in stdlib in Python 3.5+
-* `#15832 <https://github.com/numpy/numpy/pull/15832>`__: ENH: improved error message `IndexError: too many indices for...
+* `#15832 <https://github.com/numpy/numpy/pull/15832>`__: ENH: improved error message ``IndexError: too many indices for``...
+* `#15834 <https://github.com/numpy/numpy/pull/15834>`__: NEP: Add paragraph to NEP 41 about no array-object use and fix...
 * `#15836 <https://github.com/numpy/numpy/pull/15836>`__: BUG: Fix IndexError for illegal axis in np.mean
 * `#15839 <https://github.com/numpy/numpy/pull/15839>`__: DOC: Minor fix to _hist_bin_fd documentation
-* `#15840 <https://github.com/numpy/numpy/pull/15840>`__: BUG,DEP: Make `scalar.__round__()` behave like pythons round
+* `#15840 <https://github.com/numpy/numpy/pull/15840>`__: BUG,DEP: Make ``scalar.__round__()`` behave like pythons round
 * `#15843 <https://github.com/numpy/numpy/pull/15843>`__: DOC: First steps towards docs restructuring (NEP 44)
 * `#15848 <https://github.com/numpy/numpy/pull/15848>`__: DOC, TST: enable refguide_check in circleci
 * `#15850 <https://github.com/numpy/numpy/pull/15850>`__: DOC: fix typo in C-API reference
@@ -447,8 +472,9 @@ A total of 452 pull requests were merged for this release.
 * `#15866 <https://github.com/numpy/numpy/pull/15866>`__: MAINT: Bump cython from 0.29.15 to 0.29.16
 * `#15867 <https://github.com/numpy/numpy/pull/15867>`__: DEP: Deprecate ndarray.tostring()
 * `#15868 <https://github.com/numpy/numpy/pull/15868>`__: TST: use draft OpenBLAS build
+* `#15870 <https://github.com/numpy/numpy/pull/15870>`__: ENH: Add keepdims argument to count_nonzero
 * `#15872 <https://github.com/numpy/numpy/pull/15872>`__: BUG: Fix eigh and cholesky methods of numpy.random.multivariate_normal
-* `#15876 <https://github.com/numpy/numpy/pull/15876>`__: BUG: Check that `pvals` is 1D in `_generator.multinomial`.
+* `#15876 <https://github.com/numpy/numpy/pull/15876>`__: BUG: Check that ``pvals`` is 1D in ``_generator.multinomial``.
 * `#15877 <https://github.com/numpy/numpy/pull/15877>`__: DOC: Add missing signature from nditer docstring
 * `#15881 <https://github.com/numpy/numpy/pull/15881>`__: BUG: Fix empty_like to respect shape=()
 * `#15882 <https://github.com/numpy/numpy/pull/15882>`__: BUG: Do not ignore empty tuple of strides in ndarray.__new__
@@ -456,29 +482,34 @@ A total of 452 pull requests were merged for this release.
 * `#15884 <https://github.com/numpy/numpy/pull/15884>`__: BUG: Setting a 0d array's strides to themselves should be legal
 * `#15885 <https://github.com/numpy/numpy/pull/15885>`__: BUG: Respect itershape=() in nditer
 * `#15887 <https://github.com/numpy/numpy/pull/15887>`__: MAINT: Clean-up 'next = __next__' used for Python 2 compatibility
+* `#15891 <https://github.com/numpy/numpy/pull/15891>`__: DOC: Clarify docs on mixed advanced indexing and slicing
 * `#15893 <https://github.com/numpy/numpy/pull/15893>`__: TST: Run test_large_zip in a child process
 * `#15894 <https://github.com/numpy/numpy/pull/15894>`__: DOC: Add missing doc of numpy.ma.apply_over_axes in API list.
 * `#15899 <https://github.com/numpy/numpy/pull/15899>`__: DOC: Improve record module documentation
 * `#15901 <https://github.com/numpy/numpy/pull/15901>`__: DOC: Fixed order of items and link to mailing list in dev docs...
 * `#15903 <https://github.com/numpy/numpy/pull/15903>`__: BLD: report clang version on macOS
-* `#15904 <https://github.com/numpy/numpy/pull/15904>`__: MAINT: records: Remove private `format_parser._descr` attribute
+* `#15904 <https://github.com/numpy/numpy/pull/15904>`__: MAINT: records: Remove private ``format_parser._descr`` attribute
+* `#15907 <https://github.com/numpy/numpy/pull/15907>`__: DOC: Update documentation w.r.t. NPY_RELAXED_STRIDES_CHECKING
 * `#15914 <https://github.com/numpy/numpy/pull/15914>`__: BUG: random: Disallow p=0 in negative_binomial
+* `#15920 <https://github.com/numpy/numpy/pull/15920>`__: DOC: Improve docstring for numpy.linalg.lstsq
 * `#15921 <https://github.com/numpy/numpy/pull/15921>`__: ENH: Use sysconfig instead of probing Makefile
 * `#15928 <https://github.com/numpy/numpy/pull/15928>`__: DOC: Update np.copy docstring to include ragged case
 * `#15931 <https://github.com/numpy/numpy/pull/15931>`__: DOC: Correct private function name to PyArray_AdaptFlexibleDType
-* `#15936 <https://github.com/numpy/numpy/pull/15936>`__: MAINT: Fix capitalization in error message in `mtrand.pyx`
+* `#15936 <https://github.com/numpy/numpy/pull/15936>`__: MAINT: Fix capitalization in error message in ``mtrand.pyx``
+* `#15938 <https://github.com/numpy/numpy/pull/15938>`__: BUG: Add _LARGE_FILES to def_macros[] when platform is AIX.
 * `#15939 <https://github.com/numpy/numpy/pull/15939>`__: DOC: Update np.rollaxis docstring
 * `#15949 <https://github.com/numpy/numpy/pull/15949>`__: BUG: fix AttributeError on accessing object in nested MaskedArray.
-* `#15951 <https://github.com/numpy/numpy/pull/15951>`__: BUG: Alpha parameter must be 1D in `generator.dirichlet`
+* `#15951 <https://github.com/numpy/numpy/pull/15951>`__: BUG: Alpha parameter must be 1D in ``generator.dirichlet``
 * `#15953 <https://github.com/numpy/numpy/pull/15953>`__: NEP: minor maintenance, update filename and fix a cross-reference
 * `#15964 <https://github.com/numpy/numpy/pull/15964>`__: MAINT: Bump hypothesis from 5.8.0 to 5.8.3
 * `#15967 <https://github.com/numpy/numpy/pull/15967>`__: TST: Add slow_pypy support
 * `#15968 <https://github.com/numpy/numpy/pull/15968>`__: DOC: Added note to angle function docstring about angle(0) being...
 * `#15982 <https://github.com/numpy/numpy/pull/15982>`__: MAINT/BUG: Cleanup and minor fixes to conform_reduce_result
-* `#15985 <https://github.com/numpy/numpy/pull/15985>`__: BUG: Avoid duplication in stack trace of `linspace(a, b, num=1.5)`
-* `#15988 <https://github.com/numpy/numpy/pull/15988>`__: BUG: Fix inf and NaN-warnings in half float `nextafter`
+* `#15985 <https://github.com/numpy/numpy/pull/15985>`__: BUG: Avoid duplication in stack trace of ``linspace(a, b, num=1.5)``
+* `#15988 <https://github.com/numpy/numpy/pull/15988>`__: BUG: Fix inf and NaN-warnings in half float ``nextafter``
 * `#15989 <https://github.com/numpy/numpy/pull/15989>`__: MAINT: Remove 0d check for PyArray_ISONESEGMENT
 * `#15990 <https://github.com/numpy/numpy/pull/15990>`__: DEV: Pass additional runtests.py args to ASV
+* `#15991 <https://github.com/numpy/numpy/pull/15991>`__: BUG: max/min of a masked array dtype fix
 * `#15993 <https://github.com/numpy/numpy/pull/15993>`__: DOC: Fix method documentation of function sort in MaskedArray
 * `#16000 <https://github.com/numpy/numpy/pull/16000>`__: NEP: Improve Value Based Casting paragraph in NEP 40
 * `#16001 <https://github.com/numpy/numpy/pull/16001>`__: DOC: add note on flatten ordering in matlab page
@@ -496,6 +527,8 @@ A total of 452 pull requests were merged for this release.
 * `#16038 <https://github.com/numpy/numpy/pull/16038>`__: MAINT,TST: Move _repr_latex tests to test_printing.
 * `#16041 <https://github.com/numpy/numpy/pull/16041>`__: BUG: missing 'f' prefix for fstring
 * `#16042 <https://github.com/numpy/numpy/pull/16042>`__: ENH: Fix exception causes in build_ext.py
+* `#16043 <https://github.com/numpy/numpy/pull/16043>`__: DOC: Add converters example to the loadtxt docstring
+* `#16051 <https://github.com/numpy/numpy/pull/16051>`__: DOC: Add missing bracket
 * `#16053 <https://github.com/numpy/numpy/pull/16053>`__: DOC: Small typo fixes to NEP 40.
 * `#16054 <https://github.com/numpy/numpy/pull/16054>`__: DOC, BLD: update release howto and walkthrough for ananconda.org...
 * `#16061 <https://github.com/numpy/numpy/pull/16061>`__: ENH: Chained exceptions in linalg.py and polyutils.py
@@ -508,6 +541,7 @@ A total of 452 pull requests were merged for this release.
 * `#16077 <https://github.com/numpy/numpy/pull/16077>`__: BLD: fix path to libgfortran on macOS
 * `#16078 <https://github.com/numpy/numpy/pull/16078>`__: DOC: Add axis to random module "new or different" docs
 * `#16079 <https://github.com/numpy/numpy/pull/16079>`__: DOC,BLD: Limit timeit iterations in random docs.
+* `#16080 <https://github.com/numpy/numpy/pull/16080>`__: BUG: numpy.einsum indexing arrays now accept numpy int type
 * `#16081 <https://github.com/numpy/numpy/pull/16081>`__: DOC: add note on type casting to numpy.left_shift().
 * `#16083 <https://github.com/numpy/numpy/pull/16083>`__: DOC: improve development debugging doc
 * `#16084 <https://github.com/numpy/numpy/pull/16084>`__: DOC: tweak neps/scope.rst
@@ -517,10 +551,12 @@ A total of 452 pull requests were merged for this release.
 * `#16097 <https://github.com/numpy/numpy/pull/16097>`__: MAINT, DOC: Improve grammar on a comment in the quickstart
 * `#16100 <https://github.com/numpy/numpy/pull/16100>`__: NEP 41: Accept NEP 41 and add DType<->scalar duplication paragraph
 * `#16101 <https://github.com/numpy/numpy/pull/16101>`__: BLD: put openblas library in local directory on windows
+* `#16102 <https://github.com/numpy/numpy/pull/16102>`__: ENH: correct identity for logaddexp2 ufunc: -inf
 * `#16113 <https://github.com/numpy/numpy/pull/16113>`__: MAINT: Fix random.PCG64 signature
 * `#16119 <https://github.com/numpy/numpy/pull/16119>`__: DOC: Move misplaced news fragment for gh-13421
 * `#16122 <https://github.com/numpy/numpy/pull/16122>`__: DOC: Fix links for NEP 40 in NEP 41
 * `#16125 <https://github.com/numpy/numpy/pull/16125>`__: BUG: lib: Fix a problem with vectorize with default parameters.
+* `#16128 <https://github.com/numpy/numpy/pull/16128>`__: ENH: Add equal_nan keyword argument to array_equal
 * `#16129 <https://github.com/numpy/numpy/pull/16129>`__: ENH: Better error message when ``bins`` has float value in ``histogramdd``.
 * `#16133 <https://github.com/numpy/numpy/pull/16133>`__: MAINT: Unify casting error creation (outside the iterator)
 * `#16141 <https://github.com/numpy/numpy/pull/16141>`__: BENCH: Default to building HEAD instead of master
@@ -571,7 +607,7 @@ A total of 452 pull requests were merged for this release.
 * `#16344 <https://github.com/numpy/numpy/pull/16344>`__: BUG: Allow attaching documentation twice in add_docstring
 * `#16355 <https://github.com/numpy/numpy/pull/16355>`__: MAINT: Remove f-strings in setup.py. (gh-16346)
 * `#16356 <https://github.com/numpy/numpy/pull/16356>`__: BUG: Indentation for docstrings
-* `#16358 <https://github.com/numpy/numpy/pull/16358>`__: BUG: Fix dtype leak in `PyArray_FromAny` error path
+* `#16358 <https://github.com/numpy/numpy/pull/16358>`__: BUG: Fix dtype leak in ``PyArray_FromAny`` error path
 * `#16383 <https://github.com/numpy/numpy/pull/16383>`__: ENH: Optimize Cpu feature detect in X86, fix for GCC on macOS...
 * `#16398 <https://github.com/numpy/numpy/pull/16398>`__: MAINT: core: Use a raw string for the fromstring docstring.
 * `#16399 <https://github.com/numpy/numpy/pull/16399>`__: MAINT: Make ctypes optional on Windows

--- a/doc/changelog/1.20.0-changelog.rst
+++ b/doc/changelog/1.20.0-changelog.rst
@@ -193,41 +193,47 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 684 pull requests were merged for this release.
+A total of 716 pull requests were merged for this release.
 
 * `#13516 <https://github.com/numpy/numpy/pull/13516>`__: ENH: enable multi-platform SIMD compiler optimizations
 * `#14779 <https://github.com/numpy/numpy/pull/14779>`__: NEP 36 (fair play)
 * `#14882 <https://github.com/numpy/numpy/pull/14882>`__: DEP: Deprecate aliases of builtin types in python 3.7+
-* `#15037 <https://github.com/numpy/numpy/pull/15037>`__: BUG: `np.resize` negative shape and subclasses edge case fixes
-* `#15121 <https://github.com/numpy/numpy/pull/15121>`__: ENH: random: Add the method `permuted` to Generator.
+* `#15037 <https://github.com/numpy/numpy/pull/15037>`__: BUG: ``np.resize`` negative shape and subclasses edge case fixes
+* `#15121 <https://github.com/numpy/numpy/pull/15121>`__: ENH: random: Add the method ``permuted`` to Generator.
 * `#15162 <https://github.com/numpy/numpy/pull/15162>`__: BUG,MAINT: Fix issues with non-reduce broadcasting axes
 * `#15471 <https://github.com/numpy/numpy/pull/15471>`__: BUG: Ensure PyArray_FromScalar always returns the requested dtype
 * `#15507 <https://github.com/numpy/numpy/pull/15507>`__: NEP 42: Technical decisions for new DTypes
 * `#15508 <https://github.com/numpy/numpy/pull/15508>`__: API: Create Preliminary DTypeMeta class and np.dtype subclasses
+* `#15551 <https://github.com/numpy/numpy/pull/15551>`__: DOC: Simd optimization documentation
 * `#15604 <https://github.com/numpy/numpy/pull/15604>`__: MAINT: Avoid exception in NpzFile destructor if constructor raises...
-* `#15666 <https://github.com/numpy/numpy/pull/15666>`__: ENH: Improved `__str__` for polynomials
+* `#15666 <https://github.com/numpy/numpy/pull/15666>`__: ENH: Improved ``__str__`` for polynomials
 * `#15759 <https://github.com/numpy/numpy/pull/15759>`__: BUILD: Remove Accelerate support
 * `#15791 <https://github.com/numpy/numpy/pull/15791>`__: [DOC] Added tutorial about the numpy.ma module.
 * `#15852 <https://github.com/numpy/numpy/pull/15852>`__: ENH: Add where argument to np.mean
 * `#15886 <https://github.com/numpy/numpy/pull/15886>`__: DEP: Deprecate passing shape=None to mean shape=()
 * `#15900 <https://github.com/numpy/numpy/pull/15900>`__: DEP: Ensure indexing errors will be raised even on empty results
 * `#15997 <https://github.com/numpy/numpy/pull/15997>`__: ENH: improve printing of arrays with multi-line reprs
+* `#16056 <https://github.com/numpy/numpy/pull/16056>`__: DEP: Deprecate inexact matches for mode, searchside
 * `#16130 <https://github.com/numpy/numpy/pull/16130>`__: DOC: Correct documentation of ``__array__`` when used as output...
 * `#16134 <https://github.com/numpy/numpy/pull/16134>`__: ENH: Implement concatenate dtype and casting keyword arguments
-* `#16156 <https://github.com/numpy/numpy/pull/16156>`__: DEP: Deprecate `numpy.dual`.
+* `#16156 <https://github.com/numpy/numpy/pull/16156>`__: DEP: Deprecate ``numpy.dual``.
 * `#16161 <https://github.com/numpy/numpy/pull/16161>`__: BUG: Potential fix for divmod(1.0, 0.0) to raise divbyzero and...
 * `#16167 <https://github.com/numpy/numpy/pull/16167>`__: DOC: Increase guidance and detail of np.polynomial docstring
 * `#16174 <https://github.com/numpy/numpy/pull/16174>`__: DOC: Add transition note to all lib/poly functions
 * `#16200 <https://github.com/numpy/numpy/pull/16200>`__: ENH: Rewrite of array-coercion to support new dtypes
 * `#16205 <https://github.com/numpy/numpy/pull/16205>`__: ENH: Add ``full_output`` argument to ``f2py.compile``.
+* `#16207 <https://github.com/numpy/numpy/pull/16207>`__: DOC: Add PyArray_ContiguousFromObject C docs
 * `#16232 <https://github.com/numpy/numpy/pull/16232>`__: DEP: Deprecate ufunc.outer with matrix inputs
+* `#16237 <https://github.com/numpy/numpy/pull/16237>`__: MAINT: precompute ``log(2.0 * M_PI)`` in ``random_loggam``
 * `#16238 <https://github.com/numpy/numpy/pull/16238>`__: MAINT: Unify cached (C-level static) imports
 * `#16239 <https://github.com/numpy/numpy/pull/16239>`__: BUG,DOC: Allow attach docs twice but error if wrong
 * `#16242 <https://github.com/numpy/numpy/pull/16242>`__: BUG: Fix default fallback in genfromtxt
 * `#16247 <https://github.com/numpy/numpy/pull/16247>`__: ENH:Umath Replace raw SIMD of unary float point(32-64) with NPYV...
 * `#16248 <https://github.com/numpy/numpy/pull/16248>`__: MRG, ENH: added edge keyword argument to digitize
+* `#16253 <https://github.com/numpy/numpy/pull/16253>`__: DOC: Clarify tiny/xmin in finfo and machar
+* `#16254 <https://github.com/numpy/numpy/pull/16254>`__: MAINT: Chain exceptions in generate_umath.py
 * `#16257 <https://github.com/numpy/numpy/pull/16257>`__: DOC: Update the f2py section of the "Using Python as Glue" page.
-* `#16260 <https://github.com/numpy/numpy/pull/16260>`__: DOC: Improve `rec.array` function documentation (#15853)
+* `#16260 <https://github.com/numpy/numpy/pull/16260>`__: DOC: Improve ``rec.array`` function documentation
 * `#16266 <https://github.com/numpy/numpy/pull/16266>`__: ENH: include dt64/td64 isinstance checks in ``__init__.pxd``
 * `#16267 <https://github.com/numpy/numpy/pull/16267>`__: DOC: Clarifications for np.std
 * `#16273 <https://github.com/numpy/numpy/pull/16273>`__: BUG: Order percentile monotonically
@@ -238,6 +244,7 @@ A total of 684 pull requests were merged for this release.
 * `#16283 <https://github.com/numpy/numpy/pull/16283>`__: DOC: Add a note about performance of isclose compared to math.isclose
 * `#16284 <https://github.com/numpy/numpy/pull/16284>`__: MAINT: Clean up the implementation of quantile
 * `#16285 <https://github.com/numpy/numpy/pull/16285>`__: MAINT: Bump hypothesis from 5.12.0 to 5.14.0
+* `#16288 <https://github.com/numpy/numpy/pull/16288>`__: BLD: Avoid "visibility attribute not supported" warning
 * `#16291 <https://github.com/numpy/numpy/pull/16291>`__: DOC: Improve "tobytes" docstring.
 * `#16292 <https://github.com/numpy/numpy/pull/16292>`__: BUG: Fix tools/download-wheels.py.
 * `#16295 <https://github.com/numpy/numpy/pull/16295>`__: BUG: Require Python >= 3.6 in setup.py
@@ -254,14 +261,17 @@ A total of 684 pull requests were merged for this release.
 * `#16318 <https://github.com/numpy/numpy/pull/16318>`__: MAINT: Stop Using PyEval_Call* and simplify some uses
 * `#16321 <https://github.com/numpy/numpy/pull/16321>`__: ENH: Improve the ARM cpu feature detection by parsing /proc/cpuinfo
 * `#16323 <https://github.com/numpy/numpy/pull/16323>`__: DOC: Reconstruct Testing Guideline.
+* `#16327 <https://github.com/numpy/numpy/pull/16327>`__: BUG: Don't segfault on bad __len__ when assigning.
 * `#16329 <https://github.com/numpy/numpy/pull/16329>`__: MAINT: Cleanup 'tools/download-wheels.py'
 * `#16332 <https://github.com/numpy/numpy/pull/16332>`__: DOC: link np.interp to SciPy's interpolation functions (closes...
 * `#16333 <https://github.com/numpy/numpy/pull/16333>`__: DOC: Fix spelling typo - homogenous to homogeneous. (#16324)
 * `#16334 <https://github.com/numpy/numpy/pull/16334>`__: ENH: Use AVX-512 for np.isnan, np.infinite, np.isinf and np.signbit
 * `#16336 <https://github.com/numpy/numpy/pull/16336>`__: BUG: Fix refcounting in add_newdoc
 * `#16337 <https://github.com/numpy/numpy/pull/16337>`__: CI: Create a link for the circleCI artifact
-* `#16348 <https://github.com/numpy/numpy/pull/16348>`__: BUG: Fix dtype leak in `PyArray_FromAny` error path
+* `#16346 <https://github.com/numpy/numpy/pull/16346>`__: MAINT: Remove f-strings in setup.py.
+* `#16348 <https://github.com/numpy/numpy/pull/16348>`__: BUG: Fix dtype leak in ``PyArray_FromAny`` error path
 * `#16349 <https://github.com/numpy/numpy/pull/16349>`__: BUG: Indentation for docstrings
+* `#16350 <https://github.com/numpy/numpy/pull/16350>`__: BUG: Set readonly flag in array interface
 * `#16351 <https://github.com/numpy/numpy/pull/16351>`__: BUG: Fix small leaks in error path and ``empty_like`` with shape
 * `#16362 <https://github.com/numpy/numpy/pull/16362>`__: MAINT: Streamline download-wheels.
 * `#16365 <https://github.com/numpy/numpy/pull/16365>`__: DOC: Fix an obvious mistake in a message printed in doc/Makefile.
@@ -301,6 +311,7 @@ A total of 684 pull requests were merged for this release.
 * `#16447 <https://github.com/numpy/numpy/pull/16447>`__: DOC: add a "make show" command to doc/Makefile
 * `#16450 <https://github.com/numpy/numpy/pull/16450>`__: DOC: Add a NEP link to all neps.
 * `#16452 <https://github.com/numpy/numpy/pull/16452>`__: DOC,ENH: extend error message when Accelerate is detected
+* `#16454 <https://github.com/numpy/numpy/pull/16454>`__: TST: Add tests for PyArray_IntpConverter
 * `#16463 <https://github.com/numpy/numpy/pull/16463>`__: DOC: Improve assert_warns docstring with example
 * `#16464 <https://github.com/numpy/numpy/pull/16464>`__: MAINT: Bump hypothesis from 5.15.1 to 5.16.0
 * `#16465 <https://github.com/numpy/numpy/pull/16465>`__: DOC: Fix development_workflow links
@@ -308,7 +319,7 @@ A total of 684 pull requests were merged for this release.
 * `#16471 <https://github.com/numpy/numpy/pull/16471>`__: BLD: install mingw32 v7.3.0 for win32
 * `#16472 <https://github.com/numpy/numpy/pull/16472>`__: DOC: Fixes for 18 broken links
 * `#16474 <https://github.com/numpy/numpy/pull/16474>`__: MAINT: use zip instead of range in piecewise
-* `#16476 <https://github.com/numpy/numpy/pull/16476>`__: ENH: add `norm=forward,backward` to numpy.fft functions
+* `#16476 <https://github.com/numpy/numpy/pull/16476>`__: ENH: add ``norm=forward,backward`` to numpy.fft functions
 * `#16482 <https://github.com/numpy/numpy/pull/16482>`__: SIMD: Optimize the performace of np.packbits in ARM-based machine.
 * `#16485 <https://github.com/numpy/numpy/pull/16485>`__: BUG: Fix result when a gufunc output broadcasts the inputs.
 * `#16500 <https://github.com/numpy/numpy/pull/16500>`__: DOC: Point Contributing page to new NEP 45
@@ -340,6 +351,7 @@ A total of 684 pull requests were merged for this release.
 * `#16574 <https://github.com/numpy/numpy/pull/16574>`__: MAINT: fix name of first parameter to dtype constructor in type...
 * `#16581 <https://github.com/numpy/numpy/pull/16581>`__: DOC: Added an example for np.transpose(4d_array)
 * `#16583 <https://github.com/numpy/numpy/pull/16583>`__: MAINT: changed np.generic arguments to positional-only
+* `#16589 <https://github.com/numpy/numpy/pull/16589>`__: MAINT: Remove nickname from polynomial classes.
 * `#16590 <https://github.com/numpy/numpy/pull/16590>`__: DOC: Clarify dtype default for logspace and geomspace
 * `#16591 <https://github.com/numpy/numpy/pull/16591>`__: DOC: Disallow complex args in arange
 * `#16592 <https://github.com/numpy/numpy/pull/16592>`__: BUG: Raise TypeError for float->timedelta promotion
@@ -364,8 +376,9 @@ A total of 684 pull requests were merged for this release.
 * `#16633 <https://github.com/numpy/numpy/pull/16633>`__: MAINT: lib: Some code clean up in loadtxt
 * `#16635 <https://github.com/numpy/numpy/pull/16635>`__: BENCH: remove obsolete goal_time param
 * `#16639 <https://github.com/numpy/numpy/pull/16639>`__: BUG: Fix uint->timedelta promotion to raise TypeError
-* `#16642 <https://github.com/numpy/numpy/pull/16642>`__: MAINT: Replace `PyUString_GET_SIZE` with `PyUnicode_GetLength`.
+* `#16642 <https://github.com/numpy/numpy/pull/16642>`__: MAINT: Replace ``PyUString_GET_SIZE`` with ``PyUnicode_GetLength``.
 * `#16643 <https://github.com/numpy/numpy/pull/16643>`__: REL: Fix outdated docs link
+* `#16644 <https://github.com/numpy/numpy/pull/16644>`__: MAINT: Improve performance of np.full
 * `#16646 <https://github.com/numpy/numpy/pull/16646>`__: TST: add a static typing test for memoryviews as ArrayLikes
 * `#16647 <https://github.com/numpy/numpy/pull/16647>`__: ENH: Added annotations to 8 functions from np.core.fromnumeric
 * `#16648 <https://github.com/numpy/numpy/pull/16648>`__: REL: Update master after 1.19.0 release.
@@ -377,14 +390,15 @@ A total of 684 pull requests were merged for this release.
 * `#16664 <https://github.com/numpy/numpy/pull/16664>`__: DOC: Add lib.format.open_memmap to autosummary.
 * `#16666 <https://github.com/numpy/numpy/pull/16666>`__: BUG: Fix bug in AVX complex absolute while processing array of...
 * `#16669 <https://github.com/numpy/numpy/pull/16669>`__: MAINT: remove blacklist/whitelist terms
+* `#16671 <https://github.com/numpy/numpy/pull/16671>`__: DOC: Simplify and update git setup page
 * `#16674 <https://github.com/numpy/numpy/pull/16674>`__: TST: Add extra debugging information to CPU features detection
 * `#16675 <https://github.com/numpy/numpy/pull/16675>`__: ENH: Add support for file like objects to np.core.records.fromfile
 * `#16683 <https://github.com/numpy/numpy/pull/16683>`__: DOC: updated gcc minimum recommend version to build from source
-* `#16684 <https://github.com/numpy/numpy/pull/16684>`__: MAINT: Allow `None` to be passed to certain `generic` subclasses
+* `#16684 <https://github.com/numpy/numpy/pull/16684>`__: MAINT: Allow None to be passed to certain generic subclasses
 * `#16690 <https://github.com/numpy/numpy/pull/16690>`__: DOC: fixed docstring for descr_to_dtype
-* `#16691 <https://github.com/numpy/numpy/pull/16691>`__: DOC: Remove "matrix" from `triu` docstring.
+* `#16691 <https://github.com/numpy/numpy/pull/16691>`__: DOC: Remove "matrix" from ``triu`` docstring.
 * `#16696 <https://github.com/numpy/numpy/pull/16696>`__: MAINT: add py.typed sentinel to package manifest
-* `#16699 <https://github.com/numpy/numpy/pull/16699>`__: MAINT: Fixup quantile tests to not use `np.float`
+* `#16699 <https://github.com/numpy/numpy/pull/16699>`__: MAINT: Fixup quantile tests to not use ``np.float``
 * `#16702 <https://github.com/numpy/numpy/pull/16702>`__: BLD: Add CPU entry for Emscripten / WebAssembly
 * `#16704 <https://github.com/numpy/numpy/pull/16704>`__: TST: Disable Python 3.9-dev testing.
 * `#16706 <https://github.com/numpy/numpy/pull/16706>`__: DOC: Add instruction about stable symlink
@@ -393,11 +407,12 @@ A total of 684 pull requests were merged for this release.
 * `#16710 <https://github.com/numpy/numpy/pull/16710>`__: ENH, BLD: Add RPATH support for AIX
 * `#16718 <https://github.com/numpy/numpy/pull/16718>`__: DOC: fix typo
 * `#16720 <https://github.com/numpy/numpy/pull/16720>`__: BUG: Fix PyArray_SearchSorted signature.
+* `#16723 <https://github.com/numpy/numpy/pull/16723>`__: NEP: Initial draft for NEP 43 for extensible ufuncs
 * `#16729 <https://github.com/numpy/numpy/pull/16729>`__: ENH: Add annotations to the last 8 functions in numpy.core.fromnumeric
 * `#16730 <https://github.com/numpy/numpy/pull/16730>`__: ENH: Use f90 compiler specified in f2py command line args for...
 * `#16731 <https://github.com/numpy/numpy/pull/16731>`__: DOC: reword random c-api introduction, cython is documented in...
 * `#16735 <https://github.com/numpy/numpy/pull/16735>`__: DOC: Tweak a sentence about broadcasting.
-* `#16736 <https://github.com/numpy/numpy/pull/16736>`__: DOC: Prepend `ma.` to references in ``numpy.ma``
+* `#16736 <https://github.com/numpy/numpy/pull/16736>`__: DOC: Prepend ``ma.`` to references in ``numpy.ma``
 * `#16738 <https://github.com/numpy/numpy/pull/16738>`__: DOC: Remove redundant word
 * `#16742 <https://github.com/numpy/numpy/pull/16742>`__: DOC: add unique() to See Also of repeat()
 * `#16743 <https://github.com/numpy/numpy/pull/16743>`__: DOC: add example to unique() and make connection to repeat()
@@ -414,6 +429,8 @@ A total of 684 pull requests were merged for this release.
 * `#16770 <https://github.com/numpy/numpy/pull/16770>`__: MAINT: Remove unneeded call to PyUnicode_READY
 * `#16771 <https://github.com/numpy/numpy/pull/16771>`__: MAINT: Fix deprecated functions in scalarapi.c
 * `#16775 <https://github.com/numpy/numpy/pull/16775>`__: DOC: switch to logo with text
+* `#16777 <https://github.com/numpy/numpy/pull/16777>`__: BUG: Added missing return after raising error in methods.c
+* `#16778 <https://github.com/numpy/numpy/pull/16778>`__: NEP: Update NEP 42 to note the issue of circular references
 * `#16782 <https://github.com/numpy/numpy/pull/16782>`__: ENH, TST: Bring the NumPy C SIMD vectorization interface "NPYV"...
 * `#16786 <https://github.com/numpy/numpy/pull/16786>`__: BENCH: Add basic benchmarks for scalar indexing and assignment
 * `#16789 <https://github.com/numpy/numpy/pull/16789>`__: BUG: fix decode error when building and get rid of warn
@@ -467,7 +484,8 @@ A total of 684 pull requests were merged for this release.
 * `#16886 <https://github.com/numpy/numpy/pull/16886>`__: DOC: Fix types including curly braces
 * `#16887 <https://github.com/numpy/numpy/pull/16887>`__: DOC: Remove the links for ``True`` and ``False``
 * `#16888 <https://github.com/numpy/numpy/pull/16888>`__: ENH: Integrate the new CPU dispatcher with umath generator
-* `#16894 <https://github.com/numpy/numpy/pull/16894>`__: DOC: Fix wrong markups in `arrays.dtypes`
+* `#16890 <https://github.com/numpy/numpy/pull/16890>`__: TST, BUG: Re-raise MemoryError exception in test_large_zip's...
+* `#16894 <https://github.com/numpy/numpy/pull/16894>`__: DOC: Fix wrong markups in ``arrays.dtypes``
 * `#16896 <https://github.com/numpy/numpy/pull/16896>`__: DOC: Remove links for C codes
 * `#16897 <https://github.com/numpy/numpy/pull/16897>`__: DOC: Fix the declarations of C fuctions
 * `#16899 <https://github.com/numpy/numpy/pull/16899>`__: MNT: also use Py_SET_REFCNT instead of Py_REFCNT
@@ -480,23 +498,24 @@ A total of 684 pull requests were merged for this release.
 * `#16919 <https://github.com/numpy/numpy/pull/16919>`__: DOC: Add ufunc docstring to generated docs.
 * `#16925 <https://github.com/numpy/numpy/pull/16925>`__: REL: Update master after 1.19.1 release.
 * `#16931 <https://github.com/numpy/numpy/pull/16931>`__: Revert "Merge pull request #16248 from alexrockhill/edge"
+* `#16935 <https://github.com/numpy/numpy/pull/16935>`__: ENH: implement NEP-35's ``like=`` argument
 * `#16936 <https://github.com/numpy/numpy/pull/16936>`__: BUG: Fix memory leak of buffer-info cache due to relaxed strides
 * `#16938 <https://github.com/numpy/numpy/pull/16938>`__: ENH,API: Store exported buffer info on the array
 * `#16940 <https://github.com/numpy/numpy/pull/16940>`__: BLD: update OpenBLAS build
 * `#16941 <https://github.com/numpy/numpy/pull/16941>`__: BUG: Allow array-like types to be coerced as object array elements
 * `#16943 <https://github.com/numpy/numpy/pull/16943>`__: DEP: Deprecate size-one ragged array coercion
 * `#16944 <https://github.com/numpy/numpy/pull/16944>`__: Change the name of the folder "icons" to "logo".
-* `#16949 <https://github.com/numpy/numpy/pull/16949>`__: ENH: enable colors for `runtests.py --ipython`
+* `#16949 <https://github.com/numpy/numpy/pull/16949>`__: ENH: enable colors for ``runtests.py --ipython``
 * `#16950 <https://github.com/numpy/numpy/pull/16950>`__: DOC: Clarify input to irfft/irfft2/irfftn
 * `#16952 <https://github.com/numpy/numpy/pull/16952>`__: MAINT: Bump hypothesis from 5.20.2 to 5.23.2
 * `#16953 <https://github.com/numpy/numpy/pull/16953>`__: update numpy/lib/arraypad.py with appropriate chain exception
 * `#16957 <https://github.com/numpy/numpy/pull/16957>`__: MAINT: Use arm64 instead of aarch64 on travisCI.
 * `#16962 <https://github.com/numpy/numpy/pull/16962>`__: MAINT: Chain exception in ``distutils/fcompiler/environment.py``.
-* `#16966 <https://github.com/numpy/numpy/pull/16966>`__: MAINT: Added the `order` parameter to `np.array()`
+* `#16966 <https://github.com/numpy/numpy/pull/16966>`__: MAINT: Added the ``order`` parameter to ``np.array()``
 * `#16969 <https://github.com/numpy/numpy/pull/16969>`__: ENH: Add Neon SIMD implementations for add, sub, mul, and div
 * `#16973 <https://github.com/numpy/numpy/pull/16973>`__: DOC: Fixed typo in lib/recfunctions.py
 * `#16974 <https://github.com/numpy/numpy/pull/16974>`__: TST: Add pypy win32 CI testing.
-* `#16982 <https://github.com/numpy/numpy/pull/16982>`__: ENH: Increase the use of `Literal` types
+* `#16982 <https://github.com/numpy/numpy/pull/16982>`__: ENH: Increase the use of ``Literal`` types
 * `#16986 <https://github.com/numpy/numpy/pull/16986>`__: ENH: Add NumPy declarations to be used by Cython 3.0+
 * `#16988 <https://github.com/numpy/numpy/pull/16988>`__: DOC: Add the new NumPy logo to Sphinx pages
 * `#16991 <https://github.com/numpy/numpy/pull/16991>`__: MAINT: Bump hypothesis from 5.23.2 to 5.23.9
@@ -505,18 +524,24 @@ A total of 684 pull requests were merged for this release.
 * `#16996 <https://github.com/numpy/numpy/pull/16996>`__: DOC: Revise glossary page
 * `#17002 <https://github.com/numpy/numpy/pull/17002>`__: DOC: clip() allows arguments.
 * `#17009 <https://github.com/numpy/numpy/pull/17009>`__: NEP: Updated NEP-35 with keyword-only instruction
+* `#17010 <https://github.com/numpy/numpy/pull/17010>`__: BUG: Raise correct errors in boolean indexing fast path
 * `#17013 <https://github.com/numpy/numpy/pull/17013>`__: MAINT: Simplify scalar power
 * `#17014 <https://github.com/numpy/numpy/pull/17014>`__: MAINT: Improve error handling in umathmodule setup
+* `#17022 <https://github.com/numpy/numpy/pull/17022>`__: DOC: Fix non-matching pronoun.
 * `#17028 <https://github.com/numpy/numpy/pull/17028>`__: DOC: Disclaimer for FFT library
 * `#17029 <https://github.com/numpy/numpy/pull/17029>`__: MAINT: Add error return to all casting functionality and NpyIter
 * `#17033 <https://github.com/numpy/numpy/pull/17033>`__: BUG: fix a compile and a test warning
-* `#17036 <https://github.com/numpy/numpy/pull/17036>`__: DOC: Clarify that `np.char` comparison functions always return...
+* `#17036 <https://github.com/numpy/numpy/pull/17036>`__: DOC: Clarify that ``np.char`` comparison functions always return...
 * `#17039 <https://github.com/numpy/numpy/pull/17039>`__: DOC: Use a less ambiguous example for array_split
 * `#17041 <https://github.com/numpy/numpy/pull/17041>`__: MAINT: Bump hypothesis from 5.23.9 to 5.23.12
 * `#17048 <https://github.com/numpy/numpy/pull/17048>`__: STY: core._internal style fixups
 * `#17050 <https://github.com/numpy/numpy/pull/17050>`__: MAINT: Remove _EXTRAFLAGS variable
+* `#17050 <https://github.com/numpy/numpy/pull/17051>`__: MAINT: change ``for line in open()`` to ``with open() as f``
+* `#17052 <https://github.com/numpy/numpy/pull/17052>`__: MAINT: Delete obsolete conversion to list
 * `#17053 <https://github.com/numpy/numpy/pull/17053>`__: BUG: fix typo in polydiv that prevented promotion to poly1d
+* `#17055 <https://github.com/numpy/numpy/pull/17055>`__: MAINT: Replace lambda function by list comprehension
 * `#17058 <https://github.com/numpy/numpy/pull/17058>`__: MAINT: Revert boolean casting back to elementwise comparisons...
+* `#17059 <https://github.com/numpy/numpy/pull/17059>`__: BUG: fix pickling of arrays larger than 2GiB
 * `#17062 <https://github.com/numpy/numpy/pull/17062>`__: API, BUG: Raise error on complex input to i0
 * `#17063 <https://github.com/numpy/numpy/pull/17063>`__: MAINT: Remove obsolete conversion to set
 * `#17067 <https://github.com/numpy/numpy/pull/17067>`__: DEP: lib: Remove the deprecated financial functions.
@@ -530,7 +555,7 @@ A total of 684 pull requests were merged for this release.
 * `#17109 <https://github.com/numpy/numpy/pull/17109>`__: MAINT: Split einsum into multiple files
 * `#17112 <https://github.com/numpy/numpy/pull/17112>`__: BUG: Handle errors from the PyCapsule API
 * `#17115 <https://github.com/numpy/numpy/pull/17115>`__: DOC: Fix spacing in vectorize doc
-* `#17116 <https://github.com/numpy/numpy/pull/17116>`__: API: Remove `np.ctypeslib.ctypes_load_library`
+* `#17116 <https://github.com/numpy/numpy/pull/17116>`__: API: Remove ``np.ctypeslib.ctypes_load_library``
 * `#17119 <https://github.com/numpy/numpy/pull/17119>`__: DOC: make spacing consistent in NEP 41 bullet points
 * `#17121 <https://github.com/numpy/numpy/pull/17121>`__: BUG: core: fix ilp64 blas dot/vdot/... for strides > int32 max
 * `#17123 <https://github.com/numpy/numpy/pull/17123>`__: ENH: allow running mypy through runtests.py
@@ -542,13 +567,13 @@ A total of 684 pull requests were merged for this release.
 * `#17141 <https://github.com/numpy/numpy/pull/17141>`__: MAINT: Make arrayprint str and repr the ndarray defaults.
 * `#17142 <https://github.com/numpy/numpy/pull/17142>`__: DOC: NEP-42: Fix a few typos.
 * `#17143 <https://github.com/numpy/numpy/pull/17143>`__: MAINT: Change handling of the expired financial functions.
-* `#17144 <https://github.com/numpy/numpy/pull/17144>`__: ENH: Add annotations to 3 functions in `np.core.function_base`
+* `#17144 <https://github.com/numpy/numpy/pull/17144>`__: ENH: Add annotations to 3 functions in ``np.core.function_base``
 * `#17145 <https://github.com/numpy/numpy/pull/17145>`__: MAINT, BUG: Replace uses of PyString_AsString.
 * `#17146 <https://github.com/numpy/numpy/pull/17146>`__: MAINT: ``Replace PyUString_*`` by ``PyUnicode_*`` equivalents.
 * `#17149 <https://github.com/numpy/numpy/pull/17149>`__: MAINT: Replace PyInt macros with their PyLong replacement
 * `#17150 <https://github.com/numpy/numpy/pull/17150>`__: ENH: Add support for the abstract scalars to cython code
 * `#17151 <https://github.com/numpy/numpy/pull/17151>`__: BUG: Fix incorrect cython definition of npy_cfloat
-* `#17152 <https://github.com/numpy/numpy/pull/17152>`__: MAINT: Clean up some Npy_ vs Py_ macro usage
+* `#17152 <https://github.com/numpy/numpy/pull/17152>`__: MAINT: Clean up some ``Npy_`` vs ``Py_`` macro usage
 * `#17154 <https://github.com/numpy/numpy/pull/17154>`__: DOC: Remove references to PyCObject
 * `#17159 <https://github.com/numpy/numpy/pull/17159>`__: DOC: Update numpy4matlab
 * `#17160 <https://github.com/numpy/numpy/pull/17160>`__: Clean up some more bytes vs unicode handling
@@ -558,22 +583,23 @@ A total of 684 pull requests were merged for this release.
 * `#17167 <https://github.com/numpy/numpy/pull/17167>`__: BLD: Merge the npysort library into multiarray
 * `#17168 <https://github.com/numpy/numpy/pull/17168>`__: TST: Add tests mapping out the rules for metadata in promotion
 * `#17171 <https://github.com/numpy/numpy/pull/17171>`__: BUG: revert trim_zeros changes from gh-16911
-* `#17172 <https://github.com/numpy/numpy/pull/17172>`__: ENH: Make `np.complexfloating` generic w.r.t. `np.floating`
+* `#17172 <https://github.com/numpy/numpy/pull/17172>`__: ENH: Make ``np.complexfloating`` generic w.r.t. ``np.floating``
 * `#17176 <https://github.com/numpy/numpy/pull/17176>`__: MAINT/ENH: datetime: remove calls to PyUnicode_AsASCIIString,...
-* `#17180 <https://github.com/numpy/numpy/pull/17180>`__: ENH: Added missing methods to `np.flatiter`
+* `#17180 <https://github.com/numpy/numpy/pull/17180>`__: ENH: Added missing methods to ``np.flatiter``
 * `#17181 <https://github.com/numpy/numpy/pull/17181>`__: DOC: Correct error in description of ndarray.base
-* `#17182 <https://github.com/numpy/numpy/pull/17182>`__: DOC: Document `dtype.metadata`
+* `#17182 <https://github.com/numpy/numpy/pull/17182>`__: DOC: Document ``dtype.metadata``
 * `#17186 <https://github.com/numpy/numpy/pull/17186>`__: MAINT: Use utf8 strings in more of datetime
-* `#17188 <https://github.com/numpy/numpy/pull/17188>`__: MAINT: Add placeholder stubs for `ndarray` and `generic`
+* `#17188 <https://github.com/numpy/numpy/pull/17188>`__: MAINT: Add placeholder stubs for ``ndarray`` and ``generic``
 * `#17191 <https://github.com/numpy/numpy/pull/17191>`__: MAINT: Bump hypothesis from 5.26.0 to 5.30.0
 * `#17193 <https://github.com/numpy/numpy/pull/17193>`__: MAINT: Remove some callers of functions in numpy.compat
 * `#17195 <https://github.com/numpy/numpy/pull/17195>`__: ENH: Make the window functions exactly symmetric
 * `#17197 <https://github.com/numpy/numpy/pull/17197>`__: MAINT: Improve error handling in npy_cpu_init
-* `#17199 <https://github.com/numpy/numpy/pull/17199>`__: DOC: Fix the documented signatures of four `ufunc` methods
-* `#17201 <https://github.com/numpy/numpy/pull/17201>`__: MAINT: Make the `NPY_CPU_DISPATCH_CALL` macros expressions not...
+* `#17199 <https://github.com/numpy/numpy/pull/17199>`__: DOC: Fix the documented signatures of four ``ufunc`` methods
+* `#17201 <https://github.com/numpy/numpy/pull/17201>`__: MAINT: Make the ``NPY_CPU_DISPATCH_CALL`` macros expressions not...
 * `#17204 <https://github.com/numpy/numpy/pull/17204>`__: DOC: Fixed headings for tutorials so they appear at new theme...
 * `#17210 <https://github.com/numpy/numpy/pull/17210>`__: DOC: Canonical_urls
-* `#17214 <https://github.com/numpy/numpy/pull/17214>`__: MAINT: Fix various issues with the `np.generic` annotations
+* `#17214 <https://github.com/numpy/numpy/pull/17214>`__: MAINT: Fix various issues with the ``np.generic`` annotations
+* `#17215 <https://github.com/numpy/numpy/pull/17215>`__: DOC: Use official MATLAB spelling in numpy-for-matlab-users.rst
 * `#17219 <https://github.com/numpy/numpy/pull/17219>`__: BLD: enabled negation of library choices in NPY_*_ORDER
 * `#17220 <https://github.com/numpy/numpy/pull/17220>`__: BUG, DOC: comment out metadata added via javascript
 * `#17222 <https://github.com/numpy/numpy/pull/17222>`__: MAINT, DOC: move informational files from numpy.doc.*.py to their...
@@ -583,7 +609,9 @@ A total of 684 pull requests were merged for this release.
 * `#17233 <https://github.com/numpy/numpy/pull/17233>`__: DEP: Deprecated ndindex.ndincr
 * `#17235 <https://github.com/numpy/numpy/pull/17235>`__: MAINT: Remove old PY_VERSION_HEX and sys.version_info code
 * `#17237 <https://github.com/numpy/numpy/pull/17237>`__: BUG: Avoid using ``np.random`` in typing tests.
+* `#17238 <https://github.com/numpy/numpy/pull/17238>`__: DOC: Use SPDX license expressions with correct license
 * `#17239 <https://github.com/numpy/numpy/pull/17239>`__: DOC: Fix link quick-start in old random API functions
+* `#17240 <https://github.com/numpy/numpy/pull/17240>`__: MAINT: added exception chaining in shape_base.py
 * `#17241 <https://github.com/numpy/numpy/pull/17241>`__: MAINT: ``__array_interface__`` data address cannot be bytes
 * `#17242 <https://github.com/numpy/numpy/pull/17242>`__: MAINT: Run slow CI jobs earlier so builds finishes sooner
 * `#17247 <https://github.com/numpy/numpy/pull/17247>`__: ENH: Add tool to help speed up Travis CI
@@ -595,9 +623,9 @@ A total of 684 pull requests were merged for this release.
 * `#17260 <https://github.com/numpy/numpy/pull/17260>`__: MAINT: Bump pydata-sphinx-theme from 0.3.2 to 0.4.0
 * `#17263 <https://github.com/numpy/numpy/pull/17263>`__: DOC: add new glossary terms
 * `#17264 <https://github.com/numpy/numpy/pull/17264>`__: DOC: remove some glosssary terms
-* `#17267 <https://github.com/numpy/numpy/pull/17267>`__: TST: Fix the path to `mypy.ini` in `runtests.py`
+* `#17267 <https://github.com/numpy/numpy/pull/17267>`__: TST: Fix the path to ``mypy.ini`` in ``runtests.py``
 * `#17268 <https://github.com/numpy/numpy/pull/17268>`__: BUG: sysconfig attributes/distutils issue
-* `#17273 <https://github.com/numpy/numpy/pull/17273>`__: ENH: Annotate the arithmetic operations of `ndarray` and `generic`
+* `#17273 <https://github.com/numpy/numpy/pull/17273>`__: ENH: Annotate the arithmetic operations of ``ndarray`` and ``generic``
 * `#17278 <https://github.com/numpy/numpy/pull/17278>`__: MAINT: Merge together index page content into a single file
 * `#17279 <https://github.com/numpy/numpy/pull/17279>`__: DOC: Fix a typo in shape_base.
 * `#17284 <https://github.com/numpy/numpy/pull/17284>`__: ENH: Pass optimizations arguments to asv build
@@ -616,23 +644,23 @@ A total of 684 pull requests were merged for this release.
 * `#17304 <https://github.com/numpy/numpy/pull/17304>`__: BUILD: pin pygments to 2.6.1, 2.7.0 breaks custom NumPyC lexer
 * `#17307 <https://github.com/numpy/numpy/pull/17307>`__: MAINT: Bump hypothesis from 5.33.0 to 5.35.1
 * `#17308 <https://github.com/numpy/numpy/pull/17308>`__: MAINT: Bump pytest from 6.0.1 to 6.0.2
-* `#17309 <https://github.com/numpy/numpy/pull/17309>`__: MAINT: Move the `fromnumeric` annotations to their own stub file
+* `#17309 <https://github.com/numpy/numpy/pull/17309>`__: MAINT: Move the ``fromnumeric`` annotations to their own stub file
 * `#17312 <https://github.com/numpy/numpy/pull/17312>`__: MAINT: Syntax-highlight .src files on github
 * `#17313 <https://github.com/numpy/numpy/pull/17313>`__: MAINT: Mark vendored/generated files in .gitattributes
 * `#17315 <https://github.com/numpy/numpy/pull/17315>`__: MAINT: Cleanup f2py/cfuncs.py
 * `#17319 <https://github.com/numpy/numpy/pull/17319>`__: BUG: Set deprecated fields to null in PyArray_InitArrFuncs
 * `#17320 <https://github.com/numpy/numpy/pull/17320>`__: BUG: allow registration of hard-coded structured dtypes
 * `#17326 <https://github.com/numpy/numpy/pull/17326>`__: ENH: Add annotations for five array construction functions
-* `#17329 <https://github.com/numpy/numpy/pull/17329>`__: DOC: Fix incorrect `.. deprecated::` syntax that led to this...
-* `#17330 <https://github.com/numpy/numpy/pull/17330>`__: DOC: improve `issubdtype` and scalar type docs
-* `#17331 <https://github.com/numpy/numpy/pull/17331>`__: DOC: Remove the tables of scalar types, and use `..autoclass`...
+* `#17329 <https://github.com/numpy/numpy/pull/17329>`__: DOC: Fix incorrect ``.. deprecated::`` syntax that led to this...
+* `#17330 <https://github.com/numpy/numpy/pull/17330>`__: DOC: improve ``issubdtype`` and scalar type docs
+* `#17331 <https://github.com/numpy/numpy/pull/17331>`__: DOC: Remove the tables of scalar types, and use ``..autoclass``...
 * `#17332 <https://github.com/numpy/numpy/pull/17332>`__: DOC, BLD: update lexer highlighting and make numpydocs a regular...
 * `#17334 <https://github.com/numpy/numpy/pull/17334>`__: MAINT: Chaining exceptions in npyio.py
 * `#17337 <https://github.com/numpy/numpy/pull/17337>`__: NEP: Regenerate table in NEP 29 (add numpy 1.18 and 1.19 to list)
 * `#17338 <https://github.com/numpy/numpy/pull/17338>`__: DOC: Fix syntax errors in docstrings for versionchanged, versionadded
 * `#17340 <https://github.com/numpy/numpy/pull/17340>`__: SIMD: Add partial/non-contig load and store intrinsics for 32/64-bit
 * `#17344 <https://github.com/numpy/numpy/pull/17344>`__: ENH, BLD: Support for the NVIDIA HPC SDK nvfortran compiler
-* `#17346 <https://github.com/numpy/numpy/pull/17346>`__: BLD,BUG: Fix a macOS build failure when `NPY_BLAS_ORDER=""`
+* `#17346 <https://github.com/numpy/numpy/pull/17346>`__: BLD,BUG: Fix a macOS build failure when ``NPY_BLAS_ORDER=""``
 * `#17350 <https://github.com/numpy/numpy/pull/17350>`__: DEV: Add PR prefix labeler and numpy prefix mapping
 * `#17352 <https://github.com/numpy/numpy/pull/17352>`__: DOC: Guide to writing how-tos
 * `#17353 <https://github.com/numpy/numpy/pull/17353>`__: DOC: How-to guide for I/O
@@ -642,7 +670,7 @@ A total of 684 pull requests were merged for this release.
 * `#17364 <https://github.com/numpy/numpy/pull/17364>`__: MAINT: Finish replacing PyInt_Check
 * `#17369 <https://github.com/numpy/numpy/pull/17369>`__: DOC: distutils: Remove an obsolete paragraph.
 * `#17370 <https://github.com/numpy/numpy/pull/17370>`__: NEP: Edit nep-0042 for more clarity
-* `#17372 <https://github.com/numpy/numpy/pull/17372>`__: ENH: Add annotations for remaining `ndarray` / `generic` non-magic...
+* `#17372 <https://github.com/numpy/numpy/pull/17372>`__: ENH: Add annotations for remaining ``ndarray`` / ``generic`` non-magic...
 * `#17373 <https://github.com/numpy/numpy/pull/17373>`__: BUG: Fixes module data docstrings.
 * `#17375 <https://github.com/numpy/numpy/pull/17375>`__: DOC: Fix default_rng docstring
 * `#17377 <https://github.com/numpy/numpy/pull/17377>`__: BUG: ensure _UFuncNoLoopError can be pickled
@@ -654,6 +682,7 @@ A total of 684 pull requests were merged for this release.
 * `#17391 <https://github.com/numpy/numpy/pull/17391>`__: DOC: Replace "About NumPy" with "Document conventions"
 * `#17392 <https://github.com/numpy/numpy/pull/17392>`__: DOC: Update info on doc style rules
 * `#17393 <https://github.com/numpy/numpy/pull/17393>`__: BUG: Fix default void, datetime, and timedelta in array coercion
+* `#17394 <https://github.com/numpy/numpy/pull/17394>`__: ENH: Implement sliding window
 * `#17396 <https://github.com/numpy/numpy/pull/17396>`__: MAINT: Replace append_metastr_to_string function.
 * `#17399 <https://github.com/numpy/numpy/pull/17399>`__: BLD: Fixed ARGOUTVIEWM memory deallocation. Closes #17398.
 * `#17400 <https://github.com/numpy/numpy/pull/17400>`__: DOC: rm incorrect alias from recarray user article.
@@ -661,12 +690,12 @@ A total of 684 pull requests were merged for this release.
 * `#17402 <https://github.com/numpy/numpy/pull/17402>`__: DOC: Add arraysetops to an autosummary
 * `#17404 <https://github.com/numpy/numpy/pull/17404>`__: MAINT: Replace PyUString_ConcatAndDel in nditer_constr.c.
 * `#17405 <https://github.com/numpy/numpy/pull/17405>`__: MAINT: Replace PyUString_ConcatAndDel in mapping.c.
-* `#17406 <https://github.com/numpy/numpy/pull/17406>`__: ENH: Replace the module-level `__getattr__` with explicit type...
+* `#17406 <https://github.com/numpy/numpy/pull/17406>`__: ENH: Replace the module-level ``__getattr__`` with explicit type...
 * `#17407 <https://github.com/numpy/numpy/pull/17407>`__: DOC: in PR template, set expectations for PR review timeline
 * `#17409 <https://github.com/numpy/numpy/pull/17409>`__: MAINT: Cleanup remaining PyUString_ConcatAndDel use.
 * `#17410 <https://github.com/numpy/numpy/pull/17410>`__: API: Special case how numpy scalars are coerced to signed integer
 * `#17411 <https://github.com/numpy/numpy/pull/17411>`__: TST: Mark the typing tests as slow
-* `#17412 <https://github.com/numpy/numpy/pull/17412>`__: DOC: Fix a parameter type in the `putmask` docs
+* `#17412 <https://github.com/numpy/numpy/pull/17412>`__: DOC: Fix a parameter type in the ``putmask`` docs
 * `#17418 <https://github.com/numpy/numpy/pull/17418>`__: DOC: adding operational form documentation for array ops
 * `#17419 <https://github.com/numpy/numpy/pull/17419>`__: DEP: Deprecate coercion to subarray dtypes
 * `#17421 <https://github.com/numpy/numpy/pull/17421>`__: BUG: Fix memory leak in array-coercion error paths
@@ -674,7 +703,7 @@ A total of 684 pull requests were merged for this release.
 * `#17423 <https://github.com/numpy/numpy/pull/17423>`__: DOC: Remove bogus reference to _a_
 * `#17424 <https://github.com/numpy/numpy/pull/17424>`__: DOC: Fix formatting issues in description of .c.src files
 * `#17427 <https://github.com/numpy/numpy/pull/17427>`__: NEP: nep-0029 typo correction
-* `#17429 <https://github.com/numpy/numpy/pull/17429>`__: MAINT: Move aliases for common scalar unions to `numpy.typing`
+* `#17429 <https://github.com/numpy/numpy/pull/17429>`__: MAINT: Move aliases for common scalar unions to ``numpy.typing``
 * `#17430 <https://github.com/numpy/numpy/pull/17430>`__: BUG: Fix memoryleaks related to NEP 37 function overrides
 * `#17431 <https://github.com/numpy/numpy/pull/17431>`__: DOC: Fix the links for ``Ellipsis``
 * `#17432 <https://github.com/numpy/numpy/pull/17432>`__: DOC: add references to einops and opt_einsum
@@ -685,7 +714,7 @@ A total of 684 pull requests were merged for this release.
 * `#17440 <https://github.com/numpy/numpy/pull/17440>`__: DOC: Cleaner template for PRs
 * `#17442 <https://github.com/numpy/numpy/pull/17442>`__: MAINT: fix exception chaining in format.py
 * `#17443 <https://github.com/numpy/numpy/pull/17443>`__: ENH: Warn on unsupported Python 3.10+
-* `#17444 <https://github.com/numpy/numpy/pull/17444>`__: ENH: Add `Typing :: Typed` to the PyPi classifier
+* `#17444 <https://github.com/numpy/numpy/pull/17444>`__: ENH: Add ``Typing :: Typed`` to the PyPi classifier
 * `#17445 <https://github.com/numpy/numpy/pull/17445>`__: DOC: Fix the references for macros
 * `#17447 <https://github.com/numpy/numpy/pull/17447>`__: NEP: update NEP 42 with discussion of type hinting applications
 * `#17448 <https://github.com/numpy/numpy/pull/17448>`__: DOC: Remove CoC pages from Sphinx
@@ -699,16 +728,17 @@ A total of 684 pull requests were merged for this release.
 * `#17468 <https://github.com/numpy/numpy/pull/17468>`__: DOC: add some missing scalar aliases
 * `#17472 <https://github.com/numpy/numpy/pull/17472>`__: TST: Fix doctest for full_like
 * `#17473 <https://github.com/numpy/numpy/pull/17473>`__: MAINT: py3k: remove os.fspath and os.PathLike backports
-* `#17474 <https://github.com/numpy/numpy/pull/17474>`__: MAINT: Move the `np.core.numeric` annotations to their own stub...
-* `#17479 <https://github.com/numpy/numpy/pull/17479>`__: ENH: type np.unicode_ as np.str_
+* `#17474 <https://github.com/numpy/numpy/pull/17474>`__: MAINT: Move the ``np.core.numeric`` annotations to their own stub...
+* `#17479 <https://github.com/numpy/numpy/pull/17479>`__: ENH: type ``np.unicode_`` as ``np.str_``
 * `#17481 <https://github.com/numpy/numpy/pull/17481>`__: DOC: Fix the entries for members of structures
-* `#17483 <https://github.com/numpy/numpy/pull/17483>`__: DOC: Fix the references for `random.*`
+* `#17483 <https://github.com/numpy/numpy/pull/17483>`__: DOC: Fix the references for ``random.*``
 * `#17485 <https://github.com/numpy/numpy/pull/17485>`__: BLD: circleCI- merge before build, add -n to sphinx
 * `#17487 <https://github.com/numpy/numpy/pull/17487>`__: MAINT: Remove duplicate placeholder annotations
+* `#17493 <https://github.com/numpy/numpy/pull/17493>`__: DOC: New round of NEP 42 edits
 * `#17497 <https://github.com/numpy/numpy/pull/17497>`__: DOC: Use consistent lowercase on docs landing page
 * `#17498 <https://github.com/numpy/numpy/pull/17498>`__: MAINT: fix incompatible type comparison in numpy.lib.utils.info
 * `#17501 <https://github.com/numpy/numpy/pull/17501>`__: BUG: Fix failures in master related to userdtype registeration
-* `#17502 <https://github.com/numpy/numpy/pull/17502>`__: BUG: remove `sys` from the type stubs
+* `#17502 <https://github.com/numpy/numpy/pull/17502>`__: BUG: remove ``sys`` from the type stubs
 * `#17503 <https://github.com/numpy/numpy/pull/17503>`__: DOC: Fix empty 'C style guide' page
 * `#17504 <https://github.com/numpy/numpy/pull/17504>`__: DOC: Rename 'Quickstart tutorial'
 * `#17508 <https://github.com/numpy/numpy/pull/17508>`__: ENH: Added the Final feature for all constants
@@ -726,15 +756,15 @@ A total of 684 pull requests were merged for this release.
 * `#17537 <https://github.com/numpy/numpy/pull/17537>`__: MAINT: Bump hypothesis from 5.37.0 to 5.37.1
 * `#17538 <https://github.com/numpy/numpy/pull/17538>`__: MAINT: Bump pydata-sphinx-theme from 0.4.0 to 0.4.1
 * `#17539 <https://github.com/numpy/numpy/pull/17539>`__: MAINT: Bump mypy from 0.782 to 0.790
-* `#17540 <https://github.com/numpy/numpy/pull/17540>`__: ENH: Make `np.number` generic with respect to its precision
+* `#17540 <https://github.com/numpy/numpy/pull/17540>`__: ENH: Make ``np.number`` generic with respect to its precision
 * `#17541 <https://github.com/numpy/numpy/pull/17541>`__: CI: fix conditional for PR merge command
-* `#17546 <https://github.com/numpy/numpy/pull/17546>`__: MAINT: explicit disabling `CCompilerOpt` in F2PY
+* `#17546 <https://github.com/numpy/numpy/pull/17546>`__: MAINT: explicit disabling ``CCompilerOpt`` in F2PY
 * `#17548 <https://github.com/numpy/numpy/pull/17548>`__: BUG: Cygwin Workaround for #14787 on affected platforms
 * `#17549 <https://github.com/numpy/numpy/pull/17549>`__: DOC: Fix the entries of C functions
 * `#17555 <https://github.com/numpy/numpy/pull/17555>`__: DOC: Fix wrong blockquotes
 * `#17558 <https://github.com/numpy/numpy/pull/17558>`__: DOC: MAINT: Add NEP 43 links to NEP 42
 * `#17559 <https://github.com/numpy/numpy/pull/17559>`__: DOC: Remove directives for some constants
-* `#17564 <https://github.com/numpy/numpy/pull/17564>`__: MAINT: Update the annotations in `np.core.numeric`
+* `#17564 <https://github.com/numpy/numpy/pull/17564>`__: MAINT: Update the annotations in ``np.core.numeric``
 * `#17570 <https://github.com/numpy/numpy/pull/17570>`__: DOC: Add the entry for ``NPY_FEATURE_VERSION``
 * `#17571 <https://github.com/numpy/numpy/pull/17571>`__: DOC: Fix typos
 * `#17572 <https://github.com/numpy/numpy/pull/17572>`__: ENH: Add annotations for three new constants
@@ -742,27 +772,27 @@ A total of 684 pull requests were merged for this release.
 * `#17577 <https://github.com/numpy/numpy/pull/17577>`__: BUG: Respect dtype of all-zero argument to poly1d
 * `#17578 <https://github.com/numpy/numpy/pull/17578>`__: NEP36: include additional feedback
 * `#17580 <https://github.com/numpy/numpy/pull/17580>`__: MAINT: Cleanup swig for Python 3.
-* `#17581 <https://github.com/numpy/numpy/pull/17581>`__: MAINT: Move the `np.core.numerictypes` annotations to their own...
+* `#17581 <https://github.com/numpy/numpy/pull/17581>`__: MAINT: Move the ``np.core.numerictypes`` annotations to their own...
 * `#17583 <https://github.com/numpy/numpy/pull/17583>`__: MAINT: Bump hypothesis from 5.37.1 to 5.37.3
-* `#17584 <https://github.com/numpy/numpy/pull/17584>`__: ENH: Add annotations for `np.core._type_aliases`
+* `#17584 <https://github.com/numpy/numpy/pull/17584>`__: ENH: Add annotations for ``np.core._type_aliases``
 * `#17594 <https://github.com/numpy/numpy/pull/17594>`__: DOC: Typo in lexsort docstring
 * `#17596 <https://github.com/numpy/numpy/pull/17596>`__: DEP,BUG: Coercion/cast of array to a subarray dtype will be fixed
 * `#17597 <https://github.com/numpy/numpy/pull/17597>`__: TST: Clean up the errors of the typing tests
 * `#17598 <https://github.com/numpy/numpy/pull/17598>`__: BUG: Fixed file handle leak in array_tofile.
-* `#17601 <https://github.com/numpy/numpy/pull/17601>`__: TST: Fix a broken `np.core.numeric` test
+* `#17601 <https://github.com/numpy/numpy/pull/17601>`__: TST: Fix a broken ``np.core.numeric`` test
 * `#17603 <https://github.com/numpy/numpy/pull/17603>`__: MAINT: Mark dead code as intentional for clang.
 * `#17607 <https://github.com/numpy/numpy/pull/17607>`__: DOC: removed old references to submodule licenses
 * `#17608 <https://github.com/numpy/numpy/pull/17608>`__: DOC: Fix typos (general documentation)
 * `#17610 <https://github.com/numpy/numpy/pull/17610>`__: Fully qualify license trove classifier
 * `#17611 <https://github.com/numpy/numpy/pull/17611>`__: BUG: mac dylib treated as part of extra objects by f2py
-* `#17613 <https://github.com/numpy/numpy/pull/17613>`__: ENH: Add annotations for 9 `ndarray`/`generic` magic methods
+* `#17613 <https://github.com/numpy/numpy/pull/17613>`__: ENH: Add annotations for 9 ``ndarray``/``generic`` magic methods
 * `#17614 <https://github.com/numpy/numpy/pull/17614>`__: DOC: Fix the document for arrays interface
 * `#17618 <https://github.com/numpy/numpy/pull/17618>`__: MAINT: Conversion of some strings to f-strings
 * `#17619 <https://github.com/numpy/numpy/pull/17619>`__: DOC: Fix some references
 * `#17621 <https://github.com/numpy/numpy/pull/17621>`__: TST: Valid docstring for config_py function show()
 * `#17622 <https://github.com/numpy/numpy/pull/17622>`__: MAINT: Conversion of some strings to fstrings, part II
 * `#17623 <https://github.com/numpy/numpy/pull/17623>`__: MAINT: Conversion of some strings to fstrings, part III
-* `#17624 <https://github.com/numpy/numpy/pull/17624>`__: DOC: Tidy up references to str_ / bytes_
+* `#17624 <https://github.com/numpy/numpy/pull/17624>`__: DOC: Tidy up references to ``str_`` / ``bytes_``
 * `#17625 <https://github.com/numpy/numpy/pull/17625>`__: MAINT: Conversion of some strings to fstrings, part iv
 * `#17627 <https://github.com/numpy/numpy/pull/17627>`__: DOC: Fix the references for ``__array_*__``
 * `#17628 <https://github.com/numpy/numpy/pull/17628>`__: DOC: Add entries for macros
@@ -773,8 +803,8 @@ A total of 684 pull requests were merged for this release.
 * `#17639 <https://github.com/numpy/numpy/pull/17639>`__: MAINT: Bump hypothesis from 5.37.3 to 5.38.0
 * `#17641 <https://github.com/numpy/numpy/pull/17641>`__: MAINT, BLD: update to OpenBLAS v0.3.12
 * `#17642 <https://github.com/numpy/numpy/pull/17642>`__: DOC: Fix reference to atleast_1d
-* `#17643 <https://github.com/numpy/numpy/pull/17643>`__: ENH: Add annotations for `np.core._ufunc_config`
-* `#17644 <https://github.com/numpy/numpy/pull/17644>`__: ENH: Add annotations for `np.core.shape_base`
+* `#17643 <https://github.com/numpy/numpy/pull/17643>`__: ENH: Add annotations for ``np.core._ufunc_config``
+* `#17644 <https://github.com/numpy/numpy/pull/17644>`__: ENH: Add annotations for ``np.core.shape_base``
 * `#17645 <https://github.com/numpy/numpy/pull/17645>`__: BUG: fix np.timedelta64('nat').__format__ throwing an exception
 * `#17654 <https://github.com/numpy/numpy/pull/17654>`__: BUG: f2py incorrectly translates dimension declarations.
 * `#17655 <https://github.com/numpy/numpy/pull/17655>`__: BLD: Fix installing Numpy on z/OS
@@ -799,7 +829,9 @@ A total of 684 pull requests were merged for this release.
 * `#17700 <https://github.com/numpy/numpy/pull/17700>`__: Fix small typos.
 * `#17701 <https://github.com/numpy/numpy/pull/17701>`__: BUG: Fixed an issue where ``.pyi`` files were ignored by numpy...
 * `#17703 <https://github.com/numpy/numpy/pull/17703>`__: Fix Doc Typos & Added Example
+* `#17706 <https://github.com/numpy/numpy/pull/17706>`__: BUG: Raise promotion error if a DType was provided in array coercion
 * `#17708 <https://github.com/numpy/numpy/pull/17708>`__: Improve the einsum bench by adding new bench cases and variable...
+* `#17711 <https://github.com/numpy/numpy/pull/17711>`__: ENH: adds type hints to numpy.version
 * `#17715 <https://github.com/numpy/numpy/pull/17715>`__: REV: Revert gh-17654 - f2py incorrectly translates dimension...
 * `#17717 <https://github.com/numpy/numpy/pull/17717>`__: MAINT: Add more files to ``.gitgnore``
 * `#17720 <https://github.com/numpy/numpy/pull/17720>`__: API: Do not import sliding_window_view to main namespace
@@ -836,9 +868,9 @@ A total of 684 pull requests were merged for this release.
 * `#17830 <https://github.com/numpy/numpy/pull/17830>`__: TST: Add back durations flag for DEBUG builds.
 * `#17832 <https://github.com/numpy/numpy/pull/17832>`__: BUG: Fix subarray dtype used with too large count in fromfile
 * `#17833 <https://github.com/numpy/numpy/pull/17833>`__: BUG: Fix pickling of scalars with NPY_LISTPICKLE
-* `#17838 <https://github.com/numpy/numpy/pull/17838>`__: DOC: Update the `numpy.typing` documentation
+* `#17838 <https://github.com/numpy/numpy/pull/17838>`__: DOC: Update the ``numpy.typing`` documentation
 * `#17841 <https://github.com/numpy/numpy/pull/17841>`__: DOC: Fixing boilerplate code example
-* `#17844 <https://github.com/numpy/numpy/pull/17844>`__: MAINT: Add ``__all__`` to `numpy.typing`
+* `#17844 <https://github.com/numpy/numpy/pull/17844>`__: MAINT: Add ``__all__`` to ``numpy.typing``
 * `#17848 <https://github.com/numpy/numpy/pull/17848>`__: DOC: Add release note for gh-16161.
 * `#17855 <https://github.com/numpy/numpy/pull/17855>`__: BUG: Fix incorrect C function prototypes/declarations.
 * `#17857 <https://github.com/numpy/numpy/pull/17857>`__: MAINT: Prepare for the NumPy 1.20.x branch.

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -66,9 +66,13 @@ def get_authors(revision_range):
     pre = set(re.findall(pat, this_repo.git.shortlog('-s', lst_release),
                          re.M))
 
-    # Homu is the author of auto merges, clean him out.
+    # Ignore the bot Homu.
     cur.discard('Homu')
     pre.discard('Homu')
+
+    # Ignore the bot dependabot-preview
+    cur.discard('dependabot-preview')
+    pre.discard('dependabot-preview')
 
     # Append '+' to new authors.
     authors = [s + u' +' for s in cur - pre] + [s for s in cur & pre]
@@ -92,8 +96,8 @@ def get_pull_requests(repo, revision_range):
     # From fast forward squash-merges
     commits = this_repo.git.log(
         '--oneline', '--no-merges', '--first-parent', revision_range)
-    issues = re.findall(u'^.*\\(\\#(\\d+)\\)$', commits, re.M)
-    prnums.extend(int(s) for s in issues)
+    issues = re.findall(u'^.*\\((\\#|gh-|gh-\\#)(\\d+)\\)$', commits, re.M)
+    prnums.extend(int(s[1]) for s in issues)
 
     # get PR data from github repo
     prnums.sort()


### PR DESCRIPTION
The `changelog.py` script was only recognizing fast forward merges  where the PR number was of the form "(#xxxxx)", but some people were merging with the "(gh-xxxxx)"  or (typo) "gh-#xxxxx" form. Also ignore dependabot-preview as an author.

*  Update the 1.20.0 changelog.
*  Update the 1.19.0 changelog.
*  Update the 1.18.0 changelog.
*  Update the 1.17.0 changelog.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
