### PR TITLE
BLD: in conda, pin setuptools to a known working version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - compilers
   - openblas
   - nomkl
+  - setuptools=58.4
   # For testing
   - pytest
   - pytest-cov


### PR DESCRIPTION
Setuptools released 58.5 which [broke our build](https://dev.azure.com/numpy/numpy/_build/results?buildId=20833&view=logs&j=f4f599af-16a4-5739-21ab-e5c3fd4cfa58&t=2792a313-b1a0-563f-6cb8-3871b9ae7fae&l=4550) on conda since we do not pin it. Try this version which I think was working previously. Related discussion https://github.com/pypa/setuptools/issues/2849

The build came from #19173