### PR TITLE
MAINT: Avoid unicode characters in division SIMD code comments

### DIFF
--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -22,17 +22,17 @@
  ** Defining the SIMD kernels
  *
  * Floor division of signed is based on T. Granlund and P. L. Montgomery
- * “Division by invariant integers using multiplication(see [Figure 6.1]
+ * "Division by invariant integers using multiplication(see [Figure 6.1]
  * http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.1.2556)"
  * For details on TRUNC division see simd/intdiv.h for more clarification
  ***********************************************************************************
- ** Figure 6.1: Signed division by run–time invariant divisor, rounded towards -INF
+ ** Figure 6.1: Signed division by run-time invariant divisor, rounded towards -INF
  ***********************************************************************************
  * For q = FLOOR(a/d), all sword:
- *     sword −dsign = SRL(d, N − 1);
- *     uword −nsign = (n < −dsign);
- *     uword −qsign = EOR(−nsign, −dsign);
- *     q = TRUNC((n − (−dsign ) + (−nsign))/d) − (−qsign);
+ *     sword -dsign = SRL(d, N - 1);
+ *     uword -nsign = (n < -dsign);
+ *     uword -qsign = EOR(-nsign, -dsign);
+ *     q = TRUNC((n - (-dsign ) + (-nsign))/d) - (-qsign);
  ********************************************************************************/
 
 #if NPY_SIMD


### PR DESCRIPTION
Backport of #19458.

This avoids unicode characters in the division SIMD code to circumvent
problems reading the utf-8 encoded file in windows.
The proper fix is probably to just assume utf-8 and feel free to use
unicode characters in `c.src` files.
But here, it doesn't matter too much to just avoid utf-8 quickly.

See gh-19454

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
