### PR TITLE
DOC Remove reference to `PyArray_MultiIter_SIZE`

### DIFF
--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -174,14 +174,13 @@ incrementing is automatically performed by
 :c:func:`PyArray_MultiIter_NEXT` ( ``obj`` ) macro (which can handle a
 multiterator ``obj`` as either a :c:expr:`PyArrayMultiIterObject *` or a
 :c:expr:`PyObject *`). The data from input number ``i`` is available using
-:c:func:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ) and the total (broadcasted)
-size as :c:func:`PyArray_MultiIter_SIZE` ( ``obj``). An example of using this
+:c:func:`PyArray_MultiIter_DATA` ( ``obj``, ``i`` ). An example of using this
 feature follows.
 
 .. code-block:: c
 
     mobj = PyArray_MultiIterNew(2, obj1, obj2);
-    size = PyArray_MultiIter_SIZE(obj);
+    size = mobj->size;
     while(size--) {
         ptr1 = PyArray_MultiIter_DATA(mobj, 0);
         ptr2 = PyArray_MultiIter_DATA(mobj, 1);


### PR DESCRIPTION
This pull request removes from the documentation the references to the undefined `PyArray_MultiIter_SIZE`.
It fixes #19570, see also #13114.
Thanks for considering it.