### PR TITLE
TST: Make this sysconfig handling a bit more portable

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -474,23 +474,18 @@ def build_project(args):
             '--single-version-externally-managed',
             '--record=' + dst_dir + 'tmp_install_log.txt']
 
-    py_v_s = sysconfig.get_config_var('py_version_short')
-    platlibdir = getattr(sys, 'platlibdir', '')  # Python3.9+
+    config_vars = dict(sysconfig.get_config_vars())
+    config_vars["platbase"] = dst_dir
+    config_vars["base"] = dst_dir
+
     site_dir_template = os.path.normpath(sysconfig.get_path(
         'platlib', expand=False
     ))
-    site_dir = site_dir_template.format(platbase=dst_dir,
-                                        py_version_short=py_v_s,
-                                        platlibdir=platlibdir,
-                                        base=dst_dir,
-                                        )
+    site_dir = site_dir_template.format(**config_vars)
     noarch_template = os.path.normpath(sysconfig.get_path(
         'purelib', expand=False
     ))
-    site_dir_noarch = noarch_template.format(base=dst_dir,
-                                             py_version_short=py_v_s,
-                                             platlibdir=platlibdir,
-                                             )
+    site_dir_noarch = noarch_template.format(**config_vars)
 
     # easy_install won't install to a path that Python by default cannot see
     # and isn't on the PYTHONPATH.  Plus, it has to exist.


### PR DESCRIPTION
In particular this supports Pyston, which has an additional
format field in these path schemes. Instead of manually
specifying which fields we think exist, do what I assume is the
intention of using the default field values for everything
except for the few that we want to override.

I believe @mattip wrote this code originally

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
