### PR TITLE
API: Delay string and number promotion deprecation/future warning

### DIFF
--- a/doc/source/release/1.21.0-notes.rst
+++ b/doc/source/release/1.21.0-notes.rst
@@ -82,39 +82,6 @@ The methods in question are:
 Future Changes
 ==============
 
-Promotion of strings with numbers and bools is deprecated
----------------------------------------------------------
-Any promotion of numbers and strings is deprecated and will
-give a ``FutureWarning`` the main affected functionalities
-are:
-
-* `numpy.promote_types` and `numpy.result_type` which will raise
-  an error in this case in the future.
-* `numpy.concatenate` will raise an error when concatenating a string
-  and numeric array. You can use ``dtype="S"`` to explicitly request
-  a string result.
-* `numpy.array` and related functions will start returning ``object``
-  arrays because these functions use ``object`` as a fallback when
-  no common dtype can be found.  However, it may happen that future
-  releases of NumPy will generally error in these cases.
-
-This will mainly affect code such as::
-
-    np.asarray(['string', 0])
-
-and::
-
-    np.concatenate((['string'], [0]))
-
-in both cases adding ``dtype="U"`` or ``dtype="S"`` will give the
-previous (string) result, while ``dtype=object`` will ensure an array with
-object dtype is returned.
-
-Comparisons, universal functions, and casting are not affected by this.
-
-(`gh-18116 <https://github.com/numpy/numpy/pull/18116>`__)
-
-
 Expired deprecations
 ====================
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -415,19 +415,6 @@ string_unicode_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         Py_INCREF(Py_NotImplemented);
         return (PyArray_DTypeMeta *)Py_NotImplemented;
     }
-    if (other->type_num != NPY_STRING && other->type_num != NPY_UNICODE) {
-        /* Deprecated 2020-12-19, NumPy 1.21. */
-        if (DEPRECATE_FUTUREWARNING(
-                "Promotion of numbers and bools to strings is deprecated. "
-                "In the future, code such as `np.concatenate((['string'], [0]))` "
-                "will raise an error, while `np.asarray(['string', 0])` will "
-                "return an array with `dtype=object`.  To avoid the warning "
-                "while retaining a string result use `dtype='U'` (or 'S').  "
-                "To get an array of Python objects use `dtype=object`. "
-                "(Warning added in NumPy 1.21)") < 0) {
-            return NULL;
-        }
-    }
     /*
      * The builtin types are ordered by complexity (aside from object) here.
      * Arguably, we should not consider numbers and strings "common", but

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1105,41 +1105,6 @@ class TestNoseDecoratorsDeprecated(_DeprecationTestCase):
         self.assert_deprecated(_test_parametrize)
 
 
-class TestStringPromotion(_DeprecationTestCase):
-    # Deprecated 2020-12-19, NumPy 1.21
-    warning_cls = FutureWarning
-    message = "Promotion of numbers and bools to strings is deprecated."
-
-    @pytest.mark.parametrize("dtype", "?bhilqpBHILQPefdgFDG")
-    @pytest.mark.parametrize("string_dt", ["S", "U"])
-    def test_deprecated(self, dtype, string_dt):
-        self.assert_deprecated(lambda: np.promote_types(dtype, string_dt))
-
-        # concatenate has to be able to promote to find the result dtype:
-        arr1 = np.ones(3, dtype=dtype)
-        arr2 = np.ones(3, dtype=string_dt)
-        self.assert_deprecated(lambda: np.concatenate((arr1, arr2), axis=0))
-        self.assert_deprecated(lambda: np.concatenate((arr1, arr2), axis=None))
-
-        self.assert_deprecated(lambda: np.array([arr1[0], arr2[0]]))
-
-    @pytest.mark.parametrize("dtype", "?bhilqpBHILQPefdgFDG")
-    @pytest.mark.parametrize("string_dt", ["S", "U"])
-    def test_not_deprecated(self, dtype, string_dt):
-        # The ufunc type resolvers run into this, but giving a futurewarning
-        # here is unnecessary (it ends up as an error anyway), so test that
-        # no warning is given:
-        arr1 = np.ones(3, dtype=dtype)
-        arr2 = np.ones(3, dtype=string_dt)
-
-        # Adding two arrays uses result_type normally, which would fail:
-        with pytest.raises(TypeError):
-            self.assert_not_deprecated(lambda: arr1 + arr2)
-        # np.equal uses a different type resolver:
-        with pytest.raises(TypeError):
-            self.assert_not_deprecated(lambda: np.equal(arr1, arr2))
-
-
 class TestSingleElementSignature(_DeprecationTestCase):
     # Deprecated 2021-04-01, NumPy 1.21
     message = r"The use of a length 1"

--- a/numpy/core/tests/test_half.py
+++ b/numpy/core/tests/test_half.py
@@ -71,10 +71,8 @@ class TestHalf:
     def test_half_conversion_to_string(self, string_dt):
         # Currently uses S/U32 (which is sufficient for float32)
         expected_dt = np.dtype(f"{string_dt}32")
-        with pytest.warns(FutureWarning):
-            assert np.promote_types(np.float16, string_dt) == expected_dt
-        with pytest.warns(FutureWarning):
-            assert np.promote_types(string_dt, np.float16) == expected_dt
+        assert np.promote_types(np.float16, string_dt) == expected_dt
+        assert np.promote_types(string_dt, np.float16) == expected_dt
 
         arr = np.ones(3, dtype=np.float16).astype(string_dt)
         assert arr.dtype == expected_dt

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -848,12 +848,10 @@ class TestTypes:
         assert_equal(np.promote_types('<i8', '<i8'), np.dtype('i8'))
         assert_equal(np.promote_types('>i8', '>i8'), np.dtype('i8'))
 
-        with pytest.warns(FutureWarning,
-                match="Promotion of numbers and bools to strings"):
-            assert_equal(np.promote_types('>i8', '>U16'), np.dtype('U21'))
-            assert_equal(np.promote_types('<i8', '<U16'), np.dtype('U21'))
-            assert_equal(np.promote_types('>U16', '>i8'), np.dtype('U21'))
-            assert_equal(np.promote_types('<U16', '<i8'), np.dtype('U21'))
+        assert_equal(np.promote_types('>i8', '>U16'), np.dtype('U21'))
+        assert_equal(np.promote_types('<i8', '<U16'), np.dtype('U21'))
+        assert_equal(np.promote_types('>U16', '>i8'), np.dtype('U21'))
+        assert_equal(np.promote_types('<U16', '<i8'), np.dtype('U21'))
 
         assert_equal(np.promote_types('<S5', '<U8'), np.dtype('U8'))
         assert_equal(np.promote_types('>S5', '>U8'), np.dtype('U8'))
@@ -901,37 +899,32 @@ class TestTypes:
 
         S = string_dtype
         
-        with pytest.warns(FutureWarning,
-                match="Promotion of numbers and bools to strings") as record:
-            # Promote numeric with unsized string:
-            assert_equal(promote_types('bool', S), np.dtype(S+'5'))
-            assert_equal(promote_types('b', S), np.dtype(S+'4'))
-            assert_equal(promote_types('u1', S), np.dtype(S+'3'))
-            assert_equal(promote_types('u2', S), np.dtype(S+'5'))
-            assert_equal(promote_types('u4', S), np.dtype(S+'10'))
-            assert_equal(promote_types('u8', S), np.dtype(S+'20'))
-            assert_equal(promote_types('i1', S), np.dtype(S+'4'))
-            assert_equal(promote_types('i2', S), np.dtype(S+'6'))
-            assert_equal(promote_types('i4', S), np.dtype(S+'11'))
-            assert_equal(promote_types('i8', S), np.dtype(S+'21'))
-            # Promote numeric with sized string:
-            assert_equal(promote_types('bool', S+'1'), np.dtype(S+'5'))
-            assert_equal(promote_types('bool', S+'30'), np.dtype(S+'30'))
-            assert_equal(promote_types('b', S+'1'), np.dtype(S+'4'))
-            assert_equal(promote_types('b', S+'30'), np.dtype(S+'30'))
-            assert_equal(promote_types('u1', S+'1'), np.dtype(S+'3'))
-            assert_equal(promote_types('u1', S+'30'), np.dtype(S+'30'))
-            assert_equal(promote_types('u2', S+'1'), np.dtype(S+'5'))
-            assert_equal(promote_types('u2', S+'30'), np.dtype(S+'30'))
-            assert_equal(promote_types('u4', S+'1'), np.dtype(S+'10'))
-            assert_equal(promote_types('u4', S+'30'), np.dtype(S+'30'))
-            assert_equal(promote_types('u8', S+'1'), np.dtype(S+'20'))
-            assert_equal(promote_types('u8', S+'30'), np.dtype(S+'30'))
-            # Promote with object:
-            assert_equal(promote_types('O', S+'30'), np.dtype('O'))
-
-        assert len(record) == 22  # each string promotion gave one warning
-
+        # Promote numeric with unsized string:
+        assert_equal(promote_types('bool', S), np.dtype(S+'5'))
+        assert_equal(promote_types('b', S), np.dtype(S+'4'))
+        assert_equal(promote_types('u1', S), np.dtype(S+'3'))
+        assert_equal(promote_types('u2', S), np.dtype(S+'5'))
+        assert_equal(promote_types('u4', S), np.dtype(S+'10'))
+        assert_equal(promote_types('u8', S), np.dtype(S+'20'))
+        assert_equal(promote_types('i1', S), np.dtype(S+'4'))
+        assert_equal(promote_types('i2', S), np.dtype(S+'6'))
+        assert_equal(promote_types('i4', S), np.dtype(S+'11'))
+        assert_equal(promote_types('i8', S), np.dtype(S+'21'))
+        # Promote numeric with sized string:
+        assert_equal(promote_types('bool', S+'1'), np.dtype(S+'5'))
+        assert_equal(promote_types('bool', S+'30'), np.dtype(S+'30'))
+        assert_equal(promote_types('b', S+'1'), np.dtype(S+'4'))
+        assert_equal(promote_types('b', S+'30'), np.dtype(S+'30'))
+        assert_equal(promote_types('u1', S+'1'), np.dtype(S+'3'))
+        assert_equal(promote_types('u1', S+'30'), np.dtype(S+'30'))
+        assert_equal(promote_types('u2', S+'1'), np.dtype(S+'5'))
+        assert_equal(promote_types('u2', S+'30'), np.dtype(S+'30'))
+        assert_equal(promote_types('u4', S+'1'), np.dtype(S+'10'))
+        assert_equal(promote_types('u4', S+'30'), np.dtype(S+'30'))
+        assert_equal(promote_types('u8', S+'1'), np.dtype(S+'20'))
+        assert_equal(promote_types('u8', S+'30'), np.dtype(S+'30'))
+        # Promote with object:
+        assert_equal(promote_types('O', S+'30'), np.dtype('O'))
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
             [[np.dtype("V6"), np.dtype("V10")],

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -782,9 +782,7 @@ class TestRegression:
         # Ticket #514
         s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         t = []
-        with pytest.warns(FutureWarning,
-                match="Promotion of numbers and bools to strings"):
-            np.hstack((t, s))
+        np.hstack((t, s))
 
     def test_arr_transpose(self):
         # Ticket #516

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -64,8 +64,7 @@ class TestRegression:
     def test_mem_string_concat(self):
         # Ticket #469
         x = np.array([])
-        with pytest.warns(FutureWarning):
-            np.append(x, 'asdasd\tasdasd')
+        np.append(x, 'asdasd\tasdasd')
 
     def test_poly_div(self):
         # Ticket #553


### PR DESCRIPTION
Unfortunately, this seems to cause some pain in pandas at least
to circumvent the warning.

Delaying may complicate the creation of ufuncs for strings, but
otherwise should not be a big problem.  We have to make sure that
we can reimplement the change quickly though, it is an important
change in my opinion.

---

I could also just do this against the maintanence 1.20 branch (and re-add the release note on its own).  It doesn't undo the fact that `FutureWarning` during promotion is still raised, but that is probably just as well.

Ping @jorisvandenbossche, since pandas is probably the main reason for undoing. 