### PR TITLE
BUG: Distutils patch to allow for 2 as a minor version (!)

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -647,11 +647,9 @@ def generate_manifest(config):
     if msver is not None:
         if msver >= 8:
             check_embedded_msvcr_match_linked(msver)
-            ma = int(msver)
-            mi = int((msver - ma) * 10)
+            ma_str, mi_str = str(msver).split('.')
             # Write the manifest file
-            manxml = msvc_manifest_xml(ma, mi)
-            man = open(manifest_name(config), "w")
-            config.temp_files.append(manifest_name(config))
-            man.write(manxml)
-            man.close()
+            manxml = msvc_manifest_xml(int(ma_str), int(mi_str))
+            with open(manifest_name(config), "w") as man:
+                config.temp_files.append(manifest_name(config))
+                man.write(manxml)


### PR DESCRIPTION
Backport of #20155.

The float representation of e.g. 14.2 is not exact, leading to a minor
version number of int(1.999999) == 1 in the original code.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
