### PR TITLE
DEP: remove code for supporting GCC <4 in Mingw32CCompiler

### DIFF
--- a/numpy/distutils/mingw32ccompiler.py
+++ b/numpy/distutils/mingw32ccompiler.py
@@ -24,7 +24,6 @@ from numpy.distutils import log
 # 3. Force windows to use g77
 
 import distutils.cygwinccompiler
-from distutils.version import StrictVersion
 from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import get_build_version as get_build_msvc_version
 from distutils.errors import UnknownFileError
@@ -62,35 +61,6 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         distutils.cygwinccompiler.CygwinCCompiler.__init__ (self, verbose,
                                                             dry_run, force)
 
-        # we need to support 3.2 which doesn't match the standard
-        # get_versions methods regex
-        if self.gcc_version is None:
-            try:
-                out_string  = subprocess.check_output(['gcc', '-dumpversion'])
-            except (OSError, CalledProcessError):
-                out_string = ""  # ignore failures to match old behavior
-            result = re.search(r'(\d+\.\d+)', out_string)
-            if result:
-                self.gcc_version = StrictVersion(result.group(1))
-
-        # A real mingw32 doesn't need to specify a different entry point,
-        # but cygwin 2.91.57 in no-cygwin-mode needs it.
-        if self.gcc_version <= "2.91.57":
-            entry_point = '--entry _DllMain@12'
-        else:
-            entry_point = ''
-
-        if self.linker_dll == 'dllwrap':
-            # Commented out '--driver-name g++' part that fixes weird
-            #   g++.exe: g++: No such file or directory
-            # error (mingw 1.0 in Enthon24 tree, gcc-3.4.5).
-            # If the --driver-name part is required for some environment
-            # then make the inclusion of this part specific to that
-            # environment.
-            self.linker = 'dllwrap' #  --driver-name g++'
-        elif self.linker_dll == 'gcc':
-            self.linker = 'g++'
-
         # **changes: eric jones 4/11/01
         # 1. Check for import library on Windows.  Build if it doesn't exist.
 
@@ -113,42 +83,18 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
         # kind of bad consequences, like using Py_ModuleInit4 instead of
         # Py_ModuleInit4_64, etc... So we add it here
         if get_build_architecture() == 'AMD64':
-            if self.gcc_version < "4.0":
-                self.set_executables(
-                    compiler='gcc -g -DDEBUG -DMS_WIN64 -mno-cygwin -O0 -Wall',
-                    compiler_so='gcc -g -DDEBUG -DMS_WIN64 -mno-cygwin -O0'
-                                ' -Wall -Wstrict-prototypes',
-                    linker_exe='gcc -g -mno-cygwin',
-                    linker_so='gcc -g -mno-cygwin -shared')
-            else:
-                # gcc-4 series releases do not support -mno-cygwin option
-                self.set_executables(
-                    compiler='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall',
-                    compiler_so='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall -Wstrict-prototypes',
-                    linker_exe='gcc -g',
-                    linker_so='gcc -g -shared')
+            self.set_executables(
+                compiler='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall',
+                compiler_so='gcc -g -DDEBUG -DMS_WIN64 -O0 -Wall '
+                            '-Wstrict-prototypes',
+                linker_exe='gcc -g',
+                linker_so='gcc -g -shared')
         else:
-            if self.gcc_version <= "3.0.0":
-                self.set_executables(
-                    compiler='gcc -mno-cygwin -O2 -w',
-                    compiler_so='gcc -mno-cygwin -mdll -O2 -w'
-                                ' -Wstrict-prototypes',
-                    linker_exe='g++ -mno-cygwin',
-                    linker_so='%s -mno-cygwin -mdll -static %s' %
-                              (self.linker, entry_point))
-            elif self.gcc_version < "4.0":
-                self.set_executables(
-                    compiler='gcc -mno-cygwin -O2 -Wall',
-                    compiler_so='gcc -mno-cygwin -O2 -Wall'
-                                ' -Wstrict-prototypes',
-                    linker_exe='g++ -mno-cygwin',
-                    linker_so='g++ -mno-cygwin -shared')
-            else:
-                # gcc-4 series releases do not support -mno-cygwin option
-                self.set_executables(compiler='gcc -O2 -Wall',
-                                     compiler_so='gcc -O2 -Wall -Wstrict-prototypes',
-                                     linker_exe='g++ ',
-                                     linker_so='g++ -shared')
+            self.set_executables(
+                compiler='gcc -O2 -Wall',
+                compiler_so='gcc -O2 -Wall -Wstrict-prototypes',
+                linker_exe='g++ ',
+                linker_so='g++ -shared')
         # added for python2.3 support
         # we can't pass it through set_executables because pre 2.2 would fail
         self.compiler_cxx = ['g++']
@@ -198,10 +144,7 @@ class Mingw32CCompiler(distutils.cygwinccompiler.CygwinCCompiler):
                 extra_postargs,
                 build_temp,
                 target_lang)
-        if self.gcc_version < "3.0.0":
-            func = distutils.cygwinccompiler.CygwinCCompiler.link
-        else:
-            func = UnixCCompiler.link
+        func = UnixCCompiler.link
         func(*args[:func.__code__.co_argcount])
         return
 


### PR DESCRIPTION
The last GCC 3.x release before 4.0 was 3.4 which was released 2004,
so 17 years ago.

Removes all code only used with those old toolchains.

This is an alternative to #20330