### PR TITLE
BUG: protect against accessing base attribute of a NULL subarray

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -417,9 +417,6 @@ PyArray_GetCastSafety(
     if (to != NULL) {
         to_dtype = NPY_DTYPE(to);
     }
-    if (from == NULL) {
-        return -1;
-    }
     PyObject *meth = PyArray_GetCastingImpl(NPY_DTYPE(from), to_dtype);
     if (meth == NULL) {
         return -1;
@@ -3297,8 +3294,8 @@ void_to_void_resolve_descriptors(
             }
         }
 
-        PyArray_Descr *from_base = (from_sub == NULL) ? NULL : from_sub->base;
-        PyArray_Descr *to_base = (to_sub == NULL) ? NULL : to_sub->base;
+        PyArray_Descr *from_base = (from_sub == NULL) ? given_descrs[0] : from_sub->base;
+        PyArray_Descr *to_base = (to_sub == NULL) ? given_descrs[1] : to_sub->base;
         NPY_CASTING field_casting = PyArray_GetCastSafety(from_base, to_base, NULL);
         if (field_casting < 0) {
             return -1;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -417,6 +417,9 @@ PyArray_GetCastSafety(
     if (to != NULL) {
         to_dtype = NPY_DTYPE(to);
     }
+    if (from == NULL) {
+        return -1;
+    }
     PyObject *meth = PyArray_GetCastingImpl(NPY_DTYPE(from), to_dtype);
     if (meth == NULL) {
         return -1;
@@ -3293,8 +3296,10 @@ void_to_void_resolve_descriptors(
                 casting = NPY_NO_CASTING | _NPY_CAST_IS_VIEW;
             }
         }
-        NPY_CASTING field_casting = PyArray_GetCastSafety(
-                given_descrs[0]->subarray->base, given_descrs[1]->subarray->base, NULL);
+
+        PyArray_Descr *from_base = (from_sub == NULL) ? NULL : from_sub->base;
+        PyArray_Descr *to_base = (to_sub == NULL) ? NULL : to_sub->base;
+        NPY_CASTING field_casting = PyArray_GetCastSafety(from_base, to_base, NULL);
         if (field_casting < 0) {
             return -1;
         }

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -646,3 +646,9 @@ class TestCasting:
         with pytest.raises(TypeError,
                     match="casting from object to the parametric DType"):
             cast._resolve_descriptors((np.dtype("O"), None))
+
+    def test_void_to_structured_with_subarray(self):
+        # test case corresponding to gh-19325
+        dtype = np.dtype([("foo", "<f4", (3, 2))])
+        assert np.can_cast("V4", dtype, casting="unsafe")
+        assert not np.can_cast("V4", dtype, casting="no")

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -647,8 +647,10 @@ class TestCasting:
                     match="casting from object to the parametric DType"):
             cast._resolve_descriptors((np.dtype("O"), None))
 
-    def test_void_to_structured_with_subarray(self):
+    @pytest.mark.parametrize("casting", ["no", "unsafe"])
+    def test_void_and_structured_with_subarray(self, casting):
         # test case corresponding to gh-19325
         dtype = np.dtype([("foo", "<f4", (3, 2))])
-        assert np.can_cast("V4", dtype, casting="unsafe")
-        assert not np.can_cast("V4", dtype, casting="no")
+        expected = casting == "unsafe"
+        assert np.can_cast("V4", dtype, casting=casting) == expected
+        assert np.can_cast(dtype, "V4", casting=casting) == expected


### PR DESCRIPTION
closes #19325

This PR is to protect against potential segfaults in `void_to_void_resolve_descriptors`. This is the first time I have looked at this code, so there may be a better solution, but this seems to work for the example given in #19325
