### PR TITLE
MAINT: Fix LGTM.com warning: Comparison result is always the same (`denom`)

### DIFF
--- a/numpy/core/src/multiarray/datetime.c
+++ b/numpy/core/src/multiarray/datetime.c
@@ -1160,7 +1160,7 @@ get_datetime_conversion_factor(PyArray_DatetimeMetaData *src_meta,
     }
 
     /* If something overflowed, make both num and denom 0 */
-    if (denom == 0 || num == 0) {
+    if (num == 0) {
         PyErr_Format(PyExc_OverflowError,
                     "Integer overflow while computing the conversion "
                     "factor between NumPy datetime units %s and %s",


### PR DESCRIPTION
> Comparison is always false because denom >= 1.

https://lgtm.com/projects/g/numpy/numpy/snapshot/5667e0c91f0ab58b6f550fad9e98710eafff4045/files/numpy/core/src/multiarray/datetime.c#x2f5c881720f6cdf2:1

An overflow of `denom` is impossible because `denom` is initialized to `1` and then multiplied by `400*12*7` at most.

Besides, checking if the result is 0 is certainly not the proper way to check for overflow or wrapping of an integer multiplication.