### PR TITLE
BLD: Codespell for NumPy CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,6 +38,25 @@ jobs:
       run:
         python tools/linter.py --lint --branch origin/${{ github.base_ref }}
 
+  codespell:
+    if: "github.repository == 'numpy/numpy' && github.ref != 'refs/heads/main' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install linter requirements
+      run:
+        python -m pip install -r linter_requirements.txt
+    - name: Run codespell on PR diff
+      run:
+        python tools/linter.py --codespell --branch origin/${{ github.base_ref }}
+
   smoke_test:
     if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install -r linter_requirements.txt
     - name: Run linter on PR diff
       run:
-        python tools/linter.py --branch origin/${{ github.base_ref }}
+        python tools/linter.py --lint --branch origin/${{ github.base_ref }}
 
   smoke_test:
     if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,26 @@ stages:
       displayName: 'Run Lint Checks'
       failOnStderr: true
 
+  - job: Codespell
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
+        addToPath: true
+        architecture: 'x64'
+    - script: >-
+        python -m pip install -r linter_requirements.txt
+      displayName: 'Install tools'
+      # pip 21.1 emits a pile of garbage messages to annoy users :)
+      #      failOnStderr: true
+    - script: |
+        python tools/linter.py --codespell origin/$(System.PullRequest.TargetBranch)
+      displayName: 'Run Codespell Checks'
+      failOnStderr: true
+
   - job: WindowsFast
     pool:
       vmImage: 'VS2017-Win2016'

--- a/doc/source/reference/routines.linalg.rst
+++ b/doc/source/reference/routines.linalg.rst
@@ -9,11 +9,11 @@ The NumPy linear algebra functions rely on BLAS and LAPACK to provide efficient
 low level implementations of standard linear algebra algorithms. Those
 libraries may be provided by NumPy itself using C versions of a subset of their
 reference implementations but, when possible, highly optimized libraries that
-take advantage of specialized processor functionality are preferred. Examples
+take advantage of specialized processer functionality are preferred. Examples
 of such libraries are OpenBLAS_, MKL (TM), and ATLAS. Because those libraries
-are multithreaded and processor dependent, environmental variables and external
+are multithreaded and processer dependent, environmental variables and external
 packages such as threadpoolctl_ may be needed to control the number of threads
-or specify the processor architecture.
+or specify the processer architecture.
 
 .. _OpenBLAS: https://www.openblas.net/
 .. _threadpoolctl: https://github.com/joblib/threadpoolctl

--- a/linter_requirements.txt
+++ b/linter_requirements.txt
@@ -1,2 +1,3 @@
 pycodestyle==2.7.0
 GitPython==3.1.13
+codespell==2.1.0

--- a/tools/linter.py
+++ b/tools/linter.py
@@ -74,10 +74,13 @@ class DiffLinter:
 
 if __name__ == '__main__':
     parser = ArgumentParser()
+    parser.add_argument("--lint", action='store_true',
+                        help="Run Lint")
     parser.add_argument("--branch", type=str, default='main',
                         help="The branch to diff against")
     parser.add_argument("--uncommitted", action='store_true',
                         help="Check only uncommitted changes")
     args = parser.parse_args()
 
-    DiffLinter(args.branch).run_lint(args.uncommitted)
+    if args.lint:
+        DiffLinter(args.branch).run_lint(args.uncommitted)

--- a/tools/linter.py
+++ b/tools/linter.py
@@ -24,7 +24,7 @@ class DiffLinter:
         self.repo = Repo('.')
         self.head = self.repo.head.commit
 
-    def get_branch_diff(self, uncommitted = False):
+    def get_branch_diff(self, uncommitted = False, files="*"):
         """
             Determine the first common ancestor commit.
             Find diff between branch and FCA commit.
@@ -40,11 +40,11 @@ class DiffLinter:
         exclude = [f':(exclude){i}' for i in EXCLUDE]
         if uncommitted:
             diff = self.repo.git.diff(
-                self.head, '--unified=0', '***.py', *exclude
+                self.head, '--unified=0', files, *exclude
             )
         else:
             diff = self.repo.git.diff(
-                commit, self.head, '--unified=0', '***.py', *exclude
+                commit, self.head, '--unified=0', files, *exclude
             )
         return diff
 
@@ -79,7 +79,7 @@ class DiffLinter:
         return res.returncode, res.stdout
 
     def run_lint(self, uncommitted):
-        diff = self.get_branch_diff(uncommitted)
+        diff = self.get_branch_diff(uncommitted, "***.py")
         retcode, errors = self.run_pycodestyle(diff)
 
         errors and print(errors)


### PR DESCRIPTION
### Codespell CI
1. Added a new argument to linter.py to run codespell
2. Added the new tool to pipelines

### Usage
```sh
# We have misspelled processor with processer:
$ python3 tools/linter.py --codespell --uncommitted
7: +take advantage of specialized processer functionality are preferred. Examples
        processer ==> processor
10: +are multithreaded and processer dependent, environmental variables and external
        processer ==> processor
13: +or specify the processer architecture.
        processer ==> processor

-------8<-------
SUMMARY:
processer     3
```
### TODO

- [ ] Add runtest.py flags
- [ ] Add usage docs

### Note:
Adding a tmp commit 92a982688 to test the CI

resolves: #13694 
cc: @luzpaz 