### PR TITLE
MAINT: refactor NonNull in API functions

### DIFF
--- a/numpy/core/code_generators/genapi.py
+++ b/numpy/core/code_generators/genapi.py
@@ -92,17 +92,6 @@ class StealRef:
             return 'NPY_STEALS_REF_TO_ARG(%d)' % self.arg
 
 
-class NonNull:
-    def __init__(self, arg):
-        self.arg = arg # counting from 1
-
-    def __str__(self):
-        try:
-            return ' '.join('NPY_GCC_NONNULL(%d)' % x for x in self.arg)
-        except TypeError:
-            return 'NPY_GCC_NONNULL(%d)' % self.arg
-
-
 class Function:
     def __init__(self, name, return_type, args, doc=''):
         self.name = name

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -13,7 +13,7 @@ When adding a function, make sure to use the next integer not used as an index
 exception, so it should hopefully not get unnoticed).
 
 """
-from code_generators.genapi import StealRef, NonNull
+from code_generators.genapi import StealRef
 
 # index, type
 multiarray_global_vars = {
@@ -92,7 +92,7 @@ multiarray_funcs_api = {
     'PyArray_TypeObjectFromType':           (46,),
     'PyArray_Zero':                         (47,),
     'PyArray_One':                          (48,),
-    'PyArray_CastToType':                   (49, StealRef(2), NonNull(2)),
+    'PyArray_CastToType':                   (49, StealRef(2)),
     'PyArray_CastTo':                       (50,),
     'PyArray_CastAnyTo':                    (51,),
     'PyArray_CanCastSafely':                (52,),
@@ -120,15 +120,15 @@ multiarray_funcs_api = {
     'PyArray_FromBuffer':                   (74,),
     'PyArray_FromIter':                     (75, StealRef(2)),
     'PyArray_Return':                       (76, StealRef(1)),
-    'PyArray_GetField':                     (77, StealRef(2), NonNull(2)),
-    'PyArray_SetField':                     (78, StealRef(2), NonNull(2)),
+    'PyArray_GetField':                     (77, StealRef(2)),
+    'PyArray_SetField':                     (78, StealRef(2)),
     'PyArray_Byteswap':                     (79,),
     'PyArray_Resize':                       (80,),
     'PyArray_MoveInto':                     (81,),
     'PyArray_CopyInto':                     (82,),
     'PyArray_CopyAnyInto':                  (83,),
     'PyArray_CopyObject':                   (84,),
-    'PyArray_NewCopy':                      (85, NonNull(1)),
+    'PyArray_NewCopy':                      (85,),
     'PyArray_ToList':                       (86,),
     'PyArray_ToString':                     (87,),
     'PyArray_ToFile':                       (88,),
@@ -136,8 +136,8 @@ multiarray_funcs_api = {
     'PyArray_Dumps':                        (90,),
     'PyArray_ValidType':                    (91,),
     'PyArray_UpdateFlags':                  (92,),
-    'PyArray_New':                          (93, NonNull(1)),
-    'PyArray_NewFromDescr':                 (94, StealRef(2), NonNull([1, 2])),
+    'PyArray_New':                          (93,),
+    'PyArray_NewFromDescr':                 (94, StealRef(2)),
     'PyArray_DescrNew':                     (95,),
     'PyArray_DescrNewFromType':             (96,),
     'PyArray_GetPriority':                  (97,),
@@ -318,7 +318,7 @@ multiarray_funcs_api = {
     'PyArray_CanCastArrayTo':               (274,),
     'PyArray_CanCastTypeTo':                (275,),
     'PyArray_EinsteinSum':                  (276,),
-    'PyArray_NewLikeArray':                 (277, StealRef(3), NonNull(1)),
+    'PyArray_NewLikeArray':                 (277, StealRef(3)),
     'PyArray_GetArrayParamsFromObject':     (278,),
     'PyArray_ConvertClipmodeSequence':      (279,),
     'PyArray_MatrixProduct2':               (280,),
@@ -344,7 +344,7 @@ multiarray_funcs_api = {
     'PyDataMem_NEW_ZEROED':                 (299,),
     # End 1.8 API
     # End 1.9 API
-    'PyArray_CheckAnyScalarExact':          (300, NonNull(1)),
+    'PyArray_CheckAnyScalarExact':          (300,),
     # End 1.10 API
     'PyArray_MapIterArrayCopyIfOverlap':    (301,),
     # End 1.13 API

--- a/numpy/core/src/multiarray/convert.c
+++ b/numpy/core/src/multiarray/convert.c
@@ -544,6 +544,12 @@ PyArray_NewCopy(PyArrayObject *obj, NPY_ORDER order)
 {
     PyArrayObject *ret;
 
+    if (obj == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "obj is NULL in PyArray_NewCopy");
+        return NULL;
+    }
+
     ret = (PyArrayObject *)PyArray_NewLikeArray(obj, order, NULL, 1);
     if (ret == NULL) {
         return NULL;

--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -245,6 +245,12 @@ PyArray_CastToType(PyArrayObject *arr, PyArray_Descr *dtype, int is_f_order)
 {
     PyObject *out;
 
+    if (dtype == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "dtype is NULL in PyArray_CastToType");
+        return NULL;
+    }
+
     Py_SETREF(dtype, PyArray_AdaptDescriptorToArray(arr, (PyObject *)dtype));
     if (dtype == NULL) {
         return NULL;

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -958,6 +958,18 @@ PyArray_NewFromDescr(
         int nd, npy_intp const *dims, npy_intp const *strides, void *data,
         int flags, PyObject *obj)
 {
+    if (subtype == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "subtype is NULL in PyArray_NewFromDescr");
+        return NULL;
+    }
+
+    if (descr == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "descr is NULL in PyArray_NewFromDescr");
+        return NULL;
+    }
+
     return PyArray_NewFromDescrAndBase(
             subtype, descr,
             nd, dims, strides, data,
@@ -1110,6 +1122,11 @@ NPY_NO_EXPORT PyObject *
 PyArray_NewLikeArray(PyArrayObject *prototype, NPY_ORDER order,
                      PyArray_Descr *dtype, int subok)
 {
+    if (prototype == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "prototype is NULL in PyArray_NewLikeArray");
+        return NULL;
+    }
     return PyArray_NewLikeArrayWithShape(prototype, order, dtype, -1, NULL, subok);
 }
 
@@ -1124,6 +1141,12 @@ PyArray_New(
 {
     PyArray_Descr *descr;
     PyObject *new;
+
+    if (subtype == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "subtype is NULL in PyArray_New");
+        return NULL;
+    }
 
     descr = PyArray_DescrFromType(type_num);
     if (descr == NULL) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -379,6 +379,18 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
     static PyObject *checkfunc = NULL;
     int self_elsize, typed_elsize;
 
+    if (self == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "self is NULL in PyArray_GetField");
+        return NULL;
+    }
+
+    if (typed == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "typed is NULL in PyArray_GetField");
+        return NULL;
+    }
+
     /* check that we are not reinterpreting memory containing Objects. */
     if (_may_have_objects(PyArray_DESCR(self)) || _may_have_objects(typed)) {
         npy_cache_import("numpy.core._internal", "_getfield_is_safe",
@@ -456,6 +468,18 @@ PyArray_SetField(PyArrayObject *self, PyArray_Descr *dtype,
 {
     PyObject *ret = NULL;
     int retval = 0;
+
+    if (self == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "self is NULL in PyArray_SetField");
+        return NULL;
+    }
+
+    if (dtype == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "dtype is NULL in PyArray_SetField");
+        return NULL;
+    }
 
     if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {
         Py_DECREF(dtype);

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -472,13 +472,13 @@ PyArray_SetField(PyArrayObject *self, PyArray_Descr *dtype,
     if (self == NULL) {
         PyErr_SetString(PyExc_ValueError,
             "self is NULL in PyArray_SetField");
-        return NULL;
+        return -1;
     }
 
     if (dtype == NULL) {
         PyErr_SetString(PyExc_ValueError,
             "dtype is NULL in PyArray_SetField");
-        return NULL;
+        return -1;
     }
 
     if (PyArray_FailUnlessWriteable(self, "assignment destination") < 0) {

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -187,6 +187,12 @@ scalar_value(PyObject *scalar, PyArray_Descr *descr)
 NPY_NO_EXPORT int
 PyArray_CheckAnyScalarExact(PyObject * obj)
 {
+    if (obj == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+            "obj is NULL in PyArray_CheckAnyScalarExact");
+        return NULL;
+    }
+
     return is_anyscalar_exact(obj);
 }
 

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -182,7 +182,7 @@ scalar_value(PyObject *scalar, PyArray_Descr *descr)
 }
 
 /*NUMPY_API
- * return true an object is exactly a numpy scalar
+ * return 1 if an object is exactly a numpy scalar
  */
 NPY_NO_EXPORT int
 PyArray_CheckAnyScalarExact(PyObject * obj)
@@ -190,7 +190,7 @@ PyArray_CheckAnyScalarExact(PyObject * obj)
     if (obj == NULL) {
         PyErr_SetString(PyExc_ValueError,
             "obj is NULL in PyArray_CheckAnyScalarExact");
-        return NULL;
+        return 0;
     }
 
     return is_anyscalar_exact(obj);


### PR DESCRIPTION
Continuation of PR #20960 

Using the NonNull class in the API interface emits a gcc-only compiler directive
```
__attribute__((nonnull(n))
```

which will emit a compile-time warning when NULL is passed in. This is problematic since
- people ignore compile-time warnings
- it does not protect runtime use of NULL by non-gcc and non-compiler calls, for instance ctypes or other foreign-function interfaces

This PR replaces the use of NonNull with actual parameter sanitation in the functions. I don't think the performance hit by internal calls will be measurable, but if so we could replace internal use with helper functions that avoid the checks. For instance, we could avoid calling `PyArray_NewFromDescr`` with `PyArray_NewFromDescrAndBase`.