### PR TITLE
TYP,MAINT: Explicitly allow sequences of array-likes in `np.concatenate`

### DIFF
--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -11,6 +11,7 @@ from typing import (
     SupportsIndex,
     final,
     Final,
+    Protocol,
 )
 
 from numpy import (
@@ -77,6 +78,8 @@ from numpy.typing import (
     _TD64Like_co,
 )
 
+_T_co = TypeVar("_T_co", covariant=True)
+_T_contra = TypeVar("_T_contra", contravariant=True)
 _SCT = TypeVar("_SCT", bound=generic)
 _ArrayType = TypeVar("_ArrayType", bound=NDArray[Any])
 
@@ -104,6 +107,10 @@ _RollKind = L[  # `raise` is deliberately excluded
     "modifiedfollowing",
     "modifiedpreceding",
 ]
+
+class _SupportsLenAndGetItem(Protocol[_T_contra, _T_co]):
+    def __len__(self) -> int: ...
+    def __getitem__(self, key: _T_contra, /) -> _T_co: ...
 
 __all__: list[str]
 
@@ -292,6 +299,7 @@ def ravel_multi_index(
     order: _OrderCF = ...,
 ) -> NDArray[intp]: ...
 
+# NOTE: Allow any sequence of array-like objects
 @overload
 def concatenate(  # type: ignore[misc]
     arrays: _ArrayLike[_SCT],
@@ -304,7 +312,7 @@ def concatenate(  # type: ignore[misc]
 ) -> NDArray[_SCT]: ...
 @overload
 def concatenate(  # type: ignore[misc]
-    arrays: ArrayLike,
+    arrays: _SupportsLenAndGetItem[int, ArrayLike],
     /,
     axis: None | SupportsIndex = ...,
     out: None = ...,
@@ -314,7 +322,7 @@ def concatenate(  # type: ignore[misc]
 ) -> NDArray[Any]: ...
 @overload
 def concatenate(  # type: ignore[misc]
-    arrays: ArrayLike,
+    arrays: _SupportsLenAndGetItem[int, ArrayLike],
     /,
     axis: None | SupportsIndex = ...,
     out: None = ...,
@@ -324,7 +332,7 @@ def concatenate(  # type: ignore[misc]
 ) -> NDArray[_SCT]: ...
 @overload
 def concatenate(  # type: ignore[misc]
-    arrays: ArrayLike,
+    arrays: _SupportsLenAndGetItem[int, ArrayLike],
     /,
     axis: None | SupportsIndex = ...,
     out: None = ...,
@@ -334,7 +342,7 @@ def concatenate(  # type: ignore[misc]
 ) -> NDArray[Any]: ...
 @overload
 def concatenate(
-    arrays: ArrayLike,
+    arrays: _SupportsLenAndGetItem[int, ArrayLike],
     /,
     axis: None | SupportsIndex = ...,
     out: _ArrayType = ...,

--- a/numpy/typing/tests/data/fail/false_positives.pyi
+++ b/numpy/typing/tests/data/fail/false_positives.pyi
@@ -1,0 +1,11 @@
+import numpy as np
+import numpy.typing as npt
+
+AR_f8: npt.NDArray[np.float64]
+
+# NOTE: Mypy bug presumably due to the special-casing of heterogeneous tuples;
+# xref numpy/numpy#20901
+#
+# The expected output should be no different than, e.g., when using a
+# list instead of a tuple
+np.concatenate(([1], AR_f8))  # E: Argument 1 to "concatenate" has incompatible type

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -39,6 +39,11 @@ reveal_type(np.empty([1, 5, 6], dtype=np.int64))  # E: ndarray[Any, dtype[{int64
 reveal_type(np.empty([1, 5, 6], dtype='c16'))  # E: ndarray[Any, dtype[Any]]
 
 reveal_type(np.concatenate(A))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.concatenate([A, A]))  # E: Any
+reveal_type(np.concatenate([[1], A]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.concatenate([[1], [1]]))  # E: ndarray[Any, dtype[Any]]
+reveal_type(np.concatenate((A, A)))  # E: ndarray[Any, dtype[{float64}]]
+reveal_type(np.concatenate(([1], [1])))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.concatenate([1, 1.0]))  # E: ndarray[Any, dtype[Any]]
 reveal_type(np.concatenate(A, dtype=np.int64))  # E: ndarray[Any, dtype[{int64}]]
 reveal_type(np.concatenate(A, dtype='c16'))  # E: ndarray[Any, dtype[Any]]

--- a/numpy/typing/tests/data/reveal/false_positives.pyi
+++ b/numpy/typing/tests/data/reveal/false_positives.pyi
@@ -1,0 +1,10 @@
+from typing import Any
+import numpy.typing as npt
+
+AR_Any: npt.NDArray[Any]
+
+# Mypy bug where overload ambiguity is ignored for `Any`-parametrized types;
+# xref numpy/numpy#20099 and python/mypy#11347
+#
+# The expected output would be something akin to `ndarray[Any, dtype[Any]]`
+reveal_type(AR_Any + 2)  # E: ndarray[Any, dtype[signedinteger[Any]]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/20901, alternative to https://github.com/numpy/numpy/pull/20903.

Explicitly allow a sequence of array-like objects in `np.concatenate`, rather than just array-likes.
Note that this does not fully get rid of all false positives, _i.e._ heterogeneous tuples of array-likes still aren't accepted due to what appears to be a mypy bug.