### PR TITLE
BUILD: change syntax to use env variable

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -146,11 +146,11 @@ jobs:
           if [ "push" == "${{ github.event_name }}" ] && [ "${{ startsWith(github.ref, 'refs/tags/v') }}" ]; then
             echo push and tag event
             ANACONDA_ORG=multibuild-wheels-staging
-            TOKEN=${{ secrets.NUMPY_STAGING_UPLOAD_TOKEN }}
+            TOKEN=$NUMPY_STAGING_UPLOAD_TOKEN
           elif [ "schedule" == "${{ github.event_name }}" ] || [ "workflow_dispatch" == "${{ github.event_name }}" ]; then
             echo scheduled or dispatched event
             ANACONDA_ORG=scipy-wheels-nightly
-            TOKEN=${{ secrets.NUMPY_NIGHTLY_UPLOAD_TOKEN }}
+            TOKEN=$NUMPY_NIGHTLY_UPLOAD_TOKEN
           else
             echo non-dispatch event
           fi


### PR DESCRIPTION
Continuation of #21043, apparently I was using the wrong syntax