### PR TITLE
BLD: move cibuildwheel configuration to `pyproject.toml`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -109,36 +109,11 @@ jobs:
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           refreshenv
         if: ${{ env.IS_32_BIT == 'true' }}
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
-          NPY_USE_BLAS_ILP64: ${{ env.IS_32_BIT == 'true' && '0' || '1' }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_ENVIRONMENT_LINUX: CFLAGS='-std=c99 -fno-strict-aliasing'
-                                  LDFLAGS='-Wl,--strip-debug'
-                                  OPENBLAS64_=/usr/local
-                                  RUNNER_OS='Linux'
-          # MACOS linker doesn't support stripping symbols
-          CIBW_ENVIRONMENT_MACOS: CFLAGS='-std=c99 -fno-strict-aliasing'
-                                  OPENBLAS64_=/usr/local
-                                  CC=clang
-                                  CXX=clang++
-          CIBW_ENVIRONMENT_WINDOWS: OPENBLAS64_=${{ env.IS_32_BIT == 'false' && 'openblas' || '' }}
-                                    OPENBLAS=${{ env.IS_32_BIT == 'true' && 'openblas' || '' }}
-                                    CFLAGS='${{ env.IS_32_BIT == 'true' && '-m32' || '' }}'
-                                    LDFLAGS='${{ env.IS_32_BIT == 'true' && '-m32' || '' }}'
-          # TODO: Add universal2 wheels, we need to fuse them manually
-          # instead of going through cibuildwheel
-          # This is because cibuildwheel tries to make a fat wheel
-          # https://github.com/multi-build/multibuild/blame/devel/README.rst#L541-L565
-          # for more info
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
-          CIBW_BUILD_VERBOSITY: 3
-          CIBW_BEFORE_BUILD: bash {project}/tools/wheels/cibw_before_build.sh {project}
-          CIBW_BEFORE_TEST: pip install -r {project}/test_requirements.txt
-          CIBW_TEST_COMMAND:  bash {project}/tools/wheels/cibw_test_command.sh {project}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,25 +45,12 @@ jobs:
        - ATLAS=None
 
     # Wheel builders
-    # TODO: de-dup env vars in between steps?
     - python: "3.8"
       os: linux
       arch: arm64
       virt: vm
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
-        - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-        - CIBW_BUILD_VERBOSITY: 3
-        - CIBW_BEFORE_BUILD: "'bash {project}/tools/wheels/cibw_before_build.sh {project}'"
-        - CIBW_BEFORE_TEST: "'pip install -r {project}/test_requirements.txt'"
-        - CIBW_TEST_COMMAND:  "'bash {project}/tools/wheels/cibw_test_command.sh {project}'"
-        # Workaround Travis limitations
-        # set each variable separately and use cibw pass env to pass through
-        - CFLAGS: "'-std=c99 -fno-strict-aliasing'"
-        - LDFLAGS: "'-Wl,--strip-debug'"
-        - OPENBLAS64_: /usr/local
-        - RUNNER_OS: Linux
-        - CIBW_ENVIRONMENT_PASS_LINUX: "'CFLAGS LDFLAGS OPENBLAS64_ RUNNER_OS'"
       install: python3 -m pip install cibuildwheel==2.3.1
       script: |
         cibuildwheel --output-dir wheelhouse
@@ -77,18 +64,6 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-        - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-        - CIBW_BUILD_VERBOSITY: 3
-        - CIBW_BEFORE_BUILD: "'bash {project}/tools/wheels/cibw_before_build.sh {project}'"
-        - CIBW_BEFORE_TEST: "'pip install -r {project}/test_requirements.txt'"
-        - CIBW_TEST_COMMAND:  "'bash {project}/tools/wheels/cibw_test_command.sh {project}'"
-        # Workaround Travis limitations
-        # set each variable separately and use cibw pass env to pass through
-        - CFLAGS: "'-std=c99 -fno-strict-aliasing'"
-        - LDFLAGS: "'-Wl,--strip-debug'"
-        - OPENBLAS64_: /usr/local
-        - RUNNER_OS: Linux
-        - CIBW_ENVIRONMENT_PASS_LINUX: "'CFLAGS LDFLAGS OPENBLAS64_ RUNNER_OS'"
       install: python3 -m pip install cibuildwheel==2.3.1
       script: |
         cibuildwheel --output-dir wheelhouse
@@ -102,18 +77,6 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-        - CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-        - CIBW_BUILD_VERBOSITY: 3
-        - CIBW_BEFORE_BUILD: "'bash {project}/tools/wheels/cibw_before_build.sh {project}'"
-        - CIBW_BEFORE_TEST: "'pip install -r {project}/test_requirements.txt'"
-        - CIBW_TEST_COMMAND:  "'bash {project}/tools/wheels/cibw_test_command.sh {project}'"
-        # Workaround Travis limitations
-        # set each variable separately and use cibw pass env to pass through
-        - CFLAGS: "'-std=c99 -fno-strict-aliasing'"
-        - LDFLAGS: "'-Wl,--strip-debug'"
-        - OPENBLAS64_: /usr/local
-        - RUNNER_OS: Linux
-        - CIBW_ENVIRONMENT_PASS_LINUX: "'CFLAGS LDFLAGS OPENBLAS64_ RUNNER_OS'"
       install: python3 -m pip install cibuildwheel==2.3.1
       script: |
         cibuildwheel --output-dir wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,34 @@ requires = [
         directory = "change"
         name = "Changes"
         showcontent = true
+
+
+[tool.cibuildwheel]
+skip = "cp36-* cp37-* pp37-* pp38-macosx* *-manylinux_i686 *_ppc64le *_s390x *-musllinux*"
+build-verbosity = "3"
+before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
+before-test = "pip install -r {project}/test_requirements.txt"
+test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+environment = { CFLAGS="-std=c99 -fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", OPENBLAS64_="/usr/local", NPY_USE_BLAS_ILP64="1", RUNNER_OS="Linux" }
+
+[tool.cibuildwheel.macos]
+# TODO: Add universal2 wheels, we need to fuse them manually
+# instead of going through cibuildwheel
+# This is because cibuildwheel tries to make a fat wheel
+# https://github.com/multi-build/multibuild/blame/devel/README.rst#L541-L565
+# for more info
+archs = "x86_64 arm64"
+test-skip = "*_arm64 *_universal2:arm64"
+# MACOS linker doesn't support stripping symbols
+environment = { CFLAGS="-std=c99 -fno-strict-aliasing", OPENBLAS64_="/usr/local", NPY_USE_BLAS_ILP64="1", CC="clang", CXX = "clang++" }
+
+[tool.cibuildwheel.windows]
+environment = { OPENBLAS64_="openblas", OPENBLAS="", NPY_USE_BLAS_ILP64="1", CFLAGS="", LDFLAGS="" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-win32"
+environment = { OPENBLAS64_="", OPENBLAS="openblas", NPY_USE_BLAS_ILP64="0", CFLAGS="-m32", LDFLAGS="-m32" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ manylinux-aarch64-image = "manylinux2014"
 environment = { CFLAGS="-std=c99 -fno-strict-aliasing", LDFLAGS="-Wl,--strip-debug", OPENBLAS64_="/usr/local", NPY_USE_BLAS_ILP64="1", RUNNER_OS="Linux" }
 
 [tool.cibuildwheel.macos]
-# TODO: Add universal2 wheels, we need to fuse them manually
+# For universal2 wheels, we will need to fuse them manually
 # instead of going through cibuildwheel
 # This is because cibuildwheel tries to make a fat wheel
 # https://github.com/multi-build/multibuild/blame/devel/README.rst#L541-L565


### PR DESCRIPTION
This allows to share the configuration between GitHub Actions and Travis-CI.
This also allows to easily run cibuildwheel locally to debug build issues when they arise.
