### PR TITLE
MAINT: Fix a typo in numpy/f2py/capi_maps.py

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -504,7 +504,8 @@ def sign2map(a, var):
     varname,ctype,atype
     init,init.r,init.i,pytype
     vardebuginfo,vardebugshowvalue,varshowvalue
-    varrfromat
+    varrformat
+    
     intent
     """
     out_a = a


### PR DESCRIPTION
In the line 507 of capi_maps in numpy  varrformat was mispelled.
