### PR TITLE
MAINT: Fix longdouble precision check in test_umath.py

### DIFF
--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -3433,7 +3433,7 @@ class TestComplexFunctions:
         x_series = np.logspace(-20, -3.001, 200)
         x_basic = np.logspace(-2.999, 0, 10, endpoint=False)
 
-        if glibc_older_than("2.19") and dtype is np.longcomplex:
+        if dtype is np.longcomplex:
             if (platform.machine() == 'aarch64' and bad_arcsinh()):
                 pytest.skip("Trig functions of np.longcomplex values known "
                             "to be inaccurate on aarch64 for some compilation "


### PR DESCRIPTION
This is a partial reversion of #20274. My guess is that
`glibc_older_than("2.19")` is not working correctly using manylinux2014
on aarch64.

Closes #20426.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
