### PR TITLE
BLD,DOC: skip broken ipython 8.1.0

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,7 +3,7 @@ sphinx==4.2.0
 numpydoc==1.1.0
 pydata-sphinx-theme==0.7.2
 sphinx-panels
-ipython
+ipython!=8.1.0
 scipy
 matplotlib
 pandas


### PR DESCRIPTION
Backport of #21127.

ipython 8.1.0 causes the documentation build to fail because it uses features from python 3.9

Explicitly disallow pip to install this version.

fixes gh-21126

xref https://github.com/ipython/ipython/issues/13554

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
