### PR TITLE
CI: Improve concurrency to cancel running jobs on PR update

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,6 +18,10 @@ env:
   DOWNLOAD_OPENBLAS: 1
   PYTHON_VERSION: 3.8
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     if: "github.repository == 'numpy/numpy' && github.ref != 'refs/heads/main' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   cygwin_build_test:
     runs-on: windows-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,6 +21,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   get_commit_message:
     name: Get commit message


### PR DESCRIPTION
## Description

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

This will cancel old running jobs on current PRs/branches where more commits have been made, thus saving resources and relieving some spots in the queue a bit faster.

Based off my PR on SciPy here: https://github.com/scipy/scipy/pull/15634