### PR TITLE
BLD: fix submodule update in gitpod.Dockerfile

### DIFF
--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -8,7 +8,6 @@ COPY --chown=gitpod . /tmp/numpy_repo
 
 # the clone should be deep enough for versioneer to work
 RUN git clone --shallow-since=2021-05-22 file:////tmp/numpy_repo /tmp/numpy
-RUN git submodule update --init
 
 # -----------------------------------------------------------------------------
 # Using the numpy-dev Docker image as a base
@@ -35,6 +34,7 @@ COPY --from=clone --chown=gitpod /tmp/numpy ${WORKSPACE}
 WORKDIR ${WORKSPACE}
 
 # Build numpy to populate the cache used by ccache
+RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml
 RUN conda activate ${CONDA_ENV} && \ 
     python setup.py build_ext --inplace && \
     ccache -s


### PR DESCRIPTION
Follow-up to gh-20084. This is analogous to what SciPy does; it's helpful to keep the files as similar as possible.

[ci skip]