### PR TITLE
DOC: Add clarification for np.array being 0 dimensional

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -797,7 +797,7 @@ add_newdoc('numpy.core.multiarray', 'array',
         An array, any object exposing the array interface, an object whose
         __array__ method returns an array, or any (nested) sequence. However
         if a number is passed as a parameter then it will return the number itself.
-        It is done to support the 0 dimensional arrrays.
+        It is done to support the 0 dimensional arrays.
         For example np.array(2) will return 2.
     dtype : data-type, optional
         The desired data-type for the array.  If not given, then the type will

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -795,7 +795,10 @@ add_newdoc('numpy.core.multiarray', 'array',
     ----------
     object : array_like
         An array, any object exposing the array interface, an object whose
-        __array__ method returns an array, or any (nested) sequence.
+        __array__ method returns an array, or any (nested) sequence. However
+        if a number is passed as a parameter then it will return the number itself.
+        It is done to support the 0 dimensional arrrays.
+        For example np.array(2) will return 2.
     dtype : data-type, optional
         The desired data-type for the array.  If not given, then the type will
         be determined as the minimum type required to hold the objects in the


### PR DESCRIPTION
Fixes #19504
I have added the clarification along with an example.
@melissawm please check.
