### PR TITLE
TST: Add basic tests for custom DType (scaled float) ufuncs

### DIFF
--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -833,10 +833,12 @@ generic_masked_strided_loop(PyArrayMethod_Context *context,
 
 
 /*
- * Identical to the `get_loop` functions and wraps it.  This adds support
- * to a boolean mask being passed in as a last, additional, operand.
- * The wrapped loop will only be called for unmasked elements.
- * (Does not support `move_references` or inner dimensions!)
+ * Fetches a strided-loop function that supports a boolean mask as additional
+ * (last) operand to the strided-loop.  It is otherwise largely identical to
+ * the `get_loop` method which it wraps.
+ * This is the core implementation for the ufunc `where=...` keyword argument.
+ *
+ * NOTE: This function does not support `move_references` or inner dimensions.
  */
 NPY_NO_EXPORT int
 PyArrayMethod_GetMaskedStridedLoop(

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -69,8 +69,8 @@ promote_and_get_info_and_ufuncimpl(PyUFuncObject *ufunc,
  * @param ignore_duplicate If 1 and a loop with the same `dtype_tuple` is
  *        found, the function does nothing.
  */
-static int
-add_ufunc_loop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
+NPY_NO_EXPORT int
+PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
 {
     /*
      * Validate the info object, this should likely move to to a different
@@ -495,7 +495,7 @@ add_and_return_legacy_wrapping_ufunc_loop(PyUFuncObject *ufunc,
     if (info == NULL) {
         return NULL;
     }
-    if (add_ufunc_loop(ufunc, info, ignore_duplicate) < 0) {
+    if (PyUFunc_AddLoop(ufunc, info, ignore_duplicate) < 0) {
         Py_DECREF(info);
         return NULL;
     }

--- a/numpy/core/src/umath/dispatching.h
+++ b/numpy/core/src/umath/dispatching.h
@@ -7,6 +7,9 @@
 #include "array_method.h"
 
 
+NPY_NO_EXPORT int
+PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate);
+
 NPY_NO_EXPORT PyArrayMethodObject *
 promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         PyArrayObject *const ops[],


### PR DESCRIPTION
This does not actually test a lot of new paths, since the normal
ufuncs do cover most of the typical paths.

One thing it does test is that the ufunc implementation (as in
ArrayMethod) can customize the cast-safety.  This is used here
since the parametric DType considers different scalings as same-kind
casts and not safe/equiv casts.