### PR TITLE
BUG: np.tan(np.inf) test failure in Apple silicon

### DIFF
--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -457,20 +457,39 @@ NPY_INPLACE @type@ npy_frexp@c@(@type@ x, int* exp)
  * #c = l,,f#
  * #C = L,,F#
  */
+
+/*
+ * On arm64 macOS, there's a bug with sin, cos, and tan where they don't
+ * raise "invalid" when given INFINITY as input.
+ */
+#if defined(__APPLE__) && defined(__arm64__)
+#define WORKAROUND_APPLE_TRIG_BUG 1
+#else
+#define WORKAROUND_APPLE_TRIG_BUG 0
+#endif
+
 /**begin repeat1
  * #kind = sin,cos,tan,sinh,cosh,tanh,fabs,floor,ceil,rint,trunc,sqrt,log10,
  *         log,exp,expm1,asin,acos,atan,asinh,acosh,atanh,log1p,exp2,log2#
  * #KIND = SIN,COS,TAN,SINH,COSH,TANH,FABS,FLOOR,CEIL,RINT,TRUNC,SQRT,LOG10,
  *         LOG,EXP,EXPM1,ASIN,ACOS,ATAN,ASINH,ACOSH,ATANH,LOG1P,EXP2,LOG2#
+ * #TRIG_WORKAROUND = WORKAROUND_APPLE_TRIG_BUG*3, 0*22#
  */
 #ifdef HAVE_@KIND@@C@
 NPY_INPLACE @type@ npy_@kind@@c@(@type@ x)
 {
+#if @TRIG_WORKAROUND@
+    if (!npy_isfinite(x)) {
+        return (x - x);
+    }
+#endif
     return @kind@@c@(x);
 }
 #endif
 
 /**end repeat1**/
+
+#undef WORKAROUND_APPLE_TRIG_BUG
 
 /**begin repeat1
  * #kind = atan2,hypot,pow,fmod,copysign#


### PR DESCRIPTION
Numpy has a test failure where `np.tan(np.inf)` is not raising "invalid". The bug is due to an underlying bug in Apple's Libm.  The bug is only present on arm64 and does not affect x86_64.

The changes here apply to sin, cos, and tan. If the input is a non-finite value, then return `(x - x)`, which will raise "invalid" for `x=INFINITY` as well as return `NAN` for both `INFINITY` and `NAN` as input.

Testing:
On top of changes for https://github.com/numpy/numpy/pull/19926

Before change:
```
FAILED numpy/core/tests/test_umath.py::TestSpecialFloats::test_tan - AssertionError: FloatingPointError not raised by tan
1 failed, 15589 passed, 302 skipped, 1268 deselected, 31 xfailed, 3 xpassed in 70.99s (0:01:10)
```

After change:
```
15590 passed, 302 skipped, 1268 deselected, 31 xfailed, 3 xpassed in 71.38s (0:01:11)
```