### PR TITLE
ENH: help compilers to auto-vectorize reduction operators

### DIFF
--- a/doc/release/upcoming_changes/21001.performance.rst
+++ b/doc/release/upcoming_changes/21001.performance.rst
@@ -1,0 +1,3 @@
+Faster reduction operators
+---------------------
+Reduction operations like `numpy.sum`, `numpy.prod`, `numpy.add.reduce`, `numpy.logical_and.reduce` on contiguous integer-based arrays are now much faster.

--- a/doc/release/upcoming_changes/21001.performance.rst
+++ b/doc/release/upcoming_changes/21001.performance.rst
@@ -1,3 +1,5 @@
 Faster reduction operators
----------------------
-Reduction operations like `numpy.sum`, `numpy.prod`, `numpy.add.reduce`, `numpy.logical_and.reduce` on contiguous integer-based arrays are now much faster.
+--------------------------
+Reduction operations like `numpy.sum`, `numpy.prod`, `numpy.add.reduce`, 
+`numpy.logical_and.reduce` on contiguous integer-based arrays are now 
+much faster.

--- a/numpy/core/src/umath/fast_loop_macros.h
+++ b/numpy/core/src/umath/fast_loop_macros.h
@@ -103,6 +103,9 @@ abs_ptrdiff(char *a, char *b)
         && (steps[0] == steps[2])\
         && (steps[0] == 0))
 
+/* input contiguous (for binary reduces only) */
+#define IS_BINARY_REDUCE_INPUT_CONT(tin) (steps[1] == sizeof(tin))
+
 /* binary loop input and output contiguous */
 #define IS_BINARY_CONT(tin, tout) (steps[0] == sizeof(tin) && \
                                    steps[1] == sizeof(tin) && \
@@ -251,6 +254,34 @@ abs_ptrdiff(char *a, char *b)
     char *iop1 = args[0]; \
     TYPE io1 = *(TYPE *)iop1; \
     BINARY_REDUCE_LOOP_INNER
+
+/*
+ * op should be the code working on `TYPE in2` and
+ * reading/storing the result in `TYPE *io1`
+ */
+#define BASE_BINARY_REDUCE_LOOP(TYPE, op) \
+    BINARY_REDUCE_LOOP_INNER { \
+        const TYPE in2 = *(TYPE *)ip2; \
+        op; \
+    }
+
+#define BINARY_REDUCE_LOOP_FAST_INNER(TYPE, op)\
+    /* condition allows compiler to optimize the generic macro */ \
+    if(IS_BINARY_REDUCE_INPUT_CONT(TYPE)) { \
+        BASE_BINARY_REDUCE_LOOP(TYPE, op) \
+    } \
+    else { \
+        BASE_BINARY_REDUCE_LOOP(TYPE, op) \
+    }
+
+#define BINARY_REDUCE_LOOP_FAST(TYPE, op)\
+    do { \
+        char *iop1 = args[0]; \
+        TYPE io1 = *(TYPE *)iop1; \
+        BINARY_REDUCE_LOOP_FAST_INNER(TYPE, op); \
+        *((TYPE *)iop1) = io1; \
+    } \
+    while (0)
 
 #define IS_BINARY_STRIDE_ONE(esize, vsize) \
     ((steps[0] == esize) && \

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -636,10 +636,7 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
 @TYPE@_@kind@@isa@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     if (IS_BINARY_REDUCE) {
-        BINARY_REDUCE_LOOP(@type@) {
-            io1 @OP@= *(@type@ *)ip2;
-        }
-        *((@type@ *)iop1) = io1;
+        BINARY_REDUCE_LOOP_FAST(@type@, io1 @OP@= in2);
     }
     else {
         BINARY_LOOP_FAST(@type@, @type@, *out = in1 @OP@ in2);


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Hello everyone,

This PR is meant to significantly improve the performance of reduction functions (like `numpy.sum` for example): **from 2.6 to 20 times faster**. It also improves the performance of the casting function used by many Numpy functions. These changes are in response to [this](https://stackoverflow.com/questions/70134026/no-speedup-when-summing-uint16-vs-uint64-arrays-with-numpy/70136429#70136429) Stack Overflow detailed analysis showing that the current code of `numpy.sum` does not benefit from SIMD instructions (with both integers an floating-point numbers).

The PR changes the macros so the compiler can generate a faster code for reductions when the array is contiguous in a way that is similar to the current code in basic operators. It also generates an AVX2 version (if supported) of the conversion function called when the `dtype` of the reduction result type does not match with the one of the array items.

Please find below the performance results of `numpy.sum` with an array of 1 MiB on my Linux machine with an Intel i5-9600KF processor. The tests have been made for all the available integer types with and without a custom `dtype` argument set to the array `dtype` value (it is either `int64` or `uint64` by default on my machine).

```
Old:
    Default dtype argument:
        int8:    687 µs ± 4.15 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint8:   661 µs ± 2.92 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int16:   346 µs ± 1.49 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint16:  368 µs ± 3.64 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int32:   152 µs ± 1.48 µs per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint32:  196 µs ± 638 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        int64:   52.4 µs ± 120 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint64:  52.9 µs ± 521 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)

    Custom dtype argument:
        int8:    404 µs ± 3.81 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint8:   408 µs ± 751 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int16:   203 µs ± 1.46 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint16:  203 µs ± 1.97 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int32:   102 µs ± 551 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint32:  102 µs ± 438 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        int64:   52.7 µs ± 338 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint64:  52.9 µs ± 382 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)

New:
    Default dtype argument:
        int8:    263 µs ± 1.94 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint8:   248 µs ± 2.05 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int16:   120 µs ± 1.73 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint16:  116 µs ± 394 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int32:   58.7 µs ± 425 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint32:  58.6 µs ± 759 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        int64:   17.1 µs ± 130 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint64:  16.9 µs ± 291 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)

    Custom dtype argument:
        int8:    21.7 µs ± 246 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint8:   20.8 µs ± 233 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int16:   18.1 µs ± 170 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        uint16:  18.1 µs ± 230 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
        int32:   17.6 µs ± 83.9 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint32:  17.9 µs ± 109 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        int64:   16.9 µs ± 117 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)
        uint64:  17.4 µs ± 246 ns per loop (mean ± std. dev. of 7 runs, 4000 loops each)

Speed up (ie. New/old):
    Default dtype argument:
        int8:     2.61
        uint8:    2.67
        int16:    2.88
        uint16:   3.17
        int32:    2.59
        uint32:   3.34
        int64:    3.06
        uint64:   3.13

    Custom dtype argument:
        int8:    18.61
        uint8:   19.61
        int16:   11.21
        uint16:  11.21
        int32:    5.80
        uint32:   5.70
        int64:    3.12
        uint64:   3.04
```

As you can see, it significantly improves the execution time (by a factor up to ~20x). This is especially the case when a `dtype` argument is provided since a (slow sub-optimal) conversion function is applied otherwise (as described in the above detailed analysis link).

Similar improvements applies to functions like `np.prod`, `np.add.reduce`, `np.subtract.reduce`, `np.logical_and.reduce`, etc.
It turns out that improving the casting function also results in a substantial faster execution time of many functions like `np.cumsum`, `np.cumprod`, `np.all` and `np.any`. Even functions like `np.average`, `np.mean` or basic multiplications/additions/subtractions by a constant of a different type requiring the array to be casted are a bit faster with an AVX2 casting function.