### PR TITLE
TST: Make nanfunc test ignore overflow instead of xfailing test

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -257,10 +257,8 @@ class TestNanFunctions_NumberTypes:
     nanfunc_ids = [i.__name__ for i in nanfuncs]
 
     @pytest.mark.parametrize("nanfunc,func", nanfuncs.items(), ids=nanfunc_ids)
+    @np.errstate(over="ignore")
     def test_nanfunc(self, dtype, nanfunc, func):
-        if nanfunc is np.nanprod and dtype == "e":
-            pytest.xfail(reason="overflow encountered in reduce")
-
         mat = self.mat.astype(dtype)
         tgt = func(mat)
         out = nanfunc(mat)


### PR DESCRIPTION
This makes the test more precise, and I ran into having to broaden
the xfails otherwise, because right now reduce-likes incorrectly
faile to give floating point warnings (and I was fixing that).