### PR TITLE
DOC: Fix Unknown section warning when building docs

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2376,47 +2376,47 @@ def generate_config_py(target):
 
                 Notes
                 -----
-                Classes specifying the information to be printed are defined
-                in the `numpy.distutils.system_info` module.
+                1. Classes specifying the information to be printed are defined
+                   in the `numpy.distutils.system_info` module.
 
-                Information may include:
+                   Information may include:
 
-                * ``language``: language used to write the libraries (mostly
-                  C or f77)
-                * ``libraries``: names of libraries found in the system
-                * ``library_dirs``: directories containing the libraries
-                * ``include_dirs``: directories containing library header files
-                * ``src_dirs``: directories containing library source files
-                * ``define_macros``: preprocessor macros used by
-                  ``distutils.setup``
-                * ``baseline``: minimum CPU features required
-                * ``found``: dispatched features supported in the system
-                * ``not found``: dispatched features that are not supported
-                  in the system
+                   * ``language``: language used to write the libraries (mostly
+                     C or f77)
+                   * ``libraries``: names of libraries found in the system
+                   * ``library_dirs``: directories containing the libraries
+                   * ``include_dirs``: directories containing library header files
+                   * ``src_dirs``: directories containing library source files
+                   * ``define_macros``: preprocessor macros used by
+                     ``distutils.setup``
+                   * ``baseline``: minimum CPU features required
+                   * ``found``: dispatched features supported in the system
+                   * ``not found``: dispatched features that are not supported
+                     in the system
 
-                NumPy BLAS/LAPACK Installation Notes
-                ------------------------------------
-                Installing a numpy wheel (``pip install numpy`` or force it
-                via ``pip install numpy --only-binary :numpy: numpy``) includes
-                an OpenBLAS implementation of the BLAS and LAPACK linear algebra
-                APIs. In this case, ``library_dirs`` reports the original build
-                time configuration as compiled with gcc/gfortran; at run time
-                the OpenBLAS library is in
-                ``site-packages/numpy.libs/`` (linux), or
-                ``site-packages/numpy/.dylibs/`` (macOS), or
-                ``site-packages/numpy/.libs/`` (windows).
+                2. NumPy BLAS/LAPACK Installation Notes
 
-                Installing numpy from source
-                (``pip install numpy --no-binary numpy``) searches for BLAS and
-                LAPACK dynamic link libraries at build time as influenced by
-                environment variables NPY_BLAS_LIBS, NPY_CBLAS_LIBS, and
-                NPY_LAPACK_LIBS; or NPY_BLAS_ORDER and NPY_LAPACK_ORDER;
-                or the optional file ``~/.numpy-site.cfg``.
-                NumPy remembers those locations and expects to load the same
-                libraries at run-time.
-                In NumPy 1.21+ on macOS, 'accelerate' (Apple's Accelerate BLAS
-                library) is in the default build-time search order after
-                'openblas'.
+                   Installing a numpy wheel (``pip install numpy`` or force it
+                   via ``pip install numpy --only-binary :numpy: numpy``) includes
+                   an OpenBLAS implementation of the BLAS and LAPACK linear algebra
+                   APIs. In this case, ``library_dirs`` reports the original build
+                   time configuration as compiled with gcc/gfortran; at run time
+                   the OpenBLAS library is in
+                   ``site-packages/numpy.libs/`` (linux), or
+                   ``site-packages/numpy/.dylibs/`` (macOS), or
+                   ``site-packages/numpy/.libs/`` (windows).
+
+                   Installing numpy from source
+                   (``pip install numpy --no-binary numpy``) searches for BLAS and
+                   LAPACK dynamic link libraries at build time as influenced by
+                   environment variables NPY_BLAS_LIBS, NPY_CBLAS_LIBS, and
+                   NPY_LAPACK_LIBS; or NPY_BLAS_ORDER and NPY_LAPACK_ORDER;
+                   or the optional file ``~/.numpy-site.cfg``.
+                   NumPy remembers those locations and expects to load the same
+                   libraries at run-time.
+                   In NumPy 1.21+ on macOS, 'accelerate' (Apple's Accelerate BLAS
+                   library) is in the default build-time search order after
+                   'openblas'.
 
                 Examples
                 --------


### PR DESCRIPTION
When building the documentation on `main`, the following warning turns up:

```
/opt/miniconda/envs/numpy-dev/lib/python3.9/site-packages/numpydoc/docscrape.py:418: UserWarning: Unknown section Numpy Blas/lapack Installation Notes in the docstring of <function show at 0x7fc4e8d0b5e0> in /home/melissa/projects/numpy/numpy/__config__.py.
  warn(msg)
```

In the `show` function at `numpy.distutils.misc_util.py`, there is a 

```
    NumPy BLAS/LAPACK Installation Notes
    ------------------------------------
```

section (introduced in #19447), which is not recognized by `numpydoc`. This PR reformats the notes in the `show` function as a numbered list to fix the warning.