### PR TITLE
MAINT: Fix runtests.py overriding $PYTHONPATH environment variable

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -192,7 +192,12 @@ def main(argv):
         site_dir, site_dir_noarch = build_project(args)
         sys.path.insert(0, site_dir)
         sys.path.insert(0, site_dir_noarch)
-        os.environ['PYTHONPATH'] = site_dir + os.pathsep + site_dir_noarch
+        os.environ['PYTHONPATH'] = \
+            os.pathsep.join((
+                site_dir, 
+                site_dir_noarch, 
+                os.environ.get('PYTHONPATH', '')
+            ))
     else:
         _temp = __import__(PROJECT_MODULE)
         site_dir = os.path.sep.join(_temp.__file__.split(os.path.sep)[:-2])
@@ -493,7 +498,8 @@ def build_project(args):
         os.makedirs(site_dir)
     if not os.path.exists(site_dir_noarch):
         os.makedirs(site_dir_noarch)
-    env['PYTHONPATH'] = site_dir + os.pathsep + site_dir_noarch
+    env['PYTHONPATH'] = \
+        os.pathsep.join((site_dir, site_dir_noarch, env.get('PYTHONPATH', '')))
 
     log_filename = os.path.join(ROOT_DIR, 'build.log')
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Closes https://github.com/numpy/numpy/issues/20239

## What does this implement/fix?

`runtest.py` currently overrides the `$PYTHONPATH` environment variable when setting up the environment for child scripts to be invoked. This leads child processes, e.g. `setup.py`, to not run in the same environment as the parent, i.e. they cannot find python modules installed under a separate prefix.

## What changes have been made?

- Added `$PYTHONPATH` variable to environment path
- Checked the building process by running `python runtests.py -v -m full` 
- Performed lint checks by running `python runtests.py --lint uncommitted`