### PR TITLE
DOC: add a "Returns" section for `np.frombuffer`

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1536,6 +1536,10 @@ add_newdoc('numpy.core.multiarray', 'frombuffer',
 
         .. versionadded:: 1.20.0
 
+    Returns
+    -------
+    out : ndarray
+
     Notes
     -----
     If the buffer has data that is not in machine byte-order, this should


### PR DESCRIPTION
This is a pre-requisite for Issue #16751. See comments on PR #18964
starting at [pull/18964#issuecomment-847492524](https://github.com/numpy/numpy/pull/18964#issuecomment-847492524)

> Both frombuffer docstrings could use an explicit "Returns" section. 
— from mattip's [comment](https://github.com/numpy/numpy/pull/18964#issuecomment-847558574)