### PR TITLE
MAINT: Fix LGTM active errors

### DIFF
--- a/numpy/_version.py
+++ b/numpy/_version.py
@@ -498,7 +498,7 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for root in cfg.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
         return {"version": "0+unknown", "full-revisionid": None,

--- a/numpy/array_api/_typing.py
+++ b/numpy/array_api/_typing.py
@@ -37,7 +37,7 @@ NestedSequence = Sequence[Sequence[Any]]
 
 Device = Any
 Dtype = Type[
-    Union[[int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64]]
+    Union[tuple([int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64])]
 ]
 SupportsDLPack = Any
 SupportsBufferProtocol = Any

--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -224,7 +224,7 @@ def removeHeader(source):
 
 def removeSubroutinePrototypes(source):
     expression = re.compile(
-        r'/\* Subroutine \*/^\s*(?:(?:inline|static)\s+){0,2}(?!else|typedef|return)\w+\s+\*?\s*(\w+)\s*\([^0]+\)\s*;?'
+        r'\* Subroutine \*^\s*(?:(?:inline|static)\s+){0,2}(?!else|typedef|return)\w+\s+\*?\s*(\w+)\s*\([^0]+\)\s*;?'
     )
     lines = LineQueue()
     for line in StringIO(source):


### PR DESCRIPTION
Fixed LGTM 3 active security errors.
1) This instance of list is unhashable.
- create tuple as hashable.

2) For loop variable 'i' is not used in the loop body.
-used loop variable root used in the loop.

3) This regular expression includes an unmatchable caret at offset 18.
-Fixed regular expression escape sequence.