### PR TITLE
BUG: Fix passing a MaskedArray instance to ``MaskedArray.__setitem__``

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3374,7 +3374,8 @@ class MaskedArray(ndarray):
                 _mask[indx] = mval
         elif not self._hardmask:
             # Set the data, then the mask
-            if isinstance(indx, masked_array):
+            if (isinstance(indx, masked_array) and
+                    not isinstance(value, masked_array)):
                 _data[indx.data] = dval
             else:
                 _data[indx] = dval

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -704,6 +704,15 @@ class TestMa:
         a[c] = 5
         assert_(a[2] is masked)
 
+    def test_assignment_by_condition_2(self):
+        # gh-19721
+        a = masked_array([0, 1], mask=[False, False])
+        b = masked_array([0, 1], mask=[True, True])
+        mask = a < 1
+        b[mask] = a[mask]
+        expected_mask = [False, True]
+        assert_equal(b.mask, expected_mask)
+
 
 class TestUfuncs:
     def setup(self):


### PR DESCRIPTION
Fixes #19721
I'm not really satisfied with the approach (nested `isinstance`) *but* it turns out that this seems to work without breaking other related tests.
I'll take any advice on how to improve over this if required.