### PR TITLE
MAINT: Fix LGTM.com warning: Comparison result is always the same (`res`)

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2717,7 +2717,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
         /* If we exhausted the dst block, refresh it */
         if (dst_count == count) {
             res = dst_iternext(dst_iter);
-            if (!res) {
+            if (res == 0) {
                 break;
             }
             dst_count = *dst_countptr;
@@ -2731,7 +2731,7 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
         /* If we exhausted the src block, refresh it */
         if (src_count == count) {
             res = src_iternext(src_iter);
-            if (!res) {
+            if (res == 0) {
                 break;
             }
             src_count = *src_countptr;
@@ -2748,10 +2748,6 @@ PyArray_CopyAsFlat(PyArrayObject *dst, PyArrayObject *src, NPY_ORDER order)
     NPY_cast_info_xfree(&cast_info);
     NpyIter_Deallocate(dst_iter);
     NpyIter_Deallocate(src_iter);
-    if (res > 0) {
-        /* The iteration stopped successfully, do not report an error */
-        return 0;
-    }
     return res;
 }
 


### PR DESCRIPTION
> Comparison result is always the same
> Comparison is always false because `res <= 0`.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/ctors.c?sort=name&dir=ASC&mode=heatmap#xa080a7fcc79c74e4:1

Indeed the [`for(;;)`](https://github.com/numpy/numpy/blob/0cf5bc0/numpy/core/src/multiarray/ctors.c#L2708-L2744) loop may stop on 3 different breaks:

```c
            res = -1;
            break;
```
```c
            if (!res) {
                break;
```
```c
            if (!res) {
                break;
```

Therefore, after the loop, the only possible values for `res` are -1 and 0, and `(res > 0)` is always false.

This originates in 37dc69c (#17029).