### PR TITLE
ENH: Support bin width estimators for `histogramdd` and `histogram2d`

### DIFF
--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -1025,6 +1025,9 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
     if weights is not None:
         weights = np.asarray(weights)
 
+    if isinstance(bins, str):
+        bins = D*[bins]
+
     try:
         M = len(bins)
         if M != D:
@@ -1043,30 +1046,11 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
 
     # Create edge arrays
     for i in _range(D):
-        if np.ndim(bins[i]) == 0:
-            if bins[i] < 1:
-                raise ValueError(
-                    '`bins[{}]` must be positive, when an integer'.format(i))
-            smin, smax = _get_outer_edges(sample[:,i], range[i])
-            try:
-                n = operator.index(bins[i])
-            
-            except TypeError as e:
-                raise TypeError(
-                	"`bins[{}]` must be an integer, when a scalar".format(i)
-                ) from e
-                
-            edges[i] = np.linspace(smin, smax, n + 1)    
-        elif np.ndim(bins[i]) == 1:
-            edges[i] = np.asarray(bins[i])
-            if np.any(edges[i][:-1] > edges[i][1:]):
-                raise ValueError(
-                    '`bins[{}]` must be monotonically increasing, when an array'
-                    .format(i))
-        else:
+        if not isinstance(bins[i], str) and np.ndim(
+                bins[i]) == 0 and bins[i] < 1:
             raise ValueError(
-                '`bins[{}]` must be a scalar or 1d array'.format(i))
-
+                '`bins[{}]` must be positive, when an integer'.format(i))
+        edges[i], _ = _get_bin_edges(sample[:, i], bins[i], range[i], weights)
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])
 

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -359,14 +359,15 @@ def _unsigned_subtract(a, b):
 
 def _get_bin_edges(a, bins, range, weights):
     """
-    Computes the bins used internally by `histogram`.
+    Computes the bins used internally by `histogram` and `histogramdd`.
 
     Parameters
     ==========
     a : ndarray
         Ravelled data array
     bins, range
-        Forwarded arguments from `histogram`.
+        Forwarded arguments from `histogram` or passed from `histogramdd` for
+        current dimension.
     weights : ndarray, optional
         Ravelled weights array, or None
 
@@ -960,13 +961,17 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
 
         The first form should be preferred.
 
-    bins : sequence or int, optional
+    bins : sequence or int or str, optional
         The bin specification:
 
         * A sequence of arrays describing the monotonically increasing bin
           edges along each dimension.
         * The number of bins for each dimension (nx, ny, ... =bins)
         * The number of bins for all dimensions (nx=ny=...=bins).
+        * A sequence of strings defining the method to calculate the optimal
+          bin width for each dimension as defined by `histogram_bin_edges`.
+        * A string defining the method to calculate the optimal bin width for
+          all dimensions as defined by `histogram_bin_edges`.
 
     range : sequence, optional
         A sequence of length D, each an optional (lower, upper) tuple giving

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -660,18 +660,24 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     y : array_like, shape (N,)
         An array containing the y coordinates of the points to be
         histogrammed.
-    bins : int or array_like or [int, int] or [array, array], optional
+    bins : int or array_like or str or [int, int] or [array, array] or
+        [str, str], optional
         The bin specification:
 
           * If int, the number of bins for the two dimensions (nx=ny=bins).
           * If array_like, the bin edges for the two dimensions
             (x_edges=y_edges=bins).
+          * If str, the method used to calculate optimal bin width for
+            the two dimensions as defined by `histogram_bin_edges`.
           * If [int, int], the number of bins in each dimension
             (nx, ny = bins).
           * If [array, array], the bin edges in each dimension
             (x_edges, y_edges = bins).
-          * A combination [int, array] or [array, int], where int
-            is the number of bins and array is the bin edges.
+          * If [str, str], the method used to calculate optimal bin
+            width for each dimension as defined by `histogram_bin_edges`.
+          * Any combination of the above like [int, array] or [array, str],
+            where int is the number of bins, array is the bin edges and str
+            is the bin width estimator.
 
     range : array_like, shape(2,2), optional
         The leftmost and rightmost edges of the bins along each dimension

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -808,10 +808,13 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     if len(x) != len(y):
         raise ValueError('x and y must have the same length.')
 
-    try:
-        N = len(bins)
-    except TypeError:
+    if isinstance(bins, str):
         N = 1
+    else:
+        try:
+            N = len(bins)
+        except TypeError:
+            N = 1
 
     if N != 1 and N != 2:
         xedges = yedges = asarray(bins)


### PR DESCRIPTION
Resolves gh-20215.

`histogramdd` now uses `_get_bin_edges` for calculating edges of bins instead of calculating them locally. `_get_bin_edges` allows specifying an estimator to calculate optimal bin width, which is passed by `histogramdd` for each dimension.

Using `_get_bin_edges` does have the drawback of not being able to specify the dimension of the incorrect bin when raising an exception, but that could be fixed by always adding the incorrect bin to the exception message.