### PR TITLE
BUG: AVX-512F log() overflows

### DIFF
--- a/numpy/core/src/umath/loops_exponent_log.dispatch.c.src
+++ b/numpy/core/src/umath/loops_exponent_log.dispatch.c.src
@@ -868,6 +868,32 @@ AVX512F_exp_DOUBLE(npy_double * op,
  *               = p(r)
  *               = 2((r/2) + 1/3*(r/2)^3 + 1/5*(r/2)^5 + ...)
  */
+
+/* LLVM has a bug where AVX-512F intrinsic `_mm512_mask_mul_pd` emits an
+ * unmasked operation with a masked store.  This can cause FP exceptions to
+ * occur for the lanes that are suppose to have been masked.
+ *
+ * See https://bugs.llvm.org/show_bug.cgi?id=51988
+ *
+ * Note, this affects LLVM based compilers like Apple Clang, Clang, and Intel's
+ * ICX.
+ */
+#if defined(__clang__)
+    #if defined(__apple_build_version__)
+    // Apple Clang
+        #if __apple_build_version__ > 11000000
+        // Apple Clang after v11
+        #define WORKAROUND_LLVM__mm512_mask_mul_pd
+        #endif
+    #else
+    // Clang, not Apple Clang
+        #if __clang_major__ > 9
+        // Clang v9+
+        #define WORKAROUND_LLVM__mm512_mask_mul_pd
+        #endif
+    #endif
+#endif
+
 static void
 AVX512F_log_DOUBLE(npy_double * op,
                 npy_double * ip,
@@ -954,8 +980,12 @@ AVX512F_log_DOUBLE(npy_double * op,
             denormal_mask = _mm512_cmp_epi64_mask(top12, _mm512_set1_epi64(0),
                                 _CMP_EQ_OQ);
             denormal_mask = (~zero_mask) & denormal_mask;
+            __m512d masked_x = x;
+            #ifdef WORKAROUND_LLVM__mm512_mask_mul_pd
+            masked_x = avx512_set_masked_lanes_pd(masked_x, zeros_d, (~denormal_mask));
+            #endif
             ix = _mm512_castpd_si512(_mm512_mask_mul_pd(x, denormal_mask,
-                                    x, _mm512_set1_pd(0x1p52)));
+                                    masked_x, _mm512_set1_pd(0x1p52)));
             ix = _mm512_mask_sub_epi64(ix, denormal_mask,
                                     ix, _mm512_set1_epi64(52ULL << 52));
 
@@ -1039,6 +1069,9 @@ AVX512F_log_DOUBLE(npy_double * op,
         npy_set_floatstatus_divbyzero();
     }
 }
+
+#undef WORKAROUND_LLVM__mm512_mask_mul_pd
+
 #endif // AVX512F_NOCLANG_BUG
 
 #ifdef SIMD_AVX512_SKX

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -973,6 +973,12 @@ class TestLog:
         xf = np.log(x)
         assert_almost_equal(np.log(x, out=x), xf)
 
+        # test log() of max for dtype does not raise
+        for dt in ['f', 'd', 'g']:
+            with np.errstate(all='raise'):
+                x = np.finfo(dt).max
+                np.log(x)
+
     def test_log_strides(self):
         np.random.seed(42)
         strides = np.array([-4,-3,-2,-1,1,2,3,4])


### PR DESCRIPTION
LLVM has a bug with AVX-512F masked multiply intrinsic `_mm512_mask_mul_pd`.  The multiply operation is performed unmasked with a masked store.  This can cause FP exceptions for lanes that should be masked.

LLVM bug report: https://bugs.llvm.org/show_bug.cgi?id=51988.

The bug affects NumPy / SciPy because NumPy has an AVX-512F implementation for log(), which uses a masked multiply intrinsic: `_mm512_mask_mul_pd`.

The bug surfaces in SciPy when trying to setup constants:
```
# The largest [in magnitude] usable floating value.
_XMAX = np.finfo(float).max

# The log of the largest usable floating value; useful for knowing
# when exp(something) will overflow
_LOGXMAX = np.log(_XMAX)
```

The workaround here explicitly masks the inputs before the multiply operation.

**Testing**
- Added a test case to numpy/core/tests/test_umath.py
  - Fails on trunk
  - Passes after workaround

SciPy testing before:
```
93 failed, 22378 passed, 1385 skipped, 93 xfailed, 7 xpassed, 1128 errors in 117.54s (0:01:57)
```

SciPy testing after:
```
74 failed, 33361 passed, 2230 skipped, 108 xfailed, 8 xpassed in 178.19s (0:02:58)
```

Note, all `1128` errors have been resolved as well as less test failures (`93` --> `74`)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
