### PR TITLE
MAINT: Add annotations for a missing `percentile` interpolation kind: `"inclusive"`

### DIFF
--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -514,6 +514,7 @@ _InterpolationKind = L[
     "higher",
     "midpoint",
     "nearest",
+    "inclusive",
 ]
 
 @overload


### PR DESCRIPTION
`"inclusive"` was missing from the `Literal` with valid interpolation kinds.