### PR TITLE
BUG: ma.testutils.assert_equal throws AssertionError on np.nan

### DIFF
--- a/numpy/ma/tests/test_testutils.py
+++ b/numpy/ma/tests/test_testutils.py
@@ -1,0 +1,97 @@
+from numpy.testing import assert_raises
+from numpy.testing import run_module_suite
+from numpy.ma.core import MaskError
+import numpy as np
+import numpy.ma as ma
+from numpy.ma.testutils import assert_equal
+
+
+class TestAssertEqual:
+    def test_dictionary(self):
+        dict_1 = {'a': 'b', 'c': 'd'}
+        dict_2 = {'a': 'b', 'c': 'd', 'e': 'f'}
+        dict_3 = {'a': 'a', 'b': 'b', 'c': 'c'}
+        tp_1 = ('foo')
+        arr_1 = np.array([1, 2])
+
+        assert_equal({}, {})
+        assert_equal(dict_1, dict_1)
+        assert_equal(dict_2, dict_2)
+
+        assert_raises(AssertionError, assert_equal, dict_1, dict_2)
+        assert_raises(AssertionError, assert_equal, dict_2, dict_3)
+        assert_raises(AssertionError, assert_equal, dict_1, dict_3)
+        assert_raises(AssertionError, assert_equal, dict_1, 1)
+        assert_raises(AssertionError, assert_equal, dict_1, {})
+        assert_raises(AssertionError, assert_equal, dict_1, [])
+        assert_raises(AssertionError, assert_equal, dict_1, tp_1)
+        assert_raises(AssertionError, assert_equal, dict_1, arr_1)
+
+    def test_nan(self):
+        assert_equal(np.nan, np.nan)
+
+        assert_raises(AssertionError, assert_equal, np.nan, 1)
+        assert_raises(AssertionError, assert_equal, np.nan, {})
+        assert_raises(AssertionError, assert_equal, np.nan, [1])
+        assert_raises(AssertionError, assert_equal, np.nan, 1.0)
+
+    def test_list(self):
+        assert_equal([], [])
+        assert_equal([1], [1])
+        assert_raises(AssertionError, assert_equal, [1], [2])
+        assert_raises(AssertionError, assert_equal, 1, [2])
+        assert_raises(AssertionError, assert_equal, "a", ["a"])
+        assert_raises(AssertionError, assert_equal, "1", [1])
+        assert_raises(AssertionError, assert_equal, [1], 2)
+        assert_raises(AssertionError, assert_equal, [1], 1)
+        assert_raises(AssertionError, assert_equal, 1, [1])
+
+    def test_tuple(self):
+        tp_1 = ('a')
+        tup_2 = ('a', 'b', 'c')
+
+        assert_equal((), ())
+        assert_equal(tp_1, tp_1)
+        assert_equal(tup_2, tup_2)
+
+        assert_raises(AssertionError, assert_equal, tp_1, tup_2)
+        assert_raises(AssertionError, assert_equal, tp_1, 1)
+        assert_raises(AssertionError, assert_equal, tp_1, np.nan)
+        assert_raises(AssertionError, assert_equal, tp_1, ['a'])
+
+    def test_masked_array(self):
+        masked_1 = ma.masked_all((3, 3))
+        masked_2 = ma.masked_all((2, 2))
+        assert_equal(masked_1, masked_1)
+        assert_equal(masked_2, masked_2)
+        assert_raises(MaskError, assert_equal, masked_1, 2)
+        assert_raises(MaskError, assert_equal, [1], masked_1)
+        assert_raises(ValueError, assert_equal, masked_1, masked_2)
+
+    def test_array(self):
+        arr_1 = np.array([1, np.nan])
+        array_2 = np.array([1, 2, 3])
+        array_3 = np.array([1, 2, 3])
+
+        assert_equal(arr_1, arr_1)
+        assert_equal(array_2, array_3)
+        assert_equal(arr_1, [1, np.nan])
+
+        assert_raises(AssertionError, assert_equal, arr_1, array_2)
+        assert_raises(AssertionError, assert_equal, array_2, arr_1)
+        assert_raises(AssertionError, assert_equal, arr_1, np.nan)
+        assert_raises(AssertionError, assert_equal, arr_1, 1)
+
+    def test_string(self):
+        assert_equal('', '')
+        assert_equal('a', 'a')
+
+        assert_raises(AssertionError, assert_equal, 'a', 'b')
+        assert_raises(AssertionError, assert_equal, 'a', {})
+        assert_raises(AssertionError, assert_equal, 'a', 1)
+        assert_raises(AssertionError, assert_equal, 'a', [1])
+        assert_raises(AssertionError, assert_equal, 'a', np.nan)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -108,8 +108,12 @@ def assert_equal_records(a, b):
 def assert_equal(actual, desired, err_msg=''):
     """
     Asserts that two items are equal.
-
     """
+    # Default to ndarray version if nothing masked
+    if not (isinstance(actual, masked_array) or
+            isinstance(desired, masked_array)):
+        return np.testing.assert_equal(actual, desired)
+
     # Case #1: dictionary .....
     if isinstance(desired, dict):
         if not isinstance(actual, dict):

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -108,12 +108,8 @@ def assert_equal_records(a, b):
 def assert_equal(actual, desired, err_msg=''):
     """
     Asserts that two items are equal.
+    
     """
-    # Default to ndarray version if nothing masked
-    if not (isinstance(actual, masked_array) or
-            isinstance(desired, masked_array)):
-        return np.testing.assert_equal(actual, desired)
-
     # Case #1: dictionary .....
     if isinstance(desired, dict):
         if not isinstance(actual, dict):
@@ -130,7 +126,8 @@ def assert_equal(actual, desired, err_msg=''):
     if not (isinstance(actual, ndarray) or isinstance(desired, ndarray)):
         msg = build_err_msg([actual, desired], err_msg,)
         if not desired == actual:
-            raise AssertionError(msg)
+            # Handle case using testing.assert_equal
+            return np.testing.assert_equal(actual, desired)
         return
     # Case #4. arrays or equivalent
     if ((actual is masked) and not (desired is masked)) or \


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->


Fixes #6661, #20022. `np.ma.testutils.assert_equal` now defaults to `np.testing.assert_equal` if actual or desired are not masked

### Previously
```py
>>> import numpy as np
>>> np.testing.assert_qual(np.nan, np.nan)
>>> np.ma.testutils.assert_equal(np.nan, np.nan)
AssertionError: 
Items are not equal:
 ACTUAL: nan
 DESIRED: nan
```

### After Fix
```py
>>> import numpy as np
>>> np.testing.assert_qual(np.nan, np.nan)
>>> np.ma.testutils.assert_equal(np.nan, np.nan)
```
 