### PR TITLE
ENH: Use literals for annotating `int`- & `str`-based constants

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3489,29 +3489,36 @@ infty: Final[float]
 nan: Final[float]
 pi: Final[float]
 
-ERR_CALL: Final[int]
-ERR_DEFAULT: Final[int]
-ERR_IGNORE: Final[int]
-ERR_LOG: Final[int]
-ERR_PRINT: Final[int]
-ERR_RAISE: Final[int]
-ERR_WARN: Final[int]
-FLOATING_POINT_SUPPORT: Final[int]
-FPE_DIVIDEBYZERO: Final[int]
-FPE_INVALID: Final[int]
-FPE_OVERFLOW: Final[int]
-FPE_UNDERFLOW: Final[int]
-SHIFT_DIVIDEBYZERO: Final[int]
-SHIFT_INVALID: Final[int]
-SHIFT_OVERFLOW: Final[int]
-SHIFT_UNDERFLOW: Final[int]
-UFUNC_BUFSIZE_DEFAULT: Final[int]
+CLIP: L[0]
+WRAP: L[1]
+RAISE: L[2]
+
+ERR_IGNORE: L[0]
+ERR_WARN: L[1]
+ERR_RAISE: L[2]
+ERR_CALL: L[3]
+ERR_PRINT: L[4]
+ERR_LOG: L[5]
+ERR_DEFAULT: L[521]
+
+SHIFT_DIVIDEBYZERO: L[0]
+SHIFT_OVERFLOW: L[3]
+SHIFT_UNDERFLOW: L[6]
+SHIFT_INVALID: L[9]
+
+FPE_DIVIDEBYZERO: L[1]
+FPE_OVERFLOW: L[2]
+FPE_UNDERFLOW: L[4]
+FPE_INVALID: L[8]
+
+FLOATING_POINT_SUPPORT: L[1]
+UFUNC_BUFSIZE_DEFAULT = BUFSIZE
 
 little_endian: Final[bool]
 True_: Final[bool_]
 False_: Final[bool_]
 
-UFUNC_PYVALS_NAME: Final[str]
+UFUNC_PYVALS_NAME: L["UFUNC_PYVALS"]
 
 newaxis: None
 

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -226,8 +226,11 @@ from numpy.lib.utils import (
     safe_eval as safe_eval,
 )
 
+from numpy.core.multiarray import (
+    tracemalloc_domain as tracemalloc_domain,
+)
+
 __all__: List[str]
 
 __version__ = version
 emath = scimath
-tracemalloc_domain: int

--- a/numpy/typing/tests/data/fail/constants.py
+++ b/numpy/typing/tests/data/fail/constants.py
@@ -3,5 +3,5 @@ import numpy as np
 np.Inf = np.Inf  # E: Cannot assign to final
 np.ALLOW_THREADS = np.ALLOW_THREADS  # E: Cannot assign to final
 np.little_endian = np.little_endian  # E: Cannot assign to final
-np.UFUNC_PYVALS_NAME = np.UFUNC_PYVALS_NAME  # E: Cannot assign to final
+np.UFUNC_PYVALS_NAME = "bob"  # E: Incompatible types
 np.CLIP = 2  # E: Incompatible types

--- a/numpy/typing/tests/data/reveal/constants.py
+++ b/numpy/typing/tests/data/reveal/constants.py
@@ -18,27 +18,27 @@ reveal_type(np.pi)  # E: float
 reveal_type(np.ALLOW_THREADS)  # E: int
 reveal_type(np.BUFSIZE)  # E: Literal[8192]
 reveal_type(np.CLIP)  # E: Literal[0]
-reveal_type(np.ERR_CALL)  # E: int
-reveal_type(np.ERR_DEFAULT)  # E: int
-reveal_type(np.ERR_IGNORE)  # E: int
-reveal_type(np.ERR_LOG)  # E: int
-reveal_type(np.ERR_PRINT)  # E: int
-reveal_type(np.ERR_RAISE)  # E: int
-reveal_type(np.ERR_WARN)  # E: int
-reveal_type(np.FLOATING_POINT_SUPPORT)  # E: int
-reveal_type(np.FPE_DIVIDEBYZERO)  # E: int
-reveal_type(np.FPE_INVALID)  # E: int
-reveal_type(np.FPE_OVERFLOW)  # E: int
-reveal_type(np.FPE_UNDERFLOW)  # E: int
+reveal_type(np.ERR_CALL)  # E: Literal[3]
+reveal_type(np.ERR_DEFAULT)  # E: Literal[521]
+reveal_type(np.ERR_IGNORE)  # E: Literal[0]
+reveal_type(np.ERR_LOG)  # E: Literal[5]
+reveal_type(np.ERR_PRINT)  # E: Literal[4]
+reveal_type(np.ERR_RAISE)  # E: Literal[2]
+reveal_type(np.ERR_WARN)  # E: Literal[1]
+reveal_type(np.FLOATING_POINT_SUPPORT)  # E: Literal[1]
+reveal_type(np.FPE_DIVIDEBYZERO)  # E: Literal[1]
+reveal_type(np.FPE_INVALID)  # E: Literal[8]
+reveal_type(np.FPE_OVERFLOW)  # E: Literal[2]
+reveal_type(np.FPE_UNDERFLOW)  # E: Literal[4]
 reveal_type(np.MAXDIMS)  # E: Literal[32]
 reveal_type(np.MAY_SHARE_BOUNDS)  # E: Literal[0]
 reveal_type(np.MAY_SHARE_EXACT)  # E: Literal[-1]
 reveal_type(np.RAISE)  # E: Literal[2]
-reveal_type(np.SHIFT_DIVIDEBYZERO)  # E: int
-reveal_type(np.SHIFT_INVALID)  # E: int
-reveal_type(np.SHIFT_OVERFLOW)  # E: int
-reveal_type(np.SHIFT_UNDERFLOW)  # E: int
-reveal_type(np.UFUNC_BUFSIZE_DEFAULT)  # E: int
+reveal_type(np.SHIFT_DIVIDEBYZERO)  # E: Literal[0]
+reveal_type(np.SHIFT_INVALID)  # E: Literal[9]
+reveal_type(np.SHIFT_OVERFLOW)  # E: Literal[3]
+reveal_type(np.SHIFT_UNDERFLOW)  # E: Literal[6]
+reveal_type(np.UFUNC_BUFSIZE_DEFAULT)  # E: Literal[8192]
 reveal_type(np.WRAP)  # E: Literal[1]
 reveal_type(np.tracemalloc_domain)  # E: Literal[389047]
 
@@ -46,7 +46,7 @@ reveal_type(np.little_endian)  # E: bool
 reveal_type(np.True_)  # E: numpy.bool_
 reveal_type(np.False_)  # E: numpy.bool_
 
-reveal_type(np.UFUNC_PYVALS_NAME)  # E: str
+reveal_type(np.UFUNC_PYVALS_NAME)  # E: Literal['UFUNC_PYVALS']
 
 reveal_type(np.sctypeDict)  # E: dict
 reveal_type(np.sctypes)  # E: TypedDict


### PR DESCRIPTION
This PR improves the annotations of various constants in the main numpy namespace.
Values were generally taken from their C-based `UFUNC_<x>` or `NPY_<x>` counterpart.