### PR TITLE
DOC: update references to other repos head branch to 'main'

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -102,8 +102,8 @@ someone else, then create a new branch for the series. If the branch already
 exists skip this::
 
     $ cd ../numpy-wheels
-    $ git co master
-    $ git pull upstream master
+    $ git checkout main
+    $ git pull upstream main
     $ git branch v1.19.x
 
 Checkout the new branch and edit the ``azure-pipelines.yml`` and

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -295,6 +295,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
     'scipy-lecture-notes': ('https://scipy-lectures.org', None),
     'pytest': ('https://docs.pytest.org/en/stable', None),
+    'numpy-tutorials': ('https://numpy.org/numpy-tutorials', None),
 }
 
 

--- a/doc/source/user/how-to-how-to.rst
+++ b/doc/source/user/how-to-how-to.rst
@@ -105,10 +105,7 @@ deep dives intended to give understanding rather than immediate assistance,
 and `References`, which give complete, autoritative data on some concrete
 part of NumPy (like its API) but aren't obligated to paint a broader picture.
 
-For more on tutorials, see the `tutorial how-to`_.
-
-.. _`tutorial how-to`: https://github.com/numpy/numpy-tutorials/blob/main/content/tutorial-style-guide.md
-
+For more on tutorials, see :doc:`content/tutorial-style-guide`
 
 ******************************************************************************
 Is this page an example of a how-to?

--- a/doc/source/user/how-to-how-to.rst
+++ b/doc/source/user/how-to-how-to.rst
@@ -107,7 +107,7 @@ part of NumPy (like its API) but aren't obligated to paint a broader picture.
 
 For more on tutorials, see the `tutorial how-to`_.
 
-.. _`tutorial how-to`: https://github.com/numpy/numpy-tutorials/blob/master/tutorial_style.ipynb
+.. _`tutorial how-to`: https://github.com/numpy/numpy-tutorials/blob/main/content/tutorial-style-guide.md
 
 
 ******************************************************************************


### PR DESCRIPTION
These repos now have their head branch renamed to `main`:
* https://github.com/MacPython/numpy-wheels
* https://github.com/numpy/numpy-tutorials

This PR updates content related to these repos.