### PR TITLE
ENH: Add annotations for `np.lib.function_base` part 3/3

### DIFF
--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -24,13 +24,16 @@ else:
 
 from numpy import (
     vectorize as vectorize,
+    ufunc,
     dtype,
     generic,
     floating,
     complexfloating,
+    intp,
     float64,
     complex128,
     timedelta64,
+    datetime64,
     object_,
     _OrderKACF,
 )
@@ -44,9 +47,11 @@ from numpy.typing import (
     _SupportsDType,
     _FiniteNestedSequence,
     _SupportsArray,
-    _ArrayLikeComplex_co,
+    _ArrayLikeInt_co,
     _ArrayLikeFloat_co,
+    _ArrayLikeComplex_co,
     _ArrayLikeTD64_co,
+    _ArrayLikeDT64_co,
     _ArrayLikeObject_co,
     _FloatLike_co,
     _ComplexLike_co,
@@ -87,7 +92,8 @@ class _SupportsWriteFlush(Protocol):
 
 __all__: List[str]
 
-add_newdoc_ufunc = _add_newdoc_ufunc
+# NOTE: This is in reality a re-export of `np.core.umath._add_newdoc_ufunc`
+def add_newdoc_ufunc(ufunc: ufunc, new_docstring: str, /) -> None: ...
 
 @overload
 def rot90(
@@ -494,11 +500,197 @@ def median(
     keepdims: bool = ...,
 ) -> _ArrayType: ...
 
-def percentile(a, q, axis=..., out=..., overwrite_input=..., interpolation=..., keepdims=...): ...
-def quantile(a, q, axis=..., out=..., overwrite_input=..., interpolation=..., keepdims=...): ...
-def trapz(y, x=..., dx=..., axis=...): ...
-def meshgrid(*xi, copy=..., sparse=..., indexing=...): ...
-def delete(arr, obj, axis=...): ...
-def insert(arr, obj, values, axis=...): ...
-def append(arr, values, axis=...): ...
-def digitize(x, bins, right=...): ...
+_InterpolationKind = L[
+    "lower",
+    "higher",
+    "midpoint",
+    "nearest",
+    "linear",
+]
+
+@overload
+def percentile(
+    a: _ArrayLikeFloat_co,
+    q: _FloatLike_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> floating[Any]: ...
+@overload
+def percentile(
+    a: _ArrayLikeComplex_co,
+    q: _FloatLike_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> complexfloating[Any, Any]: ...
+@overload
+def percentile(
+    a: _ArrayLikeTD64_co,
+    q: _FloatLike_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> timedelta64: ...
+@overload
+def percentile(
+    a: _ArrayLikeDT64_co,
+    q: _FloatLike_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> datetime64: ...
+@overload
+def percentile(
+    a: _ArrayLikeObject_co,
+    q: _FloatLike_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> Any: ...
+@overload
+def percentile(
+    a: _ArrayLikeFloat_co,
+    q: _ArrayLikeFloat_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def percentile(
+    a: _ArrayLikeComplex_co,
+    q: _ArrayLikeFloat_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def percentile(
+    a: _ArrayLikeTD64_co,
+    q: _ArrayLikeFloat_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def percentile(
+    a: _ArrayLikeDT64_co,
+    q: _ArrayLikeFloat_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> NDArray[datetime64]: ...
+@overload
+def percentile(
+    a: _ArrayLikeObject_co,
+    q: _ArrayLikeFloat_co,
+    axis: None = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: L[False] = ...,
+) -> NDArray[object_]: ...
+@overload
+def percentile(
+    a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    q: _ArrayLikeFloat_co,
+    axis: None | _ShapeLike = ...,
+    out: None = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: bool = ...,
+) -> Any: ...
+@overload
+def percentile(
+    a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    q: _ArrayLikeFloat_co,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    overwrite_input: bool = ...,
+    interpolation: _InterpolationKind = ...,
+    keepdims: bool = ...,
+) -> _ArrayType: ...
+
+# NOTE: Not an alias, but they do have identical signatures
+# (that we can reuse)
+quantile = percentile
+
+# TODO: Returns a scalar for <= 1D array-likes; returns an ndarray otherwise
+def trapz(
+    y: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    x: None | _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co = ...,
+    dx: float = ...,
+    axis: SupportsIndex = ...,
+) -> Any: ...
+
+def meshgrid(
+    *xi: ArrayLike,
+    copy: bool = ...,
+    sparse: bool = ...,
+    indexing: L["xy", "ij"] = ...,
+) -> List[NDArray[Any]]: ...
+
+@overload
+def delete(
+    arr: _ArrayLike[_SCT],
+    obj: slice | _ArrayLikeInt_co,
+    axis: None | SupportsIndex = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def delete(
+    arr: ArrayLike,
+    obj: slice | _ArrayLikeInt_co,
+    axis: None | SupportsIndex = ...,
+) -> NDArray[Any]: ...
+
+@overload
+def insert(
+    arr: _ArrayLike[_SCT],
+    obj: slice | _ArrayLikeInt_co,
+    values: ArrayLike,
+    axis: None | SupportsIndex = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def insert(
+    arr: ArrayLike,
+    obj: slice | _ArrayLikeInt_co,
+    values: ArrayLike,
+    axis: None | SupportsIndex = ...,
+) -> NDArray[Any]: ...
+
+def append(
+    arr: ArrayLike,
+    values: ArrayLike,
+    axis: None | SupportsIndex = ...,
+) -> NDArray[Any]: ...
+
+@overload
+def digitize(
+    x: _FloatLike_co,
+    bins: _ArrayLikeFloat_co,
+    right: bool = ...,
+) -> intp: ...
+@overload
+def digitize(
+    x: _ArrayLikeFloat_co,
+    bins: _ArrayLikeFloat_co,
+    right: bool = ...,
+) -> NDArray[intp]: ...

--- a/numpy/typing/tests/data/fail/lib_function_base.pyi
+++ b/numpy/typing/tests/data/fail/lib_function_base.pyi
@@ -9,6 +9,8 @@ AR_m: npt.NDArray[np.timedelta64]
 AR_M: npt.NDArray[np.datetime64]
 AR_O: npt.NDArray[np.object_]
 
+def func(a: int) -> None: ...
+
 np.average(AR_m)  # E: incompatible type
 np.select(1, [AR_f8])  # E: incompatible type
 np.angle(AR_m)  # E: incompatible type
@@ -39,3 +41,13 @@ np.hamming(AR_c16)  # E: incompatible type
 np.kaiser(1j, 1)  # E: incompatible type
 np.sinc(AR_O)  # E: incompatible type
 np.median(AR_M)  # E: incompatible type
+
+np.add_newdoc_ufunc(func, "docstring")  # E: incompatible type
+np.percentile(AR_f8, 50j)  # E: No overload variant
+np.percentile(AR_f8, 50, interpolation="bob")  # E: No overload variant
+np.quantile(AR_f8, 0.5j)  # E: No overload variant
+np.quantile(AR_f8, 0.5, interpolation="bob")  # E: No overload variant
+np.meshgrid(AR_f8, AR_f8, indexing="bob")  # E: incompatible type
+np.delete(AR_f8, AR_f8)  # E: incompatible type
+np.insert(AR_f8, AR_f8, 1.5)  # E: incompatible type
+np.digitize(AR_f8, 1j)  # E: No overload variant

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -12,6 +12,7 @@ AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]
 AR_c16: npt.NDArray[np.complex128]
 AR_m: npt.NDArray[np.timedelta64]
+AR_M: npt.NDArray[np.datetime64]
 AR_O: npt.NDArray[np.object_]
 AR_b: npt.NDArray[np.bool_]
 AR_U: npt.NDArray[np.str_]
@@ -132,3 +133,48 @@ reveal_type(np.median(AR_O))  # E: Any
 reveal_type(np.median(AR_f8, keepdims=True))  # E: Any
 reveal_type(np.median(AR_c16, axis=0))  # E: Any
 reveal_type(np.median(AR_LIKE_f8, out=AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[{complex128}]]
+
+reveal_type(np.add_newdoc_ufunc(np.add, "docstring"))  # E: None
+
+reveal_type(np.percentile(AR_f8, 50))  # E: numpy.floating[Any]
+reveal_type(np.percentile(AR_c16, 50))  # E: numpy.complexfloating[Any, Any]
+reveal_type(np.percentile(AR_m, 50))  # E: numpy.timedelta64
+reveal_type(np.percentile(AR_M, 50, overwrite_input=True))  # E: numpy.datetime64
+reveal_type(np.percentile(AR_O, 50))  # E: Any
+reveal_type(np.percentile(AR_f8, [50]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.percentile(AR_c16, [50]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.percentile(AR_m, [50]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.percentile(AR_M, [50], interpolation="nearest"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.datetime64]]
+reveal_type(np.percentile(AR_O, [50]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
+reveal_type(np.percentile(AR_f8, [50], keepdims=True))  # E: Any
+reveal_type(np.percentile(AR_f8, [50], axis=[1]))  # E: Any
+reveal_type(np.percentile(AR_f8, [50], out=AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[{complex128}]]
+
+reveal_type(np.quantile(AR_f8, 0.5))  # E: numpy.floating[Any]
+reveal_type(np.quantile(AR_c16, 0.5))  # E: numpy.complexfloating[Any, Any]
+reveal_type(np.quantile(AR_m, 0.5))  # E: numpy.timedelta64
+reveal_type(np.quantile(AR_M, 0.5, overwrite_input=True))  # E: numpy.datetime64
+reveal_type(np.quantile(AR_O, 0.5))  # E: Any
+reveal_type(np.quantile(AR_f8, [0.5]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.quantile(AR_c16, [0.5]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.quantile(AR_m, [0.5]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.quantile(AR_M, [0.5], interpolation="nearest"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.datetime64]]
+reveal_type(np.quantile(AR_O, [0.5]))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
+reveal_type(np.quantile(AR_f8, [0.5], keepdims=True))  # E: Any
+reveal_type(np.quantile(AR_f8, [0.5], axis=[1]))  # E: Any
+reveal_type(np.quantile(AR_f8, [0.5], out=AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[{complex128}]]
+
+reveal_type(np.meshgrid(AR_f8, AR_i8, copy=False))  # E: list[numpy.ndarray[Any, numpy.dtype[Any]]]
+reveal_type(np.meshgrid(AR_f8, AR_i8, AR_c16, indexing="ij"))  # E: list[numpy.ndarray[Any, numpy.dtype[Any]]]
+
+reveal_type(np.delete(AR_f8, np.s_[:5]))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.delete(AR_LIKE_f8, [0, 4, 9], axis=0))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+
+reveal_type(np.insert(AR_f8, np.s_[:5], 5))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.insert(AR_LIKE_f8, [0, 4, 9], [0.5, 9.2, 7], axis=0))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+
+reveal_type(np.append(AR_f8, 5))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.append(AR_LIKE_f8, 1j, axis=0))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+
+reveal_type(np.digitize(4.5, [1]))  # E: {intp}
+reveal_type(np.digitize(AR_f8, [1, 2, 3]))  # E: numpy.ndarray[Any, numpy.dtype[{intp}]]


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/20034

The last PR in a series for adding `np.lib.function_base` annotations.

Adds annotations for the following functions:
* `add_newdoc_ufunc`
* `quantile`
* `percentile`
* `trapz`
* `meshgrid`
* `delete`
* `insert`
* `append`
* `digitize`
