### PR TITLE
BUG: cross product. Added dtype conversions of inputs. See. #19138

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1622,6 +1622,10 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     dtype = promote_types(a.dtype, b.dtype)
     cp = empty(shape, dtype)
 
+    # recast arrays as dtype
+    a=a.astype(dtype)
+    b=b.astype(dtype)
+
     # create local aliases for readability
     a0 = a[..., 0]
     a1 = a[..., 1]

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -1623,8 +1623,8 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     cp = empty(shape, dtype)
 
     # recast arrays as dtype
-    a=a.astype(dtype)
-    b=b.astype(dtype)
+    a = a.astype(dtype)
+    b = b.astype(dtype)
 
     # create local aliases for readability
     a0 = a[..., 0]

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3386,7 +3386,7 @@ class TestCross:
     def test_nested_diff_types(self):        
         #gh-19138
         u=np.array([[195,8,9]],np.uint8)
-        v=np.array([250,166,68],np.int)
+        v=np.array([250,166,68],np.int32)
         z=np.array([[950, 11010, -30370]], dtype=np.int32)
         assert_equal(np.cross(v,u), z)
         assert_equal(np.cross(u,v), -z)

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3385,11 +3385,11 @@ class TestCross:
 
     def test_nested_diff_types(self):        
         #gh-19138
-        u=np.array([[195,8,9]],np.uint8)
-        v=np.array([250,166,68],np.int32)
-        z=np.array([[950, 11010, -30370]], dtype=np.int32)
-        assert_equal(np.cross(v,u), z)
-        assert_equal(np.cross(u,v), -z)
+        u = np.array([[195, 8, 9]], np.uint8)
+        v = np.array([250, 166, 68], np.int32)
+        z = np.array([[950, 11010, -30370]], dtype=np.int32)
+        assert_equal(np.cross(v, u), z)
+        assert_equal(np.cross(u, v), -z)
 
 
 def test_outer_out_param():

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3383,6 +3383,14 @@ class TestCross:
         for axisc in range(-2, 2):
             assert_equal(np.cross(u, u, axisc=axisc).shape, (3, 4))
 
+    def test_nested_diff_types(self):        
+        #gh-19138
+        u=np.array([[195,8,9]],np.uint8)
+        v=np.array([250,166,68],np.int)
+        z=np.array([[950, 11010, -30370]], dtype=np.int32)
+        assert_equal(np.cross(v,u), z)
+        assert_equal(np.cross(u,v), -z)
+
 
 def test_outer_out_param():
     arr1 = np.ones((5,))

--- a/numpy/core/tests/test_numeric.py
+++ b/numpy/core/tests/test_numeric.py
@@ -3383,8 +3383,8 @@ class TestCross:
         for axisc in range(-2, 2):
             assert_equal(np.cross(u, u, axisc=axisc).shape, (3, 4))
 
-    def test_nested_diff_types(self):        
-        #gh-19138
+    def test_uint8_int32_mixed_dtypes(self):
+        # regression test for gh-19138
         u = np.array([[195, 8, 9]], np.uint8)
         v = np.array([250, 166, 68], np.int32)
         z = np.array([[950, 11010, -30370]], dtype=np.int32)


### PR DESCRIPTION
Hello np folks!

I'm new to doing open source contributions, but found a fix to the dtype bug pointed out in  #gh-19138 and [this](https://stackoverflow.com/questions/67759990/why-cant-numpy-cross-produce-correct-answer-for-multi-dimensional-array) stack overflow post. It's a simple two-line fix. Neither input was converted to the datatype given by promote_types, which seems like an oversight.

**Notes:**
- I opted not to include a TypeError exception as promote_types should take care of it (and raising an error downstream would change the behavior)
- I added in np.int -> np.int32 to silence the test warnings. Still fails without the astype(dtype) casting.
- The tests I used were just wrong-output matrix given in the initial bug example.

Since this is my first contribution to np, let me know if I'm missing something here, or need to modify my code!