### PR TITLE
DOC: Docstring improvements in the context of np.shape

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -2658,8 +2658,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('shape',
 
     See Also
     --------
-    numpy.reshape : similar function
-    ndarray.reshape : similar method
+    numpy.shape : Equivalent getter function.
+    numpy.reshape : Function similar to setting ``shape``.
+    ndarray.reshape : Method similar to setting ``shape``.
 
     """))
 

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1987,18 +1987,19 @@ def shape(a):
     --------
     >>> np.shape(np.eye(3))
     (3, 3)
-    >>> np.shape([[1, 2]])
+    >>> np.shape([[1, 3]])
     (1, 2)
     >>> np.shape([0])
     (1,)
     >>> np.shape(0)
     ()
 
-    >>> a = np.array([(1, 2), (3, 4)], dtype=[('x', 'i4'), ('y', 'i4')])
+    >>> a = np.array([(1, 2), (3, 4), (5, 6)],
+                     dtype=[('x', 'i4'), ('y', 'i4')])
     >>> np.shape(a)
-    (2,)
+    (3,)
     >>> a.shape
-    (2,)
+    (3,)
 
     """
     try:

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1980,7 +1980,8 @@ def shape(a):
 
     See Also
     --------
-    len : ``len(a)`` is equivalent to ``np.shape(a)[0]`` for 1+-dim arrays.
+    len : ``len(a)`` is equivalent to ``np.shape(a)[0]`` for N-D arrays with
+          ``N>=1``.
     ndarray.shape : Equivalent array method.
 
     Examples
@@ -1995,7 +1996,7 @@ def shape(a):
     ()
 
     >>> a = np.array([(1, 2), (3, 4), (5, 6)],
-                     dtype=[('x', 'i4'), ('y', 'i4')])
+    ...              dtype=[('x', 'i4'), ('y', 'i4')])
     >>> np.shape(a)
     (3,)
     >>> a.shape

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1980,7 +1980,7 @@ def shape(a):
 
     See Also
     --------
-    len
+    len : ``len(a)`` is equivalent to ``np.shape(a)[0]`` for 1+-dim arrays.
     ndarray.shape : Equivalent array method.
 
     Examples


### PR DESCRIPTION
- Document what len(a) is in See Also of numpy.shape
- Make numpy.shape examples less ambiguous
- Improve See Also of ndarray.shape