### PR TITLE
BUILD: Upload wheels to anaconda,org

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,12 +1,16 @@
+# To enable this workflow on a fork, comment out:
+#
+# if: github.repository == 'numpy/numpy'
 on: [status]
 jobs:
-   circleci_artifacts_redirector_job:
-     runs-on: ubuntu-latest
-     name: Run CircleCI artifacts redirector
-     steps:
-       - name: GitHub Action step
-         uses: larsoner/circleci-artifacts-redirector-action@master
-         with:
-           repo-token: ${{ secrets.GITHUB_TOKEN }}
-           artifact-path: 0/doc/build/html/index.html
-           circleci-jobs: build
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    # if: github.repository == 'numpy/numpy'
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/doc/build/html/index.html
+          circleci-jobs: build

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,3 +1,6 @@
+# To enable this workflow on a fork, comment out:
+#
+# if: github.repository == 'numpy/numpy'
 name: Test on Cygwin
 on:
   push:
@@ -9,6 +12,7 @@ on:
 jobs:
   cygwin_build_test:
     runs-on: windows-latest
+    if: github.repository == 'numpy/numpy'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -135,12 +135,12 @@ jobs:
           if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
             echo push and tag event
             echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
-            echo "TOKEN=$MULTIBUILD_WHEELS_STAGING_ACCESS" >> $GITHUB_ENV
+            echo "TOKEN=${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}" >> $GITHUB_ENV
             echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
           elif [ "schedule" == "${{ github.event_name }}" ] || [ "workflow_dispatch" == "${{ github.event_name }}" ]; then
             echo scheduled or dispatched event
             echo "ANACONDA_ORG=scipy-wheels-nightly" >> $GITHUB_ENV
-            echo "TOKEN=$SCIPY_WHEELS_NIGHTLY_ACCESS" >> $GITHUB_ENV
+            echo "TOKEN=${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}" >> $GITHUB_ENV
             echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
           else
             echo non-dispatch event
@@ -150,18 +150,12 @@ jobs:
         if: ${{ always() }}
         shell: bash
         run: |
-          # trigger an upload to the shared ecosystem
-          # infrastructure at: https://anaconda.org/scipy-wheels-nightly
-          # for cron jobs only (restricted to main branch once
-          # per week)
-          # SCIPY_WHEELS_NIGHTLY_ACCESS is a secret token
-          # used in Travis CI config, originally
-          #
-          # for merges (push events) we use the staging area instead;
-          # MULTIBUILD_WHEELS_STAGING_ACCESS is a secret token used in Travis
-          # CI config, originally generated at anaconda.org for
-          # multibuild-wheels-staging
-          # generated at anaconda.org for scipy-wheels-nightly
+          # trigger an upload to
+          # https://anaconda.org/scipy-wheels-nightly/numpy
+          # for cron jobs or "Run workflow" (restricted to main branch).
+          # Tags will upload to 
+          # https://anaconda.org/multibuild-wheels-staging/numpy
+          # The tokens were originally generated at anaconda.org
           echo ${PWD}
           if [ ${ANACONDA_UPLOAD} == true ]; then
             if [ -z ${TOKEN} ]; then

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    # if: github.repository == 'numpy/numpy'
+    if: github.repository == 'numpy/numpy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
   get_commit_message:
     name: Get commit message
     runs-on: ubuntu-latest
-    if: github.repository == 'numpy/numpy'
+    # if: github.repository == 'numpy/numpy'
     outputs:
       message: ${{ steps.commit_message.outputs.message }}
     steps:
@@ -131,17 +131,17 @@ jobs:
         shell: bash
         run: |
           if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
-			echo push and tag event
+            echo push and tag event
             echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
             echo "TOKEN=$MULTIBUILD_WHEELS_STAGING_ACCESS" >> $GITHUB_ENV
             echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
           elif [ "schedule" == "${{ github.event_name }}" ] || [ "workflow_dispatch" == "${{ github.event_name }}" ]; then
-			echo scheduled or dispatched event
+            echo scheduled or dispatched event
             echo "ANACONDA_ORG=scipy-wheels-nightly" >> $GITHUB_ENV
             echo "TOKEN=$SCIPY_WHEELS_NIGHTLY_ACCESS" >> $GITHUB_ENV
             echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
-		  else
-			echo non-dispatch event
+          else
+            echo non-dispatch event
             echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
           fi
       - name: Upload wheels
@@ -162,13 +162,13 @@ jobs:
           # generated at anaconda.org for scipy-wheels-nightly
           echo ${PWD}
           if [ ${ANACONDA_UPLOAD} == true ]; then
-	      	if [ -z ${TOKEN} ]; then
-			  echo no token set, not uploading
-			else
+            if [ -z ${TOKEN} ]; then
+              echo no token set, not uploading
+            else
               python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
               ls ./wheelhouse/*.whl
               anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
               echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
-			fi
+            fi
           fi
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,8 +10,13 @@ name: Wheel builder
 
 on:
   schedule:
-    # Nightly build at 1:42 UTC
-    - cron: "42 1 * * *"
+  #        ┌───────────── minute (0 - 59)
+  #        │  ┌───────────── hour (0 - 23)
+  #        │  │ ┌───────────── day of the month (1 - 31)
+  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │ │ │ │
+  - cron: "42 1 * * 4"
   push:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,7 +129,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Setup Upload Variables
-        if: ${{ always() }}
+        if: success()
         shell: bash
         run: |
           if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
@@ -147,7 +147,7 @@ jobs:
             echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
           fi
       - name: Upload wheels
-        if: ${{ always() }}
+        if: env.TOKEN 
         shell: bash
         run: |
           # trigger an upload to

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -125,3 +125,50 @@ jobs:
         with:
           name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
+
+      - name: Setup Upload Variables
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
+			echo push and tag event
+            echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
+            echo "TOKEN=$MULTIBUILD_WHEELS_STAGING_ACCESS" >> $GITHUB_ENV
+            echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
+          elif [ "schedule" == "${{ github.event_name }}" ] || [ "workflow_dispatch" == "${{ github.event_name }}" ]; then
+			echo scheduled or dispatched event
+            echo "ANACONDA_ORG=scipy-wheels-nightly" >> $GITHUB_ENV
+            echo "TOKEN=$SCIPY_WHEELS_NIGHTLY_ACCESS" >> $GITHUB_ENV
+            echo "ANACONDA_UPLOAD=true" >> $GITHUB_ENV
+		  else
+			echo non-dispatch event
+            echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
+          fi
+      - name: Upload wheels
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          # trigger an upload to the shared ecosystem
+          # infrastructure at: https://anaconda.org/scipy-wheels-nightly
+          # for cron jobs only (restricted to main branch once
+          # per week)
+          # SCIPY_WHEELS_NIGHTLY_ACCESS is a secret token
+          # used in Travis CI config, originally
+          #
+          # for merges (push events) we use the staging area instead;
+          # MULTIBUILD_WHEELS_STAGING_ACCESS is a secret token used in Travis
+          # CI config, originally generated at anaconda.org for
+          # multibuild-wheels-staging
+          # generated at anaconda.org for scipy-wheels-nightly
+          echo ${PWD}
+          if [ ${ANACONDA_UPLOAD} == true ]; then
+	      	if [ -z ${TOKEN} ]; then
+			  echo no token set, not uploading
+			else
+              python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+              ls ./wheelhouse/*.whl
+              anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
+              echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
+			fi
+          fi
+

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')))
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,8 @@ jobs:
     if: >-
       contains(needs.get_commit_message.outputs.message, '[wheel build]') ||
       github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -163,7 +163,7 @@ jobs:
             else
               python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
               ls ./wheelhouse/*.whl
-              anaconda -t ${TOKEN} upload --force -u ${ANACONDA_ORG} ./wheelhouse/*.whl
+              anaconda -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
               echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
             fi
           fi

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,6 +35,7 @@ jobs:
           set -xe
           COMMIT_MSG=$(git log --no-merges -1 --oneline)
           echo "::set-output name=message::$COMMIT_MSG"
+          echo github.ref ${{ github.ref }}
 
   build_wheels:
     name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -11,7 +11,7 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     PY_DIR=$(python -c "import sys; print(sys.prefix)")
     mkdir $PY_DIR/libs
 fi
-python -c "import sys; import numpy; sys.exit(not numpy.test('full', extra_argv=['-v']))"
+python -c "import sys; import numpy; sys.exit(not numpy.test('full', extra_argv=['-vvv']))"
 
 python $PROJECT_DIR/tools/wheels/check_license.py
 if [[ $UNAME == "Linux" || $UNAME == "Darwin" ]] ; then


### PR DESCRIPTION
Fixes #20262

Upload wheels to anaconda.org via cibuildwheel. The logic is:
- pushing a new tag will trigger a guthub action with `github.ref='refs/tags/v*' which will upload the wheels to [multibuild-wheels-staging](https://anaconda.org/multibuild-wheels-staging/numpy)
- the cron-scheduled job or NumPy team members clicking on the "Run workflow" button from Actions (in the menu bar above) -> Wheel builder will upload wheels to [scipy-wheels-nightly](https://anaconda.org/scipy-wheels-nightly/)

This uses the secret tokens which were generated from https://anaconda.org/multibuild-wheels-staging/settings/access https://anaconda.org/scipy-wheels-nightly/settings/access and then added to this repo at https://github.com/numpy/numpy/settings/environments/231368784/edit

This will probably influence the [release instructions](https://numpy.org/devdocs/dev/releasing.html?highlight=howto_release#trigger-the-wheel-builds)

I tested this in my fork of the repo. The commit ref is echoed in the [Get commit message step](https://github.com/mattip/numpy/runs/4935793608?check_suite_focus=true) (open the "Get commit message" fold in the CI run area to see the temporary tag in my fork of `refs/tags/v2.0.1.dev0`. Then this causes "push and tag event" to be echoed from the appropriate branch of the `if` in the "Setup Upload Variables" fold in any of the wheel builds, which will set up the `$TOKEN` and `$ANACONDA_ORG` to be appropriately set.

The use of the secrets and final upload step should Just Work(tm) but may require some tweaks.

Thanks to @bashtage for the parallel work done in MacPython/statsmodels-wheels#97

@lithomas1 - does this look right?


Along the way, I also added `if: github.repository == 'numpy/numpy'` to some other workflows so they do not run on forks.