### PR TITLE
ENH: Allow `np.fromregex` to accept `os.PathLike` implementations

### DIFF
--- a/doc/release/upcoming_changes/19680.improvement.rst
+++ b/doc/release/upcoming_changes/19680.improvement.rst
@@ -1,0 +1,5 @@
+`numpy.fromregex` now accepts ``os.PathLike`` implementations
+-------------------------------------------------------------
+
+`numpy.fromregex` now accepts objects implementing the `__fspath__<os.PathLike>`
+protocol, *e.g.* `pathlib.Path`.

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1484,8 +1484,11 @@ def fromregex(file, regexp, dtype, encoding=None):
 
     Parameters
     ----------
-    file : str or file
+    file : path or file
         Filename or file object to read.
+
+        .. versionchanged:: 1.22.0
+            Now accepts `os.PathLike` implementations.
     regexp : str or regexp
         Regular expression used to parse the file.
         Groups in the regular expression correspond to fields in the dtype.
@@ -1535,6 +1538,7 @@ def fromregex(file, regexp, dtype, encoding=None):
     """
     own_fh = False
     if not hasattr(file, "read"):
+        file = os.fspath(file)
         file = np.lib._datasource.open(file, 'rt', encoding=encoding)
         own_fh = True
 

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -182,14 +182,14 @@ def savetxt(
 
 @overload
 def fromregex(
-    file: str | IO[Any],
+    file: str | os.PathLike[str] | IO[Any],
     regexp: str | bytes | Pattern[Any],
     dtype: _DTypeLike[_SCT],
     encoding: None | str = ...
 ) -> NDArray[_SCT]: ...
 @overload
 def fromregex(
-    file: str | IO[Any],
+    file: str | os.PathLike[str] | IO[Any],
     regexp: str | bytes | Pattern[Any],
     dtype: DTypeLike,
     encoding: None | str = ...

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1229,9 +1229,11 @@ class Testfromregex:
         a = np.array([(1312,), (1534,), (4444,)], dtype=dt)
         assert_array_equal(x, a)
 
-    def test_record_unicode(self):
+    @pytest.mark.parametrize("path_type", [str, Path])
+    def test_record_unicode(self, path_type):
         utf8 = b'\xcf\x96'
-        with temppath() as path:
+        with temppath() as str_path:
+            path = path_type(str_path)
             with open(path, 'wb') as f:
                 f.write(b'1.312 foo' + utf8 + b' \n1.534 bar\n4.444 qux')
 

--- a/numpy/typing/tests/data/fail/npyio.py
+++ b/numpy/typing/tests/data/fail/npyio.py
@@ -24,7 +24,6 @@ np.savez_compressed(str_file, AR_i8)  # E: incompatible type
 np.loadtxt(bytes_path)  # E: No overload variant
 
 np.fromregex(bytes_path, ".", np.int64)  # E: No overload variant
-np.fromregex(pathlib_path, ".", np.int64)  # E: No overload variant
 
 np.recfromtxt(bytes_path)  # E: No overload variant
 

--- a/numpy/typing/tests/data/reveal/npyio.py
+++ b/numpy/typing/tests/data/reveal/npyio.py
@@ -56,6 +56,7 @@ reveal_type(np.loadtxt(str_path, ndmin=2))  # E: numpy.ndarray[Any, numpy.dtype[
 reveal_type(np.fromregex(bytes_file, "test", np.float64))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
 reveal_type(np.fromregex(str_file, b"test", dtype=float))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 reveal_type(np.fromregex(str_path, re.compile("test"), dtype=np.str_, encoding="utf8"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.str_]]
+reveal_type(np.fromregex(pathlib_path, "test", np.float64))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
 
 reveal_type(np.genfromtxt(bytes_file))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
 reveal_type(np.genfromtxt(pathlib_path, dtype=np.str_))  # E: numpy.ndarray[Any, numpy.dtype[numpy.str_]]


### PR DESCRIPTION
closes https://github.com/numpy/numpy/issues/19679

`np.fromregex` is one of the rare file-maniupulation-functions in numpy that does not accept `os.PathLike` implementations.
This PR addresses aforementioned issue.