### PR TITLE
BUG: Fix build_ext interaction with non-numpy extensions

### DIFF
--- a/numpy/distutils/command/build_ext.py
+++ b/numpy/distutils/command/build_ext.py
@@ -393,8 +393,8 @@ class build_ext (old_build_ext):
             log.info("building '%s' extension", ext.name)
 
         extra_args = ext.extra_compile_args or []
-        extra_cflags = ext.extra_c_compile_args or []
-        extra_cxxflags = ext.extra_cxx_compile_args or []
+        extra_cflags = getattr(ext, 'extra_c_compile_args', None) or []
+        extra_cxxflags = getattr(ext, 'extra_cxx_compile_args', None) or []
 
         macros = ext.define_macros[:]
         for undef in ext.undef_macros:


### PR DESCRIPTION
Numpy extensions define the extra_cxx_compile_args and extra_c_compile_args
filed, but distutils extensions don't. Take that into account when populating
build_extension.

Should fix #20928
