### PR TITLE
ENH: Move identity to the ArrayMethod to allow customization

### DIFF
--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -487,7 +487,7 @@ PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
  */
 #if !defined(NO_IMPORT) && !defined(NO_IMPORT_ARRAY)
 
-#define __EXPERIMENTAL_DTYPE_VERSION 5
+#define __EXPERIMENTAL_DTYPE_VERSION 6
 
 static int
 import_experimental_dtype_api(int version)

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -342,8 +342,9 @@ typedef enum {
  * If an identity exists, should set the `NPY_METH_ITEM_IS_IDENTITY`, normally
  * the `NPY_METH_ITEM_IS_DEFAULT` should also be set, but it is distinct.
  * By default NumPy provides a "default" for `object` dtype, but does not use
- * it as an identity.
- * The `NPY_METH_IS_REORDERABLE` flag should be set if the operatio is
+ * it as an identity (this is e.g. to allows reducing even Python strings
+ * for `np.sum()` while the empty sum returns 0).
+ * The `NPY_METH_IS_REORDERABLE` flag should be set if the operation is
  * reorderable.
  *
  * NOTE: `item` can be `NULL` when a user passed a custom initial value, in

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -332,11 +332,13 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  *
  * @param context The arraymethod context, mainly to access the descriptors.
  * @param reduction_is_empty Whether the reduction is empty. When it is, the
- *     default value for the identity might differ, for example:
+ *     value returned may differ.  In this case it is a "default" value that
+ *     may differ from the "identity" value normally used.  For example:
  *     - `0.0` is the default for `sum([])`.  But `-0.0` is the correct
  *       identity otherwise as it preserves the sign for `sum([-0.0])`.
  *     - We use no identity for object, but return the default of `0` and `1`
-         for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
+ *       for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
+ *       This allows `np.sum(np.array(["a", "b"], dtype=object))` to work.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
  * @param initial Pointer to initial data to be filled (if possible)

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -307,10 +307,10 @@ typedef NPY_CASTING (resolve_descriptors_function)(
  *
  * NOTE: As of now, NumPy will NOT use unaligned loops in ufuncs!
  */
-#define NPY_METH_strided_loop 3
-#define NPY_METH_contiguous_loop 4
-#define NPY_METH_unaligned_strided_loop 5
-#define NPY_METH_unaligned_contiguous_loop 6
+#define NPY_METH_strided_loop 4
+#define NPY_METH_contiguous_loop 5
+#define NPY_METH_unaligned_strided_loop 6
+#define NPY_METH_unaligned_contiguous_loop 7
 
 
 typedef struct {
@@ -331,12 +331,12 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  * Query an ArrayMethod for the initial value for use in reduction.
  *
  * @param context The arraymethod context, mainly to access the descriptors.
- * @param reduction_is_empty Whether the reduction is empty, when it is the
- *     default value is required, otherwise an identity value to start the
- *     the reduction.  These might differ, examples:
- *     - `0.0` as default for `sum([])`.  But `-0.0` would be the correct
- *       identity as it preserves the sign for `sum([-0.0])`.
- *     - We use no identity for object, but `0` and `1` for sum and prod.
+ * @param reduction_is_empty Whether the reduction is empty. When it is, the
+ *     default value for the identity might differ, for example:
+ *     - `0.0` is the default for `sum([])`.  But `-0.0` is the correct
+ *       identity otherwise as it preserves the sign for `sum([-0.0])`.
+ *     - We use no identity for object, but return the default of `0` and `1`
+         for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
  * @param initial Pointer to initial data to be filled (if possible)
@@ -345,8 +345,8 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  *     successfully filled.  Errors must not be given where 0 is correct, NumPy
  *     may call this even when not strictly necessary.
  */
- #define NPY_METH_get_reduction_initial 4
-typedef int (get_reduction_intial_function)(
+#define NPY_METH_get_reduction_initial 3
+typedef int (get_reduction_initial_function)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         char *initial);
 

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -321,6 +321,38 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
         NpyAuxData *transferdata);
 
 
+/*
+ * For reductions, NumPy sometimes requires an identity or default value.
+ * The typical way of relying on a single "default" for ufuncs does not always
+ * work however.  This function allows customizing the identity value as well
+ * as whether the operation is "reorderable".
+ */
+#define NPY_METH_get_identity 7
+
+typedef enum {
+    /* The value can be used as a default for empty reductions */
+    NPY_METH_ITEM_IS_DEFAULT = 1 << 0,
+    /* The value represents the identity value */
+    NPY_METH_ITEM_IS_IDENTITY = 1 << 1,
+    /* The operation is fully reorderable (iteration order may be optimized) */
+    NPY_METH_IS_REORDERABLE = 1 << 2,
+} NPY_ARRAYMETHOD_IDENTITY_FLAGS;
+
+/*
+ * If an identity exists, should set the `NPY_METH_ITEM_IS_IDENTITY`, normally
+ * the `NPY_METH_ITEM_IS_DEFAULT` should also be set, but it is distinct.
+ * By default NumPy provides a "default" for `object` dtype, but does not use
+ * it as an identity.
+ * The `NPY_METH_IS_REORDERABLE` flag should be set if the operatio is
+ * reorderable.
+ *
+ * NOTE: `item` can be `NULL` when a user passed a custom initial value, in
+ *       this case only the `reorderable` flag is valid.
+ */
+typedef int (get_identity_function)(
+        PyArrayMethod_Context *context, char *item,
+        NPY_ARRAYMETHOD_IDENTITY_FLAGS *flags);
+
 
 /*
  * ****************************

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -331,7 +331,6 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  * Query an ArrayMethod for the initial value for use in reduction.
  *
  * @param context The arraymethod context, mainly to access the descriptors.
- * @param initial Pointer to initial data to be filled (if possible)
  * @param reduction_is_empty Whether the reduction is empty, when it is the
  *     default value is required, otherwise an identity value to start the
  *     the reduction.  These might differ, examples:
@@ -340,6 +339,7 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  *     - We use no identity for object, but `0` and `1` for sum and prod.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
+ * @param initial Pointer to initial data to be filled (if possible)
  *
  * @returns -1, 0, or 1 indicating error, no initial value, and initial being
  *     successfully filled.  Errors must not be given where 0 is correct, NumPy
@@ -347,9 +347,8 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
  */
  #define NPY_METH_get_reduction_initial 4
 typedef int (get_reduction_intial_function)(
-        PyArrayMethod_Context *context, char *initial,
-        npy_bool reduction_is_empty);
-
+        PyArrayMethod_Context *context, npy_bool reduction_is_empty,
+        char *initial);
 
 /*
  * ****************************

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -166,77 +166,6 @@ npy_default_get_strided_loop(
 }
 
 
-/* TODO: Declared in `ufunc_object.c`, should be included more directly */
-NPY_NO_EXPORT PyObject *
-PyUFunc_GetIdentity(PyUFuncObject *ufunc, npy_bool *reorderable);
-
-/*
- * The default `get_reduction_initial` attempts to look up the identity
- * from the calling ufunc.
- */
-static int
-default_get_reduction_initial(PyArrayMethod_Context *context,
-        char *initial, NPY_ARRAYMETHOD_REDUCTION_FLAGS *flags)
-{
-    *flags = 0;
-
-    PyUFuncObject *ufunc = (PyUFuncObject *)context->caller;
-    if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
-        /*
-         * Could also just report no identity/reorderable, but NumPy would
-         * never get here and it is unclear that anyone else will either.
-         */
-        PyErr_SetString(PyExc_NotImplementedError,
-                "default `get_reduction_initial` requires a ufunc context; "
-                "Please contact the NumPy developers if you have questions.");
-        return -1;
-    }
-
-    npy_bool reorderable;
-    PyObject *identity_obj = PyUFunc_GetIdentity(ufunc, &reorderable);
-
-    if (identity_obj == NULL) {
-        return -1;
-    }
-    if (reorderable) {
-        *flags |= NPY_METH_IS_REORDERABLE;
-    }
-
-    if (initial == NULL || identity_obj == Py_None) {
-        /*
-         * Only reorderable flag was requested (user provided initial value)
-         * or there is no identity/default value to report.
-         */
-        Py_DECREF(identity_obj);
-        return 0;
-    }
-    if (PyTypeNum_ISUNSIGNED(context->descriptors[2]->type_num)
-            && PyLong_CheckExact(identity_obj)) {
-        /*
-         * This is a bit of a hack until we have truly loop specific
-         * identities.  Python -1 cannot be cast to unsigned so convert
-         * it to a NumPy scalar, but we use -1 for bitwise functions to
-         * signal all 1s.
-         * (A builtin identity would not overflow here, although we may
-         * unnecessary convert 0 and 1.)
-         */
-        Py_SETREF(identity_obj, PyObject_CallFunctionObjArgs(
-                     (PyObject *)&PyLongArrType_Type, identity_obj, NULL));
-        if (identity_obj == NULL) {
-            return -1;
-        }
-    }
-    /* Report the default value and identity unless object dtype */
-    *flags |= NPY_METH_INITIAL_IS_DEFAULT;
-    if (context->descriptors[0]->type_num != NPY_OBJECT) {
-        *flags |= NPY_METH_INITIAL_IS_IDENTITY;
-    }
-    int res = PyArray_Pack(context->descriptors[0], initial, identity_obj);
-    Py_DECREF(identity_obj);
-    return res;
-}
-
-
 /**
  * Validate that the input is usable to create a new ArrayMethod.
  *
@@ -322,7 +251,7 @@ fill_arraymethod_from_slots(
     /* Set the defaults */
     meth->get_strided_loop = &npy_default_get_strided_loop;
     meth->resolve_descriptors = &default_resolve_descriptors;
-    meth->get_reduction_initial = &default_get_reduction_initial;
+    meth->get_reduction_initial = NULL;  /* no initial/identity by default */
 
     /* Fill in the slots passed by the user */
     /*

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -337,6 +337,7 @@ fill_arraymethod_from_slots(
                 continue;
             case NPY_METH_get_identity:
                 meth->get_identity = slot->pfunc;
+                continue;
             default:
                 break;
         }

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -176,7 +176,7 @@ PyUFunc_GetIdentity(PyUFuncObject *ufunc, npy_bool *reorderable);
  */
 static int
 default_get_identity_function(PyArrayMethod_Context *context,
-        char *item, NPY_ARRAYMETHOD_IDENTITY_FLAGS *flags)
+        char *initial, NPY_ARRAYMETHOD_REDUCTION_FLAGS *flags)
 {
     *flags = 0;
 
@@ -202,7 +202,7 @@ default_get_identity_function(PyArrayMethod_Context *context,
         *flags |= NPY_METH_IS_REORDERABLE;
     }
 
-    if (item == NULL || identity_obj == Py_None) {
+    if (initial == NULL || identity_obj == Py_None) {
         /*
          * Only reorderable flag was requested (user provided initial value)
          * or there is no identity/default value to report.
@@ -212,11 +212,11 @@ default_get_identity_function(PyArrayMethod_Context *context,
     }
 
     /* Report the default value and identity unless object dtype */
-    *flags |= NPY_METH_ITEM_IS_DEFAULT;
+    *flags |= NPY_METH_INITIAL_IS_DEFAULT;
     if (context->descriptors[0]->type_num != NPY_OBJECT) {
-        *flags |= NPY_METH_ITEM_IS_IDENTITY;
+        *flags |= NPY_METH_INITIAL_IS_IDENTITY;
     }
-    int res = PyArray_Pack(context->descriptors[0], item, identity_obj);
+    int res = PyArray_Pack(context->descriptors[0], initial, identity_obj);
     Py_DECREF(identity_obj);
     return res;
 }
@@ -307,7 +307,7 @@ fill_arraymethod_from_slots(
     /* Set the defaults */
     meth->get_strided_loop = &npy_default_get_strided_loop;
     meth->resolve_descriptors = &default_resolve_descriptors;
-    meth->get_identity = &default_get_identity_function;
+    meth->get_reduction_initial = &default_get_identity_function;
 
     /* Fill in the slots passed by the user */
     /*
@@ -344,8 +344,8 @@ fill_arraymethod_from_slots(
             case NPY_METH_unaligned_contiguous_loop:
                 meth->unaligned_contiguous_loop = slot->pfunc;
                 continue;
-            case NPY_METH_get_identity:
-                meth->get_identity = slot->pfunc;
+            case NPY_METH_get_reduction_initial:
+                meth->get_reduction_initial = slot->pfunc;
                 continue;
             default:
                 break;

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -187,8 +187,8 @@ default_get_identity_function(PyArrayMethod_Context *context,
     }
 
     npy_bool reorderable;
-    PyObject *tmp = PyUFunc_GetIdentity(ufunc, &reorderable);
-    if (tmp == NULL) {
+    PyObject *identity_obj = PyUFunc_GetIdentity(ufunc, &reorderable);
+    if (identity_obj == NULL) {
         return -1;
     }
     if (reorderable) {
@@ -196,19 +196,21 @@ default_get_identity_function(PyArrayMethod_Context *context,
     }
     if (item == NULL) {
         /* Only reorderable flag was requested (user provided initial value) */
+        Py_DECREF(identity_obj);
         return 0;
     }
 
-    if (tmp != Py_None) {
+    if (identity_obj != Py_None) {
         /* We do not consider the value an identity for object dtype */
         *flags |= NPY_METH_ITEM_IS_DEFAULT;
         if (context->descriptors[0]->type_num != NPY_OBJECT) {
             *flags |= NPY_METH_ITEM_IS_IDENTITY;
         }
-        int res = PyArray_Pack(context->descriptors[0], item, tmp);
-        Py_DECREF(tmp);
+        int res = PyArray_Pack(context->descriptors[0], item, identity_obj);
+        Py_DECREF(identity_obj);
         return res;
     }
+    Py_DECREF(identity_obj);
     return 0;
 }
 

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -229,7 +229,7 @@ typedef struct PyArrayMethodObject_tag {
     translate_given_descrs_func *translate_given_descrs;
     translate_loop_descrs_func *translate_loop_descrs;
     /* Chunk reserved for use by the legacy fallback arraymethod */
-    char initial[sizeof(npy_clongdouble)];  /* initial value storage */
+    char legacy_initial[sizeof(npy_clongdouble)];  /* initial value storage */
 } PyArrayMethodObject;
 
 

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -105,13 +105,13 @@ typedef int (get_loop_function)(
 
 
 typedef enum {
-    /* The value can be used as a default for empty reductions */
-    NPY_METH_ITEM_IS_DEFAULT = 1 << 0,
-    /* The value represents the identity value */
-    NPY_METH_ITEM_IS_IDENTITY = 1 << 1,
+    /* The "identity" is used as result for empty reductions */
+    NPY_METH_INITIAL_IS_DEFAULT = 1 << 0,
+    /* The "identity" is used for non-empty reductions as initial value */
+    NPY_METH_INITIAL_IS_IDENTITY = 1 << 1,
     /* The operation is fully reorderable (iteration order may be optimized) */
     NPY_METH_IS_REORDERABLE = 1 << 2,
-} NPY_ARRAYMETHOD_IDENTITY_FLAGS;
+} NPY_ARRAYMETHOD_REDUCTION_FLAGS;
 
 /*
  * Query an ArrayMethod for its identity (for use with reductions) and whether
@@ -127,10 +127,9 @@ typedef enum {
  *
  * The function must return 0 on success and -1 on error (and clean up `item`).
  */
-typedef int (get_identity_function)(
-        PyArrayMethod_Context *context, char *item,
-        NPY_ARRAYMETHOD_IDENTITY_FLAGS *flags);
-
+typedef int (get_reduction_intial_function)(
+        PyArrayMethod_Context *context, char *initial,
+        NPY_ARRAYMETHOD_REDUCTION_FLAGS *flags);
 
 /*
  * The following functions are only used be the wrapping array method defined
@@ -221,7 +220,7 @@ typedef struct PyArrayMethodObject_tag {
     NPY_ARRAYMETHOD_FLAGS flags;
     resolve_descriptors_function *resolve_descriptors;
     get_loop_function *get_strided_loop;
-    get_identity_function  *get_identity;
+    get_reduction_intial_function  *get_reduction_initial;
     /* Typical loop functions (contiguous ones are used in current casts) */
     PyArrayMethod_StridedLoop *strided_loop;
     PyArrayMethod_StridedLoop *contiguous_loop;
@@ -263,7 +262,7 @@ extern NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type;
 #define NPY_METH_resolve_descriptors 1
 #define NPY_METH_get_loop 2
 #define NPY_METH_strided_loop 3
-#define NPY_METH_get_identity 4
+#define NPY_METH_get_reduction_initial 4
 #define NPY_METH_contiguous_loop 5
 #define NPY_METH_unaligned_strided_loop 6
 #define NPY_METH_unaligned_contiguous_loop 7

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -108,7 +108,6 @@ typedef int (get_loop_function)(
  * Query an ArrayMethod for the initial value for use in reduction.
  *
  * @param context The arraymethod context, mainly to access the descriptors.
- * @param initial Pointer to initial data to be filled (if possible)
  * @param reduction_is_empty Whether the reduction is empty, when it is the
  *     default value is required, otherwise an identity value to start the
  *     the reduction.  These might differ, examples:
@@ -117,14 +116,15 @@ typedef int (get_loop_function)(
  *     - We use no identity for object, but `0` and `1` for sum and prod.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
+ * @param initial Pointer to initial data to be filled (if possible)
  *
  * @returns -1, 0, or 1 indicating error, no initial value, and initial being
  *     successfully filled.  Errors must not be given where 0 is correct, NumPy
  *     may call this even when not strictly necessary.
  */
 typedef int (get_reduction_intial_function)(
-        PyArrayMethod_Context *context, char *initial,
-        npy_bool reduction_is_empty);
+        PyArrayMethod_Context *context, npy_bool reduction_is_empty,
+        char *initial);
 
 /*
  * The following functions are only used be the wrapping array method defined

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -109,11 +109,13 @@ typedef int (get_loop_function)(
  *
  * @param context The arraymethod context, mainly to access the descriptors.
  * @param reduction_is_empty Whether the reduction is empty. When it is, the
- *     default value for the identity might differ, for example:
+ *     value returned may differ.  In this case it is a "default" value that
+ *     may differ from the "identity" value normally used.  For example:
  *     - `0.0` is the default for `sum([])`.  But `-0.0` is the correct
  *       identity otherwise as it preserves the sign for `sum([-0.0])`.
  *     - We use no identity for object, but return the default of `0` and `1`
-         for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
+ *       for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
+ *       This allows `np.sum(np.array(["a", "b"], dtype=object))` to work.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
  * @param initial Pointer to initial data to be filled (if possible)
@@ -226,7 +228,7 @@ typedef struct PyArrayMethodObject_tag {
     PyArray_DTypeMeta **wrapped_dtypes;
     translate_given_descrs_func *translate_given_descrs;
     translate_loop_descrs_func *translate_loop_descrs;
-    /* Chunk used by the legacy fallback arraymethod mainly */
+    /* Chunk reserved for use by the legacy fallback arraymethod */
     char initial[sizeof(npy_clongdouble)];  /* initial value storage */
 } PyArrayMethodObject;
 

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -108,12 +108,12 @@ typedef int (get_loop_function)(
  * Query an ArrayMethod for the initial value for use in reduction.
  *
  * @param context The arraymethod context, mainly to access the descriptors.
- * @param reduction_is_empty Whether the reduction is empty, when it is the
- *     default value is required, otherwise an identity value to start the
- *     the reduction.  These might differ, examples:
- *     - `0.0` as default for `sum([])`.  But `-0.0` would be the correct
- *       identity as it preserves the sign for `sum([-0.0])`.
- *     - We use no identity for object, but `0` and `1` for sum and prod.
+ * @param reduction_is_empty Whether the reduction is empty. When it is, the
+ *     default value for the identity might differ, for example:
+ *     - `0.0` is the default for `sum([])`.  But `-0.0` is the correct
+ *       identity otherwise as it preserves the sign for `sum([-0.0])`.
+ *     - We use no identity for object, but return the default of `0` and `1`
+         for the empty `sum([], dtype=object)` and `prod([], dtype=object)`.
  *     - `-inf` or `INT_MIN` for `max` is an identity, but at least `INT_MIN`
  *       not a good *default* when there are no items.
  * @param initial Pointer to initial data to be filled (if possible)
@@ -122,7 +122,7 @@ typedef int (get_loop_function)(
  *     successfully filled.  Errors must not be given where 0 is correct, NumPy
  *     may call this even when not strictly necessary.
  */
-typedef int (get_reduction_intial_function)(
+typedef int (get_reduction_initial_function)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         char *initial);
 
@@ -215,7 +215,7 @@ typedef struct PyArrayMethodObject_tag {
     NPY_ARRAYMETHOD_FLAGS flags;
     resolve_descriptors_function *resolve_descriptors;
     get_loop_function *get_strided_loop;
-    get_reduction_intial_function  *get_reduction_initial;
+    get_reduction_initial_function  *get_reduction_initial;
     /* Typical loop functions (contiguous ones are used in current casts) */
     PyArrayMethod_StridedLoop *strided_loop;
     PyArrayMethod_StridedLoop *contiguous_loop;
@@ -258,8 +258,9 @@ extern NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type;
  */
 #define NPY_METH_resolve_descriptors 1
 #define NPY_METH_get_loop 2
-#define NPY_METH_strided_loop 3
-#define NPY_METH_get_reduction_initial 4
+#define NPY_METH_get_reduction_initial 3
+/* specific loops for constructions/default get_loop: */
+#define NPY_METH_strided_loop 4
 #define NPY_METH_contiguous_loop 5
 #define NPY_METH_unaligned_strided_loop 6
 #define NPY_METH_unaligned_contiguous_loop 7

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -221,12 +221,12 @@ typedef struct PyArrayMethodObject_tag {
     NPY_ARRAYMETHOD_FLAGS flags;
     resolve_descriptors_function *resolve_descriptors;
     get_loop_function *get_strided_loop;
+    get_identity_function  *get_identity;
     /* Typical loop functions (contiguous ones are used in current casts) */
     PyArrayMethod_StridedLoop *strided_loop;
     PyArrayMethod_StridedLoop *contiguous_loop;
     PyArrayMethod_StridedLoop *unaligned_strided_loop;
     PyArrayMethod_StridedLoop *unaligned_contiguous_loop;
-    get_identity_function  *get_identity;
     /* Chunk only used for wrapping array method defined in umath */
     struct PyArrayMethodObject_tag *wrapped_meth;
     PyArray_DTypeMeta **wrapped_dtypes;
@@ -263,10 +263,10 @@ extern NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type;
 #define NPY_METH_resolve_descriptors 1
 #define NPY_METH_get_loop 2
 #define NPY_METH_strided_loop 3
-#define NPY_METH_contiguous_loop 4
-#define NPY_METH_unaligned_strided_loop 5
-#define NPY_METH_unaligned_contiguous_loop 6
-#define NPY_METH_get_identity 7
+#define NPY_METH_get_identity 4
+#define NPY_METH_contiguous_loop 5
+#define NPY_METH_unaligned_strided_loop 6
+#define NPY_METH_unaligned_contiguous_loop 7
 
 
 /*

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -16,7 +16,7 @@
 #include "common_dtype.h"
 
 
-#define EXPERIMENTAL_DTYPE_API_VERSION 5
+#define EXPERIMENTAL_DTYPE_API_VERSION 6
 
 
 typedef struct{

--- a/numpy/core/src/umath/_scaled_float_dtype.c
+++ b/numpy/core/src/umath/_scaled_float_dtype.c
@@ -447,7 +447,7 @@ sfloat_to_bool_resolve_descriptors(
 
 
 static int
-init_casts(void)
+sfloat_init_casts(void)
 {
     PyArray_DTypeMeta *dtypes[2] = {&PyArray_SFloatDType, &PyArray_SFloatDType};
     PyType_Slot slots[4] = {{0, NULL}};
@@ -697,7 +697,7 @@ translate_loop_descrs(
 
 
 static PyObject *
-get_ufunc(const char *ufunc_name)
+sfloat_get_ufunc(const char *ufunc_name)
 {
     PyObject *mod = PyImport_ImportModule("numpy");
     if (mod == NULL) {
@@ -716,10 +716,10 @@ get_ufunc(const char *ufunc_name)
 
 
 static int
-add_loop(const char *ufunc_name,
+sfloat_add_loop(const char *ufunc_name,
         PyArray_DTypeMeta *dtypes[3], PyObject *meth_or_promoter)
 {
-    PyObject *ufunc = get_ufunc(ufunc_name);
+    PyObject *ufunc = sfloat_get_ufunc(ufunc_name);
     if (ufunc == NULL) {
         return -1;
     }
@@ -742,9 +742,9 @@ add_loop(const char *ufunc_name,
 
 
 static int
-add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
+sfloat_add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
 {
-    PyObject *ufunc = get_ufunc(ufunc_name);
+    PyObject *ufunc = sfloat_get_ufunc(ufunc_name);
     if (ufunc == NULL) {
         return -1;
     }
@@ -786,7 +786,7 @@ promote_to_sfloat(PyUFuncObject *NPY_UNUSED(ufunc),
  * get less so with the introduction of public API).
  */
 static int
-init_ufuncs(void) {
+sfloat_init_ufuncs(void) {
     PyArray_DTypeMeta *dtypes[3] = {
             &PyArray_SFloatDType, &PyArray_SFloatDType, &PyArray_SFloatDType};
     PyType_Slot slots[3] = {{0, NULL}};
@@ -807,7 +807,7 @@ init_ufuncs(void) {
     if (bmeth == NULL) {
         return -1;
     }
-    int res = add_loop("multiply",
+    int res = sfloat_add_loop("multiply",
             bmeth->dtypes, (PyObject *)bmeth->method);
     Py_DECREF(bmeth);
     if (res < 0) {
@@ -825,7 +825,7 @@ init_ufuncs(void) {
     if (bmeth == NULL) {
         return -1;
     }
-    res = add_loop("add",
+    res = sfloat_add_loop("add",
             bmeth->dtypes, (PyObject *)bmeth->method);
     Py_DECREF(bmeth);
     if (res < 0) {
@@ -833,7 +833,7 @@ init_ufuncs(void) {
     }
 
     /* N.B.: Wrapping isn't actually correct if scaling can be negative */
-    if (add_wrapping_loop("hypot", dtypes) < 0) {
+    if (sfloat_add_wrapping_loop("hypot", dtypes) < 0) {
         return -1;
     }
 
@@ -851,14 +851,14 @@ init_ufuncs(void) {
     if (promoter == NULL) {
         return -1;
     }
-    res = add_loop("multiply", promoter_dtypes, promoter);
+    res = sfloat_add_loop("multiply", promoter_dtypes, promoter);
     if (res < 0) {
         Py_DECREF(promoter);
         return -1;
     }
     promoter_dtypes[0] = double_DType;
     promoter_dtypes[1] = &PyArray_SFloatDType;
-    res = add_loop("multiply", promoter_dtypes, promoter);
+    res = sfloat_add_loop("multiply", promoter_dtypes, promoter);
     Py_DECREF(promoter);
     if (res < 0) {
         return -1;
@@ -899,11 +899,11 @@ get_sfloat_dtype(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args))
         return NULL;
     }
 
-    if (init_casts() < 0) {
+    if (sfloat_init_casts() < 0) {
         return NULL;
     }
 
-    if (init_ufuncs() < 0) {
+    if (sfloat_init_ufuncs() < 0) {
         return NULL;
     }
 

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -363,7 +363,7 @@ PyArray_NewLegacyWrappingArrayMethod(PyUFuncObject *ufunc,
         flags = _NPY_METH_FORCE_CAST_INPUTS;
     }
 
-    get_reduction_intial_function *get_reduction_intial = NULL;
+    get_reduction_initial_function *get_reduction_intial = NULL;
     if (ufunc->nin == 2 && ufunc->nout == 1) {
         npy_bool reorderable = NPY_FALSE;
         PyObject *identity_obj = PyUFunc_GetDefaultIdentity(

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -239,7 +239,8 @@ get_wrapped_legacy_ufunc_loop(PyArrayMethod_Context *context,
 
 /*
  * We can shave off a bit of time by just caching the initial and this is
- * trivial for all numeric types.  (Wrapped ufuncs never use byte-swapping.)
+ * trivial for all internal numeric types.  (Wrapped ufuncs never use
+ * byte-swapping.)
  */
 static int
 copy_cached_initial(
@@ -255,10 +256,10 @@ copy_cached_initial(
  * The default `get_reduction_initial` attempts to look up the identity
  * from the calling ufunc.  This might fail, so we only call it when necessary.
  *
- * For our numbers, we can easily cache it, so do so after the first call
- * by overriding the function with `copy_cache_initial`.  This path is not
- * publically available.  That could be added, and for a custom initial getter
- * it will usually be static/compile time data anyway.
+ * For internal number dtypes, we can easily cache it, so do so after the
+ * first call by overriding the function with `copy_cache_initial`.
+ * This path is not publically available.  That could be added, and for a
+ * custom initial getter it should be static/compile time data anyway.
  */
 static int
 get_initial_from_ufunc(

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -246,8 +246,8 @@ copy_cached_initial(
         PyArrayMethod_Context *context, char *initial,
         npy_bool NPY_UNUSED(reduction_is_empty))
 {
-    memcpy(initial, context->method->initial, sizeof(context->descriptors[0]->elsize));
-    return 0;
+    memcpy(initial, context->method->initial, context->descriptors[0]->elsize);
+    return 1;
 }
 
 
@@ -279,7 +279,7 @@ get_initial_from_ufunc(
         Py_DECREF(identity_obj);
         return 0;
     }
-    if (PyTypeNum_ISUNSIGNED(context->descriptors[0]->type_num)
+    if (PyTypeNum_ISUNSIGNED(context->descriptors[1]->type_num)
             && PyLong_CheckExact(identity_obj)) {
         /*
          * This is a bit of a hack until we have truly loop specific
@@ -297,7 +297,7 @@ get_initial_from_ufunc(
     }
     else if (context->descriptors[0]->type_num == NPY_OBJECT
             && !reduction_is_empty) {
-        /* Allow `sum([object()])` to work, but use 0 when empty */
+        /* Allows `sum([object()])` to work, but use 0 when empty. */
         Py_DECREF(identity_obj);
         return 0;
     }
@@ -309,7 +309,7 @@ get_initial_from_ufunc(
     }
 
     if (PyTypeNum_ISNUMBER(context->descriptors[0]->type_num)) {
-        /* From now on, simply use the cached version */
+        /* For numbers we can cache to avoid going via Python ints */
         memcpy(context->method->initial, initial, context->descriptors[0]->elsize);
         context->method->get_reduction_initial = &copy_cached_initial;
     }

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -274,7 +274,7 @@ get_initial_from_ufunc(
         return -1;
     }
     npy_bool reorderable;
-    PyObject *identity_obj = PyUFunc_GetIdentity(
+    PyObject *identity_obj = PyUFunc_GetDefaultIdentity(
             (PyUFuncObject *)context->caller, &reorderable);
     if (identity_obj == NULL) {
         return -1;
@@ -366,7 +366,8 @@ PyArray_NewLegacyWrappingArrayMethod(PyUFuncObject *ufunc,
     get_reduction_intial_function *get_reduction_intial = NULL;
     if (ufunc->nin == 2 && ufunc->nout == 1) {
         npy_bool reorderable = NPY_FALSE;
-        PyObject *identity_obj = PyUFunc_GetIdentity(ufunc, &reorderable);
+        PyObject *identity_obj = PyUFunc_GetDefaultIdentity(
+                ufunc, &reorderable);
         if (identity_obj == NULL) {
             return NULL;
         }

--- a/numpy/core/src/umath/legacy_array_method.c
+++ b/numpy/core/src/umath/legacy_array_method.c
@@ -247,7 +247,8 @@ copy_cached_initial(
         PyArrayMethod_Context *context, npy_bool NPY_UNUSED(reduction_is_empty),
         char *initial)
 {
-    memcpy(initial, context->method->initial, context->descriptors[0]->elsize);
+    memcpy(initial, context->method->legacy_initial,
+           context->descriptors[0]->elsize);
     return 1;
 }
 
@@ -316,7 +317,8 @@ get_initial_from_ufunc(
 
     if (PyTypeNum_ISNUMBER(context->descriptors[0]->type_num)) {
         /* For numbers we can cache to avoid going via Python ints */
-        memcpy(context->method->initial, initial, context->descriptors[0]->elsize);
+        memcpy(context->method->legacy_initial, initial,
+               context->descriptors[0]->elsize);
         context->method->get_reduction_initial = &copy_cached_initial;
     }
 

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -292,9 +292,11 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     result = NpyIter_GetOperandArray(iter)[0];
 
     /*
-     * Get the initial value (if it may exists).  If the iteration is empty
-     * then we assume the reduction is (in the other case, we do not need
-     * the initial value anyway).
+     * Get the initial value (if it exists).  If the iteration is empty
+     * then we assume the reduction is also empty.  The reason is that when
+     * the outer iteration is empty we just won't use the initial value
+     * in any case.  (`np.sum(np.zeros((0, 3)), axis=0)` is a length 3
+     * reduction but has an empty result.)
      */
     if ((initial == NULL && context->method->get_reduction_initial == NULL)
             || initial == Py_None) {

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -149,9 +149,7 @@ PyArray_CopyInitialReduceValues(
  * context     : The ArrayMethod context (with ufunc, method, and descriptors).
  * operand     : The array to be reduced.
  * out         : NULL, or the array into which to place the result.
- * wheremask   : NOT YET SUPPORTED, but this parameter is placed here
- *               so that support can be added in the future without breaking
- *               API compatibility. Pass in NULL.
+ * wheremask   : Reduction mask of valid values used for `where=`.
  * axis_flags  : Flags indicating the reduction axes of 'operand'.
  * keepdims    : If true, leaves the reduction dimensions in the result
  *               with size one.
@@ -160,7 +158,6 @@ PyArray_CopyInitialReduceValues(
  * initial     : Initial value, if NULL the default is fetched from the
  *               ArrayMethod (typically as the default from the ufunc).
  * loop        : `reduce_loop` from `ufunc_object.c`.  TODO: Refactor
- * data        : Data which is passed to the inner loop.
  * buffersize  : Buffer size for the iterator. For the default, pass in 0.
  * funcname    : The name of the reduction function, for error messages.
  * errormask   : forwarded from _get_bufsize_errmask

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -6,7 +6,6 @@
  *
  * See LICENSE.txt for the license.
  */
-#include "array_method.h"
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #define _UMATHMODULE
@@ -20,6 +19,7 @@
 #include "npy_pycompat.h"
 #include "array_assign.h"
 #include "array_coercion.h"
+#include "array_method.h"
 #include "ctors.h"
 
 #include "numpy/ufuncobject.h"

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -319,12 +319,12 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
              * empty when the iteration is.  This may be wrong, but when it is,
              * we will not need the identity as the result is also empty.
              */
-            int res = context->method->get_reduction_initial(
+            int has_initial = context->method->get_reduction_initial(
                     context, initial_buf, empty_iteration);
-            if (res < 0) {
+            if (has_initial < 0) {
                 goto fail;
             }
-            if (!res) {
+            if (!has_initial) {
                 /* We have no initial value available, free buffer to indicate */
                 PyMem_FREE(initial_buf);
                 initial_buf = NULL;

--- a/numpy/core/src/umath/reduction.c
+++ b/numpy/core/src/umath/reduction.c
@@ -320,7 +320,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
              * we will not need the identity as the result is also empty.
              */
             int has_initial = context->method->get_reduction_initial(
-                    context, initial_buf, empty_iteration);
+                    context, empty_iteration, initial_buf);
             if (has_initial < 0) {
                 goto fail;
             }

--- a/numpy/core/src/umath/reduction.h
+++ b/numpy/core/src/umath/reduction.h
@@ -64,8 +64,8 @@ typedef int (PyArray_ReduceLoopFunc)(PyArrayMethod_Context *context,
 NPY_NO_EXPORT PyArrayObject *
 PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         PyArrayObject *operand, PyArrayObject *out, PyArrayObject *wheremask,
-        npy_bool *axis_flags, int reorderable, int keepdims,
-        PyObject *identity, PyArray_ReduceLoopFunc *loop,
-        void *data, npy_intp buffersize, const char *funcname, int errormask);
+        npy_bool *axis_flags, int keepdims,
+        PyObject *initial, PyArray_ReduceLoopFunc *loop,
+        npy_intp buffersize, const char *funcname, int errormask);
 
 #endif

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -2093,7 +2093,7 @@ _get_coredim_sizes(PyUFuncObject *ufunc, PyArrayObject **op,
  *       constructing one each time
  */
 NPY_NO_EXPORT PyObject *
-PyUFunc_GetIdentity(PyUFuncObject *ufunc, npy_bool *reorderable)
+PyUFunc_GetDefaultIdentity(PyUFuncObject *ufunc, npy_bool *reorderable)
 {
     switch(ufunc->identity) {
     case PyUFunc_One:
@@ -6974,7 +6974,7 @@ static PyObject *
 ufunc_get_identity(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     npy_bool reorderable;
-    return PyUFunc_GetIdentity(ufunc, &reorderable);
+    return PyUFunc_GetDefaultIdentity(ufunc, &reorderable);
 }
 
 static PyObject *

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -3053,7 +3053,6 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
             arr, out, wheremask, axis_flags, keepdims,
             initial, reduce_loop, buffersize, ufunc_name, errormask);
 
-  finish:
     for (int i = 0; i < 3; i++) {
         Py_DECREF(descrs[i]);
     }

--- a/numpy/core/src/umath/ufunc_object.h
+++ b/numpy/core/src/umath/ufunc_object.h
@@ -13,7 +13,7 @@ NPY_NO_EXPORT const char*
 ufunc_get_name_cstr(PyUFuncObject *ufunc);
 
 NPY_NO_EXPORT PyObject *
-PyUFunc_GetIdentity(PyUFuncObject *ufunc, npy_bool *reorderable);
+PyUFunc_GetDefaultIdentity(PyUFuncObject *ufunc, npy_bool *reorderable);
 
 /* strings from umathmodule.c that are interned on umath import */
 NPY_VISIBILITY_HIDDEN extern PyObject *npy_um_str_array_ufunc;

--- a/numpy/core/src/umath/ufunc_object.h
+++ b/numpy/core/src/umath/ufunc_object.h
@@ -12,6 +12,9 @@ ufunc_seterr(PyObject *NPY_UNUSED(dummy), PyObject *args);
 NPY_NO_EXPORT const char*
 ufunc_get_name_cstr(PyUFuncObject *ufunc);
 
+NPY_NO_EXPORT PyObject *
+PyUFunc_GetIdentity(PyUFuncObject *ufunc, npy_bool *reorderable);
+
 /* strings from umathmodule.c that are interned on umath import */
 NPY_VISIBILITY_HIDDEN extern PyObject *npy_um_str_array_ufunc;
 NPY_VISIBILITY_HIDDEN extern PyObject *npy_um_str_array_prepare;

--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -177,6 +177,38 @@ wrapping_method_get_loop(
 }
 
 
+/*
+ * Wraps the original identity function, needs to translate the descriptors
+ * back to the original ones and provide an "original" context (identically to
+ * `get_loop`).
+ * We assume again that translating the descriptors is quick.
+ */
+static int
+wrapping_method_get_identity_function(PyArrayMethod_Context *context,
+        char *item, NPY_ARRAYMETHOD_IDENTITY_FLAGS *flags)
+{
+    /* Copy the context, and replace descriptors: */
+    PyArrayMethod_Context orig_context = *context;
+    PyArray_Descr *orig_descrs[NPY_MAXARGS];
+    orig_context.descriptors = orig_descrs;
+    orig_context.method = context->method->wrapped_meth;
+
+    int nin = context->method->nin, nout = context->method->nout;
+    PyArray_DTypeMeta **dtypes = context->method->wrapped_dtypes;
+
+    if (context->method->translate_given_descrs(
+            nin, nout, dtypes, context->descriptors, orig_descrs) < 0) {
+        return -1;
+    }
+    int res = context->method->wrapped_meth->get_identity(&orig_context,
+            item, flags);
+    for (int i = 0; i < nin + nout; i++) {
+        Py_DECREF(orig_descrs);
+    }
+    return res;
+}
+
+
 /**
  * Allows creating of a fairly lightweight wrapper around an existing ufunc
  * loop.  The idea is mainly for units, as this is currently slightly limited
@@ -243,6 +275,7 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     PyType_Slot slots[] = {
         {NPY_METH_resolve_descriptors, &wrapping_method_resolve_descriptors},
         {NPY_METH_get_loop, &wrapping_method_get_loop},
+        {NPY_METH_get_identity, &wrapping_method_get_identity_function},
         {0, NULL}
     };
 

--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -184,8 +184,9 @@ wrapping_method_get_loop(
  * We assume again that translating the descriptors is quick.
  */
 static int
-wrapping_method_get_identity_function(PyArrayMethod_Context *context,
-        char *item, NPY_ARRAYMETHOD_REDUCTION_FLAGS *flags)
+wrapping_method_get_identity_function(
+        PyArrayMethod_Context *context, char *item,
+        npy_bool reduction_is_empty)
 {
     /* Copy the context, and replace descriptors: */
     PyArrayMethod_Context orig_context = *context;
@@ -201,7 +202,7 @@ wrapping_method_get_identity_function(PyArrayMethod_Context *context,
         return -1;
     }
     int res = context->method->wrapped_meth->get_reduction_initial(
-            &orig_context, item, flags);
+            &orig_context, item, reduction_is_empty);
     for (int i = 0; i < nin + nout; i++) {
         Py_DECREF(orig_descrs);
     }

--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -185,7 +185,7 @@ wrapping_method_get_loop(
  */
 static int
 wrapping_method_get_identity_function(PyArrayMethod_Context *context,
-        char *item, NPY_ARRAYMETHOD_IDENTITY_FLAGS *flags)
+        char *item, NPY_ARRAYMETHOD_REDUCTION_FLAGS *flags)
 {
     /* Copy the context, and replace descriptors: */
     PyArrayMethod_Context orig_context = *context;
@@ -200,8 +200,8 @@ wrapping_method_get_identity_function(PyArrayMethod_Context *context,
             nin, nout, dtypes, context->descriptors, orig_descrs) < 0) {
         return -1;
     }
-    int res = context->method->wrapped_meth->get_identity(&orig_context,
-            item, flags);
+    int res = context->method->wrapped_meth->get_reduction_initial(
+            &orig_context, item, flags);
     for (int i = 0; i < nin + nout; i++) {
         Py_DECREF(orig_descrs);
     }
@@ -275,7 +275,8 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     PyType_Slot slots[] = {
         {NPY_METH_resolve_descriptors, &wrapping_method_resolve_descriptors},
         {NPY_METH_get_loop, &wrapping_method_get_loop},
-        {NPY_METH_get_identity, &wrapping_method_get_identity_function},
+        {NPY_METH_get_reduction_initial,
+            &wrapping_method_get_identity_function},
         {0, NULL}
     };
 

--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -185,8 +185,8 @@ wrapping_method_get_loop(
  */
 static int
 wrapping_method_get_identity_function(
-        PyArrayMethod_Context *context, char *item,
-        npy_bool reduction_is_empty)
+        PyArrayMethod_Context *context, npy_bool reduction_is_empty,
+        char *item)
 {
     /* Copy the context, and replace descriptors: */
     PyArrayMethod_Context orig_context = *context;
@@ -202,7 +202,7 @@ wrapping_method_get_identity_function(
         return -1;
     }
     int res = context->method->wrapped_meth->get_reduction_initial(
-            &orig_context, item, reduction_is_empty);
+            &orig_context, reduction_is_empty, item);
     for (int i = 0; i < nin + nout; i++) {
         Py_DECREF(orig_descrs);
     }

--- a/numpy/core/tests/test_custom_dtypes.py
+++ b/numpy/core/tests/test_custom_dtypes.py
@@ -202,3 +202,19 @@ class TestSFloat:
         # The output casting does not match the bool, bool -> bool loop:
         with pytest.raises(TypeError):
             ufunc(a, a, out=np.empty(a.shape, dtype=int), casting="equiv")
+
+    def test_wrapped_and_wrapped_reductions(self):
+        a = self._get_array(2.)
+        float_equiv = a.astype(float)
+
+        expected = np.hypot(float_equiv, float_equiv)
+        res = np.hypot(a, a)
+        assert res.dtype == a.dtype
+        res_float = res.view(np.float64) * 2
+        assert_array_equal(res_float, expected)
+
+        # Also check reduction (keepdims, due to incorrect getitem)
+        res = np.hypot.reduce(a, keepdims=True)
+        assert res.dtype == a.dtype
+        expected = np.hypot.reduce(float_equiv, keepdims=True)
+        assert res.view(np.float64) * 2 == expected

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1683,7 +1683,8 @@ class TestUfunc:
         assert_raises(ValueError, np.minimum.reduce, [], initial=None)
         assert_raises(ValueError, np.add.reduce, [], initial=None)
         # Also in the somewhat special object case:
-        assert_raises(ValueError, np.add.reduce, [], initial=None, dtype=object)
+        with pytest.raises(ValueError):
+            np.add.reduce([], initial=None, dtype=object)
 
         # Check that np._NoValue gives default behavior.
         assert_equal(np.add.reduce([], initial=np._NoValue), 0)
@@ -1692,6 +1693,18 @@ class TestUfunc:
         a = np.array([10], dtype=object)
         res = np.add.reduce(a, initial=5)
         assert_equal(res, 15)
+
+    def test_empty_reduction_and_idenity(self):
+        arr = np.zeros((0, 5))
+        # OK, since the reduction itself is *not* empty, the result is
+        assert np.true_divide.reduce(arr, axis=1).shape == (0,)
+        # Not OK, the reduction itself is empty and we have no idenity
+        with pytest.raises(ValueError):
+            np.true_divide.reduce(arr, axis=0)
+        # Test that an empty reduction fails also if the result is empty
+        arr = np.zeros((0, 0, 5))
+        with pytest.raises(ValueError):
+            np.true_divide.reduce(arr, axis=1)
 
     @pytest.mark.parametrize('axis', (0, 1, None))
     @pytest.mark.parametrize('where', (np.array([False, True, True]),


### PR DESCRIPTION
This also fixes/changes that the identity value is defined by the
reduce dtype and not by the result dtype.  That does not make a
different in any sane use-case, but there is a theoretical change:

    arr = np.array([])
    out = np.array(None)  # object array
    np.add.reduce(arr, out=out, dtype=np.float64)

Where the output result was previously an integer 0, due to the
output being of `object` dtype, but now it is the correct float
due to the _operation_ being done in `float64`, so that the output
should be `np.zeros((), dtype=np.float64).astype(object)`.

---

This is a requirement for more advanced DTypes to pick a reasonable loop.  E.g. a if there was a reduce for a structured dtype, the structured dtypes default/initial element is unlikely to fill in from a 0.
Another example is the physical unit, that may reject casting `0` to `0 meters`, but needs the `0 meters` as identity.


(Note that depending on the order of merges, the wrapping array-method stuff requires a specialized version here to make my Unit dtype reductions work.)