### PR TITLE
MAINT, SIMD: Hardened the AVX compile-time tests

### DIFF
--- a/numpy/distutils/checks/cpu_avx.c
+++ b/numpy/distutils/checks/cpu_avx.c
@@ -1,7 +1,7 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m256 a = _mm256_add_ps(_mm256_setzero_ps(), _mm256_setzero_ps());
+    __m256 a = _mm256_add_ps(_mm256_loadu_ps((const float*)argv[argc-1]), _mm256_loadu_ps((const float*)argv[1]));
     return (int)_mm_cvtss_f32(_mm256_castps256_ps128(a));
 }

--- a/numpy/distutils/checks/cpu_avx2.c
+++ b/numpy/distutils/checks/cpu_avx2.c
@@ -1,7 +1,7 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m256i a = _mm256_abs_epi16(_mm256_setzero_si256());
+    __m256i a = _mm256_abs_epi16(_mm256_loadu_si256((const __m256i*)argv[argc-1]));
     return _mm_cvtsi128_si32(_mm256_castsi256_si128(a));
 }

--- a/numpy/distutils/checks/cpu_avx512_clx.c
+++ b/numpy/distutils/checks/cpu_avx512_clx.c
@@ -1,8 +1,9 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     /* VNNI */
-    __m512i a = _mm512_dpbusd_epi32(_mm512_setzero_si512(), _mm512_setzero_si512(), _mm512_setzero_si512());
+    __m512i a = _mm512_loadu_si512((const __m512i*)argv[argc-1]);
+            a = _mm512_dpbusd_epi32(a, _mm512_setzero_si512(), a);
     return _mm_cvtsi128_si32(_mm512_castsi512_si128(a));
 }

--- a/numpy/distutils/checks/cpu_avx512_cnl.c
+++ b/numpy/distutils/checks/cpu_avx512_cnl.c
@@ -1,10 +1,11 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    __m512i a = _mm512_loadu_si512((const __m512i*)argv[argc-1]);
     /* IFMA */
-    __m512i a = _mm512_madd52hi_epu64(_mm512_setzero_si512(), _mm512_setzero_si512(), _mm512_setzero_si512());
+    a = _mm512_madd52hi_epu64(a, a, _mm512_setzero_si512());
     /* VMBI */
-    a = _mm512_permutex2var_epi8(a, _mm512_setzero_si512(), _mm512_setzero_si512());
+    a = _mm512_permutex2var_epi8(a, _mm512_setzero_si512(), a);
     return _mm_cvtsi128_si32(_mm512_castsi512_si128(a));
 }

--- a/numpy/distutils/checks/cpu_avx512_icl.c
+++ b/numpy/distutils/checks/cpu_avx512_icl.c
@@ -1,9 +1,10 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    __m512i a = _mm512_loadu_si512((const __m512i*)argv[argc-1]);
     /* VBMI2 */
-    __m512i a = _mm512_shrdv_epi64(_mm512_setzero_si512(), _mm512_setzero_si512(), _mm512_setzero_si512());
+    a = _mm512_shrdv_epi64(a, a, _mm512_setzero_si512());
     /* BITLAG */
     a = _mm512_popcnt_epi8(a);
     /* VPOPCNTDQ */

--- a/numpy/distutils/checks/cpu_avx512_knl.c
+++ b/numpy/distutils/checks/cpu_avx512_knl.c
@@ -1,10 +1,11 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     int base[128];
+    __m512d ad = _mm512_loadu_pd((const __m512d*)argv[argc-1]);
     /* ER */
-    __m512i a = _mm512_castpd_si512(_mm512_exp2a23_pd(_mm512_setzero_pd()));
+    __m512i a = _mm512_castpd_si512(_mm512_exp2a23_pd(ad));
     /* PF */
     _mm512_mask_prefetch_i64scatter_pd(base, _mm512_cmpeq_epi64_mask(a, a), a, 1, _MM_HINT_T1);
     return base[0];

--- a/numpy/distutils/checks/cpu_avx512_knm.c
+++ b/numpy/distutils/checks/cpu_avx512_knm.c
@@ -1,9 +1,9 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m512i a = _mm512_setzero_si512();
-    __m512 b = _mm512_setzero_ps();
+    __m512i a = _mm512_loadu_si512((const __m512i*)argv[argc-1]);
+    __m512 b = _mm512_loadu_ps((const __m512*)argv[argc-2]);
 
     /* 4FMAPS */
     b = _mm512_4fmadd_ps(b, b, b, b, b, NULL);

--- a/numpy/distutils/checks/cpu_avx512_skx.c
+++ b/numpy/distutils/checks/cpu_avx512_skx.c
@@ -1,9 +1,10 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
+    __m512i aa = _mm512_abs_epi32(_mm512_loadu_si512((const __m512i*)argv[argc-1]));
     /* VL */
-    __m256i a = _mm256_abs_epi64(_mm256_setzero_si256());
+    __m256i a = _mm256_abs_epi64(_mm512_extracti64x4_epi64(aa, 1));
     /* DQ */
     __m512i b = _mm512_broadcast_i32x8(a);
     /* BW */

--- a/numpy/distutils/checks/cpu_avx512cd.c
+++ b/numpy/distutils/checks/cpu_avx512cd.c
@@ -1,7 +1,7 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m512i a = _mm512_lzcnt_epi32(_mm512_setzero_si512());
+    __m512i a = _mm512_lzcnt_epi32(_mm512_loadu_si512((const __m512i*)argv[argc-1]));
     return _mm_cvtsi128_si32(_mm512_castsi512_si128(a));
 }

--- a/numpy/distutils/checks/cpu_avx512f.c
+++ b/numpy/distutils/checks/cpu_avx512f.c
@@ -1,7 +1,7 @@
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m512i a = _mm512_abs_epi32(_mm512_setzero_si512());
+    __m512i a = _mm512_abs_epi32(_mm512_loadu_si512((const __m512i*)argv[argc-1]));
     return _mm_cvtsi128_si32(_mm512_castsi512_si128(a));
 }

--- a/numpy/distutils/checks/cpu_f16c.c
+++ b/numpy/distutils/checks/cpu_f16c.c
@@ -1,9 +1,9 @@
 #include <emmintrin.h>
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m128 a  = _mm_cvtph_ps(_mm_setzero_si128());
-    __m256 a8 = _mm256_cvtph_ps(_mm_setzero_si128());
+    __m128 a  = _mm_cvtph_ps(_mm_loadu_si128((const __m128i*)argv[argc-1]));
+    __m256 a8 = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)argv[argc-2]));
     return (int)(_mm_cvtss_f32(a) + _mm_cvtss_f32(_mm256_castps256_ps128(a8)));
 }

--- a/numpy/distutils/checks/cpu_fma3.c
+++ b/numpy/distutils/checks/cpu_fma3.c
@@ -1,8 +1,9 @@
 #include <xmmintrin.h>
 #include <immintrin.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m256 a = _mm256_fmadd_ps(_mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps());
+    __m256 a = _mm256_loadu_ps((const float*)argv[argc-1]);
+           a = _mm256_fmadd_ps(a, a, a);
     return (int)_mm_cvtss_f32(_mm256_castps256_ps128(a));
 }

--- a/numpy/distutils/checks/cpu_fma4.c
+++ b/numpy/distutils/checks/cpu_fma4.c
@@ -5,8 +5,9 @@
     #include <x86intrin.h>
 #endif
 
-int main(void)
+int main(int argc, char **argv)
 {
-    __m256 a = _mm256_macc_ps(_mm256_setzero_ps(), _mm256_setzero_ps(), _mm256_setzero_ps());
+    __m256 a = _mm256_loadu_ps((const float*)argv[argc-1]);
+           a = _mm256_macc_ps(a, a, a);
     return (int)_mm_cvtss_f32(_mm256_castps256_ps128(a));
 }


### PR DESCRIPTION
Backport of #18970. 

closes #18945

#### Hardened the AVX compile-time tests 

 To avoid optimizing it out by the compiler so we make
  sure that the assembler is getting involved.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
