### PR TITLE
CI: Bump azure MacOS version to macOS-1015

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ stages:
       # the docs even though i.e., numba uses another in their
       # azure config for mac os -- Microsoft has indicated
       # they will patch this issue
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-1015'
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
The 10.14 version is deprecated and will stop working on December 10:
https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

The new image name seems to not have the `.` in it.

---

Edit: just to be sure, the "report clang version step" says:
```
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin19.6.0
```