### PR TITLE
DOC: Add documentation for round and round_ aliases

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3276,7 +3276,8 @@ def around(a, decimals=0, out=None):
     See Also
     --------
     ndarray.round : equivalent method
-
+    numpy.round: equivalent method
+    numpy.round_: equivalent method
     ceil, fix, floor, rint, trunc
 
 


### PR DESCRIPTION
Added docstring for round and round_ as aliases that both refer to around() 
This is a fix to the bug - https://github.com/numpy/numpy/issues/19717
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
