### PR TITLE
BUG: Fix unpickling an empty ndarray with a non-zero dimension

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2205,7 +2205,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 Py_DECREF(typecode);
             }
             else {
-                memcpy(PyArray_DATA(self), datastr, num);
+                memcpy(PyArray_DATA(self), datastr, PyArray_NBYTES(self));
             }
             PyArray_ENABLEFLAGS(self, NPY_ARRAY_OWNDATA);
             fa->base = NULL;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1638,7 +1638,7 @@ class TestZeroSizeFlexible:
     def test_pickle_empty(self):
         """Checking if an empty array pickled and un-pickled will not cause a
         segmentation fault"""
-        arr = np.array([]).reshape(99999999, 0)
+        arr = np.array([]).reshape(999999, 0)
         pk_dmp = pickle.dumps(arr)
         pk_load = pickle.loads(pk_dmp)
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1635,6 +1635,15 @@ class TestZeroSizeFlexible:
 
                 assert_equal(zs.dtype, zs2.dtype)
 
+    def test_pickle_empty(self):
+        """Checking if an empty array pickled and un-pickled will not cause a
+        segmentation fault"""
+        arr = np.array([]).reshape(99999999, 0)
+        pk_dmp = pickle.dumps(arr)
+        pk_load = pickle.loads(pk_dmp)
+
+        assert pk_load.size == 0
+
     @pytest.mark.skipif(pickle.HIGHEST_PROTOCOL < 5,
                         reason="requires pickle protocol 5")
     def test_pickle_with_buffercallback(self):
@@ -1649,7 +1658,6 @@ class TestZeroSizeFlexible:
         # should modify it in array_from_buffer too.
         array[0] = -1
         assert array_from_buffer[0] == -1, array_from_buffer[0]
-
 
 class TestMethods:
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1659,6 +1659,7 @@ class TestZeroSizeFlexible:
         array[0] = -1
         assert array_from_buffer[0] == -1, array_from_buffer[0]
 
+
 class TestMethods:
 
     sort_kinds = ['quicksort', 'heapsort', 'stable']


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Changing `num` to the number of bytes in the input array, `PyArray_NBYTES(self)`. Solves #21009.