### PR TITLE
 MAINT: Small cleanups in `PyArray_NewFromDescr_int`

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5982,6 +5982,7 @@ class TestStats:
         res = dat.var(1)
         assert_(res.info == dat.info)
 
+
 class TestVdot:
     def test_basic(self):
         dt_numeric = np.typecodes['AllFloat'] + np.typecodes['AllInteger']
@@ -8706,6 +8707,15 @@ class TestArrayFinalize:
 
         a = np.array(1).view(SavesBase)
         assert_(a.saved_base is a.base)
+
+    def test_bad_finalize(self):
+        class BadAttributeArray(np.ndarray):
+            @property
+            def __array_finalize__(self):
+                raise RuntimeError("boohoo!")
+
+        with pytest.raises(RuntimeError, match="boohoo!"):
+            np.arange(10).view(BadAttributeArray)
 
     def test_lifetime_on_error(self):
         # gh-11237


### PR DESCRIPTION
I admit, the start of this was that I noticed that `memcpy` is using
a significant chunk of time in the array creation. `memcpy` is typically
optimized for fairly large copies, and seems to be just slow here,
replacing it gives a ~10% boost in array creation.
We can get another small boost by skipping the contiguity flag reset.

But mostly, I think this cleans up the code a bit :).

---

Also replaces the `PyObject_Call`, with the much more convenient `PyObject_CallFunctionObjArgs` (and tidies that path up a bit, including fixing a bug).

The code is slightly moved around, which makes the diff a bit hard to read unfortunately :(.  I decided to make a single large `if (nd > 0) {` block.   Maybe avoiding `memcpy` is silly here, but timing `np.empty()` and even simple ufunc calls suggested otherwise.

Avoiding setting the contiguity flags again definitely is worth a bit!

The before/after timings for `empty = np.empty; %timeit empty((3,))` gives me `280 ns` vs. `<220 ns`.

(Going to run benchmarks over night, right now I do not know how well they will show a difference).