### PR TITLE
DOC: clarify doc re: unsupported keys in savez.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -581,9 +581,9 @@ def savez(file, *args, **kwds):
     its list of arrays (with the ``.files`` attribute), and for the arrays
     themselves.
 
-    When saving dictionaries, the dictionary keys become filenames
-    inside the ZIP archive. Therefore, keys should be valid filenames.
-    E.g., avoid keys that begin with ``/`` or contain ``.``.
+    Keys passed in `kwds` are used as filenames inside the ZIP archive.
+    Therefore, keys should be valid filenames; e.g., avoid keys that begin with
+    ``/`` or contain ``.``.
 
     When naming variables with keyword arguments, it is not possible to name a
     variable ``file``, as this would cause the ``file`` argument to be defined


### PR DESCRIPTION
The previous wording ("When saving dictionaries") could be interpreted
as refering to calls like `savez("foo.npz", {"a": 1, "b": 2})`
(literally "saving a dict to foo.npz"); reword to avoid this possibility
of confusion.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
