### PR TITLE
DOC: Fix formatting in rot90() docstring

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -88,8 +88,11 @@ def rot90(m, k=1, axes=(0, 1)):
 
     Notes
     -----
-    rot90(m, k=1, axes=(1,0)) is the reverse of rot90(m, k=1, axes=(0,1))
-    rot90(m, k=1, axes=(1,0)) is equivalent to rot90(m, k=-1, axes=(0,1))
+    ``rot90(m, k=1, axes=(1,0))``  is the reverse of
+    ``rot90(m, k=1, axes=(0,1))``
+
+    ``rot90(m, k=1, axes=(1,0))`` is equivalent to
+    ``rot90(m, k=-1, axes=(0,1))``
 
     Examples
     --------


### PR DESCRIPTION
Currently, the note is quite unreadable due to lack of formatting.

![grafik](https://user-images.githubusercontent.com/2836374/122130304-b3343b80-ce37-11eb-8d05-7df1475efe07.png)

This PR adds proper formatting.