### PR TITLE
DOC: Update Copyright to 2022 [License]

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2021, NumPy Developers.
+Copyright (c) 2005-2022, NumPy Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -108,7 +108,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'NumPy'
-copyright = '2008-2021, The NumPy community'
+copyright = '2008-2022, The NumPy community'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -108,7 +108,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'NumPy'
-copyright = '2008-2022, The NumPy community'
+copyright = '2008-2022, NumPy Developers'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
Update NumPy Copyright to 2022
Changed files:
- `LICENSE.txt`
- `doc/source/conf.py`

Happy new year :)