### PR TITLE
BUG: fix test c-extension compilation inside a venv

### DIFF
--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -183,7 +183,7 @@ def _c_compile(cfile, outputfilename, include_dirs=[], libraries=[],
                library_dirs=[]):
     if sys.platform == 'win32':
         compile_extra = ["/we4013"]
-        link_extra = ["/LIBPATH:" + os.path.join(sys.exec_prefix, 'libs')]
+        link_extra = ["/LIBPATH:" + os.path.join(sys.base_prefix, 'libs')]
     elif sys.platform.startswith('linux'):
         compile_extra = [
             "-O0", "-g", "-Werror=implicit-function-declaration", "-fPIC"]


### PR DESCRIPTION
Fixes the first part of #20209 

Inside a virtual environment, `sys.exec_prefix` is the base of the virtual environment where `sys.base_prefix` is the base of the parent installation. Outside of a virtual environment they are identical.