### PR TITLE
MAINT: Do not use deprecated ``mktemp()``

### DIFF
--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -1,10 +1,9 @@
 import sys
 import os
-import shutil
 import mmap
 import pytest
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryFile, mkdtemp
+from tempfile import NamedTemporaryFile, TemporaryFile
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
@@ -18,7 +17,6 @@ from numpy.testing import (
 class TestMemmap:
     def setup(self):
         self.tmpfp = NamedTemporaryFile(prefix='mmap')
-        self.tempdir = mkdtemp()
         self.shape = (3, 4)
         self.dtype = 'float32'
         self.data = arange(12, dtype=self.dtype)
@@ -30,7 +28,6 @@ class TestMemmap:
         if IS_PYPY:
             break_cycles()
             break_cycles()
-        shutil.rmtree(self.tempdir)
 
     def test_roundtrip(self):
         # Write data to file

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -4,7 +4,7 @@ import shutil
 import mmap
 import pytest
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryFile, mkstemp, mkdtemp
+from tempfile import NamedTemporaryFile, TemporaryFile, mkdtemp
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
@@ -46,8 +46,8 @@ class TestMemmap:
         assert_array_equal(self.data, newfp)
         assert_equal(newfp.flags.writeable, False)
 
-    def test_open_with_filename(self):
-        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
+    def test_open_with_filename(self, tmp_path):
+        tmpname = tmp_path / 'mmap'
         fp = memmap(tmpname, dtype=self.dtype, mode='w+',
                        shape=self.shape)
         fp[:] = self.data[:]
@@ -67,11 +67,11 @@ class TestMemmap:
         assert_equal(mode, fp.mode)
         del fp
 
-    def test_filename(self):
-        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
+    def test_filename(self, tmp_path):
+        tmpname = tmp_path / "mmap"
         fp = memmap(tmpname, dtype=self.dtype, mode='w+',
                        shape=self.shape)
-        abspath = os.path.abspath(tmpname)
+        abspath = Path(os.path.abspath(tmpname))
         fp[:] = self.data[:]
         assert_equal(abspath, fp.filename)
         b = fp[:1]
@@ -79,8 +79,8 @@ class TestMemmap:
         del b
         del fp
 
-    def test_path(self):
-        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
+    def test_path(self, tmp_path):
+        tmpname = tmp_path / "mmap"
         fp = memmap(Path(tmpname), dtype=self.dtype, mode='w+',
                        shape=self.shape)
         # os.path.realpath does not resolve symlinks on Windows

--- a/numpy/core/tests/test_memmap.py
+++ b/numpy/core/tests/test_memmap.py
@@ -4,7 +4,7 @@ import shutil
 import mmap
 import pytest
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryFile, mktemp, mkdtemp
+from tempfile import NamedTemporaryFile, TemporaryFile, mkstemp, mkdtemp
 
 from numpy import (
     memmap, sum, average, product, ndarray, isscalar, add, subtract, multiply)
@@ -47,7 +47,7 @@ class TestMemmap:
         assert_equal(newfp.flags.writeable, False)
 
     def test_open_with_filename(self):
-        tmpname = mktemp('', 'mmap', dir=self.tempdir)
+        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
         fp = memmap(tmpname, dtype=self.dtype, mode='w+',
                        shape=self.shape)
         fp[:] = self.data[:]
@@ -68,7 +68,7 @@ class TestMemmap:
         del fp
 
     def test_filename(self):
-        tmpname = mktemp('', 'mmap', dir=self.tempdir)
+        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
         fp = memmap(tmpname, dtype=self.dtype, mode='w+',
                        shape=self.shape)
         abspath = os.path.abspath(tmpname)
@@ -80,7 +80,7 @@ class TestMemmap:
         del fp
 
     def test_path(self):
-        tmpname = mktemp('', 'mmap', dir=self.tempdir)
+        tmpname = mkstemp('', 'mmap', dir=self.tempdir)[1]
         fp = memmap(Path(tmpname), dtype=self.dtype, mode='w+',
                        shape=self.shape)
         # os.path.realpath does not resolve symlinks on Windows

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4818,7 +4818,7 @@ class TestIO:
         self.x[0,:, 1] = [np.nan, np.inf, -np.inf, np.nan]
         self.dtype = self.x.dtype
         self.tempdir = tempfile.mkdtemp()
-        self.filename = tempfile.mktemp(dir=self.tempdir)
+        self.filename = tempfile.mkstemp(dir=self.tempdir)[1]
 
     def teardown(self):
         shutil.rmtree(self.tempdir)

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5246,7 +5246,7 @@ class TestIO:
 
     def test_read_shorter_than_count_subarray(self, tmp_filename):
         # Test that requesting more values does not cause any problems
-        # in conjuction with subarray dimensions being absored into the
+        # in conjunction with subarray dimensions being absorbed into the
         # array dimension.
         expected = np.arange(511 * 10, dtype="i").reshape(-1, 10)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4810,27 +4810,23 @@ class TestLexsort:
 class TestIO:
     """Test tofile, fromfile, tobytes, and fromstring"""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
+    @pytest.fixture()
+    def x(self):
         shape = (2, 4, 3)
         rand = np.random.random
-        self.x = rand(shape) + rand(shape).astype(complex)*1j
-        self.x[0,:, 1] = [np.nan, np.inf, -np.inf, np.nan]
-        self.dtype = self.x.dtype
-        yield
-        delattr(self, "dtype")
-        delattr(self, "x")
+        x = rand(shape) + rand(shape).astype(complex) * 1j
+        x[0, :, 1] = [np.nan, np.inf, -np.inf, np.nan]
+        return x
 
     @pytest.fixture(params=["string", "path_obj"])
     def tmp_filename(self, tmp_path, request):
         # This fixture covers two cases:
         # one where the filename is a string and
         # another where it is a pathlib object
-        self.filename = tmp_path / "file"
+        filename = tmp_path / "file"
         if request.param == "string":
-            self.filename = str(self.filename)
-        yield self.filename
-        delattr(self, "filename")
+            filename = str(filename)
+        yield filename
 
     def test_nofile(self):
         # this should probably be supported as a file
@@ -4862,47 +4858,47 @@ class TestIO:
         assert d.shape == (0,)
 
     def test_empty_files_text(self, tmp_filename):
-        with open(self.filename, 'w') as f:
+        with open(tmp_filename, 'w') as f:
             pass
-        y = np.fromfile(self.filename)
+        y = np.fromfile(tmp_filename)
         assert_(y.size == 0, "Array not empty")
 
     def test_empty_files_binary(self, tmp_filename):
-        with open(self.filename, 'wb') as f:
+        with open(tmp_filename, 'wb') as f:
             pass
-        y = np.fromfile(self.filename, sep=" ")
+        y = np.fromfile(tmp_filename, sep=" ")
         assert_(y.size == 0, "Array not empty")
 
-    def test_roundtrip_file(self, tmp_filename):
-        with open(self.filename, 'wb') as f:
-            self.x.tofile(f)
+    def test_roundtrip_file(self, x, tmp_filename):
+        with open(tmp_filename, 'wb') as f:
+            x.tofile(f)
         # NB. doesn't work with flush+seek, due to use of C stdio
-        with open(self.filename, 'rb') as f:
-            y = np.fromfile(f, dtype=self.dtype)
-        assert_array_equal(y, self.x.flat)
+        with open(tmp_filename, 'rb') as f:
+            y = np.fromfile(f, dtype=x.dtype)
+        assert_array_equal(y, x.flat)
 
-    def test_roundtrip(self, tmp_filename):
-        self.x.tofile(self.filename)
-        y = np.fromfile(self.filename, dtype=self.dtype)
-        assert_array_equal(y, self.x.flat)
+    def test_roundtrip(self, x, tmp_filename):
+        x.tofile(tmp_filename)
+        y = np.fromfile(tmp_filename, dtype=x.dtype)
+        assert_array_equal(y, x.flat)
 
-    def test_roundtrip_dump_pathlib(self, tmp_filename):
-        p = pathlib.Path(self.filename)
-        self.x.dump(p)
+    def test_roundtrip_dump_pathlib(self, x, tmp_filename):
+        p = pathlib.Path(tmp_filename)
+        x.dump(p)
         y = np.load(p, allow_pickle=True)
-        assert_array_equal(y, self.x)
+        assert_array_equal(y, x)
 
-    def test_roundtrip_binary_str(self):
-        s = self.x.tobytes()
-        y = np.frombuffer(s, dtype=self.dtype)
-        assert_array_equal(y, self.x.flat)
+    def test_roundtrip_binary_str(self, x):
+        s = x.tobytes()
+        y = np.frombuffer(s, dtype=x.dtype)
+        assert_array_equal(y, x.flat)
 
-        s = self.x.tobytes('F')
-        y = np.frombuffer(s, dtype=self.dtype)
-        assert_array_equal(y, self.x.flatten('F'))
+        s = x.tobytes('F')
+        y = np.frombuffer(s, dtype=x.dtype)
+        assert_array_equal(y, x.flatten('F'))
 
-    def test_roundtrip_str(self):
-        x = self.x.real.ravel()
+    def test_roundtrip_str(self, x):
+        x = x.real.ravel()
         s = "@".join(map(str, x))
         y = np.fromstring(s, sep="@")
         # NB. str imbues less precision
@@ -4910,57 +4906,57 @@ class TestIO:
         assert_array_equal(x[nan_mask], y[nan_mask])
         assert_array_almost_equal(x[~nan_mask], y[~nan_mask], decimal=5)
 
-    def test_roundtrip_repr(self):
-        x = self.x.real.ravel()
+    def test_roundtrip_repr(self, x):
+        x = x.real.ravel()
         s = "@".join(map(repr, x))
         y = np.fromstring(s, sep="@")
         assert_array_equal(x, y)
 
-    def test_unseekable_fromfile(self, tmp_filename):
+    def test_unseekable_fromfile(self, x, tmp_filename):
         # gh-6246
-        self.x.tofile(self.filename)
+        x.tofile(tmp_filename)
 
         def fail(*args, **kwargs):
             raise IOError('Can not tell or seek')
 
-        with io.open(self.filename, 'rb', buffering=0) as f:
+        with io.open(tmp_filename, 'rb', buffering=0) as f:
             f.seek = fail
             f.tell = fail
-            assert_raises(IOError, np.fromfile, f, dtype=self.dtype)
+            assert_raises(IOError, np.fromfile, f, dtype=x.dtype)
 
-    def test_io_open_unbuffered_fromfile(self, tmp_filename):
+    def test_io_open_unbuffered_fromfile(self, x, tmp_filename):
         # gh-6632
-        self.x.tofile(self.filename)
-        with io.open(self.filename, 'rb', buffering=0) as f:
-            y = np.fromfile(f, dtype=self.dtype)
-            assert_array_equal(y, self.x.flat)
+        x.tofile(tmp_filename)
+        with io.open(tmp_filename, 'rb', buffering=0) as f:
+            y = np.fromfile(f, dtype=x.dtype)
+            assert_array_equal(y, x.flat)
 
     def test_largish_file(self, tmp_filename):
         # check the fallocate path on files > 16MB
         d = np.zeros(4 * 1024 ** 2)
-        d.tofile(self.filename)
-        assert_equal(os.path.getsize(self.filename), d.nbytes)
-        assert_array_equal(d, np.fromfile(self.filename))
+        d.tofile(tmp_filename)
+        assert_equal(os.path.getsize(tmp_filename), d.nbytes)
+        assert_array_equal(d, np.fromfile(tmp_filename))
         # check offset
-        with open(self.filename, "r+b") as f:
+        with open(tmp_filename, "r+b") as f:
             f.seek(d.nbytes)
             d.tofile(f)
-            assert_equal(os.path.getsize(self.filename), d.nbytes * 2)
+            assert_equal(os.path.getsize(tmp_filename), d.nbytes * 2)
         # check append mode (gh-8329)
-        open(self.filename, "w").close() # delete file contents
-        with open(self.filename, "ab") as f:
+        open(tmp_filename, "w").close()  # delete file contents
+        with open(tmp_filename, "ab") as f:
             d.tofile(f)
-        assert_array_equal(d, np.fromfile(self.filename))
-        with open(self.filename, "ab") as f:
+        assert_array_equal(d, np.fromfile(tmp_filename))
+        with open(tmp_filename, "ab") as f:
             d.tofile(f)
-        assert_equal(os.path.getsize(self.filename), d.nbytes * 2)
+        assert_equal(os.path.getsize(tmp_filename), d.nbytes * 2)
 
-    def test_io_open_buffered_fromfile(self, tmp_filename):
+    def test_io_open_buffered_fromfile(self, x, tmp_filename):
         # gh-6632
-        self.x.tofile(self.filename)
-        with io.open(self.filename, 'rb', buffering=-1) as f:
-            y = np.fromfile(f, dtype=self.dtype)
-        assert_array_equal(y, self.x.flat)
+        x.tofile(tmp_filename)
+        with io.open(tmp_filename, 'rb', buffering=-1) as f:
+            y = np.fromfile(f, dtype=x.dtype)
+        assert_array_equal(y, x.flat)
 
     def test_file_position_after_fromfile(self, tmp_filename):
         # gh-4118
@@ -4969,14 +4965,14 @@ class TestIO:
                  io.DEFAULT_BUFFER_SIZE*8]
 
         for size in sizes:
-            with open(self.filename, 'wb') as f:
+            with open(tmp_filename, 'wb') as f:
                 f.seek(size-1)
                 f.write(b'\0')
 
             for mode in ['rb', 'r+b']:
                 err_msg = "%d %s" % (size, mode)
 
-                with open(self.filename, mode) as f:
+                with open(tmp_filename, mode) as f:
                     f.read(2)
                     np.fromfile(f, dtype=np.float64, count=1)
                     pos = f.tell()
@@ -4991,7 +4987,7 @@ class TestIO:
         for size in sizes:
             err_msg = "%d" % (size,)
 
-            with open(self.filename, 'wb') as f:
+            with open(tmp_filename, 'wb') as f:
                 f.seek(size-1)
                 f.write(b'\0')
                 f.seek(10)
@@ -5000,7 +4996,7 @@ class TestIO:
                 pos = f.tell()
             assert_equal(pos, 10 + 2 + 8, err_msg=err_msg)
 
-            with open(self.filename, 'r+b') as f:
+            with open(tmp_filename, 'r+b') as f:
                 f.read(2)
                 f.seek(0, 1)  # seek between read&write required by ANSI C
                 np.array([0], dtype=np.float64).tofile(f)
@@ -5009,49 +5005,53 @@ class TestIO:
 
     def test_load_object_array_fromfile(self, tmp_filename):
         # gh-12300
-        with open(self.filename, 'w') as f:
+        with open(tmp_filename, 'w') as f:
             # Ensure we have a file with consistent contents
             pass
 
-        with open(self.filename, 'rb') as f:
+        with open(tmp_filename, 'rb') as f:
             assert_raises_regex(ValueError, "Cannot read into object array",
                                 np.fromfile, f, dtype=object)
 
         assert_raises_regex(ValueError, "Cannot read into object array",
-                            np.fromfile, self.filename, dtype=object)
+                            np.fromfile, tmp_filename, dtype=object)
 
-    def test_fromfile_offset(self, tmp_filename):
-        with open(self.filename, 'wb') as f:
-            self.x.tofile(f)
+    def test_fromfile_offset(self, x, tmp_filename):
+        with open(tmp_filename, 'wb') as f:
+            x.tofile(f)
 
-        with open(self.filename, 'rb') as f:
-            y = np.fromfile(f, dtype=self.dtype, offset=0)
-            assert_array_equal(y, self.x.flat)
+        with open(tmp_filename, 'rb') as f:
+            y = np.fromfile(f, dtype=x.dtype, offset=0)
+            assert_array_equal(y, x.flat)
 
-        with open(self.filename, 'rb') as f:
-            count_items = len(self.x.flat) // 8
-            offset_items = len(self.x.flat) // 4
-            offset_bytes = self.dtype.itemsize * offset_items
-            y = np.fromfile(f, dtype=self.dtype, count=count_items, offset=offset_bytes)
-            assert_array_equal(y, self.x.flat[offset_items:offset_items+count_items])
+        with open(tmp_filename, 'rb') as f:
+            count_items = len(x.flat) // 8
+            offset_items = len(x.flat) // 4
+            offset_bytes = x.dtype.itemsize * offset_items
+            y = np.fromfile(
+                f, dtype=x.dtype, count=count_items, offset=offset_bytes
+            )
+            assert_array_equal(
+                y, x.flat[offset_items:offset_items+count_items]
+            )
 
             # subsequent seeks should stack
-            offset_bytes = self.dtype.itemsize
-            z = np.fromfile(f, dtype=self.dtype, offset=offset_bytes)
-            assert_array_equal(z, self.x.flat[offset_items+count_items+1:])
+            offset_bytes = x.dtype.itemsize
+            z = np.fromfile(f, dtype=x.dtype, offset=offset_bytes)
+            assert_array_equal(z, x.flat[offset_items+count_items+1:])
 
-        with open(self.filename, 'wb') as f:
-            self.x.tofile(f, sep=",")
+        with open(tmp_filename, 'wb') as f:
+            x.tofile(f, sep=",")
 
-        with open(self.filename, 'rb') as f:
+        with open(tmp_filename, 'rb') as f:
             assert_raises_regex(
                     TypeError,
                     "'offset' argument only permitted for binary files",
-                    np.fromfile, self.filename, dtype=self.dtype,
+                    np.fromfile, tmp_filename, dtype=x.dtype,
                     sep=",", offset=1)
 
     @pytest.mark.skipif(IS_PYPY, reason="bug in PyPy's PyNumber_AsSsize_t")
-    def test_fromfile_bad_dup(self, tmp_filename):
+    def test_fromfile_bad_dup(self, x, tmp_filename):
         def dup_str(fd):
             return 'abc'
 
@@ -5060,24 +5060,24 @@ class TestIO:
 
         old_dup = os.dup
         try:
-            with open(self.filename, 'wb') as f:
-                self.x.tofile(f)
+            with open(tmp_filename, 'wb') as f:
+                x.tofile(f)
                 for dup, exc in ((dup_str, TypeError), (dup_bigint, OSError)):
                     os.dup = dup
                     assert_raises(exc, np.fromfile, f)
         finally:
             os.dup = old_dup
 
-    def _check_from(self, s, value, **kw):
+    def _check_from(self, s, value, filename, **kw):
         if 'sep' not in kw:
             y = np.frombuffer(s, **kw)
         else:
             y = np.fromstring(s, **kw)
         assert_array_equal(y, value)
 
-        with open(self.filename, 'wb') as f:
+        with open(filename, 'wb') as f:
             f.write(s)
-        y = np.fromfile(self.filename, **kw)
+        y = np.fromfile(filename, **kw)
         assert_array_equal(y, value)
 
     @pytest.fixture(params=[True, False])
@@ -5092,22 +5092,29 @@ class TestIO:
         self._check_from(
             b"nan +nan -nan NaN nan(foo) +NaN(BAR) -NAN(q_u_u_x_)",
             [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            tmp_filename,
             sep=' ')
 
     def test_inf(self, tmp_filename, comma_decimal_point_locale):
         self._check_from(
             b"inf +inf -inf infinity -Infinity iNfInItY -inF",
             [np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf],
+            tmp_filename,
             sep=' ')
 
     def test_numbers(self, tmp_filename, comma_decimal_point_locale):
-        self._check_from(b"1.234 -1.234 .3 .3e55 -123133.1231e+133",
-                         [1.234, -1.234, .3, .3e55, -123133.1231e+133], sep=' ')
+        self._check_from(
+            b"1.234 -1.234 .3 .3e55 -123133.1231e+133",
+            [1.234, -1.234, .3, .3e55, -123133.1231e+133],
+            tmp_filename,
+            sep=' ')
 
     def test_binary(self, tmp_filename):
-        self._check_from(b'\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
-                         np.array([1, 2, 3, 4]),
-                         dtype='<f4')
+        self._check_from(
+            b'\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
+            np.array([1, 2, 3, 4]),
+            tmp_filename,
+            dtype='<f4')
 
     @pytest.mark.slow  # takes > 1 minute on mechanical hard drive
     def test_big_binary(self):
@@ -5135,50 +5142,59 @@ class TestIO:
             pass
 
     def test_string(self, tmp_filename):
-        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], sep=',')
+        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, sep=',')
 
     def test_counted_string(self, tmp_filename, comma_decimal_point_locale):
-        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], count=4, sep=',')
-        self._check_from(b'1,2,3,4', [1., 2., 3.], count=3, sep=',')
-        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], count=-1, sep=',')
+        self._check_from(
+            b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=4, sep=',')
+        self._check_from(
+            b'1,2,3,4', [1., 2., 3.], tmp_filename, count=3, sep=',')
+        self._check_from(
+            b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=-1, sep=',')
 
     def test_string_with_ws(self, tmp_filename):
-        self._check_from(b'1 2  3     4   ', [1, 2, 3, 4], dtype=int, sep=' ')
+        self._check_from(
+            b'1 2  3     4   ', [1, 2, 3, 4], tmp_filename, dtype=int, sep=' ')
 
     def test_counted_string_with_ws(self, tmp_filename):
-        self._check_from(b'1 2  3     4   ', [1, 2, 3], count=3, dtype=int,
-                         sep=' ')
+        self._check_from(
+            b'1 2  3     4   ', [1, 2, 3], tmp_filename, count=3, dtype=int,
+            sep=' ')
 
     def test_ascii(self, tmp_filename, comma_decimal_point_locale):
-        self._check_from(b'1 , 2 , 3 , 4', [1., 2., 3., 4.], sep=',')
-        self._check_from(b'1,2,3,4', [1., 2., 3., 4.], dtype=float, sep=',')
+        self._check_from(
+            b'1 , 2 , 3 , 4', [1., 2., 3., 4.], tmp_filename, sep=',')
+        self._check_from(
+            b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, dtype=float, sep=',')
 
     def test_malformed(self, tmp_filename, comma_decimal_point_locale):
         with assert_warns(DeprecationWarning):
-            self._check_from(b'1.234 1,234', [1.234, 1.], sep=' ')
+            self._check_from(
+                b'1.234 1,234', [1.234, 1.], tmp_filename, sep=' ')
 
     def test_long_sep(self, tmp_filename):
-        self._check_from(b'1_x_3_x_4_x_5', [1, 3, 4, 5], sep='_x_')
+        self._check_from(
+            b'1_x_3_x_4_x_5', [1, 3, 4, 5], tmp_filename, sep='_x_')
 
     def test_dtype(self, tmp_filename):
         v = np.array([1, 2, 3, 4], dtype=np.int_)
-        self._check_from(b'1,2,3,4', v, sep=',', dtype=np.int_)
+        self._check_from(b'1,2,3,4', v, tmp_filename, sep=',', dtype=np.int_)
 
     def test_dtype_bool(self, tmp_filename):
         # can't use _check_from because fromstring can't handle True/False
         v = np.array([True, False, True, False], dtype=np.bool_)
         s = b'1,0,-2.3,0'
-        with open(self.filename, 'wb') as f:
+        with open(tmp_filename, 'wb') as f:
             f.write(s)
-        y = np.fromfile(self.filename, sep=',', dtype=np.bool_)
+        y = np.fromfile(tmp_filename, sep=',', dtype=np.bool_)
         assert_(y.dtype == '?')
         assert_array_equal(y, v)
 
     def test_tofile_sep(self, tmp_filename, comma_decimal_point_locale):
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
-        with open(self.filename, 'w') as f:
+        with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',')
-        with open(self.filename, 'r') as f:
+        with open(tmp_filename, 'r') as f:
             s = f.read()
         #assert_equal(s, '1.51,2.0,3.51,4.0')
         y = np.array([float(p) for p in s.split(',')])
@@ -5186,28 +5202,28 @@ class TestIO:
 
     def test_tofile_format(self, tmp_filename, comma_decimal_point_locale):
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
-        with open(self.filename, 'w') as f:
+        with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',', format='%.2f')
-        with open(self.filename, 'r') as f:
+        with open(tmp_filename, 'r') as f:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
     def test_tofile_cleanup(self, tmp_filename):
         x = np.zeros((10), dtype=object)
-        with open(self.filename, 'wb') as f:
+        with open(tmp_filename, 'wb') as f:
             assert_raises(IOError, lambda: x.tofile(f, sep=''))
         # Dup-ed file handle should be closed or remove will fail on Windows OS
-        os.remove(self.filename)
+        os.remove(tmp_filename)
 
         # Also make sure that we close the Python handle
-        assert_raises(IOError, lambda: x.tofile(self.filename))
-        os.remove(self.filename)
+        assert_raises(IOError, lambda: x.tofile(tmp_filename))
+        os.remove(tmp_filename)
 
     def test_fromfile_subarray_binary(self, tmp_filename):
         # Test subarray dtypes which are absorbed into the shape
         x = np.arange(24, dtype="i4").reshape(2, 3, 4)
-        x.tofile(self.filename)
-        res = np.fromfile(self.filename, dtype="(3,4)i4")
+        x.tofile(tmp_filename)
+        res = np.fromfile(tmp_filename, dtype="(3,4)i4")
         assert_array_equal(x, res)
 
         x_str = x.tobytes()
@@ -5222,11 +5238,11 @@ class TestIO:
         with pytest.raises(ValueError):
             expected = np.fromstring(data, dtype="(3,)i", sep=",")
 
-        with open(self.filename, "w") as f:
+        with open(tmp_filename, "w") as f:
             f.write(data)
 
         with pytest.raises(ValueError):
-            np.fromfile(self.filename, dtype="(3,)i", sep=",")
+            np.fromfile(tmp_filename, dtype="(3,)i", sep=",")
 
     def test_read_shorter_than_count_subarray(self, tmp_filename):
         # Test that requesting more values does not cause any problems
@@ -5239,8 +5255,8 @@ class TestIO:
             with pytest.warns(DeprecationWarning):
                 np.fromstring(binary, dtype="(10,)i", count=10000)
 
-        expected.tofile(self.filename)
-        res = np.fromfile(self.filename, dtype="(10,)i", count=10000)
+        expected.tofile(tmp_filename)
+        res = np.fromfile(tmp_filename, dtype="(10,)i", count=10000)
         assert_array_equal(res, expected)
 
 


### PR DESCRIPTION
Closes #12071 

* Changed use of `mktemp` to `mkstemp` since `mktemp` was deprecated
* No change required for `numpy/lib/tests/test_format.py`
* Coverage report: 84%

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
