### PR TITLE
MAINT: Run wheel build on pushes to master

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,13 +62,13 @@ jobs:
           platform: manylinux_x86_64
 
         # macos builds
-        - os: macos-latest
+        - os: macos-10.15
           python: "38"
           platform: macosx_x86_64
-        - os: macos-latest
+        - os: macos-10.15
           python: "39"
           platform: macosx_x86_64
-        - os: macos-latest
+        - os: macos-10.15
           python: "310"
           platform: macosx_x86_64
           

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,6 +41,7 @@ jobs:
     needs: get_commit_message
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The macOS builds are currently broken again due to an f2py issue. 
Hopefully, running wheel builds on pushes to master will give these issues more visibility(they can't hurt I guess).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
