### PR TITLE
MAINT: Simplify element setting and use it for filling

### DIFF
--- a/doc/release/upcoming_changes/20924.compatibility.rst
+++ b/doc/release/upcoming_changes/20924.compatibility.rst
@@ -1,0 +1,23 @@
+``array.fill(scalar)`` may behave slightly different
+----------------------------------------------------
+`~numpy.ndarray.fill` may in some cases behave slightly different
+now due to the fact that the logic is aligned with item assignment::
+
+    arr = np.array([1])  # with any dtype/value
+    arr.fill(scalar)
+    # is now identical to:
+    arr[0] = scalar
+
+When previously, effectively ``arr.fill(np.asarray(scalar))`` was used
+in many cases.
+The typical possible change is that errors will be given for example for
+``np.array([0]).fill(1e300)`` or ``np.array([0]).fill(np.nan)``.
+Previously, ``arr.fill()`` would unpack 0-D object arrays if the input
+array was also of object dtype, the 0-D array will now be stored as is::
+
+    >>> arr = np.array([0], dtype=object)
+    >>> arr.fill(np.array(None, dtype=object))
+    >>> arr
+    array([array(None, dtype=object)], dtype=object)
+
+Rather than ``array([None], dtype=object)``.

--- a/doc/release/upcoming_changes/20924.compatibility.rst
+++ b/doc/release/upcoming_changes/20924.compatibility.rst
@@ -8,4 +8,6 @@ now due to the fact that the logic is aligned with item assignment::
     # is now identical to:
     arr[0] = scalar
 
-Previously casting may have produced slightly different answers when using values that could not be represented in the target `dtype` or when using `object`s.
+Previously casting may have produced slightly different answers when using
+values that could not be represented in the target ``dtype`` or when the
+target had ``object`` dtype.

--- a/doc/release/upcoming_changes/20924.compatibility.rst
+++ b/doc/release/upcoming_changes/20924.compatibility.rst
@@ -8,16 +8,4 @@ now due to the fact that the logic is aligned with item assignment::
     # is now identical to:
     arr[0] = scalar
 
-When previously, effectively ``arr.fill(np.asarray(scalar))`` was used
-in many cases.
-The typical possible change is that errors will be given for example for
-``np.array([0]).fill(1e300)`` or ``np.array([0]).fill(np.nan)``.
-Previously, ``arr.fill()`` would unpack 0-D object arrays if the input
-array was also of object dtype, the 0-D array will now be stored as is::
-
-    >>> arr = np.array([0], dtype=object)
-    >>> arr.fill(np.array(None, dtype=object))
-    >>> arr
-    array([array(None, dtype=object)], dtype=object)
-
-Rather than ``array([None], dtype=object)``.
+Previously casting may have produced slightly different answers when using values that could not be represented in the target `dtype` or when using `object`s.

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -3437,6 +3437,24 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('fill',
     >>> a
     array([1.,  1.])
 
+    Fill expects a scalar value and always behaves the same as assigning
+    to a single array element.  The following is a rare example where this
+    distinction is important:
+
+    >>> a = np.array([None, None], dtype=object)
+    >>> a[0] = np.array(3)
+    >>> a
+    array([array(3), None], dtype=object)
+    >>> a.fill(np.array(3))
+    >>> a
+    array([array(3), array(3)], dtype=object)
+
+    Where other forms of assignments will unpack the array being assigned:
+
+    >>> a[...] = np.array(3)
+    >>> a
+    array([3, 3], dtype=object)
+
     """))
 
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -613,6 +613,7 @@ string_unicode_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     return cls;
 }
 
+
 static PyArray_DTypeMeta *
 datetime_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
 {

--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -827,7 +827,8 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
     if (PyBool_Check(ind)) {
         retval = 0;
         if (PyObject_IsTrue(ind)) {
-            retval = PyArray_Pack(PyArray_DESCR(self->ao), self->dataptr, val);
+            retval = PyArray_Pack(
+                    PyArray_DESCR(self->ao), self->dataptr, val);
         }
         goto finish;
     }

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -614,8 +614,8 @@ class TestBadSequences:
 
         obj.append([2, 3])
         obj.append(mylist([1, 2]))
-        with pytest.raises(RuntimeError):
-            np.array(obj)
+        # Does not crash:
+        np.array(obj)
 
     def test_replace_0d_array(self):
         # List to coerce, `mylist` will mutate the first element

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -68,8 +68,8 @@ def _aligned_zeros(shape, dtype=float, order="C", align=None):
     # Note: slices producing 0-size arrays do not necessarily change
     # data pointer --- so we use and allocate size+1
     buf = buf[offset:offset+size+1][:-1]
+    buf.fill(0)
     data = np.ndarray(shape, dtype, buf, order=order)
-    data.fill(0)
     return data
 
 


### PR DESCRIPTION
This slightly modifies the behaviour of `arr.fill()` to be
`arr.fill(scalar)`, i.e. match `arr1d[0] = scalar`, rather than
`arr.fill(np.asarray(scalar))`, which subtely different!
(Note that object was already special cased to have the scalar
logic.)

Otherwise, `PyArray_Pack` is now the actual, full featured, "scalar"
assignment logic.  It is a bit strange due to that quantity/masked
array issue, but there is nothing to be done about it.
The simplifications in `PyArray_AssignFromCache` should not cause
any change in practice, because non 0-D arrays would have been
rejected earlier on in that path.
(Basically, it does not need the full `PyArray_Pack` logic, but that
is fine, I intially split the two, but consolidated them again.)
