### PR TITLE
MAINT: remove unused `f2py_size` function

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -256,33 +256,6 @@ cppmacros['len..'] = """\
 #define old_size(var) PyArray_SIZE((PyArrayObject *)(capi_ ## var ## _tmp))
 /* #define index(i) capi_i ## i */
 #define slen(var) capi_ ## var ## _len
-#define size(var, ...) f2py_size((PyArrayObject *)(capi_ ## var ## _tmp), ## __VA_ARGS__, -1)
-"""
-needs['f2py_size'] = ['stdarg.h']
-cfuncs['f2py_size'] = """\
-static int f2py_size(PyArrayObject* var, ...)
-{
-  npy_int sz = 0;
-  npy_int dim;
-  npy_int rank;
-  va_list argp;
-  va_start(argp, var);
-  dim = va_arg(argp, npy_int);
-  if (dim==-1)
-    {
-      sz = PyArray_SIZE(var);
-    }
-  else
-    {
-      rank = PyArray_NDIM(var);
-      if (dim>=1 && dim<=rank)
-        sz = PyArray_DIM(var, dim-1);
-      else
-        fprintf(stderr, \"f2py_size: 2nd argument value=%d fails to satisfy 1<=value<=%d. Result will be 0.\\n\", dim, rank);
-    }
-  va_end(argp);
-  return sz;
-}
 """
 
 cppmacros[


### PR DESCRIPTION
This gets rid of warnings like:
```
scipy/linalg/_flapackmodule.c:345:12: warning: 'f2py_size' defined but not used [-Wunused-function]
  345 | static int f2py_size(PyArrayObject* var, ...)
```

That warning has been there since at least 1.7.1, the last time
`f2py_size` was touched (see gh-3131).

I have built SciPy with this change, and test suite passes.