### PR TITLE
BUG: Fix setup.py to work in maintenance branches.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ import subprocess
 import textwrap
 import warnings
 import builtins
+import re
 
 
 # Python supported version checks. Keep right after stdlib imports to ensure we
@@ -46,8 +47,14 @@ builtins.__NUMPY_SETUP__ = True
 # The version components are changed from ints to strings, but only VERSION
 # seems to matter outside of this module and it was already a str.
 FULLVERSION = versioneer.get_version()
-ISRELEASED = 'dev' not in FULLVERSION
-MAJOR, MINOR, MICRO = FULLVERSION.split('.')[:3]
+
+# Capture the version string:
+# 1.22.0.dev0+ ... -> ISRELEASED == False, VERSION == 1.22.0
+# 1.22.0rc1+ ... -> ISRELEASED == False, VERSION == 1.22.0
+# 1.22.0 ... -> ISRELEASED == True, VERSION == 1.22.0
+# 1.22.0rc1 ... -> ISRELEASED == True, VERSION == 1.22.0
+ISRELEASED = re.search(r'(dev|\+)', FULLVERSION) is None
+MAJOR, MINOR, MICRO = re.match(r'(\d+)\.(\d+)\.(\d+)', FULLVERSION).groups()
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 # The first version not in the `Programming Language :: Python :: ...` classifiers above


### PR DESCRIPTION
This fixes setup.py to correctly detect the release status and base
version from the full version string provided by versioneer. Before
this fix, versions like '1.22.0.dev0+...' were correctly handled,
but versions like '1.21.0rc1+...' were not.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
