### PR TITLE
ENH: Extended choose -- add an implementation of the choose function which supports more than 32 choices

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -440,7 +440,7 @@ def extended_choose(indices, choices):
     contains in the same place.
 
     This implementation supports an arbitrary number of choices, where
-    the underlying `np.choose` only supports up to 31 choices.  This implementation
+    the underlying `np.choose` only supports up to 31 choices.  This function
     does not support the `out` or `mode` parameters accepted by `np.choose`.
 
     Parameters
@@ -467,7 +467,7 @@ def extended_choose(indices, choices):
     >>> bchoices = [i * 10 for i in range(25)]
     >>> choices = list(achoices) + list(bchoices)
     >>> indices = [38, 0, 8, 49]
-    >>> # np.choose(indices, choices) => ValueError: Need at least 0 and at most 32 array objects.
+    >>> # np.choose(indices, choices) => ValueError
     >>> for i in indices:
     ...     print (i, "::", choices[i])
     ... 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -468,13 +468,10 @@ def extended_choose(indices, choices):
     >>> choices = list(achoices) + list(bchoices)
     >>> indices = [38, 0, 8, 49]
     >>> # np.choose(indices, choices) => ValueError
-    >>> for i in indices:
-    ...     print (i, "::", choices[i])
-    ... 
-    38 :: 130
-    0 :: [0 2 4 6]
-    8 :: [ 8 10 12  9]
-    49 :: 240
+    >>> # choices[38] == 130
+    >>> # choices[0] == [0 2 4 6]
+    >>> # choices[8] == [ 8 10 12  9]
+    >>> # choices[49] == 240
     >>> np.extended_choose(indices, choices)
     array([130,   2,  12, 240])
     """

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3548,11 +3548,11 @@ class TestExtendedChoose:
         choices = list(achoices) + list(bchoices)
         indices = [38, 0, 8, 49]
         chosen = np.extended_choose(indices, choices)
-        expected = np.array([130,   2,  12, 240])
+        expected = np.array([130, 2, 12, 240])
         assert_array_equal(chosen, expected)
 
     def naive_choose_for_testing(self, indices, choices):
-        "Naive version of choose for use in testing only.  Not fully general or efficient."
+        "Naive version of choose for use in testing only."
         # find a unified shape and choice dtype
         indices = np.array(indices)
         choices = [np.array(c) for c in choices]
@@ -3579,14 +3579,14 @@ class TestExtendedChoose:
 
     def test_choosers(self):
         base_choice = np.array([
-            [0,2],
-            [1,5]
+            [0, 2],
+            [1, 5]
         ])
         base_indices = np.array([
-            [2,3],
-            [4,0]
+            [2, 3],
+            [4, 0]
         ])
-        for length in range(1,100):
+        for length in range(1, 100):
             choices = [base_choice + (10 * i) for i in range(length)]
             indices = (base_indices * int(length/6 + 1)) % length
             echoose = np.extended_choose(indices, choices)

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -51,6 +51,7 @@ def test_numpy_namespace():
         'set_string_function': 'numpy.core.arrayprint.set_string_function',
         'show_config': 'numpy.__config__.show',
         'who': 'numpy.lib.utils.who',
+        'extended_choose': 'numpy.core.fromnumeric.extended_choose',
     }
     # We override dir to not show these members
     allowlist = undocumented


### PR DESCRIPTION
The `np.choose` function raises a `ValueError` if called with more than 31 choices.
This PR adds an alternate implementation `np.extended_choose` (which uses the base implementation) that supports
any number of choices.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
