### PR TITLE
MAINT: update cython, pypy for cython0.29.28 and pypy v7.3.8 release

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -211,7 +211,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
-        python-version: pypy-3.8-v7.3.7
+        python-version: pypy-3.8-v7.3.8
     - uses: ./.github/actions
 
   sdist:
@@ -248,7 +248,7 @@ jobs:
         docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:latest /bin/bash -c "
           apt update &&
           apt install -y git python3 python3-dev python3-pip &&
-          pip3 install cython==0.29.24 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 &&
+          pip3 install cython==0.29.28 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 &&
           ln -s /host/lib64 /lib64 &&
           ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&
           ln -s /host/usr/arm-linux-gnueabihf /usr/arm-linux-gnueabihf &&

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,13 +66,10 @@ jobs:
         include:
         # manylinux pypy builds
         - buildplat: [ubuntu-20.04, manylinux_x86_64]
-          python: pp38
+          python: "pp38"
 
-        # MacOS PyPy builds
-        # Disabled for now because of a PyPy bug
-        # that prevents successful compilation
-        #- buildplat: [macos-10.15, macosx_x86_64]
-        #  python: "pp38"
+        - buildplat: [macos-10.15, macosx_x86_64]
+          python: "pp38"
 
         # Windows PyPy builds
         - buildplat: [windows-2019, win_amd64]

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -20,7 +20,7 @@ Building NumPy requires the following installed software:
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 0.29.21
+2) Cython >= 0.29.28
 
 3) pytest__ (optional) 1.15 or later
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ requires = [
     "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools==59.2.0",
     "wheel==0.37.0",
-    "Cython==0.29.24"  # pin until PyPy releases v7.3.8
-    # "Cython==0.29.24,<3.0",  # Note: keep in sync with tools/cythonize.py
+    "Cython>=0.29.28,<3.0",  # Note: keep in sync with tools/cythonize.py
 ]
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-cython==0.29.24
+cython>=0.29.28,<3.0
 wheel==0.37.0
 setuptools==59.2.0
 hypothesis==6.24.1


### PR DESCRIPTION
PyPy released v7.3.8 which should fix the macOS build and make the windows build more reliable. Cython also released 0.29.28 which is close to supporting CPython3.11, which will be freezing its C-API soon. 