### PR TITLE
ENH: core: More informative error message for broadcast(*args)

### DIFF
--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3511,6 +3511,12 @@ class TestBroadcast:
 
         assert_raises(ValueError, np.broadcast, 1, **{'x': 1})
 
+    def test_shape_mismatch_error_message(self):
+        with pytest.raises(ValueError, match=r"arg 0 with shape \(1, 3\) and "
+                                             r"arg 2 with shape \(2,\)"):
+            np.broadcast([[1, 2, 3]], [[4], [5]], [6, 7])
+
+
 class TestKeepdims:
 
     class sub_array(np.ndarray):


### PR DESCRIPTION
When broadcast(*args) fails because of a shape mismatch, include
in the error message which arguments caused the mismatch and what
their shapes are.

For example, instead of

    >>> np.broadcast([[0, 0, 0]], [[1], [1]], [2, 2])
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    ValueError: shape mismatch: objects cannot be broadcast to a
    single shape

we now get

    >>> np.broadcast([[0, 0, 0]], [[1], [1]], [2, 2])
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    ValueError: shape mismatch: objects cannot be broadcast to a
    single shape.  Mismatch is between arg 0 with shape (1, 3) and
    arg 2 with shape (2,).

This also affects broadcast_arrays() and broadcast_shapes().

Closes gh-8345.
