### PR TITLE
DOC: Fix a typo in docstring of MT19937

### DIFF
--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -109,7 +109,7 @@ cdef class MT19937(BitGenerator):
 
     **Compatibility Guarantee**
 
-    ``MT19937`` makes a guarantee that a fixed seed and will always produce
+    ``MT19937`` makes a guarantee that a fixed seed will always produce
     the same random integer stream.
 
     References


### PR DESCRIPTION
This PR suggests a fix to a typo I found in the documentation of MT19937.