### PR TITLE
DEP: Deprecate use of `axis=MAXDIMS` instead of `axis=None`

### DIFF
--- a/doc/release/upcoming_changes/20920.deprecation.rst
+++ b/doc/release/upcoming_changes/20920.deprecation.rst
@@ -1,0 +1,3 @@
+* Using ``axis=32`` (``axis=np.MAXDIMS``) in many cases had the
+  same meaning as ``axis=None``.  This is deprecated and ``axis=None``
+  must be used instead.

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -271,6 +271,13 @@ PyArray_AxisConverter(PyObject *obj, int *axis)
         if (error_converting(*axis)) {
             return NPY_FAIL;
         }
+        if(*axis == NPY_MAXDIMS){
+            /* NumPy 1.20, 2022-01-08 */
+            if (DEPRECATE("axis = 32 is deprecated "
+                          "please use axis = None instead. ") < 0) {
+                return NPY_FAIL;
+            }
+        }
     }
     return NPY_SUCCEED;
 }

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -272,7 +272,7 @@ PyArray_AxisConverter(PyObject *obj, int *axis)
             return NPY_FAIL;
         }
         if(*axis == NPY_MAXDIMS){
-            /* NumPy 1.20, 2022-01-08 */
+            /* NumPy 1.23, 2022-01-08 */
             if (DEPRECATE("axis = 32 is deprecated "
                           "please use axis = None instead. ") < 0) {
                 return NPY_FAIL;

--- a/numpy/core/src/multiarray/conversion_utils.c
+++ b/numpy/core/src/multiarray/conversion_utils.c
@@ -271,10 +271,12 @@ PyArray_AxisConverter(PyObject *obj, int *axis)
         if (error_converting(*axis)) {
             return NPY_FAIL;
         }
-        if(*axis == NPY_MAXDIMS){
-            /* NumPy 1.23, 2022-01-08 */
-            if (DEPRECATE("axis = 32 is deprecated "
-                          "please use axis = None instead. ") < 0) {
+        if (*axis == NPY_MAXDIMS){
+            /* NumPy 1.23, 2022-05-19 */
+            if (DEPRECATE("Using `axis=32` (MAXDIMS) is deprecated. "
+                          "32/MAXDIMS had the same meaning as `axis=None` which "
+                          "should be used instead.  "
+                          "(Deprecated NumPy 1.23)") < 0) {
                 return NPY_FAIL;
             }
         }

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1253,7 +1253,7 @@ class TestArrayFinalizeNone(_DeprecationTestCase):
 
 class TestAxisNotMAXDIMS(_DeprecationTestCase):
     # Deprecated 2022-01-08, NumPy 1.23
-    message = r"axis = 32 is deprecated"
+    message = r"Using `axis=32` \(MAXDIMS\) is deprecated"
 
     def test_deprecated(self):
         a = np.zeros((1,)*32)

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1250,3 +1250,11 @@ class TestArrayFinalizeNone(_DeprecationTestCase):
             __array_finalize__ = None
 
         self.assert_deprecated(lambda: np.array(1).view(NoFinalize))
+
+class TestAxisNotMAXDIMS(_DeprecationTestCase):
+    # Deprecated 2022-01-08, NumPy 1.23
+    message = r"axis = 32 is deprecated"
+
+    def test_deprecated(self):
+        a = np.zeros((1,)*32)
+        self.assert_deprecated(lambda: np.repeat(a, 1, axis=np.MAXDIMS))

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1258,4 +1258,3 @@ class TestAxisNotMAXDIMS(_DeprecationTestCase):
     def test_deprecated(self):
         a = np.zeros((1,)*32)
         self.assert_deprecated(lambda: np.repeat(a, 1, axis=np.MAXDIMS))
-        

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1258,3 +1258,4 @@ class TestAxisNotMAXDIMS(_DeprecationTestCase):
     def test_deprecated(self):
         a = np.zeros((1,)*32)
         self.assert_deprecated(lambda: np.repeat(a, 1, axis=np.MAXDIMS))
+        


### PR DESCRIPTION
addresses #20620 

A deprecation warning has been added whenever `axis==NPY_MAXDIMS` passed in functions. 

@seberg 