### PR TITLE
MAINT: Fix incorrect signature in readtext header file

### DIFF
--- a/numpy/core/src/multiarray/textreading/readtext.h
+++ b/numpy/core/src/multiarray/textreading/readtext.h
@@ -2,6 +2,7 @@
 #define NUMPY_CORE_SRC_MULTIARRAY_TEXTREADING_READTEXT_H_
 
 NPY_NO_EXPORT PyObject *
-_load_from_filelike(PyObject *self, PyObject *args, PyObject *kwargs);
+_load_from_filelike(PyObject *mod,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_TEXTREADING_READTEXT_H_ */


### PR DESCRIPTION
This is the ~public~ python API, so it is cast anyway and nothing notices it
except some compilers.  Seems our CI didn't, thus this small fixup.
