### PR TITLE
BUG: fix some memory leaks in ufunc_object 

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5218,6 +5218,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
 
     arg_typenums = PyArray_malloc(ufunc->nargs * sizeof(int));
     if (arg_typenums == NULL) {
+        Py_DECREF(key);
         PyErr_NoMemory();
         return -1;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5355,6 +5355,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     /* Get entry for this user-defined type*/
     cobj = PyDict_GetItemWithError(ufunc->userloops, key);
     if (cobj == NULL && PyErr_Occurred()) {
+        Py_DECREF(key);
         return 0;
     }
     /* If it's not there, then make one and return. */


### PR DESCRIPTION
Resolves #19336.
Resolves #19337.

Adds a *Py_DECREF* call in some specific error cases, so the reference count will be always decreased.

@seberg if you need any test for these cases, please tell me.