### PR TITLE
ENH: Add a numeric version_tuple to numpy.

### DIFF
--- a/doc/release/upcoming_changes/20803.improvement.rst
+++ b/doc/release/upcoming_changes/20803.improvement.rst
@@ -1,0 +1,16 @@
+Add a numeric ``numpy.version.__version_info__``
+------------------------------------------------
+
+This makes it easier and less error prone to write conditional code that
+depends on numpy version.
+
+We limit ``__version_info__`` tuple to be numeric only for now with only major/minor/patch.
+
+Dependencies can now check numpy version simply with, for example::
+
+   >>> import numpy
+   ... assert numpy.version.__version_info__ > (1, 22)
+
+
+For most complex comparison, you can make use of ``packaging.version.parse``
+which replace distutils's deprecated ``LooseVersion``.

--- a/numpy/version.py
+++ b/numpy/version.py
@@ -20,4 +20,34 @@ release = 'dev0' not in version and '+' not in version
 full_version = version
 short_version = version.split("+")[0]
 
-del get_versions, vinfo
+
+def make_version_info() -> tuple[int, int, int]:
+    """
+    We want to expose a numeric version tuple to make it easier for
+    dependencies to have conditional code without having to parse our version
+    string.
+
+    It can be tricky as 1) you don't want to compare string. 2) it can be
+    tempting to just split on dot and map convert to int, but that will fail on
+    rc, and others.
+
+    It is ok to drop all the non-numeric items as conditional code is unlikely
+    to rely on those values. We also don't add the non-numeric elements at the
+    end, as strings should anyway not be compared.
+
+    Matplotlib goes a bit further and make that a named tuple and include the
+    a/b/rc/... in the fourth place in the tuple, but this is generally
+    unnecessary. Though it could be added in a backward compatible manner.
+    """
+    import re
+
+    str_major, str_minor, str_patch_extra = short_version.split(".")[:3]
+    major = int(str_major)
+    minor = int(str_minor)
+    patch = int(re.findall(r"\d+", str_patch_extra)[0])
+    return (major, minor, patch)
+
+
+__version_info__ = make_version_info()
+
+del get_versions, vinfo, make_version_info


### PR DESCRIPTION
This makes it easier and less error prone to write conditional code that
depends on numpy version.

We limit version tuple to be numeric only, and only major/minor/patch.

Dependencies can now check numpy version simply with:

    >>> import numpy
    ... assert numpy.version.version_tuple > (1, 22)

Without relying on more complex dependencies like
`packaging.version.parse`, or distutils' LooseVersion (which is now
deprecated).

This also prevent roll-out of custom version parsing code that might be
error prone, or worse, comparison of strings.

-- 

Note that I would call it `version_info`, as that the name IPython uses to expose it, but ~~matplotlib exposes `version_tuple`~~, and @rgommers seem to prefer `version_tuple`.

Note: matplotlib changed the version_tuple to `__version_info__`
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
