### PR TITLE
TST: Add python 3.10 to the CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10.0-rc.2]
+        python-version: [3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ MAJOR, MINOR, MICRO = re.match(r'(\d+)\.(\d+)\.(\d+)', FULLVERSION).groups()
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 # The first version not in the `Programming Language :: Python :: ...` classifiers above
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 11):
     fmt = "NumPy {} may not yet support Python {}.{}."
     warnings.warn(
         fmt.format(VERSION, *sys.version_info[:2]),


### PR DESCRIPTION
Looks like the Python 3.10 release has officially arrived: https://docs.python.org/3.10/whatsnew/3.10.html