### PR TITLE
MAINT: Skip a type check in loadtxt when using user converters.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1142,13 +1142,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                     continue
             if byte_converters:
                 # converters may use decode to workaround numpy's old
-                # behaviour, so encode the string again before passing to
-                # the user converter
-                def tobytes_first(x, conv):
-                    if type(x) is bytes:
-                        return conv(x)
+                # behaviour, so encode the string again (converters are only
+                # called with strings) before passing to the user converter.
+                def tobytes_first(conv, x):
                     return conv(x.encode("latin1"))
-                converters[i] = functools.partial(tobytes_first, conv=conv)
+                converters[i] = functools.partial(tobytes_first, conv)
             else:
                 converters[i] = conv
 


### PR DESCRIPTION
loadtxt only ever calls converters with strs now, so the type check is
unneeded.  Skipping the type check may have a tiny performance benefit,
but the main point is just code clarity.

(See also #19609.)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
