### PR TITLE
DOC:Fixed the link on user-guide landing page

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -1,6 +1,6 @@
-.. _reference:
-
 .. module:: numpy
+
+.. _reference:
 
 ###############
 NumPy Reference


### PR DESCRIPTION
Fixed the link on user-guide landing page i.e. changed the link from [command reference](https://docs.python.org/dev/distutils/commandref.html#reference) to API reference.