### PR TITLE
CI: make sure CI stays on VS2019 unless changed explicitly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ stages:
 
   - job: Windows
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
     strategy:
       maxParallel: 6
       matrix:


### PR DESCRIPTION
To avoid the deprecation warnings on azure for the old windows images, https://github.com/numpy/numpy/pull/20234 moved to `windows-latest`. This is [currently](https://github.com/actions/virtual-environments#available-environments) equivalent to `windows-2019` (bringing visual studio 2019, and corresponding toolset), but will presumably change to `windows-2022` at some point in the future.

Such a change of compiler version should be made consciously for the numpy CI (rather than imposed by what azure does), because the compiler version used for windows effectively defines the lower bound of support on windows (as otherwise, changes that break on older compilers will not be caught in CI).

CC @charris @rgommers 

PS. If this is received favourably, I'm happy to do the same for scipy.