### PR TITLE
BUG: Integer overflow in remainder for Windows

### DIFF
--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -849,7 +849,7 @@ NPY_NO_EXPORT void
     BINARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
-        if (in2 == 0) {
+        if (in2 == 0 || (in1 == NPY_MIN_@TYPE@ && in2 == -1)) {
             npy_set_floatstatus_divbyzero();
             *((@type@ *)op1) = 0;
         }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -872,7 +872,13 @@ NPY_NO_EXPORT void
     BINARY_LOOP_TWO_OUT {
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
-        /* see FIXME note for divide above */
+        /*
+         * FIXME: On x86 at least, dividing the smallest representable integer
+         * by -1 causes a SIFGPE (division overflow). We treat this case here
+         * (to avoid a SIGFPE crash at python level), but a good solution would
+         * be to treat integer division problems separately from FPU exceptions
+         * (i.e. a different approach than npy_set_floatstatus_divbyzero()).
+         */
         if (in2 == 0 || (in1 == NPY_MIN_@TYPE@ && in2 == -1)) {
             npy_set_floatstatus_divbyzero();
             *((@type@ *)op1) = 0;

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -516,6 +516,35 @@ class TestRemainder:
                     else:
                         assert_(b > rem >= 0, msg)
 
+    @pytest.mark.parametrize("input_dtype",
+            np.sctypes['int'])
+    def test_remainder_integer(self, input_dtype):
+        iinfo = np.iinfo(input_dtype)
+
+        # Create list with min, 25th percentile, 0, 75th percentile, max
+        lst = [iinfo.min, iinfo.min//2, iinfo.max//2, iinfo.max]
+        divisors = [iinfo.min, iinfo.min//2, iinfo.max//2, iinfo.max]
+        a = np.array(lst, dtype=input_dtype)
+
+        for divisor in divisors:
+            rem_a = np.remainder(a, divisor)
+            rem_lst = [i % divisor for i in lst]
+
+            msg = "Integer arrays remainder check"
+            assert all(rem_a == rem_lst), msg
+
+            for l in lst:
+                msg = "Integer scalar remainder check"
+                assert input_dtype(l) % divisor == l % divisor, msg
+
+        with np.errstate(divide='raise'):
+            with pytest.raises(FloatingPointError):
+                np.remainder(a, 0)
+            with pytest.raises(FloatingPointError):
+                np.remainder(a, -1)
+            with pytest.raises(FloatingPointError):
+                np.remainder(iinfo.min, -1)
+
     def test_float_remainder_exact(self):
         # test that float results are exact for small integers. This also
         # holds for the same integers scaled by powers of two.


### PR DESCRIPTION
### Integer overflow in remainder for Windows
1. Aims to fix crash when `%` operator is used between MIN value of int and -1
2. Test cases for integer remainders

TODO:
- [x] Commit actual fix.
- [ ] Fix scalar case. [Comment](https://github.com/numpy/numpy/pull/19260#discussion_r652861368)

_Note: I have not committed the actual fix yet, I want to confirm if the crash is reproducible in Azure Pipelines_

<details>
<summary>Local Reproduction</summary>

```Bash

# ganes in DESKTOP-5UIVG9B  D:osnumpy on git:BUG_19246_mod_crash ≢  ~2                                                                                                             [21:58:45]
  3.9.4 ➜  python3 .\runtests.py -v -t numpy\core\tests\test_umath.py
Building, see build.log...
Build OK
NumPy version 0.3.0+25943.g8b0f1ad46
NumPy relaxed strides checking option: True
NumPy CPU features:  SSE SSE2 SSE3 SSSE3* SSE41* POPCNT* SSE42* AVX* F16C* FMA3* AVX2* AVX512F? AVX512CD? AVX512_SKX? AVX512_CLX? AVX512_CNL? AVX512_ICL?
====================================================================================== test session starts ======================================================================================
platform win32 -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: D:\os\numpy, configfile: pytest.ini
plugins: hypothesis-6.14.0, cov-2.12.1
collected 327 items

numpy\core\tests\test_umath.py ...........................................................................................FFWindows fatal exception: integer overflow

Current thread 0x00006478 (most recent call first):
  File "D:\os\numpy\build\testenv\Lib\site-packages\numpy\core\tests\test_umath.py", line 544 in test_remainder_integer
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\python.py", line 183 in pytest_pyfunc_call
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\callers.py", line 187 in _multicall
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 84 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 93 in _hookexec
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\hooks.py", line 286 in __call__
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\python.py", line 1641 in runtest
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 162 in pytest_runtest_call
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\callers.py", line 187 in _multicall
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 84 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 93 in _hookexec
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\hooks.py", line 286 in __call__
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 255 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 311 in from_call
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 254 in call_runtest_hook
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 215 in call_and_report
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 126 in runtestprotocol
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\runner.py", line 109 in pytest_runtest_protocol
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\callers.py", line 187 in _multicall
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 84 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 93 in _hookexec
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\hooks.py", line 286 in __call__
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\main.py", line 348 in pytest_runtestloop
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\callers.py", line 187 in _multicall
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 84 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 93 in _hookexec
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\hooks.py", line 286 in __call__
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\main.py", line 323 in _main
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\main.py", line 269 in wrap_session
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\main.py", line 316 in pytest_cmdline_main
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\callers.py", line 187 in _multicall
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 84 in <lambda>
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\manager.py", line 93 in _hookexec
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\pluggy\hooks.py", line 286 in __call__
  File "C:\Users\ganes\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\_pytest\config\__init__.py", line 162 in main
  File "D:\os\numpy\build\testenv\Lib\site-packages\numpy\_pytesttester.py", line 197 in __call__
  File ".\runtests.py", line 383 in main
  File ".\runtests.py", line 685 in <module>
```
</details>

resolves #19246 