### PR TITLE
MAINT: update wheel to version that supports python3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools==59.2.0",
-    "wheel==0.36.2",
+    "wheel==0.37.0",
     "Cython>=0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,11 +1,10 @@
 cython==0.29.24
-wheel<0.37.1
+wheel==0.37.0
 setuptools==59.2.0
 hypothesis==6.24.1
 pytest==6.2.5
 pytz==2021.3
 pytest-cov==3.0.0
-pickle5; python_version == '3.7' and platform_python_implementation != 'PyPy'
 # for numpy.random.test.test_extending
 cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:


### PR DESCRIPTION
Backport of #20486.

xref pypa/wheel#426 and pypa/pip#10631. 

The release blurb for [this version](https://wheel.readthedocs.io/en/stable/news.html) states

> Added official Python 3.10 support

I think updating the vendored "packaging" package also fixes the linked pypy3.8 issues
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
