### PR TITLE
ENH: Add annotations for `__path__` and `PytestTester`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from types import TracebackType, MappingProxyType
 from contextlib import ContextDecorator
 
+from numpy._pytesttester import PytestTester
 from numpy.core.multiarray import flagsobj
 from numpy.core._internal import _ctypes
 from numpy.typing import (
@@ -610,6 +611,7 @@ __all__: List[str]
 __path__: List[str]
 __version__: str
 __git_version__: str
+test: PytestTester
 
 # TODO: Move placeholders to their respective module once
 # their annotations are properly implemented

--- a/numpy/_pytesttester.pyi
+++ b/numpy/_pytesttester.pyi
@@ -1,0 +1,18 @@
+from typing import List, Iterable
+from typing_extensions import Literal as L
+
+__all__: List[str]
+
+class PytestTester:
+    module_name: str
+    def __init__(self, module_name: str) -> None: ...
+    def __call__(
+        self,
+        label: L["fast", "full"] = ...,
+        verbose: int = ...,
+        extra_argv: None | Iterable[str] = ...,
+        doctests: L[False] = ...,
+        coverage: bool = ...,
+        durations: int = ...,
+        tests: None | Iterable[str] = ...,
+    ) -> bool: ...

--- a/numpy/f2py/__init__.pyi
+++ b/numpy/f2py/__init__.pyi
@@ -3,6 +3,8 @@ import subprocess
 from typing import Any, List, Iterable, Dict, overload
 from typing_extensions import TypedDict, Literal as L
 
+from numpy._pytesttester import PytestTester
+
 class _F2PyDictBase(TypedDict):
     csrc: List[str]
     h: List[str]
@@ -13,6 +15,7 @@ class _F2PyDict(_F2PyDictBase, total=False):
 
 __all__: List[str]
 __path__: List[str]
+test: PytestTester
 
 def run_main(comline_list: Iterable[str]) -> Dict[str, _F2PyDict]: ...
 

--- a/numpy/fft/__init__.pyi
+++ b/numpy/fft/__init__.pyi
@@ -1,6 +1,9 @@
 from typing import Any, List
 
+from numpy._pytesttester import PytestTester
+
 __all__: List[str]
+test: PytestTester
 
 def fft(a, n=..., axis=..., norm=...): ...
 def ifft(a, n=..., axis=..., norm=...): ...

--- a/numpy/fft/__init__.pyi
+++ b/numpy/fft/__init__.pyi
@@ -3,6 +3,7 @@ from typing import Any, List
 from numpy._pytesttester import PytestTester
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 def fft(a, n=..., axis=..., norm=...): ...

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -1,6 +1,8 @@
 import math as math
 from typing import Any, List
 
+from numpy._pytesttester import PytestTester
+
 from numpy import (
     ndenumerate as ndenumerate,
     ndindex as ndindex,
@@ -231,6 +233,7 @@ from numpy.core.multiarray import (
 )
 
 __all__: List[str]
+test: PytestTester
 
 __version__ = version
 emath = scimath

--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -233,6 +233,7 @@ from numpy.core.multiarray import (
 )
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 __version__ = version

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -3,6 +3,7 @@ from typing import Any, List
 from numpy._pytesttester import PytestTester
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 class LinAlgError(Exception): ...

--- a/numpy/linalg/__init__.pyi
+++ b/numpy/linalg/__init__.pyi
@@ -1,6 +1,9 @@
 from typing import Any, List
 
+from numpy._pytesttester import PytestTester
+
 __all__: List[str]
+test: PytestTester
 
 class LinAlgError(Exception): ...
 

--- a/numpy/ma/__init__.pyi
+++ b/numpy/ma/__init__.pyi
@@ -1,5 +1,7 @@
 from typing import Any, List
 
+from numpy._pytesttester import PytestTester
+
 from numpy.ma import extras as extras
 
 from numpy.ma.core import (
@@ -230,3 +232,4 @@ from numpy.ma.extras import (
 )
 
 __all__: List[str]
+test: PytestTester

--- a/numpy/ma/__init__.pyi
+++ b/numpy/ma/__init__.pyi
@@ -232,4 +232,5 @@ from numpy.ma.extras import (
 )
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -7,6 +7,7 @@ from numpy import (
 )
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 def bmat(obj, ldict=..., gdict=...): ...

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -1,10 +1,13 @@
 from typing import Any, List
 
+from numpy._pytesttester import PytestTester
+
 from numpy import (
     matrix as matrix,
 )
 
 __all__: List[str]
+test: PytestTester
 
 def bmat(obj, ldict=..., gdict=...): ...
 def asmatrix(data, dtype=...): ...

--- a/numpy/polynomial/__init__.pyi
+++ b/numpy/polynomial/__init__.pyi
@@ -18,6 +18,7 @@ from numpy.polynomial.legendre import Legendre as Legendre
 from numpy.polynomial.polynomial import Polynomial as Polynomial
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 def set_default_printstyle(style): ...

--- a/numpy/polynomial/__init__.pyi
+++ b/numpy/polynomial/__init__.pyi
@@ -1,5 +1,7 @@
 from typing import List
 
+from numpy._pytesttester import PytestTester
+
 from numpy.polynomial import (
     chebyshev as chebyshev,
     hermite as hermite,
@@ -16,5 +18,6 @@ from numpy.polynomial.legendre import Legendre as Legendre
 from numpy.polynomial.polynomial import Polynomial as Polynomial
 
 __all__: List[str]
+test: PytestTester
 
 def set_default_printstyle(style): ...

--- a/numpy/random/__init__.pyi
+++ b/numpy/random/__init__.pyi
@@ -1,5 +1,7 @@
 from typing import List
 
+from numpy._pytesttester import PytestTester
+
 from numpy.random._generator import Generator as Generator
 from numpy.random._generator import default_rng as default_rng
 from numpy.random._mt19937 import MT19937 as MT19937
@@ -66,3 +68,4 @@ from numpy.random.mtrand import (
 )
 
 __all__: List[str]
+test: PytestTester

--- a/numpy/random/__init__.pyi
+++ b/numpy/random/__init__.pyi
@@ -68,4 +68,5 @@ from numpy.random.mtrand import (
 )
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester

--- a/numpy/testing/__init__.pyi
+++ b/numpy/testing/__init__.pyi
@@ -49,6 +49,7 @@ from numpy.testing._private.utils import (
 )
 
 __all__: List[str]
+__path__: List[str]
 test: PytestTester
 
 def run_module_suite(

--- a/numpy/testing/__init__.pyi
+++ b/numpy/testing/__init__.pyi
@@ -1,5 +1,7 @@
 from typing import List
 
+from numpy._pytesttester import PytestTester
+
 from unittest import (
     TestCase as TestCase,
 )
@@ -47,6 +49,7 @@ from numpy.testing._private.utils import (
 )
 
 __all__: List[str]
+test: PytestTester
 
 def run_module_suite(
     file_to_run: None | str = ...,

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -172,6 +172,7 @@ else:
     # Declare to mypy that `__all__` is a list of strings without assigning
     # an explicit value
     __all__: List[str]
+    __path__: List[str]
 
 
 @final  # Dissallow the creation of arbitrary `NBitBase` subclasses

--- a/numpy/typing/tests/data/reveal/modules.py
+++ b/numpy/typing/tests/data/reveal/modules.py
@@ -32,6 +32,8 @@ reveal_type(np.polynomial.polynomial)  # E: ModuleType
 reveal_type(np.__path__)  # E: list[builtins.str]
 reveal_type(np.__version__)  # E: str
 reveal_type(np.__git_version__)  # E: str
+reveal_type(np.test)  # E: numpy._pytesttester.PytestTester
+reveal_type(np.test.module_name)  # E: str
 
 reveal_type(np.__all__)  # E: list[builtins.str]
 reveal_type(np.char.__all__)  # E: list[builtins.str]


### PR DESCRIPTION
This PR adds annotations for two module-level attributes that were previously missing:
* `<module>.__path__`, which is always defined for (sub-)packages.
* `<module>.test`, instances of `PytestTester` that are manually added to the main numpy namespace and all its sub-packages.