### PR TITLE
PERF: Use fast tuple access macros when the arg is clearly a tuple.

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -224,7 +224,7 @@ NPY_TITLE_KEY_check(PyObject *key, PyObject *value)
     if (PyTuple_Size(value) != 3) {
         return 0;
     }
-    title = PyTuple_GetItem(value, 2);
+    title = PyTuple_GET_ITEM(value, 2);
     if (key == title) {
         return 1;
     }

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1336,7 +1336,7 @@ test_nditer_too_large(PyObject *NPY_UNUSED(self), PyObject *args) {
         PyErr_SetString(PyExc_ValueError, "tuple required as first argument");
         return NULL;
     }
-    nop = PyTuple_Size(array_tuple);
+    nop = PyTuple_GET_SIZE(array_tuple);
     if (nop > NPY_MAXARGS) {
         PyErr_SetString(PyExc_ValueError, "tuple must be smaller then maxargs");
         return NULL;

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -522,7 +522,7 @@ boundarraymethod__resolve_descripors(
     PyArray_Descr *loop_descrs[NPY_MAXARGS];
 
     if (!PyTuple_CheckExact(descr_tuple) ||
-            PyTuple_Size(descr_tuple) != nin + nout) {
+            PyTuple_GET_SIZE(descr_tuple) != nin + nout) {
         PyErr_Format(PyExc_TypeError,
                 "_resolve_descriptors() takes exactly one tuple with as many "
                 "elements as the method takes arguments (%d+%d).", nin, nout);
@@ -530,7 +530,7 @@ boundarraymethod__resolve_descripors(
     }
 
     for (int i = 0; i < nin + nout; i++) {
-        PyObject *tmp = PyTuple_GetItem(descr_tuple, i);
+        PyObject *tmp = PyTuple_GET_ITEM(descr_tuple, i);
         if (tmp == NULL) {
             return NULL;
         }
@@ -643,7 +643,7 @@ boundarraymethod__simple_strided_call(
     int nout = self->method->nout;
 
     if (!PyTuple_CheckExact(arr_tuple) ||
-            PyTuple_Size(arr_tuple) != nin + nout) {
+            PyTuple_GET_SIZE(arr_tuple) != nin + nout) {
         PyErr_Format(PyExc_TypeError,
                 "_simple_strided_call() takes exactly one tuple with as many "
                 "arrays as the method takes arguments (%d+%d).", nin, nout);
@@ -651,7 +651,7 @@ boundarraymethod__simple_strided_call(
     }
 
     for (int i = 0; i < nin + nout; i++) {
-        PyObject *tmp = PyTuple_GetItem(arr_tuple, i);
+        PyObject *tmp = PyTuple_GET_ITEM(arr_tuple, i);
         if (tmp == NULL) {
             return NULL;
         }

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -898,11 +898,11 @@ VOID_setitem(PyObject *op, void *input, void *vap)
             /* if it's a tuple, copy field-by-field to ap, */
             npy_intp names_size = PyTuple_GET_SIZE(descr->names);
 
-            if (names_size != PyTuple_Size(op)) {
+            if (names_size != PyTuple_GET_SIZE(op)) {
                 errmsg = PyUnicode_FromFormat(
                         "could not assign tuple of length %zd to structure "
                         "with %" NPY_INTP_FMT " fields.",
-                        PyTuple_Size(op), names_size);
+                        PyTuple_GET_SIZE(op), names_size);
                 PyErr_SetObject(PyExc_ValueError, errmsg);
                 Py_DECREF(errmsg);
                 return -1;
@@ -918,7 +918,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
                     failed = 1;
                     break;
                 }
-                item = PyTuple_GetItem(op, i);
+                item = PyTuple_GET_ITEM(op, i);
                 if (item == NULL) {
                     failed = 1;
                     break;

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -260,7 +260,7 @@ PyArray_ConvertMultiAxis(PyObject *axis_in, int ndim, npy_bool *out_axis_flags)
 
         memset(out_axis_flags, 0, ndim);
 
-        naxes = PyTuple_Size(axis_in);
+        naxes = PyTuple_GET_SIZE(axis_in);
         if (naxes < 0) {
             return NPY_FAIL;
         }

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -3048,7 +3048,7 @@ structured_to_nonstructured_resolve_descriptors(
             /* Only allow casting a single field */
             return -1;
         }
-        PyObject *key = PyTuple_GetItem(given_descrs[0]->names, 0);
+        PyObject *key = PyTuple_GET_ITEM(given_descrs[0]->names, 0);
         PyObject *base_tup = PyDict_GetItem(given_descrs[0]->fields, key);
         base_descr = (PyArray_Descr *)PyTuple_GET_ITEM(base_tup, 0);
     }

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2770,7 +2770,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
          * that subarray_shape obtained from subarray[1] is a tuple of integers.
          */
         if (!(PyTuple_Check(subarray) &&
-              PyTuple_Size(subarray) == 2 &&
+              PyTuple_GET_SIZE(subarray) == 2 &&
               PyArray_DescrCheck(PyTuple_GET_ITEM(subarray, 0)))) {
             PyErr_Format(PyExc_ValueError,
                          "incorrect subarray in __setstate__");
@@ -2922,7 +2922,7 @@ arraydescr_setstate(PyArray_Descr *self, PyObject *args)
         PyObject *old_metadata;
         PyArray_DatetimeMetaData temp_dt_data;
 
-        if ((! PyTuple_Check(metadata)) || (PyTuple_Size(metadata) != 2)) {
+        if ((! PyTuple_Check(metadata)) || (PyTuple_GET_SIZE(metadata) != 2)) {
             PyErr_Format(PyExc_ValueError,
                     "Invalid datetime dtype (metadata, c_metadata): %R",
                     metadata);

--- a/numpy/core/src/multiarray/hashdescr.c
+++ b/numpy/core/src/multiarray/hashdescr.c
@@ -78,9 +78,12 @@ static int _array_descr_builtin(PyArray_Descr* descr, PyObject *l)
      */
     t = Py_BuildValue("(cccii)", descr->kind, nbyteorder,
             descr->flags, descr->elsize, descr->alignment);
+    if (!t) {
+        return -1;
+    }
 
-    for(i = 0; i < PyTuple_Size(t); ++i) {
-        item = PyTuple_GetItem(t, i);
+    for(i = 0; i < PyTuple_GET_SIZE(t); ++i) {
+        item = PyTuple_GET_ITEM(t, i);
         if (item == NULL) {
             PyErr_SetString(PyExc_SystemError,
                     "(Hash) Error while computing builting hash");
@@ -198,8 +201,8 @@ static int _array_descr_walk_subarray(PyArray_ArrayDescr* adescr, PyObject *l)
      * Add shape and descr itself to the list of object to hash
      */
     if (PyTuple_Check(adescr->shape)) {
-        for(i = 0; i < PyTuple_Size(adescr->shape); ++i) {
-            item = PyTuple_GetItem(adescr->shape, i);
+        for(i = 0; i < PyTuple_GET_SIZE(adescr->shape); ++i) {
+            item = PyTuple_GET_ITEM(adescr->shape, i);
             if (item == NULL) {
                 PyErr_SetString(PyExc_SystemError,
                         "(Hash) Error while getting shape item of subarray dtype ???");

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2227,7 +2227,7 @@ voidtype_item(PyVoidScalarObject *self, Py_ssize_t n)
         return NULL;
     }
 
-    return voidtype_subscript(self, PyTuple_GetItem(flist, n));
+    return voidtype_subscript(self, PyTuple_GET_ITEM(flist, n));
 }
 
 /* get field by name or number */
@@ -2287,7 +2287,7 @@ voidtype_ass_item(PyVoidScalarObject *self, Py_ssize_t n, PyObject *val)
         return -1;
     }
 
-    return voidtype_ass_subscript(self, PyTuple_GetItem(flist, n), val);
+    return voidtype_ass_subscript(self, PyTuple_GET_ITEM(flist, n), val);
 }
 
 static int

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -82,7 +82,7 @@ PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
                 "(tuple of DTypes or None, ArrayMethod or promoter)");
         return -1;
     }
-    PyObject *DType_tuple = PyTuple_GetItem(info, 0);
+    PyObject *DType_tuple = PyTuple_GET_ITEM(info, 0);
     if (PyTuple_GET_SIZE(DType_tuple) != ufunc->nargs) {
         PyErr_SetString(PyExc_TypeError,
                 "DType tuple length does not match ufunc number of operands");

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -370,7 +370,7 @@ PyUFunc_On_Om(char **args, npy_intp const *dimensions, npy_intp const *steps, vo
             Py_XDECREF(*op);
             *op = result;
         }
-        else if (PyTuple_Check(result) && nout == PyTuple_Size(result)) {
+        else if (PyTuple_Check(result) && nout == PyTuple_GET_SIZE(result)) {
             /*
              * Multiple returns match expected number of outputs, assign
              * and continue. Will also gobble empty tuples if nout == 0.

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1760,7 +1760,7 @@ _parse_axes_arg(PyUFuncObject *ufunc, int op_core_num_dims[], PyObject *axes,
          */
         op_axes_tuple = PyList_GET_ITEM(axes, iop);
         if (PyTuple_Check(op_axes_tuple)) {
-            if (PyTuple_Size(op_axes_tuple) != op_ncore) {
+            if (PyTuple_GET_SIZE(op_axes_tuple) != op_ncore) {
                 if (op_ncore == 1) {
                     PyErr_Format(PyExc_ValueError,
                                  "axes item %d should be a tuple with a "
@@ -4056,7 +4056,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         }
     }
     else if (PyTuple_Check(axes_obj)) {
-        naxes = PyTuple_Size(axes_obj);
+        naxes = PyTuple_GET_SIZE(axes_obj);
         if (naxes < 0 || naxes > NPY_MAXDIMS) {
             PyErr_SetString(PyExc_ValueError,
                     "too many values for 'axis'");


### PR DESCRIPTION
(i.e. when the argument goes through PyTuple_Check{,Exact} or
PyTuple_Size (which calls PyTuple_Check) first, or is constructed using
Py_BuildValue; we don't assume any invariants across functions.)

This avoids having to call back into libpython; it's just a struct/array
access at a known offset instead.

It is however suprisingly difficult to actually benchmark such changes,
because e.g. gcc appears to use wildly different optimizations(?) with
and without the patch, so the benchmark deltas are all over the place
(from 1.5x to 0.5x...).
(See also https://github.com/numpy/numpy/issues/19735#issuecomment-904171451.)
So it's more a patch proposed "on general principles" rather than with
well-established benefits.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
