### PR TITLE
MAINT: Do not forward `__(deep)copy__` calls of `_GenericAlias` to the wrapped type

### DIFF
--- a/numpy/typing/_generic_alias.py
+++ b/numpy/typing/_generic_alias.py
@@ -185,6 +185,8 @@ class _GenericAlias:
         "__mro_entries__",
         "__reduce__",
         "__reduce_ex__",
+        "__copy__",
+        "__deepcopy__",
     })
 
     def __getattribute__(self, name: str) -> Any:

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import copy
 import types
 import pickle
 import weakref
@@ -77,6 +78,21 @@ class TestGenericAlias:
         value = func(NDArray)
 
         if sys.version_info >= (3, 9):
+            value_ref = func(NDArray_ref)
+            assert value == value_ref
+
+    @pytest.mark.parametrize("name,func", [
+        ("__copy__", lambda n: n == copy.copy(n)),
+        ("__deepcopy__", lambda n: n == copy.deepcopy(n)),
+    ])
+    def test_copy(self, name: str, func: FuncType) -> None:
+        value = func(NDArray)
+
+        # xref bpo-45167
+        GE_398 = (
+            sys.version_info[:2] == (3, 9) and sys.version_info >= (3, 9, 8)
+        )
+        if GE_398 or sys.version_info >= (3, 10, 1):
             value_ref = func(NDArray_ref)
             assert value == value_ref
 


### PR DESCRIPTION
Adapt to the Python 3.9.8 changes made in [bpo-45167](https://bugs.python.org/issue45167); this should fix the recent python 3.9 CI failure.