### PR TITLE
ENH: Added np.char.slice_

### DIFF
--- a/doc/release/upcoming_changes/20694.new_function.rst
+++ b/doc/release/upcoming_changes/20694.new_function.rst
@@ -1,0 +1,9 @@
+Added `numpy.char.slice_`
+-------------------------
+Allows slicing of strings within character arrays of type `np.str_` and
+`np.unicode_`. In addition to the normal slice parameters of `start`,
+`stop` and `step`, this function supports a `chunksize` parameter. Slices
+with `step == chunksize == 1` are treated slightly differently than other
+slices, in that they do not add an extra dimension to the array. This
+oft-requested feature is conceptually simple, but ran afoul of the dtype
+conversion checks in view creation until now.

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1551,7 +1551,8 @@ def slice_(a, start, stop=None, step=None, chunksize=None):
         if str(e) == 'ndarray is not contiguous':
             warnings.warn('A contiguous base array could not be found. '
                           'A slice of a copy will be returned. '
-                          'Writeback to the original array will not work.')
+                          'Writeback to the original array will not work.',
+                          stacklevel=2)
             a = a.copy()
             newarray = ndarray(buffer=a, offset=newoffset,
                                shape=newshape, strides=newstrides,

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1400,12 +1400,12 @@ def rstrip(a, chars=None):
     return _vec_string(a_arr, a_arr.dtype, 'rstrip', (chars,))
 
 
-def _slice__dispatcher(a, start, stop=None, step=None, chunksize=None):
+def _slice__dispatcher(a, start=None, stop=None, step=None, chunksize=None):
     return (a,)
 
 
 @array_function_dispatch(_slice__dispatcher)
-def slice_(a, start, stop=None, step=None, chunksize=None):
+def slice_(a, start=None, stop=None, step=None, chunksize=None):
     """
     Extract a slice from each element of string array `a`.
 
@@ -1416,8 +1416,6 @@ def slice_(a, start, stop=None, step=None, chunksize=None):
       (not necessarily the length of the individual elements).
     - Out-of-bounds limits are silently adjusted to the bounds they
       exceed.
-    - If `start` is specified but `stop` is None, they are interpreted
-      as `start, stop = 0, start`, but only if `step` is not given.
     - Inclusivity of the bounds depends on which way `step` is going,
       with the beginning being inclusive and the end always being
       exclusive.
@@ -1439,11 +1437,7 @@ def slice_(a, start, stop=None, step=None, chunksize=None):
 
     Every effort is made not to copy the data. Data is copied
     when an unsuitable array-like class is used (e.g. `list`, or
-    anything else `numpy.asanyarray` would copy data for). The only
-    other circumstance under which the underlying data is copied is
-    if a contiguous base array can not be found for the data. A
-    warning is issued in the latter case because it is much harder
-    to catch under normal circumstances.
+    anything else `numpy.asanyarray` would copy data for).
 
     Parameters
     ----------
@@ -1489,8 +1483,6 @@ def slice_(a, start, stop=None, step=None, chunksize=None):
     length = int(dtype.str[2:])
 
     # Adjust the bounds using a slice object
-    if stop is None and step is None:
-        start, stop = 0, start
     start, stop, step = slice(
                 start, stop, step
             ).indices(max(0, length - chunksize + 1))

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -1515,7 +1515,8 @@ def slice_(a, start, stop=None, step=None, chunksize=None):
         newshape = a.shape
         newstrides = a.strides
     else:
-        newshape = (*a.shape, max(0, (stop - start + (step - numpy.sign(step))) // step))
+        newshape = (*a.shape,
+                max(0, (stop - start + (step - numpy.sign(step))) // step))
         newstrides = (*a.strides, step * charsize)
     newdtype = numpy.dtype(f'{dtype.str[:2]}{chunksize}')
     newoffset = start * charsize

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -735,11 +735,11 @@ class TestSlice_:
         assert_array_equal(np.char.slice_(self.arr, 0, -399), ['', '', ''])
         assert_array_equal(np.char.slice_(self.arr, 10000, -399), ['', '', ''])
         # 8.
-        assert_array_equal(
-                np.char.slice_(self.arr, 0, 15, step=5, chunksize=5),
-                               [['This ', 'is a ', 'long '],
-                                ['Strin', 'g pro', 'lifer'],
-                                ['Quick', ' brow', 'n fox']])
+        assert_array_equal(np.char.slice_(self.arr, 0, 15,
+                                          step=5, chunksize=5),
+                           [['This ', 'is a ', 'long '],
+                            ['Strin', 'g pro', 'lifer'],
+                            ['Quick', ' brow', 'n fox']])
         # 9.
         assert_array_equal(np.char.slice_(self.arr, 16, step=-4, chunksize=4),
                            [['trin', 'ng s', 'a lo', ' is ', 'This'],

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -735,7 +735,8 @@ class TestSlice_:
         assert_array_equal(np.char.slice_(self.arr, 0, -399), ['', '', ''])
         assert_array_equal(np.char.slice_(self.arr, 10000, -399), ['', '', ''])
         # 8.
-        assert_array_equal(np.char.slice_(self.arr, 0, 15, step=5, chunksize=5),
+        assert_array_equal(
+                np.char.slice_(self.arr, 0, 15, step=5, chunksize=5),
                            [['This ', 'is a ', 'long '],
                             ['Strin', 'g pro', 'lifer'],
                             ['Quick', ' brow', 'n fox']])
@@ -835,7 +836,7 @@ class TestSlice_:
         assert result.dtype == np.dtype('<U4')
 
         result = np.char.slice_(self.arr1d, 1, step=-1, chunksize=4)
-        assert result.shape == (2   , 0)
+        assert result.shape == (2, 0)
         assert result.dtype == np.dtype('<U4')
 
     def test_non_contiguous(self):

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -751,31 +751,21 @@ class TestSlice_:
         Show that slice accepts any byteorder of S and U, but raises for
         other types.
         """
-        result = np.char.slice_(np.array(['abc', 'def'], dtype='<U3'), 1)
+        result = np.char.slice_(np.array(['abc', 'def'], dtype='<U3'), stop=1)
         assert_array_equal(result, ['a', 'd'])
         assert result.dtype.str == '<U1'
 
-        result = np.char.slice_(np.array(['abc', 'def'], dtype='>U3'), 1)
+        result = np.char.slice_(np.array(['abc', 'def'], dtype='>U3'), stop=1)
         assert_array_equal(result, ['a', 'd'])
         assert result.dtype.str == '>U1'
 
-        result = np.char.slice_(np.array(['abc', 'def'], dtype='S3'), 1)
+        result = np.char.slice_(np.array(['abc', 'def'], dtype='S3'), stop=1)
         assert_array_equal(result, [b'a', b'd'])
         assert result.dtype.str == '|S1'
 
         assert_raises(TypeError, np.char.slice_,
-                      np.array(['abc', 'def'], dtype=object), 1)
-        assert_raises(TypeError, np.char.slice_, [1, 2, 3], 1)
-
-    def test_start(self):
-        """
-        Show that start becomes stop only if both stop and step are None.
-        """
-        assert_array_equal(np.char.slice_(self.arr1d, 2), ['ab', 'de'])
-        assert_array_equal(np.char.slice_(self.arr1d, 2, stop=3), ['c', 'f'])
-        assert_array_equal(np.char.slice_(self.arr1d, 2, step=1), ['c', 'f'])
-        assert_array_equal(np.char.slice_(self.arr1d, 2, stop=3, step=1),
-                                                                  ['c', 'f'])
+                      np.array(['abc', 'def'], dtype=object), stop=1)
+        assert_raises(TypeError, np.char.slice_, [1, 2, 3], stop=1)
 
     def test_shape(self):
         """
@@ -828,14 +818,14 @@ class TestSlice_:
         Show that chunksize *must* be positive.
         Show that chunksize > length of string is OK
         """
-        assert_raises(ValueError, np.char.slice_, self.arr, 2, chunksize=0)
-        assert_raises(ValueError, np.char.slice_, self.arr, 2, chunksize=-1)
+        assert_raises(ValueError, np.char.slice_, self.arr, stop=2, chunksize=0)
+        assert_raises(ValueError, np.char.slice_, self.arr, stop=2, chunksize=-1)
 
-        result = np.char.slice_(self.arr1d, 1, chunksize=4)
+        result = np.char.slice_(self.arr1d, stop=1, chunksize=4)
         assert result.shape == (2, 0)
         assert result.dtype == np.dtype('<U4')
 
-        result = np.char.slice_(self.arr1d, 1, step=-1, chunksize=4)
+        result = np.char.slice_(self.arr1d, stop=1, step=-1, chunksize=4)
         assert result.shape == (2, 0)
         assert result.dtype == np.dtype('<U4')
 
@@ -847,7 +837,7 @@ class TestSlice_:
         base[3::5, 3::5] = self.arr2d
         arr = base[-2::-5, 3::5]
         assert not (arr.flags['C_CONTIGUOUS'] | arr.flags['F_CONTIGUOUS'])
-        result = np.char.slice_(arr, 2)
+        result = np.char.slice_(arr, stop=2)
         assert_array_equal(result, [['gh', 'jk'], ['ab', 'de']])
         assert result.base is base
 
@@ -855,7 +845,7 @@ class TestSlice_:
         """ Show that returned slices write back to the original array. """
         arr = self.arr1d.copy()
         assert arr.base is None
-        s = np.char.slice_(arr, 2)
+        s = np.char.slice_(arr, stop=2)
         assert s.base is arr
         assert s.dtype == np.dtype('<U2')
         s[:] = ['x', 'yz']
@@ -875,7 +865,7 @@ class TestSlice_:
         arr = np.ndarray(buffer=base, strides=strides,
                          shape=shape, dtype=dtype, offset=4)
 
-        result = np.char.slice_(arr, 1)
+        result = np.char.slice_(arr, stop=1)
         assert_array_equal(result, ['w', 'i', 'g', 'o', 'h'])
         assert not result.flags['WRITEABLE']
 
@@ -890,7 +880,7 @@ class TestSlice_:
         arr = np.ndarray(buffer=base, strides=strides,
                          shape=shape, dtype=dtype, offset=offset)
 
-        result = np.char.slice_(arr, 1)
+        result = np.char.slice_(arr, stop=1)
         assert_array_equal(result, ['h', 'o', 'g', 'i', 'w'])
         assert not result.flags['WRITEABLE']
 

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -773,7 +773,8 @@ class TestSlice_:
         assert_array_equal(np.char.slice_(self.arr1d, 2), ['ab', 'de'])
         assert_array_equal(np.char.slice_(self.arr1d, 2, stop=3), ['c', 'f'])
         assert_array_equal(np.char.slice_(self.arr1d, 2, step=1), ['c', 'f'])
-        assert_array_equal(np.char.slice_(self.arr1d, 2, stop=3, step=1), ['c', 'f'])
+        assert_array_equal(np.char.slice_(self.arr1d, 2, stop=3, step=1),
+                                                                  ['c', 'f'])
 
     def test_shape(self):
         """
@@ -834,11 +835,13 @@ class TestSlice_:
         assert result.dtype == np.dtype('<U4')
 
         result = np.char.slice_(self.arr1d, 1, step=-1, chunksize=4)
-        assert result.shape == (2, 0)
+        assert result.shape == (2   , 0)
         assert result.dtype == np.dtype('<U4')
 
     def test_non_contiguous(self):
-        """ Show that a contiguous base will be found whether we like it or not. """
+        """
+        Show that a contiguous base will be found whether we like it or not.
+        """
         base = np.empty((10, 10), dtype='<U10')
         base[3::5, 3::5] = self.arr2d
         arr = base[-2::-5, 3::5]

--- a/numpy/core/tests/test_defchararray.py
+++ b/numpy/core/tests/test_defchararray.py
@@ -737,9 +737,9 @@ class TestSlice_:
         # 8.
         assert_array_equal(
                 np.char.slice_(self.arr, 0, 15, step=5, chunksize=5),
-                           [['This ', 'is a ', 'long '],
-                            ['Strin', 'g pro', 'lifer'],
-                            ['Quick', ' brow', 'n fox']])
+                               [['This ', 'is a ', 'long '],
+                                ['Strin', 'g pro', 'lifer'],
+                                ['Quick', ' brow', 'n fox']])
         # 9.
         assert_array_equal(np.char.slice_(self.arr, 16, step=-4, chunksize=4),
                            [['trin', 'ng s', 'a lo', ' is ', 'This'],


### PR DESCRIPTION
There are numerous examples of string slicing being a fairly requested feature:

- https://stackoverflow.com/q/70547027/2988730
- https://stackoverflow.com/q/53296394/2988730
- https://stackoverflow.com/q/39042214/2988730
- https://stackoverflow.com/q/40976714/2988730
- https://stackoverflow.com/q/64981711/2988730
- https://stackoverflow.com/q/31387047/2988730
- https://stackoverflow.com/q/69856133/2988730
- ... I stopped searching around here

Given the existence of the `char` module, there is no reason not to include a basic slicing operation that can work cheaper than making views and copies of a string, or switching to pandas for this one feature. This PR introduces such a function. It's written entirely in python, and does its absolute best not to make a copy of any data.

The original inspiration for this is my answer to the first question in the list above. I've added a couple of features since then, like the ability to have a meaningful non-unit step and the ability to set the length of non-unit-step chunks.

There are two things I'm not sure about with this PR:
1. The other methods in `defchararray.py` appear as methods of the subclass `np.chararray`. Should `slice` be added to those as well, or is it better to keep access to it only via `np.char.slice`, as the documentation for `chararray` indicates? I left it out for now since it's a quick change to make if desired.
2. I don't really understand the `array_function_dispatch` decorator. While I've done my best to emulate the other functions in the same module, I hope someone with knowhow can look it over.

(Thorough) tests are included. Mailing list thread for new feature starts here: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/JIK2T5XJJPDFIJM5VRPDXGZFMUYCVV5H/