### PR TITLE
ENH: provide a convenience function to replace npy_load_module 

### DIFF
--- a/numpy/compat/py3k.py
+++ b/numpy/compat/py3k.py
@@ -111,7 +111,9 @@ class contextlib_nullcontext:
 
 def npy_load_module(name, fn, info=None):
     """
-    Load a module.
+    Load a module. Uses ``load_module`` which will be deprecated in python
+    3.12. An alternative that uses ``exec_module`` is in
+    numpy.distutils.misc_util.exec_mod_from_location
 
     .. versionadded:: 1.11.2
 

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -645,9 +645,9 @@ class _Distutils:
     @staticmethod
     def dist_load_module(name, path):
         """Load a module from file, required by the abstract class '_Cache'."""
-        from numpy.compat import npy_load_module
+        from .misc_util import exec_mod_from_location
         try:
-            return npy_load_module(name, path)
+            return exec_mod_from_location(name, path)
         except Exception as e:
             _Distutils.dist_log(e, stderr=True)
         return None

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import warnings
 import numpy as np
+from numpy.distutils.misc_util import exec_mod_from_location
 
 try:
     import cffi
@@ -75,10 +76,9 @@ def test_cython(tmp_path):
     assert so1 is not None
     assert so2 is not None
     # import the so's without adding the directory to sys.path
-    from importlib.machinery import ExtensionFileLoader 
-    extending = ExtensionFileLoader('extending', so1).load_module()
-    extending_distributions = ExtensionFileLoader('extending_distributions', so2).load_module()
-
+    exec_mod_from_location('extending', so1)
+    extending_distributions = exec_mod_from_location(
+                    'extending_distributions', so2)
     # actually test the cython c-extension
     from numpy.random import PCG64
     values = extending_distributions.uniforms_ex(PCG64(0), 10, 'd')

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1228,13 +1228,13 @@ def rundocs(filename=None, raise_on_error=True):
 
     >>> np.lib.test(doctests=True)  # doctest: +SKIP
     """
-    from numpy.compat import npy_load_module
+    from numpy.distutils.misc_util import exec_mod_from_location
     import doctest
     if filename is None:
         f = sys._getframe(1)
         filename = f.f_globals['__file__']
     name = os.path.splitext(os.path.basename(filename))[0]
-    m = npy_load_module(name, filename)
+    m = exec_mod_from_location(name, filename)
 
     tests = doctest.DocTestFinder().find(m)
     runner = doctest.DocTestRunner(verbose=False)


### PR DESCRIPTION
Backport of #20395.

load_module` [is deprecated](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) since python 3.4 and will be removed in python 3.12. Use `exec_module` instead. Provide a convenience function in `distutils.misc_utils` instead of `npy_load_module` from `compat.py3k`.

This PR was triggered by deprecation warnings in python 3.10.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
