### PR TITLE
ENH: add cov parameter to numpy.polynomial.polynomial.polyfit

### DIFF
--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1211,7 +1211,7 @@ def polyvander3d(x, y, z, deg):
     return pu._vander_nd_flat((polyvander, polyvander, polyvander), (x, y, z), deg)
 
 
-def polyfit(x, y, deg, rcond=None, full=False, w=None):
+def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least-squares fit of a polynomial to data.
 
@@ -1359,7 +1359,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
                0.50443316,  0.28853036]), 1.1324274851176597e-014]
 
     """
-    return pu._fit(polyvander, x, y, deg, rcond, full, w)
+    return pu._fit(polyvander, x, y, deg, rcond, full, w, cov)
 
 
 def polycompanion(c):

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -32,6 +32,11 @@ import warnings
 
 import numpy as np
 
+import numpy.core.numeric as NX
+from numpy.core import dot
+from numpy.linalg import inv
+
+
 __all__ = [
     'RankWarning', 'as_series', 'trimseq',
     'trimcoef', 'getdomain', 'mapdomain', 'mapparms']
@@ -592,7 +597,7 @@ def _sub(c1, c2):
     return trimseq(ret)
 
 
-def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
+def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Helper function used to implement the ``<type>fit`` functions.
 
@@ -634,6 +639,7 @@ def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
     # set up the least squares matrices in transposed form
     lhs = van.T
     rhs = y.T
+
     if w is not None:
         w = np.asarray(w) + 0.0
         if w.ndim != 1:
@@ -674,10 +680,18 @@ def _fit(vander_f, x, y, deg, rcond=None, full=False, w=None):
         msg = "The fit may be poorly conditioned"
         warnings.warn(msg, RankWarning, stacklevel=2)
 
-    if full:
-        return c, [resids, rank, s, rcond]
-    else:
+
+    if not full and not cov:
         return c
+ 
+    return_tuple = [c]
+
+    if full:
+        return_tuple.append([resids, rank, s, rcond])
+    if cov:
+        return_tuple.append(np.vander(c))
+    
+    return tuple(return_tuple)
 
 
 def _pow(mul_f, c, pow, maxpower):

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -32,10 +32,6 @@ import warnings
 
 import numpy as np
 
-import numpy.core.numeric as NX
-from numpy.core import dot
-from numpy.linalg import inv
-
 
 __all__ = [
     'RankWarning', 'as_series', 'trimseq',

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -581,6 +581,21 @@ class TestMisc:
         coef2 = poly.polyfit(x, y, [0, 2, 4])
         assert_almost_equal(poly.polyval(x, coef2), y)
         assert_almost_equal(coef1, coef2)
+        # test polyfit returns covariance matrix
+        x = [1., 2., 3., 4., 5., 6., 7., 8., 9.]
+        y = [1., 3., 2., 4., 5., 6., 6., 8., 9.]
+        yerr = [10., 5., 3., 2., 10., 10., 10., 10., 10.]
+        coef1, cov_matrix1 = poly.polyfit(x, y, 1, w=yerr, cov=True)
+        assert_almost_equal(coef1, [0, 1], decimal=1)
+        assert_almost_equal(cov_matrix1, [[0, 1.],[1.,1.]],decimal=0)
+        #
+        coef2, full_matrix1, cov_matrix2 = poly.polyfit(x, y, 1, full=True, cov=True)
+        assert_almost_equal(coef1, coef2, decimal=1)
+        assert_almost_equal(cov_matrix1, cov_matrix2, decimal=1)
+        assert_almost_equal(full_matrix1[0], 2.7, decimal=1)
+        assert_equal(full_matrix1[1], 2)
+        assert_almost_equal(full_matrix1[2], [1.4, 0.3],decimal=1)
+        assert_almost_equal(full_matrix1[3], 0, decimal=0)
 
     def test_polytrim(self):
         coef = [2, -1, 1, 0]

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -587,15 +587,15 @@ class TestMisc:
         yerr = [10., 5., 3., 2., 10., 10., 10., 10., 10.]
         coef1, cov_matrix1 = poly.polyfit(x, y, 1, w=yerr, cov=True)
         assert_almost_equal(coef1, [0, 1], decimal=1)
-        assert_almost_equal(cov_matrix1, [[0, 1.],[1.,1.]],decimal=0)
+        assert_almost_equal(cov_matrix1, [[0, 1.],[1., 1.]], decimal=0)
         #
-        coef2, full_matrix1, cov_matrix2 = poly.polyfit(x, y, 1, full=True, cov=True)
-        assert_almost_equal(coef1, coef2, decimal=1)
-        assert_almost_equal(cov_matrix1, cov_matrix2, decimal=1)
-        assert_almost_equal(full_matrix1[0], 2.7, decimal=1)
-        assert_equal(full_matrix1[1], 2)
-        assert_almost_equal(full_matrix1[2], [1.4, 0.3],decimal=1)
-        assert_almost_equal(full_matrix1[3], 0, decimal=0)
+        coef, full, cov = poly.polyfit(x, y, 1, full=True, cov=True)
+        assert_almost_equal(coef1, coef, decimal=1)
+        assert_almost_equal(cov_matrix1, cov, decimal=1)
+        assert_almost_equal(full[0], 2.7, decimal=1)
+        assert_equal(full[1], 2)
+        assert_almost_equal(full[2], [1.4, 0.3], decimal=1)
+        assert_almost_equal(full[3], 0, decimal=0)
 
     def test_polytrim(self):
         coef = [2, -1, 1, 0]


### PR DESCRIPTION
It seems to be that polyfit has `cov` parameter removed. According to @djpine in this issue https://github.com/numpy/numpy/issues/20871, it should have it and that's not all: `cov` and `full` should not exclude mutually. What does it mean? In the earlier version of polyfit, if you set `full` to false and `cov` to true, you get the covariance matrix. Neverthless, if we set both parameters to true, you don't get the covariance matrix. This is not useful and logic neither.

Here an example (I based it on @lfguevarag97 https://github.com/numpy/numpy/issues/20871#issuecomment-1018904968):

```
>>> x = [1., 2., 3., 4., 5., 6., 7., 8., 9.]
>>> y = [1., 3., 2., 4., 5., 6., 6., 8., 9.]
>>> poly.polyfit(x,y,1,cov=True)
(array([0.13888889, 0.95      ]), array([[0.13888889, 1.        ],
       [0.95      , 1.        ]]))
>>> poly.polyfit(x,y,1,cov=True,full=True)
(array([0.13888889, 0.95      ]), [array([2.73888889]), 2, array([1.37423554, 0.33388124]), 1.9984014443252818e-15], array([[0.13888889, 1.        ],
       [0.95      , 1.        ]]))
```
Furthermore, why not to include the covariance matrix inside the _full_ information and remove `cov` parameter?