### PR TITLE
MAINT: Clean up multiarray interned strings

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3983,8 +3983,8 @@ _array_fill_strides(npy_intp *strides, npy_intp const *dims, int nd, size_t item
 NPY_NO_EXPORT PyArrayObject *
 PyArray_SubclassWrap(PyArrayObject *arr_of_subclass, PyArrayObject *towrap)
 {
-    PyObject *wrapped = PyObject_CallMethod((PyObject *)arr_of_subclass,
-                                        "__array_wrap__", "O", towrap);
+    PyObject *wrapped = PyObject_CallMethodObjArgs((PyObject *)arr_of_subclass,
+            npy_ma_str_array_wrap, (PyObject *)towrap, NULL);
     if (wrapped == NULL) {
         return NULL;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4606,16 +4606,9 @@ set_flaginfo(PyObject *d)
     return;
 }
 
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_prepare = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_wrap = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_finalize = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_ufunc = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_implementation = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_order = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_copy = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_dtype = NULL;
-NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_ndmin = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_axis1 = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_axis2 = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_like = NULL;
@@ -4624,27 +4617,15 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_numpy = NULL;
 static int
 intern_strings(void)
 {
-    npy_ma_str_array = PyUnicode_InternFromString("__array__");
-    npy_ma_str_array_prepare = PyUnicode_InternFromString("__array_prepare__");
-    npy_ma_str_array_wrap = PyUnicode_InternFromString("__array_wrap__");
-    npy_ma_str_array_finalize = PyUnicode_InternFromString("__array_finalize__");
-    npy_ma_str_ufunc = PyUnicode_InternFromString("__array_ufunc__");
-    npy_ma_str_implementation = PyUnicode_InternFromString("_implementation");
-    npy_ma_str_order = PyUnicode_InternFromString("order");
-    npy_ma_str_copy = PyUnicode_InternFromString("copy");
-    npy_ma_str_dtype = PyUnicode_InternFromString("dtype");
-    npy_ma_str_ndmin = PyUnicode_InternFromString("ndmin");
-    npy_ma_str_axis1 = PyUnicode_InternFromString("axis1");
-    npy_ma_str_axis2 = PyUnicode_InternFromString("axis2");
-    npy_ma_str_like = PyUnicode_InternFromString("like");
-    npy_ma_str_numpy = PyUnicode_InternFromString("numpy");
+    if (!(npy_ma_str_array_wrap = PyUnicode_InternFromString("__array_wrap__"))) return -1;
+    if (!(npy_ma_str_array_finalize = PyUnicode_InternFromString("__array_finalize__"))) return -1;
+    if (!(npy_ma_str_implementation = PyUnicode_InternFromString("_implementation"))) return -1;
+    if (!(npy_ma_str_axis1 = PyUnicode_InternFromString("axis1"))) return -1;
+    if (!(npy_ma_str_axis2 = PyUnicode_InternFromString("axis2"))) return -1;
+    if (!(npy_ma_str_like = PyUnicode_InternFromString("like"))) return -1;
+    if (!(npy_ma_str_numpy = PyUnicode_InternFromString("numpy"))) return -1;
 
-    return npy_ma_str_array && npy_ma_str_array_prepare &&
-           npy_ma_str_array_wrap && npy_ma_str_array_finalize &&
-           npy_ma_str_ufunc && npy_ma_str_implementation &&
-           npy_ma_str_order && npy_ma_str_copy && npy_ma_str_dtype &&
-           npy_ma_str_ndmin && npy_ma_str_axis1 && npy_ma_str_axis2 &&
-           npy_ma_str_like && npy_ma_str_numpy;
+    return 0;
 }
 
 static struct PyModuleDef moduledef = {
@@ -4876,7 +4857,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
-    if (!intern_strings()) {
+    if (intern_strings() < 0) {
         goto err;
     }
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4617,14 +4617,34 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_numpy = NULL;
 static int
 intern_strings(void)
 {
-    if (!(npy_ma_str_array_wrap = PyUnicode_InternFromString("__array_wrap__"))) return -1;
-    if (!(npy_ma_str_array_finalize = PyUnicode_InternFromString("__array_finalize__"))) return -1;
-    if (!(npy_ma_str_implementation = PyUnicode_InternFromString("_implementation"))) return -1;
-    if (!(npy_ma_str_axis1 = PyUnicode_InternFromString("axis1"))) return -1;
-    if (!(npy_ma_str_axis2 = PyUnicode_InternFromString("axis2"))) return -1;
-    if (!(npy_ma_str_like = PyUnicode_InternFromString("like"))) return -1;
-    if (!(npy_ma_str_numpy = PyUnicode_InternFromString("numpy"))) return -1;
-
+    npy_ma_str_array_wrap = PyUnicode_InternFromString("__array_wrap__");
+    if (npy_ma_str_array_wrap == NULL) {
+        return -1;
+    }
+    npy_ma_str_array_finalize = PyUnicode_InternFromString("__array_finalize__");
+    if (npy_ma_str_array_finalize == NULL) {
+        return -1;
+    }
+    npy_ma_str_implementation = PyUnicode_InternFromString("_implementation");
+    if (npy_ma_str_implementation == NULL) {
+        return -1;
+    }
+    npy_ma_str_axis1 = PyUnicode_InternFromString("axis1");
+    if (npy_ma_str_axis1 == NULL) {
+        return -1;
+    }
+    npy_ma_str_axis2 = PyUnicode_InternFromString("axis2");
+    if (npy_ma_str_axis2 == NULL) {
+        return -1;
+    }
+    npy_ma_str_like = PyUnicode_InternFromString("like");
+    if (npy_ma_str_like == NULL) {
+        return -1;
+    }
+    npy_ma_str_numpy = PyUnicode_InternFromString("numpy");
+    if (npy_ma_str_numpy == NULL) {
+        return -1;
+    }
     return 0;
 }
 

--- a/numpy/core/src/multiarray/multiarraymodule.h
+++ b/numpy/core/src/multiarray/multiarraymodule.h
@@ -1,16 +1,9 @@
 #ifndef _NPY_MULTIARRAY_H_
 #define _NPY_MULTIARRAY_H_
 
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_prepare;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_wrap;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_finalize;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ufunc;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_implementation;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_order;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_copy;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_dtype;
-NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_ndmin;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_axis1;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_axis2;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_like;

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -224,9 +224,18 @@ NPY_VISIBILITY_HIDDEN PyObject *npy_um_str_pyvals_name = NULL;
 static int
 intern_strings(void)
 {
-    if (!(npy_um_str_array_prepare = PyUnicode_InternFromString("__array_prepare__"))) return -1;
-    if (!(npy_um_str_array_wrap = PyUnicode_InternFromString("__array_wrap__"))) return -1;
-    if (!(npy_um_str_pyvals_name = PyUnicode_InternFromString(UFUNC_PYVALS_NAME))) return -1;
+    npy_um_str_array_prepare = PyUnicode_InternFromString("__array_prepare__");
+    if (npy_um_str_array_prepare == NULL) {
+        return -1;
+    }
+    npy_um_str_array_wrap = PyUnicode_InternFromString("__array_wrap__");
+    if (npy_um_str_array_wrap == NULL) {
+        return -1;
+    }
+    npy_um_str_pyvals_name = PyUnicode_InternFromString(UFUNC_PYVALS_NAME);
+    if (npy_um_str_pyvals_name == NULL) {
+        return -1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Just a very small cleanup really, because I happened to look at that chunk of code.

This removes unused interned strings from multiarray and modifies
the pattern to the one used in `umathmodule.c` also.
(It may be that we even had this pattern here as well, but that
it was lost in a merge conflict.)

The first commit modifies the `__array_wrap__` calling functionality to use the interned strings (rather than removing it in the second commit).