### PR TITLE
DEP: Remove deprecated numeric style dtype strings

### DIFF
--- a/doc/release/upcoming_changes/19539.expired.rst
+++ b/doc/release/upcoming_changes/19539.expired.rst
@@ -1,0 +1,3 @@
+The deprecation of numeric style type-codes ``np.Bytes0``, 
+``np.Datetime64``, ``np.Str0``, ``np.Uint32`` and ``np.Uint64``  
+is expired. These have been removed from the public API. 

--- a/doc/release/upcoming_changes/19539.expired.rst
+++ b/doc/release/upcoming_changes/19539.expired.rst
@@ -1,3 +1,2 @@
-The deprecation of numeric style type-codes ``np.Bytes0``, 
-``np.Datetime64``, ``np.Str0``, ``np.Uint32`` and ``np.Uint64``  
-is expired. These have been removed from the public API. 
+* Using the strings ``"Bytes0"``, ``"Datetime64"``, ``"Str0"``, ``"Uint32"``,
+  and ``"Uint64"`` as a dtype will now raise a ``TypeError``.

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -115,15 +115,6 @@ def _add_aliases():
         # add forward, reverse, and string mapping to numarray
         sctypeDict[char] = info.type
 
-    # Add deprecated numeric-style type aliases manually, at some point
-    # we may want to deprecate the lower case "bytes0" version as well.
-    for name in ["Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"]:
-        if english_lower(name) not in allTypes:
-            # Only one of Uint32 or Uint64, aliases of `np.uintp`, was (and is) defined, note that this
-            # is not UInt32/UInt64 (capital i), which is removed.
-            continue
-        allTypes[name] = allTypes[english_lower(name)]
-        sctypeDict[name] = sctypeDict[english_lower(name)]
 
 _add_aliases()
 

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -124,7 +124,7 @@ from numpy.compat import long, unicode
 generic = allTypes['generic']
 
 genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
-                   'int32', 'uint32', 'int64', 'uint64', 'int128',
+                   'int32', 'int64', 'int128',
                    'uint128', 'float16',
                    'float32', 'float64', 'float80', 'float96', 'float128',
                    'float256',

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -124,7 +124,7 @@ from numpy.compat import long, unicode
 generic = allTypes['generic']
 
 genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
-                   'int32', 'int64', 'int128',
+                   'int32', 'uint32', 'int64', 'uint64', 'int128',
                    'uint128', 'float16',
                    'float32', 'float64', 'float80', 'float96', 'float128',
                    'float256',

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1723,21 +1723,6 @@ _convert_from_str(PyObject *obj, int align)
         }
 
 
-        /* `Uint` has deliberately weird uppercasing */
-        char *dep_tps[] = {};
-        int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
-        for (int i = 0; i < ndep_tps; ++i) {
-            char *dep_tp = dep_tps[i];
-
-            if (strncmp(type, dep_tp, strlen(dep_tp)+1) == 0) {
-                /* Deprecated 2020-06-09, NumPy 1.20 */
-                if (DEPRECATE("Numeric-style type codes are "
-                              "deprecated and will result in "
-                              "an error in the future.") < 0) {
-                    goto fail;
-                }
-            }
-        }
         /*
          * Probably only ever dispatches to `_convert_from_type`, but who
          * knows what users are injecting into `np.typeDict`.

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1724,12 +1724,12 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Check for a deprecated Numeric-style typecode */
         /* `Uint` has deliberately weird uppercasing */
-        char *dep_tps[] = {"Bytes", "Datetime64", "Str", "Uint"};
+        char *dep_tps[] = {"Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"};
         int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
         for (int i = 0; i < ndep_tps; ++i) {
             char *dep_tp = dep_tps[i];
 
-            if (strncmp(type, dep_tp, strlen(dep_tp)) == 0) {
+            if (strncmp(type, dep_tp, strlen(dep_tp)+1) == 0) {
                 /* Deprecated 2020-06-09, NumPy 1.20 */
                 if (DEPRECATE("Numeric-style type codes are "
                               "deprecated and will result in "

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1724,7 +1724,7 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Check for a deprecated Numeric-style typecode */
         /* `Uint` has deliberately weird uppercasing */
-        char *dep_tps[] = {"Bytes0", "Datetime64", "Str0", "Uint32", "Uint64"};
+        char *dep_tps[] = {};
         int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);
         for (int i = 0; i < ndep_tps; ++i) {
             char *dep_tp = dep_tps[i];

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1722,7 +1722,7 @@ _convert_from_str(PyObject *obj, int align)
             goto fail;
         }
 
-        /* Check for a deprecated Numeric-style typecode */
+
         /* `Uint` has deliberately weird uppercasing */
         char *dep_tps[] = {};
         int ndep_tps = sizeof(dep_tps) / sizeof(dep_tps[0]);

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1722,7 +1722,6 @@ _convert_from_str(PyObject *obj, int align)
             goto fail;
         }
 
-
         /*
          * Probably only ever dispatches to `_convert_from_type`, but who
          * knows what users are injecting into `np.typeDict`.

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -314,19 +314,7 @@ class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTest
         self.assert_deprecated(np.binary_repr, args=args, kwargs=kwargs)
 
 
-class TestNumericStyleTypecodes(_DeprecationTestCase):
-    """
-    Most numeric style typecodes were previously deprecated (and removed)
-    in 1.20. This also deprecates the remaining ones.
-    """
-    # 2020-06-09, NumPy 1.20
-    def test_all_dtypes(self):
-        deprecated_types = ['Bytes0', 'Datetime64', 'Str0']
-        # Depending on intp size, either Uint32 or Uint64 is defined:
-        deprecated_types.append(f"U{np.dtype(np.intp).name}")
-        for dt in deprecated_types:
-            self.assert_deprecated(np.dtype, exceptions=(TypeError,),
-                                   args=(dt,))
+
 
 
 class TestDTypeAttributeIsDTypeDeprecation(_DeprecationTestCase):

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -314,9 +314,6 @@ class TestBinaryReprInsufficientWidthParameterForRepresentation(_DeprecationTest
         self.assert_deprecated(np.binary_repr, args=args, kwargs=kwargs)
 
 
-
-
-
 class TestDTypeAttributeIsDTypeDeprecation(_DeprecationTestCase):
     # Deprecated 2021-01-05, NumPy 1.21
     message = r".*`.dtype` attribute"

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -109,9 +109,9 @@ class TestBuiltin:
             operation(np.dtype(np.int32), 7)
 
     @pytest.mark.parametrize("dtype",
-             ['Bool', 'Complex32', 'Complex64', 'Float16', 'Float32', 'Float64',
-              'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Timedelta64',
-              'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Void0',
+             ['Bool', 'Bytes0', 'Complex32', 'Complex64', 'Datetime64', 'Float16', 'Float32', 'Float64',
+              'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Str0', 'Timedelta64',
+              'UInt8', 'UInt16', 'Uint32', 'UInt32', 'Uint64', 'UInt64', 'Void0',
               "Float128", "Complex128"])
     def test_numeric_style_types_are_invalid(self, dtype):
         with assert_raises(TypeError):

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -109,9 +109,12 @@ class TestBuiltin:
             operation(np.dtype(np.int32), 7)
 
     @pytest.mark.parametrize("dtype",
-             ['Bool', 'Bytes0', 'Complex32', 'Complex64', 'Datetime64', 'Float16', 'Float32', 'Float64',
-              'Int8', 'Int16', 'Int32', 'Int64', 'Object0', 'Str0', 'Timedelta64',
-              'UInt8', 'UInt16', 'Uint32', 'UInt32', 'Uint64', 'UInt64', 'Void0',
+             ['Bool', 'Bytes0', 'Complex32', 'Complex64',
+              'Datetime64', 'Float16', 'Float32', 'Float64',
+              'Int8', 'Int16', 'Int32', 'Int64', 
+              'Object0', 'Str0', 'Timedelta64',
+              'UInt8', 'UInt16', 'Uint32', 'UInt32', 
+              'Uint64', 'UInt64', 'Void0',
               "Float128", "Complex128"])
     def test_numeric_style_types_are_invalid(self, dtype):
         with assert_raises(TypeError):


### PR DESCRIPTION

See #18993
This issue was presented by @Daybreak2019

When the function strncmp was used it did not account for a null byte character meaning it is an incomplete comparison.

The elements in the array dep_tps on line 1727 in the descriptor.c file did not match the elements in the deprecated_types array in test_deprecations.py line 324 therefore a change in the dep_tps array had to be made so the null byte character could be compared correctly.

The null byte character is compared on line 1732 in the descriptor.c file by the change strlen(dep_tp)+1 which includes the strings length but adds +1 so the null byte character can also be compared making the strncmp function compare both strings completely.