### PR TITLE
MAINT: Fix METH_NOARGS function signatures

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2237,7 +2237,7 @@ array_dumps(PyArrayObject *self, PyObject *args, PyObject *kwds)
 
 
 static PyObject *
-array_sizeof(PyArrayObject *self)
+array_sizeof(PyArrayObject *self, PyObject *NPY_UNUSED(args))
 {
     /* object + dimension and strides */
     Py_ssize_t nbytes = Py_TYPE(self)->tp_basicsize +

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4199,7 +4199,7 @@ normalize_axis_index(PyObject *NPY_UNUSED(self),
 
 
 static PyObject *
-_reload_guard(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(ignored)) {
+_reload_guard(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args)) {
     static int initialized = 0;
 
 #if !defined(PYPY_VERSION)

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4199,7 +4199,7 @@ normalize_axis_index(PyObject *NPY_UNUSED(self),
 
 
 static PyObject *
-_reload_guard(PyObject *NPY_UNUSED(self)) {
+_reload_guard(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(ignored)) {
     static int initialized = 0;
 
 #if !defined(PYPY_VERSION)

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1190,7 +1190,7 @@ npyiter_resetbasepointers(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_reset(NewNpyArrayIterObject *self)
+npyiter_reset(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1227,7 +1227,7 @@ npyiter_reset(NewNpyArrayIterObject *self)
  * copied.
  */
 static PyObject *
-npyiter_copy(NewNpyArrayIterObject *self)
+npyiter_copy(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     NewNpyArrayIterObject *iter;
 
@@ -1263,7 +1263,7 @@ npyiter_copy(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_iternext(NewNpyArrayIterObject *self)
+npyiter_iternext(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter != NULL && self->iternext != NULL &&
                         !self->finished && self->iternext(self->iter)) {
@@ -1320,7 +1320,7 @@ npyiter_remove_axis(NewNpyArrayIterObject *self, PyObject *args)
 }
 
 static PyObject *
-npyiter_remove_multi_index(NewNpyArrayIterObject *self)
+npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1345,7 +1345,7 @@ npyiter_remove_multi_index(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_enable_external_loop(NewNpyArrayIterObject *self)
+npyiter_enable_external_loop(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1370,7 +1370,7 @@ npyiter_enable_external_loop(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_debug_print(NewNpyArrayIterObject *self)
+npyiter_debug_print(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter != NULL) {
         NpyIter_DebugPrint(self->iter);
@@ -1484,7 +1484,7 @@ npyiter_itviews_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-npyiter_next(NewNpyArrayIterObject *self)
+npyiter_next(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter == NULL || self->iternext == NULL ||
                 self->finished) {
@@ -2315,7 +2315,7 @@ npyiter_ass_subscript(NewNpyArrayIterObject *self, PyObject *op,
 }
 
 static PyObject *
-npyiter_enter(NewNpyArrayIterObject *self)
+npyiter_enter(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "operation on non-initialized iterator");
@@ -2326,7 +2326,7 @@ npyiter_enter(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_close(NewNpyArrayIterObject *self)
+npyiter_close(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 {
     NpyIter *iter = self->iter;
     int ret;
@@ -2347,7 +2347,7 @@ static PyObject *
 npyiter_exit(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     /* even if called via exception handling, writeback any data */
-    return npyiter_close(self);
+    return npyiter_close(self, NULL);
 }
 
 static PyMethodDef npyiter_methods[] = {

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1320,7 +1320,8 @@ npyiter_remove_axis(NewNpyArrayIterObject *self, PyObject *args)
 }
 
 static PyObject *
-npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
+npyiter_remove_multi_index(
+    NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1345,7 +1345,8 @@ npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(arg
 }
 
 static PyObject *
-npyiter_enable_external_loop(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
+npyiter_enable_external_loop(
+    NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1484,7 +1484,7 @@ npyiter_itviews_get(NewNpyArrayIterObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-npyiter_next(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_next(NewNpyArrayIterObject *self)
 {
     if (self->iter == NULL || self->iternext == NULL ||
                 self->finished) {

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1190,7 +1190,7 @@ npyiter_resetbasepointers(NewNpyArrayIterObject *self)
 }
 
 static PyObject *
-npyiter_reset(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_reset(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1227,7 +1227,7 @@ npyiter_reset(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
  * copied.
  */
 static PyObject *
-npyiter_copy(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_copy(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     NewNpyArrayIterObject *iter;
 
@@ -1263,7 +1263,7 @@ npyiter_copy(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 }
 
 static PyObject *
-npyiter_iternext(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_iternext(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter != NULL && self->iternext != NULL &&
                         !self->finished && self->iternext(self->iter)) {
@@ -1320,7 +1320,7 @@ npyiter_remove_axis(NewNpyArrayIterObject *self, PyObject *args)
 }
 
 static PyObject *
-npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1345,7 +1345,7 @@ npyiter_remove_multi_index(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unu
 }
 
 static PyObject *
-npyiter_enable_external_loop(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_enable_external_loop(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1370,7 +1370,7 @@ npyiter_enable_external_loop(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(u
 }
 
 static PyObject *
-npyiter_debug_print(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_debug_print(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter != NULL) {
         NpyIter_DebugPrint(self->iter);
@@ -2315,7 +2315,7 @@ npyiter_ass_subscript(NewNpyArrayIterObject *self, PyObject *op,
 }
 
 static PyObject *
-npyiter_enter(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_enter(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     if (self->iter == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "operation on non-initialized iterator");
@@ -2326,7 +2326,7 @@ npyiter_enter(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
 }
 
 static PyObject *
-npyiter_close(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(unused))
+npyiter_close(NewNpyArrayIterObject *self, PyObject *NPY_UNUSED(args))
 {
     NpyIter *iter = self->iter;
     int ret;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1085,19 +1085,19 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 }
 
 static PyObject *
-gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(0);
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyArray_NewFlagsObject(NULL);
 }
 
 static PyObject *
-voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
+voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *flagobj;
     flagobj = PyArrayFlags_Type.tp_alloc(&PyArrayFlags_Type, 0);
@@ -1110,7 +1110,7 @@ voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
 }
 
 static PyObject *
-voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
+voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self->descr);
     return (PyObject *)self->descr;
@@ -1118,7 +1118,7 @@ voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
 
 
 static PyObject *
-inttype_numerator_get(PyObject *self, void *NPY_UNUSED(closure))
+inttype_numerator_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self);
     return self;
@@ -1126,21 +1126,21 @@ inttype_numerator_get(PyObject *self, void *NPY_UNUSED(closure))
 
 
 static PyObject *
-inttype_denominator_get(PyObject *self, void *NPY_UNUSED(closure))
+inttype_denominator_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(1);
 }
 
 
 static PyObject *
-gentype_data_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_data_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return PyMemoryView_FromObject(self);
 }
 
 
 static PyObject *
-gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1154,7 +1154,7 @@ gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(closure))
 }
 
 static PyObject *
-gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(1);
 }
@@ -1192,7 +1192,7 @@ gentype_struct_free(PyObject *ptr)
 }
 
 static PyObject *
-gentype_struct_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr;
     PyArrayInterface *inter;
@@ -1218,20 +1218,20 @@ gentype_struct_get(PyObject *self, void *NPY_UNUSED(closure))
 }
 
 static PyObject *
-gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyFloat_FromDouble(NPY_SCALAR_PRIORITY);
 }
 
 static PyObject *
-gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     return PyTuple_New(0);
 }
 
 
 static PyObject *
-gentype_interface_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr;
     PyObject *inter;
@@ -1251,20 +1251,20 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(closure))
 
 
 static PyObject *
-gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     return (PyObject *)PyArray_DescrFromScalar(self);
 }
 
 
 static PyObject *
-gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
+gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 {
     Py_RETURN_NONE;
 }
 
 static PyObject *
-voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
+voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
     if (self->base == NULL) {
         Py_RETURN_NONE;
@@ -1295,7 +1295,7 @@ _realdescr_fromcomplexscalar(PyObject *self, int *typenum)
 }
 
 static PyObject *
-gentype_real_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_real_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1322,7 +1322,7 @@ gentype_real_get(PyObject *self, void *NPY_UNUSED(closure))
 }
 
 static PyObject *
-gentype_imag_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode=NULL;
     PyObject *ret;
@@ -1362,7 +1362,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(closure))
 }
 
 static PyObject *
-gentype_flat_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_flat_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyObject *ret, *arr;
 
@@ -1377,7 +1377,7 @@ gentype_flat_get(PyObject *self, void *NPY_UNUSED(closure))
 
 
 static PyObject *
-gentype_transpose_get(PyObject *self, void *NPY_UNUSED(closure))
+gentype_transpose_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(self);
     return self;

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -229,7 +229,7 @@ gentype_multiply(PyObject *m1, PyObject *m2)
  * #convert = Long*8, LongLong*2#
  */
 static PyObject *
-@type@_bit_count(PyObject *self, PyObject *NPY_UNUSED(ignored))
+@type@_bit_count(PyObject *self, PyObject *NPY_UNUSED(args))
 {
     @type@ scalar = PyArrayScalar_VAL(self, @Name@);
     uint8_t count = npy_popcount@c@(scalar);
@@ -1085,19 +1085,19 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 }
 
 static PyObject *
-gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     return PyLong_FromLong(0);
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     return PyArray_NewFlagsObject(NULL);
 }
 
 static PyObject *
-voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
+voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
 {
     PyObject *flagobj;
     flagobj = PyArrayFlags_Type.tp_alloc(&PyArrayFlags_Type, 0);
@@ -1110,7 +1110,7 @@ voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
+voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
 {
     Py_INCREF(self->descr);
     return (PyObject *)self->descr;
@@ -1118,7 +1118,7 @@ voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-inttype_numerator_get(PyObject *self, void *NPY_UNUSED(ignored))
+inttype_numerator_get(PyObject *self, void *NPY_UNUSED(args))
 {
     Py_INCREF(self);
     return self;
@@ -1126,21 +1126,21 @@ inttype_numerator_get(PyObject *self, void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-inttype_denominator_get(PyObject *self, void *NPY_UNUSED(ignored))
+inttype_denominator_get(PyObject *self, void *NPY_UNUSED(args))
 {
     return PyLong_FromLong(1);
 }
 
 
 static PyObject *
-gentype_data_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_data_get(PyObject *self, void *NPY_UNUSED(args))
 {
     return PyMemoryView_FromObject(self);
 }
 
 
 static PyObject *
-gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1154,13 +1154,13 @@ gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     return PyLong_FromLong(1);
 }
 
 static PyObject *
-gentype_sizeof(PyObject *self, PyObject *NPY_UNUSED(ignored))
+gentype_sizeof(PyObject *self, PyObject *NPY_UNUSED(args))
 {
     Py_ssize_t nbytes;
     PyObject * isz = gentype_itemsize_get(self, NULL);
@@ -1192,7 +1192,7 @@ gentype_struct_free(PyObject *ptr)
 }
 
 static PyObject *
-gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_struct_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyArrayObject *arr;
     PyArrayInterface *inter;
@@ -1218,20 +1218,20 @@ gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     return PyFloat_FromDouble(NPY_SCALAR_PRIORITY);
 }
 
 static PyObject *
-gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     return PyTuple_New(0);
 }
 
 
 static PyObject *
-gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_interface_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyArrayObject *arr;
     PyObject *inter;
@@ -1251,20 +1251,20 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(args))
 {
     return (PyObject *)PyArray_DescrFromScalar(self);
 }
 
 
 static PyObject *
-gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
+gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
 {
     Py_RETURN_NONE;
 }
 
 static PyObject *
-voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
+voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
 {
     if (self->base == NULL) {
         Py_RETURN_NONE;
@@ -1295,7 +1295,7 @@ _realdescr_fromcomplexscalar(PyObject *self, int *typenum)
 }
 
 static PyObject *
-gentype_real_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_real_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1322,7 +1322,7 @@ gentype_real_get(PyObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_imag_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyArray_Descr *typecode=NULL;
     PyObject *ret;
@@ -1362,7 +1362,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_flat_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_flat_get(PyObject *self, void *NPY_UNUSED(args))
 {
     PyObject *ret, *arr;
 
@@ -1377,7 +1377,7 @@ gentype_flat_get(PyObject *self, void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-gentype_transpose_get(PyObject *self, void *NPY_UNUSED(ignored))
+gentype_transpose_get(PyObject *self, void *NPY_UNUSED(args))
 {
     Py_INCREF(self);
     return self;
@@ -1918,7 +1918,7 @@ static PyObject *
  */
 /* Heavily copied from the builtin float.as_integer_ratio */
 static PyObject *
-@name@_as_integer_ratio(PyObject *self, PyObject *NPY_UNUSED(ignored))
+@name@_as_integer_ratio(PyObject *self, PyObject *NPY_UNUSED(args))
 {
 #if @is_half@
     npy_double val = npy_half_to_double(PyArrayScalar_VAL(self, @Name@));
@@ -1999,7 +1999,7 @@ error:
  *  #c    = f, f, , l#
  */
 static PyObject *
-@name@_is_integer(PyObject *self, PyObject *NPY_UNUSED(ignored))
+@name@_is_integer(PyObject *self, PyObject *NPY_UNUSED(args))
 {
 #if @is_half@
     npy_double val = npy_half_to_double(PyArrayScalar_VAL(self, @Name@));

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -229,7 +229,7 @@ gentype_multiply(PyObject *m1, PyObject *m2)
  * #convert = Long*8, LongLong*2#
  */
 static PyObject *
-@type@_bit_count(PyObject *self)
+@type@_bit_count(PyObject *self, PyObject *NPY_UNUSED(ignored))
 {
     @type@ scalar = PyArrayScalar_VAL(self, @Name@);
     uint8_t count = npy_popcount@c@(scalar);
@@ -1160,7 +1160,7 @@ gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-gentype_sizeof(PyObject *self)
+gentype_sizeof(PyObject *self, PyObject *NPY_UNUSED(ignored))
 {
     Py_ssize_t nbytes;
     PyObject * isz = gentype_itemsize_get(self, NULL);
@@ -1918,7 +1918,7 @@ static PyObject *
  */
 /* Heavily copied from the builtin float.as_integer_ratio */
 static PyObject *
-@name@_as_integer_ratio(PyObject *self)
+@name@_as_integer_ratio(PyObject *self, PyObject *NPY_UNUSED(ignored))
 {
 #if @is_half@
     npy_double val = npy_half_to_double(PyArrayScalar_VAL(self, @Name@));
@@ -1999,7 +1999,7 @@ error:
  *  #c    = f, f, , l#
  */
 static PyObject *
-@name@_is_integer(PyObject *self)
+@name@_is_integer(PyObject *self, PyObject *NPY_UNUSED(ignored))
 {
 #if @is_half@
     npy_double val = npy_half_to_double(PyArrayScalar_VAL(self, @Name@));
@@ -2022,7 +2022,7 @@ static PyObject *
 /**end repeat**/
 
 static PyObject *
-integer_is_integer(PyObject *self) {
+integer_is_integer(PyObject *self, PyObject *NPY_UNUSED(args)) {
     Py_RETURN_TRUE;
 }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -1085,19 +1085,19 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 }
 
 static PyObject *
-gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_ndim_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     return PyLong_FromLong(0);
 }
 
 static PyObject *
-gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_flags_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     return PyArray_NewFlagsObject(NULL);
 }
 
 static PyObject *
-voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
+voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
 {
     PyObject *flagobj;
     flagobj = PyArrayFlags_Type.tp_alloc(&PyArrayFlags_Type, 0);
@@ -1110,7 +1110,7 @@ voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
 }
 
 static PyObject *
-voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
+voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
 {
     Py_INCREF(self->descr);
     return (PyObject *)self->descr;
@@ -1118,7 +1118,7 @@ voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
 
 
 static PyObject *
-inttype_numerator_get(PyObject *self, void *NPY_UNUSED(args))
+inttype_numerator_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     Py_INCREF(self);
     return self;
@@ -1126,21 +1126,21 @@ inttype_numerator_get(PyObject *self, void *NPY_UNUSED(args))
 
 
 static PyObject *
-inttype_denominator_get(PyObject *self, void *NPY_UNUSED(args))
+inttype_denominator_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     return PyLong_FromLong(1);
 }
 
 
 static PyObject *
-gentype_data_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_data_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     return PyMemoryView_FromObject(self);
 }
 
 
 static PyObject *
-gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1154,7 +1154,7 @@ gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(args))
 }
 
 static PyObject *
-gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_size_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     return PyLong_FromLong(1);
 }
@@ -1192,7 +1192,7 @@ gentype_struct_free(PyObject *ptr)
 }
 
 static PyObject *
-gentype_struct_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_struct_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyArrayObject *arr;
     PyArrayInterface *inter;
@@ -1218,20 +1218,20 @@ gentype_struct_get(PyObject *self, void *NPY_UNUSED(args))
 }
 
 static PyObject *
-gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_priority_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     return PyFloat_FromDouble(NPY_SCALAR_PRIORITY);
 }
 
 static PyObject *
-gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     return PyTuple_New(0);
 }
 
 
 static PyObject *
-gentype_interface_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_interface_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyArrayObject *arr;
     PyObject *inter;
@@ -1251,20 +1251,20 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(args))
 
 
 static PyObject *
-gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_typedescr_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     return (PyObject *)PyArray_DescrFromScalar(self);
 }
 
 
 static PyObject *
-gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(args))
+gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(closure))
 {
     Py_RETURN_NONE;
 }
 
 static PyObject *
-voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(args))
+voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(closure))
 {
     if (self->base == NULL) {
         Py_RETURN_NONE;
@@ -1295,7 +1295,7 @@ _realdescr_fromcomplexscalar(PyObject *self, int *typenum)
 }
 
 static PyObject *
-gentype_real_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_real_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
@@ -1322,7 +1322,7 @@ gentype_real_get(PyObject *self, void *NPY_UNUSED(args))
 }
 
 static PyObject *
-gentype_imag_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_imag_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyArray_Descr *typecode=NULL;
     PyObject *ret;
@@ -1362,7 +1362,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(args))
 }
 
 static PyObject *
-gentype_flat_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_flat_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     PyObject *ret, *arr;
 
@@ -1377,7 +1377,7 @@ gentype_flat_get(PyObject *self, void *NPY_UNUSED(args))
 
 
 static PyObject *
-gentype_transpose_get(PyObject *self, void *NPY_UNUSED(args))
+gentype_transpose_get(PyObject *self, void *NPY_UNUSED(closure))
 {
     Py_INCREF(self);
     return self;


### PR DESCRIPTION
This is a continuation of @joemarshall's work #19058.

> I think there should be a bunch of more issues around `METH_NOARGS` usage that would be nice to fix up as well. 
_@seberg in https://github.com/numpy/numpy/pull/19058#issuecomment-871639053_

This fixes all of the incorrect `METH_NOARGS` signatures that I managed to track down.
We need this for https://github.com/pyodide/pyodide/pull/1677.