### PR TITLE
MAINT: Python3 classes do not need to inherit from object

### DIFF
--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -478,7 +478,7 @@ are not compatible, i.e., implementations should be something like::
         except AttributeError:
             return False
 
-    class ArrayLike(object):
+    class ArrayLike:
         ...
         def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
             ...
@@ -516,7 +516,7 @@ does not know how to deal with arrays and ufuncs, and thus has set
 ``__array_ufunc__`` to :obj:`None`, but does know how to do
 multiplication::
 
-    class MyObject(object):
+    class MyObject:
         __array_ufunc__ = None
         def __init__(self, value):
             self.value = value

--- a/numpy/core/tests/test_cpu_features.py
+++ b/numpy/core/tests/test_cpu_features.py
@@ -48,7 +48,7 @@ def assert_features_equal(actual, desired, fname):
         "%s"
     ) % (fname, actual, desired, error_report))
 
-class AbstractTest(object):
+class AbstractTest:
     features = []
     features_groups = {}
     features_map = {}

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -2462,7 +2462,7 @@ class TestRegression:
             np.array([T()])
 
     def test_2d__array__shape(self):
-        class T(object):
+        class T:
             def __array__(self):
                 return np.ndarray(shape=(0,0))
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2203,7 +2203,7 @@ class TestSpecialMethods:
 
     def test_array_too_many_args(self):
 
-        class A(object):
+        class A:
             def __array__(self, dtype, context):
                 return np.zeros(1)
 
@@ -3220,7 +3220,7 @@ class TestSubclass:
         assert_equal(a+a, a)
 
 
-class TestFrompyfunc(object):
+class TestFrompyfunc:
 
     def test_identity(self):
         def mul(a, b):

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -541,7 +541,7 @@ def check_complex_value(f, x1, y1, x2, y2, exact=True):
         else:
             assert_almost_equal(f(z1), z2)
 
-class TestSpecialComplexAVX(object):
+class TestSpecialComplexAVX:
     @pytest.mark.parametrize("stride", [-4,-2,-1,1,2,4])
     @pytest.mark.parametrize("astype", [np.complex64, np.complex128])
     def test_array(self, stride, astype):
@@ -568,7 +568,7 @@ class TestSpecialComplexAVX(object):
         with np.errstate(invalid='ignore'):
             assert_equal(np.square(arr[::stride]), sq_true[::stride])
 
-class TestComplexAbsoluteAVX(object):
+class TestComplexAbsoluteAVX:
     @pytest.mark.parametrize("arraysize", [1,2,3,4,5,6,7,8,9,10,11,13,15,17,18,19])
     @pytest.mark.parametrize("stride", [-4,-3,-2,-1,1,2,3,4])
     @pytest.mark.parametrize("astype", [np.complex64, np.complex128])
@@ -579,7 +579,7 @@ class TestComplexAbsoluteAVX(object):
         assert_equal(np.abs(arr[::stride]), abs_true[::stride])
 
 # Testcase taken as is from https://github.com/numpy/numpy/issues/16660
-class TestComplexAbsoluteMixedDTypes(object):
+class TestComplexAbsoluteMixedDTypes:
     @pytest.mark.parametrize("stride", [-4,-3,-2,-1,1,2,3,4])
     @pytest.mark.parametrize("astype", [np.complex64, np.complex128])
     @pytest.mark.parametrize("func", ['abs', 'square', 'conjugate'])

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -850,7 +850,7 @@ class _Cache:
             return ccb
         return cache_wrap_me
 
-class _CCompiler(object):
+class _CCompiler:
     """A helper class for `CCompilerOpt` containing all utilities that
     related to the fundamental compiler's functions.
 

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -73,7 +73,7 @@ class FakeCCompilerOpt(CCompilerOpt):
     def dist_log(*args, stderr=False):
         pass
 
-class _Test_CCompilerOpt(object):
+class _Test_CCompilerOpt:
     arch = None # x86_64
     cc   = None # gcc
 

--- a/tools/travis-sorter.py
+++ b/tools/travis-sorter.py
@@ -103,7 +103,7 @@ def summarise(jobs):
     print("   " + "-" * end)
 
 
-class Job(object):
+class Job:
     def __init__(self, length):
         global count
         self.id = count


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3 (and the docs don't use that style [here](https://docs.python.org/3/tutorial/classes.html) or [here](https://docs.python.org/3/howto/descriptor.html)).

Edits were automated using:

    git ls-files -z | xargs -0 sed -i -re 's/class (.*)\(object\):/class \1:/g'