### PR TITLE
TYP: Add dtype-typing support to `fromnumeric` part 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,9 @@ numpy/core/src/umath/loops_minmax.dispatch.c
 numpy/core/src/umath/loops_trigonometric.dispatch.c
 numpy/core/src/umath/loops_exponent_log.dispatch.c
 numpy/core/src/umath/loops_umath_fp.dispatch.c
+numpy/core/src/umath/loops_hyperbolic.dispatch.c
 # npysort module
 numpy/core/src/npysort/x86-qsort.dispatch.c
+# multiarray module
+numpy/core/src/multiarray/argfunc.dispatch.c
+numpy/core/src/multiarray/arraytypes.h

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -5,8 +5,15 @@ from typing import Union, Any, overload, TypeVar, Literal
 from numpy import (
     ndarray,
     number,
+    uint64,
+    int_,
+    int64,
     intp,
+    float16,
     bool_,
+    floating,
+    complexfloating,
+    object_,
     generic,
     _OrderKACF,
     _OrderACF,
@@ -24,13 +31,20 @@ from numpy.typing import (
     _ShapeLike,
     _Shape,
     _ArrayLikeBool_co,
+    _ArrayLikeUInt_co,
     _ArrayLikeInt_co,
+    _ArrayLikeFloat_co,
+    _ArrayLikeComplex_co,
+    _ArrayLikeObject_co,
     _IntLike_co,
+    _BoolLike_co,
+    _ComplexLike_co,
     _NumberLike_co,
     _ScalarLike_co,
 )
 
 _SCT = TypeVar("_SCT", bound=generic)
+_SCT_uifcO = TypeVar("_SCT_uifcO", bound=number[Any] | object_)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
 __all__: list[str]
@@ -659,61 +673,377 @@ def amin(
 
 # Note that the same situation holds for all wrappers around
 # `np.ufunc.reduce`, e.g. `np.sum()` (`.__add__()`).
+@overload
 def prod(
-    a: ArrayLike,
+    a: _ArrayLikeBool_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> int_: ...
+@overload
+def prod(
+    a: _ArrayLikeUInt_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> uint64: ...
+@overload
+def prod(
+    a: _ArrayLikeInt_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> int64: ...
+@overload
+def prod(
+    a: _ArrayLikeFloat_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> floating[Any]: ...
+@overload
+def prod(
+    a: _ArrayLikeComplex_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> complexfloating[Any, Any]: ...
+@overload
+def prod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     axis: None | _ShapeLike = ...,
-    dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
+    dtype: None = ...,
+    out: None = ...,
     keepdims: bool = ...,
     initial: _NumberLike_co = ...,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def prod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
+def prod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: None | DTypeLike = ...,
+    out: None = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> Any: ...
+@overload
+def prod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: None | DTypeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    initial: _NumberLike_co = ...,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
+@overload
 def cumprod(
-    a: ArrayLike,
+    a: _ArrayLikeBool_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[int_]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeUInt_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[uint64]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeInt_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[int64]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeFloat_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[floating[Any]]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeComplex_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[complexfloating[Any, Any]]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeObject_co,
+    axis: None | int = ...,
+    dtype: None = ...,
+    out: None = ...,
+) -> NDArray[object_]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | int = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+) -> NDArray[_SCT]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     axis: None | int = ...,
     dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
-) -> ndarray: ...
+    out: None = ...,
+) -> NDArray[Any]: ...
+@overload
+def cumprod(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | int = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
 def ndim(a: ArrayLike) -> int: ...
 
 def size(a: ArrayLike, axis: None | int = ...) -> int: ...
 
+@overload
 def around(
-    a: ArrayLike,
+    a: _BoolLike_co,
     decimals: int = ...,
-    out: None | ndarray = ...,
+    out: None = ...,
+) -> float16: ...
+@overload
+def around(
+    a: _SCT_uifcO,
+    decimals: int = ...,
+    out: None = ...,
+) -> _SCT_uifcO: ...
+@overload
+def around(
+    a: _ComplexLike_co | object_,
+    decimals: int = ...,
+    out: None = ...,
 ) -> Any: ...
+@overload
+def around(
+    a: _ArrayLikeBool_co,
+    decimals: int = ...,
+    out: None = ...,
+) -> NDArray[float16]: ...
+@overload
+def around(
+    a: _ArrayLike[_SCT_uifcO],
+    decimals: int = ...,
+    out: None = ...,
+) -> NDArray[_SCT_uifcO]: ...
+@overload
+def around(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    decimals: int = ...,
+    out: None = ...,
+) -> NDArray[Any]: ...
+@overload
+def around(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    decimals: int = ...,
+    out: _ArrayType = ...,
+) -> _ArrayType: ...
 
+@overload
 def mean(
-    a: ArrayLike,
+    a: _ArrayLikeFloat_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> floating[Any]: ...
+@overload
+def mean(
+    a: _ArrayLikeComplex_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> complexfloating[Any, Any]: ...
+@overload
+def mean(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     axis: None | _ShapeLike = ...,
-    dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
+    dtype: None = ...,
+    out: None = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def mean(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
+def mean(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: None = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> Any: ...
+@overload
+def mean(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
+@overload
 def std(
-    a: ArrayLike,
+    a: _ArrayLikeComplex_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> floating[Any]: ...
+@overload
+def std(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     axis: None | _ShapeLike = ...,
-    dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
-    ddof: int = ...,
+    dtype: None = ...,
+    out: None = ...,
+    ddof: float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def std(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
+def std(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> Any: ...
+@overload
+def std(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+    ddof: float = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...
 
+@overload
 def var(
-    a: ArrayLike,
+    a: _ArrayLikeComplex_co,
+    axis: None = ...,
+    dtype: None = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> floating[Any]: ...
+@overload
+def var(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     axis: None | _ShapeLike = ...,
-    dtype: DTypeLike = ...,
-    out: None | ndarray = ...,
-    ddof: int = ...,
+    dtype: None = ...,
+    out: None = ...,
+    ddof: float = ...,
     keepdims: bool = ...,
     *,
     where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
+@overload
+def var(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None = ...,
+    dtype: _DTypeLike[_SCT] = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: Literal[False] = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _SCT: ...
+@overload
+def var(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: None = ...,
+    ddof: float = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> Any: ...
+@overload
+def var(
+    a: _ArrayLikeComplex_co | _ArrayLikeObject_co,
+    axis: None | _ShapeLike = ...,
+    dtype: DTypeLike = ...,
+    out: _ArrayType = ...,
+    ddof: float = ...,
+    keepdims: bool = ...,
+    *,
+    where: _ArrayLikeBool_co = ...,
+) -> _ArrayType: ...

--- a/numpy/typing/tests/data/fail/fromnumeric.pyi
+++ b/numpy/typing/tests/data/fail/fromnumeric.pyi
@@ -1,9 +1,11 @@
 """Tests for :mod:`numpy.core.fromnumeric`."""
 
 import numpy as np
+import numpy.typing as npt
 
 A = np.array(True, ndmin=2, dtype=bool)
 A.setflags(write=False)
+AR_U: npt.NDArray[np.str_]
 
 a = np.bool_(True)
 
@@ -124,30 +126,36 @@ np.amin(a, out=1.0)  # E: No overload variant
 np.amin(a, initial=[1.0])  # E: No overload variant
 np.amin(a, where=[1.0])  # E: incompatible type
 
-np.prod(a, axis=1.0)  # E: incompatible type
-np.prod(a, out=False)  # E: incompatible type
-np.prod(a, keepdims=1.0)  # E: incompatible type
-np.prod(a, initial=int)  # E: incompatible type
-np.prod(a, where=1.0)  # E: incompatible type
+np.prod(a, axis=1.0)  # E: No overload variant
+np.prod(a, out=False)  # E: No overload variant
+np.prod(a, keepdims=1.0)  # E: No overload variant
+np.prod(a, initial=int)  # E: No overload variant
+np.prod(a, where=1.0)  # E: No overload variant
+np.prod(AR_U)  # E: incompatible type
 
-np.cumprod(a, axis=1.0)  # E: Argument "axis" to "cumprod" has incompatible type
-np.cumprod(a, out=False)  # E: Argument "out" to "cumprod" has incompatible type
+np.cumprod(a, axis=1.0)  # E: No overload variant
+np.cumprod(a, out=False)  # E: No overload variant
+np.cumprod(AR_U)  # E: incompatible type
 
 np.size(a, axis=1.0)  # E: Argument "axis" to "size" has incompatible type
 
-np.around(a, decimals=1.0)  # E: incompatible type
-np.around(a, out=type)  # E: incompatible type
+np.around(a, decimals=1.0)  # E: No overload variant
+np.around(a, out=type)  # E: No overload variant
+np.around(AR_U)  # E: incompatible type
 
-np.mean(a, axis=1.0)  # E: incompatible type
-np.mean(a, out=False)  # E: incompatible type
-np.mean(a, keepdims=1.0)  # E: incompatible type
+np.mean(a, axis=1.0)  # E: No overload variant
+np.mean(a, out=False)  # E: No overload variant
+np.mean(a, keepdims=1.0)  # E: No overload variant
+np.mean(AR_U)  # E: incompatible type
 
-np.std(a, axis=1.0)  # E: incompatible type
-np.std(a, out=False)  # E: incompatible type
-np.std(a, ddof='test')  # E: incompatible type
-np.std(a, keepdims=1.0)  # E: incompatible type
+np.std(a, axis=1.0)  # E: No overload variant
+np.std(a, out=False)  # E: No overload variant
+np.std(a, ddof='test')  # E: No overload variant
+np.std(a, keepdims=1.0)  # E: No overload variant
+np.std(AR_U)  # E: incompatible type
 
-np.var(a, axis=1.0)  # E: incompatible type
-np.var(a, out=False)  # E: incompatible type
-np.var(a, ddof='test')  # E: incompatible type
-np.var(a, keepdims=1.0)  # E: incompatible type
+np.var(a, axis=1.0)  # E: No overload variant
+np.var(a, out=False)  # E: No overload variant
+np.var(a, ddof='test')  # E: No overload variant
+np.var(a, keepdims=1.0)  # E: No overload variant
+np.var(AR_U)  # E: incompatible type

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -8,11 +8,15 @@ class NDArraySubclass(npt.NDArray[np.complex128]):
 
 AR_b: npt.NDArray[np.bool_]
 AR_f4: npt.NDArray[np.float32]
+AR_c16: npt.NDArray[np.complex128]
+AR_u8: npt.NDArray[np.uint64]
 AR_i8: npt.NDArray[np.int64]
+AR_O: npt.NDArray[np.object_]
 AR_subclass: NDArraySubclass
 
 b: np.bool_
 f4: np.float32
+i8: np.int64
 f: float
 
 reveal_type(np.take(b, 0))  # E: bool_
@@ -214,23 +218,28 @@ reveal_type(np.amin(AR_b, keepdims=True))  # E: Any
 reveal_type(np.amin(AR_f4, keepdims=True))  # E: Any
 reveal_type(np.amin(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.prod(b))  # E: Any
-reveal_type(np.prod(f4))  # E: Any
-reveal_type(np.prod(f))  # E: Any
-reveal_type(np.prod(AR_b))  # E: Any
-reveal_type(np.prod(AR_f4))  # E: Any
-reveal_type(np.prod(AR_b, axis=0))  # E: Any
+reveal_type(np.prod(AR_b))  # E: {int_}
+reveal_type(np.prod(AR_u8))  # E: {uint64}
+reveal_type(np.prod(AR_i8))  # E: {int64}
+reveal_type(np.prod(AR_f4))  # E: floating[Any]
+reveal_type(np.prod(AR_c16))  # E: complexfloating[Any, Any]
+reveal_type(np.prod(AR_O))  # E: Any
 reveal_type(np.prod(AR_f4, axis=0))  # E: Any
-reveal_type(np.prod(AR_b, keepdims=True))  # E: Any
 reveal_type(np.prod(AR_f4, keepdims=True))  # E: Any
-reveal_type(np.prod(f4, out=AR_i8))  # E: Any
-reveal_type(np.prod(AR_f4, out=AR_i8))  # E: Any
+reveal_type(np.prod(AR_f4, dtype=np.float64))  # E: {float64}
+reveal_type(np.prod(AR_f4, dtype=float))  # E: Any
+reveal_type(np.prod(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.cumprod(b))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(f4))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(f))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(AR_b))  # E: ndarray[Any, Any]
-reveal_type(np.cumprod(AR_f4))  # E: ndarray[Any, Any]
+reveal_type(np.cumprod(AR_b))  # E: ndarray[Any, dtype[{int_}]]
+reveal_type(np.cumprod(AR_u8))  # E: ndarray[Any, dtype[{uint64}]]
+reveal_type(np.cumprod(AR_i8))  # E: ndarray[Any, dtype[{int64}]]
+reveal_type(np.cumprod(AR_f4))  # E: ndarray[Any, dtype[floating[Any]]]
+reveal_type(np.cumprod(AR_c16))  # E: ndarray[Any, dtype[complexfloating[Any, Any]]]
+reveal_type(np.cumprod(AR_O))  # E: ndarray[Any, dtype[object_]]
+reveal_type(np.cumprod(AR_f4, axis=0))  # E: ndarray[Any, dtype[floating[Any]]]
+reveal_type(np.cumprod(AR_f4, dtype=np.float64))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.cumprod(AR_f4, dtype=float))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.cumprod(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
 reveal_type(np.ndim(b))  # E: int
 reveal_type(np.ndim(f4))  # E: int
@@ -244,44 +253,45 @@ reveal_type(np.size(f))  # E: int
 reveal_type(np.size(AR_b))  # E: int
 reveal_type(np.size(AR_f4))  # E: int
 
-reveal_type(np.around(b))  # E: Any
-reveal_type(np.around(f4))  # E: Any
+reveal_type(np.around(b))  # E: {float16}
 reveal_type(np.around(f))  # E: Any
-reveal_type(np.around(AR_b))  # E: Any
-reveal_type(np.around(AR_f4))  # E: Any
+reveal_type(np.around(i8))  # E: {int64}
+reveal_type(np.around(f4))  # E: {float32}
+reveal_type(np.around(AR_b))  # E: ndarray[Any, dtype[{float16}]]
+reveal_type(np.around(AR_i8))  # E: ndarray[Any, dtype[{int64}]]
+reveal_type(np.around(AR_f4))  # E: ndarray[Any, dtype[{float32}]]
+reveal_type(np.around([1.5]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.around(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.mean(b))  # E: Any
-reveal_type(np.mean(f4))  # E: Any
-reveal_type(np.mean(f))  # E: Any
-reveal_type(np.mean(AR_b))  # E: Any
-reveal_type(np.mean(AR_f4))  # E: Any
-reveal_type(np.mean(AR_b, axis=0))  # E: Any
+reveal_type(np.mean(AR_b))  # E: floating[Any]
+reveal_type(np.mean(AR_i8))  # E: floating[Any]
+reveal_type(np.mean(AR_f4))  # E: floating[Any]
+reveal_type(np.mean(AR_c16))  # E: complexfloating[Any, Any]
+reveal_type(np.mean(AR_O))  # E: Any
 reveal_type(np.mean(AR_f4, axis=0))  # E: Any
-reveal_type(np.mean(AR_b, keepdims=True))  # E: Any
 reveal_type(np.mean(AR_f4, keepdims=True))  # E: Any
-reveal_type(np.mean(f4, out=AR_i8))  # E: Any
-reveal_type(np.mean(AR_f4, out=AR_i8))  # E: Any
+reveal_type(np.mean(AR_f4, dtype=float))  # E: Any
+reveal_type(np.mean(AR_f4, dtype=np.float64))  # E: {float64}
+reveal_type(np.mean(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.std(b))  # E: Any
-reveal_type(np.std(f4))  # E: Any
-reveal_type(np.std(f))  # E: Any
-reveal_type(np.std(AR_b))  # E: Any
-reveal_type(np.std(AR_f4))  # E: Any
-reveal_type(np.std(AR_b, axis=0))  # E: Any
+reveal_type(np.std(AR_b))  # E: floating[Any]
+reveal_type(np.std(AR_i8))  # E: floating[Any]
+reveal_type(np.std(AR_f4))  # E: floating[Any]
+reveal_type(np.std(AR_c16))  # E: floating[Any]
+reveal_type(np.std(AR_O))  # E: Any
 reveal_type(np.std(AR_f4, axis=0))  # E: Any
-reveal_type(np.std(AR_b, keepdims=True))  # E: Any
 reveal_type(np.std(AR_f4, keepdims=True))  # E: Any
-reveal_type(np.std(f4, out=AR_i8))  # E: Any
-reveal_type(np.std(AR_f4, out=AR_i8))  # E: Any
+reveal_type(np.std(AR_f4, dtype=float))  # E: Any
+reveal_type(np.std(AR_f4, dtype=np.float64))  # E: {float64}
+reveal_type(np.std(AR_f4, out=AR_subclass))  # E: NDArraySubclass
 
-reveal_type(np.var(b))  # E: Any
-reveal_type(np.var(f4))  # E: Any
-reveal_type(np.var(f))  # E: Any
-reveal_type(np.var(AR_b))  # E: Any
-reveal_type(np.var(AR_f4))  # E: Any
-reveal_type(np.var(AR_b, axis=0))  # E: Any
+reveal_type(np.var(AR_b))  # E: floating[Any]
+reveal_type(np.var(AR_i8))  # E: floating[Any]
+reveal_type(np.var(AR_f4))  # E: floating[Any]
+reveal_type(np.var(AR_c16))  # E: floating[Any]
+reveal_type(np.var(AR_O))  # E: Any
 reveal_type(np.var(AR_f4, axis=0))  # E: Any
-reveal_type(np.var(AR_b, keepdims=True))  # E: Any
 reveal_type(np.var(AR_f4, keepdims=True))  # E: Any
-reveal_type(np.var(f4, out=AR_i8))  # E: Any
-reveal_type(np.var(AR_f4, out=AR_i8))  # E: Any
+reveal_type(np.var(AR_f4, dtype=float))  # E: Any
+reveal_type(np.var(AR_f4, dtype=np.float64))  # E: {float64}
+reveal_type(np.var(AR_f4, out=AR_subclass))  # E: NDArraySubclass


### PR DESCRIPTION
Follow up on https://github.com/numpy/numpy/pull/21021

This PR adds dtype-typing support to the last few remaining functions in `np.core.fromnumeric`.

One thing that's left on the to-do list (for a future PR) is investigating whether there is a convenient way of reusing all these function signatures for their `ndarray` method counterpart.