### PR TITLE
DEP: Use `delimiter` rather than `delimitor` as kwarg in mrecords

### DIFF
--- a/doc/release/upcoming_changes/19921.deprecation.rst
+++ b/doc/release/upcoming_changes/19921.deprecation.rst
@@ -1,0 +1,3 @@
+* the misspelled keyword argument ``delimitor`` of
+  ``numpy.ma.mrecords.fromtextfile()`` has been changed into
+  ``delimiter``, using it will emit a deprecation warning.

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -667,7 +667,7 @@ def openfile(fname):
     raise NotImplementedError("Wow, binary file")
 
 
-def fromtextfile(fname, delimiter=None, commentchar='#', missingchar='',
+def fromtextfile(fname, delimitor=None, commentchar='#', missingchar='',
                  varnames=None, vartypes=None):
     """
     Creates a mrecarray from data stored in the file `filename`.
@@ -676,7 +676,7 @@ def fromtextfile(fname, delimiter=None, commentchar='#', missingchar='',
     ----------
     fname : {file name/handle}
         Handle of an opened file.
-    delimiter : {None, string}, optional
+    delimitor : {None, string}, optional
         Alphanumeric character used to separate columns in the file.
         If None, any (group of) white spacestring(s) will be used.
     commentchar : {'#', string}, optional
@@ -699,14 +699,14 @@ def fromtextfile(fname, delimiter=None, commentchar='#', missingchar='',
     while True:
         line = ftext.readline()
         firstline = line[:line.find(commentchar)].strip()
-        _varnames = firstline.split(delimiter)
+        _varnames = firstline.split(delimitor)
         if len(_varnames) > 1:
             break
     if varnames is None:
         varnames = _varnames
 
     # Get the data.
-    _variables = masked_array([line.strip().split(delimiter) for line in ftext
+    _variables = masked_array([line.strip().split(delimitor) for line in ftext
                                if line[0] != commentchar and len(line) > 1])
     (_, nfields) = _variables.shape
     ftext.close()

--- a/numpy/ma/mrecords.pyi
+++ b/numpy/ma/mrecords.pyi
@@ -78,11 +78,13 @@ def fromrecords(
 
 def fromtextfile(
     fname,
-    delimitor=...,
+    delimiter=...,
     commentchar=...,
     missingchar=...,
     varnames=...,
     vartypes=...,
+    # NOTE: deprecated: NumPy 1.22.0, 2021-09-23
+    # delimitor=..., 
 ): ...
 
 def addfield(mrecord, newfield, newfieldname=...): ...

--- a/numpy/ma/mrecords.pyi
+++ b/numpy/ma/mrecords.pyi
@@ -78,7 +78,7 @@ def fromrecords(
 
 def fromtextfile(
     fname,
-    delimiter=...,
+    delimitor=...,
     commentchar=...,
     missingchar=...,
     varnames=...,

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -1,10 +1,13 @@
 """Test deprecation and future warnings.
 
 """
+import pytest
 import numpy as np
 from numpy.testing import assert_warns
 from numpy.ma.testutils import assert_equal
 from numpy.ma.core import MaskedArrayFutureWarning
+import io
+import textwrap
 
 class TestArgsort:
     """ gh-8701 """
@@ -66,3 +69,21 @@ class TestMinimumMaximum:
         result = ma_max(data1d)
         assert_equal(result, ma_max(data1d, axis=None))
         assert_equal(result, ma_max(data1d, axis=0))
+
+
+class TestFromtextfile:
+    def test_fromtextfile_delimitor(self):
+        # NumPy 1.22.0, 2021-09-23
+
+        textfile = io.StringIO(textwrap.dedent(
+            """
+            A,B,C,D
+            'string 1';1;1.0;'mixed column'
+            'string 2';2;2.0;
+            'string 3';3;3.0;123
+            'string 4';4;4.0;3.14
+            """
+        ))
+
+        with pytest.warns(DeprecationWarning):
+            result = np.ma.mrecords.fromtextfile(textfile, delimitor=';')

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -468,7 +468,7 @@ class TestMRecordsImport:
         with temppath() as path:
             with open(path, 'w') as f:
                 f.write(fcontent)
-            mrectxt = fromtextfile(path, delimitor=',', varnames='ABCDEFG')
+            mrectxt = fromtextfile(path, delimiter=',', varnames='ABCDEFG')
         assert_(isinstance(mrectxt, MaskedRecords))
         assert_equal(mrectxt.F, [1, 1, 1, 1])
         assert_equal(mrectxt.E._mask, [1, 1, 1, 1])

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -468,7 +468,7 @@ class TestMRecordsImport:
         with temppath() as path:
             with open(path, 'w') as f:
                 f.write(fcontent)
-            mrectxt = fromtextfile(path, delimiter=',', varnames='ABCDEFG')
+            mrectxt = fromtextfile(path, delimitor=',', varnames='ABCDEFG')
         assert_(isinstance(mrectxt, MaskedRecords))
         assert_equal(mrectxt.F, [1, 1, 1, 1])
         assert_equal(mrectxt.E._mask, [1, 1, 1, 1])


### PR DESCRIPTION
First revert the previous commit, too optimistic (#19911).

Then propose a new way to fix the typo, without breaking backwards compatibility.