### PR TITLE
MAINT: Minor cleanup to F2PY

### DIFF
--- a/numpy/core/include/numpy/npy_os.h
+++ b/numpy/core/include/numpy/npy_os.h
@@ -21,6 +21,10 @@
     #define NPY_OS_CYGWIN
 #elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
     #define NPY_OS_WIN32
+#elif defined(_WIN64) || defined(__WIN64__) || defined(WIN64)
+    #define NPY_OS_WIN64
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+    #define NPY_OS_MINGW
 #elif defined(__APPLE__)
     #define NPY_OS_DARWIN
 #else

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -572,13 +572,13 @@ cppmacros["F2PY_THREAD_LOCAL_DECL"] = """\
 #ifndef F2PY_THREAD_LOCAL_DECL
 #if defined(_MSC_VER)
 #define F2PY_THREAD_LOCAL_DECL __declspec(thread)
-#elif defined(__MINGW32__) || defined(__MINGW64__)
+#elif defined(NPY_OS_MINGW)
 #define F2PY_THREAD_LOCAL_DECL __thread
 #elif defined(__STDC_VERSION__) \\
       && (__STDC_VERSION__ >= 201112L) \\
       && !defined(__STDC_NO_THREADS__) \\
       && (!defined(__GLIBC__) || __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 12)) \\
-      && !defined(__OpenBSD__)
+      && !defined(NPY_OS_OPENBSD)
 /* __STDC_NO_THREADS__ was first defined in a maintenance release of glibc 2.12,
    see https://lists.gnu.org/archive/html/commit-hurd/2012-07/msg00180.html,
    so `!defined(__STDC_NO_THREADS__)` may give false positive for the existence

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -64,7 +64,7 @@ typedefs['unsigned_short'] = 'typedef unsigned short unsigned_short;'
 typedefs['unsigned_long'] = 'typedef unsigned long unsigned_long;'
 typedefs['signed_char'] = 'typedef signed char signed_char;'
 typedefs['long_long'] = """\
-#ifdef _WIN32
+#if defined(NPY_OS_WIN32)
 typedef __int64 long_long;
 #else
 typedef long long long_long;
@@ -72,7 +72,7 @@ typedef unsigned long long unsigned_long_long;
 #endif
 """
 typedefs['unsigned_long_long'] = """\
-#ifdef _WIN32
+#if defined(NPY_OS_WIN32)
 typedef __uint64 long_long;
 #else
 typedef unsigned long long unsigned_long_long;

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -51,8 +51,6 @@ includes0['math.h'] = '#include <math.h>'
 includes0['string.h'] = '#include <string.h>'
 includes0['setjmp.h'] = '#include <setjmp.h>'
 
-includes['Python.h'] = '#include <Python.h>'
-needs['arrayobject.h'] = ['Python.h']
 includes['arrayobject.h'] = '''#define PY_ARRAY_UNIQUE_SYMBOL PyArray_API
 #include "arrayobject.h"'''
 

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -124,6 +124,9 @@ extern \"C\" {
 #define PY_SSIZE_T_CLEAN
 #endif /* PY_SSIZE_T_CLEAN */
 
+/* Unconditionally included */
+#include <Python.h>
+
 """ + gentitle("See f2py2e/cfuncs.py: includes") + """
 #includes#
 #includes0#

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -126,6 +126,7 @@ extern \"C\" {
 
 /* Unconditionally included */
 #include <Python.h>
+#include <numpy/npy_os.h>
 
 """ + gentitle("See f2py2e/cfuncs.py: includes") + """
 #includes#


### PR DESCRIPTION
This PR:
- Reuses macro definitions elsewhere in `numpy` for `f2py`
- Clarifies the includes which are generated compared to the ones always present


Draft since after #20881 is in, some of the checks there (BSD, WIN) can be kanged from `npy_os.h` as well.