### PR TITLE
DOC: improper doc syntax (markdown and imbalanced ticks).

### DIFF
--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -543,25 +543,23 @@ def _concatenate_shapes(shapes, axis):
     Returns
     -------
     shape: tuple of int
-        This tuple satisfies:
-        ```
-        shape, _ = _concatenate_shapes([arr.shape for shape in arrs], axis)
-        shape == concatenate(arrs, axis).shape
-        ```
+        This tuple satisfies::
+
+            shape, _ = _concatenate_shapes([arr.shape for shape in arrs], axis)
+            shape == concatenate(arrs, axis).shape
 
     slice_prefixes: tuple of (slice(start, end), )
         For a list of arrays being concatenated, this returns the slice
         in the larger array at axis that needs to be sliced into.
 
-        For example, the following holds:
-        ```
-        ret = concatenate([a, b, c], axis)
-        _, (sl_a, sl_b, sl_c) = concatenate_slices([a, b, c], axis)
+        For example, the following holds::
 
-        ret[(slice(None),) * axis + sl_a] == a
-        ret[(slice(None),) * axis + sl_b] == b
-        ret[(slice(None),) * axis + sl_c] == c
-        ```
+            ret = concatenate([a, b, c], axis)
+            _, (sl_a, sl_b, sl_c) = concatenate_slices([a, b, c], axis)
+
+            ret[(slice(None),) * axis + sl_a] == a
+            ret[(slice(None),) * axis + sl_b] == b
+            ret[(slice(None),) * axis + sl_c] == c
 
         These are called slice prefixes since they are used in the recursive
         blocking algorithm to compute the left-most slices during the

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -169,7 +169,7 @@ class _Config:
 
             If the compiler able to successfully compile the C file then `CCompilerOpt`
             will add a C ``#define`` for it into the main dispatch header, e.g.
-            ```#define {conf_c_prefix}_XXXX`` where ``XXXX`` is the case name in upper case.
+            ``#define {conf_c_prefix}_XXXX`` where ``XXXX`` is the case name in upper case.
 
         **NOTES**:
             * space can be used as separator with options that supports "str or list"


### PR DESCRIPTION
Here are two modifications:

The first one is the inclusion of markdown fence blocks in the middle of
RST. While this is not really a problem for current documentation as
this is a private function, it still makes other RST parser choke on
this.

In particular this is seen as a tile as it is a text line followed by
a line of only backticks, and that makes my new project to show better
docstrings in Jupyter fails.

I can locally exclude this function, but while not fix it to show good
examples ?

Second, while grepping for triple backticks I found that there are a
stray one in another place.
