### PR TITLE
TST: use pypy3.8-v7.3.7 final versions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -212,7 +212,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: pypy-3.8-v7.3.6rc1
+        python-version: pypy-3.8-v7.3.7
     - uses: ./.github/actions
 
   sdist:

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -22,7 +22,7 @@ steps:
     python -mensurepip
     echo "##vso[task.prependpath]$pypypath"
   condition: contains(variables['PYTHON_VERSION'], 'PyPy')
-  displayName: "Install PyPy pre-release"
+  displayName: "Install PyPy3.8 "
 
 - script: python -m pip install --upgrade pip wheel
   displayName: 'Install tools'

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -6,15 +6,16 @@ steps:
     architecture: $(PYTHON_ARCH)
   condition: not(contains(variables['PYTHON_VERSION'], 'PyPy'))
 - powershell: |
-    $url = "http://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-win64.zip"
+    # $url = "http://buildbot.pypy.org/nightly/py3.8/pypy-c-jit-latest-win64.zip"
+    $url = "https://downloads.python.org/pypy/pypy3.8-v7.3.7-win64.zip"
     $output = "pypy.zip"
     $wc = New-Object System.Net.WebClient
     $wc.DownloadFile($url, $output)
     echo "downloaded $url to $output"
     mkdir pypy3
     Expand-Archive $output -DestinationPath pypy3
-    move pypy3/pypy-c-*/* pypy3
-    cp pypy3/pypy3.exe pypy3/python.exe
+    # move pypy3/pypy-c-*/* pypy3
+    move pypy3/pypy*/* pypy3
     $pypypath = Join-Path (Get-Item .).FullName pypy3
     $env:Path = $pypypath + ";" + $env:Path
     setx PATH $env:Path


### PR DESCRIPTION
Backport of #20491.

pypy3.8 has formally released. Use that instead of the pre-release versions in place previously.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
