### PR TITLE
ENH: Misc typing improvements to `np.array_api`

### DIFF
--- a/numpy/array_api/_array_object.py
+++ b/numpy/array_api/_array_object.py
@@ -29,7 +29,7 @@ from ._dtypes import (
     _dtype_categories,
 )
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union, Any
 
 if TYPE_CHECKING:
     from ._typing import PyCapsule, Device, Dtype
@@ -382,7 +382,7 @@ class Array:
 
     def __array_namespace__(
         self: Array, /, *, api_version: Optional[str] = None
-    ) -> object:
+    ) -> Any:
         if api_version is not None and not api_version.startswith("2021."):
             raise ValueError(f"Unrecognized array API version: {api_version!r}")
         return array_api

--- a/numpy/array_api/_typing.py
+++ b/numpy/array_api/_typing.py
@@ -6,6 +6,8 @@ annotations in the function signatures. The functions in the module are only
 valid for inputs that match the given type annotations.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "Array",
     "Device",
@@ -16,7 +18,16 @@ __all__ = [
 ]
 
 import sys
-from typing import Any, Literal, Sequence, Type, Union, TYPE_CHECKING, TypeVar
+from typing import (
+    Any,
+    Literal,
+    Sequence,
+    Type,
+    Union,
+    TYPE_CHECKING,
+    TypeVar,
+    Protocol,
+)
 
 from ._array_object import Array
 from numpy import (
@@ -33,10 +44,11 @@ from numpy import (
     float64,
 )
 
-# This should really be recursive, but that isn't supported yet. See the
-# similar comment in numpy/typing/_array_like.py
-_T = TypeVar("_T")
-NestedSequence = Sequence[Sequence[_T]]
+_T_co = TypeVar("_T_co", covariant=True)
+
+class NestedSequence(Protocol[_T_co]):
+    def __getitem__(self, key: int, /) -> _T_co | NestedSequence[_T_co]: ...
+    def __len__(self, /) -> int: ...
 
 Device = Literal["cpu"]
 if TYPE_CHECKING or sys.version_info >= (3, 9):

--- a/numpy/array_api/_typing.py
+++ b/numpy/array_api/_typing.py
@@ -67,6 +67,8 @@ if TYPE_CHECKING or sys.version_info >= (3, 9):
 else:
     Dtype = dtype
 
-SupportsDLPack = Any
 SupportsBufferProtocol = Any
 PyCapsule = Any
+
+class SupportsDLPack(Protocol):
+    def __dlpack__(self, /, *, stream: None = ...) -> PyCapsule: ...


### PR DESCRIPTION
cc @asmeurer 

This PR introduces three typing-related changes to the `np.array_api` sub-package:
* `NestedSequence` has been replaced with a proper nested sequence protocol.
* `SupportsDLPack` has been changed from `Any` into a protocol.
* The return type of `__array_namespace__` has been changed from `object` to `Any`, as `object` cannot be used for expressing the extra attributes (_i.e._ the namespace content) contained within the namespace. `Any` will, at the very least, return `Any` for arbitrary `getattr()` operations.