### PR TITLE
ENH: Add __array__ to the array_api Array object

### DIFF
--- a/numpy/array_api/_array_object.py
+++ b/numpy/array_api/_array_object.py
@@ -108,6 +108,17 @@ class Array:
             mid = np.array2string(self._array, separator=', ', prefix=prefix, suffix=suffix)
         return prefix + mid + suffix
 
+    # This function is not required by the spec, but we implement it here for
+    # convenience so that np.asarray(np.array_api.Array) will work.
+    def __array__(self, dtype=None):
+        """
+        Warning: this method is NOT part of the array API spec. Implementers
+        of other libraries need not include it, and users should not assume it
+        will be present in other implementations.
+
+        """
+        return np.asarray(self._array, dtype=dtype)
+
     # These are various helper functions to make the array behavior match the
     # spec in places where it either deviates from or is more strict than
     # NumPy behavior

--- a/numpy/array_api/_array_object.py
+++ b/numpy/array_api/_array_object.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Union, Any
 
 if TYPE_CHECKING:
     from ._typing import Any, PyCapsule, Device, Dtype
+    import numpy.typing as npt
 
 import numpy as np
 
@@ -110,7 +111,7 @@ class Array:
 
     # This function is not required by the spec, but we implement it here for
     # convenience so that np.asarray(np.array_api.Array) will work.
-    def __array__(self, dtype=None):
+    def __array__(self, dtype: None | np.dtype[Any] = None) -> npt.NDArray[Any]:
         """
         Warning: this method is NOT part of the array API spec. Implementers
         of other libraries need not include it, and users should not assume it

--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -315,3 +315,10 @@ def test_array_properties():
     assert a.mT.shape == (1, 3, 2)
     assert isinstance(b.mT, Array)
     assert b.mT.shape == (3, 2)
+
+def test___array__():
+    a = ones((2, 3), dtype=int16)
+    assert np.asarray(a) is a._array
+    b = np.asarray(a, dtype=np.float64)
+    assert np.all(np.equal(b, np.ones((2, 3), dtype=np.float64)))
+    assert b.dtype == np.float64


### PR DESCRIPTION
This is *NOT* part of the array API spec (so it should not be relied on for
portable code). However, without this, np.asarray(np.array_api.Array) produces
an object array instead of doing the conversion to a NumPy array as expected.
This would work once np.asarray() implements dlpack support, but until then,
it seems reasonable to make the conversion work.

Note that the reverse, calling np.array_api.asarray(np.array), already works
because np.array_api.asarray() is just a wrapper for np.asarray().

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
