### PR TITLE
ENH: Improve readibility of error message in terminal.

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -383,9 +383,9 @@ else:
                 error_message = "{}: {}".format(w[-1].category.__name__, str(w[-1].message))
                 msg = (
                     "Polyfit sanity test emitted a warning, most likely due "
-                    "to using a buggy Accelerate backend.\nIf you compiled "
-                    "yourself, more information is available at:\n"
-                    "https://numpy.org/doc/stable/user/building.html#accelerated-blas-lapack-libraries"
+                    "to using a buggy Accelerate backend."
+                    "\nIf you compiled yourself, more information is available at:"
+                    "\nhttps://numpy.org/doc/stable/user/building.html#accelerated-blas-lapack-libraries"
                     "\nOtherwise report this to the vendor "
                     "that provided NumPy.\n{}\n".format(error_message))
                 raise RuntimeError(msg)

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -383,10 +383,10 @@ else:
                 error_message = "{}: {}".format(w[-1].category.__name__, str(w[-1].message))
                 msg = (
                     "Polyfit sanity test emitted a warning, most likely due "
-                    "to using a buggy Accelerate backend. If you compiled "
-                    "yourself, more information is available at "
-                    "https://numpy.org/doc/stable/user/building.html#accelerated-blas-lapack-libraries "
-                    "Otherwise report this to the vendor "
+                    "to using a buggy Accelerate backend.\nIf you compiled "
+                    "yourself, more information is available at:\n"
+                    "https://numpy.org/doc/stable/user/building.html#accelerated-blas-lapack-libraries"
+                    "\nOtherwise report this to the vendor "
                     "that provided NumPy.\n{}\n".format(error_message))
                 raise RuntimeError(msg)
     del _mac_os_check


### PR DESCRIPTION
When the polyfit sanity check fails, an informative error message
is raised, but there are no line breaks which can make it
difficult to read.

Adds linebreaks to make this message more readable.
