### PR TITLE
DOC: Remove explicit parameter sparse=False in meshgrid() indexing example

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4309,12 +4309,12 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     'xy' indexing and (M, N, P) for 'ij' indexing.  The difference is
     illustrated by the following code snippet::
 
-        xv, yv = np.meshgrid(x, y, sparse=False, indexing='ij')
+        xv, yv = np.meshgrid(x, y, indexing='ij')
         for i in range(nx):
             for j in range(ny):
                 # treat xv[i,j], yv[i,j]
 
-        xv, yv = np.meshgrid(x, y, sparse=False, indexing='xy')
+        xv, yv = np.meshgrid(x, y, indexing='xy')
         for i in range(nx):
             for j in range(ny):
                 # treat xv[j,i], yv[j,i]


### PR DESCRIPTION
`sparse=False` is the default anyway. Stating it explicitly has no
effect on the example, but clutters the code.

Semi-OT: The parameter docstring says "If True a sparse grid is returned". Is "sparse grid" a fixed technical term that everybody is supposed to know? Otherwise, that would need a bit of explanation. I could do a separatePR on that if desired.