### PR TITLE
BUG: avoid segfaults when casting from boost_python types

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -70,7 +70,10 @@ NPY_NO_EXPORT PyObject *
 PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
 {
     PyObject *res;
-    if (from == to) {
+    if (NPY_DT_SLOTS(from) == NULL) {
+        res = NULL;
+    }
+    else if (from == to) {
         res = NPY_DT_SLOTS(from)->within_dtype_castingimpl;
     }
     else {


### PR DESCRIPTION
For calls to PyArray_GetCastingImpl where `from` is a dtype of a
boost_python class, it's not safe to assume the pointer
(NPY_DType_Slots *)(from)->dt_slots is non-NULL. This causes
segfaults when resolving overloaded calls to boost_python methods. Thus
we check the pointer before dereferencing.

This would resolve https://github.com/boostorg/python/issues/376 and several more issues in downstream projects. For example cctbx_project has been pinned to numpy 1.20 for a while: https://github.com/cctbx/cctbx_project/issues/627

Testing this is a little tricky because the problem only occurs when building boost_python modules in an environment with numpy. If a regression test is needed I'm happy to try and figure something out, but would appreciate any examples of c++ code that gets built for testing, and how to add it to the build system.



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
