### PR TITLE
MAINT: removed duplicate 'int' type in ScalarType

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -516,7 +516,7 @@ def _scalar_type_key(typ):
     return (dt.kind.lower(), dt.itemsize)
 
 
-ScalarType = [int, float, complex, int, bool, bytes, str, memoryview]
+ScalarType = [int, float, complex, bool, bytes, str, memoryview]
 ScalarType += sorted(_concrete_types, key=_scalar_type_key)
 ScalarType = tuple(ScalarType)
 

--- a/numpy/core/numerictypes.pyi
+++ b/numpy/core/numerictypes.pyi
@@ -137,7 +137,6 @@ ScalarType: tuple[
     type[int],
     type[float],
     type[complex],
-    type[int],
     type[bool],
     type[bytes],
     type[str],

--- a/numpy/typing/tests/data/pass/numerictypes.py
+++ b/numpy/typing/tests/data/pass/numerictypes.py
@@ -38,9 +38,9 @@ np.nbytes[np.int64]
 
 np.ScalarType
 np.ScalarType[0]
-np.ScalarType[4]
-np.ScalarType[9]
-np.ScalarType[11]
+np.ScalarType[3]
+np.ScalarType[8]
+np.ScalarType[10]
 
 np.typecodes["Character"]
 np.typecodes["Complex"]

--- a/numpy/typing/tests/data/reveal/numerictypes.pyi
+++ b/numpy/typing/tests/data/reveal/numerictypes.pyi
@@ -33,9 +33,9 @@ reveal_type(np.nbytes[np.int64])  # E: int
 
 reveal_type(np.ScalarType)  # E: Tuple
 reveal_type(np.ScalarType[0])  # E: Type[builtins.int]
-reveal_type(np.ScalarType[4])  # E: Type[builtins.bool]
-reveal_type(np.ScalarType[9])  # E: Type[{csingle}]
-reveal_type(np.ScalarType[11])  # E: Type[{clongdouble}]
+reveal_type(np.ScalarType[3])  # E: Type[builtins.bool]
+reveal_type(np.ScalarType[8])  # E: Type[{csingle}]
+reveal_type(np.ScalarType[10])  # E: Type[{clongdouble}]
 
 reveal_type(np.typecodes["Character"])  # E: Literal['c']
 reveal_type(np.typecodes["Complex"])  # E: Literal['FDG']


### PR DESCRIPTION
This is a redo of #20526 (I had not given a proper branch name), including the test changes.