### PR TITLE
DEP: remove deprecated `alen` and `asscalar` functions

### DIFF
--- a/doc/release/upcoming_changes/20414.expired.rst
+++ b/doc/release/upcoming_changes/20414.expired.rst
@@ -1,0 +1,4 @@
+``alen`` and ``asscalar`` removed
+---------------------------------
+
+The deprecated ``np.alen`` and ``np.asscalar`` functions were removed.

--- a/doc/source/reference/routines.array-manipulation.rst
+++ b/doc/source/reference/routines.array-manipulation.rst
@@ -59,7 +59,6 @@ Changing kind of array
    asfortranarray
    ascontiguousarray
    asarray_chkfinite
-   asscalar
    require
 
 Joining arrays

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -17,7 +17,7 @@ _dt_ = nt.sctype2char
 
 # functions that are methods
 __all__ = [
-    'alen', 'all', 'alltrue', 'amax', 'amin', 'any', 'argmax',
+    'all', 'alltrue', 'amax', 'amin', 'any', 'argmax',
     'argmin', 'argpartition', 'argsort', 'around', 'choose', 'clip',
     'compress', 'cumprod', 'cumproduct', 'cumsum', 'diagonal', 'mean',
     'ndim', 'nonzero', 'partition', 'prod', 'product', 'ptp', 'put',
@@ -2915,51 +2915,6 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     """
     return _wrapreduction(a, np.minimum, 'min', axis, None, out,
                           keepdims=keepdims, initial=initial, where=where)
-
-
-def _alen_dispathcer(a):
-    return (a,)
-
-
-@array_function_dispatch(_alen_dispathcer)
-def alen(a):
-    """
-    Return the length of the first dimension of the input array.
-
-    .. deprecated:: 1.18
-       `numpy.alen` is deprecated, use `len` instead.
-
-    Parameters
-    ----------
-    a : array_like
-       Input array.
-
-    Returns
-    -------
-    alen : int
-       Length of the first dimension of `a`.
-
-    See Also
-    --------
-    shape, size
-
-    Examples
-    --------
-    >>> a = np.zeros((7,4,5))
-    >>> a.shape[0]
-    7
-    >>> np.alen(a)
-    7
-
-    """
-    # NumPy 1.18.0, 2019-08-02
-    warnings.warn(
-        "`np.alen` is deprecated, use `len` instead",
-        DeprecationWarning, stacklevel=2)
-    try:
-        return len(a)
-    except TypeError:
-        return len(array(a, ndmin=1))
 
 
 def _prod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -427,11 +427,6 @@ class TestBincount(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.bincount([1, 2, 3], minlength=None))
 
 
-class TestAlen(_DeprecationTestCase):
-    # 2019-08-02, 1.18.0
-    def test_alen(self):
-        self.assert_deprecated(lambda: np.alen(np.array([1, 2, 3])))
-
 
 class TestGeneratorSum(_DeprecationTestCase):
     # 2018-02-25, 1.15.0

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -6888,26 +6888,6 @@ class TestInner:
             assert_equal(np.inner(b, a).transpose(2,3,0,1), desired)
 
 
-class TestAlen:
-    def test_basic(self):
-        with pytest.warns(DeprecationWarning):
-            m = np.array([1, 2, 3])
-            assert_equal(np.alen(m), 3)
-
-            m = np.array([[1, 2, 3], [4, 5, 7]])
-            assert_equal(np.alen(m), 2)
-
-            m = [1, 2, 3]
-            assert_equal(np.alen(m), 3)
-
-            m = [[1, 2, 3], [4, 5, 7]]
-            assert_equal(np.alen(m), 2)
-
-    def test_singleton(self):
-        with pytest.warns(DeprecationWarning):
-            assert_equal(np.alen(5), 1)
-
-
 class TestChoose:
     def setup(self):
         self.x = 2*np.ones((3,), dtype=int)
@@ -7832,9 +7812,9 @@ class TestArrayCreationCopyArgument(object):
             pyscalar = arr.item(0)
 
             # Test never-copy raises error:
-            assert_raises(ValueError, np.array, scalar, 
+            assert_raises(ValueError, np.array, scalar,
                             copy=np._CopyMode.NEVER)
-            assert_raises(ValueError, np.array, pyscalar, 
+            assert_raises(ValueError, np.array, pyscalar,
                             copy=np._CopyMode.NEVER)
             assert_raises(ValueError, np.array, pyscalar,
                             copy=self.RaiseOnBool())

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -6,7 +6,7 @@ import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'isreal', 'nan_to_num', 'real', 'real_if_close',
-           'typename', 'asfarray', 'mintypecode', 'asscalar',
+           'typename', 'asfarray', 'mintypecode',
            'common_type']
 
 import numpy.core.numeric as _nx
@@ -276,22 +276,22 @@ def isreal(x):
     >>> a = np.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype=complex)
     >>> np.isreal(a)
     array([False,  True,  True,  True,  True, False])
-    
+
     The function does not work on string arrays.
 
     >>> a = np.array([2j, "a"], dtype="U")
     >>> np.isreal(a)  # Warns about non-elementwise comparison
     False
-    
+
     Returns True for all elements in input array of ``dtype=object`` even if
     any of the elements is complex.
 
     >>> a = np.array([1, "2", 3+4j], dtype=object)
     >>> np.isreal(a)
     array([ True,  True,  True])
-    
+
     isreal should not be used with object arrays
-    
+
     >>> a = np.array([1+2j, 2+1j], dtype=object)
     >>> np.isreal(a)
     array([ True,  True])
@@ -405,14 +405,14 @@ def _nan_to_num_dispatcher(x, copy=None, nan=None, posinf=None, neginf=None):
 def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     """
     Replace NaN with zero and infinity with large finite numbers (default
-    behaviour) or with the numbers defined by the user using the `nan`, 
+    behaviour) or with the numbers defined by the user using the `nan`,
     `posinf` and/or `neginf` keywords.
 
     If `x` is inexact, NaN is replaced by zero or by the user defined value in
-    `nan` keyword, infinity is replaced by the largest finite floating point 
-    values representable by ``x.dtype`` or by the user defined value in 
-    `posinf` keyword and -infinity is replaced by the most negative finite 
-    floating point values representable by ``x.dtype`` or by the user defined 
+    `nan` keyword, infinity is replaced by the largest finite floating point
+    values representable by ``x.dtype`` or by the user defined value in
+    `posinf` keyword and -infinity is replaced by the most negative finite
+    floating point values representable by ``x.dtype`` or by the user defined
     value in `neginf` keyword.
 
     For complex dtypes, the above is applied to each of the real and
@@ -429,27 +429,27 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
         in-place (False). The in-place operation only occurs if
         casting to an array does not require a copy.
         Default is True.
-        
+
         .. versionadded:: 1.13
     nan : int, float, optional
-        Value to be used to fill NaN values. If no value is passed 
+        Value to be used to fill NaN values. If no value is passed
         then NaN values will be replaced with 0.0.
-        
+
         .. versionadded:: 1.17
     posinf : int, float, optional
-        Value to be used to fill positive infinity values. If no value is 
+        Value to be used to fill positive infinity values. If no value is
         passed then positive infinity values will be replaced with a very
         large number.
-        
+
         .. versionadded:: 1.17
     neginf : int, float, optional
-        Value to be used to fill negative infinity values. If no value is 
+        Value to be used to fill negative infinity values. If no value is
         passed then negative infinity values will be replaced with a very
         small (or negative) number.
-        
+
         .. versionadded:: 1.17
 
-        
+
 
     Returns
     -------
@@ -483,7 +483,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     array([ 1.79769313e+308, -1.79769313e+308,  0.00000000e+000, # may vary
            -1.28000000e+002,  1.28000000e+002])
     >>> np.nan_to_num(x, nan=-9999, posinf=33333333, neginf=33333333)
-    array([ 3.3333333e+07,  3.3333333e+07, -9.9990000e+03, 
+    array([ 3.3333333e+07,  3.3333333e+07, -9.9990000e+03,
            -1.2800000e+02,  1.2800000e+02])
     >>> y = np.array([complex(np.inf, np.nan), np.nan, complex(np.nan, np.inf)])
     array([  1.79769313e+308,  -1.79769313e+308,   0.00000000e+000, # may vary
@@ -529,7 +529,7 @@ def _real_if_close_dispatcher(a, tol=None):
 @array_function_dispatch(_real_if_close_dispatcher)
 def real_if_close(a, tol=100):
     """
-    If input is complex with all imaginary parts close to zero, return 
+    If input is complex with all imaginary parts close to zero, return
     real parts.
 
     "Close to zero" is defined as `tol` * (machine epsilon of the type for
@@ -582,40 +582,6 @@ def real_if_close(a, tol=100):
         a = a.real
     return a
 
-
-def _asscalar_dispatcher(a):
-    # 2018-10-10, 1.16
-    warnings.warn('np.asscalar(a) is deprecated since NumPy v1.16, use '
-                  'a.item() instead', DeprecationWarning, stacklevel=3)
-    return (a,)
-
-
-@array_function_dispatch(_asscalar_dispatcher)
-def asscalar(a):
-    """
-    Convert an array of size 1 to its scalar equivalent.
-
-    .. deprecated:: 1.16
-
-        Deprecated, use `numpy.ndarray.item()` instead.
-
-    Parameters
-    ----------
-    a : ndarray
-        Input array of size 1.
-
-    Returns
-    -------
-    out : scalar
-        Scalar representation of `a`. The output data type is the same type
-        returned by the input's `item` method.
-
-    Examples
-    --------
-    >>> np.asscalar(np.array([24]))
-    24
-    """
-    return a.item()
 
 #-----------------------------------------------------------------------------
 

--- a/numpy/lib/type_check.pyi
+++ b/numpy/lib/type_check.pyi
@@ -151,9 +151,6 @@ def real_if_close(
     tol: float = ...,
 ) -> NDArray[Any]: ...
 
-# NOTE: deprecated
-# def asscalar(a): ...
-
 @overload
 def typename(char: L['S1']) -> L['character']: ...
 @overload

--- a/tools/functions_missing_types.py
+++ b/tools/functions_missing_types.py
@@ -32,7 +32,6 @@ EXCLUDE_LIST = {
         "math",
         # Accidentally public, deprecated, or shouldn't be used
         "Tester",
-        "alen",
         "add_docstring",
         "add_newdoc",
         "add_newdoc_ufunc",


### PR DESCRIPTION
`alen` has been removed since 1.18.0, and `asscalar` since 1.16.0