### PR TITLE
MAINT, SIMD: Pass divisor by refernce in npyv_divc_*

### DIFF
--- a/numpy/core/src/_simd/_simd.dispatch.c.src
+++ b/numpy/core/src/_simd/_simd.dispatch.c.src
@@ -357,7 +357,7 @@ SIMD_IMPL_INTRIN_2(div_@sfx@, v@sfx@, v@sfx@, v@sfx@)
 
 #if @intdiv_sup@
 SIMD_IMPL_INTRIN_1(divisor_@sfx@, v@sfx@x3, @sfx@)
-SIMD_IMPL_INTRIN_2(divc_@sfx@, v@sfx@, v@sfx@, v@sfx@x3)
+SIMD_IMPL_INTRIN_2_REFERNCE2(divc_@sfx@, v@sfx@, v@sfx@, v@sfx@x3)
 #endif // intdiv_sup
 
 #if @fused_sup@

--- a/numpy/core/src/_simd/_simd_easyintrin.inc
+++ b/numpy/core/src/_simd/_simd_easyintrin.inc
@@ -73,6 +73,28 @@
         return simd_arg_to_obj(&ret);                     \
     }
 
+#define SIMD_IMPL_INTRIN_2_REFERNCE2(NAME, RET, IN0, IN1) \
+    static PyObject *simd__intrin_##NAME                  \
+    (PyObject* NPY_UNUSED(self), PyObject *args)          \
+    {                                                     \
+        simd_arg arg1 = {.dtype = simd_data_##IN0};       \
+        simd_arg arg2 = {.dtype = simd_data_##IN1};       \
+        if (!PyArg_ParseTuple(                            \
+            args, "O&O&:"NPY_TOSTRING(NAME),              \
+            simd_arg_converter, &arg1,                    \
+            simd_arg_converter, &arg2                     \
+        )) return NULL;                                   \
+        simd_data data = {.RET = npyv_##NAME(             \
+            arg1.data.IN0, &arg2.data.IN1                 \
+        )};                                               \
+        simd_arg_free(&arg1);                             \
+        simd_arg_free(&arg2);                             \
+        simd_arg ret = {                                  \
+            .data = data, .dtype = simd_data_##RET        \
+        };                                                \
+        return simd_arg_to_obj(&ret);                     \
+    }
+
 #define SIMD__REPEAT_2IMM(C, NAME, IN0) \
     C == arg2.data.u8 ? NPY_CAT(npyv_, NAME)(arg1.data.IN0, C) :
 

--- a/numpy/core/src/common/simd/intdiv.h
+++ b/numpy/core/src/common/simd/intdiv.h
@@ -29,7 +29,7 @@
  *  1- npyv_{dtype}x3 npyv_divisor_{dtype} ({dtype} divisor);
  *     For computing the divisor parameters (multiplier + shifters + sign of divisor(signed only))
  *
- *  2- npyv_{dtype} npyv_divisor_{dtype} (npyv_{dtype} dividend, npyv_{dtype}x3 divisor_parms);
+ *  2- npyv_{dtype} npyv_divisor_{dtype} (npyv_{dtype} dividend, npyv_{dtype}x3 *divisor_parms);
  *     For performing the final division.
  *
  ** For example:
@@ -38,7 +38,7 @@
  *    npyv_s32x3 divisor = npyv_divisor_s32(x);   // init divisor params
  *    for (; len >= vstep; src += vstep, dst += vstep, len -= vstep) {
  *        npyv_s32 a = npyv_load_s32(*src);       // load s32 vector from memory
- *                 a = npyv_divc_s32(a, divisor); // divide all elements by x
+ *                 a = npyv_divc_s32(a, &divisor); // divide all elements by x
  *        npyv_store_s32(dst, a);                 // store s32 vector into memroy
  *    }
  *

--- a/numpy/core/src/common/simd/neon/arithmetic.h
+++ b/numpy/core/src/common/simd/neon/arithmetic.h
@@ -65,147 +65,147 @@
  ***************************/
 // See simd/intdiv.h for more clarification
 // divide each unsigned 8-bit element by a precomputed divisor
-NPY_FINLINE npyv_u8 npyv_divc_u8(npyv_u8 a, const npyv_u8x3 divisor)
+NPY_FINLINE npyv_u8 npyv_divc_u8(npyv_u8 a, const npyv_u8x3 *divisor)
 {
-    const uint8x8_t mulc_lo = vget_low_u8(divisor.val[0]);
+    const uint8x8_t mulc_lo = vget_low_u8(divisor->val[0]);
     // high part of unsigned multiplication
     uint16x8_t mull_lo  = vmull_u8(vget_low_u8(a), mulc_lo);
 #if NPY_SIMD_F64
-    uint16x8_t mull_hi  = vmull_high_u8(a, divisor.val[0]);
+    uint16x8_t mull_hi  = vmull_high_u8(a, divisor->val[0]);
     // get the high unsigned bytes
     uint8x16_t mulhi    = vuzp2q_u8(vreinterpretq_u8_u16(mull_lo), vreinterpretq_u8_u16(mull_hi));
 #else
-    const uint8x8_t mulc_hi = vget_high_u8(divisor.val[0]);
+    const uint8x8_t mulc_hi = vget_high_u8(divisor->val[0]);
     uint16x8_t mull_hi  = vmull_u8(vget_high_u8(a), mulc_hi);
     uint8x16_t mulhi    = vuzpq_u8(vreinterpretq_u8_u16(mull_lo), vreinterpretq_u8_u16(mull_hi)).val[1];
 #endif
     // floor(a/d)       = (mulhi + ((a-mulhi) >> sh1)) >> sh2
     uint8x16_t q        = vsubq_u8(a, mulhi);
-               q        = vshlq_u8(q, vreinterpretq_s8_u8(divisor.val[1]));
+               q        = vshlq_u8(q, vreinterpretq_s8_u8(divisor->val[1]));
                q        = vaddq_u8(mulhi, q);
-               q        = vshlq_u8(q, vreinterpretq_s8_u8(divisor.val[2]));
+               q        = vshlq_u8(q, vreinterpretq_s8_u8(divisor->val[2]));
     return q;
 }
 // divide each signed 8-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s8 npyv_divc_s8(npyv_s8 a, const npyv_s8x3 divisor)
+NPY_FINLINE npyv_s8 npyv_divc_s8(npyv_s8 a, const npyv_s8x3 *divisor)
 {
-    const int8x8_t mulc_lo = vget_low_s8(divisor.val[0]);
+    const int8x8_t mulc_lo = vget_low_s8(divisor->val[0]);
     // high part of signed multiplication
     int16x8_t mull_lo  = vmull_s8(vget_low_s8(a), mulc_lo);
 #if NPY_SIMD_F64
-    int16x8_t mull_hi  = vmull_high_s8(a, divisor.val[0]);
+    int16x8_t mull_hi  = vmull_high_s8(a, divisor->val[0]);
     // get the high unsigned bytes
     int8x16_t mulhi    = vuzp2q_s8(vreinterpretq_s8_s16(mull_lo), vreinterpretq_s8_s16(mull_hi));
 #else
-    const int8x8_t mulc_hi = vget_high_s8(divisor.val[0]);
+    const int8x8_t mulc_hi = vget_high_s8(divisor->val[0]);
     int16x8_t mull_hi  = vmull_s8(vget_high_s8(a), mulc_hi);
     int8x16_t mulhi    = vuzpq_s8(vreinterpretq_s8_s16(mull_lo), vreinterpretq_s8_s16(mull_hi)).val[1];
 #endif
     // q               = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)      = (q ^ dsign) - dsign
-    int8x16_t q        = vshlq_s8(vaddq_s8(a, mulhi), divisor.val[1]);
+    int8x16_t q        = vshlq_s8(vaddq_s8(a, mulhi), divisor->val[1]);
               q        = vsubq_s8(q, vshrq_n_s8(a, 7));
-              q        = vsubq_s8(veorq_s8(q, divisor.val[2]), divisor.val[2]);
+              q        = vsubq_s8(veorq_s8(q, divisor->val[2]), divisor->val[2]);
     return q;
 }
 // divide each unsigned 16-bit element by a precomputed divisor
-NPY_FINLINE npyv_u16 npyv_divc_u16(npyv_u16 a, const npyv_u16x3 divisor)
+NPY_FINLINE npyv_u16 npyv_divc_u16(npyv_u16 a, const npyv_u16x3 *divisor)
 {
-    const uint16x4_t mulc_lo = vget_low_u16(divisor.val[0]);
+    const uint16x4_t mulc_lo = vget_low_u16(divisor->val[0]);
     // high part of unsigned multiplication
     uint32x4_t mull_lo  = vmull_u16(vget_low_u16(a), mulc_lo);
 #if NPY_SIMD_F64
-    uint32x4_t mull_hi  = vmull_high_u16(a, divisor.val[0]);
+    uint32x4_t mull_hi  = vmull_high_u16(a, divisor->val[0]);
     // get the high unsigned bytes
     uint16x8_t mulhi    = vuzp2q_u16(vreinterpretq_u16_u32(mull_lo), vreinterpretq_u16_u32(mull_hi));
 #else
-    const uint16x4_t mulc_hi = vget_high_u16(divisor.val[0]);
+    const uint16x4_t mulc_hi = vget_high_u16(divisor->val[0]);
     uint32x4_t mull_hi  = vmull_u16(vget_high_u16(a), mulc_hi);
     uint16x8_t mulhi    = vuzpq_u16(vreinterpretq_u16_u32(mull_lo), vreinterpretq_u16_u32(mull_hi)).val[1];
 #endif
     // floor(a/d)       = (mulhi + ((a-mulhi) >> sh1)) >> sh2
     uint16x8_t q        = vsubq_u16(a, mulhi);
-               q        = vshlq_u16(q, vreinterpretq_s16_u16(divisor.val[1]));
+               q        = vshlq_u16(q, vreinterpretq_s16_u16(divisor->val[1]));
                q        = vaddq_u16(mulhi, q);
-               q        = vshlq_u16(q, vreinterpretq_s16_u16(divisor.val[2]));
+               q        = vshlq_u16(q, vreinterpretq_s16_u16(divisor->val[2]));
     return q;
 }
 // divide each signed 16-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s16 npyv_divc_s16(npyv_s16 a, const npyv_s16x3 divisor)
+NPY_FINLINE npyv_s16 npyv_divc_s16(npyv_s16 a, const npyv_s16x3 *divisor)
 {
-    const int16x4_t mulc_lo = vget_low_s16(divisor.val[0]);
+    const int16x4_t mulc_lo = vget_low_s16(divisor->val[0]);
     // high part of signed multiplication
     int32x4_t mull_lo  = vmull_s16(vget_low_s16(a), mulc_lo);
 #if NPY_SIMD_F64
-    int32x4_t mull_hi  = vmull_high_s16(a, divisor.val[0]);
+    int32x4_t mull_hi  = vmull_high_s16(a, divisor->val[0]);
     // get the high unsigned bytes
     int16x8_t mulhi    = vuzp2q_s16(vreinterpretq_s16_s32(mull_lo), vreinterpretq_s16_s32(mull_hi));
 #else
-    const int16x4_t mulc_hi = vget_high_s16(divisor.val[0]);
+    const int16x4_t mulc_hi = vget_high_s16(divisor->val[0]);
     int32x4_t mull_hi  = vmull_s16(vget_high_s16(a), mulc_hi);
     int16x8_t mulhi    = vuzpq_s16(vreinterpretq_s16_s32(mull_lo), vreinterpretq_s16_s32(mull_hi)).val[1];
 #endif
     // q               = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)      = (q ^ dsign) - dsign
-    int16x8_t q        = vshlq_s16(vaddq_s16(a, mulhi), divisor.val[1]);
+    int16x8_t q        = vshlq_s16(vaddq_s16(a, mulhi), divisor->val[1]);
               q        = vsubq_s16(q, vshrq_n_s16(a, 15));
-              q        = vsubq_s16(veorq_s16(q, divisor.val[2]), divisor.val[2]);
+              q        = vsubq_s16(veorq_s16(q, divisor->val[2]), divisor->val[2]);
     return q;
 }
 // divide each unsigned 32-bit element by a precomputed divisor
-NPY_FINLINE npyv_u32 npyv_divc_u32(npyv_u32 a, const npyv_u32x3 divisor)
+NPY_FINLINE npyv_u32 npyv_divc_u32(npyv_u32 a, const npyv_u32x3 *divisor)
 {
-    const uint32x2_t mulc_lo = vget_low_u32(divisor.val[0]);
+    const uint32x2_t mulc_lo = vget_low_u32(divisor->val[0]);
     // high part of unsigned multiplication
     uint64x2_t mull_lo  = vmull_u32(vget_low_u32(a), mulc_lo);
 #if NPY_SIMD_F64
-    uint64x2_t mull_hi  = vmull_high_u32(a, divisor.val[0]);
+    uint64x2_t mull_hi  = vmull_high_u32(a, divisor->val[0]);
     // get the high unsigned bytes
     uint32x4_t mulhi    = vuzp2q_u32(vreinterpretq_u32_u64(mull_lo), vreinterpretq_u32_u64(mull_hi));
 #else
-    const uint32x2_t mulc_hi = vget_high_u32(divisor.val[0]);
+    const uint32x2_t mulc_hi = vget_high_u32(divisor->val[0]);
     uint64x2_t mull_hi  = vmull_u32(vget_high_u32(a), mulc_hi);
     uint32x4_t mulhi    = vuzpq_u32(vreinterpretq_u32_u64(mull_lo), vreinterpretq_u32_u64(mull_hi)).val[1];
 #endif
     // floor(a/d)       = (mulhi + ((a-mulhi) >> sh1)) >> sh2
     uint32x4_t q        =  vsubq_u32(a, mulhi);
-               q        =  vshlq_u32(q, vreinterpretq_s32_u32(divisor.val[1]));
+               q        =  vshlq_u32(q, vreinterpretq_s32_u32(divisor->val[1]));
                q        =  vaddq_u32(mulhi, q);
-               q        =  vshlq_u32(q, vreinterpretq_s32_u32(divisor.val[2]));
+               q        =  vshlq_u32(q, vreinterpretq_s32_u32(divisor->val[2]));
     return q;
 }
 // divide each signed 32-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s32 npyv_divc_s32(npyv_s32 a, const npyv_s32x3 divisor)
+NPY_FINLINE npyv_s32 npyv_divc_s32(npyv_s32 a, const npyv_s32x3 *divisor)
 {
-    const int32x2_t mulc_lo = vget_low_s32(divisor.val[0]);
+    const int32x2_t mulc_lo = vget_low_s32(divisor->val[0]);
     // high part of signed multiplication
     int64x2_t mull_lo  = vmull_s32(vget_low_s32(a), mulc_lo);
 #if NPY_SIMD_F64
-    int64x2_t mull_hi  = vmull_high_s32(a, divisor.val[0]);
+    int64x2_t mull_hi  = vmull_high_s32(a, divisor->val[0]);
     // get the high unsigned bytes
     int32x4_t mulhi    = vuzp2q_s32(vreinterpretq_s32_s64(mull_lo), vreinterpretq_s32_s64(mull_hi));
 #else
-    const int32x2_t mulc_hi = vget_high_s32(divisor.val[0]);
+    const int32x2_t mulc_hi = vget_high_s32(divisor->val[0]);
     int64x2_t mull_hi  = vmull_s32(vget_high_s32(a), mulc_hi);
     int32x4_t mulhi    = vuzpq_s32(vreinterpretq_s32_s64(mull_lo), vreinterpretq_s32_s64(mull_hi)).val[1];
 #endif
     // q               = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)      = (q ^ dsign) - dsign
-    int32x4_t q        = vshlq_s32(vaddq_s32(a, mulhi), divisor.val[1]);
+    int32x4_t q        = vshlq_s32(vaddq_s32(a, mulhi), divisor->val[1]);
               q        = vsubq_s32(q, vshrq_n_s32(a, 31));
-              q        = vsubq_s32(veorq_s32(q, divisor.val[2]), divisor.val[2]);
+              q        = vsubq_s32(veorq_s32(q, divisor->val[2]), divisor->val[2]);
     return q;
 }
 // divide each unsigned 64-bit element by a divisor
-NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 divisor)
+NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 *divisor)
 {
-    const uint64_t d = vgetq_lane_u64(divisor.val[0], 0);
+    const uint64_t d = vgetq_lane_u64(divisor->val[0], 0);
     return npyv_set_u64(vgetq_lane_u64(a, 0) / d, vgetq_lane_u64(a, 1) / d);
 }
 // returns the high 64 bits of signed 64-bit multiplication
-NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
+NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 *divisor)
 {
-    const int64_t d = vgetq_lane_s64(divisor.val[0], 0);
+    const int64_t d = vgetq_lane_s64(divisor->val[0], 0);
     return npyv_set_s64(vgetq_lane_s64(a, 0) / d, vgetq_lane_s64(a, 1) / d);
 }
 /***************************

--- a/numpy/core/src/common/simd/vsx/arithmetic.h
+++ b/numpy/core/src/common/simd/vsx/arithmetic.h
@@ -102,128 +102,128 @@
  */
 // See simd/intdiv.h for more clarification
 // divide each unsigned 8-bit element by a precomputed divisor
-NPY_FINLINE npyv_u8 npyv_divc_u8(npyv_u8 a, const npyv_u8x3 divisor)
+NPY_FINLINE npyv_u8 npyv_divc_u8(npyv_u8 a, const npyv_u8x3 *divisor)
 {
     const npyv_u8 mergeo_perm = {
         1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31
     };
     // high part of unsigned multiplication
-    npyv_u16 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_u16 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_u16 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_u16 mul_odd  = vec_mulo(a, divisor->val[0]);
     npyv_u8  mulhi    = (npyv_u8)vec_perm(mul_even, mul_odd, mergeo_perm);
     // floor(a/d)     = (mulhi + ((a-mulhi) >> sh1)) >> sh2
     npyv_u8 q         = vec_sub(a, mulhi);
-            q         = vec_sr(q, divisor.val[1]);
+            q         = vec_sr(q, divisor->val[1]);
             q         = vec_add(mulhi, q);
-            q         = vec_sr(q, divisor.val[2]);
+            q         = vec_sr(q, divisor->val[2]);
     return  q;
 }
 // divide each signed 8-bit element by a precomputed divisor
-NPY_FINLINE npyv_s8 npyv_divc_s8(npyv_s8 a, const npyv_s8x3 divisor)
+NPY_FINLINE npyv_s8 npyv_divc_s8(npyv_s8 a, const npyv_s8x3 *divisor)
 {
     const npyv_u8 mergeo_perm = {
         1, 17, 3, 19, 5, 21, 7, 23, 9, 25, 11, 27, 13, 29, 15, 31
     };
     // high part of signed multiplication
-    npyv_s16 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_s16 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_s16 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_s16 mul_odd  = vec_mulo(a, divisor->val[0]);
     npyv_s8  mulhi    = (npyv_s8)vec_perm(mul_even, mul_odd, mergeo_perm);
     // q              = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)     = (q ^ dsign) - dsign
-    npyv_s8 q         = vec_sra(vec_add(a, mulhi), (npyv_u8)divisor.val[1]);
+    npyv_s8 q         = vec_sra(vec_add(a, mulhi), (npyv_u8)divisor->val[1]);
             q         = vec_sub(q, vec_sra(a, npyv_setall_u8(7)));
-            q         = vec_sub(vec_xor(q, divisor.val[2]), divisor.val[2]);
+            q         = vec_sub(vec_xor(q, divisor->val[2]), divisor->val[2]);
     return  q;
 }
 // divide each unsigned 16-bit element by a precomputed divisor
-NPY_FINLINE npyv_u16 npyv_divc_u16(npyv_u16 a, const npyv_u16x3 divisor)
+NPY_FINLINE npyv_u16 npyv_divc_u16(npyv_u16 a, const npyv_u16x3 *divisor)
 {
     const npyv_u8 mergeo_perm = {
         2, 3, 18, 19, 6, 7, 22, 23, 10, 11, 26, 27, 14, 15, 30, 31
     };
     // high part of unsigned multiplication
-    npyv_u32 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_u32 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_u32 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_u32 mul_odd  = vec_mulo(a, divisor->val[0]);
     npyv_u16 mulhi    = (npyv_u16)vec_perm(mul_even, mul_odd, mergeo_perm);
     // floor(a/d)     = (mulhi + ((a-mulhi) >> sh1)) >> sh2
     npyv_u16 q        = vec_sub(a, mulhi);
-             q        = vec_sr(q, divisor.val[1]);
+             q        = vec_sr(q, divisor->val[1]);
              q        = vec_add(mulhi, q);
-             q        = vec_sr(q, divisor.val[2]);
+             q        = vec_sr(q, divisor->val[2]);
     return   q;
 }
 // divide each signed 16-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s16 npyv_divc_s16(npyv_s16 a, const npyv_s16x3 divisor)
+NPY_FINLINE npyv_s16 npyv_divc_s16(npyv_s16 a, const npyv_s16x3 *divisor)
 {
     const npyv_u8 mergeo_perm = {
         2, 3, 18, 19, 6, 7, 22, 23, 10, 11, 26, 27, 14, 15, 30, 31
     };
     // high part of signed multiplication
-    npyv_s32 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_s32 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_s32 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_s32 mul_odd  = vec_mulo(a, divisor->val[0]);
     npyv_s16 mulhi    = (npyv_s16)vec_perm(mul_even, mul_odd, mergeo_perm);
     // q              = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)     = (q ^ dsign) - dsign
-    npyv_s16 q        = vec_sra(vec_add(a, mulhi), (npyv_u16)divisor.val[1]);
+    npyv_s16 q        = vec_sra(vec_add(a, mulhi), (npyv_u16)divisor->val[1]);
              q        = vec_sub(q, vec_sra(a, npyv_setall_u16(15)));
-             q        = vec_sub(vec_xor(q, divisor.val[2]), divisor.val[2]);
+             q        = vec_sub(vec_xor(q, divisor->val[2]), divisor->val[2]);
     return   q;
 }
 // divide each unsigned 32-bit element by a precomputed divisor
-NPY_FINLINE npyv_u32 npyv_divc_u32(npyv_u32 a, const npyv_u32x3 divisor)
+NPY_FINLINE npyv_u32 npyv_divc_u32(npyv_u32 a, const npyv_u32x3 *divisor)
 {
 #if defined(__GNUC__) && __GNUC__ < 8
     // Doubleword integer wide multiplication supported by GCC 8+
     npyv_u64 mul_even, mul_odd;
-    __asm__ ("vmulouw %0,%1,%2" : "=v" (mul_even) : "v" (a), "v" (divisor.val[0]));
-    __asm__ ("vmuleuw %0,%1,%2" : "=v" (mul_odd)  : "v" (a), "v" (divisor.val[0]));
+    __asm__ ("vmulouw %0,%1,%2" : "=v" (mul_even) : "v" (a), "v" (divisor->val[0]));
+    __asm__ ("vmuleuw %0,%1,%2" : "=v" (mul_odd)  : "v" (a), "v" (divisor->val[0]));
 #else
     // Doubleword integer wide multiplication supported by GCC 8+
-    npyv_u64 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_u64 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_u64 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_u64 mul_odd  = vec_mulo(a, divisor->val[0]);
 #endif
     // high part of unsigned multiplication
     npyv_u32 mulhi    = vec_mergeo((npyv_u32)mul_even, (npyv_u32)mul_odd);
     // floor(x/d)     = (((a-mulhi) >> sh1) + mulhi) >> sh2
     npyv_u32 q        = vec_sub(a, mulhi);
-             q        = vec_sr(q, divisor.val[1]);
+             q        = vec_sr(q, divisor->val[1]);
              q        = vec_add(mulhi, q);
-             q        = vec_sr(q, divisor.val[2]);
+             q        = vec_sr(q, divisor->val[2]);
     return   q;
 }
 // divide each signed 32-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s32 npyv_divc_s32(npyv_s32 a, const npyv_s32x3 divisor)
+NPY_FINLINE npyv_s32 npyv_divc_s32(npyv_s32 a, const npyv_s32x3 *divisor)
 {
 #if defined(__GNUC__) && __GNUC__ < 8
     // Doubleword integer wide multiplication supported by GCC8+
     npyv_s64 mul_even, mul_odd;
-    __asm__ ("vmulosw %0,%1,%2" : "=v" (mul_even) : "v" (a), "v" (divisor.val[0]));
-    __asm__ ("vmulesw %0,%1,%2" : "=v" (mul_odd)  : "v" (a), "v" (divisor.val[0]));
+    __asm__ ("vmulosw %0,%1,%2" : "=v" (mul_even) : "v" (a), "v" (divisor->val[0]));
+    __asm__ ("vmulesw %0,%1,%2" : "=v" (mul_odd)  : "v" (a), "v" (divisor->val[0]));
 #else
     // Doubleword integer wide multiplication supported by GCC8+
-    npyv_s64 mul_even = vec_mule(a, divisor.val[0]);
-    npyv_s64 mul_odd  = vec_mulo(a, divisor.val[0]);
+    npyv_s64 mul_even = vec_mule(a, divisor->val[0]);
+    npyv_s64 mul_odd  = vec_mulo(a, divisor->val[0]);
 #endif
     // high part of signed multiplication
     npyv_s32 mulhi    = vec_mergeo((npyv_s32)mul_even, (npyv_s32)mul_odd);
     // q              = ((a + mulhi) >> sh1) - XSIGN(a)
     // trunc(a/d)     = (q ^ dsign) - dsign
-    npyv_s32 q        = vec_sra(vec_add(a, mulhi), (npyv_u32)divisor.val[1]);
+    npyv_s32 q        = vec_sra(vec_add(a, mulhi), (npyv_u32)divisor->val[1]);
              q        = vec_sub(q, vec_sra(a, npyv_setall_u32(31)));
-             q        = vec_sub(vec_xor(q, divisor.val[2]), divisor.val[2]);
+             q        = vec_sub(vec_xor(q, divisor->val[2]), divisor->val[2]);
     return   q;
 }
 // divide each unsigned 64-bit element by a precomputed divisor
-NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 divisor)
+NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 *divisor)
 {
-    const npy_uint64 d = vec_extract(divisor.val[0], 0);
+    const npy_uint64 d = vec_extract(divisor->val[0], 0);
     return npyv_set_u64(vec_extract(a, 0) / d, vec_extract(a, 1) / d);
 }
 // divide each signed 64-bit element by a precomputed divisor (round towards zero)
-NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
+NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 *divisor)
 {
-    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(-1LL << 63)), (npyv_b64)divisor.val[1]);
-    npyv_s64 d = vec_sel(divisor.val[0], npyv_setall_s64(1), overflow);
+    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(-1LL << 63)), (npyv_b64)divisor->val[1]);
+    npyv_s64 d = vec_sel(divisor->val[0], npyv_setall_s64(1), overflow);
     return vec_div(a, d);
 }
 /***************************

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -82,7 +82,7 @@ simd_divide_by_scalar_contig_@sfx@(char **args, npy_intp len)
             nsign_a               = npyv_and_@sfx@(nsign_a, npyv_setall_@sfx@(1));
             npyv_@sfx@  diff_sign = npyv_sub_@sfx@(nsign_a, nsign_d);
             npyv_@sfx@  to_ninf   = npyv_xor_@sfx@(nsign_a, nsign_d);
-            npyv_@sfx@  trunc     = npyv_divc_@sfx@(npyv_add_@sfx@(a, diff_sign), divisor);
+            npyv_@sfx@  trunc     = npyv_divc_@sfx@(npyv_add_@sfx@(a, diff_sign), &divisor);
             npyv_@sfx@  floor     = npyv_sub_@sfx@(trunc, to_ninf);
             npyv_store_@sfx@(dst, floor);
         }
@@ -117,7 +117,7 @@ simd_divide_by_scalar_contig_@sfx@(char **args, npy_intp len)
 
     for (; len >= vstep; len -= vstep, src += vstep, dst += vstep) {
         npyv_@sfx@ a = npyv_load_@sfx@(src);
-        npyv_@sfx@ c = npyv_divc_@sfx@(a, divisor);
+        npyv_@sfx@ c = npyv_divc_@sfx@(a, &divisor);
         npyv_store_@sfx@(dst, c);
     }
 


### PR DESCRIPTION
### Changes:
Make `npyv_divc_*` functions take a pointer for the divisor.

ref: #19077 

cc: @seiko2plus @seberg 