### PR TITLE
BUG: Fix reference count leak in ufunc dtype handling

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4052,8 +4052,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         if (dtype == NULL) {
             goto fail;
         }
-        Py_INCREF(dtype->singleton);
         otype = dtype->singleton;
+        Py_INCREF(otype);
         Py_DECREF(dtype);
     }
     if (out_obj && !PyArray_OutputConverter(out_obj, &out)) {

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4054,6 +4054,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         }
         Py_INCREF(dtype->singleton);
         otype = dtype->singleton;
+        Py_DECREF(dtype);
     }
     if (out_obj && !PyArray_OutputConverter(out_obj, &out)) {
         goto fail;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -390,7 +390,6 @@ PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                     operands, type_tup, out_dtypes);
         }
 
-        Py_INCREF(descr);
         out_dtypes[0] = ensure_dtype_nbo(descr);
         if (out_dtypes[0] == NULL) {
             return -1;


### PR DESCRIPTION
This adds a missing decref to the signature/dtype keyword argument
logic in reductions.
(The code will change quite a bit after 1.21, but this avoids a
reference count leak on 1.21.)

EDIT: It may take until tonight for me to know whether there is much (or anything) more coming...