### PR TITLE
ENH: Using ``str.join`` instead of +=, + for concatenating strings for ``str(array)``

### DIFF
--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -706,9 +706,9 @@ def _extendLine(s, line, word, line_width, next_line_prefix, legacy):
             needs_wrap = False
 
     if needs_wrap:
-        s += line.rstrip() + "\n"
+        s = ''.join((s, line.rstrip(), "\n"))
         line = next_line_prefix
-    line += word
+    line = ''.join((line, word))
     return s, line
 
 
@@ -736,7 +736,6 @@ def _extendLine_pretty(s, line, word, line_width, next_line_prefix, legacy):
 
     suffix_length = max_word_length - len(words[-1])
     line += suffix_length*' '
-
     return s, line
 
 def _formatArray(a, format_function, line_width, next_line_prefix,
@@ -793,21 +792,21 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                 word = recurser(index + (i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
                     s, line, word, elem_width, hanging_indent, legacy)
-                line += separator
+                line = ''.join((line, separator))
 
             if show_summary:
                 s, line = _extendLine(
                     s, line, summary_insert, elem_width, hanging_indent, legacy)
                 if legacy == '1.13':
-                    line += ", "
+                    line = ''.join((line, ", "))
                 else:
-                    line += separator
+                    line = ''.join((line, separator))
 
             for i in range(trailing_items, 1, -1):
                 word = recurser(index + (-i,), next_hanging_indent, next_width)
                 s, line = _extendLine_pretty(
                     s, line, word, elem_width, hanging_indent, legacy)
-                line += separator
+                line = ''.join((line, separator))
 
             if legacy == '1.13':
                 # width of the separator is not considered on 1.13
@@ -816,7 +815,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             s, line = _extendLine_pretty(
                 s, line, word, elem_width, hanging_indent, legacy)
 
-            s += line
+            s = ''.join((s, line))
 
         # other axes - insert newlines between rows
         else:
@@ -825,25 +824,25 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
 
             for i in range(leading_items):
                 nested = recurser(index + (i,), next_hanging_indent, next_width)
-                s += hanging_indent + nested + line_sep
+                s = ''.join((s, hanging_indent, nested, line_sep))
 
             if show_summary:
                 if legacy == '1.13':
                     # trailing space, fixed nbr of newlines, and fixed separator
-                    s += hanging_indent + summary_insert + ", \n"
+                    s = ''.join((s, hanging_indent, summary_insert, ", \n"))
                 else:
-                    s += hanging_indent + summary_insert + line_sep
+                    s = ''.join((s, hanging_indent, summary_insert, line_sep))
 
             for i in range(trailing_items, 1, -1):
                 nested = recurser(index + (-i,), next_hanging_indent,
                                   next_width)
-                s += hanging_indent + nested + line_sep
+                s = ''.join((s, hanging_indent, nested, line_sep))
 
             nested = recurser(index + (-1,), next_hanging_indent, next_width)
-            s += hanging_indent + nested
+            s = ''.join((s, hanging_indent, nested))
 
         # remove the hanging indent, and wrap in []
-        s = '[' + s[len(hanging_indent):] + ']'
+        s = ''.join(('[', s[len(hanging_indent):], ']'))
         return s
 
     try:
@@ -1306,8 +1305,8 @@ class SubArrayFormat:
 
     def __call__(self, arr):
         if arr.ndim <= 1:
-            return "[" + ", ".join(self.format_function(a) for a in arr) + "]"
-        return "[" + ", ".join(self.__call__(a) for a in arr) + "]"
+            return ''.join(("[", ", ".join(self.format_function(a) for a in arr), "]"))
+        return ''.join(("[", ", ".join(self.__call__(a) for a in arr), "]"))
 
 
 class StructuredVoidFormat:
@@ -1449,7 +1448,7 @@ def _array_repr_implementation(
     else:  # show zero-length shape unless it is (0,)
         lst = "[], shape=%s" % (repr(arr.shape),)
 
-    arr_str = prefix + lst + suffix
+    arr_str = ''.join([prefix, lst, suffix])
 
     if skipdtype:
         return arr_str
@@ -1467,7 +1466,7 @@ def _array_repr_implementation(
     elif last_line_len + len(dtype_str) + 1 > max_line_width:
         spacer = '\n' + ' '*len(class_name + "(")
 
-    return arr_str + spacer + dtype_str
+    return ''.join((arr_str, spacer, dtype_str))
 
 
 def _array_repr_dispatcher(

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -843,7 +843,8 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                     # trailing space, fixed nbr of newlines, and fixed separator
                     s.append(''.join([hanging_indent, summary_insert, ", \n"]))
                 else:
-                    s.append(''.join([hanging_indent, summary_insert, line_sep]))
+                    s.append(''.join([hanging_indent, summary_insert,
+                                      line_sep]))
 
             for i in range(trailing_items, 1, -1):
                 nested = recurser(index + (-i,), next_hanging_indent,


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes https://github.com/numpy/numpy/issues/19515
**Code**
```python
import os, timeit, numpy as np, functools
import psutil
from tabulate import tabulate
print(np.__version__)
process = psutil.Process(os.getpid())

results = []
ndim = 15
result = []

x = np.random.normal(size=[2]*ndim)

timer = timeit.Timer(functools.partial(str, x))

result.append(ndim)
result.append(round(timer.timeit(1), 3))
result.append(round(process.memory_info().rss, 3))
results.append(result)
del x, timer

print(tabulate(results, headers=[
'size', 'Time (s)', 'Memory (bytes)'],
tablefmt='github'), end="\n\n")
```

**In `main`**
|   size |   Time (s) |   Memory (bytes) |
|--------|------------|------------------|
|     20 |      8.041 |         63184896 |
|     18 |      1.903 |         44249088 |

**In `print`**
|   size |   Time (s) |   Memory (bytes) |
|--------|------------|------------------|
|     20 |      8.223 |         40366080 |
|     18 |       1.92 |         34381824 |

The results seem promising. Improvements rise with increase in sizes.

I will now look into [this idea](https://github.com/numpy/numpy/issues/19515#issuecomment-885404727) which has potential. It seems like joining a large number of small strings is faster than joining small number of large strings.

Using lists to store strings and joining later on,

**[b07faa9d](https://github.com/numpy/numpy/pull/19549/commits/b07faa9d723054bea80c2c89e994ce5a4f9224a3)**

 |   size |   Time (s) |   Memory (bytes) |
|--------|------------|------------------|
|     20 |      8.479 |         40738816 |

cc @mattip @seberg @hawkinsp @rgommers 