### PR TITLE
More informative error for unparsable version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ FULLVERSION = versioneer.get_version()
 # 1.22.0 ... -> ISRELEASED == True, VERSION == 1.22.0
 # 1.22.0rc1 ... -> ISRELEASED == True, VERSION == 1.22.0
 ISRELEASED = re.search(r'(dev|\+)', FULLVERSION) is None
-MAJOR, MINOR, MICRO = re.match(r'(\d+)\.(\d+)\.(\d+)', FULLVERSION).groups()
+_V_MATCH = re.match(r'(\d+)\.(\d+)\.(\d+)', FULLVERSION)
+if _V_MATCH is None:
+    raise RuntimeError(f'Cannot parse version {FULLVERSION}')
+MAJOR, MINOR, MICRO = _V_MATCH.groups()
 VERSION = '{}.{}.{}'.format(MAJOR, MINOR, MICRO)
 
 # The first version not in the `Programming Language :: Python :: ...` classifiers above


### PR DESCRIPTION
When Git is not installed, it is possible to get useless version strings
from versioneer, such as `0+unknown`.  Give a more informative error in
that case.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->