### PR TITLE
DOC: remove html sidebar from neps.

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -99,6 +99,10 @@ html_theme_options = {
   "show_prev_next": False,
 }
 
+html_sidebars = {
+    "**": []  # Suppress sidebars on all pages
+}
+
 html_title = "%s" % (project)
 html_static_path = ['../source/_static']
 html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
This is an alternative to #20956

A *vastly* simpler solution to the sidebar being badly organized for the NEPs is just to remove the html sidebar entirely. This should be sufficient to close #20952 and is much simpler than the solution in #20956. H/T to @seberg for the idea.