### PR TITLE
DOC: Cosmetic docstring fix for numpydoc.

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4341,7 +4341,7 @@ cdef class RandomState:
             The drawn samples, of shape ``(size, k)``.
 
         Raises
-        -------
+        ------
         ValueError
             If any value in ``alpha`` is less than or equal to zero
 


### PR DESCRIPTION
Numpydoc 1.2 will raise a UserWarning when the heading length
doesn't match the heading text. This change prevents this
UserWarning during sphinx-build.