### PR TITLE
MAINT: Drop Python3.7 from supported versions.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9, 3.10.0-rc.1]
+        python-version: [3.9, 3.10.0-rc.1]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -202,18 +202,18 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
-  pypy37:
-    needs: [smoke_test]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 0
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy-3.7-v7.3.4
-    - uses: ./.github/actions
+  #pypy37:
+    #needs: [smoke_test]
+    #runs-on: ubuntu-latest
+    #steps:
+    #- uses: actions/checkout@v2
+      #with:
+        #submodules: recursive
+        #fetch-depth: 0
+    #- uses: actions/setup-python@v2
+      #with:
+        #python-version: pypy-3.7-v7.3.4
+    #- uses: ./.github/actions
 
   sdist:
     needs: [smoke_test]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,17 +241,6 @@ stages:
     strategy:
       maxParallel: 6
       matrix:
-          # Python37 32 bit fast tested in InitialTest stage.
-          Python37-64bit-full:
-            PYTHON_VERSION: '3.7'
-            PYTHON_ARCH: 'x64'
-            TEST_MODE: full
-            BITS: 64
-          #PyPy37-64bit-full:
-          #  PYTHON_VERSION: 'PyPy3.7'
-          #  PYTHON_ARCH: 'x64'
-          #  TEST_MODE: fast
-          #  BITS: 64
           Python38-32bit-fast:
             PYTHON_VERSION: '3.8'
             PYTHON_ARCH: 'x86'
@@ -277,33 +266,6 @@ stages:
     steps:
     - template: azure-steps-windows.yml
 
-
-  - job: Linux_gcc48
-    pool:
-      # ubuntu-20.04 does not provide a gcc-4.8 package
-      vmImage: 'ubuntu-18.04'
-    steps:
-    - script: |
-            sudo apt update
-            sudo apt install python3.7
-            sudo apt install python3.7-dev
-            if ! `gcc-4.8 2>/dev/null`; then
-                sudo apt install gcc-4.8
-            fi
-      displayName: 'add gcc 4.8'
-    - script: |
-            # python3 has no setuptools, so install one to get us going
-            python3.7 -m pip install --user --upgrade pip 'setuptools<49.2.0'
-            python3.7 -m pip install --user -r test_requirements.txt
-            CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
-            python3.7 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
-      displayName: 'Run gcc4.8 Build / Tests'
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFiles: '**/test-*.xml'
-        failTaskOnFailedTests: true
-        testRunTitle: 'Publish test results for gcc 4.8'
 
   - job: Linux_conda
     pool:
@@ -333,3 +295,30 @@ stages:
         failTaskOnFailedTests: true
         testRunTitle: 'Publish test results for conda installation'
 
+
+  #- job: Linux_gcc48
+    #pool:
+      ## ubuntu-20.04 does not provide a gcc-4.8 package
+      #vmImage: 'ubuntu-18.04'
+    #steps:
+    #- script: |
+            #sudo apt update
+            #sudo apt install python3.7
+            #sudo apt install python3.7-dev
+            #if ! `gcc-4.8 2>/dev/null`; then
+                #sudo apt install gcc-4.8
+            #fi
+      #displayName: 'add gcc 4.8'
+    #- script: |
+            ## python3 has no setuptools, so install one to get us going
+            #python3.7 -m pip install --user --upgrade pip 'setuptools<49.2.0'
+            #python3.7 -m pip install --user -r test_requirements.txt
+            #CPPFLAGS='' CC=gcc-4.8 F77=gfortran-5 F90=gfortran-5 \
+            #python3.7 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
+      #displayName: 'Run gcc4.8 Build / Tests'
+    #- task: PublishTestResults@2
+      #condition: succeededOrFailed()
+      #inputs:
+        #testResultsFiles: '**/test-*.xml'
+        #failTaskOnFailedTests: true
+        #testRunTitle: 'Publish test results for gcc 4.8'

--- a/doc/release/upcoming_changes/19655.change.rst
+++ b/doc/release/upcoming_changes/19655.change.rst
@@ -1,0 +1,4 @@
+Python 3.7 is no longer supported
+---------------------------------
+Python support has been dropped. This is rather strict, there are
+changes that require Python >=3.8.

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -270,69 +270,53 @@ else:
     oldnumeric = 'removed'
     numarray = 'removed'
 
-    if sys.version_info[:2] >= (3, 7):
-        # module level getattr is only supported in 3.7 onwards
-        # https://www.python.org/dev/peps/pep-0562/
-        def __getattr__(attr):
-            # Warn for expired attributes, and return a dummy function
-            # that always raises an exception.
-            try:
-                msg = __expired_functions__[attr]
-            except KeyError:
-                pass
-            else:
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    def __getattr__(attr):
+        # Warn for expired attributes, and return a dummy function
+        # that always raises an exception.
+        try:
+            msg = __expired_functions__[attr]
+        except KeyError:
+            pass
+        else:
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-                def _expired(*args, **kwds):
-                    raise RuntimeError(msg)
+            def _expired(*args, **kwds):
+                raise RuntimeError(msg)
 
-                return _expired
+            return _expired
 
-            # Emit warnings for deprecated attributes
-            try:
-                val, msg = __deprecated_attrs__[attr]
-            except KeyError:
-                pass
-            else:
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
-                return val
+        # Emit warnings for deprecated attributes
+        try:
+            val, msg = __deprecated_attrs__[attr]
+        except KeyError:
+            pass
+        else:
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return val
 
-            # Importing Tester requires importing all of UnitTest which is not a
-            # cheap import Since it is mainly used in test suits, we lazy import it
-            # here to save on the order of 10 ms of import time for most users
-            #
-            # The previous way Tester was imported also had a side effect of adding
-            # the full `numpy.testing` namespace
-            if attr == 'testing':
-                import numpy.testing as testing
-                return testing
-            elif attr == 'Tester':
-                from .testing import Tester
-                return Tester
+        # Importing Tester requires importing all of UnitTest which is not a
+        # cheap import Since it is mainly used in test suits, we lazy import it
+        # here to save on the order of 10 ms of import time for most users
+        #
+        # The previous way Tester was imported also had a side effect of adding
+        # the full `numpy.testing` namespace
+        if attr == 'testing':
+            import numpy.testing as testing
+            return testing
+        elif attr == 'Tester':
+            from .testing import Tester
+            return Tester
 
-            raise AttributeError("module {!r} has no attribute "
-                                 "{!r}".format(__name__, attr))
+        raise AttributeError("module {!r} has no attribute "
+                             "{!r}".format(__name__, attr))
 
-        def __dir__():
-            return list(globals().keys() | {'Tester', 'testing'})
-
-    else:
-        # We don't actually use this ourselves anymore, but I'm not 100% sure that
-        # no-one else in the world is using it (though I hope not)
-        from .testing import Tester
-
-        # We weren't able to emit a warning about these, so keep them around
-        globals().update({
-            k: v
-            for k, (v, msg) in __deprecated_attrs__.items()
-        })
-
+    def __dir__():
+        return list(globals().keys() | {'Tester', 'testing'})
 
     # Pytest testing
     from numpy._pytesttester import PytestTester
     test = PytestTester(__name__)
     del PytestTester
-
 
     def _sanity_check():
         """

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -3,11 +3,6 @@
 #include "structmember.h"
 
 #include <pymem.h>
-/* public api in 3.7 */
-#if PY_VERSION_HEX < 0x03070000
-#define PyTraceMalloc_Track _PyTraceMalloc_Track
-#define PyTraceMalloc_Untrack _PyTraceMalloc_Untrack
-#endif
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -52,22 +52,8 @@ def test_numpy_namespace():
         'show_config': 'numpy.__config__.show',
         'who': 'numpy.lib.utils.who',
     }
-    if sys.version_info < (3, 7):
-        # These built-in types are re-exported by numpy.
-        builtins = {
-            'bool': 'builtins.bool',
-            'complex': 'builtins.complex',
-            'float': 'builtins.float',
-            'int': 'builtins.int',
-            'long': 'builtins.int',
-            'object': 'builtins.object',
-            'str': 'builtins.str',
-            'unicode': 'builtins.str',
-        }
-        allowlist = dict(undocumented, **builtins)
-    else:
-        # after 3.7, we override dir to not show these members
-        allowlist = undocumented
+    # We override dir to not show these members
+    allowlist = undocumented
     bad_results = check_dir(np)
     # pytest gives better error messages with the builtin assert than with
     # assert_equal

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ import re
 
 # Python supported version checks. Keep right after stdlib imports to ensure we
 # get a sensible error for older Python versions
+# This needs to be changed to 3.8 for 1.22 release, but 3.7 is needed for LGTM.
 if sys.version_info[:2] < (3, 7):
-    raise RuntimeError("Python version >= 3.7 required.")
+    raise RuntimeError("Python version >= 3.8 required.")
 
 
 import versioneer
@@ -90,9 +91,9 @@ License :: OSI Approved :: BSD License
 Programming Language :: C
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development
@@ -405,7 +406,7 @@ def setup_package():
         test_suite='pytest',
         version=versioneer.get_version(),
         cmdclass=cmdclass,
-        python_requires='>=3.7',
+        python_requires='>=3.8',
         zip_safe=False,
         entry_points={
             'console_scripts': f2py_cmds


### PR DESCRIPTION
This drops Python 3.7 for NumPy 1.22.x. The following changes are made

- Python 3.7 is dropped from testing
- Setup.py is adjusted with Python 3.10 added
- Some small  code cleanups

Note that testing of gcc48 is dropped. Does that matter anymore?

EDIT: I temporarily left the version check in setup.py to 3.7+ to work around LGTM. If LGTM isn't updated by release time we will need to drop it. 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
