### PR TITLE
BUG: revise string_from_pyobj/try_pyarr_from_string with respect to malloc and copy (the second round)

### DIFF
--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -970,7 +970,8 @@ if (#varname#_cb.capi==Py_None) {
         'cleanupfrompyobj': """\
 \t\tSTRINGFREE(#varname#);
 \t}  /*if (f2py_success) of #varname#*/""",
-        'need': ['#ctype#_from_pyobj', 'len..', 'STRINGFREE', {l_not(isintent_c): 'STRINGPADN'}],
+        'need': ['#ctype#_from_pyobj', 'len..', 'STRINGFREE',
+                 {l_not(isintent_c): 'STRINGPADN'}],
         '_check':isstring,
         '_depend':''
     }, {  # Not hidden

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -943,20 +943,29 @@ if (#varname#_cb.capi==Py_None) {
                  '\tPyObject *#varname#_capi = Py_None;'],
         'callfortran':'#varname#,',
         'callfortranappend':'slen(#varname#),',
-        'pyobjfrom':[{debugcapi: '\tfprintf(stderr,"#vardebugshowvalue#\\n",slen(#varname#),#varname#);'},
-                     # The trailing null value for Fortran is blank.
-                     {l_and(isintent_out, l_not(isintent_c)): "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
+        'pyobjfrom':[
+            {debugcapi:
+             '\tfprintf(stderr,'
+             '"#vardebugshowvalue#\\n",slen(#varname#),#varname#);'},
+            # The trailing null value for Fortran is blank.
+            {l_and(isintent_out, l_not(isintent_c)):
+             "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
         ],
         'return': {isintent_out: ',#varname#'},
-        'need': ['len..', {l_and(isintent_out, l_not(isintent_c)): 'STRINGPADN'}],
+        'need': ['len..',
+                 {l_and(isintent_out, l_not(isintent_c)): 'STRINGPADN'}],
         '_check':isstring
     }, {  # Common
-        'frompyobj': ["""\
+        'frompyobj': [
+            """\
 \tslen(#varname#) = #length#;
-\tf2py_success = #ctype#_from_pyobj(&#varname#,&slen(#varname#),#init#,#varname#_capi,\"#ctype#_from_pyobj failed in converting #nth# `#varname#\' of #pyname# to C #ctype#\");
+\tf2py_success = #ctype#_from_pyobj(&#varname#,&slen(#varname#),#init#,"""
+"""#varname#_capi,\"#ctype#_from_pyobj failed in converting #nth#"""
+"""`#varname#\' of #pyname# to C #ctype#\");
 \tif (f2py_success) {""",
-                      # The trailing null value for Fortran is blank.
-                      {l_not(isintent_c): "\t\tSTRINGPADN(#varname#, slen(#varname#), '\\0', ' ');"},
+            # The trailing null value for Fortran is blank.
+            {l_not(isintent_c):
+             "\t\tSTRINGPADN(#varname#, slen(#varname#), '\\0', ' ');"},
         ],
         'cleanupfrompyobj': """\
 \t\tSTRINGFREE(#varname#);
@@ -970,7 +979,8 @@ if (#varname#_cb.capi==Py_None) {
         'args_capi': {isrequired: ',&#varname#_capi'},
         'keys_capi': {isoptional: ',&#varname#_capi'},
         'pyobjfrom': [
-            {l_and(isintent_inout, l_not(isintent_c)): "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
+            {l_and(isintent_inout, l_not(isintent_c)):
+             "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
             {isintent_inout: '''\
 \tf2py_success = try_pyarr_from_#ctype#(#varname#_capi, #varname#,
 \t                                      slen(#varname#));

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -561,7 +561,8 @@ rout_rules = [
                  '\tint #name#_return_value_len = 0;'],
         'callfortran':'#name#_return_value,#name#_return_value_len,',
         'callfortranroutine':['\t#name#_return_value_len = #rlength#;',
-                              '\tif ((#name#_return_value = (string)malloc(sizeof(char)*(#name#_return_value_len+1))) == NULL) {',
+                              '\tif ((#name#_return_value = (string)malloc('
+                                  '#name#_return_value_len+1) == NULL) {',
                               '\t\tPyErr_SetString(PyExc_MemoryError, \"out of memory\");',
                               '\t\tf2py_success = 0;',
                               '\t} else {',
@@ -942,19 +943,25 @@ if (#varname#_cb.capi==Py_None) {
                  '\tPyObject *#varname#_capi = Py_None;'],
         'callfortran':'#varname#,',
         'callfortranappend':'slen(#varname#),',
-        'pyobjfrom':{debugcapi: '\tfprintf(stderr,"#vardebugshowvalue#\\n",slen(#varname#),#varname#);'},
+        'pyobjfrom':[{debugcapi: '\tfprintf(stderr,"#vardebugshowvalue#\\n",slen(#varname#),#varname#);'},
+                     # The trailing null value for Fortran is blank.
+                     {l_and(isintent_out, l_not(isintent_c)): "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
+        ],
         'return': {isintent_out: ',#varname#'},
-        'need': ['len..'],  # 'STRINGFREE'],
+        'need': ['len..', {l_and(isintent_out, l_not(isintent_c)): 'STRINGPADN'}],
         '_check':isstring
     }, {  # Common
-        'frompyobj': """\
+        'frompyobj': ["""\
 \tslen(#varname#) = #length#;
 \tf2py_success = #ctype#_from_pyobj(&#varname#,&slen(#varname#),#init#,#varname#_capi,\"#ctype#_from_pyobj failed in converting #nth# `#varname#\' of #pyname# to C #ctype#\");
 \tif (f2py_success) {""",
+                      # The trailing null value for Fortran is blank.
+                      {l_not(isintent_c): "\t\tSTRINGPADN(#varname#, slen(#varname#), '\\0', ' ');"},
+        ],
         'cleanupfrompyobj': """\
 \t\tSTRINGFREE(#varname#);
 \t}  /*if (f2py_success) of #varname#*/""",
-        'need': ['#ctype#_from_pyobj', 'len..', 'STRINGFREE'],
+        'need': ['#ctype#_from_pyobj', 'len..', 'STRINGFREE', {l_not(isintent_c): 'STRINGPADN'}],
         '_check':isstring,
         '_depend':''
     }, {  # Not hidden
@@ -962,11 +969,15 @@ if (#varname#_cb.capi==Py_None) {
         'keyformat': {isoptional: 'O'},
         'args_capi': {isrequired: ',&#varname#_capi'},
         'keys_capi': {isoptional: ',&#varname#_capi'},
-        'pyobjfrom': {isintent_inout: '''\
-\tf2py_success = try_pyarr_from_#ctype#(#varname#_capi,#varname#);
-\tif (f2py_success) {'''},
+        'pyobjfrom': [
+            {l_and(isintent_inout, l_not(isintent_c)): "\t\tSTRINGPADN(#varname#, slen(#varname#), ' ', '\\0');"},
+            {isintent_inout: '''\
+\tf2py_success = try_pyarr_from_#ctype#(#varname#_capi, #varname#,
+\t                                      slen(#varname#));
+\tif (f2py_success) {'''}],
         'closepyobjfrom': {isintent_inout: '\t} /*if (f2py_success) of #varname# pyobjfrom*/'},
-        'need': {isintent_inout: 'try_pyarr_from_#ctype#'},
+        'need': {isintent_inout: 'try_pyarr_from_#ctype#',
+                 l_and(isintent_inout, l_not(isintent_c)): 'STRINGPADN'},
         '_check': l_and(isstring, isintent_nothide)
     }, {  # Hidden
         '_check': l_and(isstring, isintent_hide)

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -93,7 +93,7 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
   PyObject *strides = NULL;
   char s[100];
   int i;
-  memset(s,0,100*sizeof(char));
+  memset(s,0,100);
   if (!PyArg_ParseTuple(capi_args,"O!|:wrap.attrs",
                         &PyArray_Type,&arr_capi))
     return NULL;

--- a/numpy/f2py/tests/test_return_character.py
+++ b/numpy/f2py/tests/test_return_character.py
@@ -21,11 +21,11 @@ class TestReturnCharacter(util.F2PyTest):
             #assert_(_raises(ValueError, t, array([77,87])))
             #assert_(_raises(ValueError, t, array(77)))
         elif tname in ['ts', 'ss']:
-            assert_(t(23) == b'23        ', repr(t(23)))
+            assert_(t(23) == b'23', repr(t(23)))
             assert_(t('123456789abcdef') == b'123456789a')
         elif tname in ['t5', 's5']:
-            assert_(t(23) == b'23   ', repr(t(23)))
-            assert_(t('ab') == b'ab   ', repr(t('ab')))
+            assert_(t(23) == b'23', repr(t(23)))
+            assert_(t('ab') == b'ab', repr(t('ab')))
             assert_(t('123456789abcdef') == b'12345')
         else:
             raise NotImplementedError

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-
+import textwrap
 from numpy.testing import assert_array_equal
 import numpy as np
 from . import util
@@ -9,14 +9,158 @@ from . import util
 def _path(*a):
     return os.path.join(*((os.path.dirname(__file__),) + a))
 
+
 class TestString(util.F2PyTest):
     sources = [_path('src', 'string', 'char.f90')]
 
     @pytest.mark.slow
     def test_char(self):
         strings = np.array(['ab', 'cd', 'ef'], dtype='c').T
-        inp, out = self.module.char_test.change_strings(strings, strings.shape[1])
+        inp, out = self.module.char_test.change_strings(strings,
+                                                        strings.shape[1])
         assert_array_equal(inp, strings)
         expected = strings.copy()
         expected[1, :] = 'AAA'
         assert_array_equal(out, expected)
+
+
+class TestDocStringArguments(util.F2PyTest):
+    suffix = '.f'
+
+    code = """
+C FILE: STRING.F
+      SUBROUTINE FOO(A,B,C,D)
+      CHARACTER*5 A, B
+      CHARACTER*(*) C,D
+Cf2py intent(in) a,c
+Cf2py intent(inout) b,d
+      PRINT*, "A=",A
+      PRINT*, "B=",B
+      PRINT*, "C=",C
+      PRINT*, "D=",D
+      PRINT*, "CHANGE A,B,C,D"
+      A(1:1) = 'A'
+      B(1:1) = 'B'
+      C(1:1) = 'C'
+      D(1:1) = 'D'
+      PRINT*, "A=",A
+      PRINT*, "B=",B
+      PRINT*, "C=",C
+      PRINT*, "D=",D
+      END
+C END OF FILE STRING.F
+        """
+
+    def test_example(self):
+        a = np.array(b'123\0\0')
+        b = np.array(b'123\0\0')
+        c = np.array(b'123')
+        d = np.array(b'123')
+
+        self.module.foo(a, b, c, d)
+
+        assert a.tobytes() == b'123\0\0'
+        assert b.tobytes() == b'B23\0\0', (b.tobytes(),)
+        assert c.tobytes() == b'123'
+        assert d.tobytes() == b'D23'
+
+
+class TestFixedString(util.F2PyTest):
+    suffix = '.f90'
+
+    code = textwrap.dedent("""
+       function sint(s) result(i)
+          implicit none
+          character(len=*) :: s
+          integer :: j, i
+          i = 0
+          do j=len(s), 1, -1
+           if (.not.((i.eq.0).and.(s(j:j).eq.' '))) then
+             i = i + ichar(s(j:j)) * 10 ** (j - 1)
+           endif
+          end do
+          return
+        end function sint
+
+        function test_in_bytes4(a) result (i)
+          implicit none
+          integer :: sint
+          character(len=4) :: a
+          integer :: i
+          i = sint(a)
+          a(1:1) = 'A'
+          return
+        end function test_in_bytes4
+
+        function test_inout_bytes4(a) result (i)
+          implicit none
+          integer :: sint
+          character(len=4), intent(inout) :: a
+          integer :: i
+          if (a(1:1).ne.' ') then
+            a(1:1) = 'E'
+          endif
+          i = sint(a)
+          return
+        end function test_inout_bytes4
+        """)
+
+    @staticmethod
+    def _sint(s, start=0, end=None):
+        """Return the content of a string buffer as integer value.
+
+        For example:
+          _sint('1234') -> 4321
+          _sint('123A') -> 17321
+        """
+        if isinstance(s, np.ndarray):
+            s = s.tobytes()
+        elif isinstance(s, str):
+            s = s.encode()
+        assert isinstance(s, bytes)
+        if end is None:
+            end = len(s)
+        i = 0
+        for j in range(start, min(end, len(s))):
+            i += s[j] * 10 ** j
+        return i
+
+    def _get_input(self, intent='in'):
+        if intent in ['in']:
+            yield ''
+            yield '1'
+            yield '1234'
+            yield '12345'
+            yield b''
+            yield b'\0'
+            yield b'1'
+            yield b'\01'
+            yield b'1\0'
+            yield b'1234'
+            yield b'12345'
+        yield np.ndarray((), np.bytes_, buffer=b'')  # array(b'', dtype='|S0')
+        yield np.array(b'')                          # array(b'', dtype='|S1')
+        yield np.array(b'\0')
+        yield np.array(b'1')
+        yield np.array(b'1\0')
+        yield np.array(b'\01')
+        yield np.array(b'1234')
+        yield np.array(b'123\0')
+        yield np.array(b'12345')
+
+    def test_intent_in(self):
+        for s in self._get_input():
+            r = self.module.test_in_bytes4(s)
+            # also checks that s is not changed inplace
+            expected = self._sint(s, end=4)
+            assert r == expected, (s)
+
+    def test_intent_inout(self):
+        for s in self._get_input(intent='inout'):
+            rest = self._sint(s, start=4)
+            r = self.module.test_inout_bytes4(s)
+            expected = self._sint(s, end=4)
+            assert r == expected
+
+            # check that the rest of input string is preserved
+            assert rest == self._sint(s, start=4)


### PR DESCRIPTION
Improved https://github.com/numpy/numpy/pull/18759 that was reverted by https://github.com/numpy/numpy/pull/19235 .

Originally, it was assumed that Fortran treats null values in byte-strings similar to C but that turned out to be wrong and caused failures in scipy tests that use f2py wrapped functions with string `intent(inout)` arguments for Fortran fixed-width character string arguments.

This PR (in addition to original changes) replaces the trailing nulls in strings with trailing blanks that Fortran treats as "null values" and when Fortran program returns a string with trailing blanks, these will be replaced with trailing nulls because the content of numpy ndarray of strings is interpreted as C strings.

Fixes https://github.com/numpy/numpy/issues/18431 (again) and https://github.com/numpy/numpy/issues/19201 .

This PR is tested against the current scipy master: all scipy tests pass ok.