### PR TITLE
BUG: Added a raise TypeError conditional statement to numpy/fft/helper.py

### DIFF
--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -4,6 +4,7 @@ Discrete Fourier Transforms - helper.py
 """
 from numpy.core import integer, empty, arange, asarray, roll
 from numpy.core.overrides import array_function_dispatch, set_module
+import numpy as np
 
 # Created by Pearu Peterson, September 2002
 
@@ -159,6 +160,8 @@ def fftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
+    if np.ndim(d) != 0:
+        raise ValueError("d must be a scalar number")
     val = 1.0 / (n * d)
     results = empty(n, int)
     N = (n-1)//2 + 1
@@ -215,6 +218,8 @@ def rfftfreq(n, d=1.0):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
+    if np.ndim(d) != 0:
+        raise ValueError("d must be a scalar number")
     val = 1.0/(n*d)
     N = n//2 + 1
     results = arange(0, N, dtype=int)


### PR DESCRIPTION
I Added a raise TypeError in case user passes the sample spacing (d) as a non scalar object. I discovered this bug by accidentally passing d as an array in numpy.fft.fftfreq
![Screenshot from 2021-08-10 11-46-30](https://user-images.githubusercontent.com/59406352/128796166-e5ec8ccc-891d-45cf-8fc1-40dcf73e0361.png)

