### PR TITLE
MAINT: Align masked with normal ufunc loops

### DIFF
--- a/doc/release/upcoming_changes/19259.c_api.rst
+++ b/doc/release/upcoming_changes/19259.c_api.rst
@@ -1,0 +1,14 @@
+Masked inner-loops cannot be customized anymore
+-----------------------------------------------
+The masked inner-loop selector is now never used.  A warning
+will be given in the unlikely event that it was customized.
+
+We do not expect that any code uses this.  If you do use it,
+you must unset unset the selector on newer NumPy version.
+Please also contact the NumPy developers, we do anticipate
+providing a new, more specific, mechanism.
+
+This change will not affect the results of operations, since
+the fallback (which is always used internally) will handle
+the operation equivalently, the customization was a planned
+feature to allow for faster masked operation.

--- a/doc/release/upcoming_changes/19259.c_api.rst
+++ b/doc/release/upcoming_changes/19259.c_api.rst
@@ -4,7 +4,7 @@ The masked inner-loop selector is now never used.  A warning
 will be given in the unlikely event that it was customized.
 
 We do not expect that any code uses this.  If you do use it,
-you must unset unset the selector on newer NumPy version.
+you must unset the selector on newer NumPy version.
 Please also contact the NumPy developers, we do anticipate
 providing a new, more specific, mechanism.
 

--- a/doc/release/upcoming_changes/19259.c_api.rst
+++ b/doc/release/upcoming_changes/19259.c_api.rst
@@ -8,7 +8,5 @@ you must unset the selector on newer NumPy version.
 Please also contact the NumPy developers, we do anticipate
 providing a new, more specific, mechanism.
 
-This change will not affect the results of operations, since
-the fallback (which is always used internally) will handle
-the operation equivalently, the customization was a planned
-feature to allow for faster masked operation.
+The customization was part of a never-implemented feature to allow
+for faster masked operations.

--- a/numpy/core/include/numpy/ufuncobject.h
+++ b/numpy/core/include/numpy/ufuncobject.h
@@ -66,27 +66,14 @@ typedef int (PyUFunc_TypeResolutionFunc)(
                                 PyArray_Descr **out_dtypes);
 
 /*
- * Given an array of DTypes as returned by the PyUFunc_TypeResolutionFunc,
- * and an array of fixed strides (the array will contain NPY_MAX_INTP for
- * strides which are not necessarily fixed), returns an inner loop
- * with associated auxiliary data.
- *
- * For backwards compatibility, there is a variant of the inner loop
- * selection which returns an inner loop irrespective of the strides,
- * and with a void* static auxiliary data instead of an NpyAuxData *
- * dynamically allocatable auxiliary data.
+ * Legacy loop selector. (This should NOT normally be used and we can expect
+ * that only the `PyUFunc_DefaultLegacyInnerLoopSelector` is ever set).
+ * However, unlike the masked version, it probably still works.
  *
  * ufunc:             The ufunc object.
  * dtypes:            An array which has been populated with dtypes,
  *                    in most cases by the type resolution function
  *                    for the same ufunc.
- * fixed_strides:     For each input/output, either the stride that
- *                    will be used every time the function is called
- *                    or NPY_MAX_INTP if the stride might change or
- *                    is not known ahead of time. The loop selection
- *                    function may use this stride to pick inner loops
- *                    which are optimized for contiguous or 0-stride
- *                    cases.
  * out_innerloop:     Should be populated with the correct ufunc inner
  *                    loop for the given type.
  * out_innerloopdata: Should be populated with the void* data to
@@ -101,15 +88,7 @@ typedef int (PyUFunc_LegacyInnerLoopSelectionFunc)(
                             PyUFuncGenericFunction *out_innerloop,
                             void **out_innerloopdata,
                             int *out_needs_api);
-typedef int (PyUFunc_MaskedInnerLoopSelectionFunc)(
-                            struct _tagPyUFuncObject *ufunc,
-                            PyArray_Descr **dtypes,
-                            PyArray_Descr *mask_dtype,
-                            npy_intp *fixed_strides,
-                            npy_intp fixed_mask_stride,
-                            PyUFunc_MaskedStridedInnerLoopFunc **out_innerloop,
-                            NpyAuxData **out_innerloopdata,
-                            int *out_needs_api);
+
 
 typedef struct _tagPyUFuncObject {
         PyObject_HEAD
@@ -199,10 +178,8 @@ typedef struct _tagPyUFuncObject {
     #else
         void *reserved2;
     #endif
-        /*
-         * A function which returns a masked inner loop for the ufunc.
-         */
-        PyUFunc_MaskedInnerLoopSelectionFunc *masked_inner_loop_selector;
+        /* Was previously the `PyUFunc_MaskedInnerLoopSelectionFunc` */
+        void *_always_null_previously_masked_innerloop_selector;
 
         /*
          * List of flags for each operand when ufunc is called by nditer object.

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1508,29 +1508,29 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
     return raise_no_loop_found_error(ufunc, dtypes);
 }
 
+
+/*
+ * Support for masked inner-strided loops. These are currently ONLY used
+ * for normal ufuncs, and only a generic loop getter exists.
+ * It may make sense to generalize this in the future or allow specialization.
+ * Until then, the inner-loop signature is flexible.
+ */
 typedef struct {
     NpyAuxData base;
-    PyUFuncGenericFunction unmasked_innerloop;
-    void *unmasked_innerloopdata;
+    PyUFuncGenericFunction unmasked_stridedloop;
+    void *innerloopdata;
     int nargs;
-} _ufunc_masker_data;
+    char *dataptrs[];
+} _masked_stridedloop_data;
 
-static NpyAuxData *
-ufunc_masker_data_clone(NpyAuxData *data)
+
+static void
+_masked_stridedloop_data_free(NpyAuxData *auxdata)
 {
-    _ufunc_masker_data *n;
-
-    /* Allocate a new one */
-    n = (_ufunc_masker_data *)PyArray_malloc(sizeof(_ufunc_masker_data));
-    if (n == NULL) {
-        return NULL;
-    }
-
-    /* Copy the data (unmasked data doesn't have object semantics) */
-    memcpy(n, data, sizeof(_ufunc_masker_data));
-
-    return (NpyAuxData *)n;
+    _masked_stridedloop_data *data = (_masked_stridedloop_data *)auxdata;
+    PyMem_Free(data);
 }
+
 
 /*
  * This function wraps a regular unmasked ufunc inner loop as a
@@ -1539,43 +1539,39 @@ ufunc_masker_data_clone(NpyAuxData *data)
  */
 static void
 unmasked_ufunc_loop_as_masked(
-             char **dataptrs, npy_intp *strides,
-             char *mask, npy_intp mask_stride,
-             npy_intp loopsize,
-             NpyAuxData *innerloopdata)
+        char **data, const npy_intp *dimensions,
+        const npy_intp *strides, void *_auxdata)
 {
-    _ufunc_masker_data *data;
-    int iargs, nargs;
-    PyUFuncGenericFunction unmasked_innerloop;
-    void *unmasked_innerloopdata;
-    npy_intp subloopsize;
+    _masked_stridedloop_data *auxdata = (_masked_stridedloop_data *)_auxdata;
+    int nargs = auxdata->nargs;
+    PyUFuncGenericFunction strided_loop = auxdata->unmasked_stridedloop;
+    void *innerloopdata = auxdata->innerloopdata;
 
-    /* Put the aux data into local variables */
-    data = (_ufunc_masker_data *)innerloopdata;
-    unmasked_innerloop = data->unmasked_innerloop;
-    unmasked_innerloopdata = data->unmasked_innerloopdata;
-    nargs = data->nargs;
+    char **dataptrs = auxdata->dataptrs;
+    memcpy(dataptrs, data, nargs * sizeof(char *));
+    char *mask = data[nargs];
+    npy_intp mask_stride = strides[nargs];
 
+    npy_intp N = dimensions[0];
     /* Process the data as runs of unmasked values */
     do {
+        ssize_t subloopsize;
+
         /* Skip masked values */
-        mask = npy_memchr(mask, 0, mask_stride, loopsize, &subloopsize, 1);
-        for (iargs = 0; iargs < nargs; ++iargs) {
-            dataptrs[iargs] += subloopsize * strides[iargs];
+        mask = npy_memchr(mask, 0, mask_stride, N, &subloopsize, 1);
+        for (int i = 0; i < nargs; i++) {
+            dataptrs[i] += subloopsize * strides[i];
         }
-        loopsize -= subloopsize;
-        /*
-         * Process unmasked values (assumes unmasked loop doesn't
-         * mess with the 'args' pointer values)
-         */
-        mask = npy_memchr(mask, 0, mask_stride, loopsize, &subloopsize, 0);
-        unmasked_innerloop(dataptrs, &subloopsize, strides,
-                                        unmasked_innerloopdata);
-        for (iargs = 0; iargs < nargs; ++iargs) {
-            dataptrs[iargs] += subloopsize * strides[iargs];
+        N -= subloopsize;
+
+        /* Process unmasked values */
+        mask = npy_memchr(mask, 0, mask_stride, N, &subloopsize, 0);
+        strided_loop(dataptrs, &subloopsize, strides, innerloopdata);
+        for (int i = 0; i < nargs; i++) {
+            dataptrs[i] += subloopsize * strides[i];
         }
-        loopsize -= subloopsize;
-    } while (loopsize > 0);
+        N -= subloopsize;
+    } while (N > 0);
 }
 
 
@@ -1587,15 +1583,13 @@ unmasked_ufunc_loop_as_masked(
 NPY_NO_EXPORT int
 PyUFunc_DefaultMaskedInnerLoopSelector(PyUFuncObject *ufunc,
                             PyArray_Descr **dtypes,
-                            PyArray_Descr *mask_dtype,
-                            npy_intp *NPY_UNUSED(fixed_strides),
-                            npy_intp NPY_UNUSED(fixed_mask_stride),
-                            PyUFunc_MaskedStridedInnerLoopFunc **out_innerloop,
+                            PyUFuncGenericFunction *out_innerloop,
                             NpyAuxData **out_innerloopdata,
                             int *out_needs_api)
 {
     int retcode;
-    _ufunc_masker_data *data;
+    _masked_stridedloop_data *data;
+    int nargs = ufunc->nin + ufunc->nout;
 
     if (ufunc->legacy_inner_loop_selector == NULL) {
         PyErr_SetString(PyExc_RuntimeError,
@@ -1605,27 +1599,21 @@ PyUFunc_DefaultMaskedInnerLoopSelector(PyUFuncObject *ufunc,
         return -1;
     }
 
-    if (mask_dtype->type_num != NPY_BOOL) {
-        PyErr_SetString(PyExc_ValueError,
-                "only boolean masks are supported in ufunc inner loops "
-                "presently");
-        return -1;
-    }
-
-    /* Create a new NpyAuxData object for the masker data */
-    data = (_ufunc_masker_data *)PyArray_malloc(sizeof(_ufunc_masker_data));
+    /* Add working memory for the data pointers, to modify them in-place */
+    data = PyMem_Malloc(sizeof(_masked_stridedloop_data) +
+                        sizeof(char *) * nargs);
     if (data == NULL) {
         PyErr_NoMemory();
         return -1;
     }
-    memset(data, 0, sizeof(_ufunc_masker_data));
-    data->base.free = (NpyAuxData_FreeFunc *)&PyArray_free;
-    data->base.clone = &ufunc_masker_data_clone;
-    data->nargs = ufunc->nin + ufunc->nout;
+    data->base.free = _masked_stridedloop_data_free;
+    data->base.clone = NULL;  /* not currently used */
+    data->unmasked_stridedloop = NULL;
+    data->nargs = nargs;
 
     /* Get the unmasked ufunc inner loop */
     retcode = ufunc->legacy_inner_loop_selector(ufunc, dtypes,
-                    &data->unmasked_innerloop, &data->unmasked_innerloopdata,
+                    &data->unmasked_stridedloop, &data->innerloopdata,
                     out_needs_api);
     if (retcode < 0) {
         PyArray_free(data);

--- a/numpy/core/src/umath/ufunc_type_resolution.h
+++ b/numpy/core/src/umath/ufunc_type_resolution.h
@@ -138,11 +138,7 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
 NPY_NO_EXPORT int
 PyUFunc_DefaultMaskedInnerLoopSelector(PyUFuncObject *ufunc,
                                       PyArray_Descr **dtypes,
-                                      PyArray_Descr *mask_dtypes,
-                                      npy_intp *NPY_UNUSED(fixed_strides),
-                                      npy_intp NPY_UNUSED(fixed_mask_stride),
-                                      PyUFunc_MaskedStridedInnerLoopFunc 
-                                      **out_innerloop,
+                                      PyUFuncGenericFunction *out_innerloop,
                                       NpyAuxData **out_innerloopdata,
                                       int *out_needs_api);
 

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -2267,10 +2267,7 @@ class TestSpecialMethods:
 
         a = np.array(1).view(type=with_prepare)
         if use_where:
-            # Currently raises, due to the array being replaced during prepare
-            with pytest.raises(ValueError):
-                x = np.add(a, a, where=np.array(True))
-            return
+            x = np.add(a, a, where=np.array(True))
         else:
             x = np.add(a, a)
         assert_equal(x, np.array(2))
@@ -2287,10 +2284,7 @@ class TestSpecialMethods:
 
         a = np.array([1]).view(type=with_prepare)
         if use_where:
-            # Currently raises, due to the array being replaced during prepare
-            with pytest.raises(ValueError):
-                x = np.add(a, a, a, where=[True])
-            return
+            x = np.add(a, a, a, where=[True])
         else:
             x = np.add(a, a, a)
         # Returned array is new, because of the strange


### PR DESCRIPTION
This removes the ability to specialize masked inner loops (for now)
as was already noted in NEP 41 and NEP 43.

The masked array is now passed in as the last argument to use the
identical signature and avoid duplicating the code unnecessary.

This is part of the longer process to refactor ufuncs to NEP 43
and split out, to keep the diff's shorter (or at least easier
to read).

EDIT: In case anyone wonders about moving the place where the inner-loop is selected.  This is necessary, because in the future we want to do what the masked version currently pretends: use the fixed-strides array, which is only available *after* setting up the iterator.

---

**~This is based of gh-19258 and~ will have a conflict with gh-19257 (The masked+`__array_prepare__` limitation in the tests there is unnecessary, by merging the two loops the tests added there should fail and need simplification/updating).**