### PR TITLE
 BUG: Fixed an issue wherein `_GenericAlias` could raise for non-iterable parameters

### DIFF
--- a/numpy/typing/_generic_alias.py
+++ b/numpy/typing/_generic_alias.py
@@ -104,7 +104,7 @@ class _GenericAlias:
     def __init__(self, origin: type, args: Any) -> None:
         self._origin = origin
         self._args = args if isinstance(args, tuple) else (args,)
-        self._parameters = tuple(_parse_parameters(args))
+        self._parameters = tuple(_parse_parameters(self.__args__))
 
     @property
     def __call__(self) -> type:

--- a/numpy/typing/_generic_alias.py
+++ b/numpy/typing/_generic_alias.py
@@ -93,7 +93,7 @@ class _GenericAlias:
         return super().__getattribute__("_origin")
 
     @property
-    def __args__(self) -> Tuple[Any, ...]:
+    def __args__(self) -> Tuple[object, ...]:
         return super().__getattribute__("_args")
 
     @property
@@ -101,7 +101,11 @@ class _GenericAlias:
         """Type variables in the ``GenericAlias``."""
         return super().__getattribute__("_parameters")
 
-    def __init__(self, origin: type, args: Any) -> None:
+    def __init__(
+        self,
+        origin: type,
+        args: object | Tuple[object, ...],
+    ) -> None:
         self._origin = origin
         self._args = args if isinstance(args, tuple) else (args,)
         self._parameters = tuple(_parse_parameters(self.__args__))
@@ -110,7 +114,10 @@ class _GenericAlias:
     def __call__(self) -> type:
         return self.__origin__
 
-    def __reduce__(self: _T) -> Tuple[Type[_T], Tuple[type, Tuple[Any, ...]]]:
+    def __reduce__(self: _T) -> Tuple[
+        Type[_T],
+        Tuple[type, Tuple[object, ...]],
+    ]:
         cls = type(self)
         return cls, (self.__origin__, self.__args__)
 
@@ -148,7 +155,7 @@ class _GenericAlias:
         origin = _to_str(self.__origin__)
         return f"{origin}[{args}]"
 
-    def __getitem__(self: _T, key: Any) -> _T:
+    def __getitem__(self: _T, key: object | Tuple[object, ...]) -> _T:
         """Return ``self[key]``."""
         key_tup = key if isinstance(key, tuple) else (key,)
 

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -41,6 +41,12 @@ class TestGenericAlias:
 
     @pytest.mark.parametrize("name,func", [
         ("__init__", lambda n: n),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, Any)),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, (Any,))),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, (Any, Any))),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, T1)),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, (T1,))),
+        ("__init__", lambda n: _GenericAlias(np.ndarray, (T1, T2))),
         ("__origin__", lambda n: n.__origin__),
         ("__args__", lambda n: n.__args__),
         ("__parameters__", lambda n: n.__parameters__),


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/19169.

It's a bit surprising that this bug was only revealed recently in the nightly build, but so be it.

In principle the fix can be backported, but the relevant code-path is currently both private and unused as of 1.21.
So unless someone is willing to argue otherwise, I'm inclined to leave things as they are.

