### PR TITLE
Allow clib callable build flags

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -704,6 +704,7 @@ def configuration(parent_package='',top_path=None):
         we are building the library.
         """
         if build_cmd.compiler.compiler_type == 'msvc':
+            # explicitly disable whole-program optimization
             return ['/GL-']
         return []
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -696,16 +696,23 @@ def configuration(parent_package='',top_path=None):
                        join('src', 'npymath', 'halffloat.c')
                        ]
 
-    # Must be true for CRT compilers but not MinGW/cygwin. See gh-9977.
-    # Intel and Clang also don't seem happy with /GL
-    is_msvc = (platform.platform().startswith('Windows') and
-               platform.python_compiler().startswith('MS'))
+    def gl_if_msvc(build_cmd):
+        """ Add flag if we are using MSVC compiler
+
+        We can't see this in our scope, because we have not initialized the
+        distutils build command, so use this deferred calculation to run when
+        we are building the library.
+        """
+        if build_cmd.compiler.compiler_type == 'msvc':
+            return ['/GL-']
+        return []
+
     config.add_installed_library('npymath',
             sources=npymath_sources + [get_mathlib_info],
             install_dir='lib',
             build_info={
                 'include_dirs' : [],  # empty list required for creating npy_math_internal.h
-                'extra_compiler_args' : (['/GL-'] if is_msvc else []),
+                'extra_compiler_args': [gl_if_msvc],
             })
     config.add_npy_pkg_config("npymath.ini.in", "lib/npy-pkg-config",
             subst_dict)

--- a/numpy/distutils/command/build_clib.py
+++ b/numpy/distutils/command/build_clib.py
@@ -185,6 +185,30 @@ class build_clib(old_build_clib):
         for (lib_name, build_info) in libraries:
             self.build_a_library(build_info, lib_name, libraries)
 
+    def assemble_flags(self, in_flags):
+        """ Assemble flags from flag list
+
+        Parameters
+        ----------
+        in_flags : None or sequence
+            None corresponds to empty list.  Sequence elements can be strings
+            or callables that return lists of strings. Callable takes `self` as
+            single parameter.
+
+        Returns
+        -------
+        out_flags : list
+        """
+        if in_flags is None:
+            return []
+        out_flags = []
+        for in_flag in in_flags:
+            if callable(in_flag):
+                out_flags += in_flag(self)
+            else:
+                out_flags.append(in_flag)
+        return out_flags
+
     def build_a_library(self, build_info, lib_name, libraries):
         # default compilers
         compiler = self.compiler
@@ -263,9 +287,13 @@ class build_clib(old_build_clib):
         include_dirs = build_info.get('include_dirs')
         if include_dirs is None:
             include_dirs = []
-        extra_postargs = build_info.get('extra_compiler_args') or []
-        extra_cflags = build_info.get('extra_cflags') or []
-        extra_cxxflags = build_info.get('extra_cxxflags') or []
+        # Flags can be strings, or callables that return a list of strings.
+        extra_postargs = self.assemble_flags(
+            build_info.get('extra_compiler_args'))
+        extra_cflags = self.assemble_flags(
+            build_info.get('extra_cflags'))
+        extra_cxxflags = self.assemble_flags(
+            build_info.get('extra_cxxflags'))
 
         include_dirs.extend(get_numpy_include_dirs())
         # where compiled F90 module files are:

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -73,7 +73,9 @@ def configuration(parent_package='', top_path=None):
         distutils build command, so use this deferred calculation to run when
         we are building the library.
         """
+        # Keep in sync with numpy/core/setup.py
         if build_cmd.compiler.compiler_type == 'msvc':
+            # explicitly disable whole-program optimization
             return ['/GL-']
         return []
 

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -65,12 +65,24 @@ def configuration(parent_package='', top_path=None):
         'src/distributions/random_mvhg_marginals.c',
         'src/distributions/random_hypergeometric.c',
     ]
+
+    def gl_if_msvc(build_cmd):
+        """ Add flag if we are using MSVC compiler
+
+        We can't see this in our scope, because we have not initialized the
+        distutils build command, so use this deferred calculation to run when
+        we are building the library.
+        """
+        if build_cmd.compiler.compiler_type == 'msvc':
+            return ['/GL-']
+        return []
+
     config.add_installed_library('npyrandom',
         sources=npyrandom_sources,
         install_dir='lib',
         build_info={
             'include_dirs' : [],  # empty list required for creating npyrandom.h
-            'extra_compiler_args' : (['/GL-'] if is_msvc else []),
+            'extra_compiler_args': [gl_if_msvc],
         })
 
     for gen in ['mt19937']:


### PR DESCRIPTION
At the moment, we are guessing whether we have the MSVC compiler, by
looking at what Python was originally compiled for.  That works only if
we are using the same compiler, but this is not the case when we compile
with e.g. mingw-w64 using Python.org Python.

Unfortunately, at the time we are specifying build flags, we don't know
what compiler we are using.

Allow build flags to clib to be callables that return lists of strings,
instead of strings, where the callables can do work like inspecting the
compiler, at build time.

Use this to check for MSVC at build time, when specifying the
`/GL-` flag.

See gh-9977 for a related discussion about these flags.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->