### PR TITLE
MAINT: Update the `np.finfo` annotations

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3810,7 +3810,11 @@ class finfo(Generic[_FloatType]):
     nmant: int
     precision: int
     resolution: _FloatType
-    tiny: _FloatType
+    smallest_subnormal: _FloatType
+    @property
+    def smallest_normal(self) -> _FloatType: ...
+    @property
+    def tiny(self) -> _FloatType: ...
 
     # NOTE: Not technically a property, but this is the only way we can
     # access the precision of the underlying float

--- a/numpy/core/getlimits.pyi
+++ b/numpy/core/getlimits.pyi
@@ -23,6 +23,7 @@ class MachArLike(Generic[_NBit]):
         huge: floating[Any],
         tiny: floating[Any],
         ibeta: int,
+        smallest_subnormal: None | floating[Any] = ...,
         # Expand `**kwargs` into keyword-only arguments
         machep: int,
         negep: int,
@@ -33,6 +34,8 @@ class MachArLike(Generic[_NBit]):
         irnd: int,
         ngrd: int,
     ) -> None: ...
+    @property
+    def smallest_subnormal(self) -> NDArray[floating[_NBit]]: ...
     eps: NDArray[floating[_NBit]]
     epsilon: NDArray[floating[_NBit]]
     epsneg: NDArray[floating[_NBit]]
@@ -48,6 +51,7 @@ class MachArLike(Generic[_NBit]):
     ngrd: int
     precision: int
     resolution: NDArray[floating[_NBit]]
+    smallest_normal: NDArray[floating[_NBit]]
     tiny: NDArray[floating[_NBit]]
     title: str
     xmax: NDArray[floating[_NBit]]

--- a/numpy/typing/tests/data/reveal/getlimits.py
+++ b/numpy/typing/tests/data/reveal/getlimits.py
@@ -34,6 +34,8 @@ reveal_type(finfo_f8.nmant)  # E: int
 reveal_type(finfo_f8.precision)  # E: int
 reveal_type(finfo_f8.resolution)  # E: {float64}
 reveal_type(finfo_f8.tiny)  # E: {float64}
+reveal_type(finfo_f8.smallest_normal)  # E: {float64}
+reveal_type(finfo_f8.smallest_subnormal)  # E: {float64}
 reveal_type(finfo_f8.machar)  # E: MachArLike[numpy.typing._64Bit]
 
 reveal_type(np.iinfo(i))  # E: iinfo[{int_}]
@@ -56,6 +58,8 @@ reveal_type(machar_f4.resolution)  # E: numpy.ndarray[Any, numpy.dtype[{float32}
 reveal_type(machar_f4.tiny)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
 reveal_type(machar_f4.xmax)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
 reveal_type(machar_f4.xmin)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.smallest_subnormal)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
+reveal_type(machar_f4.smallest_normal)  # E: numpy.ndarray[Any, numpy.dtype[{float32}]]
 reveal_type(machar_f4.iexp)  # E: int
 reveal_type(machar_f4.irnd)  # E: int
 reveal_type(machar_f4.it)  # E: int


### PR DESCRIPTION
Reflect the `finfo` changes, made in https://github.com/numpy/numpy/pull/18536, in the classes' type annotations.