### PR TITLE
TST: avoid distutils.sysconfig in runtests.py

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -474,9 +474,19 @@ def build_project(args):
             '--single-version-externally-managed',
             '--record=' + dst_dir + 'tmp_install_log.txt']
 
-    from distutils.sysconfig import get_python_lib
-    site_dir = get_python_lib(prefix=dst_dir, plat_specific=True)
-    site_dir_noarch = get_python_lib(prefix=dst_dir, plat_specific=False)
+    py_v_s = sysconfig.get_config_var('py_version_short')
+    platlibdir = getattr(sys, 'platlibdir', '')  # Python3.9+
+    site_dir_template = sysconfig.get_path('platlib', expand=False)
+    site_dir = site_dir_template.format(platbase=dst_dir,
+                                        py_version_short=py_v_s,
+                                        platlibdir=platlibdir,
+                                        )
+    noarch_template = sysconfig.get_path('purelib', expand=False)
+    site_dir_noarch = noarch_template.format(base=dst_dir,
+                                             py_version_short=py_v_s,
+                                             platlibdir=platlibdir,
+                                             )
+
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH.  Plus, it has to exist.
     if not os.path.exists(site_dir):


### PR DESCRIPTION
Backport of #19628.

* TST: avoid distutils.sysconfig in runtests.py

* fix for platlibdir (new in python3.9)

* linting

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
