### PR TITLE
MAINT: Pin OS versions when building wheels [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,24 +50,24 @@ jobs:
       matrix:
         include:
         # manylinux builds
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           python: "38"
           platform: manylinux_x86_64
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           python: "39"
           platform: manylinux_x86_64
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           python: "310"
           platform: manylinux_x86_64
 
         # macos builds
-        - os: macos-latest
+        - os: macos-10.15
           python: "38"
           platform: macosx_x86_64
-        - os: macos-latest
+        - os: macos-10.15
           python: "39"
           platform: macosx_x86_64
-        - os: macos-latest
+        - os: macos-10.15
           python: "310"
           platform: macosx_x86_64
           


### PR DESCRIPTION
This gets the wheel builds back to green temporarily
cc @mattip
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
