### PR TITLE
DOC: rename `np.lib.scimath` to `np.emath`

### DIFF
--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -7,8 +7,7 @@ For example, for functions like `log` with branch cuts, the versions in this
 module provide the mathematically valid answers in the complex plane::
 
   >>> import math
-  >>> from numpy.lib import scimath
-  >>> scimath.log(-math.exp(1)) == (1+1j*math.pi)
+  >>> np.emath.log(-math.exp(1)) == (1+1j*math.pi)
   True
 
 Similarly, `sqrt`, other base logarithms, `power` and trig functions are
@@ -223,16 +222,16 @@ def sqrt(x):
     --------
     For real, non-negative inputs this works just like `numpy.sqrt`:
 
-    >>> np.lib.scimath.sqrt(1)
+    >>> np.emath.sqrt(1)
     1.0
-    >>> np.lib.scimath.sqrt([1, 4])
+    >>> np.emath.sqrt([1, 4])
     array([1.,  2.])
 
     But it automatically handles negative inputs:
 
-    >>> np.lib.scimath.sqrt(-1)
+    >>> np.emath.sqrt(-1)
     1j
-    >>> np.lib.scimath.sqrt([-1,4])
+    >>> np.emath.sqrt([-1,4])
     array([0.+1.j, 2.+0.j])
 
     """
@@ -367,9 +366,9 @@ def logn(n, x):
     --------
     >>> np.set_printoptions(precision=4)
 
-    >>> np.lib.scimath.logn(2, [4, 8])
+    >>> np.emath.logn(2, [4, 8])
     array([2., 3.])
-    >>> np.lib.scimath.logn(2, [-4, -8, 8])
+    >>> np.emath.logn(2, [-4, -8, 8])
     array([2.+4.5324j, 3.+4.5324j, 3.+0.j    ])
 
     """
@@ -462,11 +461,11 @@ def power(x, p):
     --------
     >>> np.set_printoptions(precision=4)
 
-    >>> np.lib.scimath.power([2, 4], 2)
+    >>> np.emath.power([2, 4], 2)
     array([ 4, 16])
-    >>> np.lib.scimath.power([2, 4], -2)
+    >>> np.emath.power([2, 4], -2)
     array([0.25  ,  0.0625])
-    >>> np.lib.scimath.power([-2, 4], 2)
+    >>> np.emath.power([-2, 4], 2)
     array([ 4.-0.j, 16.+0.j])
 
     """


### PR DESCRIPTION
As per the doc `numpy.emath is a preferred alias for numpy.lib.scimath`. Hence this PR removes usage of `np.lib.scimath` in favour of `np.emath` in the documentation of the module.