### PR TITLE
BUG: Gitpod Remove lock file --unshallow 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,7 @@ tasks:
     init: |
       mkdir -p .vscode
       cp tools/gitpod/settings.json .vscode/settings.json
+      rm -f /workspace/numpy/.git/shallow.lock  
       conda activate numpy-dev
       git pull --unshallow  # need to force this else the prebuild fails
       git fetch --tags


### PR DESCRIPTION
This PR follows the work in #20857 for some reason this worked when I ran the pre-build in my GitPod workspace but is failing in  NumPy's main branch. 

This PR ensures the `.git/shallow.lock` file is removed before attempting to pull the tags and commit history