### PR TITLE
BUG: add type check for `encoding` at `lib/npyio.py`

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -517,6 +517,10 @@ class DataSource:
         # TODO: Add a ``subdir`` parameter for specifying the subdirectory
         #       used to store URLs in self._destpath.
 
+        if encoding is not None and not isinstance(encoding, str):
+            raise TypeError(f"The encoding argument should be str or None, "
+                            f"got {encoding!r} instead")
+
         if self._isurl(path) and self._iswritemode(mode):
             raise ValueError("URLs are not writeable")
 

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -154,6 +154,12 @@ class TestDataSourceOpen:
         fp.close()
         assert_equal(magic_line, result)
 
+    def test_valid_encoding(self):
+        local_file = valid_textfile(self.tmpdir)
+        with pytest.raises(TypeError, 
+            match="encoding argument should be str or None"):
+            self.ds.open(local_file, encoding=int)
+
 
 class TestDataSourceExists:
     def setup(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2543,6 +2543,17 @@ class TestPathUsage:
             assert_(isinstance(test, np.recarray))
             assert_equal(test, control)
 
+    def test_invalid_encoding(self):
+        with pytest.raises(TypeError, 
+            match="encoding argument should be str or None") as ptr:
+            np.genfromtxt("test_io.py", encoding=int)
+            np.loadtxt("test_io.py", encoding=int)
+
+            np.genfromtxt(StringIO("a b c"), encoding=int)
+            np.loadtxt(StringIO("a b c"), encoding=int)
+
+        assert len(ptr.traceback) == 4
+
 
 def test_gzip_load():
     a = np.random.random((5, 5))


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

We should let `lib._dataloader.open` raise the exceptions needed instead of handling it for each case ourselves.

fixes https://github.com/numpy/numpy/issues/20329
