### PR TITLE
TST: Fix/Improve cast nonstandard bool to numeric test

### DIFF
--- a/numpy/core/tests/test_casting_unittests.py
+++ b/numpy/core/tests/test_casting_unittests.py
@@ -699,9 +699,14 @@ class TestCasting:
         else:
             assert_array_equal(expected, arr_NULLs.astype(dtype))
 
-    def test_float_to_bool(self):
-        # test case corresponding to gh-19514
-        # simple test for casting bool_ to float16 
-        res = np.array([0, 3, -7], dtype=np.int8).view(bool)
+    @pytest.mark.parametrize("dtype",
+            np.typecodes["AllInteger"] + np.typecodes["AllFloat"])
+    def test_nonstandard_bool_to_other(self, dtype):
+        # simple test for casting bool_ to numeric types, which should not
+        # expose the detail that NumPy bools can sometimes take values other
+        # than 0 and 1.  See also gh-19514.
+        nonstandard_bools = np.array([0, 3, -7], dtype=np.int8).view(bool)
+        res = nonstandard_bools.astype(dtype)
         expected = [0, 1, 1]
         assert_array_equal(res, expected)
+


### PR DESCRIPTION
Added `res.astype(np.float16)` to exercise the the casting code.
Additional PR to #19715