### PR TITLE
DOC: Add note to iterable docstring about 0d arrays.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -268,6 +268,19 @@ def iterable(y):
     >>> np.iterable(2)
     False
 
+    Notes
+    -----
+    In most cases, the results of ``np.iterable(obj)`` are consistent with
+    ``isinstance(obj, collections.abc.Iterable)``. One notable exception is
+    the treatment of 0-dimensional arrays::
+
+        >>> from collections.abc import Iterable
+        >>> a = np.array(1.0)  # 0-dimensional numpy array
+        >>> isinstance(a, Iterable)
+        True
+        >>> np.iterable(a)
+        False
+
     """
     try:
         iter(y)


### PR DESCRIPTION
Adds a note to the docstring of `np.iterable` to document a difference in behavior with `isinstance`-style checks for 0-D arrays.