### PR TITLE
DOC: Add documentation for `np.ctypeslib.c_intp`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -435,6 +435,11 @@ def linkcode_resolve(domain, info):
         if not fn:
             return None
 
+        # Ignore re-exports as their source files are not within the numpy repo
+        module = inspect.getmodule(obj)
+        if module is not None and not module.__name__.startswith("numpy"):
+            return None
+
         try:
             source, lineno = inspect.getsourcelines(obj)
         except Exception:

--- a/doc/source/reference/routines.ctypeslib.rst
+++ b/doc/source/reference/routines.ctypeslib.rst
@@ -11,3 +11,10 @@ C-Types Foreign Function Interface (:mod:`numpy.ctypeslib`)
 .. autofunction:: as_ctypes_type
 .. autofunction:: load_library
 .. autofunction:: ndpointer
+
+.. class:: c_intp
+
+    A `ctypes` signed integer type of the same size as `numpy.intp`.
+
+    Depending on the platform, it can be an alias for either `~ctypes.c_int`,
+    `~ctypes.c_long` or `~ctypes.c_longlong`.

--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -324,10 +324,10 @@ class _ctypes:
         """
         (c_intp*self.ndim): A ctypes array of length self.ndim where
         the basetype is the C-integer corresponding to ``dtype('p')`` on this
-        platform. This base-type could be `ctypes.c_int`, `ctypes.c_long`, or
-        `ctypes.c_longlong` depending on the platform.
-        The c_intp type is defined accordingly in `numpy.ctypeslib`.
-        The ctypes array contains the shape of the underlying array.
+        platform (see `~numpy.ctypeslib.c_intp`). This base-type could be
+        `ctypes.c_int`, `ctypes.c_long`, or `ctypes.c_longlong` depending on
+        the platform. The ctypes array contains the shape of
+        the underlying array.
         """
         return self.shape_as(_getintp_ctype())
 
@@ -907,4 +907,3 @@ class recursive:
         self.func = func
     def __call__(self, *args, **kwargs):
         return self.func(self, *args, **kwargs)
-


### PR DESCRIPTION
`np.ctypeslib.c_intp` is a public alias for one of the `ctypes` signed integer types, but it currently lacks a documentation.

This PR fixes aforementioned issue, adding a small docstring explaining that it is an alias for the `ctypes` equivalent of `np.intp`.