### PR TITLE
ENH: Add annotations for `np.f2py`

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -2,7 +2,7 @@
 """Fortran to Python Interface Generator.
 
 """
-__all__ = ['run_main', 'compile', 'get_include', 'f2py_testing']
+__all__ = ['run_main', 'compile', 'get_include']
 
 import sys
 import subprocess

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -1,18 +1,44 @@
-from typing import Any, List
+import os
+import subprocess
+from typing import Any, List, Iterable, Dict, overload
+from typing_extensions import TypedDict, Literal as L
 
 from numpy.f2py import (
     f2py_testing as f2py_testing,
 )
 
-__all__: List[str]
+class _F2PyDictBase(TypedDict):
+    csrc: List[str]
+    h: List[str]
 
-def run_main(comline_list): ...
+class _F2PyDict(_F2PyDictBase, total=False):
+    fsrc: List[str]
+    ltx: List[str]
+
+__all__: List[str]
+__path__: List[str]
+
+def run_main(comline_list: Iterable[str]) -> Dict[str, _F2PyDict]: ...
+
+@overload
+def compile(  # type: ignore[misc]
+    source: str | bytes,
+    modulename: str = ...,
+    extra_args: str | List[str] = ...,
+    verbose: bool = ...,
+    source_fn: None | str | bytes | os.PathLike[Any] = ...,
+    extension: L[".f", ".f90"] = ...,
+    full_output: L[False] = ...,
+) -> int: ...
+@overload
 def compile(
-    source,
-    modulename=...,
-    extra_args=...,
-    verbose=...,
-    source_fn=...,
-    extension=...,
-    full_output=...,
-): ...
+    source: str | bytes,
+    modulename: str = ...,
+    extra_args: str | List[str] = ...,
+    verbose: bool = ...,
+    source_fn: None | str | bytes | os.PathLike[Any] = ...,
+    extension: L[".f", ".f90"] = ...,
+    full_output: L[True] = ...,
+) -> subprocess.CompletedProcess[bytes]: ...
+
+def get_include() -> str: ...

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -3,10 +3,6 @@ import subprocess
 from typing import Any, List, Iterable, Dict, overload
 from typing_extensions import TypedDict, Literal as L
 
-from numpy.f2py import (
-    f2py_testing as f2py_testing,
-)
-
 class _F2PyDictBase(TypedDict):
     csrc: List[str]
     h: List[str]


### PR DESCRIPTION
This PR adds annotations for the `f2py` sub-package.