### PR TITLE
ENH: Add annotations for `np.memmap`

### DIFF
--- a/numpy/core/memmap.pyi
+++ b/numpy/core/memmap.pyi
@@ -1,0 +1,5 @@
+from typing import List
+
+from numpy import memmap as memmap
+
+__all__: List[str]

--- a/numpy/typing/tests/data/fail/memmap.py
+++ b/numpy/typing/tests/data/fail/memmap.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+with open("file.txt", "r") as f:
+    np.memmap(f)  # E: No overload variant
+np.memmap("test.txt", shape=[10, 5])  # E: No overload variant

--- a/numpy/typing/tests/data/reveal/memmap.py
+++ b/numpy/typing/tests/data/reveal/memmap.py
@@ -1,0 +1,16 @@
+import numpy as np
+from typing import Any
+
+memmap_obj: np.memmap[Any, np.dtype[np.str_]]
+
+reveal_type(np.memmap.__array_priority__)  # E: float
+reveal_type(memmap_obj.__array_priority__)  # E: float
+reveal_type(memmap_obj.filename)  # E: Union[builtins.str, None]
+reveal_type(memmap_obj.offset)  # E: int
+reveal_type(memmap_obj.mode)  # E: str
+reveal_type(memmap_obj.flush())  # E: None
+
+reveal_type(np.memmap("file.txt", offset=5))  # E: numpy.memmap[Any, numpy.dtype[{uint8}]]
+reveal_type(np.memmap(b"file.txt", dtype=np.float64, shape=(10, 3)))  # E: numpy.memmap[Any, numpy.dtype[{float64}]]
+with open("file.txt", "rb") as f:
+    reveal_type(np.memmap(f, dtype=float, order="K"))  # E: numpy.memmap[Any, numpy.dtype[Any]]


### PR DESCRIPTION
This PR adds annotations for the `np.memmap` class.