### PR TITLE
ENH: Regard matrix as scalar when it has shape (1,1)

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -383,6 +383,7 @@ arrays:
       matrix.H
       matrix.I
       matrix.A
+      matrix.S
 
 .. warning::
 

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1016,8 +1016,8 @@ class matrix(N.ndarray):
     def S(self):
         """
         Regard the matrix as a scalar.
-        If `self`.shape == (1, 1), then return `self`[0, 0], as it does
-        in MATLAB. Otherwise, raise ValueError().
+        If `self.shape == (1, 1)` then return `self[0, 0]` as it does
+        in MATLAB. Otherwise, `raise ValueError()`
 
         Parameters
         ----------
@@ -1025,13 +1025,13 @@ class matrix(N.ndarray):
 
         Returns
         -------
-        ret : `self`.dtype
+        ret : self.dtype
             the element of index [0, 0]
 
         Exceptions
         ----------
         ValueError 
-            when `self`.shape != (1, 1)
+            when `self.shape != (1, 1)`
 
         """
         if self.shape == (1, 1):

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1032,6 +1032,7 @@ class matrix(N.ndarray):
         ----------
         ValueError 
             when `self`.shape != (1, 1)
+
         """
         if self.shape == (1, 1):
             return self[0, 0]

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1012,6 +1012,32 @@ class matrix(N.ndarray):
     getH = H.fget
     getI = I.fget
 
+    @property
+    def S(self):
+        """
+        Regard the matrix as a scalar.
+        If `self`.shape == (1, 1), then return `self`[0, 0], as it does
+        in MATLAB. Otherwise, raise ValueError().
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        ret : `self`.dtype
+            the element of index [0, 0]
+
+        Exceptions
+        ----------
+        ValueError 
+            when `self`.shape != (1, 1)
+        """
+        if self.shape == (1, 1):
+            return self[0, 0]
+        else:
+            raise ValueError(f"The matrix to be regarded as scalar must have shape (1, 1)")
+
 def _from_string(str, gdict, ldict):
     rows = str.split(';')
     rowtup = []

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -216,7 +216,7 @@ class matrix(N.ndarray):
         if self.shape == (1, 1):
             # Act as a scalar
             return other * self[0, 0]
-        if other.shape == (1, 1):
+        if isinstance(other, N.ndarray) and other.shape == (1, 1):
             return self * other[0, 0]
         if isinstance(other, (N.ndarray, list, tuple)) :
             # This promotes 1-D vectors to row vectors

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -1036,7 +1036,8 @@ class matrix(N.ndarray):
         if self.shape == (1, 1):
             return self[0, 0]
         else:
-            raise ValueError(f"The matrix to be regarded as scalar must have shape (1, 1)")
+            raise ValueError(f"The matrix to be regarded as scalar "
+                              "must have shape (1, 1)")
 
 def _from_string(str, gdict, ldict):
     rows = str.split(';')

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -216,6 +216,8 @@ class matrix(N.ndarray):
         if self.shape == (1, 1):
             # Act as a scalar
             return other * self[0, 0]
+        if other.shape == (1, 1):
+            return self * other[0, 0]
         if isinstance(other, (N.ndarray, list, tuple)) :
             # This promotes 1-D vectors to row vectors
             return N.dot(self, asmatrix(other))

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -213,6 +213,9 @@ class matrix(N.ndarray):
         return out
 
     def __mul__(self, other):
+        if self.shape == (1, 1):
+            # Act as a scalar
+            return other * self[0, 0]
         if isinstance(other, (N.ndarray, list, tuple)) :
             # This promotes 1-D vectors to row vectors
             return N.dot(self, asmatrix(other))

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -62,3 +62,14 @@ def test_mul_as_scalar():
     y = numpy.matlib.rand(1)
     assert_array_equal(x * y, x * y[0, 0])
     assert_array_equal(y * x, x * y[0, 0])
+
+def test_as_scalar():
+    x = numpy.matlib.rand(1)
+    y = numpy.matlib.rand(2)
+    assert_array_equal(x.S, x[0, 0])
+    try:
+        y.S 
+        assert_(False, "Failed to handle with non-(1,1)shape matrix "
+                       "converting to scalar")
+    except ValueError:
+        pass

--- a/numpy/tests/test_matlib.py
+++ b/numpy/tests/test_matlib.py
@@ -56,3 +56,9 @@ def test_repmat():
     y = np.array([[0, 1, 2, 3, 0, 1, 2, 3],
                   [0, 1, 2, 3, 0, 1, 2, 3]])
     assert_array_equal(x, y)
+
+def test_mul_as_scalar():
+    x = numpy.matlib.rand(5, 5)
+    y = numpy.matlib.rand(1)
+    assert_array_equal(x * y, x * y[0, 0])
+    assert_array_equal(y * x, x * y[0, 0])


### PR DESCRIPTION
Add features:

1. When x is a np.matrix and that `x.shape == (1, 1)`, the expression `x * y` is equivalent to `x[0, 0] * y`, i.e. regard x as a scalar, as it does in MATLAB. 

2. Add property `np.matrix.S` that returns the element of index [0, 0] if the matrix has shape(1, 1), otherwise raise `ValueError()`

These features will simplify some cases in matrix algebra, where the product of two matrices has shape (1,1) and is regarded as number in mathematic context.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
