### PR TITLE
BUG: Loss of precision in longdouble min

### DIFF
--- a/numpy/core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/core/src/umath/loops_minmax.dispatch.c.src
@@ -22,12 +22,14 @@
 #define scalar_max_i(A, B) ((A > B) ? A : B)
 #define scalar_min_i(A, B) ((A < B) ? A : B)
 // fp, propagates NaNs
-#define scalar_max_f(A, B) ((A >= B || npy_isnan(A)) ? A : B)
-#define scalar_max_d scalar_max_f
-#define scalar_max_l scalar_max_f
-#define scalar_min_f(A, B) ((A <= B || npy_isnan(A)) ? A : B)
-#define scalar_min_d scalar_min_f
-#define scalar_min_l scalar_min_f
+#define scalar_max(A, B) ((A >= B || npy_isnan(A)) ? A : B)
+#define scalar_max_f scalar_max
+#define scalar_max_d scalar_max
+#define scalar_max_l scalar_max
+#define scalar_min(A, B) ((A <= B || npy_isnan(A)) ? A : B)
+#define scalar_min_f scalar_min
+#define scalar_min_d scalar_min
+#define scalar_min_l scalar_min
 // fp, ignores NaNs
 #define scalar_maxp_f fmaxf
 #define scalar_maxp_d fmax

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1728,6 +1728,29 @@ class TestMaximum(_FilterInvalids):
         assert_equal(np.maximum(arr1[:6:2], arr2[::3], out=out[::3]), np.array([-2.0, 10., np.nan]))
         assert_equal(out, out_maxtrue)
 
+    def test_precision(self):
+        dtypes = [np.float16, np.float32, np.float64]
+        if(hasattr(np, 'float128')):
+            dtypes.append(np.float128)
+
+        for dt in dtypes:
+            dtmin = np.finfo(dt).min
+            dtmax = np.finfo(dt).max
+            d1 = dt(0.1)
+            d1_next = np.nextafter(d1, np.inf)
+
+            test_cases = [
+                # v1    v2          expected
+                (dtmin, -np.inf,    dtmin),
+                (dtmax, -np.inf,    dtmax),
+                (d1,    d1_next,    d1_next),
+                (dtmax, np.nan,     np.nan),
+            ]
+
+            for v1, v2, expected in test_cases:
+                assert_equal(np.maximum([v1], [v2]), [expected])
+                assert_equal(np.maximum.reduce([v1, v2]), expected)
+
 
 class TestMinimum(_FilterInvalids):
     def test_reduce(self):
@@ -1799,6 +1822,30 @@ class TestMinimum(_FilterInvalids):
         assert_equal(np.minimum(arr1[:6:2], arr2[::3], out=out[::3]), np.array([-4.0, 1.0, np.nan]))
         assert_equal(out, out_mintrue)
 
+    def test_precision(self):
+        dtypes = [np.float16, np.float32, np.float64]
+        if(hasattr(np, 'float128')):
+            dtypes.append(np.float128)
+
+        for dt in dtypes:
+            dtmin = np.finfo(dt).min
+            dtmax = np.finfo(dt).max
+            d1 = dt(0.1)
+            d1_next = np.nextafter(d1, np.inf)
+
+            test_cases = [
+                # v1    v2          expected
+                (dtmin, np.inf,     dtmin),
+                (dtmax, np.inf,     dtmax),
+                (d1,    d1_next,    d1),
+                (dtmin, np.nan,     np.nan),
+            ]
+
+            for v1, v2, expected in test_cases:
+                assert_equal(np.minimum([v1], [v2]), [expected])
+                assert_equal(np.minimum.reduce([v1, v2]), expected)
+
+
 class TestFmax(_FilterInvalids):
     def test_reduce(self):
         dflt = np.typecodes['AllFloat']
@@ -1839,6 +1886,29 @@ class TestFmax(_FilterInvalids):
             arg2 = np.array([cnan, 0, cnan], dtype=complex)
             out = np.array([0,    0, nan], dtype=complex)
             assert_equal(np.fmax(arg1, arg2), out)
+
+    def test_precision(self):
+        dtypes = [np.float16, np.float32, np.float64]
+        if(hasattr(np, 'float128')):
+            dtypes.append(np.float128)
+
+        for dt in dtypes:
+            dtmin = np.finfo(dt).min
+            dtmax = np.finfo(dt).max
+            d1 = dt(0.1)
+            d1_next = np.nextafter(d1, np.inf)
+
+            test_cases = [
+                # v1    v2          expected
+                (dtmin, -np.inf,    dtmin),
+                (dtmax, -np.inf,    dtmax),
+                (d1,    d1_next,    d1_next),
+                (dtmax, np.nan,     dtmax),
+            ]
+
+            for v1, v2, expected in test_cases:
+                assert_equal(np.fmax([v1], [v2]), [expected])
+                assert_equal(np.fmax.reduce([v1, v2]), expected)
 
 
 class TestFmin(_FilterInvalids):
@@ -1881,6 +1951,30 @@ class TestFmin(_FilterInvalids):
             arg2 = np.array([cnan, 0, cnan], dtype=complex)
             out = np.array([0,    0, nan], dtype=complex)
             assert_equal(np.fmin(arg1, arg2), out)
+
+    def test_precision(self):
+        dtypes = [np.float16, np.float32, np.float64]
+        if(hasattr(np, 'float128')):
+            dtypes.append(np.float128)
+
+        for dt in dtypes:
+            dtmin = np.finfo(dt).min
+            dtmax = np.finfo(dt).max
+            d1 = dt(0.1)
+            d1_next = np.nextafter(d1, np.inf)
+
+            test_cases = [
+                # v1    v2          expected
+                (dtmin, np.inf,     dtmin),
+                (dtmax, np.inf,     dtmax),
+                (d1,    d1_next,    d1),
+                (dtmin, np.nan,     dtmin),
+            ]
+
+            for v1, v2, expected in test_cases:
+                assert_equal(np.fmin([v1], [v2]), [expected])
+                assert_equal(np.fmin.reduce([v1, v2]), expected)
+
 
 
 class TestBool:

--- a/numpy/core/tests/test_umath.py
+++ b/numpy/core/tests/test_umath.py
@@ -1729,9 +1729,7 @@ class TestMaximum(_FilterInvalids):
         assert_equal(out, out_maxtrue)
 
     def test_precision(self):
-        dtypes = [np.float16, np.float32, np.float64]
-        if(hasattr(np, 'float128')):
-            dtypes.append(np.float128)
+        dtypes = [np.float16, np.float32, np.float64, np.longdouble]
 
         for dt in dtypes:
             dtmin = np.finfo(dt).min
@@ -1823,9 +1821,7 @@ class TestMinimum(_FilterInvalids):
         assert_equal(out, out_mintrue)
 
     def test_precision(self):
-        dtypes = [np.float16, np.float32, np.float64]
-        if(hasattr(np, 'float128')):
-            dtypes.append(np.float128)
+        dtypes = [np.float16, np.float32, np.float64, np.longdouble]
 
         for dt in dtypes:
             dtmin = np.finfo(dt).min
@@ -1888,9 +1884,7 @@ class TestFmax(_FilterInvalids):
             assert_equal(np.fmax(arg1, arg2), out)
 
     def test_precision(self):
-        dtypes = [np.float16, np.float32, np.float64]
-        if(hasattr(np, 'float128')):
-            dtypes.append(np.float128)
+        dtypes = [np.float16, np.float32, np.float64, np.longdouble]
 
         for dt in dtypes:
             dtmin = np.finfo(dt).min
@@ -1953,9 +1947,7 @@ class TestFmin(_FilterInvalids):
             assert_equal(np.fmin(arg1, arg2), out)
 
     def test_precision(self):
-        dtypes = [np.float16, np.float32, np.float64]
-        if(hasattr(np, 'float128')):
-            dtypes.append(np.float128)
+        dtypes = [np.float16, np.float32, np.float64, np.longdouble]
 
         for dt in dtypes:
             dtmin = np.finfo(dt).min
@@ -1974,7 +1966,6 @@ class TestFmin(_FilterInvalids):
             for v1, v2, expected in test_cases:
                 assert_equal(np.fmin([v1], [v2]), [expected])
                 assert_equal(np.fmin.reduce([v1, v2]), expected)
-
 
 
 class TestBool:


### PR DESCRIPTION
Generic reuse in the latest changes around `min` works unless the macro is redefined for SIMD.

This change avoids `scalar_min_f` for generic comparisons (as it can be redefined) and defines is separately as `scalar_min`

This should resolve https://github.com/numpy/numpy/issues/20863