### PR TITLE
DOC: git:// protocol deprecated by github.

### DIFF
--- a/doc/source/dev/gitwash/following_latest.rst
+++ b/doc/source/dev/gitwash/following_latest.rst
@@ -16,7 +16,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/numpy/numpy.git
+   git clone https://github.com/numpy/numpy.git
 
 You now have a copy of the code tree in the new ``numpy`` directory.
 If this doesn't work you can try the alternative read-only url::


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/

Tell users to use https://

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
