### PR TITLE
DOC: lib/io.py was renamed to lib/npyio.py

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -157,7 +157,7 @@ class NpzFile(Mapping):
     >>> _ = outfile.seek(0)
 
     >>> npz = np.load(outfile)
-    >>> isinstance(npz, np.lib.io.NpzFile)
+    >>> isinstance(npz, np.lib.npyio.NpzFile)
     True
     >>> sorted(npz.files)
     ['x', 'y']


### PR DESCRIPTION
In 44118aedbac7c1c4465443ec23d104a83b9a24f9 (2010), so this docs
examples would raise a `ValueError`.