### PR TITLE
DOC: Clarify behavior of ``np.lib.scimath.sqrt`` apropos  -0.0

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -3827,6 +3827,7 @@ add_newdoc('numpy.core.umath', 'sqrt',
     --------
     lib.scimath.sqrt
         A version which returns complex numbers when given negative reals.
+        Note: 0.0 and -0.0 are handled differently for complex inputs.
 
     Notes
     -----

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -2759,10 +2759,10 @@ VOID_nonzero (char *ip, PyArrayObject *ap)
             dummy_fields.descr = new;
             if ((new->alignment > 1) && !__ALIGNED(ip + offset,
                         new->alignment)) {
-                PyArray_CLEARFLAGS(ap, NPY_ARRAY_ALIGNED);
+                PyArray_CLEARFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
             else {
-                PyArray_ENABLEFLAGS(ap, NPY_ARRAY_ALIGNED);
+                PyArray_ENABLEFLAGS(dummy_arr, NPY_ARRAY_ALIGNED);
             }
             if (new->f->nonzero(ip+offset, dummy_arr)) {
                 nonz = NPY_TRUE;

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -1484,6 +1484,18 @@ class TestNonzero:
         a = np.array([[False], [TrueThenFalse()]])
         assert_raises(RuntimeError, np.nonzero, a)
 
+    def test_nonzero_sideffects_structured_void(self):
+        # Checks that structured void does not mutate alignment flag of
+        # original array.
+        arr = np.zeros(5, dtype="i1,i8,i8")  # `ones` may short-circuit
+        assert arr.flags.aligned  # structs are considered "aligned"
+        assert not arr["f2"].flags.aligned
+        # make sure that nonzero/count_nonzero do not flip the flag:
+        np.nonzero(arr)
+        assert arr.flags.aligned
+        np.count_nonzero(arr)
+        assert arr.flags.aligned
+
     def test_nonzero_exception_safe(self):
         # gh-13930
 

--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -243,11 +243,6 @@ def sqrt(x):
     2j
     >>> np.emath.sqrt(complex(-4.0, -0.0))
     -2j
-
-
-
-
-
     """
     x = _fix_real_lt_zero(x)
     return nx.sqrt(x)

--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -234,6 +234,20 @@ def sqrt(x):
     >>> np.emath.sqrt([-1,4])
     array([0.+1.j, 2.+0.j])
 
+    Different results are expected because:
+    floating point 0.0 and -0.0 are distinct.
+
+    For more control, explicitly use complex() as follows:
+
+    >>> np.emath.sqrt(complex(-4.0, 0.0))
+    2j
+    >>> np.emath.sqrt(complex(-4.0, -0.0))
+    -2j
+
+
+
+
+
     """
     x = _fix_real_lt_zero(x)
     return nx.sqrt(x)


### PR DESCRIPTION
This PR adds:
- Note on the floating-point distinction between 0.0 and -0.0
- Examples for having more control over the output in the presence of a negative 0

Closes:
#20160
