### PR TITLE
MAINT: Use `Py_SET_TYPE` macro instead of assigning to `Py_TYPE`

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -62,7 +62,7 @@ get_dummy_stack_array(PyArrayObject *orig)
     PyArrayObject_fields new_fields;
     new_fields.flags = PyArray_FLAGS(orig);
     /* Set to NULL so the dummy object can be distinguished from the real one */
-    Py_TYPE(&new_fields) = NULL;
+    Py_SET_TYPE(&new_fields, NULL);
     new_fields.base = (PyObject *)orig;
     return new_fields;
 }


### PR DESCRIPTION
Change sentinel value definition to work with python 3.11.0a C API

Fixed an issue described in #20054 with compiling and importing the NumPy library in python 3.11.0a. 

The exact issue is that NumPy used a deprecated API that has been switched. This is a simple one-line fix.

This is my first ever PR so please let me know if for whatever reason I screwed something up. As far as I know building from source and all tests passed after this change in python 3.10 however there is still a number of python 3.11 issues that still need to be addressed (referenced in #20054).