### PR TITLE
MAINT: Fix LGTM.com warning: Variable `f` defined multiple times

### DIFF
--- a/numpy/distutils/system_info.py
+++ b/numpy/distutils/system_info.py
@@ -387,11 +387,10 @@ def get_standard_file(fname):
         f = __file__
     except NameError:
         f = sys.argv[0]
-    else:
-        sysfile = os.path.join(os.path.split(os.path.abspath(f))[0],
-                               fname)
-        if os.path.isfile(sysfile):
-            filenames.append(sysfile)
+    sysfile = os.path.join(os.path.split(os.path.abspath(f))[0],
+                           fname)
+    if os.path.isfile(sysfile):
+        filenames.append(sysfile)
 
     # Home directory
     # And look for the user config file


### PR DESCRIPTION
> Variable defined multiple times
> [This assignment to '`f`'](https://github.com/numpy/numpy/blob/0cf5bc0/numpy/distutils/system_info.py#L389) is unnecessary as it is redefined [here](https://github.com/numpy/numpy/blob/0cf5bc0/numpy/distutils/system_info.py#L399) before this value is used.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6152182e731afcc49e6ff6c657dcd805619bca56/files/numpy/distutils/system_info.py?sort=name&dir=ASC&mode=heatmap#x7fe3db5ea2648e74:1

This originates in 6c8412f, back in 2006, where the intent was clearly to try an alternative value for `f` in case `NameError` is raised:
```python
except NameError:
            f = sys.argv[0]
else:
```
instead of merely giving up:
```python
except NameError:
            pass
else:
```
However, for this value to be actually used, the `else:` must be removed.
