### PR TITLE
DOC: Fix sphinx warnings in c-info.beyond-basics.rst

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1278,6 +1278,14 @@ New data types
     registered (checked only by the address of the pointer), then
     return the previously-assigned type-number.
 
+.. c:function:: int PyArray_TypeNumFromName( \
+        char const *str)
+
+   Given a string return the type-number for the data-type with that string as
+   the type-object name.
+   Returns NPY_NOTYPE without setting an error if no type can be found.
+   Only works for user-defined data-types.
+
 .. c:function:: int PyArray_RegisterCastFunc( \
         PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
 
@@ -2554,6 +2562,10 @@ Broadcasting (multi-iterators)
     Evaluates TRUE as long as the multi-iterator has not looped
     through all of the elements (of the broadcasted result), otherwise
     it evaluates FALSE.
+
+.. c:function:: int PyArray_MultiIter_SIZE(PyObject* multi)
+
+    Returne the size of the multi-iterator object.
 
 .. c:function:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1310,7 +1310,7 @@ User-defined data types
 
    Given a string return the type-number for the data-type with that string as
    the type-object name.
-   Returns NPY_NOTYPE without setting an error if no type can be found.
+   Returns ``NPY_NOTYPE`` without setting an error if no type can be found.
    Only works for user-defined data-types.
 
 Special functions for NPY_OBJECT

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1250,8 +1250,8 @@ Converting data types
     function returns :c:data:`NPY_FALSE`.
 
 
-New data types
-^^^^^^^^^^^^^^
+User-defined data types
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. c:function:: void PyArray_InitArrFuncs(PyArray_ArrFuncs* f)
 
@@ -1278,14 +1278,6 @@ New data types
     registered (checked only by the address of the pointer), then
     return the previously-assigned type-number.
 
-.. c:function:: int PyArray_TypeNumFromName( \
-        char const *str)
-
-   Given a string return the type-number for the data-type with that string as
-   the type-object name.
-   Returns NPY_NOTYPE without setting an error if no type can be found.
-   Only works for user-defined data-types.
-
 .. c:function:: int PyArray_RegisterCastFunc( \
         PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
 
@@ -1303,6 +1295,13 @@ New data types
     *descr* can be cast safely to a data-type whose type_number is
     *totype*.
 
+.. c:function:: int PyArray_TypeNumFromName( \
+        char const *str)
+
+   Given a string return the type-number for the data-type with that string as
+   the type-object name.
+   Returns NPY_NOTYPE without setting an error if no type can be found.
+   Only works for user-defined data-types.
 
 Special functions for NPY_OBJECT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2565,7 +2564,7 @@ Broadcasting (multi-iterators)
 
 .. c:function:: int PyArray_MultiIter_SIZE(PyObject* multi)
 
-    Returne the size of the multi-iterator object.
+    Returns the size of the multi-iterator object.
 
 .. c:function:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -151,6 +151,16 @@ and its sub-types).
 
     `numpy.ndarray.item` is identical to PyArray_GETITEM.
 
+.. c:function:: int PyArray_FinalizeFunc(PyArrayObject* arr, PyObject* obj)
+
+    The function pointed to by the CObject
+    :obj:`~numpy.class.__array_finalize__`.
+    The first argument is the newly created sub-type. The second argument
+    (if not NULL) is the "parent" array (if the array was created using
+    slicing or some other operation where a clearly-distinguishable parent
+    is present). This routine can do anything it wants to. It should
+    return a -1 on error and 0 otherwise.
+
 
 Data access
 ^^^^^^^^^^^
@@ -2561,10 +2571,6 @@ Broadcasting (multi-iterators)
     Evaluates TRUE as long as the multi-iterator has not looped
     through all of the elements (of the broadcasted result), otherwise
     it evaluates FALSE.
-
-.. c:function:: int PyArray_MultiIter_SIZE(PyObject* multi)
-
-    Returns the size of the multi-iterator object.
 
 .. c:function:: int PyArray_Broadcast(PyArrayMultiIterObject* mit)
 

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -472,8 +472,8 @@ The __array_finalize\__ method
    members are filled in. Finally, the :obj:`~numpy.class.__array_finalize__`
    attribute is looked-up in the object dictionary. If it is present
    and not None, then it can be either a CObject containing a pointer
-   to a ``PyArray_FinalizeFunc`` or it can be a method taking a
-   single argument (which could be None).
+   to a :c:func:`PyArray_FinalizeFunc` or it can be a method taking a
+   single argument (which could be None)
 
    If the :obj:`~numpy.class.__array_finalize__` attribute is a CObject, then the pointer
    must be a pointer to a function with the signature:

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -172,7 +172,7 @@ iterators so that all that needs to be done to advance to the next element in
 each array is for PyArray_ITER_NEXT to be called for each of the inputs. This
 incrementing is automatically performed by
 :c:func:`PyArray_MultiIter_NEXT` ( ``obj`` ) macro (which can handle a
-multiterator ``obj`` as either a :c:expr:`PyArrayMultiObject *` or a
+multiterator ``obj`` as either a :c:expr:`PyArrayMultiIterObject *` or a
 :c:expr:`PyObject *`). The data from input number ``i`` is available using
 :c:func:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ) and the total (broadcasted)
 size as :c:func:`PyArray_MultiIter_SIZE` ( ``obj``). An example of using this
@@ -330,7 +330,7 @@ function :c:func:`PyArray_RegisterCanCast` (from_descr, totype_number,
 scalarkind) should be used to specify that the data-type object
 from_descr can be cast to the data-type with type number
 totype_number. If you are not trying to alter scalar coercion rules,
-then use :c:data:`NPY_NOSCALAR` for the scalarkind argument.
+then use :c:enumerator:`NPY_NOSCALAR` for the scalarkind argument.
 
 If you want to allow your new data-type to also be able to share in
 the scalar coercion rules, then you need to specify the scalarkind
@@ -340,7 +340,7 @@ available to that function). Then, you can register data-types that
 can be cast to separately for each scalar kind that may be returned
 from your user-defined data-type. If you don't register scalar
 coercion handling, then all of your user-defined data-types will be
-seen as :c:data:`NPY_NOSCALAR`.
+seen as :c:enumerator:`NPY_NOSCALAR`.
 
 
 Registering a ufunc loop
@@ -472,7 +472,7 @@ The __array_finalize\__ method
    members are filled in. Finally, the :obj:`~numpy.class.__array_finalize__`
    attribute is looked-up in the object dictionary. If it is present
    and not None, then it can be either a CObject containing a pointer
-   to a :c:func:`PyArray_FinalizeFunc` or it can be a method taking a
+   to a ``PyArray_FinalizeFunc`` or it can be a method taking a
    single argument (which could be None).
 
    If the :obj:`~numpy.class.__array_finalize__` attribute is a CObject, then the pointer

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1308,9 +1308,6 @@ typedef struct {
 #define PyArray_MultiIter_NOTDONE(multi)                \
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
-#define PyArray_MultiIter_SIZE(multi)                \
-        _PyMIT(multi)->size
-
 /*
  * Store the information needed for fancy-indexing over an array. The
  * fields are slightly unordered to keep consec, dataptr and subspace

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -1308,6 +1308,8 @@ typedef struct {
 #define PyArray_MultiIter_NOTDONE(multi)                \
         (_PyMIT(multi)->index < _PyMIT(multi)->size)
 
+#define PyArray_MultiIter_SIZE(multi)                \
+        _PyMIT(multi)->size
 
 /*
  * Store the information needed for fancy-indexing over an array. The


### PR DESCRIPTION
This pull request partially addresses #13114
In particular it fixes the sphinx warnings in [c-info.beyond-basics.rst](https://numpy.org/doc/stable/user/c-info.beyond-basics.html#beyond-the-basics).
```
/home/circleci/repo/doc/source/user/c-info.beyond-basics.rst:162: WARNING: c:identifier reference target not found: PyArrayMultiObject
/home/circleci/repo/doc/source/user/c-info.beyond-basics.rst:162: WARNING: c:func reference target not found: PyArray_MultiIter_SIZE
/home/circleci/repo/doc/source/user/c-info.beyond-basics.rst:264: WARNING: c:func reference target not found: PyArray_TypeNumFromName
/home/circleci/repo/doc/source/user/c-info.beyond-basics.rst:466: WARNING: c:func reference target not found: PyArray_FinalizeFunc
```
Hope my guesses are the right choices.