### PR TITLE
MAINT: Fix LGTM.com error: Unmatchable caret in regular expression

### DIFF
--- a/numpy/linalg/lapack_lite/clapack_scrub.py
+++ b/numpy/linalg/lapack_lite/clapack_scrub.py
@@ -228,15 +228,18 @@ def removeHeader(source):
     return lines.getValue()
 
 def removeSubroutinePrototypes(source):
-    expression = re.compile(
-        r'/\* Subroutine \*/^\s*(?:(?:inline|static)\s+){0,2}(?!else|typedef|return)\w+\s+\*?\s*(\w+)\s*\([^0]+\)\s*;?'
-    )
-    lines = LineQueue()
-    for line in UStringIO(source):
-        if not expression.match(line):
-            lines.add(line)
-
-    return lines.getValue()
+    # This function has never worked as advertised by its name:
+    # - "/* Subroutine */" declarations may span multiple lines and
+    #   cannot be matched by a line by line approach.
+    # - The caret in the initial regex would prevent any match, even
+    #   of single line "/* Subroutine */" declarations.
+    #
+    # While we could "fix" this function to do what the name implies
+    # it should do, we have no hint of what it should really do.
+    #
+    # Therefore we keep the existing (non-)functionaity, documenting
+    # this function as doing nothing at all.
+    return source
 
 def removeBuiltinFunctions(source):
     lines = LineQueue()


### PR DESCRIPTION
> Unmatchable caret in regular expression
> This regular expression includes an unmatchable caret at offset 18.

https://lgtm.com/projects/g/numpy/numpy/snapshot/8b1ae13424d3f203fb21b3063a03b80358fadfcf/files/numpy/linalg/lapack_lite/clapack_scrub.py#x56fba2496b1bf29c:1

Indeed this regex couldn't possibly match anything.

Note that this regex seems obsolete, it attempts to match "`inline`" or "`static`" specifiers, which I cannot find in the C files generated by `f2c` from LAPACK. Typical declarations look like this:
```c
    extern /* Subroutine */ int clahqr_(logical *, logical *, integer *,
            integer *, integer *, complex *, integer *, complex *, integer *,
            integer *, complex *, integer *, integer *), clacpy_(char *,
            integer *, integer *, complex *, integer *, complex *, integer *);
```

**EDIT**: Removed any reference to CLAPACK, it was confusing.