### PR TITLE
ENH: Add a mypy plugin for inferring the precision of `np.ctypeslib.c_intp`

### DIFF
--- a/doc/release/upcoming_changes/19062.new_feature.rst
+++ b/doc/release/upcoming_changes/19062.new_feature.rst
@@ -1,0 +1,21 @@
+Assign the platform-specific ``c_intp`` precision via a mypy plugin
+-------------------------------------------------------------------
+
+The mypy_ plugin, introduced in `numpy/numpy#17843`_, has again been expanded:
+the plugin now is now responsible for setting the platform-specific precision
+of `numpy.ctypeslib.c_intp`, the latter being used as data type for various
+`numpy.ndarray.ctypes` attributes.
+
+Without the plugin, aforementioned type will default to `ctypes.c_int64`.
+
+To enable the plugin, one must add it to their mypy `configuration file`_:
+
+.. code-block:: ini
+
+    [mypy]
+    plugins = numpy.typing.mypy_plugin
+
+
+.. _mypy: http://mypy-lang.org/
+.. _configuration file: https://mypy.readthedocs.io/en/stable/config_file.html
+.. _`numpy/numpy#17843`: https://github.com/numpy/numpy/pull/17843

--- a/numpy/core/_internal.pyi
+++ b/numpy/core/_internal.pyi
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Type, overload, Optional, Generic
 import ctypes as ct
 
 from numpy import ndarray
+from numpy.ctypeslib import c_intp
 
 _CastT = TypeVar("_CastT", bound=ct._CanCastTo)  # Copied from `ctypes.cast`
 _CT = TypeVar("_CT", bound=ct._CData)
@@ -15,18 +16,12 @@ class _ctypes(Generic[_PT]):
     def __new__(cls, array: ndarray[Any, Any], ptr: None = ...) -> _ctypes[None]: ...
     @overload
     def __new__(cls, array: ndarray[Any, Any], ptr: _PT) -> _ctypes[_PT]: ...
-
-    # NOTE: In practice `shape` and `strides` return one of the concrete
-    # platform dependant array-types (`c_int`, `c_long` or `c_longlong`)
-    # corresponding to C's `int_ptr_t`, as determined by `_getintp_ctype`
-    # TODO: Hook this in to the mypy plugin so that a more appropiate
-    # `ctypes._SimpleCData[int]` sub-type can be returned
     @property
     def data(self) -> _PT: ...
     @property
-    def shape(self) -> ct.Array[ct.c_int64]: ...
+    def shape(self) -> ct.Array[c_intp]: ...
     @property
-    def strides(self) -> ct.Array[ct.c_int64]: ...
+    def strides(self) -> ct.Array[c_intp]: ...
     @property
     def _as_parameter_(self) -> ct.c_void_p: ...
 

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -1,11 +1,12 @@
 from typing import List, Type
-from ctypes import _SimpleCData
+
+# NOTE: Numpy's mypy plugin is used for importing the correct
+# platform-specific `ctypes._SimpleCData[int]` sub-type
+from ctypes import c_int64 as _c_intp
 
 __all__: List[str]
 
-# TODO: Update the `npt.mypy_plugin` such that it substitutes `c_intp` for
-# a specific `_SimpleCData[int]` subclass (e.g. `ctypes.c_long`)
-c_intp: Type[_SimpleCData[int]]
+c_intp = _c_intp
 
 def load_library(libname, loader_path): ...
 def ndpointer(dtype=..., ndim=..., shape=..., flags=...): ...

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -23,15 +23,18 @@ Mypy plugin
 -----------
 
 A mypy_ plugin is distributed in `numpy.typing` for managing a number of
-platform-specific annotations. Its function can be split into to parts:
+platform-specific annotations. Its functionality can be split into three
+distinct parts:
 
 * Assigning the (platform-dependent) precisions of certain `~numpy.number` subclasses,
   including the likes of `~numpy.int_`, `~numpy.intp` and `~numpy.longlong`.
   See the documentation on :ref:`scalar types <arrays.scalars.built-in>` for a
-  comprehensive overview of the affected classes. without the plugin the precision
-  of all relevant classes will be inferred as `~typing.Any`.
+  comprehensive overview of the affected classes. Without the plugin the
+  precision of all relevant classes will be inferred as `~typing.Any`.
+* Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
+  Without the plugin aforementioned type will default to `ctypes.c_int64`.
 * Removing all extended-precision `~numpy.number` subclasses that are unavailable
-  for the platform in question. Most notable this includes the likes of
+  for the platform in question. Most notably, this includes the likes of
   `~numpy.float128` and `~numpy.complex256`. Without the plugin *all*
   extended-precision types will, as far as mypy is concerned, be available
   to all platforms.

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -62,10 +62,16 @@ def _get_extended_precision_list() -> t.List[str]:
 
 
 def _get_c_intp_name() -> str:
-    if np.ctypeslib.c_intp is np.intp:
-        return "c_int64"  # Plan B, in case `ctypes` fails to import
+    # Adapted from `np.core._internal._getintp_ctype`
+    char = np.dtype('p').char
+    if char == 'i':
+        return "c_int"
+    elif char == 'l':
+        return "c_long"
+    elif char == 'q':
+        return "c_longlong"
     else:
-        return np.ctypeslib.c_intp.__qualname__
+        return "c_long"
 
 
 #: A dictionary mapping type-aliases in `numpy.typing._nbit` to

--- a/numpy/typing/tests/data/reveal/ctypeslib.py
+++ b/numpy/typing/tests/data/reveal/ctypeslib.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+reveal_type(np.ctypeslib.c_intp())  # E: {c_intp}

--- a/numpy/typing/tests/data/reveal/ndarray_misc.py
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.py
@@ -23,8 +23,8 @@ AR_U: np.ndarray[Any, np.dtype[np.str_]]
 ctypes_obj = AR_f8.ctypes
 
 reveal_type(ctypes_obj.data)  # E: int
-reveal_type(ctypes_obj.shape)  # E: ctypes.Array[ctypes.c_int64]
-reveal_type(ctypes_obj.strides)  # E: ctypes.Array[ctypes.c_int64]
+reveal_type(ctypes_obj.shape)  # E: ctypes.Array[{c_intp}]
+reveal_type(ctypes_obj.strides)  # E: ctypes.Array[{c_intp}]
 reveal_type(ctypes_obj._as_parameter_)  # E: ctypes.c_void_p
 
 reveal_type(ctypes_obj.data_as(ct.c_void_p))  # E: ctypes.c_void_p

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -8,7 +8,11 @@ from typing import Optional, IO, Dict, List
 
 import pytest
 import numpy as np
-from numpy.typing.mypy_plugin import _PRECISION_DICT, _EXTENDED_PRECISION_LIST
+from numpy.typing.mypy_plugin import (
+    _PRECISION_DICT,
+    _EXTENDED_PRECISION_LIST,
+    _C_INTP,
+)
 
 try:
     from mypy import api
@@ -219,6 +223,9 @@ def _construct_format_dict():
 
         # numpy.typing
         "_NBitInt": dct['_NBitInt'],
+
+        # numpy.ctypeslib
+        "c_intp": f"ctypes.{_C_INTP}"
     }
 
 


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/19029.

This PR updates numpy's mypy plugin such that it can assign the platform-specific precision of `np.ctypeslib.c_intp`,
the latter taking one of the following three values: `ctypes.c_int`, `ctypes.c_long` or `ctypes.c_longlong`.

Without the plugin `c_intp` will default to `ctypes.c_int64`, which should be the correct type in most cases (_i.e._ on 64-bit platforms).