### PR TITLE
BUG: Relax unary ufunc (sqrt, etc.) stride assert

### DIFF
--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -209,7 +209,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(FLOAT_@func@)
     const npy_intp ssrc = steps[0] / lsize;
     const npy_intp sdst = steps[1] / lsize;
     npy_intp len = dimensions[0];
-    assert(steps[0] % lsize == 0 && steps[1] % lsize == 0);
+    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
 #if NPY_SIMD_FMA3
     if (is_mem_overlap(src, steps[0], dst, steps[1], len) ||
         !npyv_loadable_stride_f32(ssrc) || !npyv_storable_stride_f32(sdst)

--- a/numpy/core/src/umath/loops_umath_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_umath_fp.dispatch.c.src
@@ -96,7 +96,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
     const npy_intp ssrc = steps[0] / lsize;
     const npy_intp sdst = steps[1] / lsize;
     const npy_intp len = dimensions[0];
-    assert(steps[0] % lsize == 0 && steps[1] % lsize == 0);
+    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
         npyv_loadable_stride_@sfx@(ssrc) &&
         npyv_storable_stride_@sfx@(sdst)) {
@@ -125,7 +125,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(DOUBLE_@func@)
     const npy_intp ssrc = steps[0] / lsize;
     const npy_intp sdst = steps[1] / lsize;
     const npy_intp len = dimensions[0];
-    assert(steps[0] % lsize == 0 && steps[1] % lsize == 0);
+    assert(len <= 1 || (steps[0] % lsize == 0 && steps[1] % lsize == 0));
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
         npyv_loadable_stride_f64(ssrc) &&
         npyv_storable_stride_f64(sdst)) {

--- a/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_unary_fp.dispatch.c.src
@@ -263,7 +263,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     npy_intp len = dimensions[0];
 #if @VCHK@
     const int lsize = sizeof(npyv_lanetype_@sfx@);
-    assert(src_step % lsize == 0 && dst_step % lsize == 0);
+    assert(len <= 1 || (src_step % lsize == 0 && dst_step % lsize == 0));
     if (is_mem_overlap(src, src_step, dst, dst_step, len)) {
         goto no_unroll;
     }


### PR DESCRIPTION
The stride is never used if the length is 0 or 1, so it is OK if
if the strides have strange values here.

Not adding a test: This is a simple assert and the original issue
was found due to intentionally garbled up strides in `ufunc.at`,
but `ufunc.at` stopped doing that.

Closes gh-19806