### PR TITLE
BLD: Comment out broken macOS PyPy build [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,9 +67,12 @@ jobs:
         # manylinux pypy builds
         - buildplat: [ubuntu-20.04, manylinux_x86_64]
           python: "pp38"
-
-        - buildplat: [macos-10.15, macosx_x86_64]
-          python: "pp38"
+        
+        # TODO: Uncomment and bump cibuildwheel version
+        # once cibuildwheel adds PyPy 7.3.8
+        # macOS pypy builds
+        #- buildplat: [macos-10.15, macosx_x86_64]
+        #  python: "pp38"
 
         # Windows PyPy builds
         - buildplat: [windows-2019, win_amd64]


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Checking my intuition in https://github.com/numpy/numpy/pull/21097#issuecomment-1046386325. Looks like the PyPy build is failing(probably due to it being on 7.3.7).

I guess I will re-comment out the macOS builds again then.