### PR TITLE
PERF: Fix performance bug in dispatching cache

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -998,10 +998,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     }
     if (*allow_legacy_promotion && (!all_scalar && any_scalar)) {
         *force_legacy_promotion = should_use_min_scalar(nin, out_op, 0, NULL);
-        /*
-         * TODO: if this is False, we end up in a "very slow" path that should
-         *       be avoided.  This makes `int_arr + 0.` ~40% slower.
-         */
     }
 
     /* Convert and fill in output arguments */


### PR DESCRIPTION
Backport of #20518.

In promotion cases, the result of the dispatching was not cached
(at least not as well as it could be).  This lead to large slowdowns
in cases where promotion is necessary, one example:

    a = np.array([3]); b = np.array([3.])
    %timeit a + b

The fix here is fairly small, and almost a cleanup, since I put the
whole `cache=True` logic in the wrong place really.
(I currently do not ever cache promoters, to be fair, this could
be done but should be unnecessary and may require a bit of thought.
Another thing that could be optimized is caching if there is no
matching loop to speed up error paths.)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
