### PR TITLE
TST,BUG: Sanitize path-separators when running `runtest.py`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -476,12 +476,16 @@ def build_project(args):
 
     py_v_s = sysconfig.get_config_var('py_version_short')
     platlibdir = getattr(sys, 'platlibdir', '')  # Python3.9+
-    site_dir_template = sysconfig.get_path('platlib', expand=False)
+    site_dir_template = os.path.normpath(sysconfig.get_path(
+        'platlib', expand=False
+    ))
     site_dir = site_dir_template.format(platbase=dst_dir,
                                         py_version_short=py_v_s,
                                         platlibdir=platlibdir,
                                         )
-    noarch_template = sysconfig.get_path('purelib', expand=False)
+    noarch_template = os.path.normpath(sysconfig.get_path(
+        'purelib', expand=False
+    ))
     site_dir_noarch = noarch_template.format(base=dst_dir,
                                              py_version_short=py_v_s,
                                              platlibdir=platlibdir,


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/19667/commits/d01a312de72bb4eef007bf661c22ea8e21e71378

Another continuation of #19628.
`sysconfig.get_path` always returns a path with unix-style path-separators;
the mixed usage of `/` and `\` would subsequently break the typing tests on windows.