### PR TITLE
DOC: add citation file for GitHub support

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,20 @@
+@ARTICLE{2020NumPy-Array,
+  author  = {Harris, Charles R. and Millman, K. Jarrod and
+            van der Walt, Stéfan J and Gommers, Ralf and
+            Virtanen, Pauli and Cournapeau, David and
+            Wieser, Eric and Taylor, Julian and Berg, Sebastian and
+            Smith, Nathaniel J. and Kern, Robert and Picus, Matti and
+            Hoyer, Stephan and van Kerkwijk, Marten H. and
+            Brett, Matthew and Haldane, Allan and
+            Fernández del Río, Jaime and Wiebe, Mark and
+            Peterson, Pearu and Gérard-Marchant, Pierre and
+            Sheppard, Kevin and Reddy, Tyler and Weckesser, Warren and
+            Abbasi, Hameer and Gohlke, Christoph and
+            Oliphant, Travis E.},
+  title   = {Array programming with {NumPy}},
+  journal = {Nature},
+  year    = {2020},
+  volume  = {585},
+  pages   = {357–362},
+  doi     = {10.1038/s41586-020-2649-2}
+}


### PR DESCRIPTION
GitHub supports a citation mechanism.

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files

Mainly there are 2 options, either go with a CITATION.cff or CITATION.bib. Here I went with bib as already have a bib for the Nature article. Also CITATION.cff seems more appropriate when the repo does not have a paper.

xref https://github.com/scipy/scipy/pull/14630

[SKIP CI]