### PR TITLE
MAINT: Remove encoding declarations: `# -*- coding: utf-8 -*-`

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # NumPy Enhancement Proposals documentation build configuration file, created by
 # sphinx-quickstart on Mon Dec 11 12:45:09 2017.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import re
 import sys

--- a/numpy/core/tests/test_arrayprint.py
+++ b/numpy/core/tests/test_arrayprint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import gc
 from hypothesis import given

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ Test printing of scalar types.
 
 """

--- a/numpy/core/tests/test_scalarprint.py
+++ b/numpy/core/tests/test_scalarprint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ Test printing of scalar types.
 
 """

--- a/numpy/doc/constants.py
+++ b/numpy/doc/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 =========
 Constants

--- a/numpy/ma/bench.py
+++ b/numpy/ma/bench.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import timeit
 import numpy

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- encoding:utf-8 -*-
 """
 Script to generate contributor and pull request lists
 

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- encoding:utf-8 -*-
 """
 Script to download NumPy wheels from the Anaconda staging area.
 


### PR DESCRIPTION
In Python 3, the [default source file encoding is UTF-8](https://docs.python.org/3/reference/lexical_analysis.html#encoding-declarations).