### PR TITLE
MAINT: Fix LGTM.com warning: Comparison result is always the same (`p`)

### DIFF
--- a/numpy/core/src/multiarray/nditer_api.c
+++ b/numpy/core/src/multiarray/nditer_api.c
@@ -116,7 +116,7 @@ NpyIter_RemoveAxis(NpyIter *iter, int axis)
                 --p;
             }
         }
-        else if (p <= 0) {
+        else {
             if (p < -1-axis) {
                 ++p;
             }


### PR DESCRIPTION
> Comparison result is always the same
> Comparison is always true because p <= -1.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/nditer_api.c?sort=name&dir=ASC&mode=heatmap#xc491201328fdf501:1

While I liked the symmetry of the existing code, it is true that the second `if` is redundant.