### PR TITLE
DOC: fix remaining "easy" doctests errors

### DIFF
--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -485,7 +485,9 @@ missing.
 
      >>> from numpy.lib.recfunctions import structured_to_unstructured
      >>> structured_to_unstructured(b[['x', 'z']])
-     array([0, 0, 0])
+     array([[0., 0.],
+            [0., 0.],
+            [0., 0.]], dtype=float32)
 
 
 Assignment to an array with a multi-field index modifies the original array::
@@ -590,7 +592,7 @@ The simplest way to create a record array is with
  >>> recordarr = np.rec.array([(1, 2., 'Hello'), (2, 3., "World")],
  ...                    dtype=[('foo', 'i4'),('bar', 'f4'), ('baz', 'S10')])
  >>> recordarr.bar
- array([ 2.,  3.], dtype=float32)
+ array([2., 3.], dtype=float32)
  >>> recordarr[1:2]
  rec.array([(2, 3., b'World')],
        dtype=[('foo', '<i4'), ('bar', '<f4'), ('baz', 'S10')])

--- a/doc/source/user/misc.rst
+++ b/doc/source/user/misc.rst
@@ -81,7 +81,7 @@ Examples
  >>> np.zeros(5,dtype=np.float32)/0.
  Traceback (most recent call last):
  ...
- RuntimeWarning: invalid value encountered in true_divide
+ RuntimeWarning: invalid value encountered in divide
  >>> j = np.seterr(under='ignore')
  >>> np.array([1.e-100])**10
  array([0.])


### PR DESCRIPTION
This is the continuation of my work on passing pytest.

The PR is small but now the only tests that fail in doc/source/{user,reference}
are those that require a compiled extension.