### PR TITLE
MAINT: move "git submodule update" earlier in docker creation

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,6 @@ tasks:
       python setup.py build_ext --inplace
       echo "🛠 Completed rebuilding NumPy!! 🛠 "
       echo "📖 Building docs 📖 "
-      git submodule update --init
       cd doc
       make html
       echo "✨ Pre-build complete! You can close this terminal ✨ "

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -8,6 +8,7 @@ COPY --chown=gitpod . /tmp/numpy_repo
 
 # the clone should be deep enough for versioneer to work
 RUN git clone --shallow-since=2021-05-22 file:////tmp/numpy_repo /tmp/numpy
+RUN git submodule update --init
 
 # -----------------------------------------------------------------------------
 # Using the numpy-dev Docker image as a base


### PR DESCRIPTION
Merging #19478 broke the gitpod docker build since now numpy git has a submodule that is required for building. I have not used gitpod before so I hope this is correct. If the new repo structure breaks too many downstream users, we may need to rethink SVML as a submodule.

@rgommers