### PR TITLE
DOC: Fix typo in meshgrid example

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4907,7 +4907,7 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
 
     >>> x = np.linspace(-5, 5, 101)
     >>> y = np.linspace(-5, 5, 101)
-    >>> # full coorindate arrays
+    >>> # full coordinate arrays
     >>> xx, yy = np.meshgrid(x, y)
     >>> zz = np.sqrt(xx**2 + yy**2)
     >>> xx.shape, yy.shape, zz.shape


### PR DESCRIPTION
coordinate was misspelled in a comment in the example code

[ci skip]