### PR TITLE
MAINT: import setuptools before distutils in one np.random test

### DIFF
--- a/numpy/random/_examples/cython/setup.py
+++ b/numpy/random/_examples/cython/setup.py
@@ -4,6 +4,7 @@ Build the Cython demonstrations of low-level access to NumPy random
 
 Usage: python setup.py build_ext -i
 """
+import setuptools  # triggers monkeypatching distutils
 from distutils.core import setup
 from os.path import dirname, join, abspath
 


### PR DESCRIPTION
Backport of #20409.

Related to #20408

One day distutils will go away and we will have to use the one from setuptools. Until then, importing setuptools first removes the deprecation warning.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
