### PR TITLE
BLD: do not position 'cxx=-std=c++11' as a default compiler flag

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -196,7 +196,6 @@ class _Config:
             native = '-march=native',
             opt = '-O3',
             werror = '-Werror',
-            cxx = '-std=c++11',
         ),
         clang = dict(
             native = '-march=native',
@@ -207,25 +206,21 @@ class _Config:
             # "unused arguments" warnings.
             # see https://github.com/numpy/numpy/issues/19624
             werror = '-Werror=switch -Werror',
-            cxx = '-std=c++11',
         ),
         icc = dict(
             native = '-xHost',
             opt = '-O3',
             werror = '-Werror',
-            cxx = '-std=c++11',
         ),
         iccw = dict(
             native = '/QxHost',
             opt = '/O3',
             werror = '/Werror',
-            cxx = '-std=c++11',
         ),
         msvc = dict(
             native = None,
             opt = '/O2',
             werror = '/WX',
-            cxx = '-std=c++11',
         )
     )
     conf_min_features = dict(


### PR DESCRIPTION
Otherwise it gets used for C source too, which is either useless or invalid (for
clang(family compiler)

~Fix (or was an attempt at fixing) #20335~
