### PR TITLE
TST: Do not test for signalling NaNs not raising warnings

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2191,10 +2191,11 @@ def test_ufunc_noncontiguous(ufunc):
 
 
 @pytest.mark.parametrize('ufunc', [np.sign, np.equal])
+@np.errstate(invalid="ignore")
 def test_ufunc_warn_with_nan(ufunc):
-    # issue gh-15127
-    # test that calling certain ufuncs with a non-standard `nan` value does not
-    # emit a warning
+    # For a while we ensured to not give a warning even for signalling NaNs.
+    # that is not IEEE standard conform, and an unnecessary hassle.  This
+    # test checks for the correct result, but ignores the warnings.
     # `b` holds a 64 bit signaling nan: the most significant bit of the
     # significand is zero.
     b = np.array([0x7ff0000000000001], 'i8').view('f8')

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3619,9 +3619,11 @@ def test_memoverlap_accumulate(ftype):
     assert_equal(np.minimum.accumulate(arr), out_min)
 
 def test_signaling_nan_exceptions():
-    with assert_no_warnings():
+    # For a while, NumPy ensured the invalid warning was not set. IEEE says it
+    # should be set.  No need for strong guarantees for signalling NaNs.
+    with np.errstate(invalid="ignore"):
         a = np.ndarray(shape=(), dtype='float32', buffer=b'\x00\xe0\xbf\xff')
-        np.isnan(a)
+        assert np.isnan(a)
 
 @pytest.mark.parametrize("arr", [
     np.arange(2),


### PR DESCRIPTION
This is technically even incorrect in IEEE, signalling NaNs should
pretty much always give a warning.  But overall, it seems unlikely
NumPy should bother about it (we never create them after all).

This is split off from gh-19476.  Mainly, to check whether s390x is
broken...
