### PR TITLE
MAINT: Make Python3.8 the default for CI testing.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ defaults:
 
 env:
   DOWNLOAD_OPENBLAS: 1
-  PYTHON_VERSION: 3.7
+  PYTHON_VERSION: 3.8
 
 jobs:
   lint:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10.0-beta.4]
+        python-version: [3.7, 3.9, 3.10.0-beta.4]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: ./.github/actions
 
   basic:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,7 +68,7 @@ jobs:
     - uses: ./.github/actions
 
   debug:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-20.04
     env:
       USE_DEBUG: 1
@@ -83,7 +83,7 @@ jobs:
     - uses: ./.github/actions
 
   blas64:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       NPY_USE_BLAS_ILP64: 1
@@ -98,7 +98,7 @@ jobs:
     - uses: ./.github/actions
 
   full:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-18.04
     env:
       USE_WHEEL: 1
@@ -116,7 +116,7 @@ jobs:
     - uses: ./.github/actions
 
   benchmark:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       PYTHONOPTIMIZE: 2
@@ -137,7 +137,7 @@ jobs:
     - uses: ./.github/actions
 
   no_relaxed_strides:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       NPY_RELAXED_STRIDES_CHECKING: 0
@@ -154,7 +154,7 @@ jobs:
     - uses: ./.github/actions
 
   use_wheel:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       USE_WHEEL: 1
@@ -170,7 +170,7 @@ jobs:
     - uses: ./.github/actions
 
   no_array_func:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       NUMPY_EXPERIMENTAL_ARRAY_FUNCTION: 0
@@ -185,7 +185,7 @@ jobs:
     - uses: ./.github/actions
 
   no_openblas:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       BLAS: None
@@ -203,7 +203,7 @@ jobs:
     - uses: ./.github/actions
 
   pypy37:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -216,7 +216,7 @@ jobs:
     - uses: ./.github/actions
 
   sdist:
-    needs: [smoke_test, lint]
+    needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
       USE_SDIST: 1

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -20,10 +20,10 @@ jobs:
           platform: x64
           install-dir: 'C:\tools\cygwin'
           packages: >
-            python37-devel python37-zipp python37-importlib-metadata
-            python37-cython python37-pip python37-wheel python37-cffi
-            python37-pytz python37-setuptools python37-pytest
-            python37-hypothesis liblapack-devel libopenblas
+            python38-devel python38-zipp python38-importlib-metadata
+            python38-cython python38-pip python38-wheel python38-cffi
+            python38-pytz python38-setuptools python38-pytest
+            python38-hypothesis liblapack-devel libopenblas
             gcc-fortran git dash
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@v1
@@ -40,28 +40,28 @@ jobs:
       - name: Verify python version
         # Make sure it's the Cygwin one, not a Windows one
         run: |
-          dash -c "which python3.7; /usr/bin/python3.7 --version -V"
+          dash -c "which python3.8; /usr/bin/python3.8 --version -V"
       - name: Build NumPy wheel
         run: |
-          dash -c "/usr/bin/python3.7 -m pip install 'setuptools<49.2.0' pytest pytz cffi pickle5 importlib_metadata typing_extensions"
-          dash -c "/usr/bin/python3.7 -m pip install -r test_requirements.txt"
-          dash -c "/usr/bin/python3.7 setup.py bdist_wheel"
+          dash -c "/usr/bin/python3.8 -m pip install 'setuptools<49.2.0' pytest pytz cffi pickle5 importlib_metadata typing_extensions"
+          dash -c "/usr/bin/python3.8 -m pip install -r test_requirements.txt"
+          dash -c "/usr/bin/python3.8 setup.py bdist_wheel"
       - name: Install new NumPy
         run: |
-          bash -c "/usr/bin/python3.7 -m pip install dist/numpy-*cp37*.whl"
+          bash -c "/usr/bin/python3.8 -m pip install dist/numpy-*cp38*.whl"
       - name: Run NumPy test suite
         run: >-
-          dash -c "/usr/bin/python3.7 runtests.py -n -vv"
+          dash -c "/usr/bin/python3.8 runtests.py -n -vv"
       - name: Upload wheel if tests fail
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: numpy-cygwin-wheel
-          path: dist/numpy-*cp37*.whl
+          path: dist/numpy-*cp38*.whl
       - name: On failure check the extension modules
         if: failure()
         run: |
-          dash -c "/usr/bin/python3.7 -m pip show numpy"
-          dash -c "/usr/bin/python3.7 -m pip show -f numpy | grep .dll"
+          dash -c "/usr/bin/python3.8 -m pip show numpy"
+          dash -c "/usr/bin/python3.8 -m pip show -f numpy | grep .dll"
           dash -c "/bin/tr -d '\r' <tools/list_installed_dll_dependencies_cygwin.sh >list_dlls_unix.sh"
           dash "list_dlls_unix.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
 
 jobs:
   include:
-    - python: 3.7
+    - python: 3.8
       os: linux
       arch: ppc64le
       env:
@@ -35,7 +35,7 @@ jobs:
        - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
 
-    - python: 3.7
+    - python: 3.8
       os: linux
       arch: s390x
       env:
@@ -44,7 +44,7 @@ jobs:
        - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
 
-    - python: 3.7
+    - python: 3.8
       os: linux
       arch: arm64
       virt: vm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,25 +18,6 @@ stages:
 - stage: InitialTests
   jobs:
 
-  - job: Lint
-    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-    pool:
-      vmImage: 'ubuntu-18.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.8'
-        addToPath: true
-        architecture: 'x64'
-    - script: >-
-        python -m pip install -r linter_requirements.txt
-      displayName: 'Install tools'
-      # pip 21.1 emits a pile of garbage messages to annoy users :)
-      #      failOnStderr: true
-    - script: |
-        python tools/linter.py --branch origin/$(System.PullRequest.TargetBranch)
-      displayName: 'Run Lint Checks'
-      failOnStderr: true
   # Native build is based on gcc flag `-march=native`
   - job: Linux_baseline_native
     pool:
@@ -66,6 +47,25 @@ stages:
 - stage: ComprehensiveTests
   jobs:
 
+  - job: Lint
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
+        addToPath: true
+        architecture: 'x64'
+    - script: >-
+        python -m pip install -r linter_requirements.txt
+      displayName: 'Install tools'
+      # pip 21.1 emits a pile of garbage messages to annoy users :)
+      #      failOnStderr: true
+    - script: |
+        python tools/linter.py --branch origin/$(System.PullRequest.TargetBranch)
+      displayName: 'Run Lint Checks'
+      failOnStderr: true
 
   - job: WindowsFast
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
     strategy:
       matrix:
           Python37-32bit-fast:
-            PYTHON_VERSION: '3.7'
+            PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'
             TEST_MODE: fast
             BITS: 32
@@ -120,11 +120,11 @@ stages:
     strategy:
       maxParallel: 3
       matrix:
-          Python37:
-            PYTHON_VERSION: '3.7'
+          Python38:
+            PYTHON_VERSION: '3.8'
             USE_OPENBLAS: '1'
-          Python37-ILP64:
-            PYTHON_VERSION: '3.7'
+          Python38-ILP64:
+            PYTHON_VERSION: '3.8'
             NPY_USE_BLAS_ILP64: '1'
             USE_OPENBLAS: '1'
     steps:
@@ -232,7 +232,7 @@ stages:
       inputs:
         testResultsFiles: '**/test-*.xml'
         failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for Python 3.7 64-bit full Mac OS'
+        testRunTitle: 'Publish test results for Python 3.8 64-bit full Mac OS'
 
 
   - job: Windows


### PR DESCRIPTION
This uses Python3.8 for most CI tests. The exceptions are tests for gcc48, pypy37, and the basic tests. The direct reason for this change is to allow name-only arguments in the numpy-api interface, but it is also the case that we will drop Python3.7 in the NumPy 1.23.0 release.

This also drops the dependence of the github actions tests on lint passing. Sometimes we allow lint violations and would like the rest of the tests to run in that situation.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
