### PR TITLE
MAINT Fix typo for event name in wheels.yml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,8 +41,8 @@ jobs:
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[cd build]') ||
-      github.event.name == 'schedule' ||
-      github.event.name == 'workflow_dispatch'
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails


### PR DESCRIPTION
Fixes typo in .github/workflows/wheels.yml

CC @mattip 