### PR TITLE
MAINT: fix unique for masked arrays

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1075,7 +1075,7 @@ def unique(ar1, return_index=False, return_inverse=False):
     numpy.unique : Equivalent function for ndarrays.
 
     """
-    output = np.unique(ar1,
+    output = np.unique(ar1.data[~ar1.mask],
                        return_index=return_index,
                        return_inverse=return_inverse)
     if isinstance(output, tuple):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1548,6 +1548,12 @@ class TestArraySetOps:
         a = np.array(['a', 'b', 'c'])
         b = np.array(['a', 'b', 's'])
         assert_array_equal(setdiff1d(a, b), np.array(['c']))
+    
+    def test_uint8_unique_mask(self):
+        # Regression test for gh-14804
+        m = np.ma.masked_array(np.array([50, 255, 1, 255, 1], dtype=np.uint8), mask=[False, False, True, False, True])
+        expected =[ 50, 255]
+        assert_equal(np.ma.unique(m).data, expected)
 
 
 class TestShapeBase:


### PR DESCRIPTION
Co-authored-by: alinanesen <alina.nesen@gmail.com> / GitHub username: [@alinanesen](https://github.com/alinanesen)

Modified np.ma.unique to call the np.unique with the array without the masked values.

Closes gh-14804