### PR TITLE
MAINT: remove outdated mingw32 fseek support

### DIFF
--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -180,12 +180,6 @@
     defined(__MINGW32__) || defined(__MINGW64__)
     #include <io.h>
 
-/* mingw based on 3.4.5 has lseek but not ftell/fseek */
-#if defined(__MINGW32__) || defined(__MINGW64__)
-extern int __cdecl _fseeki64(FILE *, long long, int);
-extern long long __cdecl _ftelli64(FILE *);
-#endif
-
     #define npy_fseek _fseeki64
     #define npy_ftell _ftelli64
     #define npy_lseek _lseeki64


### PR DESCRIPTION
`_fseeki64` and `_ftelli64` have been present in mingw-w64 for a long time, see https://github.com/mingw-w64/mingw-w64/commit/d66350ea60d043a8992ada752040fc4ea48537c3

This fixes an annoying build warning in the SciPy Meson build:
```
C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\core\include/numpy/npy_common.h:185:20: warning: 'int _fseeki64(FILE*, long long int, int)' redeclared without dllimport attribute after being referenced with dll linkage
  185 | extern int __cdecl _fseeki64(FILE *, long long, int);
      |                    ^~~~~~~~~
C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\core\include/numpy/npy_common.h:186:26: warning: 'long long int _ftelli64(FILE*)' redeclared without dllimport attribute after being referenced with dll linkage
  186 | extern long long __cdecl _ftelli64(FILE *);
      |                          ^~~~~~~~~
```

It's only happening for Pythran extensions, because Pythran uses `fseek`. The cause is otherwise unrelated to Pythran though, it's `npy_common.h` redefining something that's in mingw-w64.

Cc @carlkl, @matthew-brett 