### PR TITLE
MAINT, TYP: Added missing where typehints in fromnumeric.pyi

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1024,6 +1024,8 @@ class _ArrayOrScalarCommon:
         axis: None = ...,
         out: None = ...,
         keepdims: L[False] = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> bool_: ...
     @overload
     def all(
@@ -1031,6 +1033,8 @@ class _ArrayOrScalarCommon:
         axis: None | _ShapeLike = ...,
         out: None = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> Any: ...
     @overload
     def all(
@@ -1038,6 +1042,8 @@ class _ArrayOrScalarCommon:
         axis: None | _ShapeLike = ...,
         out: _NdArraySubClass = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> _NdArraySubClass: ...
 
     @overload
@@ -1046,6 +1052,8 @@ class _ArrayOrScalarCommon:
         axis: None = ...,
         out: None = ...,
         keepdims: L[False] = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> bool_: ...
     @overload
     def any(
@@ -1053,6 +1061,8 @@ class _ArrayOrScalarCommon:
         axis: None | _ShapeLike = ...,
         out: None = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> Any: ...
     @overload
     def any(
@@ -1060,6 +1070,8 @@ class _ArrayOrScalarCommon:
         axis: None | _ShapeLike = ...,
         out: _NdArraySubClass = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> _NdArraySubClass: ...
 
     @overload
@@ -1242,6 +1254,8 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike = ...,
         out: None = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> Any: ...
     @overload
     def mean(
@@ -1250,6 +1264,8 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike = ...,
         out: _NdArraySubClass = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> _NdArraySubClass: ...
 
     @overload
@@ -1333,6 +1349,8 @@ class _ArrayOrScalarCommon:
         out: None = ...,
         ddof: int = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> Any: ...
     @overload
     def std(
@@ -1342,6 +1360,8 @@ class _ArrayOrScalarCommon:
         out: _NdArraySubClass = ...,
         ddof: int = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> _NdArraySubClass: ...
 
     @overload
@@ -1373,6 +1393,8 @@ class _ArrayOrScalarCommon:
         out: None = ...,
         ddof: int = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> Any: ...
     @overload
     def var(
@@ -1382,6 +1404,8 @@ class _ArrayOrScalarCommon:
         out: _NdArraySubClass = ...,
         ddof: int = ...,
         keepdims: bool = ...,
+        *,
+        where: _ArrayLikeBool_co = ...,
     ) -> _NdArraySubClass: ...
 
 _DType = TypeVar("_DType", bound=dtype[Any])

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -248,6 +248,7 @@ def all(
     axis: None = ...,
     out: None = ...,
     keepdims: Literal[False] = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> bool_: ...
 @overload

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -248,6 +248,7 @@ def all(
     axis: None = ...,
     out: None = ...,
     keepdims: Literal[False] = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> bool_: ...
 @overload
 def all(
@@ -255,6 +256,7 @@ def all(
     axis: None | _ShapeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
 @overload
@@ -263,6 +265,7 @@ def any(
     axis: None = ...,
     out: None = ...,
     keepdims: Literal[False] = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> bool_: ...
 @overload
 def any(
@@ -270,6 +273,7 @@ def any(
     axis: None | _ShapeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
 def cumsum(
@@ -344,6 +348,7 @@ def mean(
     dtype: DTypeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
 def std(
@@ -353,6 +358,7 @@ def std(
     out: None | ndarray = ...,
     ddof: int = ...,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
 def var(
@@ -362,4 +368,5 @@ def var(
     out: None | ndarray = ...,
     ddof: int = ...,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -257,6 +257,7 @@ def all(
     axis: None | _ShapeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
@@ -266,6 +267,7 @@ def any(
     axis: None = ...,
     out: None = ...,
     keepdims: Literal[False] = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> bool_: ...
 @overload
@@ -274,6 +276,7 @@ def any(
     axis: None | _ShapeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
@@ -349,6 +352,7 @@ def mean(
     dtype: DTypeLike = ...,
     out: None | ndarray = ...,
     keepdims: bool = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
@@ -359,6 +363,7 @@ def std(
     out: None | ndarray = ...,
     ddof: int = ...,
     keepdims: bool = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 
@@ -369,5 +374,6 @@ def var(
     out: None | ndarray = ...,
     ddof: int = ...,
     keepdims: bool = ...,
+    *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...


### PR DESCRIPTION
Adding typehints for 'where' argument in a couple of functions in fromnumeric, where it appears to be missing.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
