### PR TITLE
BUG,DOC: Fix `random.power`'s error description

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2097,7 +2097,7 @@ cdef class Generator:
         Raises
         ------
         ValueError
-            If a < 1.
+            If a <= 0.
 
         Notes
         -----

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -2527,7 +2527,7 @@ cdef class RandomState:
         Raises
         ------
         ValueError
-            If a < 1.
+            If a <= 0.
 
         See Also
         --------


### PR DESCRIPTION
Current documentation for `random.power` and `random.Generator.power` states that `ValueError` is raised if `a < 1`; however the power function distribution only supports strictly positive `a > 0` and raises `ValueError` if `a <= 0`. Fixed documentation to reflect this.


Behavior for `random.power`:
```
>>> np.random.power(0.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtrand.pyx", line 2599, in numpy.random.mtrand.RandomState.power
  File "_common.pyx", line 574, in numpy.random._common.cont
  File "_common.pyx", line 392, in numpy.random._common.check_constraint
ValueError: a <= 0
>>> np.random.power(-1.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtrand.pyx", line 2599, in numpy.random.mtrand.RandomState.power
  File "_common.pyx", line 574, in numpy.random._common.cont
  File "_common.pyx", line 392, in numpy.random._common.check_constraint
ValueError: a <= 0
>>> np.random.power(0.5)
0.00043636887112359895
```

Behavior for `random.Generator.power`:
```
>>> rng = np.random.default_rng()
>>> rng.power(0.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_generator.pyx", line 2059, in numpy.random._generator.Generator.power
  File "_common.pyx", line 553, in numpy.random._common.cont
  File "_common.pyx", line 371, in numpy.random._common.check_constraint
ValueError: a <= 0
>>> rng.power(-1.0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_generator.pyx", line 2059, in numpy.random._generator.Generator.power
  File "_common.pyx", line 553, in numpy.random._common.cont
  File "_common.pyx", line 371, in numpy.random._common.check_constraint
ValueError: a <= 0
>>> rng.power(0.5)
0.05816661653079209
```