### PR TITLE
MAINT: random: Use expm1 where appropriate.

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -452,7 +452,7 @@ double random_standard_cauchy(bitgen_t *bitgen_state) {
 }
 
 double random_pareto(bitgen_t *bitgen_state, double a) {
-  return exp(random_standard_exponential(bitgen_state) / a) - 1;
+  return expm1(random_standard_exponential(bitgen_state) / a);
 }
 
 double random_weibull(bitgen_t *bitgen_state, double a) {
@@ -463,7 +463,7 @@ double random_weibull(bitgen_t *bitgen_state, double a) {
 }
 
 double random_power(bitgen_t *bitgen_state, double a) {
-  return pow(1 - exp(-random_standard_exponential(bitgen_state)), 1. / a);
+  return pow(-expm1(-random_standard_exponential(bitgen_state)), 1. / a);
 }
 
 double random_laplace(bitgen_t *bitgen_state, double loc, double scale) {
@@ -918,7 +918,7 @@ int64_t random_logseries(bitgen_t *bitgen_state, double p) {
       return 1;
     }
     U = next_double(bitgen_state);
-    q = 1.0 - exp(r * U);
+    q = -expm1(r * U);
     if (V <= q * q) {
       result = (int64_t)floor(1 + log(V) / log(q));
       if ((result < 1) || (V == 0.0)) {


### PR DESCRIPTION
Use [`expm1(expr)`](https://numpy.org/doc/stable/reference/generated/numpy.expm1.html) instead of `exp(expr) - 1` in three places.

This will potentially change the outputs of the `pareto`, `power` and `logseries` distributions.  Each of these already has a legacy implementation, so the frozen legacy distributions are not affected.