### PR TITLE
SIMD: replace raw SIMD of ceil with universal intrinsics

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -827,7 +827,7 @@ defdict = {
           docstrings.get('numpy.core.umath.ceil'),
           None,
           TD('e', f='ceil', astype={'e': 'f'}),
-          TD(inexactvec, simd=[('fma', 'fd'), ('avx512f', 'fd')]),
+          TD(inexactvec, dispatch=[('loops_unary_fp', 'fd')]),
           TD('fdg', f='ceil'),
           TD(O, f='npy_ObjectCeil'),
           ),

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1532,8 +1532,8 @@ TIMEDELTA_mm_qm_divmod(char **args, npy_intp const *dimensions, npy_intp const *
  */
 
 /**begin repeat
- *  #func = rint, ceil, floor, trunc#
- *  #scalarf = npy_rint, npy_ceil, npy_floor, npy_trunc#
+ *  #func = rint, floor, trunc#
+ *  #scalarf = npy_rint, npy_floor, npy_trunc#
  */
 
 /**begin repeat1
@@ -1568,8 +1568,8 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 void
  */
 
 /**begin repeat2
- *  #func = rint, ceil, floor, trunc#
- *  #scalarf = npy_rint, npy_ceil, npy_floor, npy_trunc#
+ *  #func = rint, floor, trunc#
+ *  #scalarf = npy_rint, npy_floor, npy_trunc#
  */
 
 NPY_NO_EXPORT NPY_GCC_OPT_3 void

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -187,7 +187,7 @@ NPY_NO_EXPORT void
  *  #TYPE = FLOAT, DOUBLE#
  */
 /**begin repeat1
- * #kind = sqrt, absolute, square, reciprocal#
+ * #kind = ceil, sqrt, absolute, square, reciprocal#
  */
 NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@,
    (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data)))
@@ -228,7 +228,7 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@func@,
 /**end repeat**/
 
 /**begin repeat
- * #func = sin, cos# 
+ * #func = sin, cos#
  */
 
 NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void DOUBLE_@func@,
@@ -275,7 +275,7 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@, (
 /**end repeat**/
 
 /**begin repeat
- *  #func = rint, ceil, floor, trunc#
+ *  #func = rint, floor, trunc#
  */
 
 /**begin repeat1

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -1,6 +1,8 @@
 /*@targets
  ** $maxopt baseline
- ** sse2 vsx2 neon
+ ** sse2 sse41
+ ** vsx2
+ ** neon asimd
  **/
 /**
  * Force use SSE only on x86, even if AVX2 or AVX512F are enabled
@@ -64,6 +66,9 @@ NPY_FINLINE double c_square_f64(double a)
     #define c_sqrt_f32 npy_sqrtf
     #define c_sqrt_f64 npy_sqrt
 #endif
+
+#define c_ceil_f32 npy_ceilf
+#define c_ceil_f64 npy_ceil
 
 /********************************************************************************
  ** Defining the SIMD kernels
@@ -134,10 +139,10 @@ NPY_FINLINE double c_square_f64(double a)
  */
 #if @VCHK@
 /**begin repeat1
- * #kind     = sqrt, absolute, square, reciprocal#
- * #intr     = sqrt, abs,      square, recip#
- * #repl_0w1 = 0,    0,        0,      1#
- * #RECIP_WORKAROUND = 0, 0,   0,      WORKAROUND_CLANG_RECIPROCAL_BUG#
+ * #kind     = ceil, sqrt, absolute, square, reciprocal#
+ * #intr     = ceil, sqrt, abs,      square, recip#
+ * #repl_0w1 = 0,    0,    0,        0,      1#
+ * #RECIP_WORKAROUND = 0, 0, 0, 0, WORKAROUND_CLANG_RECIPROCAL_BUG#
  */
 /**begin repeat2
  * #STYPE  = CONTIG, NCONTIG, CONTIG,  NCONTIG#
@@ -245,9 +250,9 @@ static void simd_@TYPE@_@kind@_@STYPE@_@DTYPE@
  * #VCHK = NPY_SIMD, NPY_SIMD_F64#
  */
 /**begin repeat1
- * #kind  = sqrt, absolute, square, reciprocal#
- * #intr  = sqrt, abs,      square, recip#
- * #clear = 0,    1,        0,      0#
+ * #kind  = ceil, sqrt, absolute, square, reciprocal#
+ * #intr  = ceil, sqrt, abs,      square, recip#
+ * #clear = 0,    0,    1,        0,      0#
  */
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))

--- a/numpy/core/src/umath/simd.inc.src
+++ b/numpy/core/src/umath/simd.inc.src
@@ -169,7 +169,7 @@ run_@func@_avx512_skx_@TYPE@(char **args, npy_intp const *dimensions, npy_intp c
  */
 
 /**begin repeat2
- *  #func = rint, floor, ceil, trunc#
+ *  #func = rint, floor, trunc#
  */
 
 #if defined @CHK@ && defined NPY_HAVE_SSE2_INTRINSICS
@@ -850,12 +850,6 @@ fma_floor_@vsub@(@vtype@ x)
 }
 
 NPY_FINLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_FMA @vtype@
-fma_ceil_@vsub@(@vtype@ x)
-{
-    return _mm256_round_@vsub@(x, _MM_FROUND_TO_POS_INF);
-}
-
-NPY_FINLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_FMA @vtype@
 fma_trunc_@vsub@(@vtype@ x)
 {
     return _mm256_round_@vsub@(x, _MM_FROUND_TO_ZERO);
@@ -985,12 +979,6 @@ NPY_FINLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_AVX512F @vtype@
 avx512_floor_@vsub@(@vtype@ x)
 {
     return _mm512_roundscale_@vsub@(x, 0x09);
-}
-
-NPY_FINLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_AVX512F @vtype@
-avx512_ceil_@vsub@(@vtype@ x)
-{
-    return _mm512_roundscale_@vsub@(x, 0x0A);
 }
 
 NPY_FINLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_AVX512F @vtype@
@@ -1327,8 +1315,8 @@ AVX512F_@func@_@TYPE@(char **args, npy_intp const *dimensions, npy_intp const *s
  */
 
 /**begin repeat1
- *  #func = rint, ceil, floor, trunc#
- *  #vectorf = rint, ceil, floor, trunc#
+ *  #func = rint, floor, trunc#
+ *  #vectorf = rint, floor, trunc#
  */
 
 #if defined @CHK@
@@ -1398,8 +1386,8 @@ static NPY_INLINE NPY_GCC_OPT_3 NPY_GCC_TARGET_@ISA@ void
  */
 
 /**begin repeat1
- *  #func = rint, ceil, floor, trunc#
- *  #vectorf =  rint, ceil, floor, trunc#
+ *  #func = rint, floor, trunc#
+ *  #vectorf =  rint, floor, trunc#
  */
 
 #if defined @CHK@


### PR DESCRIPTION
merge after #19022

TODO:
- [x] benchmark




## Benchmarks


### X86

<details>
<summary>CPU</summary>

```Bash
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   46 bits physical, 48 bits virtual
CPU(s):                          4
On-line CPU(s) list:             0-3
Thread(s) per core:              2
Core(s) per socket:              2
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           85
Model name:                      Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
Stepping:                        4
CPU MHz:                         3410.808
BogoMIPS:                        5999.99
Hypervisor vendor:               KVM
Virtualization type:             full
L1d cache:                       64 KiB
L1i cache:                       64 KiB
L2 cache:                        2 MiB
L3 cache:                        24.8 MiB
NUMA node0 CPU(s):               0-3
Vulnerability Itlb multihit:     KVM: Mitigation: VMX unsupported
Vulnerability L1tf:              Mitigation; PTE Inversion
Vulnerability Mds:               Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
Vulnerability Meltdown:          Mitigation; PTI
Vulnerability Spec store bypass: Vulnerable
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Full generic retpoline, STIBP disabled, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant
                                 _tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt
                                 tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 hle avx2 smep b
                                 mi2 erms invpcid rtm mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat
                                 pku ospke
```
</details>

<details>
<summary>OS</summary>

```Bash
Linux ip-172-31-32-40 5.11.0-1020-aws #21~20.04.2-Ubuntu SMP Fri Oct 1 13:03:59 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
Python 3.8.10
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark
<details>
 <summary>AVX512(before) vs SSE41(after)</summary>

```Bash
unset NPY_DISABLE_CPU_FEATURES
python3 runtests.py -n --bench-compare parent/main ceil -- --sort name
```
```Bash
       before           after         ratio
     [2278119f]       [c01b5119]
     <replace_raw_ceil~1>       <replace_raw_ceil>
-       244±0.6μs        217±0.9μs     0.89  bench_ufunc.UFunc.time_ufunc_types('ceil')
-         212±6μs         94.7±2μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'd')
-       168±0.3μs       45.4±0.1μs     0.27  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'f')
-        233±10μs          170±7μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'd')
-         177±5μs         81.8±2μs     0.46  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'f')
-       214±0.5μs        124±0.3μs     0.58  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'd')
-         169±2μs       65.3±0.4μs     0.39  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'f')
-        221±10μs          190±8μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'd')
-       170±0.4μs       93.9±0.2μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'f')
-         224±1μs        186±0.5μs     0.83  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'd')
-       170±0.2μs       94.2±0.4μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'f')
-         170±5μs          125±3μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 4, 'f')
```
</details>

<details>
 <summary>AVX2(before) vs SSE41(after)</summary>

```Bash
export NPY_DISABLE_CPU_FEATURES="AVX512F AVX512_SKX"
python3 runtests.py -n --bench-compare parent/main ceil -- --sort name
```
```Bash
       before           after         ratio
     [2278119f]       [c01b5119]
     <replace_raw_ceil~1>       <replace_raw_ceil>
-      21.1±0.1μs       14.9±0.9μs     0.71  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'f')
-         212±6μs         94.6±3μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'd')
-       169±0.2μs       45.2±0.2μs     0.27  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'f')
-        233±10μs          170±7μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'd')
-         178±5μs         82.1±2μs     0.46  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'f')
-      40.7±0.6μs       37.8±0.3μs     0.93  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'f')
-         213±1μs        124±0.3μs     0.58  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'd')
-         169±1μs       65.1±0.7μs     0.38  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'f')
-        222±10μs          189±8μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'd')
-       170±0.2μs       94.2±0.3μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'f')
-         231±5μs        185±0.6μs     0.80  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'd')
-       171±0.1μs       93.7±0.5μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'f')
-         171±4μs          124±3μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 4, 'f')
```
</details>

<details>
 <summary>SSE41</summary>

```Bash
export NPY_DISABLE_CPU_FEATURES="AVX2 FMA3 AVX512F AVX512_SKX"
python3 runtests.py -n --bench-compare parent/main ceil -- --sort name
```
```Bash
       before           after         ratio
     [2278119f]       [c01b5119]
     <replace_raw_ceil~1>       <replace_raw_ceil>
-      21.2±0.2μs       14.3±0.7μs     0.67  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'f')
-         211±6μs         94.2±2μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'd')
-       169±0.2μs       45.4±0.3μs     0.27  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'f')
-        233±10μs          169±6μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'd')
-         178±5μs         81.6±2μs     0.46  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'f')
-      40.2±0.6μs       37.1±0.9μs     0.92  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'f')
-       214±0.9μs        124±0.1μs     0.58  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'd')
-         169±2μs       64.6±0.6μs     0.38  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'f')
-        219±10μs          187±8μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'd')
-       170±0.4μs       93.4±0.4μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'f')
-         227±5μs        185±0.6μs     0.82  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'd')
-       170±0.2μs       93.2±0.3μs     0.55  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'f')
-         170±5μs          124±2μs     0.73  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 4, 'f')
```
</details>

-----

### Power little-endian
<details>
<summary>CPU</summary>

```
Architecture:                    ppc64le
Byte Order:                      Little Endian
CPU(s):                          8
On-line CPU(s) list:             0-7
Thread(s) per core:              1
Core(s) per socket:              1
Socket(s):                       8
NUMA node(s):                    1
Model:                           2.2 (pvr 004e 1202)
Model name:                      POWER9 (architected), altivec supported
L1d cache:                       256 KiB
L1i cache:                       256 KiB
NUMA node0 CPU(s):               0-7
Vulnerability L1tf:              Not affected
Vulnerability Meltdown:          Mitigation; RFI Flush
Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (eieio)
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
Vulnerability Spectre v2:        Vulnerable

processor   : 7
cpu     : POWER9 (architected), altivec supported
clock       : 2200.000000MHz
revision    : 2.2 (pvr 004e 1202)

timebase    : 512000000
platform    : pSeries
model       : IBM pSeries (emulated by qemu)
machine     : CHRP IBM pSeries (emulated by qemu)
MMU     : Radix

```
</details>

<details>
<summary>OS</summary>

```Bash
Linux e517009a912a 4.19.0-2-powerpc64le #1 SMP Debian 4.19.16-1 (2019-01-17) ppc64le ppc64le ppc64le GNU/Linux
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark

<details>
 <summary>VSX2</summary>

```Bash
python3 runtests.py -n --bench-compare parent/main ceil -- --sort name
```
```Bash  before           after         ratio
[a3e8a757]       [943a2a60]
<replace_raw_ceil~1>       <replace_raw_ceil>
    821±20μs          773±2μs     0.94  bench_ufunc.UFunc.time_ufunc_types('ceil')
   124±0.3μs      58.7±0.08μs     0.47  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'd')
   146±0.2μs      33.7±0.09μs     0.23  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'f')
   125±0.3μs         93.0±2μs     0.74  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'd')
   146±0.2μs       70.8±0.1μs     0.48  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'f')
   147±0.6μs       76.0±0.6μs     0.52  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'f')
   126±0.2μs       77.2±0.3μs     0.61  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'd')
   146±0.2μs       65.9±0.2μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'f')
   126±0.3μs        118±0.3μs     0.93  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'd')
   146±0.3μs        116±0.3μs     0.79  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'f')
  146±0.08μs       116±0.07μs     0.79  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'f')
     131±2μs        102±0.5μs     0.78  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 1, 'd')
   147±0.2μs       66.8±0.1μs     0.45  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 1, 'f')
   147±0.5μs        119±0.6μs     0.81  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'f')
   148±0.5μs        120±0.4μs     0.81  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 4, 'f')
```
</details>

----

### AArch64

<details>
<summary>CPU</summary>

```Bash
Architecture:                    aarch64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
CPU(s):                          2
On-line CPU(s) list:             0,1
Thread(s) per core:              1
Core(s) per socket:              2
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       ARM
Model:                           1
Model name:                      Neoverse-N1
Stepping:                        r3p1
BogoMIPS:                        243.75
L1d cache:                       128 KiB
L1i cache:                       128 KiB
L2 cache:                        2 MiB
L3 cache:                        32 MiB
NUMA node0 CPU(s):               0,1
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
Vulnerability Spectre v2:        Not affected
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
```
</details>

<details>
<summary>OS</summary>

```Bash
Linux ip-172-31-44-172 5.11.0-1020-aws #21~20.04.2-Ubuntu SMP Fri Oct 1 13:01:34 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark

<details>
 <summary>ASIMD</summary>

```Bash
python runtests.py --bench-compare parent/main ceil
```
```Bash
       before           after         ratio
     [2278119f]       [8a02fb23]
     <replace_raw_ceil~1>       <replace_raw_ceil>
-        268±10μs          224±5μs     0.84  bench_ufunc.UFunc.time_ufunc_types('ceil')
-      85.7±0.5μs       40.0±0.6μs     0.47  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'd')
-      82.9±0.3μs       24.1±0.6μs     0.29  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 1, 'f')
-        88.9±1μs         78.7±1μs     0.89  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'd')
-      82.8±0.2μs       54.8±0.3μs     0.66  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 2, 'f')
-        89.3±1μs         74.5±1μs     0.83  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'f')
-      90.8±0.6μs       78.4±0.7μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'd')
-      86.2±0.4μs      39.6±0.07μs     0.46  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 1, 'f')
-      83.4±0.6μs       68.7±0.2μs     0.82  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'f')
-      88.1±0.2μs       79.4±0.2μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 4, 'f')
-       158±0.3μs          140±1μs     0.89  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 1, 'd')
-      89.0±0.4μs       82.1±0.6μs     0.92  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 1, 'f')
+        97.6±1μs          108±2μs     1.10  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 4, 'f')
```
</details>

-----

#### Binary size(striped)

| LIB         | Before(Bytes) | After(Bytes) | Diff(Byes) |
| ----------- | ------------- | ------------ | ---------- |
| _multiarray_umath.cpython-38-x86_64-linux-gnu.so | 4213488 | 4233968 | 20480 |

No changes, for aarch64 or ppc64le
