### PR TITLE
BUG: Check whether an error is already set for invalid casting

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1062,8 +1062,8 @@ check_for_trivial_loop(PyArrayMethodObject *ufuncimpl,
         if (dtypes[i] != PyArray_DESCR(op[i])) {
             NPY_CASTING safety = PyArray_GetCastSafety(
                     PyArray_DESCR(op[i]), dtypes[i], NULL);
-            if (safety < 0) {
-                /* A proper error during a cast check should be rare */
+            if (safety < 0 && PyErr_Occurred()) {
+                /* A proper error during a cast check, should be rare */
                 return -1;
             }
             if (!(safety & _NPY_CAST_IS_VIEW)) {

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2308,6 +2308,14 @@ def test_ufunc_casterrors():
     assert out[-1] == 1
 
 
+def test_trivial_loop_invalid_cast():
+    # This tests the fast-path "invalid cast", see gh-19904.
+    with pytest.raises(TypeError,
+            match="cast ufunc 'add' input 0"):
+        # the void dtype definitely cannot cast to double:
+        np.add(np.array(1, "i,i"), 3, signature="dd->d")
+
+
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 @pytest.mark.parametrize("offset",
         [0, np.BUFSIZE//2, int(1.5*np.BUFSIZE)])


### PR DESCRIPTION
If no error is set already, we can just continue normally (which
sets the cast error later).

Closes gh-19904

---

I need to be more awake to figure out if this path is 100% correct for outputs, but that is a different issue.