### PR TITLE
ENH: provide a convenience function to replace npy_load_module

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -107,7 +107,9 @@ class contextlib_nullcontext:
 
 def npy_load_module(name, fn, info=None):
     """
-    Load a module.
+    Load a module. Uses ``load_module`` which will be deprecated in python
+    3.12. An alternative that uses ``exec_module`` is in
+    numpy.distutils.misc_util.exec_mod_from_location
 
     .. versionadded:: 1.11.2
 

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -654,9 +654,9 @@ class _Distutils:
     @staticmethod
     def dist_load_module(name, path):
         """Load a module from file, required by the abstract class '_Cache'."""
-        from numpy.compat import npy_load_module
+        from .misc_util import exec_mod_from_location
         try:
-            return npy_load_module(name, path)
+            return exec_mod_from_location(name, path)
         except Exception as e:
             _Distutils.dist_log(e, stderr=True)
         return None

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -31,8 +31,6 @@ def clean_up_temporary_directory():
 
 atexit.register(clean_up_temporary_directory)
 
-from numpy.compat import npy_load_module
-
 __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'dict_append', 'appendpath', 'generate_config_py',
            'get_cmd', 'allpath', 'get_mathlibs',
@@ -44,7 +42,8 @@ __all__ = ['Configuration', 'get_numpy_include_dirs', 'default_config_dict',
            'dot_join', 'get_frame', 'minrelpath', 'njoin',
            'is_sequence', 'is_string', 'as_list', 'gpaths', 'get_language',
            'get_build_architecture', 'get_info', 'get_pkg_info',
-           'get_num_build_jobs', 'sanitize_cxx_flags']
+           'get_num_build_jobs', 'sanitize_cxx_flags',
+           'exec_mod_from_location']
 
 class InstallableLib:
     """
@@ -945,9 +944,8 @@ class Configuration:
         try:
             setup_name = os.path.splitext(os.path.basename(setup_py))[0]
             n = dot_join(self.name, subpackage_name, setup_name)
-            setup_module = npy_load_module('_'.join(n.split('.')),
-                                           setup_py,
-                                           ('.py', 'U', 1))
+            setup_module = exec_mod_from_location(
+                                '_'.join(n.split('.')), setup_py)
             if not hasattr(setup_module, 'configuration'):
                 if not self.options['assume_default_configuration']:
                     self.warn('Assuming default configuration '\
@@ -1993,8 +1991,8 @@ class Configuration:
                 name = os.path.splitext(os.path.basename(fn))[0]
                 n = dot_join(self.name, name)
                 try:
-                    version_module = npy_load_module('_'.join(n.split('.')),
-                                                     fn, info)
+                    version_module = exec_mod_from_location(
+                                        '_'.join(n.split('.')), fn)
                 except ImportError as e:
                     self.warn(str(e))
                     version_module = None
@@ -2490,4 +2488,14 @@ def sanitize_cxx_flags(cxxflags):
     '''
     return [flag for flag in cxxflags if flag not in _cxx_ignore_flags]
 
+
+def exec_mod_from_location(modname, modfile):
+    '''
+    Use importlib machinery to import a module `modname` from the file
+    `modfile`
+    '''
+    spec = importlib.util.spec_from_file_location(modname, modfile)
+    foo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(foo)
+    return foo
 

--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2492,7 +2492,8 @@ def sanitize_cxx_flags(cxxflags):
 def exec_mod_from_location(modname, modfile):
     '''
     Use importlib machinery to import a module `modname` from the file
-    `modfile`
+    `modfile`. Depending on the `spec.loader`, the module may not be
+    registered in sys.modules.
     '''
     spec = importlib.util.spec_from_file_location(modname, modfile)
     foo = importlib.util.module_from_spec(spec)

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import warnings
 import numpy as np
+from numpy.distutils.misc_util import exec_mod_from_location
 
 try:
     import cffi
@@ -75,10 +76,9 @@ def test_cython(tmp_path):
     assert so1 is not None
     assert so2 is not None
     # import the so's without adding the directory to sys.path
-    from importlib.machinery import ExtensionFileLoader 
-    extending = ExtensionFileLoader('extending', so1).load_module()
-    extending_distributions = ExtensionFileLoader('extending_distributions', so2).load_module()
-
+    extending = exec_mod_from_location('extending', so1)
+    extending_distributions = exec_mod_from_location(
+                    'extending_distributions', so2)
     # actually test the cython c-extension
     from numpy.random import PCG64
     values = extending_distributions.uniforms_ex(PCG64(0), 10, 'd')

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -76,7 +76,7 @@ def test_cython(tmp_path):
     assert so1 is not None
     assert so2 is not None
     # import the so's without adding the directory to sys.path
-    extending = exec_mod_from_location('extending', so1)
+    exec_mod_from_location('extending', so1)
     extending_distributions = exec_mod_from_location(
                     'extending_distributions', so2)
     # actually test the cython c-extension

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1228,13 +1228,13 @@ def rundocs(filename=None, raise_on_error=True):
 
     >>> np.lib.test(doctests=True)  # doctest: +SKIP
     """
-    from numpy.compat import npy_load_module
+    from numpy.distutils.misc_util import exec_mod_from_location
     import doctest
     if filename is None:
         f = sys._getframe(1)
         filename = f.f_globals['__file__']
     name = os.path.splitext(os.path.basename(filename))[0]
-    m = npy_load_module(name, filename)
+    m = exec_mod_from_location(name, filename)
 
     tests = doctest.DocTestFinder().find(m)
     runner = doctest.DocTestRunner(verbose=False)


### PR DESCRIPTION
`load_module` [is deprecated](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) since python 3.4 and will be removed in python 3.12. Use `exec_module` instead. Provide a convenience function in `distutils.misc_utils` instead of `npy_load_module` from `compat.py3k`.

This PR was triggered by deprecation warnings in python 3.10.