### PR TITLE
MAINT: Minor include rationalizations.

### DIFF
--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -80,6 +80,7 @@ the module.
 
     .. code-block:: c
 
+        #define PY_SSIZE_T_CLEAN
         #include <Python.h>
         #include <math.h>
 
@@ -252,11 +253,12 @@ the primary thing that must be changed to create your own ufunc.
 
     .. code-block:: c
 
-        #include "Python.h"
-        #include "math.h"
+        #define PY_SSIZE_T_CLEAN
+        #include <Python.h>
         #include "numpy/ndarraytypes.h"
         #include "numpy/ufuncobject.h"
         #include "numpy/npy_3kcompat.h"
+        #include <math.h>
 
         /*
          * single_type_logit.c
@@ -427,11 +429,12 @@ the primary thing that must be changed to create your own ufunc.
 
     .. code-block:: c
 
-        #include "Python.h"
-        #include "math.h"
+        #define PY_SSIZE_T_CLEAN
+        #include <Python.h>
         #include "numpy/ndarraytypes.h"
         #include "numpy/ufuncobject.h"
         #include "numpy/halffloat.h"
+        #include <math.h>
 
         /*
          * multi_type_logit.c
@@ -696,11 +699,12 @@ as well as all other properties of a ufunc.
 
     .. code-block:: c
 
-        #include "Python.h"
-        #include "math.h"
+        #define PY_SSIZE_T_CLEAN
+        #include <Python.h>
         #include "numpy/ndarraytypes.h"
         #include "numpy/ufuncobject.h"
         #include "numpy/halffloat.h"
+        #include <math.h>
 
         /*
          * multi_arg_logit.c
@@ -828,11 +832,12 @@ The C file is given below.
 
     .. code-block:: c
 
-        #include "Python.h"
-        #include "math.h"
+        #define PY_SSIZE_T_CLEAN
+        #include <Python.h>
         #include "numpy/ndarraytypes.h"
         #include "numpy/ufuncobject.h"
         #include "numpy/npy_3kcompat.h"
+        #include <math.h>
 
 
         /*

--- a/numpy/core/include/numpy/random/distributions.h
+++ b/numpy/core/include/numpy/random/distributions.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "Python.h"
+#include <Python.h>
 #include "numpy/npy_common.h"
 #include <stddef.h>
 #include <stdbool.h>

--- a/numpy/core/src/common/cblasfuncs.c
+++ b/numpy/core/src/common/cblasfuncs.c
@@ -3,15 +3,17 @@
  * inner product and dot for numpy arrays
  */
 
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-
-#include <Python.h>
-#include <assert.h>
-#include <numpy/arrayobject.h>
+#include "numpy/arrayobject.h"
 #include "npy_cblas.h"
 #include "arraytypes.h"
 #include "common.h"
+
+#include <assert.h>
 
 
 static const double oneD[2] = {1.0, 0.0}, zeroD[2] = {0.0, 0.0};

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -1,8 +1,8 @@
 #ifndef __LOWLEVEL_STRIDED_LOOPS_H
 #define __LOWLEVEL_STRIDED_LOOPS_H
 #include "common.h"
-#include <npy_config.h>
-#include <array_method.h>
+#include "npy_config.h"
+#include "array_method.h"
 #include "dtype_transfer.h"
 #include "mem_overlap.h"
 

--- a/numpy/core/src/common/mem_overlap.c
+++ b/numpy/core/src/common/mem_overlap.c
@@ -181,6 +181,7 @@
   All rights reserved.
   Licensed under 3-clause BSD license, see LICENSE.txt.
 */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/common/npy_argparse.c
+++ b/numpy/core/src/common/npy_argparse.c
@@ -1,4 +1,5 @@
-#include "Python.h"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/common/npy_argparse.h
+++ b/numpy/core/src/common/npy_argparse.h
@@ -1,7 +1,7 @@
 #ifndef _NPY_ARGPARSE_H
 #define _NPY_ARGPARSE_H
 
-#include "Python.h"
+#include <Python.h>
 #include "numpy/ndarraytypes.h"
 
 /*

--- a/numpy/core/src/common/npy_longdouble.c
+++ b/numpy/core/src/common/npy_longdouble.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/common/python_xerbla.c
+++ b/numpy/core/src/common/python_xerbla.c
@@ -1,4 +1,6 @@
-#include "Python.h"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "numpy/npy_common.h"
 #include "npy_cblas.h"
 

--- a/numpy/core/src/dummymodule.c
+++ b/numpy/core/src/dummymodule.c
@@ -4,12 +4,13 @@
  * This is a dummy module whose purpose is to get distutils to generate the
  * configuration files before the libraries are made.
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define NO_IMPORT_ARRAY
 
-#include <Python.h>
-#include <npy_pycompat.h>
+#include "npy_pycompat.h"
 
 static struct PyMethodDef methods[] = {
     {NULL, NULL, 0, NULL}

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -1,8 +1,8 @@
 /* -*-c-*- */
 #define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#include <Python.h>
 #define _NPY_NO_DEPRECATIONS /* for NPY_CHAR */
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"

--- a/numpy/core/src/multiarray/abstractdtypes.c
+++ b/numpy/core/src/multiarray/abstractdtypes.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #include <pymem.h>
 

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -1,8 +1,9 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
-
-#include "Python.h"
 
 #include "numpy/npy_3kcompat.h"
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -22,7 +22,7 @@ maintainer email:  oliphant.travis@ieee.org
 */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -1,7 +1,7 @@
 /* -*- c -*- */
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 #include <limits.h>
 #include <assert.h>
 

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/calculation.c
+++ b/numpy/core/src/multiarray/calculation.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -1,6 +1,6 @@
 #ifndef _NPY_PRIVATE_COMMON_H_
 #define _NPY_PRIVATE_COMMON_H_
-#include "structmember.h"
+#include <structmember.h>
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
 #include <limits.h>

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1,7 +1,8 @@
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <structmember.h>
-#include <string.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"
@@ -14,6 +15,8 @@
 #include "ctors.h"
 #include "common.h"
 #include "simd/simd.h"
+
+#include <string.h>
 
 typedef enum {
     PACK_ORDER_LITTLE = 0,

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -1,8 +1,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
-#include <npy_config.h>
+#include "npy_config.h"
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2,7 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/dragon4.h
+++ b/numpy/core/src/multiarray/dragon4.h
@@ -33,8 +33,8 @@
 #ifndef _NPY_DRAGON4_H_
 #define _NPY_DRAGON4_H_
 
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "numpy/arrayobject.h"

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -11,8 +11,8 @@
  */
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -2,7 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 #include "assert.h"
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/einsum.c.src
+++ b/numpy/core/src/multiarray/einsum.c.src
@@ -9,8 +9,8 @@
  */
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -2,7 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -2,7 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -9,7 +9,7 @@
  */
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
+#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <stdarg.h>
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -15,8 +15,8 @@
 /* $Id: multiarraymodule.c,v 1.36 2005/09/14 00:14:00 teoliphant Exp $ */
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _UMATHMODULE

--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -11,8 +11,8 @@
 #define _NPY_PRIVATE__NDITER_IMPL_H_
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -7,8 +7,8 @@
  * See LICENSE.txt for the license.
  */
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -5,7 +5,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1,7 +1,7 @@
 /* -*- c -*- */
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-#include "structmember.h"
+#include <Python.h>
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #ifndef _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/sequence.c
+++ b/numpy/core/src/multiarray/sequence.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE

--- a/numpy/core/src/multiarray/strfuncs.c
+++ b/numpy/core/src/multiarray/strfuncs.c
@@ -1,8 +1,10 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
-#include <Python.h>
-#include <numpy/arrayobject.h>
+#include "numpy/arrayobject.h"
 #include "npy_pycompat.h"
 #include "npy_import.h"
 #include "strfuncs.h"

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -22,7 +22,7 @@ maintainer email:  oliphant.travis@ieee.org
 */
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#include "structmember.h"
+#include <structmember.h>
 
 /*#include <stdio.h>*/
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION

--- a/numpy/core/src/multiarray/vdot.c
+++ b/numpy/core/src/multiarray/vdot.c
@@ -1,7 +1,9 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
-#include <Python.h>
 #include "common.h"
 #include "vdot.h"
 #include "npy_cblas.h"

--- a/numpy/core/src/umath/_operand_flag_tests.c.src
+++ b/numpy/core/src/umath/_operand_flag_tests.c.src
@@ -1,6 +1,7 @@
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include <numpy/arrayobject.h>
 #include <numpy/ufuncobject.h>
 #include "numpy/npy_3kcompat.h"

--- a/numpy/core/src/umath/_rational_tests.c.src
+++ b/numpy/core/src/umath/_rational_tests.c.src
@@ -1,15 +1,15 @@
 /* Fixed size rational numbers exposed to Python */
-
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <structmember.h>
-#include <numpy/arrayobject.h>
-#include <numpy/ufuncobject.h>
-#include <numpy/npy_3kcompat.h>
-#include <math.h>
 
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#include "numpy/arrayobject.h"
+#include "numpy/ufuncobject.h"
+#include "numpy/npy_3kcompat.h"
 #include "common.h"  /* for error_converting */
+
+#include <math.h>
 
 
 /* Relevant arithmetic exceptions */

--- a/numpy/core/src/umath/_struct_ufunc_tests.c.src
+++ b/numpy/core/src/umath/_struct_ufunc_tests.c.src
@@ -1,10 +1,12 @@
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
-#include "Python.h"
-#include "math.h"
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_3kcompat.h"
+
+#include <math.h>
 
 
 /*

--- a/numpy/core/src/umath/_umath_tests.c.src
+++ b/numpy/core/src/umath/_umath_tests.c.src
@@ -5,9 +5,10 @@
  **                            INCLUDES                                     **
  *****************************************************************************
  */
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
-#include "Python.h"
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/npy_math.h"

--- a/numpy/core/src/umath/_umath_tests.dispatch.c
+++ b/numpy/core/src/umath/_umath_tests.dispatch.c
@@ -6,7 +6,9 @@
  * VSX VSX2 VSX3
  * NEON ASIMD ASIMDHP
  */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
+
 #include "npy_cpu_dispatch.h"
 
 #ifndef NPY_DISABLE_OPTIMIZATION

--- a/numpy/core/src/umath/clip.c.src
+++ b/numpy/core/src/umath/clip.c.src
@@ -1,11 +1,12 @@
 /**
  * This module provides the inner loops for the clip ufunc
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
 
 #include "numpy/halffloat.h"
 #include "numpy/npy_math.h"

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -34,6 +34,7 @@
  *    into the `signature` so that it is available to the ufunc loop.
  *
  */
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #define _UMATHMODULE

--- a/numpy/core/src/umath/extobj.c
+++ b/numpy/core/src/umath/extobj.c
@@ -1,8 +1,9 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include <Python.h>
 
 #include "npy_config.h"
 

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -2,7 +2,7 @@
  * This file defines most of the machinery in order to wrap legacy style
  * ufunc loops into new style arraymethods.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #define _UMATHMODULE

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1,10 +1,10 @@
 /* -*- c -*- */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
 
 #include "npy_config.h"
 #include "numpy/npy_common.h"

--- a/numpy/core/src/umath/matmul.c.src
+++ b/numpy/core/src/umath/matmul.c.src
@@ -1,10 +1,10 @@
 /* -*- c -*- */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
 
 #include "npy_config.h"
 #include "numpy/npy_common.h"

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -5,12 +5,13 @@
 
    but still supports error-modes.
 */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include "Python.h"
 #include "npy_config.h"
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -23,12 +23,14 @@
  * Rick White
  *
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 
-#include "Python.h"
-#include "stddef.h"
+#include <stddef.h>
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -20,6 +20,9 @@
  *
  * See LICENSE.txt for the license.
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
@@ -30,8 +33,6 @@
 #endif
 
 #include <stdbool.h>
-
-#include "Python.h"
 
 #include "npy_config.h"
 #include "npy_pycompat.h"

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -15,11 +15,12 @@
  * This is a mess and it would be nice to fix it. It has nothing to do with
  * __ufunc_api.c
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #define _UMATHMODULE
 #define _MULTIARRAYMODULE
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
 
 #include "npy_config.h"
 

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -51,7 +51,7 @@ includes0['math.h'] = '#include <math.h>'
 includes0['string.h'] = '#include <string.h>'
 includes0['setjmp.h'] = '#include <setjmp.h>'
 
-includes['Python.h'] = '#include "Python.h"'
+includes['Python.h'] = '#include <Python.h>'
 needs['arrayobject.h'] = ['Python.h']
 includes['arrayobject.h'] = '''#define PY_ARRAY_UNIQUE_SYMBOL PyArray_API
 #include "arrayobject.h"'''

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#include "Python.h"
+#include <Python.h>
 
 #ifdef FORTRANOBJECT_C
 #define NO_IMPORT_ARRAY

--- a/numpy/f2py/src/test/foomodule.c
+++ b/numpy/f2py/src/test/foomodule.c
@@ -9,7 +9,9 @@
 extern "C" {
 #endif
 
-#include "Python.h"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "fortranobject.h"
 
 static PyObject *foo_error;

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -9,7 +9,9 @@ extern "C" {
 #endif
 
 /*********************** See f2py2e/cfuncs.py: includes ***********************/
-#include "Python.h"
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 #include "fortranobject.h"
 #include <math.h>
 

--- a/numpy/fft/_pocketfft.c
+++ b/numpy/fft/_pocketfft.c
@@ -9,17 +9,18 @@
  *  Copyright (C) 2004-2018 Max-Planck-Society
  *  \author Martin Reinecke
  */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-
-#include "Python.h"
 #include "numpy/arrayobject.h"
+
+#include "npy_config.h"
 
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
 
-#include "npy_config.h"
 #define restrict NPY_RESTRICT
 
 #define RALLOC(type,num) \

--- a/numpy/linalg/lapack_lite/python_xerbla.c
+++ b/numpy/linalg/lapack_lite/python_xerbla.c
@@ -1,4 +1,6 @@
-#include "Python.h"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "numpy/npy_common.h"
 #include "npy_cblas.h"
 

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -2,9 +2,10 @@
 Modified by Jim Hugunin
 More modifications by Jeff Whitaker
 */
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
-#include "Python.h"
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include "numpy/arrayobject.h"
 #include "npy_cblas.h"
 

--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -5,9 +5,10 @@
  **                            INCLUDES                                     **
  *****************************************************************************
  */
-#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
-#include "Python.h"
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 

--- a/numpy/random/include/aligned_malloc.h
+++ b/numpy/random/include/aligned_malloc.h
@@ -1,7 +1,7 @@
 #ifndef _RANDOMDGEN__ALIGNED_MALLOC_H_
 #define _RANDOMDGEN__ALIGNED_MALLOC_H_
 
-#include "Python.h"
+#include <Python.h>
 #include "numpy/npy_common.h"
 
 #define NPY_MEMALIGN 16 /* 16 for SSE2, 32 for AVX, 64 for Xeon Phi */


### PR DESCRIPTION
- Replace `"Python.h"` by `<Python.h>`
- Replace `"structmember.h"` by `<structmember.h>`
- Define `PY_SSIZE_T_CLEAN` before all `Python.h` includes in *.c files.

Note that the include files don't define `PY_SSIZE_T_CLEAN` to avoid redefinition
problems when they are included in C files. Some of them probably don't need
to include `Python.h` either, but that can of worms is for another day. The `.clang-format`
file will rewrite includes in the required order. 

A lot of files are touched, but little is changed.  I don't think it hurts to be consistent
about such things, it avoids confusion.

PY_SSIZE_T_CLEAN will become the default at some point several years off, but no
time soon. But now we know it won't cause problems when it happens.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
