### PR TITLE
Fix typo in test_ccompiler_otp.py

### DIFF
--- a/numpy/distutils/tests/test_ccompiler_opt.py
+++ b/numpy/distutils/tests/test_ccompiler_opt.py
@@ -303,7 +303,7 @@ class _Test_CCompilerOpt:
             return
         # check sanity of argument's validation
         for baseline, dispatch in (
-            ("unkown_feature - max +min", "unknown max min"), # unknowing features
+            ("unknown_feature - max +min", "unknown max min"), # unknowing features
             ("#avx2", "$vsx") # groups and polices aren't acceptable
         ) :
             try:


### PR DESCRIPTION
- `numpy/distutils/tests/test_ccompiler_opt.py`: unkown_feature -> **unknown_feature**