### PR TITLE
BUG, DOC: Fixes SciPy docs build warnings

### DIFF
--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -381,7 +381,7 @@ class Expr:
                                              language=language)
                                   for a in self.data]
             if language is Language.C:
-                r = f'({cond} ? {expr1} : {expr2})'
+                r = f'({cond}?{expr1}:{expr2})'
             elif language is Language.Python:
                 r = f'({expr1} if {cond} else {expr2})'
             elif language is Language.Fortran:

--- a/numpy/f2py/tests/test_symbolic.py
+++ b/numpy/f2py/tests/test_symbolic.py
@@ -201,7 +201,7 @@ class TestSymbolic(util.F2PyTest):
         assert (x + (x - y) / (x + y) +
                 n).tostring(language=language) == "123 + x + (x - y) / (x + y)"
 
-        assert as_ternary(x, y, z).tostring(language=language) == "(x ? y : z)"
+        assert as_ternary(x, y, z).tostring(language=language) == "(x?y:z)"
         assert as_eq(x, y).tostring(language=language) == "x == y"
         assert as_ne(x, y).tostring(language=language) == "x != y"
         assert as_lt(x, y).tostring(language=language) == "x < y"


### PR DESCRIPTION
The new f2py symbolic parser writes ternary expressions with
spaces surrounding the colon operator, which causes the generated
docstrings to be incorrectly parsed. Removing the spaces solves the
issue.

Fixes #20696 
