### PR TITLE
MAINT: Re-export `LinAlgError` to the `np.linalg.linalg` stubs

### DIFF
--- a/numpy/linalg/linalg.pyi
+++ b/numpy/linalg/linalg.pyi
@@ -19,6 +19,8 @@ from numpy import (
     complex128,
 )
 
+from numpy.linalg import LinAlgError as LinAlgError
+
 from numpy.typing import (
     NDArray,
     ArrayLike,


### PR DESCRIPTION
`LinAlgError` was previously missing from the `np.linalg.linalg` namespace (xref https://github.com/numpy/numpy/pull/19887).