### PR TITLE
DOC: centralized min-max documentation 

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -143,6 +143,21 @@ Handling complex numbers
    conj
    conjugate
 
+Extrema Finding
+---------------
+.. autosummary::
+   :toctree: generated/
+
+   maximum
+   fmax
+   amax
+   nanmax
+   
+   minimum
+   fmin
+   amin
+   nanmin
+   
 
 Miscellaneous
 -------------
@@ -160,11 +175,7 @@ Miscellaneous
    fabs
    sign
    heaviside
-   maximum
-   minimum
-   fmax
-   fmin
-
+   
    nan_to_num
    real_if_close
 

--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -9,11 +9,7 @@ Order statistics
 
 .. autosummary::
    :toctree: generated/
-
-   amin
-   amax
-   nanmin
-   nanmax
+   
    ptp
    percentile
    nanpercentile


### PR DESCRIPTION
Centralized min-max documentation under 'extrema finding' subsection in the mathematical functions page. 

closes #19858
