### PR TITLE
MAINT: f2py: don't  generate code that triggers ``-Wsometimes-uninitialized``

### DIFF
--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -230,7 +230,7 @@ cb_rout_rules = [
         'latexdocstrcbs': '\\noindent Call-back functions:',
         'routnote': {hasnote: '--- #note#', l_not(hasnote): ''},
     }, {  # Function
-        'decl': '    #ctype# return_value;',
+        'decl': '    #ctype# return_value = 0;',
         'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
                       '    if (capi_j>capi_i)\n        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n");',
                       {debugcapi:

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -231,11 +231,20 @@ cb_rout_rules = [
         'routnote': {hasnote: '--- #note#', l_not(hasnote): ''},
     }, {  # Function
         'decl': '    #ctype# return_value = 0;',
-        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
-                      '    if (capi_j>capi_i)\n        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n");',
-                      {debugcapi:
-                       '    fprintf(stderr,"#showvalueformat#.\\n",return_value);'}
-                      ],
+        'frompyobj': [
+            {debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
+            '''\
+    if (capi_j>capi_i)
+        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,
+          "#ctype#_from_pyobj failed in converting return_value of"
+          " call-back function #name# to C #ctype#\\n");
+    else {
+        fprintf(stderr,"Warning: call-back function #name# did not provide"
+                       " return value (index=%d, type=#ctype#)\\n",capi_i);
+    }''',
+            {debugcapi:
+             '    fprintf(stderr,"#showvalueformat#.\\n",return_value);'}
+        ],
         'need': ['#ctype#_from_pyobj', {debugcapi: 'CFUNCSMESS'}, 'GETSCALARFROMPYTUPLE'],
         'return': '    return return_value;',
         '_check': l_and(isfunction, l_not(isstringfunction), l_not(iscomplexfunction))
@@ -245,12 +254,18 @@ cb_rout_rules = [
         'args': '#ctype# return_value,int return_value_len',
         'args_nm': 'return_value,&return_value_len',
         'args_td': '#ctype# ,int',
-        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->\\"");'},
-                      """    if (capi_j>capi_i)
-        GETSTRFROMPYTUPLE(capi_return,capi_i++,return_value,return_value_len);""",
-                      {debugcapi:
-                       '    fprintf(stderr,"#showvalueformat#\\".\\n",return_value);'}
-                      ],
+        'frompyobj': [
+            {debugcapi: '    CFUNCSMESS("cb:Getting return_value->\\"");'},
+            """\
+    if (capi_j>capi_i)
+        GETSTRFROMPYTUPLE(capi_return,capi_i++,return_value,return_value_len);
+    else {
+        fprintf(stderr,"Warning: call-back function #name# did not provide"
+                       " return value (index=%d, type=#ctype#)\\n",capi_i);
+    }""",
+            {debugcapi:
+             '    fprintf(stderr,"#showvalueformat#\\".\\n",return_value);'}
+        ],
         'need': ['#ctype#_from_pyobj', {debugcapi: 'CFUNCSMESS'},
                  'string.h', 'GETSTRFROMPYTUPLE'],
         'return': 'return;',
@@ -274,27 +289,35 @@ return_value
 """,
         'decl': """
 #ifdef F2PY_CB_RETURNCOMPLEX
-    #ctype# return_value;
+    #ctype# return_value = {0, 0};
 #endif
 """,
-        'frompyobj': [{debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
-                      """\
+        'frompyobj': [
+            {debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
+            """\
     if (capi_j>capi_i)
 #ifdef F2PY_CB_RETURNCOMPLEX
-        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
+        GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,
+          \"#ctype#_from_pyobj failed in converting return_value of call-back\"
+          \" function #name# to C #ctype#\\n\");
 #else
-        GETSCALARFROMPYTUPLE(capi_return,capi_i++,return_value,#ctype#,\"#ctype#_from_pyobj failed in converting return_value of call-back function #name# to C #ctype#\\n\");
+        GETSCALARFROMPYTUPLE(capi_return,capi_i++,return_value,#ctype#,
+          \"#ctype#_from_pyobj failed in converting return_value of call-back\"
+          \" function #name# to C #ctype#\\n\");
 #endif
-""",
-                      {debugcapi: """
+    else {
+        fprintf(stderr,
+                \"Warning: call-back function #name# did not provide\"
+                \" return value (index=%d, type=#ctype#)\\n\",capi_i);
+    }""",
+            {debugcapi: """\
 #ifdef F2PY_CB_RETURNCOMPLEX
     fprintf(stderr,\"#showvalueformat#.\\n\",(return_value).r,(return_value).i);
 #else
     fprintf(stderr,\"#showvalueformat#.\\n\",(*return_value).r,(*return_value).i);
 #endif
-
 """}
-                      ],
+        ],
         'return': """
 #ifdef F2PY_CB_RETURNCOMPLEX
     return return_value;

--- a/numpy/f2py/cb_rules.py
+++ b/numpy/f2py/cb_rules.py
@@ -234,11 +234,11 @@ cb_rout_rules = [
         'frompyobj': [
             {debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
             '''\
-    if (capi_j>capi_i)
+    if (capi_j>capi_i) {
         GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,
           "#ctype#_from_pyobj failed in converting return_value of"
           " call-back function #name# to C #ctype#\\n");
-    else {
+    } else {
         fprintf(stderr,"Warning: call-back function #name# did not provide"
                        " return value (index=%d, type=#ctype#)\\n",capi_i);
     }''',
@@ -257,9 +257,9 @@ cb_rout_rules = [
         'frompyobj': [
             {debugcapi: '    CFUNCSMESS("cb:Getting return_value->\\"");'},
             """\
-    if (capi_j>capi_i)
+    if (capi_j>capi_i) {
         GETSTRFROMPYTUPLE(capi_return,capi_i++,return_value,return_value_len);
-    else {
+    } else {
         fprintf(stderr,"Warning: call-back function #name# did not provide"
                        " return value (index=%d, type=#ctype#)\\n",capi_i);
     }""",
@@ -295,7 +295,7 @@ return_value
         'frompyobj': [
             {debugcapi: '    CFUNCSMESS("cb:Getting return_value->");'},
             """\
-    if (capi_j>capi_i)
+    if (capi_j>capi_i) {
 #ifdef F2PY_CB_RETURNCOMPLEX
         GETSCALARFROMPYTUPLE(capi_return,capi_i++,&return_value,#ctype#,
           \"#ctype#_from_pyobj failed in converting return_value of call-back\"
@@ -305,7 +305,7 @@ return_value
           \"#ctype#_from_pyobj failed in converting return_value of call-back\"
           \" function #name# to C #ctype#\\n\");
 #endif
-    else {
+    } else {
         fprintf(stderr,
                 \"Warning: call-back function #name# did not provide\"
                 \" return value (index=%d, type=#ctype#)\\n\",capi_i);


### PR DESCRIPTION
Warnings all look like:

```
scipy/linalg/_flapackmodule.c:2200:9: warning: variable 'return_value' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
    if (capi_j>capi_i)
        ^~~~~~~~~~~~~
scipy/linalg/_flapackmodule.c:2217:12: note: uninitialized use occurs here
    return return_value;
           ^~~~~~~~~~~~
scipy/linalg/_flapackmodule.c:2200:5: note: remove the 'if' if its condition is always true
    if (capi_j>capi_i)
    ^~~~~~~~~~~~~~~~~~
scipy/linalg/_flapackmodule.c:2099:21: note: initialize the variable 'return_value' to silence this warning
    int return_value;
                    ^
                     = 0
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
