### PR TITLE
DOC: switch Python intersphinx link from dev to stable.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -297,7 +297,7 @@ texinfo_documents = [
 # -----------------------------------------------------------------------------
 intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
-    'python': ('https://docs.python.org/dev', None),
+    'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),


### PR DESCRIPTION
Something I noticed while reviewing #20972 - it looks like the intersphinx mapping for Python points to the development documentation rather than the latest stable release. This means any links to the Python docs that we currently have are actually pointing to the 3.11 docs, not Python 3.10 (this is indicated if you hover over a link). For example, hover over the `range` in the [Notes on the range example in the numpy for matlab users doc](https://numpy.org/doc/stable/user/numpy-for-matlab-users.html#general-purpose-equivalents).