### PR TITLE
DOC: add hypothesis test dependency in README and PyPI long-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It provides:
 
 Testing:
 
-NumPy requires `pytest`.  Tests can then be run after installation with:
+NumPy requires `pytest` and `hypothesis`.  Tests can then be run after installation with:
 
     python -c 'import numpy; numpy.test()'
 
@@ -57,7 +57,7 @@ may be a good starting point. If you are considering larger contributions
 to the source code, please contact us through the [mailing
 list](https://mail.python.org/mailman/listinfo/numpy-discussion) first.
 
-Writing code isn’t the only way to contribute to NumPy. You can also: 
+Writing code isn’t the only way to contribute to NumPy. You can also:
 - review pull requests
 - triage issues
 - develop tutorials, presentations, and other educational materials
@@ -77,7 +77,7 @@ numpy-team@googlegroups.com or on Slack (write numpy-team@googlegroups.com for
 an invitation).
 
 We also have a biweekly community call, details of which are announced on the
-mailing list. You are very welcome to join. 
+mailing list. You are very welcome to join.
 
 If you are new to contributing to open source, [this
 guide](https://opensource.guide/how-to-contribute/) helps explain why, what,

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ variety of databases.
 
 All NumPy wheels distributed on PyPI are BSD licensed.
 
+NumPy requires ``pytest`` and ``hypothesis``.  Tests can then be run after
+installation with::
+
+    python -c 'import numpy; numpy.test()'
+
 """
 DOCLINES = (__doc__ or '').split("\n")
 


### PR DESCRIPTION
This update was requested on the mailing list a few months ago: https://mail.python.org/archives/list/numpy-discussion@python.org/message/JCRWCUAORV7KO6RVI7YLOOPZEZF2PZ4J/

[ci skip]
