### PR TITLE
BLD: bump cibuildwheel 2.3.0 → 2.3.1 on GHA [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,7 @@ jobs:
           refreshenv
         if: ${{ env.IS_32_BIT == 'true' }}
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           NPY_USE_BLAS_ILP64: ${{ env.IS_32_BIT == 'true' && '0' || '1' }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}


### PR DESCRIPTION
Travis-CI already uses 2.3.1, use the same version for GitHub Actions workflow.
