### PR TITLE
DOC: nicer CMake example in the f2py docs

### DIFF
--- a/doc/source/f2py/buildtools/cmake.rst
+++ b/doc/source/f2py/buildtools/cmake.rst
@@ -48,9 +48,9 @@ with the ``cython`` information.
 
     ls .
     # CMakeLists.txt fib1.f
-    mkdir build && cd build
-    cmake ..
-    make
+    cmake -S . -B build
+    cmake --build build
+    cd build
     python -c "import numpy as np; import fibby; a = np.zeros(9); fibby.fib(a); print (a)"
     # [ 0.  1.  1.  2.  3.  5.  8. 13. 21.]
 

--- a/doc/source/f2py/buildtools/skbuild.rst
+++ b/doc/source/f2py/buildtools/skbuild.rst
@@ -44,9 +44,9 @@ The resulting extension can be built and loaded in the standard workflow.
 
     ls .
     # CMakeLists.txt fib1.f
-    mkdir build && cd build
-    cmake ..
-    make
+    cmake -S . -B build
+    cmake --build build
+    cd build
     python -c "import numpy as np; import fibby; a = np.zeros(9); fibby.fib(a); print (a)"
     # [ 0.  1.  1.  2.  3.  5.  8. 13. 21.]
 

--- a/doc/source/f2py/code/CMakeLists.txt
+++ b/doc/source/f2py/code/CMakeLists.txt
@@ -1,12 +1,10 @@
-### setup project ###
-cmake_minimum_required(VERSION 3.17.3) # 3.17 > for Python3_SOABI
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+cmake_minimum_required(VERSION 3.18) # Needed to avoid requiring embedded Python libs too
 
 project(fibby
   VERSION 1.0
   DESCRIPTION "FIB module"
   LANGUAGES C Fortran
-  )
+)
 
 # Safety net
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
@@ -16,9 +14,9 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
   )
 endif()
 
-# Grab Python
-find_package(Python3 3.9 REQUIRED
-  COMPONENTS Interpreter Development NumPy)
+# Grab Python, 3.7 or newer
+find_package(Python3 3.7 REQUIRED
+  COMPONENTS Interpreter Development.Module NumPy)
 
 # Grab the variables from a local Python installation
 # F2PY headers
@@ -29,29 +27,22 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-# Project scope; consider using target_include_directories instead
-include_directories(
-  BEFORE
-  ${Python3_INCLUDE_DIRS}
-  ${Python3_NumPy_INCLUDE_DIRS}
-  ${F2PY_INCLUDE_DIR}
-  )
+# Print out the discovered paths
+include(CMakePrintHelpers)
+cmake_print_variables(Python3_INCLUDE_DIRS)
+cmake_print_variables(F2PY_INCLUDE_DIR)
+cmake_print_variables(Python3_NumPy_INCLUDE_DIRS)
 
-message(STATUS ${Python3_INCLUDE_DIRS})
-message(STATUS ${F2PY_INCLUDE_DIR})
-message(STATUS ${Python3_NumPy_INCLUDE_DIRS})
-
-# Vars
+# Common variables
 set(f2py_module_name "fibby")
 set(fortran_src_file "${CMAKE_SOURCE_DIR}/fib1.f")
 set(f2py_module_c "${f2py_module_name}module.c")
-set(generated_module_file "${f2py_module_name}${Python3_SOABI}")
 
 # Generate sources
 add_custom_target(
   genpyf
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}"
-  )
+)
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}"
   COMMAND ${Python3_EXECUTABLE}  -m "numpy.f2py"
@@ -59,22 +50,16 @@ add_custom_command(
                    -m "fibby"
                    --lower # Important
   DEPENDS fib1.f # Fortran source
-  )
+)
 
 # Set up target
-add_library(${CMAKE_PROJECT_NAME} SHARED
+python3_add_LIBRARY(${CMAKE_PROJECT_NAME} MODULE WITH_SOABI
   "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}" # Generated
   "${F2PY_INCLUDE_DIR}/fortranobject.c" # From NumPy
   "${fortran_src_file}" # Fortran source(s)
-  )
+)
 
 # Depend on sources
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Python3::NumPy)
 add_dependencies(${CMAKE_PROJECT_NAME} genpyf)
-
-set_target_properties(
-     ${CMAKE_PROJECT_NAME}
-    PROPERTIES
-        PREFIX ""
-        OUTPUT_NAME "${CMAKE_PROJECT_NAME}"
-        LINKER_LANGUAGE C
-    )
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE "${F2PY_INCLUDE_DIR}")


### PR DESCRIPTION
This updates the CMake example with several improvements.

* The modern CLI usage (3.14+) is used for configuring and building (plain CMake and scikit-build examples)
* Removed CXX variable setting (not a CXX project)
* Ensured Python 3.7+ is discovered, and also avoid requiring `Development.Embed` (component not present in some places like manylinux)
* Nicer include directory listing when configuring
* Drop unused variable
* Use FindPython's integrated module support
* Avoid directory-level settings, use only target level settings instead (as noted in the orignal comment - also this was originally directory scope, not project scope)

I have not updated the scikit-build CMakeLists.txt example yet, will do in a followup.

Also requires CMake 3.18 instead of 3.17, the support for FindPython drastically improved in 3.18, including the ability to find Python development components without requiring the embed libraries be present!