### PR TITLE
DOC: Mention the default `dtype` in `numpy.ma.mean` documentation

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5211,8 +5211,6 @@ class MaskedArray(ndarray):
     def mean(self, axis=None, dtype=None, out=None, keepdims=np._NoValue):
         """
         Returns the average of the array elements along given axis.
-        `int32` or `uint32` intermediate and return values are used for
-        integer inputs.
 
         Masked entries are ignored, and result elements which are not
         finite will be masked.
@@ -5224,6 +5222,12 @@ class MaskedArray(ndarray):
         numpy.ndarray.mean : corresponding function for ndarrays
         numpy.mean : Equivalent function
         numpy.ma.average : Weighted average.
+
+        Notes
+        -----
+        The default size of the intermediate and return values used for
+        integer inputs is platform-dependent. This is in constast from
+        `numpy.mean` which has a fixed default `dtype` of `float64`.
 
         Examples
         --------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5211,6 +5211,8 @@ class MaskedArray(ndarray):
     def mean(self, axis=None, dtype=None, out=None, keepdims=np._NoValue):
         """
         Returns the average of the array elements along given axis.
+        `int32` or `uint32` intermediate and return values are used for
+        integer inputs.
 
         Masked entries are ignored, and result elements which are not
         finite will be masked.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5226,7 +5226,7 @@ class MaskedArray(ndarray):
         Notes
         -----
         The default size of the intermediate and return values used for
-        integer inputs is platform-dependent. This is in constast from
+        integer inputs is platform-dependent. This is in contrast from
         `numpy.mean` which has a fixed default `dtype` of `float64`.
 
         Examples


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fixes #20272
The default `dtype` of `numpy.ma.mean` is undocumented which may lead to overflow errors as described in #20272. This is now mentioned in the docs, the same way as `numpy.mean`.