### PR TITLE
MAINT: Standardize guards in numpy/core/src/common.

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -496,7 +496,7 @@ def configuration(parent_package='',top_path=None):
                 # add the guard to make sure config.h is never included directly,
                 # but always through npy_config.h
                 target_f.write(textwrap.dedent("""
-                    #ifndef _NPY_NPY_CONFIG_H_
+                    #ifndef NUMPY_CORE_SRC_COMMON_NPY_CONFIG_H_
                     #error config.h should never be included directly, include npy_config.h instead
                     #endif
                     """))

--- a/numpy/core/src/common/array_assign.h
+++ b/numpy/core/src/common/array_assign.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_PRIVATE__ARRAY_ASSIGN_H_
-#define _NPY_PRIVATE__ARRAY_ASSIGN_H_
+#ifndef NUMPY_CORE_SRC_COMMON_ARRAY_ASSIGN_H_
+#define NUMPY_CORE_SRC_COMMON_ARRAY_ASSIGN_H_
 
 /*
  * An array assignment function for copying arrays, treating the
@@ -115,4 +115,4 @@ NPY_NO_EXPORT int
 arrays_overlap(PyArrayObject *arr1, PyArrayObject *arr2);
 
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_ARRAY_ASSIGN_H_ */

--- a/numpy/core/src/common/binop_override.h
+++ b/numpy/core/src/common/binop_override.h
@@ -1,5 +1,5 @@
-#ifndef __BINOP_OVERRIDE_H
-#define __BINOP_OVERRIDE_H
+#ifndef NUMPY_CORE_SRC_COMMON_BINOP_OVERRIDE_H_
+#define NUMPY_CORE_SRC_COMMON_BINOP_OVERRIDE_H_
 
 #include <string.h>
 #include <Python.h>
@@ -212,4 +212,4 @@ binop_should_defer(PyObject *self, PyObject *other, int inplace)
         }                                                               \
     } while (0)
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_BINOP_OVERRIDE_H_ */

--- a/numpy/core/src/common/cblasfuncs.h
+++ b/numpy/core/src/common/cblasfuncs.h
@@ -1,7 +1,7 @@
-#ifndef _NPY_CBLASFUNCS_H_
-#define _NPY_CBLASFUNCS_H_
+#ifndef NUMPY_CORE_SRC_COMMON_CBLASFUNCS_H_
+#define NUMPY_CORE_SRC_COMMON_CBLASFUNCS_H_
 
 NPY_NO_EXPORT PyObject *
 cblas_matrixproduct(int, PyArrayObject *, PyArrayObject *, PyArrayObject *);
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_CBLASFUNCS_H_ */

--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -1,5 +1,5 @@
-#ifndef __GET_ATTR_STRING_H
-#define __GET_ATTR_STRING_H
+#ifndef NUMPY_CORE_SRC_COMMON_GET_ATTR_STRING_H_
+#define NUMPY_CORE_SRC_COMMON_GET_ATTR_STRING_H_
 
 static NPY_INLINE npy_bool
 _is_basic_python_type(PyTypeObject *tp)
@@ -113,4 +113,4 @@ PyArray_LookupSpecial_OnInstance(PyObject *obj, char const *name)
     return maybe_get_attr(obj, name);
 }
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_GET_ATTR_STRING_H_ */

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -1,5 +1,5 @@
-#ifndef __LOWLEVEL_STRIDED_LOOPS_H
-#define __LOWLEVEL_STRIDED_LOOPS_H
+#ifndef NUMPY_CORE_SRC_COMMON_LOWLEVEL_STRIDED_LOOPS_H_
+#define NUMPY_CORE_SRC_COMMON_LOWLEVEL_STRIDED_LOOPS_H_
 #include "common.h"
 #include "npy_config.h"
 #include "array_method.h"
@@ -770,4 +770,4 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
                     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
                 }
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_LOWLEVEL_STRIDED_LOOPS_H_ */

--- a/numpy/core/src/common/mem_overlap.h
+++ b/numpy/core/src/common/mem_overlap.h
@@ -1,5 +1,5 @@
-#ifndef MEM_OVERLAP_H_
-#define MEM_OVERLAP_H_
+#ifndef NUMPY_CORE_SRC_COMMON_MEM_OVERLAP_H_
+#define NUMPY_CORE_SRC_COMMON_MEM_OVERLAP_H_
 
 #include "npy_config.h"
 #include "numpy/ndarraytypes.h"
@@ -46,5 +46,4 @@ offset_bounds_from_strides(const int itemsize, const int nd,
                            const npy_intp *dims, const npy_intp *strides,
                            npy_intp *lower_offset, npy_intp *upper_offset);
 
-#endif
-
+#endif  /* NUMPY_CORE_SRC_COMMON_MEM_OVERLAP_H_ */

--- a/numpy/core/src/common/npy_argparse.h
+++ b/numpy/core/src/common/npy_argparse.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_ARGPARSE_H
-#define _NPY_ARGPARSE_H
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_ARGPARSE_H
+#define NUMPY_CORE_SRC_COMMON_NPY_ARGPARSE_H
 
 #include <Python.h>
 #include "numpy/ndarraytypes.h"
@@ -93,4 +93,4 @@ _npy_parse_arguments(const char *funcname,
         _npy_parse_arguments(funcname, &__argparse_cache,                \
                 args, len_args, kwnames, __VA_ARGS__)
 
-#endif /* _NPY_ARGPARSE_H */
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_ARGPARSE_H */

--- a/numpy/core/src/common/npy_cblas.h
+++ b/numpy/core/src/common/npy_cblas.h
@@ -3,8 +3,8 @@
  * because not all providers of cblas provide cblas.h. For instance, MKL provides
  * mkl_cblas.h and also typedefs the CBLAS_XXX enums.
  */
-#ifndef _NPY_CBLAS_H_
-#define _NPY_CBLAS_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_
 
 #include <stddef.h>
 
@@ -98,4 +98,4 @@ blas_stride(npy_intp stride, unsigned itemsize)
 }
 #endif
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CBLAS_H_ */

--- a/numpy/core/src/common/npy_cblas_base.h
+++ b/numpy/core/src/common/npy_cblas_base.h
@@ -9,6 +9,9 @@
  * Prototypes for level 1 BLAS functions (complex are recast as routines)
  * ===========================================================================
  */
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_
+
 float  BLASNAME(cblas_sdsdot)(const BLASINT N, const float alpha, const float *X,
                               const BLASINT incX, const float *Y, const BLASINT incY);
 double BLASNAME(cblas_dsdot)(const BLASINT N, const float *X, const BLASINT incX, const float *Y,
@@ -555,3 +558,5 @@ void BLASNAME(cblas_zher2k)(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO 
                             void *C, const BLASINT ldc);
 
 void BLASNAME(cblas_xerbla)(BLASINT p, const char *rout, const char *form, ...);
+
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CBLAS_BASE_H_ */

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_NPY_CONFIG_H_
-#define _NPY_NPY_CONFIG_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CONFIG_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CONFIG_H_
 
 #include "config.h"
 #include "npy_cpu_features.h"
@@ -167,9 +167,9 @@
 #undef HAVE_CACOSHF
 #undef HAVE_CACOSHL
 
-#endif /* __GLIBC_PREREQ(2, 18) */
-#endif /* defined(__GLIBC_PREREQ) */
+#endif  /* __GLIBC_PREREQ(2, 18) */
+#endif  /* defined(__GLIBC_PREREQ) */
 
-#endif /* defined(HAVE_FEATURES_H) */
+#endif  /* defined(HAVE_FEATURES_H) */
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CONFIG_H_ */

--- a/numpy/core/src/common/npy_cpu_dispatch.h
+++ b/numpy/core/src/common/npy_cpu_dispatch.h
@@ -1,5 +1,5 @@
-#ifndef NPY_CPU_DISPATCH_H_
-#define NPY_CPU_DISPATCH_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CPU_DISPATCH_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CPU_DISPATCH_H_
 /**
  * This file is part of the NumPy CPU dispatcher. Please have a look at doc/reference/simd-optimizations.html
  * To get a better understanding of the mechanism behind it.
@@ -262,4 +262,4 @@
 #define NPY_CPU_DISPATCH_CALL_ALL_BASE_CB_(LEFT, ...) \
     ( LEFT __VA_ARGS__ )
 
-#endif // NPY_CPU_DISPATCH_H_
+#endif  // NUMPY_CORE_SRC_COMMON_NPY_CPU_DISPATCH_H_

--- a/numpy/core/src/common/npy_cpu_features.h
+++ b/numpy/core/src/common/npy_cpu_features.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_CPU_FEATURES_H_
-#define _NPY_CPU_FEATURES_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CPU_FEATURES_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CPU_FEATURES_H_
 
 #include <Python.h> // for PyObject
 #include "numpy/numpyconfig.h" // for NPY_VISIBILITY_HIDDEN
@@ -168,4 +168,4 @@ npy_cpu_dispatch_list(void);
 }
 #endif
 
-#endif // _NPY_CPU_FEATURES_H_
+#endif  // NUMPY_CORE_SRC_COMMON_NPY_CPU_FEATURES_H_

--- a/numpy/core/src/common/npy_cpuinfo_parser.h
+++ b/numpy/core/src/common/npy_cpuinfo_parser.h
@@ -25,8 +25,8 @@
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#ifndef __NPY_CPUINFO_PARSER_H__
-#define __NPY_CPUINFO_PARSER_H__
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CPUINFO_PARSER_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CPUINFO_PARSER_H_
 #include <errno.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -259,4 +259,4 @@ get_feature_from_proc_cpuinfo(unsigned long *hwcap, unsigned long *hwcap2) {
     *hwcap2 |= has_list_item(cpuFeatures, "crc32") ? NPY__HWCAP2_CRC32 : 0;
     return 1;
 }
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CPUINFO_PARSER_H_ */

--- a/numpy/core/src/common/npy_ctypes.h
+++ b/numpy/core/src/common/npy_ctypes.h
@@ -1,5 +1,5 @@
-#ifndef NPY_CTYPES_H
-#define NPY_CTYPES_H
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CTYPES_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CTYPES_H_
 
 #include <Python.h>
 
@@ -47,4 +47,4 @@ fail:
     return 0;
 }
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_CTYPES_H_ */

--- a/numpy/core/src/common/npy_extint128.h
+++ b/numpy/core/src/common/npy_extint128.h
@@ -1,5 +1,5 @@
-#ifndef NPY_EXTINT128_H_
-#define NPY_EXTINT128_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_EXTINT128_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_EXTINT128_H_
 
 
 typedef struct {
@@ -314,4 +314,4 @@ ceildiv_128_64(npy_extint128_t a, npy_int64 b)
     return result;
 }
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_EXTINT128_H_ */

--- a/numpy/core/src/common/npy_fpmath.h
+++ b/numpy/core/src/common/npy_fpmath.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_NPY_FPMATH_H_
-#define _NPY_NPY_FPMATH_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_NPY_FPMATH_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_NPY_FPMATH_H_
 
 #include "npy_config.h"
 
@@ -27,4 +27,4 @@
     #define HAVE_LDOUBLE_DOUBLE_DOUBLE_BE
 #endif
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_NPY_FPMATH_H_ */

--- a/numpy/core/src/common/npy_hashtable.h
+++ b/numpy/core/src/common/npy_hashtable.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_NPY_HASHTABLE_H
-#define _NPY_NPY_HASHTABLE_H
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_NPY_HASHTABLE_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_NPY_HASHTABLE_H_
 
 #include <Python.h>
 
@@ -29,4 +29,4 @@ PyArrayIdentityHash_New(int key_len);
 NPY_NO_EXPORT void
 PyArrayIdentityHash_Dealloc(PyArrayIdentityHash *tb);
 
-#endif  /* _NPY_NPY_HASHTABLE_H */
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_NPY_HASHTABLE_H_ */

--- a/numpy/core/src/common/npy_import.h
+++ b/numpy/core/src/common/npy_import.h
@@ -1,5 +1,5 @@
-#ifndef NPY_IMPORT_H
-#define NPY_IMPORT_H
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_IMPORT_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_IMPORT_H_
 
 #include <Python.h>
 
@@ -29,4 +29,4 @@ npy_cache_import(const char *module, const char *attr, PyObject **cache)
     }
 }
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_IMPORT_H_ */

--- a/numpy/core/src/common/npy_longdouble.h
+++ b/numpy/core/src/common/npy_longdouble.h
@@ -1,5 +1,5 @@
-#ifndef __NPY_LONGDOUBLE_H
-#define __NPY_LONGDOUBLE_H
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_LONGDOUBLE_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_LONGDOUBLE_H_
 
 #include "npy_config.h"
 #include "numpy/ndarraytypes.h"
@@ -24,4 +24,4 @@ npy_longdouble_to_PyLong(npy_longdouble ldval);
 NPY_VISIBILITY_HIDDEN npy_longdouble
 npy_longdouble_from_PyLong(PyObject *long_obj);
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_LONGDOUBLE_H_ */

--- a/numpy/core/src/common/npy_pycompat.h
+++ b/numpy/core/src/common/npy_pycompat.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_PYCOMPAT_H_
-#define _NPY_PYCOMPAT_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_
 
 #include "numpy/npy_3kcompat.h"
 
@@ -19,4 +19,4 @@ Npy_HashDouble(PyObject *NPY_UNUSED(identity), double val)
 #endif
 
 
-#endif /* _NPY_COMPAT_H_ */
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_PYCOMPAT_H_ */

--- a/numpy/core/src/common/numpyos.h
+++ b/numpy/core/src/common/numpyos.h
@@ -1,5 +1,5 @@
-#ifndef _NPY_NUMPYOS_H_
-#define _NPY_NUMPYOS_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_NUMPYOS_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_NUMPYOS_H_
 
 NPY_NO_EXPORT char*
 NumPyOS_ascii_formatd(char *buffer, size_t buf_size,
@@ -38,4 +38,5 @@ NumPyOS_strtoll(const char *str, char **endptr, int base);
 /* Convert a string to an int in an arbitrary base */
 NPY_NO_EXPORT npy_ulonglong
 NumPyOS_strtoull(const char *str, char **endptr, int base);
-#endif
+
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_NUMPYOS_H_ */

--- a/numpy/core/src/common/ucsnarrow.h
+++ b/numpy/core/src/common/ucsnarrow.h
@@ -1,7 +1,7 @@
-#ifndef _NPY_UCSNARROW_H_
-#define _NPY_UCSNARROW_H_
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_UCSNARROW_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_UCSNARROW_H_
 
 NPY_NO_EXPORT PyUnicodeObject *
 PyUnicode_FromUCS4(char *src, Py_ssize_t size, int swap, int align);
 
-#endif
+#endif  /* NUMPY_CORE_SRC_COMMON_NPY_UCSNARROW_H_ */

--- a/numpy/core/src/common/ufunc_override.h
+++ b/numpy/core/src/common/ufunc_override.h
@@ -1,5 +1,5 @@
-#ifndef __UFUNC_OVERRIDE_H
-#define __UFUNC_OVERRIDE_H
+#ifndef NUMPY_CORE_SRC_COMMON_UFUNC_OVERRIDE_H_
+#define NUMPY_CORE_SRC_COMMON_UFUNC_OVERRIDE_H_
 
 #include "npy_config.h"
 
@@ -34,4 +34,5 @@ PyUFunc_HasOverride(PyObject *obj);
  */
 NPY_NO_EXPORT int
 PyUFuncOverride_GetOutObjects(PyObject *kwds, PyObject **out_kwd_obj, PyObject ***out_objs);
-#endif
+
+#endif  /* NUMPY_CORE_SRC_COMMON_UFUNC_OVERRIDE_H_ */

--- a/numpy/core/src/common/umathmodule.h
+++ b/numpy/core/src/common/umathmodule.h
@@ -1,3 +1,6 @@
+#ifndef NUMPY_CORE_SRC_COMMON_UMATHMODULE_H_
+#define NUMPY_CORE_SRC_COMMON_UMATHMODULE_H_
+
 #include "__umath_generated.c"
 #include "__ufunc_api.c"
 
@@ -8,4 +11,4 @@ PyObject * add_newdoc_ufunc(PyObject *NPY_UNUSED(dummy), PyObject *args);
 PyObject * ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kwds));
 int initumath(PyObject *m);
 
-
+#endif  /* NUMPY_CORE_SRC_COMMON_UMATHMODULE_H_ */


### PR DESCRIPTION
This standardizes the header guards in `numpy/core/src/common`.
The standard here is `<path>_<name>_H_` For instance:

file: `numpy/core/include/numpy/arrayobject.h`
guard: `NUMPY_CORE_INCLUDE_NUMPY_ARRAYOBJECT_H_`

Macro names can be up to 255 characters, so length is not a problem.

This convention comes from the Google code style and keeps files with
the same name but different locations from stepping on each other.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
