### PR TITLE
MAINT: Update F2PY documentation URL

### DIFF
--- a/numpy/f2py/setup.py
+++ b/numpy/f2py/setup.py
@@ -66,7 +66,6 @@ command line tool (f2py) for generating Python C/API modules for
 wrapping Fortran 77/90/95 subroutines, accessing common blocks from
 Python, and calling Python functions from Fortran (call-backs).
 Interfacing subroutines/data from Fortran 90/95 modules is supported.""",
-          url="https://web.archive.org/web/20140822061353/"\
-          "http://cens.ioc.ee/projects/f2py2e/",
+          url="https://numpy.org/doc/stable/f2py/",
           keywords=['Fortran', 'f2py'],
           **config)


### PR DESCRIPTION
http://cens.ioc.ee/projects/f2py2e/ is unavailable and links to NumPy and SciPy at https://web.archive.org/web/20140822061353/http://cens.ioc.ee:80/projects/f2py2e/ are too outdated.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
