### PR TITLE
BUG: Fix misplaced return

### DIFF
--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -3023,9 +3023,9 @@ init_cast_info(
         if (!PyErr_Occurred()) {
             PyErr_Format(PyExc_TypeError,
                     "Cannot cast array data from %R to %R.", src_dtype, dst_dtype);
-            Py_DECREF(meth);
-            return -1;
         }
+        Py_DECREF(meth);
+        return -1;
     }
     assert(PyArray_DescrCheck(cast_info->descriptors[0]));
     assert(PyArray_DescrCheck(cast_info->descriptors[1]));


### PR DESCRIPTION
This lead to crashes when casting failed with an error already set.
Internally to NumPy, this is exceedingly rare (maybe impossible aside
from catastrophic failures, such as out-of-memory).

---

No test, because I am pretty sure the only way to hit this within NumPy proper is through impossible errors.

(On the other hand the Unit dtype runs into this very quickly.)