### PR TITLE
BUG: Fix reference leak of capi_tmp in f2py/cb_rules.py

### DIFF
--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -110,6 +110,7 @@ f2py_cb_start_clock();
         capi_tmp = PyObject_GetAttrString(#modulename#_module,\"#argname#_extra_args\");
         if (capi_tmp) {
             capi_arglist = (PyTupleObject *)PySequence_Tuple(capi_tmp);
+            Py_DECREF(capi_tmp);
             if (capi_arglist==NULL) {
                 PyErr_SetString(#modulename#_error,\"Failed to convert #modulename#.#argname#_extra_args to tuple.\\n\");
                 goto capi_fail;


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

See #19575. Fixes missing `Py_DECREF` of unused `capi_tmp` in C code stored as strings in `numpy/f2py/cb_rules.py`. This is placed right after [line 112](https://github.com/numpy/numpy/blob/main/numpy/f2py/cb_rules.py#L112) and not as a `Py_XDECREF` after the `capi_fail` label as `capi_tmp` is assigned a borrowed reference [elsewhere](https://github.com/numpy/numpy/blob/main/numpy/f2py/cb_rules.py#L453-L462).

Using latest `main` checkout, built locally on WSL Ubuntu 20.04 with Python 3.8.5, GCC 9.3.0, Cython 0.29.24, tests run with `runtests.py -v`, all `f2py` tests passed. Not familiar with `f2py` but submitted based on my knowledge of the Python C API.