### PR TITLE
BUG: Fixed an issue wherein certain `nan<x>` functions could fail for object arrays

### DIFF
--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -161,9 +161,11 @@ def _remove_nan_1d(arr1d, overwrite_input=False):
         input
     """
     if arr1d.dtype == object:
-        return arr1d, True
+        # object arrays do not support `isnan` (gh-9009), so make a guess
+        c = np.not_equal(arr1d, arr1d, dtype=bool)
+    else:
+        c = np.isnan(arr1d)
 
-    c = np.isnan(arr1d)
     s = np.nonzero(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning,

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1683,11 +1683,8 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue):
                  keepdims=keepdims)
     if isinstance(var, np.ndarray):
         std = np.sqrt(var, out=var)
+    elif hasattr(var, 'dtype'):
+        std = var.dtype.type(np.sqrt(var))
     else:
-        # Precaution against reduced object arrays
-        try:
-            std = var.dtype.type(np.sqrt(var))
-        except AttributeError:
-            cls = type(var)
-            std = cls(np.sqrt(var))
+        std = np.sqrt(var)
     return std

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -250,6 +250,7 @@ class TestNanFunctions_NumberTypes:
         np.nancumsum: np.cumsum,
         np.nancumprod: np.cumprod,
         np.nanmean: np.mean,
+        np.nanmedian: np.median,
         np.nanvar: np.var,
         np.nanstd: np.std,
     }
@@ -263,6 +264,22 @@ class TestNanFunctions_NumberTypes:
         mat = self.mat.astype(dtype)
         tgt = func(mat)
         out = nanfunc(mat)
+
+        assert_almost_equal(out, tgt)
+        if dtype == "O":
+            assert type(out) is type(tgt)
+        else:
+            assert out.dtype == tgt.dtype
+
+    @pytest.mark.parametrize(
+        "nanfunc,func",
+        [(np.nanquantile, np.quantile), (np.nanpercentile, np.percentile)],
+        ids=["nanquantile", "nanpercentile"],
+    )
+    def test_nanfunc_q(self, dtype, nanfunc, func):
+        mat = self.mat.astype(dtype)
+        tgt = func(mat, q=1)
+        out = nanfunc(mat, q=1)
 
         assert_almost_equal(out, tgt)
         if dtype == "O":

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -231,79 +231,60 @@ class TestNanFunctions_ArgminArgmax:
             assert_(res.shape == ())
 
 
-class TestNanFunctions_IntTypes:
-
-    int_types = (np.int8, np.int16, np.int32, np.int64, np.uint8,
-                 np.uint16, np.uint32, np.uint64)
+@pytest.mark.parametrize(
+    "dtype",
+    np.typecodes["AllInteger"] + np.typecodes["AllFloat"] + "O",
+)
+class TestNanFunctions_NumberTypes:
 
     mat = np.array([127, 39, 93, 87, 46])
+    mat.setflags(write=False)
 
-    def integer_arrays(self):
-        for dtype in self.int_types:
-            yield self.mat.astype(dtype)
+    nanfuncs = {
+        np.nanmin: np.min,
+        np.nanmax: np.max,
+        np.nanargmin: np.argmin,
+        np.nanargmax: np.argmax,
+        np.nansum: np.sum,
+        np.nanprod: np.prod,
+        np.nancumsum: np.cumsum,
+        np.nancumprod: np.cumprod,
+        np.nanmean: np.mean,
+        np.nanvar: np.var,
+        np.nanstd: np.std,
+    }
+    nanfunc_ids = [i.__name__ for i in nanfuncs]
 
-    def test_nanmin(self):
-        tgt = np.min(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanmin(mat), tgt)
+    @pytest.mark.parametrize("nanfunc,func", nanfuncs.items(), ids=nanfunc_ids)
+    def test_nanfunc(self, dtype, nanfunc, func):
+        if nanfunc is np.nanprod and dtype == "e":
+            pytest.xfail(reason="overflow encountered in reduce")
 
-    def test_nanmax(self):
-        tgt = np.max(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanmax(mat), tgt)
+        mat = self.mat.astype(dtype)
+        tgt = func(mat)
+        out = nanfunc(mat)
 
-    def test_nanargmin(self):
-        tgt = np.argmin(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanargmin(mat), tgt)
+        assert_almost_equal(out, tgt)
+        if dtype == "O":
+            assert type(out) is type(tgt)
+        else:
+            assert out.dtype == tgt.dtype
 
-    def test_nanargmax(self):
-        tgt = np.argmax(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanargmax(mat), tgt)
+    @pytest.mark.parametrize(
+        "nanfunc,func",
+        [(np.nanvar, np.var), (np.nanstd, np.std)],
+        ids=["nanvar", "nanstd"],
+    )
+    def test_nanfunc_ddof(self, dtype, nanfunc, func):
+        mat = self.mat.astype(dtype)
+        tgt = func(mat, ddof=1)
+        out = nanfunc(mat, ddof=1)
 
-    def test_nansum(self):
-        tgt = np.sum(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nansum(mat), tgt)
-
-    def test_nanprod(self):
-        tgt = np.prod(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanprod(mat), tgt)
-
-    def test_nancumsum(self):
-        tgt = np.cumsum(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nancumsum(mat), tgt)
-
-    def test_nancumprod(self):
-        tgt = np.cumprod(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nancumprod(mat), tgt)
-
-    def test_nanmean(self):
-        tgt = np.mean(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanmean(mat), tgt)
-
-    def test_nanvar(self):
-        tgt = np.var(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanvar(mat), tgt)
-
-        tgt = np.var(mat, ddof=1)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanvar(mat, ddof=1), tgt)
-
-    def test_nanstd(self):
-        tgt = np.std(self.mat)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanstd(mat), tgt)
-
-        tgt = np.std(self.mat, ddof=1)
-        for mat in self.integer_arrays():
-            assert_equal(np.nanstd(mat, ddof=1), tgt)
+        assert_almost_equal(out, tgt)
+        if dtype == "O":
+            assert type(out) is type(tgt)
+        else:
+            assert out.dtype == tgt.dtype
 
 
 class SharedNanFunctionsTestsMixin:


### PR DESCRIPTION
Previously there were a number of cases wherein the `nan<x>` functions (_e.g._ `nanmedian`) could fail for object arrays, 
be it either due to a call to `isnan` or assuming that array reduction would always return a `generic` subclass, 
the latter being in the possession of a `dtype` attribute.