### PR TITLE
TST: Add a test for device property

### DIFF
--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -285,3 +285,8 @@ def test_python_scalar_construtors():
 
     assert_raises(TypeError, lambda: operator.index(b))
     assert_raises(TypeError, lambda: operator.index(f))
+
+
+def test_device_property():
+    a = ones((3, 4))
+    assert a.device == 'cpu'

--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -290,3 +290,9 @@ def test_python_scalar_construtors():
 def test_device_property():
     a = ones((3, 4))
     assert a.device == 'cpu'
+
+    assert np.array_equal(a.to_device('cpu'), a)
+    assert_raises(ValueError, lambda: a.to_device('gpu'))
+
+    assert np.array_equal(asarray(a, device='cpu'), a)
+    assert_raises(ValueError, lambda: asarray(a, device='gpu'))


### PR DESCRIPTION
The device support is implemented but it seems that there isn't a test for the device property. This PR adds a test for the device property defined in the the Array API NEP 47:

https://numpy.org/neps/nep-0047-array-api-standard.html#syntax-for-device-support

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
