### PR TITLE
BUG: (loadtxt) Ignore last empty field when `delimiter=None`

### DIFF
--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -165,6 +165,7 @@ def test_bad_ndmin(badval):
 @pytest.mark.parametrize(
     "ws",
     (
+            " ",  # space
             "\t",  # tab
             "\u2003",  # em
             "\u00A0",  # non-break
@@ -173,7 +174,10 @@ def test_bad_ndmin(badval):
 )
 def test_blank_lines_spaces_delimit(ws):
     txt = StringIO(
-        f"1 2{ws}30\n\n4 5 60\n  {ws}  \n7 8 {ws} 90\n  # comment\n3 2 1"
+        f"1 2{ws}30\n\n{ws}\n"
+        f"4 5 60{ws}\n  {ws}  \n"
+        f"7 8 {ws} 90\n  # comment\n"
+        f"3 2 1"
     )
     # NOTE: It is unclear that the `  # comment` should succeed. Except
     #       for delimiter=None, which should use any whitespace (and maybe


### PR DESCRIPTION
When the delimiter is None and we are splitting on whitespace,
a final empty field is always ignored to match the behaviour
of pythons split: `" 1 ".split()`.

Closes gh-21052

---

Opted for a slightly different variant of cleaning this up in hindsight.  There is a small thing that the "skip leading whitespace" may need some thought if we were to make it public.  But I think using the special "delimiter is whitspace" state here, helps with ensuring that things won't go weird.

This includes my "move to cpp" commit, I assume that will be merged so I don't need to worry about it here.