### PR TITLE
ENH: Add missing parameters to the `nan<x>` functions

### DIFF
--- a/doc/release/upcoming_changes/20027.improvement.rst
+++ b/doc/release/upcoming_changes/20027.improvement.rst
@@ -1,0 +1,17 @@
+Missing parameters have been added to the ``nan<x>`` functions
+--------------------------------------------------------------
+A number of the ``nan<x>`` functions previously lacked parameters that were
+present in their ``<x>``-based counterpart, *e.g.* the ``where`` parameter was
+present in `~numpy.mean` but absent from `~numpy.nanmean`.
+
+The following parameters have now been added to the ``nan<x>`` functions:
+
+* nanmin: ``initial`` & ``where``
+* nanmax: ``initial`` & ``where``
+* nanargmin: ``keepdims`` & ``out``
+* nanargmax: ``keepdims`` & ``out``
+* nansum: ``initial`` & ``where``
+* nanprod: ``initial`` & ``where``
+* nanmean: ``where``
+* nanvar: ``where``
+* nanstd: ``where``

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1144,6 +1144,8 @@ def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the array.
 
+        .. versionadded:: 1.22.0
+
     Returns
     -------
     index_array : ndarray of ints
@@ -1237,6 +1239,8 @@ def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the array.
+
+        .. versionadded:: 1.22.0
 
     Returns
     -------

--- a/numpy/lib/nanfunctions.pyi
+++ b/numpy/lib/nanfunctions.pyi
@@ -1,54 +1,40 @@
 from typing import List
 
+from numpy.core.fromnumeric import (
+    amin,
+    amax,
+    argmin,
+    argmax,
+    sum,
+    prod,
+    cumsum,
+    cumprod,
+    mean,
+    var,
+    std
+)
+
+from numpy.lib.function_base import (
+    median,
+    percentile,
+    quantile,
+)
+
 __all__: List[str]
 
-def nanmin(a, axis=..., out=..., keepdims=...): ...
-def nanmax(a, axis=..., out=..., keepdims=...): ...
-def nanargmin(a, axis=...): ...
-def nanargmax(a, axis=...): ...
-def nansum(a, axis=..., dtype=..., out=..., keepdims=...): ...
-def nanprod(a, axis=..., dtype=..., out=..., keepdims=...): ...
-def nancumsum(a, axis=..., dtype=..., out=...): ...
-def nancumprod(a, axis=..., dtype=..., out=...): ...
-def nanmean(a, axis=..., dtype=..., out=..., keepdims=...): ...
-def nanmedian(
-    a,
-    axis=...,
-    out=...,
-    overwrite_input=...,
-    keepdims=...,
-): ...
-def nanpercentile(
-    a,
-    q,
-    axis=...,
-    out=...,
-    overwrite_input=...,
-    interpolation=...,
-    keepdims=...,
-): ...
-def nanquantile(
-    a,
-    q,
-    axis=...,
-    out=...,
-    overwrite_input=...,
-    interpolation=...,
-    keepdims=...,
-): ...
-def nanvar(
-    a,
-    axis=...,
-    dtype=...,
-    out=...,
-    ddof=...,
-    keepdims=...,
-): ...
-def nanstd(
-    a,
-    axis=...,
-    dtype=...,
-    out=...,
-    ddof=...,
-    keepdims=...,
-): ...
+# NOTE: In reaility these functions are not aliases but distinct functions
+# with identical signatures.
+nanmin = amin
+nanmax = amax
+nanargmin = argmin
+nanargmax = argmax
+nansum = sum
+nanprod = prod
+nancumsum = cumsum
+nancumprod = cumprod
+nanmean = mean
+nanvar = var
+nanstd = std
+nanmedian = median
+nanpercentile = percentile
+nanquantile = quantile

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1,5 +1,6 @@
 import warnings
 import pytest
+import inspect
 
 import numpy as np
 from numpy.lib.nanfunctions import _nan_mask, _replace_nan
@@ -33,6 +34,53 @@ _ndat_zeros = np.array([[0.6244, 0.0, 0.2692, 0.0116, 0.0, 0.1170],
                         [0.5351, -0.9403, 0.0, 0.2100, 0.4759, 0.2833],
                         [0.0, 0.0, 0.0, 0.1042, 0.0, -0.5954],
                         [0.1610, 0.0, 0.0, 0.1859, 0.3146, 0.0]])
+
+
+class TestSignatureMatch:
+    NANFUNCS = {
+        np.nanmin: np.amin,
+        np.nanmax: np.amax,
+        np.nanargmin: np.argmin,
+        np.nanargmax: np.argmax,
+        np.nansum: np.sum,
+        np.nanprod: np.prod,
+        np.nancumsum: np.cumsum,
+        np.nancumprod: np.cumprod,
+        np.nanmean: np.mean,
+        np.nanmedian: np.median,
+        np.nanpercentile: np.percentile,
+        np.nanquantile: np.quantile,
+        np.nanvar: np.var,
+        np.nanstd: np.std,
+    }
+    IDS = [k.__name__ for k in NANFUNCS]
+
+    @staticmethod
+    def get_signature(func, default="..."):
+        """Construct a signature and replace all default parameter-values."""
+        prm_list = []
+        signature = inspect.signature(func)
+        for prm in signature.parameters.values():
+            if prm.default is inspect.Parameter.empty:
+                prm_list.append(prm)
+            else:
+                prm_list.append(prm.replace(default=default))
+        return inspect.Signature(prm_list)
+
+    @pytest.mark.parametrize("nan_func,func", NANFUNCS.items(), ids=IDS)
+    def test_signature_match(self, nan_func, func):
+        # Ignore the default parameter-values as they can sometimes differ
+        # between the two functions (*e.g.* one has `False` while the other
+        # has `np._NoValue`)
+        signature = self.get_signature(func)
+        nan_signature = self.get_signature(nan_func)
+        np.testing.assert_equal(signature, nan_signature)
+
+    def test_exhaustiveness(self):
+        """Validate that all nan functions are actually tested."""
+        np.testing.assert_equal(
+            set(self.IDS), set(np.lib.nanfunctions.__all__)
+        )
 
 
 class TestNanFunctions_MinMax:


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/20024

A number of the ``nan<x>`` functions previously lacked parameters that werepresent in their ``<x>``-based counterpart, 
*e.g.* the ``where`` parameter was present in `np.mean` but absent from `np.nanmean`.

This PR thus ports the following (previously missing) parameters to the ``nan<x>`` functions:

* nanmin: ``initial`` & ``where``
* nanmax: ``initial`` & ``where``
* nanargmin: ``keepdims`` & ``out``
* nanargmax: ``keepdims`` & ``out``
* nansum: ``initial`` & ``where``
* nanprod: ``initial`` & ``where``
* nanmean: ``where``
* nanvar: ``where``
* nanstd: ``where``