### PR TITLE
MAINT: Use SHA-256 instead of SHA-1

### DIFF
--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -135,7 +135,7 @@ rules = {
 # Hash db
 #
 def load_hashes(filename):
-    # Return { filename : (sha1 of input, sha1 of output) }
+    # Return { filename : (sha256 of input, sha256 of output) }
     if os.path.isfile(filename):
         hashes = {}
         with open(filename, 'r') as f:
@@ -151,8 +151,8 @@ def save_hashes(hash_db, filename):
         for key, value in sorted(hash_db.items()):
             f.write("%s %s %s\n" % (key, value[0], value[1]))
 
-def sha1_of_file(filename):
-    h = hashlib.sha1()
+def sha256_of_file(filename):
+    h = hashlib.sha256()
     with open(filename, "rb") as f:
         h.update(f.read())
     return h.hexdigest()
@@ -168,8 +168,8 @@ def normpath(path):
     return path
 
 def get_hash(frompath, topath):
-    from_hash = sha1_of_file(frompath)
-    to_hash = sha1_of_file(topath) if os.path.exists(topath) else None
+    from_hash = sha256_of_file(frompath)
+    to_hash = sha256_of_file(topath) if os.path.exists(topath) else None
     return (from_hash, to_hash)
 
 def process(path, fromfile, tofile, processor_function, hash_db):


### PR DESCRIPTION
While the use of SHA-1 here hardly poses any risks, its use will eventually be prohibited globally in FIPS-compliant operating
systems such as RHEL, and I don't see any downsides in moving away from using it.