### PR TITLE
TYP,TST: Bump mypy to 0.930

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.920
+  - mypy=0.930
   # For building docs
   - sphinx=4.1.1
   - numpydoc=1.1.0

--- a/numpy/typing/tests/data/fail/scalars.pyi
+++ b/numpy/typing/tests/data/fail/scalars.pyi
@@ -31,7 +31,7 @@ np.complex64([])  # E: incompatible type
 np.complex64(1, 2)  # E: Too many arguments
 # TODO: protocols (can't check for non-existent protocols w/ __getattr__)
 
-np.datetime64(0)  # E: non-matching overload
+np.datetime64(0)  # E: No overload variant
 
 class A:
     def __float__(self):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-cov==3.0.0
 cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
-mypy==0.920; platform_python_implementation != "PyPy"
+mypy==0.930; platform_python_implementation != "PyPy"


### PR DESCRIPTION
Backport of #20663.

Despite the recent release of 0.920, the 0.930 release is now here as well.

Based on the [release notes](https://mypy-lang.blogspot.com/2021/12/mypy-0930-released.html) the most interesting feature appears to be support for [`typing.ParamSpec`](https://www.python.org/dev/peps/pep-0612/), which greatly expands on how type checkers can manipulate callable signatures.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
