### PR TITLE
MAINT: Configure pytest to ignore array_api warnings.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,5 @@ filterwarnings =
     ignore:Importing from numpy.matlib is
 # pytest warning when using PYTHONOPTIMIZE
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
+# TODO: remove below when array_api user warning is removed
+    ignore:The numpy.array_api submodule is still experimental. See NEP 47.


### PR DESCRIPTION
Closes #19935 