### PR TITLE
BLD: Add NPY_DISABLE_SVML env var to opt out of SVML

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -24,6 +24,11 @@ NPY_RELAXED_STRIDES_CHECKING = (os.environ.get('NPY_RELAXED_STRIDES_CHECKING', "
 NPY_RELAXED_STRIDES_DEBUG = (os.environ.get('NPY_RELAXED_STRIDES_DEBUG', "0") != "0")
 NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CHECKING
 
+# Set NPY_DISABLE_SVML=1 in the environment to disable the vendored SVML
+# library. This option only has significance on a Linux x86_64 host and is most
+# useful to avoid improperly requiring SVML when cross compiling.
+NPY_DISABLE_SVML = (os.environ.get('NPY_DISABLE_SVML', "0") == "1")
+
 # XXX: ugly, we use a class to avoid calling twice some expensive functions in
 # config.h/numpyconfig.h. I don't see a better way because distutils force
 # config.h generation inside an Extension class, and as such sharing
@@ -68,6 +73,8 @@ def can_link_svml():
     """SVML library is supported only on x86_64 architecture and currently
     only on linux
     """
+    if NPY_DISABLE_SVML:
+        return False
     machine = platform.machine()
     system = platform.system()
     return "x86_64" in machine and system == "Linux"


### PR DESCRIPTION
Backport of #20695.

SVML uses AVX-512 extensions that are only supported on sufficiently new Intel CPUs. Hard-requiring this vendored library for all x86_64 Linux platforms is not appropriate. When I build on an AMD Zen 2 CPU, I get errors to the effect of
```
/usr/lib/python3.10/site-packages/numpy/core/_multiarray_umath.so: undefined symbol: __svml_log108
```
when trying to import numpy. Furthermore, the simple platform check thwarts cross-compilation because it is the host, rather than the target, that is checked.

This patch adds recogniton for `NPY_DISABLE_SVML=1` in the environment, which will Numpy to build without the vendored SVML library. It might also be desirable to make the default-on behavior a little more nuanced than simply looking for Linux x86_64. However, I dont' have any specific ideas about the circumstances under which it should be enabled by default.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
