### PR TITLE
CI, TST: Run Cygwin CI with Netlib reference BLAS and re-enable linalg tests

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -23,12 +23,15 @@ jobs:
             python38-devel python38-zipp python38-importlib-metadata
             python38-cython python38-pip python38-wheel python38-cffi
             python38-pytz python38-setuptools python38-pytest
-            python38-hypothesis liblapack-devel libopenblas
+            python38-hypothesis liblapack-devel
             gcc-fortran gcc-g++ git dash
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@v1
         with:
-          dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
+          dirs: 'C:\tools\cygwin\lib\lapack;C:\tools\cygwin\bin'
+      - name: Remove OpenBLAS
+        run: |
+          dash -c "/bin/rm -f /usr/bin/cygblas-0.dll"
       - name: Verify that bash is Cygwin bash
         run: |
           command bash

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           dirs: 'C:\tools\cygwin\lib\lapack;C:\tools\cygwin\bin'
       - name: Remove OpenBLAS
+        # Added to work around OpenBLAS bugs on AVX-512
+        # Add libopenblas to the Cygwin install step when removing this step
+        # Should be possible after next Cygwin OpenBLAS update.
         run: |
           dash -c "/bin/rm -f /usr/bin/cygblas-0.dll"
       - name: Verify that bash is Cygwin bash

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -467,11 +467,6 @@ class TestSolve(SolveCases):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
         assert_equal(linalg.solve(x, x).dtype, dtype)
 
-    @pytest.mark.xfail(sys.platform == 'cygwin',
-                       reason="Consistently fails on CI.")
-    def test_sq_cases(self):
-        super().test_sq_cases()
-
     def test_0_size(self):
         class ArraySubclass(np.ndarray):
             pass
@@ -538,11 +533,6 @@ class TestInv(InvCases):
     def test_types(self, dtype):
         x = np.array([[1, 0.5], [0.5, 1]], dtype=dtype)
         assert_equal(linalg.inv(x).dtype, dtype)
-
-    @pytest.mark.xfail(sys.platform == 'cygwin',
-                       reason="Consistently fails on CI.")
-    def test_sq_cases(self):
-        super().test_sq_cases()
 
     def test_0_size(self):
         # Check that all kinds of 0-sized arrays work
@@ -1783,9 +1773,6 @@ class TestQR:
 class TestCholesky:
     # TODO: are there no other tests for cholesky?
 
-    @pytest.mark.xfail(
-        sys.platform == 'cygwin', reason="Consistently fails in CI"
-    )
     @pytest.mark.parametrize(
         'shape', [(1, 1), (2, 2), (3, 3), (50, 50), (3, 10, 10)]
     )
@@ -2129,8 +2116,6 @@ class TestTensorsolve:
             b = np.ones(a.shape[:2])
             linalg.tensorsolve(a, b, axes=axes)
 
-    @pytest.mark.xfail(sys.platform == 'cygwin',
-                       reason="Consistently fails on CI")
     @pytest.mark.parametrize("shape",
         [(2, 3, 6), (3, 4, 4, 3), (0, 3, 3, 0)],
     )


### PR DESCRIPTION
The new OpenBLAS version seems to be causing problems with the linalg tests.  This checks that hypothesis by removing the OpenBLAS optimized BLAS, leaving only the Netlib reference BLAS.

This also removes the `xfail` marks on the failing tests.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
