### PR TITLE
BUILD: move to OpenBLAS 0.3.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1
+       - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
 
     - python: 3.7

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.13'
-OPENBLAS_LONG = 'v0.3.13-62-gaf2b0d02'
+OPENBLAS_V = '0.3.16'
+OPENBLAS_LONG = 'v0.3.16'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [


### PR DESCRIPTION
Move to OpenBLAS v0.3.16 which was recently released, hopefully will fix the arm64 crashes. Replaces #19387

Also move the ppc64le builds to use 64-bit interfaces