### PR TITLE
BUG: Only call the get_versions() function once on import

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -135,11 +135,7 @@ else:
                'VisibleDeprecationWarning']
 
     # get the version using versioneer
-    from ._version import get_versions
-    vinfo = get_versions()
-    __version__ = vinfo.get("closest-tag", vinfo["version"])
-    __git_version__ = vinfo.get("full-revisionid")
-    del get_versions, vinfo
+    from .version import __version__, git_revision as __git_version__
 
     # mapping of {name: (value, deprecation_msg)}
     __deprecated_attrs__ = {}
@@ -407,7 +403,3 @@ else:
     # We do this from python, since the C-module may not be reloaded and
     # it is tidier organized.
     core.multiarray._multiarray_umath._reload_guard()
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/numpy/version.py
+++ b/numpy/version.py
@@ -1,9 +1,10 @@
 from ._version import get_versions
 
-__ALL__ = ['version', 'full_version', 'git_revision', 'release']
+__ALL__ = ['version', '__version__', 'full_version', 'git_revision', 'release']
 
 vinfo = get_versions()
 version: str = vinfo["version"]
+__version__ = vinfo.get("closest-tag", vinfo["version"])
 full_version: str = vinfo['version']
 git_revision: str = vinfo['full-revisionid']
 release = 'dev0' not in version and '+' not in version


### PR DESCRIPTION
When using an in-place build, this function calls various git commands to get the version number. Previously it was called three times, making `import numpy` take over 3 seconds on my machine (it could be even slower on a slow filesystem). The code has been refactored to only call this function once in versions.py. Now 'import numpy' on an in-place build only takes 500 ms, which is still slower than importing the installed version, but that is expected when using versioneer.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
