### PR TITLE
BUG: Fix pre-builds in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,18 +6,19 @@
 
 image: numpy/numpy-gitpod:latest
 tasks:
-  - name: Prepare development
+  - name: Prepare development environment
     init: |
       mkdir -p .vscode
       cp tools/gitpod/settings.json .vscode/settings.json
       conda activate numpy-dev
+      git pull --unshallow  # need to force this else the prebuild fails
+      git fetch --tags
       python setup.py build_ext --inplace
       echo "🛠 Completed rebuilding NumPy!! 🛠 "
       echo "📖 Building docs 📖 "
       cd doc
       make html
       echo "✨ Pre-build complete! You can close this terminal ✨ "
-  
 
 # --------------------------------------------------------
 # exposing ports for liveserve
@@ -60,3 +61,4 @@ github:
     addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false
+    


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

- This PR follows #20854  and should fix the behaviour reported in #20346 

There were some issues with how Gitpod pre-builds work - my assumption is that it does a shallow clone- so this PR ensures all the tags and commit history are updated, else the `setup.py` fails to work out the proper version