### PR TITLE
BUG, DIST: Print os error message when the executable not exist

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -143,12 +143,18 @@ def CCompiler_spawn(self, cmd, display=None):
     except subprocess.CalledProcessError as exc:
         o = exc.output
         s = exc.returncode
-    except OSError:
+    except OSError as e:
         # OSError doesn't have the same hooks for the exception
         # output, but exec_command() historically would use an
         # empty string for EnvironmentError (base class for
         # OSError)
-        o = b''
+        # o = b''
+        # still that would make the end-user lost in translation!
+        o = f"\n\n{e}\n\n\n"
+        try:
+            o = o.encode(sys.stdout.encoding)
+        except AttributeError:
+            o = o.encode('utf8')
         # status previously used by exec_command() for parent
         # of OSError
         s = 127

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -708,8 +708,8 @@ class _Distutils:
         except subprocess.CalledProcessError as exc:
             o = exc.output
             s = exc.returncode
-        except OSError:
-            o = b''
+        except OSError as e:
+            o = e
             s = 127
         else:
             return None


### PR DESCRIPTION
Backport of #20353.

This patch is really important since most of the users aren't able to determine
the build error when the toolchain or the built environment missing
executable files of compiler, linker, assembler, etc.

related to #20335

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
