### PR TITLE
MAINT: Mark type-check-only ufunc subclasses as ufunc aliases during runtime

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -161,7 +161,8 @@ API
 # NOTE: The API section will be appended with additional entries
 # further down in this file
 
-from typing import TYPE_CHECKING, List, Any
+from numpy import ufunc
+from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:
     import sys
@@ -364,14 +365,16 @@ if TYPE_CHECKING:
         _GUFunc_Nin2_Nout1,
     )
 else:
-    _UFunc_Nin1_Nout1 = Any
-    _UFunc_Nin2_Nout1 = Any
-    _UFunc_Nin1_Nout2 = Any
-    _UFunc_Nin2_Nout2 = Any
-    _GUFunc_Nin2_Nout1 = Any
+    # Declare the (type-check-only) ufunc subclasses as ufunc aliases during
+    # runtime; this helps autocompletion tools such as Jedi (numpy/numpy#19834)
+    _UFunc_Nin1_Nout1 = ufunc
+    _UFunc_Nin2_Nout1 = ufunc
+    _UFunc_Nin1_Nout2 = ufunc
+    _UFunc_Nin2_Nout2 = ufunc
+    _GUFunc_Nin2_Nout1 = ufunc
 
 # Clean up the namespace
-del TYPE_CHECKING, final, List, Any
+del TYPE_CHECKING, final, List, ufunc
 
 if __doc__ is not None:
     from ._add_docstring import _docstrings


### PR DESCRIPTION
Backport of #19856. 

Closes #19834

numpy.typing currently has a number of (type-check-only) ufunc subclasses that are used for differentiation the various combinations of ufunc.nin and ufunc.nout ufuncs. These classes were previously marked as Any during runtime however, which could trip up autocompletion tools such as Jedi.

This issue has been resolved by instead treating them as ufunc aliases during runtime, similar to how typing.TypedDict is treated w.r.t. dict.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
