### PR TITLE
BUG: add base to templated arguments for platlib

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -480,6 +480,7 @@ def build_project(args):
     site_dir = site_dir_template.format(platbase=dst_dir,
                                         py_version_short=py_v_s,
                                         platlibdir=platlibdir,
+                                        base=dst_dir,
                                         )
     noarch_template = sysconfig.get_path('purelib', expand=False)
     site_dir_noarch = noarch_template.format(base=dst_dir,


### PR DESCRIPTION
Continuation of #19628.
Fixes #19653. Not clear how the original PR passed CI.