### PR TITLE
ENH: Expose promoters and Common-DType API experimentally

### DIFF
--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -295,8 +295,7 @@ typedef struct{
 
 
 #define PyArrayDTypeMeta_Type \
-    (&(PyTypeObject *)__experimental_dtype_api_table[2])
-
+    (*(PyTypeObject *)__experimental_dtype_api_table[2])
 typedef int __dtypemeta_fromspec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *dtype_spec);
 /*

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -16,13 +16,47 @@
  * in your module init.  (A version mismatch will be reported, just update
  * to the correct one, this will alert you of possible changes.)
  *
- * The two main symbols exported are:
+ * The following lists the main symbols currently exported.  Please do not
+ * hesitate to ask for help or clarification:
  *
- * - PyUFunc_AddLoopFromSpec  (Register a new loop for a ufunc)
- * - PyArrayInitDTypeMeta_FromSpec  (Create a new DType)
+ * - PyUFunc_AddLoopFromSpec:
  *
- * Please check the in-line documentation for details and do not hesitate to
- * ask for help.
+ *     Register a new loop for a ufunc.  This uses the `PyArrayMethod_Spec`
+ *     which must be filled in (see in-line comments).
+ *
+ * - PyUFunc_AddPromoter:
+ *
+ *     Register a new promoter for a ufunc.  A promoter is a function stored
+ *     in a PyCapsule (see in-line comments).  It is passed the operation and
+ *     requested DType signatures and can mutate it to attempt a new search
+ *     for a matching loop/promoter.
+ *     I.e. for Numba a promoter could even add the desired loop.
+ *
+ * - PyArrayInitDTypeMeta_FromSpec:
+ *
+ *     Initialize a new DType.  It must currently be a static Python C type
+ *     that is declared as `PyArray_DTypeMeta` and not `PyTypeObject`.
+ *     Further, it must subclass `np.dtype` and set its type to
+ *     `PyArrayDTypeMeta_Type` (before calling `PyType_Read()`).
+ *
+ * - PyArray_CommonDType:
+ *
+ *     Find the common-dtype ("promotion") for two DType classes.  Similar
+ *     to `np.result_type`, but works on the classes and not instances.
+ *
+ * - PyArray_PromoteDTypeSequence:
+ *
+ *     Same as CommonDType, but works with an arbitrary number of DTypes.
+ *     This function is smarter and can often return successful and unambiguous
+ *     results when `common_dtype(common_dtype(dt1, dt2), dt3)` would
+ *     depend on the operation order or fail.  Nevertheless, DTypes should
+ *     aim to ensure that their common-dtype implementation is associative
+ *     and commutative!  (Mainly, unsigned and signed integers are not.)
+ *
+ *     For guaranteed consistent results DTypes must implement common-Dtype
+ *     "transitively".  If A promotes B and B promotes C, than A must generally
+ *     also promote C; where "promotes" means implements the promotion.
+ *     (There are some exceptions for abstract DTypes)
  *
  * WARNING
  * =======
@@ -67,10 +101,27 @@ __not_imported(void)
     printf("*****\nCritical error, dtype API not imported\n*****\n");
 }
 static void *__uninitialized_table[] = {
+        &__not_imported, &__not_imported, &__not_imported, &__not_imported,
         &__not_imported, &__not_imported, &__not_imported, &__not_imported};
 
 
 static void **__experimental_dtype_api_table = __uninitialized_table;
+
+
+/*
+ * DTypeMeta struct, the content may be made fully opaque (except the size).
+ * We may also move everything into a single `void *dt_slots`.
+ */
+typedef struct {
+    PyHeapTypeObject super;
+    PyArray_Descr *singleton;
+    int type_num;
+    PyTypeObject *scalar_type;
+    npy_uint64 flags;
+    void *dt_slots;
+    void *reserved[3];
+} PyArray_DTypeMeta;
+
 
 /*
  * ******************************************************
@@ -126,6 +177,28 @@ typedef PyObject *_ufunc_addloop_fromspec_func(
 #define PyUFunc_AddLoopFromSpec \
     (*(_ufunc_addloop_fromspec_func *)(__experimental_dtype_api_table[0]))
 
+
+/*
+ * Type of the C promoter function, which must be wrapped into a
+ * PyCapsule with name "numpy._ufunc_promoter".
+ */
+typedef int promoter_function(PyObject *ufunc,
+        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *new_op_dtypes[]);
+
+/*
+ * Function to register a promoter.
+ *
+ * @param ufunc The ufunc object to register the promoter with.
+ * @param DType_tuple A Python tuple containing DTypes or None matching the
+ *        number of inputs and outputs of the ufunc.
+ * @param promoter A PyCapsule with name "numpy._ufunc_promoter" containing
+ *        a pointer to a `promoter_function`.
+ */
+typedef int _ufunc_addpromoter_func(
+        PyObject *ufunc, PyObject *DType_tuple, PyObject *promoter);
+#define PyUFunc_AddPromoter \
+    (*(_ufunc_addpromoter_func *)(__experimental_dtype_api_table[1]))
 
 /*
  * In addition to the normal casting levels, NPY_CAST_IS_VIEW indicates
@@ -221,23 +294,8 @@ typedef struct{
 } PyArrayDTypeMeta_Spec;
 
 
-/*
- * DTypeMeta struct, the content may be made fully opaque (except the size).
- * We may also move everything into a single `void *dt_slots`.
- */
-typedef struct {
-    PyHeapTypeObject super;
-    PyArray_Descr *singleton;
-    int type_num;
-    PyTypeObject *scalar_type;
-    npy_uint64 flags;
-    void *dt_slots;
-    void *reserved[3];
-} PyArray_DTypeMeta;
-
-
 #define PyArrayDTypeMeta_Type \
-    (&(PyTypeObject *)__experimental_dtype_api_table[1])
+    (&(PyTypeObject *)__experimental_dtype_api_table[2])
 
 typedef int __dtypemeta_fromspec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *dtype_spec);
@@ -250,8 +308,25 @@ typedef int __dtypemeta_fromspec(
  * uses `PyArray_DTypeMeta` defined above as the C-structure.
  */
 #define PyArrayInitDTypeMeta_FromSpec \
-    ((__dtypemeta_fromspec *)(__experimental_dtype_api_table[2]))
+    ((__dtypemeta_fromspec *)(__experimental_dtype_api_table[3]))
 
+
+/*
+ * *************************************
+ *          WORKING WITH DTYPES
+ * *************************************
+ */
+
+typedef PyArray_DTypeMeta *__common_dtype(
+        PyArray_DTypeMeta *DType1, PyArray_DTypeMeta *DType2);
+#define PyArray_CommonDType \
+    ((__common_dtype *)(__experimental_dtype_api_table[4]))
+
+
+typedef PyArray_DTypeMeta *__promote_dtype_sequence(
+        npy_intp num, PyArray_DTypeMeta *DTypes[]);
+#define PyArray_PromoteDTypeSequence \
+    ((__promote_dtype_sequence *)(__experimental_dtype_api_table[5]))
 
 
 /*
@@ -264,7 +339,7 @@ typedef int __dtypemeta_fromspec(
  * runtime-check this.
  * You must call this function to use the symbols defined in this file.
  */
-#define __EXPERIMENTAL_DTYPE_VERSION 1
+#define __EXPERIMENTAL_DTYPE_VERSION 2
 
 static int
 import_experimental_dtype_api(int version)

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -13,9 +13,10 @@
 #include "dtypemeta.h"
 #include "array_coercion.h"
 #include "convert_datatype.h"
+#include "common_dtype.h"
 
 
-#define EXPERIMENTAL_DTYPE_API_VERSION 1
+#define EXPERIMENTAL_DTYPE_API_VERSION 2
 
 
 typedef struct{
@@ -324,13 +325,41 @@ PyUFunc_AddLoopFromSpec(PyObject *ufunc, PyArrayMethod_Spec *spec)
 }
 
 
+static int
+PyUFunc_AddPromoter(
+        PyObject *ufunc, PyObject *DType_tuple, PyObject *promoter)
+{
+    if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
+        PyErr_SetString(PyExc_TypeError,
+                "ufunc object passed is not a ufunc!");
+        return -1;
+    }
+    if (!PyCapsule_CheckExact(promoter)) {
+        PyErr_SetString(PyExc_TypeError,
+                "promoter must (currently) be a PyCapsule.");
+        return -1;
+    }
+    if (PyCapsule_GetPointer(promoter, "numpy._ufunc_promoter") == NULL) {
+        return -1;
+    }
+    PyObject *info = PyTuple_Pack(2, DType_tuple, promoter);
+    if (info == NULL) {
+        return -1;
+    }
+    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+}
+
+
 NPY_NO_EXPORT PyObject *
 _get_experimental_dtype_api(PyObject *NPY_UNUSED(mod), PyObject *arg)
 {
     static void *experimental_api_table[] = {
             &PyUFunc_AddLoopFromSpec,
+            &PyUFunc_AddPromoter,
             &PyArrayDTypeMeta_Type,
             &PyArrayInitDTypeMeta_FromSpec,
+            &PyArray_CommonDType,
+            &PyArray_PromoteDTypeSequence,
             NULL,
     };
 


### PR DESCRIPTION
This is tested in my fork at:
https://github.com/seberg/experimental_user_dtypes/pull/4

Which tries most of the functionality newly exported here, by
testing a very basic (basically a no-op) promoter.