### PR TITLE
MAINT: Add `IS_PYSTON` to `np.testing.__all__`

### DIFF
--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -8,8 +8,7 @@ away.
 from unittest import TestCase
 
 from ._private.utils import *
-from ._private.utils import (_assert_valid_refcount, _gen_alignment_data,
-                             IS_PYSTON)
+from ._private.utils import (_assert_valid_refcount, _gen_alignment_data)
 from ._private import extbuild, decorators as dec
 from ._private.nosetester import (
     run_module_suite, NoseTester as Tester

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -35,7 +35,7 @@ __all__ = [
         'assert_allclose', 'IgnoreException', 'clear_and_catch_warnings',
         'SkipTest', 'KnownFailureException', 'temppath', 'tempdir', 'IS_PYPY',
         'HAS_REFCOUNT', 'suppress_warnings', 'assert_array_compare',
-        'assert_no_gc_cycles', 'break_cycles', 'HAS_LAPACK64'
+        'assert_no_gc_cycles', 'break_cycles', 'HAS_LAPACK64', 'IS_PYSTON',
         ]
 
 

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -133,6 +133,7 @@ class suppress_warnings:
 
 verbose: int
 IS_PYPY: Final[bool]
+IS_PYSTON: Final[bool]
 HAS_REFCOUNT: Final[bool]
 HAS_LAPACK64: Final[bool]
 


### PR DESCRIPTION
Add the `IS_PYSTON` constant to `__all__`, rather than explicitly importing it (xref https://github.com/numpy/numpy/pull/19423).