### PR TITLE
BUG,ENH: np._from_dlpack: export arrays with any-strided size-1 dimen…

### DIFF
--- a/numpy/core/src/multiarray/dlpack.c
+++ b/numpy/core/src/multiarray/dlpack.c
@@ -137,7 +137,7 @@ array_dlpack(PyArrayObject *self,
 
     if (!PyArray_IS_C_CONTIGUOUS(self) && PyArray_SIZE(self) != 1) {
         for (int i = 0; i < ndim; ++i) {
-            if (strides[i] % itemsize != 0) {
+            if (shape[i] != 1 && strides[i] % itemsize != 0) {
                 PyErr_SetString(PyExc_RuntimeError,
                         "DLPack only supports strides which are a multiple of "
                         "itemsize.");

--- a/numpy/core/tests/test_dlpack.py
+++ b/numpy/core/tests/test_dlpack.py
@@ -115,3 +115,9 @@ class TestDLPack:
         x = np.array(1.0)
         y = np._from_dlpack(x)
         assert_array_equal(x, y)
+
+    def test_size1dims_arrays(self):
+        x = np.ndarray(dtype='f8', shape=(10, 5, 1), strides=(8, 80, 4),
+                       buffer=np.ones(1000, dtype=np.uint8), order='F')
+        y = np._from_dlpack(x)
+        assert_array_equal(x, y)


### PR DESCRIPTION
fixes gh-20336

Export arrays with any strides in the dimension of size 1.

cc @seberg