### PR TITLE
BUG: Return correctly shaped inverse indices in array_api set functions

### DIFF
--- a/numpy/array_api/_set_functions.py
+++ b/numpy/array_api/_set_functions.py
@@ -41,14 +41,21 @@ def unique_all(x: Array, /) -> UniqueAllResult:
 
     See its docstring for more information.
     """
-    res = np.unique(
+    values, indices, inverse_indices, counts = np.unique(
         x._array,
         return_counts=True,
         return_index=True,
         return_inverse=True,
     )
-
-    return UniqueAllResult(*[Array._new(i) for i in res])
+    # np.unique() flattens inverse indices, but they need to share x's shape
+    # See https://github.com/numpy/numpy/issues/20638
+    inverse_indices = inverse_indices.reshape(x.shape)
+    return UniqueAllResult(
+        Array._new(values),
+        Array._new(indices),
+        Array._new(inverse_indices),
+        Array._new(counts),
+    )
 
 
 def unique_counts(x: Array, /) -> UniqueCountsResult:
@@ -68,13 +75,16 @@ def unique_inverse(x: Array, /) -> UniqueInverseResult:
 
     See its docstring for more information.
     """
-    res = np.unique(
+    values, inverse_indices = np.unique(
         x._array,
         return_counts=False,
         return_index=False,
         return_inverse=True,
     )
-    return UniqueInverseResult(*[Array._new(i) for i in res])
+    # np.unique() flattens inverse indices, but they need to share x's shape
+    # See https://github.com/numpy/numpy/issues/20638
+    inverse_indices = inverse_indices.reshape(x.shape)
+    return UniqueInverseResult(Array._new(values), Array._new(inverse_indices))
 
 
 def unique_values(x: Array, /) -> Array:

--- a/numpy/array_api/tests/test_set_functions.py
+++ b/numpy/array_api/tests/test_set_functions.py
@@ -1,0 +1,19 @@
+import pytest
+from hypothesis import given
+from hypothesis.extra.array_api import make_strategies_namespace
+
+from numpy import array_api as xp
+
+xps = make_strategies_namespace(xp)
+
+
+@pytest.mark.parametrize("func", [xp.unique_all, xp.unique_inverse])
+@given(xps.arrays(dtype=xps.scalar_dtypes(), shape=xps.array_shapes()))
+def test_inverse_indices_shape(func, x):
+    """
+    Inverse indices share shape of input array
+
+    See https://github.com/numpy/numpy/issues/20638
+    """
+    out = func(x)
+    assert out.inverse_indices.shape == x.shape


### PR DESCRIPTION
Backport of #20791.

As inverse indices from `np.unique()` are flattened when `axis=None` (the default), the related `array_api` set functions ([`xp.unique_inverse`](https://data-apis.org/array-api/latest/API_specification/set_functions.html#unique-inverse-x)/[`xp.unique_all`](https://data-apis.org/array-api/latest/API_specification/set_functions.html#unique-all-x)) don't return shape-sharing indices as the Array API specifies. This PR fixes this by internally reshaping the inverse indices. 

Tested in [array-api-tests ](https://github.com/data-apis/array-api-tests), specifically https://github.com/data-apis/array-api-tests/blob/master/array_api_tests/test_set_functions.py. Note these tests will fail due to unrelated NaN-uniqueness issues.

Related #20638 
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
