### PR TITLE
BUG: Fix an incorrect protocol used in ``np.lib.shape_base``

### DIFF
--- a/numpy/lib/shape_base.pyi
+++ b/numpy/lib/shape_base.pyi
@@ -18,7 +18,7 @@ from numpy.typing import (
     NDArray,
     _ShapeLike,
      _FiniteNestedSequence,
-     _SupportsDType,
+     _SupportsArray,
      _ArrayLikeBool_co,
      _ArrayLikeUInt_co,
      _ArrayLikeInt_co,
@@ -31,7 +31,7 @@ from numpy.core.shape_base import vstack
 
 _SCT = TypeVar("_SCT", bound=generic)
 
-_ArrayLike = _FiniteNestedSequence[_SupportsDType[dtype[_SCT]]]
+_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 # The signatures of `__array_wrap__` and `__array_prepare__` are the same;
 # give them unique names for the sake of clarity

--- a/numpy/typing/tests/data/fail/shape_base.pyi
+++ b/numpy/typing/tests/data/fail/shape_base.pyi
@@ -1,0 +1,8 @@
+import numpy as np
+
+class DTypeLike:
+    dtype: np.dtype[np.int_]
+
+dtype_like: DTypeLike
+
+np.expand_dims(dtype_like, (5, 10))  # E: No overload variant


### PR DESCRIPTION
Backport of #20433.

Stumbled upon this while running mypy against pandas; if possible I'd like to get this in for 1.22.0.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
