### PR TITLE
DOC: Fix the reported module names of objects in the `numpy.typing` API

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -21,6 +21,8 @@ Mypy plugin
 
 .. automodule:: numpy.typing.mypy_plugin
 
+.. currentmodule:: numpy.typing
+
 Differences from the runtime NumPy API
 --------------------------------------
 


### PR DESCRIPTION
Sphinx previously reported all object from the `numpy.typing` API as belonging to the `numpy.typing.mypy_plugin` namespace.

I suspect this was caused by the `automodule:: numpy.typing.mypy_plugin` directive added back in https://github.com/numpy/numpy/pull/19295.

EDIT: The generated docs: 
https://22091-908607-gh.circle-artifacts.com/0/doc/build/html/reference/typing.html?highlight=typing#api