### PR TITLE
MAINT: Rename commit trigger to "wheel build" for building wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,7 +40,7 @@ jobs:
     name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform }}
     needs: get_commit_message
     if: >-
-      contains(needs.get_commit_message.outputs.message, '[cd build]') ||
+      contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Follow up to #20102 renaming the commit trigger to "wheel build"

REF: https://github.com/numpy/numpy/pull/20102#discussion_r741679752