### PR TITLE
DOC: use FindPython instead of FindPython3

### DIFF
--- a/doc/source/f2py/code/CMakeLists.txt
+++ b/doc/source/f2py/code/CMakeLists.txt
@@ -15,13 +15,13 @@ if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
 endif()
 
 # Grab Python, 3.7 or newer
-find_package(Python3 3.7 REQUIRED
+find_package(Python 3.7 REQUIRED
   COMPONENTS Interpreter Development.Module NumPy)
 
 # Grab the variables from a local Python installation
 # F2PY headers
 execute_process(
-  COMMAND "${Python3_EXECUTABLE}"
+  COMMAND "${Python_EXECUTABLE}"
   -c "import numpy.f2py; print(numpy.f2py.get_include())"
   OUTPUT_VARIABLE F2PY_INCLUDE_DIR
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -29,9 +29,9 @@ execute_process(
 
 # Print out the discovered paths
 include(CMakePrintHelpers)
-cmake_print_variables(Python3_INCLUDE_DIRS)
+cmake_print_variables(Python_INCLUDE_DIRS)
 cmake_print_variables(F2PY_INCLUDE_DIR)
-cmake_print_variables(Python3_NumPy_INCLUDE_DIRS)
+cmake_print_variables(Python_NumPy_INCLUDE_DIRS)
 
 # Common variables
 set(f2py_module_name "fibby")
@@ -45,7 +45,7 @@ add_custom_target(
 )
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}"
-  COMMAND ${Python3_EXECUTABLE}  -m "numpy.f2py"
+  COMMAND ${Python_EXECUTABLE}  -m "numpy.f2py"
                    "${fortran_src_file}"
                    -m "fibby"
                    --lower # Important
@@ -60,6 +60,6 @@ python3_add_LIBRARY(${CMAKE_PROJECT_NAME} MODULE WITH_SOABI
 )
 
 # Depend on sources
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Python3::NumPy)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Python::NumPy)
 add_dependencies(${CMAKE_PROJECT_NAME} genpyf)
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE "${F2PY_INCLUDE_DIR}")

--- a/doc/source/f2py/code/CMakeLists.txt
+++ b/doc/source/f2py/code/CMakeLists.txt
@@ -53,7 +53,7 @@ add_custom_command(
 )
 
 # Set up target
-python3_add_LIBRARY(${CMAKE_PROJECT_NAME} MODULE WITH_SOABI
+Python_add_library(${CMAKE_PROJECT_NAME} MODULE WITH_SOABI
   "${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_c}" # Generated
   "${F2PY_INCLUDE_DIR}/fortranobject.c" # From NumPy
   "${fortran_src_file}" # Fortran source(s)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Follow up to #20435. We already set a minimum Python, so the "3" is unnecessary. The reason for this was really to allow FindPython2 and FindPython3 to both exist in parallel for dual-targeting 2 & 3.
