### PR TITLE
BLD: updated mypy version from 0.902 to 0.910

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.902
+  - mypy=0.910
   # For building docs
   - sphinx=4.1.1
   - numpydoc=1.1.0


### PR DESCRIPTION
### Build error details for - `arm64` machine :-
```
Solving environment: failed
ResolvePackageNotFound:
 - mypy=0.902
```
### Resolution :-
- updated `mypy` version to 0.910
- reference to  dependabot upgrade - [19368](https://github.com/numpy/numpy/pull/19368)


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
