### PR TITLE
BLD, SIMD: Fix testing extra checks when `-Werror` isn't applicable for Clang

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -193,7 +193,12 @@ class _Config:
         clang = dict(
             native = '-march=native',
             opt = "-O3",
-            werror = '-Werror'
+            # One of the following flags needs to be applicable for Clang to
+            # guarantee the sanity of the testing process, however in certain
+            # cases `-Werror` gets skipped during the availability test due to
+            # "unused arguments" warnings.
+            # see https://github.com/numpy/numpy/issues/19624
+            werror = '-Werror-implicit-function-declaration -Werror'
         ),
         icc = dict(
             native = '-xHost',


### PR DESCRIPTION
Backport of #19642.

In certain cases `-Werror` gets skipped during the availability test due
to "unused arguments" warnings. To solve the issue, `-Werror-implicit-function-declaration`
was added as a secondary flag, which is enough to guarantee the sanity of the testing process
when it comes to testing the availability of certain intrinsics.

closes #19624

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
