### PR TITLE
DOC: fix formatting of mean example

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -3408,6 +3408,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
     0.55000000074505806 # may vary
 
     Specifying a where argument:
+
     >>> a = np.array([[5, 9, 13], [14, 10, 12], [11, 15, 19]])
     >>> np.mean(a)
     12.0


### PR DESCRIPTION
Without this empty line, the example is rendered incorrectly by Sphinx:

![image](https://user-images.githubusercontent.com/20118130/150286561-36f8ea0f-cc1b-40f3-afbc-2d73aeff7d65.png)
