### PR TITLE
ENH Add a conda-based CI job on azure.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -310,11 +310,10 @@ stages:
       vmImage: 'ubuntu-20.04'
     steps:
     - script: |
-            # Download and install miniconda
-            MINICONDA_PATH=$HOME/miniconda
-            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-            /bin/bash miniconda.sh -b -p $MINICONDA_PATH
-            export PATH="$MINICONDA_PATH/bin:$PATH"
+            # create and activate conda environment
+            conda env create -f environment.yml
+      displayName: 'Create conda environment.'
+    - script: |
             # >>> conda initialize >>>
             # !! Contents within this block are 'conda init' !!
             # see https://github.com/conda/conda/issues/7980
@@ -322,13 +321,11 @@ stages:
             eval "$__conda_setup"
             unset __conda_setup
             # <<< conda initialize <<<
-            # create and activate conda environment
-            conda env create -f environment.yml
             conda activate numpy-dev
             # Run native baseline Build / Tests
-            python3 runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
+            python runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
             --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
-      displayName: 'Run native baseline Build / Tests in conda environment.'
+      displayName: 'Run native baseline Build / Tests in conda.'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -305,4 +305,34 @@ stages:
         failTaskOnFailedTests: true
         testRunTitle: 'Publish test results for gcc 4.8'
 
+  - job: Linux_conda
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+    - script: |
+            # Download and install miniconda
+            MINICONDA_PATH=$HOME/miniconda
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+            /bin/bash miniconda.sh -b -p $MINICONDA_PATH
+            export PATH="$MINICONDA_PATH/bin:$PATH"
+            # >>> conda initialize >>>
+            # !! Contents within this block are 'conda init' !!
+            # see https://github.com/conda/conda/issues/7980
+            __conda_setup="$('conda' 'shell.bash' 'hook' 2> /dev/null)"
+            eval "$__conda_setup"
+            unset __conda_setup
+            # <<< conda initialize <<<
+            # create and activate conda environment
+            conda env create -f environment.yml
+            conda activate numpy-dev
+            # Run native baseline Build / Tests
+            python3 runtests.py --show-build-log --cpu-baseline=native --cpu-dispatch=none \
+            --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
+      displayName: 'Run native baseline Build / Tests in conda environment.'
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: '**/test-*.xml'
+        failTaskOnFailedTests: true
+        testRunTitle: 'Publish test results for conda installation'
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations 
-  - mypy=0.812
+  - mypy=0.902
   - typing_extensions
   # For building docs
   - sphinx=4.0.1


### PR DESCRIPTION
This pull request adds a conda based job on azure, using the `environment.yml` file.
Thanks for considering it.

Closes #18711.

Please note that I can reproduce the failing test locally, in a pip virtual environment.
But I can't see the same failure in the other azure builds: I'm afraid this is beyond my understanding... :confused: 
 ```py
path = '/home/cmarmo/software/numpy/build/testenv/lib64/python3.9/site-packages/numpy/typing/tests/data/reveal/testing.py'
reveal = 'tuple[types.ModuleType]'
expected_reveal = "32: note: Revealed type is 'builtins.tuple[_importlib_modulespec.ModuleType]'", lineno = 32

    def _test_reveal(path: str, reveal: str, expected_reveal: str, lineno: int) -> None:
        if reveal not in expected_reveal:
>           raise AssertionError(_REVEAL_MSG.format(lineno, expected_reveal, reveal))
E           AssertionError: Reveal mismatch at line 32
E           
E           Expected reveal: "32: note: Revealed type is 'builtins.tuple[_importlib_modulespec.ModuleType]'"
E           Observed reveal: 'tuple[types.ModuleType]'

expected_reveal = "32: note: Revealed type is 'builtins.tuple[_importlib_modulespec.ModuleType]'"
lineno     = 32
path       = '/home/cmarmo/software/numpy/build/testenv/lib64/python3.9/site-packages/numpy/typing/tests/data/reveal/testing.py'
reveal     = 'tuple[types.ModuleType]'

numpy/typing/tests/test_typing.py:295: AssertionError
=============================================== short test summary info ===============================================
FAILED numpy/typing/tests/test_typing.py::test_reveal[testing.py] - AssertionError: Reveal mismatch at line 32
```

