### PR TITLE
MAINT: Update the required setuptools version.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - compilers
   - openblas
   - nomkl
-  - setuptools=58.4
+  - setuptools=59.2.0
   # For testing
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
-    "setuptools<49.2.0",
+    "setuptools==59.2.0",
     "wheel==0.36.2",
     "Cython>=0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 cython==0.29.24
 wheel<0.37.1
-setuptools<49.2.0
+setuptools==59.2.0
 hypothesis==6.24.1
 pytest==6.2.5
 pytz==2021.3


### PR DESCRIPTION
An newer setuptools version is needed in order to run tests in Fedora 35
using the default Python 3.10. Because the newest version (59.2.0) works
to both build and test NumPy, pin the version is to that.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
