### PR TITLE
DOC: Add a release note for fully annotating the main numpy namespace

### DIFF
--- a/doc/release/upcoming_changes/20217.improvement.rst
+++ b/doc/release/upcoming_changes/20217.improvement.rst
@@ -1,0 +1,10 @@
+Annotating the main Numpy namespace
+--------------------------------------
+Starting from the 1.20 release, PEP 484 type annotations have been included
+for parts of the NumPy library; annotating the remaining functions being a
+work in progress. With the release of 1.22 this process has been completed for
+the main NumPy namespace, which is now fully annotated.
+
+Besides the main namespace, a limited number of sub-packages contain
+annotations as well. This includes, among others, `numpy.testing`,
+`numpy.linalg` and `numpy.random` (available since 1.21).


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/16546

Annotating the main Numpy namespace
--------------------------------------
Starting from the 1.20 release, PEP 484 type annotations have been included for parts of the NumPy library; annotating the remaining functions being a work in progress. With the release of 1.22 this process has been completed for the main NumPy namespace, which is now fully annotated.

Besides the main namespace, a limited number of sub-packages contain annotations as well. This includes, among others, `numpy.testing`, `numpy.linalg` and `numpy.random` (available since 1.21).

