### PR TITLE
ENH: Reorganize string promotion, add `object_fallback=False`

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.h
+++ b/numpy/core/src/multiarray/array_coercion.h
@@ -31,7 +31,7 @@ PyArray_DiscoverDTypeAndShape(
         npy_intp out_shape[NPY_MAXDIMS],
         coercion_cache_obj **coercion_cache,
         PyArray_DTypeMeta *fixed_DType, PyArray_Descr *requested_descr,
-        PyArray_Descr **out_descr);
+        PyArray_Descr **out_descr, npy_bool object_fallback);
 
 NPY_NO_EXPORT int
 PyArray_ExtractDTypeAndDescriptor(PyObject *dtype,
@@ -39,7 +39,7 @@ PyArray_ExtractDTypeAndDescriptor(PyObject *dtype,
 
 NPY_NO_EXPORT PyObject *
 _discover_array_parameters(PyObject *NPY_UNUSED(self),
-                           PyObject *args, PyObject *kwargs);
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 
 
 /* Would make sense to inline the freeing functions everywhere */

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -92,7 +92,7 @@ default_resolve_descriptors(
     PyArray_DTypeMeta *common_dtype = dtypes[0];
     assert(common_dtype != NULL);
     for (int i = 1; i < nin; i++) {
-        Py_SETREF(common_dtype, PyArray_CommonDType(common_dtype, dtypes[i]));
+        Py_SETREF(common_dtype, PyArray_CommonDType(common_dtype, dtypes[i], 0));
         if (common_dtype == NULL) {
             goto fail;
         }

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -262,7 +262,8 @@ PyArray_CopyObject(PyArrayObject *dest, PyObject *src_object)
      */
     ndim = PyArray_DiscoverDTypeAndShape(src_object,
             PyArray_NDIM(dest), dims, &cache,
-            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest), &dtype);
+            NPY_DTYPE(PyArray_DESCR(dest)), PyArray_DESCR(dest),
+            &dtype, NPY_FALSE);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/core/src/multiarray/common.c
+++ b/numpy/core/src/multiarray/common.c
@@ -118,7 +118,7 @@ PyArray_DTypeFromObject(PyObject *obj, int maxdims, PyArray_Descr **out_dtype)
     int ndim;
 
     ndim = PyArray_DiscoverDTypeAndShape(
-            obj, maxdims, shape, &cache, NULL, NULL, out_dtype);
+            obj, maxdims, shape, &cache, NULL, NULL, out_dtype, NPY_FALSE);
     if (ndim < 0) {
         return -1;
     }

--- a/numpy/core/src/multiarray/common_dtype.h
+++ b/numpy/core/src/multiarray/common_dtype.h
@@ -8,7 +8,9 @@
 #include "dtypemeta.h"
 
 NPY_NO_EXPORT PyArray_DTypeMeta *
-PyArray_CommonDType(PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2);
+PyArray_CommonDType(
+        PyArray_DTypeMeta *dtype1, PyArray_DTypeMeta *dtype2,
+        int object_fallback);
 
 NPY_NO_EXPORT PyArray_DTypeMeta *
 PyArray_PromoteDTypeSequence(

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -968,12 +968,17 @@ PyArray_FindConcatenationDescriptor(
 }
 
 
-/*NUMPY_API
- * Produces the smallest size and lowest kind type to which both
- * input types can be cast.
+/*
+ * Same as `PyArray_PromoteTypes`, but allows falling back to an object result
+ * when no common DType is found.  This is currently only needed for the
+ * string and number promotion deprecation!
+ *
+ * TODO: After this deprecation is over, the `object_fallback` may well be
+ *       useless!
  */
 NPY_NO_EXPORT PyArray_Descr *
-PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
+PyArray_PromoteTypes_int(
+        PyArray_Descr *type1, PyArray_Descr *type2, int object_fallback)
 {
     PyArray_DTypeMeta *common_dtype;
     PyArray_Descr *res;
@@ -984,7 +989,8 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
         return type1;
     }
 
-    common_dtype = PyArray_CommonDType(NPY_DTYPE(type1), NPY_DTYPE(type2));
+    common_dtype = PyArray_CommonDType(
+            NPY_DTYPE(type1), NPY_DTYPE(type2), object_fallback);
     if (common_dtype == NULL) {
         return NULL;
     }
@@ -1019,6 +1025,18 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
     Py_DECREF(common_dtype);
     return res;
 }
+
+
+/*NUMPY_API
+ * Produces the smallest size and lowest kind type to which both
+ * input types can be cast.
+ */
+NPY_NO_EXPORT PyArray_Descr *
+PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
+{
+    return PyArray_PromoteTypes_int(type1, type2, 0);
+}
+
 
 /*
  * Produces the smallest size and lowest kind type to which all

--- a/numpy/core/src/multiarray/convert_datatype.h
+++ b/numpy/core/src/multiarray/convert_datatype.h
@@ -21,6 +21,10 @@ NPY_NO_EXPORT PyArrayObject **
 PyArray_ConvertToCommonType(PyObject *op, int *retn);
 
 NPY_NO_EXPORT PyArray_Descr *
+PyArray_PromoteTypes_int(
+        PyArray_Descr *type1, PyArray_Descr *type2, int object_fallback);
+
+NPY_NO_EXPORT PyArray_Descr *
 PyArray_LegacyResultType(
         npy_intp narrs, PyArrayObject **arr,
         npy_intp ndtypes, PyArray_Descr **dtypes);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1552,7 +1552,8 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
     Py_XDECREF(newtype);
 
     ndim = PyArray_DiscoverDTypeAndShape(op,
-            NPY_MAXDIMS, dims, &cache, fixed_DType, fixed_descriptor, &dtype);
+            NPY_MAXDIMS, dims, &cache, fixed_DType, fixed_descriptor,
+            &dtype,  NPY_FALSE);
 
     Py_XDECREF(fixed_descriptor);
     Py_XDECREF(fixed_DType);

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -416,17 +416,8 @@ string_unicode_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         return (PyArray_DTypeMeta *)Py_NotImplemented;
     }
     if (other->type_num != NPY_STRING && other->type_num != NPY_UNICODE) {
-        /* Deprecated 2020-12-19, NumPy 1.21. */
-        if (DEPRECATE_FUTUREWARNING(
-                "Promotion of numbers and bools to strings is deprecated. "
-                "In the future, code such as `np.concatenate((['string'], [0]))` "
-                "will raise an error, while `np.asarray(['string', 0])` will "
-                "return an array with `dtype=object`.  To avoid the warning "
-                "while retaining a string result use `dtype='U'` (or 'S').  "
-                "To get an array of Python objects use `dtype=object`. "
-                "(Warning added in NumPy 1.21)") < 0) {
-            return NULL;
-        }
+        /* Deprecated 2020-12-19, NumPy 1.21. (handled by caller) */
+        return NULL;
     }
     /*
      * The builtin types are ordered by complexity (aside from object) here.

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4415,7 +4415,7 @@ static struct PyMethodDef array_module_methods[] = {
     {"set_legacy_print_mode", (PyCFunction)set_legacy_print_mode,
         METH_VARARGS, NULL},
     {"_discover_array_parameters", (PyCFunction)_discover_array_parameters,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"_get_castingimpl",  (PyCFunction)_get_castingimpl,
      METH_VARARGS | METH_KEYWORDS, NULL},
     /* from umath */


### PR DESCRIPTION
(semi private)

This reorganizes promotion during array-coercion to allow flagging for
an object fallback mode.  Here only "exposed" through:

    np.core._multiarray_umath._discover_array_parameters(
            [1, "2"], object_fallback=True)

Note that as of now, it is a bit stricter then previously.  The object fallback
actually hides fewer errors, not more!  (e.g. say promotion fails for two
different structured voids, or datetimes).

But that would be trivial to allow for now...

We could probably thread this flag through by (ab)using the array-flags
that `PyArray_FromAny` allows passing.

---

@jorisvandenbossche I am thinking about something like this to fix the issue.  But its fairly annoying, at least unless we aim to make this a full new keyword argument to `np.array` as well (or similar)...

@numpy/numpy We had discussed a few times to add something like `np.array(..., dtype="allow_object")`.  This is practically that, and I can make it work (the code organization isn't pretty, but most of it is due to the FutureWarning).