### PR TITLE
BUG: Remove np.around's footnote [2]

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3320,9 +3320,6 @@ def around(a, decimals=0, out=None):
     ----------
     .. [1] "Lecture Notes on the Status of IEEE 754", William Kahan,
            https://people.eecs.berkeley.edu/~wkahan/ieee754status/IEEE754.PDF
-    .. [2] "How Futile are Mindless Assessments of
-           Roundoff in Floating-Point Computation?", William Kahan,
-           https://people.eecs.berkeley.edu/~wkahan/Mindless.pdf
 
     Examples
     --------


### PR DESCRIPTION
Since it's not used in the text there's no need for the reference.

- [x]  Closes #19765