### PR TITLE
BUG: Fix the return type of random_float_fill

### DIFF
--- a/numpy/random/_common.pxd
+++ b/numpy/random/_common.pxd
@@ -45,7 +45,7 @@ ctypedef double (*random_double_1)(void *state, double a) nogil
 ctypedef double (*random_double_2)(void *state, double a, double b) nogil
 ctypedef double (*random_double_3)(void *state, double a, double b, double c) nogil
 
-ctypedef double (*random_float_fill)(bitgen_t *state, np.npy_intp count, float* out) nogil
+ctypedef void (*random_float_fill)(bitgen_t *state, np.npy_intp count, float* out) nogil
 ctypedef float (*random_float_0)(bitgen_t *state) nogil
 ctypedef float (*random_float_1)(bitgen_t *state, float a) nogil
 


### PR DESCRIPTION
The `random_float_fill` function type is declared with return type `double` but
I think this is a typo. The actual implementation of `random_float_fill` is
`random_standard_uniform_fill_f` which has return type `void`:

```C
void random_standard_uniform_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float *out)
```

Also, `random_double_fill` is declared with return type `void`. This fixes the
return type of `random_float_fill` to match.