### PR TITLE
Support for stacked inputs to np.linalg.lstsq

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2268,7 +2268,7 @@ def lstsq(a, b, rcond="warn"):
     is_1d = b.ndim == 1
     if is_1d:
         b = b[:, newaxis]
-    _assert_2d(a, b)
+    _assert_stacked_2d(a, b)
     m, n = a.shape[-2:]
     m2, n_rhs = b.shape[-2:]
     if m != m2:
@@ -2317,8 +2317,10 @@ def lstsq(a, b, rcond="warn"):
         # we probably should squeeze resids too, but we can't
         # without breaking compatibility.
 
+    # Since matrices are stacked all the ranks will be same.
+    rank_val = rank[0] if a.ndim > 2 else rank
     # as documented
-    if rank != n or m <= n:
+    if rank_val != n or m <= n:
         resids = array([], result_real_t)
 
     # coerce output arrays


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

I have made some minor changes to allow stacked matrices as input to `np.linalg.lstsq`. No change in C backend was required for supporting this feature. Locally all the tests pass. Following is an example after this change. Please let me know if this works. I will add one test case for this after a thumbs up on this approach. Thanks.

**Code**

```python
Stacked Outputs
===============

Stacked Outputs
===============

(array([[[[ 0.32612054,  1.14540955,  0.02972337],
         [-0.05919986, -1.90496675,  0.78381663],
         [-0.14406915, -1.13843815,  1.1118298 ]],

        [[-0.56572966, -0.13566249, -0.51485472],
         [ 0.47419322,  0.00800012, -0.92140694],
         [-0.1546948 , -0.61969837, -0.33042568]]],


       [[[-0.26376158, -0.39273329,  0.67303169],
         [ 0.23407106, -0.45633909,  0.09286505],
         [ 1.01984472,  0.5703874 ,  0.41875056]],

        [[-1.83333333, -7.16666667, -5.33333333],
         [-0.33333333, -1.66666667, -1.33333333],
         [ 1.16666667,  3.83333333,  2.66666667]]]]), array([], dtype=float64), array([[3, 3],
       [3, 2]], dtype=int32), array([[[3.45699448e+00, 1.54054236e+00, 5.53652645e-01],
        [3.05103868e+00, 2.37214633e+00, 1.18476503e+00]],

       [[2.69263303e+00, 1.99516995e+00, 1.43607378e+00],
        [1.12185998e+01, 3.78179165e-01, 2.50154395e-16]]]))
===============

Outputs for a1
==============

(array([[ 0.32612054,  1.14540955,  0.02972337],
       [-0.05919986, -1.90496675,  0.78381663],
       [-0.14406915, -1.13843815,  1.1118298 ]]), array([], dtype=float64), 3, array([3.45699448, 1.54054236, 0.55365264]))
==============

Outputs for a2
==============

(array([[-0.56572966, -0.13566249, -0.51485472],
       [ 0.47419322,  0.00800012, -0.92140694],
       [-0.1546948 , -0.61969837, -0.33042568]]), array([], dtype=float64), 3, array([3.05103868, 2.37214633, 1.18476503]))
==============

Outputs for a3
==============

(array([[-0.26376158, -0.39273329,  0.67303169],
       [ 0.23407106, -0.45633909,  0.09286505],
       [ 1.01984472,  0.5703874 ,  0.41875056]]), array([], dtype=float64), 3, array([2.69263303, 1.99516995, 1.43607378]))
==============

Outputs for a4
==============

(array([[-1.83333333, -7.16666667, -5.33333333],
       [-0.33333333, -1.66666667, -1.33333333],
       [ 1.16666667,  3.83333333,  2.66666667]]), array([], dtype=float64), 2, array([1.12185998e+01, 3.78179165e-01, 2.50154395e-16]))
==============
```

ping @mattip 
