### PR TITLE
TST: Bump mypy: 0.910 -> 0.920

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.910
+  - mypy=0.920
   # For building docs
   - sphinx=4.1.1
   - numpydoc=1.1.0

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -180,17 +180,17 @@ reveal_type(np.atleast_2d(A))  # E: ndarray[Any, dtype[{float64}]]
 
 reveal_type(np.atleast_3d(A))  # E: ndarray[Any, dtype[{float64}]]
 
-reveal_type(np.vstack([A, A]))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.vstack([A, A]))  # E: ndarray[Any, Any]
 reveal_type(np.vstack([A, C]))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.vstack([C, C]))  # E: ndarray[Any, dtype[Any]]
 
-reveal_type(np.hstack([A, A]))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.hstack([A, A]))  # E: ndarray[Any, Any]
 
-reveal_type(np.stack([A, A]))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.stack([A, A]))  # E: Any
 reveal_type(np.stack([A, C]))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.stack([C, C]))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.stack([A, A], axis=0))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.stack([A, A], axis=0))  # E: Any
 reveal_type(np.stack([A, A], out=B))  # E: SubClass[{float64}]
 
-reveal_type(np.block([[A, A], [A, A]]))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.block([[A, A], [A, A]]))  # E: ndarray[Any, Any]
 reveal_type(np.block(C))  # E: ndarray[Any, dtype[Any]]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-cov==3.0.0
 cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
-mypy==0.910; platform_python_implementation != "PyPy"
+mypy==0.920; platform_python_implementation != "PyPy"


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/20597

Unfortunately there seems to have been a minor regression this patch, as mypy is now failing to handle `list[_ArrayLike[~T]]`-style patterns (most notably in the `np.<X>stack` functions).