### PR TITLE
REV,BUG: Replace `NotImplemented` with `typing.Any`

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -164,7 +164,7 @@ API
 # NOTE: The API section will be appended with additional entries
 # further down in this file
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Any
 
 if TYPE_CHECKING:
     # typing_extensions is always available when type-checking
@@ -376,14 +376,14 @@ if TYPE_CHECKING:
         _GUFunc_Nin2_Nout1,
     )
 else:
-    _UFunc_Nin1_Nout1 = NotImplemented
-    _UFunc_Nin2_Nout1 = NotImplemented
-    _UFunc_Nin1_Nout2 = NotImplemented
-    _UFunc_Nin2_Nout2 = NotImplemented
-    _GUFunc_Nin2_Nout1 = NotImplemented
+    _UFunc_Nin1_Nout1 = Any
+    _UFunc_Nin2_Nout1 = Any
+    _UFunc_Nin1_Nout2 = Any
+    _UFunc_Nin2_Nout2 = Any
+    _GUFunc_Nin2_Nout1 = Any
 
 # Clean up the namespace
-del TYPE_CHECKING, final, List
+del TYPE_CHECKING, final, List, Any
 
 if __doc__ is not None:
     from ._add_docstring import _docstrings

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, Sequence, TYPE_CHECKING, Union, TypeVar
+from typing import Any, Sequence, TYPE_CHECKING, Union, TypeVar, Generic
 
 from numpy import (
     ndarray,
@@ -43,7 +43,7 @@ if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
     class _SupportsArray(Protocol[_DType_co]):
         def __array__(self) -> ndarray[Any, _DType_co]: ...
 else:
-    _SupportsArray = Any
+    class _SupportsArray(Generic[_DType_co]): ...
 
 # TODO: Wait for support for recursive types
 _NestedSequence = Union[

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -34,7 +34,7 @@ _ScalarType = TypeVar("_ScalarType", bound=generic)
 _DType = TypeVar("_DType", bound="dtype[Any]")
 _DType_co = TypeVar("_DType_co", covariant=True, bound="dtype[Any]")
 
-if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
+if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS or sys.version_info >= (3, 8):
     # The `_SupportsArray` protocol only cares about the default dtype
     # (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
     # array.

--- a/numpy/typing/_callable.py
+++ b/numpy/typing/_callable.py
@@ -332,25 +332,25 @@ if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
         def __call__(self, __other: _T2) -> NDArray[bool_]: ...
 
 else:
-    _BoolOp = NotImplemented
-    _BoolBitOp = NotImplemented
-    _BoolSub = NotImplemented
-    _BoolTrueDiv = NotImplemented
-    _BoolMod = NotImplemented
-    _BoolDivMod = NotImplemented
-    _TD64Div = NotImplemented
-    _IntTrueDiv = NotImplemented
-    _UnsignedIntOp = NotImplemented
-    _UnsignedIntBitOp = NotImplemented
-    _UnsignedIntMod = NotImplemented
-    _UnsignedIntDivMod = NotImplemented
-    _SignedIntOp = NotImplemented
-    _SignedIntBitOp = NotImplemented
-    _SignedIntMod = NotImplemented
-    _SignedIntDivMod = NotImplemented
-    _FloatOp = NotImplemented
-    _FloatMod = NotImplemented
-    _FloatDivMod = NotImplemented
-    _ComplexOp = NotImplemented
-    _NumberOp = NotImplemented
-    _ComparisonOp = NotImplemented
+    _BoolOp = Any
+    _BoolBitOp = Any
+    _BoolSub = Any
+    _BoolTrueDiv = Any
+    _BoolMod = Any
+    _BoolDivMod = Any
+    _TD64Div = Any
+    _IntTrueDiv = Any
+    _UnsignedIntOp = Any
+    _UnsignedIntBitOp = Any
+    _UnsignedIntMod = Any
+    _UnsignedIntDivMod = Any
+    _SignedIntOp = Any
+    _SignedIntBitOp = Any
+    _SignedIntMod = Any
+    _SignedIntDivMod = Any
+    _FloatOp = Any
+    _FloatMod = Any
+    _FloatDivMod = Any
+    _ComplexOp = Any
+    _NumberOp = Any
+    _ComparisonOp = Any

--- a/numpy/typing/_callable.py
+++ b/numpy/typing/_callable.py
@@ -53,7 +53,7 @@ if sys.version_info >= (3, 8):
 elif _HAS_TYPING_EXTENSIONS:
     from typing_extensions import Protocol
 
-if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
+if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS or sys.version_info >= (3, 8):
     _T1 = TypeVar("_T1")
     _T2 = TypeVar("_T2")
     _2Tuple = Tuple[_T1, _T1]

--- a/numpy/typing/_char_codes.py
+++ b/numpy/typing/_char_codes.py
@@ -120,52 +120,52 @@ if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
     ]
 
 else:
-    _BoolCodes = NotImplemented
+    _BoolCodes = Any
 
-    _UInt8Codes = NotImplemented
-    _UInt16Codes = NotImplemented
-    _UInt32Codes = NotImplemented
-    _UInt64Codes = NotImplemented
+    _UInt8Codes = Any
+    _UInt16Codes = Any
+    _UInt32Codes = Any
+    _UInt64Codes = Any
 
-    _Int8Codes = NotImplemented
-    _Int16Codes = NotImplemented
-    _Int32Codes = NotImplemented
-    _Int64Codes = NotImplemented
+    _Int8Codes = Any
+    _Int16Codes = Any
+    _Int32Codes = Any
+    _Int64Codes = Any
 
-    _Float16Codes = NotImplemented
-    _Float32Codes = NotImplemented
-    _Float64Codes = NotImplemented
+    _Float16Codes = Any
+    _Float32Codes = Any
+    _Float64Codes = Any
 
-    _Complex64Codes = NotImplemented
-    _Complex128Codes = NotImplemented
+    _Complex64Codes = Any
+    _Complex128Codes = Any
 
-    _ByteCodes = NotImplemented
-    _ShortCodes = NotImplemented
-    _IntCCodes = NotImplemented
-    _IntPCodes = NotImplemented
-    _IntCodes = NotImplemented
-    _LongLongCodes = NotImplemented
+    _ByteCodes = Any
+    _ShortCodes = Any
+    _IntCCodes = Any
+    _IntPCodes = Any
+    _IntCodes = Any
+    _LongLongCodes = Any
 
-    _UByteCodes = NotImplemented
-    _UShortCodes = NotImplemented
-    _UIntCCodes = NotImplemented
-    _UIntPCodes = NotImplemented
-    _UIntCodes = NotImplemented
-    _ULongLongCodes = NotImplemented
+    _UByteCodes = Any
+    _UShortCodes = Any
+    _UIntCCodes = Any
+    _UIntPCodes = Any
+    _UIntCodes = Any
+    _ULongLongCodes = Any
 
-    _HalfCodes = NotImplemented
-    _SingleCodes = NotImplemented
-    _DoubleCodes = NotImplemented
-    _LongDoubleCodes = NotImplemented
+    _HalfCodes = Any
+    _SingleCodes = Any
+    _DoubleCodes = Any
+    _LongDoubleCodes = Any
 
-    _CSingleCodes = NotImplemented
-    _CDoubleCodes = NotImplemented
-    _CLongDoubleCodes = NotImplemented
+    _CSingleCodes = Any
+    _CDoubleCodes = Any
+    _CLongDoubleCodes = Any
 
-    _StrCodes = NotImplemented
-    _BytesCodes = NotImplemented
-    _VoidCodes = NotImplemented
-    _ObjectCodes = NotImplemented
+    _StrCodes = Any
+    _BytesCodes = Any
+    _VoidCodes = Any
+    _ObjectCodes = Any
 
-    _DT64Codes = NotImplemented
-    _TD64Codes = NotImplemented
+    _DT64Codes = Any
+    _TD64Codes = Any

--- a/numpy/typing/_char_codes.py
+++ b/numpy/typing/_char_codes.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 8):
 elif _HAS_TYPING_EXTENSIONS:
     from typing_extensions import Literal
 
-if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
+if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS or sys.version_info >= (3, 8):
     _BoolCodes = Literal["?", "=?", "<?", ">?", "bool", "bool_", "bool8"]
 
     _UInt8Codes = Literal["uint8", "u1", "=u1", "<u1", ">u1"]

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -11,9 +11,6 @@ if sys.version_info >= (3, 8):
     from typing import Protocol, TypedDict
 elif _HAS_TYPING_EXTENSIONS:
     from typing_extensions import Protocol, TypedDict
-
-if sys.version_info >= (3, 9):
-    from types import GenericAlias
 else:
     from ._generic_alias import _GenericAlias as GenericAlias
 
@@ -62,7 +59,7 @@ from ._char_codes import (
 _DTypeLikeNested = Any  # TODO: wait for support for recursive types
 _DType_co = TypeVar("_DType_co", covariant=True, bound=DType[Any])
 
-if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
+if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS or sys.version_info >= (3, 8):
     # Mandatory keys
     class _DTypeDictBase(TypedDict):
         names: Sequence[str]

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING or _HAS_TYPING_EXTENSIONS:
         def dtype(self) -> _DType_co: ...
 
 else:
-    _DTypeDict = NotImplemented
+    _DTypeDict = Any
 
     class _SupportsDType: ...
     _SupportsDType = GenericAlias(_SupportsDType, _DType_co)

--- a/numpy/typing/_extended_precision.py
+++ b/numpy/typing/_extended_precision.py
@@ -28,15 +28,15 @@ if TYPE_CHECKING:
     complex256 = np.complexfloating[_128Bit, _128Bit]
     complex512 = np.complexfloating[_256Bit, _256Bit]
 else:
-    uint128 = NotImplemented
-    uint256 = NotImplemented
-    int128 = NotImplemented
-    int256 = NotImplemented
-    float80 = NotImplemented
-    float96 = NotImplemented
-    float128 = NotImplemented
-    float256 = NotImplemented
-    complex160 = NotImplemented
-    complex192 = NotImplemented
-    complex256 = NotImplemented
-    complex512 = NotImplemented
+    uint128 = Any
+    uint256 = Any
+    int128 = Any
+    int256 = Any
+    float80 = Any
+    float96 = Any
+    float128 = Any
+    float256 = Any
+    complex160 = Any
+    complex192 = Any
+    complex256 = Any
+    complex512 = Any

--- a/numpy/typing/_shape.py
+++ b/numpy/typing/_shape.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union, Any
 
 from . import _HAS_TYPING_EXTENSIONS
 
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 8):
 elif _HAS_TYPING_EXTENSIONS:
     from typing_extensions import SupportsIndex
 else:
-    SupportsIndex = NotImplemented
+    SupportsIndex = Any
 
 _Shape = Tuple[int, ...]
 

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -21,8 +21,8 @@ if sys.version_info >= (3, 9):
     NDArray_ref = types.GenericAlias(np.ndarray, (Any, DType_ref))
     FuncType = Callable[[Union[_GenericAlias, types.GenericAlias]], Any]
 else:
-    DType_ref = NotImplemented
-    NDArray_ref = NotImplemented
+    DType_ref = Any
+    NDArray_ref = Any
     FuncType = Callable[[_GenericAlias], Any]
 
 GETATTR_NAMES = sorted(set(dir(np.ndarray)) - _GenericAlias._ATTR_EXCEPTIONS)


### PR DESCRIPTION
Reverts https://github.com/numpy/numpy/pull/19118/commits/c646ab78d780a9bb06cdd8d7fba6b29092aa7507.

Aforementioned commit replaced the `Any`-based runtime placeholders with `NotImplemented`, 
as the latter's name provides a better explanation of what's going on. The problem with this approach 
is that `typing` lacks the necessary special-casing for `NotImplemented`, and will thus raise an exception 
when used with subscriptable typing constructs (_e.g._ `Union`).