### PR TITLE
ENH,TST: Add the `--pdb` and `--pdbcls` parameters to runtest.py

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -79,7 +79,8 @@ class PytestTester:
         self.module_name = module_name
 
     def __call__(self, label='fast', verbose=1, extra_argv=None,
-                 doctests=False, coverage=False, durations=-1, tests=None):
+                 doctests=False, coverage=False, durations=-1, tests=None,
+                 pdb=False, pdbcls=None):
         """
         Run tests for module using pytest.
 
@@ -103,6 +104,12 @@ class PytestTester:
             report the time of the slowest `timer` tests. Default is -1.
         tests : test or list of tests
             Tests to be executed with pytest '--pyargs'
+        pdb : bool
+            Start the interactive Python debugger on errors
+            or KeyboardInterrupt.
+        pdbcls : str, optional
+            start a custom interactive Python debugger on errors. For example:
+            ``--pdbcls=IPython.terminal.debugger:TerminalPd``.
 
         Returns
         -------
@@ -194,6 +201,12 @@ class PytestTester:
 
         if tests is None:
             tests = [self.module_name]
+
+        if pdb:
+            pytest_args += ["--pdb"]
+
+        if pdbcls is not None:
+            pytest_args += [f"--pdbcls={pdbcls}"]
 
         pytest_args += ["--pyargs"] + list(tests)
 

--- a/numpy/_pytesttester.pyi
+++ b/numpy/_pytesttester.pyi
@@ -14,4 +14,6 @@ class PytestTester:
         coverage: bool = ...,
         durations: int = ...,
         tests: None | Iterable[str] = ...,
+        pdb: bool = ...,
+        pdbcls: None | str = ...,
     ) -> bool: ...

--- a/runtests.py
+++ b/runtests.py
@@ -156,6 +156,18 @@ def main(argv):
                               "--bench-compare=COMMIT to override HEAD with "
                               "COMMIT. Note that you need to commit your "
                               "changes first!"))
+    parser.add_argument("--pdb", action="store_true", default=False,
+                        help=("Start the interactive Python debugger on "
+                              "errors or KeyboardInterrupt."))
+    parser.add_argument(
+        "--pdbcls",
+        action="store",
+        type=str,
+        default=None,
+        metavar="modulename:classname",
+        help=("Start a custom interactive Python debugger on errors. "
+              "For example: --pdbcls=IPython.terminal.debugger:TerminalPdb"),
+    )
     parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
                         help="Arguments to pass to pytest, asv, mypy, Python "
                              "or shell")
@@ -386,7 +398,9 @@ def main(argv):
                       doctests=args.doctests,
                       coverage=args.coverage,
                       durations=args.durations,
-                      tests=tests)
+                      tests=tests,
+                      pdb=args.pdb,
+                      pdbcls=args.pdbcls)
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
This PR exposes the pytest `--pdb` and `--pdbcls` parameters to the numpy `runtest.py` script.

`--pdb` will automatically open the python debugger whenever an (unexpected) exception is raised.
`--pdbcls` allows you to pass custom debuggers, such as `ipdb`.