### PR TITLE
MAINT: Only warn for transferred ownership if env variable is set

### DIFF
--- a/doc/release/upcoming_changes/17582.new_feature.rst
+++ b/doc/release/upcoming_changes/17582.new_feature.rst
@@ -3,6 +3,8 @@ NEP 49 configurable allocators
 As detailed in `NEP 49`_, the function used for allocation of the data segment
 of a ndarray can be changed. The policy can be set globally or in a context.
 For more information see the NEP and the :ref:`data_memory` reference docs.
+Also add a ``NUMPY_WARN_IF_NO_MEM_POLICY`` override to warn on dangerous use
+of transfering ownership by setting ``NPY_ARRAY_OWNDATA``.
 
 .. _`NEP 49`: https://numpy.org/neps/nep-0049.html
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -325,8 +325,7 @@ From scratch
     should be increased after the pointer is passed in, and the base member
     of the returned ndarray should point to the Python object that owns
     the data. This will ensure that the provided memory is not
-    freed while the returned array is in existence. To free memory as soon
-    as the ndarray is deallocated, set the OWNDATA flag on the returned ndarray.
+    freed while the returned array is in existence.
 
 .. c:function:: PyObject* PyArray_SimpleNewFromDescr( \
         int nd, npy_int const* dims, PyArray_Descr* descr)
@@ -1463,7 +1462,9 @@ of the constant names is deprecated in 1.7.
 
 .. c:macro:: NPY_ARRAY_OWNDATA
 
-    The data area is owned by this array.
+    The data area is owned by this array. Should never be set manually, instead
+    create a ``PyObject`` wrapping the data and set the array's base to that
+    object. For an example, see the test in ``test_mem_policy``.
 
 .. c:macro:: NPY_ARRAY_ALIGNED
 

--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -119,3 +119,36 @@ For an example of setting up and using the PyDataMem_Handler, see the test in
     operations that might cause new allocation events (such as the
     creation/destruction numpy objects, or creating/destroying Python
     objects which might cause a gc)
+
+What happens when deallocating if there is no policy set
+--------------------------------------------------------
+
+A rare but useful technique is to allocate a buffer outside NumPy, use
+:c:function:`PyArray_NewFromDescr` to wrap the buffer in a ``ndarray``, then switch
+the ``OWNDATA`` flag to true. When the ``ndarray`` is released, the
+appropriate function from the ``ndarray``'s ``PyDataMem_Handler`` should be
+called to free the buffer. But the ``PyDataMem_Handler`` field was never set,
+it will be ``NULL``. For backward compatibility, NumPy will call ``free()`` to
+release the buffer. If ``NUMPY_WARN_IF_NO_MEM_POLICY`` is set to ``1``, a
+warning will be emitted. The current default is not to emit a warning, this may
+change in a future version of NumPy.
+
+A better technique would be to use a ``PyCapsule`` as a base object:
+
+.. code-block:: c
+
+    /* define a PyCapsule_Destructor, using the correct deallocator for buff */
+    void free_wrap(PyObject *obj){ free(obj); };
+
+    /* then inside the function that creates arr from buff */
+    ...
+    arr = PyArray_NewFromDescr(... buf, ...);
+    if (arr == NULL) {
+        return NULL;
+    }
+    capsule = PyCapsule_New(buf, "my_wrapped_buffer", free_wrap);
+    if (PyArray_SetBaseObject(arr, capsule) == -1) {
+        Py_DECREF(arr);
+        return NULL;
+    }
+    ...

--- a/doc/source/reference/global_state.rst
+++ b/doc/source/reference/global_state.rst
@@ -84,3 +84,13 @@ contiguous in memory.
 Most users will have no reason to change these; for details
 see the :ref:`memory layout <memory-layout>` documentation.
 
+
+Warn if no memory allocation policy when deallocating data
+----------------------------------------------------------
+
+Some users might pass ownership of the data pointer to the ``ndarray`` by
+setting the ``OWNDATA`` flag. If they do this without setting (manually) a
+memory allocation policy, the default will be to call ``free``. If
+``NUMPY_WARN_IF_NO_MEM_POLICY`` is set to ``"1"``, a ``RuntimeWarning`` will
+be emitted. A better alternative is to use a ``PyCapsule`` with a deallocator
+and set the ``ndarray.base``.

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -506,7 +506,7 @@ array_dealloc(PyArrayObject *self)
             if ((env == NULL) || (strncmp(env, "1", 1) == 0)) {
                 char const * msg = "Trying to dealloc data, but a memory policy "
                     "is not set. If you take ownership of the data, you must "
-                    "set a base owning the data (e.g. a PyCapsule)."
+                    "set a base owning the data (e.g. a PyCapsule).";
                 WARN_IN_DEALLOC(PyExc_RuntimeWarning, msg);
             }
             // Guess at malloc/free ???

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -503,14 +503,10 @@ array_dealloc(PyArrayObject *self)
         }
         if (fa->mem_handler == NULL) {
             char *env = getenv("NUMPY_WARN_IF_NO_MEM_POLICY");
-            if (env == NULL) {
-                env = "0";
-            }
-            if (strncmp(env, "1", 1) == 0)
-            {
+            if ((env == NULL) || (strncmp(env, "1", 1) == 0)) {
                 char const * msg = "Trying to dealloc data, but a memory policy "
                     "is not set. If you take ownership of the data, you must "
-                    "also set a memory policy.";
+                    "set a base owning the data (e.g. a PyCapsule)."
                 WARN_IN_DEALLOC(PyExc_RuntimeWarning, msg);
             }
             // Guess at malloc/free ???

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -502,10 +502,17 @@ array_dealloc(PyArrayObject *self)
             nbytes = fa->descr->elsize ? fa->descr->elsize : 1;
         }
         if (fa->mem_handler == NULL) {
-            char const * msg = "Trying to dealloc data, but a memory policy "
-                "is not set. If you take ownership of the data, you must "
-                "also set a memory policy.";
-            WARN_IN_DEALLOC(PyExc_RuntimeWarning, msg);
+            char *env = getenv("NUMPY_WARN_IF_NO_MEM_POLICY");
+            if (env == NULL) {
+                env = "0";
+            }
+            if (strncmp(env, "1", 1) == 0)
+            {
+                char const * msg = "Trying to dealloc data, but a memory policy "
+                    "is not set. If you take ownership of the data, you must "
+                    "also set a memory policy.";
+                WARN_IN_DEALLOC(PyExc_RuntimeWarning, msg);
+            }
             // Guess at malloc/free ???
             free(fa->data);
         } else {

--- a/numpy/core/tests/test_mem_policy.py
+++ b/numpy/core/tests/test_mem_policy.py
@@ -77,7 +77,7 @@ def get_module(tmp_path):
                 Py_DECREF(arr);
                 return NULL;
             }
-            if (PyArray_SetBaseObject((PyArrayObject *)arr, obj) == -1) {
+            if (PyArray_SetBaseObject((PyArrayObject *)arr, obj) < 0) {
                 Py_DECREF(arr);
                 Py_DECREF(obj);
                 return NULL;


### PR DESCRIPTION
Builds on #20194. Fixes breakage of SciPy in https://github.com/scipy/scipy/issues/14917

At some point we could flip the default to "warn" instead of "no warning"