### PR TITLE
ENH: Add annotations for `np.core.getlimits`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -10,6 +10,8 @@ from contextlib import ContextDecorator
 
 from numpy.core.multiarray import flagsobj
 from numpy.core._internal import _ctypes
+from numpy.core.getlimits import MachArLike
+
 from numpy.typing import (
     # Arrays
     ArrayLike,
@@ -680,10 +682,6 @@ class chararray(ndarray[_ShapeType, _DType_co]):
     def isnumeric(self): ...
     def isdecimal(self): ...
 
-class finfo:
-    def __new__(cls, dtype: Any) -> Any: ...
-    def __getattr__(self, key: str) -> Any: ...
-
 class format_parser:
     def __init__(
         self,
@@ -693,10 +691,6 @@ class format_parser:
         aligned: Any = ...,
         byteorder: Any = ...,
     ) -> None: ...
-
-class iinfo:
-    def __init__(self, int_type: Any) -> None: ...
-    def __getattr__(self, key: str) -> Any: ...
 
 class matrix(ndarray[_ShapeType, _DType_co]):
     def __new__(
@@ -3762,3 +3756,58 @@ class busdaycalendar:
     def weekmask(self) -> NDArray[bool_]: ...
     @property
     def holidays(self) -> NDArray[datetime64]: ...
+
+class finfo(Generic[_FloatType]):
+    dtype: dtype[_FloatType]
+    bits: int
+    eps: _FloatType
+    epsneg: _FloatType
+    iexp: int
+    machep: int
+    max: _FloatType
+    maxexp: int
+    min: _FloatType
+    minexp: int
+    negep: int
+    nexp: int
+    nmant: int
+    precision: int
+    resolution: _FloatType
+    tiny: _FloatType
+
+    # NOTE: Not technically a property, but this is the only way we can
+    # access the precision of the underlying float
+    @property
+    def machar(self: finfo[floating[_NBit1]]) -> MachArLike[_NBit1]: ...
+    @machar.setter
+    def machar(self: finfo[floating[_NBit1]], value: MachArLike[_NBit1]) -> None: ...
+
+    @overload
+    def __new__(
+        cls, dtype: inexact[_NBit1] | _DTypeLike[inexact[_NBit1]]
+    ) -> finfo[floating[_NBit1]]: ...
+    @overload
+    def __new__(
+        cls, dtype: complex | float | Type[complex] | Type[float]
+    ) -> finfo[float_]: ...
+    @overload
+    def __new__(
+        cls, dtype: str
+    ) -> finfo[floating[Any]]: ...
+
+class iinfo(Generic[_IntType]):
+    dtype: dtype[_IntType]
+    kind: str
+    bits: int
+    key: str
+    @property
+    def min(self) -> int: ...
+    @property
+    def max(self) -> int: ...
+
+    @overload
+    def __new__(cls, dtype: _IntType | _DTypeLike[_IntType]) -> iinfo[_IntType]: ...
+    @overload
+    def __new__(cls, dtype: int | Type[int]) -> iinfo[int_]: ...
+    @overload
+    def __new__(cls, dtype: str) -> iinfo[Any]: ...

--- a/numpy/core/getlimits.pyi
+++ b/numpy/core/getlimits.pyi
@@ -1,0 +1,54 @@
+from typing import Any, Generic, List, Type, TypeVar
+
+from numpy import (
+    finfo as finfo,
+    iinfo as iinfo,
+    floating,
+    signedinteger,
+)
+
+from numpy.typing import NBitBase, NDArray
+
+_NBit = TypeVar("_NBit", bound=NBitBase)
+
+__all__: List[str]
+
+class MachArLike(Generic[_NBit]):
+    def __init__(
+        self,
+        ftype: Type[floating[_NBit]],
+        *,
+        eps: floating[Any],
+        epsneg: floating[Any],
+        huge: floating[Any],
+        tiny: floating[Any],
+        ibeta: int,
+        # Expand `**kwargs` into keyword-only arguments
+        machep: int,
+        negep: int,
+        minexp: int,
+        maxexp: int,
+        it: int,
+        iexp: int,
+        irnd: int,
+        ngrd: int,
+    ) -> None: ...
+    eps: NDArray[floating[_NBit]]
+    epsilon: NDArray[floating[_NBit]]
+    epsneg: NDArray[floating[_NBit]]
+    huge: NDArray[floating[_NBit]]
+    ibeta: signedinteger[_NBit]
+    iexp: int
+    irnd: int
+    it: int
+    machep: int
+    maxexp: int
+    minexp: int
+    negep: int
+    ngrd: int
+    precision: int
+    resolution: NDArray[floating[_NBit]]
+    tiny: NDArray[floating[_NBit]]
+    title: str
+    xmax: NDArray[floating[_NBit]]
+    xmin: NDArray[floating[_NBit]]

--- a/numpy/typing/tests/data/reveal/getlimits.py
+++ b/numpy/typing/tests/data/reveal/getlimits.py
@@ -1,0 +1,69 @@
+import numpy as np
+from numpy.typing import _32Bit
+
+f: float
+f8: np.float64
+c8: np.complex64
+
+i: int
+i8: np.int64
+u4: np.uint32
+
+finfo_f8: np.finfo[np.float64]
+iinfo_i8: np.iinfo[np.int64]
+machar_f4: np.core.getlimits.MachArLike[_32Bit]
+
+reveal_type(np.finfo(f))  # E: numpy.finfo[{double}]
+reveal_type(np.finfo(f8))  # E: numpy.finfo[{float64}]
+reveal_type(np.finfo(c8))  # E: numpy.finfo[{float32}]
+reveal_type(np.finfo('f2'))  # E: numpy.finfo[numpy.floating[Any]]
+
+reveal_type(finfo_f8.dtype)  # E: numpy.dtype[{float64}]
+reveal_type(finfo_f8.bits)  # E: int
+reveal_type(finfo_f8.eps)  # E: {float64}
+reveal_type(finfo_f8.epsneg)  # E: {float64}
+reveal_type(finfo_f8.iexp)  # E: int
+reveal_type(finfo_f8.machep)  # E: int
+reveal_type(finfo_f8.max)  # E: {float64}
+reveal_type(finfo_f8.maxexp)  # E: int
+reveal_type(finfo_f8.min)  # E: {float64}
+reveal_type(finfo_f8.minexp)  # E: int
+reveal_type(finfo_f8.negep)  # E: int
+reveal_type(finfo_f8.nexp)  # E: int
+reveal_type(finfo_f8.nmant)  # E: int
+reveal_type(finfo_f8.precision)  # E: int
+reveal_type(finfo_f8.resolution)  # E: {float64}
+reveal_type(finfo_f8.tiny)  # E: {float64}
+reveal_type(finfo_f8.machar)  # E: MachArLike[numpy.typing._64Bit]
+
+reveal_type(np.iinfo(i))  # E: iinfo[{int_}]
+reveal_type(np.iinfo(i8))  # E: iinfo[{int64}]
+reveal_type(np.iinfo(u4))  # E: iinfo[{uint32}]
+reveal_type(np.iinfo('i2'))  # E: iinfo[Any]
+
+reveal_type(iinfo_i8.dtype)  # E: numpy.dtype[{int64}]
+reveal_type(iinfo_i8.kind)  # E: str
+reveal_type(iinfo_i8.bits)  # E: int
+reveal_type(iinfo_i8.key)  # E: str
+reveal_type(iinfo_i8.min)  # E: int
+reveal_type(iinfo_i8.max)  # E: int
+
+reveal_type(machar_f4.eps)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.epsilon)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.epsneg)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.huge)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.resolution)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.tiny)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.xmax)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.xmin)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.iexp)  # E: int
+reveal_type(machar_f4.irnd)  # E: int
+reveal_type(machar_f4.it)  # E: int
+reveal_type(machar_f4.machep)  # E: int
+reveal_type(machar_f4.maxexp)  # E: int
+reveal_type(machar_f4.minexp)  # E: int
+reveal_type(machar_f4.negep)  # E: int
+reveal_type(machar_f4.ngrd)  # E: int
+reveal_type(machar_f4.precision)  # E: int
+reveal_type(machar_f4.ibeta)  # E: {int32}
+reveal_type(machar_f4.title)  # E: str


### PR DESCRIPTION
This PR adds annotations for all classes in `np.core.getlimits`, most notably `finfo` and `iinfo`.

The module in question also contains the private `MachArLike` class. While I'd love to skip it in its entirety,
`MachArLike` instances are exposed via the public `finfo.machar` attribute.