### PR TITLE
ENH: Add dtype typing support to `np.core.numeric`

### DIFF
--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -1,6 +1,5 @@
 from typing import (
     Any,
-    Optional,
     Union,
     Sequence,
     Tuple,
@@ -8,17 +7,63 @@ from typing import (
     List,
     overload,
     TypeVar,
-    Iterable,
     Literal,
+    Type,
+    SupportsAbs,
+    SupportsIndex,
+    NoReturn,
+)
+from typing_extensions import TypeGuard
+
+from numpy import (
+    ComplexWarning as ComplexWarning,
+    dtype,
+    generic,
+    unsignedinteger,
+    signedinteger,
+    floating,
+    complexfloating,
+    bool_,
+    int_,
+    intp,
+    float64,
+    timedelta64,
+    object_,
+    _OrderKACF,
+    _OrderCF,
 )
 
-from numpy import ndarray, generic, dtype, bool_, signedinteger, _OrderKACF, _OrderCF
-from numpy.typing import ArrayLike, DTypeLike, _ShapeLike
+from numpy.typing import (
+    ArrayLike,
+    NDArray,
+    DTypeLike,
+    _ShapeLike,
+    _SupportsDType,
+    _FiniteNestedSequence,
+    _SupportsArray,
+    _ScalarLike_co,
+    _ArrayLikeBool_co,
+    _ArrayLikeUInt_co,
+    _ArrayLikeInt_co,
+    _ArrayLikeFloat_co,
+    _ArrayLikeComplex_co,
+    _ArrayLikeTD64_co,
+    _ArrayLikeObject_co,
+)
 
 _T = TypeVar("_T")
-_ArrayType = TypeVar("_ArrayType", bound=ndarray)
+_SCT = TypeVar("_SCT", bound=generic)
+_ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
+_DTypeLike = Union[
+    dtype[_SCT],
+    Type[_SCT],
+    _SupportsDType[dtype[_SCT]],
+]
+_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 _CorrelateMode = Literal["valid", "same", "full"]
+
+__all__: List[str]
 
 @overload
 def zeros_like(
@@ -30,20 +75,61 @@ def zeros_like(
 ) -> _ArrayType: ...
 @overload
 def zeros_like(
-    a: ArrayLike,
-    dtype: DTypeLike = ...,
+    a: _ArrayLike[_SCT],
+    dtype: None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
+    shape: None | _ShapeLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def zeros_like(
+    a: object,
+    dtype: None = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
+@overload
+def zeros_like(
+    a: Any,
+    dtype: _DTypeLike[_SCT],
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[_SCT]: ...
+@overload
+def zeros_like(
+    a: Any,
+    dtype: DTypeLike,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
 
+@overload
 def ones(
     shape: _ShapeLike,
-    dtype: DTypeLike = ...,
+    dtype: None = ...,
     order: _OrderCF = ...,
     *,
     like: ArrayLike = ...,
-) -> ndarray: ...
+) -> NDArray[float64]: ...
+@overload
+def ones(
+    shape: _ShapeLike,
+    dtype: _DTypeLike[_SCT],
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def ones(
+    shape: _ShapeLike,
+    dtype: DTypeLike,
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[Any]: ...
 
 @overload
 def ones_like(
@@ -55,21 +141,64 @@ def ones_like(
 ) -> _ArrayType: ...
 @overload
 def ones_like(
-    a: ArrayLike,
-    dtype: DTypeLike = ...,
+    a: _ArrayLike[_SCT],
+    dtype: None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
+    shape: None | _ShapeLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def ones_like(
+    a: object,
+    dtype: None = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
+@overload
+def ones_like(
+    a: Any,
+    dtype: _DTypeLike[_SCT],
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[_SCT]: ...
+@overload
+def ones_like(
+    a: Any,
+    dtype: DTypeLike,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
 
+@overload
 def full(
     shape: _ShapeLike,
     fill_value: Any,
-    dtype: DTypeLike = ...,
+    dtype: None = ...,
     order: _OrderCF = ...,
     *,
     like: ArrayLike = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
+@overload
+def full(
+    shape: _ShapeLike,
+    fill_value: Any,
+    dtype: _DTypeLike[_SCT],
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def full(
+    shape: _ShapeLike,
+    fill_value: Any,
+    dtype: DTypeLike,
+    order: _OrderCF = ...,
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[Any]: ...
 
 @overload
 def full_like(
@@ -82,13 +211,40 @@ def full_like(
 ) -> _ArrayType: ...
 @overload
 def full_like(
-    a: ArrayLike,
+    a: _ArrayLike[_SCT],
     fill_value: Any,
-    dtype: DTypeLike = ...,
+    dtype: None = ...,
     order: _OrderKACF = ...,
     subok: bool = ...,
-    shape: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
+    shape: None | _ShapeLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def full_like(
+    a: object,
+    fill_value: Any,
+    dtype: None = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
+@overload
+def full_like(
+    a: Any,
+    fill_value: Any,
+    dtype: _DTypeLike[_SCT],
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[_SCT]: ...
+@overload
+def full_like(
+    a: Any,
+    fill_value: Any,
+    dtype: DTypeLike,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    shape: None | _ShapeLike= ...,
+) -> NDArray[Any]: ...
 
 @overload
 def count_nonzero(
@@ -105,78 +261,306 @@ def count_nonzero(
     keepdims: bool = ...,
 ) -> Any: ...  # TODO: np.intp or ndarray[np.intp]
 
-def isfortran(a: Union[ndarray, generic]) -> bool: ...
+def isfortran(a: NDArray[Any] | generic) -> bool: ...
 
-def argwhere(a: ArrayLike) -> ndarray: ...
+def argwhere(a: ArrayLike) -> NDArray[intp]: ...
 
-def flatnonzero(a: ArrayLike) -> ndarray: ...
+def flatnonzero(a: ArrayLike) -> NDArray[intp]: ...
 
+@overload
 def correlate(
-    a: ArrayLike,
-    v: ArrayLike,
+    a: _ArrayLikeBool_co,
+    v: _ArrayLikeBool_co,
     mode: _CorrelateMode = ...,
-) -> ndarray: ...
+) -> NDArray[bool_]: ...
+@overload
+def correlate(
+    a: _ArrayLikeUInt_co,
+    v: _ArrayLikeUInt_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def correlate(
+    a: _ArrayLikeInt_co,
+    v: _ArrayLikeInt_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[signedinteger[Any]]: ...
+@overload
+def correlate(
+    a: _ArrayLikeFloat_co,
+    v: _ArrayLikeFloat_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def correlate(
+    a: _ArrayLikeComplex_co,
+    v: _ArrayLikeComplex_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def correlate(
+    a: _ArrayLikeTD64_co,
+    v: _ArrayLikeTD64_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def correlate(
+    a: _ArrayLikeObject_co,
+    v: _ArrayLikeObject_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[object_]: ...
 
+@overload
 def convolve(
-    a: ArrayLike,
-    v: ArrayLike,
+    a: _ArrayLikeBool_co,
+    v: _ArrayLikeBool_co,
     mode: _CorrelateMode = ...,
-) -> ndarray: ...
+) -> NDArray[bool_]: ...
+@overload
+def convolve(
+    a: _ArrayLikeUInt_co,
+    v: _ArrayLikeUInt_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def convolve(
+    a: _ArrayLikeInt_co,
+    v: _ArrayLikeInt_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[signedinteger[Any]]: ...
+@overload
+def convolve(
+    a: _ArrayLikeFloat_co,
+    v: _ArrayLikeFloat_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def convolve(
+    a: _ArrayLikeComplex_co,
+    v: _ArrayLikeComplex_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def convolve(
+    a: _ArrayLikeTD64_co,
+    v: _ArrayLikeTD64_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def convolve(
+    a: _ArrayLikeObject_co,
+    v: _ArrayLikeObject_co,
+    mode: _CorrelateMode = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def outer(
-    a: ArrayLike,
-    b: ArrayLike,
+    a: _ArrayLikeBool_co,
+    b: _ArrayLikeBool_co,
     out: None = ...,
-) -> ndarray: ...
+) -> NDArray[bool_]: ...
 @overload
 def outer(
-    a: ArrayLike,
-    b: ArrayLike,
-    out: _ArrayType = ...,
+    a: _ArrayLikeUInt_co,
+    b: _ArrayLikeUInt_co,
+    out: None = ...,
+) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def outer(
+    a: _ArrayLikeInt_co,
+    b: _ArrayLikeInt_co,
+    out: None = ...,
+) -> NDArray[signedinteger[Any]]: ...
+@overload
+def outer(
+    a: _ArrayLikeFloat_co,
+    b: _ArrayLikeFloat_co,
+    out: None = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def outer(
+    a: _ArrayLikeComplex_co,
+    b: _ArrayLikeComplex_co,
+    out: None = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def outer(
+    a: _ArrayLikeTD64_co,
+    b: _ArrayLikeTD64_co,
+    out: None = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def outer(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    out: None = ...,
+) -> NDArray[object_]: ...
+@overload
+def outer(
+    a: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    b: _ArrayLikeComplex_co | _ArrayLikeTD64_co | _ArrayLikeObject_co,
+    out: _ArrayType,
 ) -> _ArrayType: ...
 
+@overload
 def tensordot(
-    a: ArrayLike,
-    b: ArrayLike,
-    axes: Union[int, Tuple[_ShapeLike, _ShapeLike]] = ...,
-) -> ndarray: ...
+    a: _ArrayLikeBool_co,
+    b: _ArrayLikeBool_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[bool_]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeUInt_co,
+    b: _ArrayLikeUInt_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeInt_co,
+    b: _ArrayLikeInt_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[signedinteger[Any]]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeFloat_co,
+    b: _ArrayLikeFloat_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeComplex_co,
+    b: _ArrayLikeComplex_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeTD64_co,
+    b: _ArrayLikeTD64_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[timedelta64]: ...
+@overload
+def tensordot(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axes: int | Tuple[_ShapeLike, _ShapeLike] = ...,
+) -> NDArray[object_]: ...
 
+@overload
+def roll(
+    a: _ArrayLike[_SCT],
+    shift: _ShapeLike,
+    axis: None | _ShapeLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def roll(
     a: ArrayLike,
     shift: _ShapeLike,
-    axis: Optional[_ShapeLike] = ...,
-) -> ndarray: ...
+    axis: None | _ShapeLike = ...,
+) -> NDArray[Any]: ...
 
-def rollaxis(a: ndarray, axis: int, start: int = ...) -> ndarray: ...
+def rollaxis(
+    a: NDArray[_SCT],
+    axis: int,
+    start: int = ...,
+) -> NDArray[_SCT]: ...
 
 def moveaxis(
-    a: ndarray,
+    a: NDArray[_SCT],
     source: _ShapeLike,
     destination: _ShapeLike,
-) -> ndarray: ...
+) -> NDArray[_SCT]: ...
 
+@overload
 def cross(
-    a: ArrayLike,
-    b: ArrayLike,
+    a: _ArrayLikeBool_co,
+    b: _ArrayLikeBool_co,
     axisa: int = ...,
     axisb: int = ...,
     axisc: int = ...,
-    axis: Optional[int] = ...,
-) -> ndarray: ...
+    axis: None | int = ...,
+) -> NoReturn: ...
+@overload
+def cross(
+    a: _ArrayLikeUInt_co,
+    b: _ArrayLikeUInt_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[unsignedinteger[Any]]: ...
+@overload
+def cross(
+    a: _ArrayLikeInt_co,
+    b: _ArrayLikeInt_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[signedinteger[Any]]: ...
+@overload
+def cross(
+    a: _ArrayLikeFloat_co,
+    b: _ArrayLikeFloat_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def cross(
+    a: _ArrayLikeComplex_co,
+    b: _ArrayLikeComplex_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def cross(
+    a: _ArrayLikeObject_co,
+    b: _ArrayLikeObject_co,
+    axisa: int = ...,
+    axisb: int = ...,
+    axisc: int = ...,
+    axis: None | int = ...,
+) -> NDArray[object_]: ...
 
 @overload
 def indices(
     dimensions: Sequence[int],
-    dtype: DTypeLike = ...,
+    dtype: Type[int] = ...,
     sparse: Literal[False] = ...,
-) -> ndarray: ...
+) -> NDArray[int_]: ...
 @overload
 def indices(
     dimensions: Sequence[int],
-    dtype: DTypeLike = ...,
+    dtype: Type[int] = ...,
     sparse: Literal[True] = ...,
-) -> Tuple[ndarray, ...]: ...
+) -> Tuple[NDArray[int_], ...]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
+    dtype: _DTypeLike[_SCT],
+    sparse: Literal[False] = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
+    dtype: _DTypeLike[_SCT],
+    sparse: Literal[True],
+) -> Tuple[NDArray[_SCT], ...]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
+    dtype: DTypeLike,
+    sparse: Literal[False] = ...,
+) -> NDArray[Any]: ...
+@overload
+def indices(
+    dimensions: Sequence[int],
+    dtype: DTypeLike,
+    sparse: Literal[True],
+) -> Tuple[NDArray[Any], ...]: ...
 
 def fromfunction(
     function: Callable[..., _T],
@@ -187,18 +571,39 @@ def fromfunction(
     **kwargs: Any,
 ) -> _T: ...
 
-def isscalar(element: Any) -> bool: ...
+def isscalar(element: object) -> TypeGuard[
+    generic | bool | int | float | complex | str | bytes | memoryview
+]: ...
 
-def binary_repr(num: int, width: Optional[int] = ...) -> str: ...
+def binary_repr(num: int, width: None | int = ...) -> str: ...
 
-def base_repr(number: int, base: int = ..., padding: int = ...) -> str: ...
+def base_repr(
+    number: SupportsAbs[float],
+    base: float = ...,
+    padding: SupportsIndex = ...,
+) -> str: ...
 
+@overload
 def identity(
     n: int,
-    dtype: DTypeLike = ...,
+    dtype: None = ...,
     *,
     like: ArrayLike = ...,
-) -> ndarray: ...
+) -> NDArray[float64]: ...
+@overload
+def identity(
+    n: int,
+    dtype: _DTypeLike[_SCT],
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def identity(
+    n: int,
+    dtype: DTypeLike,
+    *,
+    like: ArrayLike = ...,
+) -> NDArray[Any]: ...
 
 def allclose(
     a: ArrayLike,
@@ -208,13 +613,22 @@ def allclose(
     equal_nan: bool = ...,
 ) -> bool: ...
 
+@overload
+def isclose(
+    a: _ScalarLike_co,
+    b: _ScalarLike_co,
+    rtol: float = ...,
+    atol: float = ...,
+    equal_nan: bool = ...,
+) -> bool_: ...
+@overload
 def isclose(
     a: ArrayLike,
     b: ArrayLike,
     rtol: float = ...,
     atol: float = ...,
     equal_nan: bool = ...,
-) -> Any: ...
+) -> NDArray[bool_]: ...
 
 def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = ...) -> bool: ...
 

--- a/numpy/typing/tests/data/fail/array_constructors.pyi
+++ b/numpy/typing/tests/data/fail/array_constructors.pyi
@@ -10,7 +10,7 @@ np.zeros("test")  # E: incompatible type
 np.zeros()  # E: require at least one argument
 
 np.ones("test")  # E: incompatible type
-np.ones()  # E: Missing positional argument
+np.ones()  # E: require at least one argument
 
 np.array(0, float, True)  # E: No overload variant
 

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -120,32 +120,41 @@ reveal_type(np.logspace(0, 10))  # E: numpy.ndarray[Any, Any]
 reveal_type(np.geomspace(1, 10))  # E: numpy.ndarray[Any, Any]
 
 reveal_type(np.zeros_like(A))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
-reveal_type(np.zeros_like(C))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.zeros_like(B))  # E: SubClass
-reveal_type(np.zeros_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.zeros_like(C))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.zeros_like(A, dtype=float))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.zeros_like(B))  # E: SubClass[{float64}]
+reveal_type(np.zeros_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
 
 reveal_type(np.ones_like(A))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
-reveal_type(np.ones_like(C))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.ones_like(B))  # E: SubClass
-reveal_type(np.ones_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ones_like(C))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.ones_like(A, dtype=float))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.ones_like(B))  # E: SubClass[{float64}]
+reveal_type(np.ones_like(B, dtype=np.int64))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
 
 reveal_type(np.full_like(A, i8))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
-reveal_type(np.full_like(C, i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.full_like(C, i8))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.full_like(A, i8, dtype=int))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 reveal_type(np.full_like(B, i8))  # E: SubClass[{float64}]
-reveal_type(np.full_like(B, i8, dtype=np.int64))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.full_like(B, i8, dtype=np.int64))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
 
-reveal_type(np.ones(1))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.ones([1, 1, 1]))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.ones(1))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.ones([1, 1, 1]))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.ones(5, dtype=np.int64))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
+reveal_type(np.ones(5, dtype=int))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 
-reveal_type(np.full(1, i8))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.full([1, 1, 1], i8))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.full(1, i8))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.full([1, 1, 1], i8))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.full(1, i8, dtype=np.float64))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.full(1, i8, dtype=float))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 
-reveal_type(np.indices([1, 2, 3]))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.indices([1, 2, 3], sparse=True))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.indices([1, 2, 3]))  # E: numpy.ndarray[Any, numpy.dtype[{int_}]]
+reveal_type(np.indices([1, 2, 3], sparse=True))  # E: tuple[numpy.ndarray[Any, numpy.dtype[{int_}]]]
 
 reveal_type(np.fromfunction(func, (3, 5)))  # E: SubClass[{float64}]
 
-reveal_type(np.identity(10))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.identity(10))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.identity(10, dtype=np.int64))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
+reveal_type(np.identity(10, dtype=int))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 
 reveal_type(np.atleast_1d(A))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
 reveal_type(np.atleast_1d(C))  # E: numpy.ndarray[Any, numpy.dtype[Any]]

--- a/numpy/typing/tests/data/reveal/numeric.pyi
+++ b/numpy/typing/tests/data/reveal/numeric.pyi
@@ -7,83 +7,128 @@ Does not include tests which fall under ``array_constructors``.
 
 from typing import List
 import numpy as np
+import numpy.typing as npt
 
-class SubClass(np.ndarray):
+class SubClass(npt.NDArray[np.int64]):
     ...
 
 i8: np.int64
 
-A: np.ndarray
+AR_b: npt.NDArray[np.bool_]
+AR_u8: npt.NDArray[np.uint64]
+AR_i8: npt.NDArray[np.int64]
+AR_f8: npt.NDArray[np.float64]
+AR_c16: npt.NDArray[np.complex128]
+AR_m: npt.NDArray[np.timedelta64]
+AR_O: npt.NDArray[np.object_]
+
 B: List[int]
 C: SubClass
 
 reveal_type(np.count_nonzero(i8))  # E: int
-reveal_type(np.count_nonzero(A))  # E: int
+reveal_type(np.count_nonzero(AR_i8))  # E: int
 reveal_type(np.count_nonzero(B))  # E: int
-reveal_type(np.count_nonzero(A, keepdims=True))  # E: Any
-reveal_type(np.count_nonzero(A, axis=0))  # E: Any
+reveal_type(np.count_nonzero(AR_i8, keepdims=True))  # E: Any
+reveal_type(np.count_nonzero(AR_i8, axis=0))  # E: Any
 
 reveal_type(np.isfortran(i8))  # E: bool
-reveal_type(np.isfortran(A))  # E: bool
+reveal_type(np.isfortran(AR_i8))  # E: bool
 
-reveal_type(np.argwhere(i8))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.argwhere(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.argwhere(i8))  # E: numpy.ndarray[Any, numpy.dtype[{intp}]]
+reveal_type(np.argwhere(AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[{intp}]]
 
-reveal_type(np.flatnonzero(i8))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.flatnonzero(A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.flatnonzero(i8))  # E: numpy.ndarray[Any, numpy.dtype[{intp}]]
+reveal_type(np.flatnonzero(AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[{intp}]]
 
-reveal_type(np.correlate(B, A, mode="valid"))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.correlate(A, A, mode="same"))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.correlate(B, AR_i8, mode="valid"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.correlate(AR_i8, AR_i8, mode="same"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.correlate(AR_b, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.correlate(AR_b, AR_u8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.unsignedinteger[Any]]]
+reveal_type(np.correlate(AR_i8, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.correlate(AR_i8, AR_f8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.correlate(AR_i8, AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.correlate(AR_i8, AR_m))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.correlate(AR_O, AR_O))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
 
-reveal_type(np.convolve(B, A, mode="valid"))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.convolve(A, A, mode="same"))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.convolve(B, AR_i8, mode="valid"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.convolve(AR_i8, AR_i8, mode="same"))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.convolve(AR_b, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.convolve(AR_b, AR_u8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.unsignedinteger[Any]]]
+reveal_type(np.convolve(AR_i8, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.convolve(AR_i8, AR_f8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.convolve(AR_i8, AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.convolve(AR_i8, AR_m))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.convolve(AR_O, AR_O))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
 
-reveal_type(np.outer(i8, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.outer(B, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.outer(A, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.outer(A, A, out=C))  # E: SubClass
+reveal_type(np.outer(i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.outer(B, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.outer(AR_i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.outer(AR_i8, AR_i8, out=C))  # E: SubClass
+reveal_type(np.outer(AR_b, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.outer(AR_b, AR_u8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.unsignedinteger[Any]]]
+reveal_type(np.outer(AR_i8, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.convolve(AR_i8, AR_f8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.outer(AR_i8, AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.outer(AR_i8, AR_m))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.outer(AR_O, AR_O))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
 
-reveal_type(np.tensordot(B, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.tensordot(A, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.tensordot(A, A, axes=0))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.tensordot(A, A, axes=(0, 1)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.tensordot(B, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_i8, axes=0))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_i8, axes=(0, 1)))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.tensordot(AR_b, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.tensordot(AR_b, AR_u8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.unsignedinteger[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_f8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.tensordot(AR_i8, AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.tensordot(AR_i8, AR_m))  # E: numpy.ndarray[Any, numpy.dtype[numpy.timedelta64]]
+reveal_type(np.tensordot(AR_O, AR_O))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
 
 reveal_type(np.isscalar(i8))  # E: bool
-reveal_type(np.isscalar(A))  # E: bool
+reveal_type(np.isscalar(AR_i8))  # E: bool
 reveal_type(np.isscalar(B))  # E: bool
 
-reveal_type(np.roll(A, 1))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.roll(A, (1, 2)))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.roll(B, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.roll(AR_i8, 1))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
+reveal_type(np.roll(AR_i8, (1, 2)))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
+reveal_type(np.roll(B, 1))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
 
-reveal_type(np.rollaxis(A, 0, 1))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.rollaxis(AR_i8, 0, 1))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
 
-reveal_type(np.moveaxis(A, 0, 1))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.moveaxis(A, (0, 1), (1, 2)))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.moveaxis(AR_i8, 0, 1))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
+reveal_type(np.moveaxis(AR_i8, (0, 1), (1, 2)))  # E: numpy.ndarray[Any, numpy.dtype[{int64}]]
 
-reveal_type(np.cross(B, A))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.cross(A, A))  # E: numpy.ndarray[Any, Any]
+reveal_type(np.cross(B, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.cross(AR_i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.cross(AR_b, AR_u8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.unsignedinteger[Any]]]
+reveal_type(np.cross(AR_i8, AR_b))  # E: numpy.ndarray[Any, numpy.dtype[numpy.signedinteger[Any]]]
+reveal_type(np.cross(AR_i8, AR_f8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.floating[Any]]]
+reveal_type(np.cross(AR_i8, AR_c16))  # E: numpy.ndarray[Any, numpy.dtype[numpy.complexfloating[Any, Any]]]
+reveal_type(np.cross(AR_O, AR_O))  # E: numpy.ndarray[Any, numpy.dtype[numpy.object_]]
 
-reveal_type(np.indices([0, 1, 2]))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.indices([0, 1, 2], sparse=False))  # E: numpy.ndarray[Any, Any]
-reveal_type(np.indices([0, 1, 2], sparse=True))  # E: tuple[numpy.ndarray[Any, Any]]
+reveal_type(np.indices([0, 1, 2]))  # E: numpy.ndarray[Any, numpy.dtype[{int_}]]
+reveal_type(np.indices([0, 1, 2], sparse=True))  # E: tuple[numpy.ndarray[Any, numpy.dtype[{int_}]]]
+reveal_type(np.indices([0, 1, 2], dtype=np.float64))  # E: numpy.ndarray[Any, numpy.dtype[{float64}]]
+reveal_type(np.indices([0, 1, 2], sparse=True, dtype=np.float64))  # E: tuple[numpy.ndarray[Any, numpy.dtype[{float64}]]]
+reveal_type(np.indices([0, 1, 2], dtype=float))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.indices([0, 1, 2], sparse=True, dtype=float))  # E: tuple[numpy.ndarray[Any, numpy.dtype[Any]]]
 
 reveal_type(np.binary_repr(1))  # E: str
 
 reveal_type(np.base_repr(1))  # E: str
 
-reveal_type(np.allclose(i8, A))  # E: bool
-reveal_type(np.allclose(B, A))  # E: bool
-reveal_type(np.allclose(A, A))  # E: bool
+reveal_type(np.allclose(i8, AR_i8))  # E: bool
+reveal_type(np.allclose(B, AR_i8))  # E: bool
+reveal_type(np.allclose(AR_i8, AR_i8))  # E: bool
 
-reveal_type(np.isclose(i8, A))  # E: Any
-reveal_type(np.isclose(B, A))  # E: Any
-reveal_type(np.isclose(A, A))  # E: Any
+reveal_type(np.isclose(i8, i8))  # E: numpy.bool_
+reveal_type(np.isclose(i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.isclose(B, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
+reveal_type(np.isclose(AR_i8, AR_i8))  # E: numpy.ndarray[Any, numpy.dtype[numpy.bool_]]
 
-reveal_type(np.array_equal(i8, A))  # E: bool
-reveal_type(np.array_equal(B, A))  # E: bool
-reveal_type(np.array_equal(A, A))  # E: bool
+reveal_type(np.array_equal(i8, AR_i8))  # E: bool
+reveal_type(np.array_equal(B, AR_i8))  # E: bool
+reveal_type(np.array_equal(AR_i8, AR_i8))  # E: bool
 
-reveal_type(np.array_equiv(i8, A))  # E: bool
-reveal_type(np.array_equiv(B, A))  # E: bool
-reveal_type(np.array_equiv(A, A))  # E: bool
+reveal_type(np.array_equiv(i8, AR_i8))  # E: bool
+reveal_type(np.array_equiv(B, AR_i8))  # E: bool
+reveal_type(np.array_equiv(AR_i8, AR_i8))  # E: bool

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -98,16 +98,10 @@ def run_mypy() -> None:
 def get_test_cases(directory: str) -> Iterator[ParameterSet]:
     for root, _, files in os.walk(directory):
         for fname in files:
-            if os.path.splitext(fname)[-1] in (".pyi", ".py"):
+            short_fname, ext = os.path.splitext(fname)
+            if ext in (".pyi", ".py"):
                 fullpath = os.path.join(root, fname)
-                # Use relative path for nice py.test name
-                relpath = os.path.relpath(fullpath, start=directory)
-
-                yield pytest.param(
-                    fullpath,
-                    # Manually specify a name for the test
-                    id=relpath,
-                )
+                yield pytest.param(fullpath, id=short_fname)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This PR adds dtype typing support to the functions in `np.core.numeric`.