### PR TITLE
BUG: Add parameter check to negative_binomial

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3037,26 +3037,21 @@ cdef class Generator:
             max_lam_arr = (1 - p_arr) / p_arr * (n_arr + 10 * np.sqrt(n_arr))
             if np.any(np.greater(max_lam_arr, POISSON_LAM_MAX)):
                 raise ValueError("n too large or p too small")
+        else:
+            _dp = PyFloat_AsDouble(p)
+            _in = PyFloat_AsDouble(n)
 
-            return disc(&random_negative_binomial, &self._bitgen, size, self.lock, 2, 0,
-                        n, '', CONS_NONE,
-                        p, '', CONS_NONE,
-                        0.0, '', CONS_NONE)
-
-        _dp = PyFloat_AsDouble(p)
-        _in = PyFloat_AsDouble(n)
-
-        check_constraint(<double>_in, 'n', CONS_POSITIVE_NOT_NAN)
-        check_constraint(_dp, 'p', CONS_BOUNDED_GT_0_1)
-        # Check that the choice of negative_binomial parameters won't result in a
-        # call to the poisson distribution function with a value of lam too large.
-        _dmax_lam = (1 - _dp) / _dp * (_in + 10 * np.sqrt(_in))
-        if _dmax_lam > POISSON_LAM_MAX:
-            raise ValueError("n too large or p too small")
+            check_constraint(<double>_in, 'n', CONS_POSITIVE_NOT_NAN)
+            check_constraint(_dp, 'p', CONS_BOUNDED_GT_0_1)
+            # Check that the choice of negative_binomial parameters won't result in a
+            # call to the poisson distribution function with a value of lam too large.
+            _dmax_lam = (1 - _dp) / _dp * (_in + 10 * np.sqrt(_in))
+            if _dmax_lam > POISSON_LAM_MAX:
+                raise ValueError("n too large or p too small")
 
         return disc(&random_negative_binomial, &self._bitgen, size, self.lock, 2, 0,
-                    n, 'n', CONS_NONE,
-                    p, 'p', CONS_NONE,
+                    n_arr, 'n', CONS_NONE,
+                    p_arr, 'p', CONS_NONE,
                     0.0, '', CONS_NONE)
 
     def poisson(self, lam=1.0, size=None):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1485,6 +1485,12 @@ class TestRandomDist:
         with assert_raises(ValueError):
             x = random.negative_binomial(1, 0)
 
+    def test_negative_binomial_invalid_p_n_combination(self):
+        # Verify that values of p and n that would result in an overflow
+        # or infinite loop raise an exception.
+        with np.errstate(invalid='ignore'):
+            assert_raises(ValueError, random.negative_binomial, 2**62, 0.1)
+
     def test_noncentral_chisquare(self):
         random = Generator(MT19937(self.seed))
         actual = random.noncentral_chisquare(df=5, nonc=5, size=(3, 2))

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1490,6 +1490,7 @@ class TestRandomDist:
         # or infinite loop raise an exception.
         with np.errstate(invalid='ignore'):
             assert_raises(ValueError, random.negative_binomial, 2**62, 0.1)
+            assert_raises(ValueError, random.negative_binomial, [2**62], [0.1])
 
     def test_noncentral_chisquare(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
Hi!

First contribution to numpy here, hope I did it right. ~Searched the repo to see if this had been solved, but I couldn't find any other PR regarding this. PR marked as draft since it has no tests. **Will add tests if you deem this approach to solving #18997 acceptable.**~

-------------
Add parameter check to ```negative_binomial``` to avoid internally calling poisson distribution generator with an invalid lam parameter.

Fixes #18997, noticed that it Numpy 1.22.2, macOS 12.3, Arm64 (Apple Silicon), Python 3.8.5, calling the issue's sample code:
```python
default_rng(1).negative_binomial(2**62, 0.1)
```

No longer makes a silent overflow, but instead enters an infinite loop. To solve it:

- ~Modified the internal ```disc``` function to support parameter checks acting on pairs of parameters (the value that caused an overflow / infinite loop was dependant on both the ```n``` and ```p``` values).~
- ~Added extra parameter constraint type ```CONS_NEGATIVE_BINOMIAL_POISSON```. This parameter check:~
  - Computes the mean value of the gamma distribution used as an intermediate step in building the negative binomial distribution.
  - Computes the standard deviation of that gamma distribution.
  - If a value within 10 standard deviations of the mean of such gamma function would invoke the poisson generator with a value of λ (lam) that would be above the (already present) max safe value of lam (```POISSON_LAM_MAX```), raise a ```ValueError```.

### Sample code
After the fix, the sample code (above), returns the following:
```
>>> np.random.default_rng(1).negative_binomial(2.0**62, 0.1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_generator.pyx", line 3051, in numpy.random._generator.Generator.negative_binomial
ValueError: n too large or p too small
```

### Notes:
The parameter check is very conservative (maybe too much?). Since the ```POISSON_LAM_MAX``` is already conservative (same 10-std deviation margin) and I added another 10-std margin on top of that for the ```negative_binomial``` generator (the gamma function would have to get to a sample value 10-stds above the mean, and then call the poisson function with that value and get another 10-std above the (poisson) mean to cause a numerical overflow. Maybe the threshold of the negative binomial check could be brought down a bit (5-stds for the gamma function max, for example, but that would mean that occasionally the poisson generator could be called with a lam value above what is possible by directly calling ```np.random.default_rng(1).poisson```.

Thoughts?