### PR TITLE
Replace posix specific ssize_t with py_ssize_t to compile on windows

### DIFF
--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -808,7 +808,7 @@ unmasked_ufunc_loop_as_masked(
     npy_intp N = dimensions[0];
     /* Process the data as runs of unmasked values */
     do {
-        ssize_t subloopsize;
+        Py_ssize_t subloopsize;
 
         /* Skip masked values */
         mask = npy_memchr(mask, 0, mask_stride, N, &subloopsize, 1);


### PR DESCRIPTION
ssize_t is not available on windows so instead use python provided Py_ssize_t which has a definition for all platforms.

There is only one place where ssize_t is directly used and in the rest of the places, py_ssize_t was used hence I assume it was unintentional to directly use ssize_t.
