### PR TITLE
MAINT: Fix warning message for deprecated keyword

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4411,7 +4411,7 @@ def _check_interpolation_as_method(method, interpolation, fname):
         f"the `interpolation=` argument to {fname} was renamed to "
         "`method=`, which has additional options.\n"
         "Users of the modes 'nearest', 'lower', 'higher', or "
-        "'midpoint' are encouraged to review the method they. "
+        "'midpoint' are encouraged to review the method they used. "
         "(Deprecated NumPy 1.22)",
         DeprecationWarning, stacklevel=4)
     if method != "linear":


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

In an Actions CI job on our project that makes widespread use of `numpy` I noticed the following deprecation warning appear due to use of the `interpolation` kwarg:

```bash
  p = np.nanpercentile(
/home/runner/work/cf-python/cf-python/main/cf/data/dask_utils.py:276: DeprecationWarning: the `interpolation=` argument to nanpercentile was renamed to `method=`, which has additional options.
Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they. (Deprecated NumPy 1.22)
```

though the final word appears to missing from the message in order for it to make full/grammatical sense. I have updated the message accordingly in this PR to fix it.

From searching through the Issue Tracker and open PR list I couldn't find anything that records or mentions the above issue, but since this is a very self-contained change, and it would take longer to report in an Issue than to open a PR to fix, I have made a PR directly. I hope that is OK. Thanks!