### PR TITLE
ENH: Avoid full data sorts in masked array median

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -736,7 +736,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         if axis.shape[0] == 1 and axis[0] in [0, -1] and len(a.shape) == 1:
             axis = None
 
-    if axis is None :
+    if axis is None:
         if isinstance(a, np.ma.core.MaskedArray) and np.all(a.mask):
             m = np.ma.core.MaskedConstant()
         else:


### PR DESCRIPTION
Fixes #18821

Currently, calling `np.ma.median` will do a full sort of the data, which is inefficient if one needs to get only the median. This PR changes it to instead filter the data and call the non-ma median on that filtered data, which only requires an argpartition operation instead.

Before:
```python
import numpy as np, pandas as pd

rng = np.random.default_rng(seed=1)
nrows = int(1e6)
ncols = 10
X = pd.DataFrame(rng.normal(size=(nrows, ncols)))
```
```python
%%timeit
np.ma.median(X, axis=0)
```
```
1.07 s ± 12.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:
```
212 ms ± 2.66 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```