### PR TITLE
MAINT: Raise RuntimeError if setuptools version is too recent.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,10 @@ if os.path.exists('MANIFEST'):
 # so that it is in sys.modules
 import numpy.distutils.command.sdist
 import setuptools
+if int(setuptools.__version__.split('.')[0]) >= 60:
+    raise RuntimeError(
+        "Setuptools version is '{}', version < '60.0.0' is required. "
+        "See pyproject.toml".format(setuptools.__version__))
 
 # Initialize cmdclass from versioneer
 from numpy.distutils.core import numpy_cmdclass


### PR DESCRIPTION
Backport of #20759.

NumPy does not build with setuptools versions greater than '60.0.0'.
Check the version when setuptools is imported in setup.py and raise
a RuntimeError if the version is too recent. That way we avoid people
opening issues when their build fails for that reason.

Closes #20692.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
