### PR TITLE
MAINT: Define old header guard in ndarrayobject.h

### DIFF
--- a/numpy/core/include/numpy/ndarrayobject.h
+++ b/numpy/core/include/numpy/ndarrayobject.h
@@ -4,6 +4,12 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NDARRAYOBJECT_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NDARRAYOBJECT_H_
 
+/*
+ * define old header guard for backwards compatibility
+ * with older Cython. This can be removed at some point.
+ */
+#define NPY_NDARRAYOBJECT_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Cython was checking for the presence of that header guard. See https://github.com/scipy/scipy/issues/14732.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
