### PR TITLE
TYP, ENH: Mark non-subclassable classes as `final`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -930,6 +930,7 @@ _ArrayLikeInt = Union[
 
 _FlatIterSelf = TypeVar("_FlatIterSelf", bound=flatiter)
 
+@final
 class flatiter(Generic[_NdArraySubClass]):
     @property
     def base(self) -> _NdArraySubClass: ...
@@ -3136,6 +3137,7 @@ UFUNC_PYVALS_NAME: L["UFUNC_PYVALS"]
 newaxis: None
 
 # See `npt._ufunc` for more concrete nin-/nout-specific stubs
+@final
 class ufunc:
     @property
     def __name__(self) -> str: ...
@@ -3372,6 +3374,7 @@ class DataSource:
 # TODO: The type of each `__next__` and `iters` return-type depends
 # on the length and dtype of `args`; we can't describe this behavior yet
 # as we lack variadics (PEP 646).
+@final
 class broadcast:
     def __new__(cls, *args: ArrayLike) -> broadcast: ...
     @property
@@ -3392,6 +3395,7 @@ class broadcast:
     def __iter__(self: _T) -> _T: ...
     def reset(self) -> None: ...
 
+@final
 class busdaycalendar:
     def __new__(
         cls,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -676,6 +676,7 @@ _NdArraySubClass = TypeVar("_NdArraySubClass", bound=ndarray)
 _DTypeScalar_co = TypeVar("_DTypeScalar_co", covariant=True, bound=generic)
 _ByteOrder = L["S", "<", ">", "=", "|", "L", "B", "N", "I"]
 
+@final
 class dtype(Generic[_DTypeScalar_co]):
     names: None | tuple[builtins.str, ...]
     # Overload for subclass of generic

--- a/numpy/typing/_ufunc.pyi
+++ b/numpy/typing/_ufunc.pyi
@@ -48,7 +48,7 @@ _NameType = TypeVar("_NameType", bound=str)
 # NOTE: If 2 output types are returned then `out` must be a
 # 2-tuple of arrays. Otherwise `None` or a plain array are also acceptable
 
-class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):
+class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
@@ -108,7 +108,7 @@ class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):
         /,
     ) -> None: ...
 
-class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):
+class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
@@ -223,7 +223,7 @@ class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):
         extobj: list[Any] = ...,
     ) -> NDArray[Any]: ...
 
-class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):
+class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
@@ -281,7 +281,7 @@ class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):
         extobj: list[Any] = ...,
     ) -> _2Tuple[NDArray[Any]]: ...
 
-class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):
+class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
@@ -341,7 +341,7 @@ class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):
         extobj: list[Any] = ...,
     ) -> _2Tuple[NDArray[Any]]: ...
 
-class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):
+class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property


### PR DESCRIPTION
This PR marks a number of non-subclassable classes with [`typing.final`](https://docs.python.org/3/library/typing.html#typing.final), which will cause type checkers to start complaining if downstream users try to subclass them.

The classes in question are:
* `flatiter`
* `ufunc`
* `broadcast`
* `ufunc`
* EDIT: `dtype`

Notable in it's absence here is `dtype`, as from what I understand it will become a valid baseclass soonish with NEP 42 (@seberg could you confirm this?).