### PR TITLE
WIP: ENH: ns datetime "now"

### DIFF
--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -11,6 +11,7 @@
 #include <Python.h>
 
 #include <time.h>
+#include <pytime.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
@@ -323,21 +324,20 @@ parse_iso_8601_datetime(char const *str, Py_ssize_t len,
     if (len == 3 && tolower(str[0]) == 'n' &&
                     tolower(str[1]) == 'o' &&
                     tolower(str[2]) == 'w') {
-        NPY_TIME_T rawtime = 0;
         PyArray_DatetimeMetaData meta;
 
-        time(&rawtime);
+        int64_t rawtime = _PyTime_GetSystemClock();
 
         /* Set up a dummy metadata for the conversion */
-        meta.base = NPY_FR_s;
+        meta.base = NPY_FR_ns;
         meta.num = 1;
 
-        bestunit = NPY_FR_s;
+        bestunit = NPY_FR_ns;
 
         /*
          * Indicate that this was a special value, and
-         * use 's' because the time() function has resolution
-         * seconds.
+         * use 'ns' because the _PyTime_GetSystemClock()
+         * function has a resolution of nanoseconds.
          */
         if (out_bestunit != NULL) {
             *out_bestunit = bestunit;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 from numpy.testing import (
     assert_, assert_equal, assert_raises, assert_warns, suppress_warnings,
-    assert_raises_regex, assert_array_equal,
+    assert_raises_regex, assert_array_equal, assert_array_less,
     )
 from numpy.compat import pickle
 
@@ -512,7 +512,7 @@ class TestDateTime:
 
         # 'now' special value
         assert_equal(np.datetime64('now').dtype,
-                     np.dtype('M8[s]'))
+                     np.dtype('M8[ns]'))
 
     def test_datetime_nat_casting(self):
         a = np.array('NaT', dtype='M8[D]')
@@ -2445,6 +2445,15 @@ class TestDateTime:
         # week reprs are not distinguishable.
         limit_via_str = np.datetime64(str(limit), time_unit)
         assert limit_via_str == limit
+
+    def test_now_resolution_ns(self):
+        # test for gh-13372
+        stamp = np.datetime64(datetime.datetime.utcnow())
+        newer_stamp = np.datetime64("now", "ns")
+        # before supporting ns resolution, the
+        # second-truncated newer_stamp would
+        # fail this test
+        assert_array_less(stamp, newer_stamp)
 
 
 class TestDateTimeData:


### PR DESCRIPTION
Fixes #13372

* use `_PyTime_GetSystemClock()`, which provides nanosecond
resolution time in a portable manner via the Python C
API, to provide high resolution time information for
`np.datetime64("now", "ns")`

* note that the displays differ slightly here
in the number of digits after the decimal (I
believe the 000 convention is normal for datetime
reporting, but we may want to adjust that, not sure):
```
np.datetime64(datetime.utcnow())
np.datetime64("now", "ns")
2021-07-24T23:52:33.303293
2021-07-24T23:52:33.303595000
```

* we may want to consider using `_PyTime_GetSystemClockWithInfo()`,
which actually returns a `-1` we could use as a handle for
some degree of error checking

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
