### PR TITLE
TST: Bump the python 3.10 test version from beta4 to rc1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9, 3.10.0-beta.4]
+        python-version: [3.7, 3.9, 3.10.0-rc.1]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/numpy/core/numerictypes.pyi
+++ b/numpy/core/numerictypes.pyi
@@ -86,8 +86,8 @@ class _typedict(Dict[Type[generic], _T]):
 if sys.version_info >= (3, 10):
     _TypeTuple = Union[
         Type[Any],
-        types.Union,
-        Tuple[Union[Type[Any], types.Union, Tuple[Any, ...]], ...],
+        types.UnionType,
+        Tuple[Union[Type[Any], types.UnionType, Tuple[Any, ...]], ...],
     ]
 else:
     _TypeTuple = Union[

--- a/numpy/core/tests/test_umath_complex.py
+++ b/numpy/core/tests/test_umath_complex.py
@@ -372,11 +372,18 @@ class TestCpow:
         x = np.array([1, 1j,         2,  2.5+.37j, np.inf, np.nan])
         y = np.array([1, 1j, -0.5+1.5j, -0.5+1.5j,      2,      3])
         lx = list(range(len(x)))
-        # Compute the values for complex type in python
-        p_r = [complex(x[i]) ** complex(y[i]) for i in lx]
-        # Substitute a result allowed by C99 standard
-        p_r[4] = complex(np.inf, np.nan)
-        # Do the same with numpy complex scalars
+
+        # Hardcode the expected `builtins.complex` values,
+        # as complex exponentiation is broken as of bpo-44698
+        p_r = [
+            1+0j,
+            0.20787957635076193+0j,
+            0.35812203996480685+0.6097119028618724j,
+            0.12659112128185032+0.48847676699581527j,
+            complex(np.inf, np.nan),
+            complex(np.nan, np.nan),
+        ]
+
         n_r = [x[i] ** y[i] for i in lx]
         for i in lx:
             assert_almost_equal(n_r[i], p_r[i], err_msg='Loop %d\n' % i)
@@ -385,11 +392,18 @@ class TestCpow:
         x = np.array([1, 1j,         2,  2.5+.37j, np.inf, np.nan])
         y = np.array([1, 1j, -0.5+1.5j, -0.5+1.5j,      2,      3])
         lx = list(range(len(x)))
-        # Compute the values for complex type in python
-        p_r = [complex(x[i]) ** complex(y[i]) for i in lx]
-        # Substitute a result allowed by C99 standard
-        p_r[4] = complex(np.inf, np.nan)
-        # Do the same with numpy arrays
+
+        # Hardcode the expected `builtins.complex` values,
+        # as complex exponentiation is broken as of bpo-44698
+        p_r = [
+            1+0j,
+            0.20787957635076193+0j,
+            0.35812203996480685+0.6097119028618724j,
+            0.12659112128185032+0.48847676699581527j,
+            complex(np.inf, np.nan),
+            complex(np.nan, np.nan),
+        ]
+
         n_r = x ** y
         for i in lx:
             assert_almost_equal(n_r[i], p_r[i], err_msg='Loop %d\n' % i)
@@ -583,7 +597,7 @@ class TestComplexAbsoluteMixedDTypes:
     @pytest.mark.parametrize("stride", [-4,-3,-2,-1,1,2,3,4])
     @pytest.mark.parametrize("astype", [np.complex64, np.complex128])
     @pytest.mark.parametrize("func", ['abs', 'square', 'conjugate'])
-    
+
     def test_array(self, stride, astype, func):
         dtype = [('template_id', '<i8'), ('bank_chisq','<f4'),
                  ('bank_chisq_dof','<i8'), ('chisq', '<f4'), ('chisq_dof','<i8'),
@@ -602,9 +616,9 @@ class TestComplexAbsoluteMixedDTypes:
         myfunc = getattr(np, func)
         a = vec['mycomplex']
         g = myfunc(a[::stride])
-        
+
         b = vec['mycomplex'].copy()
         h = myfunc(b[::stride])
-        
+
         assert_array_max_ulp(h.real, g.real, 1)
         assert_array_max_ulp(h.imag, g.imag, 1)

--- a/numpy/lib/tests/test_utils.py
+++ b/numpy/lib/tests/test_utils.py
@@ -11,6 +11,10 @@ from io import StringIO
 
 
 @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")
+@pytest.mark.skipif(
+    sys.version_info == (3, 10, 0, "candidate", 1),
+    reason="Broken as of bpo-44524",
+)
 def test_lookfor():
     out = StringIO()
     utils.lookfor('eigenvalue', module='numpy', output=out,
@@ -160,7 +164,7 @@ def test_info_method_heading():
     class WithPublicMethods:
         def first_method():
             pass
-            
+
     def _has_method_heading(cls):
         out = StringIO()
         utils.info(cls, output=out)


### PR DESCRIPTION
Use the new python 3.10rc1 release for testing.