### PR TITLE
BLD: Fix Macos Builds [wheel build]

### DIFF
--- a/numpy/distutils/misc_util.py
+++ b/numpy/distutils/misc_util.py
@@ -2481,7 +2481,7 @@ def get_build_architecture():
     return get_build_architecture()
 
 
-_cxx_ignore_flags = {'-Werror=implicit-function-declaration'}
+_cxx_ignore_flags = {'-Werror=implicit-function-declaration', '-std=c99'}
 
 
 def sanitize_cxx_flags(cxxflags):


### PR DESCRIPTION
Backport of #20398.

fixes:

creating build/src.macosx-10.9-x86_64-3.8/numpy/distutils
    INFO: building library "npymath" sources
    error: invalid argument '-std=c99' not allowed with 'C++'
related to #20354
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
