### PR TITLE
BUG: Fix `npt.ArrayLike` treating (builtin) scalar- and `__array__`-sequences as mutually exclusive

### DIFF
--- a/numpy/typing/_array_like.py
+++ b/numpy/typing/_array_like.py
@@ -68,9 +68,8 @@ _ArrayLike = Union[
 # and another one for the rest
 _DualArrayLike = Union[
     _SupportsArray[_DType],
-    _NestedSequence[_SupportsArray[_DType]],
     _T,
-    _NestedSequence[_T],
+    _NestedSequence[Union[_T, _SupportsArray[_DType]]],
 ]
 
 # TODO: support buffer protocols once

--- a/numpy/typing/tests/data/reveal/array_like.pyi
+++ b/numpy/typing/tests/data/reveal/array_like.pyi
@@ -1,0 +1,31 @@
+from typing import Any
+import numpy as np
+import numpy.typing as npt
+
+def func(array_like: npt.ArrayLike) -> None: ...
+
+a: npt.NDArray[Any]
+b: npt.NDArray[np.int64]
+c: int
+d: list[int]
+e: int | npt.NDArray[np.int64]
+f: list[int | npt.NDArray[np.int64]]
+g: tuple[int | npt.NDArray[np.int64], ...]
+h: list[list[int] | npt.NDArray[np.int64]]
+i: tuple[list[int] | npt.NDArray[np.int64], ...]
+j: np.int64
+k: list[np.str_ | npt.NDArray[np.int64]]
+l: tuple[np.str_ | npt.NDArray[np.int64], ...]
+
+reveal_type(func(a))  # E: None
+reveal_type(func(b))  # E: None
+reveal_type(func(c))  # E: None
+reveal_type(func(d))  # E: None
+reveal_type(func(e))  # E: None
+reveal_type(func(f))  # E: None
+reveal_type(func(g))  # E: None
+reveal_type(func(h))  # E: None
+reveal_type(func(i))  # E: None
+reveal_type(func(j))  # E: None
+reveal_type(func(k))  # E: None
+reveal_type(func(l))  # E: None


### PR DESCRIPTION
cc @bashtage 

`npt.ArrayLike` consists four components:
* Builtin scalar types
* `__array__` implementation
* Nested sequences of builtins scalar types
* Nested sequences of `__array__` implementation

The problem was that, previously, the latter two were considered mutually exclusive, _e.g._ `list[list[int] | np.ndarray]` was not considered a proper `npt.ArrayLike` subtype. This PR fixes aforementioned issue by shuffling around the relevant union a bit.