### PR TITLE
DOC: Adds valgrind to the test command

### DIFF
--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -106,7 +106,7 @@ Valgrind is a powerful tool to find certain memory access problems and should
 be run on complicated C code.
 Basic use of ``valgrind`` usually requires no more than::
 
-    PYTHONMALLOC=malloc python runtests.py
+    PYTHONMALLOC=malloc valgrind python runtests.py
 
 where ``PYTHONMALLOC=malloc`` is necessary to avoid false positives from python
 itself.


### PR DESCRIPTION
I think `valgrind` is required in the test command.

CC @seberg 