### PR TITLE
BUG: Fix PyInit__umath_linalg type

### DIFF
--- a/numpy/linalg/umath_linalg.c.src
+++ b/numpy/linalg/umath_linalg.c.src
@@ -4396,7 +4396,7 @@ static struct PyModuleDef moduledef = {
         NULL
 };
 
-PyObject *PyInit__umath_linalg(void)
+PyMODINIT_FUNC PyInit__umath_linalg(void)
 {
     PyObject *m;
     PyObject *d;


### PR DESCRIPTION
### Description
Use `PyMODINIT_FUNC` instead of `PyObject *` for `PyInit__umath_linalg` to fix missing export function.

### Problem

`import numpy` fails with the following error on Windows binary built with Clang toolchain.

      File "numpy\linalg\linalg.py", lin
    e 33, in <module>
        from numpy.linalg import lapack_lite, _umath_linalg
    ImportError: dynamic module does not define module export function (PyInit__umath_linalg)

### Appendix

`PyInit__umath_linalg` is the only function which is not `PyMODINIT_FUNC` type in the numpy codebase.

    $ find * -type f|xargs grep PyInit__ | grep PyMODINIT_FUNC

    core/src/_simd/_simd.c:PyMODINIT_FUNC PyInit__simd(void)
    core/src/dummymodule.c:PyMODINIT_FUNC PyInit__dummy(void) {
    core/src/multiarray/_multiarray_tests.c.src:PyMODINIT_FUNC PyInit__multiarray_tests(void)
    core/src/multiarray/multiarraymodule.c:PyMODINIT_FUNC PyInit__multiarray_umath(void) {
    core/src/umath/_operand_flag_tests.c:PyMODINIT_FUNC PyInit__operand_flag_tests(void)
    core/src/umath/_rational_tests.c.src:PyMODINIT_FUNC PyInit__rational_tests(void) {
    core/src/umath/_struct_ufunc_tests.c.src:PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
    core/src/umath/_umath_tests.c.src:PyMODINIT_FUNC PyInit__umath_tests(void) {
    fft/_pocketfft.c:PyMODINIT_FUNC PyInit__pocketfft_internal(void)

    $ find * -type f|xargs grep PyInit__ | grep -v PyMODINIT_FUNC

    linalg/umath_linalg.c.src:PyObject *PyInit__umath_linalg(void)
