### PR TITLE
MAINT: Add `complex` as allowed type for the `np.complexfloating` constructor

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3042,11 +3042,24 @@ class datetime64(generic):
 if sys.version_info >= (3, 8):
     _IntValue = Union[SupportsInt, _CharLike_co, SupportsIndex]
     _FloatValue = Union[None, _CharLike_co, SupportsFloat, SupportsIndex]
-    _ComplexValue = Union[None, _CharLike_co, SupportsFloat, SupportsComplex, SupportsIndex]
+    _ComplexValue = Union[
+        None,
+        _CharLike_co,
+        SupportsFloat,
+        SupportsComplex,
+        SupportsIndex,
+        complex,  # `complex` is not a subtype of `SupportsComplex`
+    ]
 else:
     _IntValue = Union[SupportsInt, _CharLike_co]
     _FloatValue = Union[None, _CharLike_co, SupportsFloat]
-    _ComplexValue = Union[None, _CharLike_co, SupportsFloat, SupportsComplex]
+    _ComplexValue = Union[
+        None,
+        _CharLike_co,
+        SupportsFloat,
+        SupportsComplex,
+        complex,
+    ]
 
 class integer(number[_NBit1]):  # type: ignore
     # NOTE: `__index__` is technically defined in the bottom-most


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/19218.

The new mypy 0.90x release includes updated stubs for `builtins.complex`, most notably its `__complex__` method 
[has been removed](https://github.com/python/typeshed/pull/4945). This leaves us with a situation wherein one is no longer allowed to pass a complex number to its 
numpy-based counterpart (once dependabot wakes up and updates mypy, that is), as we previously relied on the 
presence of aforementioned method.

This PR fixes aforementioned issue by updating the types supported by the `np.complexfloating` constructors.

Examples
---------
With mypy 0.902:
``` python
import numpy as np

# error: Argument 1 to "complexfloating" has incompatible type "complex"
np.complex128(1j)
```
