### PR TITLE
DOC: fixed typo of the absolute beginners doc, the result in the example s…

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -904,7 +904,7 @@ columns or rows using the ``axis`` parameter::
   >>> data.max(axis=0)
   array([5, 6])
   >>> data.max(axis=1)
-  array([2, 4, 6])
+  array([2, 5, 6])
 
 .. image:: images/np_matrix_aggregation_row.png
 


### PR DESCRIPTION
The result in the example should be [2, 5, 6] instead of [2, 4, 6].
The attached figure also shows result of [2, 5, 6], so it should be a typo.