### PR TITLE
 DOC: Add a release note for the improved placeholder annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ numpy/random/legacy/*.c
 numpy/random/_mtrand/randint_helpers.pxi
 numpy/random/bounded_integers.pyx
 numpy/random/bounded_integers.pxd
+numpy/random/lib/npyrandom.lib
 tools/swig/test/Array_wrap.cxx
 tools/swig/test/Farray_wrap.cxx
 tools/swig/test/Farray.py

--- a/doc/release/upcoming_changes/18934.improvement.rst
+++ b/doc/release/upcoming_changes/18934.improvement.rst
@@ -1,0 +1,5 @@
+Placeholder annotations have been improved
+------------------------------------------
+All placeholder annotations, that were previously annotated as ``typing.Any``,
+have been improved. Where appropiate they have been replaced with explicit
+function definitions, classes or other miscellaneous objects.


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/18838.

Adds a release note for improved placeholder annotations referenced in the PRs associated with aforementioned issue.