### PR TITLE
ENH: review return values for PyArray_DescrNew

### DIFF
--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -643,7 +643,6 @@ static PyObject *
 fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
 {
     char *string;
-    PyArray_Descr *descr;
 
     string = PyBytes_AsString(byte_obj);
     if (string == NULL) {

--- a/numpy/core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/core/src/multiarray/_multiarray_tests.c.src
@@ -649,8 +649,7 @@ fromstring_null_term_c_api(PyObject *dummy, PyObject *byte_obj)
     if (string == NULL) {
         return NULL;
     }
-    descr = PyArray_DescrNewFromType(NPY_FLOAT64);
-    return PyArray_FromString(string, -1, descr, -1, " ");
+    return PyArray_FromString(string, -1, NULL, -1, " ");
 }
 
 

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -966,6 +966,9 @@ _strings_richcompare(PyArrayObject *self, PyArrayObject *other, int cmp_op,
     if (PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(other)) {
         /* Cast `other` to the same byte order as `self` (both unicode here) */
         PyArray_Descr* unicode = PyArray_DescrNew(PyArray_DESCR(self));
+        if (unicode == NULL) {
+            return NULL;
+        }
         unicode->elsize = PyArray_DESCR(other)->elsize;
         PyObject *new = PyArray_FromAny((PyObject *)other,
                 unicode, 0, 0, 0, NULL);

--- a/numpy/core/src/multiarray/buffer.c
+++ b/numpy/core/src/multiarray/buffer.c
@@ -1048,12 +1048,18 @@ _descriptor_from_pep3118_format_fast(char const *s, PyObject **result)
     }
 
     descr = PyArray_DescrFromType(type_num);
+    if (descr == NULL) {
+        return 0;
+    }
     if (byte_order == '=') {
         *result = (PyObject*)descr;
     }
     else {
         *result = (PyObject*)PyArray_DescrNewByteorder(descr, byte_order);
         Py_DECREF(descr);
+        if (result == NULL) {
+            return 0;
+        }
     }
 
     return 1;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -668,6 +668,11 @@ PyArray_NewFromDescr_int(
     PyArrayObject_fields *fa;
     npy_intp nbytes;
 
+    if (descr == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "NULL descr in call to PyArray_NewFromDescr*");
+        return NULL;
+    }
     if (nd > NPY_MAXDIMS || nd < 0) {
         PyErr_Format(PyExc_ValueError,
                 "number of dimensions must be within [0, %d]", NPY_MAXDIMS);
@@ -1137,6 +1142,9 @@ PyArray_New(
             return NULL;
         }
         PyArray_DESCR_REPLACE(descr);
+        if (descr == NULL) {
+            return NULL;
+        }
         descr->elsize = itemsize;
     }
     new = PyArray_NewFromDescr(subtype, descr, nd, dims, strides,
@@ -1162,6 +1170,9 @@ _dtype_from_buffer_3118(PyObject *memoryview)
          *       terminate.
          */
         descr = PyArray_DescrNewFromType(NPY_STRING);
+        if (descr == NULL) {
+            return NULL;
+        }
         descr->elsize = view->itemsize;
     }
     return descr;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -976,11 +976,6 @@ PyArray_NewFromDescrAndBase(
         int nd, npy_intp const *dims, npy_intp const *strides, void *data,
         int flags, PyObject *obj, PyObject *base)
 {
-    if (descr == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "NULL descr in call to PyArray_NewFromDescrAndBase");
-        return NULL;
-    }
     return PyArray_NewFromDescr_int(subtype, descr, nd,
                                     dims, strides, data,
                                     flags, obj, base, 0, 0);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -961,18 +961,6 @@ PyArray_NewFromDescr(
         int nd, npy_intp const *dims, npy_intp const *strides, void *data,
         int flags, PyObject *obj)
 {
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnonnull-compare"
-#endif
-    if (descr == NULL) {
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-        PyErr_Format(PyExc_ValueError,
-                "NULL descr in call to PyArray_NewFromDescr");
-        return NULL;
-    }
     return PyArray_NewFromDescrAndBase(
             subtype, descr,
             nd, dims, strides, data,
@@ -988,6 +976,11 @@ PyArray_NewFromDescrAndBase(
         int nd, npy_intp const *dims, npy_intp const *strides, void *data,
         int flags, PyObject *obj, PyObject *base)
 {
+    if (descr == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "NULL descr in call to PyArray_NewFromDescrAndBase");
+        return NULL;
+    }
     return PyArray_NewFromDescr_int(subtype, descr, nd,
                                     dims, strides, data,
                                     flags, obj, base, 0, 0);

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -669,8 +669,6 @@ PyArray_NewFromDescr_int(
     npy_intp nbytes;
 
     if (descr == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "NULL descr in call to PyArray_NewFromDescr*");
         return NULL;
     }
     if (nd > NPY_MAXDIMS || nd < 0) {
@@ -963,6 +961,18 @@ PyArray_NewFromDescr(
         int nd, npy_intp const *dims, npy_intp const *strides, void *data,
         int flags, PyObject *obj)
 {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+    if (descr == NULL) {
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+        PyErr_Format(PyExc_ValueError,
+                "NULL descr in call to PyArray_NewFromDescr");
+        return NULL;
+    }
     return PyArray_NewFromDescrAndBase(
             subtype, descr,
             nd, dims, strides, data,
@@ -3570,6 +3580,12 @@ PyArray_FromFile(FILE *fp, PyArray_Descr *dtype, npy_intp num, char *sep)
     PyArrayObject *ret;
     size_t nread = 0;
 
+    if (dtype == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "NULL dtype in call to PyArray_FromFile");
+        return NULL;
+    }
+
     if (PyDataType_REFCHK(dtype)) {
         PyErr_SetString(PyExc_ValueError,
                 "Cannot read into object array");
@@ -3637,6 +3653,11 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
     int itemsize;
     int writeable = 1;
 
+    if (type == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "NULL type in call to PyArray_FromBuffer");
+        return NULL;
+    }
 
     if (PyDataType_REFCHK(type)) {
         PyErr_SetString(PyExc_ValueError,
@@ -3852,6 +3873,12 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     if (iter == NULL) {
         goto done;
     }
+    if (dtype == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "NULL dtype in call to PyArray_FromIter");
+        goto done;
+    }
+
     if (PyDataType_ISUNSIZED(dtype)) {
         PyErr_SetString(PyExc_ValueError,
                 "Must specify length when using variable-size data-type.");

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3569,8 +3569,6 @@ PyArray_FromFile(FILE *fp, PyArray_Descr *dtype, npy_intp num, char *sep)
     size_t nread = 0;
 
     if (dtype == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "NULL dtype in call to PyArray_FromFile");
         return NULL;
     }
 
@@ -3642,8 +3640,6 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
     int writeable = 1;
 
     if (type == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "NULL type in call to PyArray_FromBuffer");
         return NULL;
     }
 
@@ -3853,17 +3849,17 @@ NPY_NO_EXPORT PyObject *
 PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
 {
     PyObject *value;
-    PyObject *iter = PyObject_GetIter(obj);
+    PyObject *iter = NULL;
     PyArrayObject *ret = NULL;
     npy_intp i, elsize, elcount;
     char *item, *new_data;
 
-    if (iter == NULL) {
-        goto done;
-    }
     if (dtype == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "NULL dtype in call to PyArray_FromIter");
+        return NULL;
+    }
+
+    iter = PyObject_GetIter(obj);
+    if (iter == NULL) {
         goto done;
     }
 

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -1381,8 +1381,11 @@ PyArray_DescrNewFromType(int type_num)
     PyArray_Descr *new;
 
     old = PyArray_DescrFromType(type_num);
+    if (old == NULL) {
+        return NULL;
+    }
     new = PyArray_DescrNew(old);
-    Py_XDECREF(old);
+    Py_DECREF(old);
     return new;
 }
 

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -181,7 +181,7 @@ void_discover_descr_from_pyobject(
         if (itemsize > NPY_MAX_INT) {
             PyErr_SetString(PyExc_TypeError,
                     "byte-like to large to store inside array.");
-            Py_DECREF(desr);
+            Py_DECREF(descr);
             return NULL;
         }
         descr->elsize = (int)itemsize;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -181,6 +181,7 @@ void_discover_descr_from_pyobject(
         if (itemsize > NPY_MAX_INT) {
             PyErr_SetString(PyExc_TypeError,
                     "byte-like to large to store inside array.");
+            Py_DECREF(desr);
             return NULL;
         }
         descr->elsize = (int)itemsize;

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -153,6 +153,9 @@ string_discover_descr_from_pyobject(
                     "string to large to store inside array.");
         }
         PyArray_Descr *res = PyArray_DescrNewFromType(cls->type_num);
+        if (res == NULL) {
+            return NULL;
+        }
         res->elsize = (int)itemsize;
         return res;
     }
@@ -171,10 +174,14 @@ void_discover_descr_from_pyobject(
     }
     if (PyBytes_Check(obj)) {
         PyArray_Descr *descr = PyArray_DescrNewFromType(NPY_VOID);
+        if (descr == NULL) {
+            return NULL;
+        }
         Py_ssize_t itemsize = PyBytes_Size(obj);
         if (itemsize > NPY_MAX_INT) {
             PyErr_SetString(PyExc_TypeError,
                     "byte-like to large to store inside array.");
+            return NULL;
         }
         descr->elsize = (int)itemsize;
         return descr;

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -698,12 +698,18 @@ _get_part(PyArrayObject *self, int imag)
 
     }
     type = PyArray_DescrFromType(float_type_num);
+    if (type == NULL) {
+        return NULL;
+    }
 
     offset = (imag ? type->elsize : 0);
 
     if (!PyArray_ISNBO(PyArray_DESCR(self)->byteorder)) {
         PyArray_Descr *new;
         new = PyArray_DescrNew(type);
+        if (new == NULL) {
+            return NULL;
+        }
         new->byteorder = PyArray_DESCR(self)->byteorder;
         Py_DECREF(type);
         type = new;

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -705,14 +705,11 @@ _get_part(PyArrayObject *self, int imag)
     offset = (imag ? type->elsize : 0);
 
     if (!PyArray_ISNBO(PyArray_DESCR(self)->byteorder)) {
-        PyArray_Descr *new;
-        new = PyArray_DescrNew(type);
-        if (new == NULL) {
+        Py_SETREF(type, PyArray_DescrNew(type));
+        if (type == NULL) {
             return NULL;
         }
-        new->byteorder = PyArray_DESCR(self)->byteorder;
-        Py_DECREF(type);
-        type = new;
+        type->byteorder = PyArray_DESCR(self)->byteorder;
     }
     ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
             Py_TYPE(self),

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1467,6 +1467,7 @@ array_argsort(PyArrayObject *self,
         }
         newd = PyArray_DescrNew(saved);
         if (newd == NULL) {
+            Py_DECREF(new_name);
             return NULL;
         }
         Py_DECREF(newd->names);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1338,6 +1338,7 @@ array_sort(PyArrayObject *self,
         }
         newd = PyArray_DescrNew(saved);
         if (newd == NULL) {
+            Py_DECREF(new_name);
             return NULL;
         }
         Py_DECREF(newd->names);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1527,6 +1527,7 @@ array_argpartition(PyArrayObject *self,
         }
         newd = PyArray_DescrNew(saved);
         if (newd == NULL) {
+            Py_DECREF(new_name);
             return NULL;
         }
         Py_DECREF(newd->names);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1337,6 +1337,9 @@ array_sort(PyArrayObject *self,
             return NULL;
         }
         newd = PyArray_DescrNew(saved);
+        if (newd == NULL) {
+            return NULL;
+        }
         Py_DECREF(newd->names);
         newd->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
@@ -1462,6 +1465,9 @@ array_argsort(PyArrayObject *self,
             return NULL;
         }
         newd = PyArray_DescrNew(saved);
+        if (newd == NULL) {
+            return NULL;
+        }
         Py_DECREF(newd->names);
         newd->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
@@ -1519,6 +1525,9 @@ array_argpartition(PyArrayObject *self,
             return NULL;
         }
         newd = PyArray_DescrNew(saved);
+        if (newd == NULL) {
+            return NULL;
+        }
         Py_DECREF(newd->names);
         newd->names = new_name;
         ((PyArrayObject_fields *)self)->descr = newd;
@@ -2150,6 +2159,11 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 }
                 else {
                     fa->descr = PyArray_DescrNew(typecode);
+                    if (fa->descr == NULL) {
+                        Py_CLEAR(fa->mem_handler);
+                        Py_DECREF(rawdata);
+                        return NULL;
+                    }
                     if (PyArray_DESCR(self)->byteorder == NPY_BIG) {
                         PyArray_DESCR(self)->byteorder = NPY_LITTLE;
                     }

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1132,6 +1132,9 @@ npyiter_prepare_one_operand(PyArrayObject **op,
 
                 /* Replace with a new descr which is in native byte order */
                 nbo_dtype = PyArray_DescrNewByteorder(*op_dtype, NPY_NATIVE);
+                if (nbo_dtype == NULL) {
+                    return 0;
+                }
                 Py_DECREF(*op_dtype);
                 *op_dtype = nbo_dtype;
 

--- a/numpy/core/src/multiarray/nditer_constr.c
+++ b/numpy/core/src/multiarray/nditer_constr.c
@@ -1128,16 +1128,12 @@ npyiter_prepare_one_operand(PyArrayObject **op,
         if (op_flags & NPY_ITER_NBO) {
             /* Check byte order */
             if (!PyArray_ISNBO((*op_dtype)->byteorder)) {
-                PyArray_Descr *nbo_dtype;
-
                 /* Replace with a new descr which is in native byte order */
-                nbo_dtype = PyArray_DescrNewByteorder(*op_dtype, NPY_NATIVE);
-                if (nbo_dtype == NULL) {
+                Py_SETREF(*op_dtype,
+                          PyArray_DescrNewByteorder(*op_dtype, NPY_NATIVE));
+                if (*op_dtype == NULL) {
                     return 0;
-                }
-                Py_DECREF(*op_dtype);
-                *op_dtype = nbo_dtype;
-
+                }                
                 NPY_IT_DBG_PRINT("Iterator: Setting NPY_OP_ITFLAG_CAST "
                                     "because of NPY_ITER_NBO\n");
                 /* Indicate that byte order or alignment needs fixing */

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -625,6 +625,9 @@ PyArray_DescrFromScalar(PyObject *sc)
     }
     if (PyDataType_ISUNSIZED(descr)) {
         PyArray_DESCR_REPLACE(descr);
+        if (descr == NULL) {
+            return NULL;
+        }
         type_num = descr->type_num;
         if (type_num == NPY_STRING) {
             descr->elsize = PyBytes_GET_SIZE(sc);

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3212,16 +3212,17 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         }
         ((PyVoidScalarObject *)ret)->obval = destptr;
         Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
+        ((PyVoidScalarObject *)ret)->flags = NPY_ARRAY_BEHAVED |
+                                             NPY_ARRAY_OWNDATA;
+        ((PyVoidScalarObject *)ret)->base = NULL;
         ((PyVoidScalarObject *)ret)->descr =
             PyArray_DescrNewFromType(NPY_VOID);
         if ( ((PyVoidScalarObject *)ret)->descr == NULL) {
             npy_free_cache(destptr, memu);
+            Py_DECREF(ret);
             return NULL;
         }
         ((PyVoidScalarObject *)ret)->descr->elsize = (int) memu;
-        ((PyVoidScalarObject *)ret)->flags = NPY_ARRAY_BEHAVED |
-                                             NPY_ARRAY_OWNDATA;
-        ((PyVoidScalarObject *)ret)->base = NULL;
         return ret;
     }
 

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3217,8 +3217,7 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         ((PyVoidScalarObject *)ret)->base = NULL;
         ((PyVoidScalarObject *)ret)->descr =
             PyArray_DescrNewFromType(NPY_VOID);
-        if ( ((PyVoidScalarObject *)ret)->descr == NULL) {
-            npy_free_cache(destptr, memu);
+        if (((PyVoidScalarObject *)ret)->descr == NULL) {
             Py_DECREF(ret);
             return NULL;
         }

--- a/numpy/core/src/multiarray/scalartypes.c.src
+++ b/numpy/core/src/multiarray/scalartypes.c.src
@@ -3214,6 +3214,10 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
         ((PyVoidScalarObject *)ret)->descr =
             PyArray_DescrNewFromType(NPY_VOID);
+        if ( ((PyVoidScalarObject *)ret)->descr == NULL) {
+            npy_free_cache(destptr, memu);
+            return NULL;
+        }
         ((PyVoidScalarObject *)ret)->descr->elsize = (int) memu;
         ((PyVoidScalarObject *)ret)->flags = NPY_ARRAY_BEHAVED |
                                              NPY_ARRAY_OWNDATA;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -641,7 +641,7 @@ PyUFunc_SimpleUniformOperationTypeResolver(
     /* Check against the casting rules */
     if (PyUFunc_ValidateCasting(ufunc, casting, operands, out_dtypes) < 0) {
         for (int iop = 0; iop < nop; iop++) {
-            Py_XDECREF(out_dtypes[iop]);
+            Py_DECREF(out_dtypes[iop]);
             out_dtypes[iop] = NULL;
         }
         return -1;

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -641,7 +641,7 @@ PyUFunc_SimpleUniformOperationTypeResolver(
     /* Check against the casting rules */
     if (PyUFunc_ValidateCasting(ufunc, casting, operands, out_dtypes) < 0) {
         for (int iop = 0; iop < nop; iop++) {
-            Py_DECREF(out_dtypes[iop]);
+            Py_XDECREF(out_dtypes[iop]);
             out_dtypes[iop] = NULL;
         }
         return -1;


### PR DESCRIPTION
Fixes #19038

Review all the places `PyArray_DescrNew` and first derivative functions are used, and make sure to check the return value. Functions grepped for:
- `PyArray_DescrNew` (API function)
- `PyArray_DescrNewFromType` (API function)
- `PyArray_DescrNewByteOrder` (API function)
- `PyArray_DESCR_REPLACE` (macro)
- `ensure_dtype_nbo` (helper function)
- `_descriptor_from_pep3118_format` (helper function)
- `arraydescr_newbyteorder` (helper function)

An alternative would be to use `exit(1)` where malloc fails in `PyArray_DescrNew` since allocating a new descriptor should only fail on out-of-memory, and there is no real way to recover from that. Here are a few recommendations for using `exit(1)` (thanks @rgommers):
- https://titanwolf.org/Network/Articles/Article?AID=55f68680-740b-4f0b-ad05-a991894108bb.
  > It can be concluded that for applications above 32 bits, the "out of memory" error handler is useless

- https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
  > The abort policy is simple and familiar: when no memory is available, print a polite error message and exit (abort) the application. This is the most commonly used policy - most command-line tools and desktop applications use it.
  > As a matter of fact, this policy is so common that most Unix programs use a gnulib library function [`xmalloc`](https://manpages.ubuntu.com/manpages/xenial/man3/xmalloc.3pub.html) instead of malloc