### PR TITLE
TST: Drop typing-extensions from test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,6 +11,3 @@ cffi
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 mypy==0.910; platform_python_implementation != "PyPy"
-
-# TODO: Remove once 3.10.0.2 has been released (xref python/typing#865)
-typing_extensions==3.10.0.0; python_version == '3.10'


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/19784.

With the release of 3.10.0.2 we no longer have to worry about mypy installing a broken typing-extensions version for python 3.10.