### PR TITLE
BUG: Fixes to getter signatures

### DIFF
--- a/numpy/core/src/_simd/_simd_vector.inc
+++ b/numpy/core/src/_simd/_simd_vector.inc
@@ -33,7 +33,7 @@ static PySequenceMethods simd__vector_as_sequence = {
 };
 
 static PyObject *
-simd__vector_name(PySIMDVectorObject *self)
+simd__vector_name(PySIMDVectorObject *self, void *NPY_UNUSED(ignored))
 {
     return PyUnicode_FromString(simd_data_getinfo(self->dtype)->pyname);
 }

--- a/numpy/core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/core/src/multiarray/datetime_busdaycal.c
@@ -434,7 +434,7 @@ busdaycalendar_dealloc(NpyBusDayCalendar *self)
 }
 
 static PyObject *
-busdaycalendar_weekmask_get(NpyBusDayCalendar *self)
+busdaycalendar_weekmask_get(NpyBusDayCalendar *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
     npy_intp size = 7;
@@ -452,7 +452,7 @@ busdaycalendar_weekmask_get(NpyBusDayCalendar *self)
 }
 
 static PyObject *
-busdaycalendar_holidays_get(NpyBusDayCalendar *self)
+busdaycalendar_holidays_get(NpyBusDayCalendar *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
     PyArray_Descr *date_dtype;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1895,7 +1895,7 @@ static PyMemberDef arraydescr_members[] = {
 };
 
 static PyObject *
-arraydescr_subdescr_get(PyArray_Descr *self)
+arraydescr_subdescr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (!PyDataType_HASSUBARRAY(self)) {
         Py_RETURN_NONE;
@@ -1905,7 +1905,7 @@ arraydescr_subdescr_get(PyArray_Descr *self)
 }
 
 NPY_NO_EXPORT PyObject *
-arraydescr_protocol_typestr_get(PyArray_Descr *self)
+arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     char basic_ = self->kind;
     char endian = self->byteorder;
@@ -1951,7 +1951,7 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_name_get(PyArray_Descr *self)
+arraydescr_name_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     /* let python handle this */
     PyObject *_numpy_dtype;
@@ -1966,7 +1966,7 @@ arraydescr_name_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_base_get(PyArray_Descr *self)
+arraydescr_base_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (!PyDataType_HASSUBARRAY(self)) {
         Py_INCREF(self);
@@ -1977,7 +1977,7 @@ arraydescr_base_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_shape_get(PyArray_Descr *self)
+arraydescr_shape_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (!PyDataType_HASSUBARRAY(self)) {
         return PyTuple_New(0);
@@ -1988,7 +1988,7 @@ arraydescr_shape_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_ndim_get(PyArray_Descr *self)
+arraydescr_ndim_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     Py_ssize_t ndim;
 
@@ -2006,7 +2006,7 @@ arraydescr_ndim_get(PyArray_Descr *self)
 
 
 NPY_NO_EXPORT PyObject *
-arraydescr_protocol_descr_get(PyArray_Descr *self)
+arraydescr_protocol_descr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     PyObject *dobj, *res;
     PyObject *_numpy_internal;
@@ -2018,7 +2018,7 @@ arraydescr_protocol_descr_get(PyArray_Descr *self)
             return NULL;
         }
         PyTuple_SET_ITEM(dobj, 0, PyUnicode_FromString(""));
-        PyTuple_SET_ITEM(dobj, 1, arraydescr_protocol_typestr_get(self));
+        PyTuple_SET_ITEM(dobj, 1, arraydescr_protocol_typestr_get(self, NULL));
         res = PyList_New(1);
         if (res == NULL) {
             Py_DECREF(dobj);
@@ -2043,7 +2043,7 @@ arraydescr_protocol_descr_get(PyArray_Descr *self)
  * return 0 if neither (i.e. it's a copy of one)
  */
 static PyObject *
-arraydescr_isbuiltin_get(PyArray_Descr *self)
+arraydescr_isbuiltin_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     long val;
     val = 0;
@@ -2090,7 +2090,7 @@ _arraydescr_isnative(PyArray_Descr *self)
  * fields are defined
  */
 static PyObject *
-arraydescr_isnative_get(PyArray_Descr *self)
+arraydescr_isnative_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
     int retval;
@@ -2104,7 +2104,7 @@ arraydescr_isnative_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_isalignedstruct_get(PyArray_Descr *self)
+arraydescr_isalignedstruct_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
     ret = (self->flags&NPY_ALIGNED_STRUCT) ? Py_True : Py_False;
@@ -2113,7 +2113,7 @@ arraydescr_isalignedstruct_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_fields_get(PyArray_Descr *self)
+arraydescr_fields_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (!PyDataType_HASFIELDS(self)) {
         Py_RETURN_NONE;
@@ -2122,7 +2122,7 @@ arraydescr_fields_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_metadata_get(PyArray_Descr *self)
+arraydescr_metadata_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (self->metadata == NULL) {
         Py_RETURN_NONE;
@@ -2131,7 +2131,7 @@ arraydescr_metadata_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_hasobject_get(PyArray_Descr *self)
+arraydescr_hasobject_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (PyDataType_FLAGCHK(self, NPY_ITEM_HASOBJECT)) {
         Py_RETURN_TRUE;
@@ -2142,7 +2142,7 @@ arraydescr_hasobject_get(PyArray_Descr *self)
 }
 
 static PyObject *
-arraydescr_names_get(PyArray_Descr *self)
+arraydescr_names_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
     if (!PyDataType_HASFIELDS(self)) {
         Py_RETURN_NONE;
@@ -2152,7 +2152,8 @@ arraydescr_names_get(PyArray_Descr *self)
 }
 
 static int
-arraydescr_names_set(PyArray_Descr *self, PyObject *val)
+arraydescr_names_set(
+        PyArray_Descr *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     int N = 0;
     int i;
@@ -2536,7 +2537,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
     }
 
     PyTuple_SET_ITEM(state, 1, PyUnicode_FromFormat("%c", endian));
-    PyTuple_SET_ITEM(state, 2, arraydescr_subdescr_get(self));
+    PyTuple_SET_ITEM(state, 2, arraydescr_subdescr_get(self, NULL));
     if (PyDataType_HASFIELDS(self)) {
         Py_INCREF(self->names);
         Py_INCREF(self->fields);

--- a/numpy/core/src/multiarray/descriptor.h
+++ b/numpy/core/src/multiarray/descriptor.h
@@ -1,8 +1,10 @@
 #ifndef _NPY_ARRAYDESCR_H_
 #define _NPY_ARRAYDESCR_H_
 
-NPY_NO_EXPORT PyObject *arraydescr_protocol_typestr_get(PyArray_Descr *);
-NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(PyArray_Descr *self);
+NPY_NO_EXPORT PyObject *arraydescr_protocol_typestr_get(
+        PyArray_Descr *, void *);
+NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(
+        PyArray_Descr *self, void *);
 
 NPY_NO_EXPORT PyObject *
 array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -200,7 +200,8 @@ arrayflags_dealloc(PyArrayFlagsObject *self)
 
 #define _define_get(UPPER, lower) \
     static PyObject * \
-    arrayflags_ ## lower ## _get(PyArrayFlagsObject *self) \
+    arrayflags_ ## lower ## _get( \
+            PyArrayFlagsObject *self, void *NPY_UNUSED(ignored)) \
     { \
         return PyBool_FromLong((self->flags & (UPPER)) == (UPPER)); \
     }
@@ -211,7 +212,8 @@ static char *msg = "future versions will not create a writeable "
 
 #define _define_get_warn(UPPER, lower) \
     static PyObject * \
-    arrayflags_ ## lower ## _get(PyArrayFlagsObject *self) \
+    arrayflags_ ## lower ## _get( \
+            PyArrayFlagsObject *self, void *NPY_UNUSED(ignored)) \
     { \
         if (self->flags & NPY_ARRAY_WARN_ON_WRITE) { \
             if (PyErr_Warn(PyExc_FutureWarning, msg) < 0) {\
@@ -236,7 +238,7 @@ _define_get_warn(NPY_ARRAY_ALIGNED|
             NPY_ARRAY_C_CONTIGUOUS, carray)
 
 static PyObject *
-arrayflags_updateifcopy_get(PyArrayFlagsObject *self)
+arrayflags_updateifcopy_get(PyArrayFlagsObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *item;
     /* 2017-Nov-10 1.14 */
@@ -255,7 +257,7 @@ arrayflags_updateifcopy_get(PyArrayFlagsObject *self)
 
 
 static PyObject *
-arrayflags_forc_get(PyArrayFlagsObject *self)
+arrayflags_forc_get(PyArrayFlagsObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *item;
 
@@ -271,7 +273,7 @@ arrayflags_forc_get(PyArrayFlagsObject *self)
 }
 
 static PyObject *
-arrayflags_fnc_get(PyArrayFlagsObject *self)
+arrayflags_fnc_get(PyArrayFlagsObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *item;
 
@@ -287,7 +289,7 @@ arrayflags_fnc_get(PyArrayFlagsObject *self)
 }
 
 static PyObject *
-arrayflags_farray_get(PyArrayFlagsObject *self)
+arrayflags_farray_get(PyArrayFlagsObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *item;
 
@@ -305,14 +307,15 @@ arrayflags_farray_get(PyArrayFlagsObject *self)
 }
 
 static PyObject *
-arrayflags_num_get(PyArrayFlagsObject *self)
+arrayflags_num_get(PyArrayFlagsObject *self, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(self->flags);
 }
 
 /* relies on setflags order being write, align, uic */
 static int
-arrayflags_updateifcopy_set(PyArrayFlagsObject *self, PyObject *obj)
+arrayflags_updateifcopy_set(
+        PyArrayFlagsObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyObject *res;
 
@@ -341,7 +344,8 @@ arrayflags_updateifcopy_set(PyArrayFlagsObject *self, PyObject *obj)
 
 /* relies on setflags order being write, align, uic */
 static int
-arrayflags_writebackifcopy_set(PyArrayFlagsObject *self, PyObject *obj)
+arrayflags_writebackifcopy_set(
+        PyArrayFlagsObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyObject *res;
 
@@ -365,7 +369,8 @@ arrayflags_writebackifcopy_set(PyArrayFlagsObject *self, PyObject *obj)
 }
 
 static int
-arrayflags_aligned_set(PyArrayFlagsObject *self, PyObject *obj)
+arrayflags_aligned_set(
+        PyArrayFlagsObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyObject *res;
 
@@ -390,7 +395,8 @@ arrayflags_aligned_set(PyArrayFlagsObject *self, PyObject *obj)
 }
 
 static int
-arrayflags_writeable_set(PyArrayFlagsObject *self, PyObject *obj)
+arrayflags_writeable_set(
+        PyArrayFlagsObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyObject *res;
 
@@ -415,7 +421,8 @@ arrayflags_writeable_set(PyArrayFlagsObject *self, PyObject *obj)
 }
 
 static int
-arrayflags_warn_on_write_set(PyArrayFlagsObject *self, PyObject *obj)
+arrayflags_warn_on_write_set(
+        PyArrayFlagsObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     /*
      * This code should go away in a future release, so do not mangle the
@@ -554,89 +561,89 @@ arrayflags_getitem(PyArrayFlagsObject *self, PyObject *ind)
     case 1:
         switch(key[0]) {
         case 'C':
-            return arrayflags_contiguous_get(self);
+            return arrayflags_contiguous_get(self, NULL);
         case 'F':
-            return arrayflags_fortran_get(self);
+            return arrayflags_fortran_get(self, NULL);
         case 'W':
-            return arrayflags_writeable_get(self);
+            return arrayflags_writeable_get(self, NULL);
         case 'B':
-            return arrayflags_behaved_get(self);
+            return arrayflags_behaved_get(self, NULL);
         case 'O':
-            return arrayflags_owndata_get(self);
+            return arrayflags_owndata_get(self, NULL);
         case 'A':
-            return arrayflags_aligned_get(self);
+            return arrayflags_aligned_get(self, NULL);
         case 'X':
-            return arrayflags_writebackifcopy_get(self);
+            return arrayflags_writebackifcopy_get(self, NULL);
         case 'U':
-            return arrayflags_updateifcopy_get(self);
+            return arrayflags_updateifcopy_get(self, NULL);
         default:
             goto fail;
         }
         break;
     case 2:
         if (strncmp(key, "CA", n) == 0) {
-            return arrayflags_carray_get(self);
+            return arrayflags_carray_get(self, NULL);
         }
         if (strncmp(key, "FA", n) == 0) {
-            return arrayflags_farray_get(self);
+            return arrayflags_farray_get(self, NULL);
         }
         break;
     case 3:
         if (strncmp(key, "FNC", n) == 0) {
-            return arrayflags_fnc_get(self);
+            return arrayflags_fnc_get(self, NULL);
         }
         break;
     case 4:
         if (strncmp(key, "FORC", n) == 0) {
-            return arrayflags_forc_get(self);
+            return arrayflags_forc_get(self, NULL);
         }
         break;
     case 6:
         if (strncmp(key, "CARRAY", n) == 0) {
-            return arrayflags_carray_get(self);
+            return arrayflags_carray_get(self, NULL);
         }
         if (strncmp(key, "FARRAY", n) == 0) {
-            return arrayflags_farray_get(self);
+            return arrayflags_farray_get(self, NULL);
         }
         break;
     case 7:
         if (strncmp(key,"FORTRAN",n) == 0) {
-            return arrayflags_fortran_get(self);
+            return arrayflags_fortran_get(self, NULL);
         }
         if (strncmp(key,"BEHAVED",n) == 0) {
-            return arrayflags_behaved_get(self);
+            return arrayflags_behaved_get(self, NULL);
         }
         if (strncmp(key,"OWNDATA",n) == 0) {
-            return arrayflags_owndata_get(self);
+            return arrayflags_owndata_get(self, NULL);
         }
         if (strncmp(key,"ALIGNED",n) == 0) {
-            return arrayflags_aligned_get(self);
+            return arrayflags_aligned_get(self, NULL);
         }
         break;
     case 9:
         if (strncmp(key,"WRITEABLE",n) == 0) {
-            return arrayflags_writeable_get(self);
+            return arrayflags_writeable_get(self, NULL);
         }
         break;
     case 10:
         if (strncmp(key,"CONTIGUOUS",n) == 0) {
-            return arrayflags_contiguous_get(self);
+            return arrayflags_contiguous_get(self, NULL);
         }
         break;
     case 12:
         if (strncmp(key, "UPDATEIFCOPY", n) == 0) {
-            return arrayflags_updateifcopy_get(self);
+            return arrayflags_updateifcopy_get(self, NULL);
         }
         if (strncmp(key, "C_CONTIGUOUS", n) == 0) {
-            return arrayflags_contiguous_get(self);
+            return arrayflags_contiguous_get(self, NULL);
         }
         if (strncmp(key, "F_CONTIGUOUS", n) == 0) {
-            return arrayflags_fortran_get(self);
+            return arrayflags_fortran_get(self, NULL);
         }
         break;
     case 15:
         if (strncmp(key, "WRITEBACKIFCOPY", n) == 0) {
-            return arrayflags_writebackifcopy_get(self);
+            return arrayflags_writebackifcopy_get(self, NULL);
         }
         break;
     }
@@ -671,19 +678,19 @@ arrayflags_setitem(PyArrayFlagsObject *self, PyObject *ind, PyObject *item)
     }
     if (((n==9) && (strncmp(key, "WRITEABLE", n) == 0)) ||
         ((n==1) && (strncmp(key, "W", n) == 0))) {
-        return arrayflags_writeable_set(self, item);
+        return arrayflags_writeable_set(self, item, NULL);
     }
     else if (((n==7) && (strncmp(key, "ALIGNED", n) == 0)) ||
              ((n==1) && (strncmp(key, "A", n) == 0))) {
-        return arrayflags_aligned_set(self, item);
+        return arrayflags_aligned_set(self, item, NULL);
     }
     else if (((n==12) && (strncmp(key, "UPDATEIFCOPY", n) == 0)) ||
              ((n==1) && (strncmp(key, "U", n) == 0))) {
-        return arrayflags_updateifcopy_set(self, item);
+        return arrayflags_updateifcopy_set(self, item, NULL);
     }
     else if (((n==15) && (strncmp(key, "WRITEBACKIFCOPY", n) == 0)) ||
              ((n==1) && (strncmp(key, "X", n) == 0))) {
-        return arrayflags_writebackifcopy_set(self, item);
+        return arrayflags_writebackifcopy_set(self, item, NULL);
     }
 
  fail:

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -26,26 +26,26 @@
 /*******************  array attribute get and set routines ******************/
 
 static PyObject *
-array_ndim_get(PyArrayObject *self)
+array_ndim_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(PyArray_NDIM(self));
 }
 
 static PyObject *
-array_flags_get(PyArrayObject *self)
+array_flags_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_NewFlagsObject((PyObject *)self);
 }
 
 static PyObject *
-array_shape_get(PyArrayObject *self)
+array_shape_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_IntTupleFromIntp(PyArray_NDIM(self), PyArray_DIMS(self));
 }
 
 
 static int
-array_shape_set(PyArrayObject *self, PyObject *val)
+array_shape_set(PyArrayObject *self, PyObject *val, void* NPY_UNUSED(ignored))
 {
     int nd;
     PyArrayObject *ret;
@@ -103,13 +103,13 @@ array_shape_set(PyArrayObject *self, PyObject *val)
 
 
 static PyObject *
-array_strides_get(PyArrayObject *self)
+array_strides_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_IntTupleFromIntp(PyArray_NDIM(self), PyArray_STRIDES(self));
 }
 
 static int
-array_strides_set(PyArrayObject *self, PyObject *obj)
+array_strides_set(PyArrayObject *self, PyObject *obj, void *NPY_UNUSED(ignored))
 {
     PyArray_Dims newstrides = {NULL, -1};
     PyArrayObject *new;
@@ -182,7 +182,7 @@ array_strides_set(PyArrayObject *self, PyObject *obj)
 
 
 static PyObject *
-array_priority_get(PyArrayObject *NPY_UNUSED(self))
+array_priority_get(PyArrayObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyFloat_FromDouble(NPY_PRIORITY);
 }
@@ -190,11 +190,11 @@ array_priority_get(PyArrayObject *NPY_UNUSED(self))
 static PyObject *
 array_typestr_get(PyArrayObject *self)
 {
-    return arraydescr_protocol_typestr_get(PyArray_DESCR(self));
+    return arraydescr_protocol_typestr_get(PyArray_DESCR(self), NULL);
 }
 
 static PyObject *
-array_descr_get(PyArrayObject *self)
+array_descr_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(PyArray_DESCR(self));
     return (PyObject *)PyArray_DESCR(self);
@@ -206,7 +206,7 @@ array_protocol_descr_get(PyArrayObject *self)
     PyObject *res;
     PyObject *dobj;
 
-    res = arraydescr_protocol_descr_get(PyArray_DESCR(self));
+    res = arraydescr_protocol_descr_get(PyArray_DESCR(self), NULL);
     if (res) {
         return res;
     }
@@ -240,7 +240,7 @@ array_protocol_strides_get(PyArrayObject *self)
 
 
 static PyObject *
-array_dataptr_get(PyArrayObject *self)
+array_dataptr_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return Py_BuildValue("NO",
                          PyLong_FromVoidPtr(PyArray_DATA(self)),
@@ -250,7 +250,7 @@ array_dataptr_get(PyArrayObject *self)
 }
 
 static PyObject *
-array_ctypes_get(PyArrayObject *self)
+array_ctypes_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *_numpy_internal;
     PyObject *ret;
@@ -265,7 +265,7 @@ array_ctypes_get(PyArrayObject *self)
 }
 
 static PyObject *
-array_interface_get(PyArrayObject *self)
+array_interface_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *dict;
     PyObject *obj;
@@ -278,7 +278,7 @@ array_interface_get(PyArrayObject *self)
     int ret;
 
     /* dataptr */
-    obj = array_dataptr_get(self);
+    obj = array_dataptr_get(self, NULL);
     ret = PyDict_SetItemString(dict, "data", obj);
     Py_DECREF(obj);
     if (ret < 0) {
@@ -302,7 +302,7 @@ array_interface_get(PyArrayObject *self)
         return NULL;
     }
 
-    obj = arraydescr_protocol_typestr_get(PyArray_DESCR(self));
+    obj = arraydescr_protocol_typestr_get(PyArray_DESCR(self), NULL);
     ret = PyDict_SetItemString(dict, "typestr", obj);
     Py_DECREF(obj);
     if (ret < 0) {
@@ -310,7 +310,7 @@ array_interface_get(PyArrayObject *self)
         return NULL;
     }
 
-    obj = array_shape_get(self);
+    obj = array_shape_get(self, NULL);
     ret = PyDict_SetItemString(dict, "shape", obj);
     Py_DECREF(obj);
     if (ret < 0) {
@@ -330,13 +330,13 @@ array_interface_get(PyArrayObject *self)
 }
 
 static PyObject *
-array_data_get(PyArrayObject *self)
+array_data_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyMemoryView_FromObject((PyObject *)self);
 }
 
 static int
-array_data_set(PyArrayObject *self, PyObject *op)
+array_data_set(PyArrayObject *self, PyObject *op, void *NPY_UNUSED(ignored))
 {
     void *buf;
     Py_ssize_t buf_len;
@@ -411,19 +411,19 @@ array_data_set(PyArrayObject *self, PyObject *op)
 
 
 static PyObject *
-array_itemsize_get(PyArrayObject *self)
+array_itemsize_get(PyArrayObject *self, void* NPY_UNUSED(ignored))
 {
     return PyLong_FromLong((long) PyArray_DESCR(self)->elsize);
 }
 
 static PyObject *
-array_size_get(PyArrayObject *self)
+array_size_get(PyArrayObject *self, void* NPY_UNUSED(ignored))
 {
     return PyArray_PyIntFromIntp(PyArray_SIZE(self));
 }
 
 static PyObject *
-array_nbytes_get(PyArrayObject *self)
+array_nbytes_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_PyIntFromIntp(PyArray_NBYTES(self));
 }
@@ -438,7 +438,7 @@ array_nbytes_get(PyArrayObject *self)
  * will be adjusted in that case as well.
  */
 static int
-array_descr_set(PyArrayObject *self, PyObject *arg)
+array_descr_set(PyArrayObject *self, PyObject *arg, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *newtype = NULL;
 
@@ -598,7 +598,7 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
 }
 
 static PyObject *
-array_struct_get(PyArrayObject *self)
+array_struct_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayInterface *inter;
 
@@ -641,7 +641,7 @@ array_struct_get(PyArrayObject *self)
     }
     inter->data = PyArray_DATA(self);
     if (PyDataType_HASFIELDS(PyArray_DESCR(self))) {
-        inter->descr = arraydescr_protocol_descr_get(PyArray_DESCR(self));
+        inter->descr = arraydescr_protocol_descr_get(PyArray_DESCR(self), NULL);
         if (inter->descr == NULL) {
             PyErr_Clear();
         }
@@ -664,7 +664,7 @@ array_struct_get(PyArrayObject *self)
 }
 
 static PyObject *
-array_base_get(PyArrayObject *self)
+array_base_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     if (PyArray_BASE(self) == NULL) {
         Py_RETURN_NONE;
@@ -734,7 +734,7 @@ _get_part(PyArrayObject *self, int imag)
  */
 
 static PyObject *
-array_real_get(PyArrayObject *self)
+array_real_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
 
@@ -750,7 +750,7 @@ array_real_get(PyArrayObject *self)
 
 
 static int
-array_real_set(PyArrayObject *self, PyObject *val)
+array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
     PyArrayObject *new;
@@ -788,7 +788,7 @@ array_real_set(PyArrayObject *self, PyObject *val)
 */
 
 static PyObject *
-array_imag_get(PyArrayObject *self)
+array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *ret;
 
@@ -816,7 +816,7 @@ array_imag_get(PyArrayObject *self)
 }
 
 static int
-array_imag_set(PyArrayObject *self, PyObject *val)
+array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     if (val == NULL) {
         PyErr_SetString(PyExc_AttributeError,
@@ -850,13 +850,13 @@ array_imag_set(PyArrayObject *self, PyObject *val)
 }
 
 static PyObject *
-array_flat_get(PyArrayObject *self)
+array_flat_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_IterNew((PyObject *)self);
 }
 
 static int
-array_flat_set(PyArrayObject *self, PyObject *val)
+array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr = NULL;
     int retval = -1;
@@ -928,7 +928,7 @@ array_flat_set(PyArrayObject *self, PyObject *val)
 }
 
 static PyObject *
-array_transpose_get(PyArrayObject *self)
+array_transpose_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_Transpose(self, NULL);
 }
@@ -937,7 +937,7 @@ array_transpose_get(PyArrayObject *self)
    --- default sub-class behavior
 */
 static PyObject *
-array_finalize_get(PyArrayObject *NPY_UNUSED(self))
+array_finalize_get(PyArrayObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     Py_RETURN_NONE;
 }

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1067,13 +1067,13 @@ static PyMemberDef iter_members[] = {
 };
 
 static PyObject *
-iter_index_get(PyArrayIterObject *self)
+iter_index_get(PyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_PyIntFromIntp(self->index);
 }
 
 static PyObject *
-iter_coords_get(PyArrayIterObject *self)
+iter_coords_get(PyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     int nd;
     nd = PyArray_NDIM(self->ao);
@@ -1413,25 +1413,25 @@ arraymultiter_dealloc(PyArrayMultiIterObject *multi)
 }
 
 static PyObject *
-arraymultiter_size_get(PyArrayMultiIterObject *self)
+arraymultiter_size_get(PyArrayMultiIterObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_PyIntFromIntp(self->size);
 }
 
 static PyObject *
-arraymultiter_index_get(PyArrayMultiIterObject *self)
+arraymultiter_index_get(PyArrayMultiIterObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_PyIntFromIntp(self->index);
 }
 
 static PyObject *
-arraymultiter_shape_get(PyArrayMultiIterObject *self)
+arraymultiter_shape_get(PyArrayMultiIterObject *self, void *NPY_UNUSED(ignored))
 {
     return PyArray_IntTupleFromIntp(self->nd, self->dimensions);
 }
 
 static PyObject *
-arraymultiter_iters_get(PyArrayMultiIterObject *self)
+arraymultiter_iters_get(PyArrayMultiIterObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *res;
     int i, n;

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1384,7 +1384,8 @@ npyiter_debug_print(NewNpyArrayIterObject *self)
 NPY_NO_EXPORT PyObject *
 npyiter_seq_item(NewNpyArrayIterObject *self, Py_ssize_t i);
 
-static PyObject *npyiter_value_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_value_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
 
@@ -1420,7 +1421,8 @@ static PyObject *npyiter_value_get(NewNpyArrayIterObject *self)
     return ret;
 }
 
-static PyObject *npyiter_operands_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_operands_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
 
@@ -1449,7 +1451,8 @@ static PyObject *npyiter_operands_get(NewNpyArrayIterObject *self)
     return ret;
 }
 
-static PyObject *npyiter_itviews_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_itviews_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
 
@@ -1508,10 +1511,11 @@ npyiter_next(NewNpyArrayIterObject *self)
     }
     self->started = 1;
 
-    return npyiter_value_get(self);
+    return npyiter_value_get(self, NULL);
 };
 
-static PyObject *npyiter_shape_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_shape_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     npy_intp ndim, shape[NPY_MAXDIMS];
 
@@ -1529,7 +1533,8 @@ static PyObject *npyiter_shape_get(NewNpyArrayIterObject *self)
     return NULL;
 }
 
-static PyObject *npyiter_multi_index_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_multi_index_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     npy_intp ndim, multi_index[NPY_MAXDIMS];
 
@@ -1565,7 +1570,8 @@ static PyObject *npyiter_multi_index_get(NewNpyArrayIterObject *self)
 }
 
 static int
-npyiter_multi_index_set(NewNpyArrayIterObject *self, PyObject *value)
+npyiter_multi_index_set(
+        NewNpyArrayIterObject *self, PyObject *value, void *NPY_UNUSED(ignored))
 {
     npy_intp idim, ndim, multi_index[NPY_MAXDIMS];
 
@@ -1620,7 +1626,8 @@ npyiter_multi_index_set(NewNpyArrayIterObject *self, PyObject *value)
     }
 }
 
-static PyObject *npyiter_index_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_index_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL || self->finished) {
         PyErr_SetString(PyExc_ValueError,
@@ -1639,7 +1646,9 @@ static PyObject *npyiter_index_get(NewNpyArrayIterObject *self)
     }
 }
 
-static int npyiter_index_set(NewNpyArrayIterObject *self, PyObject *value)
+static int
+npyiter_index_set(
+        NewNpyArrayIterObject *self, PyObject *value, void *NPY_UNUSED(ignored))
 {
     if (value == NULL) {
         PyErr_SetString(PyExc_AttributeError,
@@ -1678,7 +1687,8 @@ static int npyiter_index_set(NewNpyArrayIterObject *self, PyObject *value)
     }
 }
 
-static PyObject *npyiter_iterindex_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_iterindex_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL || self->finished) {
         PyErr_SetString(PyExc_ValueError,
@@ -1689,7 +1699,9 @@ static PyObject *npyiter_iterindex_get(NewNpyArrayIterObject *self)
     return PyLong_FromLong(NpyIter_GetIterIndex(self->iter));
 }
 
-static int npyiter_iterindex_set(NewNpyArrayIterObject *self, PyObject *value)
+static int
+npyiter_iterindex_set(
+        NewNpyArrayIterObject *self, PyObject *value, void *NPY_UNUSED(ignored))
 {
     npy_intp iterindex;
 
@@ -1722,7 +1734,8 @@ static int npyiter_iterindex_set(NewNpyArrayIterObject *self, PyObject *value)
     return 0;
 }
 
-static PyObject *npyiter_iterrange_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_iterrange_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     npy_intp istart = 0, iend = 0;
     PyObject *ret;
@@ -1746,7 +1759,9 @@ static PyObject *npyiter_iterrange_get(NewNpyArrayIterObject *self)
     return ret;
 }
 
-static int npyiter_iterrange_set(NewNpyArrayIterObject *self, PyObject *value)
+static int
+npyiter_iterrange_set(
+        NewNpyArrayIterObject *self, PyObject *value, void *NPY_UNUSED(ignored))
 {
     npy_intp istart = 0, iend = 0;
 
@@ -1788,7 +1803,9 @@ static int npyiter_iterrange_set(NewNpyArrayIterObject *self, PyObject *value)
     return 0;
 }
 
-static PyObject *npyiter_has_delayed_bufalloc_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_has_delayed_bufalloc_get(
+        NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1804,7 +1821,9 @@ static PyObject *npyiter_has_delayed_bufalloc_get(NewNpyArrayIterObject *self)
     }
 }
 
-static PyObject *npyiter_iterationneedsapi_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_iterationneedsapi_get(
+        NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1820,7 +1839,9 @@ static PyObject *npyiter_iterationneedsapi_get(NewNpyArrayIterObject *self)
     }
 }
 
-static PyObject *npyiter_has_multi_index_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_has_multi_index_get(
+        NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1836,7 +1857,8 @@ static PyObject *npyiter_has_multi_index_get(NewNpyArrayIterObject *self)
     }
 }
 
-static PyObject *npyiter_has_index_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_has_index_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1852,7 +1874,8 @@ static PyObject *npyiter_has_index_get(NewNpyArrayIterObject *self)
     }
 }
 
-static PyObject *npyiter_dtypes_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_dtypes_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret;
 
@@ -1881,7 +1904,8 @@ static PyObject *npyiter_dtypes_get(NewNpyArrayIterObject *self)
     return ret;
 }
 
-static PyObject *npyiter_ndim_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_ndim_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1892,7 +1916,8 @@ static PyObject *npyiter_ndim_get(NewNpyArrayIterObject *self)
     return PyLong_FromLong(NpyIter_GetNDim(self->iter));
 }
 
-static PyObject *npyiter_nop_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_nop_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1903,7 +1928,8 @@ static PyObject *npyiter_nop_get(NewNpyArrayIterObject *self)
     return PyLong_FromLong(NpyIter_GetNOp(self->iter));
 }
 
-static PyObject *npyiter_itersize_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_itersize_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1914,7 +1940,8 @@ static PyObject *npyiter_itersize_get(NewNpyArrayIterObject *self)
     return PyLong_FromLong(NpyIter_GetIterSize(self->iter));
 }
 
-static PyObject *npyiter_finished_get(NewNpyArrayIterObject *self)
+static PyObject *
+npyiter_finished_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->iter == NULL || !self->finished) {
         Py_RETURN_FALSE;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1054,19 +1054,19 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 }
 
 static PyObject *
-gentype_ndim_get(PyObject *NPY_UNUSED(self))
+gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(0);
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self))
+gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyArray_NewFlagsObject(NULL);
 }
 
 static PyObject *
-voidtype_flags_get(PyVoidScalarObject *self)
+voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *flagobj;
     flagobj = PyArrayFlags_Type.tp_alloc(&PyArrayFlags_Type, 0);
@@ -1079,7 +1079,7 @@ voidtype_flags_get(PyVoidScalarObject *self)
 }
 
 static PyObject *
-voidtype_dtypedescr_get(PyVoidScalarObject *self)
+voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self->descr);
     return (PyObject *)self->descr;
@@ -1087,7 +1087,7 @@ voidtype_dtypedescr_get(PyVoidScalarObject *self)
 
 
 static PyObject *
-inttype_numerator_get(PyObject *self)
+inttype_numerator_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self);
     return self;
@@ -1095,21 +1095,21 @@ inttype_numerator_get(PyObject *self)
 
 
 static PyObject *
-inttype_denominator_get(PyObject *self)
+inttype_denominator_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(1);
 }
 
 
 static PyObject *
-gentype_data_get(PyObject *self)
+gentype_data_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return PyMemoryView_FromObject(self);
 }
 
 
 static PyObject *
-gentype_itemsize_get(PyObject *self)
+gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1123,7 +1123,7 @@ gentype_itemsize_get(PyObject *self)
 }
 
 static PyObject *
-gentype_size_get(PyObject *NPY_UNUSED(self))
+gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(1);
 }
@@ -1132,7 +1132,7 @@ static PyObject *
 gentype_sizeof(PyObject *self)
 {
     Py_ssize_t nbytes;
-    PyObject * isz = gentype_itemsize_get(self);
+    PyObject * isz = gentype_itemsize_get(self, NULL);
     if (isz == NULL) {
         return NULL;
     }
@@ -1161,7 +1161,7 @@ gentype_struct_free(PyObject *ptr)
 }
 
 static PyObject *
-gentype_struct_get(PyObject *self)
+gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr;
     PyArrayInterface *inter;
@@ -1187,20 +1187,20 @@ gentype_struct_get(PyObject *self)
 }
 
 static PyObject *
-gentype_priority_get(PyObject *NPY_UNUSED(self))
+gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyFloat_FromDouble(NPY_SCALAR_PRIORITY);
 }
 
 static PyObject *
-gentype_shape_get(PyObject *NPY_UNUSED(self))
+gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyTuple_New(0);
 }
 
 
 static PyObject *
-gentype_interface_get(PyObject *self)
+gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr;
     PyObject *inter;
@@ -1220,20 +1220,20 @@ gentype_interface_get(PyObject *self)
 
 
 static PyObject *
-gentype_typedescr_get(PyObject *self)
+gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return (PyObject *)PyArray_DescrFromScalar(self);
 }
 
 
 static PyObject *
-gentype_base_get(PyObject *NPY_UNUSED(self))
+gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     Py_RETURN_NONE;
 }
 
 static PyObject *
-voidtype_base_get(PyVoidScalarObject *self)
+voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->base == NULL) {
         Py_RETURN_NONE;
@@ -1264,7 +1264,7 @@ _realdescr_fromcomplexscalar(PyObject *self, int *typenum)
 }
 
 static PyObject *
-gentype_real_get(PyObject *self)
+gentype_real_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1291,7 +1291,7 @@ gentype_real_get(PyObject *self)
 }
 
 static PyObject *
-gentype_imag_get(PyObject *self)
+gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode=NULL;
     PyObject *ret;
@@ -1331,7 +1331,7 @@ gentype_imag_get(PyObject *self)
 }
 
 static PyObject *
-gentype_flat_get(PyObject *self)
+gentype_flat_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret, *arr;
 
@@ -1346,7 +1346,7 @@ gentype_flat_get(PyObject *self)
 
 
 static PyObject *
-gentype_transpose_get(PyObject *self)
+gentype_transpose_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self);
     return self;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5998,7 +5998,7 @@ _typecharfromnum(int num) {
 
 
 static PyObject *
-ufunc_get_doc(PyUFuncObject *ufunc)
+ufunc_get_doc(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     static PyObject *_sig_formatter;
     PyObject *doc;
@@ -6030,31 +6030,31 @@ ufunc_get_doc(PyUFuncObject *ufunc)
 
 
 static PyObject *
-ufunc_get_nin(PyUFuncObject *ufunc)
+ufunc_get_nin(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(ufunc->nin);
 }
 
 static PyObject *
-ufunc_get_nout(PyUFuncObject *ufunc)
+ufunc_get_nout(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(ufunc->nout);
 }
 
 static PyObject *
-ufunc_get_nargs(PyUFuncObject *ufunc)
+ufunc_get_nargs(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(ufunc->nargs);
 }
 
 static PyObject *
-ufunc_get_ntypes(PyUFuncObject *ufunc)
+ufunc_get_ntypes(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(ufunc->ntypes);
 }
 
 static PyObject *
-ufunc_get_types(PyUFuncObject *ufunc)
+ufunc_get_types(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     /* return a list with types grouped input->output */
     PyObject *list;
@@ -6088,20 +6088,20 @@ ufunc_get_types(PyUFuncObject *ufunc)
 }
 
 static PyObject *
-ufunc_get_name(PyUFuncObject *ufunc)
+ufunc_get_name(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyUnicode_FromString(ufunc->name);
 }
 
 static PyObject *
-ufunc_get_identity(PyUFuncObject *ufunc)
+ufunc_get_identity(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     npy_bool reorderable;
     return _get_identity(ufunc, &reorderable);
 }
 
 static PyObject *
-ufunc_get_signature(PyUFuncObject *ufunc)
+ufunc_get_signature(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     if (!ufunc->core_enabled) {
         Py_RETURN_NONE;


### PR DESCRIPTION
CPython defines getters as `typedef PyObject *(*getter)(PyObject *, void *);`
and setters as `typedef int (*setter)(PyObject *, PyObject *, void *);`
(from https://github.com/python/cpython/blob/main/Include/descrobject.h )

These have a void* argument for context which is often ignored. In numpy, we cast loads of things to (getter) which are defined as PyObject*(PyObject*) without the extra void* argument. Because the argument isn't used, in most C compilers this works fine. However this is relying on undefined behaviour in the C spec, and actually in some architectures (webassembly), this will cause a runtime error and mean that numpy will build without errors, but won't work. 

This patch fixes I think all of them (I found them using -Wcast-function-type and doing a clean build). 