### PR TITLE
Update ARM cpu_asimdfhm.c check

### DIFF
--- a/numpy/distutils/checks/cpu_asimdfhm.c
+++ b/numpy/distutils/checks/cpu_asimdfhm.c
@@ -10,8 +10,8 @@ int main(void)
     float32x4_t vf   = vdupq_n_f32(1.0f);
     float32x2_t vlf  = vdup_n_f32(1.0f);
 
-    int ret  = (int)vget_lane_f32(vfmlal_low_u32(vlf, vlhp, vlhp), 0);
-        ret += (int)vgetq_lane_f32(vfmlslq_high_u32(vf, vhp, vhp), 0);
+    int ret  = (int)vget_lane_f32(vfmlal_low_f16(vlf, vlhp, vlhp), 0);
+        ret += (int)vgetq_lane_f32(vfmlslq_high_f16(vf, vhp, vhp), 0);
 
     return ret;
 }


### PR DESCRIPTION
Updated `vfmlal_low_u32` and `vfmlslq_high_u32` to their `f16` new names.  Described here:

https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg664008.html

Many of the intrinsics had names updated.  Supposedly previous specifications were not published so old names not required.

Tested on GW4 Isambard ARM HPC cluster on A64fx processor.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
