### PR TITLE
DOC: Do not leave space between directive name and double colon.

### DIFF
--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -556,7 +556,7 @@ in turn immediately raises :exc:`TypeError`, because one of its operands
 ``arr.__array_ufunc__``, which will return :obj:`NotImplemented`, which
 we catch.
 
-.. note :: the reason for not allowing in-place operations to return
+.. note:: the reason for not allowing in-place operations to return
    :obj:`NotImplemented` is that these cannot generically be replaced by
    a simple reverse operation: most array operations assume the contents
    of the instance are changed in-place, and do not expect a new

--- a/doc/neps/nep-0027-zero-rank-arrarys.rst
+++ b/doc/neps/nep-0027-zero-rank-arrarys.rst
@@ -10,7 +10,7 @@ NEP 27 — Zero rank arrays
 :Created: 2006-06-10
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2018-October/078824.html
 
-.. note ::
+.. note::
 
     NumPy has both zero rank arrays and scalars. This design document, adapted
     from a `2006 wiki entry`_, describes what zero rank arrays are and why they

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -550,7 +550,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     -----
     The solution minimizes the squared error
 
-    .. math ::
+    .. math::
         E = \\sum_{j=0}^k |p(x_j) - y_j|^2
 
     in the equations::

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -88,13 +88,13 @@ Notes
 The implementations of multiplication, division, integration, and
 differentiation use the algebraic identities [1]_:
 
-.. math ::
+.. math::
     T_n(x) = \\frac{z^n + z^{-n}}{2} \\\\
     z\\frac{dx}{dz} = \\frac{z - z^{-1}}{2}.
 
 where
 
-.. math :: x = \\frac{z + z^{-1}}{2}.
+.. math:: x = \\frac{z + z^{-1}}{2}.
 
 These identities allow a Chebyshev series to be expressed as a finite,
 symmetric Laurent series.  In this module, this sort of Laurent series

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1304,12 +1304,12 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     The solution is the coefficients of the polynomial `p` that minimizes
     the sum of the weighted squared errors
 
-    .. math :: E = \\sum_j w_j^2 * |y_j - p(x_j)|^2,
+    .. math:: E = \\sum_j w_j^2 * |y_j - p(x_j)|^2,
 
     where the :math:`w_j` are the weights. This problem is solved by
     setting up the (typically) over-determined matrix equation:
 
-    .. math :: V(x) * c = w * y,
+    .. math:: V(x) * c = w * y,
 
     where `V` is the weighted pseudo Vandermonde matrix of `x`, `c` are the
     coefficients to be solved for, `w` are the weights, and `y` are the

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -330,12 +330,12 @@ def mapdomain(x, old, new):
     -----
     Effectively, this implements:
 
-    .. math ::
+    .. math::
         x\\_out = new[0] + m(x - old[0])
 
     where
 
-    .. math ::
+    .. math::
         m = \\frac{new[1]-new[0]}{old[1]-old[0]}
 
     Examples


### PR DESCRIPTION
From my regular expression foo, those are the only 9 case whereas there
are about ~2000 usage that do not have spaces.

While this is ok with docutils/sphinx, it does not seem to be
documented, and that means that other parsers will see that as comments,
leading to for example improper syntax highlighting.

This make it also a tiny bit harder to develop alternative rst parsers
