### PR TITLE
BUG: Fixed an issue wherein `nanmedian` could return an array with the wrong dtype

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -965,7 +965,9 @@ def _nanmedian1d(arr1d, overwrite_input=False):
     arr1d, overwrite_input = _remove_nan_1d(arr1d,
                                             overwrite_input=overwrite_input)
     if arr1d.size == 0:
-        return np.nan
+        # Ensure that a nan-esque scalar of the appropiate type (and unit)
+        # is returned for `timedelta64` and `complexfloating`
+        return np.array(np.nan).astype(arr1d.dtype, copy=False)[()]
 
     return np.median(arr1d, overwrite_input=overwrite_input)
 

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -962,14 +962,16 @@ def _nanmedian1d(arr1d, overwrite_input=False):
     Private function for rank 1 arrays. Compute the median ignoring NaNs.
     See nanmedian for parameter usage
     """
-    arr1d, overwrite_input = _remove_nan_1d(arr1d,
-                                            overwrite_input=overwrite_input)
-    if arr1d.size == 0:
+    arr1d_parsed, overwrite_input = _remove_nan_1d(
+        arr1d, overwrite_input=overwrite_input,
+    )
+
+    if arr1d_parsed.size == 0:
         # Ensure that a nan-esque scalar of the appropiate type (and unit)
         # is returned for `timedelta64` and `complexfloating`
-        return np.array(np.nan).astype(arr1d.dtype, copy=False)[()]
+        return arr1d[-1]
 
-    return np.median(arr1d, overwrite_input=overwrite_input)
+    return np.median(arr1d_parsed, overwrite_input=overwrite_input)
 
 
 def _nanmedian(a, axis=None, out=None, overwrite_input=False):

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1010,10 +1010,12 @@ def _nanmedian_small(a, axis=None, out=None, overwrite_input=False):
     for i in range(np.count_nonzero(m.mask.ravel())):
         warnings.warn("All-NaN slice encountered", RuntimeWarning,
                       stacklevel=4)
+
+    fill_value = np.timedelta64("NaT") if m.dtype.kind == "m" else np.nan
     if out is not None:
-        out[...] = m.filled(np.nan)
+        out[...] = m.filled(fill_value)
         return out
-    return m.filled(np.nan)
+    return m.filled(fill_value)
 
 
 def _nanmedian_dispatcher(


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/19051.
closes https://github.com/numpy/numpy/issues/19050.

`np.nanmedian` would, prior to this PR, return `np.nan` for a given axes if all its elements are pass an `np.isnan` check.
The issue here is that this could force the dtype of the output array to `float64`,  regardless of the input arrays 
original dtype.

Coincidentally, I also stumbled upon a fix for https://github.com/numpy/numpy/issues/19050 while updating the tests, so that's a nice bonus.

Examples
---------
The behavior prior to this PR:
``` python
In [1]: import numpy as np

In [2]: c16 = np.array(np.nan, dtype=np.complex128)
   ...: np.nanmedian(c16)
Out[2]: nan  # builtins.float

In [3]: m = np.array("nat", dtype="timedelta64[s]")
   ...: np.nanmedian(m)
Out[3]: nan
```