### PR TITLE
DOC: ndindex class docstrings fix

### DIFF
--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -631,7 +631,7 @@ class ndindex:
 
     Examples
     --------
-    # dimensions as individual arguments
+    >>> # dimensions as individual arguments
     >>> for index in np.ndindex(3, 2, 1):
     ...     print(index)
     (0, 0, 0)
@@ -641,7 +641,7 @@ class ndindex:
     (2, 0, 0)
     (2, 1, 0)
 
-    # same dimensions - but in a tuple (3, 2, 1)
+    >>> # same dimensions - but in a tuple (3, 2, 1)
     >>> for index in np.ndindex((3, 2, 1)):
     ...     print(index)
     (0, 0, 0)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -631,7 +631,8 @@ class ndindex:
 
     Examples
     --------
-    >>> # dimensions as individual arguments
+    Dimensions as individual arguments
+    
     >>> for index in np.ndindex(3, 2, 1):
     ...     print(index)
     (0, 0, 0)

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -642,7 +642,8 @@ class ndindex:
     (2, 0, 0)
     (2, 1, 0)
 
-    >>> # same dimensions - but in a tuple (3, 2, 1)
+    Same dimensions - but in a tuple ``(3, 2, 1)``
+    
     >>> for index in np.ndindex((3, 2, 1)):
     ...     print(index)
     (0, 0, 0)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
It seems ndindex docstring examples are not rendering properly on every browser. In this PR I am introducing a small change to fix rendering issue of the examples for the ndindex class.
