### PR TITLE
BUG: Fix missing intrinsics for windows/arm64 target 

### DIFF
--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -887,7 +887,7 @@ npy_popcountu@c@(npy_@type@ a)
 /* use built-in popcount if present, else use our implementation */
 #if (defined(__clang__) || defined(__GNUC__)) && NPY_BITSOF_@STYPE@ >= 32
     return __builtin_popcount@c@(a);
-#elif defined(_MSC_VER) && NPY_BITSOF_@STYPE@ >= 16 && !defined(_M_ARM64)
+#elif defined(_MSC_VER) && NPY_BITSOF_@STYPE@ >= 16 && !defined(_M_ARM64) && !defined(_M_ARM)
     /* no builtin __popcnt64 for 32 bits */
     #if defined(_WIN64) || (defined(_WIN32) && NPY_BITSOF_@STYPE@ != 64)
         return TO_BITS_LEN(__popcnt)(a);

--- a/numpy/core/src/npymath/npy_math_internal.h.src
+++ b/numpy/core/src/npymath/npy_math_internal.h.src
@@ -887,7 +887,7 @@ npy_popcountu@c@(npy_@type@ a)
 /* use built-in popcount if present, else use our implementation */
 #if (defined(__clang__) || defined(__GNUC__)) && NPY_BITSOF_@STYPE@ >= 32
     return __builtin_popcount@c@(a);
-#elif defined(_MSC_VER) && NPY_BITSOF_@STYPE@ >= 16
+#elif defined(_MSC_VER) && NPY_BITSOF_@STYPE@ >= 16 && !defined(_M_ARM64)
     /* no builtin __popcnt64 for 32 bits */
     #if defined(_WIN64) || (defined(_WIN32) && NPY_BITSOF_@STYPE@ != 64)
         return TO_BITS_LEN(__popcnt)(a);


### PR DESCRIPTION
Fixes #20930

__popcnt and variants are not available for arm64 msvc intrinsic so use numpy population count implementation for win/arm64 targets.

https://docs.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=msvc-170

### Test Result

16356 passed, 649 skipped, 1296 deselected, 18 xfailed, 1 xpassed in 245.28s (0:04:05)

