### PR TITLE
 BUG: Fixed an issue wherein `poly1d.__getitem__` could return scalars of the wrong dtype

### DIFF
--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -494,11 +494,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     cov : bool or str, optional
         If given and not `False`, return not just the estimate but also its
         covariance matrix. By default, the covariance are scaled by
-        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed 
-        to be unreliable except in a relative sense and everything is scaled 
-        such that the reduced chi2 is unity. This scaling is omitted if 
-        ``cov='unscaled'``, as is relevant for the case that the weights are 
-        1/sigma**2, with sigma known to be a reliable estimate of the 
+        chi2/dof, where dof = M - (deg + 1), i.e., the weights are presumed
+        to be unreliable except in a relative sense and everything is scaled
+        such that the reduced chi2 is unity. This scaling is omitted if
+        ``cov='unscaled'``, as is relevant for the case that the weights are
+        1/sigma**2, with sigma known to be a reliable estimate of the
         uncertainty.
 
     Returns
@@ -1394,9 +1394,9 @@ class poly1d:
     def __getitem__(self, val):
         ind = self.order - val
         if val > self.order:
-            return 0
+            return self.coeffs.dtype.type(0)
         if val < 0:
-            return 0
+            return self.coeffs.dtype.type(0)
         return self.coeffs[ind]
 
     def __setitem__(self, key, val):


### PR DESCRIPTION
`poly1d.__getitem__` would previously always return `0` (`builtins.int`) if the passed index is either negative or out of bounds, regardless of the dtype of the underlying `poly1d.coeffs`.

This PR fixes aforementioned issue, `__getitem__` now always returning a scalar of the appropiate dtype.

Examples
----------
Prior to this PR:
``` python
In [1]: import numpy as np
   ...: 
   ...: p = np.poly1d([1.0, 2.0, 3.0])

In [2]: p[-1], type(p[-1])
Out[2]: (0, int)

In [3]: p[0], type(p[0])
Out[3]: (3.0, numpy.float64)
```