### PR TITLE
TYP,ENH: Add dtype-typing support to `fromnumeric` (part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ numpy/core/src/multiarray/lowlevel_strided_loops.c
 numpy/core/src/multiarray/multiarray_tests.c
 numpy/core/src/multiarray/nditer_templ.c
 numpy/core/src/multiarray/scalartypes.c
+numpy/core/src/multiarray/textreading/tokenize.c
 numpy/core/src/npymath/ieee754.c
 numpy/core/src/npymath/npy_math_complex.c
 numpy/core/src/npymath/npy_math_internal.h
@@ -222,3 +223,5 @@ numpy/core/src/umath/loops_minmax.dispatch.c
 numpy/core/src/umath/loops_trigonometric.dispatch.c
 numpy/core/src/umath/loops_exponent_log.dispatch.c
 numpy/core/src/umath/loops_umath_fp.dispatch.c
+# npysort module
+numpy/core/src/npysort/x86-qsort.dispatch.c

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -17,6 +17,7 @@ from numpy import (
 )
 from numpy.typing import (
     DTypeLike,
+    _DTypeLike,
     ArrayLike,
     _ArrayLike,
     NDArray,
@@ -34,13 +35,46 @@ _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 __all__: list[str]
 
+@overload
+def take(
+    a: _ArrayLike[_SCT],
+    indices: _IntLike_co,
+    axis: None = ...,
+    out: None = ...,
+    mode: _ModeKind = ...,
+) -> _SCT: ...
+@overload
+def take(
+    a: ArrayLike,
+    indices: _IntLike_co,
+    axis: None | int = ...,
+    out: None = ...,
+    mode: _ModeKind = ...,
+) -> Any: ...
+@overload
+def take(
+    a: _ArrayLike[_SCT],
+    indices: _ArrayLikeInt_co,
+    axis: None | int = ...,
+    out: None = ...,
+    mode: _ModeKind = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def take(
     a: ArrayLike,
     indices: _ArrayLikeInt_co,
     axis: None | int = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     mode: _ModeKind = ...,
-) -> Any: ...
+) -> NDArray[Any]: ...
+@overload
+def take(
+    a: ArrayLike,
+    indices: _ArrayLikeInt_co,
+    axis: None | int = ...,
+    out: _ArrayType = ...,
+    mode: _ModeKind = ...,
+) -> _ArrayType: ...
 
 @overload
 def reshape(
@@ -179,7 +213,7 @@ def argsort(
 def argmax(
     a: ArrayLike,
     axis: None = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     *,
     keepdims: Literal[False] = ...,
 ) -> intp: ...
@@ -187,16 +221,24 @@ def argmax(
 def argmax(
     a: ArrayLike,
     axis: None | int = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     *,
     keepdims: bool = ...,
 ) -> Any: ...
+@overload
+def argmax(
+    a: ArrayLike,
+    axis: None | int = ...,
+    out: _ArrayType = ...,
+    *,
+    keepdims: bool = ...,
+) -> _ArrayType: ...
 
 @overload
 def argmin(
     a: ArrayLike,
     axis: None = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     *,
     keepdims: Literal[False] = ...,
 ) -> intp: ...
@@ -204,10 +246,18 @@ def argmin(
 def argmin(
     a: ArrayLike,
     axis: None | int = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     *,
     keepdims: bool = ...,
 ) -> Any: ...
+@overload
+def argmin(
+    a: ArrayLike,
+    axis: None | int = ...,
+    out: _ArrayType = ...,
+    *,
+    keepdims: bool = ...,
+) -> _ArrayType: ...
 
 @overload
 def searchsorted(
@@ -266,14 +316,24 @@ def diagonal(
     axis2: int = ...,  # >= 2D array
 ) -> NDArray[Any]: ...
 
+@overload
 def trace(
     a: ArrayLike,  # >= 2D array
     offset: int = ...,
     axis1: int = ...,
     axis2: int = ...,
     dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
 ) -> Any: ...
+@overload
+def trace(
+    a: ArrayLike,  # >= 2D array
+    offset: int = ...,
+    axis1: int = ...,
+    axis2: int = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
 @overload
 def ravel(a: _ArrayLike[_SCT], order: _OrderKACF = ...) -> NDArray[_SCT]: ...
@@ -308,30 +368,119 @@ def compress(
 
 @overload
 def clip(
-    a: ArrayLike,
-    a_min: ArrayLike,
+    a: _SCT,
+    a_min: None | ArrayLike,
     a_max: None | ArrayLike,
-    out: None | ndarray = ...,
-    **kwargs: Any,
+    out: None = ...,
+    *,
+    dtype: None = ...,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
+) -> _SCT: ...
+@overload
+def clip(
+    a: _ScalarLike_co,
+    a_min: None | ArrayLike,
+    a_max: None | ArrayLike,
+    out: None = ...,
+    *,
+    dtype: None = ...,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
+) -> Any: ...
+@overload
+def clip(
+    a: _ArrayLike[_SCT],
+    a_min: None | ArrayLike,
+    a_max: None | ArrayLike,
+    out: None = ...,
+    *,
+    dtype: None = ...,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def clip(
+    a: ArrayLike,
+    a_min: None | ArrayLike,
+    a_max: None | ArrayLike,
+    out: None = ...,
+    *,
+    dtype: None = ...,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
+) -> NDArray[Any]: ...
+@overload
+def clip(
+    a: ArrayLike,
+    a_min: None | ArrayLike,
+    a_max: None | ArrayLike,
+    out: _ArrayType = ...,
+    *,
+    dtype: DTypeLike,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
 ) -> Any: ...
 @overload
 def clip(
     a: ArrayLike,
-    a_min: None,
-    a_max: ArrayLike,
-    out: None | ndarray = ...,
-    **kwargs: Any,
-) -> Any: ...
+    a_min: None | ArrayLike,
+    a_max: None | ArrayLike,
+    out: _ArrayType,
+    *,
+    dtype: DTypeLike = ...,
+    where: None | _ArrayLikeBool_co = ...,
+    order: _OrderKACF = ...,
+    subok: bool = ...,
+    signature: str | tuple[None | str, ...] = ...,
+    extobj: list[Any] = ...,
+) -> _ArrayType: ...
 
+@overload
+def sum(
+    a: _ArrayLike[_SCT],
+    axis: None = ...,
+    dtype: None = ...,
+    out: None  = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
 def sum(
     a: ArrayLike,
-    axis: _ShapeLike = ...,
+    axis: None | _ShapeLike = ...,
     dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
+    out: None  = ...,
     keepdims: bool = ...,
     initial: _NumberLike_co = ...,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def sum(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType  = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
 @overload
 def all(
@@ -346,11 +495,20 @@ def all(
 def all(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def all(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
 @overload
 def any(
@@ -365,43 +523,134 @@ def any(
 def any(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def any(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
+@overload
+def cumsum(
+    a: _ArrayLike[_SCT],
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def cumsum(
+    a: ArrayLike,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[Any]: ...
+@overload
+def cumsum(
+    a: ArrayLike,
+    axis: None | int = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+) -> NDArray[_SCT]: ...
+@overload
 def cumsum(
     a: ArrayLike,
     axis: None | int = ...,
     dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
-) -> ndarray: ...
+    out: None = ...,
+) -> NDArray[Any]: ...
+@overload
+def cumsum(
+    a: ArrayLike,
+    axis: None | int = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
+@overload
+def ptp(
+    a: _ArrayLike[_SCT],
+    axis: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+) -> _SCT: ...
+@overload
 def ptp(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     keepdims: bool = ...,
 ) -> Any: ...
+@overload
+def ptp(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+) -> _ArrayType: ...
 
+@overload
+def amax(
+    a: _ArrayLike[_SCT],
+    axis: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
 def amax(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     keepdims: bool = ...,
     initial: _NumberLike_co = ...,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def amax(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
+@overload
+def amin(
+    a: _ArrayLike[_SCT],
+    axis: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
 def amin(
     a: ArrayLike,
     axis: None | _ShapeLike = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
     keepdims: bool = ...,
     initial: _NumberLike_co = ...,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def amin(
+    a: ArrayLike,
+    axis: None | _ShapeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
 # TODO: `np.prod()``: For object arrays `initial` does not necessarily
 # have to be a numerical scalar.

--- a/numpy/typing/tests/data/fail/fromnumeric.pyi
+++ b/numpy/typing/tests/data/fail/fromnumeric.pyi
@@ -7,10 +7,10 @@ A.setflags(write=False)
 
 a = np.bool_(True)
 
-np.take(a, None)  # E: incompatible type
-np.take(a, axis=1.0)  # E: incompatible type
-np.take(A, out=1)  # E: incompatible type
-np.take(A, mode="bob")  # E: incompatible type
+np.take(a, None)  # E: No overload variant
+np.take(a, axis=1.0)  # E: No overload variant
+np.take(A, out=1)  # E: No overload variant
+np.take(A, mode="bob")  # E: No overload variant
 
 np.reshape(a, None)  # E: No overload variant
 np.reshape(A, 1, order="bob")  # E: No overload variant
@@ -80,9 +80,9 @@ np.diagonal(A, offset=None)  # E: No overload variant
 np.diagonal(A, axis1="bob")  # E: No overload variant
 np.diagonal(A, axis2=[])  # E: No overload variant
 
-np.trace(A, offset=None)  # E: Argument "offset" to "trace" has incompatible type
-np.trace(A, axis1="bob")  # E: Argument "axis1" to "trace" has incompatible type
-np.trace(A, axis2=[])  # E: Argument "axis2" to "trace" has incompatible type
+np.trace(A, offset=None)  # E: No overload variant
+np.trace(A, axis1="bob")  # E: No overload variant
+np.trace(A, axis2=[])  # E: No overload variant
 
 np.ravel(a, order="bob")  # E: No overload variant
 
@@ -91,11 +91,10 @@ np.compress(  # E: No overload variant
 )
 
 np.clip(a, 1, 2, out=1)  # E: No overload variant of "clip" matches argument type
-np.clip(1, None, None)  # E: No overload variant of "clip" matches argument type
 
-np.sum(a, axis=1.0)  # E: incompatible type
-np.sum(a, keepdims=1.0)  # E: incompatible type
-np.sum(a, initial=[1])  # E: incompatible type
+np.sum(a, axis=1.0)  # E: No overload variant
+np.sum(a, keepdims=1.0)  # E: No overload variant
+np.sum(a, initial=[1])  # E: No overload variant
 
 np.all(a, axis=1.0)  # E: No overload variant
 np.all(a, keepdims=1.0)  # E: No overload variant
@@ -105,24 +104,24 @@ np.any(a, axis=1.0)  # E: No overload variant
 np.any(a, keepdims=1.0)  # E: No overload variant
 np.any(a, out=1.0)  # E: No overload variant
 
-np.cumsum(a, axis=1.0)  # E: incompatible type
-np.cumsum(a, dtype=1.0)  # E: incompatible type
-np.cumsum(a, out=1.0)  # E: incompatible type
+np.cumsum(a, axis=1.0)  # E: No overload variant
+np.cumsum(a, dtype=1.0)  # E: No overload variant
+np.cumsum(a, out=1.0)  # E: No overload variant
 
-np.ptp(a, axis=1.0)  # E: incompatible type
-np.ptp(a, keepdims=1.0)  # E: incompatible type
-np.ptp(a, out=1.0)  # E: incompatible type
+np.ptp(a, axis=1.0)  # E: No overload variant
+np.ptp(a, keepdims=1.0)  # E: No overload variant
+np.ptp(a, out=1.0)  # E: No overload variant
 
-np.amax(a, axis=1.0)  # E: incompatible type
-np.amax(a, keepdims=1.0)  # E: incompatible type
-np.amax(a, out=1.0)  # E: incompatible type
-np.amax(a, initial=[1.0])  # E: incompatible type
+np.amax(a, axis=1.0)  # E: No overload variant
+np.amax(a, keepdims=1.0)  # E: No overload variant
+np.amax(a, out=1.0)  # E: No overload variant
+np.amax(a, initial=[1.0])  # E: No overload variant
 np.amax(a, where=[1.0])  # E: incompatible type
 
-np.amin(a, axis=1.0)  # E: incompatible type
-np.amin(a, keepdims=1.0)  # E: incompatible type
-np.amin(a, out=1.0)  # E: incompatible type
-np.amin(a, initial=[1.0])  # E: incompatible type
+np.amin(a, axis=1.0)  # E: No overload variant
+np.amin(a, keepdims=1.0)  # E: No overload variant
+np.amin(a, out=1.0)  # E: No overload variant
+np.amin(a, initial=[1.0])  # E: No overload variant
 np.amin(a, where=[1.0])  # E: incompatible type
 
 np.prod(a, axis=1.0)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -3,21 +3,27 @@
 import numpy as np
 import numpy.typing as npt
 
+class NDArraySubclass(npt.NDArray[np.complex128]):
+    ...
+
 AR_b: npt.NDArray[np.bool_]
 AR_f4: npt.NDArray[np.float32]
 AR_i8: npt.NDArray[np.int64]
+AR_subclass: NDArraySubclass
 
 b: np.bool_
 f4: np.float32
 f: float
 
-reveal_type(np.take(b, 0))  # E: Any
-reveal_type(np.take(f4, 0))  # E: Any
+reveal_type(np.take(b, 0))  # E: bool_
+reveal_type(np.take(f4, 0))  # E: {float32}
 reveal_type(np.take(f, 0))  # E: Any
-reveal_type(np.take(AR_b, 0))  # E: Any
-reveal_type(np.take(AR_f4, 0))  # E: Any
-reveal_type(np.take(AR_b, [0]))  # E: Any
-reveal_type(np.take(AR_f4, [0]))  # E: Any
+reveal_type(np.take(AR_b, 0))  # E: bool_
+reveal_type(np.take(AR_f4, 0))  # E: {float32}
+reveal_type(np.take(AR_b, [0]))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.take(AR_f4, [0]))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.take([1], [0]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.take(AR_f4, [0], out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.reshape(b, 1))  # E: ndarray[Any, dtype[bool_]]
 reveal_type(np.reshape(f4, 1))  # E: ndarray[Any, dtype[{float32}]]
@@ -71,11 +77,13 @@ reveal_type(np.argmax(AR_b))  # E: {intp}
 reveal_type(np.argmax(AR_f4))  # E: {intp}
 reveal_type(np.argmax(AR_b, axis=0))  # E: Any
 reveal_type(np.argmax(AR_f4, axis=0))  # E: Any
+reveal_type(np.argmax(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.argmin(AR_b))  # E: {intp}
 reveal_type(np.argmin(AR_f4))  # E: {intp}
 reveal_type(np.argmin(AR_b, axis=0))  # E: Any
 reveal_type(np.argmin(AR_f4, axis=0))  # E: Any
+reveal_type(np.argmin(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.searchsorted(AR_b[0], 0))  # E: {intp}
 reveal_type(np.searchsorted(AR_f4[0], 0))  # E: {intp}
@@ -99,6 +107,7 @@ reveal_type(np.diagonal(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
 reveal_type(np.trace(AR_b))  # E: Any
 reveal_type(np.trace(AR_f4))  # E: Any
+reveal_type(np.trace(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.ravel(b))  # E: ndarray[Any, dtype[bool_]]
 reveal_type(np.ravel(f4))  # E: ndarray[Any, dtype[{float32}]]
@@ -124,19 +133,22 @@ reveal_type(np.compress([True], f))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.compress([True], AR_b))  # E: ndarray[Any, dtype[bool_]]
 reveal_type(np.compress([True], AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.clip(b, 0, 1.0))  # E: Any
-reveal_type(np.clip(f4, -1, 1))  # E: Any
+reveal_type(np.clip(b, 0, 1.0))  # E: bool_
+reveal_type(np.clip(f4, -1, 1))  # E: {float32}
 reveal_type(np.clip(f, 0, 1))  # E: Any
-reveal_type(np.clip(AR_b, 0, 1))  # E: Any
-reveal_type(np.clip(AR_f4, 0, 1))  # E: Any
+reveal_type(np.clip(AR_b, 0, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.clip(AR_f4, 0, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.clip([0], 0, 1))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.clip(AR_b, 0, 1, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.sum(b))  # E: Any
-reveal_type(np.sum(f4))  # E: Any
+reveal_type(np.sum(b))  # E: bool_
+reveal_type(np.sum(f4))  # E: {float32}
 reveal_type(np.sum(f))  # E: Any
-reveal_type(np.sum(AR_b))  # E: Any
-reveal_type(np.sum(AR_f4))  # E: Any
+reveal_type(np.sum(AR_b))  # E: bool_
+reveal_type(np.sum(AR_f4))  # E: {float32}
 reveal_type(np.sum(AR_b, axis=0))  # E: Any
 reveal_type(np.sum(AR_f4, axis=0))  # E: Any
+reveal_type(np.sum(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.all(b))  # E: bool_
 reveal_type(np.all(f4))  # E: bool_
@@ -147,6 +159,7 @@ reveal_type(np.all(AR_b, axis=0))  # E: Any
 reveal_type(np.all(AR_f4, axis=0))  # E: Any
 reveal_type(np.all(AR_b, keepdims=True))  # E: Any
 reveal_type(np.all(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.all(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.any(b))  # E: bool_
 reveal_type(np.any(f4))  # E: bool_
@@ -157,42 +170,49 @@ reveal_type(np.any(AR_b, axis=0))  # E: Any
 reveal_type(np.any(AR_f4, axis=0))  # E: Any
 reveal_type(np.any(AR_b, keepdims=True))  # E: Any
 reveal_type(np.any(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.any(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.cumsum(b))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(f4))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(f))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(AR_b))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(AR_f4))  # E: ndarray[Any, Any]
+reveal_type(np.cumsum(b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.cumsum(f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.cumsum(f))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.cumsum(AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.cumsum(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.cumsum(f, dtype=float))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.cumsum(f, dtype=np.float64))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.cumsum(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.ptp(b))  # E: Any
-reveal_type(np.ptp(f4))  # E: Any
+reveal_type(np.ptp(b))  # E: bool_
+reveal_type(np.ptp(f4))  # E: {float32}
 reveal_type(np.ptp(f))  # E: Any
-reveal_type(np.ptp(AR_b))  # E: Any
-reveal_type(np.ptp(AR_f4))  # E: Any
+reveal_type(np.ptp(AR_b))  # E: bool_
+reveal_type(np.ptp(AR_f4))  # E: {float32}
 reveal_type(np.ptp(AR_b, axis=0))  # E: Any
 reveal_type(np.ptp(AR_f4, axis=0))  # E: Any
 reveal_type(np.ptp(AR_b, keepdims=True))  # E: Any
 reveal_type(np.ptp(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.ptp(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.amax(b))  # E: Any
-reveal_type(np.amax(f4))  # E: Any
+reveal_type(np.amax(b))  # E: bool_
+reveal_type(np.amax(f4))  # E: {float32}
 reveal_type(np.amax(f))  # E: Any
-reveal_type(np.amax(AR_b))  # E: Any
-reveal_type(np.amax(AR_f4))  # E: Any
+reveal_type(np.amax(AR_b))  # E: bool_
+reveal_type(np.amax(AR_f4))  # E: {float32}
 reveal_type(np.amax(AR_b, axis=0))  # E: Any
 reveal_type(np.amax(AR_f4, axis=0))  # E: Any
 reveal_type(np.amax(AR_b, keepdims=True))  # E: Any
 reveal_type(np.amax(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.amax(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.amin(b))  # E: Any
-reveal_type(np.amin(f4))  # E: Any
+reveal_type(np.amin(b))  # E: bool_
+reveal_type(np.amin(f4))  # E: {float32}
 reveal_type(np.amin(f))  # E: Any
-reveal_type(np.amin(AR_b))  # E: Any
-reveal_type(np.amin(AR_f4))  # E: Any
+reveal_type(np.amin(AR_b))  # E: bool_
+reveal_type(np.amin(AR_f4))  # E: {float32}
 reveal_type(np.amin(AR_b, axis=0))  # E: Any
 reveal_type(np.amin(AR_f4, axis=0))  # E: Any
 reveal_type(np.amin(AR_b, keepdims=True))  # E: Any
 reveal_type(np.amin(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.amin(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.prod(b))  # E: Any
 reveal_type(np.prod(f4))  # E: Any

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -1,268 +1,267 @@
 """Tests for :mod:`core.fromnumeric`."""
 
 import numpy as np
+import numpy.typing as npt
 
-A = np.array(True, ndmin=2, dtype=np.bool_)
-B = np.array(1.0, ndmin=2, dtype=np.float32)
-A.setflags(write=False)
-B.setflags(write=False)
+AR_b: npt.NDArray[np.bool_]
+AR_f4: npt.NDArray[np.float32]
+AR_i8: npt.NDArray[np.int64]
 
-a = np.bool_(True)
-b = np.float32(1.0)
-c = 1.0
-d = np.array(1.0, dtype=np.float32)  # writeable
+b: np.bool_
+f4: np.float32
+f: float
 
-reveal_type(np.take(a, 0))  # E: Any
 reveal_type(np.take(b, 0))  # E: Any
-reveal_type(np.take(c, 0))  # E: Any
-reveal_type(np.take(A, 0))  # E: Any
-reveal_type(np.take(B, 0))  # E: Any
-reveal_type(np.take(A, [0]))  # E: Any
-reveal_type(np.take(B, [0]))  # E: Any
+reveal_type(np.take(f4, 0))  # E: Any
+reveal_type(np.take(f, 0))  # E: Any
+reveal_type(np.take(AR_b, 0))  # E: Any
+reveal_type(np.take(AR_f4, 0))  # E: Any
+reveal_type(np.take(AR_b, [0]))  # E: Any
+reveal_type(np.take(AR_f4, [0]))  # E: Any
 
-reveal_type(np.reshape(a, 1))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.reshape(b, 1))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.reshape(c, 1))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.reshape(A, 1))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.reshape(B, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.reshape(b, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.reshape(f4, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.reshape(f, 1))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.reshape(AR_b, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.reshape(AR_f4, 1))  # E: ndarray[Any, dtype[{float32}]]
 
 reveal_type(np.choose(1, [True, True]))  # E: Any
 reveal_type(np.choose([1], [True, True]))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.choose([1], A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.choose([1], A, out=B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.choose([1], AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.choose([1], AR_b, out=AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.repeat(a, 1))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.repeat(b, 1))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.repeat(c, 1))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.repeat(A, 1))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.repeat(B, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.repeat(b, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.repeat(f4, 1))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.repeat(f, 1))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.repeat(AR_b, 1))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.repeat(AR_f4, 1))  # E: ndarray[Any, dtype[{float32}]]
 
-# TODO: Add tests for np.put()
+# TODO: array_bdd tests for np.put()
 
 reveal_type(np.swapaxes([[0, 1]], 0, 0))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.swapaxes(A, 0, 0))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.swapaxes(B, 0, 0))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.swapaxes(AR_b, 0, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.swapaxes(AR_f4, 0, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.transpose(a))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.transpose(b))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.transpose(c))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.transpose(A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.transpose(B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.transpose(b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.transpose(f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.transpose(f))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.transpose(AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.transpose(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.partition(a, 0, axis=None))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.partition(b, 0, axis=None))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.partition(c, 0, axis=None))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.partition(A, 0))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.partition(B, 0))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.partition(b, 0, axis=None))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.partition(f4, 0, axis=None))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.partition(f, 0, axis=None))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.partition(AR_b, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.partition(AR_f4, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.argpartition(a, 0))  # E: ndarray[Any, dtype[{intp}]]
 reveal_type(np.argpartition(b, 0))  # E: ndarray[Any, dtype[{intp}]]
-reveal_type(np.argpartition(c, 0))  # E: ndarray[Any, dtype[{intp}]]
-reveal_type(np.argpartition(A, 0))  # E: ndarray[Any, dtype[{intp}]]
-reveal_type(np.argpartition(B, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(f4, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(f, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(AR_b, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argpartition(AR_f4, 0))  # E: ndarray[Any, dtype[{intp}]]
 
 reveal_type(np.sort([2, 1], 0))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.sort(A, 0))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.sort(B, 0))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.sort(AR_b, 0))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.sort(AR_f4, 0))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.argsort(A, 0))  # E: ndarray[Any, dtype[{intp}]]
-reveal_type(np.argsort(B, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argsort(AR_b, 0))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.argsort(AR_f4, 0))  # E: ndarray[Any, dtype[{intp}]]
 
-reveal_type(np.argmax(A))  # E: {intp}
-reveal_type(np.argmax(B))  # E: {intp}
-reveal_type(np.argmax(A, axis=0))  # E: Any
-reveal_type(np.argmax(B, axis=0))  # E: Any
+reveal_type(np.argmax(AR_b))  # E: {intp}
+reveal_type(np.argmax(AR_f4))  # E: {intp}
+reveal_type(np.argmax(AR_b, axis=0))  # E: Any
+reveal_type(np.argmax(AR_f4, axis=0))  # E: Any
 
-reveal_type(np.argmin(A))  # E: {intp}
-reveal_type(np.argmin(B))  # E: {intp}
-reveal_type(np.argmin(A, axis=0))  # E: Any
-reveal_type(np.argmin(B, axis=0))  # E: Any
+reveal_type(np.argmin(AR_b))  # E: {intp}
+reveal_type(np.argmin(AR_f4))  # E: {intp}
+reveal_type(np.argmin(AR_b, axis=0))  # E: Any
+reveal_type(np.argmin(AR_f4, axis=0))  # E: Any
 
-reveal_type(np.searchsorted(A[0], 0))  # E: {intp}
-reveal_type(np.searchsorted(B[0], 0))  # E: {intp}
-reveal_type(np.searchsorted(A[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
-reveal_type(np.searchsorted(B[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.searchsorted(AR_b[0], 0))  # E: {intp}
+reveal_type(np.searchsorted(AR_f4[0], 0))  # E: {intp}
+reveal_type(np.searchsorted(AR_b[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
+reveal_type(np.searchsorted(AR_f4[0], [0]))  # E: ndarray[Any, dtype[{intp}]]
 
-reveal_type(np.resize(a, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.resize(b, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.resize(c, (5, 5)))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.resize(A, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.resize(B, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.resize(b, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.resize(f4, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.resize(f, (5, 5)))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.resize(AR_b, (5, 5)))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.resize(AR_f4, (5, 5)))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.squeeze(a))  # E: bool_
-reveal_type(np.squeeze(b))  # E: {float32}
-reveal_type(np.squeeze(c))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.squeeze(A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.squeeze(B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.squeeze(b))  # E: bool_
+reveal_type(np.squeeze(f4))  # E: {float32}
+reveal_type(np.squeeze(f))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.squeeze(AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.squeeze(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.diagonal(A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.diagonal(B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.diagonal(AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.diagonal(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.trace(A))  # E: Any
-reveal_type(np.trace(B))  # E: Any
+reveal_type(np.trace(AR_b))  # E: Any
+reveal_type(np.trace(AR_f4))  # E: Any
 
-reveal_type(np.ravel(a))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.ravel(b))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.ravel(c))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.ravel(A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.ravel(B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.ravel(b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.ravel(f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.ravel(f))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.ravel(AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.ravel(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.nonzero(a))  # E: tuple[ndarray[Any, dtype[{intp}]]]
 reveal_type(np.nonzero(b))  # E: tuple[ndarray[Any, dtype[{intp}]]]
-reveal_type(np.nonzero(c))  # E: tuple[ndarray[Any, dtype[{intp}]]]
-reveal_type(np.nonzero(A))  # E: tuple[ndarray[Any, dtype[{intp}]]]
-reveal_type(np.nonzero(B))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(f4))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(f))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(AR_b))  # E: tuple[ndarray[Any, dtype[{intp}]]]
+reveal_type(np.nonzero(AR_f4))  # E: tuple[ndarray[Any, dtype[{intp}]]]
 
-reveal_type(np.shape(a))  # E: tuple[builtins.int]
 reveal_type(np.shape(b))  # E: tuple[builtins.int]
-reveal_type(np.shape(c))  # E: tuple[builtins.int]
-reveal_type(np.shape(A))  # E: tuple[builtins.int]
-reveal_type(np.shape(B))  # E: tuple[builtins.int]
+reveal_type(np.shape(f4))  # E: tuple[builtins.int]
+reveal_type(np.shape(f))  # E: tuple[builtins.int]
+reveal_type(np.shape(AR_b))  # E: tuple[builtins.int]
+reveal_type(np.shape(AR_f4))  # E: tuple[builtins.int]
 
-reveal_type(np.compress([True], a))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.compress([True], b))  # E: ndarray[Any, dtype[{float32}]]
-reveal_type(np.compress([True], c))  # E: ndarray[Any, dtype[Any]]
-reveal_type(np.compress([True], A))  # E: ndarray[Any, dtype[bool_]]
-reveal_type(np.compress([True], B))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.compress([True], b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.compress([True], f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.compress([True], f))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.compress([True], AR_b))  # E: ndarray[Any, dtype[bool_]]
+reveal_type(np.compress([True], AR_f4))  # E: ndarray[Any, dtype[{float32}]]
 
-reveal_type(np.clip(a, 0, 1.0))  # E: Any
-reveal_type(np.clip(b, -1, 1))  # E: Any
-reveal_type(np.clip(c, 0, 1))  # E: Any
-reveal_type(np.clip(A, 0, 1))  # E: Any
-reveal_type(np.clip(B, 0, 1))  # E: Any
+reveal_type(np.clip(b, 0, 1.0))  # E: Any
+reveal_type(np.clip(f4, -1, 1))  # E: Any
+reveal_type(np.clip(f, 0, 1))  # E: Any
+reveal_type(np.clip(AR_b, 0, 1))  # E: Any
+reveal_type(np.clip(AR_f4, 0, 1))  # E: Any
 
-reveal_type(np.sum(a))  # E: Any
 reveal_type(np.sum(b))  # E: Any
-reveal_type(np.sum(c))  # E: Any
-reveal_type(np.sum(A))  # E: Any
-reveal_type(np.sum(B))  # E: Any
-reveal_type(np.sum(A, axis=0))  # E: Any
-reveal_type(np.sum(B, axis=0))  # E: Any
+reveal_type(np.sum(f4))  # E: Any
+reveal_type(np.sum(f))  # E: Any
+reveal_type(np.sum(AR_b))  # E: Any
+reveal_type(np.sum(AR_f4))  # E: Any
+reveal_type(np.sum(AR_b, axis=0))  # E: Any
+reveal_type(np.sum(AR_f4, axis=0))  # E: Any
 
-reveal_type(np.all(a))  # E: bool_
 reveal_type(np.all(b))  # E: bool_
-reveal_type(np.all(c))  # E: bool_
-reveal_type(np.all(A))  # E: bool_
-reveal_type(np.all(B))  # E: bool_
-reveal_type(np.all(A, axis=0))  # E: Any
-reveal_type(np.all(B, axis=0))  # E: Any
-reveal_type(np.all(A, keepdims=True))  # E: Any
-reveal_type(np.all(B, keepdims=True))  # E: Any
+reveal_type(np.all(f4))  # E: bool_
+reveal_type(np.all(f))  # E: bool_
+reveal_type(np.all(AR_b))  # E: bool_
+reveal_type(np.all(AR_f4))  # E: bool_
+reveal_type(np.all(AR_b, axis=0))  # E: Any
+reveal_type(np.all(AR_f4, axis=0))  # E: Any
+reveal_type(np.all(AR_b, keepdims=True))  # E: Any
+reveal_type(np.all(AR_f4, keepdims=True))  # E: Any
 
-reveal_type(np.any(a))  # E: bool_
 reveal_type(np.any(b))  # E: bool_
-reveal_type(np.any(c))  # E: bool_
-reveal_type(np.any(A))  # E: bool_
-reveal_type(np.any(B))  # E: bool_
-reveal_type(np.any(A, axis=0))  # E: Any
-reveal_type(np.any(B, axis=0))  # E: Any
-reveal_type(np.any(A, keepdims=True))  # E: Any
-reveal_type(np.any(B, keepdims=True))  # E: Any
+reveal_type(np.any(f4))  # E: bool_
+reveal_type(np.any(f))  # E: bool_
+reveal_type(np.any(AR_b))  # E: bool_
+reveal_type(np.any(AR_f4))  # E: bool_
+reveal_type(np.any(AR_b, axis=0))  # E: Any
+reveal_type(np.any(AR_f4, axis=0))  # E: Any
+reveal_type(np.any(AR_b, keepdims=True))  # E: Any
+reveal_type(np.any(AR_f4, keepdims=True))  # E: Any
 
-reveal_type(np.cumsum(a))  # E: ndarray[Any, Any]
 reveal_type(np.cumsum(b))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(c))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(A))  # E: ndarray[Any, Any]
-reveal_type(np.cumsum(B))  # E: ndarray[Any, Any]
+reveal_type(np.cumsum(f4))  # E: ndarray[Any, Any]
+reveal_type(np.cumsum(f))  # E: ndarray[Any, Any]
+reveal_type(np.cumsum(AR_b))  # E: ndarray[Any, Any]
+reveal_type(np.cumsum(AR_f4))  # E: ndarray[Any, Any]
 
-reveal_type(np.ptp(a))  # E: Any
 reveal_type(np.ptp(b))  # E: Any
-reveal_type(np.ptp(c))  # E: Any
-reveal_type(np.ptp(A))  # E: Any
-reveal_type(np.ptp(B))  # E: Any
-reveal_type(np.ptp(A, axis=0))  # E: Any
-reveal_type(np.ptp(B, axis=0))  # E: Any
-reveal_type(np.ptp(A, keepdims=True))  # E: Any
-reveal_type(np.ptp(B, keepdims=True))  # E: Any
+reveal_type(np.ptp(f4))  # E: Any
+reveal_type(np.ptp(f))  # E: Any
+reveal_type(np.ptp(AR_b))  # E: Any
+reveal_type(np.ptp(AR_f4))  # E: Any
+reveal_type(np.ptp(AR_b, axis=0))  # E: Any
+reveal_type(np.ptp(AR_f4, axis=0))  # E: Any
+reveal_type(np.ptp(AR_b, keepdims=True))  # E: Any
+reveal_type(np.ptp(AR_f4, keepdims=True))  # E: Any
 
-reveal_type(np.amax(a))  # E: Any
 reveal_type(np.amax(b))  # E: Any
-reveal_type(np.amax(c))  # E: Any
-reveal_type(np.amax(A))  # E: Any
-reveal_type(np.amax(B))  # E: Any
-reveal_type(np.amax(A, axis=0))  # E: Any
-reveal_type(np.amax(B, axis=0))  # E: Any
-reveal_type(np.amax(A, keepdims=True))  # E: Any
-reveal_type(np.amax(B, keepdims=True))  # E: Any
+reveal_type(np.amax(f4))  # E: Any
+reveal_type(np.amax(f))  # E: Any
+reveal_type(np.amax(AR_b))  # E: Any
+reveal_type(np.amax(AR_f4))  # E: Any
+reveal_type(np.amax(AR_b, axis=0))  # E: Any
+reveal_type(np.amax(AR_f4, axis=0))  # E: Any
+reveal_type(np.amax(AR_b, keepdims=True))  # E: Any
+reveal_type(np.amax(AR_f4, keepdims=True))  # E: Any
 
-reveal_type(np.amin(a))  # E: Any
 reveal_type(np.amin(b))  # E: Any
-reveal_type(np.amin(c))  # E: Any
-reveal_type(np.amin(A))  # E: Any
-reveal_type(np.amin(B))  # E: Any
-reveal_type(np.amin(A, axis=0))  # E: Any
-reveal_type(np.amin(B, axis=0))  # E: Any
-reveal_type(np.amin(A, keepdims=True))  # E: Any
-reveal_type(np.amin(B, keepdims=True))  # E: Any
+reveal_type(np.amin(f4))  # E: Any
+reveal_type(np.amin(f))  # E: Any
+reveal_type(np.amin(AR_b))  # E: Any
+reveal_type(np.amin(AR_f4))  # E: Any
+reveal_type(np.amin(AR_b, axis=0))  # E: Any
+reveal_type(np.amin(AR_f4, axis=0))  # E: Any
+reveal_type(np.amin(AR_b, keepdims=True))  # E: Any
+reveal_type(np.amin(AR_f4, keepdims=True))  # E: Any
 
-reveal_type(np.prod(a))  # E: Any
 reveal_type(np.prod(b))  # E: Any
-reveal_type(np.prod(c))  # E: Any
-reveal_type(np.prod(A))  # E: Any
-reveal_type(np.prod(B))  # E: Any
-reveal_type(np.prod(A, axis=0))  # E: Any
-reveal_type(np.prod(B, axis=0))  # E: Any
-reveal_type(np.prod(A, keepdims=True))  # E: Any
-reveal_type(np.prod(B, keepdims=True))  # E: Any
-reveal_type(np.prod(b, out=d))  # E: Any
-reveal_type(np.prod(B, out=d))  # E: Any
+reveal_type(np.prod(f4))  # E: Any
+reveal_type(np.prod(f))  # E: Any
+reveal_type(np.prod(AR_b))  # E: Any
+reveal_type(np.prod(AR_f4))  # E: Any
+reveal_type(np.prod(AR_b, axis=0))  # E: Any
+reveal_type(np.prod(AR_f4, axis=0))  # E: Any
+reveal_type(np.prod(AR_b, keepdims=True))  # E: Any
+reveal_type(np.prod(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.prod(f4, out=AR_i8))  # E: Any
+reveal_type(np.prod(AR_f4, out=AR_i8))  # E: Any
 
-reveal_type(np.cumprod(a))  # E: ndarray[Any, Any]
 reveal_type(np.cumprod(b))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(c))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(A))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(B))  # E: ndarray[Any, Any]
+reveal_type(np.cumprod(f4))  # E: ndarray[Any, Any]
+reveal_type(np.cumprod(f))  # E: ndarray[Any, Any]
+reveal_type(np.cumprod(AR_b))  # E: ndarray[Any, Any]
+reveal_type(np.cumprod(AR_f4))  # E: ndarray[Any, Any]
 
-reveal_type(np.ndim(a))  # E: int
 reveal_type(np.ndim(b))  # E: int
-reveal_type(np.ndim(c))  # E: int
-reveal_type(np.ndim(A))  # E: int
-reveal_type(np.ndim(B))  # E: int
+reveal_type(np.ndim(f4))  # E: int
+reveal_type(np.ndim(f))  # E: int
+reveal_type(np.ndim(AR_b))  # E: int
+reveal_type(np.ndim(AR_f4))  # E: int
 
-reveal_type(np.size(a))  # E: int
 reveal_type(np.size(b))  # E: int
-reveal_type(np.size(c))  # E: int
-reveal_type(np.size(A))  # E: int
-reveal_type(np.size(B))  # E: int
+reveal_type(np.size(f4))  # E: int
+reveal_type(np.size(f))  # E: int
+reveal_type(np.size(AR_b))  # E: int
+reveal_type(np.size(AR_f4))  # E: int
 
-reveal_type(np.around(a))  # E: Any
 reveal_type(np.around(b))  # E: Any
-reveal_type(np.around(c))  # E: Any
-reveal_type(np.around(A))  # E: Any
-reveal_type(np.around(B))  # E: Any
+reveal_type(np.around(f4))  # E: Any
+reveal_type(np.around(f))  # E: Any
+reveal_type(np.around(AR_b))  # E: Any
+reveal_type(np.around(AR_f4))  # E: Any
 
-reveal_type(np.mean(a))  # E: Any
 reveal_type(np.mean(b))  # E: Any
-reveal_type(np.mean(c))  # E: Any
-reveal_type(np.mean(A))  # E: Any
-reveal_type(np.mean(B))  # E: Any
-reveal_type(np.mean(A, axis=0))  # E: Any
-reveal_type(np.mean(B, axis=0))  # E: Any
-reveal_type(np.mean(A, keepdims=True))  # E: Any
-reveal_type(np.mean(B, keepdims=True))  # E: Any
-reveal_type(np.mean(b, out=d))  # E: Any
-reveal_type(np.mean(B, out=d))  # E: Any
+reveal_type(np.mean(f4))  # E: Any
+reveal_type(np.mean(f))  # E: Any
+reveal_type(np.mean(AR_b))  # E: Any
+reveal_type(np.mean(AR_f4))  # E: Any
+reveal_type(np.mean(AR_b, axis=0))  # E: Any
+reveal_type(np.mean(AR_f4, axis=0))  # E: Any
+reveal_type(np.mean(AR_b, keepdims=True))  # E: Any
+reveal_type(np.mean(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.mean(f4, out=AR_i8))  # E: Any
+reveal_type(np.mean(AR_f4, out=AR_i8))  # E: Any
 
-reveal_type(np.std(a))  # E: Any
 reveal_type(np.std(b))  # E: Any
-reveal_type(np.std(c))  # E: Any
-reveal_type(np.std(A))  # E: Any
-reveal_type(np.std(B))  # E: Any
-reveal_type(np.std(A, axis=0))  # E: Any
-reveal_type(np.std(B, axis=0))  # E: Any
-reveal_type(np.std(A, keepdims=True))  # E: Any
-reveal_type(np.std(B, keepdims=True))  # E: Any
-reveal_type(np.std(b, out=d))  # E: Any
-reveal_type(np.std(B, out=d))  # E: Any
+reveal_type(np.std(f4))  # E: Any
+reveal_type(np.std(f))  # E: Any
+reveal_type(np.std(AR_b))  # E: Any
+reveal_type(np.std(AR_f4))  # E: Any
+reveal_type(np.std(AR_b, axis=0))  # E: Any
+reveal_type(np.std(AR_f4, axis=0))  # E: Any
+reveal_type(np.std(AR_b, keepdims=True))  # E: Any
+reveal_type(np.std(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.std(f4, out=AR_i8))  # E: Any
+reveal_type(np.std(AR_f4, out=AR_i8))  # E: Any
 
-reveal_type(np.var(a))  # E: Any
 reveal_type(np.var(b))  # E: Any
-reveal_type(np.var(c))  # E: Any
-reveal_type(np.var(A))  # E: Any
-reveal_type(np.var(B))  # E: Any
-reveal_type(np.var(A, axis=0))  # E: Any
-reveal_type(np.var(B, axis=0))  # E: Any
-reveal_type(np.var(A, keepdims=True))  # E: Any
-reveal_type(np.var(B, keepdims=True))  # E: Any
-reveal_type(np.var(b, out=d))  # E: Any
-reveal_type(np.var(B, out=d))  # E: Any
+reveal_type(np.var(f4))  # E: Any
+reveal_type(np.var(f))  # E: Any
+reveal_type(np.var(AR_b))  # E: Any
+reveal_type(np.var(AR_f4))  # E: Any
+reveal_type(np.var(AR_b, axis=0))  # E: Any
+reveal_type(np.var(AR_f4, axis=0))  # E: Any
+reveal_type(np.var(AR_b, keepdims=True))  # E: Any
+reveal_type(np.var(AR_f4, keepdims=True))  # E: Any
+reveal_type(np.var(f4, out=AR_i8))  # E: Any
+reveal_type(np.var(AR_f4, out=AR_i8))  # E: Any


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/20902.

Second part in a series of PRs for adding dtype-typing support to `np.core.fromnumeric`.