### PR TITLE
BUG: Added check for NULL data in ufuncs

### DIFF
--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -109,6 +109,9 @@ Types
             that can be stored with the ufunc and will be passed in
             when it is called. May be ``NULL``.
 
+            .. versionchanged:: 1.23.0
+               Accepts ``NULL`` `data` in addition to array of ``NULL`` values.
+
         This is an example of a func specialized for addition of doubles
         returning doubles.
 

--- a/doc/source/reference/c-api/ufunc.rst
+++ b/doc/source/reference/c-api/ufunc.rst
@@ -107,7 +107,7 @@ Types
 
             Arbitrary data (extra arguments, function names, *etc.* )
             that can be stored with the ufunc and will be passed in
-            when it is called.
+            when it is called. May be ``NULL``.
 
         This is an example of a func specialized for addition of doubles
         returning doubles.
@@ -158,9 +158,10 @@ Functions
         :c:type:`PyUFuncGenericFunction` items.
 
     :param data:
-        Should be ``NULL`` or a pointer to an array of size *ntypes*
-        . This array may contain arbitrary extra-data to be passed to
-        the corresponding loop function in the func array.
+        Should be ``NULL`` or a pointer to an array of size *ntypes*.
+        This array may contain arbitrary extra-data to be passed to
+        the corresponding loop function in the func array, including
+        ``NULL``.
 
     :param types:
        Length ``(nin + nout) * ntypes`` array of ``char`` encoding the

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -1528,7 +1528,7 @@ PyUFunc_DefaultLegacyInnerLoopSelector(PyUFuncObject *ufunc,
         }
         if (j == nargs) {
             *out_innerloop = ufunc->functions[i];
-            *out_innerloopdata = ufunc->data[i];
+            *out_innerloopdata = (ufunc->data == NULL) ? NULL : ufunc->data[i];
             return 0;
         }
 

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -56,7 +56,7 @@ object_ufunc_loop_selector(PyUFuncObject *ufunc,
                             int *out_needs_api)
 {
     *out_innerloop = ufunc->functions[0];
-    *out_innerloopdata = ufunc->data[0];
+    *out_innerloopdata = (ufunc->data == NULL) ? NULL : ufunc->data[0];
     *out_needs_api = 1;
 
     return 0;


### PR DESCRIPTION
Closes #14613. Supersedes and invalidates #20686.

Out of the two solutions (this and #20686), this one is clearly preferable. While this part of the C API is "soon" to be deprecated, it appears prominently in the tutorial, so may as well be correct.

I am not very familiar with the C-API, so the changes you see may be incomplete. My methodology was to run `grep -rnH -- '->data\>'` on the main repository, and update anything that looked like a reference to a ufunc's `data` field. I also ran `grep -rnH -- '.data\>'` and `grep -rnHF loopdata` for good measure, but that yielded no meaningful results, as expected.

This PR is not marked as WIP, but someone that actually knows what they are doing should probably look at it.