### PR TITLE
DOC: Updated C ufunc API doc

### DIFF
--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -154,13 +154,13 @@ Functions
        ufunc object is alive.
 
     :param func:
-        Must to an array of length *ntypes* containing
+        Must point to an array of length *ntypes* containing
         :c:type:`PyUFuncGenericFunction` items.
 
     :param data:
-        Should be ``NULL`` or a pointer to an array of size *ntypes*
-        . This array may contain arbitrary extra-data to be passed to
-        the corresponding loop function in the func array.
+        A pointer to an array of size *ntypes* containing arbitrary
+        additional data to be passed to the corresponding loop function
+        in the `func` array. Must not be NULL, but may contain NULLs.
 
     :param types:
        Length ``(nin + nout) * ntypes`` array of ``char`` encoding the


### PR DESCRIPTION
Potentially closes #14613. The function `PyUFunc_FromFuncAndData` should be fixed, but since it's going to be deprecated anyway, the docs have been updated to match reality. The pragmatic solution is not necessarily best, but it works.

See #20689 for an alternative solution that may supersede this.