### PR TITLE
ENH: Add spaces after punctuation in dtype repr/str.

### DIFF
--- a/doc/release/upcoming_changes/19687.change.rst
+++ b/doc/release/upcoming_changes/19687.change.rst
@@ -1,0 +1,8 @@
+str/repr of complex dtypes now include space after punctuation
+--------------------------------------------------------------
+
+The repr of ``np.dtype({"names": ["a"], "formats": [int], "offsets": [2]})`` is
+now ``dtype({'names': ['a'], 'formats': ['<i8'], 'offsets': [2], 'itemsize': 10})``,
+whereas spaces where previously omitted after colons and between fields.
+
+The old behavior can be restored via ``np.set_printoptions(legacy="1.21")``.

--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -128,7 +128,7 @@ summary they are:
       ...           'formats': ['i4', 'f4'],
       ...           'offsets': [0, 4],
       ...           'itemsize': 12})
-      dtype({'names':['col1','col2'], 'formats':['<i4','<f4'], 'offsets':[0,4], 'itemsize':12})
+      dtype({'names': ['col1', 'col2'], 'formats': ['<i4', '<f4'], 'offsets': [0, 4], 'itemsize': 12})
 
      Offsets may be chosen such that the fields overlap, though this will mean
      that assigning to one field may clobber any overlapping field's data. As

--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -201,29 +201,29 @@ def _struct_dict_str(dtype, includealignedflag):
     # Build up a string to make the dictionary
 
     # First, the names
-    ret = "{'names':["
-    ret += ",".join(repr(name) for name in names)
+    ret = "{'names': ["
+    ret += ", ".join(repr(name) for name in names)
 
     # Second, the formats
-    ret += "], 'formats':["
-    ret += ",".join(
+    ret += "], 'formats': ["
+    ret += ", ".join(
         _construction_repr(fld_dtype, short=True) for fld_dtype in fld_dtypes)
 
     # Third, the offsets
-    ret += "], 'offsets':["
-    ret += ",".join("%d" % offset for offset in offsets)
+    ret += "], 'offsets': ["
+    ret += ", ".join("%d" % offset for offset in offsets)
 
     # Fourth, the titles
     if any(title is not None for title in titles):
-        ret += "], 'titles':["
-        ret += ",".join(repr(title) for title in titles)
+        ret += "], 'titles': ["
+        ret += ", ".join(repr(title) for title in titles)
 
     # Fifth, the itemsize
-    ret += "], 'itemsize':%d" % dtype.itemsize
+    ret += "], 'itemsize': %d" % dtype.itemsize
 
     if (includealignedflag and dtype.isalignedstruct):
         # Finally, the aligned flag
-        ret += ", 'aligned':True}"
+        ret += ", 'aligned': True}"
     else:
         ret += "}"
 

--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -200,30 +200,37 @@ def _struct_dict_str(dtype, includealignedflag):
 
     # Build up a string to make the dictionary
 
+    if np.core.arrayprint._get_legacy_print_mode() <= 121:
+        colon = ":"
+        fieldsep = ","
+    else:
+        colon = ": "
+        fieldsep = ", "
+
     # First, the names
-    ret = "{'names': ["
-    ret += ", ".join(repr(name) for name in names)
+    ret = "{'names'%s[" % colon
+    ret += fieldsep.join(repr(name) for name in names)
 
     # Second, the formats
-    ret += "], 'formats': ["
-    ret += ", ".join(
+    ret += "], 'formats'%s[" % colon
+    ret += fieldsep.join(
         _construction_repr(fld_dtype, short=True) for fld_dtype in fld_dtypes)
 
     # Third, the offsets
-    ret += "], 'offsets': ["
-    ret += ", ".join("%d" % offset for offset in offsets)
+    ret += "], 'offsets'%s[" % colon
+    ret += fieldsep.join("%d" % offset for offset in offsets)
 
     # Fourth, the titles
     if any(title is not None for title in titles):
-        ret += "], 'titles': ["
-        ret += ", ".join(repr(title) for title in titles)
+        ret += "], 'titles'%s[" % colon
+        ret += fieldsep.join(repr(title) for title in titles)
 
     # Fifth, the itemsize
-    ret += "], 'itemsize': %d" % dtype.itemsize
+    ret += "], 'itemsize'%s%d" % (colon, dtype.itemsize)
 
     if (includealignedflag and dtype.isalignedstruct):
         # Finally, the aligned flag
-        ret += ", 'aligned': True}"
+        ret += ", 'aligned'%sTrue}" % colon
     else:
         ret += "}"
 

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -24,6 +24,7 @@ __docformat__ = 'restructuredtext'
 
 import functools
 import numbers
+import sys
 try:
     from _thread import get_ident
 except ImportError:
@@ -56,12 +57,17 @@ _format_options = {
     'infstr': 'inf',
     'sign': '-',
     'formatter': None,
-    'legacy': False}
+    # Internally stored as an int to simplify comparisons; converted from/to
+    # str/False on the way in/out.
+    'legacy': sys.maxsize}
 
 def _make_options_dict(precision=None, threshold=None, edgeitems=None,
                        linewidth=None, suppress=None, nanstr=None, infstr=None,
                        sign=None, formatter=None, floatmode=None, legacy=None):
-    """ make a dictionary out of the non-None arguments, plus sanity checks """
+    """
+    Make a dictionary out of the non-None arguments, plus conversion of
+    *legacy* and sanity checks.
+    """
 
     options = {k: v for k, v in locals().items() if v is not None}
 
@@ -76,9 +82,18 @@ def _make_options_dict(precision=None, threshold=None, edgeitems=None,
     if sign not in [None, '-', '+', ' ']:
         raise ValueError("sign option must be one of ' ', '+', or '-'")
 
-    if legacy not in [None, False, '1.13']:
-        warnings.warn("legacy printing option can currently only be '1.13' or "
-                      "`False`", stacklevel=3)
+    if legacy == False:
+        options['legacy'] = sys.maxsize
+    elif legacy == '1.13':
+        options['legacy'] = 113
+    elif legacy == '1.21':
+        options['legacy'] = 121
+    elif legacy is None:
+        pass  # OK, do nothing.
+    else:
+        warnings.warn(
+            "legacy printing option can currently only be '1.13', '1.21', or "
+            "`False`", stacklevel=3)
 
     if threshold is not None:
         # forbid the bad threshold arg suggested by stack overflow, gh-12351
@@ -186,11 +201,21 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     legacy : string or `False`, optional
         If set to the string `'1.13'` enables 1.13 legacy printing mode. This
         approximates numpy 1.13 print output by including a space in the sign
-        position of floats and different behavior for 0d arrays. If set to
-        `False`, disables legacy mode. Unrecognized strings will be ignored
-        with a warning for forward compatibility.
+        position of floats and different behavior for 0d arrays. This also
+        enables 1.21 legacy printing mode (described below).
+
+        If set to the string `'1.21'` enables 1.21 legacy printing mode. This
+        approximates numpy 1.21 print output of complex structured dtypes
+        by not inserting spaces after commas that separate fields and after
+        colons.
+
+        If set to `False`, disables legacy mode.
+
+        Unrecognized strings will be ignored with a warning for forward
+        compatibility.
 
         .. versionadded:: 1.14.0
+        .. versionchanged:: 1.22.0
 
     See Also
     --------
@@ -257,11 +282,13 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     _format_options.update(opt)
 
     # set the C variable for legacy mode
-    if _format_options['legacy'] == '1.13':
+    if _format_options['legacy'] == 113:
         set_legacy_print_mode(113)
         # reset the sign option in legacy mode to avoid confusion
         _format_options['sign'] = '-'
-    elif _format_options['legacy'] is False:
+    elif _format_options['legacy'] == 121:
+        set_legacy_print_mode(121)
+    elif _format_options['legacy'] == sys.maxsize:
         set_legacy_print_mode(0)
 
 
@@ -292,7 +319,16 @@ def get_printoptions():
     set_printoptions, printoptions, set_string_function
 
     """
-    return _format_options.copy()
+    opts = _format_options.copy()
+    opts['legacy'] = {
+        113: '1.13', 121: '1.21', sys.maxsize: False,
+    }[opts['legacy']]
+    return opts
+
+
+def _get_legacy_print_mode():
+    """Return the legacy print mode as an int."""
+    return _format_options['legacy']
 
 
 @set_module('numpy')
@@ -678,7 +714,7 @@ def array2string(a, max_line_width=None, precision=None,
     options = _format_options.copy()
     options.update(overrides)
 
-    if options['legacy'] == '1.13':
+    if options['legacy'] <= 113:
         if style is np._NoValue:
             style = repr
 
@@ -690,7 +726,7 @@ def array2string(a, max_line_width=None, precision=None,
                       " except in 1.13 'legacy' mode",
                       DeprecationWarning, stacklevel=3)
 
-    if options['legacy'] != '1.13':
+    if options['legacy'] > 113:
         options['linewidth'] -= len(suffix)
 
     # treat as a null array if any of shape elements == 0
@@ -702,7 +738,7 @@ def array2string(a, max_line_width=None, precision=None,
 
 def _extendLine(s, line, word, line_width, next_line_prefix, legacy):
     needs_wrap = len(line) + len(word) > line_width
-    if legacy != '1.13':
+    if legacy > 113:
         # don't wrap lines if it won't help
         if len(line) <= len(next_line_prefix):
             needs_wrap = False
@@ -719,7 +755,7 @@ def _extendLine_pretty(s, line, word, line_width, next_line_prefix, legacy):
     Extends line with nicely formatted (possibly multi-line) string ``word``.
     """
     words = word.splitlines()
-    if len(words) == 1 or legacy == '1.13':
+    if len(words) == 1 or legacy <= 113:
         return _extendLine(s, line, word, line_width, next_line_prefix, legacy)
 
     max_word_length = max(len(word) for word in words)
@@ -765,7 +801,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
         # when recursing, add a space to align with the [ added, and reduce the
         # length of the line by 1
         next_hanging_indent = hanging_indent + ' '
-        if legacy == '1.13':
+        if legacy <= 113:
             next_width = curr_width
         else:
             next_width = curr_width - len(']')
@@ -785,7 +821,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
         # last axis (rows) - wrap elements if they would not fit on one line
         if axes_left == 1:
             # the length up until the beginning of the separator / bracket
-            if legacy == '1.13':
+            if legacy <= 113:
                 elem_width = curr_width - len(separator.rstrip())
             else:
                 elem_width = curr_width - max(len(separator.rstrip()), len(']'))
@@ -800,7 +836,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             if show_summary:
                 s, line = _extendLine(
                     s, line, summary_insert, elem_width, hanging_indent, legacy)
-                if legacy == '1.13':
+                if legacy <= 113:
                     line += ", "
                 else:
                     line += separator
@@ -811,7 +847,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                     s, line, word, elem_width, hanging_indent, legacy)
                 line += separator
 
-            if legacy == '1.13':
+            if legacy <= 113:
                 # width of the separator is not considered on 1.13
                 elem_width = curr_width
             word = recurser(index + (-1,), next_hanging_indent, next_width)
@@ -830,7 +866,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                 s += hanging_indent + nested + line_sep
 
             if show_summary:
-                if legacy == '1.13':
+                if legacy <= 113:
                     # trailing space, fixed nbr of newlines, and fixed separator
                     s += hanging_indent + summary_insert + ", \n"
                 else:
@@ -875,7 +911,7 @@ class FloatingFormat:
             sign = '+' if sign else '-'
 
         self._legacy = legacy
-        if self._legacy == '1.13':
+        if self._legacy <= 113:
             # when not 0d, legacy does not support '-'
             if data.shape != () and sign == '-':
                 sign = ' '
@@ -919,7 +955,7 @@ class FloatingFormat:
             self.min_digits = None
         elif self.exp_format:
             trim, unique = '.', True
-            if self.floatmode == 'fixed' or self._legacy == '1.13':
+            if self.floatmode == 'fixed' or self._legacy <= 113:
                 trim, unique = 'k', False
             strs = (dragon4_scientific(x, precision=self.precision,
                                unique=unique, trim=trim, sign=self.sign == '+')
@@ -934,7 +970,7 @@ class FloatingFormat:
             self.unique = unique
 
             # for back-compat with np 1.13, use 2 spaces & sign and full prec
-            if self._legacy == '1.13':
+            if self._legacy <= 113:
                 self.pad_left = 3
             else:
                 # this should be only 1 or 2. Can be calculated from sign.
@@ -951,7 +987,7 @@ class FloatingFormat:
                                        sign=self.sign == '+')
                     for x in finite_vals)
             int_part, frac_part = zip(*(s.split('.') for s in strs))
-            if self._legacy == '1.13':
+            if self._legacy <= 113:
                 self.pad_left = 1 + max(len(s.lstrip('-+')) for s in int_part)
             else:
                 self.pad_left = max(len(s) for s in int_part)
@@ -966,7 +1002,7 @@ class FloatingFormat:
                 self.trim = '.'
                 self.min_digits = 0
 
-        if self._legacy != '1.13':
+        if self._legacy > 113:
             # account for sign = ' ' by adding one to pad_left
             if self.sign == ' ' and not any(np.signbit(finite_vals)):
                 self.pad_left += 1
@@ -1215,7 +1251,7 @@ class ComplexFloatingFormat:
             sign = '+' if sign else '-'
 
         floatmode_real = floatmode_imag = floatmode
-        if legacy == '1.13':
+        if legacy <= 113:
             floatmode_real = 'maxprec_equal'
             floatmode_imag = 'maxprec'
 
@@ -1286,7 +1322,7 @@ class DatetimeFormat(_TimelikeFormat):
         super().__init__(x)
 
     def __call__(self, x):
-        if self.legacy == '1.13':
+        if self.legacy <= 113:
             return self._format_non_nat(x)
         return super().__call__(x)
 
@@ -1390,7 +1426,7 @@ def dtype_is_implied(dtype):
     array([1, 2, 3], dtype=int8)
     """
     dtype = np.dtype(dtype)
-    if _format_options['legacy'] == '1.13' and dtype.type == bool_:
+    if _format_options['legacy'] <= 113 and dtype.type == bool_:
         return False
 
     # not just void types can be structured, and names are not part of the repr
@@ -1445,7 +1481,7 @@ def _array_repr_implementation(
     prefix = class_name + "("
     suffix = ")" if skipdtype else ","
 
-    if (_format_options['legacy'] == '1.13' and
+    if (_format_options['legacy'] <= 113 and
             arr.shape == () and not arr.dtype.names):
         lst = repr(arr.item())
     elif arr.size > 0 or arr.shape == (0,):
@@ -1466,7 +1502,7 @@ def _array_repr_implementation(
     # Note: This line gives the correct result even when rfind returns -1.
     last_line_len = len(arr_str) - (arr_str.rfind('\n') + 1)
     spacer = " "
-    if _format_options['legacy'] == '1.13':
+    if _format_options['legacy'] <= 113:
         if issubclass(arr.dtype.type, flexible):
             spacer = '\n' + ' '*len(class_name + "(")
     elif last_line_len + len(dtype_str) + 1 > max_line_width:
@@ -1540,7 +1576,7 @@ def _array_str_implementation(
         a, max_line_width=None, precision=None, suppress_small=None,
         array2string=array2string):
     """Internal version of array_str() that allows overriding array2string."""
-    if (_format_options['legacy'] == '1.13' and
+    if (_format_options['legacy'] <= 113 and
             a.shape == () and not a.dtype.names):
         return str(a.item())
 

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -59,7 +59,7 @@ class _FormatOptions(TypedDict):
     formatter: Optional[_FormatDict]
     sign: Literal["-", "+", " "]
     floatmode: _FloatMode
-    legacy: Literal[False, "1.13"]
+    legacy: Literal[False, "1.13", "1.21"]
 
 def set_printoptions(
     precision: Optional[SupportsIndex] = ...,
@@ -73,7 +73,7 @@ def set_printoptions(
     sign: Optional[Literal["-", "+", " "]] = ...,
     floatmode: Optional[_FloatMode] = ...,
     *,
-    legacy: Optional[Literal[False, "1.13"]] = ...
+    legacy: Optional[Literal[False, "1.13", "1.21"]] = ...
 ) -> None: ...
 def get_printoptions() -> _FormatOptions: ...
 def array2string(
@@ -93,7 +93,7 @@ def array2string(
     sign: Optional[Literal["-", "+", " "]] = ...,
     floatmode: Optional[_FloatMode] = ...,
     suffix: str = ...,
-    legacy: Optional[Literal[False, "1.13"]] = ...,
+    legacy: Optional[Literal[False, "1.13", "1.21"]] = ...,
 ) -> str: ...
 def format_float_scientific(
     x: _FloatLike_co,
@@ -143,5 +143,5 @@ def printoptions(
     sign: Optional[Literal["-", "+", " "]] = ...,
     floatmode: Optional[_FloatMode] = ...,
     *,
-    legacy: Optional[Literal[False, "1.13"]] = ...
+    legacy: Optional[Literal[False, "1.13", "1.21"]] = ...
 ) -> _GeneratorContextManager[_FormatOptions]: ...

--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -41,7 +41,7 @@ from . import numeric as sb
 from . import numerictypes as nt
 from numpy.compat import os_fspath
 from numpy.core.overrides import set_module
-from .arrayprint import get_printoptions
+from .arrayprint import _get_legacy_print_mode
 
 # All of the functions allow formats to be a dtype
 __all__ = [
@@ -230,12 +230,12 @@ class record(nt.void):
     __module__ = 'numpy'
 
     def __repr__(self):
-        if get_printoptions()['legacy'] == '1.13':
+        if _get_legacy_print_mode() <= 113:
             return self.__str__()
         return super().__repr__()
 
     def __str__(self):
-        if get_printoptions()['legacy'] == '1.13':
+        if _get_legacy_print_mode() <= 113:
             return str(self.item())
         return super().__str__()
 
@@ -551,7 +551,7 @@ class recarray(ndarray):
             lst = "[], shape=%s" % (repr(self.shape),)
 
         lf = '\n'+' '*len(prefix)
-        if get_printoptions()['legacy'] == '1.13':
+        if _get_legacy_print_mode() <= 113:
             lf = ' ' + lf  # trailing space
         return fmt % (lst, lf, repr_dtype)
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -84,17 +84,21 @@ NPY_NO_EXPORT int set_matmul_flags(PyObject *d); /* in ufunc_object.c */
 
 /*
  * global variable to determine if legacy printing is enabled, accessible from
- * C. For simplicity the mode is encoded as an integer where '0' means no
- * legacy mode, and '113' means 1.13 legacy mode. We can upgrade this if we
- * have more complex requirements in the future.
+ * C. For simplicity the mode is encoded as an integer where INT_MAX means no
+ * legacy mode, and '113'/'121' means 1.13/1.21 legacy mode; and 0 maps to
+ * INT_MAX. We can upgrade this if we have more complex requirements in the
+ * future.
  */
-int npy_legacy_print_mode = 0;
+int npy_legacy_print_mode = INT_MAX;
 
 static PyObject *
 set_legacy_print_mode(PyObject *NPY_UNUSED(self), PyObject *args)
 {
     if (!PyArg_ParseTuple(args, "i", &npy_legacy_print_mode)) {
         return NULL;
+    }
+    if (!npy_legacy_print_mode) {
+        npy_legacy_print_mode = INT_MAX;
     }
     Py_RETURN_NONE;
 }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -866,7 +866,7 @@ static PyObject *
 {
     npy_@name@ absval;
 
-    if (npy_legacy_print_mode == 113) {
+    if (npy_legacy_print_mode <= 113) {
         return legacy_@name@_format@kind@(val);
     }
 
@@ -892,7 +892,7 @@ c@name@type_@kind@(PyObject *self)
     npy_c@name@ val = PyArrayScalar_VAL(self, C@Name@);
     TrimMode trim = TrimMode_DptZeros;
 
-    if (npy_legacy_print_mode == 113) {
+    if (npy_legacy_print_mode <= 113) {
         return legacy_c@name@_format@kind@(val);
     }
 
@@ -957,7 +957,7 @@ halftype_@kind@(PyObject *self)
     float floatval = npy_half_to_float(val);
     float absval;
 
-    if (npy_legacy_print_mode == 113) {
+    if (npy_legacy_print_mode <= 113) {
         return legacy_float_format@kind@(floatval);
     }
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -884,6 +884,16 @@ class TestString:
                     " 'offsets': [0, 76800],"
                     " 'itemsize': 80000,"
                     " 'aligned': True}")
+        with np.printoptions(legacy='1.21'):
+            assert_equal(str(dt),
+                        "{'names':['top','bottom'], "
+                         "'formats':[([('tiles', ('>f4', (64, 64)), (1,)), "
+                                      "('rtile', '>f4', (64, 36))], (3,)),"
+                                     "[('bleft', ('>f4', (8, 64)), (1,)), "
+                                      "('bright', '>f4', (8, 36))]], "
+                         "'offsets':[0,76800], "
+                         "'itemsize':80000, "
+                         "'aligned':True}")
         assert_equal(np.dtype(eval(str(dt))), dt)
 
         dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -876,14 +876,14 @@ class TestString:
                                    ('bright', '>f4', (8, 36))])],
                        align=True)
         assert_equal(str(dt),
-                    "{'names':['top','bottom'], "
-                     "'formats':[([('tiles', ('>f4', (64, 64)), (1,)), "
-                                  "('rtile', '>f4', (64, 36))], (3,)),"
-                                 "[('bleft', ('>f4', (8, 64)), (1,)), "
-                                  "('bright', '>f4', (8, 36))]], "
-                     "'offsets':[0,76800], "
-                     "'itemsize':80000, "
-                     "'aligned':True}")
+                    "{'names': ['top', 'bottom'],"
+                    " 'formats': [([('tiles', ('>f4', (64, 64)), (1,)), "
+                                   "('rtile', '>f4', (64, 36))], (3,)), "
+                                  "[('bleft', ('>f4', (8, 64)), (1,)), "
+                                   "('bright', '>f4', (8, 36))]],"
+                    " 'offsets': [0, 76800],"
+                    " 'itemsize': 80000,"
+                    " 'aligned': True}")
         assert_equal(np.dtype(eval(str(dt))), dt)
 
         dt = np.dtype({'names': ['r', 'g', 'b'], 'formats': ['u1', 'u1', 'u1'],
@@ -900,22 +900,22 @@ class TestString:
                        'titles': ['Color', 'Red pixel',
                                   'Green pixel', 'Blue pixel']})
         assert_equal(str(dt),
-                    "{'names':['rgba','r','g','b'],"
-                    " 'formats':['<u4','u1','u1','u1'],"
-                    " 'offsets':[0,0,1,2],"
-                    " 'titles':['Color','Red pixel',"
-                              "'Green pixel','Blue pixel'],"
-                    " 'itemsize':4}")
+                    "{'names': ['rgba', 'r', 'g', 'b'],"
+                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
+                    " 'offsets': [0, 0, 1, 2],"
+                    " 'titles': ['Color', 'Red pixel', "
+                               "'Green pixel', 'Blue pixel'],"
+                    " 'itemsize': 4}")
 
         dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
                         'offsets': [0, 2],
                         'titles': ['Red pixel', 'Blue pixel']})
         assert_equal(str(dt),
-                    "{'names':['r','b'],"
-                    " 'formats':['u1','u1'],"
-                    " 'offsets':[0,2],"
-                    " 'titles':['Red pixel','Blue pixel'],"
-                    " 'itemsize':3}")
+                    "{'names': ['r', 'b'],"
+                    " 'formats': ['u1', 'u1'],"
+                    " 'offsets': [0, 2],"
+                    " 'titles': ['Red pixel', 'Blue pixel'],"
+                    " 'itemsize': 3}")
 
         dt = np.dtype([('a', '<m8[D]'), ('b', '<M8[us]')])
         assert_equal(str(dt),
@@ -948,23 +948,23 @@ class TestString:
                        'titles': ['Color', 'Red pixel',
                                   'Green pixel', 'Blue pixel']}, align=True)
         assert_equal(repr(dt),
-                    "dtype({'names':['rgba','r','g','b'],"
-                    " 'formats':['<u4','u1','u1','u1'],"
-                    " 'offsets':[0,0,1,2],"
-                    " 'titles':['Color','Red pixel',"
-                              "'Green pixel','Blue pixel'],"
-                    " 'itemsize':4}, align=True)")
+                    "dtype({'names': ['rgba', 'r', 'g', 'b'],"
+                    " 'formats': ['<u4', 'u1', 'u1', 'u1'],"
+                    " 'offsets': [0, 0, 1, 2],"
+                    " 'titles': ['Color', 'Red pixel', "
+                                "'Green pixel', 'Blue pixel'],"
+                    " 'itemsize': 4}, align=True)")
 
         dt = np.dtype({'names': ['r', 'b'], 'formats': ['u1', 'u1'],
                         'offsets': [0, 2],
                         'titles': ['Red pixel', 'Blue pixel'],
                         'itemsize': 4})
         assert_equal(repr(dt),
-                    "dtype({'names':['r','b'], "
-                    "'formats':['u1','u1'], "
-                    "'offsets':[0,2], "
-                    "'titles':['Red pixel','Blue pixel'], "
-                    "'itemsize':4})")
+                    "dtype({'names': ['r', 'b'], "
+                    "'formats': ['u1', 'u1'], "
+                    "'offsets': [0, 2], "
+                    "'titles': ['Red pixel', 'Blue pixel'], "
+                    "'itemsize': 4})")
 
     def test_repr_structured_datetime(self):
         dt = np.dtype([('a', '<M8[D]'), ('b', '<m8[us]')])

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -819,7 +819,8 @@ def repack_fields(a, align=False, recurse=False):
     ...
     >>> dt = np.dtype('u1, <i8, <f8', align=True)
     >>> dt
-    dtype({'names':['f0','f1','f2'], 'formats':['u1','<i8','<f8'], 'offsets':[0,8,16], 'itemsize':24}, align=True)
+    dtype({'names': ['f0', 'f1', 'f2'], 'formats': ['u1', '<i8', '<f8'], \
+'offsets': [0, 8, 16], 'itemsize': 24}, align=True)
     >>> print_offsets(dt)
     offsets: [0, 8, 16]
     itemsize: 24

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3948,7 +3948,7 @@ class MaskedArray(ndarray):
 
 
         # 2016-11-19: Demoted to legacy format
-        if np.get_printoptions()['legacy'] == '1.13':
+        if np.core.arrayprint._get_legacy_print_mode() <= 113:
             is_long = self.ndim > 1
             parameters = dict(
                 name=name,


### PR DESCRIPTION
Before:
```
In [1]: np.dtype({"names": ["a"], "formats": [int], "offsets": [2]})
Out[1]: dtype({'names':['a'], 'formats':['<i8'], 'offsets':[2], 'itemsize':10})
```

After:
```
In [1]: np.dtype({"names": ["a"], "formats": [int], "offsets": [2]})
Out[1]: dtype({'names': ['a'], 'formats': ['<i8'], 'offsets': [2], 'itemsize': 10})
```

The version with spaces feels much more idiomatic to me...

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
