### PR TITLE
BUG: Adjust shallow clone in the gitpod container

### DIFF
--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -5,7 +5,9 @@ ARG BASE_CONTAINER="numpy/numpy-dev:latest"
 FROM gitpod/workspace-base:latest as clone
 
 COPY --chown=gitpod . /tmp/numpy_repo
-RUN git clone --depth 1 file:////tmp/numpy_repo /tmp/numpy
+
+# the clone should be deep enough for versioneer to work
+RUN git clone --depth=20 file:////tmp/numpy_repo /tmp/numpy
 
 # -----------------------------------------------------------------------------
 # Using the numpy-dev Docker image as a base

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -7,7 +7,7 @@ FROM gitpod/workspace-base:latest as clone
 COPY --chown=gitpod . /tmp/numpy_repo
 
 # the clone should be deep enough for versioneer to work
-RUN git clone --depth=20 file:////tmp/numpy_repo /tmp/numpy
+RUN git clone --shallow-since=2021-05-22 file:////tmp/numpy_repo /tmp/numpy
 
 # -----------------------------------------------------------------------------
 # Using the numpy-dev Docker image as a base


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->


Closes #19103 

`setup.py` was recently updated to better identify the tags through versioneer (see #19096) which meant the previous shallow clone in the Gitpod Docker container was no longer compatible with how tags are handled


Replacing `--depth=1` with `--depth=20` works well enough to fix the issue and still keep the clone shallow enough to not bloat the image

