### PR TITLE
BUG: fix potential use of null pointer in nditer buffers

### DIFF
--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -594,8 +594,10 @@ NpyIter_Copy(NpyIter *iter)
                     if (buffers[iop] == NULL) {
                         out_of_memory = 1;
                     }
-                    if (PyDataType_FLAGCHK(dtypes[iop], NPY_NEEDS_INIT)) {
-                        memset(buffers[iop], '\0', itemsize*buffersize);
+                    else {
+                        if (PyDataType_FLAGCHK(dtypes[iop], NPY_NEEDS_INIT)) {
+                            memset(buffers[iop], '\0', itemsize*buffersize);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The `buffers[iop]` pointer was used unsafely in `memset` after it was verified against nullptr. 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
