### PR TITLE
MAINT, DOC: get rid of unicode, unicode_, string_

### DIFF
--- a/numpy/core/_dtype.py
+++ b/numpy/core/_dtype.py
@@ -114,13 +114,13 @@ def _scalar_str(dtype, short):
         # platforms, so it should never include the itemsize here.
         return "'O'"
 
-    elif dtype.type == np.string_:
+    elif dtype.type == np.bytes_:
         if _isunsized(dtype):
             return "'S'"
         else:
             return "'S%d'" % dtype.itemsize
 
-    elif dtype.type == np.unicode_:
+    elif dtype.type == np.str_:
         if _isunsized(dtype):
             return "'%sU'" % byteorder
         else:

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -169,7 +169,7 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
         - 'longfloat' : 128-bit floats
         - 'complexfloat'
         - 'longcomplexfloat' : composed of two 128-bit floats
-        - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
+        - 'numpystr' : types `numpy.bytes_` and `numpy.str_`
         - 'object' : `np.object_` arrays
 
         Other keys that can be used to set a group of types at once are:
@@ -475,7 +475,7 @@ def _get_format_function(data, **options):
             return formatdict['longcomplexfloat']()
         else:
             return formatdict['complexfloat']()
-    elif issubclass(dtypeobj, (_nt.unicode_, _nt.string_)):
+    elif issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
         return formatdict['numpystr']()
     elif issubclass(dtypeobj, _nt.datetime64):
         return formatdict['datetime']()
@@ -616,7 +616,7 @@ def array2string(a, max_line_width=None, precision=None,
         - 'complexfloat'
         - 'longcomplexfloat' : composed of two 128-bit floats
         - 'void' : type `numpy.void`
-        - 'numpystr' : types `numpy.string_` and `numpy.unicode_`
+        - 'numpystr' : types `numpy.bytes_` and `numpy.str_`
 
         Other keys that can be used to set a group of types at once are:
 

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1850,7 +1850,7 @@ def isnumeric(a):
     For each element, return True if there are only numeric
     characters in the element.
 
-    Calls `unicode.isnumeric` element-wise.
+    Calls `str.isnumeric` element-wise.
 
     Numeric characters include digit characters, and all characters
     that have the Unicode numeric value property, e.g. ``U+2155,
@@ -1868,7 +1868,7 @@ def isnumeric(a):
 
     See Also
     --------
-    unicode.isnumeric
+    str.isnumeric
 
     Examples
     --------
@@ -1887,7 +1887,7 @@ def isdecimal(a):
     For each element, return True if there are only decimal
     characters in the element.
 
-    Calls `unicode.isdecimal` element-wise.
+    Calls `str.isdecimal` element-wise.
 
     Decimal characters include digit characters, and all characters
     that can be used to form decimal-radix numbers,
@@ -1905,7 +1905,7 @@ def isdecimal(a):
 
     See Also
     --------
-    unicode.isdecimal
+    str.isdecimal
 
     Examples
     --------

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -6,7 +6,7 @@ operations and methods.
    The `chararray` class exists for backwards compatibility with
    Numarray, it is not recommended for new development. Starting from numpy
    1.4, if one needs arrays of strings, it is recommended to use arrays of
-   `dtype` `object_`, `string_` or `unicode_`, and use the free functions
+   `dtype` `object_`, `bytes_` or `str_`, and use the free functions
    in the `numpy.char` module for fast vectorized string operations.
 
 Some methods will only be available if the corresponding string method is
@@ -19,7 +19,7 @@ import functools
 
 from .._utils import set_module
 from .numerictypes import (
-    string_, unicode_, integer, int_, object_, bool_, character)
+    bytes_, str_, integer, int_, object_, bool_, character)
 from .numeric import ndarray, compare_chararrays
 from .numeric import array as narray
 from numpy.core.multiarray import _vec_string
@@ -57,7 +57,7 @@ def _is_unicode(arr):
     return False
 
 
-def _to_string_or_unicode_array(result, output_dtype_like=None):
+def _to_bytes_or_str_array(result, output_dtype_like=None):
     """
     Helper function to cast a result back into an array
     with the appropriate dtype if an object array must be used
@@ -92,7 +92,7 @@ def _get_num_chars(a):
     a string or unicode array.  This is to abstract out the fact that
     for a unicode array this is itemsize / 4.
     """
-    if issubclass(a.dtype.type, unicode_):
+    if issubclass(a.dtype.type, str_):
         return a.itemsize // 4
     return a.itemsize
 
@@ -315,7 +315,7 @@ def add(x1, x2):
     Returns
     -------
     add : ndarray
-        Output array of `string_` or `unicode_`, depending on input types
+        Output array of `bytes_` or `str_`, depending on input types
         of the same shape as `x1` and `x2`.
 
     """
@@ -415,7 +415,7 @@ def mod(a, values):
     str.__mod__
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, '__mod__', (values,)), a)
 
 
@@ -509,7 +509,7 @@ def center(a, width, fillchar=' '):
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
-    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+    if numpy.issubdtype(a_arr.dtype, numpy.bytes_):
         fillchar = asbytes(fillchar)
     return _vec_string(
         a_arr, type(a_arr.dtype)(size), 'center', (width_arr, fillchar))
@@ -611,7 +611,7 @@ def decode(a, encoding=None, errors=None):
     array(['aAaAaA', '  aA  ', 'abBABba'], dtype='<U7')
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'decode', _clean_args(encoding, errors)))
 
 
@@ -647,7 +647,7 @@ def encode(a, encoding=None, errors=None):
     The type of the result will depend on the encoding specified.
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'encode', _clean_args(encoding, errors)))
 
 
@@ -735,7 +735,7 @@ def expandtabs(a, tabsize=8):
     str.expandtabs
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'expandtabs', (tabsize,)), a)
 
 
@@ -1055,7 +1055,7 @@ def join(sep, seq):
     array(['g-h-c', 'o.s.d'], dtype='<U5')
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(sep, object_, 'join', (seq,)), seq)
 
 
@@ -1094,7 +1094,7 @@ def ljust(a, width, fillchar=' '):
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
-    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+    if numpy.issubdtype(a_arr.dtype, numpy.bytes_):
         fillchar = asbytes(fillchar)
     return _vec_string(
         a_arr, type(a_arr.dtype)(size), 'ljust', (width_arr, fillchar))
@@ -1230,7 +1230,7 @@ def partition(a, sep):
     str.partition
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'partition', (sep,)), a)
 
 
@@ -1275,7 +1275,7 @@ def replace(a, old, new, count=None):
     >>> np.char.replace(a, 'is', 'was')
     array(['The dwash was fresh', 'Thwas was it'], dtype='<U19')
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'replace', [old, new] + _clean_args(count)), a)
 
 
@@ -1372,7 +1372,7 @@ def rjust(a, width, fillchar=' '):
     a_arr = numpy.asarray(a)
     width_arr = numpy.asarray(width)
     size = int(numpy.max(width_arr.flat))
-    if numpy.issubdtype(a_arr.dtype, numpy.string_):
+    if numpy.issubdtype(a_arr.dtype, numpy.bytes_):
         fillchar = asbytes(fillchar)
     return _vec_string(
         a_arr, type(a_arr.dtype)(size), 'rjust', (width_arr, fillchar))
@@ -1410,7 +1410,7 @@ def rpartition(a, sep):
     str.rpartition
 
     """
-    return _to_string_or_unicode_array(
+    return _to_bytes_or_str_array(
         _vec_string(a, object_, 'rpartition', (sep,)), a)
 
 
@@ -1766,7 +1766,7 @@ def translate(a, table, deletechars=None):
 
     """
     a_arr = numpy.asarray(a)
-    if issubclass(a_arr.dtype.type, unicode_):
+    if issubclass(a_arr.dtype.type, str_):
         return _vec_string(
             a_arr, a_arr.dtype, 'translate', (table,))
     else:
@@ -1931,7 +1931,7 @@ class chararray(ndarray):
        The `chararray` class exists for backwards compatibility with
        Numarray, it is not recommended for new development. Starting from numpy
        1.4, if one needs arrays of strings, it is recommended to use arrays of
-       `dtype` `object_`, `string_` or `unicode_`, and use the free functions
+       `dtype` `object_`, `bytes_` or `str_`, and use the free functions
        in the `numpy.char` module for fast vectorized string operations.
 
     Versus a regular NumPy array of type `str` or `unicode`, this
@@ -2065,9 +2065,9 @@ class chararray(ndarray):
         global _globalvar
 
         if unicode:
-            dtype = unicode_
+            dtype = str_
         else:
-            dtype = string_
+            dtype = bytes_
 
         # force itemsize to be a Python int, since using NumPy integer
         # types results in itemsize.itemsize being used as the size of
@@ -2191,7 +2191,7 @@ class chararray(ndarray):
     def __radd__(self, other):
         """
         Return (other + self), that is string concatenation,
-        element-wise for a pair of array_likes of `string_` or `unicode_`.
+        element-wise for a pair of array_likes of `bytes_` or `str_`.
 
         See Also
         --------
@@ -2224,8 +2224,8 @@ class chararray(ndarray):
     def __mod__(self, i):
         """
         Return (self % i), that is pre-Python 2.6 string formatting
-        (interpolation), element-wise for a pair of array_likes of `string_`
-        or `unicode_`.
+        (interpolation), element-wise for a pair of array_likes of `bytes_`
+        or `str_`.
 
         See Also
         --------
@@ -2735,7 +2735,7 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
     .. note::
        This class is provided for numarray backward-compatibility.
        New code (not concerned with numarray compatibility) should use
-       arrays of type `string_` or `unicode_` and use the free functions
+       arrays of type `bytes_` or `str_` and use the free functions
        in :mod:`numpy.char <numpy.core.defchararray>` for fast
        vectorized string operations instead.
 
@@ -2818,26 +2818,26 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
             # itemsize is in 8-bit chars, so for Unicode, we need
             # to divide by the size of a single Unicode character,
             # which for NumPy is always 4
-            if issubclass(obj.dtype.type, unicode_):
+            if issubclass(obj.dtype.type, str_):
                 itemsize //= 4
 
         if unicode is None:
-            if issubclass(obj.dtype.type, unicode_):
+            if issubclass(obj.dtype.type, str_):
                 unicode = True
             else:
                 unicode = False
 
         if unicode:
-            dtype = unicode_
+            dtype = str_
         else:
-            dtype = string_
+            dtype = bytes_
 
         if order is not None:
             obj = numpy.asarray(obj, order=order)
         if (copy or
                 (itemsize != obj.itemsize) or
-                (not unicode and isinstance(obj, unicode_)) or
-                (unicode and isinstance(obj, string_))):
+                (not unicode and isinstance(obj, str_)) or
+                (unicode and isinstance(obj, bytes_))):
             obj = obj.astype((dtype, int(itemsize)))
         return obj
 
@@ -2850,9 +2850,9 @@ def array(obj, itemsize=None, copy=True, unicode=None, order=None):
             # Fall through to the default case
 
     if unicode:
-        dtype = unicode_
+        dtype = str_
     else:
-        dtype = string_
+        dtype = bytes_
 
     if itemsize is None:
         val = narray(obj, dtype=dtype, order=order, subok=True)

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -320,7 +320,7 @@ def test_array_astype_warning(t):
 
 @pytest.mark.parametrize(["dtype", "out_dtype"],
         [(np.bytes_, np.bool_),
-         (np.unicode_, np.bool_),
+         (np.str_, np.bool_),
          (np.dtype("S10,S9"), np.dtype("?,?"))])
 def test_string_to_boolean_cast(dtype, out_dtype):
     """
@@ -334,7 +334,7 @@ def test_string_to_boolean_cast(dtype, out_dtype):
 
 @pytest.mark.parametrize(["dtype", "out_dtype"],
         [(np.bytes_, np.bool_),
-         (np.unicode_, np.bool_),
+         (np.str_, np.bool_),
          (np.dtype("S10,S9"), np.dtype("?,?"))])
 def test_string_to_boolean_cast_errors(dtype, out_dtype):
     """

--- a/numpy/core/tests/test_argparse.py
+++ b/numpy/core/tests/test_argparse.py
@@ -53,8 +53,8 @@ def test_multiple_values():
 def test_string_fallbacks():
     # We can (currently?) use numpy strings to test the "slow" fallbacks
     # that should normally not be taken due to string interning.
-    arg2 = np.unicode_("arg2")
-    missing_arg = np.unicode_("missing_arg")
+    arg2 = np.str_("arg2")
+    missing_arg = np.str_("missing_arg")
     func(1, **{arg2: 3})
     with pytest.raises(TypeError,
             match="got an unexpected keyword argument 'missing_arg'"):

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -130,7 +130,7 @@ def scalar_instances(times=True, extended_precision=True, user_dtype=True):
 
     # Strings and unstructured void:
     yield param(np.bytes_(b"1234"), id="bytes")
-    yield param(np.unicode_("2345"), id="unicode")
+    yield param(np.str_("2345"), id="unicode")
     yield param(np.void(b"4321"), id="unstructured_void")
 
 

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -719,8 +719,8 @@ class TestDateTime:
         assert_equal(uni_a, uni_b)
 
         # Datetime to long string - gh-9712
-        assert_equal(str_a, dt_a.astype((np.string_, 128)))
-        str_b = np.empty(str_a.shape, dtype=(np.string_, 128))
+        assert_equal(str_a, dt_a.astype((np.bytes_, 128)))
+        str_b = np.empty(str_a.shape, dtype=(np.bytes_, 128))
         str_b[...] = dt_a
         assert_equal(str_a, str_b)
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -31,7 +31,7 @@ class TestBasic:
     def test_from_string_array(self):
         A = np.array([[b'abc', b'foo'],
                       [b'long   ', b'0123456789']])
-        assert_equal(A.dtype.type, np.string_)
+        assert_equal(A.dtype.type, np.bytes_)
         B = np.char.array(A)
         assert_array_equal(B, A)
         assert_equal(B.dtype, A.dtype)
@@ -48,7 +48,7 @@ class TestBasic:
     def test_from_unicode_array(self):
         A = np.array([['abc', 'Sigma \u03a3'],
                       ['long   ', '0123456789']])
-        assert_equal(A.dtype.type, np.unicode_)
+        assert_equal(A.dtype.type, np.str_)
         B = np.char.array(A)
         assert_array_equal(B, A)
         assert_equal(B.dtype, A.dtype)
@@ -66,40 +66,40 @@ class TestBasic:
     def test_unicode_upconvert(self):
         A = np.char.array(['abc'])
         B = np.char.array(['\u03a3'])
-        assert_(issubclass((A + B).dtype.type, np.unicode_))
+        assert_(issubclass((A + B).dtype.type, np.str_))
 
     def test_from_string(self):
         A = np.char.array(b'abc')
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 3)
-        assert_(issubclass(A.dtype.type, np.string_))
+        assert_(issubclass(A.dtype.type, np.bytes_))
 
     def test_from_unicode(self):
         A = np.char.array('\u03a3')
         assert_equal(len(A), 1)
         assert_equal(len(A[0]), 1)
         assert_equal(A.itemsize, 4)
-        assert_(issubclass(A.dtype.type, np.unicode_))
+        assert_(issubclass(A.dtype.type, np.str_))
 
 class TestVecString:
     def test_non_existent_method(self):
 
         def fail():
-            _vec_string('a', np.string_, 'bogus')
+            _vec_string('a', np.bytes_, 'bogus')
 
         assert_raises(AttributeError, fail)
 
     def test_non_string_array(self):
 
         def fail():
-            _vec_string(1, np.string_, 'strip')
+            _vec_string(1, np.bytes_, 'strip')
 
         assert_raises(TypeError, fail)
 
     def test_invalid_args_tuple(self):
 
         def fail():
-            _vec_string(['a'], np.string_, 'strip', 1)
+            _vec_string(['a'], np.bytes_, 'strip', 1)
 
         assert_raises(TypeError, fail)
 
@@ -113,7 +113,7 @@ class TestVecString:
     def test_invalid_function_args(self):
 
         def fail():
-            _vec_string(['a'], np.string_, 'strip', (1,))
+            _vec_string(['a'], np.bytes_, 'strip', (1,))
 
         assert_raises(TypeError, fail)
 
@@ -192,7 +192,7 @@ class TestComparisonsMixed1(TestComparisons):
     def setup_method(self):
         TestComparisons.setup_method(self)
         self.B = np.array([['efg', '123  '],
-                           ['051', 'tuv']], np.unicode_).view(np.chararray)
+                           ['051', 'tuv']], np.str_).view(np.chararray)
 
 class TestComparisonsMixed2(TestComparisons):
     """Ticket #1276"""
@@ -200,7 +200,7 @@ class TestComparisonsMixed2(TestComparisons):
     def setup_method(self):
         TestComparisons.setup_method(self)
         self.A = np.array([['abc', '123'],
-                           ['789', 'xyz']], np.unicode_).view(np.chararray)
+                           ['789', 'xyz']], np.str_).view(np.chararray)
 
 class TestInformation:
     def setup_method(self):
@@ -322,17 +322,17 @@ class TestMethods:
         tgt = [[b' abc ', b''],
                [b'12345', b'Mixedcase'],
                [b'123 \t 345 \0 ', b'Upper']]
-        assert_(issubclass(self.A.capitalize().dtype.type, np.string_))
+        assert_(issubclass(self.A.capitalize().dtype.type, np.bytes_))
         assert_array_equal(self.A.capitalize(), tgt)
 
         tgt = [[' \u03c3 ', ''],
                ['12345', 'Mixedcase'],
                ['123 \t 345 \0 ', 'Upper']]
-        assert_(issubclass(self.B.capitalize().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.capitalize().dtype.type, np.str_))
         assert_array_equal(self.B.capitalize(), tgt)
 
     def test_center(self):
-        assert_(issubclass(self.A.center(10).dtype.type, np.string_))
+        assert_(issubclass(self.A.center(10).dtype.type, np.bytes_))
         C = self.A.center([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
 
@@ -343,7 +343,7 @@ class TestMethods:
         C = np.char.center(b'FOO', [[10, 20], [15, 8]])
         tgt = [[b'   FOO    ', b'        FOO         '],
                [b'      FOO      ', b'  FOO   ']]
-        assert_(issubclass(C.dtype.type, np.string_))
+        assert_(issubclass(C.dtype.type, np.bytes_))
         assert_array_equal(C, tgt)
 
     def test_decode(self):
@@ -364,14 +364,14 @@ class TestMethods:
         A0 = self.A.decode('ascii')
 
         A = np.char.join([',', '#'], A0)
-        assert_(issubclass(A.dtype.type, np.unicode_))
+        assert_(issubclass(A.dtype.type, np.str_))
         tgt = np.array([[' ,a,b,c, ', ''],
                         ['1,2,3,4,5', 'M#i#x#e#d#C#a#s#e'],
                         ['1,2,3, ,\t, ,3,4,5, ,\x00, ', 'U#P#P#E#R']])
         assert_array_equal(np.char.join([',', '#'], A0), tgt)
 
     def test_ljust(self):
-        assert_(issubclass(self.A.ljust(10).dtype.type, np.string_))
+        assert_(issubclass(self.A.ljust(10).dtype.type, np.bytes_))
 
         C = self.A.ljust([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
@@ -384,27 +384,27 @@ class TestMethods:
         C = np.char.ljust(b'FOO', [[10, 20], [15, 8]])
         tgt = [[b'FOO       ', b'FOO                 '],
                [b'FOO            ', b'FOO     ']]
-        assert_(issubclass(C.dtype.type, np.string_))
+        assert_(issubclass(C.dtype.type, np.bytes_))
         assert_array_equal(C, tgt)
 
     def test_lower(self):
         tgt = [[b' abc ', b''],
                [b'12345', b'mixedcase'],
                [b'123 \t 345 \0 ', b'upper']]
-        assert_(issubclass(self.A.lower().dtype.type, np.string_))
+        assert_(issubclass(self.A.lower().dtype.type, np.bytes_))
         assert_array_equal(self.A.lower(), tgt)
 
         tgt = [[' \u03c3 ', ''],
                ['12345', 'mixedcase'],
                ['123 \t 345 \0 ', 'upper']]
-        assert_(issubclass(self.B.lower().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.lower().dtype.type, np.str_))
         assert_array_equal(self.B.lower(), tgt)
 
     def test_lstrip(self):
         tgt = [[b'abc ', b''],
                [b'12345', b'MixedCase'],
                [b'123 \t 345 \0 ', b'UPPER']]
-        assert_(issubclass(self.A.lstrip().dtype.type, np.string_))
+        assert_(issubclass(self.A.lstrip().dtype.type, np.bytes_))
         assert_array_equal(self.A.lstrip(), tgt)
 
         tgt = [[b' abc', b''],
@@ -415,7 +415,7 @@ class TestMethods:
         tgt = [['\u03a3 ', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345 \0 ', 'UPPER']]
-        assert_(issubclass(self.B.lstrip().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.lstrip().dtype.type, np.str_))
         assert_array_equal(self.B.lstrip(), tgt)
 
     def test_partition(self):
@@ -423,7 +423,7 @@ class TestMethods:
         tgt = [[(b' abc ', b'', b''), (b'', b'', b'')],
                [(b'12', b'3', b'45'), (b'', b'M', b'ixedCase')],
                [(b'12', b'3', b' \t 345 \0 '), (b'UPPER', b'', b'')]]
-        assert_(issubclass(P.dtype.type, np.string_))
+        assert_(issubclass(P.dtype.type, np.bytes_))
         assert_array_equal(P, tgt)
 
     def test_replace(self):
@@ -432,11 +432,11 @@ class TestMethods:
         tgt = [[b' abc ', b''],
                [b'12##########45', b'MixedC@se'],
                [b'12########## \t ##########45 \x00', b'UPPER']]
-        assert_(issubclass(R.dtype.type, np.string_))
+        assert_(issubclass(R.dtype.type, np.bytes_))
         assert_array_equal(R, tgt)
 
     def test_rjust(self):
-        assert_(issubclass(self.A.rjust(10).dtype.type, np.string_))
+        assert_(issubclass(self.A.rjust(10).dtype.type, np.bytes_))
 
         C = self.A.rjust([10, 20])
         assert_array_equal(np.char.str_len(C), [[10, 20], [10, 20], [12, 20]])
@@ -449,7 +449,7 @@ class TestMethods:
         C = np.char.rjust(b'FOO', [[10, 20], [15, 8]])
         tgt = [[b'       FOO', b'                 FOO'],
                [b'            FOO', b'     FOO']]
-        assert_(issubclass(C.dtype.type, np.string_))
+        assert_(issubclass(C.dtype.type, np.bytes_))
         assert_array_equal(C, tgt)
 
     def test_rpartition(self):
@@ -457,7 +457,7 @@ class TestMethods:
         tgt = [[(b'', b'', b' abc '), (b'', b'', b'')],
                [(b'12', b'3', b'45'), (b'', b'M', b'ixedCase')],
                [(b'123 \t ', b'3', b'45 \0 '), (b'', b'', b'UPPER')]]
-        assert_(issubclass(P.dtype.type, np.string_))
+        assert_(issubclass(P.dtype.type, np.bytes_))
         assert_array_equal(P, tgt)
 
     def test_rsplit(self):
@@ -469,7 +469,7 @@ class TestMethods:
         assert_equal(A.tolist(), tgt)
 
     def test_rstrip(self):
-        assert_(issubclass(self.A.rstrip().dtype.type, np.string_))
+        assert_(issubclass(self.A.rstrip().dtype.type, np.bytes_))
 
         tgt = [[b' abc', b''],
                [b'12345', b'MixedCase'],
@@ -485,14 +485,14 @@ class TestMethods:
         tgt = [[' \u03a3', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345', 'UPPER']]
-        assert_(issubclass(self.B.rstrip().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.rstrip().dtype.type, np.str_))
         assert_array_equal(self.B.rstrip(), tgt)
 
     def test_strip(self):
         tgt = [[b'abc', b''],
                [b'12345', b'MixedCase'],
                [b'123 \t 345', b'UPPER']]
-        assert_(issubclass(self.A.strip().dtype.type, np.string_))
+        assert_(issubclass(self.A.strip().dtype.type, np.bytes_))
         assert_array_equal(self.A.strip(), tgt)
 
         tgt = [[b' abc ', b''],
@@ -503,7 +503,7 @@ class TestMethods:
         tgt = [['\u03a3', ''],
                ['12345', 'MixedCase'],
                ['123 \t 345', 'UPPER']]
-        assert_(issubclass(self.B.strip().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.strip().dtype.type, np.str_))
         assert_array_equal(self.B.strip(), tgt)
 
     def test_split(self):
@@ -525,39 +525,39 @@ class TestMethods:
         tgt = [[b' ABC ', b''],
                [b'12345', b'mIXEDcASE'],
                [b'123 \t 345 \0 ', b'upper']]
-        assert_(issubclass(self.A.swapcase().dtype.type, np.string_))
+        assert_(issubclass(self.A.swapcase().dtype.type, np.bytes_))
         assert_array_equal(self.A.swapcase(), tgt)
 
         tgt = [[' \u03c3 ', ''],
                ['12345', 'mIXEDcASE'],
                ['123 \t 345 \0 ', 'upper']]
-        assert_(issubclass(self.B.swapcase().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.swapcase().dtype.type, np.str_))
         assert_array_equal(self.B.swapcase(), tgt)
 
     def test_title(self):
         tgt = [[b' Abc ', b''],
                [b'12345', b'Mixedcase'],
                [b'123 \t 345 \0 ', b'Upper']]
-        assert_(issubclass(self.A.title().dtype.type, np.string_))
+        assert_(issubclass(self.A.title().dtype.type, np.bytes_))
         assert_array_equal(self.A.title(), tgt)
 
         tgt = [[' \u03a3 ', ''],
                ['12345', 'Mixedcase'],
                ['123 \t 345 \0 ', 'Upper']]
-        assert_(issubclass(self.B.title().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.title().dtype.type, np.str_))
         assert_array_equal(self.B.title(), tgt)
 
     def test_upper(self):
         tgt = [[b' ABC ', b''],
                [b'12345', b'MIXEDCASE'],
                [b'123 \t 345 \0 ', b'UPPER']]
-        assert_(issubclass(self.A.upper().dtype.type, np.string_))
+        assert_(issubclass(self.A.upper().dtype.type, np.bytes_))
         assert_array_equal(self.A.upper(), tgt)
 
         tgt = [[' \u03a3 ', ''],
                ['12345', 'MIXEDCASE'],
                ['123 \t 345 \0 ', 'UPPER']]
-        assert_(issubclass(self.B.upper().dtype.type, np.unicode_))
+        assert_(issubclass(self.B.upper().dtype.type, np.str_))
         assert_array_equal(self.B.upper(), tgt)
 
     def test_isnumeric(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1706,7 +1706,7 @@ class TestBool:
 
     @pytest.mark.xfail(reason="See gh-9847")
     def test_cast_from_unicode(self):
-        self._test_cast_from_flexible(np.unicode_)
+        self._test_cast_from_flexible(np.str_)
 
     @pytest.mark.xfail(reason="See gh-9847")
     def test_cast_from_bytes(self):
@@ -2088,7 +2088,7 @@ class TestMethods:
                 msg = 'byte-swapped complex sort, dtype={0}'.format(dt)
                 assert_equal(c, arr, msg)
 
-    @pytest.mark.parametrize('dtype', [np.bytes_, np.unicode_])
+    @pytest.mark.parametrize('dtype', [np.bytes_, np.str_])
     def test_sort_string(self, dtype):
         # np.array will perform the encoding to bytes for us in the bytes test
         a = np.array(['aaaaaaaa' + chr(i) for i in range(101)], dtype=dtype)
@@ -2362,7 +2362,7 @@ class TestMethods:
 
         # test unicode argsorts.
         s = 'aaaaaaaa'
-        a = np.array([s + chr(i) for i in range(101)], dtype=np.unicode_)
+        a = np.array([s + chr(i) for i in range(101)], dtype=np.str_)
         b = a[::-1]
         r = np.arange(101)
         rr = r[::-1]
@@ -2445,7 +2445,7 @@ class TestMethods:
         a = np.array(['aaaaaaaaa' for i in range(100)])
         assert_equal(a.argsort(kind='m'), r)
         # unicode
-        a = np.array(['aaaaaaaaa' for i in range(100)], dtype=np.unicode_)
+        a = np.array(['aaaaaaaaa' for i in range(100)], dtype=np.str_)
         assert_equal(a.argsort(kind='m'), r)
 
     def test_sort_unicode_kind(self):
@@ -2589,7 +2589,7 @@ class TestMethods:
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100197_1',
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100198_1',
                       'P:\\20x_dapi_cy3\\20x_dapi_cy3_20100199_1'],
-                     dtype=np.unicode_)
+                     dtype=np.str_)
         ind = np.arange(len(a))
         assert_equal([a.searchsorted(v, 'left') for v in a], ind)
         assert_equal([a.searchsorted(v, 'right') for v in a], ind + 1)
@@ -8701,7 +8701,7 @@ class TestConversion:
             # gh-9972
             assert_equal(4, int_func(np.array('4')))
             assert_equal(5, int_func(np.bytes_(b'5')))
-            assert_equal(6, int_func(np.unicode_('6')))
+            assert_equal(6, int_func(np.str_('6')))
 
             # The delegation of int() to __trunc__ was deprecated in
             # Python 3.11.
@@ -9073,33 +9073,33 @@ class TestUnicodeEncoding:
     def test_assign_scalar(self):
         # gh-3258
         l = np.array(['aa', 'bb'])
-        l[:] = np.unicode_('cc')
+        l[:] = np.str_('cc')
         assert_equal(l, ['cc', 'cc'])
 
     def test_fill_scalar(self):
         # gh-7227
         l = np.array(['aa', 'bb'])
-        l.fill(np.unicode_('cc'))
+        l.fill(np.str_('cc'))
         assert_equal(l, ['cc', 'cc'])
 
 
 class TestUnicodeArrayNonzero:
 
     def test_empty_ustring_array_is_falsey(self):
-        assert_(not np.array([''], dtype=np.unicode_))
+        assert_(not np.array([''], dtype=np.str_))
 
     def test_whitespace_ustring_array_is_falsey(self):
-        a = np.array(['eggs'], dtype=np.unicode_)
+        a = np.array(['eggs'], dtype=np.str_)
         a[0] = '  \0\0'
         assert_(not a)
 
     def test_all_null_ustring_array_is_falsey(self):
-        a = np.array(['eggs'], dtype=np.unicode_)
+        a = np.array(['eggs'], dtype=np.str_)
         a[0] = '\0\0\0\0'
         assert_(not a)
 
     def test_null_inside_ustring_array_is_truthy(self):
-        a = np.array(['eggs'], dtype=np.unicode_)
+        a = np.array(['eggs'], dtype=np.str_)
         a[0] = ' \0 \0'
         assert_(a)
 

--- a/numpy/core/tests/test_nditer.py
+++ b/numpy/core/tests/test_nditer.py
@@ -2257,7 +2257,7 @@ def test_iter_buffering_string():
     assert_equal(i[0], b'abc')
     assert_equal(i[0].dtype, np.dtype('S6'))
 
-    a = np.array(['abc', 'a', 'abcd'], dtype=np.unicode_)
+    a = np.array(['abc', 'a', 'abcd'], dtype=np.str_)
     assert_equal(a.dtype, np.dtype('U4'))
     assert_raises(TypeError, nditer, a, ['buffered'], ['readonly'],
                     op_dtypes='U2')

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -473,7 +473,8 @@ class TestMaximumSctype:
     def test_complex(self, t):
         assert_equal(np.maximum_sctype(t), np.sctypes['complex'][-1])
 
-    @pytest.mark.parametrize('t', [np.bool_, np.object_, np.unicode_, np.bytes_, np.void])
+    @pytest.mark.parametrize('t', [np.bool_, np.object_, np.str_, np.bytes_,
+                                   np.void])
     def test_other(self, t):
         assert_equal(np.maximum_sctype(t), t)
 
@@ -485,7 +486,7 @@ class Test_sctype2char:
     def test_scalar_type(self):
         assert_equal(np.sctype2char(np.double), 'd')
         assert_equal(np.sctype2char(np.int_), 'l')
-        assert_equal(np.sctype2char(np.unicode_), 'U')
+        assert_equal(np.sctype2char(np.str_), 'U')
         assert_equal(np.sctype2char(np.bytes_), 'S')
 
     def test_other_type(self):

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -292,7 +292,7 @@ class TestRegression:
 
     def test_unicode_string_comparison(self):
         # Ticket #190
-        a = np.array('hello', np.unicode_)
+        a = np.array('hello', np.str_)
         b = np.array('world')
         a == b
 
@@ -455,7 +455,7 @@ class TestRegression:
 
         test_data = [
             # (original, py2_pickle)
-            (np.unicode_('\u6f2c'),
+            (np.str_('\u6f2c'),
              b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
              b"(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\n"
              b"I0\ntp6\nbS',o\\x00\\x00'\np7\ntp8\nRp9\n."),
@@ -1685,7 +1685,7 @@ class TestRegression:
         # number 2, and the exception hung around until something checked
         # PyErr_Occurred() and returned an error.
         assert_equal(np.dtype('S10').itemsize, 10)
-        np.array([['abc', 2], ['long   ', '0123456789']], dtype=np.string_)
+        np.array([['abc', 2], ['long   ', '0123456789']], dtype=np.bytes_)
         assert_equal(np.dtype('S10').itemsize, 10)
 
     def test_any_float(self):
@@ -1954,7 +1954,7 @@ class TestRegression:
         # Python2 output for pickle.dumps(...)
         datas = [
             # (original, python2_pickle, koi8r_validity)
-            (np.unicode_('\u6bd2'),
+            (np.str_('\u6bd2'),
              (b"cnumpy.core.multiarray\nscalar\np0\n(cnumpy\ndtype\np1\n"
               b"(S'U1'\np2\nI0\nI1\ntp3\nRp4\n(I3\nS'<'\np5\nNNNI4\nI4\nI0\n"
               b"tp6\nbS'\\xd2k\\x00\\x00'\np7\ntp8\nRp9\n."),
@@ -2078,7 +2078,7 @@ class TestRegression:
         # Ticket #1578, the mismatch only showed up when running
         # python-debug for python versions >= 2.7, and then as
         # a core dump and error message.
-        a = np.array(['abc'], dtype=np.unicode_)[0]
+        a = np.array(['abc'], dtype=np.str_)[0]
         del a
 
     def test_refcount_error_in_clip(self):
@@ -2225,7 +2225,7 @@ class TestRegression:
     def test_pickle_empty_string(self):
         # gh-3926
         for proto in range(2, pickle.HIGHEST_PROTOCOL + 1):
-            test_string = np.string_('')
+            test_string = np.bytes_('')
             assert_equal(pickle.loads(
                 pickle.dumps(test_string, protocol=proto)), test_string)
 
@@ -2346,7 +2346,7 @@ class TestRegression:
         values = {
             np.void: b"a",
             np.bytes_: b"a",
-            np.unicode_: "a",
+            np.str_: "a",
             np.datetime64: "2017-08-25",
         }
         for sctype in scalar_types:

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -68,11 +68,11 @@ class TestScalarPEP3118:
             get_buffer_info(x, ["WRITABLE"])
 
     def test_void_scalar_structured_data(self):
-        dt = np.dtype([('name', np.unicode_, 16), ('grades', np.float64, (2,))])
+        dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
         x = np.array(('ndarray_scalar', (1.2, 3.0)), dtype=dt)[()]
         assert_(isinstance(x, np.void))
         mv_x = memoryview(x)
-        expected_size = 16 * np.dtype((np.unicode_, 1)).itemsize
+        expected_size = 16 * np.dtype((np.str_, 1)).itemsize
         expected_size += 2 * np.dtype(np.float64).itemsize
         assert_equal(mv_x.itemsize, expected_size)
         assert_equal(mv_x.ndim, 0)

--- a/numpy/core/tests/test_scalarinherit.py
+++ b/numpy/core/tests/test_scalarinherit.py
@@ -58,8 +58,8 @@ class TestInherit:
 class TestCharacter:
     def test_char_radd(self):
         # GH issue 9620, reached gentype_add and raise TypeError
-        np_s = np.string_('abc')
-        np_u = np.unicode_('abc')
+        np_s = np.bytes_('abc')
+        np_u = np.str_('abc')
         s = b'def'
         u = 'def'
         assert_(np_s.__radd__(np_s) is NotImplemented)
@@ -90,8 +90,8 @@ class TestCharacter:
         assert ret == b"defabc"
 
     def test_char_repeat(self):
-        np_s = np.string_('abc')
-        np_u = np.unicode_('abc')
+        np_s = np.bytes_('abc')
+        np_u = np.str_('abc')
         res_s = b'abc' * 5
         res_u = 'abc' * 5
         assert_(np_s * 5 == res_s)

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -513,8 +513,8 @@ class StringConverter:
                     (nx.complexfloating, complex, nx.nan + 0j),
                     # Last, try with the string types (must be last, because
                     # `_mapper[-1]` is used as default in some cases)
-                    (nx.unicode_, asunicode, '???'),
-                    (nx.string_, asbytes, '???'),
+                    (nx.str_, asunicode, '???'),
+                    (nx.bytes_, asbytes, '???'),
                     ])
 
     @classmethod

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -2319,7 +2319,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         column_types = [conv.type for conv in converters]
         # Find the columns with strings...
         strcolidx = [i for (i, v) in enumerate(column_types)
-                     if v == np.unicode_]
+                     if v == np.str_]
 
         if byte_converters and strcolidx:
             # convert strings back to bytes for backward compatibility

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -522,7 +522,7 @@ class TestSaveTxt:
 
     def test_unicode(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode_)
+        a = np.array([utf8], dtype=np.str_)
         with tempdir() as tmpdir:
             # set encoding as on windows it may not be unicode even on py3
             np.savetxt(os.path.join(tmpdir, 'test.csv'), a, fmt=['%s'],
@@ -530,7 +530,7 @@ class TestSaveTxt:
 
     def test_unicode_roundtrip(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode_)
+        a = np.array([utf8], dtype=np.str_)
         # our gz wrapper support encoding
         suffixes = ['', '.gz']
         if HAS_BZ2:
@@ -542,12 +542,12 @@ class TestSaveTxt:
                 np.savetxt(os.path.join(tmpdir, 'test.csv' + suffix), a,
                            fmt=['%s'], encoding='UTF-16-LE')
                 b = np.loadtxt(os.path.join(tmpdir, 'test.csv' + suffix),
-                               encoding='UTF-16-LE', dtype=np.unicode_)
+                               encoding='UTF-16-LE', dtype=np.str_)
                 assert_array_equal(a, b)
 
     def test_unicode_bytestream(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode_)
+        a = np.array([utf8], dtype=np.str_)
         s = BytesIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
@@ -555,7 +555,7 @@ class TestSaveTxt:
 
     def test_unicode_stringstream(self):
         utf8 = b'\xcf\x96'.decode('UTF-8')
-        a = np.array([utf8], dtype=np.unicode_)
+        a = np.array([utf8], dtype=np.str_)
         s = StringIO()
         np.savetxt(s, a, fmt=['%s'], encoding='UTF-8')
         s.seek(0)
@@ -652,12 +652,12 @@ class LoadTxtBase:
         with temppath() as path:
             with open(path, "wb") as f:
                 f.write(nonascii.encode("UTF-16"))
-            x = self.loadfunc(path, encoding="UTF-16", dtype=np.unicode_)
+            x = self.loadfunc(path, encoding="UTF-16", dtype=np.str_)
             assert_array_equal(x, nonascii)
 
     def test_binary_decode(self):
         utf16 = b'\xff\xfeh\x04 \x00i\x04 \x00j\x04'
-        v = self.loadfunc(BytesIO(utf16), dtype=np.unicode_, encoding='UTF-16')
+        v = self.loadfunc(BytesIO(utf16), dtype=np.str_, encoding='UTF-16')
         assert_array_equal(v, np.array(utf16.decode('UTF-16').split()))
 
     def test_converters_decode(self):
@@ -665,7 +665,7 @@ class LoadTxtBase:
         c = TextIO()
         c.write(b'\xcf\x96')
         c.seek(0)
-        x = self.loadfunc(c, dtype=np.unicode_,
+        x = self.loadfunc(c, dtype=np.str_,
                           converters={0: lambda x: x.decode('UTF-8')})
         a = np.array([b'\xcf\x96'.decode('UTF-8')])
         assert_array_equal(x, a)
@@ -676,7 +676,7 @@ class LoadTxtBase:
         with temppath() as path:
             with io.open(path, 'wt', encoding='UTF-8') as f:
                 f.write(utf8)
-            x = self.loadfunc(path, dtype=np.unicode_,
+            x = self.loadfunc(path, dtype=np.str_,
                               converters={0: lambda x: x + 't'},
                               encoding='UTF-8')
             a = np.array([utf8 + 't'])
@@ -1161,7 +1161,7 @@ class TestLoadTxt(LoadTxtBase):
             with open(path, "wb") as f:
                 f.write(butf8)
             with open(path, "rb") as f:
-                x = np.loadtxt(f, encoding="UTF-8", dtype=np.unicode_)
+                x = np.loadtxt(f, encoding="UTF-8", dtype=np.str_)
             assert_array_equal(x, sutf8)
             # test broken latin1 conversion people now rely on
             with open(path, "rb") as f:
@@ -2219,7 +2219,7 @@ M   33  21.99
             ctl = np.array([
                      ["test1", "testNonethe" + utf8.decode("UTF-8"), "test3"],
                      ["test1", "testNonethe" + utf8.decode("UTF-8"), "test3"]],
-                     dtype=np.unicode_)
+                     dtype=np.str_)
             assert_array_equal(test, ctl)
 
             # test a mixed dtype
@@ -2262,7 +2262,7 @@ M   33  21.99
                      ["norm1", "norm2", "norm3"],
                      ["norm1", latin1, "norm3"],
                      ["test1", "testNonethe" + utf8, "test3"]],
-                     dtype=np.unicode_)
+                     dtype=np.str_)
             assert_array_equal(test, ctl)
 
     def test_recfromtxt(self):

--- a/numpy/typing/tests/data/pass/dtype.py
+++ b/numpy/typing/tests/data/pass/dtype.py
@@ -15,7 +15,7 @@ np.dtype({"names": ["a", "b"], "formats": [int, float]})
 np.dtype({"names": ["a"], "formats": [int], "titles": [object]})
 np.dtype({"names": ["a"], "formats": [int], "titles": [object()]})
 
-np.dtype([("name", np.unicode_, 16), ("grades", np.float64, (2,)), ("age", "int32")])
+np.dtype([("name", np.str_, 16), ("grades", np.float64, (2,)), ("age", "int32")])
 
 np.dtype(
     {

--- a/numpy/typing/tests/data/pass/numerictypes.py
+++ b/numpy/typing/tests/data/pass/numerictypes.py
@@ -8,7 +8,7 @@ np.issctype("S8")
 
 np.obj2sctype(list)
 np.obj2sctype(list, default=None)
-np.obj2sctype(list, default=np.string_)
+np.obj2sctype(list, default=np.bytes_)
 
 np.issubclass_(np.int32, int)
 np.issubclass_(np.float64, float)
@@ -17,7 +17,7 @@ np.issubclass_(np.float64, (int, float))
 np.issubsctype("int64", int)
 np.issubsctype(np.array([1]), np.array([1]))
 
-np.issubdtype("S1", np.string_)
+np.issubdtype("S1", np.bytes_)
 np.issubdtype(np.float64, np.float32)
 
 np.sctype2char("S1")

--- a/numpy/typing/tests/data/pass/simple.py
+++ b/numpy/typing/tests/data/pass/simple.py
@@ -33,13 +33,13 @@ np.dtype(two_tuples_dtype)
 three_tuples_dtype = [("R", "u1", 2)]
 np.dtype(three_tuples_dtype)
 
-mixed_tuples_dtype = [("R", "u1"), ("G", np.unicode_, 1)]
+mixed_tuples_dtype = [("R", "u1"), ("G", np.str_, 1)]
 np.dtype(mixed_tuples_dtype)
 
 shape_tuple_dtype = [("R", "u1", (2, 2))]
 np.dtype(shape_tuple_dtype)
 
-shape_like_dtype = [("R", "u1", (2, 2)), ("G", np.unicode_, 1)]
+shape_like_dtype = [("R", "u1", (2, 2)), ("G", np.str_, 1)]
 np.dtype(shape_like_dtype)
 
 object_dtype = [("field1", object)]

--- a/pavement.py
+++ b/pavement.py
@@ -184,7 +184,7 @@ def write_release_task(options, filename='README'):
     ----------
     options :
         Set by ``task`` decorator.
-    filename : string
+    filename : str
         Filename of the modified notes. The file is written
         in the release directory.
 


### PR DESCRIPTION
* Change occurrences of `unicode_` and `string_` into `str_` and `bytes_`, both in code and documentation.
* Start changing `unicode` into `str`.
* Change a single occurrence of `string` into `str`.

Partially addresses #20062.