### PR TITLE
ENH: Makes np.delete() preserve contiguity

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4423,7 +4423,7 @@ def delete(arr, obj, axis=None):
     """
     Return a new array with sub-arrays along an axis deleted. For a one
     dimensional array, this returns those entries not returned by
-    `arr[obj]`.
+    `arr[obj]`. Preserves contiguity of the input array.
 
     Parameters
     ----------
@@ -4591,7 +4591,7 @@ def delete(arr, obj, axis=None):
             keep[obj,] = False
 
         slobj[axis] = keep
-        new = arr[tuple(slobj)]
+        new = arr[tuple(slobj)].copy(order=arrorder)
 
     if wrap:
         return wrap(new)

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4591,7 +4591,7 @@ def delete(arr, obj, axis=None):
             keep[obj,] = False
 
         slobj[axis] = keep
-        new = arr[tuple(slobj)].copy(order=arrorder)
+        new = asanyarray(arr[tuple(slobj)],order=arrorder)
 
     if wrap:
         return wrap(new)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -885,6 +885,11 @@ class TestDelete:
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
+    def test_stride_calculation(self):
+        arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
+        res = np.delete(arr, [1], 1)
+        assert_equal(res.strides, (60, 20, 4))
+ 
 
 class TestGradient:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -885,11 +885,14 @@ class TestDelete:
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
-    def test_stride_calculation(self):
-        arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
-        res = np.delete(arr, [1], 1)
-        assert_equal(res.strides, (60, 20, 4))
- 
+    def test_contiguity(self):
+        a = np.arange(1 * 2 * 3).reshape(1, 2, 3)
+        result = np.delete(a, [1], 1)
+        assert_equal(result.flags['C_CONTIGUOUS'], True)
+        a = np.arange(1 * 2 * 3).reshape(3, 2, 1, order='F')
+        result = np.delete(a, [1], 1)
+        assert_equal(result.flags['F_CONTIGUOUS'], True)
+
 
 class TestGradient:
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #19588.
This PR makes the `np.delete()` function preserve contiguity for input arrays. The function already seemed to preserve contiguity in cases where `obj` was of type `slice` or `int`, this functionality has been extended for all cases.
A simple test was adapted from the PR for testing the same.