### PR TITLE
ENH, TEST: silence prints when testing -m full

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -758,14 +758,6 @@ PyArray_NewFromDescr_int(
         for (int i = 0; i < nd; i++) {
             fa->dimensions[i] = dims[i];
 
-            if (fa->dimensions[i] == 0) {
-                /*
-                 * Compare to PyArray_OverflowMultiplyList that
-                 * returns 0 in this case.
-                 */
-                continue;
-            }
-
             if (fa->dimensions[i] < 0) {
                 PyErr_SetString(PyExc_ValueError,
                         "negative dimensions are not allowed");

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -34,19 +34,19 @@ C FILE: STRING.F
       CHARACTER*(*) C,D
 Cf2py intent(in) a,c
 Cf2py intent(inout) b,d
-      PRINT*, "A=",A
-      PRINT*, "B=",B
-      PRINT*, "C=",C
-      PRINT*, "D=",D
-      PRINT*, "CHANGE A,B,C,D"
+      ! PRINT*, "A=",A
+      ! PRINT*, "B=",B
+      ! PRINT*, "C=",C
+      ! PRINT*, "D=",D
+      ! PRINT*, "CHANGE A,B,C,D"
       A(1:1) = 'A'
       B(1:1) = 'B'
       C(1:1) = 'C'
       D(1:1) = 'D'
-      PRINT*, "A=",A
-      PRINT*, "B=",B
-      PRINT*, "C=",C
-      PRINT*, "D=",D
+      ! PRINT*, "A=",A
+      ! PRINT*, "B=",B
+      ! PRINT*, "C=",C
+      ! PRINT*, "D=",D
       END
 C END OF FILE STRING.F
         """


### PR DESCRIPTION
Closes #20289

- stop printing spurious values in an f2py test
- when calling `np.empty([200, 200, 0])`, only allocate the minimum data required (a single element). Previously this would allocate `200 * 200 * 1` elements.