### PR TITLE
ENH: Prefix log messages with their levels

### DIFF
--- a/numpy/distutils/log.py
+++ b/numpy/distutils/log.py
@@ -87,3 +87,25 @@ _global_color_map = {
 
 # don't use INFO,.. flags in set_verbosity, these flags are for set_threshold.
 set_verbosity(0, force=True)
+
+
+_error = error
+_warn = warn
+_info = info
+_debug = debug
+
+
+def error(msg, *a, **kw):
+    _error(f"ERROR: {msg}", *a, **kw)
+
+
+def warn(msg, *a, **kw):
+    _warn(f"WARN: {msg}", *a, **kw)
+
+
+def info(msg, *a, **kw):
+    _info(f"INFO: {msg}", *a, **kw)
+
+
+def debug(msg, *a, **kw):
+    _debug(f"DEBUG: {msg}", *a, **kw)

--- a/numpy/distutils/tests/test_log.py
+++ b/numpy/distutils/tests/test_log.py
@@ -1,0 +1,32 @@
+import io
+import re
+from contextlib import redirect_stdout
+
+import pytest
+
+from numpy.distutils import log
+
+
+def setup_module():
+    log.set_verbosity(2, force=True)  # i.e. DEBUG
+
+
+def teardown_module():
+    log.set_verbosity(0, force=True)  # the default
+
+
+r_ansi = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+@pytest.mark.parametrize("func_name", ["error", "warn", "info", "debug"])
+def test_log_prefix(func_name):
+    func = getattr(log, func_name)
+    msg = f"{func_name} message"
+    f = io.StringIO()
+    with redirect_stdout(f):
+        func(msg)
+    out = f.getvalue()
+    assert out  # sanity check
+    clean_out = r_ansi.sub("", out)
+    line = next(line for line in clean_out.splitlines())
+    assert line == f"{func_name.upper()}: {msg}"


### PR DESCRIPTION
This PR prefixes log messages (from `numpy.distutils`) with their respective log level, e.g.
```python
>>> from numpy.distutils import log
>>> log.warn("a warning message")
a warning message
```
now works like
```python
>>> log.warn("a warning message")
WARN: a warning message
```
This comes from discussion with @rgommers and @asmeurer, where Aaron identified that build warnings and errors are only distinguished by colour and it'd be nice if they also were prefixed with their log level.

Personally I found `numpy.distutils` rather magical in how it works... lest I waste more time understanding `distutils` proper (and it's use of `logging`), my solution here was to just `copy.copy()` the existing logging methods, to be subsequently wrapped. Pointers appreciated if folk have any better ideas.

`distutils.log` (and thus `numpy.distutils.log`) doesn't play nice with existing pytest tools for logging i.e. its `caplog` fixture, so I've just opted to capture the stdout and test with that.

<details><summary>An example of the stdout now</summary>

```bash
$ python setup.py build_ext --inplace
Running from numpy source directory.
Cythonizing sources
numpy/random/_bounded_integers.pxd.in has not changed
Processing numpy/random/_generator.pyx
numpy/random/_common.pyx has not changed
numpy/random/_bounded_integers.pyx.in has not changed
numpy/random/_bounded_integers.pyx has not changed
numpy/random/_sfc64.pyx has not changed
numpy/random/_pcg64.pyx has not changed
numpy/random/_philox.pyx has not changed
numpy/random/_mt19937.pyx has not changed
Processing numpy/random/mtrand.pyx
numpy/random/bit_generator.pyx has not changed
INFO: blas_opt_info:
INFO: blas_mkl_info:
INFO: customize UnixCCompiler
INFO:   libraries mkl_rt not found in ['/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/lib', '/usr/local/lib', '/usr/lib64', '/usr/lib', '/usr/lib/x86_64-linux-gnu']
INFO:   NOT AVAILABLE
INFO: 
INFO: blis_info:
INFO:   libraries blis not found in ['/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/lib', '/usr/local/lib', '/usr/lib64', '/usr/lib', '/usr/lib/x86_64-linux-gnu']
INFO:   NOT AVAILABLE
INFO: 
INFO: openblas_info:
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

creating /tmp/tmpozkr3odf/tmp
creating /tmp/tmpozkr3odf/tmp/tmpozkr3odf
INFO: compile options: '-c'
INFO: x86_64-linux-gnu-gcc: /tmp/tmpozkr3odf/source.c
INFO: x86_64-linux-gnu-gcc -pthread /tmp/tmpozkr3odf/tmp/tmpozkr3odf/source.o -lopenblas -o /tmp/tmpozkr3odf/a.out
INFO:   FOUND:
INFO:     libraries = ['openblas', 'openblas']
INFO:     library_dirs = ['/usr/lib/x86_64-linux-gnu']
INFO:     language = c
INFO:     define_macros = [('HAVE_CBLAS', None)]
INFO: 
INFO:   FOUND:
INFO:     libraries = ['openblas', 'openblas']
INFO:     library_dirs = ['/usr/lib/x86_64-linux-gnu']
INFO:     language = c
INFO:     define_macros = [('HAVE_CBLAS', None)]
INFO: 
non-existing path in 'numpy/distutils': 'site.cfg'
INFO: lapack_opt_info:
INFO: lapack_mkl_info:
INFO:   libraries mkl_rt not found in ['/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/lib', '/usr/local/lib', '/usr/lib64', '/usr/lib', '/usr/lib/x86_64-linux-gnu']
INFO:   NOT AVAILABLE
INFO: 
INFO: openblas_lapack_info:
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

creating /tmp/tmp7c1dqun7/tmp
creating /tmp/tmp7c1dqun7/tmp/tmp7c1dqun7
INFO: compile options: '-c'
INFO: x86_64-linux-gnu-gcc: /tmp/tmp7c1dqun7/source.c
INFO: x86_64-linux-gnu-gcc -pthread /tmp/tmp7c1dqun7/tmp/tmp7c1dqun7/source.o -lopenblas -o /tmp/tmp7c1dqun7/a.out
INFO:   FOUND:
INFO:     libraries = ['openblas', 'openblas']
INFO:     library_dirs = ['/usr/lib/x86_64-linux-gnu']
INFO:     language = c
INFO:     define_macros = [('HAVE_CBLAS', None)]
INFO: 
INFO:   FOUND:
INFO:     libraries = ['openblas', 'openblas']
INFO:     library_dirs = ['/usr/lib/x86_64-linux-gnu']
INFO:     language = c
INFO:     define_macros = [('HAVE_CBLAS', None)]
INFO: 
Warning: attempted relative import with no known parent package
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'define_macros'
  warnings.warn(msg)
running build_ext
running build_src
INFO: build_src
INFO: building py_modules sources
INFO: building library "npymath" sources
INFO:   adding 'numpy/core/src/npymath' to include_dirs.
INFO: None - nothing done with h_files = ['numpy/core/src/npymath/npy_math_internal.h']
INFO: building library "npyrandom" sources
INFO: building extension "numpy.core._multiarray_tests" sources
INFO: building extension "numpy.core._multiarray_umath" sources
INFO:   adding 'numpy/core/src/common' to include_dirs.
INFO:   adding 'numpy/core/src/umath' to include_dirs.
INFO: numpy.core - nothing done with h_files = ['numpy/core/src/common/npy_sort.h', 'numpy/core/src/common/npy_partition.h', 'numpy/core/src/common/npy_binsearch.h', 'numpy/core/src/umath/funcs.inc', 'numpy/core/src/umath/simd.inc', 'numpy/core/src/umath/loops.h', 'numpy/core/src/umath/loops_utils.h', 'numpy/core/src/umath/matmul.h', 'numpy/core/src/umath/clip.h', 'numpy/core/src/common/templ_common.h', 'numpy/core/include/numpy/config.h', 'numpy/core/include/numpy/_numpyconfig.h', 'numpy/core/include/numpy/__multiarray_api.h', 'numpy/core/include/numpy/__ufunc_api.h']
INFO: building extension "numpy.core._umath_tests" sources
INFO: building extension "numpy.core._rational_tests" sources
INFO: building extension "numpy.core._struct_ufunc_tests" sources
INFO: building extension "numpy.core._operand_flag_tests" sources
INFO: building extension "numpy.core._simd" sources
INFO:   adding 'numpy/core/src/_simd' to include_dirs.
INFO: numpy.core - nothing done with h_files = ['numpy/core/src/_simd/_simd_inc.h', 'numpy/core/src/_simd/_simd_data.inc']
INFO: building extension "numpy.fft._pocketfft_internal" sources
INFO: building extension "numpy.linalg.lapack_lite" sources
INFO: building extension "numpy.linalg._umath_linalg" sources
INFO: building extension "numpy.random._mt19937" sources
INFO: building extension "numpy.random._philox" sources
INFO: building extension "numpy.random._pcg64" sources
INFO: building extension "numpy.random._sfc64" sources
INFO: building extension "numpy.random._common" sources
INFO: building extension "numpy.random.bit_generator" sources
INFO: building extension "numpy.random._generator" sources
INFO: building extension "numpy.random._bounded_integers" sources
INFO: building extension "numpy.random.mtrand" sources
INFO: building data_files sources
INFO: build_src: building npy-pkg config files
INFO: customize UnixCCompiler
INFO: customize UnixCCompiler using new_build_clib
INFO: CCompilerOpt.__init__[773] : load cache from file -> /home/honno/gdrive/GitHub/numpy/build/temp.linux-x86_64-3.8/ccompiler_opt_cache_clib.py
INFO: CCompilerOpt.__init__[789] : miss the file cache
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-march=native)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

creating /tmp/tmpsm8v_0fc/home
creating /tmp/tmpsm8v_0fc/home/honno
creating /tmp/tmpsm8v_0fc/home/honno/gdrive
creating /tmp/tmpsm8v_0fc/home/honno/gdrive/GitHub
creating /tmp/tmpsm8v_0fc/home/honno/gdrive/GitHub/numpy
creating /tmp/tmpsm8v_0fc/home/honno/gdrive/GitHub/numpy/numpy
creating /tmp/tmpsm8v_0fc/home/honno/gdrive/GitHub/numpy/numpy/distutils
creating /tmp/tmpsm8v_0fc/home/honno/gdrive/GitHub/numpy/numpy/distutils/checks
INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-march=native'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-O3)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-Werror)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-Werror'
INFO: CCompilerOpt.__init__[1709] : check requested baseline
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-msse)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-msse2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse2'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSE' with flags (-msse -msse2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSE2' with flags (-msse -msse2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-msse3)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse3'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSE3' with flags (-msse -msse2 -msse3)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -Werror'
INFO: CCompilerOpt.__init__[1718] : check requested dispatch-able features
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mssse3)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mssse3'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-msse4.1)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse4.1'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mpopcnt)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mpopcnt'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-msse4.2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse4.2'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSE41' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mf16c)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mf16c'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'F16C' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSSE3' with flags (-msse -msse2 -msse3 -mssse3)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mfma)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mfma'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx2'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512f)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512f'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512F' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'FMA3' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'POPCNT' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512cd)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512cd'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512CD' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'SSE42' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -Werror'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX2' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mavx2)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mavx2 -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512vl -mavx512bw -mavx512dq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512vl -mavx512bw -mavx512dq'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_SKX' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512ifma -mavx512vbmi)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512ifma -mavx512vbmi'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_CNL' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512ifma -mavx512vbmi -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512vnni)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512vnni'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_CLX' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512vnni)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512vnni -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512er -mavx512pf)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512er -mavx512pf'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_KNL' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512er -mavx512pf)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512er -mavx512pf -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx5124fmaps -mavx5124vnniw -mavx512vpopcntdq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx5124fmaps -mavx5124vnniw -mavx512vpopcntdq'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_KNM' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512er -mavx512pf -mavx5124fmaps -mavx5124vnniw -mavx512vpopcntdq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512er -mavx512pf -mavx5124fmaps -mavx5124vnniw -mavx512vpopcntdq -Werror'
INFO: CCompilerOpt.cc_test_flags[1021] : testing flags (-mavx512vbmi2 -mavx512bitalg -mavx512vpopcntdq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-mavx512vbmi2 -mavx512bitalg -mavx512vpopcntdq'
INFO: CCompilerOpt.feature_test[1474] : testing feature 'AVX512_ICL' with flags (-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512vnni -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512bitalg -mavx512vpopcntdq)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -mavx512vnni -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512bitalg -mavx512vpopcntdq -Werror'
INFO: CCompilerOpt.__init__[1730] : skip features (SSE3 SSE2 SSE) since its part of baseline
INFO: CCompilerOpt.__init__[1734] : initialize targets groups
INFO: CCompilerOpt.__init__[1736] : parse target group simd_test
INFO: CCompilerOpt._parse_target_tokens[1947] : skip targets (ASIMD XOP VSX NEON VSX2 VSX3 FMA4) not part of baseline or dispatch-able features
INFO: CCompilerOpt._parse_policy_not_keepbase[2059] : skip baseline features (SSE2)
INFO: CCompilerOpt.generate_dispatch_header[2280] : generate CPU dispatch header: (build/src.linux-x86_64-3.8/numpy/distutils/include/npy_cpu_dispatch_config.h)
INFO: CCompilerOpt.feature_extra_checks[1554] : Testing extra checks for feature 'AVX512F' (AVX512F_REDUCE)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -Werror'
INFO: CCompilerOpt.feature_extra_checks[1554] : Testing extra checks for feature 'AVX512_SKX' (AVX512BW_MASK AVX512DQ_MASK)
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -Werror'
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq -Werror'
INFO: building 'npymath' library
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/src/npymath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npymath/ieee754.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npymath/npy_math.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npymath/npy_math_complex.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npymath/halffloat.c
INFO: x86_64-linux-gnu-gcc-ar: adding 4 object files to build/temp.linux-x86_64-3.8/libnpymath.a
INFO: building 'npyrandom' library
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/logfactorial.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/distributions.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/random_mvhg_count.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/random_mvhg_marginals.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/random_hypergeometric.c
INFO: x86_64-linux-gnu-gcc-ar: adding 5 object files to build/temp.linux-x86_64-3.8/libnpyrandom.a
INFO: customize UnixCCompiler
INFO: customize UnixCCompiler using new_build_ext
INFO: CCompilerOpt.__init__[773] : load cache from file -> /home/honno/gdrive/GitHub/numpy/build/temp.linux-x86_64-3.8/ccompiler_opt_cache_ext.py
INFO: CCompilerOpt.__init__[789] : miss the file cache
INFO: CCompilerOpt.__init__[794] : hit the memory cache
INFO: CCompilerOpt.generate_dispatch_header[2280] : generate CPU dispatch header: (build/src.linux-x86_64-3.8/numpy/distutils/include/npy_cpu_dispatch_config.h)
WARN: resetting extension 'numpy.core._multiarray_umath' language from 'c' to 'c++'.
INFO: customize UnixCCompiler
INFO: customize UnixCCompiler using new_build_ext
INFO: building 'numpy.core._multiarray_tests' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/mem_overlap.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/_multiarray_tests.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_argparse.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_hashtable.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/_multiarray_tests.o build/temp.linux-x86_64-3.8/numpy/core/src/common/mem_overlap.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_argparse.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_hashtable.o -Lbuild/temp.linux-x86_64-3.8 -lnpymath -o numpy/core/_multiarray_tests.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._multiarray_umath' extension
INFO: compiling C dispatch-able sources
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_unary_fp.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1947] : skip targets (ASIMD NEON VSX2) not part of baseline or dispatch-able features
INFO: CCompilerOpt._parse_policy_not_keepbase[2059] : skip baseline features (SSE2)
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_arithm_fp.dispatch.c
INFO: CCompilerOpt._parse_policy_not_keepbase[2059] : skip baseline features (SSE2)
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_arithmetic.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1947] : skip targets (NEON VSX2) not part of baseline or dispatch-able features
INFO: CCompilerOpt._parse_policy_not_keepbase[2059] : skip baseline features (SSE2)
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_trigonometric.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1947] : skip targets (NEON_VFPV4 VSX2) not part of baseline or dispatch-able features
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_umath_fp.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/loops_exponent_log.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'MAXOPT' is ON
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3 -mssse3 -msse4.1'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithmetic.dispatch.sse41.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_unary_fp.dispatch.sse41.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithm_fp.dispatch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_unary_fp.dispatch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithmetic.dispatch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_trigonometric.dispatch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_umath_fp.dispatch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_exponent_log.dispatch.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithmetic.dispatch.avx512f.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithm_fp.dispatch.avx512f.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_trigonometric.dispatch.avx512f.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_exponent_log.dispatch.avx512f.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mavx2'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithmetic.dispatch.avx2.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithm_fp.dispatch.avx2.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_arithmetic.dispatch.avx512_skx.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_umath_fp.dispatch.avx512_skx.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_exponent_log.dispatch.avx512_skx.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-O3 -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_trigonometric.dispatch.fma3.avx2.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops_exponent_log.dispatch.fma3.avx2.c
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/abstractdtypes.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/compiled_base.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/alloc.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/arrayobject.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/common.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/common_dtype.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/convert.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/arraytypes.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/convert_datatype.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/conversion_utils.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/ctors.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/datetime.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/datetime_strings.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/datetime_busday.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/datetime_busdaycal.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/descriptor.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/dlpack.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/dtypemeta.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/dragon4.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/array_coercion.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/dtype_transfer.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/array_method.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/array_assign_scalar.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/array_assign_array.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/einsum.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/arrayfunction_override.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/einsum_sumprod.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/buffer.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/calculation.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/item_selection.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/iterators.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/legacy_dtype_implementation.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/experimental_public_dtype_api.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/lowlevel_strided_loops.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/flagsobject.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/getset.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/hashdescr.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/number.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/refcount.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/sequence.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/shape.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/scalarapi.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/scalartypes.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/strfuncs.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/temp_elide.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/typeinfo.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/usertypes.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/vdot.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/quicksort.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/mergesort.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/timsort.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/mapping.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/methods.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/multiarraymodule.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/nditer_templ.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/nditer_api.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/heapsort.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/nditer_constr.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/selection.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/multiarray/nditer_pywrap.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/legacy_array_method.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/ufunc_object.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/extobj.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/scalarmath.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/npysort/binsearch.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/umathmodule.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/reduction.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/loops.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/ufunc_type_resolution.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/override.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_scaled_float_dtype.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/array_assign.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/mem_overlap.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_argparse.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_hashtable.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_longdouble.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/ucsnarrow.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/ufunc_override.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/numpyos.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_cpu_features.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/cblasfuncs.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/python_xerbla.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/matmul.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/dispatching.c
INFO: compiling C++ sources
INFO: C compiler: x86_64-linux-gnu-g++ -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DHAVE_CBLAS -Inumpy/core/src/common -Inumpy/core/src/umath -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -std=c++11 -D__STDC_VERSION__=0 -fno-exceptions -fno-rtti'
INFO: x86_64-linux-gnu-g++: numpy/core/src/npysort/radixsort.cpp
INFO: x86_64-linux-gnu-g++: numpy/core/src/umath/clip.cpp
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_unary_fp.dispatch.sse41.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithmetic.dispatch.sse41.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_unary_fp.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithm_fp.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithmetic.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_trigonometric.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_umath_fp.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_exponent_log.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithm_fp.dispatch.avx512f.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithmetic.dispatch.avx512f.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_trigonometric.dispatch.avx512f.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_exponent_log.dispatch.avx512f.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithm_fp.dispatch.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithmetic.dispatch.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_arithmetic.dispatch.avx512_skx.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_umath_fp.dispatch.avx512_skx.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_exponent_log.dispatch.avx512_skx.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_trigonometric.dispatch.fma3.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops_exponent_log.dispatch.fma3.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/abstractdtypes.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/alloc.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/arrayobject.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/arraytypes.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/array_coercion.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/array_method.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/array_assign_scalar.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/array_assign_array.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/arrayfunction_override.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/buffer.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/calculation.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/compiled_base.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/common.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/common_dtype.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/convert.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/convert_datatype.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/conversion_utils.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/ctors.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/datetime.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/datetime_strings.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/datetime_busday.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/datetime_busdaycal.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/descriptor.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/dlpack.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/dtypemeta.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/dragon4.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/dtype_transfer.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/einsum.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/einsum_sumprod.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/experimental_public_dtype_api.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/flagsobject.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/getset.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/hashdescr.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/item_selection.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/iterators.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/legacy_dtype_implementation.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/lowlevel_strided_loops.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/mapping.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/methods.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/multiarraymodule.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/nditer_templ.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/nditer_api.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/nditer_constr.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/nditer_pywrap.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/number.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/refcount.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/sequence.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/shape.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/scalarapi.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/scalartypes.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/strfuncs.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/temp_elide.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/typeinfo.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/usertypes.o build/temp.linux-x86_64-3.8/numpy/core/src/multiarray/vdot.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/quicksort.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/mergesort.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/timsort.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/heapsort.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/selection.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/binsearch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/umathmodule.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/reduction.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/loops.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/matmul.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/dispatching.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/legacy_array_method.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/ufunc_object.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/extobj.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/scalarmath.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/ufunc_type_resolution.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/override.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/_scaled_float_dtype.o build/temp.linux-x86_64-3.8/numpy/core/src/common/array_assign.o build/temp.linux-x86_64-3.8/numpy/core/src/common/mem_overlap.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_argparse.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_hashtable.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_longdouble.o build/temp.linux-x86_64-3.8/numpy/core/src/common/ucsnarrow.o build/temp.linux-x86_64-3.8/numpy/core/src/common/ufunc_override.o build/temp.linux-x86_64-3.8/numpy/core/src/common/numpyos.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_cpu_features.o build/temp.linux-x86_64-3.8/numpy/core/src/common/cblasfuncs.o build/temp.linux-x86_64-3.8/numpy/core/src/common/python_xerbla.o build/temp.linux-x86_64-3.8/numpy/core/src/npysort/radixsort.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/clip.o numpy/core/src/umath/svml/linux/avx512/svml_z0_acos_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cos_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log1p_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log1p_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_acosh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atanh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_expm1_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cbrt_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atanh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_asinh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_sin_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_exp2_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atan2_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atan_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_asin_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_acosh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cos_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_expm1_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_asinh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cosh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log10_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log2_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_tan_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log10_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_sinh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_sin_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_tanh_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cosh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_pow_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_log2_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atan_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_exp_d_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_pow_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_asin_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_tan_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_exp2_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_exp_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_cbrt_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_sinh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_tanh_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_atan2_s_la.s numpy/core/src/umath/svml/linux/avx512/svml_z0_acos_d_la.s -Lbuild/temp.linux-x86_64-3.8 -lnpymath -lopenblas -lopenblas -lm -o numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._umath_tests' extension
INFO: compiling C dispatch-able sources
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/umath/_umath_tests.dispatch.c
INFO: CCompilerOpt._parse_target_tokens[1947] : skip targets (ASIMD VSX NEON ASIMDHP VSX2 VSX3) not part of baseline or dispatch-able features
INFO: CCompilerOpt._parse_policy_not_keepbase[2059] : skip baseline features (SSE2)
INFO: CCompilerOpt._parse_target_tokens[1971] : policy 'WERROR' is ON
INFO: CCompilerOpt._parse_policy_werror[2103] : compiler warnings are treated as errors
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-Werror -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mavx2'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_umath_tests.dispatch.avx2.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-Werror -msse -msse2 -msse3 -mssse3 -msse4.1'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_umath_tests.dispatch.sse41.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-Werror -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_umath_tests.dispatch.c
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_cpu_features.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_umath_tests.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/umath/_umath_tests.dispatch.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/_umath_tests.dispatch.sse41.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/_umath_tests.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/umath/_umath_tests.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_cpu_features.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/core/_umath_tests.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._rational_tests' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_rational_tests.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/umath/_rational_tests.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/core/_rational_tests.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._struct_ufunc_tests' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_struct_ufunc_tests.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/umath/_struct_ufunc_tests.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/core/_struct_ufunc_tests.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._operand_flag_tests' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/umath/_operand_flag_tests.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/umath/_operand_flag_tests.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/core/_operand_flag_tests.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.core._simd' extension
INFO: compiling C dispatch-able sources
INFO: CCompilerOpt.parse_targets[1776] : looking for '@targets' inside ->  numpy/core/src/_simd/_simd.dispatch.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.dispatch.avx512_skx.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.dispatch.avx512f.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.dispatch.fma3.avx2.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.dispatch.sse42.c
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.dispatch.c
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DNPY_INTERNAL_BUILD=1 -DHAVE_NPY_CONFIG_H=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -Inumpy/core/src/_simd -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/core/src/common/npy_cpu_features.c
INFO: x86_64-linux-gnu-gcc: numpy/core/src/_simd/_simd.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.dispatch.avx512_skx.o build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.dispatch.avx512f.o build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.dispatch.fma3.avx2.o build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.dispatch.sse42.o build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.dispatch.o build/temp.linux-x86_64-3.8/numpy/core/src/common/npy_cpu_features.o build/temp.linux-x86_64-3.8/numpy/core/src/_simd/_simd.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/core/_simd.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.fft._pocketfft_internal' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/fft/_pocketfft.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/fft/_pocketfft.o -Lbuild/temp.linux-x86_64-3.8 -o numpy/fft/_pocketfft_internal.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.linalg.lapack_lite' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DHAVE_CBLAS -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/linalg/lapack_litemodule.c
INFO: x86_64-linux-gnu-gcc: numpy/linalg/lapack_lite/python_xerbla.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/linalg/lapack_litemodule.o build/temp.linux-x86_64-3.8/numpy/linalg/lapack_lite/python_xerbla.o -Lbuild/temp.linux-x86_64-3.8 -lopenblas -lopenblas -o numpy/linalg/lapack_lite.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.linalg._umath_linalg' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-DHAVE_CBLAS -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/linalg/umath_linalg.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/linalg/umath_linalg.o build/temp.linux-x86_64-3.8/numpy/linalg/lapack_lite/python_xerbla.o -Lbuild/temp.linux-x86_64-3.8 -lnpymath -lopenblas -lopenblas -o numpy/linalg/_umath_linalg.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._mt19937' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/random/src/mt19937 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_mt19937.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/mt19937/mt19937.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/mt19937/mt19937-jump.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_mt19937.o build/temp.linux-x86_64-3.8/numpy/random/src/mt19937/mt19937.o build/temp.linux-x86_64-3.8/numpy/random/src/mt19937/mt19937-jump.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/_mt19937.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._philox' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/random/src/philox -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_philox.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/philox/philox.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_philox.o build/temp.linux-x86_64-3.8/numpy/random/src/philox/philox.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/_philox.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._pcg64' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/random/src/pcg64 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_pcg64.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/pcg64/pcg64.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_pcg64.o build/temp.linux-x86_64-3.8/numpy/random/src/pcg64/pcg64.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/_pcg64.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._sfc64' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/random/src/sfc64 -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_sfc64.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/sfc64/sfc64.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_sfc64.o build/temp.linux-x86_64-3.8/numpy/random/src/sfc64/sfc64.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/_sfc64.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._common' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_common.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_common.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/_common.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random.bit_generator' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/bit_generator.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/bit_generator.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -o numpy/random/bit_generator.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._generator' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_generator.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_generator.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -lnpymath -o numpy/random/_generator.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random._bounded_integers' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -Inumpy/random -Inumpy/random/src -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/_bounded_integers.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/_bounded_integers.o -Lbuild/temp.linux-x86_64-3.8 -lnpyrandom -lm -lnpymath -o numpy/random/_bounded_integers.cpython-38-x86_64-linux-gnu.so
INFO: building 'numpy.random.mtrand' extension
INFO: compiling C sources
INFO: C compiler: x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC

INFO: compile options: '-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -DNPY_NO_DEPRECATED_API=0 -DNP_RANDOM_LEGACY=1 -Inumpy/random -Inumpy/random/src -Inumpy/random/src/legacy -Inumpy/core/include -Inumpy/core/include/numpy -Ibuild/src.linux-x86_64-3.8/numpy/distutils/include -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/honno/.local/share/virtualenvs/numpy-A2JVJrTg/include -I/usr/include/python3.8 -Inumpy/core/src/common -Inumpy/core/src/npymath -c'
extra options: '-U__GNUC_GNU_INLINE__ -std=c99 -msse -msse2 -msse3'
INFO: x86_64-linux-gnu-gcc: numpy/random/mtrand.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/legacy/legacy-distributions.c
INFO: x86_64-linux-gnu-gcc: numpy/random/src/distributions/distributions.c
INFO: x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.8/numpy/random/mtrand.o build/temp.linux-x86_64-3.8/numpy/random/src/legacy/legacy-distributions.o build/temp.linux-x86_64-3.8/numpy/random/src/distributions/distributions.o -Lbuild/temp.linux-x86_64-3.8 -lm -lnpymath -o numpy/random/mtrand.cpython-38-x86_64-linux-gnu.so
INFO: 
########### EXT COMPILER OPTIMIZATION ###########
INFO: Platform      : 
  Architecture: x64
  Compiler    : gcc

CPU baseline  : 
  Requested   : 'min'
  Enabled     : SSE SSE2 SSE3
  Flags       : -msse -msse2 -msse3
  Extra checks: none

CPU dispatch  : 
  Requested   : 'max -xop -fma4'
  Enabled     : SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL
  Generated   : 
              : 
  SSE41       : SSE SSE2 SSE3 SSSE3
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1
  Extra checks: none
  Detect      : SSE SSE2 SSE3 SSSE3 SSE41
              : numpy/core/src/umath/loops_unary_fp.dispatch.c
              : numpy/core/src/umath/loops_arithmetic.dispatch.c
              : numpy/core/src/umath/_umath_tests.dispatch.c
              : 
  SSE42       : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2
  Extra checks: none
  Detect      : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42
              : numpy/core/src/_simd/_simd.dispatch.c
              : 
  AVX2        : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mavx2
  Extra checks: none
  Detect      : AVX F16C AVX2
              : numpy/core/src/umath/loops_arithm_fp.dispatch.c
              : numpy/core/src/umath/loops_arithmetic.dispatch.c
              : numpy/core/src/umath/_umath_tests.dispatch.c
              : 
  (FMA3 AVX2) : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2
  Extra checks: none
  Detect      : AVX F16C FMA3 AVX2
              : numpy/core/src/umath/loops_trigonometric.dispatch.c
              : numpy/core/src/umath/loops_exponent_log.dispatch.c
              : numpy/core/src/_simd/_simd.dispatch.c
              : 
  AVX512F     : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f
  Extra checks: AVX512F_REDUCE
  Detect      : AVX512F
              : numpy/core/src/umath/loops_arithm_fp.dispatch.c
              : numpy/core/src/umath/loops_arithmetic.dispatch.c
              : numpy/core/src/umath/loops_trigonometric.dispatch.c
              : numpy/core/src/umath/loops_exponent_log.dispatch.c
              : numpy/core/src/_simd/_simd.dispatch.c
              : 
  AVX512_SKX  : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD
  Flags       : -msse -msse2 -msse3 -mssse3 -msse4.1 -mpopcnt -msse4.2 -mavx -mf16c -mfma -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512bw -mavx512dq
  Extra checks: AVX512BW_MASK AVX512DQ_MASK
  Detect      : AVX512_SKX
              : numpy/core/src/umath/loops_arithmetic.dispatch.c
              : numpy/core/src/umath/loops_umath_fp.dispatch.c
              : numpy/core/src/umath/loops_exponent_log.dispatch.c
              : numpy/core/src/_simd/_simd.dispatch.c
INFO: CCompilerOpt.cache_flush[817] : write cache to path -> /home/honno/gdrive/GitHub/numpy/build/temp.linux-x86_64-3.8/ccompiler_opt_cache_ext.py
INFO: 
########### CLIB COMPILER OPTIMIZATION ###########
INFO: Platform      : 
  Architecture: x64
  Compiler    : gcc

CPU baseline  : 
  Requested   : 'min'
  Enabled     : SSE SSE2 SSE3
  Flags       : -msse -msse2 -msse3
  Extra checks: none

CPU dispatch  : 
  Requested   : 'max -xop -fma4'
  Enabled     : SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL
  Generated   : none
INFO: CCompilerOpt.cache_flush[817] : write cache to path -> /home/honno/gdrive/GitHub/numpy/build/temp.linux-x86_64-3.8/ccompiler_opt_cache_clib.py
```
</details>

In hindsight, folk might find printing the levels for the many info logs distracting. Let me know if it's preferred just to have log levels for debugs/warns/errors.