### PR TITLE
TST: Fix a `GenericAlias` test failure for python 3.9.0

### DIFF
--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -60,7 +60,6 @@ class TestGenericAlias:
         ("__call__", lambda n: n(shape=(1,), dtype=np.int64, buffer=BUFFER)),
         ("subclassing", lambda n: _get_subclass_mro(n)),
         ("pickle", lambda n: n == pickle.loads(pickle.dumps(n))),
-        ("__weakref__", lambda n: n == weakref.ref(n)()),
     ])
     def test_pass(self, name: str, func: FuncType) -> None:
         """Compare `types.GenericAlias` with its numpy-based backport.
@@ -73,6 +72,14 @@ class TestGenericAlias:
 
         if sys.version_info >= (3, 9):
             value_ref = func(NDArray_ref)
+            assert value == value_ref
+
+    def test_weakref(self) -> None:
+        """Test ``__weakref__``."""
+        value = weakref.ref(NDArray)()
+
+        if sys.version_info >= (3, 9, 1):  # xref bpo-42332
+            value_ref = weakref.ref(NDArray_ref)()
             assert value == value_ref
 
     @pytest.mark.parametrize("name", GETATTR_NAMES)


### PR DESCRIPTION
Backport of #19456.

closes #19452

The GenericAlias.__weakref__ attribute (that is used in one of the tests) was only added in Python 3.9.1,
thus raising an exception for earlier version.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
