### PR TITLE
DOC: change copyright SciPy to NumPy

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -99,7 +99,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'NumPy'
-copyright = '2008-2021, The SciPy community'
+copyright = '2008-2021, The NumPy community'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
closes #18952  

changes SciPy to Numpy in the copyrights, with 2008-2021 as date
