### PR TITLE
TST: Simplify property-based test

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -2334,8 +2334,14 @@ class TestClip:
         actual = np.clip(arr, amin, amax)
         assert_equal(actual, expected)
 
-    @given(data=st.data(), shape=hynp.array_shapes())
-    def test_clip_property(self, data, shape):
+    @given(
+        data=st.data(),
+        arr=hynp.arrays(
+            dtype=hynp.integer_dtypes() | hynp.floating_dtypes(),
+            shape=hynp.array_shapes()
+        )
+    )
+    def test_clip_property(self, data, arr):
         """A property-based test using Hypothesis.
 
         This aims for maximum generality: it could in principle generate *any*
@@ -2351,44 +2357,29 @@ class TestClip:
         That accounts for most of the function; the actual test is just three
         lines to calculate and compare actual vs expected results!
         """
-        # Our base array and bounds should not need to be of the same type as
-        # long as they are all compatible - so we allow any int or float type.
-        dtype_strategy = hynp.integer_dtypes() | hynp.floating_dtypes()
-
-        # The following line is a total hack to disable the varied-dtypes
-        # component of this test, because result != expected if dtypes can vary.
-        dtype_strategy = st.just(data.draw(dtype_strategy))
-
-        # Generate an arbitrary array of the chosen shape and dtype
-        # This is the value that we clip.
-        arr = data.draw(hynp.arrays(dtype=dtype_strategy, shape=shape))
-
         # Generate shapes for the bounds which can be broadcast with each other
         # and with the base shape.  Below, we might decide to use scalar bounds,
         # but it's clearer to generate these shapes unconditionally in advance.
         in_shapes, result_shape = data.draw(
             hynp.mutually_broadcastable_shapes(
                 num_shapes=2,
-                base_shape=shape,
+                base_shape=arr.shape,
                 # Commenting out the min_dims line allows zero-dimensional arrays,
                 # and zero-dimensional arrays containing NaN make the test fail.
                 min_dims=1
-  
             )
         )
+        # This test can fail if we allow either bound to be a scalar `nan`, or
+        # if bounds are of a different (still integer or float) dtype than the 
+        # array.  At some point we should investigate and fix those problems.
         amin = data.draw(
-            dtype_strategy.flatmap(hynp.from_dtype)
-            | hynp.arrays(dtype=dtype_strategy, shape=in_shapes[0])
+            hynp.from_dtype(arr.dtype, allow_nan=False)
+            | hynp.arrays(dtype=arr.dtype, shape=in_shapes[0])
         )
         amax = data.draw(
-            dtype_strategy.flatmap(hynp.from_dtype)
-            | hynp.arrays(dtype=dtype_strategy, shape=in_shapes[1])
+            hynp.from_dtype(arr.dtype, allow_nan=False)
+            | hynp.arrays(dtype=arr.dtype, shape=in_shapes[1])
         )
-        # If we allow either bound to be a scalar `nan`, the test will fail -
-        # so we just "assume" that away (if it is, this raises a special
-        # exception and Hypothesis will try again with different inputs)
-        assume(not np.isscalar(amin) or not np.isnan(amin))
-        assume(not np.isscalar(amax) or not np.isnan(amax))
 
         # Then calculate our result and expected result and check that they're
         # equal!  See gh-12519 for discussion deciding on this property.


### PR DESCRIPTION
@mattip - this is the refactoring I mentioned on https://github.com/HypothesisWorks/hypothesis/issues/3028; there's a chance that it resolves the flaky error in https://github.com/conda-forge/numpy-feedstock/pull/238 and if not it should at least give a more informative error message.

Substantively, it makes the test more efficient by skipping the generalisation that we're not actually using, and using the `allow_nan=False` passthrough I added in [Hypothesis 5.36 (2020-09-24)](https://hypothesis.readthedocs.io/en/latest/changes.html#v5-36-0); IMO it's therefore worth merging independently of the feedstock issue.