### PR TITLE
MAINT: Fix LGTM.com warning in nditer_imp.h

### DIFF
--- a/numpy/core/src/multiarray/nditer_impl.h
+++ b/numpy/core/src/multiarray/nditer_impl.h
@@ -289,7 +289,7 @@ struct NpyIter_AxisData_tag {
         1 + \
         /* intp stride[nop+1] AND char* ptr[nop+1] */ \
         2*((nop)+1) \
-        )*NPY_SIZEOF_INTP )
+        )*(size_t)NPY_SIZEOF_INTP)
 
 /*
  * Macro to advance an AXISDATA pointer by a specified count.


### PR DESCRIPTION
> Multiplication result converted to larger type
> Multiplication result may overflow '`int`' before it is converted to '`unsigned long`'.

https://lgtm.com/projects/g/numpy/numpy/snapshot/f7878388a77d0b4483665adc3c4f94328c332649/files/numpy/core/src/multiarray/nditer_constr.c?sort=name&dir=ASC&mode=heatmap#x150061adf51051e9:1

Start multiplication by a variable of type `size_t`.