### PR TITLE
ENH: Prepare umath module for the C++

### DIFF
--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -463,15 +463,6 @@ defdict = {
           ]),
           TD(O, f='Py_reciprocal'),
           ),
-# This is no longer used as numpy.ones_like, however it is
-# still used by some internal calls.
-'_ones_like':
-    Ufunc(1, 1, None,
-          docstrings.get('numpy._core.umath._ones_like'),
-          'PyUFunc_OnesLikeTypeResolver',
-          TD(noobj),
-          TD(O, f='Py_get_one'),
-          ),
 'power':
     Ufunc(2, 1, None,
           docstrings.get('numpy._core.umath.power'),
@@ -1064,12 +1055,6 @@ defdict = {
           docstrings.get('numpy._core.umath.signbit'),
           None,
           TD(flts, out='?', dispatch=[('loops_unary_fp_le', inexactvec)]),
-          ),
-'copysign':
-    Ufunc(2, 1, None,
-          docstrings.get('numpy._core.umath.copysign'),
-          None,
-          TD(flts),
           ),
 'nextafter':
     Ufunc(2, 1, None,

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1145,6 +1145,7 @@ src_umath = umath_gen_headers + [
   src_file.process('src/umath/scalarmath.c.src'),
   'src/umath/ufunc_object.c',
   'src/umath/umathmodule.c',
+  'src/umath/ufunc_operations.cpp',
   'src/umath/special_integer_comparisons.cpp',
   'src/umath/string_ufuncs.cpp',
   'src/umath/wrapping_array_method.c',

--- a/numpy/_core/src/common/common.hpp
+++ b/numpy/_core/src/common/common.hpp
@@ -12,6 +12,5 @@
 #include "float_status.hpp"
 #include "slice.hpp"
 #include "math.hpp"
-#include "ufunc_object.hpp"
 
 #endif // NUMPY_CORE_SRC_COMMON_COMMON_HPP

--- a/numpy/_core/src/common/common.hpp
+++ b/numpy/_core/src/common/common.hpp
@@ -10,5 +10,8 @@
 #include "half.hpp"
 #include "meta.hpp"
 #include "float_status.hpp"
+#include "slice.hpp"
+#include "math.hpp"
+#include "ufunc_object.hpp"
 
 #endif // NUMPY_CORE_SRC_COMMON_COMMON_HPP

--- a/numpy/_core/src/common/math.hpp
+++ b/numpy/_core/src/common/math.hpp
@@ -1,0 +1,24 @@
+#ifndef NUMPY_CORE_SRC_COMMON_MATH_HPP
+#define NUMPY_CORE_SRC_COMMON_MATH_HPP
+
+#include "npstd.hpp"
+#include "half.hpp"
+
+namespace np {
+
+template<typename T>
+inline std::enable_if_t<kIsFloat<T>, T> Copysign(const T &a, const T &b)
+{
+    if constexpr (std::is_same_v<T, Half>) {
+        return Half::FromBits((a.Bits()&0x7fffu) | (b.Bits()&0x8000u));
+    }
+    else {
+        return std::copysign(a, b);
+    }
+}
+
+} // namespace np
+
+
+#endif // NUMPY_CORE_SRC_COMMON_MATH_HPP
+

--- a/numpy/_core/src/common/npstd.hpp
+++ b/numpy/_core/src/common/npstd.hpp
@@ -1,6 +1,8 @@
 #ifndef NUMPY_CORE_SRC_COMMON_NPSTD_HPP
 #define NUMPY_CORE_SRC_COMMON_NPSTD_HPP
 
+#include <Python.h>
+
 #include <cstddef>
 #include <cstring>
 #include <cctype>
@@ -13,10 +15,7 @@
 #include <cmath>
 #include <complex>
 #include <type_traits>
-
-#include <numpy/npy_common.h>
-
-#include "npy_config.h"
+#include <limits>
 
 namespace np {
 /// @addtogroup cpp_core_types
@@ -34,21 +33,432 @@ using std::intptr_t;
 using std::complex;
 using std::uint_fast16_t;
 using std::uint_fast32_t;
+/// Wide enough to hold pointers
+using IntPtr = Py_intptr_t;
+/// Signed integral type such that sizeof(Py_ssize_t) == sizeof(size_t)
 using SSize = Py_ssize_t;
-/** Guard for long double.
- *
- * The C implementation defines long double as double
- * on MinGW to provide compatibility with MSVC to unify
- * one behavior under Windows OS, which makes npy_longdouble
- * not fit to be used with template specialization or overloading.
- *
- * This type will be set to `void` when `npy_longdouble` is not defined
- * as `long double`.
+/// @} cpp_core_types
+
+/// @addtogroup cpp_core_constants
+/// @{
+/// Enumerated values represents the basic 24 data types.
+enum class TypeID : char {
+    /// Represents `Bool`.
+    kBool = 0,
+    /// Represents `Byte`.
+    kByte,
+    /// Represents `UByte`.
+    kUByte,
+    /// Represents `Short`.
+    kShort,
+    /// Represents `UShort`.
+    kUShort,
+    /// Represents `Int`.
+    kInt,
+    /// Represents `UInt`.
+    kUInt,
+    /// Represents `Long`.
+    kLong,
+    /// Represents `ULong`.
+    kULong,
+    /// Represents `LongLong`.
+    kLongLong,
+    /// Represents `ULongLong`.
+    kULongLong,
+    /// Represents `Float`.
+    kFloat,
+    /// Represents `Double`.
+    kDouble,
+    /// Represents `LongDouble`.
+    kLongDouble,
+    /// Represents `CFloat`.
+    kCFloat,
+    /// Represents `CDouble`.
+    kCDouble,
+    /// Represents `CLongDouble`.
+    kCLongDouble,
+    /// Represents `Object`.
+    kObject = 17,
+    /// Represents `String`.
+    kString,
+    /// Represents `Unicode`.
+    kUnicode,
+    /// Represents `Void`.
+    kVoid,
+    /// Represents `DateTime`.
+    kDateTime,
+    /// Represents `TimeDelta`.
+    kTimeDelta,
+    /// Represents `Half`.
+    kHalf
+};
+
+/// @name Types IDs alias
+/// For lazy access to enumeration values of `TypeID`.
+/// @{
+constexpr auto kBool = TypeID::kBool;
+constexpr auto kByte = TypeID::kByte;
+constexpr auto kUByte = TypeID::kUByte;
+constexpr auto kShort = TypeID::kShort;
+constexpr auto kUShort = TypeID::kUShort;
+constexpr auto kInt = TypeID::kInt;
+constexpr auto kUInt = TypeID::kUInt;
+constexpr auto kLong = TypeID::kLong;
+constexpr auto kULong = TypeID::kULong;
+constexpr auto kLongLong = TypeID::kLongLong;
+constexpr auto kULongLong = TypeID::kULongLong;
+constexpr auto kHalf = TypeID::kHalf;
+constexpr auto kFloat = TypeID::kFloat;
+constexpr auto kDouble = TypeID::kDouble;
+constexpr auto kLongDouble = TypeID::kLongDouble;
+constexpr auto kCFloat = TypeID::kCFloat;
+constexpr auto kCDouble = TypeID::kCDouble;
+constexpr auto kCLongDouble = TypeID::kCLongDouble;
+constexpr auto kObject = TypeID::kObject;
+constexpr auto kString = TypeID::kString;
+constexpr auto kUnicode = TypeID::kUnicode;
+constexpr auto kVoid = TypeID::kVoid;
+constexpr auto kDateTime = TypeID::kDateTime;
+constexpr auto kTimeDelta = TypeID::kTimeDelta;
+/// @}
+
+/// Number of supported basic data types (24).
+constexpr int kNTypes = static_cast<int>(kHalf) + 1;
+/// Whether long double is forced or has the same precision as double.
+#if defined(WIN32) || defined(_WIN32)
+constexpr bool kLongDoubleIsDouble = true;
+#else
+constexpr bool kLongDoubleIsDouble = sizeof(long double) == sizeof(double);
+#endif
+
+template<typename T, TypeID>
+class Holder;
+class Half;
+class DateTime;
+class TimeDelta;
+class Object;
+
+namespace details {
+template<typename T>
+struct Traits;
+template<>
+struct Traits<bool> { static constexpr TypeID kID = kBool; };
+template<>
+struct Traits<Half> { static constexpr TypeID kID = kHalf; };
+template<>
+struct Traits<float> { static constexpr TypeID kID = kFloat; };
+template<>
+struct Traits<double> { static constexpr TypeID kID = kDouble; };
+template<>
+struct Traits<long double> { static constexpr TypeID kID = kLongDouble;};
+template<>
+struct Traits<complex<float>> { static constexpr TypeID kID = kCFloat; };
+template<>
+struct Traits<complex<double>> { static constexpr TypeID kID = kCDouble; };
+template<>
+struct Traits<complex<long double>> { static constexpr TypeID kID = kCLongDouble; };
+template<>
+struct Traits<Object> { static constexpr TypeID kID = kObject; };
+template<>
+struct Traits<DateTime> { static constexpr TypeID kID = kDateTime; };
+template<>
+struct Traits<TimeDelta> { static constexpr TypeID kID = kTimeDelta; };
+template<typename T, TypeID ID>
+struct Traits<Holder<T, ID>> { static constexpr TypeID kID = ID; };
+} // namespace details
+
+/// Returns TypeID based on @tparam T.
+template<typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>>>
+constexpr TypeID kTypeID = details::Traits<TBase>::kID;
+
+/// Checks whether @tparam `T` is an boolean type.
+template<typename T>
+constexpr bool kIsBool = kTypeID<T> == kBool;
+
+/// Checks whether `T` is an unsigned integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsUnsigned = ID == kUByte || ID == kUShort || ID == kUInt ||
+                             ID == kULong || ID == kULongLong;
+
+/// Checks whether `T` is an signed integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsSigned = ID == kByte || ID == kShort || ID == kInt ||
+                           ID == kLong || ID == kLongLong;
+
+/// Checks whether `T` is an integer type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsIntegral = kIsSigned<T> || kIsUnsigned<T>;
+
+/// Checks whether `T` is an floating-point type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsFloat = ID == kHalf || ID == kFloat ||
+                          ID == kDouble || ID == kLongDouble;
+
+/// Checks whether `T` is an complex type.
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsComplex = ID == kCFloat || ID == kCDouble ||
+                            ID == kCLongDouble;
+
+/// Checks whether `T` is an time type (`DateTime`, `Timedelta`).
+template<typename T, TypeID ID = kTypeID<T>>
+constexpr bool kIsTime = ID == kDateTime || ID == kTimeDelta;
+/// @} cpp_core_constants
+
+/// @addtogroup cpp_core_containers
+/// @{
+/// Class wraps builtin data types.
+/// To distinct them, and gives the room for dealing
+/// with platform compatiblty.
+template <typename T, TypeID>
+class Holder {
+  public:
+    /// initlize nothing.
+    Holder() = default;
+    /// Construct from `T`
+    constexpr Holder(const T &val) : val_(val)
+    {}
+    /// cast
+    constexpr operator T () const
+    { return val_; }
+
+  private:
+    T val_;
+};
+template<template<class> class C, typename T, TypeID ID>
+class Holder<C<T>, ID> : public C<T> {
+  public:
+    using C<T>::C;
+};
+/// @} cpp_core_containers
+
+/// @addtogroup cpp_core_types
+/// @{
+/// Signed integer with at least 8-bit width.
+using Byte = Holder<signed char, kByte>;
+/// Unsigned integer with at least 8-bit width.
+using UByte = Holder<unsigned char, kUByte>;
+/// Signed integer with at least 16-bit width.
+using Short = Holder<short, kShort>;
+/// Unsigned integer with at least 16-bit width.
+using UShort = Holder<unsigned short, kUShort>;
+/// Signed integer with at least 16-bit width.
+using Int = Holder<int, kInt>;
+/// Unsigned integer with at least 16-bit width.
+using UInt = Holder<unsigned int, kUInt>;
+/// Signed integer with at least 32-bit width.
+using Long = Holder<long, kLong>;
+/// Unsigned integer with at least 32-bit width.
+using ULong = Holder<unsigned long, kULong>;
+/// Signed integer with at least 64-bit width.
+using LongLong = Holder<long long, kLongLong>;
+/// Unsigned integer with at least 64-bit width.
+using ULongLong = Holder<unsigned long long, kULongLong>;
+/// Boolean type, stored as `Byte`.
+/// It may only be set to the values false and true.
+using Bool = std::conditional_t<sizeof(bool) == sizeof(unsigned char),
+    bool, Holder<unsigned char, kBool>>;
+/// single-precision floating-point type, compatible with IEEE-754.
+using Float = float;
+/// double-precision floating-point type, compatible with IEEE-754.
+using Double = double;
+/**
+ * Extended precision floating-point type, compatible with IEEE-754.
+ * Provides at least the same precision of `Double`.
+ * Note:
+ *  The C implementation defines long double as double
+ *  on MinGW to provide compatibility with MSVC to unify
+ *  one behavior under Windows OS.
  */
-using LongDouble = typename std::conditional<
-    !std::is_same<npy_longdouble, long double>::value,
-     void, npy_longdouble
->::type;
+using LongDouble = std::conditional_t<kLongDoubleIsDouble,
+      Holder<double, kLongDouble>, long double>;
+/// Complex type made up of two `Float` values.
+using CFloat = complex<float>;
+/// Complex type made up of two `Double` values.
+using CDouble = complex<double>;
+/// Complex type made up of two `LongDouble` values.
+using CLongDouble = std::conditional_t<kLongDoubleIsDouble,
+      Holder<complex<double>, kCLongDouble>, complex<long double>>;
+/// Element type of ASCII string
+using String = Holder<unsigned char, kString>;
+/// Element type of UCS4 string.
+using Unicode = Holder<uint32_t, kUnicode>;
+
+/** An abstract type that implements general date/time
+ * operations for types `DateTime` and `Timedelta`.
+ *
+ * This type is ensured to be 64-bits size.
+ */
+class AbstractTime {
+ public:
+    /// initlize nothing.
+    AbstractTime() = default;
+    /// Constructs from int64_t
+    constexpr AbstractTime(int64_t d) : bits_(d)
+    {}
+    /// cast to int64_t.
+    constexpr operator int64_t() const
+    {
+        return bits_;
+    }
+    /// Initialize with not-a-time value.
+    constexpr static AbstractTime NaT()
+    {
+        return AbstractTime(std::numeric_limits<int64_t>::min());
+    }
+    /// @name Comparison operators
+    /// @{
+    constexpr bool operator==(const AbstractTime &r) const
+    {
+        return bits_ == r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator!=(const AbstractTime &r) const
+    {
+        return bits_ != r.bits_ || IsNaT() || r.IsNaT();
+    }
+    constexpr bool operator<(const AbstractTime &r) const
+    {
+        return bits_ < r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator>(const AbstractTime &r) const
+    {
+        return r < *this;
+    }
+    constexpr bool operator<=(const AbstractTime &r) const
+    {
+        return bits_ <= r.bits_ && IsFinite() && r.IsFinite();
+    }
+    constexpr bool operator>=(const AbstractTime &r) const
+    {
+        return r <= *this;
+    }
+    /// @}
+
+    /// @name Arithmetic operators
+    /// @{
+    constexpr AbstractTime operator+(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ + r.bits_);
+    }
+    constexpr AbstractTime &operator+=(const AbstractTime &r)
+    {
+        *this = (*this) + r;
+        return *this;
+    }
+    constexpr AbstractTime operator-(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ - r.bits_);
+    }
+    constexpr AbstractTime &operator-=(const AbstractTime &r)
+    {
+        *this = (*this) - r;
+        return *this;
+    }
+    constexpr AbstractTime operator*(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ * r.bits_);
+    }
+    constexpr AbstractTime &operator*=(const AbstractTime &r)
+    {
+        *this = (*this) * r;
+        return *this;
+    }
+    constexpr AbstractTime operator/(const AbstractTime &r) const
+    {
+        if (IsNaT() || r.IsNaT()) {
+            return NaT();
+        }
+        return AbstractTime(bits_ / r.bits_);
+    }
+    constexpr AbstractTime &operator/=(const AbstractTime &r)
+    {
+        *this = (*this) / r;
+        return *this;
+    }
+    /// @}
+
+    /// @name Properties
+    /// @{
+    constexpr bool IsNaT() const
+    {
+        return bits_ == static_cast<int64_t>(NaT());
+    }
+    constexpr bool IsFinite() const
+    {
+        return bits_ != static_cast<int64_t>(NaT());
+    }
+    /// @}
+
+  private:
+    int64_t bits_;
+};
+
+/// Holds dates or datetimes with a precision based on selectable date or time units.
+class DateTime : public AbstractTime
+{
+  public:
+    using AbstractTime::AbstractTime;
+};
+/// Holds lengths of times in integers of selectable date or time units.
+class TimeDelta : public AbstractTime
+{
+  public:
+    using AbstractTime::AbstractTime;
+};
+
+/** Hold the reference of arbitrary Python object.
+  *
+  * Note: this class doesn't handel reference counting
+  * via RAII or raise any kind of exceptions.
+  */
+class Object {
+  public:
+    /// Constructs from PyObject.
+    explicit constexpr Object(PyObject *ref) noexcept : ref_(ref)
+    {}
+    /// Copy
+    explicit constexpr Object(const Object &o) noexcept : ref_(o.ref_)
+    {}
+    /// Constructs from long.
+    Object(long i) noexcept : ref_(PyLong_FromLong(i))
+    {}
+    /// Constructs from int.
+    explicit Object(int i) noexcept : ref_(PyLong_FromLong(i))
+    {}
+    /// Constructs from long long.
+    explicit Object(long long i) noexcept : ref_(PyLong_FromLongLong(i))
+    {}
+    /// Constructs from double.
+    explicit Object(double f) noexcept : ref_(PyFloat_FromDouble(f))
+    {}
+    /// Constructs from bool.
+    explicit Object(bool v) noexcept
+        : ref_(PyBool_FromLong(static_cast<long>(v)))
+    {}
+    /// Returns false if the construction fails.
+    constexpr bool IsNull() const
+    { return ref_ == nullptr; }
+
+    /// Cast to bool
+    explicit operator bool() const
+    { return PyObject_IsTrue(ref_) != 0; }
+    /// cast to PyObject pointer
+    constexpr operator PyObject*()
+    { return ref_; }
+    constexpr operator const PyObject*() const
+    { return ref_; }
+
+  private:
+    PyObject *ref_;
+};
 /// @} cpp_core_types
 
 } // namespace np

--- a/numpy/_core/src/common/slice.hpp
+++ b/numpy/_core/src/common/slice.hpp
@@ -1,0 +1,241 @@
+#ifndef NUMPY_CORE_SRC_COMMON_SLICE_HPP
+#define NUMPY_CORE_SRC_COMMON_SLICE_HPP
+
+#include "npstd.hpp"
+
+namespace np {
+
+namespace slice_helper {
+/** Iterator template class for traversing through a non-contiguous memory block.
+ * This is a C++ class that is not supposed to be used directly,
+ * but rather through the class `Slice`.
+ *
+ * @tparam T        The data type of the memory block.
+ * @tparam is_const A boolean indicating whether the memory block is const or not.
+ */
+template<typename T, bool is_const = false>
+class Iterator {
+  public:
+    /// A type alias for a byte pointer.
+    using BytePointer = std::conditional_t<is_const, const char*, char*>;
+    /// A type alias for a pointer to the memory block.
+    using Pointer = std::conditional_t<is_const, const T*, T*>;
+    /// A type alias for a reference to the memory block.
+    using Reference = std::conditional_t<is_const, const T&, T&>;
+    /** Constructs an Iterator object using a pointer and a stride.
+     *
+     * @param ptr    The pointer to the start of the container.
+     * @param stride The stride of the container.
+     *               The default is 1 (contiguous).
+     */
+    Iterator(Pointer ptr, SSize stride = 1) noexcept
+        : ptr_(ptr), byte_stride_(stride * sizeof(T))
+    {}
+    /** Constructs an Iterator object using a byte pointer and a byte stride.
+     *
+     * @param ptr         The byte pointer to the start of the container.
+     * @param byte_stride The byte stride of the container.
+     *                    The default is sizeof(T) (non-contiguous).
+     */
+    Iterator(BytePointer ptr, SSize byte_stride = sizeof(T)) noexcept
+        : ptr_(reinterpret_cast<Pointer>(ptr)), byte_stride_(byte_stride)
+    {}
+    /// Returns the reference to the current element.
+    Reference operator*() const
+    { return *ptr_; }
+    /// Returns a pointer of the current element.
+    Pointer operator->() const
+    { return ptr_; }
+    /// Returns the reference to the element at the given offset.
+    Reference operator[](SSize offset) const noexcept
+    {
+        return *reinterpret_cast<Pointer>(
+            reinterpret_cast<BytePointer>(ptr_) + offset * byte_stride_
+        );
+    }
+    /// Decrements the iterator by the given offset.
+    Iterator &operator-=(SSize r)
+    {
+        ptr_ = reinterpret_cast<Pointer>(
+            reinterpret_cast<BytePointer>(ptr_) - byte_stride_ * r
+        );
+        return *this;
+    }
+    /// Increments the iterator by the given offset.
+    Iterator &operator+=(SSize r)
+    {
+        ptr_ = reinterpret_cast<Pointer>(
+            reinterpret_cast<BytePointer>(ptr_) + byte_stride_ * r
+        );
+        return *this;
+    }
+    /// Adds a offset to the Iterator and returns a new Iterator object.
+    Iterator operator+(SSize r) const
+    { auto tmp = *this; tmp += r; return tmp; }
+    /// Subtracts a offset from the Iterator and returns a new Iterator object.
+    Iterator operator-(SSize r) const
+    { auto tmp = *this; tmp -= r; return tmp; }
+    /// Returns the sum between the iterator and another iterator
+    SSize operator+(Iterator r) const
+    { return ptr_ + r.ptr_; }
+    /// Returns the difference between the iterator and another iterator
+    SSize operator-(Iterator r) const
+    { return ptr_ - r.ptr_; }
+    /// Prefix increments the iterator.
+    /// Increments the iterator and returns a reference to the iterator.
+    Iterator &operator++()
+    {
+        ptr_ = reinterpret_cast<Pointer>(
+            reinterpret_cast<BytePointer>(ptr_) + byte_stride_
+        );
+        return *this;
+    }
+    /// Prefix decrements the iterator.
+    /// Decrements the iterator and returns a reference to the iterator.
+    Iterator &operator--()
+    {
+        ptr_ = reinterpret_cast<Pointer>(
+            reinterpret_cast<BytePointer>(ptr_) - byte_stride_
+        );
+        return *this;
+    }
+    /// Postfix increments the iterator.
+    Iterator operator++(int)
+    { auto tmp = *this; ++*this; return tmp; }
+    /// Postfix decrements the iterator.
+    Iterator operator--(int)
+    { auto tmp = *this; --*this; return tmp; }
+
+    /// @name Comparison operators
+    /// @{
+    constexpr bool operator==(Pointer r) const
+    { return ptr_ == r; }
+    constexpr bool operator!=(Pointer r) const
+    { return ptr_ != r; }
+    constexpr bool operator<(Iterator r) const
+    { return ptr_ < r.ptr_; }
+    constexpr bool operator<=(Iterator r) const
+    { return ptr_ <= r.ptr_; }
+    constexpr bool operator>(Iterator r) const
+    { return ptr_ > r.ptr_; }
+    constexpr bool operator>=(Iterator r) const
+    { return ptr_ >= r.ptr_; }
+    constexpr bool operator==(Iterator r) const
+    { return ptr_ == r.ptr_; }
+    constexpr bool operator!=(Iterator r) const
+    { return ptr_ != r.ptr_; }
+    /// @}
+
+  private:
+    Pointer ptr_;
+    SSize byte_stride_;
+};
+} // namespace np::slice_helper
+
+/** One-dimensional subset of an array.
+ *
+ * This template class represents a one-dimensional subset of an array.
+ * It can be created from a dynamic array by specifying three parameters:
+ * `start` is a pointer to the beginning of the array,
+ * `size` is the total number of elements in the subset, and
+ * `stride` represents the distance between each successive array element
+ * to include in the subset between beginnings of successive array elements.
+ *
+ * @tparam T The type of the elements of the array.
+ */
+template<typename T>
+class Slice {
+  public:
+    /// Element type.
+    using ElementType = T;
+    /// @name Iterators types
+    /// @{
+    using Iterator = slice_helper::Iterator<T>;
+    using ConstIterator = slice_helper::Iterator<T, true>;
+    /// @}
+
+    /// @name Iterators types STD style
+    using iterator = slice_helper::Iterator<T>;
+    using const_iterator = slice_helper::Iterator<T, true>;
+    /// @}
+
+    /** Construct a slice from dynamic array.
+     *
+     * @param start  Pointer of the first element.
+     * @param len    Number of elements.
+     * @param stride Stride between array elements in the size of
+     *               of the array's element.
+     */
+    constexpr Slice(T *start, SSize len, SSize stride) noexcept
+        : begin_(Iterator(start, stride)), len_(len)
+    {}
+    /** Construct a slice from dynamic byte array.
+     *
+     * @param start  Pointer of the first element.
+     * @param len    Number of elements.
+     * @param stride Stride between array elements in bytes.
+     */
+    constexpr Slice(char *start, SSize len, SSize stride) noexcept
+        : begin_(Iterator(start, stride)), len_(len)
+    {}
+
+    /// @name Iterators
+    /// @{
+    constexpr Iterator Begin() noexcept
+    { return begin_; }
+    constexpr ConstIterator Begin() const noexcept
+    { return ConstIterator(begin_); }
+    constexpr Iterator End() noexcept
+    { return begin_ + len_; }
+    constexpr ConstIterator End() const noexcept
+    { return ConstIterator(begin_ + len_); }
+    /// @}
+
+    /// @name Iterators STD style
+    /// @{
+    constexpr Iterator begin() noexcept
+    { return begin_; }
+    constexpr ConstIterator begin() const noexcept
+    { return ConstIterator(begin_); }
+    constexpr Iterator end() noexcept
+    { return begin_ + len_; }
+    constexpr ConstIterator end() const noexcept
+    { return ConstIterator(begin_ + len_); }
+    /// @}
+
+    /// Number of elements.
+    constexpr SSize Length() const
+    { return len_; }
+    /// Stride size in bytes
+    constexpr SSize Stride() const
+    { return begin_.Stride(); }
+    /// Byte pointer of the first element.
+    constexpr char *Data() noexcept
+    { return reinterpret_cast<char*>(&begin_[0]); }
+    /// Byte pointer of the first element.
+    constexpr const char *Data() const noexcept
+    { return reinterpret_cast<char*>(&begin_[0]); }
+    /** Overloaded indexing operator to access slice elements.
+     *
+     * @param i Index of the element to access.
+     * @return Reference to the element at the given index.
+     */
+    constexpr T &operator[](SSize i) noexcept
+    { return begin_[i]; }
+    /** Overloaded indexing operator to access slice elements as constant.
+     *
+     * @param i Index of the element to access.
+     * @return Const reference to the element at the given index.
+     */
+    constexpr const T&operator[](SSize i) const noexcept
+    { return begin_[i]; }
+
+  private:
+    Iterator begin_;
+    SSize len_;
+};
+
+} // namespace np
+
+#endif // NUMPY_CORE_SRC_COMMON_SLICE_HPP
+

--- a/numpy/_core/src/npysort/x86_simd_qsort.hpp
+++ b/numpy/_core/src/npysort/x86_simd_qsort.hpp
@@ -2,6 +2,7 @@
 #define NUMPY_SRC_COMMON_NPYSORT_X86_SIMD_QSORT_HPP
 
 #include "common.hpp"
+#include <numpy/npy_common.h> // npy_intp
 
 namespace np { namespace qsort_simd {
 

--- a/numpy/_core/src/umath/funcs.inc.src
+++ b/numpy/_core/src/umath/funcs.inc.src
@@ -24,12 +24,6 @@ Py_square(PyObject *o)
 }
 
 static PyObject *
-Py_get_one(PyObject *NPY_UNUSED(o))
-{
-    return PyLong_FromLong(1);
-}
-
-static PyObject *
 Py_reciprocal(PyObject *o)
 {
     PyObject *one = PyLong_FromLong(1);

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -396,20 +396,6 @@ PyUFunc_On_Om(char **args, npy_intp const *dimensions, npy_intp const *steps, vo
 
 /*
  *****************************************************************************
- **                             BOOLEAN LOOPS                               **
- *****************************************************************************
- */
-
-NPY_NO_EXPORT void
-BOOL__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((npy_bool *)op1) = 1;
-    }
-}
-
-/*
- *****************************************************************************
  **                           INTEGER LOOPS
  *****************************************************************************
  */
@@ -431,14 +417,6 @@ BOOL__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, 
 #define @TYPE@_fmax_indexed @TYPE@_maximum_indexed
 #define @TYPE@_fmin @TYPE@_minimum
 #define @TYPE@_fmin_indexed @TYPE@_minimum_indexed
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((@type@ *)op1) = 1;
-    }
-}
 
 /**begin repeat1
  * Arithmetic
@@ -663,14 +641,6 @@ NPY_NO_EXPORT void
     UNARY_LOOP {
         const @type@ in1 = *(@type@ *)ip1;
         *((npy_bool *)op1) = (in1 != NPY_DATETIME_NAT);
-    }
-}
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((@type@ *)op1) = 1;
     }
 }
 
@@ -1210,16 +1180,6 @@ NPY_NO_EXPORT void
 }
 
 NPY_NO_EXPORT void
-@TYPE@_copysign(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        const @type@ in1 = *(@type@ *)ip1;
-        const @type@ in2 = *(@type@ *)ip2;
-        *((@type@ *)op1)= npy_copysign@c@(in1, in2);
-    }
-}
-
-NPY_NO_EXPORT void
 @TYPE@_nextafter(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
@@ -1280,14 +1240,6 @@ NPY_NO_EXPORT void
         const @type@ in1 = *(@type@ *)ip1;
         const @type@ in2 = *(@type@ *)ip2;
         *((@type@ *)op1) = npy_divmod@c@(in1, in2, (@type@ *)op2);
-    }
-}
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((@type@ *)op1) = 1;
     }
 }
 
@@ -1619,16 +1571,6 @@ HALF_spacing(char **args, npy_intp const *dimensions, npy_intp const *steps, voi
 }
 
 NPY_NO_EXPORT void
-HALF_copysign(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
-{
-    BINARY_LOOP {
-        const npy_half in1 = *(npy_half *)ip1;
-        const npy_half in2 = *(npy_half *)ip2;
-        *((npy_half *)op1)= npy_half_copysign(in1, in2);
-    }
-}
-
-NPY_NO_EXPORT void
 HALF_nextafter(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
@@ -1805,14 +1747,6 @@ HALF_reciprocal(char **args, npy_intp const *dimensions, npy_intp const *steps, 
     UNARY_LOOP {
         const float in1 = npy_half_to_float(*(npy_half *)ip1);
         *((npy_half *)op1) = npy_float_to_half(1/in1);
-    }
-}
-
-NPY_NO_EXPORT void
-HALF__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        *((npy_half *)op1) = NPY_HALF_ONE;
     }
 }
 
@@ -2184,15 +2118,6 @@ NPY_NO_EXPORT void
             ((@ftype@ *)op1)[0] = r/d;
             ((@ftype@ *)op1)[1] = -1/d;
         }
-    }
-}
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
-{
-    OUTPUT_LOOP {
-        ((@ftype@ *)op1)[0] = 1;
-        ((@ftype@ *)op1)[1] = 0;
     }
 }
 

--- a/numpy/_core/src/umath/loops.h.src
+++ b/numpy/_core/src/umath/loops.h.src
@@ -58,9 +58,6 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void BOOL_@kind@,
    (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data)))
 /**end repeat**/
 
-NPY_NO_EXPORT void
-BOOL__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
-
 /**begin repeat
  * #kind = isnan, isinf, isfinite#
  **/
@@ -168,9 +165,6 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@,
 #define @S@@TYPE@_fmin @S@@TYPE@_minimum
 #define @S@@TYPE@_fmax_indexed @S@@TYPE@_maximum_indexed
 #define @S@@TYPE@_fmin_indexed @S@@TYPE@_minimum_indexed
-
-NPY_NO_EXPORT void
-@S@@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
 
 NPY_NO_EXPORT void
 @S@@TYPE@_positive(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
@@ -444,9 +438,9 @@ NPY_NO_EXPORT void
 @TYPE@_logical_not(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 /**begin repeat1
- * #kind = isnan, isinf, isfinite, signbit, copysign, nextafter, spacing#
- * #func = npy_isnan, npy_isinf, npy_isfinite, npy_signbit, npy_copysign, nextafter, spacing#
- * #dispatched = 1, 1, 1, 1, 0, 0, 0#
+ * #kind = isnan, isinf, isfinite, signbit, nextafter, spacing#
+ * #func = npy_isnan, npy_isinf, npy_isfinite, npy_signbit, nextafter, spacing#
+ * #dispatched = 1, 1, 1, 1, 0, 0#
  **/
 
 #if !@fd@ || !@dispatched@
@@ -495,9 +489,6 @@ NPY_NO_EXPORT void
 
 NPY_NO_EXPORT void
 @TYPE@_reciprocal(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
 
 NPY_NO_EXPORT void
 @TYPE@_conjugate(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
@@ -649,9 +640,6 @@ NPY_NO_EXPORT void
 C@TYPE@_reciprocal(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
 
 NPY_NO_EXPORT void
-C@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
-
-NPY_NO_EXPORT void
 C@TYPE@_conjugate(char **args, const npy_intp *dimensions, const npy_intp *steps, void *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
@@ -720,9 +708,6 @@ NPY_NO_EXPORT void
 @TYPE@_isfinite(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
 #define @TYPE@_isnan @TYPE@_isnat
-
-NPY_NO_EXPORT void
-@TYPE@__ones_like(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data));
 
 /**begin repeat1
  * #kind = equal, not_equal, greater, greater_equal, less, less_equal#

--- a/numpy/_core/src/umath/ufunc_object.hpp
+++ b/numpy/_core/src/umath/ufunc_object.hpp
@@ -1,0 +1,292 @@
+#ifndef NUMPY_CORE_SRC_COMMON_UFUNC_OBJECT_HPP
+#define NUMPY_CORE_SRC_COMMON_UFUNC_OBJECT_HPP
+
+#ifndef NPY_NO_DEPRECATED_API
+    #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#endif
+
+#ifndef NO_IMPORT_ARRAY
+    #define NO_IMPORT_ARRAY // supress warning: ‘int _import_array()’ defined but not used [-Wunused-function]
+#endif
+
+#ifndef _UMATHMODULE
+    #define _UMATHMODULE // initlize UFunc API for internal build
+#endif
+
+#include <numpy/ndarrayobject.h>
+#include <numpy/ufuncobject.h>
+
+#include "common.hpp"
+
+#include <functional>
+
+namespace np {
+
+namespace ufunc_helper {
+
+template <typename T>
+struct IsSliceBase_ : std::false_type {};
+template <typename T>
+struct IsSliceBase_<Slice<T>> : std::true_type {};
+// Determines if a type is a specialization of Slice.
+template <typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>>>
+constexpr bool kIsSliceBase = IsSliceBase_<TBase>::value;
+
+template <typename T>
+struct FuncDeduce_;
+template <typename Ret, typename ..._Args>
+struct FuncDeduce_<std::function<Ret(_Args...)>> {
+    static constexpr int kNumArgs = sizeof...(_Args);
+    static constexpr int kNumIn = ((
+        std::is_const_v<std::remove_reference_t<_Args>> ||
+        !std::is_reference_v<_Args>
+    ) + ...);
+    static constexpr int kNumOut = kNumArgs - kNumIn;
+    static constexpr bool kIsSlice = (kIsSliceBase<_Args> && ...);
+    using Args = std::tuple<_Args...>;
+};
+// This metafunction deduces information about a callable object, including the number of input
+// and output arguments, whether any of the input arguments are slices, and the types of all the arguments.
+template<typename T>
+struct FuncDeduce : FuncDeduce_<decltype(std::function{std::declval<T>()})> {};
+// Determines the type ID of a Slice<T>'s element type.
+template <typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>>>
+constexpr char ElementTypeID = static_cast<char>(kTypeID<typename TBase::ElementType>);
+
+} // namespace np::ufunc_helper
+
+/** Universal function object.
+ *
+ * This class simplifies the creation of UFunc objects by deducing
+ * the signature of function pointers in order to determine the desired operands of
+ * the overloaded functions (inner loops) rather than specify it manually similar to C API.
+ * Since this class still counts on the C API, the following limitations are observed:
+ *   - All C++ functions must have the same number of inputs and outputs
+ *   - Outputs parmaters must start at the end of the inputs.
+ *   - No support for return type.
+ *   - Only datatype Slice<T> is supported and there's no room for
+ *     supporting scalars yet.
+ *
+ * Some examples:
+ *
+ * @code
+ * template<typename T>
+ * static void Add(
+ *      // Prpamerts without references represent the inputs
+ *      np::Slice<T> in0, np::Slice<T> in1,
+ *      // and with reference `&` represents the output
+ *      np::Slice<T> &out
+ * )
+ * {
+ *     for (auto a = in0.begin(), b = in1.begin(), c = out.begin(),
+ *             end = out.end();  c != end; ++a, ++b, ++c) {
+ *         *c = *a + *b;
+ *     }
+ * }
+ *
+ * template<typename T>
+ * static void CompareEqual(np::Slice<T> in0, np::Slice<T> in1,
+ *      // non-symmetric types are allowed
+ *      np::Slice<Bool> &out
+ * )
+ * {
+ *     auto c = out.begin();
+ *     auto end = c.end();
+ *     for (auto a = in0.begin(), b = in1.begin(), c != end; ++a, ++b, ++c) {
+ *         *c = *a == *b;
+ *     }
+ * }
+ *
+ * void MyCallee(PyObject *module_dict)
+ * {
+ *     using namespace np;
+ *     static UFuncObject add_obj(
+ *          // name/doc of the ufunc
+ *          "add", "this doc of add function",
+ *          // passing the pointers of the inner functions
+ *          // Signature of these functions will be detected and
+ *          // converted into python calls.
+ *          Add<Float>, Add<Double> // more data types are welcome
+ *     );
+ *     if (!add_obj.IsNull()) {
+ *        // now the following signatures are supported from the python level:
+ *        // add(np.array(dtype=np.float32), np.array(dtype=np.float32), out=np.array(dtype=np.float32))
+ *        // add(np.array(dtype=np.float64), np.array(dtype=np.float64), out=np.array(dtype=np.float64))
+ *        PyDict_SetItemString(module_dict, "add", add_obj);
+ *        Py_DECREF(add_obj);
+ *     }
+ *     static UFuncObject compare_equal_obj(
+ *          "compare_equal", "this doc of compare_equal function",
+ *          // passing the pointers of the inner functions
+ *          // Signature of these functions will be detected and
+ *          // converted into python calls.
+ *          Add<Float>, Add<Double> // more data types are welcome
+ *     );
+ *     if (!compare_equal_obj.IsNull()) {
+ *         // now the following signatures are supported from the python level:
+ *         // add(np.array(dtype=np.float32), np.array(dtype=np.float32), out=np.array(dtype=np.bool_))
+ *         // add(np.array(dtype=np.float64), np.array(dtype=np.float64), out=np.array(dtype=np.bool_))
+ *     }
+ * }
+ * @endcode
+ */
+template <typename ...TFuncOverloads>
+class UFuncObject {
+  public:
+    /// Number of overloaded functions (inner loops)
+    static constexpr int kNumOverloads = sizeof...(TFuncOverloads);
+    static_assert(kNumOverloads > 0, "Requires at least one function pointer");
+    static_assert(
+        ((std::is_function_v<std::remove_pointer_t<TFuncOverloads>>) && ...),
+        "Expected function pointers"
+    );
+   /** Constructs a UFuncObject
+    * @param name           The name of the UFuncObject
+    * @param doc            The documentation of the UFuncObject
+    * @param identity       The identity of the UFuncObject
+    * @param identity_value The identity value of the UFuncObject
+    * @param signature      The signature of the UFuncObject
+    * @param funcs          The function pointers of each overload.
+    */
+    constexpr UFuncObject(const char *name, const char *doc,
+                         int identity, PyObject *identity_value,
+                         const char *signature, TFuncOverloads ...funcs)
+        : UFuncObject(
+            name, doc, identity, identity_value, signature,
+            funcs...,
+            std::make_index_sequence<std::tuple_size_v<AllParamsTypes_>>{})
+    {}
+   /** Constructs a UFuncObject
+    * @param name           The name of the UFuncObject
+    * @param doc            The documentation of the UFuncObject
+    * @param funcs          The function pointers of each overload.
+    */
+    constexpr UFuncObject(const char *name, const char *doc, TFuncOverloads ...funcs)
+        : UFuncObject(
+            name, doc, PyUFunc_None, nullptr, nullptr,
+            funcs...)
+    {}
+    /// Returns false if the construction fails.
+    /// Since there's no support of exceptions, this function must be called
+    /// after construction.
+    bool IsNull() const
+    { return ref_ == nullptr; }
+    /// Update an existance overload of UFuncObject.
+    template <typename TFunc>
+    constexpr void Update(TFunc func)
+    {
+        constexpr size_t idx = Index_<TFunc>(
+            std::make_index_sequence<kNumOverloads>{}
+        );
+        printf("%d\n", idx);
+        data_[idx] = reinterpret_cast<void*>(func);
+    }
+    /// Implicitly converts the UFuncObject to a PyObject pointer.
+    operator PyObject*()
+    { return ref_; }
+    /// Implicitly converts the UFuncObject to a PyUFuncObject pointer.
+    operator PyUFuncObject*()
+    { return reinterpret_cast<PyUFuncObject*>(ref_); }
+
+  private:
+    // get the first function signature
+    using FuncDeduce_ = ufunc_helper::FuncDeduce<std::tuple_element_t<
+        0, std::tuple<TFuncOverloads...>
+    >>;
+    // number of ufunc args
+    static constexpr int kNumArgs_ = FuncDeduce_::kNumArgs;
+    // number of inputs
+    static constexpr int kNumIn_ = FuncDeduce_::kNumIn;
+    // number of ouput
+    static constexpr int kNumOut_ = FuncDeduce_::kNumOut;
+    static_assert(
+        kNumOut_ > 0,
+        "Overloaded functions must have at least one return (reference)"
+    );
+    static_assert(
+        ((ufunc_helper::FuncDeduce<TFuncOverloads>::kNumIn == kNumIn_) && ...),
+        "Overloaded functions must have the same number of inputs,"
+        "variant order overloading is not supported yet"
+    );
+    static_assert(
+        ((ufunc_helper::FuncDeduce<TFuncOverloads>::kNumOut == kNumOut_) && ...),
+        "Overloaded functions must have the same number of output,"
+        "variant order overloading is not supported yet"
+    );
+    static_assert(
+        (ufunc_helper::FuncDeduce<TFuncOverloads>::kIsSlice && ...),
+        "Only np::Slice<T> is supported as parmater type at current moment"
+    );
+
+    // concate all types of all functions parmaters into a single tuple
+    using AllParamsTypes_ = decltype(std::tuple_cat(
+        std::declval<typename ufunc_helper::FuncDeduce<TFuncOverloads>::Args>()...
+    ));
+
+    // the main constracing function, requires the indices
+    // of `AllParamsTypes_` so we keep it private.
+    template <std::size_t ...Ind>
+    constexpr UFuncObject(const char *name, const char *doc,
+                          int identity, PyObject *identity_value,
+                          const char *signature, TFuncOverloads ...funcs,
+                          std::index_sequence<Ind...>
+    )
+        : // intilize C function pointers
+          functions_{ToLegacyCFunc_(std::forward<TFuncOverloads>(funcs))...},
+          // convert all parmaters types into TypeIDs
+          ids_{ufunc_helper::ElementTypeID<
+              std::tuple_element_t<Ind, AllParamsTypes_>
+          >...},
+          // Initlize the C++ function pointers
+          data_{reinterpret_cast<void*>(funcs)...},
+          ref_(
+              PyUFunc_FromFuncAndDataAndSignatureAndIdentity(
+                  functions_, data_, ids_, kNumOverloads, kNumIn_, kNumOut_, identity,
+                  name, doc, 0/*unused*/, signature, identity_value
+              )
+          )
+    {}
+
+    template <typename TFunc, size_t ...Ind>
+    static constexpr size_t Index_(std::index_sequence<Ind...>)
+    {
+        static_assert(
+            (std::is_same_v<TFuncOverloads, TFunc> || ...),
+            "Unable to find an existance signature for this overload"
+        );
+        return ((std::is_same_v<TFuncOverloads, TFunc> ? Ind + 1 : 0) + ...) - 1;
+    }
+
+    // returns C function pointer after wraps C++ calls, we use
+    // data* to store C++ function pointer
+    template <typename TFunc, typename TArgs, size_t ...Ind>
+    static constexpr PyUFuncGenericFunction ToLegacyCFunc_(std::index_sequence<Ind...>)
+    {
+        return [](char **args, IntPtr const *dimensions, IntPtr const *strides, void *data) -> void {
+            using base_types = std::tuple<std::remove_reference_t<
+                std::tuple_element_t<Ind, TArgs>
+            >...>;
+            auto params = base_types(
+                std::tuple_element_t<Ind, base_types>(
+                    args[Ind], dimensions[0], strides[Ind]
+                )...
+            );
+            std::apply(reinterpret_cast<TFunc>(data), params);
+        };
+    }
+    template <typename TFunc, typename TDeduce = ufunc_helper::FuncDeduce<TFunc>>
+    static constexpr PyUFuncGenericFunction ToLegacyCFunc_(TFunc)
+    {
+        return ToLegacyCFunc_<TFunc, typename TDeduce::Args>(
+            std::make_index_sequence<TDeduce::kNumArgs>{}
+        );
+    }
+
+    PyUFuncGenericFunction functions_[kNumOverloads];
+    char ids_[kNumArgs_*kNumOverloads];
+    void *data_[kNumOverloads];
+    PyObject *ref_;
+};
+} // namespace np
+#endif // NUMPY_CORE_SRC_COMMON_UFUNC_OBJECT_HPP
+

--- a/numpy/_core/src/umath/ufunc_object.hpp
+++ b/numpy/_core/src/umath/ufunc_object.hpp
@@ -33,9 +33,11 @@ template <typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>
 constexpr bool kIsSliceBase = IsSliceBase_<TBase>::value;
 
 template <typename T>
-struct FuncDeduce_;
-template <typename Ret, typename ..._Args>
-struct FuncDeduce_<std::function<Ret(_Args...)>> {
+struct ObjFuncDeduce_;
+
+template<typename Ret, typename Class, typename ..._Args>
+struct ObjFuncDeduce_<Ret(Class::*)(_Args...)>
+{
     static constexpr int kNumArgs = sizeof...(_Args);
     static constexpr int kNumIn = ((
         std::is_const_v<std::remove_reference_t<_Args>> ||
@@ -45,69 +47,75 @@ struct FuncDeduce_<std::function<Ret(_Args...)>> {
     static constexpr bool kIsSlice = (kIsSliceBase<_Args> && ...);
     using Args = std::tuple<_Args...>;
 };
+
 // This metafunction deduces information about a callable object, including the number of input
 // and output arguments, whether any of the input arguments are slices, and the types of all the arguments.
 template<typename T>
-struct FuncDeduce : FuncDeduce_<decltype(std::function{std::declval<T>()})> {};
+struct ObjFuncDeduce : ObjFuncDeduce_<decltype(&T::operator())> {};
 // Determines the type ID of a Slice<T>'s element type.
 template <typename T, typename TBase=std::remove_cv_t<std::remove_reference_t<T>>>
 constexpr char ElementTypeID = static_cast<char>(kTypeID<typename TBase::ElementType>);
 
 } // namespace np::ufunc_helper
 
-/** Universal function object.
+/** Universal Function Object Wrapper for C UFunc.
  *
- * This class simplifies the creation of UFunc objects by deducing
- * the signature of function pointers in order to determine the desired operands of
- * the overloaded functions (inner loops) rather than specify it manually similar to C API.
- * Since this class still counts on the C API, the following limitations are observed:
- *   - All C++ functions must have the same number of inputs and outputs
- *   - Outputs parmaters must start at the end of the inputs.
- *   - No support for return type.
- *   - Only datatype Slice<T> is supported and there's no room for
- *     supporting scalars yet.
+ * This class provides a convenient way to create universal function (UFunc) objects in C++ for use with NumPy internaly,
+ * it leverages template metaprogramming to deduce function signatures and manage the conversion of C++ functor objects
+ * to be compatible with NumPy UFuncs.
  *
- * Some examples:
+ * Constraints:
+ * - All functor types must have a uniform number of input and output parameters.
+ * - Output parameters must be passed by reference and follow all input parameters in the functor's signature.
+ * - Direct return values are not supported; use output parameters to return results.
+ * - Only supports parameters of type `np::Slice<T>`, where `T` can be any data type compatible with NumPy arrays.
+ * - The class does not manage the lifetime of the created PyObject*; users are responsible for reference counting.
+ *
+ ** Usage Examples:
+ *
+ * Define functor objects that implement the `operator()` method with desired functionality. Inputs are
+ * passed by value, and outputs are passed by non-const reference. These structs can then be used to instantiate
+ * `UFuncObject`, which automatically makes these operations available as UFuncs.
  *
  * @code
  * template<typename T>
- * static void Add(
+ * struct AddOP {
+ *    void operator ()(
  *      // Prpamerts without references represent the inputs
- *      np::Slice<T> in0, np::Slice<T> in1,
+ *      Slice<T> in0, Slice<T> in1,
  *      // and with reference `&` represents the output
  *      np::Slice<T> &out
- * )
- * {
- *     for (auto a = in0.begin(), b = in1.begin(), c = out.begin(),
- *             end = out.end();  c != end; ++a, ++b, ++c) {
- *         *c = *a + *b;
- *     }
- * }
+ *    )
+ *    {
+ *        for (auto a = in0.Begin(), b = in1.Begin(), c = out.Begin(),
+ *             end = out.End();  c != end; ++a, ++b, ++c) {
+ *            *c = *a + *b;
+ *        }
+ *    }
+ * };
  *
  * template<typename T>
- * static void CompareEqual(np::Slice<T> in0, np::Slice<T> in1,
+ * struct CompareEqualOP {
+ *    void operator ()(
+ *      np::Slice<T> in0, np::Slice<T> in1,
  *      // non-symmetric types are allowed
  *      np::Slice<Bool> &out
- * )
- * {
- *     auto c = out.begin();
- *     auto end = c.end();
- *     for (auto a = in0.begin(), b = in1.begin(), c != end; ++a, ++b, ++c) {
- *         *c = *a == *b;
- *     }
- * }
+ *    )
+ *    {
+ *        auto c = out.Begin();
+ *        auto end = c.End();
+ *        for (auto a = in0.Begin(), b = in1.Begin(), c != end; ++a, ++b, ++c) {
+ *            *c = *a == *b;
+ *        }
+ *    }
+ * };
  *
  * void MyCallee(PyObject *module_dict)
  * {
  *     using namespace np;
- *     static UFuncObject add_obj(
- *          // name/doc of the ufunc
- *          "add", "this doc of add function",
- *          // passing the pointers of the inner functions
- *          // Signature of these functions will be detected and
- *          // converted into python calls.
- *          Add<Float>, Add<Double> // more data types are welcome
- *     );
+ *     // Instantiate and register the 'add' UFunc
+ *     static UFuncObject<AddOP<Float>, AddOP<Double>> add_obj("add", "Addition operation");
+ *     // Register the UFunc with the Python module if not null
  *     if (!add_obj.IsNull()) {
  *        // now the following signatures are supported from the python level:
  *        // add(np.array(dtype=np.float32), np.array(dtype=np.float32), out=np.array(dtype=np.float32))
@@ -115,71 +123,66 @@ constexpr char ElementTypeID = static_cast<char>(kTypeID<typename TBase::Element
  *        PyDict_SetItemString(module_dict, "add", add_obj);
  *        Py_DECREF(add_obj);
  *     }
- *     static UFuncObject compare_equal_obj(
+ *     static UFuncObject <
+ *         // passing the pointers of the inner functions
+ *         // Signature of these functions will be detected and
+ *         // converted into python calls.
+ *         CompareEqualOP<Float>, CompareEqualOP<Double> // more data types are welcome
+ *     > compare_equal_obj(
  *          "compare_equal", "this doc of compare_equal function",
- *          // passing the pointers of the inner functions
- *          // Signature of these functions will be detected and
- *          // converted into python calls.
- *          Add<Float>, Add<Double> // more data types are welcome
  *     );
  *     if (!compare_equal_obj.IsNull()) {
- *         // now the following signatures are supported from the python level:
- *         // add(np.array(dtype=np.float32), np.array(dtype=np.float32), out=np.array(dtype=np.bool_))
- *         // add(np.array(dtype=np.float64), np.array(dtype=np.float64), out=np.array(dtype=np.bool_))
+ *        // now the following signatures are supported from the python level:
+ *        // compare_equal(np.array(dtype=np.float32), np.array(dtype=np.float32), out=np.array(dtype=np.bool_))
+ *        // compare_equal(np.array(dtype=np.float64), np.array(dtype=np.float64), out=np.array(dtype=np.bool_))
+ *        PyDict_SetItemString(module_dict, "compare_equal", compare_equal_obj);
+ *        Py_DECREF(add_obj);
  *     }
  * }
  * @endcode
+ *
+ * @tparam TObjFuncOverloads Variadic template parameters representing the functor types that define the operations.
  */
-template <typename ...TFuncOverloads>
+template <typename ...TObjFuncOverloads>
 class UFuncObject {
   public:
     /// Number of overloaded functions (inner loops)
-    static constexpr int kNumOverloads = sizeof...(TFuncOverloads);
-    static_assert(kNumOverloads > 0, "Requires at least one function pointer");
-    static_assert(
-        ((std::is_function_v<std::remove_pointer_t<TFuncOverloads>>) && ...),
-        "Expected function pointers"
-    );
-   /** Constructs a UFuncObject
-    * @param name           The name of the UFuncObject
-    * @param doc            The documentation of the UFuncObject
-    * @param identity       The identity of the UFuncObject
-    * @param identity_value The identity value of the UFuncObject
-    * @param signature      The signature of the UFuncObject
-    * @param funcs          The function pointers of each overload.
-    */
+    static constexpr int kNumOverloads = sizeof...(TObjFuncOverloads);
+    /** Constructs a UFuncObject with detailed configuration.
+     * @param name The name of the UFunc, as it will appear in Python.
+     * @param doc Documentation string for the UFunc, explaining its purpose and usage.
+     * @param identity Identity element for the UFunc operation, used in reduction operations.
+     * @param identity_value The identity value, typically a PyObject representing the identity.
+     * @param signature The signature string for the UFunc, describing input and output types.
+     */
     constexpr UFuncObject(const char *name, const char *doc,
                          int identity, PyObject *identity_value,
-                         const char *signature, TFuncOverloads ...funcs)
+                         const char *signature)
         : UFuncObject(
             name, doc, identity, identity_value, signature,
-            funcs...,
             std::make_index_sequence<std::tuple_size_v<AllParamsTypes_>>{})
     {}
-   /** Constructs a UFuncObject
-    * @param name           The name of the UFuncObject
-    * @param doc            The documentation of the UFuncObject
-    * @param funcs          The function pointers of each overload.
-    */
-    constexpr UFuncObject(const char *name, const char *doc, TFuncOverloads ...funcs)
+    /** Simplified constructor for UFuncObject without identity and signature.
+     * @param name The name of the UFunc.
+     * @param doc Documentation string for the UFunc.
+     */
+    constexpr UFuncObject(const char *name, const char *doc)
         : UFuncObject(
-            name, doc, PyUFunc_None, nullptr, nullptr,
-            funcs...)
+            name, doc, PyUFunc_None, nullptr, nullptr)
     {}
-    /// Returns false if the construction fails.
-    /// Since there's no support of exceptions, this function must be called
-    /// after construction.
+    /// Checks if the UFuncObject was successfully constructed.
+    /// @return True if the object is "not" in a valid state, False otherwise.
     bool IsNull() const
     { return ref_ == nullptr; }
-    /// Update an existance overload of UFuncObject.
-    template <typename TFunc>
-    constexpr void Update(TFunc func)
+    /// Updates an existing signature of the UFuncObject with a new functor type.
+    /// @tparam TObjFunc The type of the functor object to update the UFunc with.
+    template <typename TObjFunc>
+    constexpr void Update()
     {
-        constexpr size_t idx = Index_<TFunc>(
+        constexpr size_t idx = Index_<TObjFunc>(
             std::make_index_sequence<kNumOverloads>{}
         );
-        printf("%d\n", idx);
-        data_[idx] = reinterpret_cast<void*>(func);
+        functions_[idx] = ToLegacyCFunc_<TObjFunc>();
     }
     /// Implicitly converts the UFuncObject to a PyObject pointer.
     operator PyObject*()
@@ -189,56 +192,56 @@ class UFuncObject {
     { return reinterpret_cast<PyUFuncObject*>(ref_); }
 
   private:
+    static_assert(kNumOverloads > 0, "UFuncObject requires at least one functor type as a template parameter.");
     // get the first function signature
-    using FuncDeduce_ = ufunc_helper::FuncDeduce<std::tuple_element_t<
-        0, std::tuple<TFuncOverloads...>
+    using ObjFuncDeduce_ = ufunc_helper::ObjFuncDeduce<std::tuple_element_t<
+        0, std::tuple<TObjFuncOverloads...>
     >>;
     // number of ufunc args
-    static constexpr int kNumArgs_ = FuncDeduce_::kNumArgs;
+    static constexpr int kNumArgs_ = ObjFuncDeduce_::kNumArgs;
     // number of inputs
-    static constexpr int kNumIn_ = FuncDeduce_::kNumIn;
+    static constexpr int kNumIn_ = ObjFuncDeduce_::kNumIn;
     // number of ouput
-    static constexpr int kNumOut_ = FuncDeduce_::kNumOut;
+    static constexpr int kNumOut_ = ObjFuncDeduce_::kNumOut;
     static_assert(
         kNumOut_ > 0,
-        "Overloaded functions must have at least one return (reference)"
+        "The functor types must have at least one output which can defined by passing reference to parameter type."
     );
     static_assert(
-        ((ufunc_helper::FuncDeduce<TFuncOverloads>::kNumIn == kNumIn_) && ...),
-        "Overloaded functions must have the same number of inputs,"
-        "variant order overloading is not supported yet"
+        ((ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::kNumIn == kNumIn_) && ...),
+        "All functor types must have the same number of input parameters."
+        "Variant input parameter counts are not supported."
     );
     static_assert(
-        ((ufunc_helper::FuncDeduce<TFuncOverloads>::kNumOut == kNumOut_) && ...),
-        "Overloaded functions must have the same number of output,"
-        "variant order overloading is not supported yet"
+        ((ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::kNumOut == kNumOut_) && ...),
+        "All functor types must have the same number of output parameters."
+        "Variant output parameter counts are not supported."
     );
     static_assert(
-        (ufunc_helper::FuncDeduce<TFuncOverloads>::kIsSlice && ...),
-        "Only np::Slice<T> is supported as parmater type at current moment"
+        (ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::kIsSlice && ...),
+        "Only np::Slice<T> parameter types are supported."
+        "Scalar types or other container types are not currently supported."
     );
 
-    // concate all types of all functions parmaters into a single tuple
+    // Concatenates the parameter types of all provided functor objects into a single tuple.
     using AllParamsTypes_ = decltype(std::tuple_cat(
-        std::declval<typename ufunc_helper::FuncDeduce<TFuncOverloads>::Args>()...
+        std::declval<typename ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::Args>()...
     ));
-
-    // the main constracing function, requires the indices
-    // of `AllParamsTypes_` so we keep it private.
+    // The main constructor for UFuncObject, leveraging template metaprogramming to deduce and manage parameter types.
+    // Requires the indices of `AllParamsTypes_` so we keep it private.
     template <std::size_t ...Ind>
     constexpr UFuncObject(const char *name, const char *doc,
                           int identity, PyObject *identity_value,
-                          const char *signature, TFuncOverloads ...funcs,
-                          std::index_sequence<Ind...>
+                          const char *signature, std::index_sequence<Ind...>
     )
         : // intilize C function pointers
-          functions_{ToLegacyCFunc_(std::forward<TFuncOverloads>(funcs))...},
+          functions_{ToLegacyCFunc_<TObjFuncOverloads>()...},
           // convert all parmaters types into TypeIDs
           ids_{ufunc_helper::ElementTypeID<
               std::tuple_element_t<Ind, AllParamsTypes_>
           >...},
           // Initlize the C++ function pointers
-          data_{reinterpret_cast<void*>(funcs)...},
+          data_{nullptr},
           ref_(
               PyUFunc_FromFuncAndDataAndSignatureAndIdentity(
                   functions_, data_, ids_, kNumOverloads, kNumIn_, kNumOut_, identity,
@@ -246,23 +249,26 @@ class UFuncObject {
               )
           )
     {}
-
-    template <typename TFunc, size_t ...Ind>
+    template <typename TObjFunc, size_t ...Ind>
     static constexpr size_t Index_(std::index_sequence<Ind...>)
     {
+        using ObjArgs_ = typename ufunc_helper::ObjFuncDeduce<TObjFunc>::Args;
         static_assert(
-            (std::is_same_v<TFuncOverloads, TFunc> || ...),
-            "Unable to find an existance signature for this overload"
+            (std::is_same_v<typename ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::Args,
+                            ObjArgs_> || ...),
+            "Unable to find a matching signature for this functor type."
+            "Ensure the functor's parameter type align with those of the existing functors types."
         );
-        return ((std::is_same_v<TFuncOverloads, TFunc> ? Ind + 1 : 0) + ...) - 1;
+        return ((std::is_same_v<
+                    typename ufunc_helper::ObjFuncDeduce<TObjFuncOverloads>::Args, ObjArgs_
+                > ? Ind + 1 : 0) + ...) - 1;
     }
 
-    // returns C function pointer after wraps C++ calls, we use
-    // data* to store C++ function pointer
-    template <typename TFunc, typename TArgs, size_t ...Ind>
+    // returns C function pointer after wraps C++ calls
+    template <typename TObjFunc, typename TArgs, size_t ...Ind>
     static constexpr PyUFuncGenericFunction ToLegacyCFunc_(std::index_sequence<Ind...>)
     {
-        return [](char **args, IntPtr const *dimensions, IntPtr const *strides, void *data) -> void {
+        return [](char **args, IntPtr const *dimensions, IntPtr const *strides, void*) -> void {
             using base_types = std::tuple<std::remove_reference_t<
                 std::tuple_element_t<Ind, TArgs>
             >...>;
@@ -271,13 +277,14 @@ class UFuncObject {
                     args[Ind], dimensions[0], strides[Ind]
                 )...
             );
-            std::apply(reinterpret_cast<TFunc>(data), params);
+            TObjFunc f;
+            std::apply(f, params);
         };
     }
-    template <typename TFunc, typename TDeduce = ufunc_helper::FuncDeduce<TFunc>>
-    static constexpr PyUFuncGenericFunction ToLegacyCFunc_(TFunc)
+    template <typename TObjFunc, typename TDeduce = ufunc_helper::ObjFuncDeduce<TObjFunc>>
+    static constexpr PyUFuncGenericFunction ToLegacyCFunc_()
     {
-        return ToLegacyCFunc_<TFunc, typename TDeduce::Args>(
+        return ToLegacyCFunc_<TObjFunc, typename TDeduce::Args>(
             std::make_index_sequence<TDeduce::kNumArgs>{}
         );
     }
@@ -287,6 +294,8 @@ class UFuncObject {
     void *data_[kNumOverloads];
     PyObject *ref_;
 };
+
+
 } // namespace np
 #endif // NUMPY_CORE_SRC_COMMON_UFUNC_OBJECT_HPP
 

--- a/numpy/_core/src/umath/ufunc_operations.cpp
+++ b/numpy/_core/src/umath/ufunc_operations.cpp
@@ -33,7 +33,7 @@ struct CopysignOP {
     }
 };
 
-int InitOperations(PyObject *mdict)
+int InitCPPOperations(PyObject *mdict)
 {
     // This is no longer used as numpy.ones_like, however it is
     // still used by some internal calls.
@@ -48,7 +48,9 @@ int InitOperations(PyObject *mdict)
         OnesLikeOP<CFloat>, OnesLikeOP<CDouble>, OnesLikeOP<CLongDouble>,
         OnesLikeOP<TimeDelta>, OnesLikeOP<DateTime>, OnesLikeOP<Object>
     > ones_like_obj("_ones_like", DOC_NUMPY__CORE_UMATH__ONES_LIKE);
-
+    if (ones_like_obj.IsNull()) {
+        return -1;
+    }
     static_cast<PyUFuncObject*>(ones_like_obj)->type_resolver = &PyUFunc_OnesLikeTypeResolver;
     PyDict_SetItemString(mdict, "_ones_like", ones_like_obj);
     Py_DECREF(ones_like_obj);

--- a/numpy/_core/src/umath/ufunc_operations.cpp
+++ b/numpy/_core/src/umath/ufunc_operations.cpp
@@ -1,0 +1,66 @@
+#include "ufunc_object.hpp"
+
+#include "ufunc_type_resolution.h"
+
+#include "ufunc_operations.h"
+#include "_umath_doc_generated.h"
+
+using namespace np;
+
+template <typename T>
+static void op_ones_like(Slice<T>, Slice<T> &out)
+{
+    for (auto &a : out) {
+        if constexpr (std::is_same_v<T, Half>) {
+            a = Half::FromBits(0x3c00u);
+        }
+        else {
+            a = 1;
+        }
+    }
+}
+
+template <typename T>
+static void op_copysign(Slice<T> in0, Slice<T> in1, Slice<T> &out)
+{
+    for (auto a = in0.Begin(), b = in1.Begin(), c = out.Begin(),
+            end = out.End();  c != end; ++a, ++b, ++c) {
+        *c = Copysign(*a, *b);
+    }
+}
+
+int InitOperations(PyObject *mdict)
+{
+    // This is no longer used as numpy.ones_like, however it is
+    // still used by some internal calls.
+    static UFuncObject ones_like_obj(
+        "_ones_like", DOC_NUMPY_CORE_UMATH__ONES_LIKE,
+        op_ones_like<Bool>,
+        op_ones_like<Byte>, op_ones_like<UByte>,
+        op_ones_like<Short>, op_ones_like<UShort>,
+        op_ones_like<Int>, op_ones_like<UInt>,
+        op_ones_like<Long>, op_ones_like<ULong>,
+        op_ones_like<LongLong>, op_ones_like<ULongLong>,
+        op_ones_like<Half>, op_ones_like<Float>, op_ones_like<Double>, op_ones_like<LongDouble>,
+        op_ones_like<CFloat>, op_ones_like<CDouble>, op_ones_like<CLongDouble>,
+        op_ones_like<TimeDelta>, op_ones_like<DateTime>, op_ones_like<Object>
+    );
+    if (ones_like_obj.IsNull()) {
+        return -1;
+    }
+    static_cast<PyUFuncObject*>(ones_like_obj)->type_resolver = &PyUFunc_OnesLikeTypeResolver;
+    PyDict_SetItemString(mdict, "_ones_like", ones_like_obj);
+    Py_DECREF(ones_like_obj);
+
+    static UFuncObject copysign_obj(
+        "copysign", DOC_NUMPY_CORE_UMATH_COPYSIGN,
+        op_copysign<Half>, op_copysign<Float>,
+        op_copysign<Double>, op_copysign<LongDouble>
+    );
+    if (copysign_obj.IsNull()) {
+        return -1;
+    }
+    PyDict_SetItemString(mdict, "copysign", copysign_obj);
+    Py_DECREF(copysign_obj);
+    return 0;
+}

--- a/numpy/_core/src/umath/ufunc_operations.cpp
+++ b/numpy/_core/src/umath/ufunc_operations.cpp
@@ -47,7 +47,7 @@ int InitOperations(PyObject *mdict)
         OnesLikeOP<Half>, OnesLikeOP<Float>, OnesLikeOP<Double>, OnesLikeOP<LongDouble>,
         OnesLikeOP<CFloat>, OnesLikeOP<CDouble>, OnesLikeOP<CLongDouble>,
         OnesLikeOP<TimeDelta>, OnesLikeOP<DateTime>, OnesLikeOP<Object>
-    > ones_like_obj("_ones_like", DOC_NUMPY_CORE_UMATH__ONES_LIKE);
+    > ones_like_obj("_ones_like", DOC_NUMPY__CORE_UMATH__ONES_LIKE);
 
     static_cast<PyUFuncObject*>(ones_like_obj)->type_resolver = &PyUFunc_OnesLikeTypeResolver;
     PyDict_SetItemString(mdict, "_ones_like", ones_like_obj);
@@ -57,7 +57,7 @@ int InitOperations(PyObject *mdict)
         CopysignOP<Half>, CopysignOP<Float>,
         CopysignOP<Double>, CopysignOP<LongDouble>
     > copysign_obj(
-        "copysign", DOC_NUMPY_CORE_UMATH_COPYSIGN
+        "copysign", DOC_NUMPY__CORE_UMATH_COPYSIGN
     );
     if (copysign_obj.IsNull()) {
         return -1;

--- a/numpy/_core/src/umath/ufunc_operations.cpp
+++ b/numpy/_core/src/umath/ufunc_operations.cpp
@@ -8,54 +8,56 @@
 using namespace np;
 
 template <typename T>
-static void op_ones_like(Slice<T>, Slice<T> &out)
-{
-    for (auto &a : out) {
-        if constexpr (std::is_same_v<T, Half>) {
-            a = Half::FromBits(0x3c00u);
-        }
-        else {
-            a = 1;
+struct OnesLikeOP {
+    void operator ()(Slice<T>, Slice<T> &out)
+    {
+        for (auto &a : out) {
+            if constexpr (std::is_same_v<T, Half>) {
+                a = Half::FromBits(0x3c00u);
+            }
+            else {
+                a = 1;
+            }
         }
     }
-}
+};
 
 template <typename T>
-static void op_copysign(Slice<T> in0, Slice<T> in1, Slice<T> &out)
-{
-    for (auto a = in0.Begin(), b = in1.Begin(), c = out.Begin(),
-            end = out.End();  c != end; ++a, ++b, ++c) {
-        *c = Copysign(*a, *b);
+struct CopysignOP {
+    void operator ()(Slice<T> in0, Slice<T> in1, Slice<T> &out)
+    {
+        for (auto a = in0.Begin(), b = in1.Begin(), c = out.Begin(),
+             end = out.End();  c != end; ++a, ++b, ++c) {
+            *c = Copysign(*a, *b);
+        }
     }
-}
+};
 
 int InitOperations(PyObject *mdict)
 {
     // This is no longer used as numpy.ones_like, however it is
     // still used by some internal calls.
-    static UFuncObject ones_like_obj(
-        "_ones_like", DOC_NUMPY_CORE_UMATH__ONES_LIKE,
-        op_ones_like<Bool>,
-        op_ones_like<Byte>, op_ones_like<UByte>,
-        op_ones_like<Short>, op_ones_like<UShort>,
-        op_ones_like<Int>, op_ones_like<UInt>,
-        op_ones_like<Long>, op_ones_like<ULong>,
-        op_ones_like<LongLong>, op_ones_like<ULongLong>,
-        op_ones_like<Half>, op_ones_like<Float>, op_ones_like<Double>, op_ones_like<LongDouble>,
-        op_ones_like<CFloat>, op_ones_like<CDouble>, op_ones_like<CLongDouble>,
-        op_ones_like<TimeDelta>, op_ones_like<DateTime>, op_ones_like<Object>
-    );
-    if (ones_like_obj.IsNull()) {
-        return -1;
-    }
+    static UFuncObject<
+        OnesLikeOP<Bool>,
+        OnesLikeOP<Byte>, OnesLikeOP<UByte>,
+        OnesLikeOP<Short>, OnesLikeOP<UShort>,
+        OnesLikeOP<Int>, OnesLikeOP<UInt>,
+        OnesLikeOP<Long>, OnesLikeOP<ULong>,
+        OnesLikeOP<LongLong>, OnesLikeOP<ULongLong>,
+        OnesLikeOP<Half>, OnesLikeOP<Float>, OnesLikeOP<Double>, OnesLikeOP<LongDouble>,
+        OnesLikeOP<CFloat>, OnesLikeOP<CDouble>, OnesLikeOP<CLongDouble>,
+        OnesLikeOP<TimeDelta>, OnesLikeOP<DateTime>, OnesLikeOP<Object>
+    > ones_like_obj("_ones_like", DOC_NUMPY_CORE_UMATH__ONES_LIKE);
+
     static_cast<PyUFuncObject*>(ones_like_obj)->type_resolver = &PyUFunc_OnesLikeTypeResolver;
     PyDict_SetItemString(mdict, "_ones_like", ones_like_obj);
     Py_DECREF(ones_like_obj);
 
-    static UFuncObject copysign_obj(
-        "copysign", DOC_NUMPY_CORE_UMATH_COPYSIGN,
-        op_copysign<Half>, op_copysign<Float>,
-        op_copysign<Double>, op_copysign<LongDouble>
+    static UFuncObject<
+        CopysignOP<Half>, CopysignOP<Float>,
+        CopysignOP<Double>, CopysignOP<LongDouble>
+    > copysign_obj(
+        "copysign", DOC_NUMPY_CORE_UMATH_COPYSIGN
     );
     if (copysign_obj.IsNull()) {
         return -1;

--- a/numpy/_core/src/umath/ufunc_operations.h
+++ b/numpy/_core/src/umath/ufunc_operations.h
@@ -1,5 +1,5 @@
-#ifndef NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H
-#define NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H
+#ifndef NUMPY__CORE_SRC_UMATH_UFUNC_OPERATIONS_H
+#define NUMPY__CORE_SRC_UMATH_UFUNC_OPERATIONS_H
 
 #include "numpy/ndarraytypes.h"
 
@@ -7,10 +7,10 @@
 extern "C" {
 #endif
 
-NPY_VISIBILITY_HIDDEN int InitOperations(PyObject *mdict);
+NPY_VISIBILITY_HIDDEN int InitCPPOperations(PyObject *mdict);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H
+#endif // NUMPY__CORE_SRC_UMATH_UFUNC_OPERATIONS_H

--- a/numpy/_core/src/umath/ufunc_operations.h
+++ b/numpy/_core/src/umath/ufunc_operations.h
@@ -1,0 +1,16 @@
+#ifndef NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H
+#define NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H
+
+#include "numpy/ndarraytypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NPY_VISIBILITY_HIDDEN int InitOperations(PyObject *mdict);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NUMPY_CORE_SRC_UMATH_UFUNC_OPERATIONS_H

--- a/numpy/_core/src/umath/ufunc_type_resolution.h
+++ b/numpy/_core/src/umath/ufunc_type_resolution.h
@@ -1,6 +1,10 @@
 #ifndef _NPY_PRIVATE__UFUNC_TYPE_RESOLUTION_H_
 #define _NPY_PRIVATE__UFUNC_TYPE_RESOLUTION_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 NPY_NO_EXPORT int
 PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                                            NPY_CASTING casting,
@@ -141,5 +145,9 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
 
 NPY_NO_EXPORT int
 raise_no_loop_found_error(PyUFuncObject *ufunc, PyObject **dtypes);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -29,7 +29,7 @@
 #include "string_ufuncs.h"
 #include "special_integer_comparisons.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
-#include "ufunc_operations.h"
+#include "ufunc_operations.h" // InitCPPOperations
 
 /* Automatically generated code to define all ufuncs: */
 #include "funcs.inc"
@@ -247,7 +247,7 @@ int initumath(PyObject *m)
     if (InitOperators(d) < 0) {
         return -1;
     }
-    if (InitOperations(d) < 0) {
+    if (InitCPPOperations(d) < 0) {
         return -1;
     }
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -29,6 +29,7 @@
 #include "string_ufuncs.h"
 #include "special_integer_comparisons.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
+#include "ufunc_operations.h"
 
 /* Automatically generated code to define all ufuncs: */
 #include "funcs.inc"
@@ -244,6 +245,9 @@ int initumath(PyObject *m)
     d = PyModule_GetDict(m);
 
     if (InitOperators(d) < 0) {
+        return -1;
+    }
+    if (InitOperations(d) < 0) {
         return -1;
     }
 


### PR DESCRIPTION
merge after #23298 

This work aims to greatly reduce reliance on the C API, in order to facilitate the complete elimination of C code in the future and count on modern C++.

This request includes multiple patches, the main purpose of which is to impose a framework that facilitates the creation of universal functions using the C++ language without the need of use python code as generator.

Two examples have been added to show how to use it. You can explore them by reviewing [ufunc_operations.cpp](https://github.com/numpy/numpy/blob/9a25ad09fc4c22fc1450d5819b4cdc4f4fa31670/numpy/core/src/umath/ufunc_operations.cpp)


TODO:
- [x] ~wrapping PyObject and PyArray~ Adding `Array` to manage the array data only
- [x] ~tweak the C++ wrapper for universal functions(add Doxygen comment blocks, add static assertation)~
       will be included by #21057
- [x] add C++ types for float16, datetime, timedelta for type safety and overloading.
- [x] ~add testing unit for the C++ wrapper~ 
- [x] add more examples
