### PR TITLE
MAINT: use brackets in github action syntax

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -152,7 +152,7 @@ jobs:
             echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
           fi
       - name: Upload wheels
-        if: env.TOKEN 
+        if: ${{ env.TOKEN }}
         shell: bash
         run: |
           # trigger an upload to


### PR DESCRIPTION
Fix triggering the wheel upload step in the wheel building github action. I [tested this](https://github.com/mattip/numpy/runs/5063574812?check_suite_focus=true) in my fork (using an invalid token so uploads failed)