### PR TITLE
TST: Some fixes & refactoring around glibc-dependent skips in test_umath.py

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -28,9 +28,7 @@ def get_glibc_version():
 
 
 glibcver = get_glibc_version()
-glibc_newerthan_2_17 = pytest.mark.xfail(
-        glibcver != '0.0' and glibcver < '2.17',
-        reason="Older glibc versions may not raise appropriate FP exceptions")
+glibc_older_than_2_17 = (glibcver != '0.0' and glibcver < '2.17')
 
 def on_powerpc():
     """ True if we are running on a Power PC platform."""
@@ -1024,7 +1022,10 @@ class TestSpecialFloats:
 
     # Older version of glibc may not raise the correct FP exceptions
     # See: https://github.com/numpy/numpy/issues/19192
-    @glibc_newerthan_2_17
+    @pytest.mark.xfail(
+        glibc_older_than_2_17,
+        reason="Older glibc versions may not raise appropriate FP exceptions"
+    )
     def test_exp_exceptions(self):
         with np.errstate(over='raise'):
             assert_raises(FloatingPointError, np.exp, np.float32(100.))

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -28,7 +28,7 @@ def get_glibc_version():
 
 
 glibcver = get_glibc_version()
-glibc_older_than_2_17 = (glibcver != '0.0' and glibcver < '2.17')
+glibc_older_than = lambda x: (glibcver != '0.0' and glibcver < x)
 
 def on_powerpc():
     """ True if we are running on a Power PC platform."""
@@ -1012,10 +1012,9 @@ class TestSpecialFloats:
             yf = np.array(y, dtype=dt)
             assert_equal(np.exp(yf), xf)
 
-    # Older version of glibc may not raise the correct FP exceptions
     # See: https://github.com/numpy/numpy/issues/19192
     @pytest.mark.xfail(
-        glibc_older_than_2_17,
+        glibc_older_than("2.17"),
         reason="Older glibc versions may not raise appropriate FP exceptions"
     )
     def test_exp_exceptions(self):
@@ -1398,7 +1397,7 @@ class TestAVXFloat32Transcendental:
         M = np.int_(N/20)
         index = np.random.randint(low=0, high=N, size=M)
         x_f32 = np.float32(np.random.uniform(low=-100.,high=100.,size=N))
-        if not glibc_older_than_2_17:
+        if not glibc_older_than("2.17"):
             # test coverage for elements > 117435.992f for which glibc is used
             # this is known to be problematic on old glibc, so skip it there
             x_f32[index] = np.float32(10E+10*np.random.rand(M))
@@ -3434,7 +3433,7 @@ class TestComplexFunctions:
         x_series = np.logspace(-20, -3.001, 200)
         x_basic = np.logspace(-2.999, 0, 10, endpoint=False)
 
-        if glibc_older_than_2_17 and dtype is np.longcomplex:
+        if glibc_older_than("2.19") and dtype is np.longcomplex:
             if (platform.machine() == 'aarch64' and bad_arcsinh()):
                 pytest.skip("Trig functions of np.longcomplex values known "
                             "to be inaccurate on aarch64 for some compilation "

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1398,8 +1398,10 @@ class TestAVXFloat32Transcendental:
         M = np.int_(N/20)
         index = np.random.randint(low=0, high=N, size=M)
         x_f32 = np.float32(np.random.uniform(low=-100.,high=100.,size=N))
-        # test coverage for elements > 117435.992f for which glibc is used
-        x_f32[index] = np.float32(10E+10*np.random.rand(M))
+        if not glibc_older_than_2_17:
+            # test coverage for elements > 117435.992f for which glibc is used
+            # this is known to be problematic on old glibc, so skip it there
+            x_f32[index] = np.float32(10E+10*np.random.rand(M))
         x_f64 = np.float64(x_f32)
         assert_array_max_ulp(np.sin(x_f32), np.float32(np.sin(x_f64)), maxulp=2)
         assert_array_max_ulp(np.cos(x_f32), np.float32(np.cos(x_f64)), maxulp=2)


### PR DESCRIPTION
I was looking at the test [skips](https://github.com/conda-forge/numpy-feedstock/blob/99ba8ef9cd600d3fbeca27360b58abe90c66a890/recipe/meta.yaml#L40-L44) in the numpy feedstock by chance, and thought of fixing #15179, now that there's a glibc-version check that was introduced in #19209.

First step is taking that check and turning it into a reusable boolean. The second commit applies that also to a different glibc-relevant test ~(though, strictly speaking, it's left open in https://github.com/numpy/numpy/commit/8b2b7a2a5549e33f2d7187c4f78de69a8c482c83 whether this also works for 2.17 & 2.18 - I can parametrize the check of course, but not sure that's worth the effort?)~

Finally, applying the fix [suggested](https://github.com/numpy/numpy/issues/15179#issuecomment-839070581) by @r-devulap (which has been tested in a conda-forge PR to work) conditionally on the glibc-version, so that the test in the numpy-feedstock can be switched on unconditionally.

Fixes #15179