### PR TITLE
BUG: fixed ma.average ignoring masked weights

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -614,10 +614,10 @@ def average(a, axis=None, weights=None, returned=False):
                     "Length of weights not compatible with specified axis.")
 
             # setup wgt to broadcast along axis
-            wgt = np.broadcast_to(wgt, (a.ndim-1)*(1,) + wgt.shape)
+            wgt = np.broadcast_to(wgt, (a.ndim-1)*(1,) + wgt.shape, subok=True)
             wgt = wgt.swapaxes(-1, axis)
 
-        if m is not nomask:
+        if m is nomask:
             wgt = wgt*(~a.mask)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -617,7 +617,7 @@ def average(a, axis=None, weights=None, returned=False):
             wgt = np.broadcast_to(wgt, (a.ndim-1)*(1,) + wgt.shape, subok=True)
             wgt = wgt.swapaxes(-1, axis)
 
-        if m is nomask:
+        if m is not nomask:
             wgt = wgt*(~a.mask)
 
         scl = wgt.sum(axis=axis, dtype=result_dtype)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -292,7 +292,20 @@ class TestAverage:
         assert_almost_equal(wav1.real, expected1.real)
         assert_almost_equal(wav1.imag, expected1.imag)
 
+    def test_masked_weights(self):
+            # Test with masked weights.
+            # (Regression test for https://github.com/numpy/numpy/issues/10438)
+            a = np.ma.array(np.arange(9).reshape(3, 3), mask=[[1, 0, 0], [1, 0, 0], [0, 0, 0]])
+            weights_unmasked = masked_array([5,28,31],mask=False)
+            weights_masked = masked_array([5,28,31],mask=[1,0,0])
 
+            avg_unmasked = average(a, axis=0, weights=weights_unmasked, returned=False)
+            expected_unmasked = np.array([6.0, 5.21875, 6.21875])
+            assert_almost_equal(avg_unmasked,expected_unmasked)
+
+            avg_masked = average(a, axis=0, weights=weights_masked, returned=False)
+            expected_masked = np.array([6.0, 5.576271186440678, 6.576271186440678])
+            assert_almost_equal(avg_masked,expected_masked)
 class TestConcatenator:
     # Tests for mr_, the equivalent of r_ for masked arrays.
 

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -293,19 +293,23 @@ class TestAverage:
         assert_almost_equal(wav1.imag, expected1.imag)
 
     def test_masked_weights(self):
-            # Test with masked weights.
-            # (Regression test for https://github.com/numpy/numpy/issues/10438)
-            a = np.ma.array(np.arange(9).reshape(3, 3), mask=[[1, 0, 0], [1, 0, 0], [0, 0, 0]])
-            weights_unmasked = masked_array([5,28,31],mask=False)
-            weights_masked = masked_array([5,28,31],mask=[1,0,0])
+        # Test with masked weights.
+        # (Regression test for https://github.com/numpy/numpy/issues/10438)
+        a = np.ma.array(np.arange(9).reshape(3, 3),
+                        mask=[[1, 0, 0], [1, 0, 0], [0, 0, 0]])
+        weights_unmasked = masked_array([5, 28, 31], mask=False)
+        weights_masked = masked_array([5, 28, 31], mask=[1, 0, 0])
 
-            avg_unmasked = average(a, axis=0, weights=weights_unmasked, returned=False)
-            expected_unmasked = np.array([6.0, 5.21875, 6.21875])
-            assert_almost_equal(avg_unmasked,expected_unmasked)
+        avg_unmasked = average(a, axis=0,
+                               weights=weights_unmasked, returned=False)
+        expected_unmasked = np.array([6.0, 5.21875, 6.21875])
+        assert_almost_equal(avg_unmasked, expected_unmasked)
 
-            avg_masked = average(a, axis=0, weights=weights_masked, returned=False)
-            expected_masked = np.array([6.0, 5.576271186440678, 6.576271186440678])
-            assert_almost_equal(avg_masked,expected_masked)
+        avg_masked = average(a, axis=0, weights=weights_masked, returned=False)
+        expected_masked = np.array([6.0, 5.576271186440678, 6.576271186440678])
+        assert_almost_equal(avg_masked, expected_masked)
+
+
 class TestConcatenator:
     # Tests for mr_, the equivalent of r_ for masked arrays.
 


### PR DESCRIPTION
Closes #10438

Co-authored-by: mecopur <24374426+mecopur@users.noreply.github.com> 