### PR TITLE
BUG: core: result_type(0, np.timedelta64(4)) would seg. fault.

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1549,7 +1549,7 @@ should_use_min_scalar(npy_intp narrs, PyArrayObject **arr,
 
 
 /*
- * Utility function used in PyArray_ResultType.
+ * Utility function used only in PyArray_ResultType for value-based logic.
  * See that function for the meaning and contents of the parameters.
  */
 static PyArray_Descr *

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1553,12 +1553,12 @@ should_use_min_scalar(npy_intp narrs, PyArrayObject **arr,
  * See that function for the meaning and contents of the parameters.
  */
 static PyArray_Descr *
-get_dtype_from_descr_and_common(
-    npy_intp i,
-    PyArrayObject *arrs[],
-    npy_intp ndtypes,
-    PyArray_Descr *descriptor,
-    PyArray_DTypeMeta *common_dtype)
+get_descr_from_cast_or_value(
+        npy_intp i,
+        PyArrayObject *arrs[],
+        npy_intp ndtypes,
+        PyArray_Descr *descriptor,
+        PyArray_DTypeMeta *common_dtype)
 {
     PyArray_Descr *curr;
     if (NPY_LIKELY(i < ndtypes ||
@@ -1718,14 +1718,14 @@ PyArray_ResultType(
         result = NPY_DT_CALL_default_descr(common_dtype);
     }
     else {
-        result = get_dtype_from_descr_and_common(
+        result = get_descr_from_cast_or_value(
                     0, arrs, ndtypes, all_descriptors[0], common_dtype);
         if (result == NULL) {
             goto error;
         }
 
         for (npy_intp i = 1; i < ndtypes+narrs; i++) {
-            PyArray_Descr *curr = get_dtype_from_descr_and_common(
+            PyArray_Descr *curr = get_descr_from_cast_or_value(
                     i, arrs, ndtypes, all_descriptors[i], common_dtype);
             if (curr == NULL) {
                 goto error;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1548,6 +1548,40 @@ should_use_min_scalar(npy_intp narrs, PyArrayObject **arr,
 }
 
 
+/*
+ * Utility function used in PyArray_ResultType.
+ * See that function for the meaning and contents of the parameters.
+ */
+static PyArray_Descr *
+get_dtype_from_descr_and_common(
+    npy_intp i,
+    PyArrayObject *arrs[],
+    npy_intp ndtypes,
+    PyArray_Descr *descriptor,
+    PyArray_DTypeMeta *common_dtype)
+{
+    PyArray_Descr *curr;
+    if (NPY_LIKELY(i < ndtypes ||
+            !(PyArray_FLAGS(arrs[i-ndtypes]) & _NPY_ARRAY_WAS_PYSCALAR))) {
+        curr = PyArray_CastDescrToDType(descriptor, common_dtype);
+    }
+    else {
+        /*
+         * Unlike `PyArray_CastToDTypeAndPromoteDescriptors`, deal with
+         * plain Python values "graciously". This recovers the original
+         * value the long route, but it should almost never happen...
+         */
+        PyObject *tmp = PyArray_GETITEM(arrs[i-ndtypes],
+                                        PyArray_BYTES(arrs[i-ndtypes]));
+        if (tmp == NULL) {
+            return NULL;
+        }
+        curr = NPY_DT_CALL_discover_descr_from_pyobject(common_dtype, tmp);
+        Py_DECREF(tmp);
+    }
+    return curr;
+}
+
 /*NUMPY_API
  *
  * Produces the result type of a bunch of inputs, using the same rules
@@ -1684,28 +1718,15 @@ PyArray_ResultType(
         result = NPY_DT_CALL_default_descr(common_dtype);
     }
     else {
-        result = PyArray_CastDescrToDType(all_descriptors[0], common_dtype);
+        result = get_dtype_from_descr_and_common(
+                    0, arrs, ndtypes, all_descriptors[0], common_dtype);
+        if (result == NULL) {
+            goto error;
+        }
 
         for (npy_intp i = 1; i < ndtypes+narrs; i++) {
-            PyArray_Descr *curr;
-            if (NPY_LIKELY(i < ndtypes ||
-                    !(PyArray_FLAGS(arrs[i-ndtypes]) & _NPY_ARRAY_WAS_PYSCALAR))) {
-                curr = PyArray_CastDescrToDType(all_descriptors[i], common_dtype);
-            }
-            else {
-                /*
-                 * Unlike `PyArray_CastToDTypeAndPromoteDescriptors` deal with
-                 * plain Python values "graciously". This recovers the original
-                 * value the long route, but it should almost never happen...
-                 */
-                PyObject *tmp = PyArray_GETITEM(
-                        arrs[i-ndtypes], PyArray_BYTES(arrs[i-ndtypes]));
-                if (tmp == NULL) {
-                    goto error;
-                }
-                curr = NPY_DT_CALL_discover_descr_from_pyobject(common_dtype, tmp);
-                Py_DECREF(tmp);
-            }
+            PyArray_Descr *curr = get_dtype_from_descr_and_common(
+                    i, arrs, ndtypes, all_descriptors[i], common_dtype);
             if (curr == NULL) {
                 goto error;
             }

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1590,6 +1590,14 @@ class TestClassGetItem:
         assert np.dtype[Any]
 
 
+def test_result_type_integers_and_unitless_timedelta64():
+    # Regression test for gh-20077.  The following call of `result_type`
+    # would cause a seg. fault.
+    td = np.timedelta64(4)
+    result = np.result_type(0, td)
+    assert_dtype_equal(result, td.dtype)
+
+
 @pytest.mark.skipif(sys.version_info >= (3, 9), reason="Requires python 3.8")
 def test_class_getitem_38() -> None:
     match = "Type subscription requires python >= 3.9"


### PR DESCRIPTION
Before this change, the line in convert_datatype.c

    result = PyArray_CastDescrToDType(all_descriptors[0], common_dtype);

would trigger a seg. fault with a call such as

    np.result_type(0, np.timedelta64(4))

The problem was that `all_descriptors[0]` was NULL, and it was
dereferenced in PyArray_CastDescrToDType.

The code in the loop that followed the above line avoided passing
NULL values in all_descriptors[i] to PyArray_CastDescrToDType by
checking that the corresponding input argument to `result_type`
was not a Python scalar.  A different code path was taken in that
case.  The seg. fault is fixed by applying that same check to the
first argument.

Closes gh-20077.
