### PR TITLE
BLD,ENH: Add vsx3 and vsx4 as targets when building cos/sin and tanh

### DIFF
--- a/numpy/core/src/umath/loops_hyperbolic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_hyperbolic.dispatch.c.src
@@ -1,7 +1,7 @@
 /*@targets
  ** $maxopt baseline
  ** (avx2 fma3) AVX512_SKX
- ** vsx2
+ ** vsx2 vsx4
  ** neon_vfpv4
  **/
 #include "numpy/npy_math.h"

--- a/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
+++ b/numpy/core/src/umath/loops_trigonometric.dispatch.c.src
@@ -1,7 +1,7 @@
 /*@targets
  ** $maxopt baseline
  ** (avx2 fma3) avx512f
- ** vsx2
+ ** vsx2 vsx3 vsx4
  ** neon_vfpv4
  **/
 #include "numpy/npy_math.h"


### PR DESCRIPTION
This PR:
- adds vsx3 and vsx4 as targets when building `sin/cos` (FP32)
- adds vsx4 as target when building `tanh`

The compiler generates better code when we use vsx3/vsx4 flags on Power9/Power10, respectively.

**Power10/VSX4**:
```
TANH
-        1.28±0ms        550±0.5μs     0.43  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 2, 1, 'f')
-        1.31±0ms          530±3μs     0.41  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 4, 'f')
-        1.30±0ms        525±0.6μs     0.40  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 2, 'f')
-        1.28±0ms        502±0.5μs     0.39  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 1, 'f')

COS/SIN
-       391±0.3μs        237±0.3μs     0.60  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 4, 1, 'f')
-       366±0.2μs        211±0.6μs     0.58  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 1, 1, 'f')
-       406±0.8μs        233±0.2μs     0.57  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 4, 1, 'f')
-         375±2μs        212±0.7μs     0.56  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 1, 1, 'f')
```

**Power9/VSX3**:
```
TANH
+        1.48±0ms         1.63±0ms     1.10  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 1, 'd')
+     1.55±0.01ms      1.70±0.01ms     1.09  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 4, 'd')
-        1.13±0ms        906±0.3μs     0.80  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 4, 1, 'f')
-        1.06±0ms        838±0.3μs     0.79  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'tanh'>, 1, 1, 'f')

COS/SIN
-        634±20μs          454±1μs     0.72  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 2, 1, 'f')
-        629±20μs          448±8μs     0.71  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 2, 1, 'f')
-         671±2μs        477±0.6μs     0.71  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sin'>, 1, 2, 'f')
-        601±20μs          425±6μs     0.71  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'cos'>, 1, 1, 'f')
```

- I did not add vsx3 for `tanh` since we have slowdown for dtype=double
- The improvements above show up only for `gcc >=10`

