### PR TITLE
MAINT: Fix newlines in diagnostics output of numpy.f2py.

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -442,7 +442,7 @@ def getpydocsign(a, var):
         sigout = sig
     else:
         errmess(
-            'getpydocsign: Could not resolve docsignature for "%s".\\n' % a)
+            'getpydocsign: Could not resolve docsignature for "%s".\n' % a)
     return sig, sigout
 
 

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1170,10 +1170,10 @@ def analyzeline(m, case, line):
                                 groupcache[groupcounter]['args'].append(k)
                         else:
                             errmess(
-                                'analyzeline: intent(callback) %s is ignored' % (k))
+                                'analyzeline: intent(callback) %s is ignored\n' % (k))
                     else:
                         errmess('analyzeline: intent(callback) %s is already'
-                                ' in argument list' % (k))
+                                ' in argument list\n' % (k))
             if case in ['optional', 'required', 'public', 'external', 'private', 'intrinsic']:
                 ap = case
             if 'attrspec' in edecl[k]:
@@ -1868,11 +1868,11 @@ def get_useparameters(block, param_map=None):
             continue
         # XXX: apply mapping
         if mapping:
-            errmess('get_useparameters: mapping for %s not impl.' % (mapping))
+            errmess('get_useparameters: mapping for %s not impl.\n' % (mapping))
         for k, v in list(params.items()):
             if k in param_map:
                 outmess('get_useparameters: overriding parameter %s with'
-                        ' value from module %s' % (repr(k), repr(usename)))
+                        ' value from module %s\n' % (repr(k), repr(usename)))
             param_map[k] = v
 
     return param_map
@@ -2385,7 +2385,7 @@ def get_parameters(vars, global_params={}):
 
             elif iscomplex(vars[n]):
                 outmess(f'get_parameters[TODO]: '
-                        f'implement evaluation of complex expression {v}')
+                        f'implement evaluation of complex expression {v}\n')
 
             try:
                 params[n] = eval(v, g_params, params)
@@ -2633,7 +2633,7 @@ def analyzevars(block):
                             vars[n]['intent'].append('c')
                     else:
                         errmess(
-                            "analyzevars: charselector=%r unhandled." % (d))
+                            "analyzevars: charselector=%r unhandled.\n" % (d))
 
         if 'check' not in vars[n] and 'args' in block and n in block['args']:
             # n is an argument that has no checks defined. Here we

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -286,7 +286,7 @@ def scaninputline(inputline):
         sys.exit()
     if not os.path.isdir(buildpath):
         if not verbose:
-            outmess('Creating build directory %s' % (buildpath))
+            outmess('Creating build directory %s\n' % (buildpath))
         os.mkdir(buildpath)
     if signsfile:
         signsfile = os.path.join(buildpath, signsfile)


### PR DESCRIPTION
Linebreaks were not consistently added to errmess/outmess
arguments, which led to very long lines and wrong
concatenation with compiler messages in f2py console output.

I initially noticed this during working with f2py. The `errmess('get_useparameters: mapping for %s not impl.' % (mapping))` output repeats a couple of times, creating very long lines due to a missing `\n`. Additionally, subsequent compiler output _also_ continued on that line, so was hard to discover.

I fixed that error, but then I thought I'd check the rest of the errmess/outmess invocations, and found a couple occurrences where newlines had to be added. I also found one curious instance of ` \\n`, which I'm pretty sure from the surrounding context is just a mistake, so I fixed that, too.
