### PR TITLE
DEV: Update default Python in benchmark config.

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -35,7 +35,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.7"],
+    // "pythons": ["3.9"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/benchmarks/asv_compare.conf.json.tpl
+++ b/benchmarks/asv_compare.conf.json.tpl
@@ -39,7 +39,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.7"],
+    // "pythons": ["3.9"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty


### PR DESCRIPTION
Update `asv` configuration files to use whichever version of Python invoked the benchmarks.  This affects users who use e.g. `python runtests.py --bench` or `python runtests.py --bench-compare` to run the benchmark suite. Currently, `asv` is configured to run w/ Python 3.7.

Commenting these lines out yields a more sensible and future-proof default, while still documenting for users how to configure the benchmarks to run with specific (or multiple) Python versions.