### PR TITLE
BLD,DOC: skip broken ipython 8.1.0

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,7 +3,7 @@ sphinx==4.2.0
 numpydoc==1.2.0
 pydata-sphinx-theme==0.7.2
 sphinx-panels
-ipython
+ipython!=8.1.0
 scipy
 matplotlib
 pandas


### PR DESCRIPTION
ipython 8.1.0 causes the documentation build to fail because it uses features from python 3.9

Explicitly disallow pip to install this version.

fixes gh-21126

xref https://github.com/ipython/ipython/issues/13554
