### PR TITLE
BUILD: pin to cython 0.29.24 to hide PyPy3.8 bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools==59.2.0",
     "wheel==0.37.0",
-    "Cython>=0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
+    "Cython==0.29.24"  # pin until PyPy releases v7.3.8
+    # "Cython==0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 
 


### PR DESCRIPTION
PyPy has a bug in the `PyTypeObject` structure with PyPy3.8: it is missing the `tp_vectorcall` slot. Cython<0.29.26 also has a PyPy-related problem: the PyTypeObject structures it emits do not include the PyPy-specific `tp_pypy_flags` slot used to speed up subclass detection on PyPy.  So the Cython `PyTypeObject` definitions were one slot short on PyPy<3.8, and the correct length on PyPy3.8. Cython 0.29.26 (released a few days ago) began emitting the slot for `tp_pypy_flags`, so now it is one slot too long. This is why the cibuildwheel CI run is failing: while gcc doesn't seem to mind the mismatch, MSVC does and errors out with `error C2078: too many initializers`.

So for now pin Cython in the `pyproject.toml` to 0.29.24, which is consistent with the pip `requrements.txt` files.