### PR TITLE
MAINT: update OpenBLAS to 0.3.18

### DIFF
--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.17'
-OPENBLAS_LONG = 'v0.3.17'
+OPENBLAS_V = '0.3.18'
+OPENBLAS_LONG = 'v0.3.18'
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [


### PR DESCRIPTION
This version was released 4 days ago. https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.18 for the release notes.