### PR TITLE
ENH: don't use logarithm in random exponential and normal distributions

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -46,8 +46,8 @@ void random_standard_uniform_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float 
 static double standard_exponential_unlikely(bitgen_t *bitgen_state,
                                                 uint8_t idx, double x) {
   if (idx == 0) {
-    /* Switch to 1.0 - U to avoid log(0.0), see GH 13361 */
-    return ziggurat_exp_r - npy_log1p(-next_double(bitgen_state));
+    /* The tail of the exponential looks exactly like its body */
+    return ziggurat_exp_r + random_standard_exponential(bitgen_state);
   } else if ((fe_double[idx - 1] - fe_double[idx]) * next_double(bitgen_state) +
                  fe_double[idx] <
              exp(-x)) {
@@ -83,8 +83,8 @@ void random_standard_exponential_fill(bitgen_t * bitgen_state, npy_intp cnt, dou
 static float standard_exponential_unlikely_f(bitgen_t *bitgen_state,
                                                  uint8_t idx, float x) {
   if (idx == 0) {
-    /* Switch to 1.0 - U to avoid log(0.0), see GH 13361 */
-    return ziggurat_exp_r_f - npy_log1pf(-next_float(bitgen_state));
+    /* The tail of the exponential looks exactly like its body */
+    return ziggurat_exp_r_f + random_standard_exponential_f(bitgen_state);
   } else if ((fe_float[idx - 1] - fe_float[idx]) * next_float(bitgen_state) +
                  fe_float[idx] <
              expf(-x)) {
@@ -154,9 +154,8 @@ double random_standard_normal(bitgen_t *bitgen_state) {
       return x; /* 99.3% of the time return here */
     if (idx == 0) {
       for (;;) {
-        /* Switch to 1.0 - U to avoid log(0.0), see GH 13361 */
-        xx = -ziggurat_nor_inv_r * npy_log1p(-next_double(bitgen_state));
-        yy = -npy_log1p(-next_double(bitgen_state));
+        xx = ziggurat_nor_inv_r * random_standard_exponential(bitgen_state);
+        yy = random_standard_exponential(bitgen_state);
         if (yy + yy > xx * xx)
           return ((rabs >> 8) & 0x1) ? -(ziggurat_nor_r + xx)
                                      : ziggurat_nor_r + xx;
@@ -195,9 +194,8 @@ float random_standard_normal_f(bitgen_t *bitgen_state) {
       return x; /* # 99.3% of the time return here */
     if (idx == 0) {
       for (;;) {
-        /* Switch to 1.0 - U to avoid log(0.0), see GH 13361 */
-        xx = -ziggurat_nor_inv_r_f * npy_log1pf(-next_float(bitgen_state));
-        yy = -npy_log1pf(-next_float(bitgen_state));
+        xx = ziggurat_nor_inv_r_f * random_standard_exponential_f(bitgen_state);
+        yy = random_standard_exponential_f(bitgen_state);
         if (yy + yy > xx * xx)
           return ((rabs >> 8) & 0x1) ? -(ziggurat_nor_r_f + xx)
                                      : ziggurat_nor_r_f + xx;


### PR DESCRIPTION
Hello Numpy developers,

Here is a pull request for the exponential distribution. We are submitting this PR mostly out of curiosity, to understand if there is any particular reason behind an implementation detail.

The current implementation of the exponential distribution relies on the Ziggurat algorithm for the body of the distribution. However, the tail (which is still an exponential) is instead sampled using the inverse of the CDF method, which involves calculating a logarithm. If we understand correctly, the whole point of using the Ziggurat is to avoid not only the expensive log calls, but also the precision loss and the undesired truncation which arise when using a log function to map the 0-1 interval to an infinite or semi-infinite range.

Therefore, rather than calling `-npy_log1p(-next_double(bitgen_state))`, we can simply call `random_stantard_exponential()` whenever a random exponential variate is needed. Replacing these calls should not only make the code more readable, but also improve performance and precision. This is the approach found, for instance, in boost random for the [exponential](https://github.com/boostorg/random/blob/a2740d4b30178cb187fabca163e5be7803a577b9/include/boost/random/exponential_distribution.hpp#L193) and for the [normal](https://github.com/boostorg/random/blob/a2740d4b30178cb187fabca163e5be7803a577b9/include/boost/random/normal_distribution.hpp#L188) distributions.

Is there a particular reason for not calling `random_stantard_exponential()` in the tails of the exponential and normal distributions? If not, the first commit replaces `-npy_log1p(-next_double(bitgen_state))` with a call to `random_stantard_exponential()`.

The second commit is just a refactoring of `random_stantard_exponential()` to avoid recursion. This, in our opinion, makes the code more readable.

We are looking forward to your feedback and hope that these observations may be useful!

Giacomo Mazzamuto, Lorenzo Pattelli

PS: the style of that particualr file was followed