### PR TITLE
MAINT: Fix LGTM.com warning

### DIFF
--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -2206,7 +2206,7 @@ Dragon4_PrintFloat_IEEE_binary16(
         Dragon4_Scratch *scratch, npy_half *value, Dragon4_Options *opt)
 {
     char *buffer = scratch->repr;
-    npy_uint32 bufferSize = sizeof(scratch->repr);
+    const npy_uint32 bufferSize = sizeof(scratch->repr);
     BigInt *bigints = scratch->bigints;
 
     npy_uint16 val = *value;
@@ -2217,15 +2217,6 @@ Dragon4_PrintFloat_IEEE_binary16(
     npy_uint32 mantissaBit;
     npy_bool hasUnequalMargins;
     char signbit = '\0';
-
-    if (bufferSize == 0) {
-        return 0;
-    }
-
-    if (bufferSize == 1) {
-        buffer[0] = '\0';
-        return 0;
-    }
 
     /* deconstruct the floating point value */
     floatMantissa = val & bitmask_u32(10);


### PR DESCRIPTION
> Comparison result is always the same
> Comparison is always false because `bufferSize` >= 16384.

https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x41f0b18900083e2a:1
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x1c5044f5d875f481:1
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x41f0b18900083e2a:2
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x1cdee036789f3496:1
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x41f0b18900083e2a:3
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x1cdee036789f3496:2
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x41f0b18900083e2a:4
https://lgtm.com/projects/g/numpy/numpy/snapshot/6fd377657ac7fcc9d244e2d1ebae26e70f60db51/files/numpy/core/src/multiarray/dragon4.c#x4742a195804a77a8:1

Indeed `Dragon4_Scratch` is defined as:
```c
typedef struct {
    BigInt bigints[BIGINT_DRAGON4_GROUPSIZE];
    char repr[16384];
} Dragon4_Scratch;
```
Therefore `sizeof(scratch->repr) == 16384`. It cannot be 0 or 1. Make `bufferSize` `const` for clarity.

Not sure what the initial intent was. Handle different `Dragon4_Scratch` definitions?