### PR TITLE
DOC: Unpin pydata sphinx theme and update config to avoid long doc build times

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -164,6 +164,7 @@ html_theme_options = {
   "logo_link": "index",
   "github_url": "https://github.com/numpy/numpy",
   "twitter_url": "https://twitter.com/numpy_team",
+  "collapse_navigation": True,
 }
 
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,4 +4,4 @@ ipython
 scipy
 matplotlib
 pandas
-pydata-sphinx-theme==0.5.2
+pydata-sphinx-theme

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - scipy
   - pandas
   - matplotlib
-  - pydata-sphinx-theme=0.5.2
+  - pydata-sphinx-theme
   # For linting
   - pycodestyle=2.7.0
   - gitpython


### PR DESCRIPTION
The pydata-sphinx-theme introduced a [collapsible navigation feature](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html#configure-the-navigation-depth-and-collapsing-of-the-sidebar) in version 0.6. This led to very long build times, thus we pinned the theme to 0.5.2 in #18789 to avoid the slowdown. There is now a configuration option in the theme to disable this feature and keep the build times and html file sizes from increasing drastically.

There *shouldn't* be any difference with the current sidebar behavior on devdocs since we were pinned to a version that didn't have it. However, please compare the sidebar behavior in the [development documentation](https://numpy.org/devdocs/) to the behavior in the circleci artifact below during review.
