### PR TITLE
removed two redundant '\\' typos

### DIFF
--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -258,8 +258,8 @@ compiler's ``long double`` available as ``np.longdouble`` (and
 numpy provides with ``np.finfo(np.longdouble)``.
 
 NumPy does not provide a dtype with more precision than C's
-``long double``\\; in particular, the 128-bit IEEE quad precision
-data type (FORTRAN's ``REAL*16``\\) is not available.
+``long double``; in particular, the 128-bit IEEE quad precision
+data type (FORTRAN's ``REAL*16``) is not available.
 
 For efficient memory alignment, ``np.longdouble`` is usually stored
 padded with zero bits, either to 96 or 128 bits. Which is more efficient


### PR DESCRIPTION
Based on issue DOC: typo in basics.types.rst #20581

I fixed the the documentation in one file by removing extra "\\" in two places
