### PR TITLE
NEP: Accept NEP 35 as final

### DIFF
--- a/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
+++ b/doc/neps/nep-0035-array-creation-dispatch-with-array-function.rst
@@ -5,11 +5,11 @@ NEP 35 — Array Creation Dispatching With __array_function__
 ===========================================================
 
 :Author: Peter Andreas Entschev <pentschev@nvidia.com>
-:Status: Draft
+:Status: Final
 :Type: Standards Track
 :Created: 2019-10-15
 :Updated: 2020-11-06
-:Resolution:
+:Resolution: https://mail.python.org/pipermail/numpy-discussion/2021-May/081761.html
 
 Abstract
 --------

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -18,11 +18,7 @@ array_function_like_doc = (
         NumPy arrays. If an array-like passed in as ``like`` supports
         the ``__array_function__`` protocol, the result will be defined
         by it. In this case, it ensures the creation of an array object
-        compatible with that passed in via this argument.
-
-        .. note::
-            The ``like`` keyword is an experimental feature pending on
-            acceptance of :ref:`NEP 35 <NEP35>`."""
+        compatible with that passed in via this argument."""
 )
 
 def set_array_function_like_doc(public_api):


### PR DESCRIPTION
Backport of #19188. 

This accepts NEP 35 as final.  There has been no discussion about it
in a long time.  The current mode is strict about type input
(`like=` must be an array-like).  So that most of the "open" points
are OK to remain open.
Unless we need to discuss the name `like` or the fact that we pass
an array-like itself, the previously noted open points gh-17075
all seem not very relevant anymore.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
