### PR TITLE
MAINT: Fix LGTM.com warning: Unreachable code

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -535,7 +535,6 @@ def _can_target(cmd, arch):
                 os.remove(output)
     finally:
         os.remove(filename)
-    return False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
> Unreachable code
> Unreachable statement.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6152182e731afcc49e6ff6c657dcd805619bca56/files/numpy/distutils/fcompiler/gnu.py#xdc63ee34fc590eb7:1

The code is equivalent to:
```python
    try:
        [...]
        try:
            [...]
            return p.returncode == 0
        finally:
            [...]
    finally:
        [...]
    return False
```
The only way the function does not reach `return p.returncode == 0`, is when an exception is raised - in which case `return False` cannot be reached.