### PR TITLE
BUG: Fixed an issue wherein `_GenericAlias.__getitem__` would raise for types with >1 parameters

### DIFF
--- a/numpy/typing/_add_docstring.py
+++ b/numpy/typing/_add_docstring.py
@@ -114,7 +114,7 @@ add_newdoc('DTypeLike', 'typing.Union[...]',
 add_newdoc('NDArray', repr(NDArray),
     """
     A :term:`generic <generic type>` version of
-    `np.ndarray[Any, np.dtype[~ScalarType]] <numpy.ndarray>`.
+    `np.ndarray[Any, np.dtype[+ScalarType]] <numpy.ndarray>`.
 
     Can be used during runtime for typing arrays with a given dtype
     and unspecified shape.
@@ -127,7 +127,7 @@ add_newdoc('NDArray', repr(NDArray),
         >>> import numpy.typing as npt
 
         >>> print(npt.NDArray)
-        numpy.ndarray[typing.Any, numpy.dtype[~ScalarType]]
+        numpy.ndarray[typing.Any, numpy.dtype[+ScalarType]]
 
         >>> print(npt.NDArray[np.float64])
         numpy.ndarray[typing.Any, numpy.dtype[numpy.float64]]

--- a/numpy/typing/_generic_alias.py
+++ b/numpy/typing/_generic_alias.py
@@ -63,7 +63,8 @@ def _reconstruct_alias(alias: _T, parameters: Iterator[TypeVar]) -> _T:
         elif isinstance(i, _GenericAlias):
             value = _reconstruct_alias(i, parameters)
         elif hasattr(i, "__parameters__"):
-            value = i[next(parameters)]
+            prm_tup = tuple(next(parameters) for _ in i.__parameters__)
+            value = i[prm_tup]
         else:
             value = i
         args.append(value)

--- a/numpy/typing/_generic_alias.py
+++ b/numpy/typing/_generic_alias.py
@@ -196,7 +196,7 @@ if sys.version_info >= (3, 9):
 else:
     _GENERIC_ALIAS_TYPE = (_GenericAlias,)
 
-ScalarType = TypeVar("ScalarType", bound=np.generic)
+ScalarType = TypeVar("ScalarType", bound=np.generic, covariant=True)
 
 if TYPE_CHECKING:
     NDArray = np.ndarray[Any, np.dtype[ScalarType]]

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 from numpy.typing._generic_alias import _GenericAlias
 
-ScalarType = TypeVar("ScalarType", bound=np.generic)
+ScalarType = TypeVar("ScalarType", bound=np.generic, covariant=True)
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 DType = _GenericAlias(np.dtype, (ScalarType,))

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -11,6 +11,8 @@ import numpy as np
 from numpy.typing._generic_alias import _GenericAlias
 
 ScalarType = TypeVar("ScalarType", bound=np.generic)
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
 DType = _GenericAlias(np.dtype, (ScalarType,))
 NDArray = _GenericAlias(np.ndarray, (Any, DType))
 
@@ -50,6 +52,7 @@ class TestGenericAlias:
         ("__getitem__", lambda n: n[np.float64]),
         ("__getitem__", lambda n: n[ScalarType][np.float64]),
         ("__getitem__", lambda n: n[Union[np.int64, ScalarType]][np.float64]),
+        ("__getitem__", lambda n: n[Union[T1, T2]][np.float32, np.float64]),
         ("__eq__", lambda n: n == n),
         ("__ne__", lambda n: n != np.ndarray),
         ("__dir__", lambda n: dir(n)),


### PR DESCRIPTION
Found and fixed a minor bug wherein `_GenericAlias` could raise under certain circumstances.

The issue was that only a single parameter was passed to underlying generic types, 
even if aforementioned types would demand more than 1 parameter.

Examples
----------
The behavior prior to this PR:
``` python
In [1]: from typing import TypeVar, Union
   ...: 
   ...: import numpy as np
   ...: import numpy.typing as npt
   ...: 
   ...: T1 = TypeVar("T1", bound=np.generic)
   ...: T2 = TypeVar("T2", bound=np.generic)
   ...: 
   ...: NDArray_A_or_B = npt.NDArray[Union[T1, T2]]

In [2]: NDArray_A_or_B[np.float32, np.float64]
  ...
TypeError: Too few parameters for typing.Union[~T1, ~T2]; actual 1, expected 2
```