### PR TITLE
BUILD: if travis build is triggered manually, then upload wheels

### DIFF
--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -9,6 +9,9 @@ set_travis_vars() {
     fi
     if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
       IS_SCHEDULE_DISPATCH="true"
+    elif [[ "$TRAVIS_EVENT_TYPE" == "api" ]]; then
+      # Manual CI run, so upload
+      IS_SCHEDULE_DISPATCH="true"
     else
       IS_SCHEDULE_DISPATCH="false"
     fi


### PR DESCRIPTION
Continuation of #20987 to allow uploads from manually triggered travis builds. Only maintainers will see the UI option to trigger a build [ci skip].