### PR TITLE
API: Fix structured dtype cast-safety, promotion, and comparison

### DIFF
--- a/doc/release/upcoming_changes/19226.compatibility.rst
+++ b/doc/release/upcoming_changes/19226.compatibility.rst
@@ -1,20 +1,8 @@
 Changes to structured (void) dtype promotion and comparisons
 ------------------------------------------------------------
-NumPy usually uses field position of structured dtypes when assigning
-from one structured dtype to another.  This means that::
-
-    arr[["field1", "field2"]] = arr[["field2", "field1"]]
-
-swaps the data of the two fields.  However, until now this behaviour
-was not matched for ``np.concatenate``.  NumPy was also overly
-restrictive when comparing two structured dtypes.  For exmaple::
-
-    np.ones(3, dtype="i,i") == np.ones(3, dtype="i,d")
-
-will now succeed instead of giving a ``FutureWarning`` and return ``False``.
-
 In general, NumPy now defines correct, but slightly limited, promotion for
-structured dtypes::
+structured dtypes by promoting the subtypes of each field instead of raising
+an exception::
 
     >>> np.result_type(np.dtype("i,i"), np.dtype("i,d"))
     dtype([('f0', '<i4'), ('f1', '<f8')])

--- a/doc/release/upcoming_changes/19226.compatibility.rst
+++ b/doc/release/upcoming_changes/19226.compatibility.rst
@@ -9,45 +9,11 @@ an exception::
 
 For promotion matching field names, order, and titles are enforced, however
 padding is ignored.
-Note that this also now always ensures native byte-order for all fields,
-which can change the result (this can affect ``np.concatenate``)::
-
-    >>> np.result_type(np.dtype("i,>i"))
-    dtype([('f0', '<i4'), ('f1', '<i4')])
-    >>> np.result_type(np.dtype("i,>i"), np.dtype("i,i"))
-    dtype([('f0', '<i4'), ('f1', '<i4')])
-
-which previously returned the first dtype unmodified.
-
-Further, the new result of ``np.result_type`` and promotion in general
-is considered "canonical".  Additionally to ensuring native byte-order
-for all fields, the result will also be "packed".  This means that
-all fields is ordered contiguously and any unnecessary padding
-is now removed::
-
-    >>> dt = np.dtype("i1,V3,i4,V1")[["f0", "f2"]]
-    >>> dt
-    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':9})
-    >>> np.result_type(dt)
-    dtype([('f0', 'i1'), ('f2', '<i4')])
-
-Note that the result prints without ``offsets`` or ``itemsize`` indicating no
-additional padding.
-If a structured dtype is created with ``align=True`` ensuring that
-``dtype.isalignedstruct`` is true, this property is preserved:
-
-    >>> dt = np.dtype("i1,V3,i4,V1", align=True)[["f0", "f2"]]
-    >>> dt
-    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':12}, align=True)
-    >>> np.result_type(dt)
-    dtype([('f0', 'i1'), ('f2', '<i4')], align=True)
-    >>> np.result_type(dt).isalignedstruct
-    True
-
-When promoting multiple dtypes, the result is aligned if any of the inputs is::
-
-    >>> np.result_type(np.dtype("i,i"), np.dtype("i,i", align=True))
-    dtype([('f0', '<i4'), ('f1', '<i4')], align=True)
+Promotion involving structured dtypes now always ensures native byte-order for
+all fields (which may change the result of ``np.concatenate``)
+and ensures that the result will be "packed", i.e. all fields are ordered
+contiguously and padding is removed.
+See :ref:`structured_dtype_comparison_and_promotion` for further details.
 
 The ``repr`` of aligned structures will now never print the long form
 including ``offsets`` and ``itemsize`` unless the struct includes padding

--- a/doc/release/upcoming_changes/19226.compatibility.rst
+++ b/doc/release/upcoming_changes/19226.compatibility.rst
@@ -1,0 +1,85 @@
+Changes to structured (void) dtype promotion and comparisons
+------------------------------------------------------------
+NumPy usually uses field position of structured dtypes when assigning
+from one structured dtype to another.  This means that::
+
+    arr[["field1", "field2"]] = arr[["field2", "field1"]]
+
+swaps the data of the two fields.  However, until now this behaviour
+was not matched for ``np.concatenate``.  NumPy was also overly
+restrictive when comparing two structured dtypes.  For exmaple::
+
+    np.ones(3, dtype="i,i") == np.ones(3, dtype="i,d")
+
+will now succeed instead of giving a ``FutureWarning`` and return ``False``.
+
+In general, NumPy now defines correct, but slightly limited, promotion for
+structured dtypes::
+
+    >>> np.result_type(np.dtype("i,i"), np.dtype("i,d"))
+    dtype([('f0', '<i4'), ('f1', '<f8')])
+
+For promotion matching field names, order, and titles are enforced, however
+padding is ignored.
+Note that this also now always ensures native byte-order for all fields,
+which can change the result (this can affect ``np.concatenate``)::
+
+    >>> np.result_type(np.dtype("i,>i"))
+    dtype([('f0', '<i4'), ('f1', '<i4')])
+    >>> np.result_type(np.dtype("i,>i"), np.dtype("i,i"))
+    dtype([('f0', '<i4'), ('f1', '<i4')])
+
+which previously returned the first dtype unmodified.
+
+Further, the new result of ``np.result_type`` and promotion in general
+is considered "canonical".  Additionally to ensuring native byte-order
+for all fields, the result will also be "packed".  This means that
+all fields is ordered contiguously and any unnecessary padding
+is now removed::
+
+    >>> dt = np.dtype("i1,V3,i4,V1")[["f0", "f2"]]
+    >>> dt
+    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':9})
+    >>> np.result_type(dt)
+    dtype([('f0', 'i1'), ('f2', '<i4')])
+
+Note that the result prints without ``offsets`` or ``itemsize`` indicating no
+additional padding.
+If a structured dtype is created with ``align=True`` ensuring that
+``dtype.isalignedstruct`` is true, this property is preserved:
+
+    >>> dt = np.dtype("i1,V3,i4,V1", align=True)[["f0", "f2"]]
+    >>> dt
+    dtype({'names':['f0','f2'], 'formats':['i1','<i4'], 'offsets':[0,4], 'itemsize':12}, align=True)
+    >>> np.result_type(dt)
+    dtype([('f0', 'i1'), ('f2', '<i4')], align=True)
+    >>> np.result_type(dt).isalignedstruct
+    True
+
+When promoting multiple dtypes, the result is aligned if any of the inputs is::
+
+    >>> np.result_type(np.dtype("i,i"), np.dtype("i,i", align=True))
+    dtype([('f0', '<i4'), ('f1', '<i4')], align=True)
+
+The ``repr`` of aligned structures will now never print the long form
+including ``offsets`` and ``itemsize`` unless the struct includes padding
+not guaranteed by ``align=True``.
+
+
+Changes to structured dtype casting safety
+------------------------------------------
+In alignment with the above changes to the promotion logic, the
+casting safety has been updated:
+
+* ``"equiv"`` enforces matching names and titles. The itemsize
+  is allowed to differ due to padding.
+* ``"safe"`` allows mismatching field names and titles
+* The cast safety is limited by the cast safety of each included
+  field.
+* The order of fields is used to decide cast safety of each
+  individual field.  Previously, the field names were used and
+  only unsafe casts were possible when names mismatched.
+
+The main important change here is that name mismatches are now
+considered "safe" casts.
+

--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -556,22 +556,35 @@ Structure Comparison
 If the dtypes of two void structured arrays are equal, testing the equality of
 the arrays will result in a boolean array with the dimensions of the original
 arrays, with elements set to ``True`` where all fields of the corresponding
-structures are equal. Structured dtypes are equal if the field names,
-dtypes and titles are the same, ignoring endianness, and the fields are in
-the same order::
+structures are equal::
 
- >>> a = np.zeros(2, dtype=[('a', 'i4'), ('b', 'i4')])
- >>> b = np.ones(2, dtype=[('a', 'i4'), ('b', 'i4')])
+ >>> a = np.array([(1, 1), (2, 2)], dtype=[('a', 'i4'), ('b', 'i4')])
+ >>> b = np.array([(1, 1), (2, 3)], dtype=[('a', 'i4'), ('b', 'i4')])
  >>> a == b
- array([False, False])
+ array([True, False])
 
-Currently, if the dtypes of two void structured arrays are not equivalent the
-comparison fails, returning the scalar value ``False``. This behavior is
-deprecated as of numpy 1.10 and will raise an error or perform elementwise
-comparison in the future.
+NumPy will promote individual field datatypes to perform the comparison.
+So the following is also valid (note the ``'f4'`` dtype for the ``'a'`` field):
+
+ >>> b = np.array([(1.0, 1), (2.5, 2)], dtype=[("a", "f4"), ("b", "i4")])
+ >>> a == b
+ array([True, False])
+
+To compare two structured arrays, it must be possible to promote them to a
+common dtype as returned by `numpy.result_type` and `np.promote_types`.
+This enforces that the number of fields, the field names, and the field titles
+must match precisely.
+When promotion is not possible, for example due to mismatching field names,
+NumPy will raise an error.
 
 The ``<`` and ``>`` operators always return ``False`` when comparing void
 structured arrays, and arithmetic and bitwise operations are not supported.
+
+.. versionchanged::
+    Before NumPy 1.23, a warning was given and ``False`` returned when
+    promotion to a common dtype failed.
+    Further, promotion was much more restrictive: It would reject the mixed
+    float/integer comparison example above.
 
 Record Arrays
 =============

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1808,7 +1808,8 @@ add_newdoc('numpy.core.multiarray', 'promote_types',
 
     Returns the data type with the smallest size and smallest scalar
     kind to which both ``type1`` and ``type2`` may be safely cast.
-    The returned data type is always in native byte order.
+    The returned data type is always considered "canonical", this mainly
+    means that the promoted dtype will always be in native byte order.
 
     This function is symmetric, but rarely associative.
 
@@ -1826,6 +1827,8 @@ add_newdoc('numpy.core.multiarray', 'promote_types',
 
     Notes
     -----
+    Please see `numpy.result_type` for additional information about promotion.
+
     .. versionadded:: 1.6.0
 
     Starting in NumPy 1.9, promote_types function now returns a valid string
@@ -1833,6 +1836,12 @@ add_newdoc('numpy.core.multiarray', 'promote_types',
     dtype as another argument. Previously it always returned the input string
     dtype, even if it wasn't long enough to store the max integer/float value
     converted to a string.
+
+    .. versionchanged:: 1.23.0
+
+    NumPy now supports promotion for more structured dtypes.  It will now
+    remove unnecessary padding from a structure dtype and promote included
+    fields individually.
 
     See Also
     --------

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -10,7 +10,7 @@ import sys
 import platform
 import warnings
 
-from .multiarray import dtype, array, ndarray
+from .multiarray import dtype, array, ndarray, promote_types
 try:
     import ctypes
 except ImportError:
@@ -432,6 +432,46 @@ def _copy_fields(ary):
     copy_dtype = {'names': dt.names,
                   'formats': [dt.fields[name][0] for name in dt.names]}
     return array(ary, dtype=copy_dtype, copy=True)
+
+def _promote_fields(dt1, dt2):
+    """ Perform type promotion for two structured dtypes.
+
+    Parameters
+    ----------
+    dt1 : structured dtype
+        First dtype.
+    dt2 : structured dtype
+        Second dtype.
+
+    Returns
+    -------
+    out : dtype
+        The promoted dtype
+
+    Notes
+    -----
+    If one of the inputs is aligned, the result will be.  The titles of
+    both descriptors must match (point to the same field).
+    """
+    # Both must be structured and have the same names in the same order
+    if (dt1.names is None or dt2.names is None) or dt1.names != dt2.names:
+        raise TypeError("invalid type promotion")
+
+    new_fields = []
+    for name in dt1.names:
+        field1 = dt1.fields[name]
+        field2 = dt2.fields[name]
+        new_descr = promote_types(field1[0], field2[0])
+        # Check that the titles match (if given):
+        if field1[2:] != field2[2:]:
+            raise TypeError("invalid type promotion")
+        if len(field1) == 2:
+            new_fields.append((name, new_descr))
+        else:
+            new_fields.append(((field1[2], name), new_descr))
+
+    return dtype(new_fields, align=dt1.isalignedstruct or dt2.isalignedstruct)
+
 
 def _getfield_is_safe(oldtype, newtype, offset):
     """ Checks safety of getfield for object arrays.

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -457,11 +457,15 @@ def _promote_fields(dt1, dt2):
     if (dt1.names is None or dt2.names is None) or dt1.names != dt2.names:
         raise TypeError("invalid type promotion")
 
+    # if both are identical, we can (maybe!) just return the same dtype.
+    identical = dt1 is dt2
     new_fields = []
     for name in dt1.names:
         field1 = dt1.fields[name]
         field2 = dt2.fields[name]
         new_descr = promote_types(field1[0], field2[0])
+        identical = identical and new_descr is field1[0]
+
         # Check that the titles match (if given):
         if field1[2:] != field2[2:]:
             raise TypeError("invalid type promotion")
@@ -470,7 +474,18 @@ def _promote_fields(dt1, dt2):
         else:
             new_fields.append(((field1[2], name), new_descr))
 
-    return dtype(new_fields, align=dt1.isalignedstruct or dt2.isalignedstruct)
+    res = dtype(new_fields, align=dt1.isalignedstruct or dt2.isalignedstruct)
+
+    # Might as well preserve identity (and metadata) if the dtype is identical
+    # and the itemsize, offsets are also unmodified.  This could probably be
+    # sped up, but also probably just be removed entirely.
+    if identical and res.itemsize == dt1.itemsize:
+        for name in dt1.names:
+            if dt1.fields[name][1] != res.fields[name][1]:
+                return res  # the dtype changed.
+        return dt1
+
+    return res
 
 
 def _getfield_is_safe(oldtype, newtype, offset):

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -588,7 +588,7 @@ boundarraymethod__resolve_descripors(
         return NULL;
     }
     else if (casting < 0) {
-        return Py_BuildValue("iO", casting, Py_None, Py_None);
+        return Py_BuildValue("iOO", casting, Py_None, Py_None);
     }
 
     PyObject *result_tuple = PyTuple_New(nin + nout);

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1035,8 +1035,7 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
     }
     if (PyArray_TYPE(other) != NPY_VOID) {
         PyErr_SetString(PyExc_ValueError,
-                "Cannot compare structured or void to non-void arrays.  "
-                "(This may return array of False in the future.)");
+                "Cannot compare structured or void to non-void arrays.");
         return NULL;
     }
     if (PyArray_HASFIELDS(self) && PyArray_HASFIELDS(other)) {
@@ -1049,8 +1048,7 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
             PyErr_SetString(PyExc_TypeError,
                     "Cannot compare structured arrays unless they have a "
                     "common dtype.  I.e. `np.result_type(arr1, arr2)` must "
-                   "be defined.\n"
-                    "(This may return array of False in the future.)");
+                    "be defined.");
             return NULL;
         }
         Py_DECREF(promoted);
@@ -1196,8 +1194,8 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
     }
     else if (PyArray_HASFIELDS(self) || PyArray_HASFIELDS(other)) {
         PyErr_SetString(PyExc_TypeError,
-                "Cannot compare structured with unstructured void.  "
-                "(This may return array of False in the future.)");
+                "Cannot compare structured with unstructured void arrays. "
+                "(unreachable error, please report to NumPy devs.)");
         return NULL;
     }
     else {

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1396,8 +1396,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
-            int _res;
-
             array_other = (PyArrayObject *)PyArray_FROM_O(other);
             /*
              * If not successful, indicate that the items cannot be compared
@@ -1430,8 +1428,6 @@ array_richcompare(PyArrayObject *self, PyObject *other, int cmp_op)
          */
 
         if (PyArray_TYPE(self) == NPY_VOID) {
-            int _res;
-
             array_other = (PyArrayObject *)PyArray_FROM_O(other);
             /*
              * If not successful, indicate that the items cannot be compared

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -1029,12 +1029,12 @@ static PyObject *
 _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
 {
     if (!(cmp_op == Py_EQ || cmp_op == Py_NE)) {
-        PyErr_SetString(PyExc_ValueError,
+        PyErr_SetString(PyExc_TypeError,
                 "Void-arrays can only be compared for equality.");
         return NULL;
     }
     if (PyArray_TYPE(other) != NPY_VOID) {
-        PyErr_SetString(PyExc_ValueError,
+        PyErr_SetString(PyExc_TypeError,
                 "Cannot compare structured or void to non-void arrays.");
         return NULL;
     }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1075,8 +1075,11 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
 
     /* Fast path for identical inputs (NOTE: This path preserves metadata!) */
     if (type1 == type2
-            /* Use for builtin except void, void has no reliable byteorder */
-            && type1->type_num >= 0 && type1->type_num < NPY_NTYPES
+            /*
+             * Short-cut for legacy/builtin dtypes except void, since void has
+             * no reliable byteorder.  Note: This path preserves metadata!
+             */
+            && NPY_DT_is_legacy(NPY_DTYPE(type1))
             && PyArray_ISNBO(type1->byteorder) && type1->type_num != NPY_VOID) {
         Py_INCREF(type1);
         return type1;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1076,7 +1076,7 @@ PyArray_PromoteTypes(PyArray_Descr *type1, PyArray_Descr *type2)
     /* Fast path for identical inputs (NOTE: This path preserves metadata!) */
     if (type1 == type2
             /* Use for builtin except void, void has no reliable byteorder */
-            && type1->type_num > 0 && type1->type_num < NPY_NTYPES
+            && type1->type_num >= 0 && type1->type_num < NPY_NTYPES
             && PyArray_ISNBO(type1->byteorder) && type1->type_num != NPY_VOID) {
         Py_INCREF(type1);
         return type1;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -452,6 +452,16 @@ void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
         if (new_base == NULL) {
             return NULL;
         }
+        /*
+         * If it is the same dtype and the contained did not change, we might
+         * as well preserve identity and metadata.  This could probably be
+         * changed.
+         */
+        if (descr1 == descr2 && new_base == descr1->subarray->base) {
+            Py_DECREF(new_base);
+            Py_INCREF(descr1);
+            return descr1;
+        }
 
         PyArray_Descr *new_descr = PyArray_DescrNew(descr1);
         if (new_descr == NULL) {

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -446,6 +446,7 @@ void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
             PyErr_SetString(PyExc_TypeError,
                     "invalid type promotion with subarray datatypes "
                     "(shape mismatch).");
+            return NULL;
         }
         PyArray_Descr *new_base = PyArray_PromoteTypes(
                 descr1->subarray->base, descr2->subarray->base);

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -454,7 +454,7 @@ void_common_instance(PyArray_Descr *descr1, PyArray_Descr *descr2)
             return NULL;
         }
         /*
-         * If it is the same dtype and the contained did not change, we might
+         * If it is the same dtype and the container did not change, we might
          * as well preserve identity and metadata.  This could probably be
          * changed.
          */

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -185,14 +185,6 @@ class TestComparisonDeprecations(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.arange(2) == NotArray())
         self.assert_deprecated(lambda: np.arange(2) != NotArray())
 
-        struct1 = np.zeros(2, dtype="i4,i4")
-        struct2 = np.zeros(2, dtype="i4,i4,i4")
-
-        assert_warns(FutureWarning, lambda: struct1 == 1)
-        assert_warns(FutureWarning, lambda: struct1 == struct2)
-        assert_warns(FutureWarning, lambda: struct1 != 1)
-        assert_warns(FutureWarning, lambda: struct1 != struct2)
-
     def test_array_richcompare_legacy_weirdness(self):
         # It doesn't really work to use assert_deprecated here, b/c part of
         # the point of assert_deprecated is to check that when warnings are

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1157,7 +1157,7 @@ class TestDTypeMakeCanonical:
     def test_make_canonical_hypothesis(self, dtype):
         canonical = np.result_type(dtype)
         self.check_canonical(dtype, canonical)
-        # np.result_type with two arguments should always identical results:
+        # result_type with two arguments should always give identical results:
         two_arg_result = np.result_type(dtype, dtype)
         assert np.can_cast(two_arg_result, canonical, casting="no")
 
@@ -1174,7 +1174,7 @@ class TestDTypeMakeCanonical:
         assert dtype_with_empty_space.itemsize == dtype.itemsize
         canonicalized = np.result_type(dtype_with_empty_space)
         self.check_canonical(dtype_with_empty_space, canonicalized)
-        # np.promote_types with two arguments should always identical results:
+        # promotion with two arguments should always give identical results:
         two_arg_result = np.promote_types(
                 dtype_with_empty_space, dtype_with_empty_space)
         assert np.can_cast(two_arg_result, canonicalized, casting="no")
@@ -1186,7 +1186,7 @@ class TestDTypeMakeCanonical:
         assert dtype_with_empty_space.itemsize == dtype_aligned.itemsize
         canonicalized = np.result_type(dtype_with_empty_space)
         self.check_canonical(dtype_with_empty_space, canonicalized)
-        # np.promote_types with two arguments should always identical results:
+        # promotion with two arguments should always give identical results:
         two_arg_result = np.promote_types(
             dtype_with_empty_space, dtype_with_empty_space)
         assert np.can_cast(two_arg_result, canonicalized, casting="no")

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -180,11 +180,11 @@ class TestBuiltin:
                       'formats': ['i4', 'f4'],
                       'offsets': [0, 4]})
         y = np.dtype({'names': ['B', 'A'],
-                      'formats': ['f4', 'i4'],
+                      'formats': ['i4', 'f4'],
                       'offsets': [4, 0]})
         assert_equal(x == y, False)
-        # But it is currently an equivalent cast:
-        assert np.can_cast(x, y, casting="equiv")
+        # This is an safe cast (not equiv) due to the different names:
+        assert np.can_cast(x, y, casting="safe")
 
 
 class TestRecord:

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1157,6 +1157,9 @@ class TestDTypeMakeCanonical:
     def test_make_canonical_hypothesis(self, dtype):
         canonical = np.result_type(dtype)
         self.check_canonical(dtype, canonical)
+        # np.result_type with two arguments should always identical results:
+        two_arg_result = np.result_type(dtype, dtype)
+        assert np.can_cast(two_arg_result, canonical, casting="no")
 
     @pytest.mark.slow
     @hypothesis.given(
@@ -1171,6 +1174,10 @@ class TestDTypeMakeCanonical:
         assert dtype_with_empty_space.itemsize == dtype.itemsize
         canonicalized = np.result_type(dtype_with_empty_space)
         self.check_canonical(dtype_with_empty_space, canonicalized)
+        # np.promote_types with two arguments should always identical results:
+        two_arg_result = np.promote_types(
+                dtype_with_empty_space, dtype_with_empty_space)
+        assert np.can_cast(two_arg_result, canonicalized, casting="no")
 
         # Ensure that we also check aligned struct (check the opposite, in
         # case hypothesis grows support for `align`.  Then repeat the test:
@@ -1179,6 +1186,10 @@ class TestDTypeMakeCanonical:
         assert dtype_with_empty_space.itemsize == dtype_aligned.itemsize
         canonicalized = np.result_type(dtype_with_empty_space)
         self.check_canonical(dtype_with_empty_space, canonicalized)
+        # np.promote_types with two arguments should always identical results:
+        two_arg_result = np.promote_types(
+            dtype_with_empty_space, dtype_with_empty_space)
+        assert np.can_cast(two_arg_result, canonicalized, casting="no")
 
 
 class TestPickling:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1265,6 +1265,26 @@ class TestStructured:
         assert_equal(a == b, [False, True])
         assert_equal(a != b, [True, False])
 
+    def test_void_comparison_failures(self):
+        # In principle, one could decide to return an array of False for some
+        # if comparisons are impossible.  But right now we return TypeError
+        # when "void" dtype are involved.
+        x = np.zeros(3, dtype=[('a', 'i1')])
+        y = np.zeros(3)
+        # Cannot compare non-structured to structured:
+        with pytest.raises(TypeError):
+            x == y
+
+        # Added title prevents promotion:
+        y = np.zeros(3, dtype=[('a', 'i1', 'title')])
+        with pytest.raises(TypeError):
+            x == y
+
+        x = np.zeros(3, dtype="V7")
+        y = np.zeros(3, dtype="V8")
+        with pytest.raises(TypeError):
+            x == y
+
     def test_casting(self):
         # Check that casting a structured array to change its byte order
         # works

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1246,7 +1246,7 @@ class TestStructured:
             x == y
 
     def test_structured_comparisons_with_promotion(self):
-        # Check that structured arrays can be compared so long that their
+        # Check that structured arrays can be compared so long as their
         # dtypes promote fine:
         a = np.array([(5, 42), (10, 1)], dtype=[('a', '>i8'), ('b', '<f8')])
         b = np.array([(5, 43), (10, 1)], dtype=[('a', '<i8'), ('b', '>f8')])

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1275,8 +1275,9 @@ class TestStructured:
         with pytest.raises(TypeError):
             x == y
 
-        # Added title prevents promotion:
-        y = np.zeros(3, dtype=[('a', 'i1', 'title')])
+        # Added title prevents promotion, but casts are OK:
+        y = np.zeros(3, dtype=[(('title', 'a'), 'i1')])
+        assert np.can_cast(y.dtype, x.dtype)
         with pytest.raises(TypeError):
             x == y
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1990,13 +1990,13 @@ def test_iter_buffered_cast_structured_type_failure_with_cleanup():
     a = np.array([(1, 2, 3), (4, 5, 6)], dtype=sdt1)
 
     for intent in ["readwrite", "readonly", "writeonly"]:
-        # If the following assert fails, the place where the error is raised
-        # within nditer may change. That is fine, but it may make sense for
-        # a new (hard to design) test to replace it. The `simple_arr` is
-        # designed to require a multi-step cast (due to having fields).
-        assert np.can_cast(a.dtype, sdt2, casting="unsafe")
+        # This test was initially designed to test an error at a different
+        # place, but will now raise earlier to to the cast not being possible:
+        # `assert np.can_cast(a.dtype, sdt2, casting="unsafe")` fails.
+        # Without a faulty DType, there is probably probably no reliable
+        # way to get the initial tested behaviour.
         simple_arr = np.array([1, 2], dtype="i,i")  # requires clean up
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             nditer((simple_arr, a), ['buffered', 'refs_ok'], [intent, intent],
                    casting='unsafe', op_dtypes=["f,f", sdt2])
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -1993,7 +1993,7 @@ def test_iter_buffered_cast_structured_type_failure_with_cleanup():
         # This test was initially designed to test an error at a different
         # place, but will now raise earlier to to the cast not being possible:
         # `assert np.can_cast(a.dtype, sdt2, casting="unsafe")` fails.
-        # Without a faulty DType, there is probably probably no reliable
+        # Without a faulty DType, there is probably no reliable
         # way to get the initial tested behaviour.
         simple_arr = np.array([1, 2], dtype="i,i")  # requires clean up
         with pytest.raises(TypeError):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -932,6 +932,25 @@ class TestTypes:
         # Promote with object:
         assert_equal(promote_types('O', S+'30'), np.dtype('O'))
 
+    @pytest.mark.parametrize(["dtype1", "dtype2"],
+            [[np.dtype("V6"), np.dtype("V10")],
+             [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
+            ])
+    def test_invalid_void_promotion(self, dtype1, dtype2):
+        # Mainly test structured void promotion, which currently allows
+        # byte-swapping, but nothing else:
+        with pytest.raises(TypeError):
+            np.promote_types(dtype1, dtype2)
+
+    @pytest.mark.parametrize(["dtype1", "dtype2"],
+            [[np.dtype("V10"), np.dtype("V10")],
+             [np.dtype([("name1", "<i8")]), np.dtype([("name1", ">i8")])],
+             [np.dtype("i8,i8"), np.dtype("i8,>i8")],
+             [np.dtype("i8,i8"), np.dtype("i4,i4")],
+            ])
+    def test_valid_void_promotion(self, dtype1, dtype2):
+        assert np.promote_types(dtype1, dtype2) == dtype1
+
     @pytest.mark.parametrize("dtype",
            list(np.typecodes["All"]) +
            ["i,i", "S3", "S100", "U3", "U100", rational])
@@ -1014,25 +1033,6 @@ class TestTypes:
         else:
             assert res_bs == res
         assert res_bs.metadata == res.metadata
-
-    @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V6"), np.dtype("V10")],
-             [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
-             [np.dtype("i8,i8"), np.dtype("i4,i4")],
-            ])
-    def test_invalid_void_promotion(self, dtype1, dtype2):
-        # Mainly test structured void promotion, which currently allows
-        # byte-swapping, but nothing else:
-        with pytest.raises(TypeError):
-            np.promote_types(dtype1, dtype2)
-
-    @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V10"), np.dtype("V10")],
-             [np.dtype([("name1", "<i8")]), np.dtype([("name1", ">i8")])],
-             [np.dtype("i8,i8"), np.dtype("i8,>i8")],
-            ])
-    def test_valid_void_promotion(self, dtype1, dtype2):
-        assert np.promote_types(dtype1, dtype2) is dtype1
 
     def test_can_cast(self):
         assert_(np.can_cast(np.int32, np.int64))

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -953,7 +953,7 @@ class TestTypes:
 
     @pytest.mark.parametrize("dtype",
            list(np.typecodes["All"]) +
-           ["i,i", "S3", "S100", "U3", "U100", rational])
+           ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
     def test_promote_identical_types_metadata(self, dtype):
         # The same type passed in twice to promote types always
         # preserves metadata
@@ -970,14 +970,14 @@ class TestTypes:
             return
 
         res = np.promote_types(dtype, dtype)
-        if res.char in "?bhilqpBHILQPefdgFDGOmM" or dtype.type is rational:
-            # Metadata is lost for simple promotions (they create a new dtype)
+
+        # Metadata is (currently) generally lost on byte-swapping (except for
+        # unicode.
+        if dtype.char != "U":
             assert res.metadata is None
         else:
             assert res.metadata == metadata
-        if dtype.kind != "V":
-            # the result is native (except for structured void)
-            assert res.isnative
+        assert res.isnative
 
     @pytest.mark.slow
     @pytest.mark.filterwarnings('ignore:Promotion of numbers:FutureWarning')

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -933,12 +933,11 @@ class TestTypes:
         assert_equal(promote_types('O', S+'30'), np.dtype('O'))
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
-            [[np.dtype("V6"), np.dtype("V10")],
+            [[np.dtype("V6"), np.dtype("V10")],  # mismatch shape
+             # Mismatching names:
              [np.dtype([("name1", "i8")]), np.dtype([("name2", "i8")])],
             ])
     def test_invalid_void_promotion(self, dtype1, dtype2):
-        # Mainly test structured void promotion, which currently allows
-        # byte-swapping, but nothing else:
         with pytest.raises(TypeError):
             np.promote_types(dtype1, dtype2)
 

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -952,8 +952,8 @@ class TestTypes:
         assert np.promote_types(dtype1, dtype2) == dtype1
 
     @pytest.mark.parametrize("dtype",
-           list(np.typecodes["All"]) +
-           ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
+            list(np.typecodes["All"]) +
+            ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
     def test_promote_identical_types_metadata(self, dtype):
         # The same type passed in twice to promote types always
         # preserves metadata

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1006,8 +1006,10 @@ class TestTypes:
             # Promotion failed, this test only checks metadata
             return
 
-        if res.char in "?bhilqpBHILQPefdgFDGOmM" or res.type is rational:
-            # All simple types lose metadata (due to using promotion table):
+        if res.char not in "USV" or res.names is not None or res.shape != ():
+            # All except string dtypes (and unstructured void) lose metadata
+            # on promotion (unless both dtypes are identical).
+            # At some point structured ones did not, but were restrictive.
             assert res.metadata is None
         elif res == dtype1:
             # If one result is the result, it is usually returned unchanged:
@@ -1027,11 +1029,7 @@ class TestTypes:
         dtype1 = dtype1.newbyteorder()
         assert dtype1.metadata == metadata1
         res_bs = np.promote_types(dtype1, dtype2)
-        if res_bs.names is not None:
-            # Structured promotion doesn't remove byteswap:
-            assert res_bs.newbyteorder() == res
-        else:
-            assert res_bs == res
+        assert res_bs == res
         assert res_bs.metadata == res.metadata
 
     def test_can_cast(self):

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -944,7 +944,8 @@ class TestTypes:
 
     @pytest.mark.parametrize(["dtype1", "dtype2"],
             [[np.dtype("V10"), np.dtype("V10")],
-             [np.dtype([("name1", "<i8")]), np.dtype([("name1", ">i8")])],
+             [np.dtype([("name1", "i8")]),
+              np.dtype([("name1", np.dtype("i8").newbyteorder())])],
              [np.dtype("i8,i8"), np.dtype("i8,>i8")],
              [np.dtype("i8,i8"), np.dtype("i4,i4")],
             ])

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -835,7 +835,6 @@ class TestJoinBy:
         b = np.ones(3, dtype=[('c', 'u1'), ('b', 'f4'), ('a', 'i4')])
         assert_raises(ValueError, join_by, ['a', 'b', 'b'], a, b)
 
-    @pytest.mark.xfail(reason="See comment at gh-9343")
     def test_same_name_different_dtypes_key(self):
         a_dtype = np.dtype([('key', 'S5'), ('value', '<f4')])
         b_dtype = np.dtype([('key', 'S10'), ('value', '<f4')])

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -151,14 +151,13 @@ class TestArrayEqual(_GenericTest):
 
         self._test_equal(a, b)
 
-        c = np.empty(2, [('floupipi', float), ('floupa', float)])
+        c = np.empty(2, [('floupipi', float),
+                         ('floupi', float), ('floupa', float)])
         c['floupipi'] = a['floupi'].copy()
         c['floupa'] = a['floupa'].copy()
 
-        with suppress_warnings() as sup:
-            l = sup.record(FutureWarning, message="elementwise == ")
+        with pytest.raises(TypeError):
             self._test_not_equal(c, b)
-            assert_equal(len(l), 1)
 
     def test_masked_nan_inf(self):
         # Regression test for gh-11121


### PR DESCRIPTION
This PR replaces the old gh-15509 implementing proper type promotion
for structured voids.  It further fixes the casting safety to consider
casts with equivalent field number and matching order as "safe"
and if the names, titles, and offsets match as "equiv".

The change perculates into the void comparison, and since it fixes
the order, it removes the current FutureWarning there as well.

This addresses https://github.com/liberfa/pyerfa/issues/77
and replaces gh-15509 (the implementation has changed too much).

Fixes gh-15494  (and probably a few more)

Co-authored-by: Allan Haldane <allan.haldane@gmail.com>

---

Ping @ahaldane, @mhvk.  The tests will fail right now.  And we have to decide a few things, and probably one more change that is necessary here:

- [x] The tests fail, because the old PR included a test which ensured that the promotion result is always a packed struct.  I think this makes sense, but we further should ensure the promotion result is always native byte order (the old code probably did this also).  The new code doesn't call "promotion" because both descriptors are identical.  This calls `ensure_nbo`.  My plan for `ensure_nbo(descr)` is to actually call a new `DType.ensure_canonical(descr)` (for native dtypes, this will just do the same as `ensure_nbo`) but for structured ones it would: Recursively call `ensure_canonical` and drop offsets.  (Fixing the test failure)  *This should be simple, but requires adding the new slot to the DType, I will probably just do this soon.*  
- [x] I removed the `FutureWarning` from the void comparison path.  This means we have to decide wether void comparisons should ever return an array of `False` if the types they include mismatch.  Or if they should raise an error.  Note that most field mismatches will still raise a `FutureWarning` (since it will call `self[field1_self] == other[field1_other]` which will give a warning when the types are not comparable.  This is thus only about the explicit error messages below.  (Or alternatively, keep the warning for now, even if it is very strange for dtypes that can promote to not also compare.)
- [x] We need to improve test coverage (at least in all those points that coverage points too)

**As such this is currently draft, although all changes should be good, there are some things missing.  But I decided to have a look since gh-15509 is outdated now and it might be tricky to resurrect it without knowing the new layout well.**

**EDIT: Currently based off gh-19346**