### PR TITLE
MAINT: Use Ubuntu focal for travis-ci builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 group: travis_latest
 os: linux
-dist: bionic
+dist: focal
 
 # Travis allows these packages, additions can be requested
 #   https://github.com/travis-ci/apt-package-safelist


### PR DESCRIPTION
~The arm64 builds are failing to run, both for NumPy wheels and for
NumPy main using bionic.~ Try focal instead.

Arm64 is back on line. This PR is still good if we want to use a more recent Ubuntu version.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
