### PR TITLE
DOC: Additional ideas related to numpy-tutorials integration

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -20,7 +20,7 @@
       <p class="biglink"><a class="biglink" href="{{ pathto("user/quickstart") }}">NumPy quickstart</a><br/>
     <span class="linkdescr">Aimed at domain experts or people migrating to NumPy</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("user/numpy-for-matlab-users") }}">NumPy for MATLAB users</a><br/>    
-      <p class="biglink"><a class="biglink" href="{{ pathto("user/tutorials_index") }}">NumPy Tutorials</a><br/>
+      <p class="biglink"><a class="biglink" href="https://numpy.org/numpy-tutorials/">NumPy Tutorials</a><br/>
 	<span class="linkdescr">Learn about concepts and submodules</span></p>
       <p class="biglink"><a class="biglink" href="{{ pathto("user/howtos_index") }}">NumPy How Tos</a><br/>
 	<span class="linkdescr">How to do common tasks with NumPy</span></p>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -165,7 +165,9 @@ html_theme_options = {
   "github_url": "https://github.com/numpy/numpy",
   "twitter_url": "https://twitter.com/numpy_team",
   "collapse_navigation": True,
-  "external_links": [{"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"}],
+  "external_links": [
+      {"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"}
+      ],
 }
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -165,6 +165,7 @@ html_theme_options = {
   "github_url": "https://github.com/numpy/numpy",
   "twitter_url": "https://twitter.com/numpy_team",
   "collapse_navigation": True,
+  "external_links": [{"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"}],
 }
 
 

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -21,7 +21,7 @@ details are found in :ref:`reference`.
    numpy-for-matlab-users
    building
    c-info
-   NumPy Tutorials <https://numpy.org/numpy-tutorials>
+   NumPy Tutorials <https://numpy.org/numpy-tutorials/features.html>
    howtos_index
    depending_on_numpy
 

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1482,4 +1482,4 @@ Further reading
 -  `SciPy Tutorial <https://docs.scipy.org/doc/scipy/reference/tutorial/index.html>`__
 -  `SciPy Lecture Notes <https://scipy-lectures.org>`__
 -  A `matlab, R, IDL, NumPy/SciPy dictionary <http://mathesaurus.sf.net/>`__
--  `Linear algebra on n-dimensional arrays (Tutorial) <https://numpy.org/numpy-tutorials/content/tutorial-svd.html>`__
+-  :doc:`tutorial-svd <content/tutorial-svd>`


### PR DESCRIPTION
A couple of ideas related to #19191 and #19418

1. Adds a link to `numpy-tutorials` to the numpy docs nav-bar. This isn't critical, I just wanted to highlight this feature of the pydata sphinx theme in case we wanted to have the tutorials accessible from every page in the numpy docs. Note that I (arbitrarily) chose "Learn" for the link name, but that's probably confusing since there's already `numpy.org/learn` which points elsewhere. This could be added separately from #19418 if desired.

2. Illustrates an alternative to the approach taken in #19418 to address https://github.com/numpy/numpy/pull/19418#issuecomment-874513439 in particular. Instead of having `tutorials_index.rst` as a stub providing the user with a link to `numpy.org/numpy-tutorials`, we can instead add external links to `numpy-tutorials` directly to the toctrees/templates. This is similar to the pattern already used for the installation instructions (see e.g. the toctree in `source/user/index`). The main advantage of doing it this way is that it requires one less click from the user and integrates `numpy-tutorials` more tightly with the numpy reference docs.

This PR is just to illustrate ideas via the circleci build artifact, mostly to compare with #19418.