### PR TITLE
TST: Bump mypy to 0.931

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.930
+  - mypy=0.931
   # For building docs
   - sphinx=4.1.1
   - numpydoc=1.1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-cov==3.0.0
 cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
-mypy==0.930; platform_python_implementation != "PyPy"
+mypy==0.931; platform_python_implementation != "PyPy"


### PR DESCRIPTION
Bump mypy to the 0.931.

The 0.930 and 0.930 releases appear to be fully compatible, so no need for a backport.