### PR TITLE
BLD: Use the new hypotl on Cygwin, rather than defaulting to npy_hypot

### DIFF
--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -135,10 +135,6 @@
 /* np.power(..., dtype=np.complex256) doesn't report overflow */
 #undef HAVE_CPOWL
 #undef HAVE_CEXPL
-
-/* Builtin abs reports overflow */
-#undef HAVE_CABSL
-#undef HAVE_HYPOTL
 #endif
 
 /* Disable broken gnu trig functions */

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -135,6 +135,22 @@
 /* np.power(..., dtype=np.complex256) doesn't report overflow */
 #undef HAVE_CPOWL
 #undef HAVE_CEXPL
+
+#include <cygwin/version.h>
+#if CYGWIN_VERSION_DLL_MAJOR < 3003
+/* https://cygwin.com/pipermail/cygwin-announce/2021-October/010268.html */
+/* Builtin abs reports overflow */
+#undef HAVE_CABSL
+#undef HAVE_HYPOTL
+#endif
+
+#if CYGWIN_VERSION_DLL_MAJOR < 3002
+/* https://cygwin.com/pipermail/cygwin-announce/2021-March/009987.html */
+/* Segfault */
+#undef HAVE_MODFL
+/* sqrt(-inf) returns -inf instead of -nan */
+#undef HAVE_SQRTL
+#endif
 #endif
 
 /* Disable broken gnu trig functions */

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -683,7 +683,10 @@ class TestAbs:
     def test_builtin_abs(self, dtype):
         if (
                 sys.platform == "cygwin" and dtype == np.clongdouble and
-                _LooseVersion(platform.release().split("-")[0]) < _LooseVersion("3.3.0")
+                (
+                    _LooseVersion(platform.release().split("-")[0])
+                    < _LooseVersion("3.3.0")
+                )
         ):
             pytest.xfail(
                 reason="absl is computed in double precision on cygwin < 3.3"
@@ -694,7 +697,10 @@ class TestAbs:
     def test_numpy_abs(self, dtype):
         if (
                 sys.platform == "cygwin" and dtype == np.clongdouble and
-                _LooseVersion(platform.release().split("-")[0]) < _LooseVersion("3.3.0")
+                (
+                    _LooseVersion(platform.release().split("-")[0])
+                    < _LooseVersion("3.3.0")
+                )
         ):
             pytest.xfail(
                 reason="absl is computed in double precision on cygwin < 3.3"

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -680,18 +680,10 @@ class TestAbs:
 
     @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_builtin_abs(self, dtype):
-        if sys.platform == "cygwin" and dtype == np.clongdouble:
-            pytest.xfail(
-                reason="absl is computed in double precision on cygwin"
-            )
         self._test_abs_func(abs, dtype)
 
     @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_numpy_abs(self, dtype):
-        if sys.platform == "cygwin" and dtype == np.clongdouble:
-            pytest.xfail(
-                reason="absl is computed in double precision on cygwin"
-            )
         self._test_abs_func(np.abs, dtype)
 
 class TestBitShifts:

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -4,6 +4,7 @@ import warnings
 import itertools
 import operator
 import platform
+from distutils.version import LooseVersion as _LooseVersion
 import pytest
 from hypothesis import given, settings, Verbosity
 from hypothesis.strategies import sampled_from
@@ -680,10 +681,24 @@ class TestAbs:
 
     @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_builtin_abs(self, dtype):
+        if (
+                sys.platform == "cygwin" and dtype == np.clongdouble and
+                _LooseVersion(platform.release().split("-")[0]) < _LooseVersion("3.3.0")
+        ):
+            pytest.xfail(
+                reason="absl is computed in double precision on cygwin < 3.3"
+            )
         self._test_abs_func(abs, dtype)
 
     @pytest.mark.parametrize("dtype", floating_types + complex_floating_types)
     def test_numpy_abs(self, dtype):
+        if (
+                sys.platform == "cygwin" and dtype == np.clongdouble and
+                _LooseVersion(platform.release().split("-")[0]) < _LooseVersion("3.3.0")
+        ):
+            pytest.xfail(
+                reason="absl is computed in double precision on cygwin < 3.3"
+            )
         self._test_abs_func(np.abs, dtype)
 
 class TestBitShifts:


### PR DESCRIPTION
Cygwin has a new `hypotl` that avoids overflow for large numbers.  The new function was released in 3.2 or 3.3 a few weeks ago.  NumPy currently uses its fallback/reference implementation, which is based on `npy_hypot`.

I don't know if there should be a delay for a bit so most people can update their installation.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
