### PR TITLE
REV: Revert pull request #20466 from charris/backport-20365

### DIFF
--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1325,7 +1325,7 @@ _convert_from_dict(PyObject *obj, int align)
             goto fail;
         }
         /* If align is set, make sure the alignment divides into the size */
-        if (align && new->alignment > 0 && itemsize % new->alignment != 0) {
+        if (align && itemsize % new->alignment != 0) {
             PyErr_Format(PyExc_ValueError,
                     "NumPy dtype descriptor requires alignment of %d bytes, "
                     "which is not divisible into the specified itemsize %d",

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -621,12 +621,6 @@ class TestSubarray:
         t2 = np.dtype('2i4', align=True)
         assert_equal(t1.alignment, t2.alignment)
 
-    def test_aligned_empty(self):
-        # Mainly regression test for gh-19696: construction failed completely
-        dt = np.dtype([], align=True)
-        assert dt == np.dtype([])
-        dt = np.dtype({"names": [], "formats": [], "itemsize": 0}, align=True)
-        assert dt == np.dtype([])
 
 def iter_struct_object_dtypes():
     """


### PR DESCRIPTION
This reverts commit 157ee4f58d6f9f9c63ee7fdedf581785a7c51ec3, reversing
changes made to 87d6f96d7f107ced83eded0a04ec6519bef27448.

The reverted PR was a mistaken backport that introduced C++ into the
1.21.5 release, causing problems for some projects.

Closes #20765.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
