### PR TITLE
BUG: Fixed output variable overriding in numpy.info()

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -499,7 +499,8 @@ def info(object=None, maxwidth=76, output=None, toplevel='numpy'):
         Printing width.
     output : file like object, optional
         File like object that the output is written to, default is
-        ``None``.  The object has to be opened in 'w' or 'a' mode.
+        ``None``, in which case ``sys.stdout`` will be used.
+        The object has to be opened in 'w' or 'a' mode.
     toplevel : str, optional
         Start search at this level.
 

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -429,7 +429,7 @@ def _makenamedict(module='numpy'):
     return thedict, dictlist
 
 
-def _info(obj, output=sys.stdout):
+def _info(obj, output=None):
     """Provide information about ndarray obj.
 
     Parameters
@@ -454,6 +454,9 @@ def _info(obj, output=sys.stdout):
     nm = getattr(cls, '__name__', cls)
     strides = obj.strides
     endian = obj.dtype.byteorder
+
+    if output is None:
+        output = sys.stdout
 
     print("class: ", nm, file=output)
     print("shape: ", obj.shape, file=output)
@@ -481,7 +484,7 @@ def _info(obj, output=sys.stdout):
 
 
 @set_module('numpy')
-def info(object=None, maxwidth=76, output=sys.stdout, toplevel='numpy'):
+def info(object=None, maxwidth=76, output=None, toplevel='numpy'):
     """
     Get help information for a function, class, or module.
 
@@ -540,6 +543,9 @@ def info(object=None, maxwidth=76, output=sys.stdout, toplevel='numpy'):
         object = object._ppimport_module
     elif hasattr(object, '_ppimport_attr'):
         object = object._ppimport_attr
+
+    if output is None:
+        output = sys.stdout
 
     if object is None:
         info(info)

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -499,7 +499,7 @@ def info(object=None, maxwidth=76, output=None, toplevel='numpy'):
         Printing width.
     output : file like object, optional
         File like object that the output is written to, default is
-        ``stdout``.  The object has to be opened in 'w' or 'a' mode.
+        ``None``.  The object has to be opened in 'w' or 'a' mode.
     toplevel : str, optional
         Start search at this level.
 


### PR DESCRIPTION
Closes #20423. 

## What does this implement/fix?
`numpy.info()` currently overrides the `output` variable, so that we are not able to see the output in Google Colab.
![image](https://user-images.githubusercontent.com/55283735/143157125-7caa49e3-bda1-4373-bde2-3a291ee2bca4.png)

This is due to the use of `sys.stdout` as a default value for `output` parameter. So, I have implemented the changes that were proposed in issue #20423. Specifically, I have changed the default value to `None`, and made a check if the value of parameter `output` is `None`, then set the `output` value to `sys.stdout`. 

## What changes have been made?
- Changed default value of a parameter `output` to `None`.
- Added additional check that sets the value of `output` variable to `sys.stdout`, if it is `None`. 
- Checked if the changes are working in Google Colab
<img width="1646" alt="Screen Shot 2021-11-23 at 6 34 25 PM" src="https://user-images.githubusercontent.com/55283735/143157695-49e57115-082a-46e0-b8b6-9deb694e64d6.png">

