### PR TITLE
MAINT: set Python version for 1.21.x to `<3.11`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ def setup_package():
         test_suite='pytest',
         version=versioneer.get_version(),
         cmdclass=cmdclass,
-        python_requires='>=3.7,<3.10',
+        python_requires='>=3.7,<3.11',
         zip_safe=False,
         entry_points={
             'console_scripts': f2py_cmds

--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ def setup_package():
         test_suite='pytest',
         version=versioneer.get_version(),
         cmdclass=cmdclass,
-        python_requires='>=3.7',
+        python_requires='>=3.7,<3.10',
         zip_safe=False,
         entry_points={
             'console_scripts': f2py_cmds


### PR DESCRIPTION
Note that SciPy has a more elaborate method here, using `IS_RELEASE_BRANCH`. Given that we're switching away from `setup.py` at some point and the ship kind of has sailed for 1.21.x already, I don't want to replicate that logic here.