### PR TITLE
MAINT: make sure CI stays on VS2019 unless changed explicitly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,7 +230,7 @@ stages:
 
   - job: Windows
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
     strategy:
       maxParallel: 6
       matrix:


### PR DESCRIPTION
Backport of #20524.

To avoid the deprecation warnings on azure for the old windows images, #20234 moved to windows-latest. This is currently equivalent to windows-2019 (bringing visual studio 2019, and corresponding toolset), but will presumably change to windows-2022 at some point in the future.

Such a change of compiler version should be made consciously for the numpy CI (rather than imposed by what azure does), because the compiler version used for windows effectively defines the lower bound of support on windows (as otherwise, changes that break on older compilers will not be caught in CI).
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
