### PR TITLE
BUG: Fix `np.array_api.can_cast()` by not relying on `np.can_cast()`

### DIFF
--- a/numpy/array_api/_data_type_functions.py
+++ b/numpy/array_api/_data_type_functions.py
@@ -56,10 +56,15 @@ def can_cast(from_: Union[Dtype, Array], to: Dtype, /) -> bool:
         raise TypeError(f"{from_=}, but should be an array_api array or dtype")
     if to not in _all_dtypes:
         raise TypeError(f"{to=}, but should be a dtype")
+    # Note: We avoid np.can_cast() as it has discrepancies with the array API.
+    # See https://github.com/numpy/numpy/issues/20870
     try:
+        # We promote `from_` and `to` together. We then check if the promoted
+        # dtype is `to`, which indicates if `from_` can (up)cast to `to`.
         dtype = _result_type(from_, to)
         return to == dtype
     except TypeError:
+        # _result_type() raises if the dtypes don't promote together
         return False
 
 

--- a/numpy/array_api/_data_type_functions.py
+++ b/numpy/array_api/_data_type_functions.py
@@ -50,11 +50,17 @@ def can_cast(from_: Union[Dtype, Array], to: Dtype, /) -> bool:
 
     See its docstring for more information.
     """
-    from ._array_object import Array
-
     if isinstance(from_, Array):
-        from_ = from_._array
-    return np.can_cast(from_, to)
+        from_ = from_.dtype
+    elif from_ not in _all_dtypes:
+        raise TypeError(f"{from_=}, but should be an array_api array or dtype")
+    if to not in _all_dtypes:
+        raise TypeError(f"{to=}, but should be a dtype")
+    try:
+        dtype = _result_type(from_, to)
+        return to == dtype
+    except TypeError:
+        return False
 
 
 # These are internal objects for the return types of finfo and iinfo, since

--- a/numpy/array_api/tests/test_data_type_functions.py
+++ b/numpy/array_api/tests/test_data_type_functions.py
@@ -8,8 +8,6 @@ from numpy import array_api as xp
     [
         (xp.int8, xp.int16, True),
         (xp.int16, xp.int8, False),
-        # np.can_cast has discrepancies with the Array API
-        # See https://github.com/numpy/numpy/issues/20870
         (xp.bool, xp.int8, False),
         (xp.asarray(0, dtype=xp.uint8), xp.int8, False),
     ],

--- a/numpy/array_api/tests/test_data_type_functions.py
+++ b/numpy/array_api/tests/test_data_type_functions.py
@@ -1,0 +1,21 @@
+import pytest
+
+from numpy import array_api as xp
+
+
+@pytest.mark.parametrize(
+    "from_, to, expected",
+    [
+        (xp.int8, xp.int16, True),
+        (xp.int16, xp.int8, False),
+        # np.can_cast has discrepancies with the Array API
+        # See https://github.com/numpy/numpy/issues/20870
+        (xp.bool, xp.int8, False),
+        (xp.asarray(0, dtype=xp.uint8), xp.int8, False),
+    ],
+)
+def test_can_cast(from_, to, expected):
+    """
+    can_cast() returns correct result
+    """
+    assert xp.can_cast(from_, to) == expected

--- a/numpy/array_api/tests/test_validation.py
+++ b/numpy/array_api/tests/test_validation.py
@@ -1,0 +1,27 @@
+from typing import Callable
+
+import pytest
+
+from numpy import array_api as xp
+
+
+def p(func: Callable, *args, **kwargs):
+    f_sig = ", ".join(
+        [str(a) for a in args] + [f"{k}={v}" for k, v in kwargs.items()]
+    )
+    id_ = f"{func.__name__}({f_sig})"
+    return pytest.param(func, args, kwargs, id=id_)
+
+
+@pytest.mark.parametrize(
+    "func, args, kwargs",
+    [
+        p(xp.can_cast, 42, xp.int8),
+        p(xp.can_cast, xp.int8, 42),
+        p(xp.result_type, 42),
+    ],
+)
+def test_raises_on_invalid_types(func, args, kwargs):
+    """Function raises TypeError when passed invalidly-typed inputs"""
+    with pytest.raises(TypeError):
+        func(*args, **kwargs)


### PR DESCRIPTION
Resolves #20870 by falling back on `_result_type()` as per @asmeurer's suggestion.

Introduces a test to check for regressions, as well as a test to check our validation logic (in the future we can use `test_validation.py` to cover any custom validation logic we do).

Also has more thorough compliance testing in `array-api-tests`, specifically https://github.com/data-apis/array-api-tests/blob/693c29b6b3a627b93f1a79615dcb3482c9249d2b/array_api_tests/test_data_type_functions.py#L104