### PR TITLE
DOC: Fixed typo in "Creating matrices" section of Absolute Beginners guide, array([2, 4, 6]) should be array([2, 5, 6])

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -904,7 +904,7 @@ columns or rows using the ``axis`` parameter::
   >>> data.max(axis=0)
   array([5, 6])
   >>> data.max(axis=1)
-  array([2, 4, 6])
+  array([2, 5, 6])
 
 .. image:: images/np_matrix_aggregation_row.png
 


### PR DESCRIPTION
In Absolute Beginners guide, "Creating matrices" section, after the text starting from "You can aggregate all the values in a matrix and you can aggregate them across columns or rows" the example text had `array([2, 4, 6])` incorrectly, while the accompanying picture showed the right value. Updated the text to correctly say `array([2, 5, 6])`.