### PR TITLE
BUG: fix gcc version detection fallback for Mingw32CCompiler

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -66,8 +66,10 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         # get_versions methods regex
         if self.gcc_version is None:
             try:
-                out_string  = subprocess.check_output(['gcc', '-dumpversion'])
-            except (OSError, CalledProcessError):
+                out_string = subprocess.check_output(
+                    ['gcc', '-dumpversion'],
+                    text=True)
+            except (OSError, subprocess.CalledProcessError):
                 out_string = ""  # ignore failures to match old behavior
             result = re.search(r'(\d+\.\d+)', out_string)
             if result:


### PR DESCRIPTION
In case gcc_version is None it would try to parse the output, but
this code was never ported to Python 3, so it matches str with bytes
which raises a TypeError.

Fix by decoding the gcc output via the text option (available since py3.7)

Also fixes the reference to CalledProcessError