### PR TITLE
BLD, SIMD: Fix testing extra checks when `-Werror` isn't applicable for Clang

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -193,7 +193,12 @@ class _Config:
         clang = dict(
             native = '-march=native',
             opt = "-O3",
-            werror = '-Werror'
+            # One of the following flags needs to be applicable for Clang to
+            # guarantee the sanity of the testing process, however in certain
+            # cases `-Werror` gets skipped during the availability test due to
+            # "unused arguments" warnings.
+            # see https://github.com/numpy/numpy/issues/19624
+            werror = '-Werror-implicit-function-declaration -Werror'
         ),
         icc = dict(
             native = '-xHost',


### PR DESCRIPTION
#### Fix testing extra checks when `-Werror` isn't applicable for Clang

   In certain cases `-Werror` gets skipped during the availability test due
   to "unused arguments" warnings. To solve the issue, `-Werror-implicit-function-declaration`
   was added as a secondary flag, which is enough to guarantee the sanity of the testing process
   when it comes to testing the availability of certain intrinsics.

closes #19624