### PR TITLE
MAINT: fix overly broad exception handling listed in LGTM

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -904,7 +904,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
                                 sys.stdout = old_stdout
                                 sys.stderr = old_stderr
                         # Catch SystemExit, too
-                        except BaseException:
+                        except SystemExit:
                             continue
 
             for n, v in _getmembers(item):

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -904,7 +904,7 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
                                 sys.stdout = old_stdout
                                 sys.stderr = old_stderr
                         # Catch SystemExit, too
-                        except SystemExit:
+                        except (Exception, SystemExit):
                             continue
 
             for n, v in _getmembers(item):

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -275,8 +275,8 @@ def scrubF2CSource(c_file):
 def ensure_executable(name):
     try:
         which(name)
-    except Exception:
-        raise SystemExit(name + ' not found')
+    except Exception as ex:
+        raise SystemExit(name + ' not found') from ex
 
 def create_name_header(output_dir):
     routine_re = re.compile(r'^      (subroutine|.* function)\s+(\w+)\(.*$',

--- a/numpy/linalg/lapack_lite/make_lite.py
+++ b/numpy/linalg/lapack_lite/make_lite.py
@@ -275,7 +275,7 @@ def scrubF2CSource(c_file):
 def ensure_executable(name):
     try:
         which(name)
-    except:
+    except Exception:
         raise SystemExit(name + ' not found')
 
 def create_name_header(output_dir):


### PR DESCRIPTION
Modified instances of `except BaseException:` and `except:` to catch narrower exception classes as suggested by LGTM.

Relates to ticket #19077

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
