### PR TITLE
BUG,ENH: Use F2PyDict_SetItemString everywhere

### DIFF
--- a/numpy/f2py/common_rules.py
+++ b/numpy/f2py/common_rules.py
@@ -122,7 +122,6 @@ def buildhooks(m):
         cadd('}\n')
         iadd('\ttmp = PyFortranObject_New(f2py_%s_def,f2py_init_%s);' % (name, name))
         iadd('\tF2PyDict_SetItemString(d, \"%s\", tmp);' % name)
-        iadd('\tPy_DECREF(tmp);')
         tname = name.replace('_', '\\_')
         dadd('\\subsection{Common block \\texttt{%s}}\n' % (tname))
         dadd('\\begin{description}')

--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -237,7 +237,7 @@ def buildhooks(pymod):
              % (F_FUNC, m['name'], m['name'].upper(), m['name']))
         iadd('}\n')
         ret['f90modhooks'] = ret['f90modhooks'] + chooks + ihooks
-        ret['initf90modhooks'] = ['\tPyDict_SetItemString(d, "%s", PyFortranObject_New(f2py_%s_def,f2py_init_%s));' % (
+        ret['initf90modhooks'] = ['\tF2PyDict_SetItemString(d, "%s", PyFortranObject_New(f2py_%s_def,f2py_init_%s));' % (
             m['name'], m['name'], m['name'])] + ret['initf90modhooks']
         fadd('')
         fadd('subroutine f2pyinit%s(f2pysetupfunc)' % (m['name']))

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -204,26 +204,21 @@ PyMODINIT_FUNC PyInit_#modulename#(void) {
         {PyErr_SetString(PyExc_ImportError, \"can't initialize module #modulename# (failed to import numpy)\"); return m;}
     d = PyModule_GetDict(m);
     s = PyUnicode_FromString(\"#f2py_version#\");
-    PyDict_SetItemString(d, \"__version__\", s);
-    Py_DECREF(s);
+    F2PyDict_SetItemString(d, \"__version__\", s);
     s = PyUnicode_FromString(
         \"This module '#modulename#' is auto-generated with f2py (version:#f2py_version#).\\nFunctions:\\n\"\n#docs#\".\");
-    PyDict_SetItemString(d, \"__doc__\", s);
-    Py_DECREF(s);
+    F2PyDict_SetItemString(d, \"__doc__\", s);
     s = PyUnicode_FromString(\"""" + numpy_version + """\");
-    PyDict_SetItemString(d, \"__f2py_numpy_version__\", s);
-    Py_DECREF(s);
+    F2PyDict_SetItemString(d, \"__f2py_numpy_version__\", s);
     #modulename#_error = PyErr_NewException (\"#modulename#.error\", NULL, NULL);
     /*
      * Store the error object inside the dict, so that it could get deallocated.
      * (in practice, this is a module, so it likely will not and cannot.)
      */
-    PyDict_SetItemString(d, \"_#modulename#_error\", #modulename#_error);
-    Py_DECREF(#modulename#_error);
+    F2PyDict_SetItemString(d, \"_#modulename#_error\", #modulename#_error);
     for(i=0;f2py_routine_defs[i].name!=NULL;i++) {
         tmp = PyFortranObject_NewAsAttr(&f2py_routine_defs[i]);
-        PyDict_SetItemString(d, f2py_routine_defs[i].name, tmp);
-        Py_DECREF(tmp);
+        F2PyDict_SetItemString(d, f2py_routine_defs[i].name, tmp);
     }
 #initf2pywraphooks#
 #initf90modhooks#

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -31,7 +31,7 @@ F2PyDict_SetItemString(PyObject *dict, char *name, PyObject *obj)
     }
     else {
         retval = PyDict_SetItemString(dict, name, obj);
-        Py_XDECREF(obj);  // Cannot be NULL, is OK
+        Py_DECREF(obj);
     }
     return retval;
 }

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -149,14 +149,12 @@ PyMODINIT_FUNC PyInit_test_array_from_pyobj_ext(void) {
   s = PyUnicode_FromString("This module 'wrap' is auto-generated with f2py (version:2_1330).\nFunctions:\n"
                            "  arr = call(type_num,dims,intent,obj)\n"
                            ".");
-  PyDict_SetItemString(d, "__doc__", s);
+  F2PyDict_SetItemString(d, "__doc__", s);
   wrap_error = PyErr_NewException ("wrap.error", NULL, NULL);
-  Py_DECREF(s);
 
 #define ADDCONST(NAME, CONST)              \
     s = PyLong_FromLong(CONST);             \
-    PyDict_SetItemString(d, NAME, s);      \
-    Py_DECREF(s)
+    F2PyDict_SetItemString(d, NAME, s);      \
 
   ADDCONST("F2PY_INTENT_IN", F2PY_INTENT_IN);
   ADDCONST("F2PY_INTENT_INOUT", F2PY_INTENT_INOUT);


### PR DESCRIPTION
It is safer, and makes for smaller, easier to reason about wrappers.
Also allows for using the faster DECREF where it is known to be non-NULL

What this PR does:
- Improves `F2PyDict_SetItemString` to deal with the refcount correctly (`PyDict_SetItemString(PyObject *p, const char *key, PyObject *val)` doesn't steal a reference for `*val`
- Changes `PyDict_SetItemString` to `F2PyDict_SetItemString` everywhere
  - Cleaning things up a lot

Closes #19573.