### PR TITLE
BUG: fix string truncation bug in loadtxt

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1149,6 +1149,14 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             if X is None:
                 X = np.array(x, dtype)
             else:
+                # If using unsized string or byte dtype, make sure that the
+                # existing array is capable of storing the new data. If not,
+                # change the dtype so it is capable of doing so.
+                if (dtype.type in (np.str_, np.bytes_)
+                        and dtype.itemsize == 0):
+                    x = np.array(x, dtype)
+                    if x.dtype.itemsize > X.dtype.itemsize:
+                        X = X.astype(x.dtype)
                 nshape = list(X.shape)
                 pos = nshape[0]
                 nshape[0] += len(x)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -918,6 +918,14 @@ class TestLoadTxt(LoadTxtBase):
             x = np.loadtxt(c, dtype=dt)
             assert_array_equal(x, a)
 
+    def test_str_dtype_differing_lengths(self):
+        c = ["str1", "str2", "str3verylong"]
+
+        for dt in (str, np.bytes_):
+            a = np.array(["str1", "str2", "str3verylong"], dtype=dt)
+            x = np.loadtxt(c, dtype=dt)
+            assert_array_equal(x, a)
+
     def test_empty_file(self):
         with suppress_warnings() as sup:
             sup.filter(message="loadtxt: Empty input file:")


### PR DESCRIPTION
Closes #17277. If loadtxt is passed an unsized string or byte dtype,
the size is set automatically from the longest entry in the first
50000 lines. If longer entries appeared later, they were silently
truncated.
