### PR TITLE
BUG,DEP: Non-default UFunc signature/dtype usage should be deprecated

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -4286,7 +4286,8 @@ _get_dtype(PyObject *dtype_obj) {
         else if (NPY_UNLIKELY(out->singleton != descr)) {
             /* This does not warn about `metadata`, but units is important. */
             if (!PyArray_EquivTypes(out->singleton, descr)) {
-                PyErr_Format(PyExc_TypeError,
+                /* Deprecated NumPy 1.21.2 (was an accidental error in 1.21) */
+                if (DEPRECATE(
                         "The `dtype` and `signature` arguments to "
                         "ufuncs only select the general DType and not details "
                         "such as the byte order or time unit (with rare "
@@ -4296,9 +4297,11 @@ _get_dtype(PyObject *dtype_obj) {
                         "In rare cases where the time unit was preserved, "
                         "either cast the inputs or provide an output array. "
                         "In the future NumPy may transition to allow providing "
-                        "`dtype=` to denote the outputs `dtype` as well");
-                Py_DECREF(descr);
-                return NULL;
+                        "`dtype=` to denote the outputs `dtype` as well. "
+                        "(Deprecated NumPy 1.21)") < 0) {
+                    Py_DECREF(descr);
+                    return NULL;
+                }
             }
         }
         Py_INCREF(out);

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1174,3 +1174,36 @@ class TestCtypesGetter(_DeprecationTestCase):
     )
     def test_not_deprecated(self, name: str) -> None:
         self.assert_not_deprecated(lambda: getattr(self.ctypes, name))
+
+
+class TestUFuncForcedDTypeWarning(_DeprecationTestCase):
+    message = "The `dtype` and `signature` arguments to ufuncs only select the"
+
+    def test_not_deprecated(self):
+        import pickle
+        # does not warn (test relies on bad pickling behaviour, simply remove
+        # it if the `assert int64 is not int64_2` should start failing.
+        int64 = np.dtype("int64")
+        int64_2 = pickle.loads(pickle.dumps(int64))
+        assert int64 is not int64_2
+        self.assert_not_deprecated(lambda: np.add(3, 4, dtype=int64_2))
+
+    def test_deprecation(self):
+        int64 = np.dtype("int64")
+        self.assert_deprecated(lambda: np.add(3, 5, dtype=int64.newbyteorder()))
+        self.assert_deprecated(lambda: np.add(3, 5, dtype="m8[ns]"))
+
+    def test_behaviour(self):
+        int64 = np.dtype("int64")
+        arr = np.arange(10, dtype="m8[s]")
+
+        with pytest.warns(DeprecationWarning, match=self.message):
+            np.add(3, 5, dtype=int64.newbyteorder())
+        with pytest.warns(DeprecationWarning, match=self.message):
+            np.add(3, 5, dtype="m8[ns]")  # previously used the "ns"
+        with pytest.warns(DeprecationWarning, match=self.message):
+            np.add(arr, arr, dtype="m8[ns]")  # never preserved the "ns"
+        with pytest.warns(DeprecationWarning, match=self.message):
+            np.maximum(arr, arr, dtype="m8[ns]")  # previously used the "ns"
+        with pytest.warns(DeprecationWarning, match=self.message):
+            np.maximum.reduce(arr, dtype="m8[ns]")  # never preserved the "ns"

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -518,27 +518,6 @@ class TestUfunc:
         np.add(arr, arr, dtype="m")
         np.maximum(arr, arr, dtype="m")
 
-    def test_forced_dtype_warning(self):
-        # does not warn (test relies on bad pickling behaviour, simply remove
-        # it if the `assert int64 is not int64_2` should start failing.
-        int64 = np.dtype("int64")
-        int64_2 = pickle.loads(pickle.dumps(int64))
-        assert int64 is not int64_2
-        np.add(3, 4, dtype=int64_2)
-
-        arr = np.arange(10, dtype="m8[s]")
-        msg = "The `dtype` and `signature` arguments to ufuncs only select the"
-        with pytest.raises(TypeError, match=msg):
-            np.add(3, 5, dtype=int64.newbyteorder())
-        with pytest.raises(TypeError, match=msg):
-            np.add(3, 5, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.add(arr, arr, dtype="m8[ns]")  # never preserved the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.maximum(arr, arr, dtype="m8[ns]")  # previously used the "ns"
-        with pytest.raises(TypeError, match=msg):
-            np.maximum.reduce(arr, dtype="m8[ns]")  # never preserved the "ns"
-
     def test_true_divide(self):
         a = np.array(10)
         b = np.array(20)


### PR DESCRIPTION
Previously, this was an straight typeerror that went mostly unnoticed
for 1.21.0 and 1.21.1.  However, that was never the intention, it should
have been a normal DeprecationWarning to allow transition where necessary.

Closes gh-19625