### PR TITLE
BUG: method without self argument should be static

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -14,6 +14,7 @@ MinusInfinity = 'PyFloat_FromDouble(-NPY_INFINITY)'
 ReorderableNone = "(Py_INCREF(Py_None), Py_None)"
 
 class docstrings:
+    @staticmethod
     def get(place):
         """
         Returns the C #definition name of docstring according


### PR DESCRIPTION
Fixes this LGTM.com alert:
https://lgtm.com/projects/g/numpy/numpy/snapshot/e802a82acaae0d71a42e15af761036416c3e96d8/files/numpy/core/code_generators/generate_umath.py?sort=name&dir=ASC&mode=heatmap#x911c70912edab39d:1