### PR TITLE
BUG: Fix compile-time test of POPCNT

### DIFF
--- a/numpy/distutils/checks/cpu_popcnt.c
+++ b/numpy/distutils/checks/cpu_popcnt.c
@@ -4,26 +4,16 @@
     #include <popcntintrin.h>
 #endif
 
-#include <stdlib.h>
-
-int main(void)
+int main(int argc, char **argv)
 {
-    long long a = 0;
-    int b;
-    
-    a = random();
-    b = random();
-      
-#ifdef _MSC_VER
-    #ifdef _M_X64
+    // To make sure popcnt instructions are generated
+    // and been tested against the assembler
+    unsigned long long a = *((unsigned long long*)argv[argc-1]);
+    unsigned int b = *((unsigned int*)argv[argc-2]);
+
+#if defined(_M_X64) || defined(__x86_64__)    
     a = _mm_popcnt_u64(a);
-    #endif
-    b = _mm_popcnt_u32(b);
-#else
-    #ifdef __x86_64__
-    a = __builtin_popcountll(a);
-    #endif
-    b = __builtin_popcount(b);
 #endif
+    b = _mm_popcnt_u32(b);
     return (int)a + b;
 }

--- a/numpy/distutils/checks/cpu_popcnt.c
+++ b/numpy/distutils/checks/cpu_popcnt.c
@@ -4,20 +4,26 @@
     #include <popcntintrin.h>
 #endif
 
+#include <stdlib.h>
+
 int main(void)
 {
     long long a = 0;
     int b;
+    
+    a = random();
+    b = random();
+      
 #ifdef _MSC_VER
     #ifdef _M_X64
-    a = _mm_popcnt_u64(1);
+    a = _mm_popcnt_u64(a);
     #endif
-    b = _mm_popcnt_u32(1);
+    b = _mm_popcnt_u32(b);
 #else
     #ifdef __x86_64__
-    a = __builtin_popcountll(1);
+    a = __builtin_popcountll(a);
     #endif
-    b = __builtin_popcount(1);
+    b = __builtin_popcount(b);
 #endif
     return (int)a + b;
 }


### PR DESCRIPTION
The compile-time test of POPCNT, cpu_popcnt.c produced code that would
execute without error even if the machine didn't support the popcnt
instruction. This patch changes the test so that it attempts to use popcnt on
random numbers so the compiler can't substitute the answer at compile
time. Resolves issue #19067. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
