### PR TITLE
NEP: Update NEP 47: Adopting the array API standard

### DIFF
--- a/doc/neps/nep-0047-array-api-standard.rst
+++ b/doc/neps/nep-0047-array-api-standard.rst
@@ -91,7 +91,7 @@ In addition to those use cases, the new namespace contains functionality that
 is widely used and supported by many array libraries. As such, it is a good
 set of functions to teach to newcomers to NumPy and recommend as "best
 practice". That contrasts with NumPy's main namespace, which contains many
-functions and objects that have been superceded or we consider mistakes - but
+functions and objects that have been superseded or we consider mistakes - but
 that we can't remove because of backwards compatibility reasons.
 
 The usage of the ``numpy.array_api`` namespace by downstream libraries is
@@ -104,7 +104,7 @@ Adoption in downstream libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The prototype implementation of the ``array_api`` namespace will be used with
-SciPy, scikit-learn and other libraries of interest that depend on NumPy, in
+SciPy, scikit-learn, and other libraries of interest that depend on NumPy, in
 order to get more experience with the design and find out if any important
 parts are missing.
 
@@ -179,35 +179,41 @@ have a direct NumPy equivalent. This figure shows what is included at a high lev
 
 The most important changes compared to what NumPy currently offers are:
 
-- A new array object which:
+- A new array object, ``numpy.array_api.Array`` which:
 
-    - conforms to the casting rules and indexing behaviour specified by the
+    - is a thin pure Python (non-subclass) wrapper around ``np.ndarray``,
+    - conforms to the casting rules and indexing behavior specified by the
       standard,
     - does not have methods other than dunder methods,
-    - does not support the full range of NumPy indexing behaviour. Advanced
-      indexing with integers is not supported. Only boolean indexing
-      with a single (possibly multi-dimensional) boolean array is supported.
-      An indexing expression that selects a single element returns a 0-D array
-      rather than a scalar.
+    - does not support the full range of NumPy indexing behavior (see
+      :ref:`indexing` below),
+    - does not have distinct scalar objects, only 0-D arrays,
+    - cannot be constructed directly. Instead array construction functions
+      like ``asarray()`` should be used.
 
 - Functions in the ``array_api`` namespace:
 
-    - do not accept ``array_like`` inputs, only NumPy arrays and Python scalars
+    - do not accept ``array_like`` inputs, only ``numpy.array_api`` array
+      objects, with Python scalars only being supported in dunder operators on
+      the array object,
     - do not support ``__array_ufunc__`` and ``__array_function__``,
     - use positional-only and keyword-only parameters in their signatures,
     - have inline type annotations,
     - may have minor changes to signatures and semantics of individual
       functions compared to their equivalents already present in NumPy,
     - only support dtype literals, not format strings or other ways of
-      specifying dtypes
+      specifying dtypes,
+    - generally may only support a restricted set of dtypes compared to their
+      NumPy counterparts.
 
 - DLPack_ support will be added to NumPy,
 - New syntax for "device support" will be added, through a ``.device``
   attribute on the new array object, and ``device=`` keywords in array creation
   functions in the ``array_api`` namespace,
-- Casting rules that differ from those NumPy currently has. Output dtypes can
+- Casting rules will differ from those NumPy currently has. Output dtypes can
   be derived from input dtypes (i.e. no value-based casting), and 0-D arrays
-  are treated like >=1-D arrays.
+  are treated like >=1-D arrays. Cross-kind casting (e.g., int to float) is
+  not allowed.
 - Not all dtypes NumPy has are part of the standard. Only boolean, signed and
   unsigned integers, and floating-point dtypes up to ``float64`` are supported.
   Complex dtypes are expected to be added in the next version of the standard.
@@ -220,6 +226,31 @@ Improvements to existing NumPy functionality that are needed include:
   that are currently missing such support.
 - Add the ``keepdims`` keyword to ``np.argmin`` and ``np.argmax``.
 - Add a "never copy" mode to ``np.asarray``.
+- Add smallest_normal to ``np.finfo()``.
+- DLPack_ support.
+
+Additionally, the ``numpy.array_api`` implementation was chosen to be a
+*minimal* implementation of the array API standard. This means that it not
+only conforms to all the requirements of the array API, but it explicitly does
+not include any APIs or behaviors not explicitly required by it. The standard
+itself does not require implementations to be so restrictive, but doing this
+with the NumPy array API implementation will allow it to become a canonical
+implementation of the array API standard. Anyone who wants to make use of the
+array API standard can use the NumPy implementation and be sure that their
+code is not making use of behaviors that will not be in other conforming
+implementations.
+
+In particular, this means
+
+- ``numpy.array_api`` will only include those functions that are listed in the
+  standard. This also applies to methods on the ``Array`` object,
+- Functions will only accept input dtypes that are required by the standard
+  (e.g., transcendental functions like ``cos`` will not accept integer dtypes
+  because the standard only requires them to accept floating-point dtypes),
+- Type promotion will only occur for combinations of dtypes required by the
+  standard (see the :ref:`dtypes-and-casting-rules` section below),
+- Indexing is limited to a subset of possible index types (see :ref:`indexing`
+  below).
 
 
 Functions in the ``array_api`` namespace
@@ -228,41 +259,56 @@ Functions in the ``array_api`` namespace
 Let's start with an example of a function implementation that shows the most
 important differences with the equivalent function in the main namespace::
 
-    def max(x: array, /, *,
-            axis: Optional[Union[int, Tuple[int, ...]]] = None,
-            keepdims: bool = False
-        ) -> array:
+    def matmul(x1: Array, x2: Array, /) -> Array:
         """
-        Array API compatible wrapper for :py:func:`np.max <numpy.max>`.
+        Array API compatible wrapper for :py:func:`np.matmul <numpy.matmul>`.
+        See its docstring for more information.
         """
-        return np.max._implementation(x, axis=axis, keepdims=keepdims)
+        if x1.dtype not in _numeric_dtypes or x2.dtype not in _numeric_dtypes:
+            raise TypeError("Only numeric dtypes are allowed in matmul")
 
-This function does not accept ``array_like`` inputs, only ``ndarray``. There
-are multiple reasons for this. Other array libraries all work like this.
-Letting the user do coercion of lists, generators, or other foreign objects
-separately results in a cleaner design with less unexpected behaviour.
-It's higher-performance - less overhead from ``asarray`` calls. Static typing
-is easier. Subclasses will work as expected. And the slight increase in verbosity
-because users have to explicitly coerce to ``ndarray`` on rare occasions
-seems like a small price to pay.
+        # Call result type here just to raise on disallowed type combinations
+        _result_type(x1.dtype, x2.dtype)
+
+        return Array._new(np.matmul(x1._array, x2._array))
+
+This function does not accept ``array_like`` inputs, only
+``numpy.array_api.Array``. There are multiple reasons for this. Other array
+libraries all work like this. Requiring the user to do coercion of Python
+scalars, lists, generators, or other foreign objects explicitly results in a
+cleaner design with less unexpected behavior. It is higher-performance---less
+overhead from ``asarray`` calls. Static typing is easier. Subclasses will work
+as expected. And the slight increase in verbosity because users have to
+explicitly coerce to ``ndarray`` on rare occasions seems like a small price to
+pay.
 
 This function does not support ``__array_ufunc__`` nor ``__array_function__``.
 These protocols serve a similar purpose as the array API standard module itself,
-but through a different mechanisms. Because only ``ndarray`` instances are accepted,
+but through a different mechanisms. Because only ``Array`` instances are accepted,
 dispatching via one of these protocols isn't useful anymore.
 
-This function uses positional-only parameters in its signature. This makes code
-more portable - writing ``max(x=x, ...)`` is no longer valid, hence if other
-libraries call the first parameter ``input`` rather than ``x``, that is fine.
-The rationale for keyword-only parameters (not shown in the above example) is
-two-fold: clarity of end user code, and it being easier to extend the signature
-in the future with keywords in the desired order.
+This function uses positional-only parameters in its signature. This makes
+code more portable---writing, for instance, ``max(a=a, ...)`` is no longer
+valid, hence if other libraries call the first parameter ``input`` rather than
+``a``, that is fine. Note that NumPy already uses positional-only arguments
+for functions that are ufuncs. The rationale for keyword-only parameters (not
+shown in the above example) is two-fold: clarity of end user code, and it
+being easier to extend the signature in the future without worrying about the
+order of keywords.
 
 This function has inline type annotations. Inline annotations are far easier to
 maintain than separate stub files. And because the types are simple, this will
 not result in a large amount of clutter with type aliases or unions like in the
 current stub files NumPy has.
 
+This function only accepts numeric dtypes (i.e., not ``bool``). It also does
+not allow the input dtypes to be of different kinds (the internal
+``_result_type()`` function will raise ``TypeError`` on cross-kind type
+combinations like ``_result_type(int32, float64)``). This allows the
+implementation to be minimal. Preventing combinations that work in NumPy but
+are not required by the array API specification lets users of the submodule
+know they are not relying on NumPy specific behavior that may not be present
+in array API conforming implementations from other libraries.
 
 DLPack support for zero-copy data interchange
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -283,16 +329,16 @@ the options already present in NumPy are:
    ROCm drivers, or OpenCL devices). NumPy is CPU-only, but other array
    libraries are not. Having one protocol per device isn't tenable, hence
    device support is a must.
-2. Widespread support. DLPack has the widest adoption of all protocols, only
-   NumPy is missing support. And the experiences of other libraries with it
+2. Widespread support. DLPack has the widest adoption of all protocols. Only
+   NumPy is missing support, and the experiences of other libraries with it
    are positive. This contrasts with the protocols NumPy does support, which
-   are used very little - when other libraries want to interoperate with
+   are used very little---when other libraries want to interoperate with
    NumPy, they typically use the (more limited, and NumPy-specific)
    ``__array__`` protocol.
 
 Adding support for DLPack to NumPy entails:
 
-- Adding a ``ndarray.__dlpack__`` method
+- Adding a ``ndarray.__dlpack__`` method.
 - Adding a ``from_dlpack`` function, which takes as input an object
   supporting ``__dlpack__``, and returns an ``ndarray``.
 
@@ -307,7 +353,7 @@ NumPy itself is CPU-only, so it clearly doesn't have a need for device support.
 However, other libraries (e.g. TensorFlow, PyTorch, JAX, MXNet) support
 multiple types of devices: CPU, GPU, TPU, and more exotic hardware.
 To write portable code on systems with multiple devices, it's often necessary
-to create new arrays on the same device as some other array, or check that
+to create new arrays on the same device as some other array, or to check that
 two arrays live on the same device. Hence syntax for that is needed.
 
 The array object will have a ``.device`` attribute which enables comparing
@@ -317,16 +363,19 @@ from the same library and it's the same hardware device). Furthermore,
 
     def empty(shape: Union[int, Tuple[int, ...]], /, *,
               dtype: Optional[dtype] = None,
-              device: Optional[device] = None) -> array:
+              device: Optional[device] = None) -> Array:
         """
         Array API compatible wrapper for :py:func:`np.empty <numpy.empty>`.
         """
-        return np.empty(shape, dtype=dtype, device=device)
+        if device not in ["cpu", None]:
+            raise ValueError(f"Unsupported device {device!r}")
+        return Array._new(np.empty(shape, dtype=dtype))
 
-The implementation for NumPy may be as simple as setting the device attribute to
-the string ``'cpu'`` and raising an exception if array creation functions
+The implementation for NumPy is as simple as setting the device attribute to
+the string ``"cpu"`` and raising an exception if array creation functions
 encounter any other value.
 
+.. _dtypes-and-casting-rules:
 
 Dtypes and casting rules
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -345,79 +394,101 @@ for more details).
 
 Specifying dtypes to functions, e.g. via the ``dtype=`` keyword, is expected
 to only use the dtype literals. Format strings, Python builtin dtypes, or
-string representations of the dtype literals are not accepted - this will
-improve readability and portability of code at little cost.
+string representations of the dtype literals are not accepted. This will
+improve readability and portability of code at little cost. Furthermore, no
+behavior is expected of these dtype literals themselves other than basic
+equality comparison. In particular, since the array API does not have scalar
+objects, syntax like ``float32(0.0)`` is not allowed (a 0-D array can be
+created with ``asarray(0.0, dtype=float32)``).
 
-Casting rules are only defined between different dtypes of the same kind. The
-rationale for this is that mixed-kind (e.g., integer to floating-point)
-casting behavior differs between libraries. NumPy's mixed-kind casting
-behavior doesn't need to be changed or restricted, it only needs to be
-documented that if users use mixed-kind casting, their code may not be
-portable.
+Casting rules are only defined between different dtypes of the same kind
+(i.e., boolean to boolean, integer to integer, or floating-point to
+floating-point). This also means omitting integer-uint64 combinations that
+would upcast to float64 in NumPy. The rationale for this is that mixed-kind
+(e.g., integer to floating-point) casting behaviors differ between libraries.
 
 .. image:: _static/nep-0047-casting-rules-lattice.png
 
 *Type promotion diagram. Promotion between any two types is given by their
-join on this lattice. Only the types of participating arrays matter, not
-their values. Dashed lines indicate that behaviour for Python scalars is
-undefined on overflow. Boolean, integer and floating-point dtypes are not
-connected, indicating mixed-kind promotion is undefined.*
+join on this lattice. Only the types of participating arrays matter, not their
+values. Dashed lines indicate that behavior for Python scalars is undefined on
+overflow. The Python scalars themselves are only allowed in operators on the
+array object, not inside of functions. Boolean, integer and floating-point
+dtypes are not connected, indicating mixed-kind promotion is undefined (for
+the NumPy implementation, these raise an exception).*
 
 The most important difference between the casting rules in NumPy and in the
-array API standard is how scalars and 0-dimensional arrays are handled. In
-the standard, array scalars do not exist and 0-dimensional arrays follow the
-same casting rules as higher-dimensional arrays.
+array API standard is how scalars and 0-dimensional arrays are handled. In the
+standard, array scalars do not exist and 0-dimensional arrays follow the same
+casting rules as higher-dimensional arrays. Furthermore, there is no
+value-based casting in the standard. The result type of an operation can be
+predicted entirely from its input arrays' dtypes, regardless of their shapes
+or values. Python scalars are only allowed in dunder operations (like
+``__add__``), and only if they are of the same kind as the array dtype. They
+always cast to the dtype of the array, regardless of value. Overflow behavior
+is undefined.
 
 See the `Type Promotion Rules section of the array API standard <https://data-apis.github.io/array-api/latest/API_specification/type_promotion.html>`__
 for more details.
 
-.. note::
+In the implementation, this means
 
-    It is not clear what the best way is to support the different casting rules
-    for 0-dimensional arrays and no value-based casting. One option may be to
-    implement this second set of casting rules, keep them private, mark the
-    array API functions with a private attribute that says they adhere to
-    these different rules, and let the casting machinery check whether for
-    that attribute.
+- Ensuring any operation that would produce an scalar object in NumPy is
+  converted to a 0-D array in the ``Array`` constructor,
+- Checking for combinations that would apply value-based casting and
+  ensuring they promote to the correct type. This can be achieved, e.g., by
+  manually broadcasting 0-D inputs (preventing them from participating in
+  value-based casting), or by explicitly passing the ``signature`` argument
+  to the underlying ufunc,
+- In dunder operator methods, manually converting Python scalar inputs to 0-D
+  arrays of the matching dtype if they are the same kind, and raising otherwise. For scalars out of
+  bounds of the given dtype (for which the behavior is undefined by the spec),
+  the behavior of ``np.array(scalar, dtype=dtype)`` is used (either cast or
+  raise OverflowError).
 
-    This needs discussion.
-
+.. _indexing:
 
 Indexing
 ~~~~~~~~
 
 An indexing expression that would return a scalar with ``ndarray``, e.g.
-``arr_2d[0, 0]``, will return a 0-D array with the new array object. There are
-several reasons for that: array scalars are largely considered a design mistake
+``arr_2d[0, 0]``, will return a 0-D array with the new ``Array`` object. There are
+several reasons for this: array scalars are largely considered a design mistake
 which no other array library copied; it works better for non-CPU libraries
 (typically arrays can live on the device, scalars live on the host); and it's
-simply a consistent design. To get a Python scalar out of a 0-D array, one can
-simply use the builtin for the type, e.g. ``float(arr_0d)``.
+simply a more consistent design. To get a Python scalar out of a 0-D array, one can
+use the builtin for the type, e.g. ``float(arr_0d)``.
 
 The other `indexing modes in the standard <https://data-apis.github.io/array-api/latest/API_specification/indexing.html>`__
 do work largely the same as they do for ``numpy.ndarray``. One noteworthy
 difference is that clipping in slice indexing (e.g., ``a[:n]`` where ``n`` is
-larger than the size of the first axis) is unspecified behaviour, because
+larger than the size of the first axis) is unspecified behavior, because
 that kind of check can be expensive on accelerators.
 
-The lack of advanced indexing, and boolean indexing being limited to a single
-n-D boolean array, is due to those indexing modes not being suitable for all
-types of arrays or JIT compilation. Their absence does not seem to be
+The standard omits advanced indexing (indexing by an integer array), and boolean indexing is limited to a
+single n-D boolean array. This is due to those indexing modes not being
+suitable for all types of arrays or JIT compilation. Furthermore, some
+advanced NumPy indexing semantics, such as the semantics for mixing advanced
+and non-advanced indices in a single index, are considered design mistakes in
+NumPy. The absence of these more advanced index types does not seem to be
 problematic; if a user or library author wants to use them, they can do so
 through zero-copy conversion to ``numpy.ndarray``. This will signal correctly
 to whomever reads the code that it is then NumPy-specific rather than portable
 to all conforming array types.
 
-
+Being a minimal implementation, ``numpy.array_api`` will explicitly disallow
+slices with clipped bounds, advanced indexing, and boolean indices mixed with
+other indices.
 
 The array object
 ~~~~~~~~~~~~~~~~
 
 The array object in the standard does not have methods other than dunder
-methods. The rationale for that is that not all array libraries have methods
-on their array object (e.g., TensorFlow does not). It also provides only a
-single way of doing something, rather than have functions and methods that
-are effectively duplicate.
+methods. It also does not allow direct construction, preferring instead array
+construction methods like ``asarray``. The rationale for that is that not all
+array libraries have methods on their array object (e.g., TensorFlow does
+not). It also provides only a single way of doing something, rather than have
+functions and methods that are effectively duplicate.
 
 Mixing operations that may produce views (e.g., indexing, ``nonzero``)
 in combination with mutation (e.g., item or slice assignment) is
@@ -425,41 +496,60 @@ in combination with mutation (e.g., item or slice assignment) is
 This cannot easily be prohibited in the array object itself; instead this will
 be guidance to the user via documentation.
 
-The standard current does not prescribe a name for the array object itself.
-We propose to simply name it ``ndarray``. This is the most obvious name, and
-because of the separate namespace should not clash with ``numpy.ndarray``.
-
+The standard current does not prescribe a name for the array object itself. We
+propose to name it ``Array``. This uses proper PEP 8 capitalization for a
+class, and does not conflict with any existing NumPy class names. [3]_ Note
+that the actual name of the array class does not actually matter that much as
+it is not itself included in the top-level namespace, and cannot be directly
+constructed.
 
 Implementation
 --------------
 
-.. note::
-
-    This section needs a lot more detail, which will gradually be added when
-    the implementation progresses.
-
 A prototype of the ``array_api`` namespace can be found in
-https://github.com/data-apis/numpy/tree/array-api/numpy/_array_api.
-The docstring in its ``__init__.py`` has notes on completeness of the
-implementation. The code for the wrapper functions also contains ``# Note:``
-comments everywhere there is a difference with the NumPy API.
-Two important parts that are not implemented yet are the new array object and
-DLPack support. Functions may need changes to ensure the changed casting rules
-are respected.
+https://github.com/numpy/numpy/pull/18585. The docstring in its
+``__init__.py`` has several important notes about implementation details. The
+code for the wrapper functions also contains ``# Note:`` comments everywhere
+there is a difference with the NumPy API. The
+implementation is entirely in pure Python, and consists primarily of wrapper
+classes/functions that pass through to the corresponding NumPy functions after
+applying input validation and any changed behavior. One important part that is not
+implemented yet is DLPack_ support, as its implementation in ``np.ndarray`` is
+still in progress (https://github.com/numpy/numpy/pull/19083).
 
-The array object
-~~~~~~~~~~~~~~~~
+The ``numpy.array_api`` module is considered experimental. This means that
+importing it will issue a ``UserWarning``. The alternative to this was naming
+the module ``numpy._array_api``, but the warning was chosen instead so that it
+does not become necessary to rename the module in the future, potentially
+breaking user code. The module also requires Python 3.8 or greater due to
+extensive use of the positional-only argument syntax.
 
-Regarding the array object implementation, we plan to start with a regular
-Python class that wraps a ``numpy.ndarray`` instance. Attributes and methods
-can forward to that wrapped instance, applying input validation and
-implementing changed behaviour as needed.
+The experimental nature of the module also means that it is not yet mentioned
+anywhere in the NumPy documentation, outside of its module docstring and this
+NEP. Documentation for the implementation is itself a challenging problem.
+Presently every docstring in the implementation simply references the
+underlying NumPy function it implements. However, this is not ideal, as the
+underlying NumPy function may have different behavior from the corresponding
+function in the array API, for instance, additional keyword arguments that are
+not present in the array API. It has been suggested that documentation may be
+pulled directly from the spec itself, but support for this would require
+making some technical changes to the way the spec is written, and so the
+current implementation does not yet make any attempt to do this.
 
-The casting rules are probably the most challenging part. The in-progress
-dtype system refactor (NEPs 40-43) should make implementing the correct casting
-behaviour easier - it is already moving away from value-based casting for
-example.
-
+The array API specification is accompanied by an in-progress `official test
+suite <https://github.com/data-apis/array-api-tests>`_, which is designed to
+test conformance of any library to the array API specification. The tests
+included with the implementation will therefore be minimal, as the majority of
+the behavior will be verified by this test suite. The tests in NumPy itself
+for the ``array_api`` submodule will only include testing for behavior not
+covered by the array API test suite, for instance, tests that the
+implementation is minimal and properly rejects things like disallowed type
+combinations. A CI job will be added to the array API test suite repository to
+regularly test it against the NumPy implementation. The array API test suite
+is designed to be vendored if libraries wish to do that, but this idea was
+rejected for NumPy because the time taken by it is significant relative to the
+existing NumPy test suite, and because the test suite is itself still
+a work in progress.
 
 The dtype objects
 ~~~~~~~~~~~~~~~~~
@@ -476,16 +566,20 @@ Dtypes should not be assumed to have a class hierarchy by users, however we are
 free to implement it with a class hierarchy if that's convenient. We considered
 the following options to implement dtype objects:
 
-1. Alias dtypes to those in the main namespace. E.g., ``np.array_api.float32 =
+1. Alias dtypes to those in the main namespace, e.g., ``np.array_api.float32 =
    np.float32``.
-2. Make the dtypes instances of ``np.dtype``. E.g., ``np.array_api.float32 =
+2. Make the dtypes instances of ``np.dtype``, e.g., ``np.array_api.float32 =
    np.dtype(np.float32)``.
 3. Create new singleton classes with only the required methods/attributes
    (currently just ``__eq__``).
 
 It seems like (2) would be easiest from the perspective of interacting with
-functions outside the main namespace. And (3) would adhere best to the
-standard.
+functions outside the main namespace and (3) would adhere best to the
+standard. (2) does not prevent users from accessing NumPy-specific attributes
+of the dtype objects like (3) would, although unlike (1), it does disallow
+creating scalar objects like ``float32(0.0)``. (2) also keeps only one object
+per dtype---with (1), ``arr.dtype`` would be still be a dtype instance. The
+implementation currently uses (2).
 
 TBD: the standard does not yet have a good way to inspect properties of a
 dtype, to ask questions like "is this an integer dtype?". Perhaps this is easy
@@ -533,8 +627,11 @@ between many array libraries rather than only between NumPy and one other librar
 Alternatives
 ------------
 
-
-
+It was proposed to have the NumPy array API implementation as a separate
+library from NumPy. This was rejected because keeping it separate will make it
+less likely for people to review it, and including it in NumPy itself as an
+experimental submodule will make it easier for end users and library authors
+who already depend on NumPy to access the implementation.
 
 Appendix - a possible ``get_namespace`` implementation
 ------------------------------------------------------
@@ -569,6 +666,11 @@ Discussion
 
 - `First discussion on the mailing list about the array API standard <https://mail.python.org/pipermail/numpy-discussion/2020-November/081181.html>`__
 
+- `Discussion of NEP 47 on the mailing list
+  <https://mail.python.org/pipermail/numpy-discussion/2021-February/081530.html>`_
+
+- `PR #18585 implementing numpy.array_api
+  <https://github.com/numpy/numpy/pull/18585>`_
 
 References and Footnotes
 ------------------------
@@ -583,6 +685,7 @@ References and Footnotes
 
 .. [2] https://data-apis.org/blog/array_api_standard_release/
 
+.. [3] https://github.com/numpy/numpy/pull/18585#discussion_r641370294
 
 Copyright
 ---------


### PR DESCRIPTION
The NEP has been updated and expanded to more accurately correspond to the
implementation in #18585, as well as various wording and grammar fixes.

CC @rgommers @shoyer 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
