### PR TITLE
BUG: fixes for MSVC version checks

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -549,10 +549,12 @@ if sys.platform == 'win32':
         _MSVCRVER_TO_FULLVER['100'] = "10.0.30319.460"
         # Python 3.7 uses 1415, but get_build_version returns 140 ??
         _MSVCRVER_TO_FULLVER['140'] = "14.15.26726.0"
-        if hasattr(msvcrt, "CRT_ASSEMBLY_VERSION"):
-            major, minor, rest = msvcrt.CRT_ASSEMBLY_VERSION.split(".", 2)
-            _MSVCRVER_TO_FULLVER[major + minor] = msvcrt.CRT_ASSEMBLY_VERSION
-            del major, minor, rest
+        crt_ver = getattr(msvcrt, 'CRT_ASSEMBLY_VERSION', None)
+        if crt_ver is not None:  # Available at least back to Python 3.3
+            maj, min = re.match(r'(\d+)\.(\d)', crt_ver).groups()
+            _MSVCRVER_TO_FULLVER[maj + min] = crt_ver
+            del maj, min
+        del crt_ver
     except ImportError:
         # If we are here, means python was not built with MSVC. Not sure what
         # to do in that case: manifest building will fail, but it should not be

--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -547,8 +547,6 @@ if sys.platform == 'win32':
         # Value from msvcrt.CRT_ASSEMBLY_VERSION under Python 3.3.0
         # on Windows XP:
         _MSVCRVER_TO_FULLVER['100'] = "10.0.30319.460"
-        # Python 3.7 uses 1415, but get_build_version returns 140 ??
-        _MSVCRVER_TO_FULLVER['140'] = "14.15.26726.0"
         crt_ver = getattr(msvcrt, 'CRT_ASSEMBLY_VERSION', None)
         if crt_ver is not None:  # Available at least back to Python 3.3
             maj, min = re.match(r'(\d+)\.(\d)', crt_ver).groups()


### PR DESCRIPTION
The original implementation did not deal correctly with MSVC
CRT_ASSEMBLY_VERSIONs when the minor version number was > 9.

With this fix, the code correctly finds the version that is being patched with
the specific '140' clause that I've removed here.  The patch was needed both
because of the bug fixed here, and also because of the bug fixed in gh-20155.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->