### PR TITLE
MAINT: Update Cython version for Python 3.10.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools<49.2.0",
     "wheel==0.36.2",
-    "Cython>=0.29.21,<3.0",  # Note: keep in sync with tools/cythonize.py
+    "Cython>=0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 
 

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -72,7 +72,8 @@ def process_pyx(fromfile, tofile):
         # other fixes in the 0.29 series that are needed even for earlier
         # Python versions.
         # Note: keep in sync with that in pyproject.toml
-        required_version = LooseVersion('0.29.21')
+        # Update for Python 3.10
+        required_version = LooseVersion('0.29.24')
 
         if LooseVersion(cython_version) < required_version:
             cython_path = Cython.__file__


### PR DESCRIPTION
Update the required Cython version to 0.29.24 for Python 3.10
compatibility.  The 0.29.22 version might work, but taking the time to
find the oldest working version is not worth the trouble.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
