### PR TITLE
BUG: numpy.ma: Fix `ma.in1d`

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1203,13 +1203,16 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     # We need this to be a stable sort, so always use 'mergesort'
     # here. The values from the first array should always come before
     # the values from the second array.
-    order = ar.argsort(kind='mergesort')
+    order = ar.data.argsort(kind='mergesort')
     sar = ar[order]
+    m = ~sar.mask
+    usar = sar[m].ravel()
+    flag = ma.empty_like(sar, dtype='bool')
     if invert:
-        bool_ar = (sar[1:] != sar[:-1])
+        bool_ar = (usar[1:] != usar[:-1])
     else:
-        bool_ar = (sar[1:] == sar[:-1])
-    flag = ma.concatenate((bool_ar, [invert]))
+        bool_ar = (usar[1:] == usar[:-1])
+    flag[m] = ma.concatenate((bool_ar, [invert]))
     indx = order.argsort(kind='mergesort')[:len(ar1)]
 
     if assume_unique:

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1195,30 +1195,20 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
     .. versionadded:: 1.4.0
 
     """
-    if not assume_unique:
-        ar1, rev_idx = unique(ar1, return_inverse=True)
-        ar2 = unique(ar2)
-
-    ar = ma.concatenate((ar1, ar2))
-    # We need this to be a stable sort, so always use 'mergesort'
-    # here. The values from the first array should always come before
-    # the values from the second array.
-    order = ar.data.argsort(kind='mergesort')
-    sar = ar[order]
-    m = ~sar.mask
-    usar = sar[m].ravel()
-    flag = ma.empty_like(sar, dtype='bool')
-    if invert:
-        bool_ar = (usar[1:] != usar[:-1])
+    ar1, ar2 = ma.asarray(ar1), ma.asarray(ar2)
+    m = getmask(ar1)
+    res = ma.empty_like(ar1, dtype='bool')
+    if ar1.mask is not nomask:
+        ar1 = ar1[~ar1.mask]
+    if ar2.mask is not nomask:
+        ar2 = ar2[~ar2.mask]
+    out = np.in1d(ar1, ar2, assume_unique=assume_unique,
+                  invert=invert)
+    if m is not nomask:
+        res[~m] = out
     else:
-        bool_ar = (usar[1:] == usar[:-1])
-    flag[m] = ma.concatenate((bool_ar, [invert]))
-    indx = order.argsort(kind='mergesort')[:len(ar1)]
-
-    if assume_unique:
-        return flag[indx]
-    else:
-        return flag[indx][rev_idx]
+        res[:] = out
+    return res
 
 
 def isin(element, test_elements, assume_unique=False, invert=False):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1551,6 +1551,16 @@ class TestArraySetOps:
         #compare results of np.isin to ma.isin
         d = np.isin(a, b[~b.mask]) & ~a.mask
         assert_array_equal(c, d)
+        # test case in gh-19877
+        a = MaskedArray([[1, 2, 3],[4, 5, 6]],
+                        [[True, False, False],
+                         [False, False, False]])
+        ta = array([1, 4, 5])
+        ex = MaskedArray([[True, False, False],
+                          [True, True, False]],
+                         [[True, False, False],
+                          [False, False, False]])
+        assert_array_equal(isin(a, ta), ex)
 
     def test_in1d(self):
         # Test in1d
@@ -1565,6 +1575,21 @@ class TestArraySetOps:
         assert_equal(test, [True, True, False, True, True])
         #
         assert_array_equal([], in1d([], []))
+
+    def test_isin_edge_cases(self):
+        # test cases in gh-19877
+        w = masked_array(np.arange(5), mask=[0, 1, 0, 0, 1])
+        res = isin(w, [])
+        ex = masked_array(5*[False], w.mask)
+        assert_array_equal(res, ex)
+
+        res = isin(w, [2])
+        ex = masked_array([False, False, True, False, False], w.mask)
+        assert_array_equal(res, ex)
+
+        res = isin(w, [2, 3, 4])
+        ex = masked_array([False, False, True, True, True], w.mask)
+        assert_array_equal(res, ex)
 
     def test_in1d_invert(self):
         # Test in1d's invert parameter

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1552,7 +1552,7 @@ class TestArraySetOps:
         d = np.isin(a, b[~b.mask]) & ~a.mask
         assert_array_equal(c, d)
         # test case in gh-19877
-        a = MaskedArray([[1, 2, 3],[4, 5, 6]],
+        a = MaskedArray([[1, 2, 3], [4, 5, 6]],
                         [[True, False, False],
                          [False, False, False]])
         ta = array([1, 4, 5])


### PR DESCRIPTION
Fixes #19877

Fixed `ma.in1d` and add tests cases from gh-19877.

I just rewrote the function to use `numpy.in1d` instead of reinventing the wheel for masked arrays. To me, this seems more maintainable. I don't know if there is any reason to handle masked arrays differently. If so, sorry; I'll close this PR.