### PR TITLE
DOC: Deindent some sphinx declarations to avoid warnings.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -519,34 +519,34 @@ From other objects
 
         :c:data:`NPY_ARRAY_CARRAY`
 
-    .. c:macro:: NPY_ARRAY_IN_ARRAY
+.. c:macro:: NPY_ARRAY_IN_ARRAY
 
-        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
     .. c:macro:: NPY_ARRAY_IN_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:macro:: NPY_OUT_ARRAY
+.. c:macro:: NPY_OUT_ARRAY
 
-        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
-        :c:data:`NPY_ARRAY_ALIGNED`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+    :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:macro:: NPY_ARRAY_OUT_ARRAY
+.. c:macro:: NPY_ARRAY_OUT_ARRAY
 
-        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED` \|
-        :c:data:`NPY_ARRAY_WRITEABLE`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED` \|
+    :c:data:`NPY_ARRAY_WRITEABLE`
 
     .. c:macro:: NPY_ARRAY_OUT_FARRAY
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED`
 
-    .. c:macro:: NPY_ARRAY_INOUT_ARRAY
+.. c:macro:: NPY_ARRAY_INOUT_ARRAY
 
-        :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
-        :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` \|
-        :c:data:`NPY_ARRAY_UPDATEIFCOPY`
+    :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
+    :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` \|
+    :c:data:`NPY_ARRAY_UPDATEIFCOPY`
 
     .. c:macro:: NPY_ARRAY_INOUT_FARRAY
 
@@ -584,26 +584,26 @@ From other objects
     did not have the _ARRAY_ macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
-    .. c:macro:: NPY_ARRAY_NOTSWAPPED
+.. c:macro:: NPY_ARRAY_NOTSWAPPED
 
-        Make sure the returned array has a data-type descriptor that is in
-        machine byte-order, over-riding any specification in the *dtype*
-        argument. Normally, the byte-order requirement is determined by
-        the *dtype* argument. If this flag is set and the dtype argument
-        does not indicate a machine byte-order descriptor (or is NULL and
-        the object is already an array with a data-type descriptor that is
-        not in machine byte- order), then a new data-type descriptor is
-        created and used with its byte-order field set to native.
+    Make sure the returned array has a data-type descriptor that is in
+    machine byte-order, over-riding any specification in the *dtype*
+    argument. Normally, the byte-order requirement is determined by
+    the *dtype* argument. If this flag is set and the dtype argument
+    does not indicate a machine byte-order descriptor (or is NULL and
+    the object is already an array with a data-type descriptor that is
+    not in machine byte- order), then a new data-type descriptor is
+    created and used with its byte-order field set to native.
 
     .. c:macro:: NPY_ARRAY_BEHAVED_NS
 
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_NOTSWAPPED`
 
-    .. c:macro:: NPY_ARRAY_ELEMENTSTRIDES
+.. c:macro:: NPY_ARRAY_ELEMENTSTRIDES
 
-        Make sure the returned array has strides that are multiples of the
-        element size.
+    Make sure the returned array has strides that are multiples of the
+    element size.
 
 .. c:function:: PyObject* PyArray_FromArray( \
         PyArrayObject* op, PyArray_Descr* newtype, int requirements)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -519,6 +519,9 @@ From other objects
 
         :c:data:`NPY_ARRAY_CARRAY`
 
+..
+  dedented to allow internal linking, pending a refactoring
+
 .. c:macro:: NPY_ARRAY_IN_ARRAY
 
     :c:data:`NPY_ARRAY_C_CONTIGUOUS` \| :c:data:`NPY_ARRAY_ALIGNED`
@@ -541,6 +544,9 @@ From other objects
 
         :c:data:`NPY_ARRAY_F_CONTIGUOUS` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_ALIGNED`
+
+..
+  dedented to allow internal linking, pending a refactoring
 
 .. c:macro:: NPY_ARRAY_INOUT_ARRAY
 
@@ -584,6 +590,9 @@ From other objects
     did not have the _ARRAY_ macro namespace in them. That form
     of the constant names is deprecated in 1.7.
 
+..
+  dedented to allow internal linking, pending a refactoring
+
 .. c:macro:: NPY_ARRAY_NOTSWAPPED
 
     Make sure the returned array has a data-type descriptor that is in
@@ -599,6 +608,9 @@ From other objects
 
         :c:data:`NPY_ARRAY_ALIGNED` \| :c:data:`NPY_ARRAY_WRITEABLE` \|
         :c:data:`NPY_ARRAY_NOTSWAPPED`
+
+..
+  dedented to allow internal linking, pending a refactoring
 
 .. c:macro:: NPY_ARRAY_ELEMENTSTRIDES
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -286,6 +286,9 @@ PyArrayDescr_Type and PyArray_Descr
        array like behavior. Each bit in this member is a flag which are named
        as:
 
+..
+  dedented to allow internal linking, pending a refactoring
+
 .. c:macro:: NPY_ITEM_REFCOUNT
 
     Indicates that items of this data-type must be reference
@@ -294,6 +297,9 @@ PyArrayDescr_Type and PyArray_Descr
        .. c:macro:: NPY_ITEM_HASOBJECT
 
            Same as :c:data:`NPY_ITEM_REFCOUNT`.
+
+..
+  dedented to allow internal linking, pending a refactoring
 
 .. c:macro:: NPY_LIST_PICKLE
 
@@ -988,6 +994,9 @@ PyUFunc_Type and PyUFuncObject
    .. c:member:: npy_uint32 *core_dim_flags
 
        For each distinct core dimension, a set of ``UFUNC_CORE_DIM*`` flags
+
+..
+  dedented to allow internal linking, pending a refactoring
 
 .. c:macro:: UFUNC_CORE_DIM_CAN_IGNORE
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -286,48 +286,48 @@ PyArrayDescr_Type and PyArray_Descr
        array like behavior. Each bit in this member is a flag which are named
        as:
 
-       .. c:macro:: NPY_ITEM_REFCOUNT
+.. c:macro:: NPY_ITEM_REFCOUNT
 
-           Indicates that items of this data-type must be reference
-           counted (using :c:func:`Py_INCREF` and :c:func:`Py_DECREF` ).
+    Indicates that items of this data-type must be reference
+    counted (using :c:func:`Py_INCREF` and :c:func:`Py_DECREF` ).
 
        .. c:macro:: NPY_ITEM_HASOBJECT
 
            Same as :c:data:`NPY_ITEM_REFCOUNT`.
 
-       .. c:macro:: NPY_LIST_PICKLE
+.. c:macro:: NPY_LIST_PICKLE
 
-           Indicates arrays of this data-type must be converted to a list
-           before pickling.
+    Indicates arrays of this data-type must be converted to a list
+    before pickling.
 
-       .. c:macro:: NPY_ITEM_IS_POINTER
+.. c:macro:: NPY_ITEM_IS_POINTER
 
-           Indicates the item is a pointer to some other data-type
+    Indicates the item is a pointer to some other data-type
 
-       .. c:macro:: NPY_NEEDS_INIT
+.. c:macro:: NPY_NEEDS_INIT
 
-           Indicates memory for this data-type must be initialized (set
-           to 0) on creation.
+    Indicates memory for this data-type must be initialized (set
+    to 0) on creation.
 
-       .. c:macro:: NPY_NEEDS_PYAPI
+.. c:macro:: NPY_NEEDS_PYAPI
 
-           Indicates this data-type requires the Python C-API during
-           access (so don't give up the GIL if array access is going to
-           be needed).
+    Indicates this data-type requires the Python C-API during
+    access (so don't give up the GIL if array access is going to
+    be needed).
 
-       .. c:macro:: NPY_USE_GETITEM
+.. c:macro:: NPY_USE_GETITEM
 
-           On array access use the ``f->getitem`` function pointer
-           instead of the standard conversion to an array scalar. Must
-           use if you don't define an array scalar to go along with
-           the data-type.
+    On array access use the ``f->getitem`` function pointer
+    instead of the standard conversion to an array scalar. Must
+    use if you don't define an array scalar to go along with
+    the data-type.
 
-       .. c:macro:: NPY_USE_SETITEM
+.. c:macro:: NPY_USE_SETITEM
 
-           When creating a 0-d array from an array scalar use
-           ``f->setitem`` instead of the standard copy from an array
-           scalar. Must use if you don't define an array scalar to go
-           along with the data-type.
+    When creating a 0-d array from an array scalar use
+    ``f->setitem`` instead of the standard copy from an array
+    scalar. Must use if you don't define an array scalar to go
+    along with the data-type.
 
        .. c:macro:: NPY_FROM_FIELDS
 
@@ -989,14 +989,14 @@ PyUFunc_Type and PyUFuncObject
 
        For each distinct core dimension, a set of ``UFUNC_CORE_DIM*`` flags
 
-       .. c:macro:: UFUNC_CORE_DIM_CAN_IGNORE
+.. c:macro:: UFUNC_CORE_DIM_CAN_IGNORE
 
-           if the dim name ends in ``?``
+    if the dim name ends in ``?``
 
-       .. c:macro:: UFUNC_CORE_DIM_SIZE_INFERRED
+.. c:macro:: UFUNC_CORE_DIM_SIZE_INFERRED
 
-           if the dim size will be determined from the operands
-           and not from a :ref:`frozen <frozen>` signature
+    if the dim size will be determined from the operands
+    and not from a :ref:`frozen <frozen>` signature
 
    .. c:member:: PyObject *identity_value
 


### PR DESCRIPTION
Partially addresses #13114.
Similar to #19590.
Some missing reference warnings are raised when macros do not have global scope.
Those declarations are deindented... waiting for a reorganization....

Note that some indented macros were not raising warnings because they are declared twice, once in the right scope: see for example `NPY_ARRAY_C_CONTIGUOUS` defined in
https://github.com/numpy/numpy/blob/bb33a1f/doc/source/reference/c-api/array.rst#L441
and in
https://github.com/numpy/numpy/blob/bb33a1f/doc/source/reference/c-api/array.rst#1426