### PR TITLE
DEP: Deprecate 4 `ndarray.ctypes` methods

### DIFF
--- a/doc/release/upcoming_changes/19031.deprecation.rst
+++ b/doc/release/upcoming_changes/19031.deprecation.rst
@@ -2,7 +2,7 @@ Four `ndarray.ctypes` methods have been deprecated
 --------------------------------------------------
 Four methods of the `ndarray.ctypes` object have been deprecated,
 as they are (undocumentated) implementation artifacts of their respective
-property.
+properties.
 
 The methods in question are:
 

--- a/doc/release/upcoming_changes/xxxxx.deprecation.rst
+++ b/doc/release/upcoming_changes/xxxxx.deprecation.rst
@@ -1,0 +1,12 @@
+Four `ndarray.ctypes` methods have been deprecated
+--------------------------------------------------
+Four methods of the `ndarray.ctypes` object have been deprecated,
+as they are (undocumentated) implementation artifacts of their respective
+property.
+
+The methods in question are:
+
+* ``_ctypes.get_data`` (use ``_ctypes.data`` instead)
+* ``_ctypes.get_shape`` (use ``_ctypes.shape`` instead)
+* ``_ctypes.get_strides`` (use ``_ctypes.strides`` instead)
+* ``_ctypes.get_as_parameter`` (use ``_ctypes._as_parameter_`` instead)

--- a/doc/source/user/misc.rst
+++ b/doc/source/user/misc.rst
@@ -149,11 +149,12 @@ Only a survey of the choices. Little detail on how each works.
    - good numpy support: arrays have all these in their ctypes
      attribute: ::
 
-       a.ctypes.data              a.ctypes.get_strides
-       a.ctypes.data_as           a.ctypes.shape
-       a.ctypes.get_as_parameter  a.ctypes.shape_as
-       a.ctypes.get_data          a.ctypes.strides
-       a.ctypes.get_shape         a.ctypes.strides_as
+       a.ctypes.data
+       a.ctypes.data_as
+       a.ctypes.shape
+       a.ctypes.shape_as
+       a.ctypes.strides
+       a.ctypes.strides_as
 
  - Minuses:
 

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -246,15 +246,6 @@ class _missing_ctypes:
             self.value = ptr
 
 
-# A dict mapping (deprecated) property getters to their respective property
-_CTYPES_DEPRECATED = {
-    "get_data": "data",
-    "get_shape": "shape",
-    "get_strides": "strides",
-    "get_as_parameter": "_as_parameter_",
-}
-
-
 class _ctypes:
     def __init__(self, array, ptr=None):
         self._arr = array
@@ -272,16 +263,6 @@ class _ctypes:
             self._zerod = True
         else:
             self._zerod = False
-
-    def __getattr__(self, name):
-        # Numpy 1.21.0, 2021-05-18
-        if name in _CTYPES_DEPRECATED:
-            name_new = _CTYPES_DEPRECATED[name]
-            warnings.warn(f"{name!r} is deprecated. Use {name_new!r} instead",
-                          DeprecationWarning, stacklevel=2)
-            return getattr(type(self), name_new).fget
-        else:
-            return super().__getattribute__(name)
 
     def data_as(self, obj):
         """
@@ -369,6 +350,46 @@ class _ctypes:
         Enables `c_func(some_array.ctypes)`
         """
         return self.data_as(ctypes.c_void_p)
+
+    # Numpy 1.21.0, 2021-05-18
+
+    def get_data(self):
+        """Deprecated getter for the `_ctypes.data` property.
+
+        .. deprecated:: 1.21
+        """
+        warnings.warn('"get_data" is deprecated. Use "data" instead',
+                      DeprecationWarning, stacklevel=2)
+        return self.data
+
+    def get_shape(self):
+        """Deprecated getter for `_ctypes.shape` property.
+
+        .. deprecated:: 1.21
+        """
+        warnings.warn('"get_shape" is deprecated. Use "shape" instead',
+                      DeprecationWarning, stacklevel=2)
+        return self.shape
+
+    def get_strides(self):
+        """Deprecated getter for `_ctypes.strides` property.
+
+        .. deprecated:: 1.21
+        """
+        warnings.warn('"get_strides" is deprecated. Use "strides" instead',
+                      DeprecationWarning, stacklevel=2)
+        return self.strides
+
+    def get_as_parameter(self):
+        """Deprecated getter for `_ctypes._as_parameter_` property.
+
+        .. deprecated:: 1.21
+        """
+        warnings.warn(
+            '"get_as_parameter" is deprecated. Use "_as_parameter_" instead',
+            DeprecationWarning, stacklevel=2,
+        )
+        return self._as_parameter_
 
 
 def _newnames(datatype, order):

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -363,7 +363,7 @@ class _ctypes:
         return self.data
 
     def get_shape(self):
-        """Deprecated getter for `_ctypes.shape` property.
+        """Deprecated getter for the `_ctypes.shape` property.
 
         .. deprecated:: 1.21
         """
@@ -372,7 +372,7 @@ class _ctypes:
         return self.shape
 
     def get_strides(self):
-        """Deprecated getter for `_ctypes.strides` property.
+        """Deprecated getter for the `_ctypes.strides` property.
 
         .. deprecated:: 1.21
         """
@@ -381,7 +381,7 @@ class _ctypes:
         return self.strides
 
     def get_as_parameter(self):
-        """Deprecated getter for `_ctypes._as_parameter_` property.
+        """Deprecated getter for the `_ctypes._as_parameter_` property.
 
         .. deprecated:: 1.21
         """

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -273,13 +273,15 @@ class _ctypes:
         else:
             self._zerod = False
 
-    def __getattribute__(self, name):
+    def __getattr__(self, name):
         # Numpy 1.21.0, 2021-05-18
         if name in _CTYPES_DEPRECATED:
             name_new = _CTYPES_DEPRECATED[name]
             warnings.warn(f"{name!r} is deprecated. Use {name_new!r} instead",
                           DeprecationWarning, stacklevel=2)
-        return super().__getattribute__(name)
+            return getattr(type(self), name_new).fget
+        else:
+            return super().__getattribute__(name)
 
     def data_as(self, obj):
         """
@@ -367,12 +369,6 @@ class _ctypes:
         Enables `c_func(some_array.ctypes)`
         """
         return self.data_as(ctypes.c_void_p)
-
-    # kept for compatibility
-    get_data = data.fget
-    get_shape = shape.fget
-    get_strides = strides.fget
-    get_as_parameter = _as_parameter_.fget
 
 
 def _newnames(datatype, order):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -906,7 +906,7 @@ else:
 class TestNoseDecoratorsDeprecated(_DeprecationTestCase):
     class DidntSkipException(Exception):
         pass
-    
+
     def test_slow(self):
         def _test_slow():
             @np.testing.dec.slow
@@ -1172,3 +1172,21 @@ class TestComparisonBadObjectDType(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.equal(1, 1, dtype=object))
         self.assert_deprecated(
                 lambda: np.equal(1, 1, sig=(None, None, object)))
+
+
+class TestCtypesGetter(_DeprecationTestCase):
+    # Deprecated 2021-05-18, Numpy 1.21.0
+    warning_cls = DeprecationWarning
+    ctypes = np.array([1]).ctypes
+
+    @pytest.mark.parametrize(
+        "name", ["get_data", "get_shape", "get_strides", "get_as_parameter"]
+    )
+    def test_deprecated(self, name: str) -> None:
+        self.assert_deprecated(lambda: getattr(self.ctypes, name))
+
+    @pytest.mark.parametrize(
+        "name", ["data", "shape", "strides", "_as_parameter_"]
+    )
+    def test_not_deprecated(self, name: str) -> None:
+        self.assert_not_deprecated(lambda: getattr(self.ctypes, name))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1183,7 +1183,8 @@ class TestCtypesGetter(_DeprecationTestCase):
         "name", ["get_data", "get_shape", "get_strides", "get_as_parameter"]
     )
     def test_deprecated(self, name: str) -> None:
-        self.assert_deprecated(lambda: getattr(self.ctypes, name))
+        func = getattr(self.ctypes, name)
+        self.assert_deprecated(lambda: func())
 
     @pytest.mark.parametrize(
         "name", ["data", "shape", "strides", "_as_parameter_"]


### PR DESCRIPTION
Xref https://github.com/numpy/numpy/pull/19029#discussion_r634396040.

Four methods of the [`ndarray.ctypes`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.ctypes.html) object have been deprecated, as they are (undocumentated) implementation artifacts of their respective property. They were originally kept around for the sake of backwards compatibility (https://github.com/numpy/numpy/commit/79baef7a80769842f1c7f14e31056e4750a122e8), but as this was three years ago it should be safe to formally deprecate them by now.

https://github.com/numpy/numpy/blob/bfb1ac86588456a78af63fa314b768f4ebc764ff/numpy/core/_internal.py#L353-L357
