### PR TITLE
DOC Fix 'size' sphinx warnings.

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -701,18 +701,18 @@ class ABCPolyBase(abc.ABC):
         return self.__class__(coef, self.domain, self.window)
 
     def truncate(self, size):
-        """Truncate series to length `size`.
+        """Truncate series to length ``size``.
 
-        Reduce the series to length `size` by discarding the high
-        degree terms. The value of `size` must be a positive integer. This
+        Reduce the series to length ``size`` by discarding the high
+        degree terms. The value of ``size`` must be a positive integer. This
         can be useful in least squares where the coefficients of the
         high degree terms may be very small.
 
         Parameters
         ----------
         size : positive int
-            The series is reduced to length `size` by discarding the high
-            degree terms. The value of `size` must be a positive integer.
+            The series is reduced to length ``size`` by discarding the high
+            degree terms. The value of ``size`` must be a positive integer.
 
         Returns
         -------

--- a/numpy/random/_bounded_integers.pyx.in
+++ b/numpy/random/_bounded_integers.pyx.in
@@ -288,8 +288,8 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
     Returns
     -------
     out : python scalar or ndarray of np.{{otype}}
-          `size`-shaped array of random integers from the appropriate
-          distribution, or a single such random int if `size` not provided.
+          ``size``-shaped array of random integers from the appropriate
+          distribution, or a single such random int if ``size`` not provided.
 
     Notes
     -----

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -146,9 +146,9 @@ cdef class Generator:
     ``Generator`` exposes a number of methods for generating random
     numbers drawn from a variety of probability distributions. In addition to
     the distribution-specific arguments, each method takes a keyword argument
-    `size` that defaults to ``None``. If `size` is ``None``, then a single
-    value is generated and returned. If `size` is an integer, then a 1-D
-    array filled with generated values is returned. If `size` is a tuple,
+    ``size`` that defaults to ``None``. If ``size`` is ``None``, then a single
+    value is generated and returned. If ``size`` is an integer, then a 1-D
+    array filled with generated values is returned. If ``size`` is a tuple,
     then an array with that shape is filled and returned.
 
     The function :func:`numpy.random.default_rng` will instantiate
@@ -261,7 +261,7 @@ cdef class Generator:
         Returns
         -------
         out : float or ndarray of floats
-            Array of random floats of shape `size` (unless ``size=None``, in which
+            Array of random floats of shape ``size`` (unless ``size=None``, in which
             case a single float is returned).
 
         Examples
@@ -477,8 +477,8 @@ cdef class Generator:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         Notes
         -----
@@ -609,7 +609,7 @@ cdef class Generator:
         size : {int, tuple[int]}, optional
             Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
             ``m * n * k`` samples are drawn from the 1-d `a`. If `a` has more
-            than one dimension, the `size` shape will be inserted into the
+            than one dimension, the ``size`` shape will be inserted into the
             `axis` dimension, so the output ``ndim`` will be ``a.ndim - 1 +
             len(size)``. Default is None, in which case a single value is
             returned.
@@ -1498,7 +1498,7 @@ cdef class Generator:
         Raises
         ------
         ValueError
-            When `df` <= 0 or when an inappropriate `size` (e.g. ``size=-1``)
+            When `df` <= 0 or when an inappropriate ``size`` (e.g. ``size=-1``)
             is given.
 
         Notes
@@ -3859,7 +3859,7 @@ cdef class Generator:
             holding the shape of the array of variates.  If the given size is,
             e.g., ``(k, m)``, then ``k * m`` variates are drawn, where one
             variate is a vector of length ``len(colors)``, and the return value
-            has shape ``(k, m, len(colors))``.  If `size` is an integer, the
+            has shape ``(k, m, len(colors))``.  If ``size`` is an integer, the
             output has shape ``(size, len(colors))``.  Default is None, in
             which case a single variate is returned as an array with shape
             ``(len(colors),)``.
@@ -4041,7 +4041,7 @@ cdef class Generator:
 
         Draw samples from the Dirichlet distribution.
 
-        Draw `size` samples of dimension k from a Dirichlet distribution. A
+        Draw ``size`` samples of dimension k from a Dirichlet distribution. A
         Dirichlet-distributed random variable can be seen as a multivariate
         generalization of a Beta distribution. The Dirichlet distribution
         is a conjugate prior of a multinomial distribution in Bayesian

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -128,9 +128,9 @@ cdef class RandomState:
     `RandomState` and `Generator` expose a number of methods for generating
     random numbers drawn from a variety of probability distributions. In
     addition to the distribution-specific arguments, each method takes a
-    keyword argument `size` that defaults to ``None``. If `size` is ``None``,
-    then a single value is generated and returned. If `size` is an integer,
-    then a 1-D array filled with generated values is returned. If `size` is a
+    keyword argument ``size`` that defaults to ``None``. If ``size`` is ``None``,
+    then a single value is generated and returned. If ``size`` is an integer,
+    then a 1-D array filled with generated values is returned. If ``size`` is a
     tuple, then an array with that shape is filled and returned.
 
     **Compatibility Guarantee**
@@ -397,7 +397,7 @@ cdef class RandomState:
         Returns
         -------
         out : float or ndarray of floats
-            Array of random floats of shape `size` (unless ``size=None``, in which
+            Array of random floats of shape ``size`` (unless ``size=None``, in which
             case a single float is returned).
 
         See Also
@@ -680,8 +680,8 @@ cdef class RandomState:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         See Also
         --------
@@ -1275,8 +1275,8 @@ cdef class RandomState:
         Returns
         -------
         out : int or ndarray of ints
-            `size`-shaped array of random integers from the appropriate
-            distribution, or a single such random int if `size` not provided.
+            ``size``-shaped array of random integers from the appropriate
+            distribution, or a single such random int if ``size`` not provided.
 
         See Also
         --------
@@ -1884,7 +1884,7 @@ cdef class RandomState:
         Raises
         ------
         ValueError
-            When `df` <= 0 or when an inappropriate `size` (e.g. ``size=-1``)
+            When `df` <= 0 or when an inappropriate ``size`` (e.g. ``size=-1``)
             is given.
 
         See Also
@@ -4277,7 +4277,7 @@ cdef class RandomState:
 
         Draw samples from the Dirichlet distribution.
 
-        Draw `size` samples of dimension k from a Dirichlet distribution. A
+        Draw ``size`` samples of dimension k from a Dirichlet distribution. A
         Dirichlet-distributed random variable can be seen as a multivariate
         generalization of a Beta distribution. The Dirichlet distribution
         is a conjugate prior of a multinomial distribution in Bayesian


### PR DESCRIPTION
This pull request partially addresses #13114, fixing the sphinx warnings related to single back-quoting `size`.