### PR TITLE
Fix broken link in nep-0046-sponsorship-guidelines.rst

### DIFF
--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -219,8 +219,8 @@ https://scikit-learn.org/stable/about.html#funding. Plus a separate section
 https://jupyter.org/about. Some subprojects have separate approaches, for
 example sponsors are listed (by using the `all-contributors
 <https://github.com/all-contributors/all-contributors>`__ bot) in the README for
-`jupyterlab-git <https://github.com/jupyterlab/jupyterlab-git>`__. For a recent
-discussion on that, see
+`jupyterlab-git <https://github.com/jupyterlab/jupyterlab-git>`__.
+For a discussion from Jan 2020 on that, see
 `here <https://discourse.jupyter.org/t/ideas-for-recognizing-developer-contributions-by-companies-institutes/3178>`_.
 
 *NumFOCUS* has a large banner with sponsor logos on its front page at

--- a/doc/neps/nep-0046-sponsorship-guidelines.rst
+++ b/doc/neps/nep-0046-sponsorship-guidelines.rst
@@ -220,7 +220,8 @@ https://jupyter.org/about. Some subprojects have separate approaches, for
 example sponsors are listed (by using the `all-contributors
 <https://github.com/all-contributors/all-contributors>`__ bot) in the README for
 `jupyterlab-git <https://github.com/jupyterlab/jupyterlab-git>`__. For a recent
-discussion on that, see `here <jupyterlab-git acknowledgements discussion>`_.
+discussion on that, see
+`here <https://discourse.jupyter.org/t/ideas-for-recognizing-developer-contributions-by-companies-institutes/3178>`_.
 
 *NumFOCUS* has a large banner with sponsor logos on its front page at
 https://numfocus.org, and a full page with sponsors at different sponsorship


### PR DESCRIPTION
There was a broken link in [nep-0046-sponsorship-guidelines.rst](https://github.com/numpy/numpy/blob/main/doc/neps/nep-0046-sponsorship-guidelines.rst) file that I fixed it.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
