### PR TITLE
MAINT: Optimize loadtxt usecols.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1023,7 +1023,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             usecols_getter = itemgetter(*usecols)
         else:
             # Get an iterable back, even if using a single column.
-            def usecols_getter(words, _col=usecols[0]): return [words[_col]]
+            usecols_getter = lambda obj, c=usecols[0]: [obj[c]]
     else:
         usecols_getter = None
 


### PR DESCRIPTION
7-10% speedup in usecols benchmarks; it appears that even in the
single-usecol case, avoiding the iteration over `usecols` more than
compensates the cost of the extra function call to usecols_getter.

```
       before           after         ratio
     [cc7f1504]       [649b0461]
     <main>           <loadtxtusecols>
-     6.96±0.03ms      6.46±0.03ms     0.93  bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv(2)
-      11.5±0.1ms      10.4±0.04ms     0.90  bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv([1, 3, 5, 7])
-      9.39±0.1ms      8.47±0.05ms     0.90  bench_io.LoadtxtUseColsCSV.time_loadtxt_usecols_csv([1, 3])
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
