### PR TITLE
MAINT: revise OSError aliases (IOError, EnvironmentError)

### DIFF
--- a/numpy/core/records.py
+++ b/numpy/core/records.py
@@ -939,7 +939,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
         _array = recarray(shape, descr)
         nbytesread = fd.readinto(_array.data)
         if nbytesread != nbytes:
-            raise IOError("Didn't read as many bytes as expected")
+            raise OSError("Didn't read as many bytes as expected")
 
     return _array
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -381,9 +381,9 @@ def check_mathlib(config_cmd):
             mathlibs = libs
             break
     else:
-        raise EnvironmentError("math library missing; rerun "
-                               "setup.py after setting the "
-                               "MATHLIB env variable")
+        raise RuntimeError(
+            "math library missing; rerun setup.py after setting the "
+            "MATHLIB env variable")
     return mathlibs
 
 def visibility_define(config):

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -61,7 +61,7 @@ npy_fallocate(npy_intp nbytes, FILE * fp)
      * early exit on no space, other errors will also get found during fwrite
      */
     if (r == -1 && errno == ENOSPC) {
-        PyErr_Format(PyExc_IOError, "Not enough free space to write "
+        PyErr_Format(PyExc_OSError, "Not enough free space to write "
                      "%"NPY_INTP_FMT" bytes", nbytes);
         return -1;
     }
@@ -138,7 +138,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
     if (n3 == 0) {
         /* binary data */
         if (PyDataType_FLAGCHK(PyArray_DESCR(self), NPY_LIST_PICKLE)) {
-            PyErr_SetString(PyExc_IOError,
+            PyErr_SetString(PyExc_OSError,
                     "cannot write object arrays to a file in binary mode");
             return -1;
         }
@@ -182,7 +182,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
 #endif
             NPY_END_ALLOW_THREADS;
             if (n < size) {
-                PyErr_Format(PyExc_IOError,
+                PyErr_Format(PyExc_OSError,
                         "%ld requested and %ld written",
                         (long) size, (long) n);
                 return -1;
@@ -198,7 +198,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                             (size_t) PyArray_DESCR(self)->elsize,
                             1, fp) < 1) {
                     NPY_END_THREADS;
-                    PyErr_Format(PyExc_IOError,
+                    PyErr_Format(PyExc_OSError,
                             "problem writing element %" NPY_INTP_FMT
                             " to file", it->index);
                     Py_DECREF(it);
@@ -266,7 +266,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             NPY_END_ALLOW_THREADS;
             Py_DECREF(byteobj);
             if (n < n2) {
-                PyErr_Format(PyExc_IOError,
+                PyErr_Format(PyExc_OSError,
                         "problem writing element %" NPY_INTP_FMT
                         " to file", it->index);
                 Py_DECREF(strobj);
@@ -276,7 +276,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             /* write separator for all but last one */
             if (it->index != it->size-1) {
                 if (fwrite(sep, 1, n3, fp) < n3) {
-                    PyErr_Format(PyExc_IOError,
+                    PyErr_Format(PyExc_OSError,
                             "problem writing separator to file");
                     Py_DECREF(strobj);
                     Py_DECREF(it);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3321,7 +3321,7 @@ array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nrea
             fail = 1;
         }
         if (fail) {
-            PyErr_SetString(PyExc_IOError,
+            PyErr_SetString(PyExc_OSError,
                             "could not seek in file");
             return NULL;
         }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -2270,7 +2270,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
         return NULL;
     }
     if (npy_fseek(fp, offset, SEEK_CUR) != 0) {
-        PyErr_SetFromErrno(PyExc_IOError);
+        PyErr_SetFromErrno(PyExc_OSError);
         goto cleanup;
     }
     if (type == NULL) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -4885,9 +4885,9 @@ class TestIO:
         # this should probably be supported as a file
         # but for now test for proper errors
         b = io.BytesIO()
-        assert_raises(IOError, np.fromfile, b, np.uint8, 80)
+        assert_raises(OSError, np.fromfile, b, np.uint8, 80)
         d = np.ones(7)
-        assert_raises(IOError, lambda x: x.tofile(b), d)
+        assert_raises(OSError, lambda x: x.tofile(b), d)
 
     def test_bool_fromstring(self):
         v = np.array([True, False, True, False], dtype=np.bool_)
@@ -4970,12 +4970,12 @@ class TestIO:
         x.tofile(tmp_filename)
 
         def fail(*args, **kwargs):
-            raise IOError('Can not tell or seek')
+            raise OSError('Can not tell or seek')
 
         with io.open(tmp_filename, 'rb', buffering=0) as f:
             f.seek = fail
             f.tell = fail
-            assert_raises(IOError, np.fromfile, f, dtype=x.dtype)
+            assert_raises(OSError, np.fromfile, f, dtype=x.dtype)
 
     def test_io_open_unbuffered_fromfile(self, x, tmp_filename):
         # gh-6632
@@ -5284,12 +5284,12 @@ class TestIO:
     def test_tofile_cleanup(self, tmp_filename):
         x = np.zeros((10), dtype=object)
         with open(tmp_filename, 'wb') as f:
-            assert_raises(IOError, lambda: x.tofile(f, sep=''))
+            assert_raises(OSError, lambda: x.tofile(f, sep=''))
         # Dup-ed file handle should be closed or remove will fail on Windows OS
         os.remove(tmp_filename)
 
         # Also make sure that we close the Python handle
-        assert_raises(IOError, lambda: x.tofile(tmp_filename))
+        assert_raises(OSError, lambda: x.tofile(tmp_filename))
         os.remove(tmp_filename)
 
     def test_fromfile_subarray_binary(self, tmp_filename):

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -521,7 +521,7 @@ class _Config:
             def rm_temp():
                 try:
                     shutil.rmtree(tmp)
-                except IOError:
+                except OSError:
                     pass
             atexit.register(rm_temp)
             self.conf_tmp_path = tmp
@@ -2500,7 +2500,7 @@ class CCompilerOpt(_Config, _Distutils, _Cache, _CCompiler, _Feature, _Parse):
                 last_hash = f.readline().split("cache_hash:")
                 if len(last_hash) == 2 and int(last_hash[1]) == cache_hash:
                     return True
-        except IOError:
+        except OSError:
             pass
 
         self.dist_log("generate dispatched config -> ", config_path)

--- a/numpy/distutils/cpuinfo.py
+++ b/numpy/distutils/cpuinfo.py
@@ -27,7 +27,7 @@ from subprocess import getstatusoutput
 def getoutput(cmd, successful_status=(0,), stacklevel=1):
     try:
         status, output = getstatusoutput(cmd)
-    except EnvironmentError as e:
+    except OSError as e:
         warnings.warn(str(e), UserWarning, stacklevel=stacklevel)
         return False, ""
     if os.WIFEXITED(status) and os.WEXITSTATUS(status) in successful_status:
@@ -109,7 +109,7 @@ class LinuxCPUInfo(CPUInfoBase):
             info[0]['uname_m'] = output.strip()
         try:
             fo = open('/proc/cpuinfo')
-        except EnvironmentError as e:
+        except OSError as e:
             warnings.warn(str(e), UserWarning, stacklevel=2)
         else:
             for line in fo:

--- a/numpy/distutils/exec_command.py
+++ b/numpy/distutils/exec_command.py
@@ -284,7 +284,7 @@ def _exec_command(command, use_shell=None, use_tee = None, **env):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
                                 universal_newlines=False)
-    except EnvironmentError:
+    except OSError:
         # Return 127, as os.spawn*() and /bin/sh do
         return 127, ''
 

--- a/numpy/distutils/fcompiler/compaq.py
+++ b/numpy/distutils/fcompiler/compaq.py
@@ -84,9 +84,9 @@ class CompaqVisualFCompiler(FCompiler):
                 print('Ignoring "%s" (I think it is msvccompiler.py bug)' % (e))
             else:
                 raise
-        except IOError as e:
+        except OSError as e:
             if not "vcvarsall.bat" in str(e):
-                print("Unexpected IOError in", __file__)
+                print("Unexpected OSError in", __file__)
                 raise
         except ValueError as e:
             if not "'path'" in str(e):

--- a/numpy/distutils/npy_pkg_config.py
+++ b/numpy/distutils/npy_pkg_config.py
@@ -9,7 +9,7 @@ __all__ = ['FormatError', 'PkgNotFound', 'LibraryInfo', 'VariableSet',
 
 _VAR = re.compile(r'\$\{([a-zA-Z0-9_-]+)\}')
 
-class FormatError(IOError):
+class FormatError(OSError):
     """
     Exception thrown when there is a problem parsing a configuration file.
 
@@ -20,7 +20,7 @@ class FormatError(IOError):
     def __str__(self):
         return self.msg
 
-class PkgNotFound(IOError):
+class PkgNotFound(OSError):
     """Exception raised when a package can not be located."""
     def __init__(self, msg):
         self.msg = msg

--- a/numpy/distutils/unixccompiler.py
+++ b/numpy/distutils/unixccompiler.py
@@ -105,7 +105,7 @@ def UnixCCompiler_create_static_lib(self, objects, output_libname,
             # and recreate.
             # Also, ar on OS X doesn't handle updating universal archives
             os.unlink(output_filename)
-        except (IOError, OSError):
+        except OSError:
             pass
         self.mkpath(os.path.dirname(output_filename))
         tmp_objects = objects + self.objects

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3414,8 +3414,8 @@ if __name__ == "__main__":
             try:
                 open(l).close()
                 files.append(l)
-            except IOError as detail:
-                errmess('IOError: %s\n' % str(detail))
+            except OSError as detail:
+                errmess(f'OSError: {detail!s}\n')
         else:
             funcs.append(l)
     if not strictf77 and f77modulename and not skipemptyends:

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -275,9 +275,8 @@ def scaninputline(inputline):
                 with open(l):
                     pass
                 files.append(l)
-            except IOError as detail:
-                errmess('IOError: %s. Skipping file "%s".\n' %
-                        (str(detail), l))
+            except OSError as detail:
+                errmess(f'OSError: {detail!s}. Skipping file "{l!s}".\n')
         elif f == -1:
             skipfuncs.append(l)
         elif f == 0:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -36,7 +36,7 @@ def _cleanup():
             pass
         try:
             shutil.rmtree(_module_dir)
-        except (IOError, OSError):
+        except OSError:
             pass
         _module_dir = None
 

--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -530,7 +530,7 @@ class DataSource:
             return _file_openers[ext](found, mode=mode,
                                       encoding=encoding, newline=newline)
         else:
-            raise IOError("%s not found." % path)
+            raise FileNotFoundError(f"{path} not found.")
 
 
 class Repository (DataSource):

--- a/numpy/lib/format.py
+++ b/numpy/lib/format.py
@@ -162,7 +162,6 @@ evolved with time and this document is more current.
 
 """
 import numpy
-import io
 import warnings
 from numpy.lib.utils import safe_eval
 from numpy.compat import (
@@ -831,7 +830,7 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
     ------
     ValueError
         If the data or the mode is invalid.
-    IOError
+    OSError
         If the file is not found or cannot be opened correctly.
 
     See Also
@@ -909,7 +908,7 @@ def _read_bytes(fp, size, error_template="ran out of data"):
             data += r
             if len(r) == 0 or len(data) == size:
                 break
-        except io.BlockingIOError:
+        except BlockingIOError:
             pass
     if len(data) != size:
         msg = "EOF: reading %s, expected %d bytes got %d"

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -324,10 +324,12 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
 
     Raises
     ------
-    IOError
+    OSError
         If the input file does not exist or cannot be read.
+    UnpicklingError
+        If ``allow_pickle=True``, but the file cannot be loaded as a pickle.
     ValueError
-        The file contains an object array, but allow_pickle=False given.
+        The file contains an object array, but ``allow_pickle=False`` given.
 
     See Also
     --------
@@ -436,8 +438,8 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
             try:
                 return pickle.load(fid, **pickle_kwargs)
             except Exception as e:
-                raise IOError(
-                    "Failed to interpret file %s as a pickle" % repr(file)) from e
+                raise pickle.UnpicklingError(
+                    f"Failed to interpret file {file!r} as a pickle") from e
 
 
 def _save_dispatcher(file, arr, allow_pickle=None, fix_imports=None):

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -102,10 +102,10 @@ class TestDataSourceOpen:
 
     def test_InvalidHTTP(self):
         url = invalid_httpurl()
-        assert_raises(IOError, self.ds.open, url)
+        assert_raises(OSError, self.ds.open, url)
         try:
             self.ds.open(url)
-        except IOError as e:
+        except OSError as e:
             # Regression test for bug fixed in r4342.
             assert_(e.errno is None)
 
@@ -120,7 +120,7 @@ class TestDataSourceOpen:
 
     def test_InvalidFile(self):
         invalid_file = invalid_textfile(self.tmpdir)
-        assert_raises(IOError, self.ds.open, invalid_file)
+        assert_raises(OSError, self.ds.open, invalid_file)
 
     def test_ValidGzipFile(self):
         try:

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -658,8 +658,8 @@ def openfile(fname):
     # Try to open the file and guess its type
     try:
         f = open(fname)
-    except IOError as e:
-        raise IOError(f"No such file: '{fname}'") from e
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"No such file: '{fname}'") from e
     if f.readline()[:2] != "\\x":
         f.seek(0, 0)
         return f

--- a/runtests.py
+++ b/runtests.py
@@ -624,7 +624,7 @@ def asv_substitute_config(in_config, out_config, **custom_vars):
             hash_line = wfd.readline().split('hash:')
             if len(hash_line) > 1 and int(hash_line[1]) == vars_hash:
                 return True
-    except IOError:
+    except OSError:
         pass
 
     custom_vars = {f'{{{k}}}':v for k, v in custom_vars.items()}

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -40,12 +40,6 @@ HASH_FILE = 'cythonize.dat'
 DEFAULT_ROOT = 'numpy'
 VENDOR = 'NumPy'
 
-# WindowsError is not defined on unix systems
-try:
-    WindowsError
-except NameError:
-    WindowsError = None
-
 #
 # Rules
 #


### PR DESCRIPTION
Since Python 3.3,  IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including IOError and EnvironmentError (i.e. `assert IOError is OSError is EnvironmentError`). This is consistent for the [C API](https://docs.python.org/3/c-api/exceptions.html#standard-exceptions), where `PyExc_IOError` is a compatibility alias for `PyExc_OSError`.

This PR changes many of the old alias to OSError, with a few exceptions:

- Instances of `PyExc_IOError` in `numpy/core/include/numpy/npy_3kcompat.h` were not touched (should they? Python 2 had separate IO and OS exceptions)
- Versioneer EnvironmentError were not modified (this change has been sent upstream)
- IOError in `numpy/distutils/command/config.py` was not modified, as this mentions a Python 2.6 hack, and looks due for a cleanup

Other notes commented in-line in code.