### PR TITLE
BUG: fix time cast-safety for `factor*unit` e.g. in `10**6*ms == 1*s`

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -12,11 +12,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <time.h>
-
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#define _MULTIARRAYMODULE
-#include <numpy/arrayobject.h>
+#include "numpy/arrayobject.h"
 #include "numpyos.h"
 
 #include "npy_config.h"

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -723,17 +723,27 @@ parse_datetime_extended_unit_from_string(char const *str, Py_ssize_t len,
 {
     char const *substr = str, *substrend = NULL;
     int den = 1;
-    int64_t true_meta_num;
 
     /* First comes an optional integer multiplier */
-    true_meta_num = strtol_const(substr, &substrend, 10);
-    // check for 32-bit integer overflow
-    if (true_meta_num > INT_MAX) {
-        goto bad_input;
-    }
-    out_meta->num = (int)true_meta_num;
+    out_meta->num = (int)strtol_const(substr, &substrend, 10);
     if (substr == substrend) {
         out_meta->num = 1;
+    }
+    else {
+        // check for 32-bit integer overflow
+        char subs_digits[20];
+        strcpy(subs_digits, substr);
+        uint64_t idx;
+        for(idx=0; idx<strlen(substr); idx++) {
+            if(isdigit(substr[idx]) == 0) {
+                break;
+            }
+        }
+        subs_digits[idx] = '\0';
+        PyObject *true_meta_num = PyLong_FromString(subs_digits, NULL, 0);
+        if (PyLong_AsLongLong(true_meta_num) > INT_MAX) {
+            goto bad_input;
+        }
     }
     substr = substrend;
 

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -735,7 +735,7 @@ parse_datetime_extended_unit_from_string(char const *str, Py_ssize_t len,
         // check for 32-bit integer overflow
         char *endptr = NULL;
         true_meta_val = NumPyOS_strtoll(substr, &endptr, 10);
-        if (true_meta_val > INT_MAX) {
+        if (true_meta_val > INT_MAX || true_meta_val < 0) {
             goto bad_input;
         }
     }

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -3776,7 +3776,15 @@ time_to_time_resolve_descriptors(
     meta2 = get_datetime_metadata_from_dtype(loop_descrs[1]);
     assert(meta2 != NULL);
 
-    if (meta1->base == meta2->base && meta1->num == meta2->num) {
+    if ((meta1->base == meta2->base && meta1->num == meta2->num) ||
+        // handle some common metric prefix conversions
+        // 1000 fold conversions
+        ((meta2->base >= 7) && (meta1->base - meta2->base == 1)
+          && ((meta1->num / meta2->num) == 1000)) ||
+        // 10^6 fold conversions
+        ((meta2->base >= 7) && (meta1->base - meta2->base == 2)
+          && ((meta1->num / meta2->num) == 1000000))
+        )  {
         if (byteorder_may_allow_view) {
             return NPY_NO_CASTING | byteorder_may_allow_view;
         }

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -723,7 +723,7 @@ parse_datetime_extended_unit_from_string(char const *str, Py_ssize_t len,
 {
     char const *substr = str, *substrend = NULL;
     int den = 1;
-    long int true_meta_num;
+    long long int true_meta_num;
 
     /* First comes an optional integer multiplier */
     true_meta_num = strtol_const(substr, &substrend, 10);
@@ -3786,14 +3786,13 @@ time_to_time_resolve_descriptors(
         // handle some common metric prefix conversions
         // 1000 fold conversions
         ((meta2->base >= 7) && (meta1->base - meta2->base == 1)
-          && ((meta1->num / meta2->num) == 1000)) ||
+        && ((meta1->num / meta2->num) == 1000)) ||
         // 10^6 fold conversions
         ((meta2->base >= 7) && (meta1->base - meta2->base == 2)
-          && ((meta1->num / meta2->num) == 1000000)) ||
+        && ((meta1->num / meta2->num) == 1000000)) ||
         // 10^9 fold conversions
         ((meta2->base >= 7) && (meta1->base - meta2->base == 3)
-          && ((meta1->num / meta2->num) == 1000000000))
-        )  {
+        && ((meta1->num / meta2->num) == 1000000000))) {
         if (byteorder_may_allow_view) {
             return NPY_NO_CASTING | byteorder_may_allow_view;
         }

--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -723,7 +723,7 @@ parse_datetime_extended_unit_from_string(char const *str, Py_ssize_t len,
 {
     char const *substr = str, *substrend = NULL;
     int den = 1;
-    long long int true_meta_num;
+    int64_t true_meta_num;
 
     /* First comes an optional integer multiplier */
     true_meta_num = strtol_const(substr, &substrend, 10);
@@ -3783,16 +3783,16 @@ time_to_time_resolve_descriptors(
     assert(meta2 != NULL);
 
     if ((meta1->base == meta2->base && meta1->num == meta2->num) ||
-        // handle some common metric prefix conversions
-        // 1000 fold conversions
-        ((meta2->base >= 7) && (meta1->base - meta2->base == 1)
-        && ((meta1->num / meta2->num) == 1000)) ||
-        // 10^6 fold conversions
-        ((meta2->base >= 7) && (meta1->base - meta2->base == 2)
-        && ((meta1->num / meta2->num) == 1000000)) ||
-        // 10^9 fold conversions
-        ((meta2->base >= 7) && (meta1->base - meta2->base == 3)
-        && ((meta1->num / meta2->num) == 1000000000))) {
+            // handle some common metric prefix conversions
+            // 1000 fold conversions
+            ((meta2->base >= 7) && (meta1->base - meta2->base == 1)
+              && ((meta1->num / meta2->num) == 1000)) ||
+            // 10^6 fold conversions
+            ((meta2->base >= 7) && (meta1->base - meta2->base == 2)
+              && ((meta1->num / meta2->num) == 1000000)) ||
+            // 10^9 fold conversions
+            ((meta2->base >= 7) && (meta1->base - meta2->base == 3)
+              && ((meta1->num / meta2->num) == 1000000000))) {
         if (byteorder_may_allow_view) {
             return NPY_NO_CASTING | byteorder_may_allow_view;
         }

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -63,6 +63,7 @@ class TestDateTime:
         assert_raises(TypeError, np.dtype, 'm7')
         assert_raises(TypeError, np.dtype, 'M16')
         assert_raises(TypeError, np.dtype, 'm16')
+        assert_raises(TypeError, np.dtype, 'M8[3000000000ps]')
 
     def test_datetime_casting_rules(self):
         # Cannot cast safely/same_kind between timedelta and datetime
@@ -150,6 +151,9 @@ class TestDateTime:
         # 10^6 conversions
         assert np.can_cast('M8[2000000ps]', 'M8[2us]', casting='safe')
         assert np.can_cast('M8[1000000as]', 'M8[1ps]', casting='safe')
+        # 10^9 conversions below 32-bit overflow limit
+        assert np.can_cast('M8[2000000000ps]', 'M8[2ms]', casting='safe')
+        assert np.can_cast('M8[1000000000as]', 'M8[1ns]', casting='safe')
 
     def test_compare_generic_nat(self):
         # regression tests for gh-6452

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -137,6 +137,20 @@ class TestDateTime:
         assert_(not np.can_cast('M8[h]', 'M8', casting='same_kind'))
         assert_(not np.can_cast('M8[h]', 'M8', casting='safe'))
 
+        # regression tests related to gh-19631;
+        # test metric prefixes from seconds down to
+        # attoseconds for 1000x conversions
+        assert np.can_cast('M8[7000ms]', 'M8[7s]', casting='safe')
+        assert np.can_cast('M8[2000us]', 'M8[2ms]', casting='safe')
+        assert np.can_cast('M8[1000ns]', 'M8[us]', casting='safe')
+        assert np.can_cast('M8[5000ns]', 'M8[5us]', casting='safe')
+        assert np.can_cast('M8[2000ps]', 'M8[2ns]', casting='safe')
+        assert np.can_cast('M8[9000fs]', 'M8[9ps]', casting='safe')
+        assert np.can_cast('M8[1000as]', 'M8[1fs]', casting='safe')
+        # 10^6 conversions
+        assert np.can_cast('M8[2000000ps]', 'M8[2us]', casting='safe')
+        assert np.can_cast('M8[1000000as]', 'M8[1ps]', casting='safe')
+
     def test_compare_generic_nat(self):
         # regression tests for gh-6452
         assert_(np.datetime64('NaT') !=

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -168,6 +168,12 @@ class TestDateTime:
             assert np.can_cast(larger_unit, smaller_unit, casting='safe')
             assert np.can_cast(smaller_unit, larger_unit, casting='safe')
 
+    @pytest.mark.parametrize("unit", [
+        "s", "ms", "us", "ns", "ps", "fs", "as"])
+    def test_prohibit_negative_datetime(self, unit):
+        with assert_raises(TypeError):
+            np.array([1], dtype=f"M8[-1{unit}]")
+
     def test_compare_generic_nat(self):
         # regression tests for gh-6452
         assert_(np.datetime64('NaT') !=

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -138,22 +138,37 @@ class TestDateTime:
         assert_(not np.can_cast('M8[h]', 'M8', casting='same_kind'))
         assert_(not np.can_cast('M8[h]', 'M8', casting='safe'))
 
+    def test_datetime_prefix_conversions(self):
         # regression tests related to gh-19631;
         # test metric prefixes from seconds down to
-        # attoseconds for 1000x conversions
-        assert np.can_cast('M8[7000ms]', 'M8[7s]', casting='safe')
-        assert np.can_cast('M8[2000us]', 'M8[2ms]', casting='safe')
-        assert np.can_cast('M8[1000ns]', 'M8[us]', casting='safe')
-        assert np.can_cast('M8[5000ns]', 'M8[5us]', casting='safe')
-        assert np.can_cast('M8[2000ps]', 'M8[2ns]', casting='safe')
-        assert np.can_cast('M8[9000fs]', 'M8[9ps]', casting='safe')
-        assert np.can_cast('M8[1000as]', 'M8[1fs]', casting='safe')
-        # 10^6 conversions
-        assert np.can_cast('M8[2000000ps]', 'M8[2us]', casting='safe')
-        assert np.can_cast('M8[1000000as]', 'M8[1ps]', casting='safe')
-        # 10^9 conversions below 32-bit overflow limit
-        assert np.can_cast('M8[2000000000ps]', 'M8[2ms]', casting='safe')
-        assert np.can_cast('M8[1000000000as]', 'M8[1ns]', casting='safe')
+        # attoseconds for bidirectional conversions
+        smaller_units = ['M8[7000ms]',
+                         'M8[2000us]',
+                         'M8[1000ns]',
+                         'M8[5000ns]',
+                         'M8[2000ps]',
+                         'M8[9000fs]',
+                         'M8[1000as]',
+                         'M8[2000000ps]',
+                         'M8[1000000as]',
+                         'M8[2000000000ps]',
+                         'M8[1000000000as]',
+                        ]
+        larger_units = ['M8[7s]',
+                        'M8[2ms]',
+                        'M8[us]',
+                        'M8[5us]',
+                        'M8[2ns]',
+                        'M8[9ps]',
+                        'M8[1fs]',
+                        'M8[2us]',
+                        'M8[1ps]',
+                        'M8[2ms]',
+                        'M8[1ns]',
+                         ]
+        for larger_unit, smaller_unit in zip(larger_units, smaller_units):
+            assert np.can_cast(larger_unit, smaller_unit, casting='safe')
+            assert np.can_cast(smaller_unit, larger_unit, casting='safe')
 
     def test_compare_generic_nat(self):
         # regression tests for gh-6452

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -152,8 +152,7 @@ class TestDateTime:
                          'M8[2000000ps]',
                          'M8[1000000as]',
                          'M8[2000000000ps]',
-                         'M8[1000000000as]',
-                        ]
+                         'M8[1000000000as]']
         larger_units = ['M8[7s]',
                         'M8[2ms]',
                         'M8[us]',
@@ -164,8 +163,7 @@ class TestDateTime:
                         'M8[2us]',
                         'M8[1ps]',
                         'M8[2ms]',
-                        'M8[1ns]',
-                         ]
+                        'M8[1ns]']
         for larger_unit, smaller_unit in zip(larger_units, smaller_units):
             assert np.can_cast(larger_unit, smaller_unit, casting='safe')
             assert np.can_cast(smaller_unit, larger_unit, casting='safe')


### PR DESCRIPTION
Fixes #19631

* for `datetime64` units smaller than `s`, handle some
common/reasonable "metrix prefix" casting conversions like
1000 ns == 1 us

* this adds support specifically for equivalencies that span
10^3 and 10^6 fold, but there are even more beyond that, and if
we want to handle them all we may want to abstract to a handler
function

* that said, this still seems like a solid improvement that covers
some of the more common cases?

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
