### PR TITLE
MAINT: Use arm64-graviton2 for testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ jobs:
 
     - python: 3.7
       os: linux
-      arch: arm64
+      arch: arm64-graviton2
+      virt: vm
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1


### PR DESCRIPTION
This avoids the errors we have seen with the lxd containers in recent weeks.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
