### PR TITLE
BUILD: tweak upload to use python3, less verbose

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -159,9 +159,9 @@ jobs:
           if [ -z ${TOKEN} ]; then
             echo no token set, not uploading
           else
-            python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+            python3 -m pip install git+https://github.com/Anaconda-Server/anaconda-client
             ls ./wheelhouse/*.whl
-            anaconda -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
+            anaconda -t ${TOKEN} upload --no-progress --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
             echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
           fi
 


### PR DESCRIPTION
Upload [started working](https://github.com/numpy/numpy/runs/5174812926?check_suite_focus=true) in #21049, now make it work on macOS.