### PR TITLE
ENH: Support major version larger than 9 in NumpyVersion

### DIFF
--- a/numpy/lib/_version.py
+++ b/numpy/lib/_version.py
@@ -15,7 +15,7 @@ class NumpyVersion():
     """Parse and compare numpy version strings.
 
     NumPy has the following versioning scheme (numbers given are examples; they
-    can be > 9) in principle):
+    can be > 9 in principle):
 
     - Released version: '1.8.0', '1.8.1', etc.
     - Alpha: '1.8.0a1', '1.8.0a2', etc.

--- a/numpy/lib/_version.py
+++ b/numpy/lib/_version.py
@@ -54,7 +54,7 @@ class NumpyVersion():
 
     def __init__(self, vstring):
         self.vstring = vstring
-        ver_main = re.match(r'\d\.\d+\.\d+', vstring)
+        ver_main = re.match(r'\d+\.\d+\.\d+', vstring)
         if not ver_main:
             raise ValueError("Not a valid numpy version string")
 

--- a/numpy/lib/tests/test__version.py
+++ b/numpy/lib/tests/test__version.py
@@ -7,7 +7,7 @@ from numpy.lib import NumpyVersion
 
 def test_main_versions():
     assert_(NumpyVersion('1.8.0') == '1.8.0')
-    for ver in ['1.9.0', '2.0.0', '1.8.1']:
+    for ver in ['1.9.0', '2.0.0', '1.8.1', '10.0.1']:
         assert_(NumpyVersion('1.8.0') < ver)
 
     for ver in ['1.7.0', '1.7.1', '0.9.9']:


### PR DESCRIPTION
Backport of #19214. 

This PR fixes `numpy.lib.NumpyVersion` to be able to parse major versions larger than 9, as the docstring says:

> numbers given are examples; they can be > 9 in principle

Currently minor and bugfix version supports > 9 but major is not.

Motivation: I'm maintaining CuPy, and we are expecting the next major release to be v10.x. I understand this enhancement is not necessary for NumPy for the foreseeable future, but it would be great if CuPy's version strings (which follows the NumPy's convention) can be parsed as well.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
