### PR TITLE
BUG: lib: Fix error raised by insert.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4753,9 +4753,8 @@ def insert(arr, obj, values, axis=None):
     if indices.size == 1:
         index = indices.item()
         if index < -N or index > N:
-            raise IndexError(
-                "index %i is out of bounds for axis %i with "
-                "size %i" % (obj, axis, N))
+            raise IndexError(f"index {obj} is out of bounds for axis {axis} "
+                             f"with size {N}")
         if (index < 0):
             index += N
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -553,6 +553,11 @@ class TestInsert:
         with pytest.raises(IndexError):
             np.insert([0, 1, 2], np.array([], dtype=float), [])
 
+    @pytest.mark.parametrize('idx', [4, -4])
+    def test_index_out_of_bounds(self, idx):
+        with pytest.raises(IndexError, match='out of bounds'):
+            np.insert([0, 1, 2], [idx], [3, 4])
+
 
 class TestAmax:
 


### PR DESCRIPTION
When `insert` is given a single out-of-bounds index in a
list, e.g.

    np.insert([0, 1, 2], [99], [3, 4])  # 99 is out of bounds

a TypeError was being raised because of a bug in the formatting
of the message.

Before this change, the error is

    TypeError: %i format: a number is required, not list

After, we get the expected

    IndexError: index [99] is out of bounds for axis 0 with size 3
