### PR TITLE
ENH: fix a typo in the example trigger for wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,7 @@
 #
 # if: github.repository == 'numpy/numpy'
 #
-# in the get_commit_message job. Be sure to include [cd build] in your commit
+# in the get_commit_message job. Be sure to include [wheel build] in your commit
 # message to trigger the build. All files related to wheel building are located
 # at tools/wheels/
 name: Wheel builder


### PR DESCRIPTION
The `[cd build]` trigger in the example (line 6) does not correspond to the one that is actually used: `[wheel build]` trigger (line 43). This might be confusing for newcomers.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
