### PR TITLE
PERF: Avoid unnecessary string operations in loadtxt.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1137,9 +1137,6 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             for i, (lineno, words) in enumerate(lineno_words_iter):
                 if usecols:
                     words = usecols_getter(words)
-                elif len(words) != ncols:
-                    raise ValueError(
-                        f"Wrong number of columns at line {lineno}")
                 try:
                     X[i] = tuple(words)  # Try implicit conversion of strs.
                     continue  # OK, done.
@@ -1147,8 +1144,13 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
                     # Resize, and, for simplicity, use explicit converters too.
                     X.resize(2 * len(X), refcheck=False)
                 except ValueError:
-                    # Fallback to explicit converters.
-                    pass
+                    # ValueError can be raised either by a length mismatch...
+                    if len(words) != ncols:
+                        raise ValueError(
+                            f"Wrong number of columns at line {lineno}"
+                        ) from None
+                    # Or because the explicit (more lenient) converter (below)
+                    # is needed.
                 X[i] = convert_row(words)
             if i is None:
                 X = None

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1166,6 +1166,14 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             if X is None:
                 X = np.array(chunk, dtype)
             else:
+                # If using unsized string or byte dtype, make sure that the
+                # existing array is capable of storing the new data. If not,
+                # change the dtype so it is capable of doing so.
+                if (dtype.type in (np.str_, np.bytes_)
+                        and dtype.itemsize == 0):
+                    chunk = np.array(chunk, dtype)
+                    if chunk.dtype.itemsize > X.dtype.itemsize:
+                        X = X.astype(chunk.dtype)
                 nshape = list(X.shape)
                 pos = nshape[0]
                 nshape[0] += len(chunk)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -918,6 +918,14 @@ class TestLoadTxt(LoadTxtBase):
             x = np.loadtxt(c, dtype=dt)
             assert_array_equal(x, a)
 
+    def test_str_dtype_differing_lengths(self):
+        c = ["str1", "str2", "str3verylong"]
+
+        for dt in (str, np.bytes_):
+            a = np.array(["str1", "str2", "str3verylong"], dtype=dt)
+            x = np.loadtxt(c, dtype=dt)
+            assert_array_equal(x, a)
+
     def test_empty_file(self):
         with suppress_warnings() as sup:
             sup.filter(message="loadtxt: Empty input file:")


### PR DESCRIPTION
This PR goes on top of #19687 (only the last commit is new), but showcases another speed benefit of special-casing numeric types in loadtxt, so I thought I may as well post it already :-)

-----

When using _IMPLICIT_CONVERTERS, it is actually OK if strings are
passed with trailing newlines (so we don't need to strip `"\r\n"`),
and comments can be implicitly detected because the converters raise
ValueError on them.  Therefore, one can use an "approximate" line
splitter, which doesn't remove trailing comments and newlines, falling
back on the full line splitter if needed.  This provides a 10-20%
speedup in the case where there are actually no comments in the file (we
could instead check the value of the `comments` kwarg, but it defaults
to a non-empty value and it seems likely most users will not notice that
a large speedup can be achieved by emptying it).

However, if there *are* actual comments in the file, then recreating the
original string from the approximately split one and then re-splitting
it is very costly (it would incur a >2x slowdown), so switch back to the
full splitter (controlled by a local flag) in that case.  Overall, only
very short (10 rows) loads that include comments are slowed down by ~10%
(likely by the extra processing on the row with comments).

(To be fully explicit, despite its name, the "approximate" splitter will
never parse incorrect values; it may simply "fail", but we just fall
back to the full/slow splitter in that case.)

-----

The obligatory benchmarks:
```
       before           after         ratio
     [df5ee9f3]       [a40561a7]
     <loadtxtflatdtype>       <loadtxt-approx-split-line>
+      44.9±0.5μs       50.0±0.1μs     1.11  bench_io.LoadtxtCSVComments.time_comment_loadtxt_csv(10)
-     46.3±0.05μs       44.0±0.1μs     0.95  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float32', 10)
-     47.5±0.05μs       45.1±0.4μs     0.95  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 10)
-      45.3±0.1μs      42.7±0.08μs     0.94  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int32', 10)
-       133±0.7ms        113±0.2ms     0.85  bench_io.LoadtxtCSVSkipRows.time_skiprows_csv(10000)
-       146±0.7ms        124±0.5ms     0.85  bench_io.LoadtxtCSVSkipRows.time_skiprows_csv(0)
-       145±0.7ms        123±0.4ms     0.85  bench_io.LoadtxtCSVSkipRows.time_skiprows_csv(500)
-         115±1μs       97.2±0.2μs     0.84  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float32', 100)
-         125±1μs        106±0.5μs     0.84  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 100)
-     8.94±0.05ms      7.49±0.09ms     0.84  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 10000)
-         116±1μs       96.9±0.6μs     0.83  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float64', 100)
-      88.9±0.6ms       73.8±0.6ms     0.83  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('complex128', 100000)
-         113±2μs       93.2±0.6μs     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int64', 100)
-         795±6μs          654±4μs     0.82  bench_io.LoadtxtReadUint64Integers.time_read_uint64(1000)
-         459±4μs          376±1μs     0.82  bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values(550)
-         798±6μs          654±5μs     0.82  bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values(1000)
-         458±2μs          375±2μs     0.82  bench_io.LoadtxtReadUint64Integers.time_read_uint64(550)
-     7.94±0.03ms      6.47±0.04ms     0.82  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float32', 10000)
-         114±1μs       92.5±0.3μs     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int32', 100)
-      78.3±0.3ms       63.6±0.2ms     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float32', 100000)
-      7.68±0.1ms      6.23±0.09ms     0.81  bench_io.LoadtxtReadUint64Integers.time_read_uint64_neg_values(10000)
-     7.97±0.04ms      6.47±0.05ms     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float64', 10000)
-     7.67±0.07ms      6.21±0.08ms     0.81  bench_io.LoadtxtReadUint64Integers.time_read_uint64(10000)
-      79.2±0.7ms       64.0±0.4ms     0.81  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('float64', 100000)
-     7.67±0.05ms       6.00±0.1ms     0.78  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int64', 10000)
-      76.1±0.8ms       59.5±0.9ms     0.78  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int32', 100000)
-      7.69±0.1ms       5.98±0.1ms     0.78  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int32', 10000)
-      76.6±0.4ms       59.1±0.9ms     0.77  bench_io.LoadtxtCSVdtypes.time_loadtxt_dtypes_csv('int64', 100000)
```