### PR TITLE
MAINT: import setuptools before distutils in one `np.random` test

### DIFF
--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -4,6 +4,7 @@ Build the Cython demonstrations of low-level access to NumPy random
 
 Usage: python setup.py build_ext -i
 """
+import setuptools  # triggers monkeypatching distutils
 from distutils.core import setup
 from os.path import dirname, join, abspath
 


### PR DESCRIPTION
Related to #20408

One day distutils will go away and we will have to use the one from setuptools. Until then, importing setuptools first removes the deprecation warning.