### PR TITLE
MAINT, BUG: Adapt `castingimpl.casting` to denote a minimal level

### DIFF
--- a/doc/neps/nep-0042-new-dtypes.rst
+++ b/doc/neps/nep-0042-new-dtypes.rst
@@ -1334,7 +1334,7 @@ Although verbose, the API will mimic the one for creating a new DType:
     typedef struct{
       int flags;                  /* e.g. whether the cast requires the API */
       int nin, nout;              /* Number of Input and outputs (always 1) */
-      NPY_CASTING casting;        /* The default casting level */
+      NPY_CASTING casting;        /* The "minimal casting level" */
       PyArray_DTypeMeta *dtypes;  /* input and output DType class */
       /* NULL terminated slots defining the methods */
       PyType_Slot *slots;
@@ -1342,7 +1342,7 @@ Although verbose, the API will mimic the one for creating a new DType:
 
 The focus differs between casting and general ufuncs.  For example, for casts
 ``nin == nout == 1`` is always correct, while for ufuncs ``casting`` is
-expected to be usually `"safe"`.
+expected to be usually `"no"`.
 
 **Notes:** We may initially allow users to define only a single loop.
 Internally NumPy optimizes far more, and this should be made public
@@ -1356,6 +1356,11 @@ incrementally in one of two ways:
 
 * Or, more likely, expose the ``get_loop`` function which is passed additional
   information, such as the fixed strides (similar to our internal API).
+
+* The casting level denotes the minimal guaranteed casting level and can be
+  ``-1`` if the cast may be impossible.  For most non-parametric casts, this
+  value will be the casting level.  NumPy may skip the ``resolve_descriptors``
+  call for ``np.can_cast()`` when the result is ``True`` based on this level.
 
 The example does not yet include setup and error handling. Since these are
 similar to the UFunc machinery, they  will be defined in :ref:`NEP 43 <NEP43>` and then

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -262,8 +262,8 @@ to define string equality, will be added to a ufunc.
             if given_descrs[2] is None:
                 out_descr = DTypes[2]()
 
-            # The operation is always "safe" casting (most ufuncs are)
-            return (given_descrs[0], given_descrs[1], out_descr), "safe"
+            # The operation is always "no" casting (most ufuncs are)
+            return (given_descrs[0], given_descrs[1], out_descr), "no"
 
         def strided_loop(context, dimensions, data, strides, innerloop_data):
             """The 1-D strided loop, similar to those used in current ufuncs"""
@@ -434,7 +434,7 @@ a new ``ArrayMethod`` object:
 
         # Casting safety information (almost always "safe", necessary to
         # unify casting and universal functions)
-        casting: Casting = "safe"
+        casting: Casting = "no"
 
         # More general flags:
         flags: int
@@ -751,7 +751,7 @@ This step is required to allocate output arrays and has to happen before
 casting can be prepared.
 
 While the returned casting-safety (``NPY_CASTING``) will almost always be
-"safe" for universal functions, including it has two big advantages:
+"no" for universal functions, including it has two big advantages:
 
 * ``-1`` indicates that an error occurred. If a Python error is set, it will
   be raised.  If no Python error is set this will be considered an "impossible"
@@ -767,7 +767,7 @@ While the returned casting-safety (``NPY_CASTING``) will almost always be
   perspective. Currently, this would use ``int64 + int64 -> int64`` and then
   cast to ``int32``. An implementation that skips the cast would
   have to signal that it effectively includes the "same-kind" cast and is
-  thus not considered "safe".
+  thus not considered "no".
 
 
 ``get_loop`` method

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -358,45 +358,15 @@ PyArray_CastAnyTo(PyArrayObject *out, PyArrayObject *mp)
 }
 
 
-/**
- * Given two dtype instances, find the correct casting safety.
- *
- * Note that in many cases, it may be preferable to fetch the casting
- * implementations fully to have them available for doing the actual cast
- * later.
- *
- * @param from
- * @param to The descriptor to cast to (may be NULL)
- * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
- *        is ignored).
- * @return NPY_CASTING or -1 on error or if the cast is not possible.
- */
-NPY_NO_EXPORT NPY_CASTING
-PyArray_GetCastSafety(
-        PyArray_Descr *from, PyArray_Descr *to, PyArray_DTypeMeta *to_dtype)
+static NPY_CASTING
+_get_cast_safety_from_castingimpl(PyArrayMethodObject *castingimpl,
+        PyArray_DTypeMeta *dtypes[2], PyArray_Descr *from, PyArray_Descr *to)
 {
-    NPY_CASTING casting;
-    if (to != NULL) {
-        to_dtype = NPY_DTYPE(to);
-    }
-    PyObject *meth = PyArray_GetCastingImpl(NPY_DTYPE(from), to_dtype);
-    if (meth == NULL) {
-        return -1;
-    }
-    if (meth == Py_None) {
-        Py_DECREF(Py_None);
-        return -1;
-    }
-
-    PyArrayMethodObject *castingimpl = (PyArrayMethodObject *)meth;
-
-    PyArray_DTypeMeta *dtypes[2] = {NPY_DTYPE(from), to_dtype};
     PyArray_Descr *descrs[2] = {from, to};
     PyArray_Descr *out_descrs[2];
 
-    casting = castingimpl->resolve_descriptors(
+    NPY_CASTING casting = castingimpl->resolve_descriptors(
             castingimpl, dtypes, descrs, out_descrs);
-    Py_DECREF(meth);
     if (casting < 0) {
         return -1;
     }
@@ -424,6 +394,100 @@ PyArray_GetCastSafety(
     /* NPY_NO_CASTING has to be used for (NPY_EQUIV_CASTING|_NPY_CAST_IS_VIEW) */
     assert(casting != (NPY_EQUIV_CASTING|_NPY_CAST_IS_VIEW));
     return casting;
+}
+
+
+/**
+ * Given two dtype instances, find the correct casting safety.
+ *
+ * Note that in many cases, it may be preferable to fetch the casting
+ * implementations fully to have them available for doing the actual cast
+ * later.
+ *
+ * @param from
+ * @param to The descriptor to cast to (may be NULL)
+ * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
+ *        is ignored).
+ * @return NPY_CASTING or -1 on error or if the cast is not possible.
+ */
+NPY_NO_EXPORT NPY_CASTING
+PyArray_GetCastSafety(
+        PyArray_Descr *from, PyArray_Descr *to, PyArray_DTypeMeta *to_dtype)
+{
+    if (to != NULL) {
+        to_dtype = NPY_DTYPE(to);
+    }
+    PyObject *meth = PyArray_GetCastingImpl(NPY_DTYPE(from), to_dtype);
+    if (meth == NULL) {
+        return -1;
+    }
+    if (meth == Py_None) {
+        Py_DECREF(Py_None);
+        return -1;
+    }
+
+    PyArrayMethodObject *castingimpl = (PyArrayMethodObject *)meth;
+    PyArray_DTypeMeta *dtypes[2] = {NPY_DTYPE(from), to_dtype};
+    NPY_CASTING casting = _get_cast_safety_from_castingimpl(castingimpl,
+            dtypes, from, to);
+    Py_DECREF(meth);
+
+    return casting;
+}
+
+
+/**
+ * Check whether a cast is safe, see also `PyArray_GetCastSafety` for
+ * a similiar function.  Unlike GetCastSafety, this function checks the
+ * `castingimpl->casting` when available.  This allows for two things:
+ *
+ * 1. It avoids  calling `resolve_descriptors` in some cases.
+ * 2. Strings need to discover the length, but in some cases we know that the
+ *    cast is valid (assuming the string length is discovered first).
+ *
+ * The latter means that a `can_cast` could return True, but the cast fail
+ * because the parametric type cannot guess the correct output descriptor.
+ * (I.e. if `object_arr.astype("S")` did _not_ inspect the objects, and the
+ * user would have to guess the string length.)
+ *
+ * @param casting the requested casting safety.
+ * @param from
+ * @param to The descriptor to cast to (may be NULL)
+ * @param to_dtype If `to` is NULL, must pass the to_dtype (otherwise this
+ *        is ignored).
+ * @return 0 for an invalid cast, 1 for a valid and -1 for an error.
+ */
+static int
+PyArray_CheckCastSafety(NPY_CASTING casting,
+        PyArray_Descr *from, PyArray_Descr *to, PyArray_DTypeMeta *to_dtype)
+{
+    if (to != NULL) {
+        to_dtype = NPY_DTYPE(to);
+    }
+    PyObject *meth = PyArray_GetCastingImpl(NPY_DTYPE(from), to_dtype);
+    if (meth == NULL) {
+        return -1;
+    }
+    if (meth == Py_None) {
+        Py_DECREF(Py_None);
+        return -1;
+    }
+    PyArrayMethodObject *castingimpl = (PyArrayMethodObject *)meth;
+
+    if (PyArray_MinCastSafety(castingimpl->casting, casting) == casting) {
+        /* No need to check using `castingimpl.resolve_descriptors()` */
+        return 1;
+    }
+
+    PyArray_DTypeMeta *dtypes[2] = {NPY_DTYPE(from), to_dtype};
+    NPY_CASTING safety = _get_cast_safety_from_castingimpl(castingimpl,
+            dtypes, from, to);
+    Py_DECREF(meth);
+    /* If casting is the smaller (or equal) safety we match */
+    if (safety < 0) {
+        return -1;
+    }
+    return PyArray_MinCastSafety(safety, casting) == casting;
 }
 
 
@@ -565,6 +629,8 @@ NPY_NO_EXPORT npy_bool
 PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
         NPY_CASTING casting)
 {
+    PyArray_DTypeMeta *to_dtype = NPY_DTYPE(to);
+
     /*
      * NOTE: This code supports U and S, this is identical to the code
      *       in `ctors.c` which does not allow these dtypes to be attached
@@ -576,21 +642,21 @@ PyArray_CanCastTypeTo(PyArray_Descr *from, PyArray_Descr *to,
      * TODO: We should grow support for `np.can_cast("d", "S")` being
      *       different from `np.can_cast("d", "S0")` here, at least for
      *       the python side API.
+     *       The `to = NULL` branch, which considers "S0" to be "flexible"
+     *       should probably be deprecated.
+     *       (This logic is duplicated in `PyArray_CanCastArrayTo`)
      */
-    NPY_CASTING safety;
     if (PyDataType_ISUNSIZED(to) && to->subarray == NULL) {
-        safety = PyArray_GetCastSafety(from, NULL, NPY_DTYPE(to));
-    }
-    else {
-        safety = PyArray_GetCastSafety(from, to, NPY_DTYPE(to));
+        to = NULL;  /* consider mainly S0 and U0 as S and U */
     }
 
-    if (safety < 0) {
+    int is_valid = PyArray_CheckCastSafety(casting, from, to, to_dtype);
+    /* Clear any errors and consider this unsafe (should likely be changed) */
+    if (is_valid < 0) {
         PyErr_Clear();
         return 0;
     }
-    /* If casting is the smaller (or equal) safety we match */
-    return PyArray_MinCastSafety(safety, casting) == casting;
+    return is_valid;
 }
 
 
@@ -610,27 +676,21 @@ can_cast_scalar_to(PyArray_Descr *scal_type, char *scal_data,
     /*
      * If the two dtypes are actually references to the same object
      * or if casting type is forced unsafe then always OK.
+     *
+     * TODO: Assuming that unsafe casting always works is not actually correct
      */
     if (scal_type == to || casting == NPY_UNSAFE_CASTING ) {
         return 1;
     }
 
-    /* NOTE: This is roughly the same code as `PyArray_CanCastTypeTo`: */
-    NPY_CASTING safety;
-    if (PyDataType_ISUNSIZED(to) && to->subarray == NULL) {
-        safety = PyArray_GetCastSafety(scal_type, NULL, NPY_DTYPE(to));
-    }
-    else {
-        safety = PyArray_GetCastSafety(scal_type, to, NPY_DTYPE(to));
-    }
-    if (safety < 0) {
-        PyErr_Clear();
-        return 0;
-    }
-    safety = PyArray_MinCastSafety(safety, casting);
-    if (safety == casting) {
+    int valid = PyArray_CheckCastSafety(casting, scal_type, to, NPY_DTYPE(to));
+    if (valid == 1) {
         /* This is definitely a valid cast. */
         return 1;
+    }
+    if (valid < 0) {
+        /* Probably must return 0, but just keep trying for now. */
+        PyErr_Clear();
     }
 
     /*
@@ -692,14 +752,29 @@ PyArray_CanCastArrayTo(PyArrayObject *arr, PyArray_Descr *to,
                         NPY_CASTING casting)
 {
     PyArray_Descr *from = PyArray_DESCR(arr);
+    PyArray_DTypeMeta *to_dtype = NPY_DTYPE(to);
 
-    /* If it's a scalar, check the value */
-    if (PyArray_NDIM(arr) == 0 && !PyArray_HASFIELDS(arr)) {
+    /* NOTE, TODO: The same logic as `PyArray_CanCastTypeTo`: */
+    if (PyDataType_ISUNSIZED(to) && to->subarray == NULL) {
+        to = NULL;
+    }
+
+    /*
+     * If it's a scalar, check the value.  (This only currently matters for
+     * numeric types and for `to == NULL` it can't be numeric.)
+     */
+    if (PyArray_NDIM(arr) == 0 && !PyArray_HASFIELDS(arr) && to != NULL) {
         return can_cast_scalar_to(from, PyArray_DATA(arr), to, casting);
     }
 
-    /* Otherwise, use the standard rules */
-    return PyArray_CanCastTypeTo(from, to, casting);
+    /* Otherwise, use the standard rules (same as `PyArray_CanCastTypeTo`) */
+    int is_valid = PyArray_CheckCastSafety(casting, from, to, to_dtype);
+    /* Clear any errors and consider this unsafe (should likely be changed) */
+    if (is_valid < 0) {
+        PyErr_Clear();
+        return 0;
+    }
+    return is_valid;
 }
 
 
@@ -2122,13 +2197,6 @@ PyArray_AddCastingImplementation(PyBoundArrayMethodObject *meth)
                     meth->method->name);
             return -1;
         }
-        if ((meth->method->casting & ~_NPY_CAST_IS_VIEW) != NPY_NO_CASTING) {
-            PyErr_Format(PyExc_TypeError,
-                    "A cast where input and output DType (class) are identical "
-                    "must signal `no-casting`. (method: %s)",
-                    meth->method->name);
-            return -1;
-        }
         if (meth->dtypes[0]->within_dtype_castingimpl != NULL) {
             PyErr_Format(PyExc_RuntimeError,
                     "A cast was already added for %S -> %S. (method: %s)",
@@ -2400,7 +2468,7 @@ add_numeric_cast(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 
     /* Find the correct casting level, and special case no-cast */
     if (dtypes[0]->kind == dtypes[1]->kind && from_itemsize == to_itemsize) {
-        spec.casting = NPY_NO_CASTING;
+        spec.casting = NPY_EQUIV_CASTING;
 
         /* When there is no casting (equivalent C-types) use byteswap loops */
         slots[0].slot = NPY_METH_resolve_descriptors;
@@ -2558,7 +2626,6 @@ cast_to_string_resolve_descriptors(
                dtypes[1]->type_num == NPY_STRING);
         return NPY_UNSAFE_CASTING;
     }
-    assert(self->casting == NPY_SAFE_CASTING);
 
     if (loop_descrs[1]->elsize >= size) {
         return NPY_SAFE_CASTING;
@@ -2600,9 +2667,9 @@ add_other_to_and_from_string_cast(
         .dtypes = dtypes,
         .slots = slots,
     };
-    /* Almost everything can be safely cast to string (except unicode) */
+    /* Almost everything can be same-kind cast to string (except unicode) */
     if (other->type_num != NPY_UNICODE) {
-        spec.casting = NPY_SAFE_CASTING;
+        spec.casting = NPY_SAME_KIND_CASTING;  /* same-kind if too short */
     }
     else {
         spec.casting = NPY_UNSAFE_CASTING;
@@ -2722,7 +2789,7 @@ PyArray_InitializeStringCasts(void)
             {0, NULL}};
     PyArrayMethod_Spec spec = {
             .name = "string_to_string_cast",
-            .casting = NPY_NO_CASTING,
+            .casting = NPY_UNSAFE_CASTING,
             .nin = 1,
             .nout = 1,
             .flags = (NPY_METH_REQUIRES_PYAPI |
@@ -2935,7 +3002,7 @@ PyArray_GetGenericToVoidCastingImpl(void)
 
     method->name = "any_to_void_cast";
     method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
-    method->casting = NPY_SAFE_CASTING;
+    method->casting = -1;
     method->resolve_descriptors = &nonstructured_to_structured_resolve_descriptors;
     method->get_strided_loop = &nonstructured_to_structured_get_loop;
 
@@ -3074,7 +3141,7 @@ PyArray_GetVoidToGenericCastingImpl(void)
 
     method->name = "void_to_any_cast";
     method->flags = NPY_METH_SUPPORTS_UNALIGNED | NPY_METH_REQUIRES_PYAPI;
-    method->casting = NPY_UNSAFE_CASTING;
+    method->casting = -1;
     method->resolve_descriptors = &structured_to_nonstructured_resolve_descriptors;
     method->get_strided_loop = &structured_to_nonstructured_get_loop;
 
@@ -3306,7 +3373,7 @@ PyArray_InitializeVoidToVoidCast(void)
             {0, NULL}};
     PyArrayMethod_Spec spec = {
             .name = "void_to_void_cast",
-            .casting = NPY_NO_CASTING,
+            .casting = -1,  /* may not cast at all */
             .nin = 1,
             .nout = 1,
             .flags = NPY_METH_REQUIRES_PYAPI | NPY_METH_SUPPORTS_UNALIGNED,

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3952,7 +3952,6 @@ time_to_string_resolve_descriptors(
         return -1;
     }
 
-    assert(self->casting == NPY_UNSAFE_CASTING);
     return NPY_UNSAFE_CASTING;
 }
 
@@ -4059,7 +4058,7 @@ PyArray_InitializeDatetimeCasts()
         .name = "datetime_casts",
         .nin = 1,
         .nout = 1,
-        .casting = NPY_NO_CASTING,
+        .casting = NPY_UNSAFE_CASTING,
         .flags = NPY_METH_SUPPORTS_UNALIGNED,
         .slots = slots,
         .dtypes = dtypes,

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -281,6 +281,19 @@ def test_array_astype():
     a = np.array(1000, dtype='i4')
     assert_raises(TypeError, a.astype, 'U1', casting='safe')
 
+@pytest.mark.parametrize("dt", ["S", "U"])
+def test_array_astype_to_string_discovery_empty(dt):
+    # See also gh-19085
+    arr = np.array([""], dtype=object)
+    # Note, the itemsize is the `0 -> 1` logic, which should change.
+    # The important part the test is rather that it does not error.
+    assert arr.astype(dt).dtype.itemsize == np.dtype(f"{dt}1").itemsize
+
+    # check the same thing for `np.can_cast` (since it accepts arrays)
+    assert np.can_cast(arr, dt, casting="unsafe")
+    assert not np.can_cast(arr, dt, casting="same_kind")
+    # as well as for the object as a descriptor:
+    assert np.can_cast("O", dt, casting="unsafe")
 
 @pytest.mark.parametrize("dt", ["d", "f", "S13", "U32"])
 def test_array_astype_to_void(dt):


### PR DESCRIPTION
This also allows skipping the call to `resolve_descriptors()` when
the casting level guarantees that the cast will be successfull.

This is sufficient to "tape over" problems with object to string
casts, because it means that an "unsafe" cast is known to work
(no matter the string length).
Note that there is a theoretical anomaly remaining:  Casting
object to string without first discovering the correct string length
will fail (because it is unclear which string length to pick), even
though no matter which string length is picked "unsafe" is correct.

NumPy should never do this, we always first discover the string
length when casting from `object` DType specifically (object is
special that way -- not string itself).

In general, this seems fine to me, in practice, the behaviour would
probably not be quite fixed yet.

---

This is independent from the fact that we should probably duplicate the `CanCast` API functions so that they do not use flexible DType logic.  Or even just modify them on the C-level (for the Python level we can move the "flexible" logic to the Python entry point).