### PR TITLE
BUG: Fix test_numpy_version.

### DIFF
--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -1,3 +1,20 @@
+"""
+Check the numpy version is valid.
+
+Note that a development version is marked by the presence of 'dev0' or '+'
+in the version string, all else is treated as a release. The version string
+itself is set from the output of ``git describe`` which relies on tags.
+
+Examples
+--------
+
+Valid Development: 1.22.0.dev0 1.22.0.dev0+5-g7999db4df2 1.22.0+5-g7999db4df2
+Valid Release: 1.21.0.rc1, 1.21.0.b1, 1.21.0
+Invalid: 1.22.0.dev, 1.22.0.dev0-5-g7999db4dfB, 1.21.0.d1, 1.21.a
+
+Note that a release is determined by the version string, which in turn
+is controlled by the result of the ``git describe`` command.
+"""
 import re
 
 import numpy as np
@@ -7,11 +24,11 @@ from numpy.testing import assert_
 def test_valid_numpy_version():
     # Verify that the numpy version is a valid one (no .post suffix or other
     # nonsense).  See gh-6431 for an issue caused by an invalid version.
-    version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(|a[0-9]|b[0-9]|rc[0-9])"
-    dev_suffix = r"\.dev0\+[0-9]*\.g[0-9a-f]+"
+    version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(a[0-9]|b[0-9]|rc[0-9]|)"
+    dev_suffix = r"(\.dev0|)(\+[0-9]*\.g[0-9a-f]+|)"
     if np.version.release:
-        res = re.match(version_pattern, np.__version__)
+        res = re.match(version_pattern + '$', np.__version__)
     else:
-        res = re.match(version_pattern + dev_suffix, np.__version__)
+        res = re.match(version_pattern + dev_suffix + '$', np.__version__)
 
     assert_(res is not None, np.__version__)

--- a/numpy/version.py
+++ b/numpy/version.py
@@ -6,6 +6,6 @@ vinfo = get_versions()
 version: str = vinfo["version"]
 full_version: str = vinfo['version']
 git_revision: str = vinfo['full-revisionid']
-release = 'dev0' not in version
+release = 'dev0' not in version and '+' not in version
 
 del get_versions, vinfo


### PR DESCRIPTION
Backport of #19072.

- Make versions of the form '1.22.0.dev0' valid for non-releases.
- Put empty match at end of groups instead of at the beginning.
- Require eol in match, do not allow trailing characters.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
