### PR TITLE
ENH: Removed requirement for C-contiguity when changing to dtype of different size

### DIFF
--- a/doc/release/upcoming_changes/20722.expired.rst
+++ b/doc/release/upcoming_changes/20722.expired.rst
@@ -1,0 +1,52 @@
+Changing to dtype of different size in F-contiguous arrays no longer permitted
+------------------------------------------------------------------------------
+
+Behavior deprecated in NumPy 1.11.0 allowed the following counterintuitive result::
+
+    >>> x = np.array(["aA", "bB", "cC", "dD", "eE", "fF"]).reshape(1, 2, 3).transpose()
+    >>> x.view('U1')  # deprecated behavior, shape (6, 2, 1)
+    DeprecationWarning: ...
+    array([[['a'],
+            ['d']],
+    
+           [['A'],
+            ['D']],
+    
+           [['b'],
+            ['e']],
+    
+           [['B'],
+            ['E']],
+    
+           [['c'],
+            ['f']],
+    
+           [['C'],
+            ['F']]], dtype='<U1')
+
+Now that the deprecation has expired, dtype reassignment only happens along the
+last axis, so the above will result in::
+
+    >>> x.view('U1')  # new behavior, shape (3, 2, 2)
+    array([[['a', 'A'],
+            ['d', 'D']],
+    
+           [['b', 'B'],
+            ['e', 'E']],
+    
+           [['c', 'C'],
+            ['f', 'F']]], dtype='<U1')
+
+When the last axis is not contiguous, an error is now raised in place of the `DeprecationWarning`::
+
+    >>> x = np.array(["aA", "bB", "cC", "dD", "eE", "fF"]).reshape(2, 3).transpose()
+    >>> x.view('U1')
+    ValueError: To change to a dtype of a different size, the last axis must be contiguous
+
+The new behavior is equivalent to the more intuitive::
+
+    >>> x.copy().view('U1')
+
+To replicate the old behavior on F-but-not-C-contiguous arrays, use::
+
+    >>> x.T.view('U1').T

--- a/doc/release/upcoming_changes/20722.new_feature.rst
+++ b/doc/release/upcoming_changes/20722.new_feature.rst
@@ -1,0 +1,13 @@
+Changing to dtype of a different size now requires contiguity of only the last axis
+-----------------------------------------------------------------------------------
+
+Previously, viewing an array with a dtype of a different itemsize required that
+the entire array be C-contiguous. This limitation would unnecessarily force the
+user to make contiguous copies of non-contiguous arrays before being able to
+change the dtype.
+
+This change affects not only ``ndarray.view``, but other construction
+mechanisms, including the discouraged direct assignment to ``ndarray.dtype``.
+
+This change expires the deprecation regarding the viewing of F-contiguous
+arrays, described elsewhere in the release notes.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -4450,14 +4450,13 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     memory.
 
     For ``a.view(some_dtype)``, if ``some_dtype`` has a different number of
-    bytes per entry than the previous dtype (for example, converting a
-    regular array to a structured array), then the behavior of the view
-    cannot be predicted just from the superficial appearance of ``a`` (shown
-    by ``print(a)``). It also depends on exactly how ``a`` is stored in
-    memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
-    defined as a slice or transpose, etc., the view may give different
-    results.
+    bytes per entry than the previous dtype (for example, converting a regular
+    array to a structured array), then the last axis of ``a`` must be
+    contiguous. This axis will be resized in the result.
 
+    .. versionchanged:: 1.23.0
+       Only the last axis needs to be contiguous. Previously, the entire array
+       had to be C-contiguous.
 
     Examples
     --------
@@ -4502,19 +4501,34 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('view',
     Views that change the dtype size (bytes per entry) should normally be
     avoided on arrays defined by slices, transposes, fortran-ordering, etc.:
 
-    >>> x = np.array([[1,2,3],[4,5,6]], dtype=np.int16)
-    >>> y = x[:, 0:2]
+    >>> x = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
+    >>> y = x[:, ::2]
     >>> y
-    array([[1, 2],
-           [4, 5]], dtype=int16)
+    array([[1, 3],
+           [4, 6]], dtype=int16)
     >>> y.view(dtype=[('width', np.int16), ('length', np.int16)])
     Traceback (most recent call last):
         ...
-    ValueError: To change to a dtype of a different size, the array must be C-contiguous
+    ValueError: To change to a dtype of a different size, the last axis must be contiguous
     >>> z = y.copy()
     >>> z.view(dtype=[('width', np.int16), ('length', np.int16)])
-    array([[(1, 2)],
-           [(4, 5)]], dtype=[('width', '<i2'), ('length', '<i2')])
+    array([[(1, 3)],
+           [(4, 6)]], dtype=[('width', '<i2'), ('length', '<i2')])
+
+    However, views that change dtype are totally fine for arrays with a
+    contiguous last axis, even if the rest of the axes are not C-contiguous:
+
+    >>> x = np.arange(2 * 3 * 4, dtype=np.int8).reshape(2, 3, 4)
+    >>> x.transpose(1, 0, 2).view(np.int16)
+    array([[[ 256,  770],
+            [3340, 3854]],
+    <BLANKLINE>
+           [[1284, 1798],
+            [4368, 4882]],
+    <BLANKLINE>
+           [[2312, 2826],
+            [5396, 5910]]], dtype=int16)
+
     """))
 
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -257,20 +257,6 @@ class TestDatetime64Timezone(_DeprecationTestCase):
         self.assert_deprecated(np.datetime64, args=(dt,))
 
 
-class TestNonCContiguousViewDeprecation(_DeprecationTestCase):
-    """View of non-C-contiguous arrays deprecated in 1.11.0.
-
-    The deprecation will not be raised for arrays that are both C and F
-    contiguous, as C contiguous is dominant. There are more such arrays
-    with relaxed stride checking than without so the deprecation is not
-    as visible with relaxed stride checking in force.
-    """
-
-    def test_fortran_contiguous(self):
-        self.assert_deprecated(np.ones((2,2)).T.view, args=(complex,))
-        self.assert_deprecated(np.ones((2,2)).T.view, args=(np.int8,))
-
-
 class TestArrayDataAttributeAssignmentDeprecation(_DeprecationTestCase):
     """Assigning the 'data' attribute of an ndarray is unsafe as pointed
      out in gh-7093. Eventually, such assignment should NOT be allowed, but

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9191,3 +9191,66 @@ def test_getfield():
     pytest.raises(ValueError, a.getfield, 'uint8', -1)
     pytest.raises(ValueError, a.getfield, 'uint8', 16)
     pytest.raises(ValueError, a.getfield, 'uint64', 0)
+
+
+class TestViewDtype:
+    """
+    Verify that making a view of a non-contiguous array works as expected.
+    """
+    def test_smaller_dtype_multiple(self):
+        # x is non-contiguous
+        x = np.arange(10, dtype='<i4')[::2]
+        with pytest.raises(ValueError,
+                           match='the last axis must be contiguous'): 
+            x.view('<i2')
+        expected = [[0, 0], [2, 0], [4, 0], [6, 0], [8, 0]]
+        assert_array_equal(x[:, np.newaxis].view('<i2'), expected)
+
+    def test_smaller_dtype_not_multiple(self):
+        # x is non-contiguous
+        x = np.arange(5, dtype='<i4')[::2]
+
+        with pytest.raises(ValueError,
+                           match='the last axis must be contiguous'):
+            x.view('S3')
+        with pytest.raises(ValueError,
+                           match='When changing to a smaller dtype'):
+            x[:, np.newaxis].view('S3')
+
+        # Make sure the problem is because of the dtype size
+        expected = [[b''], [b'\x02'], [b'\x04']]
+        assert_array_equal(x[:, np.newaxis].view('S4'), expected)
+
+    def test_larger_dtype_multiple(self):
+        # x is non-contiguous in the first dimension, contiguous in the last
+        x = np.arange(20, dtype='<i2').reshape(10, 2)[::2, :]
+        expected = np.array([[65536], [327684], [589832],
+                             [851980], [1114128]], dtype='<i4')
+        assert_array_equal(x.view('<i4'), expected)
+
+    def test_larger_dtype_not_multiple(self):
+        # x is non-contiguous in the first dimension, contiguous in the last
+        x = np.arange(20, dtype='<i2').reshape(10, 2)[::2, :]
+        with pytest.raises(ValueError,
+                           match='When changing to a larger dtype'):
+            x.view('S3')
+        # Make sure the problem is because of the dtype size
+        expected = [[b'\x00\x00\x01'], [b'\x04\x00\x05'], [b'\x08\x00\t'],
+                    [b'\x0c\x00\r'], [b'\x10\x00\x11']]
+        assert_array_equal(x.view('S4'), expected)
+
+    def test_f_contiguous(self):
+        # x is F-contiguous
+        x = np.arange(4 * 3, dtype='<i4').reshape(4, 3).T
+        with pytest.raises(ValueError,
+                           match='the last axis must be contiguous'):
+            x.view('<i2')
+
+    def test_non_c_contiguous(self):
+        # x is contiguous in axis=-1, but not C-contiguous in other axes
+        x = np.arange(2 * 3 * 4, dtype='i1').\
+                    reshape(2, 3, 4).transpose(1, 0, 2)
+        expected = [[[256, 770], [3340, 3854]],
+                    [[1284, 1798], [4368, 4882]],
+                    [[2312, 2826], [5396, 5910]]]
+        assert_array_equal(x.view('<i2'), expected)

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -86,6 +86,7 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
     Vectorized write operations on such arrays will typically be
     unpredictable. They may even give different results for small, large,
     or transposed arrays.
+
     Since writing to these arrays has to be tested and done with great
     care, you may want to use ``writeable=False`` to avoid accidental write
     operations.


### PR DESCRIPTION
This is a first attempt to fix some of #20705. In this PR, I attempt to make the following two changes to `np.ndarray.view`:

1. If `dtype` is smaller than the current dtype, and it divides the current one evenly, and there is at least one unit dimension, expand the last unit dimension instead of crashing.
2. If `dtype` is larger than the current dtype, and there exists an axis along which the current array is contiguous (stride == current dtype.itemsize), use that axis instead of crashing.

Both cases are valid because the check for dtype multiplicative compatibility is still done, and the dimension/stride checks guarantee that the resulting shape changes do not exceed known owned memory.

One possible modification is that we may want to restrict this only to the last dimension. Will let reviewers with more understanding decide.

This PR will allow a non-hacky rewrite of most of the functionality of #20694. If accepted, the second half of the functionality will be allowing `as_strided` to modify the offset and dtype of an array, in addition to its strides and shape.

---

**Edit by seberg, posting the summary of the changes for Fortran order arrays here, in case someone comes here from the release notes:**

Behavior deprecated in NumPy 1.11.0 allowed the following counterintuitive result::

     >>> x = np.array(["aA", "bB", "cC", "dD", "eE", "fF"]).reshape(1, 2, 3).transpose()
     >>> x.view('U1')  # deprecated behavior, shape (6, 2, 1)
     DeprecationWarning: ...
     array([[['a'],
             ['d']],
     
            [['A'],
             ['D']],
     
            [['b'],
             ['e']],
     
            [['B'],
             ['E']],
     
            [['c'],
             ['f']],
     
            [['C'],
             ['F']]], dtype='<U1')

 Now that the deprecation has expired, dtype reassignment only happens along the
 last axis, so the above will result in::

     >>> x.view('U1')  # new behavior, shape (3, 2, 2)
     array([[['a', 'A'],
             ['d', 'D']],
     
            [['b', 'B'],
             ['e', 'E']],
     
            [['c', 'C'],
             ['f', 'F']]], dtype='<U1')

 When the last axis is not contiguous, an error is now raised in place of the `DeprecationWarning`::

     >>> x = np.array(["aA", "bB", "cC", "dD", "eE", "fF"]).reshape(2, 3).transpose()
     >>> x.view('U1')
     ValueError: To change to a dtype of a different size, the last axis must be contiguous

 The new behavior is equivalent to the more intuitive::

     >>> x.copy().view('U1')

 To replicate the old behavior on F-but-not-C-contiguous arrays, use::

     >>> x.T.view('U1').T
 