### PR TITLE
MAINT: removed unused import and unreachable code

### DIFF
--- a/numpy/array_api/_typing.py
+++ b/numpy/array_api/_typing.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 import sys
-from typing import Any, Literal, Sequence, Type, Union, TYPE_CHECKING, TypeVar
+from typing import Any, Literal, Sequence, Union, TYPE_CHECKING, TypeVar
 
 from ._array_object import Array
 from numpy import (

--- a/numpy/distutils/log.py
+++ b/numpy/distutils/log.py
@@ -21,11 +21,6 @@ class Log(old_Log):
         if level >= self.threshold:
             if args:
                 msg = msg % _fix_args(args)
-            if 0:
-                if msg.startswith('copying ') and msg.find(' -> ') != -1:
-                    return
-                if msg.startswith('byte-compiling '):
-                    return
             print(_global_color_map[level](msg))
             sys.stdout.flush()
 

--- a/numpy/ma/timer_comparison.py
+++ b/numpy/ma/timer_comparison.py
@@ -175,7 +175,6 @@ class ModuleTester:
         x3[:] = self.masked_array([1, 2, 3, 4], [0, 1, 1, 0])
         x4[:] = self.masked_array([1, 2, 3, 4], [0, 1, 1, 0])
         x1 = np.arange(5)*1.0
-        x2 = self.masked_values(x1, 3.0)
         x1 = self.array([1, 'hello', 2, 3], object)
         x2 = np.array([1, 'hello', 2, 3], object)
         # check that no error occurs.


### PR DESCRIPTION
removes import  'Type' _typing
removes unreachable code in distutils/log.py
removes duplicated assignment of x2 in numpy/ma/timer_comparison.py

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
