### PR TITLE
BLD,API: (distutils) Force strict floating point error model on clang

### DIFF
--- a/doc/release/upcoming_changes/19049.compatibility.rst
+++ b/doc/release/upcoming_changes/19049.compatibility.rst
@@ -1,0 +1,6 @@
+Distutils forces strict floating point model on clang
+-----------------------------------------------------
+NumPy distutils will now always add the ``-ffp-exception-behavior=strict``
+compiler flag when compiling with clang.  Clang defaults to a non-strict
+version, which allows the compiler to generate code that does not set
+floating point warnings/errors correctly.

--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -384,6 +384,12 @@ def CCompiler_customize_cmd(self, cmd, ignore=()):
     """
     log.info('customize %s using %s' % (self.__class__.__name__,
                                         cmd.__class__.__name__))
+
+    if hasattr(self, 'compiler') and 'clang' in self.compiler[0]:
+        # clang defaults to a non-strict floating error point model.
+        # Since NumPy and most Python libs give warnings for these, override:
+        self.compiler.append('-ffp-exception-behavior=strict')
+
     def allow(attr):
         return getattr(cmd, attr, None) is not None and attr not in ignore
 


### PR DESCRIPTION
I am not quite sure this is the right way to do it, it feels hackish... but distutils tends to I guess.

~I tried removing some of the hacks that were probably in place just because of the missing compile time flag, so hopefully this will work out.~  Do we test clang properly in CI? Otherwise we will have to double check before merging (I would have to set up clang first).

Closes gh-18005