### PR TITLE
TEST: filter warnings on tests for running after installation

### DIFF
--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -3,15 +3,15 @@ from numpy.testing import assert_array_equal, assert_
 
 import pytest
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
-@pytest.mark.filterwarnings("ignore:Importing from numpy.matlib")
+pytestmark = pytest.mark.filterwarnings("ignore:the matrix subclass is not",
+                                        "ignore:Importing from numpy.matlib")
+
 def test_empty():
     import numpy.matlib
     x = numpy.matlib.empty((2,))
     assert_(isinstance(x, np.matrix))
     assert_(x.shape, (1, 2))
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_ones():
     import numpy.matlib
     assert_array_equal(numpy.matlib.ones((2, 3)),
@@ -20,7 +20,6 @@ def test_ones():
 
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_zeros():
     import numpy.matlib
     assert_array_equal(numpy.matlib.zeros((2, 3)),
@@ -29,13 +28,11 @@ def test_zeros():
 
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_identity():
     import numpy.matlib
     x = numpy.matlib.identity(2, dtype=int)
     assert_array_equal(x, np.matrix([[1, 0], [0, 1]]))
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_eye():
     import numpy.matlib
     xc = numpy.matlib.eye(3, k=1, dtype=int)
@@ -52,14 +49,12 @@ def test_eye():
     assert not xf.flags.c_contiguous
     assert xf.flags.f_contiguous
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_rand():
     import numpy.matlib
     x = numpy.matlib.rand(3)
     # check matrix type, array would have shape (3,)
     assert_(x.ndim == 2)
 
-@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_randn():
     import numpy.matlib
     x = np.matlib.randn(3)

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -1,31 +1,43 @@
 import numpy as np
-import numpy.matlib
 from numpy.testing import assert_array_equal, assert_
 
+import pytest
+
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
+@pytest.mark.filterwarnings("ignore:Importing from numpy.matlib")
 def test_empty():
+    import numpy.matlib
     x = numpy.matlib.empty((2,))
     assert_(isinstance(x, np.matrix))
     assert_(x.shape, (1, 2))
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_ones():
+    import numpy.matlib
     assert_array_equal(numpy.matlib.ones((2, 3)),
                        np.matrix([[ 1.,  1.,  1.],
                                  [ 1.,  1.,  1.]]))
 
     assert_array_equal(numpy.matlib.ones(2), np.matrix([[ 1.,  1.]]))
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_zeros():
+    import numpy.matlib
     assert_array_equal(numpy.matlib.zeros((2, 3)),
                        np.matrix([[ 0.,  0.,  0.],
                                  [ 0.,  0.,  0.]]))
 
     assert_array_equal(numpy.matlib.zeros(2), np.matrix([[ 0.,  0.]]))
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_identity():
+    import numpy.matlib
     x = numpy.matlib.identity(2, dtype=int)
     assert_array_equal(x, np.matrix([[1, 0], [0, 1]]))
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_eye():
+    import numpy.matlib
     xc = numpy.matlib.eye(3, k=1, dtype=int)
     assert_array_equal(xc, np.matrix([[ 0,  1,  0],
                                       [ 0,  0,  1],
@@ -40,17 +52,22 @@ def test_eye():
     assert not xf.flags.c_contiguous
     assert xf.flags.f_contiguous
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_rand():
+    import numpy.matlib
     x = numpy.matlib.rand(3)
     # check matrix type, array would have shape (3,)
     assert_(x.ndim == 2)
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass is not")
 def test_randn():
+    import numpy.matlib
     x = np.matlib.randn(3)
     # check matrix type, array would have shape (3,)
     assert_(x.ndim == 2)
 
 def test_repmat():
+    import numpy.matlib
     a1 = np.arange(4)
     x = numpy.matlib.repmat(a1, 2, 2)
     y = np.array([[0, 1, 2, 3, 0, 1, 2, 3],

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,8 +11,5 @@ filterwarnings =
     ignore:numpy.dtype size changed
     ignore:numpy.ufunc size changed
     ignore::UserWarning:cpuinfo,
-# Matrix PendingDeprecationWarning.
-    ignore:the matrix subclass is not
-    ignore:Importing from numpy.matlib is
 # pytest warning when using PYTHONOPTIMIZE
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning


### PR DESCRIPTION
When running tests after installing numpy, the filters in `pytest.ini` are not available since `pytest.ini` is not part of the installed package. Instead, filter the FutureDeprecationWarnings on the matrix-specific tests.

Since this showed up on the conda-forge numpy-feedstock which uses [pytest directly](https://github.com/conda-forge/numpy-feedstock/blob/7d3540329392de095b7a06ca356e3e06d9159555/recipe/meta.yaml#L66), perhaps the azure pipeline job to build and test numpy under conda should be modified to run the same way.