### PR TITLE
BUG: Fix leaks found using pytest-leaks

### DIFF
--- a/numpy/core/src/_simd/_simd_convert.inc
+++ b/numpy/core/src/_simd/_simd_convert.inc
@@ -94,6 +94,7 @@ simd_sequence_from_iterable(PyObject *obj, simd_data_type dtype, Py_ssize_t min_
             "minimum acceptable size of the required sequence is %d, given(%d)",
             min_size, seq_size
         );
+        Py_DECREF(seq_obj);
         return NULL;
     }
     npyv_lanetype_u8 *dst = simd_sequence_new(seq_size, dtype);

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -401,6 +401,7 @@ array_data_set(PyArrayObject *self, PyObject *op, void *NPY_UNUSED(ignored))
             return -1;
         }
         PyDataMem_UserFREE(PyArray_DATA(self), nbytes, handler);
+        Py_CLEAR(((PyArrayObject_fields *)self)->mem_handler);
     }
     if (PyArray_BASE(self)) {
         if ((PyArray_FLAGS(self) & NPY_ARRAY_WRITEBACKIFCOPY) ||

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -2585,6 +2585,7 @@ gentype_arrtype_getbuffer(PyObject *self, Py_buffer *view, int flags)
                 "user-defined scalar %R registered for built-in dtype %S? "
                 "This should be impossible.",
                 self, descr);
+        Py_DECREF(descr);
         return -1;
     }
     view->ndim = 0;

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -583,6 +583,10 @@ legacy_promote_using_legacy_type_resolver(PyUFuncObject *ufunc,
             NPY_UNSAFE_CASTING, (PyArrayObject **)ops, type_tuple,
             out_descrs) < 0) {
         Py_XDECREF(type_tuple);
+        /* Not all legacy resolvers clean up on failures: */
+        for (int i = 0; i < nargs; i++) {
+            Py_CLEAR(out_descrs[i]);
+        }
         return -1;
     }
     Py_XDECREF(type_tuple);


### PR DESCRIPTION
This fixes a few more issues.  I believe all remaining ones are
just false positives (pytest fixtures are not accounted for correctly),
in f2py (many probably fine, as it compiles new modules), or due to
pickling empty arrays (i.e. the problem in `setstate`).

---

Sorry, followup for the other PR.  But can look into the unpickling/setstate problem here.  (Either way works for me, all changes are completely unrelated to that anyway.)