### PR TITLE
BUILD: remove condition on upload step

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -152,7 +152,7 @@ jobs:
             echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
           fi
       - name: Upload wheels
-        if: ${{ env.TOKEN }}
+        # if: ${{ env.TOKEN }}  # doesn't work
         shell: bash
         run: |
           # trigger an upload to

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -137,6 +137,12 @@ jobs:
         if: success()
         shell: bash
         run: |
+          # trigger an upload to
+          # https://anaconda.org/scipy-wheels-nightly/numpy
+          # for cron jobs or "Run workflow" (restricted to main branch).
+          # Tags will upload to 
+          # https://anaconda.org/multibuild-wheels-staging/numpy
+          # The tokens were originally generated at anaconda.org
           if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
             echo push and tag event
             echo "ANACONDA_ORG=multibuild-wheels-staging" >> $GITHUB_ENV
@@ -151,17 +157,8 @@ jobs:
             echo non-dispatch event
             echo "ANACONDA_UPLOAD=false" >> $GITHUB_ENV
           fi
-      - name: Upload wheels
-        # if: ${{ env.TOKEN }}  # doesn't work
-        shell: bash
-        run: |
-          # trigger an upload to
-          # https://anaconda.org/scipy-wheels-nightly/numpy
-          # for cron jobs or "Run workflow" (restricted to main branch).
-          # Tags will upload to 
-          # https://anaconda.org/multibuild-wheels-staging/numpy
-          # The tokens were originally generated at anaconda.org
-          echo ${PWD}
+          # Now do the upload as needed
+          # echo ${PWD}
           if [ ${ANACONDA_UPLOAD} == true ]; then
             if [ -z ${TOKEN} ]; then
               echo no token set, not uploading


### PR DESCRIPTION
The condition for the "Upload wheels" step is not working, see [this scheduled build](https://github.com/numpy/numpy/runs/5134852848?check_suite_focus=true) which should have uploaded (the "Set Upload Variables" step prints "scheduled or dispatched event", so the environment variables are set).

Removing the condition will allow the step to silently skip since there is a check that `$TOKEN` is set.