### PR TITLE
PERF: Speedup comments handling in loadtxt.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -966,9 +966,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     def split_line(line):
         """Chop off comments, strip, and split at delimiter. """
         line = _decode_line(line, encoding=encoding)
-
-        if comments is not None:
-            line = regex_comments.split(line, maxsplit=1)[0]
+        for comment in comments:  # Much faster than using a single regex.
+            line = line.split(comment, 1)[0]
         line = line.strip('\r\n')
         return line.split(delimiter) if line else []
 
@@ -1023,9 +1022,8 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         if isinstance(comments, (str, bytes)):
             comments = [comments]
         comments = [_decode_line(x) for x in comments]
-        # Compile regex for comments beforehand
-        comments = (re.escape(comment) for comment in comments)
-        regex_comments = re.compile('|'.join(comments))
+    else:
+        comments = []
 
     if delimiter is not None:
         delimiter = _decode_line(delimiter)


### PR DESCRIPTION
Regexes are quite slow; using str.split instead improves performance
(likely, regexes could be better for somewhat artificial cases where
there's a lot of different comment strings).

`python runtests.py --bench bench_io` reports a ~5% perf gain.

Before:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                            ok
[ 78.95%] ··· =========== ==========
               num_lines            
              ----------- ----------
                   10      80.9±3μs 
                  100      572±20μs 
                 10000     56.0±2ms 
                 100000    586±20ms 
              =========== ==========

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                           ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20        150±3μs   
                  200      1.18±0.05ms 
                  2000      11.5±0.2ms 
                 20000       116±3ms   
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                   ok
[ 84.21%] ··· ========== ==========
               skiprows            
              ---------- ----------
                  0       728±20ms 
                 500      719±7ms  
                10000     660±6ms  
              ========== ==========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                464±4ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                               ok
[ 89.47%] ··· ============ ========== =========== ============ =========
              --                             num_lines                  
              ------------ ---------------------------------------------
                 dtype         10         100        10000       100000 
              ============ ========== =========== ============ =========
                float32     84.3±2μs    613±30μs   57.7±0.8ms   590±3ms 
                float64     83.0±1μs    586±20μs   57.4±0.8ms   590±5ms 
                 int32      80.8±2μs    579±20μs    56.6±1ms    591±5ms 
                 int64      86.4±4μs   770±300μs   60.2±0.7ms   617±2ms 
               complex128   96.6±3μs    661±20μs   65.5±0.7ms   671±6ms 
                  str       89.7±4μs    628±10μs   60.6±0.4ms   599±3ms 
                 object     81.3±3μs    555±10μs   55.3±0.6ms   570±5ms 
              ============ ========== =========== ============ =========

[ 92.11%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64                             ok
[ 92.11%] ··· ======= =============
                size               
              ------- -------------
                550    1.73±0.03ms 
                1000   3.11±0.06ms 
               10000    31.2±0.6ms 
              ======= =============

[ 94.74%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values                  ok
[ 94.74%] ··· ======= =============
                size               
              ------- -------------
                550    1.68±0.03ms 
                1000   3.09±0.04ms 
               10000    31.2±0.6ms 
              ======= =============

[ 97.37%] ··· bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv                             ok
[ 97.37%] ··· ============== ============
                 usecols                 
              -------------- ------------
                    2         17.1±0.4ms 
                  [1, 3]      29.6±0.3ms 
               [1, 3, 5, 7]   34.4±0.6ms 
              ============== ============
```
After:
```
[ 78.95%] ··· bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv                            ok
[ 78.95%] ··· =========== ==========
               num_lines            
              ----------- ----------
                   10      70.8±6μs 
                  100      513±30μs 
                 10000     56.1±2ms 
                 100000    555±30ms 
              =========== ==========

[ 81.58%] ··· bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime                           ok
[ 81.58%] ··· =========== =============
               num_lines               
              ----------- -------------
                   20        128±5μs   
                  200      1.04±0.03ms 
                  2000      10.9±0.8ms 
                 20000       107±6ms   
              =========== =============

[ 84.21%] ··· bench_io.LoadtxtCSVSkipRows.time_skiprows_csv                                   ok
[ 84.21%] ··· ========== ==========
               skiprows            
              ---------- ----------
                  0       697±30ms 
                 500      676±30ms 
                10000     615±20ms 
              ========== ==========

[ 86.84%] ··· bench_io.LoadtxtCSVStructured.time_loadtxt_csv_struct_dtype                444±9ms
[ 89.47%] ··· bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv                               ok
[ 89.47%] ··· ============ ============ ========== ============ ==========
              --                              num_lines                   
              ------------ -----------------------------------------------
                 dtype          10         100        10000       100000  
              ============ ============ ========== ============ ==========
                float32      73.4±2μs    540±10μs    53.5±1ms    564±10ms 
                float64     74.8±0.7μs   544±8μs    54.0±0.4ms   566±4ms  
                 int32      75.1±0.5μs   534±8μs    53.4±0.7ms   548±10ms 
                 int64       84.9±4μs    606±30μs   67.3±20ms    613±80ms 
               complex128    92.2±7μs    658±50μs    69.0±7ms    675±50ms 
                  str        79.9±9μs    554±6μs     60.5±4ms    592±30ms 
                 object      78.1±4μs    546±60μs    56.7±4ms    549±50ms 
              ============ ============ ========== ============ ==========

[ 92.11%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64                             ok
[ 92.11%] ··· ======= =============
                size               
              ------- -------------
                550    1.71±0.09ms 
                1000    3.17±0.9ms 
               10000     28.7±2ms  
              ======= =============

[ 94.74%] ··· bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values                  ok
[ 94.74%] ··· ======= ============
                size              
              ------- ------------
                550    1.75±0.2ms 
                1000   3.36±0.4ms 
               10000    31.7±6ms  
              ======= ============

[ 97.37%] ··· bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv                             ok
[ 97.37%] ··· ============== ============
                 usecols                 
              -------------- ------------
                    2         15.9±0.4ms 
                  [1, 3]       29.3±1ms  
               [1, 3, 5, 7]    33.7±1ms  
              ============== ============
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
