### PR TITLE
ENH: Add hints about a.max() and a.min() to ndarray error mesage

### DIFF
--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -833,7 +833,7 @@ _array_nonzero(PyArrayObject *mp)
         PyErr_SetString(PyExc_ValueError,
                         "The truth value of an array "
                         "with more than one element is ambiguous. "
-                        "Use a.any() or a.all()");
+                        "Consider using: a.any(), a.all(), a.max() or a.min()");
         return -1;
     }
 }

--- a/numpy/ma/API_CHANGES.txt
+++ b/numpy/ma/API_CHANGES.txt
@@ -111,7 +111,7 @@ converted to booleans:
   >>> bool(x)
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
-  ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
+  ValueError: The truth value of an array with more than one element is ambiguous. Consider using: a.any(), a.all(), a.max() or a.min()
 
 
 ==================================


### PR DESCRIPTION
It seems like an easy mistake to do `max(a)` instead of `a.max()` or
`np.max(a)` for an ndarray `a`. This adds a hint to the resulting error message,
complementing the existing hint about `a.any()`/`a.all()`.