### PR TITLE
REV,BUG: Replace `NotImplemented` with `typing.Any`

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -161,7 +161,7 @@ API
 # NOTE: The API section will be appended with additional entries
 # further down in this file
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Any
 
 if TYPE_CHECKING:
     import sys
@@ -364,14 +364,14 @@ if TYPE_CHECKING:
         _GUFunc_Nin2_Nout1,
     )
 else:
-    _UFunc_Nin1_Nout1 = NotImplemented
-    _UFunc_Nin2_Nout1 = NotImplemented
-    _UFunc_Nin1_Nout2 = NotImplemented
-    _UFunc_Nin2_Nout2 = NotImplemented
-    _GUFunc_Nin2_Nout1 = NotImplemented
+    _UFunc_Nin1_Nout1 = Any
+    _UFunc_Nin2_Nout1 = Any
+    _UFunc_Nin1_Nout2 = Any
+    _UFunc_Nin2_Nout2 = Any
+    _GUFunc_Nin2_Nout1 = Any
 
 # Clean up the namespace
-del TYPE_CHECKING, final, List
+del TYPE_CHECKING, final, List, Any
 
 if __doc__ is not None:
     from ._add_docstring import _docstrings

--- a/numpy/typing/_extended_precision.py
+++ b/numpy/typing/_extended_precision.py
@@ -4,7 +4,7 @@ The subclasses are defined here (instead of ``__init__.pyi``) such
 that they can be imported conditionally via the numpy's mypy plugin.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from . import (
@@ -28,15 +28,15 @@ if TYPE_CHECKING:
     complex256 = np.complexfloating[_128Bit, _128Bit]
     complex512 = np.complexfloating[_256Bit, _256Bit]
 else:
-    uint128 = NotImplemented
-    uint256 = NotImplemented
-    int128 = NotImplemented
-    int256 = NotImplemented
-    float80 = NotImplemented
-    float96 = NotImplemented
-    float128 = NotImplemented
-    float256 = NotImplemented
-    complex160 = NotImplemented
-    complex192 = NotImplemented
-    complex256 = NotImplemented
-    complex512 = NotImplemented
+    uint128 = Any
+    uint256 = Any
+    int128 = Any
+    int256 = Any
+    float80 = Any
+    float96 = Any
+    float128 = Any
+    float256 = Any
+    complex160 = Any
+    complex192 = Any
+    complex256 = Any
+    complex512 = Any

--- a/numpy/typing/_shape.py
+++ b/numpy/typing/_shape.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union, Any
 
 if sys.version_info >= (3, 8):
     from typing import SupportsIndex
@@ -7,7 +7,7 @@ else:
     try:
         from typing_extensions import SupportsIndex
     except ImportError:
-        SupportsIndex = NotImplemented
+        SupportsIndex = Any
 
 _Shape = Tuple[int, ...]
 

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -21,8 +21,8 @@ if sys.version_info >= (3, 9):
     NDArray_ref = types.GenericAlias(np.ndarray, (Any, DType_ref))
     FuncType = Callable[[Union[_GenericAlias, types.GenericAlias]], Any]
 else:
-    DType_ref = NotImplemented
-    NDArray_ref = NotImplemented
+    DType_ref = Any
+    NDArray_ref = Any
     FuncType = Callable[[_GenericAlias], Any]
 
 GETATTR_NAMES = sorted(set(dir(np.ndarray)) - _GenericAlias._ATTR_EXCEPTIONS)


### PR DESCRIPTION
Partial backport of https://github.com/numpy/numpy/pull/19176.
Closes https://github.com/numpy/numpy/issues/19310.

Replace all `NotImplemented`-based runtime placeholders with `typing.Any`. The problem with the previous 
approach is that typing lacks the necessary special-casing for `NotImplemented`, and will thus raise an exception
when used with subscriptable typing constructs (_e.g._ `Union`).

Note that the relevant issue is limited to python 3.7 installations that lack the typing-extensions package.