### PR TITLE
DOC: Restore MaskedArray.hardmask documentation

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3542,7 +3542,7 @@ class MaskedArray(ndarray):
 
     def harden_mask(self):
         """
-        Force the mask to hard.
+        Force the mask to hard, preventing unmasking by assignment.
 
         Whether the mask of a masked array is hard or soft is determined by
         its `~ma.MaskedArray.hardmask` property. `harden_mask` sets
@@ -3551,6 +3551,7 @@ class MaskedArray(ndarray):
         See Also
         --------
         ma.MaskedArray.hardmask
+        ma.MaskedArray.soften_mask
 
         """
         self._hardmask = True
@@ -3558,7 +3559,7 @@ class MaskedArray(ndarray):
 
     def soften_mask(self):
         """
-        Force the mask to soft.
+        Force the mask to soft (default), allowing unmasking by assignment.
 
         Whether the mask of a masked array is hard or soft is determined by
         its `~ma.MaskedArray.hardmask` property. `soften_mask` sets
@@ -3567,6 +3568,7 @@ class MaskedArray(ndarray):
         See Also
         --------
         ma.MaskedArray.hardmask
+        ma.MaskedArray.harden_mask
 
         """
         self._hardmask = False
@@ -3574,7 +3576,19 @@ class MaskedArray(ndarray):
 
     @property
     def hardmask(self):
-        """ Hardness of the mask """
+        """
+        Specifies whether values can be unmasked through assignments.
+
+        By default, assigning definite values to masked array entries will
+        unmask them.  When `hardmask` is ``True``, the mask will not change
+        through assignments.
+        
+        See Also
+        --------
+        ma.MaskedArray.harden_mask
+        ma.MaskedArray.soften_mask
+
+        """
         return self._hardmask
 
     def unshare_mask(self):

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3546,7 +3546,8 @@ class MaskedArray(ndarray):
 
         Whether the mask of a masked array is hard or soft is determined by
         its `~ma.MaskedArray.hardmask` property. `harden_mask` sets
-        `~ma.MaskedArray.hardmask` to ``True``.
+        `~ma.MaskedArray.hardmask` to ``True`` (and returns the modified
+        self).
 
         See Also
         --------
@@ -3563,7 +3564,8 @@ class MaskedArray(ndarray):
 
         Whether the mask of a masked array is hard or soft is determined by
         its `~ma.MaskedArray.hardmask` property. `soften_mask` sets
-        `~ma.MaskedArray.hardmask` to ``False``.
+        `~ma.MaskedArray.hardmask` to ``False`` (and returns the modified
+        self).
 
         See Also
         --------
@@ -3593,7 +3595,7 @@ class MaskedArray(ndarray):
 
     def unshare_mask(self):
         """
-        Copy the mask and set the sharedmask flag to False.
+        Copy the mask and set the `sharedmask` flag to ``False``.
 
         Whether the mask is shared between masked arrays can be seen from
         the `sharedmask` property. `unshare_mask` ensures the mask is not shared.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3590,6 +3590,33 @@ class MaskedArray(ndarray):
         ma.MaskedArray.harden_mask
         ma.MaskedArray.soften_mask
 
+        Examples
+        --------
+        >>> x = np.arange(10)
+        >>> m = np.ma.masked_array(x, x>5)
+        >>> assert not m.hardmask
+
+        Since `m` has a soft mask, assigning an element value unmasks that
+        element:
+
+        >>> m[8] = 42
+        >>> m
+        masked_array(data=[0, 1, 2, 3, 4, 5, --, --, 42, --],
+                     mask=[False, False, False, False, False, False,  True,  True,
+                           False,  True],
+               fill_value=999999)
+
+        After hardening, the mask is not affected by assignments:
+
+        >>> hardened = np.ma.harden_mask(m)
+        >>> assert m.hardmask and hardened is m
+        >>> m[:] = 23
+        >>> m
+        masked_array(data=[23, 23, 23, 23, 23, 23, --, --, 23, --],
+                     mask=[False, False, False, False, False, False,  True,  True,
+                           False,  True],
+               fill_value=999999)
+
         """
         return self._hardmask
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3602,8 +3602,8 @@ class MaskedArray(ndarray):
         >>> m[8] = 42
         >>> m
         masked_array(data=[0, 1, 2, 3, 4, 5, --, --, 42, --],
-                     mask=[False, False, False, False, False, False,  True,  True,
-                           False,  True],
+                     mask=[False, False, False, False, False, False,
+                           True, True, False, True],
                fill_value=999999)
 
         After hardening, the mask is not affected by assignments:
@@ -3613,8 +3613,8 @@ class MaskedArray(ndarray):
         >>> m[:] = 23
         >>> m
         masked_array(data=[23, 23, 23, 23, 23, 23, --, --, 23, --],
-                     mask=[False, False, False, False, False, False,  True,  True,
-                           False,  True],
+                     mask=[False, False, False, False, False, False,
+                           True, True, False, True],
                fill_value=999999)
 
         """
@@ -3625,8 +3625,8 @@ class MaskedArray(ndarray):
         Copy the mask and set the `sharedmask` flag to ``False``.
 
         Whether the mask is shared between masked arrays can be seen from
-        the `sharedmask` property. `unshare_mask` ensures the mask is not shared.
-        A copy of the mask is only made if it was shared.
+        the `sharedmask` property. `unshare_mask` ensures the mask is not
+        shared. A copy of the mask is only made if it was shared.
 
         See Also
         --------


### PR DESCRIPTION
Fix #19331 by properly documenting the purpose of MaskedArray.hardmask