### PR TITLE
DOC: fix typo in example

### DIFF
--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -296,7 +296,7 @@ There are a number of routines to join existing arrays e.g. :func:`numpy.vstack`
 arrays into a 4-by-4 array using ``block``::
 
  >>> A = np.ones((2, 2))
- >>> B = np.eye((2, 2))
+ >>> B = np.eye(2, 2)
  >>> C = np.zeros((2, 2))
  >>> D = np.diag((-3, -4))
  >>> np.block([[A, B], 


### PR DESCRIPTION
	B = np.eye((2, 2))
	It should be B = np.eye(2, 2)

Signed-off-by: yan <yan-wyb@foxmail.com>

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
