### PR TITLE
BUG: Fix refcounting in string-promotion deprecation code path

### DIFF
--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -540,7 +540,12 @@ PyUFunc_SimpleUniformOperationTypeResolver(
                     out_dtypes[iop] = PyArray_DESCR(operands[iop]);
                     Py_INCREF(out_dtypes[iop]);
                 }
-                return raise_no_loop_found_error(ufunc, out_dtypes);
+                raise_no_loop_found_error(ufunc, out_dtypes);
+                for (iop = 0; iop < ufunc->nin; iop++) {
+                    Py_DECREF(out_dtypes[iop]);
+                    out_dtypes[iop] = NULL;
+                }
+                return -1;
             }
             out_dtypes[0] = PyArray_ResultType(ufunc->nin, operands, 0, NULL);
         }


### PR DESCRIPTION
This is a workaround to avoid string deprecation warning when it
will not make a difference. But it was lacking the decref'ing
and clearing (just in case, this code normally does so).

---

Just a small fix, that showed up on valgrind testing other things.