### PR TITLE
MAINT: Override __eq__ in NpzFile (LGTM alert)

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -248,6 +248,10 @@ class NpzFile(Mapping):
         else:
             raise KeyError("%s is not a file in the archive" % key)
 
+    def __eq__(self, other):
+        if not isinstance(other, NpzFile):
+            return False
+        return dict(self.items()) == dict(other.items())
 
     # deprecate the python 2 dict apis that we supported by accident in
     # python 3. We forgot to implement itervalues() at all in earlier


### PR DESCRIPTION
Hello, this is my first contribution to an open-source project.

I tried to fix a LGTM warning (issue #19077). LGTM suggests that when adding new attributes to instances of a
class, equality for that class needs to be defined. This PR does that. 

Other solution would be to ignore this alert ( with `# lgtm[py/missing-equals]` ) but the alert seemed reasonable to me.