### PR TITLE
DEP: Deprecate quote_args (from numpy.distutils.misc_util)

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -42,7 +42,7 @@ __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'get_script_files', 'get_lib_source_files', 'get_data_files',
            'dot_join', 'get_frame', 'minrelpath', 'njoin',
            'is_sequence', 'is_string', 'as_list', 'gpaths', 'get_language',
-           'quote_args', 'get_build_architecture', 'get_info', 'get_pkg_info',
+           'get_build_architecture', 'get_info', 'get_pkg_info',
            'get_num_build_jobs']
 
 class InstallableLib:
@@ -110,6 +110,13 @@ def get_num_build_jobs():
         return max(x for x in cmdattr if x is not None)
 
 def quote_args(args):
+    """Quote list of arguments.
+
+    .. deprecated:: 1.22.
+    """
+    import warnings
+    warnings.warn('"quote_args" is deprecated.',
+                  DeprecationWarning, stacklevel=2)
     # don't used _nt_quote_args as it does not check if
     # args items already have quotes or not.
     args = list(args)


### PR DESCRIPTION
The utility function `quote_args` was in-use until [gh-12413](https://github.com/numpy/numpy/pull/12413), but this functions is no longer used in NumPy. It is not used by SciPy.

An alternative proposal is to simply remove the function.

Xref [gh-19781 (comment)](https://github.com/numpy/numpy/pull/19781#discussion_r698521554), [gh-12411 (comment)](https://github.com/numpy/numpy/issues/12411#issuecomment-439751661) and [gh-12892](https://github.com/numpy/numpy/pull/12892).