### PR TITLE
MAINT: removed duplicate 'int' type in ScalarType

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -516,7 +516,7 @@ def _scalar_type_key(typ):
     return (dt.kind.lower(), dt.itemsize)
 
 
-ScalarType = [int, float, complex, int, bool, bytes, str, memoryview]
+ScalarType = [int, float, complex, bool, bytes, str, memoryview]
 ScalarType += sorted(_concrete_types, key=_scalar_type_key)
 ScalarType = tuple(ScalarType)
 


### PR DESCRIPTION
AFAICT, it is not needed, and it *seems* to be a left-over from Python2 (see commit https://github.com/numpy/numpy/commit/e4b10510507d0b4d22e8fa9589a6232889d40fac).

The only reason to keep it would be if the order/index of types is actually important. 

Looking at all references to ScalarType in the repository, it does not seem to be the case, except in tests:

https://github.com/numpy/numpy/blob/c08f4a84d506012ac7c236eabc2470689c17d5eb/numpy/typing/tests/data/pass/numerictypes.py#L41
https://github.com/numpy/numpy/blob/b7dc11cbc1dc4c41475f001f2ee5ccbfe6d1a847/numpy/typing/tests/data/reveal/numerictypes.pyi#L36

My questions are:
1) Is the actual order/indexes of types part of the API? I don't see why anyone would use ScalarType[index] but this change would break such code.
2) Is there somewhere another variable with type to index, or which is supposed to be kept in sync with this variable?

In any case, if we cannot apply this change (for whatever reason), I would appreciate a comment stating that the duplication is on purpose. It's not the first time I stumble on this little oddity and scratch my head 😉.