### PR TITLE
MAINT: Check for buffer interface support rather than try/except

### DIFF
--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -1301,9 +1301,10 @@ _array_from_array_like(PyObject *op,
      * We skip bytes and unicode since they are considered scalars. Unicode
      * would fail but bytes would be incorrectly converted to a uint8 array.
      */
-    if (!PyBytes_Check(op) && !PyUnicode_Check(op)) {
+    if (PyObject_CheckBuffer(op) && !PyBytes_Check(op) && !PyUnicode_Check(op)) {
         PyObject *memoryview = PyMemoryView_FromObject(op);
         if (memoryview == NULL) {
+            /* TODO: Should probably not blanket ignore errors. */
             PyErr_Clear();
         }
         else {


### PR DESCRIPTION
This checks for buffer interface support using `PyObject_CheckBuffer`
up-front.  That seems to shave off about 100ns e.g. when importing
pandas DataFrames (which do not support the buffer interface, but
do support `__array__`.
The reason is that building a TypeError and then clearing it takes
time.

It felt like a clear, easy win, since the check should be so fast
that checking twice (in the case that it is indeed a buffer) does
not really matter.

But, if nobody likes to think about it just close :).
