### PR TITLE
DOC: Remove misleading info about Fortran compiler in Building from source doc

### DIFF
--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -24,8 +24,8 @@ Building NumPy requires the following software installed:
 2) Compilers
 
    To build any extension modules for Python, you'll need a C compiler.
-   Various NumPy modules use FORTRAN 77 libraries, so you'll also need a
-   FORTRAN 77 compiler installed.
+   While a FORTRAN 77 compiler is not necessary for building NumPy, it is needed to run
+   the ``numpy.f2py`` tests. These tests are skipped if the compiler is not auto-detected.
 
    Note that NumPy is developed mainly using GNU compilers and tested on
    MSVC and Clang compilers. Compilers from other vendors such as Intel,


### PR DESCRIPTION
Currently the doc implies that the compiler is necessary. I have reworded it to clarify that it is optional and explained where it is required.

Fixes #7992

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
