### PR TITLE
ENH: F90 bind(c) intrinsic derived types

### DIFF
--- a/doc/release/upcoming_changes/15844.new_feature.rst
+++ b/doc/release/upcoming_changes/15844.new_feature.rst
@@ -1,0 +1,4 @@
+f2py supports reading access type attributes from derived type statements
+-------------------------------------------------------------------------
+As a result, one does not need to use `public` or `private` statements to
+specify derived type access properties.

--- a/numpy/f2py/_isocbind.py
+++ b/numpy/f2py/_isocbind.py
@@ -1,3 +1,5 @@
+# Partially from:
+# https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html
 iso_c_binding_map = {
     'integer': {
         'c_int': 'int',
@@ -44,3 +46,10 @@ isoc_kindmap = {}
 for fortran_type, c_type_dict in iso_c_binding_map.items():
     for c_type in c_type_dict.keys():
         isoc_kindmap[c_type] = fortran_type
+
+# For derived type maps
+flatisoc = {
+    c_type: ctype
+    for type_category in iso_c_binding_map.values()
+    for c_type, ctype in type_category.items()
+}

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -44,9 +44,9 @@ __all__ = [
     'ismodule', 'ismoduleroutine', 'isoptional', 'isprivate', 'isrequired',
     'isroutine', 'isscalar', 'issigned_long_longarray', 'isstring',
     'isstringarray', 'isstring_or_stringarray', 'isstringfunction',
-    'issubroutine', 'get_f2py_modulename',
+    'issubroutine', 'get_f2py_modulename', 'isderivedtype',
     'issubroutine_wrap', 'isthreadsafe', 'isunsigned', 'isunsigned_char',
-    'isunsigned_chararray', 'isunsigned_long_long',
+    'isunsigned_chararray', 'isunsigned_long_long', 'isvalidintrinsicmod',
     'isunsigned_long_longarray', 'isunsigned_short',
     'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess',
     'replace', 'show', 'stripcomma', 'throw_error', 'isattr_value',
@@ -118,8 +118,12 @@ def isarray(var):
     return 'dimension' in var and not isexternal(var)
 
 
+def isderivedtype(var):
+    return var.get('typespec')=='type'
+
+
 def isscalar(var):
-    return not (isarray(var) or isstring(var) or isexternal(var))
+    return not (isarray(var) or isstring(var) or isexternal(var) or isderivedtype(var))
 
 
 def iscomplex(var):
@@ -937,3 +941,11 @@ def get_f2py_modulename(source):
                 name = m.group('name')
                 break
     return name
+
+# Intrinsic modules
+# References:
+# - J3/21-007: Draft Fortran 202x. https://j3-fortran.org/doc/year/21/21-007.pdf
+intrinsic_modules = ["iso_c_binding", "iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]
+
+def isvalidintrinsicmod(modu):
+    return modu in intrinsic_modules

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -18,6 +18,7 @@ import pprint
 import sys
 import re
 import types
+import re
 from functools import reduce
 from copy import deepcopy
 
@@ -941,6 +942,73 @@ def get_f2py_modulename(source):
                 name = m.group('name')
                 break
     return name
+
+##################
+#  Crackfortran  #
+##################
+
+def split_by_unquoted(line, characters):
+    """
+    Splits the line into (line[:i], line[i:]),
+    where i is the index of first occurrence of one of the characters
+    not within quotes, or len(line) if no such index exists
+    """
+    assert not (set('"\'') & set(characters)), "cannot split by unquoted quotes"
+    r = re.compile(
+        r"\A(?P<before>({single_quoted}|{double_quoted}|{not_quoted})*)"
+        r"(?P<after>{char}.*)\Z".format(
+            not_quoted="[^\"'{}]".format(re.escape(characters)),
+            char="[{}]".format(re.escape(characters)),
+            single_quoted=r"('([^'\\]|(\\.))*')",
+            double_quoted=r'("([^"\\]|(\\.))*")'))
+    m = r.match(line)
+    if m:
+        d = m.groupdict()
+        return (d["before"], d["after"])
+    return (line, "")
+
+
+def markouterparen(line):
+    l = ''
+    f = 0
+    for c in line:
+        if c == '(':
+            f = f + 1
+            if f == 1:
+                l = l + '@(@'
+                continue
+        elif c == ')':
+            f = f - 1
+            if f == 0:
+                l = l + '@)@'
+                continue
+        l = l + c
+    return l
+
+
+def markoutercomma(line, comma=','):
+    l = ''
+    f = 0
+    before, after = split_by_unquoted(line, comma + '()')
+    l += before
+    while after:
+        if (after[0] == comma) and (f == 0):
+            l += '@' + comma + '@'
+        else:
+            l += after[0]
+            if after[0] == '(':
+                f += 1
+            elif after[0] == ')':
+                f -= 1
+        before, after = split_by_unquoted(after[1:], comma + '()')
+        l += before
+    assert not f, repr((f, line, l))
+    return l
+
+
+def unmarkouterparen(line):
+    r = line.replace('@(@', '(').replace('@)@', ')')
+    return r
 
 # Intrinsic modules
 # References:

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -129,7 +129,48 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
               'double complex': {'': 'complex_double'},
               'double precision': {'': 'double'},
               'byte': {'': 'char'},
+              'type': {'': 'struct'},
+              'character': {'': 'string'}
               }
+# From:
+# https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html
+iso_c_binding_map = {
+    # Integers
+    'c_int': 'int',
+    'c_short': 'short int',
+    'c_long': 'long int',
+    'c_long_long': 'long long int',
+    'c_signed_char': 'signed char',
+    'c_size_t': 'size_t',
+    'c_int8_t': 'int8_t',
+    'c_int16_t': 'int16_t',
+    'c_int32_t': 'int32_t',
+    'c_int64_t': 'int64_t',
+    'c_int_least8_t': 'int_least8_t',
+    'c_int_least16_t': 'int_least16_t',
+    'c_int_least32_t': 'int_least32_t',
+    'c_int_least64_t': 'int_least64_t',
+    'c_int_fast8_t': 'int_fast8_t',
+    'c_int_fast16_t': 'int_fast16_t',
+    'c_int_fast32_t': 'int_fast32_t',
+    'c_int_fast64_t': 'int_fast64_t',
+    'c_intmax_t': 'intmax_t',
+    'c_intptr_t': 'intptr_t',
+    'c_ptrdiff_t': 'ptrdiff_t',
+    # Floating Point Numbers
+    'c_float': 'float',
+    'c_double': 'double',
+    'c_long_double': 'long double',
+    # Complex Numbers
+    'c_float_complex': 'float _Complex',
+    'c_double_complex': 'double _Complex',
+    'c_long_double_complex': 'long double _Complex',
+    # Logical
+    'c_bool': '_Bool',
+    # Char
+    'c_char': 'char',
+}
+# TODO:Support ["iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]
 
 f2cmap_all = deep_merge(f2cmap_all, iso_c_binding_map)
 f2cmap_default = copy.deepcopy(f2cmap_all)

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -132,44 +132,6 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
               'type': {'': 'struct'},
               'character': {'': 'string'}
               }
-# From:
-# https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html
-iso_c_binding_map = {
-    # Integers
-    'c_int': 'int',
-    'c_short': 'short int',
-    'c_long': 'long int',
-    'c_long_long': 'long long int',
-    'c_signed_char': 'signed char',
-    'c_size_t': 'size_t',
-    'c_int8_t': 'int8_t',
-    'c_int16_t': 'int16_t',
-    'c_int32_t': 'int32_t',
-    'c_int64_t': 'int64_t',
-    'c_int_least8_t': 'int_least8_t',
-    'c_int_least16_t': 'int_least16_t',
-    'c_int_least32_t': 'int_least32_t',
-    'c_int_least64_t': 'int_least64_t',
-    'c_int_fast8_t': 'int_fast8_t',
-    'c_int_fast16_t': 'int_fast16_t',
-    'c_int_fast32_t': 'int_fast32_t',
-    'c_int_fast64_t': 'int_fast64_t',
-    'c_intmax_t': 'intmax_t',
-    'c_intptr_t': 'intptr_t',
-    'c_ptrdiff_t': 'ptrdiff_t',
-    # Floating Point Numbers
-    'c_float': 'float',
-    'c_double': 'double',
-    'c_long_double': 'long double',
-    # Complex Numbers
-    'c_float_complex': 'float _Complex',
-    'c_double_complex': 'double _Complex',
-    'c_long_double_complex': 'long double _Complex',
-    # Logical
-    'c_bool': '_Bool',
-    # Char
-    'c_char': 'char',
-}
 # TODO:Support ["iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]
 
 f2cmap_all = deep_merge(f2cmap_all, iso_c_binding_map)

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -55,6 +55,7 @@ c2py_map = {'double': 'float',
             'complex_long_double': 'complex',          # forced casting
             'string': 'string',
             'character': 'bytes',
+            'struct': 'struct',
             }
 
 c2capi_map = {'double': 'NPY_DOUBLE',
@@ -75,7 +76,9 @@ c2capi_map = {'double': 'NPY_DOUBLE',
                 'complex_double': 'NPY_CDOUBLE',
                 'complex_long_double': 'NPY_CDOUBLE',
                 'string': 'NPY_STRING',
-                'character': 'NPY_STRING'}
+                'character': 'NPY_STRING',
+                'struct': 'struct'
+              }
 
 c2pycode_map = {'double': 'd',
                 'float': 'f',
@@ -201,6 +204,7 @@ cformat_map = {'double': '%g',
                'complex_long_double': '(%Lg,%Lg)',
                'string': '\\"%s\\"',
                'character': "'%c'",
+               'struct': '%s',
                }
 
 # Auxiliary functions
@@ -226,6 +230,9 @@ def getctype(var):
         return 'character'
     elif isstring_or_stringarray(var):
         return 'string'
+    elif isderivedtype(var):
+        ctype = var['typename']
+        return ctype
     elif 'typespec' in var and var['typespec'].lower() in f2cmap_all:
         typespec = var['typespec'].lower()
         f2cmap = f2cmap_all[typespec]
@@ -428,6 +435,9 @@ def getpydocsign(a, var):
             else:
                 ua = ''
         sig = '%s : call-back function%s' % (a, ua)
+        sigout = sig
+    elif isderivedtype(var):
+        sig = f"{a} : derived type {var['typename']} with intent {var['intent']}"
         sigout = sig
     else:
         errmess(

--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -17,7 +17,7 @@ f2py_version = __version__.version
 import copy
 import re
 import os
-from .crackfortran import markoutercomma
+from .auxfuncs import markoutercomma
 from . import cb_rules
 from ._isocbind import iso_c_binding_map
 

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -25,9 +25,9 @@ errmess = sys.stderr.write
 ##################### Definitions ##################
 
 outneeds = {'includes0': [], 'includes': [], 'typedefs': [], 'typedefs_generated': [],
-            'typedefs_derivedtypes': [], 'userincludes': [],
-            'cppmacros': [], 'cfuncs': [], 'callbacks': [], 'f90modhooks': [],
-            'commonhooks': []}
+            'typedefs_derivedtypes': [], 'typedefs_derivedtypedefs': [],
+            'typedefs_derivedtypefuncs': [],'userincludes': [], 'cppmacros': [],
+            'cfuncs': [], 'callbacks': [], 'f90modhooks': [], 'commonhooks': []}
 needs = {}
 includes0 = {'includes0': '/*need_includes0*/'}
 includes = {'includes': '/*need_includes*/'}
@@ -35,6 +35,8 @@ userincludes = {'userincludes': '/*need_userincludes*/'}
 typedefs = {'typedefs': '/*need_typedefs*/'}
 typedefs_generated = {'typedefs_generated': '/*need_typedefs_generated*/'}
 typedefs_derivedtypes = {'typedefs_derivedtypes': '/*need_typedefs_derivedtypes*/'}
+typedefs_derivedtypedefs = {'typedefs_derivedtypedefs': '/*need_typedefs_derivedtypedefs*/'}
+typedefs_derivedtypefuncs = {'typedefs_derivedtypefuncs': '/*need_typedefs_derivedtypefuncs*/'}
 cppmacros = {'cppmacros': '/*need_cppmacros*/'}
 cfuncs = {'cfuncs': '/*need_cfuncs*/'}
 callbacks = {'callbacks': '/*need_callbacks*/'}

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -25,7 +25,7 @@ errmess = sys.stderr.write
 ##################### Definitions ##################
 
 outneeds = {'includes0': [], 'includes': [], 'typedefs': [], 'typedefs_generated': [],
-            'userincludes': [],
+            'typedefs_derivedtypes': [], 'userincludes': [],
             'cppmacros': [], 'cfuncs': [], 'callbacks': [], 'f90modhooks': [],
             'commonhooks': []}
 needs = {}
@@ -34,6 +34,7 @@ includes = {'includes': '/*need_includes*/'}
 userincludes = {'userincludes': '/*need_userincludes*/'}
 typedefs = {'typedefs': '/*need_typedefs*/'}
 typedefs_generated = {'typedefs_generated': '/*need_typedefs_generated*/'}
+typedefs_derivedtypes = {'typedefs_derivedtypes': '/*need_typedefs_derivedtypes*/'}
 cppmacros = {'cppmacros': '/*need_cppmacros*/'}
 cfuncs = {'cfuncs': '/*need_cfuncs*/'}
 callbacks = {'callbacks': '/*need_callbacks*/'}
@@ -1444,6 +1445,8 @@ def append_needs(need, flag=1):
             n = 'typedefs'
         elif need in typedefs_generated:
             n = 'typedefs_generated'
+        elif need in typedefs_derivedtypes:
+            n = 'typedefs_derivedtypes'
         elif need in cppmacros:
             n = 'cppmacros'
         elif need in cfuncs:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -1521,8 +1521,13 @@ def analyzeline(m, case, line):
         groupcache[groupcounter]['common'] = commonkey
         previous_context = ('common', bn, groupcounter)
     elif case == 'use':
+        # Regular modules
         m1 = re.match(
             r'\A\s*(?P<name>\b\w+\b)\s*((,(\s*\bonly\b\s*:|(?P<notonly>))\s*(?P<list>.*))|)\s*\Z', m.group('after'), re.I)
+        # Intrinsic modules
+        mintrin = re.match(
+            r',?\s*(?P<isintrin>intrinsic)?\s*(::)?(?P<allintrin>((\s*,?\s*(?:\b\w+\b)\s*)*))\Z', m.group('after'), re.I
+        )
         if m1:
             mm = m1.groupdict()
             if 'use' not in groupcache[groupcounter]:
@@ -1549,6 +1554,19 @@ def analyzeline(m, case, line):
                     else:
                         rl[l] = l
                     groupcache[groupcounter]['use'][name]['map'] = rl
+        elif mintrin:
+            # Intrinsic check
+            intrmm = mintrin.groupdict()
+            if 'use' not in groupcache[groupcounter]:
+                groupcache[groupcounter]['use'] = {}
+            intrmm_ll = [x.strip() for x in intrmm['allintrin'].split(',')]
+            for l in intrmm_ll:
+                if not isvalidintrinsicmod(l):
+                    outmess(
+                        'analyzeline: Not a valid intrinsic, must be one of ["iso_c_binding", "iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]'
+                    )
+                else:
+                      groupcache[groupcounter]['use'][l] = {}
             else:
                 pass
         else:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -161,6 +161,7 @@ from . import __version__
 from .auxfuncs import *
 from . import auxfuncs as aux
 from . import symbolic
+from . import capi_maps as capim
 
 f2py_version = __version__.version
 
@@ -1492,6 +1493,8 @@ def analyzeline(m, case, line):
                                 'analyzeline: Not local=>use pattern found in %s\n' % repr(l))
                     else:
                         rl[l] = l
+                    if name == "iso_c_binding":
+                        rl = {k:capim.iso_c_binding_map.get(k) for k,v in rl.items()}
                     groupcache[groupcounter]['use'][name]['map'] = rl
         elif mintrin:
             # Intrinsic check
@@ -1500,12 +1503,25 @@ def analyzeline(m, case, line):
                 groupcache[groupcounter]['use'] = {}
             intrmm_ll = [x.strip() for x in intrmm['allintrin'].split(',')]
             for l in intrmm_ll:
-                if not isvalidintrinsicmod(l):
+                if l =="iso_c_binding":
+                    groupcache[groupcounter]['use'][l] = capim.iso_c_binding_map
+                elif l =="iso_fortran_env":
+                     outmess(
+                        'analyzeline: Not a valid intrinsic, must be one of ["iso_c_binding", "iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]'
+                        'analyzeline: ISO_FORTRAN_ENV types are not yet supported'
+                    )
+                elif l =="ieee_exceptions":
+                    outmess(
+                        'analyzeline: IEEE_EXCEPTIONS are not yet supported'
+                    )
+                elif l =="ieee_arithmetic":
+                    outmess(
+                        'analyzeline: IEEE_ARITHMETIC are not yet supported'
+                     )
+                else:
                     outmess(
                         'analyzeline: Not a valid intrinsic, must be one of ["iso_c_binding", "iso_fortran_env", "ieee_exceptions", "ieee_arithmetic", "ieee_features"]'
                     )
-                else:
-                      groupcache[groupcounter]['use'][l] = {}
             else:
                 pass
         else:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -162,6 +162,7 @@ from .auxfuncs import *
 from . import auxfuncs as aux
 from . import symbolic
 from . import capi_maps as capim
+from . import _isocbind as _isoc
 
 f2py_version = __version__.version
 
@@ -1494,7 +1495,7 @@ def analyzeline(m, case, line):
                     else:
                         rl[l] = l
                     if name == "iso_c_binding":
-                        rl = {k:capim.iso_c_binding_map.get(k) for k,v in rl.items()}
+                        rl = {k:_isoc.flatisoc.get(k) for k,v in rl.items()}
                     groupcache[groupcounter]['use'][name]['map'] = rl
         elif mintrin:
             # Intrinsic check

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -159,6 +159,7 @@ from . import __version__
 # As the needed functions cannot be determined by static inspection of the
 # code, it is safest to use import * pending a major refactoring of f2py.
 from .auxfuncs import *
+from . import auxfuncs as aux
 from . import symbolic
 
 f2py_version = __version__.version
@@ -428,10 +429,10 @@ def readfortrancode(ffile, dowithline=show, istop=1):
                 break
             l = l[:-1]
         if not strictf77:
-            (l, rl) = split_by_unquoted(l, '!')
+            (l, rl) = aux.split_by_unquoted(l, '!')
             l += ' '
             if rl[:5].lower() == '!f2py':  # f2py directive
-                l, _ = split_by_unquoted(l + 4 * ' ' + rl[5:], '!')
+                l, _ = aux.split_by_unquoted(l + 4 * ' ' + rl[5:], '!')
         if l.strip() == '':  # Skip empty line
             if sourcecodeform == 'free':
                 # In free form, a statement continues in the next line
@@ -667,29 +668,9 @@ multilinepattern = re.compile(
     r"\s*(?P<before>''')(?P<this>.*?)(?P<after>''')\s*\Z", re.S), 'multiline'
 ##
 
-def split_by_unquoted(line, characters):
-    """
-    Splits the line into (line[:i], line[i:]),
-    where i is the index of first occurrence of one of the characters
-    not within quotes, or len(line) if no such index exists
-    """
-    assert not (set('"\'') & set(characters)), "cannot split by unquoted quotes"
-    r = re.compile(
-        r"\A(?P<before>({single_quoted}|{double_quoted}|{not_quoted})*)"
-        r"(?P<after>{char}.*)\Z".format(
-            not_quoted="[^\"'{}]".format(re.escape(characters)),
-            char="[{}]".format(re.escape(characters)),
-            single_quoted=r"('([^'\\]|(\\.))*')",
-            double_quoted=r'("([^"\\]|(\\.))*")'))
-    m = r.match(line)
-    if m:
-        d = m.groupdict()
-        return (d["before"], d["after"])
-    return (line, "")
-
 def _simplifyargs(argsline):
     a = []
-    for n in markoutercomma(argsline).split('@,@'):
+    for n in aux.markoutercomma(argsline).split('@,@'):
         for r in '(),':
             n = n.replace(r, '_')
         a.append(n)
@@ -711,16 +692,16 @@ def crackline(line, reset=0):
     global filepositiontext, currentfilename, neededmodule, expectbegin
     global skipblocksuntil, skipemptyends, previous_context, gotnextfile
 
-    _, has_semicolon = split_by_unquoted(line, ";")
+    _, has_semicolon = aux.split_by_unquoted(line, ";")
     if has_semicolon and not (f2pyenhancementspattern[0].match(line) or
                                multilinepattern[0].match(line)):
         # XXX: non-zero reset values need testing
         assert reset == 0, repr(reset)
         # split line on unquoted semicolons
-        line, semicolon_line = split_by_unquoted(line, ";")
+        line, semicolon_line = aux.split_by_unquoted(line, ";")
         while semicolon_line:
             crackline(line, reset)
-            line, semicolon_line = split_by_unquoted(semicolon_line[1:], ";")
+            line, semicolon_line = aux.split_by_unquoted(semicolon_line[1:], ";")
         crackline(line, reset)
         return
     if reset < 0:
@@ -791,7 +772,7 @@ def crackline(line, reset=0):
                 if 'interfaced' in groupcache[groupcounter] and name in groupcache[groupcounter]['interfaced']:
                     continue
                 m1 = re.match(
-                    r'(?P<before>[^"]*)\b%s\b\s*@\(@(?P<args>[^@]*)@\)@.*\Z' % name, markouterparen(line), re.I)
+                    r'(?P<before>[^"]*)\b%s\b\s*@\(@(?P<args>[^@]*)@\)@.*\Z' % name, aux.markouterparen(line), re.I)
                 if m1:
                     m2 = re_1.match(m1.group('before'))
                     a = _simplifyargs(m1.group('args'))
@@ -856,48 +837,6 @@ def crackline(line, reset=0):
         if 0 <= skipblocksuntil <= groupcounter:
             return
         analyzeline(m, pat[1], line)
-
-
-def markouterparen(line):
-    l = ''
-    f = 0
-    for c in line:
-        if c == '(':
-            f = f + 1
-            if f == 1:
-                l = l + '@(@'
-                continue
-        elif c == ')':
-            f = f - 1
-            if f == 0:
-                l = l + '@)@'
-                continue
-        l = l + c
-    return l
-
-
-def markoutercomma(line, comma=','):
-    l = ''
-    f = 0
-    before, after = split_by_unquoted(line, comma + '()')
-    l += before
-    while after:
-        if (after[0] == comma) and (f == 0):
-            l += '@' + comma + '@'
-        else:
-            l += after[0]
-            if after[0] == '(':
-                f += 1
-            elif after[0] == ')':
-                f -= 1
-        before, after = split_by_unquoted(after[1:], comma + '()')
-        l += before
-    assert not f, repr((f, line, l))
-    return l
-
-def unmarkouterparen(line):
-    r = line.replace('@(@', '(').replace('@)@', ')')
-    return r
 
 
 def appenddecl(decl, decl2, force=1):
@@ -980,7 +919,7 @@ def parse_name_for_bind(line):
 
 def _resolvenameargspattern(line):
     line, bind_cname = parse_name_for_bind(line)
-    line = markouterparen(line)
+    line = aux.markouterparen(line)
     m1 = nameargspattern.match(line)
     if m1:
         return m1.group('name'), m1.group('args'), m1.group('result'), bind_cname
@@ -1045,7 +984,7 @@ def analyzeline(m, case, line):
         previous_context = (block, name, groupcounter)
         if args:
             args = rmbadname([x.strip()
-                              for x in markoutercomma(args).split('@,@')])
+                              for x in aux.markoutercomma(args).split('@,@')])
         else:
             args = []
         if '' in args:
@@ -1196,7 +1135,7 @@ def analyzeline(m, case, line):
         if name is not None:
             if args:
                 args = rmbadname([x.strip()
-                                  for x in markoutercomma(args).split('@,@')])
+                                  for x in aux.markoutercomma(args).split('@,@')])
             else:
                 args = []
             assert result is None, repr(result)
@@ -1213,7 +1152,7 @@ def analyzeline(m, case, line):
         ll = m.group('after').strip()
         i = ll.find('::')
         if i < 0 and case == 'intent':
-            i = markouterparen(ll).find('@)@') - 2
+            i = aux.markouterparen(ll).find('@)@') - 2
             ll = ll[:i + 1] + '::' + ll[i + 1:]
             i = ll.find('::')
             if ll[i:] == '::' and 'args' in groupcache[groupcounter]:
@@ -1226,14 +1165,14 @@ def analyzeline(m, case, line):
         else:
             pl = ll[:i].strip()
             ll = ll[i + 2:]
-        ch = markoutercomma(pl).split('@,@')
+        ch = aux.markoutercomma(pl).split('@,@')
         if len(ch) > 1:
             pl = ch[0]
             outmess('analyzeline: cannot handle multiple attributes without type specification. Ignoring %r.\n' % (
                 ','.join(ch[1:])))
         last_name = None
 
-        for e in [x.strip() for x in markoutercomma(ll).split('@,@')]:
+        for e in [x.strip() for x in aux.markoutercomma(ll).split('@,@')]:
             m1 = namepattern.match(e)
             if not m1:
                 if case in ['public', 'private']:
@@ -1297,7 +1236,7 @@ def analyzeline(m, case, line):
         edecl = groupcache[groupcounter]['vars']
         ll = m.group('after').strip()[1:-1]
         last_name = None
-        for e in markoutercomma(ll).split('@,@'):
+        for e in aux.markoutercomma(ll).split('@,@'):
             try:
                 k, initexpr = [x.strip() for x in e.split('=')]
             except Exception:
@@ -1349,7 +1288,7 @@ def analyzeline(m, case, line):
                 outmess(
                     'analyzeline: Overwriting earlier "implicit none" statement.\n')
                 impl = {}
-            for e in markoutercomma(m.group('after')).split('@,@'):
+            for e in aux.markoutercomma(m.group('after')).split('@,@'):
                 decl = {}
                 m1 = re.match(
                     r'\s*(?P<this>.*?)\s*(\(\s*(?P<after>[a-z-, ]+)\s*\)\s*|)\Z', e, re.I)
@@ -1373,7 +1312,7 @@ def analyzeline(m, case, line):
                 for k in list(decl.keys()):
                     if not decl[k]:
                         del decl[k]
-                for r in markoutercomma(m1.group('after')).split('@,@'):
+                for r in aux.markoutercomma(m1.group('after')).split('@,@'):
                     if '-' in r:
                         try:
                             begc, endc = [x.strip() for x in r.split('-')]
@@ -1434,7 +1373,7 @@ def analyzeline(m, case, line):
             if l[0].startswith('('):
                 outmess('analyzeline: implied-DO list "%s" is not supported. Skipping.\n' % l[0])
                 continue
-            for idx, v in enumerate(rmbadname([x.strip() for x in markoutercomma(l[0]).split('@,@')])):
+            for idx, v in enumerate(rmbadname([x.strip() for x in aux.markoutercomma(l[0]).split('@,@')])):
                 if v.startswith('('):
                     outmess('analyzeline: implied-DO list "%s" is not supported. Skipping.\n' % v)
                     # XXX: subsequent init expressions may get wrong values.
@@ -1515,7 +1454,7 @@ def analyzeline(m, case, line):
         for c in cl:
             if c[0] not in commonkey:
                 commonkey[c[0]] = []
-            for i in [x.strip() for x in markoutercomma(c[1]).split('@,@')]:
+            for i in [x.strip() for x in aux.markoutercomma(c[1]).split('@,@')]:
                 if i:
                     commonkey[c[0]].append(i)
         groupcache[groupcounter]['common'] = commonkey
@@ -1616,14 +1555,14 @@ def cracktypespec0(typespec, ll):
         typespec = 'double precision'
     else:
         typespec = typespec.strip().lower()
-    m1 = selectpattern.match(markouterparen(ll))
+    m1 = selectpattern.match(aux.markouterparen(ll))
     if not m1:
         outmess(
             'cracktypespec0: no kind/char_selector pattern found for line.\n')
         return
     d = m1.groupdict()
     for k in list(d.keys()):
-        d[k] = unmarkouterparen(d[k])
+        d[k] = aux.unmarkouterparen(d[k])
     if typespec in ['complex', 'integer', 'logical', 'real', 'character', 'type']:
         selector = d['this']
         ll = d['after']
@@ -1704,7 +1643,7 @@ def updatevars(typespec, selector, attrspec, entitydecl):
     last_name = None
     kindselect, charselect, typename = cracktypespec(typespec, selector)
     if attrspec:
-        attrspec = [x.strip() for x in markoutercomma(attrspec).split('@,@')]
+        attrspec = [x.strip() for x in aux.markoutercomma(attrspec).split('@,@')]
         l = []
         c = re.compile(r'(?P<start>[a-zA-Z]+)')
         for a in attrspec:
@@ -1716,10 +1655,10 @@ def updatevars(typespec, selector, attrspec, entitydecl):
                 a = s + a[len(s):]
             l.append(a)
         attrspec = l
-    el = [x.strip() for x in markoutercomma(entitydecl).split('@,@')]
+    el = [x.strip() for x in aux.markoutercomma(entitydecl).split('@,@')]
     el1 = []
     for e in el:
-        for e1 in [x.strip() for x in markoutercomma(removespaces(markinnerspaces(e)), comma=' ').split('@ @')]:
+        for e1 in [x.strip() for x in aux.markoutercomma(removespaces(markinnerspaces(e)), comma=' ').split('@ @')]:
             if e1:
                 el1.append(e1.replace('@_@', ' '))
     for e in el1:
@@ -1782,7 +1721,7 @@ def updatevars(typespec, selector, attrspec, entitydecl):
                 groupcache[groupcounter]['externals'] = []
             groupcache[groupcounter]['externals'].append(e)
         if m.group('after'):
-            m1 = lenarraypattern.match(markouterparen(m.group('after')))
+            m1 = lenarraypattern.match(aux.markouterparen(m.group('after')))
             if m1:
                 d1 = m1.groupdict()
                 for lk in ['len', 'array', 'init']:
@@ -1791,7 +1730,7 @@ def updatevars(typespec, selector, attrspec, entitydecl):
                         del d1[lk + '2']
                 for k in list(d1.keys()):
                     if d1[k] is not None:
-                        d1[k] = unmarkouterparen(d1[k])
+                        d1[k] = aux.unmarkouterparen(d1[k])
                     else:
                         del d1[k]
 
@@ -1889,7 +1828,7 @@ def cracktypespec(typespec, selector):
             del charselect['charlen']
             if charselect['lenkind']:
                 lenkind = lenkindpattern.match(
-                    markoutercomma(charselect['lenkind']))
+                    aux.markoutercomma(charselect['lenkind']))
                 lenkind = lenkind.groupdict()
                 for lk in ['len', 'kind']:
                     if lenkind[lk + '2']:
@@ -2206,7 +2145,7 @@ def analyzecommon(block):
                 dims = []
                 if m.group('dims'):
                     dims = [x.strip()
-                            for x in markoutercomma(m.group('dims')).split('@,@')]
+                            for x in aux.markoutercomma(m.group('dims')).split('@,@')]
                 n = rmbadname1(m.group('name').strip())
                 if n in block['vars']:
                     if 'attrspec' in block['vars'][n]:
@@ -2697,7 +2636,7 @@ def analyzevars(block):
                 if intent:
                     if 'intent' not in vars[n]:
                         vars[n]['intent'] = []
-                    for c in [x.strip() for x in markoutercomma(intent).split('@,@')]:
+                    for c in [x.strip() for x in aux.markoutercomma(intent).split('@,@')]:
                         # Remove spaces so that 'in out' becomes 'inout'
                         tmp = c.replace(' ', '')
                         if tmp not in vars[n]['intent']:
@@ -2714,20 +2653,20 @@ def analyzevars(block):
                 if depend is not None:
                     if 'depend' not in vars[n]:
                         vars[n]['depend'] = []
-                    for c in rmbadname([x.strip() for x in markoutercomma(depend).split('@,@')]):
+                    for c in rmbadname([x.strip() for x in aux.markoutercomma(depend).split('@,@')]):
                         if c not in vars[n]['depend']:
                             vars[n]['depend'].append(c)
                     depend = None
                 if check is not None:
                     if 'check' not in vars[n]:
                         vars[n]['check'] = []
-                    for c in [x.strip() for x in markoutercomma(check).split('@,@')]:
+                    for c in [x.strip() for x in aux.markoutercomma(check).split('@,@')]:
                         if c not in vars[n]['check']:
                             vars[n]['check'].append(c)
                     check = None
             if dim and 'dimension' not in vars[n]:
                 vars[n]['dimension'] = []
-                for d in rmbadname([x.strip() for x in markoutercomma(dim).split('@,@')]):
+                for d in rmbadname([x.strip() for x in aux.markoutercomma(dim).split('@,@')]):
                     star = ':' if d == ':' else '*'
                     # Evaluate `d` with respect to params
                     if d in params:
@@ -2743,7 +2682,7 @@ def analyzevars(block):
                     if d == star:
                         dl = [star]
                     else:
-                        dl = markoutercomma(d, ':').split('@:@')
+                        dl = aux.markoutercomma(d, ':').split('@:@')
                     if len(dl) == 2 and '*' in dl:  # e.g. dimension(5:*)
                         dl = ['*']
                         d = '*'
@@ -3086,7 +3025,7 @@ def determineexprtype(expr, vars, rules={}):
                 'determineexprtype: selected kind types not supported (%s)\n' % repr(expr))
         return {'typespec': 'real'}
     for op in ['+', '-', '*', '/']:
-        for e in [x.strip() for x in markoutercomma(expr, comma=op).split('@' + op + '@')]:
+        for e in [x.strip() for x in aux.markoutercomma(expr, comma=op).split('@' + op + '@')]:
             if e in vars:
                 return _ensure_exprdict(vars[e])
     t = {}

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -71,7 +71,7 @@ from .auxfuncs import (
     islong_double, islong_doublefunction, islong_long,
     islong_longfunction, ismoduleroutine, isoptional, isrequired,
     isscalar, issigned_long_longarray, isstring, isstringarray,
-    isstringfunction, issubroutine, isattr_value,
+    isstringfunction, issubroutine, isattr_value, isderivedtype,
     issubroutine_wrap, isthreadsafe, isunsigned, isunsigned_char,
     isunsigned_chararray, isunsigned_long_long,
     isunsigned_long_longarray, isunsigned_short, isunsigned_shortarray,
@@ -83,6 +83,7 @@ from . import cfuncs
 from . import common_rules
 from . import use_rules
 from . import f90mod_rules
+from . import simple_derived_types as sdt
 from . import func2subr
 
 f2py_version = __version__.version
@@ -96,8 +97,8 @@ for k in ['decl',
           'cleanupfrompyobj',
           'topyarr', 'method',
           'pyobjfrom', 'closepyobjfrom',
-          'freemem',
-          'userincludes',
+          'freemem', 'typedefs_derivedtypefuncs',
+          'userincludes', 'typedefs_derivedtypedefs',
           'includes0', 'includes', 'typedefs', 'typedefs_generated',
           'cppmacros', 'cfuncs', 'callbacks',
           'latexdoc',
@@ -147,11 +148,17 @@ static PyObject *#modulename#_module;
 """ + gentitle("See f2py2e/cfuncs.py: typedefs_generated") + """
 #typedefs_generated#
 
+""" + gentitle("See f2py2e/simple_derived_types.py") + """
+#typedefs_derivedtypedefs#
+
 """ + gentitle("See f2py2e/cfuncs.py: cppmacros") + """
 #cppmacros#
 
 """ + gentitle("See f2py2e/cfuncs.py: cfuncs") + """
 #cfuncs#
+
+""" + gentitle("See f2py2e/simple_derived_types.py") + """
+#typedefs_derivedtypefuncs#
 
 """ + gentitle("See f2py2e/cfuncs.py: userincludes") + """
 #userincludes#
@@ -588,7 +595,7 @@ rout_rules = [
                  {iscomplexfunction: 'pyobj_from_#ctype#1'},
                  {islong_longfunction: 'long_long'},
                  {islong_doublefunction: 'long_double'}],
-        'returnformat': {l_not(isintent_hide): '#rformat#'},
+        'returnformat': {l_and(l_not(isintent_hide), l_not(isderivedtype)): '#rformat#'},
         'return': {iscomplexfunction: ',#name#_return_value_capi',
                    l_not(l_or(iscomplexfunction, isintent_hide)): ',#name#_return_value'},
         '_check': l_and(isfunction, l_not(isstringfunction), l_not(isfunction_wrap))
@@ -666,7 +673,7 @@ aux_rules = [
     },
     {  # Common
         'frompyobj': ['    /* Processing auxiliary variable #varname# */',
-                      {debugcapi: '    fprintf(stderr,"#vardebuginfo#\\n");'}, ],
+                      {l_and(debugcapi, l_not(isderivedtype)): '    fprintf(stderr,"#vardebuginfo#\\n");'}, ],
         'cleanupfrompyobj': '    /* End of cleaning variable #varname# */',
         'need': typedef_need_dict,
     },
@@ -751,8 +758,8 @@ arg_rules = [
         'separatorsfor': sepdict
     },
     {  # Common
-        'frompyobj': ['    /* Processing variable #varname# */',
-                      {debugcapi: '    fprintf(stderr,"#vardebuginfo#\\n");'}, ],
+        'frompyobj': [{l_not(isderivedtype):'    /* Processing variable #varname# */'},
+                      {l_and(debugcapi, l_not(isderivedtype)): '    fprintf(stderr,"#vardebuginfo#\\n");'}, ],
         'cleanupfrompyobj': '    /* End of cleaning variable #varname# */',
         '_depend': '',
         'need': typedef_need_dict,
@@ -1202,6 +1209,20 @@ if (#varname#_cb.capi==Py_None) {
         'callfortranappend': {isarrayofstrings: 'flen(#varname#),'},
         'need': 'string',
         '_check': isstringarray
+    },
+    # Derived types
+    {
+        'decl': ['    #ctype# #varname#;',
+                 '    memset(&#varname#, 0, sizeof(#ctype#));',
+                 '    PyObject *#varname#_capi = Py_None;'],
+        'args_capi': {isrequired: ',&#varname#_capi'},
+        'keys_capi': {isoptional: ',&#varname#_capi'},
+        'argformat': ['##varname#_format#'],
+        'callfortran':["##varname#_dcf#"],
+        'returnformat': "##varname#_drf#",
+        'return': "##varname#_ret#",
+        'need':['typedefs_derivedtypes'],
+        '_check':isderivedtype
     }
 ]
 
@@ -1243,7 +1264,12 @@ check_rules = [
 
 def buildmodule(m, um):
     """
-    Return
+    Parameters
+    ----------
+    m : dictionary
+        This is the dictionary representing the cracked form of the module.
+    um : string
+        This is the name of the module.
     """
     outmess('    Building module "%s"...\n' % (m['name']))
     ret = {}
@@ -1318,6 +1344,11 @@ def buildmodule(m, um):
     ar = applyrules(mr, vrd)
     rd = dictappend(rd, ar)
 
+    # Construct F90 simple derived type declarations
+    mr = sdt.buildhooks(m)
+    ar = applyrules(mr, vrd)
+    rd = dictappend(rd, ar)
+
     for u in um:
         ar = use_rules.buildusevars(u, m['use'][u['name']])
         rd = dictappend(rd, ar)
@@ -1341,6 +1372,10 @@ def buildmodule(m, um):
                 c = cfuncs.typedefs[k]
             elif k in cfuncs.typedefs_generated:
                 c = cfuncs.typedefs_generated[k]
+            elif k in cfuncs.typedefs_derivedtypedefs:
+                c = cfuncs.typedefs_derivedtypedefs[k]
+            elif k in cfuncs.typedefs_derivedtypefuncs:
+                c = cfuncs.typedefs_derivedtypefuncs[k]
             elif k in cfuncs.cppmacros:
                 c = cfuncs.cppmacros[k]
             elif k in cfuncs.cfuncs:
@@ -1469,6 +1504,17 @@ def buildapi(rout):
             ar = applyrules(r, vrd, rout)
             rd = dictappend(rd, ar)
 
+    # Derived type returns
+    isDerived = [True for x in var.values() if x.get('typespec')=='type']
+    if len(isDerived)>0:
+        mr = sdt.routine_rules(rout)
+        ar = applyrules(mr, vrd)
+        rd = dictappend(rd, ar)
+
+        marg = sdt.arg_rules(rout)
+        ar = applyrules(marg, vrd)
+        rd = dictappend(rd, ar)
+
     # Args
     nth, nthk = 0, 0
     savevrd = {}
@@ -1515,10 +1561,13 @@ def buildapi(rout):
                 vrd['check'] = c
                 ar = applyrules(check_rules, vrd, var[a])
                 rd = dictappend(rd, ar)
+
+    # Cleanup
     if isinstance(rd['cleanupfrompyobj'], list):
         rd['cleanupfrompyobj'].reverse()
     if isinstance(rd['closepyobjfrom'], list):
         rd['closepyobjfrom'].reverse()
+    # Documentation
     rd['docsignature'] = stripcomma(replace('#docsign##docsignopt##docsignxa#',
                                             {'docsign': rd['docsign'],
                                              'docsignopt': rd['docsignopt'],

--- a/numpy/f2py/simple_derived_types.py
+++ b/numpy/f2py/simple_derived_types.py
@@ -1,0 +1,275 @@
+"""
+
+Build F90 derived types support for f2py2e.
+
+Copyright 2020 NumPy developers,
+Permission to use, modify, and distribute this software is given under the
+terms of the NumPy License.
+
+NO WARRANTY IS EXPRESSED OR IMPLIED.  USE AT YOUR OWN RISK.
+
+"""
+
+import functools as fn
+from collections import namedtuple
+from . import auxfuncs as aux
+from . import capi_maps as capim
+
+FCPyConversionRow = namedtuple(
+    'FCPyConversionRow',
+    ['fortran_isoc', 'ctype', 'py_type', 'py_conv', 'varname'],
+    defaults=[None])
+
+# These are sourced from:
+# ISO_C_BINDINGS: https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html
+# Python Types: https://docs.python.org/3/c-api/arg.html
+# Py_Conv: https://docs.python.org/3/c-api/
+fcpyconv = [
+    # Integers
+    # TODO: Use cfuncs.py versions
+    FCPyConversionRow(fortran_isoc='c_int',
+                      ctype='int',
+                      py_type='i',
+                      py_conv='PyLong_FromLong'),
+    FCPyConversionRow(fortran_isoc='c_short',
+                      ctype='short int',
+                      py_type='h',
+                      py_conv='PyLong_FromLong'),
+    FCPyConversionRow(fortran_isoc='c_long',
+                      ctype='long int',
+                      py_type='l',
+                      py_conv='PyLong_FromLong'),
+    FCPyConversionRow(fortran_isoc='c_long_long',
+                      ctype='long long int',
+                      py_type='L',
+                      py_conv='PyLong_FromLongLong'),
+    # TODO: Add int6 and other sizes
+    # Evidently ISO_C_BINDINGs do not have unsigned integers
+    # Floats
+    FCPyConversionRow(fortran_isoc='c_float',
+                      ctype='float',
+                      py_type='f',
+                      py_conv='float_from_pyobj'),
+    FCPyConversionRow(fortran_isoc='c_double',
+                      ctype='double',
+                      py_type='d',
+                      py_conv='double_from_pyobj'),
+    FCPyConversionRow(
+        fortran_isoc='c_long_double',
+        ctype='long double',
+        py_type='d',  # No long double
+        py_conv='long_double_from_pyobj'),
+    # Strings
+    # TODO: Fortran has special identifiers for NULL / CR etc.
+    FCPyConversionRow(fortran_isoc='c_char',
+                      ctype='char',
+                      py_type='z',
+    # TODO: This is broken for now, need to generate wrappers with ISO_Fortran_binding.h
+    # See: https://www.cdslab.org/recipes/programming/fortran-c-interoperation-string/fortran-c-interoperation-string
+    # https://community.intel.com/t5/Intel-Fortran-Compiler/passing-string-from-Fortran-to-C/td-p/1138766
+                      py_conv='string_from_pyobj'),
+]
+
+
+def find_typeblocks(pymod):
+    """Return a list of type definitions
+
+    Parameters
+    ----------
+    pymod : dict
+        The python module dictionary.
+
+    Returns
+    -------
+    ret : list
+       This returns a list of module blocks
+    """
+    ret = []
+    m = pymod.get('body')
+    for blockdef in m:
+        if blockdef['block'] == 'type':
+            del blockdef['parent_body']
+            ret.append(blockdef)
+    return ret
+
+
+def extract_typedat(typeblock):
+    assert typeblock['block'] == 'type'
+    typevars = []
+    alldtypes = typeblock['parent_block']['vars']
+    structname = typeblock['name']
+    for vname in typeblock['varnames']:
+        tbv = typeblock['vars'][vname]
+        if tbv['typespec'] == 'character':
+            vfkind = tbv['charselector']['kind']
+            tvar = [x for x in fcpyconv if x.fortran_isoc == vfkind][0]
+            typevars.append(tvar._replace(varname=vname))
+        elif 'typename' in tbv.keys():
+            breakpoint()
+            if tbv['typename'] in alldtypes:
+                vfkind = tbv['typename']
+                tvar = FCPyConversionRow(
+                    fortran_isoc=vfkind,
+                    ctype=vfkind,
+                    py_type='[f,f]',  # No long double
+                    py_conv='NULL'),
+        else:
+            vfkind = tbv['kindselector']['kind']
+            tvar = [x for x in fcpyconv if x.fortran_isoc == vfkind][0]
+            typevars.append(tvar._replace(varname=vname))
+    return structname, typevars
+
+
+def gen_typedecl(structname, tvars):
+    vdefs = [''.join(f"{x.ctype} {x.varname};") for x in tvars]
+    tdecl = f"""
+    typedef struct {{
+    {' '.join(vdefs)}
+    }} {structname};
+    """
+    return tdecl
+
+
+# TODO: Generalize to have an extract_from_pydict in need
+def gen_typefunc(structname, tvars):
+    clines = [
+        f"{tv.py_conv}(&xstruct->{tv.varname}, PyDict_GetItemString(x_capi, \"{tv.varname}\"), \"Error during conversion of {tv.varname} to {tv.ctype}\");\n\t "
+        for tv in tvars
+    ]
+    rvfunc = f"""
+static int {structname}_from_pyobj({structname} *xstruct, PyObject *x_capi){{
+   {''.join(clines)}
+   return 1;
+   }}
+    """
+    return rvfunc
+
+
+def gen_typeret(structname, tvars, vname):
+    """
+    The return value is generated from:
+        capi_buildvalue = Py_BuildValue(\"#returnformat#\"#return#);
+    Mapping:
+    returnformat -> retvardecl
+    return -> dretlines
+
+    Parameters
+    ===========
+    structname : string
+         The name of the derived type
+    tvars : list of namedtuple
+         Conversion rules for derived type elements
+    vname : string
+         The name of the variable in the subprogram
+    """
+    retvardecl = f"{{{','.join([f's:{x.py_type}' for x in tvars])}}}"
+    # XXX: Ugly hack, this forces
+    # capi_buildvalue = Py_BuildValue("#returnformat#","x", array.x,
+    # "y", array.y,
+    # "z", array.z # -> Note the missing ,
+    # );
+    dretlines = [
+        f"""{',' if idx==0 else ''}\
+\t \"{tv.varname}\", {vname}.{tv.varname}\
+{'' if idx==len(tvars)-1 else ','}
+        """ for idx, tv in enumerate(tvars)
+    ]
+    return retvardecl, ''.join(dretlines)
+
+
+def buildhooks(pymod):
+    # One structure and function for each derived type
+    tdefs = []
+    tfuncs = []
+    needs = []
+    # XXX: Get the type definitions in a sane way
+    for pym in pymod.get('body'):
+        for blk in pym['body']:
+            for typedet in blk['body']:
+                if typedet['block'] != 'type':
+                    continue
+                sname, vardefs = extract_typedat(typedet)
+                needs.append([x.py_conv for x in vardefs])
+                tdefs.append('\n'.join([gen_typedecl(sname, vardefs)]))
+                tfuncs.append('\n'.join([gen_typefunc(sname, vardefs)]))
+    # TODO: Document how these dictionary items get used in rules.py
+    return {
+        'typedefs_derivedtypedefs': tdefs,
+        'typedefs_derivedtypefuncs': tfuncs,
+        'need': needs
+    }
+
+
+def get_dtargs(rout_vars):
+    return [var for var in rout_vars if rout_vars[var]['typespec'] == 'type']
+
+
+def routine_rules(rout):
+    args, _ = aux.getargs2(rout)
+    larg = [arg_routines(rout, idx) for idx, arg in enumerate(args)]
+    return fn.reduce(lambda a,b: dict(a, **b), filter(None,larg))
+
+# TODO: Refactor, this is not Pythonic
+def arg_routines(rout, idx):
+    args, _ = aux.getargs2(rout)
+    rv = rout['vars'][args[idx]]
+    if aux.isscalar(rv):
+        return
+    rettype = [
+        x['typename'] for x in rout['vars'].values()
+        if (x['typespec'] == 'type') and (
+            ('inout' in x['intent']) or ('out' in x['intent']))
+    ][0]
+    for typedet in rout.get('parent_block').get('body'):
+        if typedet['block'] != 'type':
+            continue
+        if typedet['name'] == rettype:
+            sname, vardefs = extract_typedat(typedet)
+            if aux.isintent_in(rv):
+                dretf = dret = ''
+            else:
+                dretf, dret = gen_typeret(sname, vardefs, args[idx])
+    return {
+        f'{args[idx]}_drf': dretf,
+        f'{args[idx]}_ret': dret,
+        f'{args[idx]}_format': "O",
+        f'{args[idx]}_dcf': f"&{args[idx]},",
+    }
+
+
+def arg_rules(rout):
+    args, depargs = aux.getargs2(rout)
+    alltypes = [capim.getctype(rout['vars'][x]) for x in get_dtargs(rout['vars'])]
+    lstring = []
+    dstring = []
+    pstring = []
+    for arg in args:
+        rv = rout['vars'][arg]
+        ctype = capim.getctype(rv)
+        if ctype not in alltypes:
+            # These are processed for ParseTuple
+            lstring.append([x.py_type for x in fcpyconv
+                            if x.ctype == ctype][0])
+            dstring.append(f"&{arg}")
+        else:
+            lstring.append('O')
+            dstring.append(f"&{arg}_capi")
+            # Non derived types are processed in rules
+            pstring.append(f"    /* Processing variable {arg} */")
+            pstring.append(
+                f"    f2py_success = {ctype}_from_pyobj(&{arg}, {arg}_capi);")
+            if aux.debugcapi(rv):
+                pstring.append(
+                    f"""\
+            fprintf(stderr, "debug-capi:{ctype} {arg}=:{rv['intent'][0]},{rv['typespec']}\\n");
+            fprintf(stderr, "debug-capi:{arg}=");
+            PyObject_Print({arg}_capi, stderr, 0);
+            fprintf(stderr, "\\n");\
+                   """
+                )
+    fpyparse = f"""
+    /* Parsing arguments */
+    f2py_success = PyArg_ParseTuple(capi_args, \"{''.join(lstring)}\", {','.join(dstring)});
+   """
+    fpyobj = '\n'.join([fpyparse, '\n'.join(pstring)])
+    return {'frompyobj': fpyobj}

--- a/numpy/f2py/tests/src/crackfortran/isocbind.f90
+++ b/numpy/f2py/tests/src/crackfortran/isocbind.f90
@@ -1,0 +1,13 @@
+module vec
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+  type, bind(c) :: cartesian
+     real(c_float) :: x(2),y,z
+  end type cartesian
+
+  type, bind(c) :: radial
+     real(c_double) :: rad, theta
+  end type radial
+
+end module vec

--- a/numpy/f2py/tests/src/crackfortran/isocbindonly.f90
+++ b/numpy/f2py/tests/src/crackfortran/isocbindonly.f90
@@ -1,0 +1,13 @@
+module vec
+  use iso_c_binding, only: c_float, c_double
+  implicit none
+
+  type, bind(c) :: cartesian
+     real(c_float) :: x(2),y,z
+  end type cartesian
+
+  type, bind(c) :: radial
+     real(c_double) :: rad, theta
+  end type radial
+
+end module vec

--- a/numpy/f2py/tests/src/simple_derived_types/vecmod.f90
+++ b/numpy/f2py/tests/src/simple_derived_types/vecmod.f90
@@ -1,0 +1,19 @@
+module vec
+  use iso_c_binding, only: c_float, c_double
+  implicit none
+
+  type, bind(c) :: cartesian
+     real(c_float) :: x,y,z
+  end type cartesian
+
+  contains
+
+  subroutine n_move(array, di) bind(c)
+    type(cartesian), intent(inout) :: array
+    real(c_float), intent(in) :: di
+    array%x = array%x+di
+    array%y = array%y+di
+    array%z = array%z+di
+  end subroutine n_move
+
+end module vec

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -323,7 +323,6 @@ class TestNameArgsPatternBacktracking:
             good_version_of_adversary = repeated_adversary + '@)@'
             assert nameargspattern.search(good_version_of_adversary)
 
-
 class TestFunctionReturn(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "gh23598.f90")]
 
@@ -348,3 +347,18 @@ class TestF77CommonBlockReader():
         with contextlib.redirect_stdout(io.StringIO()) as stdout_f2py:
             mod = crackfortran.crackfortran([str(fpath)])
         assert "Mismatch" not in stdout_f2py.getvalue()
+
+
+class TestIntrinsicModule:
+    def test_dependencies_only(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "isocbindonly.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        assert mod[0]["use"] == {'iso_c_binding': {'map': {'c_double': 'double', 'c_float': 'float'}, 'only': 1}}
+
+    def test_dependencies(self, tmp_path):
+        fpath = util.getpath("tests", "src", "crackfortran", "isocbind.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        assert len(mod) == 1
+        from numpy.f2py import capi_maps as capim
+        assert list(mod[0]["use"].values())[0] == capim.iso_c_binding_map

--- a/numpy/f2py/tests/test_simple_derived_types.py
+++ b/numpy/f2py/tests/test_simple_derived_types.py
@@ -1,0 +1,9 @@
+from . import util
+
+class TestSimpleDerivedType(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "simple_derived_types", "vecmod.f90")]
+
+    def test_n_move(self):
+        a = {'x': 1, 'y': 2, 'z': 3}
+        assert a == self.module.vec.n_move(a, 0)
+        assert {'x': 3, 'y': 4, 'z': 5} == self.module.vec.n_move(a, 2)

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -194,6 +194,7 @@ PRIVATE_BUT_PRESENT_MODULES = ['numpy.' + s for s in [
     "f2py.rules",
     "f2py.symbolic",
     "f2py.use_rules",
+    "f2py.simple_derived_types",
     "fft.helper",
     "lib.user_array",  # note: not in np.lib, but probably should just be deleted
     "linalg.lapack_lite",


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR will establish the following:
- [x] Intrinsic modules do not cause `crackfortran` failures
  - Currently only `iso_c_binding` generates correct wrappers
- [x] The mapping for ISO_C_BINDING types

Additionally, for derived types:
- [x] Scalar numeric types (`c_float`, `c_double`)
- [ ] Derived types containing arrays of numeric data
- [ ] Arrays of derived types

These are being ported over from https://github.com/HaoZeke/f2py_skel/pull/17/files.

The F90 derived type support is in line with [#14938](https://github.com/numpy/numpy/issues/14938#issuecomment-636380425).

The implementation is fairly modular, and modifies the global dictionary to generate `bind(c)` compatible code.

A tracking issue should cover the rest of the items (strings, pointers) which are needed to fully support the standard interoperable C structures.

**Requires** #15844.