### PR TITLE
TST: avoid distutils.sysconfig in runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -475,8 +475,13 @@ def build_project(args):
             '--record=' + dst_dir + 'tmp_install_log.txt']
 
     from distutils.sysconfig import get_python_lib
-    site_dir = get_python_lib(prefix=dst_dir, plat_specific=True)
-    site_dir_noarch = get_python_lib(prefix=dst_dir, plat_specific=False)
+    py_v_s = sysconfig.get_config_var('py_version_short')
+    site_dir_template = sysconfig.get_path('platlib', expand=False)
+    site_dir = site_dir_template.format(platbase=dst_dir, py_version_short=py_v_s)
+    site_dir_noarch_template = sysconfig.get_path('purelib', expand=False)
+    site_dir_noarch = site_dir_noarch_template.format(base=dst_dir,
+                                                      py_version_short=py_v_s)
+
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH.  Plus, it has to exist.
     if not os.path.exists(site_dir):

--- a/runtests.py
+++ b/runtests.py
@@ -474,20 +474,18 @@ def build_project(args):
             '--single-version-externally-managed',
             '--record=' + dst_dir + 'tmp_install_log.txt']
 
-    from distutils.sysconfig import get_python_lib
     py_v_s = sysconfig.get_config_var('py_version_short')
+    platlibdir = getattr(sys, 'platlibdir', '')  # Python3.9+
     site_dir_template = sysconfig.get_path('platlib', expand=False)
     site_dir = site_dir_template.format(platbase=dst_dir,
                                         py_version_short=py_v_s,
-                                        # Python 3.9+
-                                        platlibdir=getattr(sys, 'platlibdir', ''),
-                                       )
-    site_dir_noarch_template = sysconfig.get_path('purelib', expand=False)
-    site_dir_noarch = site_dir_noarch_template.format(base=dst_dir,
-                                                      py_version_short=py_v_s,
-                                                      # Python 3.9+
-                                                      platlibdir=getattr(sys, 'platlibdir', ''),
-                                                     )
+                                        platlibdir=platlibdir,
+                                        )
+    noarch_template = sysconfig.get_path('purelib', expand=False)
+    site_dir_noarch = noarch_template.format(base=dst_dir,
+                                             py_version_short=py_v_s,
+                                             platlibdir=platlibdir,
+                                             )
 
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH.  Plus, it has to exist.

--- a/runtests.py
+++ b/runtests.py
@@ -477,10 +477,17 @@ def build_project(args):
     from distutils.sysconfig import get_python_lib
     py_v_s = sysconfig.get_config_var('py_version_short')
     site_dir_template = sysconfig.get_path('platlib', expand=False)
-    site_dir = site_dir_template.format(platbase=dst_dir, py_version_short=py_v_s)
+    site_dir = site_dir_template.format(platbase=dst_dir,
+                                        py_version_short=py_v_s,
+                                        # Python 3.9+
+                                        platlibdir=getattr(sys, 'platlibdir', ''),
+                                       )
     site_dir_noarch_template = sysconfig.get_path('purelib', expand=False)
     site_dir_noarch = site_dir_noarch_template.format(base=dst_dir,
-                                                      py_version_short=py_v_s)
+                                                      py_version_short=py_v_s,
+                                                      # Python 3.9+
+                                                      platlibdir=getattr(sys, 'platlibdir', ''),
+                                                     )
 
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH.  Plus, it has to exist.


### PR DESCRIPTION
Python 3.10 raises a DeprecationWarning on distutils. There is an alternative in sysconfig. 

`sysconfig.get_path('platlib', expand=False)` returns a templated string like `'{platbase}/lib/python{py_version_short}/site-packages'`, so expand it with `str.format(platbase=..., py_version_short=...)`