### PR TITLE
MAINT: Fix LGTM.com warning: Variable `isrec` defined multiple times

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2891,8 +2891,6 @@ def analyzevars(block):
                     vars[n] = appenddecl(vars[n], vars[block['result']])
                 if 'prefix' in block:
                     pr = block['prefix']
-                    ispure = 0
-                    isrec = 1
                     pr1 = pr.replace('pure', '')
                     ispure = (not pr == pr1)
                     pr = pr1.replace('recursive', '')


### PR DESCRIPTION
> Variable defined multiple times
> [This assignment to '`isrec`'](https://github.com/numpy/numpy/blob/0cf5bc0/numpy/f2py/crackfortran.py#L2895) is unnecessary as it is redefined [here](https://github.com/numpy/numpy/blob/0cf5bc0/numpy/f2py/crackfortran.py#L2899) before this value is used.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6152182e731afcc49e6ff6c657dcd805619bca56/files/numpy/f2py/crackfortran.py?sort=name&dir=ASC&mode=heatmap#xf4ef447f175373c8:1