### PR TITLE
DOC: Remove overstated TDD evangelism.

### DIFF
--- a/doc/TESTS.rst.txt
+++ b/doc/TESTS.rst.txt
@@ -16,13 +16,7 @@ Our goal is that every module and package in NumPy
 should have a thorough set of unit
 tests. These tests should exercise the full functionality of a given
 routine as well as its robustness to erroneous or unexpected input
-arguments. Long experience has shown that by far the best time to
-write the tests is before you write or change the code - this is
-`test-driven development
-<https://en.wikipedia.org/wiki/Test-driven_development>`__.  The
-arguments for this can sound rather abstract, but we can assure you
-that you will find that writing the tests first leads to more robust
-and better designed code. Well-designed tests with good coverage make
+arguments. Well-designed tests with good coverage make
 an enormous difference to the ease of refactoring. Whenever a new bug
 is found in a routine, you should write a new test for that specific
 case and add it to the test suite to prevent that bug from creeping


### PR DESCRIPTION
This language promoting test-driven development dates from the old SciPy wiki, so before 2008 or so. [Longer experience and (more importantly) rigorous empirical software engineering research](https://neverworkintheory.org/2021/09/16/analyzing-the-effects-of-tdd-in-github.html) has shown that TDD does not have the claimed benefits, so I would like to remove the evangelism. I don't think the core dev team promotes that way of working in other venues.

I have not replaced the language with any other suggestions on how to write tests or balance test-writing with library-code-writing. The things I would suggest (work in small chunks, testing frequently; for bugfixes, run the new tests on the unfixed library code to ensure that the test is testing what you think it is) don't really fit there in the flow of the document. But if people want, I could draft some text.