### PR TITLE
BLD: load extra flags when checking for libflame

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -2426,6 +2426,10 @@ class flame_info(system_info):
         if info is None:
             return
 
+        # Add the extra flag args to info
+        extra_info = self.calc_extra_info()
+        dict_append(info, **extra_info)
+
         if self.check_embedded_lapack(info):
             # check if the user has supplied all information required
             self.set_info(**info)


### PR DESCRIPTION
Backport of #19582.

When trying to build numpy with a locally compiled [libflame](https://github.com/flame/libflame), it fails in `calc_info()` ([here](https://github.com/numpy/numpy/blob/2c1a34daa024398cdf9c6e1fbeff52b4eb280551/numpy/distutils/system_info.py#L2427)) when calling `check_embedded_lapack()`, if the library needs additional flags when compiling / linking. In this function, when calling `extra_args = info.get('extra_link_args', [])` ([here](https://github.com/numpy/numpy/blob/2c1a34daa024398cdf9c6e1fbeff52b4eb280551/numpy/distutils/system_info.py#L2404)), it returns an empty list, even if arguments are provided in `site.cfg`, as stated in the [example configuration file](https://github.com/numpy/numpy/blob/main/site.cfg.example). This pull request loads the extra arguments, before trying to compile. 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
