### PR TITLE
BUG: Fix NaT handling in the PyArray_CompareFunc for datetime and timedelta

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2932,7 +2932,6 @@ static int
     const @type@ b = *pb;
     int ret;
 
-    printf("Calling @TYPE@_compare\n");
     if (a == NPY_DATETIME_NAT) {
         ret = 1;
     }

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2805,11 +2805,9 @@ BOOL_compare(npy_bool *ip1, npy_bool *ip2, PyArrayObject *NPY_UNUSED(ap))
 
 /**begin repeat
  * #TYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
- *         LONG, ULONG, LONGLONG, ULONGLONG,
- *         DATETIME, TIMEDELTA#
+ *         LONG, ULONG, LONGLONG, ULONGLONG#
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_datetime, npy_timedelta#
+ *         npy_long, npy_ulong, npy_longlong, npy_ulonglong#
  */
 
 static int
@@ -2913,6 +2911,43 @@ C@TYPE@_compare(@type@ *pa, @type@ *pb)
         ret = 1;
     }
 
+    return ret;
+}
+
+#undef LT
+
+/**end repeat**/
+
+/**begin repeat
+ * #TYPE = DATETIME, TIMEDELTA#
+ * #type = npy_datetime, npy_timedelta#
+ */
+
+#define LT(a,b) ((a) < (b) || ((b) != (b) && (a) ==(a)))
+
+static int
+@TYPE@_compare(@type@ *pa, @type@ *pb)
+{
+    const @type@ a = *pa;
+    const @type@ b = *pb;
+    int ret;
+
+    printf("Calling @TYPE@_compare\n");
+    if (a == NPY_DATETIME_NAT) {
+        ret = 1;
+    }
+    else if (b == NPY_DATETIME_NAT) {
+        ret = -1;
+    }
+    else if (LT(a,b)) {
+        ret = -1;
+    }
+    else if (LT(b,a)) {
+        ret = 1;
+    }
+    else {
+        ret = 0;
+    }
     return ret;
 }
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2923,8 +2923,6 @@ C@TYPE@_compare(@type@ *pa, @type@ *pb)
  * #type = npy_datetime, npy_timedelta#
  */
 
-#define LT(a,b) ((a) < (b) || ((b) != (b) && (a) ==(a)))
-
 static int
 @TYPE@_compare(@type@ *pa, @type@ *pb)
 {
@@ -2933,24 +2931,21 @@ static int
     int ret;
 
     if (a == NPY_DATETIME_NAT) {
-        ret = 1;
+        if (b == NPY_DATETIME_NAT) {
+            ret = 0;
+        }
+        else {
+            ret = 1;
+        }
     }
     else if (b == NPY_DATETIME_NAT) {
         ret = -1;
     }
-    else if (LT(a,b)) {
-        ret = -1;
-    }
-    else if (LT(b,a)) {
-        ret = 1;
-    }
     else {
-        ret = 0;
+        ret = a < b ? -1 : a == b ? 0 : 1;
     }
     return ret;
 }
-
-#undef LT
 
 /**end repeat**/
 


### PR DESCRIPTION
In #12658 and #15068 the sort ordering for datetime and timedelta was changed
so that NaT sorts to the end, but the internal compare array function was not
updated.

Fixes #19574.

If a test should be added for this, please let me know where. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
