### PR TITLE
BUG: fix f2py's define for threading when building with Mingw

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -572,18 +572,20 @@ cppmacros['OLDPYNUM'] = """\
 """
 cppmacros["F2PY_THREAD_LOCAL_DECL"] = """\
 #ifndef F2PY_THREAD_LOCAL_DECL
-#if defined(_MSC_VER) \\
-      || defined(_WIN32) || defined(_WIN64) \\
-      || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_MSC_VER)
 #define F2PY_THREAD_LOCAL_DECL __declspec(thread)
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+#define F2PY_THREAD_LOCAL_DECL __thread
 #elif defined(__STDC_VERSION__) \\
       && (__STDC_VERSION__ >= 201112L) \\
       && !defined(__STDC_NO_THREADS__) \\
-      && (!defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 12))
+      && (!defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 12)) \\
+      && !defined(__OpenBSD__)
 /* __STDC_NO_THREADS__ was first defined in a maintenance release of glibc 2.12,
    see https://lists.gnu.org/archive/html/commit-hurd/2012-07/msg00180.html,
    so `!defined(__STDC_NO_THREADS__)` may give false positive for the existence
-   of `threads.h` when using an older release of glibc 2.12 */
+   of `threads.h` when using an older release of glibc 2.12
+   See gh-19437 for details on OpenBSD */
 #include <threads.h>
 #define F2PY_THREAD_LOCAL_DECL thread_local
 #elif defined(__GNUC__) \\


### PR DESCRIPTION
Closes https://github.com/rgommers/scipy/issues/125
This is a follow-up of gh-18910 (included in 1.20.3 and 1.21.0), which looks incorrect.

This fixes warnings like these when building SciPy with Mingw-w64:
```
[94/1557] Compiling C object scipy/linalg/_flapack.cp39-win_amd64.pyd.p/meson-generated_..__flapackmodule.c.obj
In file included from C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\core\include/numpy/ndarraytypes.h:4,
                 from C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\core\include/numpy/ndarrayobject.h:12,
                 from C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\core\include/numpy/arrayobject.h:4,
                 from C:\hostedtoolcache\windows\Python\3.9.9\x64\lib\site-packages\numpy\f2py\src/fortranobject.h:13,
                 from scipy/linalg/_flapackmodule.c:16:
scipy/linalg/_flapackmodule.c:1248:1: warning: 'thread' attribute directive ignored [-Wattributes]
 1248 | static F2PY_THREAD_LOCAL_DECL cb_cselect_in_gees__user__routines_t *_active_cb_cselect_in_gees__user__routines = NULL;
      | ^~~~~~
scipy/linalg/_flapackmodule.c:1410:1: warning: 'thread' attribute directive ignored [-Wattributes]
 1410 | static F2PY_THREAD_LOCAL_DECL cb_zselect_in_gees__user__routines_t *_active_cb_zselect_in_gees__user__routines = NULL;
      | ^~~~~~
scipy/linalg/_flapackmodule.c:1572:1: warning: 'thread' attribute directive ignored [-Wattributes]
 1572 | static F2PY_THREAD_LOCAL_DECL cb_sselect_in_gees__user__routines_t *_active_cb_sselect_in_gees__user__routines = NULL;
      | ^~~~~~
scipy/linalg/_flapackmodule.c:1738:1: warning: 'thread' attribute directive ignored [-Wattributes]
 1738 | static F2PY_THREAD_LOCAL_DECL cb_dselect_in_gees__user__routines_t *_active_cb_dselect_in_gees__user__routines = NULL;
      | ^~~~~~

...
```

Also fixes gh-19437, where `__STDC_NO_THREADS__` should be defined but isn't (this seems to be more common, e.g. one can reports for ICC about this).