### PR TITLE
MAINT: Remove warning when checking AVX512f on MSVC

### DIFF
--- a/numpy/distutils/checks/extra_avx512f_reduce.c
+++ b/numpy/distutils/checks/extra_avx512f_reduce.c
@@ -8,7 +8,7 @@ int main(void)
 {
     __m512  one_ps = _mm512_set1_ps(1.0f);
     __m512d one_pd = _mm512_set1_pd(1.0);
-    __m512i one_i64 = _mm512_set1_epi64(1.0);
+    __m512i one_i64 = _mm512_set1_epi64(1);
     // add
     float sum_ps  = _mm512_reduce_add_ps(one_ps);
     double sum_pd = _mm512_reduce_add_pd(one_pd);


### PR DESCRIPTION
This [appears in the checks for AVX512f features](https://dev.azure.com/numpy/numpy/_build/results?buildId=17251&view=logs&j=41da7a62-01d8-5a8a-1897-893bcc993eb5&t=5d0f3858-8fad-5013-c44a-f2b1f688724a&l=773). @seiko2plus will the failure to build disable the optimization?