### PR TITLE
TYP,ENH: Add dtype-typing support to `np.core.fromnumeric` (part 1)

### DIFF
--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -5,7 +5,6 @@ from typing import Union, Any, overload, TypeVar, Literal
 from numpy import (
     ndarray,
     number,
-    integer,
     intp,
     bool_,
     generic,
@@ -27,26 +26,14 @@ from numpy.typing import (
     _ArrayLikeInt_co,
     _IntLike_co,
     _NumberLike_co,
+    _ScalarLike_co,
 )
 
-# Various annotations for scalars
-
-# While dt.datetime and dt.timedelta are not technically part of NumPy,
-# they are one of the rare few builtin scalars which serve as valid return types.
-# See https://github.com/numpy/numpy-stubs/pull/67#discussion_r412604113.
-_ScalarNumpy = Union[generic, dt.datetime, dt.timedelta]
-_ScalarBuiltin = Union[str, bytes, dt.date, dt.timedelta, bool, int, float, complex]
-_Scalar = Union[_ScalarBuiltin, _ScalarNumpy]
-
 _SCT = TypeVar("_SCT", bound=generic)
-_Number = TypeVar("_Number", bound=number)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
-# The signature of take() follows a common theme with its overloads:
-# 1. A generic comes in; the same generic comes out
-# 2. A scalar comes in; a generic comes out
-# 3. An array-like object comes in; some keyword ensures that a generic comes out
-# 4. An array-like object comes in; an ndarray or generic comes out
+__all__: list[str]
+
 def take(
     a: ArrayLike,
     indices: _ArrayLikeInt_co,
@@ -225,7 +212,7 @@ def argmin(
 @overload
 def searchsorted(
     a: ArrayLike,
-    v: _Scalar,
+    v: _ScalarLike_co,
     side: _SortSide = ...,
     sorter: None | _ArrayLikeInt_co = ...,  # 1D int array
 ) -> intp: ...

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -19,11 +19,13 @@ from numpy import (
 from numpy.typing import (
     DTypeLike,
     ArrayLike,
+    _ArrayLike,
     NDArray,
     _ShapeLike,
     _Shape,
     _ArrayLikeBool_co,
     _ArrayLikeInt_co,
+    _IntLike_co,
     _NumberLike_co,
 )
 
@@ -36,10 +38,9 @@ _ScalarNumpy = Union[generic, dt.datetime, dt.timedelta]
 _ScalarBuiltin = Union[str, bytes, dt.date, dt.timedelta, bool, int, float, complex]
 _Scalar = Union[_ScalarBuiltin, _ScalarNumpy]
 
-# Integers and booleans can generally be used interchangeably
-_ScalarGeneric = TypeVar("_ScalarGeneric", bound=generic)
-
+_SCT = TypeVar("_SCT", bound=generic)
 _Number = TypeVar("_Number", bound=number)
+_ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 # The signature of take() follows a common theme with its overloads:
 # 1. A generic comes in; the same generic comes out
@@ -54,50 +55,108 @@ def take(
     mode: _ModeKind = ...,
 ) -> Any: ...
 
+@overload
+def reshape(
+    a: _ArrayLike[_SCT],
+    newshape: _ShapeLike,
+    order: _OrderACF = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def reshape(
     a: ArrayLike,
     newshape: _ShapeLike,
     order: _OrderACF = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
+@overload
+def choose(
+    a: _IntLike_co,
+    choices: ArrayLike,
+    out: None = ...,
+    mode: _ModeKind = ...,
+) -> Any: ...
+@overload
+def choose(
+    a: _ArrayLikeInt_co,
+    choices: _ArrayLike[_SCT],
+    out: None = ...,
+    mode: _ModeKind = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def choose(
     a: _ArrayLikeInt_co,
     choices: ArrayLike,
-    out: None | ndarray = ...,
+    out: None = ...,
     mode: _ModeKind = ...,
-) -> Any: ...
+) -> NDArray[Any]: ...
+@overload
+def choose(
+    a: _ArrayLikeInt_co,
+    choices: ArrayLike,
+    out: _ArrayType = ...,
+    mode: _ModeKind = ...,
+) -> _ArrayType: ...
 
+@overload
+def repeat(
+    a: _ArrayLike[_SCT],
+    repeats: _ArrayLikeInt_co,
+    axis: None | int = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def repeat(
     a: ArrayLike,
     repeats: _ArrayLikeInt_co,
     axis: None | int = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
 def put(
-    a: ndarray,
+    a: NDArray[Any],
     ind: _ArrayLikeInt_co,
     v: ArrayLike,
     mode: _ModeKind = ...,
 ) -> None: ...
 
+@overload
+def swapaxes(
+    a: _ArrayLike[_SCT],
+    axis1: int,
+    axis2: int,
+) -> NDArray[_SCT]: ...
+@overload
 def swapaxes(
     a: ArrayLike,
     axis1: int,
     axis2: int,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
+@overload
+def transpose(
+    a: _ArrayLike[_SCT],
+    axes: None | _ShapeLike = ...
+) -> NDArray[_SCT]: ...
+@overload
 def transpose(
     a: ArrayLike,
-    axes: None | Sequence[int] | NDArray[Any] = ...
-) -> ndarray: ...
+    axes: None | _ShapeLike = ...
+) -> NDArray[Any]: ...
 
+@overload
+def partition(
+    a: _ArrayLike[_SCT],
+    kth: _ArrayLikeInt_co,
+    axis: None | int = ...,
+    kind: _PartitionKind = ...,
+    order: None | str | Sequence[str] = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt_co,
     axis: None | int = ...,
     kind: _PartitionKind = ...,
     order: None | str | Sequence[str] = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
 def argpartition(
     a: ArrayLike,
@@ -105,21 +164,29 @@ def argpartition(
     axis: None | int = ...,
     kind: _PartitionKind = ...,
     order: None | str | Sequence[str] = ...,
-) -> Any: ...
+) -> NDArray[intp]: ...
 
+@overload
+def sort(
+    a: _ArrayLike[_SCT],
+    axis: None | int = ...,
+    kind: None | _SortKind = ...,
+    order: None | str | Sequence[str] = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def sort(
     a: ArrayLike,
     axis: None | int = ...,
     kind: None | _SortKind = ...,
     order: None | str | Sequence[str] = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
 def argsort(
     a: ArrayLike,
     axis: None | int = ...,
     kind: None | _SortKind = ...,
     order: None | str | Sequence[str] = ...,
-) -> ndarray: ...
+) -> NDArray[intp]: ...
 
 @overload
 def argmax(
@@ -168,30 +235,49 @@ def searchsorted(
     v: ArrayLike,
     side: _SortSide = ...,
     sorter: None | _ArrayLikeInt_co = ...,  # 1D int array
-) -> ndarray: ...
+) -> NDArray[intp]: ...
 
+@overload
+def resize(
+    a: _ArrayLike[_SCT],
+    new_shape: _ShapeLike,
+) -> NDArray[_SCT]: ...
+@overload
 def resize(
     a: ArrayLike,
     new_shape: _ShapeLike,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
 @overload
 def squeeze(
-    a: _ScalarGeneric,
+    a: _SCT,
     axis: None | _ShapeLike = ...,
-) -> _ScalarGeneric: ...
+) -> _SCT: ...
+@overload
+def squeeze(
+    a: _ArrayLike[_SCT],
+    axis: None | _ShapeLike = ...,
+) -> NDArray[_SCT]: ...
 @overload
 def squeeze(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
+@overload
+def diagonal(
+    a: _ArrayLike[_SCT],
+    offset: int = ...,
+    axis1: int = ...,
+    axis2: int = ...,  # >= 2D array
+) -> NDArray[_SCT]: ...
+@overload
 def diagonal(
     a: ArrayLike,
     offset: int = ...,
     axis1: int = ...,
     axis2: int = ...,  # >= 2D array
-) -> ndarray: ...
+) -> NDArray[Any]: ...
 
 def trace(
     a: ArrayLike,  # >= 2D array
@@ -202,18 +288,36 @@ def trace(
     out: None | ndarray = ...,
 ) -> Any: ...
 
-def ravel(a: ArrayLike, order: _OrderKACF = ...) -> ndarray: ...
+@overload
+def ravel(a: _ArrayLike[_SCT], order: _OrderKACF = ...) -> NDArray[_SCT]: ...
+@overload
+def ravel(a: ArrayLike, order: _OrderKACF = ...) -> NDArray[Any]: ...
 
-def nonzero(a: ArrayLike) -> tuple[ndarray, ...]: ...
+def nonzero(a: ArrayLike) -> tuple[NDArray[intp], ...]: ...
 
 def shape(a: ArrayLike) -> _Shape: ...
 
+@overload
 def compress(
-    condition: ArrayLike,  # 1D bool array
+    condition: _ArrayLikeBool_co,  # 1D bool array
+    a: _ArrayLike[_SCT],
+    axis: None | int = ...,
+    out: None = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def compress(
+    condition: _ArrayLikeBool_co,  # 1D bool array
     a: ArrayLike,
     axis: None | int = ...,
-    out: None | ndarray = ...,
-) -> ndarray: ...
+    out: None = ...,
+) -> NDArray[Any]: ...
+@overload
+def compress(
+    condition: _ArrayLikeBool_co,  # 1D bool array
+    a: ArrayLike,
+    axis: None | int = ...,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
 @overload
 def clip(

--- a/numpy/typing/tests/data/fail/fromnumeric.pyi
+++ b/numpy/typing/tests/data/fail/fromnumeric.pyi
@@ -12,27 +12,27 @@ np.take(a, axis=1.0)  # E: incompatible type
 np.take(A, out=1)  # E: incompatible type
 np.take(A, mode="bob")  # E: incompatible type
 
-np.reshape(a, None)  # E: Argument 2 to "reshape" has incompatible type
-np.reshape(A, 1, order="bob")  # E: Argument "order" to "reshape" has incompatible type
+np.reshape(a, None)  # E: No overload variant
+np.reshape(A, 1, order="bob")  # E: No overload variant
 
-np.choose(a, None)  # E: incompatible type
-np.choose(a, out=1.0)  # E: incompatible type
-np.choose(A, mode="bob")  # E: incompatible type
+np.choose(a, None)  # E: No overload variant
+np.choose(a, out=1.0)  # E: No overload variant
+np.choose(A, mode="bob")  # E: No overload variant
 
-np.repeat(a, None)  # E: Argument 2 to "repeat" has incompatible type
-np.repeat(A, 1, axis=1.0)  # E: Argument "axis" to "repeat" has incompatible type
+np.repeat(a, None)  # E: No overload variant
+np.repeat(A, 1, axis=1.0)  # E: No overload variant
 
-np.swapaxes(A, None, 1)  # E: Argument 2 to "swapaxes" has incompatible type
-np.swapaxes(A, 1, [0])  # E: Argument 3 to "swapaxes" has incompatible type
+np.swapaxes(A, None, 1)  # E: No overload variant
+np.swapaxes(A, 1, [0])  # E: No overload variant
 
-np.transpose(A, axes=1.0)  # E: Argument "axes" to "transpose" has incompatible type
+np.transpose(A, axes=1.0)  # E: No overload variant
 
-np.partition(a, None)  # E: Argument 2 to "partition" has incompatible type
-np.partition(
-    a, 0, axis="bob"  # E: Argument "axis" to "partition" has incompatible type
+np.partition(a, None)  # E: No overload variant
+np.partition(  # E: No overload variant
+    a, 0, axis="bob"
 )
-np.partition(
-    A, 0, kind="bob"  # E: Argument "kind" to "partition" has incompatible type
+np.partition(  # E: No overload variant
+    A, 0, kind="bob"
 )
 np.partition(
     A, 0, order=range(5)  # E: Argument "order" to "partition" has incompatible type
@@ -51,8 +51,8 @@ np.argpartition(
     A, 0, order=range(5)  # E: Argument "order" to "argpartition" has incompatible type
 )
 
-np.sort(A, axis="bob")  # E: Argument "axis" to "sort" has incompatible type
-np.sort(A, kind="bob")  # E: Argument "kind" to "sort" has incompatible type
+np.sort(A, axis="bob")  # E: No overload variant
+np.sort(A, kind="bob")  # E: No overload variant
 np.sort(A, order=range(5))  # E: Argument "order" to "sort" has incompatible type
 
 np.argsort(A, axis="bob")  # E: Argument "axis" to "argsort" has incompatible type
@@ -72,22 +72,22 @@ np.searchsorted(  # E: No overload variant of "searchsorted" matches argument ty
     A[0], 0, sorter=1.0
 )
 
-np.resize(A, 1.0)  # E: Argument 2 to "resize" has incompatible type
+np.resize(A, 1.0)  # E: No overload variant
 
 np.squeeze(A, 1.0)  # E: No overload variant of "squeeze" matches argument type
 
-np.diagonal(A, offset=None)  # E: Argument "offset" to "diagonal" has incompatible type
-np.diagonal(A, axis1="bob")  # E: Argument "axis1" to "diagonal" has incompatible type
-np.diagonal(A, axis2=[])  # E: Argument "axis2" to "diagonal" has incompatible type
+np.diagonal(A, offset=None)  # E: No overload variant
+np.diagonal(A, axis1="bob")  # E: No overload variant
+np.diagonal(A, axis2=[])  # E: No overload variant
 
 np.trace(A, offset=None)  # E: Argument "offset" to "trace" has incompatible type
 np.trace(A, axis1="bob")  # E: Argument "axis1" to "trace" has incompatible type
 np.trace(A, axis2=[])  # E: Argument "axis2" to "trace" has incompatible type
 
-np.ravel(a, order="bob")  # E: Argument "order" to "ravel" has incompatible type
+np.ravel(a, order="bob")  # E: No overload variant
 
-np.compress(
-    [True], A, axis=1.0  # E: Argument "axis" to "compress" has incompatible type
+np.compress(  # E: No overload variant
+    [True], A, axis=1.0
 )
 
 np.clip(a, 1, 2, out=1)  # E: No overload variant of "clip" matches argument type

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-A = np.array(True, ndmin=2, dtype=bool)
+A = np.array(True, ndmin=2, dtype=np.bool_)
 B = np.array(1.0, ndmin=2, dtype=np.float32)
 A.setflags(write=False)
 B.setflags(write=False)
@@ -20,49 +20,53 @@ reveal_type(np.take(B, 0))  # E: Any
 reveal_type(np.take(A, [0]))  # E: Any
 reveal_type(np.take(B, [0]))  # E: Any
 
-reveal_type(np.reshape(a, 1))  # E: ndarray[Any, Any]
-reveal_type(np.reshape(b, 1))  # E: ndarray[Any, Any]
-reveal_type(np.reshape(c, 1))  # E: ndarray[Any, Any]
-reveal_type(np.reshape(A, 1))  # E: ndarray[Any, Any]
-reveal_type(np.reshape(B, 1))  # E: ndarray[Any, Any]
+reveal_type(np.reshape(a, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.reshape(b, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.reshape(c, 1))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.reshape(A, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.reshape(B, 1))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.choose(a, [True, True]))  # E: Any
-reveal_type(np.choose(A, [True, True]))  # E: Any
+reveal_type(np.choose(1, [True, True]))  # E: Any
+reveal_type(np.choose([1], [True, True]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.choose([1], A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.choose([1], A, out=B))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.repeat(a, 1))  # E: ndarray[Any, Any]
-reveal_type(np.repeat(b, 1))  # E: ndarray[Any, Any]
-reveal_type(np.repeat(c, 1))  # E: ndarray[Any, Any]
-reveal_type(np.repeat(A, 1))  # E: ndarray[Any, Any]
-reveal_type(np.repeat(B, 1))  # E: ndarray[Any, Any]
+reveal_type(np.repeat(a, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.repeat(b, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.repeat(c, 1))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.repeat(A, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.repeat(B, 1))  # E: ndarray[Any, dtype[{float32}]]
 
 # TODO: Add tests for np.put()
 
-reveal_type(np.swapaxes(A, 0, 0))  # E: ndarray[Any, Any]
-reveal_type(np.swapaxes(B, 0, 0))  # E: ndarray[Any, Any]
+reveal_type(np.swapaxes([[0, 1]], 0, 0))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.swapaxes(A, 0, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.swapaxes(B, 0, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.transpose(a))  # E: ndarray[Any, Any]
-reveal_type(np.transpose(b))  # E: ndarray[Any, Any]
-reveal_type(np.transpose(c))  # E: ndarray[Any, Any]
-reveal_type(np.transpose(A))  # E: ndarray[Any, Any]
-reveal_type(np.transpose(B))  # E: ndarray[Any, Any]
+reveal_type(np.transpose(a))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.transpose(b))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.transpose(c))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.transpose(A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.transpose(B))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.partition(a, 0, axis=None))  # E: ndarray[Any, Any]
-reveal_type(np.partition(b, 0, axis=None))  # E: ndarray[Any, Any]
-reveal_type(np.partition(c, 0, axis=None))  # E: ndarray[Any, Any]
-reveal_type(np.partition(A, 0))  # E: ndarray[Any, Any]
-reveal_type(np.partition(B, 0))  # E: ndarray[Any, Any]
+reveal_type(np.partition(a, 0, axis=None))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.partition(b, 0, axis=None))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.partition(c, 0, axis=None))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.partition(A, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.partition(B, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.argpartition(a, 0))  # E: Any
-reveal_type(np.argpartition(b, 0))  # E: Any
-reveal_type(np.argpartition(c, 0))  # E: Any
-reveal_type(np.argpartition(A, 0))  # E: Any
-reveal_type(np.argpartition(B, 0))  # E: Any
+reveal_type(np.argpartition(a, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(b, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(c, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(A, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(B, 0))  # E: ndarray[Any, dtype[{intp}]]
 
-reveal_type(np.sort(A, 0))  # E: ndarray[Any, Any]
-reveal_type(np.sort(B, 0))  # E: ndarray[Any, Any]
+reveal_type(np.sort([2, 1], 0))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.sort(A, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.sort(B, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.argsort(A, 0))  # E: ndarray[Any, Any]
-reveal_type(np.argsort(B, 0))  # E: ndarray[Any, Any]
+reveal_type(np.argsort(A, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argsort(B, 0))  # E: ndarray[Any, dtype[{intp}]]
 
 reveal_type(np.argmax(A))  # E: {intp}
 reveal_type(np.argmax(B))  # E: {intp}
@@ -76,38 +80,38 @@ reveal_type(np.argmin(B, axis=0))  # E: Any
 
 reveal_type(np.searchsorted(A[0], 0))  # E: {intp}
 reveal_type(np.searchsorted(B[0], 0))  # E: {intp}
-reveal_type(np.searchsorted(A[0], [0]))  # E: ndarray[Any, Any]
-reveal_type(np.searchsorted(B[0], [0]))  # E: ndarray[Any, Any]
+reveal_type(np.searchsorted(A[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.searchsorted(B[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
 
-reveal_type(np.resize(a, (5, 5)))  # E: ndarray[Any, Any]
-reveal_type(np.resize(b, (5, 5)))  # E: ndarray[Any, Any]
-reveal_type(np.resize(c, (5, 5)))  # E: ndarray[Any, Any]
-reveal_type(np.resize(A, (5, 5)))  # E: ndarray[Any, Any]
-reveal_type(np.resize(B, (5, 5)))  # E: ndarray[Any, Any]
+reveal_type(np.resize(a, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.resize(b, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.resize(c, (5, 5)))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.resize(A, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.resize(B, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
 
 reveal_type(np.squeeze(a))  # E: bool_
 reveal_type(np.squeeze(b))  # E: {float32}
-reveal_type(np.squeeze(c))  # E: ndarray[Any, Any]
-reveal_type(np.squeeze(A))  # E: ndarray[Any, Any]
-reveal_type(np.squeeze(B))  # E: ndarray[Any, Any]
+reveal_type(np.squeeze(c))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.squeeze(A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.squeeze(B))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.diagonal(A))  # E: ndarray[Any, Any]
-reveal_type(np.diagonal(B))  # E: ndarray[Any, Any]
+reveal_type(np.diagonal(A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.diagonal(B))  # E: ndarray[Any, dtype[{float32}]]
 
 reveal_type(np.trace(A))  # E: Any
 reveal_type(np.trace(B))  # E: Any
 
-reveal_type(np.ravel(a))  # E: ndarray[Any, Any]
-reveal_type(np.ravel(b))  # E: ndarray[Any, Any]
-reveal_type(np.ravel(c))  # E: ndarray[Any, Any]
-reveal_type(np.ravel(A))  # E: ndarray[Any, Any]
-reveal_type(np.ravel(B))  # E: ndarray[Any, Any]
+reveal_type(np.ravel(a))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.ravel(b))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.ravel(c))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.ravel(A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.ravel(B))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.nonzero(a))  # E: tuple[ndarray[Any, Any]]
-reveal_type(np.nonzero(b))  # E: tuple[ndarray[Any, Any]]
-reveal_type(np.nonzero(c))  # E: tuple[ndarray[Any, Any]]
-reveal_type(np.nonzero(A))  # E: tuple[ndarray[Any, Any]]
-reveal_type(np.nonzero(B))  # E: tuple[ndarray[Any, Any]]
+reveal_type(np.nonzero(a))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(b))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(c))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(A))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(B))  # E: tuple[ndarray[Any, dtype[{intp}]]]
 
 reveal_type(np.shape(a))  # E: tuple[builtins.int]
 reveal_type(np.shape(b))  # E: tuple[builtins.int]
@@ -115,11 +119,11 @@ reveal_type(np.shape(c))  # E: tuple[builtins.int]
 reveal_type(np.shape(A))  # E: tuple[builtins.int]
 reveal_type(np.shape(B))  # E: tuple[builtins.int]
 
-reveal_type(np.compress([True], a))  # E: ndarray[Any, Any]
-reveal_type(np.compress([True], b))  # E: ndarray[Any, Any]
-reveal_type(np.compress([True], c))  # E: ndarray[Any, Any]
-reveal_type(np.compress([True], A))  # E: ndarray[Any, Any]
-reveal_type(np.compress([True], B))  # E: ndarray[Any, Any]
+reveal_type(np.compress([True], a))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.compress([True], b))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.compress([True], c))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.compress([True], A))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.compress([True], B))  # E: ndarray[Any, dtype[{float32}]]
 
 reveal_type(np.clip(a, 0, 1.0))  # E: Any
 reveal_type(np.clip(b, -1, 1))  # E: Any


### PR DESCRIPTION
Initial PR for introducing dtype-typing support to `np.core.fromnumeric`.

This far the changes have been limited to some of the low hanging fruit, _i.e._ functions that lack `axis` and/or `dtype` parameters.