### PR TITLE
BUG: Fix requirement that user DTypes had to be heaptypes

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -2305,8 +2305,9 @@ arraydescr_new(PyTypeObject *subtype,
 {
     if (subtype != &PyArrayDescr_Type) {
         if (Py_TYPE(subtype) == &PyArrayDTypeMeta_Type &&
-                !(PyType_GetFlags(Py_TYPE(subtype)) & Py_TPFLAGS_HEAPTYPE) &&
-                (NPY_DT_SLOTS((PyArray_DTypeMeta *)subtype)) != NULL) {
+                (NPY_DT_SLOTS((PyArray_DTypeMeta *)subtype)) != NULL &&
+                !NPY_DT_is_legacy((PyArray_DTypeMeta *)subtype) &&
+                subtype->tp_new != PyArrayDescr_Type.tp_new) {
             /*
              * Appears to be a properly initialized user DType. Allocate
              * it and initialize the main part as best we can.
@@ -2333,7 +2334,9 @@ arraydescr_new(PyTypeObject *subtype,
         }
         /* The DTypeMeta class should prevent this from happening. */
         PyErr_Format(PyExc_SystemError,
-                "'%S' must not inherit np.dtype.__new__().", subtype);
+                "'%S' must not inherit np.dtype.__new__(). User DTypes should "
+                "currently call `PyArrayDescr_Type.tp_new` from their new.",
+                subtype);
         return NULL;
     }
 

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -131,6 +131,14 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
+    if (((PyTypeObject *)DType)->tp_repr == PyArrayDescr_Type.tp_repr
+            || ((PyTypeObject *)DType)->tp_str == PyArrayDescr_Type.tp_str) {
+        PyErr_SetString(PyExc_TypeError,
+                "A custom DType must implement `__repr__` and `__str__` since "
+                "the default inherited version (currently) fails.");
+        return -1;
+    }
+
     if (spec->typeobj == NULL || !PyType_Check(spec->typeobj)) {
         PyErr_SetString(PyExc_TypeError,
                 "Not giving a type object is currently not supported, but "


### PR DESCRIPTION
Requiring heap-types currently does not make sense, because the
way to create a new DType is clunky if you were to make a heaptype.

This was an initial thought, which panned out inconvenient now, so
changing.  This has no effect, except for experimental user DTypes
when `NUMPY_EXPERIMENTAL_DTYPE_API=1` is used.
