### PR TITLE
BUG: genfromtxt should return empty array when file is empty

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1850,6 +1850,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             first_line = ''
             first_values = []
             warnings.warn('genfromtxt: Empty input file: "%s"' % fname, stacklevel=2)
+            return np.array([])
 
         # Should we take the first values as names ?
         if names is True:


### PR DESCRIPTION
72ab385 says genfromtxt returns empty array for empty input file instead of an error. 
This should work regardless of the parameters we pass to np.genfromtxt() 

But currently it doesn't work when `names=True`:
```
data = io.StringIO()
test = np.genfromtxt(data, names=True)
```
This produces the warning, and instead of returning an empty array, we get an IndexError on the line:
	`fval = first_values[0].strip()`

To address this, an empty array must be returned directly after the warning.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
