### PR TITLE
BUG: Casting bool_ to float16 

### DIFF
--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -819,6 +819,10 @@ NPY_NO_EXPORT PyArrayMethod_StridedLoop *
 #    define _CONVERT_FN(x) npy_floatbits_to_halfbits(x)
 #  elif @is_double1@
 #    define _CONVERT_FN(x) npy_doublebits_to_halfbits(x)
+#  elif @is_half1@
+#    define _CONVERT_FN(x) (x)
+#  elif @is_bool1@
+#    define _CONVERT_FN(x) npy_float_to_half((float)(x!=0))
 #  else
 #    define _CONVERT_FN(x) npy_float_to_half((float)x)
 #  endif

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -190,6 +190,12 @@ class TestCasting:
 
         return arr1, arr2, values
 
+    res = np.array([0, 3, -7], dtype=np.int8).view(bool)
+    expected = [0, 1, 1]
+
+    def conversion(self, res, expected):
+        assert_array_equal(res, expected)
+
     def get_data_variation(self, arr1, arr2, aligned=True, contig=True):
         """
         Returns a copy of arr1 that may be non-contiguous or unaligned, and a

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -190,12 +190,6 @@ class TestCasting:
 
         return arr1, arr2, values
 
-    res = np.array([0, 3, -7], dtype=np.int8).view(bool)
-    expected = [0, 1, 1]
-
-    def conversion(self, res, expected):
-        assert_array_equal(res, expected)
-
     def get_data_variation(self, arr1, arr2, aligned=True, contig=True):
         """
         Returns a copy of arr1 that may be non-contiguous or unaligned, and a
@@ -701,6 +695,14 @@ class TestCasting:
             expected = arr_normal.astype(dtype)
         except TypeError:
             with pytest.raises(TypeError):
-                arr_NULLs.astype(dtype)
+                arr_NULLs.astype(dtype),
         else:
             assert_array_equal(expected, arr_NULLs.astype(dtype))
+
+
+    def test_float_to_bool(self):
+        # test case corresponding to gh-19514
+        # simple test for casting bool_ to float16 
+        res = np.array([0, 3, -7], dtype=np.int8).view(bool)
+        expected = [0, 1, 1]
+        assert_array_equal(res, expected)

--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -699,7 +699,6 @@ class TestCasting:
         else:
             assert_array_equal(expected, arr_NULLs.astype(dtype))
 
-
     def test_float_to_bool(self):
         # test case corresponding to gh-19514
         # simple test for casting bool_ to float16 


### PR DESCRIPTION
Fixes #19514

For the conversion `bool` -->  `float`  --> `half` made the `@is_half2@ && @is_bool1@` case which was not present.