### PR TITLE
DOC: Consistency of :: syntax.

### DIFF
--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -25,8 +25,7 @@ def get_include():
 
     Notes
     -----
-    When using ``distutils``, for example in ``setup.py``.
-    ::
+    When using ``distutils``, for example in ``setup.py``::
 
         import numpy as np
         ...


### PR DESCRIPTION
This one is a bit weird, I would understand if it was refused.
Having the `::` on new line can be ambiguous for RST parsers,
as `:` is a valid character for header underlines. And as underlines do
not have to be as long as the title for some rst parser this appears to
be a title.

Workaround is to have either a blank line, or put the `::` at the end of
previous one.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
