### PR TITLE
TST: xfail `test_overrides` when numpy is built with MKL support

### DIFF
--- a/numpy/distutils/tests/test_system_info.py
+++ b/numpy/distutils/tests/test_system_info.py
@@ -254,6 +254,10 @@ class TestSystemInfoReading:
         finally:
             os.chdir(previousDir)
 
+    HAS_MKL = "mkl_rt" in mkl_info().calc_libraries_info().get("libraries", [])
+
+    @pytest.mark.xfail(HAS_MKL, reason=("`[DEFAULT]` override doesn't work if "
+                                        "numpy is built with MKL support"))
     def test_overrides(self):
         previousDir = os.getcwd()
         cfg = os.path.join(self._dir1, 'site.cfg')


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16769

The exact details are not 100% clear to me, but the test seems to act on the assumption that numpy is build without MKL supports and fails when this is not the case.

Alternative solutions (that do not involve `xfail`) are also welcome; the failing test simply has been bothering me for some time.