### PR TITLE
DOC,TST: Fix Pandas code example

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -1588,7 +1588,7 @@ If you created this array "a" ::
 
 .. for doctests
    The continuous integration truncates dataframe display without this setting.
-   >>> pd.set_option('max_columns', 10)
+   >>> pd.set_option('display.max_columns', 10)
 
 You could create a Pandas dataframe ::
 


### PR DESCRIPTION
Fixes #20877.

Panda's [`set_option`](https://pandas.pydata.org/docs/reference/api/pandas.set_option.html?highlight=set_options) requires us to specify the full option name in the `pat` parameter. This should fix the doctest failure.