### PR TITLE
ENH, SIMD: improve argmax/argmin performance

### DIFF
--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -73,7 +73,8 @@ class FMinMax(Benchmark):
         np.fmax.reduce(self.d)
 
 class ArgMax(Benchmark):
-    params = [np.float32, np.float64, bool]
+    params = [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32,
+              np.int64, np.uint64, np.float32, np.float64, bool]
     param_names = ['dtype']
 
     def setup(self, dtype):
@@ -81,6 +82,17 @@ class ArgMax(Benchmark):
 
     def time_argmax(self, dtype):
         np.argmax(self.d)
+
+class ArgMin(Benchmark):
+    params = [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32,
+              np.int64, np.uint64, np.float32, np.float64, bool]
+    param_names = ['dtype']
+
+    def setup(self, dtype):
+        self.d = np.ones(200000, dtype=dtype)
+
+    def time_argmin(self, dtype):
+        np.argmin(self.d)
 
 class SmallReduction(Benchmark):
     def setup(self):

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -830,7 +830,7 @@ def configuration(parent_package='',top_path=None):
     multiarray_deps = [
             join('src', 'multiarray', 'abstractdtypes.h'),
             join('src', 'multiarray', 'arrayobject.h'),
-            join('src', 'multiarray', 'arraytypes.h'),
+            join('src', 'multiarray', 'arraytypes.h.src'),
             join('src', 'multiarray', 'arrayfunction_override.h'),
             join('src', 'multiarray', 'array_coercion.h'),
             join('src', 'multiarray', 'array_method.h'),
@@ -892,7 +892,9 @@ def configuration(parent_package='',top_path=None):
             join('src', 'multiarray', 'abstractdtypes.c'),
             join('src', 'multiarray', 'alloc.c'),
             join('src', 'multiarray', 'arrayobject.c'),
+            join('src', 'multiarray', 'arraytypes.h.src'),
             join('src', 'multiarray', 'arraytypes.c.src'),
+            join('src', 'multiarray', 'argfunc.dispatch.c.src'),
             join('src', 'multiarray', 'array_coercion.c'),
             join('src', 'multiarray', 'array_method.c'),
             join('src', 'multiarray', 'array_assign_scalar.c'),

--- a/numpy/core/src/multiarray/argfunc.dispatch.c.src
+++ b/numpy/core/src/multiarray/argfunc.dispatch.c.src
@@ -1,0 +1,392 @@
+/* -*- c -*- */
+/*@targets
+ ** $maxopt baseline
+ ** sse2 sse42 xop avx2 avx512_skx
+ ** vsx2
+ ** neon asimd
+ **/
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include "simd/simd.h"
+#include "numpy/npy_math.h"
+
+#include "arraytypes.h"
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+#if NPY_SIMD
+#if NPY_SIMD > 512 || NPY_SIMD < 0
+    #error "the following 8/16-bit argmax kernel isn't applicable for larger SIMD"
+    // TODO: add special loop for large SIMD width.
+    // i.e avoid unroll by x4 should be numerically safe till 2048-bit SIMD width
+    // or maybe expand the indices to 32|64-bit vectors(slower).
+#endif
+/**begin repeat
+ * #sfx = u8, s8, u16, s16#
+ * #usfx = u8, u8, u16, u16#
+ * #bsfx = b8, b8, b16, b16#
+ * #idx_max = NPY_MAX_UINT8*2, NPY_MAX_UINT16*2#
+ */
+/**begin repeat1
+ * #intrin = cmpgt, cmplt#
+ * #func = argmax, argmin#
+ * #op = >, <#
+ */
+static inline npy_intp
+simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
+{
+    npyv_lanetype_@sfx@ s_acc = *ip;
+    npy_intp ret_idx = 0, i = 0;
+
+    const int vstep = npyv_nlanes_@sfx@;
+    const int wstep = vstep*4;
+    npyv_lanetype_@usfx@ d_vindices[npyv_nlanes_@sfx@*4];
+    for (int vi = 0; vi < wstep; ++vi) {
+        d_vindices[vi] = vi;
+    }
+    const npyv_@usfx@ vindices_0 = npyv_load_@usfx@(d_vindices);
+    const npyv_@usfx@ vindices_1 = npyv_load_@usfx@(d_vindices + vstep);
+    const npyv_@usfx@ vindices_2 = npyv_load_@usfx@(d_vindices + vstep*2);
+    const npyv_@usfx@ vindices_3 = npyv_load_@usfx@(d_vindices + vstep*3);
+
+    const npy_intp max_block = @idx_max@*wstep & -wstep;
+    npy_intp len0 = len & -wstep;
+    while (i < len0) {
+        npyv_@sfx@ acc = npyv_setall_@sfx@(s_acc);
+        npyv_@usfx@ acc_indices = npyv_zero_@usfx@();
+        npyv_@usfx@ acc_indices_scale = npyv_zero_@usfx@();
+
+        npy_intp n = i + MIN(len0 - i, max_block);
+        npy_intp ik = i, i2 = 0;
+        for (; i < n; i += wstep, ++i2) {
+            npyv_@usfx@ vi = npyv_setall_@usfx@((npyv_lanetype_@usfx@)i2);
+            npyv_@sfx@ a = npyv_load_@sfx@(ip + i);
+            npyv_@sfx@ b = npyv_load_@sfx@(ip + i + vstep);
+            npyv_@sfx@ c = npyv_load_@sfx@(ip + i + vstep*2);
+            npyv_@sfx@ d = npyv_load_@sfx@(ip + i + vstep*3);
+
+            // reverse to put lowest index first in case of matched values
+            npyv_@bsfx@ m_ba = npyv_@intrin@_@sfx@(b, a);
+            npyv_@bsfx@ m_dc = npyv_@intrin@_@sfx@(d, c);
+            npyv_@sfx@  x_ba = npyv_select_@sfx@(m_ba, b, a);
+            npyv_@sfx@  x_dc = npyv_select_@sfx@(m_dc, d, c);
+            npyv_@bsfx@ m_dcba = npyv_@intrin@_@sfx@(x_dc, x_ba);
+            npyv_@sfx@  x_dcba = npyv_select_@sfx@(m_dcba, x_dc, x_ba);
+
+            npyv_@usfx@ idx_ba = npyv_select_@usfx@(m_ba, vindices_1, vindices_0);
+            npyv_@usfx@ idx_dc = npyv_select_@usfx@(m_dc, vindices_3, vindices_2);
+            npyv_@usfx@ idx_dcba = npyv_select_@usfx@(m_dcba, idx_dc, idx_ba);
+            npyv_@bsfx@ m_acc = npyv_@intrin@_@sfx@(x_dcba, acc);
+            acc = npyv_select_@sfx@(m_acc, x_dcba, acc);
+            acc_indices = npyv_select_@usfx@(m_acc, idx_dcba, acc_indices);
+            acc_indices_scale = npyv_select_@usfx@(m_acc, vi, acc_indices_scale);
+        }
+        // reduce
+        npyv_lanetype_@sfx@ dacc[npyv_nlanes_@sfx@];
+        npyv_lanetype_@usfx@ dacc_i[npyv_nlanes_@sfx@];
+        npyv_lanetype_@usfx@ dacc_s[npyv_nlanes_@sfx@];
+        npyv_store_@sfx@(dacc, acc);
+        npyv_store_@usfx@(dacc_i, acc_indices);
+        npyv_store_@usfx@(dacc_s, acc_indices_scale);
+
+        for (int vi = 0; vi < vstep; ++vi) {
+            if (dacc[vi] @op@ s_acc) {
+                s_acc = dacc[vi];
+                ret_idx = ik + (npy_intp)dacc_s[vi]*wstep + dacc_i[vi];
+            }
+        }
+        // get the lowest index in case of matched values
+        for (int vi = 0; vi < vstep; ++vi) {
+            npy_intp idx = ik + (npy_intp)dacc_s[vi]*wstep + dacc_i[vi];
+            if (s_acc == dacc[vi] && ret_idx > idx) {
+                ret_idx = idx;
+            }
+        }
+    }
+    for (; i < len; ++i) {
+        npyv_lanetype_@sfx@ a = ip[i];
+        if (a @op@ s_acc) {
+            s_acc = a;
+            ret_idx = i;
+        }
+    }
+    return ret_idx;
+}
+/**end repeat1**/
+/**end repeat**/
+#endif
+
+/**begin repeat
+ * #sfx = u32, s32, u64, s64, f32, f64#
+ * #usfx = u32, u32, u64, u64, u32, u64#
+ * #bsfx = b32, b32, b64, b64, b32, b64#
+ * #is_fp = 0*4, 1*2#
+ * #is_idx32 = 1*2, 0*2, 1, 0#
+ * #chk_simd = NPY_SIMD*5, NPY_SIMD_F64#
+ */
+#if @chk_simd@
+/**begin repeat1
+ * #intrin = cmpgt, cmplt#
+ * #func = argmax, argmin#
+ * #op = >, <#
+ * #iop = <, >#
+ */
+static inline npy_intp
+simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
+{
+    npyv_lanetype_@sfx@ s_acc = *ip;
+    npy_intp ret_idx = 0, i = 0;
+    const int vstep = npyv_nlanes_@sfx@;
+    const int wstep = vstep*4;
+    // loop by a scalar will perform better for small arrays
+    if (len < wstep) {
+        goto scalar_loop;
+    }
+    npy_intp len0 = len;
+    // guard against wraparound vector addition for 32-bit indices
+    // in case of the array length is larger than 16gb
+#if @is_idx32@
+    if (len0 > NPY_MAX_UINT32) {
+        len0 = NPY_MAX_UINT32;
+    }
+#endif
+    // create index for vector indices
+    npyv_lanetype_@usfx@ d_vindices[npyv_nlanes_@sfx@*4];
+    for (int vi = 0; vi < wstep; ++vi) {
+        d_vindices[vi] = vi;
+    }
+    const npyv_@usfx@ vindices_0 = npyv_load_@usfx@(d_vindices);
+    const npyv_@usfx@ vindices_1 = npyv_load_@usfx@(d_vindices + vstep);
+    const npyv_@usfx@ vindices_2 = npyv_load_@usfx@(d_vindices + vstep*2);
+    const npyv_@usfx@ vindices_3 = npyv_load_@usfx@(d_vindices + vstep*3);
+    // initialize vector accumulator for highest values and its indexes
+    npyv_@usfx@ acc_indices = npyv_zero_@usfx@();
+    npyv_@sfx@ acc = npyv_setall_@sfx@(s_acc);
+    for (npy_intp n = len0 & -wstep; i < n; i += wstep) {
+        npyv_@usfx@ vi = npyv_setall_@usfx@((npyv_lanetype_@usfx@)i);
+        npyv_@sfx@ a = npyv_load_@sfx@(ip + i);
+        npyv_@sfx@ b = npyv_load_@sfx@(ip + i + vstep);
+        npyv_@sfx@ c = npyv_load_@sfx@(ip + i + vstep*2);
+        npyv_@sfx@ d = npyv_load_@sfx@(ip + i + vstep*3);
+
+        // reverse to put lowest index first in case of matched values
+        npyv_@bsfx@ m_ba = npyv_@intrin@_@sfx@(b, a);
+        npyv_@bsfx@ m_dc = npyv_@intrin@_@sfx@(d, c);
+        npyv_@sfx@  x_ba = npyv_select_@sfx@(m_ba, b, a);
+        npyv_@sfx@  x_dc = npyv_select_@sfx@(m_dc, d, c);
+        npyv_@bsfx@ m_dcba = npyv_@intrin@_@sfx@(x_dc, x_ba);
+        npyv_@sfx@  x_dcba = npyv_select_@sfx@(m_dcba, x_dc, x_ba);
+
+        npyv_@usfx@ idx_ba = npyv_select_@usfx@(m_ba, vindices_1, vindices_0);
+        npyv_@usfx@ idx_dc = npyv_select_@usfx@(m_dc, vindices_3, vindices_2);
+        npyv_@usfx@ idx_dcba = npyv_select_@usfx@(m_dcba, idx_dc, idx_ba);
+        npyv_@bsfx@ m_acc = npyv_@intrin@_@sfx@(x_dcba, acc);
+        acc = npyv_select_@sfx@(m_acc, x_dcba, acc);
+        acc_indices = npyv_select_@usfx@(m_acc, npyv_add_@usfx@(vi, idx_dcba), acc_indices);
+
+    #if @is_fp@
+        npyv_@bsfx@ nnan_a = npyv_notnan_@sfx@(a);
+        npyv_@bsfx@ nnan_b = npyv_notnan_@sfx@(b);
+        npyv_@bsfx@ nnan_c = npyv_notnan_@sfx@(c);
+        npyv_@bsfx@ nnan_d = npyv_notnan_@sfx@(d);
+        npyv_@bsfx@ nnan_ab = npyv_and_@bsfx@(nnan_a, nnan_b);
+        npyv_@bsfx@ nnan_cd = npyv_and_@bsfx@(nnan_c, nnan_d);
+        npy_uint64 nnan = npyv_tobits_@bsfx@(npyv_and_@bsfx@(nnan_ab, nnan_cd));
+        if (nnan != ((1LL << vstep) - 1)) {
+            npy_uint64 nnan_4[4];
+            nnan_4[0] = npyv_tobits_@bsfx@(nnan_a);
+            nnan_4[1] = npyv_tobits_@bsfx@(nnan_b);
+            nnan_4[2] = npyv_tobits_@bsfx@(nnan_c);
+            nnan_4[3] = npyv_tobits_@bsfx@(nnan_d);
+            for (int ni = 0; ni < 4; ++ni) {
+                for (int vi = 0; vi < vstep; ++vi) {
+                    if (!((nnan_4[ni] >> vi) & 1)) {
+                        return i + ni*vstep + vi;
+                    }
+                }
+            }
+        }
+    #endif
+    }
+    for (npy_intp n = len0 & -vstep; i < n; i += vstep) {
+        npyv_@usfx@ vi = npyv_setall_@usfx@((npyv_lanetype_@usfx@)i);
+        npyv_@sfx@ a = npyv_load_@sfx@(ip + i);
+        npyv_@bsfx@ m_acc = npyv_@intrin@_@sfx@(a, acc);
+        acc = npyv_select_@sfx@(m_acc, a, acc);
+        acc_indices = npyv_select_@usfx@(m_acc, npyv_add_@usfx@(vi, vindices_0), acc_indices);
+    #if @is_fp@
+        npyv_@bsfx@ nnan_a = npyv_notnan_@sfx@(a);
+        npy_uint64 nnan = npyv_tobits_@bsfx@(nnan_a);
+        if (nnan != ((1LL << vstep) - 1)) {
+            for (int vi = 0; vi < vstep; ++vi) {
+                if (!((nnan >> vi) & 1)) {
+                    return i + vi;
+                }
+            }
+        }
+    #endif
+    }
+
+    // reduce
+    npyv_lanetype_@sfx@ dacc[npyv_nlanes_@sfx@];
+    npyv_lanetype_@usfx@ dacc_i[npyv_nlanes_@sfx@];
+    npyv_store_@usfx@(dacc_i, acc_indices);
+    npyv_store_@sfx@(dacc, acc);
+
+    s_acc = dacc[0];
+    ret_idx = dacc_i[0];
+    for (int vi = 1; vi < vstep; ++vi) {
+        if (dacc[vi] @op@ s_acc) {
+            s_acc = dacc[vi];
+            ret_idx = (npy_intp)dacc_i[vi];
+        }
+    }
+    // get the lowest index in case of matched values
+    for (int vi = 0; vi < vstep; ++vi) {
+        if (s_acc == dacc[vi] && ret_idx > (npy_intp)dacc_i[vi]) {
+            ret_idx = dacc_i[vi];
+        }
+    }
+scalar_loop:
+    for (; i < len; ++i) {
+        npyv_lanetype_@sfx@ a = ip[i];
+    #if @is_fp@
+        if (!(a @iop@= s_acc)) {  // negated, for correct nan handling
+    #else
+        if (a @op@ s_acc) {
+    #endif
+            s_acc = a;
+            ret_idx = i;
+        #if @is_fp@
+            if (npy_isnan(s_acc)) {
+                // nan encountered, it's maximal
+                return ret_idx;
+            }
+        #endif
+        }
+    }
+    return ret_idx;
+}
+/**end repeat1**/
+#endif // chk_simd
+/**end repeat**/
+
+/**begin repeat
+ * #TYPE = UBYTE, USHORT, UINT, ULONG, ULONGLONG,
+ *         BYTE, SHORT, INT, LONG, LONGLONG,
+ *         FLOAT, DOUBLE, LONGDOUBLE#
+ *
+ * #BTYPE = BYTE, SHORT, INT, LONG, LONGLONG,
+ *          BYTE, SHORT, INT, LONG, LONGLONG,
+ *          FLOAT, DOUBLE, LONGDOUBLE#
+ * #type = npy_ubyte, npy_ushort, npy_uint, npy_ulong, npy_ulonglong,
+ *         npy_byte, npy_short, npy_int, npy_long, npy_longlong,
+ *         npy_float, npy_double, npy_longdouble#
+ *
+ * #is_fp = 0*10, 1*3#
+ * #is_unsigned = 1*5, 0*5, 0*3#
+ */
+#undef TO_SIMD_SFX
+#if 0
+/**begin repeat1
+ * #len = 8, 16, 32, 64#
+ */
+#elif NPY_SIMD && NPY_BITSOF_@BTYPE@ == @len@
+    #if @is_fp@
+        #define TO_SIMD_SFX(X) X##_f@len@
+        #if NPY_BITSOF_@BTYPE@ == 64 && !NPY_SIMD_F64
+            #undef TO_SIMD_SFX
+        #endif
+    #elif @is_unsigned@
+        #define TO_SIMD_SFX(X) X##_u@len@
+    #else
+        #define TO_SIMD_SFX(X) X##_s@len@
+    #endif
+/**end repeat1**/
+#endif
+
+/**begin repeat1
+ * #func = argmax, argmin#
+ * #op = >, <#
+ * #iop = <, >#
+ */
+NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
+(@type@ *ip, npy_intp n, npy_intp *mindx, PyArrayObject *NPY_UNUSED(aip))
+{
+#if @is_fp@
+    if (npy_isnan(*ip)) {
+        // nan encountered; it's maximal|minimal
+        *mindx = 0;
+        return 0;
+    }
+#endif
+#ifdef TO_SIMD_SFX
+    *mindx = TO_SIMD_SFX(simd_@func@)((TO_SIMD_SFX(npyv_lanetype)*)ip, n);
+#else
+    @type@ mp = *ip;
+    *mindx = 0;
+    npy_intp i = 1;
+
+    for (; i < n; ++i) {
+        @type@ a = ip[i];
+    #if @is_fp@
+        if (!(a @iop@= mp)) {  // negated, for correct nan handling
+    #else
+        if (a @op@ mp) {
+    #endif
+            mp = a;
+            *mindx = i;
+        #if @is_fp@
+            if (npy_isnan(mp)) {
+                // nan encountered, it's maximal|minimal
+                break;
+            }
+        #endif
+        }
+    }
+#endif // TO_SIMD_SFX
+    return 0;
+}
+/**end repeat1**/
+/**end repeat**/
+
+NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(BOOL_argmax)
+(npy_bool *ip, npy_intp len, npy_intp *mindx, PyArrayObject *NPY_UNUSED(aip))
+
+{
+    npy_intp i = 0;
+#if NPY_SIMD
+    const npyv_u8 zero = npyv_zero_u8();
+    const int vstep = npyv_nlanes_u8;
+    const int wstep = vstep * 4;
+    for (npy_intp n = len & -wstep; i < n; i += wstep) {
+        npyv_u8 a = npyv_load_u8(ip + i + vstep*0);
+        npyv_u8 b = npyv_load_u8(ip + i + vstep*1);
+        npyv_u8 c = npyv_load_u8(ip + i + vstep*2);
+        npyv_u8 d = npyv_load_u8(ip + i + vstep*3);
+        npyv_b8 m_a = npyv_cmpeq_u8(a, zero);
+        npyv_b8 m_b = npyv_cmpeq_u8(b, zero);
+        npyv_b8 m_c = npyv_cmpeq_u8(c, zero);
+        npyv_b8 m_d = npyv_cmpeq_u8(d, zero);
+        npyv_b8 m_ab = npyv_and_b8(m_a, m_b);
+        npyv_b8 m_cd = npyv_and_b8(m_c, m_d);
+        npy_uint64 m = npyv_tobits_b8(npyv_and_b8(m_ab, m_cd));
+    #if NPY_SIMD == 512
+        if (m != NPY_MAX_UINT64) {
+    #else
+        if ((npy_int64)m != ((1LL << vstep) - 1)) {
+    #endif
+            break;
+        }
+    }
+#endif // NPY_SIMD
+    for (; i < len; ++i) {
+        if (ip[i]) {
+            *mindx = i;
+            return 0;
+        }
+    }
+    *mindx = 0;
+    return 0;
+}

--- a/numpy/core/src/multiarray/argfunc.dispatch.c.src
+++ b/numpy/core/src/multiarray/argfunc.dispatch.c.src
@@ -323,6 +323,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@func@)
 #endif
 #ifdef TO_SIMD_SFX
     *mindx = TO_SIMD_SFX(simd_@func@)((TO_SIMD_SFX(npyv_lanetype)*)ip, n);
+    npyv_cleanup();
 #else
     @type@ mp = *ip;
     *mindx = 0;
@@ -380,6 +381,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(BOOL_argmax)
             break;
         }
     }
+    npyv_cleanup();
 #endif // NPY_SIMD
     for (; i < len; ++i) {
         if (ip[i]) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -27,12 +27,6 @@
 #include "arrayobject.h"
 #include "alloc.h"
 #include "typeinfo.h"
-#if defined(__ARM_NEON__) || defined (__ARM_NEON)
-#include <arm_neon.h>
-#endif
-#ifdef NPY_HAVE_SSE2_INTRINSICS
-#include <emmintrin.h>
-#endif
 
 #include "npy_longdouble.h"
 #include "numpyos.h"
@@ -42,7 +36,7 @@
 #include "npy_cblas.h"
 #include "npy_buffer.h"
 
-
+#include "arraytypes.h"
 /*
  * Define a stack allocated dummy array with only the minimum information set:
  *   1. The descr, the main field interesting here.
@@ -3176,77 +3170,21 @@ finish:
  **                                 ARGFUNC                                 **
  *****************************************************************************
  */
-#if defined(__ARM_NEON__) || defined (__ARM_NEON)
-    int32_t _mm_movemask_epi8_neon(uint8x16_t input)
-    {
-        int8x8_t m0 = vcreate_s8(0x0706050403020100ULL);
-        uint8x16_t v0 = vshlq_u8(vshrq_n_u8(input, 7), vcombine_s8(m0, m0));
-        uint64x2_t v1 = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(v0)));
-        return (int)vgetq_lane_u64(v1, 0) + ((int)vgetq_lane_u64(v1, 1) << 8);
-    }
-#endif
+
 #define _LESS_THAN_OR_EQUAL(a,b) ((a) <= (b))
-
-static int
-BOOL_argmax(npy_bool *ip, npy_intp n, npy_intp *max_ind,
-            PyArrayObject *NPY_UNUSED(aip))
-
-{
-    npy_intp i = 0;
-    /* memcmp like logical_and on i386 is maybe slower for small arrays */
-#ifdef NPY_HAVE_SSE2_INTRINSICS
-    const __m128i zero = _mm_setzero_si128();
-    for (; i < n - (n % 32); i+=32) {
-        __m128i d1 = _mm_loadu_si128((__m128i*)&ip[i]);
-        __m128i d2 = _mm_loadu_si128((__m128i*)&ip[i + 16]);
-        d1 = _mm_cmpeq_epi8(d1, zero);
-        d2 = _mm_cmpeq_epi8(d2, zero);
-        if (_mm_movemask_epi8(_mm_min_epu8(d1, d2)) != 0xFFFF) {
-            break;
-        }
-    }
-#else
-    #if defined(__ARM_NEON__) || defined (__ARM_NEON)
-        uint8x16_t zero = vdupq_n_u8(0);
-        for(; i < n - (n % 32); i+=32) {
-            uint8x16_t d1 = vld1q_u8((uint8_t *)&ip[i]);
-            uint8x16_t d2 = vld1q_u8((uint8_t *)&ip[i + 16]);
-            d1 = vceqq_u8(d1, zero);
-            d2 = vceqq_u8(d2, zero);
-            if(_mm_movemask_epi8_neon(vminq_u8(d1, d2)) != 0xFFFF) {
-                break;
-            }
-        }
-    #endif
-#endif
-    for (; i < n; i++) {
-        if (ip[i]) {
-            *max_ind = i;
-            return 0;
-        }
-    }
-    *max_ind = 0;
-    return 0;
-}
 
 /**begin repeat
  *
- * #fname = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
- *          LONG, ULONG, LONGLONG, ULONGLONG,
- *          HALF, FLOAT, DOUBLE, LONGDOUBLE,
- *          CFLOAT, CDOUBLE, CLONGDOUBLE,
+ * #fname = HALF, CFLOAT, CDOUBLE, CLONGDOUBLE,
  *          DATETIME, TIMEDELTA#
- * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_double, npy_longdouble,
- *         npy_float, npy_double, npy_longdouble,
+ * #type = npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_datetime, npy_timedelta#
- * #isfloat = 0*10, 1*7, 0*2#
- * #isnan = nop*10, npy_half_isnan, npy_isnan*6, nop*2#
- * #le = _LESS_THAN_OR_EQUAL*10, npy_half_le, _LESS_THAN_OR_EQUAL*8#
- * #iscomplex = 0*14, 1*3, 0*2#
- * #incr = ip++*14, ip+=2*3, ip++*2#
- * #isdatetime = 0*17, 1*2#
+ * #isfloat = 1*4, 0*2#
+ * #isnan = npy_half_isnan, npy_isnan*3, nop*2#
+ * #le = npy_half_le, _LESS_THAN_OR_EQUAL*5#
+ * #iscomplex = 0, 1*3, 0*2#
+ * #incr = ip++, ip+=2*3, ip++*2#
+ * #isdatetime = 0*4, 1*2#
  */
 static int
 @fname@_argmax(@type@ *ip, npy_intp n, npy_intp *max_ind,
@@ -3337,22 +3275,16 @@ BOOL_argmin(npy_bool *ip, npy_intp n, npy_intp *min_ind,
 
 /**begin repeat
  *
- * #fname = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
- *          LONG, ULONG, LONGLONG, ULONGLONG,
- *          HALF, FLOAT, DOUBLE, LONGDOUBLE,
- *          CFLOAT, CDOUBLE, CLONGDOUBLE,
+ * #fname = HALF, CFLOAT, CDOUBLE, CLONGDOUBLE,
  *          DATETIME, TIMEDELTA#
- * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
- *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
- *         npy_half, npy_float, npy_double, npy_longdouble,
- *         npy_float, npy_double, npy_longdouble,
+ * #type = npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_datetime, npy_timedelta#
- * #isfloat = 0*10, 1*7, 0*2#
- * #isnan = nop*10, npy_half_isnan, npy_isnan*6, nop*2#
- * #le = _LESS_THAN_OR_EQUAL*10, npy_half_le, _LESS_THAN_OR_EQUAL*8#
- * #iscomplex = 0*14, 1*3, 0*2#
- * #incr = ip++*14, ip+=2*3, ip++*2#
- * #isdatetime = 0*17, 1*2#
+ * #isfloat = 1*4, 0*2#
+ * #isnan = npy_half_isnan, npy_isnan*3, nop*2#
+ * #le = npy_half_le, _LESS_THAN_OR_EQUAL*5#
+ * #iscomplex = 0, 1*3, 0*2#
+ * #incr = ip++, ip+=2*3, ip++*2#
+ * #isdatetime = 0*4, 1*2#
  */
 static int
 @fname@_argmin(@type@ *ip, npy_intp n, npy_intp *min_ind,
@@ -3409,7 +3341,7 @@ static int
             *min_ind = i;
             break;
         }
-#endif 
+#endif
         if (!@le@(mp, *ip)) {  /* negated, for correct nan handling */
             mp = *ip;
             *min_ind = i;
@@ -4493,6 +4425,27 @@ set_typeinfo(PyObject *dict)
 
     PyArray_Descr *dtype;
     PyObject *cobj, *key;
+
+    // SIMD runtime dispatching
+    #ifndef NPY_DISABLE_OPTIMIZATION
+        #include "argfunc.dispatch.h"
+    #endif
+    /**begin repeat
+     * #FROM = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+     *         LONG, ULONG, LONGLONG, ULONGLONG,
+     *         FLOAT, DOUBLE, LONGDOUBLE#
+     *
+     * #NAME = Byte, UByte, Short, UShort, Int, UInt,
+     *         Long, ULong, LongLong, ULongLong,
+     *         Float, Double, LongDouble#
+     */
+    /**begin repeat1
+     * #func = argmax, argmin#
+     */
+    NPY_CPU_DISPATCH_CALL_XB(_Py@NAME@_ArrFuncs.@func@ = (PyArray_ArgFunc*)@FROM@_@func@);
+    /**end repeat1**/
+    /**end repeat**/
+    NPY_CPU_DISPATCH_CALL_XB(_PyBool_ArrFuncs.argmax = (PyArray_ArgFunc*)BOOL_argmax);
 
     /*
      * Override the base class for all types, eventually all of this logic

--- a/numpy/core/src/multiarray/arraytypes.h.src
+++ b/numpy/core/src/multiarray/arraytypes.h.src
@@ -28,4 +28,25 @@ small_correlate(const char * d_, npy_intp dstride,
                 npy_intp nk, enum NPY_TYPES ktype,
                 char * out_, npy_intp ostride);
 
+#ifndef NPY_DISABLE_OPTIMIZATION
+    #include "argfunc.dispatch.h"
+#endif
+/**begin repeat
+ * #TYPE = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         FLOAT, DOUBLE, LONGDOUBLE#
+ * #type = byte, ubyte, short, ushort, int, uint,
+ *         long, ulong, longlong, ulonglong,
+ *         float, double, longdouble#
+ */
+/**begin repeat1
+ * #func = argmax, argmin#
+ */
+NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT int @TYPE@_@func@,
+    (npy_@type@ *ip, npy_intp n, npy_intp *max_ind, PyArrayObject *aip))
+/**end repeat1**/
+/**end repeat**/
+NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT int BOOL_argmax,
+    (npy_bool *ip, npy_intp n, npy_intp *max_ind, PyArrayObject *aip))
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_ARRAYTYPES_H_ */


### PR DESCRIPTION
  for all integers, f32 and f64 data types on all
  supported architectures via universal intrinsics.

related to #20785, #20131


### X86

<details>
<summary>CPU</summary>

```Bash
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   46 bits physical, 48 bits virtual
CPU(s):                          4
On-line CPU(s) list:             0-3
Thread(s) per core:              2
Core(s) per socket:              2
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           85
Model name:                      Intel(R) Xeon(R) Platinum 8124M CPU @ 3.00GHz
Stepping:                        4
CPU MHz:                         3410.808
BogoMIPS:                        5999.99
Hypervisor vendor:               KVM
Virtualization type:             full
L1d cache:                       64 KiB
L1i cache:                       64 KiB
L2 cache:                        2 MiB
L3 cache:                        24.8 MiB
NUMA node0 CPU(s):               0-3
Vulnerability Itlb multihit:     KVM: Mitigation: VMX unsupported
Vulnerability L1tf:              Mitigation; PTE Inversion
Vulnerability Mds:               Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
Vulnerability Meltdown:          Mitigation; PTI
Vulnerability Spec store bypass: Vulnerable
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Full generic retpoline, STIBP disabled, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Vulnerable: Clear CPU buffers attempted, no microcode; SMT Host state unknown
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant
                                 _tsc rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt
                                 tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase tsc_adjust bmi1 hle avx2 smep b
                                 mi2 erms invpcid rtm mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves ida arat
                                 pku ospke
```
</details>

<details>
<summary>OS</summary>

```Bash
Linux ip-172-31-32-40 5.11.0-1020-aws #21~20.04.2-Ubuntu SMP Fri Oct 1 13:03:59 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
Python 3.8.10
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark
<details>
 <summary>AVX512_SKX</summary>

```Bash
unset NPY_DISABLE_CPU_FEATURES
python runtests.py -n --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-        1.66±0ms         1.54±0ms     0.93  bench_lib.Nan.time_nanargmax(200000, 50.0)
-         926±3μs          850±3μs     0.92  bench_lib.Nan.time_nanargmax(200000, 90.0)
-        1.72±0ms         1.55±0ms     0.90  bench_lib.Nan.time_nanargmin(200000, 50.0)
-         380±3μs        325±0.4μs     0.86  bench_lib.Nan.time_nanargmax(200000, 0.1)
-         993±4μs          849±3μs     0.85  bench_lib.Nan.time_nanargmin(200000, 90.0)
-         378±3μs        323±0.2μs     0.85  bench_lib.Nan.time_nanargmax(200000, 0)
-         482±3μs        406±0.8μs     0.84  bench_lib.Nan.time_nanargmax(200000, 2.0)
-         548±3μs        407±0.8μs     0.74  bench_lib.Nan.time_nanargmin(200000, 2.0)
-         444±3μs        326±0.9μs     0.73  bench_lib.Nan.time_nanargmin(200000, 0.1)
-         441±3μs        322±0.9μs     0.73  bench_lib.Nan.time_nanargmin(200000, 0)
-     6.49±0.08μs      4.45±0.01μs     0.68  bench_reduce.ArgMax.time_argmax(<class 'bool'>)
-       182±0.3μs       59.8±0.4μs     0.33  bench_reduce.ArgMin.time_argmin(<class 'numpy.float64'>)
-       182±0.1μs       59.6±0.6μs     0.33  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint64'>)
-      182±0.07μs       59.2±0.2μs     0.33  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-       124±0.4μs        26.8±20μs     0.22  bench_reduce.ArgMax.time_argmax(<class 'numpy.float64'>)
-       122±0.4μs       18.9±0.2μs     0.16  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-       180±0.2μs       18.8±0.1μs     0.10  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-       180±0.2μs       18.6±0.4μs     0.10  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-         202±4μs        19.1±20μs     0.09  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-         204±4μs        19.1±20μs     0.09  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-       120±0.1μs      9.56±0.04μs     0.08  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-       120±0.2μs      9.54±0.02μs     0.08  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-         218±3μs         13.7±2μs     0.06  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-         193±5μs         11.0±4μs     0.06  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-         212±2μs         11.0±3μs     0.05  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-      179±0.07μs      6.15±0.02μs     0.03  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
-      179±0.05μs      6.12±0.02μs     0.03  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-       218±0.7μs         7.07±1μs     0.03  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-         219±1μs         7.05±1μs     0.03  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-         190±2μs      6.01±0.02μs     0.03  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
-         191±3μs      6.02±0.01μs     0.03  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
```
</details>


<details>
 <summary>AVX2</summary>

```Bash
export NPY_DISABLE_CPU_FEATURES="AVX512F AVX512_SKX"
python runtests.py -n --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-         964±3μs         895±10μs     0.93  bench_lib.Nan.time_nanargmin(200000, 90.0)
-        1.65±0ms         1.53±0ms     0.93  bench_lib.Nan.time_nanargmin(200000, 50.0)
-         365±1μs        332±0.9μs     0.91  bench_lib.Nan.time_nanargmax(200000, 0)
-       370±0.5μs          336±1μs     0.91  bench_lib.Nan.time_nanargmax(200000, 0.1)
-     6.49±0.06μs      5.80±0.04μs     0.89  bench_reduce.ArgMax.time_argmax(<class 'bool'>)
-         470±2μs          417±1μs     0.89  bench_lib.Nan.time_nanargmax(200000, 2.0)
-         532±2μs        418±0.5μs     0.79  bench_lib.Nan.time_nanargmin(200000, 2.0)
-       432±0.8μs        335±0.6μs     0.78  bench_lib.Nan.time_nanargmin(200000, 0.1)
-         428±2μs          332±1μs     0.77  bench_lib.Nan.time_nanargmin(200000, 0)
-       124±0.1μs         61.4±7μs     0.50  bench_reduce.ArgMax.time_argmax(<class 'numpy.float64'>)
-      182±0.09μs       75.1±0.3μs     0.41  bench_reduce.ArgMin.time_argmin(<class 'numpy.float64'>)
-      182±0.08μs       71.4±0.3μs     0.39  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint64'>)
-      182±0.09μs       66.2±0.3μs     0.36  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-         202±4μs         59.5±6μs     0.29  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-       122±0.3μs       35.3±0.3μs     0.29  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-         203±3μs         49.7±8μs     0.25  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-      180±0.09μs       32.5±0.3μs     0.18  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-       180±0.1μs       28.8±0.2μs     0.16  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-         198±4μs         30.0±2μs     0.15  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-         217±4μs         32.0±2μs     0.15  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-       120±0.2μs      17.3±0.05μs     0.14  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-       120±0.1μs      15.2±0.02μs     0.13  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-         213±5μs         25.2±1μs     0.12  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-       218±0.7μs       16.4±0.2μs     0.08  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-         217±2μs      15.3±0.03μs     0.07  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-      179±0.05μs      9.81±0.04μs     0.05  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-         193±4μs      9.80±0.04μs     0.05  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
-      179±0.07μs      8.47±0.01μs     0.05  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
-         193±3μs      8.64±0.03μs     0.04  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
```
</details>

<details>
 <summary>SSE42</summary>

```Bash
export NPY_DISABLE_CPU_FEATURES="AVX2 AVX512F AVX512_SKX"
python runtests.py -n --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-        1.60±0ms         1.52±0ms     0.95  bench_lib.Nan.time_nanargmax(200000, 50.0)
-       470±0.7μs          442±4μs     0.94  bench_lib.Nan.time_nanargmax(200000, 2.0)
-     6.55±0.08μs      6.05±0.02μs     0.92  bench_reduce.ArgMax.time_argmax(<class 'bool'>)
-        1.66±0ms         1.51±0ms     0.91  bench_lib.Nan.time_nanargmin(200000, 50.0)
-         964±2μs          865±2μs     0.90  bench_lib.Nan.time_nanargmin(200000, 90.0)
-       430±0.9μs          359±3μs     0.84  bench_lib.Nan.time_nanargmin(200000, 0)
-         433±1μs          360±3μs     0.83  bench_lib.Nan.time_nanargmin(200000, 0.1)
-         534±1μs          441±3μs     0.83  bench_lib.Nan.time_nanargmin(200000, 2.0)
-       124±0.1μs         95.6±3μs     0.77  bench_reduce.ArgMax.time_argmax(<class 'numpy.float64'>)
-       182±0.1μs        102±0.9μs     0.56  bench_reduce.ArgMin.time_argmin(<class 'numpy.float64'>)
-       182±0.1μs        101±0.4μs     0.55  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint64'>)
-       182±0.2μs       81.6±0.2μs     0.45  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-         122±4μs       54.3±0.4μs     0.44  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-        213±10μs         89.3±6μs     0.42  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-         209±8μs         72.9±6μs     0.35  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-       180±0.2μs       48.3±0.2μs     0.27  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-         218±3μs         48.4±2μs     0.22  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-      180±0.06μs       39.3±0.4μs     0.22  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-        209±10μs         45.2±1μs     0.22  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-         122±2μs      24.1±0.03μs     0.20  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-         219±4μs         38.7±1μs     0.18  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-         120±2μs      19.4±0.01μs     0.16  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-       219±0.5μs      24.2±0.05μs     0.11  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-       219±0.9μs      20.5±0.04μs     0.09  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-      179±0.05μs      13.2±0.01μs     0.07  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-        207±10μs      13.3±0.03μs     0.06  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
-       179±0.1μs      11.0±0.02μs     0.06  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
-        209±10μs      11.1±0.02μs     0.05  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
```
</details>

<details>
 <summary>BASELINE(SSE3)</summary>

```Bash
export NPY_DISABLE_CPU_FEATURES="SSE42 AVX2 AVX512F AVX512_SKX"
python runtests.py -n --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-        1.66±0ms      1.54±0.01ms     0.93  bench_lib.Nan.time_nanargmin(200000, 50.0)
-         198±5μs          183±1μs     0.93  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-         967±3μs          883±2μs     0.91  bench_lib.Nan.time_nanargmin(200000, 90.0)
-         433±2μs          376±4μs     0.87  bench_lib.Nan.time_nanargmin(200000, 0)
-         438±2μs          377±3μs     0.86  bench_lib.Nan.time_nanargmin(200000, 0.1)
-       124±0.3μs          106±6μs     0.86  bench_reduce.ArgMax.time_argmax(<class 'numpy.float64'>)
-         535±3μs          457±4μs     0.85  bench_lib.Nan.time_nanargmin(200000, 2.0)
-       182±0.2μs        153±0.6μs     0.84  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-         202±3μs          150±1μs     0.75  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-       182±0.2μs          115±2μs     0.63  bench_reduce.ArgMin.time_argmin(<class 'numpy.float64'>)
-       122±0.4μs       64.2±0.9μs     0.53  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-       180±0.1μs       58.4±0.6μs     0.32  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-       180±0.2μs       50.4±0.8μs     0.28  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-         197±7μs         55.0±2μs     0.28  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-         218±3μs         58.4±3μs     0.27  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-       121±0.2μs       29.6±0.5μs     0.25  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-         213±2μs         47.0±1μs     0.22  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-       120±0.3μs       24.0±0.4μs     0.20  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-       219±0.4μs       29.3±0.2μs     0.13  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-       219±0.9μs       23.7±0.2μs     0.11  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-       179±0.2μs       17.7±0.1μs     0.10  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-         192±1μs      17.7±0.08μs     0.09  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
-       179±0.1μs      15.4±0.06μs     0.09  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
-         188±2μs      14.8±0.08μs     0.08  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
```
</details>

----

### Power little-endian
<details>
<summary>CPU</summary>

```
Architecture:                    ppc64le
Byte Order:                      Little Endian
CPU(s):                          8
On-line CPU(s) list:             0-7
Thread(s) per core:              1
Core(s) per socket:              1
Socket(s):                       8
NUMA node(s):                    1
Model:                           2.2 (pvr 004e 1202)
Model name:                      POWER9 (architected), altivec supported
L1d cache:                       256 KiB
L1i cache:                       256 KiB
NUMA node0 CPU(s):               0-7
Vulnerability L1tf:              Not affected
Vulnerability Meltdown:          Mitigation; RFI Flush
Vulnerability Spec store bypass: Mitigation; Kernel entry/exit barrier (eieio)
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
Vulnerability Spectre v2:        Vulnerable

processor   : 7
cpu     : POWER9 (architected), altivec supported
clock       : 2200.000000MHz
revision    : 2.2 (pvr 004e 1202)

timebase    : 512000000
platform    : pSeries
model       : IBM pSeries (emulated by qemu)
machine     : CHRP IBM pSeries (emulated by qemu)
MMU     : Radix

```
</details>

<details>
<summary>OS</summary>

```Bash
Linux e517009a912a 4.19.0-2-powerpc64le #1 SMP Debian 4.19.16-1 (2019-01-17) ppc64le ppc64le ppc64le GNU/Linux
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark

<details>
 <summary>baseline(VSX2)</summary>

```Bash
python runtests.py -n --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-     1.90±0.01ms         1.78±0ms     0.93  bench_lib.Nan.time_nanargmin(200000, 90.0)
-       294±0.6μs        275±0.9μs     0.93  bench_reduce.ArgMax.time_argmax(<class 'numpy.float64'>)
-     1.10±0.01ms          997±7μs     0.90  bench_lib.Nan.time_nanargmin(200000, 2.0)
-         896±6μs          778±2μs     0.87  bench_lib.Nan.time_nanargmin(200000, 0.1)
-        885±10μs          767±2μs     0.87  bench_lib.Nan.time_nanargmin(200000, 0)
-         373±2μs        275±0.3μs     0.74  bench_reduce.ArgMin.time_argmin(<class 'numpy.float64'>)
-       219±0.2μs        156±0.5μs     0.71  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-         219±2μs          154±1μs     0.70  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-      218±0.08μs        152±0.3μs     0.70  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-       218±0.2μs       152±0.08μs     0.70  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint64'>)
-       218±0.3μs          148±2μs     0.68  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-       219±0.8μs          149±2μs     0.68  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-      237±0.09μs        156±0.4μs     0.66  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-         235±1μs          155±1μs     0.66  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-       329±0.2μs        178±0.3μs     0.54  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-         327±1μs          176±1μs     0.54  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-      216±0.07μs       50.3±0.1μs     0.23  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-         215±1μs         50.0±1μs     0.23  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-       233±0.5μs      50.6±0.06μs     0.22  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-       232±0.9μs       48.9±0.9μs     0.21  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-      216±0.06μs       28.7±0.1μs     0.13  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-       216±0.6μs      28.5±0.04μs     0.13  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
-       214±0.5μs       28.0±0.1μs     0.13  bench_reduce.ArgMax.time_argmax(<class 'bool'>)
-       233±0.1μs       28.6±0.1μs     0.12  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
-       233±0.2μs       28.6±0.1μs     0.12  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
```
</details>

----

### AArch64

<details>
<summary>CPU</summary>

```Bash
Architecture:                    aarch64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
CPU(s):                          2
On-line CPU(s) list:             0,1
Thread(s) per core:              1
Core(s) per socket:              2
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       ARM
Model:                           1
Model name:                      Neoverse-N1
Stepping:                        r3p1
BogoMIPS:                        243.75
L1d cache:                       128 KiB
L1i cache:                       128 KiB
L2 cache:                        2 MiB
L3 cache:                        32 MiB
NUMA node0 CPU(s):               0,1
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:        Mitigation; __user pointer sanitization
Vulnerability Spectre v2:        Not affected
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
```
</details>

<details>
<summary>OS</summary>

```Bash
Linux ip-172-31-44-172 5.11.0-1020-aws #21~20.04.2-Ubuntu SMP Fri Oct 1 13:01:34 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
</details>

#### Benchmark

<details>
 <summary>baseline(ASIMD)</summary>

```Bash
python runtests.py --bench-compare parent/main "argmax|argmin" -- --sort ratio
```
```Bash
       before           after         ratio
     [4b985e2b]       [c99921ad]
     <simd_argmaxmin~1>       <simd_argmaxmin>
-     20.5±0.02μs      18.2±0.01μs     0.89  bench_reduce.ArgMax.time_argmax(<class 'bool'>)
-         169±2μs         88.9±4μs     0.53  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint64'>)
-         169±2μs         88.9±3μs     0.53  bench_reduce.ArgMax.time_argmax(<class 'numpy.int64'>)
-       165±0.1μs       83.1±0.6μs     0.50  bench_reduce.ArgMin.time_argmin(<class 'numpy.int64'>)
-       165±0.3μs       82.8±0.5μs     0.50  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint64'>)
-         246±1μs       81.1±0.9μs     0.33  bench_reduce.ArgMax.time_argmax(<class 'numpy.float32'>)
-       244±0.2μs       79.1±0.2μs     0.32  bench_reduce.ArgMin.time_argmin(<class 'numpy.float32'>)
-       166±0.8μs         45.1±2μs     0.27  bench_reduce.ArgMax.time_argmax(<class 'numpy.int32'>)
-       166±0.9μs         44.8±1μs     0.27  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint32'>)
-       164±0.2μs       43.1±0.3μs     0.26  bench_reduce.ArgMin.time_argmin(<class 'numpy.int32'>)
-      164±0.06μs       43.0±0.2μs     0.26  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint32'>)
-       170±0.4μs       24.9±0.5μs     0.15  bench_reduce.ArgMax.time_argmax(<class 'numpy.int16'>)
-       170±0.3μs       24.9±0.5μs     0.15  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint16'>)
-       169±0.1μs       24.6±0.2μs     0.15  bench_reduce.ArgMin.time_argmin(<class 'numpy.int16'>)
-       169±0.2μs      24.5±0.07μs     0.15  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint16'>)
-       163±0.1μs      13.9±0.04μs     0.08  bench_reduce.ArgMax.time_argmax(<class 'numpy.int8'>)
-       163±0.1μs      13.9±0.09μs     0.08  bench_reduce.ArgMin.time_argmin(<class 'numpy.int8'>)
-      163±0.09μs      13.8±0.01μs     0.08  bench_reduce.ArgMin.time_argmin(<class 'numpy.uint8'>)
-       163±0.1μs      13.8±0.03μs     0.08  bench_reduce.ArgMax.time_argmax(<class 'numpy.uint8'>)
```
</details>

-----

#### Binary size(striped)

| LIB         | Before(KB) | After(KB) | Diff(KB) |
| ----------- | ------------- | ------------ | ---------- |
| _multiarray_umath.cpython-38-x86_64-linux-gnu.so | 4428 | 4532 | 104 |
| _multiarray_umath.cpython-38-powerpc64le-linux-gnu.so | 4264 | 4292 | 29 |
| _multiarray_umath.cpython-38-aarch64-linux-gnu.so | 3424 | 3444 | 20 |
