### PR TITLE
MAINT: Delete old SSE2 `absolute` implementation

### DIFF
--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -205,9 +205,9 @@ run_unary_@isa@_@func@_@TYPE@(char **args, npy_intp const *dimensions, npy_intp 
  */
 
 /**begin repeat1
- * #func = absolute, negative, minimum, maximum#
- * #check = IS_BLOCKABLE_UNARY*2, IS_BLOCKABLE_REDUCE*2 #
- * #name = unary*2, unary_reduce*2#
+ * #func = negative, minimum, maximum#
+ * #check = IS_BLOCKABLE_UNARY, IS_BLOCKABLE_REDUCE*2 #
+ * #name = unary, unary_reduce*2#
  */
 
 #if @vector@ && defined NPY_HAVE_SSE2_INTRINSICS
@@ -644,26 +644,9 @@ sse2_binary_scalar2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, @type@ * ip2, npy
 }
 /**end repeat1**/
 
-static NPY_INLINE
-@type@ scalar_abs_@type@(@type@ v)
-{
-    /* add 0 to clear -0.0 */
-    return (v > 0 ? v: -v) + 0;
-}
 
-static NPY_INLINE
-@type@ scalar_neg_@type@(@type@ v)
-{
-    return -v;
-}
-
-/**begin repeat1
- * #kind = absolute, negative#
- * #VOP = andnot, xor#
- * #scalar = scalar_abs, scalar_neg#
- **/
 static void
-sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
+sse2_negative_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 {
     /*
      * get 0x7FFFFFFF mask (everything but signbit set)
@@ -674,24 +657,24 @@ sse2_@kind@_@TYPE@(@type@ * op, @type@ * ip, const npy_intp n)
 
     /* align output to VECTOR_SIZE_BYTES bytes */
     LOOP_BLOCK_ALIGN_VAR(op, @type@, VECTOR_SIZE_BYTES) {
-        op[i] = @scalar@_@type@(ip[i]);
+        op[i] = -ip[i];
     }
     assert((npy_uintp)n < (VECTOR_SIZE_BYTES / sizeof(@type@)) ||
            npy_is_aligned(&op[i], VECTOR_SIZE_BYTES));
     if (npy_is_aligned(&ip[i], VECTOR_SIZE_BYTES)) {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
             @vtype@ a = @vpre@_load_@vsuf@(&ip[i]);
-            @vpre@_store_@vsuf@(&op[i], @vpre@_@VOP@_@vsuf@(mask, a));
+            @vpre@_store_@vsuf@(&op[i], @vpre@_xor_@vsuf@(mask, a));
         }
     }
     else {
         LOOP_BLOCKED(@type@, VECTOR_SIZE_BYTES) {
             @vtype@ a = @vpre@_loadu_@vsuf@(&ip[i]);
-            @vpre@_store_@vsuf@(&op[i], @vpre@_@VOP@_@vsuf@(mask, a));
+            @vpre@_store_@vsuf@(&op[i], @vpre@_xor_@vsuf@(mask, a));
         }
     }
     LOOP_BLOCKED_END {
-        op[i] = @scalar@_@type@(ip[i]);
+        op[i] = -ip[i];
     }
 }
 /**end repeat1**/


### PR DESCRIPTION
This implementation appears to be unused as it is superceded
by the universal intrinsics based implementation.

---

@seiko2plus is this correct and we now only use your version from here:
https://github.com/numpy/numpy/blob/34d2672bcb8e0005fde3488dd053a9a5bbd97b12/numpy/core/src/umath/loops_unary_fp.dispatch.c.src#L68-L97

I am a bit surprised nothing warns about an unused function, since these are all static?