### PR TITLE
DOC: fix OpenBLAS version in release note

### DIFF
--- a/doc/source/release/1.22.0-notes.rst
+++ b/doc/source/release/1.22.0-notes.rst
@@ -450,9 +450,9 @@ double precision functions respectively.
 
 (`gh-19478 <https://github.com/numpy/numpy/pull/19478>`__)
 
-OpenBLAS v0.3.17
+OpenBLAS v0.3.18
 ----------------
-Update the OpenBLAS used in testing and in wheels to v0.3.17
+Update the OpenBLAS used in testing and in wheels to v0.3.18
 
-(`gh-19462 <https://github.com/numpy/numpy/pull/19462>`__)
+(`gh-20058 <https://github.com/numpy/numpy/pull/20058>`__)
 


### PR DESCRIPTION
small whoops in the release note: OpenBLAS 0.3.17 -> 0.3.18