### PR TITLE
DOC: random: Fix a mistake in the zipf example.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3107,7 +3107,7 @@ cdef class Generator:
         `a` > 1.
 
         The Zipf distribution (also known as the zeta distribution) is a
-        continuous probability distribution that satisfies Zipf's law: the
+        discrete probability distribution that satisfies Zipf's law: the
         frequency of an item is inversely proportional to its rank in a
         frequency table.
 
@@ -3135,9 +3135,10 @@ cdef class Generator:
         -----
         The probability density for the Zipf distribution is
 
-        .. math:: p(x) = \\frac{x^{-a}}{\\zeta(a)},
+        .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 
-        where :math:`\\zeta` is the Riemann Zeta function.
+        for integers ``k`` >= 1, where :math:`\\zeta` is the Riemann Zeta
+        function.
 
         It is named for the American linguist George Kingsley Zipf, who noted
         that the frequency of any word in a sample of a language is inversely
@@ -3167,10 +3168,10 @@ cdef class Generator:
         `bincount` provides a fast histogram for small integers.
 
         >>> count = np.bincount(s)
-        >>> x = np.arange(1, s.max() + 1)
+        >>> k = np.arange(1, s.max() + 1)
 
-        >>> plt.bar(x, count[1:], alpha=0.5, label='sample count')
-        >>> plt.plot(x, n*(x**-a)/zeta(a), 'k.-', alpha=0.5,
+        >>> plt.bar(k, count[1:], alpha=0.5, label='sample count')
+        >>> plt.plot(k, n*(k**-a)/zeta(a), 'k.-', alpha=0.5,
         ...          label='expected count')   # doctest: +SKIP
         >>> plt.semilogy()
         >>> plt.grid(alpha=0.4)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3153,22 +3153,29 @@ cdef class Generator:
         --------
         Draw samples from the distribution:
 
-        >>> a = 2. # parameter
-        >>> s = np.random.default_rng().zipf(a, 1000)
+        >>> a = 4.0
+        >>> n = 20000
+        >>> s = np.random.default_rng().zipf(a, size=n)
 
         Display the histogram of the samples, along with
-        the probability density function:
+        the expected histogram based on the probability
+        density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> from scipy import special  # doctest: +SKIP
+        >>> from scipy.special import zeta  # doctest: +SKIP
 
-        Truncate s values at 50 so plot is interesting:
+        `bincount` provides a fast histogram for small integers.
 
-        >>> count, bins, ignored = plt.hist(s[s<50],
-        ...         50, density=True)
-        >>> x = np.arange(1., 50.)
-        >>> y = x**(-a) / special.zetac(a)  # doctest: +SKIP
-        >>> plt.plot(x, y/max(y), linewidth=2, color='r')  # doctest: +SKIP
+        >>> count = np.bincount(s)
+        >>> x = np.arange(1, s.max() + 1)
+
+        >>> plt.bar(x, count[1:], alpha=0.5, label='sample count')
+        >>> plt.plot(x, n*(x**-a)/zeta(a), 'k.-', alpha=0.5,
+        ...          label='expected count')   # doctest: +SKIP
+        >>> plt.semilogy()
+        >>> plt.grid(alpha=0.4)
+        >>> plt.legend()
+        >>> plt.title(f'Zipf sample, a={a}, size={n}')
         >>> plt.show()
 
         """

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3137,7 +3137,7 @@ cdef class Generator:
 
         .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 
-        for integers ``k`` >= 1, where :math:`\\zeta` is the Riemann Zeta
+        for integers :math:`k \geq 1`, where :math:`\\zeta` is the Riemann Zeta
         function.
 
         It is named for the American linguist George Kingsley Zipf, who noted

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3609,7 +3609,7 @@ cdef class RandomState:
         `a` > 1.
 
         The Zipf distribution (also known as the zeta distribution) is a
-        continuous probability distribution that satisfies Zipf's law: the
+        discrete probability distribution that satisfies Zipf's law: the
         frequency of an item is inversely proportional to its rank in a
         frequency table.
 
@@ -3642,9 +3642,10 @@ cdef class RandomState:
         -----
         The probability density for the Zipf distribution is
 
-        .. math:: p(x) = \\frac{x^{-a}}{\\zeta(a)},
+        .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 
-        where :math:`\\zeta` is the Riemann Zeta function.
+        for integers ``k`` >= 1, where :math:`\\zeta` is the Riemann Zeta
+        function.
 
         It is named for the American linguist George Kingsley Zipf, who noted
         that the frequency of any word in a sample of a language is inversely
@@ -3674,10 +3675,10 @@ cdef class RandomState:
         `bincount` provides a fast histogram for small integers.
 
         >>> count = np.bincount(s)
-        >>> x = np.arange(1, s.max() + 1)
+        >>> k = np.arange(1, s.max() + 1)
 
-        >>> plt.bar(x, count[1:], alpha=0.5, label='sample count')
-        >>> plt.plot(x, n*(x**-a)/zeta(a), 'k.-', alpha=0.5,
+        >>> plt.bar(k, count[1:], alpha=0.5, label='sample count')
+        >>> plt.plot(k, n*(k**-a)/zeta(a), 'k.-', alpha=0.5,
         ...          label='expected count')   # doctest: +SKIP
         >>> plt.semilogy()
         >>> plt.grid(alpha=0.4)

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3660,21 +3660,29 @@ cdef class RandomState:
         --------
         Draw samples from the distribution:
 
-        >>> a = 2. # parameter
-        >>> s = np.random.zipf(a, 1000)
+        >>> a = 4.0
+        >>> n = 20000
+        >>> s = np.random.zipf(a, n)
 
         Display the histogram of the samples, along with
-        the probability density function:
+        the expected histogram based on the probability
+        density function:
 
         >>> import matplotlib.pyplot as plt
-        >>> from scipy import special  # doctest: +SKIP
+        >>> from scipy.special import zeta  # doctest: +SKIP
 
-        Truncate s values at 50 so plot is interesting:
+        `bincount` provides a fast histogram for small integers.
 
-        >>> count, bins, ignored = plt.hist(s[s<50], 50, density=True)
-        >>> x = np.arange(1., 50.)
-        >>> y = x**(-a) / special.zetac(a)  # doctest: +SKIP
-        >>> plt.plot(x, y/max(y), linewidth=2, color='r')  # doctest: +SKIP
+        >>> count = np.bincount(s)
+        >>> x = np.arange(1, s.max() + 1)
+
+        >>> plt.bar(x, count[1:], alpha=0.5, label='sample count')
+        >>> plt.plot(x, n*(x**-a)/zeta(a), 'k.-', alpha=0.5,
+        ...          label='expected count')   # doctest: +SKIP
+        >>> plt.semilogy()
+        >>> plt.grid(alpha=0.4)
+        >>> plt.legend()
+        >>> plt.title(f'Zipf sample, a={a}, size={n}')
         >>> plt.show()
 
         """

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3644,7 +3644,7 @@ cdef class RandomState:
 
         .. math:: p(k) = \\frac{k^{-a}}{\\zeta(a)},
 
-        for integers ``k`` >= 1, where :math:`\\zeta` is the Riemann Zeta
+        for integers :math:`k \geq 1`, where :math:`\\zeta` is the Riemann Zeta
         function.
 
         It is named for the American linguist George Kingsley Zipf, who noted


### PR DESCRIPTION
There was a mistake in the code that generated
the plot in the zipf docstring.  The Riemann
zeta function is `scipy.special.zeta`, not
`scipy.special.zetac`.

I also tweaked the sample parameters and the plot
code so the plot is a bit more informative.
