### PR TITLE
DOC: fix np.ma.flatnotmasked_contiguous docstring

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1628,7 +1628,7 @@ def notmasked_edges(a, axis=None):
 
 def flatnotmasked_contiguous(a):
     """
-    Find contiguous unmasked data in a masked array along the given axis.
+    Find contiguous unmasked data in a masked array.
 
     Parameters
     ----------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1632,7 +1632,7 @@ def flatnotmasked_contiguous(a):
 
     Parameters
     ----------
-    a : narray
+    a : array_like
         The input array.
 
     Returns


### PR DESCRIPTION
The first line of the docstring for `flatnotmasked_contiguous` was identical to that in `notmasked_contiguous` and refered to a given axis despite the fact that no axis is given as an argument.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
