### PR TITLE
MAINT: update wheel to version that supports python3.10

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -21,9 +21,10 @@ from numpy.distutils import log
 from numpy.distutils.exec_command import (
     filepath_from_subprocess_output, forward_bytes_to_stdout
 )
-from numpy.distutils.misc_util import cyg2win32, is_sequence, mingw32, \
-                                      get_num_build_jobs, \
-                                      _commandline_dep_string
+from numpy.distutils.misc_util import (
+        cyg2win32, is_sequence, mingw32, get_num_build_jobs,
+        _commandline_dep_string, sanitize_cxx_flags
+)
 
 # globals for parallel build management
 import threading
@@ -682,7 +683,10 @@ def CCompiler_cxx_compiler(self):
         return self
 
     cxx = copy(self)
-    cxx.compiler_so = [cxx.compiler_cxx[0]] + cxx.compiler_so[1:]
+    cxx.compiler_cxx = cxx.compiler_cxx
+    cxx.compiler_so = [cxx.compiler_cxx[0]] + \
+                      sanitize_cxx_flags(cxx.compiler_so[1:])
+    #cxx.compiler_so = [cxx.compiler_cxx[0]] + cxx.compiler_so[1:]
     if sys.platform.startswith('aix') and 'ld_so_aix' in cxx.linker_so[0]:
         # AIX needs the ld_so_aix script included with Python
         cxx.linker_so = [cxx.linker_so[0], cxx.compiler_cxx[0]] \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
-    "setuptools<49.2.0",
-    "wheel==0.36.2",
+    "setuptools==59.2.0",
+    "wheel==0.37.0",
     "Cython>=0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,15 +1,15 @@
 cython==0.29.24
-wheel<0.36.3
-setuptools<49.2.0
-hypothesis==6.12.0
-pytest==6.2.4
-pytz==2021.1
-pytest-cov==2.12.0
+wheel==0.37.0
+setuptools==59.2.0
+hypothesis==6.24.1
+pytest==6.2.5
+pytz==2021.3
+pytest-cov==3.0.0
 pickle5; python_version == '3.7' and platform_python_implementation != 'PyPy'
 # for numpy.random.test.test_extending
-cffi
+cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # - There is no point in installing typing_extensions without mypy
-mypy==0.812; platform_python_implementation != "PyPy"
-typing_extensions==3.10.0.0; platform_python_implementation != "PyPy"
+mypy==0.910; platform_python_implementation != "PyPy"
+#typing_extensions==3.10.0.0; platform_python_implementation != "PyPy"


### PR DESCRIPTION
Backport of #20486.

xref pypa/wheel#426 and pypa/pip#10631. 

The release blurb for [this version](https://wheel.readthedocs.io/en/stable/news.html) states

> Added official Python 3.10 support

I think updating the vendored "packaging" package also fixes the linked pypy3.8 issues
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
