### PR TITLE
BUG: Replace ``ssize_t`` with ``size_t`` in tokenize.cpp

### DIFF
--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -389,8 +389,8 @@ tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
      */
     if (ts->num_fields == 1
             || ts->unquoted_state == TOKENIZE_UNQUOTED_WHITESPACE) {
-        ssize_t offset_last = ts->fields[ts->num_fields-1].offset;
-        ssize_t end_last = ts->fields[ts->num_fields].offset;
+        std::ptrdiff_t offset_last = ts->fields[ts->num_fields-1].offset;
+        std::ptrdiff_t end_last = ts->fields[ts->num_fields].offset;
         if (!ts->fields->quoted && end_last - offset_last == 1) {
             ts->num_fields--;
         }

--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -389,8 +389,8 @@ tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
      */
     if (ts->num_fields == 1
             || ts->unquoted_state == TOKENIZE_UNQUOTED_WHITESPACE) {
-        std::ptrdiff_t offset_last = ts->fields[ts->num_fields-1].offset;
-        std::ptrdiff_t end_last = ts->fields[ts->num_fields].offset;
+        size_t offset_last = ts->fields[ts->num_fields-1].offset;
+        size_t end_last = ts->fields[ts->num_fields].offset;
         if (!ts->fields->quoted && end_last - offset_last == 1) {
             ts->num_fields--;
         }


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/21073

`ssize_t` is not defined for all platforms in C++ (_e.g._ windows), so replace it with `ptrdiff_t`.