### PR TITLE
PERF: Speed-up common case of loadtxt()ing non-hex floats.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -733,10 +733,15 @@ def _getconv(dtype):
     """ Find the correct dtype converter. Adapted from matplotlib """
 
     def floatconv(x):
-        x.lower()
-        if '0x' in x:
-            return float.fromhex(x)
-        return float(x)
+        try:
+            return float(x)  # The fastest path.
+        except ValueError:
+            if '0x' in x:  # Don't accidentally convert "a" ("0xa") to 10.
+                try:
+                    return float.fromhex(x)
+                except ValueError:
+                    pass
+            raise  # Raise the original exception, which makes more sense.
 
     typ = dtype.type
     if issubclass(typ, np.bool_):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -984,6 +984,28 @@ class TestLoadTxt(LoadTxtBase):
             res = np.loadtxt(c, dtype=dt)
             assert_equal(res, tgt, err_msg="%s" % dt)
 
+    def test_default_float_converter_no_default_hex_conversion(self):
+        """
+        Ensure that fromhex is only used for values with the correct prefix and
+        is not called by default. Regression test related to gh-19598.
+        """
+        c = TextIO("a b c")
+        with pytest.raises(
+            ValueError, match="could not convert string to float"
+        ):
+            np.loadtxt(c)
+
+    def test_default_float_converter_exception(self):
+        """
+        Ensure that the exception message raised during failed floating point
+        conversion is correct. Regression test related to gh-19598.
+        """
+        c = TextIO("qrs tuv")  # Invalid values for default float converter
+        with pytest.raises(
+            ValueError, match="could not convert string to float"
+        ):
+            np.loadtxt(c)
+
     def test_from_complex(self):
         tgt = (complex(1, 1), complex(1, -1))
         c = TextIO()


### PR DESCRIPTION
`python runtests.py --bench bench_io` reports a ~5-10% perf gain.
(It's not huge, but it's a very low-hanging fruit.)

See also https://github.com/numpy/numpy/issues/19541.

Example benchmark runs:

Before:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                                                ok
[ 78.95%] ··· =========== ============
               num_lines              
              ----------- ------------
                   10      51.7±0.1μs 
                  100       336±3μs   
                 10000     31.7±0.8ms 
                 100000     329±2ms   
              =========== ============

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                                               ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20       92.0±0.4μs 
                  200        677±3μs   
                  2000     6.44±0.03ms 
                 20000      65.5±0.2ms 
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                                       ok
[ 84.21%] ··· ========== =========
               skiprows           
              ---------- ---------
                  0       402±3ms 
                 500      403±3ms 
                10000     362±1ms 
              ========== =========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                                  255±0.4ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                                                   ok
[ 89.47%] ··· ============ ============ =========== ============= ===========
              --                               num_lines                     
              ------------ --------------------------------------------------
                 dtype          10          100         10000        100000  
              ============ ============ =========== ============= ===========
                float32     53.1±0.7μs    334±2μs     31.0±0.1ms    327±4ms  
                float64     52.9±0.4μs    337±2μs     31.3±0.2ms    324±1ms  
                 int32      53.5±0.8μs    328±1μs     30.6±0.3ms    315±2ms  
                 int64      54.6±0.3μs    360±1μs    33.6±0.08ms    351±1ms  
               complex128   57.4±0.3μs    380±1μs     35.1±0.1ms    365±1ms  
                  str       55.4±0.4μs    347±1μs     32.2±0.1ms    330±2ms  
                 object     51.0±0.3μs   318±0.9μs    29.7±0.1ms   308±0.6ms 
              ============ ============ =========== ============= ===========
```

After:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                                                ok
[ 78.95%] ··· =========== ============
               num_lines              
              ----------- ------------
                   10      50.6±0.3μs 
                  100       314±3μs   
                 10000     29.6±0.1ms 
                 100000     310±2ms   
              =========== ============

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                                               ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20       90.1±0.4μs 
                  200        662±4μs   
                  2000     6.37±0.06ms 
                 20000      63.9±0.9ms 
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                                       ok
[ 84.21%] ··· ========== =========
               skiprows           
              ---------- ---------
                  0       376±4ms 
                 500      375±6ms 
                10000     335±6ms 
              ========== =========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                                  250±0.6ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                                                   ok
[ 89.47%] ··· ============ ============ ========= ============= ===========
              --                              num_lines                    
              ------------ ------------------------------------------------
                 dtype          10         100        10000        100000  
              ============ ============ ========= ============= ===========
                float32     50.0±0.1μs   309±1μs     29.3±2ms     305±9ms  
                float64     50.6±0.4μs   315±5μs   28.9±0.07ms   302±0.9ms 
                 int32      51.3±0.4μs   319±2μs   29.9±0.05ms   308±0.5ms 
                 int64      53.9±0.3μs   350±1μs   32.8±0.09ms    341±1ms  
               complex128   56.9±0.3μs   370±3μs    35.0±0.2ms    359±1ms  
                  str       54.7±0.5μs   339±1μs    31.9±0.2ms    326±1ms  
                 object     50.5±0.2μs   326±2μs    30.5±0.7ms    305±2ms  
              ============ ============ ========= ============= ===========
```