### PR TITLE
BUG: Ignore whitespaces while parsing gufunc signatures

### DIFF
--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -388,6 +388,24 @@ class TestUfunc:
         assert_equal(ixs, (0, 0, 0, 1, 2))
         assert_equal(flags, (self.can_ignore, self.size_inferred, 0))
         assert_equal(sizes, (3, -1, 9))
+    
+    def test_signature9(self):
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            1, 1, "(  3)  -> ( )")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 0))
+        assert_equal(ixs, (0,))
+        assert_equal(flags, (0,))
+        assert_equal(sizes, (3,))
+
+    def test_signature10(self):
+        enabled, num_dims, ixs, flags, sizes = umt.test_signature(
+            3, 1, "( 3? ) , (3? ,  3?) ,(n )-> ( 9)")
+        assert_equal(enabled, 1)
+        assert_equal(num_dims, (1, 2, 1, 1))
+        assert_equal(ixs, (0, 0, 0, 1, 2))
+        assert_equal(flags, (self.can_ignore, self.size_inferred, 0))
+        assert_equal(sizes, (3, -1, 9))
 
     def test_signature_failure_extra_parenthesis(self):
         with assert_raises(ValueError):

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1869,7 +1869,8 @@ def _parse_gufunc_signature(signature):
     if not re.match(_SIGNATURE, signature):
         raise ValueError(
             'not a valid gufunc signature: {}'.format(signature))
-    return tuple([tuple([dim.strip() for dim in re.findall(_DIMENSION_NAME, arg)])
+    return tuple([tuple([dim.strip() 
+                    for dim in re.findall(_DIMENSION_NAME, arg)])
                   for arg in re.findall(_ARGUMENT, arg_list)]
                  for arg_list in signature.split('->'))
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1844,9 +1844,9 @@ def disp(mesg, device=None, linefeed=True):
 
 
 # See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
-_DIMENSION_NAME = r'\w+'
+_DIMENSION_NAME = r'\s*\w+\s*'
 _CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
-_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
+_ARGUMENT = r'\s*\({}\s*\)\s*'.format(_CORE_DIMENSION_LIST)
 _ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
 _SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
 
@@ -1869,7 +1869,7 @@ def _parse_gufunc_signature(signature):
     if not re.match(_SIGNATURE, signature):
         raise ValueError(
             'not a valid gufunc signature: {}'.format(signature))
-    return tuple([tuple(re.findall(_DIMENSION_NAME, arg))
+    return tuple([tuple([dim.strip() for dim in re.findall(_DIMENSION_NAME, arg)])
                   for arg in re.findall(_ARGUMENT, arg_list)]
                  for arg_list in signature.split('->'))
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -1844,9 +1844,9 @@ def disp(mesg, device=None, linefeed=True):
 
 
 # See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
-_DIMENSION_NAME = r'\s*\w+\s*'
+_DIMENSION_NAME = r'\w+'
 _CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
-_ARGUMENT = r'\s*\({}\s*\)\s*'.format(_CORE_DIMENSION_LIST)
+_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
 _ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
 _SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
 
@@ -1866,11 +1866,12 @@ def _parse_gufunc_signature(signature):
     Tuple of input and output core dimensions parsed from the signature, each
     of the form List[Tuple[str, ...]].
     """
+    signature = re.sub(r'\s+', '', signature)
+
     if not re.match(_SIGNATURE, signature):
         raise ValueError(
             'not a valid gufunc signature: {}'.format(signature))
-    return tuple([tuple([dim.strip() 
-                    for dim in re.findall(_DIMENSION_NAME, arg)])
+    return tuple([tuple(re.findall(_DIMENSION_NAME, arg))
                   for arg in re.findall(_ARGUMENT, arg_list)]
                  for arg_list in signature.split('->'))
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1528,6 +1528,20 @@ class TestVectorize:
                      ([('x',)], [('y',), ()]))
         assert_equal(nfb._parse_gufunc_signature('(),(a,b,c),(d)->(d,e)'),
                      ([(), ('a', 'b', 'c'), ('d',)], [('d', 'e')]))
+        
+        # Test if whitespaces are ignored
+        assert_equal(nfb._parse_gufunc_signature('(x )->()'), ([('x',)], [()]))
+        assert_equal(nfb._parse_gufunc_signature('( x , y )->(  )'),
+                     ([('x', 'y')], [()]))
+        assert_equal(nfb._parse_gufunc_signature('(x),( y) ->()'),
+                     ([('x',), ('y',)], [()]))
+        assert_equal(nfb._parse_gufunc_signature('(  x)-> (y )  '),
+                     ([('x',)], [('y',)]))
+        assert_equal(nfb._parse_gufunc_signature(' (x)->( y),( )'),
+                     ([('x',)], [('y',), ()]))
+        assert_equal(nfb._parse_gufunc_signature('(  ), ( a,  b,c )  ,(  d)   ->   (d  ,  e)'),
+                     ([(), ('a', 'b', 'c'), ('d',)], [('d', 'e')]))
+
         with assert_raises(ValueError):
             nfb._parse_gufunc_signature('(x)(y)->()')
         with assert_raises(ValueError):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1529,7 +1529,7 @@ class TestVectorize:
         assert_equal(nfb._parse_gufunc_signature('(),(a,b,c),(d)->(d,e)'),
                      ([(), ('a', 'b', 'c'), ('d',)], [('d', 'e')]))
         
-        # Test if whitespaces are ignored
+        # Tests to check if whitespaces are ignored
         assert_equal(nfb._parse_gufunc_signature('(x )->()'), ([('x',)], [()]))
         assert_equal(nfb._parse_gufunc_signature('( x , y )->(  )'),
                      ([('x', 'y')], [()]))

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1539,7 +1539,8 @@ class TestVectorize:
                      ([('x',)], [('y',)]))
         assert_equal(nfb._parse_gufunc_signature(' (x)->( y),( )'),
                      ([('x',)], [('y',), ()]))
-        assert_equal(nfb._parse_gufunc_signature('(  ), ( a,  b,c )  ,(  d)   ->   (d  ,  e)'),
+        assert_equal(nfb._parse_gufunc_signature(
+                     '(  ), ( a,  b,c )  ,(  d)   ->   (d  ,  e)'),
                      ([(), ('a', 'b', 'c'), ('d',)], [('d', 'e')]))
 
         with assert_raises(ValueError):


### PR DESCRIPTION
Resolves #19597 

Based on the [description of gufunc signatures](https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html?#details-of-signature), whitespaces in the signature should be ignored, which is not the current behavior for the `signature` argument to `np.vectorize`. This pull request attempts to address that.

