### PR TITLE
BUG: Use larger fetch depth in gitpod.yml

### DIFF
--- a/.github/workflows/gitpod.yml
+++ b/.github/workflows/gitpod.yml
@@ -4,19 +4,21 @@ on:
   push:
     branches:
       - main
-      
+
 jobs:
   build:
-    name: Build Gitpod Docker image 
+    name: Build Gitpod Docker image
     runs-on: ubuntu-latest
     environment: numpy-dev
     if: "github.repository_owner == 'numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
-      - name: Lint Docker 
+        with:
+          fetch-depth: 0
+      - name: Lint Docker
         uses: brpaz/hadolint-action@v1.2.1
-        with: 
+        with:
           dockerfile: ./tools/gitpod/gitpod.Dockerfile
       - name: Get refs
         shell: bash
@@ -50,6 +52,6 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
             numpy/numpy-gitpod:${{ steps.getrefs.outputs.date }}-${{ steps.getrefs.outputs.branch}}-${{ steps.getrefs.outputs.sha8 }}, numpy/numpy-gitpod:latest
-      - name: Image digest 
+      - name: Image digest
         # Return details of the image build: sha and shell
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Change the checkout@v2 fetch-depth parameter to zero, which means
everything. We could probably use a smaller number, but a full
checkout should only add a minute or two.

Related to #19119.

See https://github.com/actions/checkout for an explanation of the checkout@v2 parameters.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
