### PR TITLE
DOC: Remove non-existent quantile `interpolation="inclusive"` alias

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3901,7 +3901,7 @@ def percentile(a,
         * (NPY 2): 'higher',
         * (NPY 3): 'midpoint'
         * (NPY 4): 'nearest'
-        * (NPY 5): 'linear', aliased with 'inclusive'  (default)
+        * (NPY 5): 'linear'
 
         New options:
 
@@ -3911,7 +3911,7 @@ def percentile(a,
         * (H&F 4): 'interpolated_inverted_cdf'
         * (H&F 5): 'hazen'
         * (H&F 6): 'weibull'
-        * (H&F 7): 'inclusive',  aliased with 'linear'  (default)
+        * (H&F 7): 'linear'  (default)
         * (H&F 8): 'median_unbiased'
         * (H&F 9): 'normal_unbiased'
 
@@ -4007,8 +4007,7 @@ def percentile(a,
         * alpha = 0
         * beta = 0
 
-    inclusive:
-        Default method, aliased with "linear".
+    linear:
         method 7 of H&F [1]_.
         This method give continuous results using:
         * alpha = 1
@@ -4164,7 +4163,7 @@ def quantile(a,
         * (NPY 2): 'higher',
         * (NPY 3): 'midpoint'
         * (NPY 4): 'nearest'
-        * (NPY 5): 'linear', aliased with 'inclusive'  (default)
+        * (NPY 5): 'linear'
 
         New options:
 
@@ -4174,7 +4173,7 @@ def quantile(a,
         * (H&F 4): 'interpolated_inverted_cdf'
         * (H&F 5): 'hazen'
         * (H&F 6): 'weibull'
-        * (H&F 7): 'inclusive',  aliased with 'linear'  (default)
+        * (H&F 7): 'linear'  (default)
         * (H&F 8): 'median_unbiased'
         * (H&F 9): 'normal_unbiased'
 
@@ -4261,8 +4260,7 @@ def quantile(a,
         * alpha = 0
         * beta = 0
 
-    inclusive:
-        Default method, aliased with "linear".
+    linear:
         method 7 of H&F [1]_.
         This method give continuous results using:
         * alpha = 1

--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -514,7 +514,6 @@ _InterpolationKind = L[
     "higher",
     "midpoint",
     "nearest",
-    "inclusive",
 ]
 
 @overload

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -1277,7 +1277,7 @@ def nanpercentile(
         * (NPY 2): 'higher',
         * (NPY 3): 'midpoint'
         * (NPY 4): 'nearest'
-        * (NPY 5): 'linear', aliased with 'inclusive'  (default)
+        * (NPY 5): 'linear'  (default)
 
         New options:
 
@@ -1287,7 +1287,7 @@ def nanpercentile(
         * (H&F 4): 'interpolated_inverted_cdf'
         * (H&F 5): 'hazen'
         * (H&F 6): 'weibull'
-        * (H&F 7): 'inclusive',  aliased with 'linear'  (default)
+        * (H&F 7): 'linear'  (default)
         * (H&F 8): 'median_unbiased'
         * (H&F 9): 'normal_unbiased'
 
@@ -1418,7 +1418,7 @@ def nanquantile(
         * (NPY 2): 'higher',
         * (NPY 3): 'midpoint'
         * (NPY 4): 'nearest'
-        * (NPY 5): 'linear', aliased with 'inclusive'  (default)
+        * (NPY 5): 'linear'  (default)
 
         New options:
 
@@ -1428,7 +1428,7 @@ def nanquantile(
         * (H&F 4): 'interpolated_inverted_cdf'
         * (H&F 5): 'hazen'
         * (H&F 6): 'weibull'
-        * (H&F 7): 'inclusive',  aliased with 'linear'  (default)
+        * (H&F 7): 'linear'  (default)
         * (H&F 8): 'median_unbiased'
         * (H&F 9): 'normal_unbiased'
 


### PR DESCRIPTION
Fix #20324

This PR remove `inclusive` from the documented values of `np.percentile` interpolation parameter. 
This alias does not exist in the source code.