### PR TITLE
DOC: Add `versionadded` directives to `numpy.typing`

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -3,6 +3,8 @@
 Typing (:mod:`numpy.typing`)
 ============================
 
+.. versionadded:: 1.20
+
 .. warning::
 
   Some of the types in this module rely on features only present in
@@ -21,6 +23,8 @@ the two below:
 
 Mypy plugin
 -----------
+
+.. versionadded:: 1.21
 
 .. automodule:: numpy.typing.mypy_plugin
 
@@ -179,6 +183,8 @@ class NBitBase:
     represents the base of a hierarchical set of subclasses.
     Each subsequent subclass is herein used for representing a lower level
     of precision, *e.g.* ``64Bit > 32Bit > 16Bit``.
+
+    .. versionadded:: 1.20
 
     Examples
     --------

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -22,32 +22,7 @@ the two below:
 Mypy plugin
 -----------
 
-A mypy_ plugin is distributed in `numpy.typing` for managing a number of
-platform-specific annotations. Its functionality can be split into three
-distinct parts:
-
-* Assigning the (platform-dependent) precisions of certain `~numpy.number` subclasses,
-  including the likes of `~numpy.int_`, `~numpy.intp` and `~numpy.longlong`.
-  See the documentation on :ref:`scalar types <arrays.scalars.built-in>` for a
-  comprehensive overview of the affected classes. Without the plugin the
-  precision of all relevant classes will be inferred as `~typing.Any`.
-* Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
-  Without the plugin aforementioned type will default to `ctypes.c_int64`.
-* Removing all extended-precision `~numpy.number` subclasses that are unavailable
-  for the platform in question. Most notably, this includes the likes of
-  `~numpy.float128` and `~numpy.complex256`. Without the plugin *all*
-  extended-precision types will, as far as mypy is concerned, be available
-  to all platforms.
-
-To enable the plugin, one must add it to their mypy `configuration file`_:
-
-.. code-block:: ini
-
-    [mypy]
-    plugins = numpy.typing.mypy_plugin
-
-.. _mypy: http://mypy-lang.org/
-.. _configuration file: https://mypy.readthedocs.io/en/stable/config_file.html
+.. automodule:: numpy.typing.mypy_plugin
 
 Differences from the runtime NumPy API
 --------------------------------------

--- a/numpy/typing/_add_docstring.py
+++ b/numpy/typing/_add_docstring.py
@@ -67,6 +67,8 @@ add_newdoc('ArrayLike', 'typing.Union[...]',
     * (Nested) sequences.
     * Objects implementing the `~class.__array__` protocol.
 
+    .. versionadded:: 1.20
+
     See Also
     --------
     :term:`array_like`:
@@ -94,6 +96,8 @@ add_newdoc('DTypeLike', 'typing.Union[...]',
     * Character codes or the names of :class:`type` objects.
     * Objects with the ``.dtype`` attribute.
 
+    .. versionadded:: 1.20
+
     See Also
     --------
     :ref:`Specifying and constructing data types <arrays.dtypes.constructing>`
@@ -118,6 +122,8 @@ add_newdoc('NDArray', repr(NDArray),
 
     Can be used during runtime for typing arrays with a given dtype
     and unspecified shape.
+
+    .. versionadded:: 1.21
 
     Examples
     --------

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -12,9 +12,9 @@ Its functionality can be split into three distinct parts:
   likes of `~numpy.float128` and `~numpy.complex256`. Without the plugin *all*
   extended-precision types will, as far as mypy is concerned, be available
   to all platforms.
-* Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
-  Without the plugin aforementioned type will default to `ctypes.c_int64`.
-
+* .. versionadded:: 1.22
+    Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
+    Without the plugin aforementioned type will default to `ctypes.c_int64`.
 
 Examples
 --------

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -12,9 +12,10 @@ Its functionality can be split into three distinct parts:
   likes of `~numpy.float128` and `~numpy.complex256`. Without the plugin *all*
   extended-precision types will, as far as mypy is concerned, be available
   to all platforms.
-* .. versionadded:: 1.22
-    Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
-    Without the plugin aforementioned type will default to `ctypes.c_int64`.
+* Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
+  Without the plugin aforementioned type will default to `ctypes.c_int64`.
+
+  .. versionadded:: 1.22
 
 Examples
 --------

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -1,4 +1,34 @@
-"""A module containing `numpy`-specific plugins for mypy."""
+"""A mypy_ plugin for managing a number of platform-specific annotations.
+Its functionality can be split into three distinct parts:
+
+* Assigning the (platform-dependent) precisions of certain `~numpy.number`
+  subclasses, including the likes of `~numpy.int_`, `~numpy.intp` and
+  `~numpy.longlong`. See the documentation on
+  :ref:`scalar types <arrays.scalars.built-in>` for a comprehensive overview
+  of the affected classes. Without the plugin the precision of all relevant
+  classes will be inferred as `~typing.Any`.
+* Removing all extended-precision `~numpy.number` subclasses that are
+  unavailable for the platform in question. Most notably this includes the
+  likes of `~numpy.float128` and `~numpy.complex256`. Without the plugin *all*
+  extended-precision types will, as far as mypy is concerned, be available
+  to all platforms.
+* Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
+  Without the plugin aforementioned type will default to `ctypes.c_int64`.
+
+
+Examples
+--------
+To enable the plugin, one must add it to their mypy `configuration file`_:
+
+.. code-block:: ini
+
+    [mypy]
+    plugins = numpy.typing.mypy_plugin
+
+.. _mypy: http://mypy-lang.org/
+.. _configuration file: https://mypy.readthedocs.io/en/stable/config_file.html
+
+"""
 
 from __future__ import annotations
 

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -13,7 +13,7 @@ Its functionality can be split into three distinct parts:
   extended-precision types will, as far as mypy is concerned, be available
   to all platforms.
 * Assigning the (platform-dependent) precision of `~numpy.ctypeslib.c_intp`.
-  Without the plugin aforementioned type will default to `ctypes.c_int64`.
+  Without the plugin the type will default to `ctypes.c_int64`.
 
   .. versionadded:: 1.22
 


### PR DESCRIPTION
Prior to this PR there were no `versionadded` directives in  `numpy.typing`, which could lead to 
version-related problems such as https://github.com/numpy/numpy/issues/19215. This has now been fixed.

The rendered docs: https://20557-908607-gh.circle-artifacts.com/0/doc/build/html/reference/typing.html