### PR TITLE
NEP: add qualifier for free(), mention ContextVar

### DIFF
--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -164,9 +164,18 @@ NumPy C-API functions
 
 ``PyDataMem_Handler`` thread safety and lifetime
 ================================================
-As an implementation detail, currently the ``Set`` function will store the
-``PyDataMem_Handler`` in a ``PyCapsule`` as a :py:class:`ContextVar
-<contextvars.ContextVar>`.
+The active handler is stored in the current :py:class:`~contextvars.Context`
+via a :py:class:`~contextvars.ContextVar`. This ensures it can be configured both
+per-thread and per-async-coroutine.
+
+There is currently no lifetime management of ``PyDataMem_Handler``.
+The user of `PyDataMem_SetHandler` must ensure that the argument remains alive
+for as long as any objects allocated with it, and while it is the active handler.
+In practice, this means the handler must be immortal.
+
+As an implementation detail, currently this ``ContextVar`` contains a ``PyCapsule``
+object storing a pointer to a ``PyDataMem_Handler`` with no destructor,
+but this should not be relied upon.
 
 Sample code
 ===========

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -143,9 +143,6 @@ NumPy C-API functions
 
     The consumer of the `PyDataMemAllocator` interface must keep track of ``size`` and make sure it is
     consistent with the parameter passed to the ``(m|c|re)alloc``  functions.
-    NumPy itself will violate this requirement when the shape of the requested
-    array contains a ``0``, so authors of PyDataMemAllocators should relate to
-    the ``size`` parameter as a best-guess.
 
 .. c:function:: const PyDataMem_Handler * PyDataMem_SetHandler(PyDataMem_Handler *handler)
 

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -144,6 +144,12 @@ NumPy C-API functions
     The consumer of the `PyDataMemAllocator` interface must keep track of ``size`` and make sure it is
     consistent with the parameter passed to the ``(m|c|re)alloc``  functions.
 
+    NumPy itself may violate this requirement when the shape of the requested
+    array contains a ``0``, so authors of PyDataMemAllocators should relate to
+    the ``size`` parameter as a best-guess. Work to fix this is ongoing in PRs
+    15780_ and 15788_ but has not yet been resolved. When it is this NEP should
+    be revisited.
+
 .. c:function:: const PyDataMem_Handler * PyDataMem_SetHandler(PyDataMem_Handler *handler)
 
    Sets a new allocation policy. If the input value is ``NULL``, will reset
@@ -323,6 +329,8 @@ References and Footnotes
 .. _`PR 17582`: https://github.com/numpy/numpy/pull/17582
 .. _`PR 5457`: https://github.com/numpy/numpy/pull/5457
 .. _`PR 5470`: https://github.com/numpy/numpy/pull/5470
+.. _`15780`: https://github.com/numpy/numpy/pull/15780
+.. _`15788`: https://github.com/numpy/numpy/pull/15788
 .. _`PR 390`: https://github.com/numpy/numpy/pull/390
 .. _`issue 17467`: https://github.com/numpy/numpy/issues/17467
 .. _`comment in the PR`: https://github.com/numpy/numpy/pull/17582#issuecomment-809145547

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -159,7 +159,7 @@ NumPy C-API functions
 .. c:function:: const PyDataMem_Handler * PyDataMem_GetHandler(PyArrayObject *obj)
 
    Return the ``PyDataMem_Handler`` used by the
-   ``PyArrayObject``. If ``NULL``, return the name of the current global policy
+   ``PyArrayObject``. If ``NULL``, return the handler
    that will be used to allocate data for the next ``PyArrayObject``.
 
 ``PyDataMem_Handler`` thread safety and lifetime

--- a/doc/neps/nep-0049.rst
+++ b/doc/neps/nep-0049.rst
@@ -143,6 +143,9 @@ NumPy C-API functions
 
     The consumer of the `PyDataMemAllocator` interface must keep track of ``size`` and make sure it is
     consistent with the parameter passed to the ``(m|c|re)alloc``  functions.
+    NumPy itself will violate this requirement when the shape of the requested
+    array contains a ``0``, so authors of PyDataMemAllocators should relate to
+    the ``size`` parameter as a best-guess.
 
 .. c:function:: const PyDataMem_Handler * PyDataMem_SetHandler(PyDataMem_Handler *handler)
 
@@ -153,12 +156,17 @@ NumPy C-API functions
    hooks. All the function pointers must be filled in, ``NULL`` is not
    accepted.
 
-.. c:function:: const char * PyDataMem_GetHandlerName(PyArrayObject *obj)
+.. c:function:: const PyDataMem_Handler * PyDataMem_GetHandler(PyArrayObject *obj)
 
-   Return the const char name of the ``PyDataMem_Handler`` used by the
+   Return the ``PyDataMem_Handler`` used by the
    ``PyArrayObject``. If ``NULL``, return the name of the current global policy
    that will be used to allocate data for the next ``PyArrayObject``.
 
+``PyDataMem_Handler`` thread safety and lifetime
+================================================
+As an implementation detail, currently the ``Set`` function will store the
+``PyDataMem_Handler`` in a ``PyCapsule`` as a :py:class:`ContextVar
+<contextvars.ContextVar>`.
 
 Sample code
 ===========
@@ -219,7 +227,7 @@ the ``sz`` argument is correct.
             if (i != sz) {
                 fprintf(stderr, "uh-oh, unmatched shift_free"
                         "(ptr, %ld) but allocated %ld\\n", sz, i);
-                /* This happens in some places, only print */
+                /* This happens when the shape has a 0, only print */
                 ctx->free(real);
             }
             else {
@@ -266,7 +274,6 @@ the ``sz`` argument is correct.
             shift_free       /* free */
         }
     };
-    '''
 
 Related Work
 ------------


### PR DESCRIPTION
Update the NEP to reflect the latest state of PR #17582.

- Mention that the `PyDataMem_Handler` is stored as a `ContextVar`
- Mention the problem with `np.empty([2, 0, 2])` [allocating memory as if](https://github.com/numpy/numpy/blob/df6d2600c51502e1877aac563658d0616a75c5e5/numpy/core/src/multiarray/ctors.c#L759) it were `np.empty([2, 1, 2])`, so that the `free()` call does not match the `alloc()`.