### PR TITLE
DEV: add distutils deprecation warning filter to pytest conf

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,4 @@ filterwarnings =
     ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning
 # Ignore DeprecationWarnings from distutils
     ignore::DeprecationWarning:.*distutils
+    ignore:\n\n  `numpy.distutils`:DeprecationWarning


### PR DESCRIPTION
Followup to #20875: add a new filter to ignore the new distutils deprecation warning. 