### PR TITLE
BUG: expose short_version as previously in version.py

### DIFF
--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -37,8 +37,8 @@ def test_valid_numpy_version():
 def test_short_version():
     # Check numpy.short_version actually exists
     if np.version.release:
-        assert_(numpy.__version__ == numpy.version.short_version,
+        assert_(np.__version__ == np.version.short_version,
         "short_version in release")
     else:
-        assert_(numpy.__version__.split("+")[0] == numpy.version.short_version,
+        assert_(np.__version__.split("+")[0] == np.version.short_version,
         "short_version not in release")

--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -37,6 +37,8 @@ def test_valid_numpy_version():
 def test_short_version():
     # Check numpy.short_version actually exists
     if np.version.release:
-        assert_(numpy.__version__ == numpy.version.short_version, "short_version in release")
+        assert_(numpy.__version__ == numpy.version.short_version,
+        "short_version in release")
     else:
-        assert_(numpy.__version__.split("+")[0] == numpy.version.short_version, "short_version not in release")
+        assert_(numpy.__version__.split("+")[0] == numpy.version.short_version,
+        "short_version not in release")

--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -32,3 +32,11 @@ def test_valid_numpy_version():
         res = re.match(version_pattern + dev_suffix + '$', np.__version__)
 
     assert_(res is not None, np.__version__)
+
+
+def test_short_version():
+    # Check numpy.short_version actually exists
+    if np.version.release:
+        assert_(numpy.__version__ == numpy.version.short_version, "short_version in release")
+    else:
+        assert_(numpy.__version__.split("+")[0] == numpy.version.short_version, "short_version not in release")

--- a/numpy/tests/test_numpy_version.py
+++ b/numpy/tests/test_numpy_version.py
@@ -38,7 +38,7 @@ def test_short_version():
     # Check numpy.short_version actually exists
     if np.version.release:
         assert_(np.__version__ == np.version.short_version,
-        "short_version in release")
+                "short_version mismatch in release version")
     else:
         assert_(np.__version__.split("+")[0] == np.version.short_version,
-        "short_version not in release")
+                "short_version mismatch in development version")

--- a/numpy/version.py
+++ b/numpy/version.py
@@ -5,8 +5,8 @@ __ALL__ = ['version', 'full_version', 'git_revision', 'release']
 vinfo = get_versions()
 version: str = vinfo["version"]
 full_version: str = vinfo['version']
-short_version: str = vinfo['version']
 git_revision: str = vinfo['full-revisionid']
 release = 'dev0' not in version and '+' not in version
+short_version: str = vinfo['version'].split("+")[0]
 
 del get_versions, vinfo

--- a/numpy/version.py
+++ b/numpy/version.py
@@ -5,6 +5,7 @@ __ALL__ = ['version', 'full_version', 'git_revision', 'release']
 vinfo = get_versions()
 version: str = vinfo["version"]
 full_version: str = vinfo['version']
+short_version: str = vinfo['version']
 git_revision: str = vinfo['full-revisionid']
 release = 'dev0' not in version and '+' not in version
 


### PR DESCRIPTION
Backport of #18142. 

Expose numpy.version.short_version which disappeared with PR between numpy 1.20 and 1.21 in commit:
`40fd17e`.

Regression tests follow...

Close #19141

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
