### PR TITLE
DOC: Add link to NumPy PDF docs

### DIFF
--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -6,8 +6,8 @@
 {% block body %}
 <h1>{{ docstitle|e }}</h1>
 <p>
-  Welcome! This is the documentation for NumPy {{ release|e }}
-  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}.
+  Welcome! This is the documentation for NumPy {{ release|e }} 
+  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}. For a PDF version of the documentation, go to https://numpy.org/doc/.
 </p>
 <p><strong>For users:</strong></p>
 <table class="contentstable" align="center"><tr>

--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -7,7 +7,7 @@
 <h1>{{ docstitle|e }}</h1>
 <p>
   Welcome! This is the documentation for NumPy {{ release|e }} 
-  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}. For a PDF version of the documentation, go to https://numpy.org/doc/.
+  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}. For a PDF version of the documentation, go to <a href="https://numpy.org/doc/">https://numpy.org/doc/</a>.
 </p>
 <p><strong>For users:</strong></p>
 <table class="contentstable" align="center"><tr>

--- a/doc/source/_templates/indexcontent.html
+++ b/doc/source/_templates/indexcontent.html
@@ -7,7 +7,8 @@
 <h1>{{ docstitle|e }}</h1>
 <p>
   Welcome! This is the documentation for NumPy {{ release|e }} 
-  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}. For a PDF version of the documentation, go to <a href="https://numpy.org/doc/">https://numpy.org/doc/</a>.
+  {%- if last_updated %}, last updated {{ last_updated|e }}{% endif %}. 
+  For a PDF version of the documentation, go to <a href="https://numpy.org/doc/">https://numpy.org/doc/</a>.
 </p>
 <p><strong>For users:</strong></p>
 <table class="contentstable" align="center"><tr>


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Fixes #19303

Added the line ``For a PDF version of the documentation, go to https://numpy.org/doc/.``  under NumPy v1.21 Manual heading
Please check
