### PR TITLE
ENH: Add entry point for Array API implementation

### DIFF
--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -465,12 +465,18 @@ def test_array_api_entry_point():
     Entry point for Array API implementation can be found with importlib and
     returns the numpy.array_api namespace.
     """
-    from numpy import array_api
-
     eps = importlib.metadata.entry_points()
-    assert "array_api" in eps.keys()
-    xp_eps = eps["array_api"]
+    try:
+        xp_eps = eps.select(group="array_api")
+    except AttributeError:
+        # The select interface for entry_points was introduced in py3.10,
+        # deprecating its dict interface. We fallback to dict keys for finding
+        # Array API entry points so that running this test in <=3.9 will
+        # still work - see https://github.com/numpy/numpy/pull/19800.
+        assert "array_api" in eps.keys()
+        xp_eps = eps["array_api"]
+    assert len(xp_eps) > 0
     assert "numpy" in (ep.name for ep in xp_eps)
     ep = next(ep for ep in xp_eps if ep.name == "numpy")
     xp = importlib.import_module(ep.value)
-    assert xp is array_api
+    assert xp is numpy.array_api

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -458,3 +458,19 @@ def test_api_importable():
         raise AssertionError("Modules that are not really public but looked "
                              "public and can not be imported: "
                              "{}".format(module_names))
+
+
+def test_array_api_entry_point():
+    """
+    Entry point for Array API implementation can be found with importlib and
+    returns the numpy.array_api namespace.
+    """
+    from numpy import array_api
+
+    eps = importlib.metadata.entry_points()
+    assert "array_api" in eps.keys()
+    xp_eps = eps["array_api"]
+    assert "numpy" in (ep.name for ep in xp_eps)
+    ep = next(ep for ep in xp_eps if ep.name == "numpy")
+    xp = importlib.import_module(ep.value)
+    assert xp is array_api

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -481,7 +481,7 @@ def test_array_api_entry_point():
     except StopIteration:
         raise AssertionError("'numpy' not in array_api entry points") from None
 
-    xp = importlib.import_module(ep.value)
+    xp = ep.load()
     msg = (
         f"numpy entry point value '{ep.value}' "
         "does not point to our Array API implementation"

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -473,10 +473,17 @@ def test_array_api_entry_point():
         # deprecating its dict interface. We fallback to dict keys for finding
         # Array API entry points so that running this test in <=3.9 will
         # still work - see https://github.com/numpy/numpy/pull/19800.
-        assert "array_api" in eps.keys()
-        xp_eps = eps["array_api"]
-    assert len(xp_eps) > 0
-    assert "numpy" in (ep.name for ep in xp_eps)
-    ep = next(ep for ep in xp_eps if ep.name == "numpy")
+        xp_eps = eps.get("array_api", [])
+    assert len(xp_eps) > 0, "No entry points for 'array_api' found"
+
+    try:
+        ep = next(ep for ep in xp_eps if ep.name == "numpy")
+    except StopIteration:
+        raise AssertionError("'numpy' not in array_api entry points") from None
+
     xp = importlib.import_module(ep.value)
-    assert xp is numpy.array_api
+    msg = (
+        f"numpy entry point value '{ep.value}' "
+        "does not point to our Array API implementation"
+    )
+    assert xp is numpy.array_api, msg

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -1,4 +1,5 @@
 import sys
+import sysconfig
 import subprocess
 import pkgutil
 import types
@@ -460,6 +461,14 @@ def test_api_importable():
                              "{}".format(module_names))
 
 
+@pytest.mark.xfail(
+    sysconfig.get_config_var("Py_DEBUG") is not None,
+    reason=(
+        "NumPy possibly built with `USE_DEBUG=True ./tools/travis-test.sh`, "
+        "which does not expose the `array_api` entry point. "
+        "See https://github.com/numpy/numpy/pull/19800"
+    ),
+)
 def test_array_api_entry_point():
     """
     Entry point for Array API implementation can be found with importlib and

--- a/setup.py
+++ b/setup.py
@@ -411,7 +411,8 @@ def setup_package():
         python_requires='>=3.8',
         zip_safe=False,
         entry_points={
-            'console_scripts': f2py_cmds
+            'console_scripts': f2py_cmds,
+            'array_api': ['numpy = numpy.array_api'],
         },
     )
 


### PR DESCRIPTION
On @mattip's suggestion, this PR simple adds an entry point for NumPy's Array API implementation in `setup.py`:

```diff
        entry_points={
            'console_scripts': f2py_cmds,
+           'array_api': ['numpy = numpy.array_api'],
        },
```

The Data APIs consortium is currently discussing whether Array API adaptors should have an entry point to point to their actual implementation in data-apis/array-api#244. In summary: for array consuming libraries you can currently get the Array API namespace via `xp = x.__array_namespace__()`, but for array *generating* libraries (e.g. Hypothesis in HypothesisWorks/hypothesis#3065) the entry point would allow programmatic discovery of the available Array API implementations in the Python environment.
```
>>> from importlib.metadata import entry_points
>>> eps = entry_points()
>>> eps["array_api"]
(EntryPoint(name='numpy', value='numpy.array_api', group='array_api'), ...)
>>> ep = next(ep for ep in eps["array_api"] if ep.name == "numpy")
>>> xp = ep.load()
```

I thought I'd make this PR more-so to demonstrate how the proposal would work in practice, and it's something that can be returned to if the proposal goes through.