### PR TITLE
ENH: numpy.random: add `multivariate_t` distribution to random module

### DIFF
--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -157,6 +157,7 @@ Distributions
    ~numpy.random.Generator.lognormal
    ~numpy.random.Generator.logseries
    ~numpy.random.Generator.multinomial
+   ~numpy.random.Generator.multivariate_t
    ~numpy.random.Generator.multivariate_hypergeometric
    ~numpy.random.Generator.multivariate_normal
    ~numpy.random.Generator.negative_binomial

--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -622,6 +622,17 @@ class Generator:
         *,
         method: Literal["svd", "eigh", "cholesky"] = ...,
     ) -> ndarray[Any, dtype[float64]]: ...
+    def multivariate_t(
+        self,
+        mean: _ArrayLikeFloat_co,
+        cov: _ArrayLikeFloat_co,
+        df: float,
+        size: Optional[_ShapeLike] = ...,
+        check_valid: Literal["warn", "raise", "ignore"] = ...,
+        tol: float = ...,
+        *,
+        method: Literal["svd", "eigh", "cholesky"] = ...,
+    ) -> ndarray[Any, dtype[float64]]: ...
     def multinomial(
         self, n: _ArrayLikeInt_co, pvals: _ArrayLikeFloat_co, size: Optional[_ShapeLike] = ...
     ) -> ndarray[Any, dtype[int64]]: ...

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -285,6 +285,55 @@ class TestMultivariateHypergeometric:
         assert_array_equal(sample, expected)
 
 
+class TestMultivariateT:
+
+    def setup(self):
+        self.seed = 8675309
+
+    def test_argument_validation(self):
+        # `df` must be positive
+        with pytest.raises(ValueError, match="df <= 0"):
+            random.multivariate_t([0], [[1]], df=-1)
+
+    def test_size(self):
+        df = 1.
+        assert_equal(random.multivariate_t([0], [[1]], df=df).shape, (1,))
+        assert_equal(random.multivariate_t([0], [[1]], df=df, size=1).shape,
+                     (1, 1))
+        assert_equal(random.multivariate_t([0, 0], [[1, 0], [0, 1]],
+                                           df=df).shape, (2,))
+        assert_equal(random.multivariate_t([0, 0], [[1, 0], [0, 1]],
+                                           df=df, size=1).shape, (1, 2))
+        assert_equal(random.multivariate_t([0, 0], [[1, 0], [0, 1]],
+                                           df=df, size=[2, 2]).shape,
+                     (2, 2, 2))
+
+    def test_limiting_case(self):
+        rng = Generator(MT19937(self.seed))
+        rng2 = Generator(MT19937(self.seed))
+
+        rvs = rng.multivariate_t([0], [[1]], df=np.inf, size=100)
+        rvs_ex = rng2.multivariate_normal([0], [[1]], size=100)
+        assert_equal(rvs, rvs_ex)
+
+    def test_reproducibility(self):
+        rng = Generator(MT19937(self.seed))
+        rng2 = Generator(MT19937(self.seed))
+
+        rvs = rng.multivariate_t([0], [[1]], df=1., size=100)
+        rvs2 = rng2.multivariate_t([0], [[1]], df=1., size=100)
+        assert_equal(rvs, rvs2)
+
+        rng = Generator(MT19937(self.seed))
+        rvs = rng.multivariate_t([0, 0], [[1, 0], [0, 1]], df=1, size=5)
+        rvs_ex = np.array([[0.00990161, 0.06227337],
+                           [-0.87933569, -0.96921587],
+                           [0.97128127, 0.96660057],
+                           [-1.26135999, -0.51913132],
+                           [-0.72377948, 0.40111199]])
+        assert_allclose(rvs, rvs_ex, rtol=5e-7)
+
+
 class TestSetState:
     def setup(self):
         self.seed = 1234567890


### PR DESCRIPTION
I have added the multivariate t distribution to the random module. Basic tests and docs have also been added. I will add more docs and tests after some initial reviews. Some points to note:

- Broadcasting isn't supported because most multivariate distributions don't support it. I can add support for broadcasting if that is the right thing to do.
- Unlike `standard_t`, users can specify the mean and covariance matrix to shift and scale the distribution. I don't know if something like `multivariate_standard_t` would be preferred instead. I would personally prefer to let the users specify a mean/covariance even though it is easy to shift and scale the standard distribution.
