### PR TITLE
ENH: Add annotations for `np.ctypeslib`

### DIFF
--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -1,15 +1,268 @@
-from typing import List, Type
-
 # NOTE: Numpy's mypy plugin is used for importing the correct
 # platform-specific `ctypes._SimpleCData[int]` sub-type
 from ctypes import c_int64 as _c_intp
+
+import os
+import sys
+import ctypes
+from typing import (
+    Literal as L,
+    Any,
+    List,
+    Union,
+    TypeVar,
+    Type,
+    Generic,
+    Optional,
+    overload,
+    Iterable,
+    ClassVar,
+    Tuple,
+    Sequence,
+    Dict,
+)
+
+from numpy import (
+    ndarray,
+    dtype,
+    generic,
+    bool_,
+    byte,
+    short,
+    intc,
+    int_,
+    longlong,
+    ubyte,
+    ushort,
+    uintc,
+    uint,
+    ulonglong,
+    single,
+    double,
+    float_,
+    longdouble,
+    void,
+)
+from numpy.core._internal import _ctypes
+from numpy.core.multiarray import flagsobj
+from numpy.typing import (
+    # Arrays
+    ArrayLike,
+    NDArray,
+    _FiniteNestedSequence,
+    _SupportsArray,
+
+    # Shapes
+    _ShapeLike,
+
+    # DTypes
+    DTypeLike,
+    _SupportsDType,
+    _VoidDTypeLike,
+    _BoolCodes,
+    _UByteCodes,
+    _UShortCodes,
+    _UIntCCodes,
+    _UIntCodes,
+    _ULongLongCodes,
+    _ByteCodes,
+    _ShortCodes,
+    _IntCCodes,
+    _IntCodes,
+    _LongLongCodes,
+    _SingleCodes,
+    _DoubleCodes,
+    _LongDoubleCodes,
+)
+
+# TODO: Add a proper `_Shape` bound once we've got variadic typevars
+_DType = TypeVar("_DType", bound=dtype[Any])
+_DTypeOptional = TypeVar("_DTypeOptional", bound=Optional[dtype[Any]])
+_SCT = TypeVar("_SCT", bound=generic)
+
+_DTypeLike = Union[
+    dtype[_SCT],
+    Type[_SCT],
+    _SupportsDType[dtype[_SCT]],
+]
+_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
+
+_FlagsKind = L[
+    'C_CONTIGUOUS', 'CONTIGUOUS', 'C',
+    'F_CONTIGUOUS', 'FORTRAN', 'F',
+    'ALIGNED', 'A',
+    'WRITEABLE', 'W',
+    'OWNDATA', 'O',
+    'UPDATEIFCOPY', 'U',
+    'WRITEBACKIFCOPY', 'X',
+]
+
+# TODO: Add a shape typevar once we have variadic typevars (PEP 646)
+class _ndptr(ctypes.c_void_p, Generic[_DTypeOptional]):
+    # In practice these 4 classvars are defined in the dynamic class
+    # returned by `ndpointer`
+    _dtype_: ClassVar[_DTypeOptional]
+    _shape_: ClassVar[None]
+    _ndim_: ClassVar[None | int]
+    _flags_: ClassVar[None | List[_FlagsKind]]
+
+    @overload
+    @classmethod
+    def from_param(cls: Type[_ndptr[None]], obj: ndarray[Any, Any]) -> _ctypes: ...
+    @overload
+    @classmethod
+    def from_param(cls: Type[_ndptr[_DType]], obj: ndarray[Any, _DType]) -> _ctypes: ...
+
+class _concrete_ndptr(_ndptr[_DType]):
+    _dtype_: ClassVar[_DType]
+    _shape_: ClassVar[Tuple[int, ...]]
+    @property
+    def contents(self) -> ndarray[Any, _DType]: ...
+
+def load_library(
+    libname: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+    loader_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+) -> ctypes.CDLL: ...
 
 __all__: List[str]
 
 c_intp = _c_intp
 
-def load_library(libname, loader_path): ...
-def ndpointer(dtype=..., ndim=..., shape=..., flags=...): ...
-def as_ctypes(obj): ...
-def as_array(obj, shape=...): ...
-def as_ctypes_type(dtype): ...
+@overload
+def ndpointer(
+    dtype: None = ...,
+    ndim: int = ...,
+    shape: None | _ShapeLike = ...,
+    flags: None | _FlagsKind | Iterable[_FlagsKind] | int | flagsobj = ...,
+) -> Type[_ndptr[None]]: ...
+@overload
+def ndpointer(
+    dtype: _DTypeLike[_SCT],
+    ndim: int = ...,
+    *,
+    shape: _ShapeLike,
+    flags: None | _FlagsKind | Iterable[_FlagsKind] | int | flagsobj = ...,
+) -> Type[_concrete_ndptr[dtype[_SCT]]]: ...
+@overload
+def ndpointer(
+    dtype: DTypeLike,
+    ndim: int = ...,
+    *,
+    shape: _ShapeLike,
+    flags: None | _FlagsKind | Iterable[_FlagsKind] | int | flagsobj = ...,
+) -> Type[_concrete_ndptr[dtype[Any]]]: ...
+@overload
+def ndpointer(
+    dtype: _DTypeLike[_SCT],
+    ndim: int = ...,
+    shape: None = ...,
+    flags: None | _FlagsKind | Iterable[_FlagsKind] | int | flagsobj = ...,
+) -> Type[_ndptr[dtype[_SCT]]]: ...
+@overload
+def ndpointer(
+    dtype: DTypeLike,
+    ndim: int = ...,
+    shape: None = ...,
+    flags: None | _FlagsKind | Iterable[_FlagsKind] | int | flagsobj = ...,
+) -> Type[_ndptr[dtype[Any]]]: ...
+
+@overload
+def as_ctypes_type(dtype: _BoolCodes | _DTypeLike[bool_] | Type[ctypes.c_bool]) -> Type[ctypes.c_bool]: ...
+@overload
+def as_ctypes_type(dtype: _ByteCodes | _DTypeLike[byte] | Type[ctypes.c_byte]) -> Type[ctypes.c_byte]: ...
+@overload
+def as_ctypes_type(dtype: _ShortCodes | _DTypeLike[short] | Type[ctypes.c_short]) -> Type[ctypes.c_short]: ...
+@overload
+def as_ctypes_type(dtype: _IntCCodes | _DTypeLike[intc] | Type[ctypes.c_int]) -> Type[ctypes.c_int]: ...
+@overload
+def as_ctypes_type(dtype: _IntCodes | _DTypeLike[int_] | Type[int | ctypes.c_long]) -> Type[ctypes.c_long]: ...
+@overload
+def as_ctypes_type(dtype: _LongLongCodes | _DTypeLike[longlong] | Type[ctypes.c_longlong]) -> Type[ctypes.c_longlong]: ...
+@overload
+def as_ctypes_type(dtype: _UByteCodes | _DTypeLike[ubyte] | Type[ctypes.c_ubyte]) -> Type[ctypes.c_ubyte]: ...
+@overload
+def as_ctypes_type(dtype: _UShortCodes | _DTypeLike[ushort] | Type[ctypes.c_ushort]) -> Type[ctypes.c_ushort]: ...
+@overload
+def as_ctypes_type(dtype: _UIntCCodes | _DTypeLike[uintc] | Type[ctypes.c_uint]) -> Type[ctypes.c_uint]: ...
+@overload
+def as_ctypes_type(dtype: _UIntCodes | _DTypeLike[uint] | Type[ctypes.c_ulong]) -> Type[ctypes.c_ulong]: ...
+@overload
+def as_ctypes_type(dtype: _ULongLongCodes | _DTypeLike[ulonglong] | Type[ctypes.c_ulonglong]) -> Type[ctypes.c_ulonglong]: ...
+@overload
+def as_ctypes_type(dtype: _SingleCodes | _DTypeLike[single] | Type[ctypes.c_float]) -> Type[ctypes.c_float]: ...
+@overload
+def as_ctypes_type(dtype: _DoubleCodes | _DTypeLike[double] | Type[float | ctypes.c_double]) -> Type[ctypes.c_double]: ...
+@overload
+def as_ctypes_type(dtype: _LongDoubleCodes | _DTypeLike[longdouble] | Type[ctypes.c_longdouble]) -> Type[ctypes.c_longdouble]: ...
+@overload
+def as_ctypes_type(dtype: _VoidDTypeLike) -> Type[Any]: ...  # `ctypes.Union` or `ctypes.Structure`
+@overload
+def as_ctypes_type(dtype: str) -> Type[Any]: ...
+
+@overload
+def as_array(obj: ctypes._PointerLike, shape: Sequence[int]) -> NDArray[Any]: ...
+@overload
+def as_array(obj: _ArrayLike[_SCT], shape: None | _ShapeLike = ...) -> NDArray[_SCT]: ...
+@overload
+def as_array(obj: object, shape: None | _ShapeLike = ...) -> NDArray[Any]: ...
+
+@overload
+def as_ctypes(obj: bool_) -> ctypes.c_bool: ...
+@overload
+def as_ctypes(obj: byte) -> ctypes.c_byte: ...
+@overload
+def as_ctypes(obj: short) -> ctypes.c_short: ...
+@overload
+def as_ctypes(obj: intc) -> ctypes.c_int: ...
+@overload
+def as_ctypes(obj: int_) -> ctypes.c_long: ...
+@overload
+def as_ctypes(obj: longlong) -> ctypes.c_longlong: ...
+@overload
+def as_ctypes(obj: ubyte) -> ctypes.c_ubyte: ...
+@overload
+def as_ctypes(obj: ushort) -> ctypes.c_ushort: ...
+@overload
+def as_ctypes(obj: uintc) -> ctypes.c_uint: ...
+@overload
+def as_ctypes(obj: uint) -> ctypes.c_ulong: ...
+@overload
+def as_ctypes(obj: ulonglong) -> ctypes.c_ulonglong: ...
+@overload
+def as_ctypes(obj: single) -> ctypes.c_float: ...
+@overload
+def as_ctypes(obj: double) -> ctypes.c_double: ...
+@overload
+def as_ctypes(obj: longdouble) -> ctypes.c_longdouble: ...
+@overload
+def as_ctypes(obj: void) -> Any: ...  # `ctypes.Union` or `ctypes.Structure`
+@overload
+def as_ctypes(obj: NDArray[bool_]) -> ctypes.Array[ctypes.c_bool]: ...
+@overload
+def as_ctypes(obj: NDArray[byte]) -> ctypes.Array[ctypes.c_byte]: ...
+@overload
+def as_ctypes(obj: NDArray[short]) -> ctypes.Array[ctypes.c_short]: ...
+@overload
+def as_ctypes(obj: NDArray[intc]) -> ctypes.Array[ctypes.c_int]: ...
+@overload
+def as_ctypes(obj: NDArray[int_]) -> ctypes.Array[ctypes.c_long]: ...
+@overload
+def as_ctypes(obj: NDArray[longlong]) -> ctypes.Array[ctypes.c_longlong]: ...
+@overload
+def as_ctypes(obj: NDArray[ubyte]) -> ctypes.Array[ctypes.c_ubyte]: ...
+@overload
+def as_ctypes(obj: NDArray[ushort]) -> ctypes.Array[ctypes.c_ushort]: ...
+@overload
+def as_ctypes(obj: NDArray[uintc]) -> ctypes.Array[ctypes.c_uint]: ...
+@overload
+def as_ctypes(obj: NDArray[uint]) -> ctypes.Array[ctypes.c_ulong]: ...
+@overload
+def as_ctypes(obj: NDArray[ulonglong]) -> ctypes.Array[ctypes.c_ulonglong]: ...
+@overload
+def as_ctypes(obj: NDArray[single]) -> ctypes.Array[ctypes.c_float]: ...
+@overload
+def as_ctypes(obj: NDArray[double]) -> ctypes.Array[ctypes.c_double]: ...
+@overload
+def as_ctypes(obj: NDArray[longdouble]) -> ctypes.Array[ctypes.c_longdouble]: ...
+@overload
+def as_ctypes(obj: NDArray[void]) -> ctypes.Array[Any]: ...  # `ctypes.Union` or `ctypes.Structure`

--- a/numpy/typing/tests/data/reveal/ctypeslib.pyi
+++ b/numpy/typing/tests/data/reveal/ctypeslib.pyi
@@ -1,3 +1,83 @@
+import ctypes
+from typing import Any
+
 import numpy as np
+import numpy.typing as npt
+
+AR_bool: npt.NDArray[np.bool_]
+AR_ubyte: npt.NDArray[np.ubyte]
+AR_ushort: npt.NDArray[np.ushort]
+AR_uintc: npt.NDArray[np.uintc]
+AR_uint: npt.NDArray[np.uint]
+AR_ulonglong: npt.NDArray[np.ulonglong]
+AR_byte: npt.NDArray[np.byte]
+AR_short: npt.NDArray[np.short]
+AR_intc: npt.NDArray[np.intc]
+AR_int: npt.NDArray[np.int_]
+AR_longlong: npt.NDArray[np.longlong]
+AR_single: npt.NDArray[np.single]
+AR_double: npt.NDArray[np.double]
+AR_void: npt.NDArray[np.void]
+
+pointer: ctypes.pointer[Any]
 
 reveal_type(np.ctypeslib.c_intp())  # E: {c_intp}
+
+reveal_type(np.ctypeslib.ndpointer())  # E: Type[numpy.ctypeslib._ndptr[None]]
+reveal_type(np.ctypeslib.ndpointer(dtype=np.float64))  # E: Type[numpy.ctypeslib._ndptr[numpy.dtype[{float64}]]]
+reveal_type(np.ctypeslib.ndpointer(dtype=float))  # E: Type[numpy.ctypeslib._ndptr[numpy.dtype[Any]]]
+reveal_type(np.ctypeslib.ndpointer(shape=(10, 3)))  # E: Type[numpy.ctypeslib._ndptr[None]]
+reveal_type(np.ctypeslib.ndpointer(np.int64, shape=(10, 3)))  # E: Type[numpy.ctypeslib._concrete_ndptr[numpy.dtype[{int64}]]]
+reveal_type(np.ctypeslib.ndpointer(int, shape=(1,)))  # E: Type[numpy.ctypeslib._concrete_ndptr[numpy.dtype[Any]]]
+
+reveal_type(np.ctypeslib.as_ctypes_type(np.bool_))  # E: Type[ctypes.c_bool]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ubyte))  # E: Type[ctypes.c_ubyte]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ushort))  # E: Type[ctypes.c_ushort]
+reveal_type(np.ctypeslib.as_ctypes_type(np.uintc))  # E: Type[ctypes.c_uint]
+reveal_type(np.ctypeslib.as_ctypes_type(np.uint))  # E: Type[ctypes.c_ulong]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ulonglong))  # E: Type[ctypes.c_ulong]
+reveal_type(np.ctypeslib.as_ctypes_type(np.byte))  # E: Type[ctypes.c_byte]
+reveal_type(np.ctypeslib.as_ctypes_type(np.short))  # E: Type[ctypes.c_short]
+reveal_type(np.ctypeslib.as_ctypes_type(np.intc))  # E: Type[ctypes.c_int]
+reveal_type(np.ctypeslib.as_ctypes_type(np.int_))  # E: Type[ctypes.c_long]
+reveal_type(np.ctypeslib.as_ctypes_type(np.longlong))  # E: Type[ctypes.c_long]
+reveal_type(np.ctypeslib.as_ctypes_type(np.single))  # E: Type[ctypes.c_float]
+reveal_type(np.ctypeslib.as_ctypes_type(np.double))  # E: Type[ctypes.c_double]
+reveal_type(np.ctypeslib.as_ctypes_type(ctypes.c_double))  # E: Type[ctypes.c_double]
+reveal_type(np.ctypeslib.as_ctypes_type("q"))  # E: Type[ctypes.c_longlong]
+reveal_type(np.ctypeslib.as_ctypes_type([("i8", np.int64), ("f8", np.float64)]))  # E: Type[Any]
+reveal_type(np.ctypeslib.as_ctypes_type("i8"))  # E: Type[Any]
+reveal_type(np.ctypeslib.as_ctypes_type("f8"))  # E: Type[Any]
+
+reveal_type(np.ctypeslib.as_ctypes(AR_bool.take(0)))  # E: ctypes.c_bool
+reveal_type(np.ctypeslib.as_ctypes(AR_ubyte.take(0)))  # E: ctypes.c_ubyte
+reveal_type(np.ctypeslib.as_ctypes(AR_ushort.take(0)))  # E: ctypes.c_ushort
+reveal_type(np.ctypeslib.as_ctypes(AR_uintc.take(0)))  # E: ctypes.c_uint
+reveal_type(np.ctypeslib.as_ctypes(AR_uint.take(0)))  # E: ctypes.c_ulong
+reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong.take(0)))  # E: ctypes.c_ulong
+reveal_type(np.ctypeslib.as_ctypes(AR_byte.take(0)))  # E: ctypes.c_byte
+reveal_type(np.ctypeslib.as_ctypes(AR_short.take(0)))  # E: ctypes.c_short
+reveal_type(np.ctypeslib.as_ctypes(AR_intc.take(0)))  # E: ctypes.c_int
+reveal_type(np.ctypeslib.as_ctypes(AR_int.take(0)))  # E: ctypes.c_long
+reveal_type(np.ctypeslib.as_ctypes(AR_longlong.take(0)))  # E: ctypes.c_long
+reveal_type(np.ctypeslib.as_ctypes(AR_single.take(0)))  # E: ctypes.c_float
+reveal_type(np.ctypeslib.as_ctypes(AR_double.take(0)))  # E: ctypes.c_double
+reveal_type(np.ctypeslib.as_ctypes(AR_void.take(0)))  # E: Any
+reveal_type(np.ctypeslib.as_ctypes(AR_bool))  # E: ctypes.Array[ctypes.c_bool]
+reveal_type(np.ctypeslib.as_ctypes(AR_ubyte))  # E: ctypes.Array[ctypes.c_ubyte]
+reveal_type(np.ctypeslib.as_ctypes(AR_ushort))  # E: ctypes.Array[ctypes.c_ushort]
+reveal_type(np.ctypeslib.as_ctypes(AR_uintc))  # E: ctypes.Array[ctypes.c_uint]
+reveal_type(np.ctypeslib.as_ctypes(AR_uint))  # E: ctypes.Array[ctypes.c_ulong]
+reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong))  # E: ctypes.Array[ctypes.c_ulong]
+reveal_type(np.ctypeslib.as_ctypes(AR_byte))  # E: ctypes.Array[ctypes.c_byte]
+reveal_type(np.ctypeslib.as_ctypes(AR_short))  # E: ctypes.Array[ctypes.c_short]
+reveal_type(np.ctypeslib.as_ctypes(AR_intc))  # E: ctypes.Array[ctypes.c_int]
+reveal_type(np.ctypeslib.as_ctypes(AR_int))  # E: ctypes.Array[ctypes.c_long]
+reveal_type(np.ctypeslib.as_ctypes(AR_longlong))  # E: ctypes.Array[ctypes.c_long]
+reveal_type(np.ctypeslib.as_ctypes(AR_single))  # E: ctypes.Array[ctypes.c_float]
+reveal_type(np.ctypeslib.as_ctypes(AR_double))  # E: ctypes.Array[ctypes.c_double]
+reveal_type(np.ctypeslib.as_ctypes(AR_void))  # E: ctypes.Array[Any]
+
+reveal_type(np.ctypeslib.as_array(AR_ubyte))  # E: numpy.ndarray[Any, numpy.dtype[{ubyte}]]
+reveal_type(np.ctypeslib.as_array(1))  # E: numpy.ndarray[Any, numpy.dtype[Any]]
+reveal_type(np.ctypeslib.as_array(pointer))  # E: numpy.ndarray[Any, numpy.dtype[Any]]

--- a/numpy/typing/tests/data/reveal/ctypeslib.pyi
+++ b/numpy/typing/tests/data/reveal/ctypeslib.pyi
@@ -17,6 +17,7 @@ AR_int: npt.NDArray[np.int_]
 AR_longlong: npt.NDArray[np.longlong]
 AR_single: npt.NDArray[np.single]
 AR_double: npt.NDArray[np.double]
+AR_longdouble: npt.NDArray[np.longdouble]
 AR_void: npt.NDArray[np.void]
 
 pointer: ctypes.pointer[Any]
@@ -31,51 +32,54 @@ reveal_type(np.ctypeslib.ndpointer(np.int64, shape=(10, 3)))  # E: Type[numpy.ct
 reveal_type(np.ctypeslib.ndpointer(int, shape=(1,)))  # E: Type[numpy.ctypeslib._concrete_ndptr[numpy.dtype[Any]]]
 
 reveal_type(np.ctypeslib.as_ctypes_type(np.bool_))  # E: Type[ctypes.c_bool]
-reveal_type(np.ctypeslib.as_ctypes_type(np.ubyte))  # E: Type[ctypes.c_ubyte]
-reveal_type(np.ctypeslib.as_ctypes_type(np.ushort))  # E: Type[ctypes.c_ushort]
-reveal_type(np.ctypeslib.as_ctypes_type(np.uintc))  # E: Type[ctypes.c_uint]
-reveal_type(np.ctypeslib.as_ctypes_type(np.uint))  # E: Type[ctypes.c_ulong]
-reveal_type(np.ctypeslib.as_ctypes_type(np.ulonglong))  # E: Type[ctypes.c_ulong]
-reveal_type(np.ctypeslib.as_ctypes_type(np.byte))  # E: Type[ctypes.c_byte]
-reveal_type(np.ctypeslib.as_ctypes_type(np.short))  # E: Type[ctypes.c_short]
-reveal_type(np.ctypeslib.as_ctypes_type(np.intc))  # E: Type[ctypes.c_int]
-reveal_type(np.ctypeslib.as_ctypes_type(np.int_))  # E: Type[ctypes.c_long]
-reveal_type(np.ctypeslib.as_ctypes_type(np.longlong))  # E: Type[ctypes.c_long]
-reveal_type(np.ctypeslib.as_ctypes_type(np.single))  # E: Type[ctypes.c_float]
-reveal_type(np.ctypeslib.as_ctypes_type(np.double))  # E: Type[ctypes.c_double]
-reveal_type(np.ctypeslib.as_ctypes_type(ctypes.c_double))  # E: Type[ctypes.c_double]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ubyte))  # E: Type[{c_ubyte}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ushort))  # E: Type[{c_ushort}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.uintc))  # E: Type[{c_uint}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.uint))  # E: Type[{c_ulong}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.ulonglong))  # E: Type[{c_ulonglong}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.byte))  # E: Type[{c_byte}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.short))  # E: Type[{c_short}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.intc))  # E: Type[{c_int}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.int_))  # E: Type[{c_long}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.longlong))  # E: Type[{c_longlong}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.single))  # E: Type[{c_float}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.double))  # E: Type[{c_double}]
+reveal_type(np.ctypeslib.as_ctypes_type(np.longdouble))  # E: Type[{c_longdouble}]
+reveal_type(np.ctypeslib.as_ctypes_type(ctypes.c_double))  # E: Type[{c_double}]
 reveal_type(np.ctypeslib.as_ctypes_type("q"))  # E: Type[ctypes.c_longlong]
 reveal_type(np.ctypeslib.as_ctypes_type([("i8", np.int64), ("f8", np.float64)]))  # E: Type[Any]
 reveal_type(np.ctypeslib.as_ctypes_type("i8"))  # E: Type[Any]
 reveal_type(np.ctypeslib.as_ctypes_type("f8"))  # E: Type[Any]
 
 reveal_type(np.ctypeslib.as_ctypes(AR_bool.take(0)))  # E: ctypes.c_bool
-reveal_type(np.ctypeslib.as_ctypes(AR_ubyte.take(0)))  # E: ctypes.c_ubyte
-reveal_type(np.ctypeslib.as_ctypes(AR_ushort.take(0)))  # E: ctypes.c_ushort
-reveal_type(np.ctypeslib.as_ctypes(AR_uintc.take(0)))  # E: ctypes.c_uint
-reveal_type(np.ctypeslib.as_ctypes(AR_uint.take(0)))  # E: ctypes.c_ulong
-reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong.take(0)))  # E: ctypes.c_ulong
-reveal_type(np.ctypeslib.as_ctypes(AR_byte.take(0)))  # E: ctypes.c_byte
-reveal_type(np.ctypeslib.as_ctypes(AR_short.take(0)))  # E: ctypes.c_short
-reveal_type(np.ctypeslib.as_ctypes(AR_intc.take(0)))  # E: ctypes.c_int
-reveal_type(np.ctypeslib.as_ctypes(AR_int.take(0)))  # E: ctypes.c_long
-reveal_type(np.ctypeslib.as_ctypes(AR_longlong.take(0)))  # E: ctypes.c_long
-reveal_type(np.ctypeslib.as_ctypes(AR_single.take(0)))  # E: ctypes.c_float
-reveal_type(np.ctypeslib.as_ctypes(AR_double.take(0)))  # E: ctypes.c_double
+reveal_type(np.ctypeslib.as_ctypes(AR_ubyte.take(0)))  # E: {c_ubyte}
+reveal_type(np.ctypeslib.as_ctypes(AR_ushort.take(0)))  # E: {c_ushort}
+reveal_type(np.ctypeslib.as_ctypes(AR_uintc.take(0)))  # E: {c_uint}
+reveal_type(np.ctypeslib.as_ctypes(AR_uint.take(0)))  # E: {c_ulong}
+reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong.take(0)))  # E: {c_ulonglong}
+reveal_type(np.ctypeslib.as_ctypes(AR_byte.take(0)))  # E: {c_byte}
+reveal_type(np.ctypeslib.as_ctypes(AR_short.take(0)))  # E: {c_short}
+reveal_type(np.ctypeslib.as_ctypes(AR_intc.take(0)))  # E: {c_int}
+reveal_type(np.ctypeslib.as_ctypes(AR_int.take(0)))  # E: {c_long}
+reveal_type(np.ctypeslib.as_ctypes(AR_longlong.take(0)))  # E: {c_longlong}
+reveal_type(np.ctypeslib.as_ctypes(AR_single.take(0)))  # E: {c_float}
+reveal_type(np.ctypeslib.as_ctypes(AR_double.take(0)))  # E: {c_double}
+reveal_type(np.ctypeslib.as_ctypes(AR_longdouble.take(0)))  # E: {c_longdouble}
 reveal_type(np.ctypeslib.as_ctypes(AR_void.take(0)))  # E: Any
 reveal_type(np.ctypeslib.as_ctypes(AR_bool))  # E: ctypes.Array[ctypes.c_bool]
-reveal_type(np.ctypeslib.as_ctypes(AR_ubyte))  # E: ctypes.Array[ctypes.c_ubyte]
-reveal_type(np.ctypeslib.as_ctypes(AR_ushort))  # E: ctypes.Array[ctypes.c_ushort]
-reveal_type(np.ctypeslib.as_ctypes(AR_uintc))  # E: ctypes.Array[ctypes.c_uint]
-reveal_type(np.ctypeslib.as_ctypes(AR_uint))  # E: ctypes.Array[ctypes.c_ulong]
-reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong))  # E: ctypes.Array[ctypes.c_ulong]
-reveal_type(np.ctypeslib.as_ctypes(AR_byte))  # E: ctypes.Array[ctypes.c_byte]
-reveal_type(np.ctypeslib.as_ctypes(AR_short))  # E: ctypes.Array[ctypes.c_short]
-reveal_type(np.ctypeslib.as_ctypes(AR_intc))  # E: ctypes.Array[ctypes.c_int]
-reveal_type(np.ctypeslib.as_ctypes(AR_int))  # E: ctypes.Array[ctypes.c_long]
-reveal_type(np.ctypeslib.as_ctypes(AR_longlong))  # E: ctypes.Array[ctypes.c_long]
-reveal_type(np.ctypeslib.as_ctypes(AR_single))  # E: ctypes.Array[ctypes.c_float]
-reveal_type(np.ctypeslib.as_ctypes(AR_double))  # E: ctypes.Array[ctypes.c_double]
+reveal_type(np.ctypeslib.as_ctypes(AR_ubyte))  # E: ctypes.Array[{c_ubyte}]
+reveal_type(np.ctypeslib.as_ctypes(AR_ushort))  # E: ctypes.Array[{c_ushort}]
+reveal_type(np.ctypeslib.as_ctypes(AR_uintc))  # E: ctypes.Array[{c_uint}]
+reveal_type(np.ctypeslib.as_ctypes(AR_uint))  # E: ctypes.Array[{c_ulong}]
+reveal_type(np.ctypeslib.as_ctypes(AR_ulonglong))  # E: ctypes.Array[{c_ulonglong}]
+reveal_type(np.ctypeslib.as_ctypes(AR_byte))  # E: ctypes.Array[{c_byte}]
+reveal_type(np.ctypeslib.as_ctypes(AR_short))  # E: ctypes.Array[{c_short}]
+reveal_type(np.ctypeslib.as_ctypes(AR_intc))  # E: ctypes.Array[{c_int}]
+reveal_type(np.ctypeslib.as_ctypes(AR_int))  # E: ctypes.Array[{c_long}]
+reveal_type(np.ctypeslib.as_ctypes(AR_longlong))  # E: ctypes.Array[{c_longlong}]
+reveal_type(np.ctypeslib.as_ctypes(AR_single))  # E: ctypes.Array[{c_float}]
+reveal_type(np.ctypeslib.as_ctypes(AR_double))  # E: ctypes.Array[{c_double}]
+reveal_type(np.ctypeslib.as_ctypes(AR_longdouble))  # E: ctypes.Array[{c_longdouble}]
 reveal_type(np.ctypeslib.as_ctypes(AR_void))  # E: ctypes.Array[Any]
 
 reveal_type(np.ctypeslib.as_array(AR_ubyte))  # E: numpy.ndarray[Any, numpy.dtype[{ubyte}]]

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -152,8 +152,9 @@ def test_fail(path: str) -> None:
         target_line = lines[lineno - 1]
         if "# E:" in target_line:
             expression, _, marker = target_line.partition("  # E: ")
-            expected_error = errors[lineno]
-            _test_fail(path, expression, marker.strip(), expected_error.strip(), lineno)
+            expected_error = errors[lineno].strip()
+            marker = marker.strip()
+            _test_fail(path, expression, marker, expected_error, lineno)
         else:
             pytest.fail(
                 f"Unexpected mypy output at line {lineno}\n\n{errors[lineno]}"
@@ -184,7 +185,9 @@ def _test_fail(
     if expected_error is None:
         raise AssertionError(_FAIL_MSG1.format(lineno, expression, error))
     elif error not in expected_error:
-        raise AssertionError(_FAIL_MSG2.format(lineno, expression, expected_error, error))
+        raise AssertionError(_FAIL_MSG2.format(
+            lineno, expression, expected_error, error
+        ))
 
 
 def _construct_ctypes_dict() -> dict[str, str]:


### PR DESCRIPTION
This PR adds annotations for the `np.ctypeslib` subpackage.

There are only 6 public objects in the namespace, but mapping all `ctypes` types to their 
numpy-based counterpart does get pretty repetive (albeit simple).