### PR TITLE
PERF: Simplify some of loadtxt's standard converters.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -740,16 +740,16 @@ def _floatconv(x):
         raise  # Raise the original exception, which makes more sense.
 
 
-_CONVERTERS = [
+_CONVERTERS = [  # These converters only ever get strs (not bytes) as input.
     (np.bool_, lambda x: bool(int(x))),
     (np.uint64, np.uint64),
     (np.int64, np.int64),
     (np.integer, lambda x: int(float(x))),
     (np.longdouble, np.longdouble),
     (np.floating, _floatconv),
-    (complex, lambda x: complex(asstr(x).replace('+-', '-'))),
-    (np.bytes_, asbytes),
-    (np.unicode_, asunicode),
+    (complex, lambda x: complex(x.replace('+-', '-'))),
+    (np.bytes_, methodcaller('encode', 'latin-1')),
+    (np.unicode_, str),
 ]
 
 
@@ -763,7 +763,7 @@ def _getconv(dtype):
     for base, conv in _CONVERTERS:
         if issubclass(dtype.type, base):
             return conv
-    return asstr
+    return str
 
 
 # _loadtxt_flatten_dtype_internal and _loadtxt_pack_items are loadtxt helpers


### PR DESCRIPTION
Standard converters only ever get called with str inputs (loadtxt
performs the required decoding); saving a bunch of runtime typechecks
(in `asstr`) results in a 15-20% speedup when loadtxt()ing the
corresponding types.

```
       before           after         ratio
     [cc7f1504]       [3fd5664b]
     <main>           <_psuhme/loadtxtconvs>
-         753±4μs          716±5μs     0.95  bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime(200)
-     7.24±0.08ms      6.88±0.03ms     0.95  bench_io.LoadtxtCSVDateTime.time_loadtxt_csv_datetime(2000)
-      50.7±0.5μs       44.7±0.4μs     0.88  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('str', 10)
-        47.5±3μs       40.7±0.6μs     0.86  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('object', 10)
-      57.6±0.8μs       47.5±0.4μs     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 10)
-        34.2±3ms       28.1±0.4ms     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('str', 10000)
-        29.8±2ms       24.4±0.3ms     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('object', 10000)
-         382±3μs          313±4μs     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 100)
-        315±20μs          256±3μs     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('object', 100)
-       313±100ms          254±4ms     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('object', 100000)
-        368±40μs          292±2μs     0.79  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('str', 100)
-        381±20ms        301±0.9ms     0.79  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 100000)
-        37.6±1ms      29.1±0.04ms     0.78  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 10000)
```