### PR TITLE
MAINT: Help boost::python libraries at least not crash

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1478,6 +1478,24 @@ PyArray_EquivTypes(PyArray_Descr *type1, PyArray_Descr *type2)
     if (type1 == type2) {
         return 1;
     }
+
+    if (Py_TYPE(Py_TYPE(type1)) == &PyType_Type) {
+        /*
+         * 2021-12-17: This case is nonsense and should be removed eventually!
+         *
+         * boost::python has/had a bug effectively using EquivTypes with
+         * `type(arbitrary_obj)`.  That is clearly wrong as that cannot be a
+         * `PyArray_Descr *`.  We assume that `type(type(type(arbitrary_obj))`
+         * is always in practice `type` (this is the type of the metaclass),
+         * but for our descriptors, `type(type(descr))` is DTypeMeta.
+         *
+         * In that case, we just return False.  There is a possibility that
+         * this actually _worked_ effectively (returning 1 sometimes).
+         * We ignore that possibility for simplicity; it really is not our bug.
+         */
+        return 0;
+    }
+
     /*
      * Do not use PyArray_CanCastTypeTo because it supports legacy flexible
      * dtypes as input.


### PR DESCRIPTION
This adds an almost random "sanity check" to `PyArray_EquivTypes`
for the sole purpose of allowing boost::python compiled libs to
_not crash_.
boost::python is buggy, it needs to be fixed.  This may break them
(I am unsure), because some conversions which used to work may fail
here (if they worked, they only worked because random type data may
have matched up correctly for our scalar types).

We could error, or warn or... but I hope boost::python will just fix
this soon enough and future us can just delete the whole branch.

Replaces gh-20507 