### PR TITLE
BUG: Don't pass /arch:SSE2 to MSVC when targeting x64

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -406,8 +406,8 @@ class _Config:
             AVX512_ICL = dict(flags="/Qx:ICELAKE-CLIENT")
         )
         if on_x86 and self.cc_is_msvc: return dict(
-            SSE    = dict(flags="/arch:SSE"),
-            SSE2   = dict(flags="/arch:SSE2"),
+            SSE    = dict(flags="/arch:SSE") if self.cc_on_x86 else {},
+            SSE2   = dict(flags="/arch:SSE2") if self.cc_on_x86 else {},
             SSE3   = {},
             SSSE3  = {},
             SSE41  = {},

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -406,8 +406,8 @@ class _Config:
             AVX512_ICL = dict(flags="/Qx:ICELAKE-CLIENT")
         )
         if on_x86 and self.cc_is_msvc: return dict(
-            SSE    = dict(flags="/arch:SSE") if self.cc_on_x86 else {},
-            SSE2   = dict(flags="/arch:SSE2") if self.cc_on_x86 else {},
+            SSE = dict(flags="/arch:SSE") if self.cc_on_x86 else {},
+            SSE2 = dict(flags="/arch:SSE2") if self.cc_on_x86 else {},
             SSE3   = {},
             SSSE3  = {},
             SSE41  = {},

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -434,7 +434,8 @@ class _Test_CCompilerOpt:
         self.expect_flags(
             "sse sse2 vsx vsx2 neon neon_fp16",
             x86_gcc="-msse -msse2", x86_icc="-msse -msse2",
-            x86_iccw="/arch:SSE2", x86_msvc="/arch:SSE2",
+            x86_iccw="/arch:SSE2",
+            x86_msvc="/arch:SSE2" if self.march() == "x86" else "",
             ppc64_gcc= "-mcpu=power8",
             ppc64_clang="-maltivec -mvsx -mpower8-vector",
             armhf_gcc="-mfpu=neon-fp16 -mfp16-format=ieee",
@@ -636,8 +637,8 @@ class _Test_CCompilerOpt:
             x86_gcc="avx512f avx2 sse42 sse41 sse2",
             x86_icc="avx512f avx2 sse42 sse41 sse2",
             x86_iccw="avx512f avx2 sse42 sse41 sse2",
-            x86_msvc="avx512f avx2 sse2" if self.march() == 'x86'
-                else "avx512f avx2",
+            x86_msvc="avx512f avx2 sse2"
+                     if self.march() == 'x86' else "avx512f avx2",
             ppc64="vsx3 vsx2",
             armhf="asimddp asimd neon_vfpv4 neon",
             # neon, neon_vfpv4, asimd implies each other

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -636,7 +636,7 @@ class _Test_CCompilerOpt:
             x86_gcc="avx512f avx2 sse42 sse41 sse2",
             x86_icc="avx512f avx2 sse42 sse41 sse2",
             x86_iccw="avx512f avx2 sse42 sse41 sse2",
-            x86_msvc="avx512f avx2 sse2",
+            x86_msvc="avx512f avx2 sse2" if self.march() == 'x86' else "avx512f avx2",
             ppc64="vsx3 vsx2",
             armhf="asimddp asimd neon_vfpv4 neon",
             # neon, neon_vfpv4, asimd implies each other

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -636,7 +636,8 @@ class _Test_CCompilerOpt:
             x86_gcc="avx512f avx2 sse42 sse41 sse2",
             x86_icc="avx512f avx2 sse42 sse41 sse2",
             x86_iccw="avx512f avx2 sse42 sse41 sse2",
-            x86_msvc="avx512f avx2 sse2" if self.march() == 'x86' else "avx512f avx2",
+            x86_msvc="avx512f avx2 sse2" if self.march() == 'x86'
+                else "avx512f avx2",
             ppc64="vsx3 vsx2",
             armhf="asimddp asimd neon_vfpv4 neon",
             # neon, neon_vfpv4, asimd implies each other


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

In the current `build_ext` task of numpy, `/arch:SSE2` is passed to MSVC when targeting x64, but it is not a valid option at least since Visual Studio 2015 (see the [document](https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=msvc-140) on MSDN), and following warning will be emitted to the output with it. Also according to the [remarks](https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=msvc-140#remarks) section from the same document, SSE2 is the default mode for MSVC X64 without any `/arch:` option, so this PR set both SSE and SSE2 option to empty for MSVC x64 toolchain.

> cl : Command line warning D9002 : ignoring unknown option '/arch:SSE2'
