### PR TITLE
BUG: Fix bad write in masked iterator output copy paths

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1316,7 +1316,7 @@ PyArray_TransferMaskedStridedToNDim(npy_intp ndim,
                 args, &count, strides, mask, mask_stride, cast_info->auxdata);
     }
     int res = stransfer(&cast_info->context,
-            args, &count, strides, mask, mask_stride, cast_info->auxdata);
+            args, &N, strides, mask, mask_stride, cast_info->auxdata);
     if (res < 0) {
         return -1;
     }

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2738,7 +2738,12 @@ def _is_buffered(iterator):
 @pytest.mark.parametrize("a",
         [np.zeros((3,), dtype='f8'),
          np.zeros((9876, 3*5), dtype='f8')[::2, :],
-         np.zeros((4, 312, 124, 3), dtype='f8')[::2, :, ::2, :]])
+         np.zeros((4, 312, 124, 3), dtype='f8')[::2, :, ::2, :],
+         # Also test with the last dimension strided (so it does not fit if
+         # there is repeated access)
+         np.zeros((9,), dtype='f8')[::3],
+         np.zeros((9876, 3*10), dtype='f8')[::2, ::5],
+         np.zeros((4, 312, 124, 3), dtype='f8')[::2, :, ::2, ::-1]])
 def test_iter_writemasked(a):
     # Note, the slicing above is to ensure that nditer cannot combine multiple
     # axes into one.  The repetition is just to make things a bit more


### PR DESCRIPTION
Backport of #19600.

There was an unfortunate typo which leads to writing too many values
back when wheremask is used in a non-continguous N-D context.

Closes gh-19589

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
