### PR TITLE
MAINT: Fix floating point warning flag as much as possible

### DIFF
--- a/doc/source/reference/routines.err.rst
+++ b/doc/source/reference/routines.err.rst
@@ -1,6 +1,48 @@
 Floating point error handling
 *****************************
 
+NumPy supports floating-point exceptions as defined in the IEEE 745
+standard [1]_:
+
+- Invalid operation: result is not an expressible number.  This typically
+  indicates that a new NaN (not a number) was produced, e.g. by ``0. / 0.``.
+- Division by zero: infinite result obtained from finite numbers,
+  e.g. by ``1. / 0.``
+- Overflow: result too large to be expressed.
+- Underflow: result so close to zero that some precision was lost.
+
+NumPy does not warn for comparisons involving a NaN, such as ``NaN < 0.``.
+This differs from the IEEE standard, which specifies warning for the default
+operators: ``<, <=, >, >=`` when at least one value is a NaN.
+
+The floating-point error handling can be customized using the below functions.
+By default all except "underflow" give a warning.
+
+In some cases NumPy will use these floating point error settings
+also for Integer operations.
+
+.. admonition:: Advanced details
+
+   * Floating-point errors rely on the compiler, hardware, and math library.
+     NumPy tries to ensure correct warning behavior, but some systems may
+     have incomplete support or choose speed over correct floating-point errors.
+     For example the MacOS math library is known to not indicate some errors.
+
+   * IEEE defines a "signalling NaN" or sNaN.  NumPy will never create these.
+     If you import data containing such an sNaN you may see unexpected
+     warnings.  In that case you can use::
+
+         with np.errstate(invalid="ignore"):
+             np.add(arr, 0, out=arr)
+
+     to convert all signalling NaNs to normal (quiet) ones.  Signalling NaNs
+     are expected to signal an error on almost all operations.  However, NumPy
+     may not always behave IEEE conform with respect to warnings.
+
+
+.. [1] https://en.wikipedia.org/wiki/IEEE_754
+
+
 .. currentmodule:: numpy
 
 Setting and getting error handling

--- a/doc/source/reference/routines.err.rst
+++ b/doc/source/reference/routines.err.rst
@@ -1,3 +1,5 @@
+.. _routines.err:
+
 Floating point error handling
 *****************************
 

--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -71,14 +71,15 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
 
     Notes
     -----
-    The floating-point exceptions are defined in the IEEE 754 standard [1]_:
+    See also :ref:`routines.err`.  The floating-point exceptions follow
+    those defined in the IEEE 745 standard [1]_:
 
-    - Division by zero: infinite result obtained from finite numbers.
+    - Invalid operation: result is not an expressible number.  This typically
+      indicates that a new NaN (not a number) was produced, e.g. by ``0. / 0.``
+    - Division by zero: infinite result obtained from finite numbers,
+      e.g. by ``1. / 0.``
     - Overflow: result too large to be expressed.
-    - Underflow: result so close to zero that some precision
-      was lost.
-    - Invalid operation: result is not an expressible number, typically
-      indicates that a NaN was produced.
+    - Underflow: result so close to zero that some precision was lost.
 
     .. [1] https://en.wikipedia.org/wiki/IEEE_754
 

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1595,9 +1595,8 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 void
  *  #C = F, , L#
  */
 /**begin repeat1
- * #kind = equal, not_equal, less, less_equal, greater, greater_equal,
- *        logical_and, logical_or#
- * #OP = ==, !=, <, <=, >, >=, &&, ||#
+ * #kind = equal, not_equal, logical_and, logical_or#
+ * #OP = ==, !=, &&, ||#
  */
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
@@ -1609,7 +1608,29 @@ NPY_NO_EXPORT void
             *((npy_bool *)op1) = in1 @OP@ in2;
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
+}
+/**end repeat1**/
+
+/**begin repeat1
+ * #kind = less, less_equal, greater, greater_equal#
+ * #comp = isless, islessequal, isgreater, isgreaterequal#
+ */
+ /*
+  * Note: Unlike the operators, the functions `isless`, etc. do not set
+  *       floating point exceptions.  NumPy currently does not warn for
+  *       comparisons like `NaN > 0`, using the operators would add the
+  *       warning, as it is the main/default comparison as per IEEE.
+  */
+NPY_NO_EXPORT void
+@TYPE@_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    if (!run_binary_simd_@kind@_@TYPE@(args, dimensions, steps)) {
+        BINARY_LOOP {
+            const @type@ in1 = *(@type@ *)ip1;
+            const @type@ in2 = *(@type@ *)ip2;
+            *((npy_bool *)op1) = @comp@(in1, in2);
+        }
+    }
 }
 /**end repeat1**/
 
@@ -1650,7 +1671,6 @@ NPY_NO_EXPORT void
             *((npy_bool *)op1) = @func@(in1) != 0;
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat2**/
 /**end repeat1**/
@@ -1686,7 +1706,7 @@ NPY_NO_EXPORT void
 
 /**begin repeat1
  * #kind = maximum, minimum#
- * #OP =  >=, <=#
+ * #comp = isgreaterequal, islessequal#
  **/
 NPY_NO_EXPORT void
 @TYPE@_@kind@_avx512f(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
@@ -1697,7 +1717,7 @@ NPY_NO_EXPORT void
             BINARY_REDUCE_LOOP(@type@) {
                 const @type@ in2 = *(@type@ *)ip2;
                 /* Order of operations important for MSVC 2015 */
-                io1 = (io1 @OP@ in2 || npy_isnan(io1)) ? io1 : in2;
+                io1 = (@comp@(io1, in2) || npy_isnan(io1)) ? io1 : in2;
             }
             *((@type@ *)iop1) = io1;
         }
@@ -1708,12 +1728,11 @@ NPY_NO_EXPORT void
                 @type@ in1 = *(@type@ *)ip1;
                 const @type@ in2 = *(@type@ *)ip2;
                 /* Order of operations important for MSVC 2015 */
-                in1 = (in1 @OP@ in2 || npy_isnan(in1)) ? in1 : in2;
+                in1 = (@comp@(in1, in2) || npy_isnan(in1)) ? in1 : in2;
                 *((@type@ *)op1) = in1;
             }
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 
 NPY_NO_EXPORT void
@@ -1725,7 +1744,7 @@ NPY_NO_EXPORT void
             BINARY_REDUCE_LOOP(@type@) {
                 const @type@ in2 = *(@type@ *)ip2;
                 /* Order of operations important for MSVC 2015 */
-                io1 = (io1 @OP@ in2 || npy_isnan(io1)) ? io1 : in2;
+                io1 = (@comp@(io1, in2) || npy_isnan(io1)) ? io1 : in2;
             }
             *((@type@ *)iop1) = io1;
         }
@@ -1735,17 +1754,16 @@ NPY_NO_EXPORT void
             @type@ in1 = *(@type@ *)ip1;
             const @type@ in2 = *(@type@ *)ip2;
             /* Order of operations important for MSVC 2015 */
-            in1 = (in1 @OP@ in2 || npy_isnan(in1)) ? in1 : in2;
+            in1 = (@comp@(in1, in2) || npy_isnan(in1)) ? in1 : in2;
             *((@type@ *)op1) = in1;
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat1**/
 
 /**begin repeat1
  * #kind = fmax, fmin#
- * #OP =  >=, <=#
+ * #comp = isgreaterequal, islessequal#
  **/
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
@@ -1755,7 +1773,7 @@ NPY_NO_EXPORT void
         BINARY_REDUCE_LOOP(@type@) {
             const @type@ in2 = *(@type@ *)ip2;
             /* Order of operations important for MSVC 2015 */
-            io1 = (io1 @OP@ in2 || npy_isnan(in2)) ? io1 : in2;
+            io1 = (@comp@(io1, in2) || npy_isnan(in2)) ? io1 : in2;
         }
         *((@type@ *)iop1) = io1;
     }
@@ -1764,10 +1782,9 @@ NPY_NO_EXPORT void
             const @type@ in1 = *(@type@ *)ip1;
             const @type@ in2 = *(@type@ *)ip2;
             /* Order of operations important for MSVC 2015 */
-            *((@type@ *)op1) = (in1 @OP@ in2 || npy_isnan(in2)) ? in1 : in2;
+            *((@type@ *)op1) = (@comp@(in1, in2) || npy_isnan(in2)) ? in1 : in2;
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat1**/
 
@@ -1844,9 +1861,9 @@ NPY_NO_EXPORT void
     /* Sign of nan is nan */
     UNARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
-        *((@type@ *)op1) = in1 > 0 ? 1 : (in1 < 0 ? -1 : (in1 == 0 ? 0 : in1));
+        *((@type@ *)op1) = isgreater(in1, 0) ? 1 : (
+                isless(in1, 0) ? -1 : (in1 == 0 ? 0 : in1));
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 
 NPY_NO_EXPORT void
@@ -1942,11 +1959,10 @@ LONGDOUBLE_absolute(char **args, npy_intp const *dimensions, npy_intp const *ste
 {
     UNARY_LOOP {
         const npy_longdouble in1 = *(npy_longdouble *)ip1;
-        const npy_longdouble tmp = in1 > 0 ? in1 : -in1;
+        const npy_longdouble tmp = isgreater(in1, 0) ? in1 : -in1;
         /* add 0 to clear -0.0 */
         *((npy_longdouble *)op1) = tmp + 0;
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 
 NPY_NO_EXPORT void
@@ -2068,7 +2084,6 @@ HALF_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void
         const npy_half in1 = *(npy_half *)ip1;
         *((npy_bool *)op1) = @func@(in1) != 0;
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat**/
 
@@ -2313,14 +2328,18 @@ HALF_ldexp_long(char **args, npy_intp const *dimensions, npy_intp const *steps, 
  *****************************************************************************
  */
 
-#define CGE(xr,xi,yr,yi) ((xr > yr && !npy_isnan(xi) && !npy_isnan(yi)) \
-                          || (xr == yr && xi >= yi))
-#define CLE(xr,xi,yr,yi) ((xr < yr && !npy_isnan(xi) && !npy_isnan(yi)) \
-                          || (xr == yr && xi <= yi))
-#define CGT(xr,xi,yr,yi) ((xr > yr && !npy_isnan(xi) && !npy_isnan(yi)) \
-                          || (xr == yr && xi > yi))
-#define CLT(xr,xi,yr,yi) ((xr < yr && !npy_isnan(xi) && !npy_isnan(yi)) \
-                          || (xr == yr && xi < yi))
+#define CGE(xr,xi,yr,yi) ((isgreater(xr, yr) \
+                               && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && isgreaterequal(xi, yi)))
+#define CLE(xr,xi,yr,yi) ((isless(xr, yr) \
+                               && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && islessequal(xi, yi)))
+#define CGT(xr,xi,yr,yi) ((isgreater(xr, yr) \
+                               && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && isgreater(xi, yi)))
+#define CLT(xr,xi,yr,yi) ((isless(xr, yr) \
+                               && !npy_isnan(xi) && !npy_isnan(yi)) \
+                          || (xr == yr && isless(xi, yi)))
 #define CEQ(xr,xi,yr,yi) (xr == yr && xi == yi)
 #define CNE(xr,xi,yr,yi) (xr != yr || xi != yi)
 
@@ -2488,7 +2507,6 @@ NPY_NO_EXPORT void
         const @ftype@ in1i = ((@ftype@ *)ip1)[1];
         *((npy_bool *)op1) = @func@(in1r) @OP@ @func@(in1i);
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat1**/
 
@@ -2610,7 +2628,6 @@ NPY_NO_EXPORT void
         ((@ftype@ *)op1)[0] = in1r;
         ((@ftype@ *)op1)[1] = in1i;
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat1**/
 
@@ -2635,7 +2652,6 @@ NPY_NO_EXPORT void
             ((@ftype@ *)op1)[1] = in2i;
         }
     }
-    npy_clear_floatstatus_barrier((char*)dimensions);
 }
 /**end repeat1**/
 

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -23,7 +23,7 @@ NPY_FINLINE float c_recip_f32(float a)
 { return 1.0f / a; }
 NPY_FINLINE float c_abs_f32(float a)
 {
-    const float tmp = a > 0 ? a : -a;
+    const float tmp = isgreater(a, 0) ? a : -a;
     /* add 0 to clear -0.0 */
     return tmp + 0;
 }
@@ -36,7 +36,7 @@ NPY_FINLINE double c_recip_f64(double a)
 { return 1.0 / a; }
 NPY_FINLINE double c_abs_f64(double a)
 {
-    const double tmp = a > 0 ? a : -a;
+    const double tmp = isgreater(a, 0) ? a : -a;
     /* add 0 to clear -0.0 */
     return tmp + 0;
 }
@@ -252,7 +252,6 @@ static void simd_@TYPE@_@kind@_@STYPE@_@DTYPE@
 /**begin repeat1
  * #kind  = ceil, sqrt, absolute, square, reciprocal#
  * #intr  = ceil, sqrt, abs,      square, recip#
- * #clear = 0,    0,    1,        0,      0#
  */
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
@@ -283,7 +282,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     } else {
         simd_@TYPE@_@kind@_NCONTIG_NCONTIG(src, ssrc, dst, sdst, len);
     }
-    goto clear;
+    return;
 no_unroll:
 #endif // @VCHK@
     for (; len > 0; --len, src += src_step, dst += dst_step) {
@@ -295,12 +294,6 @@ no_unroll:
         *(npyv_lanetype_@sfx@*)dst = c_@intr@_@sfx@(src0);
     #endif
     }
-#if @VCHK@
-clear:;
-#endif
-#if @clear@
-    npy_clear_floatstatus_barrier((char*)dimensions);
-#endif
 }
 /**end repeat1**/
 /**end repeat**/

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -493,12 +493,10 @@ sse2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, npy_intp n)
 #if @var@ != 0 /* isinf/isfinite */
     /* signbit mask 0x7FFFFFFF after andnot */
     const @vtype@ mask = @vpre@_set1_@vsuf@(-0.@c@);
-    const @vtype@ ones = @vpre@_cmpeq_@vsuf@(@vpre@_setzero_@vsuf@(),
-                                             @vpre@_setzero_@vsuf@());
 #if @double@
-    const @vtype@ fltmax = @vpre@_set1_@vsuf@(DBL_MAX);
+    const @vtype@ infinity = @vpre@_set1_@vsuf@(NPY_INFINITY);
 #else
-    const @vtype@ fltmax = @vpre@_set1_@vsuf@(FLT_MAX);
+    const @vtype@ infinity = @vpre@_set1_@vsuf@(NPY_INFINITY);
 #endif
 #endif
     LOOP_BLOCK_ALIGN_VAR(ip1, @type@, VECTOR_SIZE_BYTES) {
@@ -510,38 +508,39 @@ sse2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, npy_intp n)
         @vtype@ c = @vpre@_load_@vsuf@(&ip1[i + 2 * VECTOR_SIZE_BYTES / sizeof(@type@)]);
         @vtype@ d = @vpre@_load_@vsuf@(&ip1[i + 3 * VECTOR_SIZE_BYTES / sizeof(@type@)]);
         @vtype@ r1, r2, r3, r4;
+
 #if @var@ != 0 /* isinf/isfinite */
-        /* fabs via masking of sign bit */
+        /* Convert -infinity to infinity: fabs via masking of sign bit */
         r1 = @vpre@_andnot_@vsuf@(mask, a);
         r2 = @vpre@_andnot_@vsuf@(mask, b);
         r3 = @vpre@_andnot_@vsuf@(mask, c);
         r4 = @vpre@_andnot_@vsuf@(mask, d);
-#if @var@ == 1 /* isfinite */
-        /* negative compare against max float, nan is always true */
-        r1 = @vpre@_cmpnle_@vsuf@(r1, fltmax);
-        r2 = @vpre@_cmpnle_@vsuf@(r2, fltmax);
-        r3 = @vpre@_cmpnle_@vsuf@(r3, fltmax);
-        r4 = @vpre@_cmpnle_@vsuf@(r4, fltmax);
-#else /* isinf */
-        r1 = @vpre@_cmpnlt_@vsuf@(fltmax, r1);
-        r2 = @vpre@_cmpnlt_@vsuf@(fltmax, r2);
-        r3 = @vpre@_cmpnlt_@vsuf@(fltmax, r3);
-        r4 = @vpre@_cmpnlt_@vsuf@(fltmax, r4);
 #endif
-        /* flip results to what we want (andnot as there is no sse not) */
-        r1 = @vpre@_andnot_@vsuf@(r1, ones);
-        r2 = @vpre@_andnot_@vsuf@(r2, ones);
-        r3 = @vpre@_andnot_@vsuf@(r3, ones);
-        r4 = @vpre@_andnot_@vsuf@(r4, ones);
-#endif
+
 #if @var@ == 0 /* isnan */
         r1 = @vpre@_cmpneq_@vsuf@(a, a);
         r2 = @vpre@_cmpneq_@vsuf@(b, b);
         r3 = @vpre@_cmpneq_@vsuf@(c, c);
         r4 = @vpre@_cmpneq_@vsuf@(d, d);
+#elif @var@ == 1 /* isfinite */
+        /* compare against infinity, nan is always false */
+        r1 = @vpre@_cmplt_@vsuf@(r1, infinity);
+        r2 = @vpre@_cmplt_@vsuf@(r2, infinity);
+        r3 = @vpre@_cmplt_@vsuf@(r3, infinity);
+        r4 = @vpre@_cmplt_@vsuf@(r4, infinity);
+#elif @var@ == 2  /* isinf */
+        r1 = @vpre@_cmpeq_@vsuf@(infinity, r1);
+        r2 = @vpre@_cmpeq_@vsuf@(infinity, r2);
+        r3 = @vpre@_cmpeq_@vsuf@(infinity, r3);
+        r4 = @vpre@_cmpeq_@vsuf@(infinity, r4);
 #endif
         sse2_compress4_to_byte_@TYPE@(r1, r2, r3, &r4, &op[i]);
     }
+
+#if @var@ == 1  /* isfinite */
+    /* `isfinite` uses `cmplt`, which will set invalid value FPE for NaNs. */
+    npy_clear_floatstatus_barrier((char *)op);
+#endif
     LOOP_BLOCKED_END {
         op[i] = npy_@kind@(ip1[i]) != 0;
     }
@@ -592,6 +591,7 @@ sse2_binary_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, @type@ * ip2, npy_intp n)
     LOOP_BLOCKED_END {
         op[i] = sse2_ordered_cmp_@kind@_@TYPE@(ip1[i], ip2[i]);
     }
+    npy_clear_floatstatus_barrier((char *)op);
 }
 
 
@@ -616,6 +616,7 @@ sse2_binary_scalar1_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, @type@ * ip2, npy
     LOOP_BLOCKED_END {
         op[i] = sse2_ordered_cmp_@kind@_@TYPE@(ip1[0], ip2[i]);
     }
+    npy_clear_floatstatus_barrier((char *)op);
 }
 
 
@@ -640,6 +641,7 @@ sse2_binary_scalar2_@kind@_@TYPE@(npy_bool * op, @type@ * ip1, @type@ * ip2, npy
     LOOP_BLOCKED_END {
         op[i] = sse2_ordered_cmp_@kind@_@TYPE@(ip1[i], ip2[0]);
     }
+    npy_clear_floatstatus_barrier((char *)op);
 }
 /**end repeat1**/
 

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -1204,6 +1204,7 @@ AVX512_SKX_@func@_@TYPE@(npy_bool* op, @type@* ip, const npy_intp array_size, co
 /**begin repeat
  * #type = npy_float, npy_double#
  * #TYPE = FLOAT, DOUBLE#
+ * #NAN = NPY_NANF, NPY_NAN#
  * #num_lanes = 16, 8#
  * #vsuffix = ps, pd#
  * #mask = __mmask16, __mmask8#
@@ -1228,6 +1229,8 @@ AVX512_SKX_@func@_@TYPE@(npy_bool* op, @type@* ip, const npy_intp array_size, co
 static NPY_INLINE NPY_GCC_TARGET_AVX512F void
 AVX512F_@func@_@TYPE@(char **args, npy_intp const *dimensions, npy_intp const *steps)
 {
+    @vtype1@ nan = _mm512_set1_@vsuffix@(@NAN@);
+
     const npy_intp stride_ip1 = steps[0]/(npy_intp)sizeof(@type@);
     const npy_intp stride_ip2 = steps[1]/(npy_intp)sizeof(@type@);
     const npy_intp stride_op = steps[2]/(npy_intp)sizeof(@type@);
@@ -1276,13 +1279,12 @@ AVX512F_@func@_@TYPE@(char **args, npy_intp const *dimensions, npy_intp const *s
         }
 
         /*
-         * when only one of the argument is a nan, the maxps/maxpd instruction
-         * returns the second argument. The additional blend instruction fixes
-         * this issue to conform with NumPy behaviour.
+         * First check whether the two numbers are ordered (neither is NaN).
+         * If they are not ordered, simply set it to NaN.  (In IEEE theory,
+         * we should propagate one of the NaNs, we don't bother here.)
          */
-        @mask@ nan_mask = _mm512_cmp_@vsuffix@_mask(x1, x1, _CMP_NEQ_UQ);
-        @vtype1@ out = _mm512_@vectorf@_@vsuffix@(x1, x2);
-        out = _mm512_mask_blend_@vsuffix@(nan_mask, out, x1);
+        @mask@ not_nan_mask = _mm512_cmp_@vsuffix@_mask(x1, x2, _CMP_ORD_Q);
+        @vtype1@ out = _mm512_mask_@vectorf@_@vsuffix@(nan, not_nan_mask, x1, x2);
 
         if (stride_op == 1) {
             _mm512_mask_storeu_@vsuffix@(op, load_mask, out);

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2312,10 +2312,11 @@ def test_ufunc_noncontiguous(ufunc):
 
 
 @pytest.mark.parametrize('ufunc', [np.sign, np.equal])
+@np.errstate(invalid="ignore")
 def test_ufunc_warn_with_nan(ufunc):
-    # issue gh-15127
-    # test that calling certain ufuncs with a non-standard `nan` value does not
-    # emit a warning
+    # For a while we ensured to not give a warning even for signalling NaNs.
+    # that is not IEEE standard conform, and an unnecessary hassle.  This
+    # test checks for the correct result, but ignores the warnings.
     # `b` holds a 64 bit signaling nan: the most significant bit of the
     # significand is zero.
     b = np.array([0x7ff0000000000001], 'i8').view('f8')

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3811,7 +3811,7 @@ def test_signaling_nan_exceptions():
     # For a while, NumPy ensured the invalid warning was not set. IEEE says it
     # should be set.  No need for strong guarantees for signalling NaNs.
     with np.errstate(invalid="ignore"):
-        a = np.ndarray(shape=(), dtype='float32', buffer=b'\x00\xe0\xbf\xff')
+        a = np.ndarray(shape=(), dtype='<f4', buffer=b'\x00\xe0\xbf\xff')
         assert np.isnan(a)
 
 @pytest.mark.parametrize("arr", [

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3808,9 +3808,11 @@ def test_memoverlap_accumulate(ftype):
     assert_equal(np.minimum.accumulate(arr), out_min)
 
 def test_signaling_nan_exceptions():
-    with assert_no_warnings():
+    # For a while, NumPy ensured the invalid warning was not set. IEEE says it
+    # should be set.  No need for strong guarantees for signalling NaNs.
+    with np.errstate(invalid="ignore"):
         a = np.ndarray(shape=(), dtype='float32', buffer=b'\x00\xe0\xbf\xff')
-        np.isnan(a)
+        assert np.isnan(a)
 
 @pytest.mark.parametrize("arr", [
     np.arange(2),


### PR DESCRIPTION
This PR avoids setting FPE flag flags rather than clearing them
where possible.

The main place where this is not easy is SSE (I could not yet find
the `isless` equivalent for basic SSE), and did not want to modify
the code too much.

This also updates the docs to copy the informational section to the
"Floating point error handling" landing page.  Right now, the docs
assume that we (for now) keep the behaviour of NOT giving floating
point warnings for comparisons with NaN.

Hopefully, using these functions should not have any speed impact.
There is some chance that compilers will not honor the contract
and replace `isless` with instructions that do set floating point
error flags.  If/where this happens, we may have to undo the changes.

This should have no impact on functionality (except if compilers
do not follow C99/IEEE correctly, which is entirely possible).

However, signalling NaNs WILL now warn more often (as per C99/IEEE),
since we do not clear the warnings as agressively.

---

A few notes:

1. I am not sure that we can trust compilers.  so there is some chance that relying on `isless` and friends won't work perfectly.  There is also some chance of performance regressions forcing us back.
2. Maybe @seiko2plus can have a look at the SIMD related changes?  Otherwise, I could split them out to make things simpler.

To some degree getting warning flags right seems a bit "aspirational"...