### PR TITLE
EHN: add numpy.topk

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -23,7 +23,7 @@ __all__ = [
     'ndim', 'nonzero', 'partition', 'prod', 'product', 'ptp', 'put',
     'ravel', 'repeat', 'reshape', 'resize', 'round_',
     'searchsorted', 'shape', 'size', 'sometrue', 'sort', 'squeeze',
-    'std', 'sum', 'swapaxes', 'take', 'trace', 'transpose', 'var',
+    'std', 'sum', 'swapaxes', 'take', 'topk', 'trace', 'transpose', 'var',
 ]
 
 _gentype = types.GeneratorType
@@ -1274,6 +1274,109 @@ def argmin(a, axis=None, out=None):
 
     """
     return _wrapfunc(a, 'argmin', axis=axis, out=out)
+
+
+def _topk_dispatcher(a, k, axis=None, largest=None, sorted=None):
+    return (a,)
+
+
+@array_function_dispatch(_topk_dispatcher)
+def topk(a, k, axis=-1, largest=True, sorted=True):
+    """
+    Finds values and indices of the `k` largest/smallest 
+    elements along the given `axis`.
+
+    Parameters
+    ----------
+    a: array_like
+        Array with given axis at least k.
+    k: int
+        Number of top elements to look for along the given axis.
+    axis: int or None, optional
+        Axis along which to find topk. If None, the array is flattened 
+        before sorting. The default is -1 (the last axis).
+    largest: bool, optional
+        Controls whether to return largest or smallest elements. 
+    sorted: bool, optional
+        If true the resulting k elements will be sorted by the values.
+
+    Returns
+    -------
+    topk_values : ndarray
+        Array of values of `k` largest/smallest elements 
+        along the specified `axis`.
+    topk_indices: ndarray, int
+        Array of indices of `k` largest/smallest elements 
+        along the specified `axis`.
+
+    See Also
+    --------
+    sort : Describes sorting algorithms used.
+    argsort : Indirect sort.
+    partition : Describes partition algorithms used.
+    argpartition : Indirect partial sort.
+    take_along_axis : Take values from the input array by 
+                      matching 1d index and data slices.
+
+    Examples
+    --------
+    One dimensional array:
+
+    >>> x = np.array([3, 1, 2])
+    >>> np.topk(x, 2)
+    (array([3, 2]), array([0, 2], dtype=int64))
+
+    Two-dimensional array:
+
+    >>> x = np.array([[0, 3, 4], [3, 2, 1], [5, 1, 2]])
+    >>> val, ind = np.topk(x, 2, axis=1) # along the last axis
+    >>> val
+    array([[4, 3],
+           [3, 2],
+           [5, 2]])
+    >>> ind
+    array([[2, 1],
+           [0, 1],
+           [0, 2]])
+
+    >>> val, ind = np.topk(x, 2, axis=None) # along the flattened array
+    >>> val
+    array([5, 4])
+    >>> ind
+    array([6, 2])
+
+    >>> val, ind = np.topk(x, 2, axis=0) # along the first axis
+    >>> val
+    array([[5, 3, 4],
+           [3, 2, 2]])
+    >>> ind
+    array([[2, 0, 0],
+           [1, 1, 2]])
+    """
+    if axis is None:
+        axis_size = a.size
+    else:
+        axis_size = a.shape[axis]
+    assert 1 <= k <= axis_size
+
+    a = np.asanyarray(a)
+    if largest:
+        index_array = np.argpartition(a, axis_size-k, axis=axis)
+        topk_indices = np.take(index_array, -np.arange(k)-1, axis=axis)
+    else:
+        index_array = np.argpartition(a, k-1, axis=axis)
+        topk_indices = np.take(index_array, np.arange(k), axis=axis)
+    topk_values = np.take_along_axis(a, topk_indices, axis=axis)
+    if sorted:
+        sorted_indices_in_topk = np.argsort(topk_values, axis=axis)
+        if largest:
+            sorted_indices_in_topk = np.flip(sorted_indices_in_topk, axis=axis)
+        sorted_topk_values = np.take_along_axis(
+            topk_values, sorted_indices_in_topk, axis=axis)
+        sorted_topk_indices = np.take_along_axis(
+            topk_indices, sorted_indices_in_topk, axis=axis)
+        return sorted_topk_values, sorted_topk_indices
+    return topk_values, topk_indices
 
 
 def _searchsorted_dispatcher(a, v, side=None, sorter=None):

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -152,6 +152,23 @@ def argmin(
 ) -> Any: ...
 
 @overload
+def topk(
+    a: ArrayLike,
+    k: int = ...,
+    axis: None = ...,
+    largest: Optional[bool] = ...,
+    sorted: Optional[bool] = ...,
+) -> Tuple[ndarray, ndarray]: ...
+@overload
+def topk(
+    a: ArrayLike,
+    k: int = ...,
+    axis: Optional[int] = ...,
+    largest: Optional[bool] = ...,
+    sorted: Optional[bool] = ...,
+) -> Tuple[ndarray, ndarray]: ...
+
+@overload
 def searchsorted(
     a: ArrayLike,
     v: _Scalar,


### PR DESCRIPTION
Hi, find topk elements is widely used in machine learning and elsewhere, and some python frameworks have implemented it, e.g. TensorFlow (`tf.math.top_k`), PyTorch (`torch.topk`). 

I try to implement topk using core numpy functions, and have checked its correctness using `torch.topk`. The following is the test code snippet:

```python
import random

import torch
import numpy as np


def topk_np(a, k, axis=-1, largest=True, sorted=True):
    if axis is None:
        axis_size = a.size
    else:
        axis_size = a.shape[axis]
    assert 1 <= k <= axis_size

    a = np.asanyarray(a)
    if largest:
        index_array = np.argpartition(a, axis_size-k, axis=axis)
        topk_indices = np.take(index_array, -np.arange(k)-1, axis=axis)
    else:
        index_array = np.argpartition(a, k-1, axis=axis)
        topk_indices = np.take(index_array, np.arange(k), axis=axis)
    topk_values = np.take_along_axis(a, topk_indices, axis=axis)
    if sorted:
        sorted_indices_in_topk = np.argsort(topk_values, axis=axis)
        if largest:
            sorted_indices_in_topk = np.flip(sorted_indices_in_topk, axis=axis)
        sorted_topk_values = np.take_along_axis(
            topk_values, sorted_indices_in_topk, axis=axis)
        sorted_topk_indices = np.take_along_axis(
            topk_indices, sorted_indices_in_topk, axis=axis)
        return sorted_topk_values, sorted_topk_indices
    return topk_values, topk_indices
    

def test_for_float_types():
    # could change its shape
    arr = np.random.rand(100, 34, 43, 54)

    axis = random.choice([*range(arr.ndim), None])
    if axis is not None:
        k = random.choice(range(1, arr.shape[axis]))
    else:
        k = random.choice(range(1, arr.size))
    largest = random.choice([True, False])
    sorted = True
    print('axis={}, k={}, largest={}, sorted={}'.format(axis, k, largest, sorted))

    top_values, top_indices = topk_np(arr, k, axis=axis, largest=largest, sorted=sorted)
    
    # topk(): argument 'dim' must be int, not NoneType, so fix it!
    if axis is None:
        arr = arr.flatten()
        axis = 0
    arr_pt = torch.from_numpy(arr)
    top_values_pt, top_indices_pt = torch.topk(arr_pt, k, dim=axis, largest=largest, sorted=sorted)

    assert np.allclose(top_values, top_values_pt.numpy())
    assert np.allclose(top_indices, top_indices_pt.numpy())


def test_for_signed_int_types():
    # could change its shape
    shape = (100, 34, 43, 54)
    # for the consistency of indices, use unique numbers
    arr = np.arange(np.prod(shape), dtype=np.int32)
    np.random.shuffle(arr)

    axis = random.choice([*range(arr.ndim), None])
    if axis is not None:
        k = random.choice(range(1, arr.shape[axis]))
    else:
        k = random.choice(range(1, arr.size))
    largest = random.choice([True, False])
    sorted = True
    print('axis={}, k={}, largest={}, sorted={}'.format(axis, k, largest, sorted))

    top_values, top_indices = topk_np(arr, k, axis=axis, largest=largest, sorted=sorted)
    # topk(): argument 'dim' must be int, not NoneType, so fix it!
    if axis is None:
        arr = arr.flatten()
        axis = 0
    arr_pt = torch.from_numpy(arr)
    top_values_pt, top_indices_pt = torch.topk(arr_pt, k, dim=axis, largest=largest, sorted=sorted)

    assert np.allclose(top_values, top_values_pt.numpy())
    assert np.allclose(top_indices, top_indices_pt.numpy())


def test_for_unsigned_int_types():
    # could change its shape
    shape = (100, 34, 43, 54)
    # for the consistency of indices, use unique numbers
    arr = np.arange(np.prod(shape), dtype=np.uint32)
    np.random.shuffle(arr)

    axis = random.choice([*range(arr.ndim), None])
    if axis is not None:
        k = random.choice(range(1, arr.shape[axis]))
    else:
        k = random.choice(range(1, arr.size))
    largest = random.choice([True, False])
    sorted = True
    print('axis={}, k={}, largest={}, sorted={}'.format(axis, k, largest, sorted))

    top_values, top_indices = topk_np(arr, k, axis=axis, largest=largest, sorted=sorted)
    # topk(): argument 'dim' must be int, not NoneType, so fix it!
    if axis is None:
        arr = arr.flatten()
        axis = 0
    # torch.from_numpy does not support uint32, so fix it!
    arr_pt = torch.from_numpy(arr.astype(np.float32))
    top_values_pt, top_indices_pt = torch.topk(arr_pt, k, dim=axis, largest=largest, sorted=sorted)

    assert np.allclose(top_values, top_values_pt.numpy())
    assert np.allclose(top_indices, top_indices_pt.numpy())


if __name__ == '__main__':
    num_repeats = 100
    for k in range(num_repeats):
        # test_for_float_types()
        test_for_signed_int_types()
        # test_for_unsigned_int_types()
```