### PR TITLE
MAINT: remove `print()`'s in distutils template handling

### DIFF
--- a/numpy/distutils/conv_template.py
+++ b/numpy/distutils/conv_template.py
@@ -271,7 +271,6 @@ def resolve_includes(source):
                 if not os.path.isabs(fn):
                     fn = os.path.join(d, fn)
                 if os.path.isfile(fn):
-                    print('Including file', fn)
                     lines.extend(resolve_includes(fn))
                 else:
                     lines.append(line)

--- a/numpy/distutils/from_template.py
+++ b/numpy/distutils/from_template.py
@@ -219,7 +219,6 @@ def resolve_includes(source):
                 if not os.path.isabs(fn):
                     fn = os.path.join(d, fn)
                 if os.path.isfile(fn):
-                    print('Including file', fn)
                     lines.extend(resolve_includes(fn))
                 else:
                     lines.append(line)


### PR DESCRIPTION
These print statements were not warnings, they're simply printing things out that work as designed. This is never a good design - it should not emit anything but warnings.

I considered adding a `quiet` keyword, but that doesn't seem warranted here.

[ci skip]