### PR TITLE
DOC: Added note about possible arange signatures

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1598,15 +1598,24 @@ add_newdoc('numpy.core.multiarray', 'arange',
 
     Return evenly spaced values within a given interval.
 
-    Values are generated within the half-open interval ``[start, stop)``
-    (in other words, the interval including `start` but excluding `stop`).
+    ``arange`` can be called with a varying number of positional arguments:
+
+    * ``arange(stop)``: Values are generated within the half-open interval
+      ``[0, stop)`` (in other words, the interval including `start` but
+      excluding `stop`).
+    * ``arange(start, stop)``: Values are generated within the half-open
+      interval ``[start, stop)``.
+    * ``arange(start, stop, step)`` Values are generated within the half-open
+      interval ``[start, stop)``, with spacing between values given by
+      ``step``.
+
     For integer arguments the function is roughly equivalent to the Python
     built-in :py:class:`range`, but returns an ndarray rather than a ``range``
     instance.
 
     When using a non-integer step, such as 0.1, it is often better to use
     `numpy.linspace`.
-    
+
     See the Warning sections below for more information.
 
     Parameters
@@ -1623,10 +1632,10 @@ add_newdoc('numpy.core.multiarray', 'arange',
         between two adjacent values, ``out[i+1] - out[i]``.  The default
         step size is 1.  If `step` is specified as a position argument,
         `start` must also be given.
-    dtype : dtype
+    dtype : dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from the other input arguments.
-    ${ARRAY_FUNCTION_LIKE}
+    ${ARRAY_FUNCTION_LIKE} This is an optional argument.
 
         .. versionadded:: 1.20.0
 

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1635,7 +1635,7 @@ add_newdoc('numpy.core.multiarray', 'arange',
     dtype : dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from the other input arguments.
-    ${ARRAY_FUNCTION_LIKE} This is an optional argument.
+    ${ARRAY_FUNCTION_LIKE}
 
         .. versionadded:: 1.20.0
 

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -12,7 +12,7 @@ ARRAY_FUNCTION_ENABLED = bool(
     int(os.environ.get('NUMPY_EXPERIMENTAL_ARRAY_FUNCTION', 1)))
 
 array_function_like_doc = (
-    """like : array_like
+    """like : array_like, optional
         Reference object to allow the creation of arrays which are not
         NumPy arrays. If an array-like passed in as ``like`` supports
         the ``__array_function__`` protocol, the result will be defined


### PR DESCRIPTION
`arange` includes a unique formatting style for its signature, which is sometimes confusing to users. This is a compromise, not requiring changes to the docstring signature extracting mechanism but making the options clearer.

Fixes #18563

