### PR TITLE
DEV: add a warningfilter to fix pytest workflow.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,5 @@ filterwarnings =
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
 # TODO: remove below when array_api user warning is removed
     ignore:The numpy.array_api submodule is still experimental. See NEP 47.
+# Ignore DeprecationWarnings from distutils
+    ignore::DeprecationWarning:.*distutils


### PR DESCRIPTION
Python 3.10 adds an explicit `DeprecationWarning` for the `distutils` module. In the pytest configuration (see pytest.ini) warnings are treated as errors by default, which means the distutils DeprecationWarning breaks test collection by pytest. This PR adds a new warnings filter to the `pytest.ini` so that the `pytest` workflow will work w/ Python 3.10+.