### PR TITLE
DOC: broadcast_to() supports int as shape parameter

### DIFF
--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -371,8 +371,9 @@ def broadcast_to(array, shape, subok=False):
     ----------
     array : array_like
         The array to broadcast.
-    shape : tuple
-        The shape of the desired array.
+    shape : tuple or int
+        The shape of the desired array. A single integer ``i`` is interpreted
+        as ``(i,)``.
     subok : bool, optional
         If True, then sub-classes will be passed-through, otherwise
         the returned array will be forced to be a base-class array (default).


### PR DESCRIPTION
See here for the implementation:
https://github.com/numpy/numpy/blob/df9c973f28fb9c0e713db29285b07b57c622652a/numpy/lib/stride_tricks.py#L340

Technically this is even more permissive by allowing any iterabale, but I wouldn't document that.

