### PR TITLE
MAINT: Fixed an issue wherein `npt._NestedSequence` was not a `range` supertype

### DIFF
--- a/numpy/typing/_nested_sequence.py
+++ b/numpy/typing/_nested_sequence.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import (
     Any,
     Iterator,
@@ -86,8 +85,6 @@ class _NestedSequence(Protocol[_T_co]):
         """Return the number of occurrences of `value`."""
         raise NotImplementedError
 
-    def index(
-        self, value: Any, start: int = 0, stop: int = sys.maxsize, /
-    ) -> int:
+    def index(self, value: Any, /) -> int:
         """Return the first index of `value`."""
         raise NotImplementedError

--- a/numpy/typing/tests/data/reveal/nested_sequence.pyi
+++ b/numpy/typing/tests/data/reveal/nested_sequence.pyi
@@ -21,3 +21,4 @@ reveal_type(func(e))  # E: None
 reveal_type(func(f))  # E: None
 reveal_type(func(g))  # E: None
 reveal_type(func(h))  # E: None
+reveal_type(func(range(15)))  # E: None


### PR DESCRIPTION
The recently introduced `npt._NestedSequence` protocol (used in the definition of `npt.ArrayLike`) would 
previously failed to recognize `range` objects as valid subtypes.

The root of this issue lies in the fact that `range` does not fully conform to the interface specified 
by the `collections.abc.Sequence` ABC (despite claiming to do so), as `range.index` lacks the `start` 
and `stop` parameters. The resulting signature mismatch would consequently exclude `range`from being a `npt._NestedSequence` subtype, as protocol (sub-)typing is exclusivelly based on signature matching.
