### PR TITLE
DOC: Fix typo in release notes for v1.21

### DIFF
--- a/doc/release/upcoming_changes/17727.performance.rst
+++ b/doc/release/upcoming_changes/17727.performance.rst
@@ -1,7 +1,7 @@
 Improved performance in integer division of NumPy arrays
 --------------------------------------------------------
 Integer division of NumPy arrays now uses `libdivide <https://libdivide.com/>` 
-when the divisor is a constant. With the usage of libdivde and
+when the divisor is a constant. With the usage of libdivide and
 other minor optimizations, there is a large speedup.
 The ``//`` operator and ``np.floor_divide`` makes use
 of the new changes.


### PR DESCRIPTION
libdivde -> libdivide