### PR TITLE
TYP,MAINT: Add aliases for commonly used unions

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -38,6 +38,7 @@ from numpy.typing import (
 
     # DTypes
     DTypeLike,
+    _DTypeLike,
     _SupportsDType,
     _VoidDTypeLike,
 
@@ -1410,12 +1411,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _2Tuple = tuple[_T, _T]
 _CastingKind = L["no", "equiv", "safe", "same_kind", "unsafe"]
-
-_DTypeLike = Union[
-    dtype[_ScalarType],
-    type[_ScalarType],
-    _SupportsDType[dtype[_ScalarType]],
-]
 
 _ArrayUInt_co = NDArray[Union[bool_, unsignedinteger[Any]]]
 _ArrayInt_co = NDArray[Union[bool_, integer[Any]]]

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,31 +1,21 @@
 from typing import (
     Literal as L,
     overload,
-    Union,
     Any,
     SupportsIndex,
     TypeVar,
 )
 
-from numpy import floating, complexfloating, generic, dtype
+from numpy import floating, complexfloating, generic
 from numpy.typing import (
     NDArray,
-    ArrayLike,
     DTypeLike,
-    _SupportsDType,
-    _SupportsArray,
-    _NumberLike_co,
+    _DTypeLike,
     _ArrayLikeFloat_co,
     _ArrayLikeComplex_co,
 )
 
 _SCT = TypeVar("_SCT", bound=generic)
-
-_DTypeLike = Union[
-    dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 
 __all__: list[str]
 

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -58,10 +58,9 @@ from numpy.typing import (
     # Arrays
     NDArray,
     ArrayLike,
-    _SupportsArray,
+    _ArrayLike,
     _SupportsArrayFunc,
     _NestedSequence,
-    _FiniteNestedSequence,
     _ArrayLikeBool_co,
     _ArrayLikeUInt_co,
     _ArrayLikeInt_co,
@@ -80,8 +79,6 @@ from numpy.typing import (
 
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 # Valid time units
 _UnitKind = L[

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -8,11 +8,9 @@ from typing import (
     Any,
     overload,
     TypeVar,
-    Union,
     SupportsIndex,
     final,
     Final,
-    Protocol,
 )
 
 from numpy import (
@@ -55,7 +53,7 @@ from numpy.typing import (
 
     # DTypes
     DTypeLike,
-    _SupportsDType,
+    _DTypeLike,
 
     # Arrays
     NDArray,
@@ -83,12 +81,6 @@ from numpy.typing import (
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-# Subscriptable subsets of `npt.DTypeLike` and `npt.ArrayLike`
-_DTypeLike = Union[
-    dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 _ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 # Valid time units

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -12,7 +12,6 @@ from typing_extensions import TypeGuard
 
 from numpy import (
     ComplexWarning as ComplexWarning,
-    dtype,
     generic,
     unsignedinteger,
     signedinteger,
@@ -34,8 +33,7 @@ from numpy.typing import (
     DTypeLike,
     _ShapeLike,
     _DTypeLike,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
     _SupportsArrayFunc,
     _ScalarLike_co,
     _ArrayLikeBool_co,
@@ -51,7 +49,6 @@ _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 _CorrelateMode = Literal["valid", "same", "full"]
 
 __all__: list[str]

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
-    Union,
     overload,
     TypeVar,
     Literal,
@@ -34,7 +33,7 @@ from numpy.typing import (
     NDArray,
     DTypeLike,
     _ShapeLike,
-    _SupportsDType,
+    _DTypeLike,
     _FiniteNestedSequence,
     _SupportsArray,
     _SupportsArrayFunc,
@@ -52,11 +51,6 @@ _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-_DTypeLike = Union[
-    dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 _ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 _CorrelateMode = Literal["valid", "same", "full"]
 

--- a/numpy/core/numerictypes.pyi
+++ b/numpy/core/numerictypes.pyi
@@ -46,17 +46,10 @@ from numpy.core._type_aliases import (
     sctypes as sctypes,
 )
 
-from numpy.typing import DTypeLike, ArrayLike, _SupportsDType
+from numpy.typing import DTypeLike, ArrayLike, _DTypeLike
 
 _T = TypeVar("_T")
 _SCT = TypeVar("_SCT", bound=generic)
-
-# A paramtrizable subset of `npt.DTypeLike`
-_DTypeLike = Union[
-    type[_SCT],
-    dtype[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 
 class _CastFunc(Protocol):
     def __call__(

--- a/numpy/core/shape_base.pyi
+++ b/numpy/core/shape_base.pyi
@@ -1,13 +1,11 @@
 from collections.abc import Sequence
 from typing import TypeVar, overload, Any, SupportsIndex
 
-from numpy import generic, dtype
-from numpy.typing import ArrayLike, NDArray, _FiniteNestedSequence, _SupportsArray
+from numpy import generic
+from numpy.typing import ArrayLike, NDArray, _ArrayLike
 
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -33,7 +33,6 @@ from numpy import (
     ulonglong,
     single,
     double,
-    float_,
     longdouble,
     void,
 )
@@ -41,10 +40,8 @@ from numpy.core._internal import _ctypes
 from numpy.core.multiarray import flagsobj
 from numpy.typing import (
     # Arrays
-    ArrayLike,
     NDArray,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
 
     # Shapes
     _ShapeLike,
@@ -73,8 +70,6 @@ from numpy.typing import (
 _DType = TypeVar("_DType", bound=dtype[Any])
 _DTypeOptional = TypeVar("_DTypeOptional", bound=None | dtype[Any])
 _SCT = TypeVar("_SCT", bound=generic)
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 _FlagsKind = L[
     'C_CONTIGUOUS', 'CONTIGUOUS', 'C',

--- a/numpy/ctypeslib.pyi
+++ b/numpy/ctypeslib.pyi
@@ -51,7 +51,7 @@ from numpy.typing import (
 
     # DTypes
     DTypeLike,
-    _SupportsDType,
+    _DTypeLike,
     _VoidDTypeLike,
     _BoolCodes,
     _UByteCodes,
@@ -74,11 +74,6 @@ _DType = TypeVar("_DType", bound=dtype[Any])
 _DTypeOptional = TypeVar("_DTypeOptional", bound=None | dtype[Any])
 _SCT = TypeVar("_SCT", bound=generic)
 
-_DTypeLike = Union[
-    dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 _ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 _FlagsKind = L[

--- a/numpy/fft/helper.pyi
+++ b/numpy/fft/helper.pyi
@@ -1,19 +1,16 @@
 from typing import Any, TypeVar, overload
 
-from numpy import generic, dtype, integer, floating, complexfloating
+from numpy import generic, integer, floating, complexfloating
 from numpy.typing import (
     NDArray,
     ArrayLike,
     _ShapeLike,
-    _SupportsArray,
-    _FiniteNestedSequence,
+    _ArrayLike,
     _ArrayLikeFloat_co,
     _ArrayLikeComplex_co,
 )
 
 _SCT = TypeVar("_SCT", bound=generic)
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/lib/arraypad.pyi
+++ b/numpy/lib/arraypad.pyi
@@ -6,14 +6,13 @@ from typing import (
     Protocol,
 )
 
-from numpy import ndarray, dtype, generic
+from numpy import generic
 
 from numpy.typing import (
     ArrayLike,
     NDArray,
     _ArrayLikeInt,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
 )
 
 _SCT = TypeVar("_SCT", bound=generic)
@@ -41,8 +40,6 @@ _ModeKind = L[
     "wrap",
     "empty",
 ]
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/lib/arraysetops.pyi
+++ b/numpy/lib/arraysetops.pyi
@@ -7,7 +7,6 @@ from typing import (
 )
 
 from numpy import (
-    dtype,
     generic,
     number,
     bool_,
@@ -41,8 +40,7 @@ from numpy import (
 from numpy.typing import (
     ArrayLike,
     NDArray,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
     _ArrayLikeBool_co,
     _ArrayLikeDT64_co,
     _ArrayLikeTD64_co,
@@ -86,8 +84,6 @@ _SCTNoCast = TypeVar(
     bytes_,
     void,
 )
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -18,7 +18,6 @@ else:
 from numpy import (
     vectorize as vectorize,
     ufunc,
-    dtype,
     generic,
     floating,
     complexfloating,
@@ -38,8 +37,7 @@ from numpy.typing import (
     _ShapeLike,
     _ScalarLike_co,
     _DTypeLike,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
     _ArrayLikeInt_co,
     _ArrayLikeFloat_co,
     _ArrayLikeComplex_co,
@@ -67,7 +65,6 @@ _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 _2Tuple = tuple[_T, _T]
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 class _TrimZerosSequence(Protocol[_T_co]):
     def __len__(self) -> int: ...

--- a/numpy/lib/function_base.pyi
+++ b/numpy/lib/function_base.pyi
@@ -2,7 +2,6 @@ import sys
 from collections.abc import Sequence, Iterator, Callable, Iterable
 from typing import (
     Literal as L,
-    Union,
     Any,
     TypeVar,
     overload,
@@ -38,7 +37,7 @@ from numpy.typing import (
     DTypeLike,
     _ShapeLike,
     _ScalarLike_co,
-    _SupportsDType,
+    _DTypeLike,
     _FiniteNestedSequence,
     _SupportsArray,
     _ArrayLikeInt_co,
@@ -69,11 +68,6 @@ _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 _2Tuple = tuple[_T, _T]
 _ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
-_DTypeLike = Union[
-    dtype[_SCT],
-    type[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 
 class _TrimZerosSequence(Protocol[_T_co]):
     def __len__(self) -> int: ...

--- a/numpy/lib/npyio.pyi
+++ b/numpy/lib/npyio.pyi
@@ -9,7 +9,6 @@ from typing import (
     Any,
     TypeVar,
     Generic,
-    Union,
     IO,
     overload,
     Protocol,
@@ -31,7 +30,7 @@ from numpy.typing import (
     ArrayLike,
     DTypeLike,
     NDArray,
-    _SupportsDType,
+    _DTypeLike,
     _SupportsArrayFunc,
 )
 
@@ -46,12 +45,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
 _CharType_co = TypeVar("_CharType_co", str, bytes, covariant=True)
 _CharType_contra = TypeVar("_CharType_contra", str, bytes, contravariant=True)
-
-_DTypeLike = Union[
-    type[_SCT],
-    dtype[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 
 class _SupportsGetItem(Protocol[_T_contra, _T_co]):
     def __getitem__(self, key: _T_contra, /) -> _T_co: ...

--- a/numpy/lib/shape_base.pyi
+++ b/numpy/lib/shape_base.pyi
@@ -4,7 +4,6 @@ from typing import TypeVar, Any, overload, SupportsIndex, Protocol
 from numpy import (
     generic,
     integer,
-    dtype,
     ufunc,
     bool_,
     unsignedinteger,
@@ -18,21 +17,18 @@ from numpy.typing import (
     ArrayLike,
     NDArray,
     _ShapeLike,
-     _FiniteNestedSequence,
-     _SupportsArray,
-     _ArrayLikeBool_co,
-     _ArrayLikeUInt_co,
-     _ArrayLikeInt_co,
-     _ArrayLikeFloat_co,
-     _ArrayLikeComplex_co,
-     _ArrayLikeObject_co,
+    _ArrayLike,
+    _ArrayLikeBool_co,
+    _ArrayLikeUInt_co,
+    _ArrayLikeInt_co,
+    _ArrayLikeFloat_co,
+    _ArrayLikeComplex_co,
+    _ArrayLikeObject_co,
 )
 
 from numpy.core.shape_base import vstack
 
 _SCT = TypeVar("_SCT", bound=generic)
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 # The signatures of `__array_wrap__` and `__array_prepare__` are the same;
 # give them unique names for the sake of clarity

--- a/numpy/lib/stride_tricks.pyi
+++ b/numpy/lib/stride_tricks.pyi
@@ -1,18 +1,16 @@
 from collections.abc import Iterable
 from typing import Any, TypeVar, overload, SupportsIndex
 
-from numpy import dtype, generic
+from numpy import generic
 from numpy.typing import (
     NDArray,
     ArrayLike,
     _ShapeLike,
     _Shape,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike
 )
 
 _SCT = TypeVar("_SCT", bound=generic)
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/lib/twodim_base.pyi
+++ b/numpy/lib/twodim_base.pyi
@@ -7,8 +7,6 @@ from typing import (
 )
 
 from numpy import (
-    ndarray,
-    dtype,
     generic,
     number,
     bool_,
@@ -28,9 +26,8 @@ from numpy.typing import (
     DTypeLike,
     _DTypeLike,
     ArrayLike,
+    _ArrayLike,
     NDArray,
-    _FiniteNestedSequence,
-    _SupportsArray,
     _SupportsArrayFunc,
     _ArrayLikeInt_co,
     _ArrayLikeFloat_co,
@@ -46,8 +43,6 @@ _MaskFunc = Callable[
     [NDArray[int_], _T],
     NDArray[Union[number[Any], bool_, timedelta64, datetime64, object_]],
 ]
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]
 

--- a/numpy/lib/twodim_base.pyi
+++ b/numpy/lib/twodim_base.pyi
@@ -26,7 +26,7 @@ from numpy import (
 
 from numpy.typing import (
     DTypeLike,
-    _SupportsDType,
+    _DTypeLike,
     ArrayLike,
     NDArray,
     _FiniteNestedSequence,
@@ -47,11 +47,6 @@ _MaskFunc = Callable[
     NDArray[Union[number[Any], bool_, timedelta64, datetime64, object_]],
 ]
 
-_DTypeLike = Union[
-    type[_SCT],
-    dtype[_SCT],
-    _SupportsDType[dtype[_SCT]],
-]
 _ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 __all__: list[str]

--- a/numpy/lib/type_check.pyi
+++ b/numpy/lib/type_check.pyi
@@ -25,8 +25,7 @@ from numpy.typing import (
     _64Bit,
     _SupportsDType,
     _ScalarLike_co,
-    _FiniteNestedSequence,
-    _SupportsArray,
+    _ArrayLike,
     _DTypeLikeComplex,
 )
 
@@ -35,8 +34,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
 _NBit1 = TypeVar("_NBit1", bound=NBitBase)
 _NBit2 = TypeVar("_NBit2", bound=NBitBase)
-
-_ArrayLike = _FiniteNestedSequence[_SupportsArray[dtype[_SCT]]]
 
 class _SupportsReal(Protocol[_T_co]):
     @property

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -323,6 +323,7 @@ from ._scalars import (
 from ._shape import _Shape, _ShapeLike
 from ._dtype_like import (
     DTypeLike as DTypeLike,
+    _DTypeLike,
     _SupportsDType,
     _VoidDTypeLike,
     _DTypeLikeBool,

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -57,6 +57,12 @@ _FiniteNestedSequence = Union[
     Sequence[Sequence[Sequence[Sequence[_T]]]],
 ]
 
+# A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
+_ArrayLike = Union[
+    _SupportsArray["dtype[_ScalarType]"],
+    _NestedSequence[_SupportsArray["dtype[_ScalarType]"]],
+]
+
 # A union representing array-like objects; consists of two typevars:
 # One representing types that can be parametrized w.r.t. `np.dtype`
 # and another one for the rest

--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -60,7 +60,7 @@ _FiniteNestedSequence = Union[
 # A union representing array-like objects; consists of two typevars:
 # One representing types that can be parametrized w.r.t. `np.dtype`
 # and another one for the rest
-_ArrayLike = Union[
+_DualArrayLike = Union[
     _SupportsArray[_DType],
     _NestedSequence[_SupportsArray[_DType]],
     _T,
@@ -74,38 +74,38 @@ _ArrayLike = Union[
 # is resolved. See also the mypy issue:
 #
 # https://github.com/python/typing/issues/593
-ArrayLike = _ArrayLike[
+ArrayLike = _DualArrayLike[
     dtype,
     Union[bool, int, float, complex, str, bytes],
 ]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`
-_ArrayLikeBool_co = _ArrayLike[
+_ArrayLikeBool_co = _DualArrayLike[
     "dtype[bool_]",
     bool,
 ]
-_ArrayLikeUInt_co = _ArrayLike[
+_ArrayLikeUInt_co = _DualArrayLike[
     "dtype[Union[bool_, unsignedinteger[Any]]]",
     bool,
 ]
-_ArrayLikeInt_co = _ArrayLike[
+_ArrayLikeInt_co = _DualArrayLike[
     "dtype[Union[bool_, integer[Any]]]",
     Union[bool, int],
 ]
-_ArrayLikeFloat_co = _ArrayLike[
+_ArrayLikeFloat_co = _DualArrayLike[
     "dtype[Union[bool_, integer[Any], floating[Any]]]",
     Union[bool, int, float],
 ]
-_ArrayLikeComplex_co = _ArrayLike[
+_ArrayLikeComplex_co = _DualArrayLike[
     "dtype[Union[bool_, integer[Any], floating[Any], complexfloating[Any, Any]]]",
     Union[bool, int, float, complex],
 ]
-_ArrayLikeNumber_co = _ArrayLike[
+_ArrayLikeNumber_co = _DualArrayLike[
     "dtype[Union[bool_, number[Any]]]",
     Union[bool, int, float, complex],
 ]
-_ArrayLikeTD64_co = _ArrayLike[
+_ArrayLikeTD64_co = _DualArrayLike[
     "dtype[Union[bool_, integer[Any], timedelta64]]",
     Union[bool, int],
 ]
@@ -122,16 +122,16 @@ _ArrayLikeVoid_co = Union[
     _SupportsArray["dtype[void]"],
     _NestedSequence[_SupportsArray["dtype[void]"]],
 ]
-_ArrayLikeStr_co = _ArrayLike[
+_ArrayLikeStr_co = _DualArrayLike[
     "dtype[str_]",
     str,
 ]
-_ArrayLikeBytes_co = _ArrayLike[
+_ArrayLikeBytes_co = _DualArrayLike[
     "dtype[bytes_]",
     bytes,
 ]
 
-_ArrayLikeInt = _ArrayLike[
+_ArrayLikeInt = _DualArrayLike[
     "dtype[integer[Any]]",
     int,
 ]

--- a/numpy/typing/_dtype_like.py
+++ b/numpy/typing/_dtype_like.py
@@ -57,8 +57,11 @@ from ._char_codes import (
     _ObjectCodes,
 )
 
-_DTypeLikeNested = Any  # TODO: wait for support for recursive types
+_SCT = TypeVar("_SCT", bound=np.generic)
 _DType_co = TypeVar("_DType_co", covariant=True, bound=DType[Any])
+
+_DTypeLikeNested = Any  # TODO: wait for support for recursive types
+
 
 # Mandatory keys
 class _DTypeDictBase(TypedDict):
@@ -80,6 +83,14 @@ class _DTypeDict(_DTypeDictBase, total=False):
 class _SupportsDType(Protocol[_DType_co]):
     @property
     def dtype(self) -> _DType_co: ...
+
+
+# A subset of `npt.DTypeLike` that can be parametrized w.r.t. `np.generic`
+_DTypeLike = Union[
+    "np.dtype[_SCT]",
+    Type[_SCT],
+    _SupportsDType["np.dtype[_SCT]"],
+]
 
 
 # Would create a dtype[np.void]

--- a/numpy/typing/tests/data/fail/multiarray.pyi
+++ b/numpy/typing/tests/data/fail/multiarray.pyi
@@ -39,7 +39,7 @@ np.arange(stop=10)  # E: No overload variant
 
 np.datetime_data(int)  # E: incompatible type
 
-np.busday_offset("2012", 10)  # E: incompatible type
+np.busday_offset("2012", 10)  # E: No overload variant
 
 np.datetime_as_string("2012")  # E: No overload variant
 

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -193,5 +193,5 @@ reveal_type(np.stack([C, C]))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.stack([A, A], axis=0))  # E: Any
 reveal_type(np.stack([A, A], out=B))  # E: SubClass[{float64}]
 
-reveal_type(np.block([[A, A], [A, A]]))  # E: ndarray[Any, Any]
+reveal_type(np.block([[A, A], [A, A]]))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.block(C))  # E: ndarray[Any, dtype[Any]]


### PR DESCRIPTION
This PR adds two type-aliases for commonly used types, namelly the subsets of `npt.DTypeLike` and `npt.ArrayLike` that can be parameterized w.r.t. `np.generic`. Previously, similar aliases were scathered throughout the stub files, this PR centralizing them in the `np.typing` namespace.