### PR TITLE
DOC: Clarify minimum numpy version needed to use random c-api

### DIFF
--- a/doc/source/reference/random/c-api.rst
+++ b/doc/source/reference/random/c-api.rst
@@ -3,7 +3,7 @@ C API for random
 
 .. currentmodule:: numpy.random
 
-Access to various distributions below is available via Cython or C-wrapper
+Since version ``1.19.0``, access to various distributions below is available via Cython or C-wrapper
 libraries like CFFI. All the functions accept a :c:type:`bitgen_t` as their
 first argument.  To access these from Cython or C, you must link with the
 ``npyrandom`` library which is part of the NumPy distribution, located in

--- a/doc/source/reference/random/c-api.rst
+++ b/doc/source/reference/random/c-api.rst
@@ -3,7 +3,9 @@ C API for random
 
 .. currentmodule:: numpy.random
 
-Since version ``1.19.0``, access to various distributions below is available via Cython or C-wrapper
+.. versionadded:: 1.19.0
+
+Access to various distributions below is available via Cython or C-wrapper
 libraries like CFFI. All the functions accept a :c:type:`bitgen_t` as their
 first argument.  To access these from Cython or C, you must link with the
 ``npyrandom`` library which is part of the NumPy distribution, located in


### PR DESCRIPTION
This PR clarifies the minimum version of numpy needed to use the random c-api. See https://github.com/numpy/numpy/issues/17140#issuecomment-842197400 and https://github.com/numpy/numpy/issues/17140#issuecomment-842340164.



Is this enough or does this need a ``..versionadded:: 1.19.0`` line somewhere on the same page @rkern ?
