### PR TITLE
DOC: Add explanation of a sparse mesh grid

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4277,7 +4277,13 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
 
         .. versionadded:: 1.7.0
     sparse : bool, optional
-        If True a sparse grid is returned in order to conserve memory.
+        If True the shape of the returned coordinate array for dimension *i*
+        is reduced from ``(N1, ..., Ni, ... Nn)`` to
+        ``(1, ..., 1, Ni, 1, ..., 1)``.  These sparse coordinate grids are
+        intended to be use with :ref:`basics.broadcasting`.  When all
+        coordinates are used in an expression, broadcasting still leads to a
+        fully-dimensonal result array.
+
         Default is False.
 
         .. versionadded:: 1.7.0
@@ -4348,17 +4354,30 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     array([[0.],
            [1.]])
 
-    `meshgrid` is very useful to evaluate functions on a grid.
+    `meshgrid` is very useful to evaluate functions on a grid.  If the
+    function depends on all coordinates, you can use the parameter
+    ``sparse=True`` to save memory and computation time.
+
+    >>> x = np.linspace(-5, 5, 101)
+    >>> y = np.linspace(-5, 5, 101)
+    # full coorindate arrays
+    >>> xx, yy = np.meshgrid(x, y)
+    >>> zz = np.sqrt(xx**2 + yy**2)
+    >>> xx.shape, yy.shape, zz.shape
+    ((101, 101), (101, 101), (101, 101))
+    # sparse coordinate arrays
+    >>> xs, ys = np.meshgrid(x, y, sparse=True)
+    >>> zs = np.sqrt(xs**2 + ys**2)
+    >>> xs.shape, ys.shape, zs.shape
+    ((1, 101), (101, 1), (101, 101))
+    >>> np.array_equal(zz, zs)
+    True
 
     >>> import matplotlib.pyplot as plt
-    >>> x = np.arange(-5, 5, 0.1)
-    >>> y = np.arange(-5, 5, 0.1)
-    >>> xx, yy = np.meshgrid(x, y, sparse=True)
-    >>> z = np.sin(xx**2 + yy**2) / (xx**2 + yy**2)
-    >>> h = plt.contourf(x, y, z)
+    >>> h = plt.contourf(x, y, zs)
     >>> plt.axis('scaled')
+    >>> plt.colorbar()
     >>> plt.show()
-
     """
     ndim = len(xi)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4360,12 +4360,12 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
 
     >>> x = np.linspace(-5, 5, 101)
     >>> y = np.linspace(-5, 5, 101)
-    # full coorindate arrays
+    >>> # full coorindate arrays
     >>> xx, yy = np.meshgrid(x, y)
     >>> zz = np.sqrt(xx**2 + yy**2)
     >>> xx.shape, yy.shape, zz.shape
     ((101, 101), (101, 101), (101, 101))
-    # sparse coordinate arrays
+    >>> # sparse coordinate arrays
     >>> xs, ys = np.meshgrid(x, y, sparse=True)
     >>> zs = np.sqrt(xs**2 + ys**2)
     >>> xs.shape, ys.shape, zs.shape


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/19561#issuecomment-886501122.

I've also changed `np.arange(-5, 5, 0.1)` to `np.linspace(-5, 5, 101)` in the example because `arange` for non-integer steps is generally not recommended.

https://numpy.org/doc/stable/reference/generated/numpy.arange.html:

> When using a non-integer step, such as 0.1, the results will often not be consistent. It is better to use numpy.linspace for these cases.