### PR TITLE
ENH: Add annotations to `np.core.multiarray` part 4/4

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -10,7 +10,6 @@ from types import TracebackType, MappingProxyType
 from contextlib import ContextDecorator
 
 from numpy._pytesttester import PytestTester
-from numpy.core.multiarray import flagsobj
 from numpy.core._internal import _ctypes
 from numpy.core.getlimits import MachArLike
 
@@ -193,6 +192,7 @@ from typing import (
     Protocol,
     SupportsIndex,
     Final,
+    final,
 )
 
 # Ensures that the stubs are picked up
@@ -348,6 +348,8 @@ from numpy.core.multiarray import (
     geterrobj as geterrobj,
     fromstring as fromstring,
     frompyfunc as frompyfunc,
+    nested_iters as nested_iters,
+    flagsobj,
 )
 
 from numpy.core.numeric import (
@@ -765,35 +767,6 @@ class memmap(ndarray[_ShapeType, _DType_co]):
     ) -> Any: ...
     def __getattr__(self, key: str) -> Any: ...
 
-class nditer:
-    def __new__(
-        cls,
-        op: Any,
-        flags: Any = ...,
-        op_flags: Any = ...,
-        op_dtypes: Any = ...,
-        order: Any = ...,
-        casting: Any = ...,
-        op_axes: Any = ...,
-        itershape: Any = ...,
-        buffersize: Any = ...,
-    ) -> Any: ...
-    def __getattr__(self, key: str) -> Any: ...
-    def __enter__(self) -> nditer: ...
-    def __exit__(
-        self,
-        exc_type: None | Type[BaseException],
-        exc_value: None | BaseException,
-        traceback: None | TracebackType,
-    ) -> None: ...
-    def __iter__(self) -> Iterator[Any]: ...
-    def __next__(self) -> Any: ...
-    def __len__(self) -> int: ...
-    def __copy__(self) -> nditer: ...
-    def __getitem__(self, index: SupportsIndex | slice) -> Any: ...
-    def __setitem__(self, index: SupportsIndex | slice, value: Any) -> None: ...
-    def __delitem__(self, key: SupportsIndex | slice) -> None: ...
-
 class poly1d:
     def __init__(
         self,
@@ -881,9 +854,6 @@ sometrue = any
 alltrue = all
 
 def show_config() -> None: ...
-
-# TODO: Sort out which parameters are positional-only
-def nested_iters(*args, **kwargs): ... # TODO: Sort out parameters
 
 _NdArraySubClass = TypeVar("_NdArraySubClass", bound=ndarray)
 _DTypeScalar_co = TypeVar("_DTypeScalar_co", covariant=True, bound=generic)
@@ -3739,3 +3709,110 @@ class record(void):
     def __getitem__(self, key: str | SupportsIndex) -> Any: ...
     @overload
     def __getitem__(self, key: list[str]) -> record: ...
+
+_NDIterFlagsKind = L[
+    "buffered",
+    "c_index",
+    "copy_if_overlap",
+    "common_dtype",
+    "delay_bufalloc",
+    "external_loop",
+    "f_index",
+    "grow_inner", "growinner",
+    "multi_index",
+    "ranged",
+    "refs_ok",
+    "reduce_ok",
+    "zerosize_ok",
+]
+
+_NDIterOpFlagsKind = L[
+    "aligned",
+    "allocate",
+    "arraymask",
+    "copy",
+    "config",
+    "nbo",
+    "no_subtype",
+    "no_broadcast",
+    "overlap_assume_elementwise",
+    "readonly",
+    "readwrite",
+    "updateifcopy",
+    "virtual",
+    "writeonly",
+    "writemasked"
+]
+
+@final
+class nditer:
+    def __new__(
+        cls,
+        op: ArrayLike | Sequence[ArrayLike],
+        flags: None | Sequence[_NDIterFlagsKind] = ...,
+        op_flags: None | Sequence[Sequence[_NDIterOpFlagsKind]] = ...,
+        op_dtypes: DTypeLike | Sequence[DTypeLike] = ...,
+        order: _OrderKACF = ...,
+        casting: _CastingKind = ...,
+        op_axes: None | Sequence[Sequence[SupportsIndex]] = ...,
+        itershape: None | _ShapeLike = ...,
+        buffersize: SupportsIndex = ...,
+    ) -> nditer: ...
+    def __enter__(self) -> nditer: ...
+    def __exit__(
+        self,
+        exc_type: None | Type[BaseException],
+        exc_value: None | BaseException,
+        traceback: None | TracebackType,
+    ) -> None: ...
+    def __iter__(self) -> nditer: ...
+    def __next__(self) -> Tuple[NDArray[Any], ...]: ...
+    def __len__(self) -> int: ...
+    def __copy__(self) -> nditer: ...
+    @overload
+    def __getitem__(self, index: SupportsIndex) -> NDArray[Any]: ...
+    @overload
+    def __getitem__(self, index: slice) -> Tuple[NDArray[Any], ...]: ...
+    def __setitem__(self, index: slice | SupportsIndex, value: ArrayLike) -> None: ...
+    def close(self) -> None: ...
+    def copy(self) -> nditer: ...
+    def debug_print(self) -> None: ...
+    def enable_external_loop(self) -> None: ...
+    def iternext(self) -> bool: ...
+    def remove_axis(self, i: SupportsIndex, /) -> None: ...
+    def remove_multi_index(self) -> None: ...
+    def reset(self) -> None: ...
+    @property
+    def dtypes(self) -> Tuple[dtype[Any], ...]: ...
+    @property
+    def finished(self) -> bool: ...
+    @property
+    def has_delayed_bufalloc(self) -> bool: ...
+    @property
+    def has_index(self) -> bool: ...
+    @property
+    def has_multi_index(self) -> bool: ...
+    @property
+    def index(self) -> int: ...
+    @property
+    def iterationneedsapi(self) -> bool: ...
+    @property
+    def iterindex(self) -> int: ...
+    @property
+    def iterrange(self) -> Tuple[int, ...]: ...
+    @property
+    def itersize(self) -> int: ...
+    @property
+    def itviews(self) -> Tuple[NDArray[Any], ...]: ...
+    @property
+    def multi_index(self) -> Tuple[int, ...]: ...
+    @property
+    def ndim(self) -> int: ...
+    @property
+    def nop(self) -> int: ...
+    @property
+    def operands(self) -> Tuple[NDArray[Any], ...]: ...
+    @property
+    def shape(self) -> Tuple[int, ...]: ...
+    @property
+    def value(self) -> Tuple[NDArray[Any], ...]: ...

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -478,7 +478,7 @@ add_newdoc('numpy.core', 'nditer', ('iternext',
 
 add_newdoc('numpy.core', 'nditer', ('remove_axis',
     """
-    remove_axis(i)
+    remove_axis(i, /)
 
     Removes axis `i` from the iterator. Requires that the flag "multi_index"
     be enabled.
@@ -504,6 +504,8 @@ add_newdoc('numpy.core', 'nditer', ('reset',
 
 add_newdoc('numpy.core', 'nested_iters',
     """
+    nested_iters(op, axes, flags=None, op_flags=None, op_dtypes=None, order="K", casting="safe", buffersize=0)
+
     Create nditers for use in nested loops
 
     Create a tuple of `nditer` objects which iterate in nested loops over
@@ -796,7 +798,7 @@ add_newdoc('numpy.core.multiarray', 'array',
     object : array_like
         An array, any object exposing the array interface, an object whose
         __array__ method returns an array, or any (nested) sequence.
-        If object is a scalar, a 0-dimensional array containing object is 
+        If object is a scalar, a 0-dimensional array containing object is
         returned.
     dtype : data-type, optional
         The desired data-type for the array.  If not given, then the type will

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -504,7 +504,8 @@ add_newdoc('numpy.core', 'nditer', ('reset',
 
 add_newdoc('numpy.core', 'nested_iters',
     """
-    nested_iters(op, axes, flags=None, op_flags=None, op_dtypes=None, order="K", casting="safe", buffersize=0)
+    nested_iters(op, axes, flags=None, op_flags=None, op_dtypes=None, \
+    order="K", casting="safe", buffersize=0)
 
     Create nditers for use in nested loops
 

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -30,7 +30,6 @@ from numpy import (
     nditer as nditer,
 
     # The rest
-    nditer,
     ufunc,
     str_,
     bool_,
@@ -51,6 +50,8 @@ from numpy import (
     _ModeKind,
     _SupportsBuffer,
     _IOProtocol,
+    _NDIterFlagsKind,
+    _NDIterOpFlagsKind,
 )
 
 from numpy.typing import (
@@ -1012,3 +1013,14 @@ class flagsobj:
     def owndata(self) -> bool: ...
     def __getitem__(self, key: _GetItemKeys) -> bool: ...
     def __setitem__(self, key: _SetItemKeys, value: bool) -> None: ...
+
+def nested_iters(
+    op: ArrayLike | Sequence[ArrayLike],
+    axes: Sequence[Sequence[SupportsIndex]],
+    flags: None | Sequence[_NDIterFlagsKind] = ...,
+    op_flags: None | Sequence[Sequence[_NDIterOpFlagsKind]] = ...,
+    op_dtypes: DTypeLike | Sequence[DTypeLike] = ...,
+    order: _OrderKACF = ...,
+    casting: _CastingKind = ...,
+    buffersize: SupportsIndex = ...,
+) -> Tuple[nditer, ...]: ...

--- a/numpy/typing/tests/data/fail/multiarray.py
+++ b/numpy/typing/tests/data/fail/multiarray.py
@@ -47,3 +47,10 @@ np.datetime_as_string("2012")  # E: No overload variant
 np.compare_chararrays("a", b"a", "==", False)  # E: No overload variant
 
 np.add_docstring(func, None)  # E: incompatible type
+
+np.nested_iters([AR_i8, AR_i8])  # E: Missing positional argument
+np.nested_iters([AR_i8, AR_i8], 0)  # E: incompatible type
+np.nested_iters([AR_i8, AR_i8], [0])  # E: incompatible type
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], flags=["test"])  # E: incompatible type
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], op_flags=[["test"]])  # E: incompatible type
+np.nested_iters([AR_i8, AR_i8], [[0], [1]], buffersize=1.0)  # E: incompatible type

--- a/numpy/typing/tests/data/fail/nditer.py
+++ b/numpy/typing/tests/data/fail/nditer.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+class Test(np.nditer): ...  # E: Cannot inherit from final class
+
+np.nditer([0, 1], flags=["test"])  # E: incompatible type
+np.nditer([0, 1], op_flags=[["test"]])  # E: incompatible type
+np.nditer([0, 1], itershape=(1.0,))  # E: incompatible type
+np.nditer([0, 1], buffersize=1.0)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/multiarray.py
+++ b/numpy/typing/tests/data/reveal/multiarray.py
@@ -25,6 +25,8 @@ M: np.datetime64
 b_f8 = np.broadcast(AR_f8)
 b_i8_f8_f8 = np.broadcast(AR_i8, AR_f8, AR_f8)
 
+nditer_obj: np.nditer
+
 def func(a: int) -> bool: ...
 
 reveal_type(next(b_f8))  # E: tuple[Any]
@@ -123,3 +125,8 @@ reveal_type(np.compare_chararrays("a", "b", "!=", rstrip=False))  # E: numpy.nda
 reveal_type(np.compare_chararrays(b"a", b"a", "==", True))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
 
 reveal_type(np.add_docstring(func, "test"))  # E: None
+
+reveal_type(np.nested_iters([AR_i8, AR_i8], [[0], [1]], flags=["c_index"]))  # E: tuple[numpy.nditer]
+reveal_type(np.nested_iters([AR_i8, AR_i8], [[0], [1]], op_flags=[["readonly", "readonly"]]))  # E: tuple[numpy.nditer]
+reveal_type(np.nested_iters([AR_i8, AR_i8], [[0], [1]], op_dtypes=np.int_))  # E: tuple[numpy.nditer]
+reveal_type(np.nested_iters([AR_i8, AR_i8], [[0], [1]], order="C", casting="no"))  # E: tuple[numpy.nditer]

--- a/numpy/typing/tests/data/reveal/nditer.py
+++ b/numpy/typing/tests/data/reveal/nditer.py
@@ -1,19 +1,46 @@
-import copy
 import numpy as np
 
 nditer_obj: np.nditer
 
-with nditer_obj as context:
-    reveal_type(context)   # E: numpy.nditer
+reveal_type(np.nditer([0, 1], flags=["c_index"]))  # E: numpy.nditer
+reveal_type(np.nditer([0, 1], op_flags=[["readonly", "readonly"]]))  # E: numpy.nditer
+reveal_type(np.nditer([0, 1], op_dtypes=np.int_))  # E: numpy.nditer
+reveal_type(np.nditer([0, 1], order="C", casting="no"))  # E: numpy.nditer
 
-reveal_type(len(nditer_obj))  # E: builtins.int
-reveal_type(copy.copy(nditer_obj))  # E: numpy.nditer
-reveal_type(next(nditer_obj))  # E: Any
-reveal_type(iter(nditer_obj))  # E: typing.Iterator[Any]
-reveal_type(nditer_obj[1])  # E: Any
-reveal_type(nditer_obj[1:5])  # E: Any
+reveal_type(nditer_obj.dtypes)  # E: tuple[numpy.dtype[Any]]
+reveal_type(nditer_obj.finished)  # E: bool
+reveal_type(nditer_obj.has_delayed_bufalloc)  # E: bool
+reveal_type(nditer_obj.has_index)  # E: bool
+reveal_type(nditer_obj.has_multi_index)  # E: bool
+reveal_type(nditer_obj.index)  # E: int
+reveal_type(nditer_obj.iterationneedsapi)  # E: bool
+reveal_type(nditer_obj.iterindex)  # E: int
+reveal_type(nditer_obj.iterrange)  # E: tuple[builtins.int]
+reveal_type(nditer_obj.itersize)  # E: int
+reveal_type(nditer_obj.itviews)  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
+reveal_type(nditer_obj.multi_index)  # E: tuple[builtins.int]
+reveal_type(nditer_obj.ndim)  # E: int
+reveal_type(nditer_obj.nop)  # E: int
+reveal_type(nditer_obj.operands)  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
+reveal_type(nditer_obj.shape)  # E: tuple[builtins.int]
+reveal_type(nditer_obj.value)  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
 
-nditer_obj[1] = 1
-nditer_obj[1:5] = 1
-del nditer_obj[1]
-del nditer_obj[1:5]
+reveal_type(nditer_obj.close())  # E: None
+reveal_type(nditer_obj.copy())  # E: numpy.nditer
+reveal_type(nditer_obj.debug_print())  # E: None
+reveal_type(nditer_obj.enable_external_loop())  # E: None
+reveal_type(nditer_obj.iternext())  # E: bool
+reveal_type(nditer_obj.remove_axis(0))  # E: None
+reveal_type(nditer_obj.remove_multi_index())  # E: None
+reveal_type(nditer_obj.reset())  # E: None
+
+reveal_type(len(nditer_obj))  # E: int
+reveal_type(iter(nditer_obj))  # E: Iterator[builtins.tuple[numpy.ndarray[Any, numpy.dtype[Any]]]]
+reveal_type(next(nditer_obj))  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
+reveal_type(nditer_obj.__copy__())  # E: numpy.nditer
+with nditer_obj as f:
+    reveal_type(f)  # E: numpy.nditer
+reveal_type(nditer_obj[0])  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(nditer_obj[:])  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
+nditer_obj[0] = 0
+nditer_obj[:] = [0, 1]


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/19237

This PR adds annotations for the final two objects in the `np.core.multiarray` namespace: 
* The `nested_iters` function 
* The `nditer` class.