### PR TITLE
BUG,DOC: Resolve a refguide failure for `ndarray.__class_getitem__`

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2819,7 +2819,7 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('__class_getitem__',
     >>> import numpy as np
 
     >>> np.ndarray[Any, np.dtype[Any]]
-    numpy.ndarray[typing.Any, numpy.dtype[Any]]
+    numpy.ndarray[typing.Any, numpy.dtype[typing.Any]]
 
     Notes
     -----


### PR DESCRIPTION
Xref https://github.com/numpy/numpy/pull/20161#issuecomment-950652814

A module-name was missing from a string-representation.