### PR TITLE
DEV: Add `TYP`, a standard acronym for static typing

### DIFF
--- a/.github/pr-prefix-labeler.yml
+++ b/.github/pr-prefix-labeler.yml
@@ -12,3 +12,4 @@
 "TST": "05 - Testing"
 "REL": "14 - Release"
 "WIP": "25 - WIP"
+"TYP": "static typing"

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -185,6 +185,7 @@ Standard acronyms to start the commit message with are::
    REV: revert an earlier commit
    STY: style fix (whitespace, PEP8)
    TST: addition or modification of tests
+   TYP: static typing
    REL: related to releasing numpy
 
 Commands to skip continuous integration


### PR DESCRIPTION
Inspired by the pandas folks, this PR adds a `TYP` acronym that can be used for PRs/issues related to static typing.

Considering there have been a fair number of typing-related PRs, I feel that there is some value here in adding the acronym.