### PR TITLE
BUG: fix ValueError in PyArray_Std on win_amd64

### DIFF
--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -392,7 +392,7 @@ __New_PyArray_Std(PyArrayObject *self, int axis, int rtype, PyArrayObject *out,
         else {
             val = PyArray_DIM(arrnew,i);
         }
-        PyTuple_SET_ITEM(newshape, i, PyLong_FromLong((long)val));
+        PyTuple_SET_ITEM(newshape, i, PyLong_FromSsize_t(val));
     }
     arr2 = (PyArrayObject *)PyArray_Reshape(arr1, newshape);
     Py_DECREF(arr1);


### PR DESCRIPTION
Backport of #19011.

Fixes the following type of `ValueError` on 64-bit Python for Windows, which is due to casting of 64-bit `ssize_t` to 32-bit `long` :

```Cython
# test.pyx
import sys
import numpy
from numpy cimport PyArray_Std, NPY_FLOAT, ndarray, import_array

import_array()
print(sys.version)

cdef ndarray a = numpy.zeros((2**32 + 1023, 1), dtype='uint8')
PyArray_Std(a, -1, NPY_FLOAT, None, 0)
```
```Python
# setup.py
from setuptools import setup, Extension
import numpy

setup(
    name='test',
    ext_modules=[
        Extension('test', ['test.pyx'], include_dirs=[numpy.get_include()])
    ],
)
```
```CMD
> python setup.py build_ext --inplace
> python -c"import test"
```
```Python-traceback
3.9.5 (tags/v3.9.5:0a7dcbd, May  3 2021, 17:27:52) [MSC v.1928 64 bit (AMD64)]
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "test.pyx", line 10, in init test
    PyArray_Std(a, -1, NPY_FLOAT, None, 0)
ValueError: cannot reshape array of size 4294968319 into shape (1023,1)
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
