### PR TITLE
BUG: ufunc: Fix potential memory leak.

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5578,7 +5578,6 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     /* Get entry for this user-defined type*/
     cobj = PyDict_GetItemWithError(ufunc->userloops, key);
     if (cobj == NULL && PyErr_Occurred()) {
-        Py_DECREF(key);
         goto fail;
     }
     /* If it's not there, then make one and return. */

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5579,7 +5579,7 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     cobj = PyDict_GetItemWithError(ufunc->userloops, key);
     if (cobj == NULL && PyErr_Occurred()) {
         Py_DECREF(key);
-        return 0;
+        goto fail;
     }
     /* If it's not there, then make one and return. */
     else if (cobj == NULL) {


### PR DESCRIPTION
Change a return statement to 'goto fail;' to ensure that memory
previously allocated with PyArray_malloc() is freed.  (The memory
pointers are 'funcdata' and 'newtypes'.)

The return *value* in this case is also changed, from 0 to -1, to indicate
that an error occurred.  The exceptional return occurs because an unexpected
error occurred in the call to PyDict_GetItemWithError.

Closes gh-19548.
