### PR TITLE
BUG: Ensure masked arrays with boolean index can be copied (`masked_array.__setitem__`)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3374,7 +3374,7 @@ class MaskedArray(ndarray):
                 _mask[indx] = mval
         elif not self._hardmask:
             # Set the data, then the mask
-            if isinstance(indx, masked_array):
+            if isinstance(indx, masked_array) and not isinstance(value, masked_array):
                 _data[indx.data] = dval
             else:
                 _data[indx] = dval

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3374,7 +3374,8 @@ class MaskedArray(ndarray):
                 _mask[indx] = mval
         elif not self._hardmask:
             # Set the data, then the mask
-            if isinstance(indx, masked_array) and not isinstance(value, masked_array):
+            if (isinstance(indx, masked_array) and
+                not isinstance(value, masked_array)):
                 _data[indx.data] = dval
             else:
                 _data[indx] = dval

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3375,7 +3375,7 @@ class MaskedArray(ndarray):
         elif not self._hardmask:
             # Set the data, then the mask
             if (isinstance(indx, masked_array) and
-                not isinstance(value, masked_array)):
+                    not isinstance(value, masked_array)):
                 _data[indx.data] = dval
             else:
                 _data[indx] = dval

--- a/numpy/ma/tests/test_old_ma.py
+++ b/numpy/ma/tests/test_old_ma.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.core.umath as umath
 import numpy.core.fromnumeric as fromnumeric
 from numpy.testing import (
-    assert_, assert_raises, assert_equal,
+    assert_, assert_raises, assert_equal, assert_array_equal
     )
 from numpy.ma import (
     MaskType, MaskedArray, absolute, add, all, allclose, allequal, alltrue,
@@ -703,6 +703,15 @@ class TestMa:
         c = a >= 3
         a[c] = 5
         assert_(a[2] is masked)
+    
+    def test_assignment_by_condition_nomask(self):
+        # Test for gh-19721
+        a = masked_array([0, 1], mask=[False, False])
+        b = masked_array([0, 1], mask=[True, True])
+        mask = a < 1
+        b[mask] = a[mask]
+        expected_mask = [False, True]
+        assert_array_equal(b.mask, expected_mask)
 
 
 class TestUfuncs:


### PR DESCRIPTION
For `masked_array.__setitem__`, add a check to ensure a masked array can be copied properly. Check should have been added in PR #19244 and fixes #19721.