### PR TITLE
DOC: correct the versionadded number for `f2py.get_include`

### DIFF
--- a/numpy/f2py/__init__.py
+++ b/numpy/f2py/__init__.py
@@ -145,7 +145,7 @@ def get_include():
 
     Notes
     -----
-    .. versionadded:: 1.22.0
+    .. versionadded:: 1.21.1
 
     Unless the build system you are using has specific support for f2py,
     building a Python extension using a ``.pyf`` signature file is a two-step


### PR DESCRIPTION
This feature was backported to 1.21.1 in gh-19348

[ci skip]
