### PR TITLE
MAINT: be more tolerant of setuptools>=60

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,16 @@ if os.path.exists('MANIFEST'):
 import numpy.distutils.command.sdist
 import setuptools
 if int(setuptools.__version__.split('.')[0]) >= 60:
-    raise RuntimeError(
-        "Setuptools version is '{}', version < '60.0.0' is required. "
-        "See pyproject.toml".format(setuptools.__version__))
+    # setuptools >= 60 switches to vendored distutils by default; this
+    # may break the numpy build, so make sure the stdlib version is used
+    try:
+        setuptools_use_distutils = os.environ['SETUPTOOLS_USE_DISTUTILS']
+    except KeyError:
+        os.environ['SETUPTOOLS_USE_DISTUTILS'] = "stdlib"
+    else:
+        if setuptools_use_distutils != "stdlib":
+            raise RuntimeError("setuptools versions >= '60.0.0' require "
+                    "SETUPTOOLS_USE_DISTUTILS=stdlib in the environment")
 
 # Initialize cmdclass from versioneer
 from numpy.distutils.core import numpy_cmdclass


### PR DESCRIPTION
NumPy may fail to build with the default vendored distutils in setuptools>=60. Rather than panic and die when new setuptools is found, let's check (or set, if possible) the `SETUPTOOLS_USE_DISTUTILS` environment variable that restores "proper" setuptools behavior.

We were bitten by #20759 and #20795 in Void Linux, which has already moved to setuptools>60.

Note that I *cannot* reproduce a build failure (at least not on maintenance/v.1.22.x) even when the new default isn't overridden. (That is, reverting #20759/#20795 is sufficient to allow NumPy to build for me.) However, in certain cases where it the new default might cause problems, this change should thread the needle. Sticking with setuptools < 60 for the next year while NumPy moves to a new build system is simply not a good option for Linux packagers.