### PR TITLE
MAINT: graviton2 reguires ``group: edge``.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
       os: linux
       arch: arm64-graviton2
       virt: vm
-      group: edge
+      #group: edge
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,12 @@ jobs:
        - ATLAS=None
 
     - python: 3.7
+      # see https://docs.travis-ci.com/user/multi-cpu-architectures/
+      # for information on using arm64-graviton2.
       os: linux
       arch: arm64-graviton2
       virt: vm
+      group: edge
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1


### PR DESCRIPTION
The group is needed to run on ec2. See https://docs.travis-ci.com/user/multi-cpu-architectures/. I'm not clear on what test
platform it is running on without it.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
