### PR TITLE
PERF: Avoid using `@recursive`.

### DIFF
--- a/numpy/core/_internal.py
+++ b/numpy/core/_internal.py
@@ -876,34 +876,3 @@ def npy_ctypes_check(cls):
         return '_ctypes' in ctype_base.__module__
     except Exception:
         return False
-
-
-class recursive:
-    '''
-    A decorator class for recursive nested functions.
-    Naive recursive nested functions hold a reference to themselves:
-
-    def outer(*args):
-        def stringify_leaky(arg0, *arg1):
-            if len(arg1) > 0:
-                return stringify_leaky(*arg1)  # <- HERE
-            return str(arg0)
-        stringify_leaky(*args)
-
-    This design pattern creates a reference cycle that is difficult for a
-    garbage collector to resolve. The decorator class prevents the
-    cycle by passing the nested function in as an argument `self`:
-
-    def outer(*args):
-        @recursive
-        def stringify(self, arg0, *arg1):
-            if len(arg1) > 0:
-                return self(*arg1)
-            return str(arg0)
-        stringify(*args)
-
-    '''
-    def __init__(self, func):
-        self.func = func
-    def __call__(self, *args, **kwargs):
-        return self.func(self, *args, **kwargs)


### PR DESCRIPTION
None of the functions decorated with `@recursive` actually need to close
over internal variables, so they can be lifted to become toplevel
recursive functions which avoid the need for an `@recursive` decorator.
(No change was made to the logic of any of the functions.)

As it turns out, the `@recursive` decorator adds a lot of overhead:
`python runtests.py --bench bench_io` reports a ~15-20% perf gain(!)
for `loadtxt` from this PR.  (`_recursive_mask_or` seems less likely to
matter performance-wise, but I also lifted it out for good measure...)

Before:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                                                ok
[ 78.95%] ··· =========== ============
               num_lines              
              ----------- ------------
                   10      51.7±0.1μs 
                  100       336±3μs   
                 10000     31.7±0.8ms 
                 100000     329±2ms   
              =========== ============

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                                               ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20       92.0±0.4μs 
                  200        677±3μs   
                  2000     6.44±0.03ms 
                 20000      65.5±0.2ms 
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                                       ok
[ 84.21%] ··· ========== =========
               skiprows           
              ---------- ---------
                  0       402±3ms 
                 500      403±3ms 
                10000     362±1ms 
              ========== =========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                                  255±0.4ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                                                   ok
[ 89.47%] ··· ============ ============ =========== ============= ===========
              --                               num_lines                     
              ------------ --------------------------------------------------
                 dtype          10          100         10000        100000  
              ============ ============ =========== ============= ===========
                float32     53.1±0.7μs    334±2μs     31.0±0.1ms    327±4ms  
                float64     52.9±0.4μs    337±2μs     31.3±0.2ms    324±1ms  
                 int32      53.5±0.8μs    328±1μs     30.6±0.3ms    315±2ms  
                 int64      54.6±0.3μs    360±1μs    33.6±0.08ms    351±1ms  
               complex128   57.4±0.3μs    380±1μs     35.1±0.1ms    365±1ms  
                  str       55.4±0.4μs    347±1μs     32.2±0.1ms    330±2ms  
                 object     51.0±0.3μs   318±0.9μs    29.7±0.1ms   308±0.6ms 
              ============ ============ =========== ============= ===========

[ 92.11%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64                                                 ok
[ 92.11%] ··· ======= =============
                size               
              ------- -------------
                550      968±6μs   
                1000   1.74±0.02ms 
               10000    17.0±0.2ms 
              ======= =============

[ 94.74%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values                                      ok
[ 94.74%] ··· ======= =============
                size               
              ------- -------------
                550      971±10μs  
                1000   1.73±0.01ms 
               10000    17.2±0.3ms 
              ======= =============

[ 97.37%] ··· bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv                                                 ok
[ 97.37%] ··· ============== =============
                 usecols                  
              -------------- -------------
                    2         9.20±0.03ms 
                  [1, 3]      15.9±0.06ms 
               [1, 3, 5, 7]    18.6±0.2ms 
              ============== =============
```
After:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                                                ok
[ 78.95%] ··· =========== ============
               num_lines              
              ----------- ------------
                   10      45.5±0.2μs 
                  100       281±3μs   
                 10000     26.6±0.2ms 
                 100000    275±0.7ms  
              =========== ============

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                                               ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20       75.1±0.3μs 
                  200        524±5μs   
                  2000     4.97±0.05ms 
                 20000      50.5±0.4ms 
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                                       ok
[ 84.21%] ··· ========== ===========
               skiprows             
              ---------- -----------
                  0       350±0.6ms 
                 500      349±0.7ms 
                10000      316±1ms  
              ========== ===========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                                    183±1ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                                                   ok
[ 89.47%] ··· ============ ============= =========== ============ ===========
              --                               num_lines                     
              ------------ --------------------------------------------------
                 dtype           10          100        10000        100000  
              ============ ============= =========== ============ ===========
                float32      45.7±0.3μs   278±0.7μs   26.5±0.2ms    275±2ms  
                float64      45.9±0.3μs    285±5μs    26.4±0.2ms    275±1ms  
                 int32      44.6±0.09μs    273±3μs    25.7±0.1ms    267±1ms  
                 int64       48.3±0.7μs    302±2μs    28.7±0.2ms    296±1ms  
               complex128     49.7±2μs     321±1μs    30.5±0.1ms   313±0.8ms 
                  str        46.9±0.1μs    289±2μs    27.5±0.1ms    288±8ms  
                 object      45.5±0.7μs    270±1μs    24.8±0.1ms    264±5ms  
              ============ ============= =========== ============ ===========

[ 92.11%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64                                                 ok
[ 92.11%] ··· ======= =============
                size               
              ------- -------------
                550      807±4μs   
                1000     1.44±0ms  
               10000   14.2±0.06ms 
              ======= =============

[ 94.74%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values                                      ok
[ 94.74%] ··· ======= =============
                size               
              ------- -------------
                550      799±3μs   
                1000   1.45±0.01ms 
               10000   14.3±0.05ms 
              ======= =============

[ 97.37%] ··· bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv                                                 ok
[ 97.37%] ··· ============== =============
                 usecols                  
              -------------- -------------
                    2         7.87±0.02ms 
                  [1, 3]       13.8±0.3ms 
               [1, 3, 5, 7]   15.9±0.07ms 
              ============== =============
```