### PR TITLE
DOC: "See Also" should not have backticks.

### DIFF
--- a/numpy/typing/_nested_sequence.py
+++ b/numpy/typing/_nested_sequence.py
@@ -25,7 +25,7 @@ class _NestedSequence(Protocol[_T_co]):
 
     See Also
     --------
-    `collections.abc.Sequence`
+    collections.abc.Sequence
         ABCs for read-only and mutable :term:`sequences`.
 
     Examples


### PR DESCRIPTION
NumpyDoc fails on this with a parse Error

