### PR TITLE
BUG: fix np.ma.MaskedArray.anom when input is masked

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5290,9 +5290,6 @@ class MaskedArray(ndarray):
 
         """
         m = self.mean(axis, dtype)
-        if m is masked:
-            return m
-
         if not axis:
             return self - m
         else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3823,11 +3823,11 @@ class TestMaskedArrayMathMethods:
         assert_(np.ma.is_masked(a.anom()))
 
     def test_anom(self):
-        a = masked_array(np.arange(1,7).reshape(2,3))
-        assert_equal(a.anom(), [[-2.5, -1.5, -0.5], [ 0.5, 1.5, 2.5]])
+        a = masked_array(np.arange(1, 7).reshape(2, 3))
+        assert_equal(a.anom(), [[-2.5, -1.5, -0.5], [0.5, 1.5, 2.5]])
         assert_equal(a.anom(axis=0), [[-1.5, -1.5, -1.5], [1.5, 1.5, 1.5]])
-        assert_equal(a.anom(axis=1), [[-1., 0., 1.],[-1., 0., 1.]])
-        a.mask = [[0,0,1],[0,1,0]]
+        assert_equal(a.anom(axis=1), [[-1., 0., 1.], [-1., 0., 1.]])
+        a.mask = [[0, 0, 1], [0, 1, 0]]
         assert_equal(format(a.anom()), '[[-2.25 -1.25 --]\n [0.75 -- 2.75]]')
         assert_equal(format(a.anom(axis=0)), '[[-1.5 0.0 --]\n [1.5 -- 0.0]]')
         assert_equal(format(a.anom(axis=1)), '[[-0.5 0.5 --]\n [-1.0 -- 1.0]]')

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3814,13 +3814,23 @@ class TestMaskedArrayMathMethods:
         a = masked_array([1, 2, 3], dtype=object)
         assert_equal(a.mean(), 2)
         assert_equal(a.anom(), [-1, 0, 1])
-    
+
     def test_anom_shape(self):
         a = masked_array([1, 2, 3])
         assert_equal(a.anom().shape, a.shape)
         a.mask = True
         assert_equal(a.anom().shape, a.shape)
         assert_(np.ma.is_masked(a.anom()))
+
+    def test_anom(self):
+        a = masked_array(np.arange(1,7).reshape(2,3))
+        assert_equal(a.anom(), [[-2.5, -1.5, -0.5], [ 0.5, 1.5, 2.5]])
+        assert_equal(a.anom(axis=0), [[-1.5, -1.5, -1.5], [1.5, 1.5, 1.5]])
+        assert_equal(a.anom(axis=1), [[-1., 0., 1.],[-1., 0., 1.]])
+        a.mask = [[0,0,1],[0,1,0]]
+        assert_equal(format(a.anom()), '[[-2.25 -1.25 --]\n [0.75 -- 2.75]]')
+        assert_equal(format(a.anom(axis=0)), '[[-1.5 0.0 --]\n [1.5 -- 0.0]]')
+        assert_equal(format(a.anom(axis=1)), '[[-0.5 0.5 --]\n [-1.0 -- 1.0]]')
 
     def test_trace(self):
         # Tests trace on MaskedArrays.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3814,6 +3814,13 @@ class TestMaskedArrayMathMethods:
         a = masked_array([1, 2, 3], dtype=object)
         assert_equal(a.mean(), 2)
         assert_equal(a.anom(), [-1, 0, 1])
+    
+    def test_anom_shape(self):
+        a = masked_array([1, 2, 3])
+        assert_equal(a.anom().shape, a.shape)
+        a.mask = True
+        assert_equal(a.anom().shape, a.shape)
+        assert_(np.ma.is_masked(a.anom()))
 
     def test_trace(self):
         # Tests trace on MaskedArrays.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3824,13 +3824,20 @@ class TestMaskedArrayMathMethods:
 
     def test_anom(self):
         a = masked_array(np.arange(1, 7).reshape(2, 3))
-        assert_equal(a.anom(), [[-2.5, -1.5, -0.5], [0.5, 1.5, 2.5]])
-        assert_equal(a.anom(axis=0), [[-1.5, -1.5, -1.5], [1.5, 1.5, 1.5]])
-        assert_equal(a.anom(axis=1), [[-1., 0., 1.], [-1., 0., 1.]])
+        assert_almost_equal(a.anom(),
+                            [[-2.5, -1.5, -0.5], [0.5, 1.5, 2.5]])
+        assert_almost_equal(a.anom(axis=0),
+                            [[-1.5, -1.5, -1.5], [1.5, 1.5, 1.5]])
+        assert_almost_equal(a.anom(axis=1),
+                            [[-1., 0., 1.], [-1., 0., 1.]])
         a.mask = [[0, 0, 1], [0, 1, 0]]
-        assert_equal(format(a.anom()), '[[-2.25 -1.25 --]\n [0.75 -- 2.75]]')
-        assert_equal(format(a.anom(axis=0)), '[[-1.5 0.0 --]\n [1.5 -- 0.0]]')
-        assert_equal(format(a.anom(axis=1)), '[[-0.5 0.5 --]\n [-1.0 -- 1.0]]')
+        mval = -99
+        assert_almost_equal(a.anom().filled(mval),
+                            [[-2.25, -1.25, mval], [0.75, mval, 2.75]])
+        assert_almost_equal(a.anom(axis=0).filled(mval),
+                            [[-1.5, 0.0, mval], [1.5, mval, 0.0]])
+        assert_almost_equal(a.anom(axis=1).filled(mval),
+                            [[-0.5, 0.5, mval], [-1.0, mval, 1.0]])
 
     def test_trace(self):
         # Tests trace on MaskedArrays.


### PR DESCRIPTION
Fixes [#10481](https://github.com/numpy/numpy/issues/10481)