### PR TITLE
PR: np.select function does not work with BooleanDtype  Closes#43228 

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -697,7 +697,7 @@ def select(condlist, choicelist, default=0):
     condlist = np.broadcast_arrays(*condlist)
     choicelist = np.broadcast_arrays(*choicelist)
 
-    #Convert conditions to BooleanDtype to numpy bool
+    #Convert condlist array datatype from BooleanDtype to numpy bool
     try:
         condlist = [i.astype(bool) for i in condlist]
     except :

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -697,6 +697,12 @@ def select(condlist, choicelist, default=0):
     condlist = np.broadcast_arrays(*condlist)
     choicelist = np.broadcast_arrays(*choicelist)
 
+    #Convert conditions to BooleanDtype to numpy bool
+    try:
+        condlist = [i.astype(bool) for i in condlist]
+    except :
+        raise TypeError
+
     # If cond array is not an ndarray in boolean format or scalar bool, abort.
     for i, cond in enumerate(condlist):
         if cond.dtype.type is not np.bool_:


### PR DESCRIPTION
np.select function does not work with BooleanDtype Closes#43228
p
LETS US MERGE CHANGES

AFTER CHANGES 👍 
```
df = pd.DataFrame({"col1": list("ABBC"), "col2": list("ZZXY")}).astype("string")
conditions = [
    (df["col2"] == "Z") & (df["col1"] == "A"),
    (df["col2"] == "Z") & (df["col1"] == "B"),
    (df["col1"] == "B"),
]
print((df["col2"] == "Z").dtype) #BooleanDtype
choices = ['yellow', 'blue', 'purple']
df['color'] = np.select(conditions, choices, default='black')

output:
col1 col2   color
0    A    Z  yellow
1    B    Z    blue
2    B    X  purple
3    C    Y   black


```