### PR TITLE
ENH: Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+# A clang-format style that approximates Python's PEP 7
+# Useful for IDE integration
+#
+# Based on Paul Ganssle's version at
+# https://gist.github.com/pganssle/0e3a5f828b4d07d79447f6ced8e7e4db
+# and modified for NumPy
+BasedOnStyle: Google
+AlignAfterOpenBracket: Align
+AllowShortEnumsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AlwaysBreakAfterReturnType: TopLevel
+BreakBeforeBraces: Stroustrup
+ColumnLimit: 79
+ContinuationIndentWidth: 8
+DerivePointerAlignment: false
+IndentWidth: 4
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^[<"](Python|structmember)'
+    Priority:        -3
+    CaseSensitive:   true
+  - Regex:           '^"numpy/'
+    Priority:        -2
+  - Regex:           '^"(npy_pycompat|npy_config)'
+    Priority:        -1
+  - Regex:           '^"[[:alnum:]_.]+"'
+    Priority:        1
+  - Regex:           '^<[[:alnum:]_.]+"'
+    Priority:        2
+Language: Cpp
+PointerAlignment: Right
+ReflowComments: true
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+StatementMacros: [PyObject_HEAD, PyObject_VAR_HEAD, PyObject_HEAD_EXTRA]
+TabWidth: 4
+UseTab: Never

--- a/doc/release/upcoming_changes/19754.new_feature.rst
+++ b/doc/release/upcoming_changes/19754.new_feature.rst
@@ -1,0 +1,7 @@
+A ``.clang-format`` file has been added
+---------------------------------------
+Clang-format is a C/C++ code formatter, together with the added
+``.clang-format`` file, it produces code close enough to the NumPy
+C_STYLE_GUIDE for general use. Clang-format version 12+ is required
+due to the use of several new features, it is available in
+Fedora 34 and Ubuntu Focal among other distributions.


### PR DESCRIPTION
Clang-format can be used to reformat C/C++ code for codestyle fixups. The `.clang-format` file here implements the NumPy codestyle document as much as possible. The initial version here is taken from @pganssle's file at 
https://gist.github.com/pganssle/0e3a5f828b4d07d79447f6ced8e7e4db, he is listed as co-author.

I've included a formatted version of convert.c for before/after comparison, it can be removed before merging.

Closes #19363.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
