### PR TITLE
 TST: Test that `numpy.typing` can be imported in the absence of typing-extensions

### DIFF
--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -57,5 +57,8 @@ def test_full_reimport():
         with warns(UserWarning):
             import numpy as np
         """)
-    p = subprocess.run([sys.executable, '-c', code])
-
+    p = subprocess.run([sys.executable, '-c', code], capture_output=True)
+    if p.returncode:
+        raise AssertionError(
+            f"Non-zero return code: {p.returncode!r}\n\n{p.stderr.decode()}"
+        )

--- a/numpy/typing/tests/test_typing_extensions.py
+++ b/numpy/typing/tests/test_typing_extensions.py
@@ -1,0 +1,56 @@
+"""Tests for the optional typing-extensions dependency."""
+
+import sys
+import types
+import inspect
+import importlib
+
+import typing_extensions
+import numpy.typing as npt
+
+
+def _is_sub_module(obj: object) -> bool:
+    """Check if `obj` is a `numpy.typing` submodule."""
+    return inspect.ismodule(obj) and obj.__name__.startswith("numpy.typing")
+
+
+def _is_dunder(name: str) -> bool:
+    """Check whether `name` is a dunder."""
+    return name.startswith("__") and name.endswith("__")
+
+
+def _clear_attr(module: types.ModuleType) -> None:
+    """Clear all (non-dunder) module-level attributes."""
+    del_names = [name for name in vars(module) if not _is_dunder(name)]
+    for name in del_names:
+        delattr(module, name)
+
+
+MODULES = {"numpy.typing": npt}
+MODULES.update({
+    f"numpy.typing.{k}": v for k, v in vars(npt).items() if _is_sub_module(v)
+})
+
+
+def test_no_typing_extensions() -> None:
+    """Import `numpy.typing` in the absence of typing-extensions.
+
+    Notes
+    -----
+    Ideally, we'd just run the normal typing tests in an environment where
+    typing-extensions is not installed, but unfortunatelly this is currently
+    impossible as it is an indirect hard dependency of pytest.
+
+    """
+    assert "typing_extensions" in sys.modules
+
+    try:
+        sys.modules["typing_extensions"] = None
+        for name, module in MODULES.items():
+            _clear_attr(module)
+            assert importlib.reload(module), name
+    finally:
+        sys.modules["typing_extensions"] = typing_extensions
+        for module in MODULES.values():
+            _clear_attr(module)
+            importlib.reload(module)

--- a/numpy/typing/tests/test_typing_extensions.py
+++ b/numpy/typing/tests/test_typing_extensions.py
@@ -1,35 +1,20 @@
 """Tests for the optional typing-extensions dependency."""
 
 import sys
-import types
-import inspect
-import importlib
+import textwrap
+import subprocess
 
-import typing_extensions
-import numpy.typing as npt
+CODE = textwrap.dedent(r"""
+    import sys
+    import importlib
 
+    assert "typing_extensions" not in sys.modules
+    assert "numpy.typing" not in sys.modules
 
-def _is_sub_module(obj: object) -> bool:
-    """Check if `obj` is a `numpy.typing` submodule."""
-    return inspect.ismodule(obj) and obj.__name__.startswith("numpy.typing")
-
-
-def _is_dunder(name: str) -> bool:
-    """Check whether `name` is a dunder."""
-    return name.startswith("__") and name.endswith("__")
-
-
-def _clear_attr(module: types.ModuleType) -> None:
-    """Clear all (non-dunder) module-level attributes."""
-    del_names = [name for name in vars(module) if not _is_dunder(name)]
-    for name in del_names:
-        delattr(module, name)
-
-
-MODULES = {"numpy.typing": npt}
-MODULES.update({
-    f"numpy.typing.{k}": v for k, v in vars(npt).items() if _is_sub_module(v)
-})
+    # Importing `typing_extensions` will now raise an `ImportError`
+    sys.modules["typing_extensions"] = None
+    assert importlib.import_module("numpy.typing")
+""")
 
 
 def test_no_typing_extensions() -> None:
@@ -42,15 +27,9 @@ def test_no_typing_extensions() -> None:
     impossible as it is an indirect hard dependency of pytest.
 
     """
-    assert "typing_extensions" in sys.modules
+    p = subprocess.run([sys.executable, '-c', CODE], capture_output=True)
+    if p.returncode:
+        raise AssertionError(
+            f"Non-zero return code: {p.returncode!r}\n\n{p.stderr.decode()}"
+        )
 
-    try:
-        sys.modules["typing_extensions"] = None
-        for name, module in MODULES.items():
-            _clear_attr(module)
-            assert importlib.reload(module), name
-    finally:
-        sys.modules["typing_extensions"] = typing_extensions
-        for module in MODULES.values():
-            _clear_attr(module)
-            importlib.reload(module)


### PR DESCRIPTION
xref https://github.com/numpy/numpy/issues/19521

On a semi-frequent we're running into issues with `numpy.typing` when the following 2 conditions are met:
* Python 3.7 is used.
* typing-extensions is not installed.

Ideally we'd just run a CI job without typing-extensions installed and see if the tests run as expected
but unfortunately this is not possible, as it is an (indirect) hard dependency of pytest. 

This PR instead opts for an alternative approach: the test introduced herein reloads the `numpy.typing` 
submodules after manually invalidating typing-extensions, thus making the package inaccessible as if it 
weren't installed in the first place.