### PR TITLE
BUG, DIST: fix normalize IBMZ features flags

### DIFF
--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -899,7 +899,11 @@ class _CCompiler:
     cc_on_x64 : bool
         True when the target architecture is 64-bit x86
     cc_on_ppc64 : bool
-        True when the target architecture is 64-bit big-endian PowerPC
+        True when the target architecture is 64-bit big-endian powerpc
+    cc_on_ppc64le : bool
+        True when the target architecture is 64-bit litle-endian powerpc
+    cc_on_s390x : bool
+        True when the target architecture is IBM/ZARCH on linux
     cc_on_armhf : bool
         True when the target architecture is 32-bit ARMv7+
     cc_on_aarch64 : bool
@@ -1009,7 +1013,7 @@ class _CCompiler:
             self.cc_is_gcc = True
 
         self.cc_march = "unknown"
-        for arch in ("x86", "x64", "ppc64", "ppc64le", 
+        for arch in ("x86", "x64", "ppc64", "ppc64le",
                      "armhf", "aarch64", "s390x"):
             if getattr(self, "cc_on_" + arch):
                 self.cc_march = arch
@@ -1090,7 +1094,9 @@ class _CCompiler:
     _cc_normalize_unix_frgx = re.compile(
         # 2- to remove any flags starts with
         # -march, -mcpu, -x(INTEL) and '-m' without '='
-        r"^(?!(-mcpu=|-march=|-x[A-Z0-9\-]))(?!-m[a-z0-9\-\.]*.$)"
+        r"^(?!(-mcpu=|-march=|-x[A-Z0-9\-]|-m[a-z0-9\-\.]*.$))|"
+        # exclude:
+        r"(?:-mzvector)"
     )
     _cc_normalize_unix_krgx = re.compile(
         # 3- keep only the highest of

--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -443,7 +443,7 @@ class _Test_CCompilerOpt:
             ppc64_clang="-maltivec -mvsx -mpower8-vector",
             armhf_gcc="-mfpu=neon-fp16 -mfp16-format=ieee",
             aarch64="",
-            s390="-mzvector -march=arch12"
+            s390x="-mzvector -march=arch12"
         )
         # testing normalize -march
         self.expect_flags(
@@ -466,6 +466,10 @@ class _Test_CCompilerOpt:
         self.expect_flags(
             "asimddp asimdhp asimdfhm",
             aarch64_gcc=r"-march=armv8.2-a\+dotprod\+fp16\+fp16fml"
+        )
+        self.expect_flags(
+            "vx vxe vxe2",
+            s390x=r"-mzvector -march=arch13"
         )
 
     def test_targets_exceptions(self):


### PR DESCRIPTION
The normal behavior is to erase any flag that starts with
`-m[a-z0-9\-\.]` when flag `-march` or `-mcpu` specified. for example:
```Python
cc_normalize_flags([
   '-msse', '-msse2', '-msse3', '-mssse3', '-march=core-avx2'
])
```
should be normalized to:
```Python
['-march=core-avx2']
```
but in the case of `s390x`, on GCC flag `-march=arch[0-9]` doesn't  implies flag
`-mzvector` which is required to enable zvector api. for example:
   
```Python
cc_normalize_flags([
   '-mzvector', '-march=arch11', '-march=arch12', '-march=arch13']
)
```
should be normalized to:
```Python
['-mzvector', '-march=arch13']
```
instead of:
```Python
['-march=arch13']
```
The test unit didn't detect this bug because of a single-letter typo(my bad).

---

Build error:
```Bash
WARN: CCompilerOpt.dist_test[615] : CCompilerOpt._dist_test_spawn[749] : Command (gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Werror=vla -Werror=nonnull -Werror=pointer-arith -Werror=implicit-function-declaration -Wlogical-op -Wno-sign-compare -Werror=undef -fPIC -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/travis/build/numpy/numpy/builds/venv/include -I/opt/python/3.8.12/include/python3.8 -Ibuild/src.linux-s390x-3.8/numpy/core/src/common -Ibuild/src.linux-s390x-3.8/numpy/core/src/npymath -c /home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.c -o /tmp/tmpa6x2ndqc/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.o -MMD -MF /tmp/tmpa6x2ndqc/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.o.d -march=arch12 -Werror) failed with exit status 1 output -> 
/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.c:1:6: error: "__VEC__" is not defined, evaluates to 0 [-Werror=undef]
    1 | #if (__VEC__ < 10302) || (__ARCH__ < 12)
      |      ^~~~~~~
/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.c:2:6: error: #error VXE not supported
    2 |     #error VXE not supported
      |      ^~~~~
/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.c: In function â€˜mainâ€™:
/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vxe.c:8:5: error: â€˜__vectorâ€™ undeclared (first use in this function); did you mean â€˜vec_orâ€™?
    8 |     __vector float x = vec_nabs(vec_xl(argc, (float*)argv));
      |     ^~~~~~~~
      |     vec_or
```

relates #20552