### PR TITLE
BUG: mtrand cannot be imported on Cygwin

### DIFF
--- a/numpy/core/include/numpy/random/distributions.h
+++ b/numpy/core/include/numpy/random/distributions.h
@@ -28,7 +28,7 @@ extern "C" {
 #define RAND_INT_MAX INT64_MAX
 #endif
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
+#ifdef _MSC_VER
 #define DECLDIR __declspec(dllexport)
 #else
 #define DECLDIR extern

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -50,6 +50,13 @@ def configuration(parent_package='', top_path=None):
         # Some bit generators require c99
         EXTRA_COMPILE_ARGS += ['-std=c99']
 
+    if sys.platform == 'cygwin':
+        # Export symbols without __declspec(dllexport) for using by cython.
+        # Using __declspec(dllexport) does not export other necessary symbols
+        # in Cygwin package's Cython enviroment, making it impossible to
+        # import modules.
+        EXTRA_LINK_ARGS += ['-Wl,--export-all-symbols']
+
     # Use legacy integer variable sizes
     LEGACY_DEFS = [('NP_RANDOM_LEGACY', '1')]
     PCG64_DEFS = []


### PR DESCRIPTION
There is an issue that mtrand in numpy-1.22.x cannot be imported
because `PyInit_mtrand` is not exported on Cygwin.
https://cygwin.com/pipermail/cygwin/2022-January/250481.html

mtrand is generated from three sources, mtrand.c,
src/legacy/legacy-distributions.c, and src/distributions/distributions.c.
In numpy-1.21.x, there are no symbols with
a `__declspec(dllexport)` attribute in the source files.
On the other hand, in numpy-1.22.0,
the commit b797a0cb97a8a9e7e36962dc8c37c075967aa88b adds the attribute
to the symbols in src/distributions/distributions.c.
`PyInit_mtrand` is contained in mtrand.c, so the attribute is not added.

Cygwin's ld exports all symbols if there are no symbols
with the `__declspec(dllexport)` attribute.
Therefore, in numpy-1.21.x,
`PyInit_mtrand` without the attribute is also exported.
However, if there is even one symbol
with the `__declspec(dllexport)` attribute,
Cygwin's ld does not export symbols without the attribute.
Therefore, in numpy-1.22.0, `PyInit_mtrand`
without the attribute is not also exported.
https://sourceware.org/binutils/docs/ld/WIN32.html

This commit solves the issue by removing the unnecessary
`__declspec(dllexport)` attribute.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
