### PR TITLE
TYP, MAINT: Add annotations for `flatiter.__setitem__`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -944,11 +944,12 @@ class flatiter(Generic[_NdArraySubClass]):
     @overload
     def __getitem__(
         self: flatiter[ndarray[Any, dtype[_ScalarType]]],
-        key: int | integer,
+        key: int | integer | tuple[int | integer],
     ) -> _ScalarType: ...
     @overload
     def __getitem__(
-        self, key: _ArrayLikeInt | slice | ellipsis
+        self,
+        key: _ArrayLikeInt | slice | ellipsis | tuple[_ArrayLikeInt | slice | ellipsis],
     ) -> _NdArraySubClass: ...
     @overload
     def __array__(self: flatiter[ndarray[Any, _DType]], dtype: None = ..., /) -> ndarray[Any, _DType]: ...

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -951,6 +951,15 @@ class flatiter(Generic[_NdArraySubClass]):
         self,
         key: _ArrayLikeInt | slice | ellipsis | tuple[_ArrayLikeInt | slice | ellipsis],
     ) -> _NdArraySubClass: ...
+    # TODO: `__setitem__` operates via `unsafe` casting rules, and can
+    # thus accept any type accepted by the relevant underlying `np.generic`
+    # constructor.
+    # This means that `value` must in reality be a supertype of `npt.ArrayLike`.
+    def __setitem__(
+        self,
+        key: _ArrayLikeInt | slice | ellipsis | tuple[_ArrayLikeInt | slice | ellipsis],
+        value: Any,
+    ) -> None: ...
     @overload
     def __array__(self: flatiter[ndarray[Any, _DType]], dtype: None = ..., /) -> ndarray[Any, _DType]: ...
     @overload

--- a/numpy/typing/tests/data/reveal/flatiter.pyi
+++ b/numpy/typing/tests/data/reveal/flatiter.pyi
@@ -17,3 +17,7 @@ reveal_type(a[(...,)])  # E: ndarray[Any, dtype[str_]]
 reveal_type(a[(0,)])  # E: str_
 reveal_type(a.__array__())  # E: ndarray[Any, dtype[str_]]
 reveal_type(a.__array__(np.dtype(np.float64)))  # E: ndarray[Any, dtype[{float64}]]
+a[0] = "a"
+a[:5] = "a"
+a[...] = "a"
+a[(...,)] = "a"

--- a/numpy/typing/tests/data/reveal/flatiter.pyi
+++ b/numpy/typing/tests/data/reveal/flatiter.pyi
@@ -13,5 +13,7 @@ reveal_type(a[0])  # E: str_
 reveal_type(a[[0, 1, 2]])  # E: ndarray[Any, dtype[str_]]
 reveal_type(a[...])  # E: ndarray[Any, dtype[str_]]
 reveal_type(a[:])  # E: ndarray[Any, dtype[str_]]
+reveal_type(a[(...,)])  # E: ndarray[Any, dtype[str_]]
+reveal_type(a[(0,)])  # E: str_
 reveal_type(a.__array__())  # E: ndarray[Any, dtype[str_]]
 reveal_type(a.__array__(np.dtype(np.float64)))  # E: ndarray[Any, dtype[{float64}]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/20915

Turns out that I missed `__setitem__` back in https://github.com/numpy/numpy/pull/17180, an issue that's rectified in this PR.