### PR TITLE
REV: Revert adding a default ufunc promoter

### DIFF
--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -592,17 +592,19 @@ legacy_promote_using_legacy_type_resolver(PyUFuncObject *ufunc,
         Py_INCREF(operation_DTypes[i]);
         Py_DECREF(out_descrs[i]);
     }
-    if (ufunc->type_resolver == &PyUFunc_SimpleBinaryComparisonTypeResolver) {
-        /*
-         * In this one case, the deprecation means that we actually override
-         * the signature.
-         */
-        for (int i = 0; i < nargs; i++) {
-            if (signature[i] != NULL && signature[i] != operation_DTypes[i]) {
-                Py_INCREF(operation_DTypes[i]);
-                Py_SETREF(signature[i], operation_DTypes[i]);
-                *out_cacheable = 0;
-            }
+    /*
+     * The PyUFunc_SimpleBinaryComparisonTypeResolver has a deprecation
+     * warning (ignoring `dtype=`) and cannot be cached.
+     * All datetime ones *should* have a warning, but currently don't,
+     * but ignore all signature passing also.  So they can also
+     * not be cached, and they mutate the signature which of course is wrong,
+     * but not doing it would confuse the code later.
+     */
+    for (int i = 0; i < nargs; i++) {
+        if (signature[i] != NULL && signature[i] != operation_DTypes[i]) {
+            Py_INCREF(operation_DTypes[i]);
+            Py_SETREF(signature[i], operation_DTypes[i]);
+            *out_cacheable = 0;
         }
     }
     return 0;

--- a/numpy/core/tests/test_datetime.py
+++ b/numpy/core/tests/test_datetime.py
@@ -2029,11 +2029,17 @@ class TestDateTime:
         assert_equal(np.maximum.reduce(a),
                      np.timedelta64(7, 's'))
 
+    def test_timedelta_correct_mean(self):
+        # test mainly because it worked only via a bug in that allowed:
+        # `timedelta.sum(dtype="f8")` to ignore the dtype request.
+        a = np.arange(1000, dtype="m8[s]")
+        assert_array_equal(a.mean(), a.sum() / len(a))
+
     def test_datetime_no_subtract_reducelike(self):
         # subtracting two datetime64 works, but we cannot reduce it, since
         # the result of that subtraction will have a different dtype.
         arr = np.array(["2021-12-02", "2019-05-12"], dtype="M8[ms]")
-        msg = r"ufunc 'subtract' did not contain a loop with signature "
+        msg = r"the resolved dtypes are not compatible"
 
         with pytest.raises(TypeError, match=msg):
             np.subtract.reduce(arr)


### PR DESCRIPTION
Adding a default promoter should not be necessary with the
reduction-hack (use output DType to guess loop DType if incompatible
with the loop).

However, using it had two effects:
1. SciPy has a ufunc that has a loop it does not want to exist.
   This loop is homogeneous (unlike the correct one) and gives
   a deprecation warning.  The default promoter would assume the
   homogeneous loop is OK (maybe not ideal) if it exists.
   Since it is a "bad" loop that gives a deprecation warning, it
   is not really true though.
2. Datetime promotion is currently utterly buggy, leading to:
       timedelta.sum(dtype="f8")
   ignoring the `f8` requests.  But we actually end up relying on
   that behaviour in our `np.mean` implementation...

---

I did not bother some of the other code, because I really want to use in the future, but can if necessary.

Hopefully this doe the trick now, since it should revert things largely to the old stuff (but well, its complicated by the fact that the old stuff was not consistent, with that timedelta problem showing part of that...)