### PR TITLE
duplicate item in see also.

### DIFF
--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -425,7 +425,7 @@ def legmulx(c):
 
     See Also
     --------
-    legadd, legmul, legmul, legdiv, legpow
+    legadd, legmul, legdiv, legpow
 
     Notes
     -----


### PR DESCRIPTION
Ok, I know legmul is important, I'm not sure I need it twice.

Joking aside, I believe that's a wrong copy-past, as other functions have
`legmulx, legmul`, but as this is the docs of legmulx, I guess the
author removed the `x` without realising legmul was already present.