### PR TITLE
MAINT: Cleanup unused function _move_axis_to_0

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1466,11 +1466,6 @@ def moveaxis(a, source, destination):
     return result
 
 
-# fix hack in scipy which imports this function
-def _move_axis_to_0(a, axis):
-    return moveaxis(a, axis, 0)
-
-
 def _cross_dispatcher(a, b, axisa=None, axisb=None, axisc=None, axis=None):
     return (a, b)
 


### PR DESCRIPTION
**What does this fix?**
This PR removes an old unused internal function defined earlier for SciPy. I double-checked (`grep` in `SciPy`) to confirm there is no reference of `_move_axis_to_0` currently. Hence it is safe to remove this and clean things here.

**Additional Information**
I came across this while reading the source code for `np.move_axis`.