### PR TITLE
BUG, ENH: np._from_dlpack: export correct device information

### DIFF
--- a/numpy/core/src/multiarray/dlpack.c
+++ b/numpy/core/src/multiarray/dlpack.c
@@ -88,6 +88,12 @@ array_get_dl_device(PyArrayObject *self) {
     ret.device_type = kDLCPU;
     ret.device_id = 0;
     PyObject *base = PyArray_BASE(self);
+
+    // walk the bases (see gh-20340)
+    while (base != NULL && PyArray_Check(base)) {
+        base = PyArray_BASE((PyArrayObject *)base);
+    }
+
     // The outer if is due to the fact that NumPy arrays are on the CPU
     // by default (if not created from DLPack).
     if (PyCapsule_IsValid(base, NPY_DLPACK_INTERNAL_CAPSULE_NAME)) {

--- a/numpy/core/tests/test_dlpack.py
+++ b/numpy/core/tests/test_dlpack.py
@@ -91,7 +91,10 @@ class TestDLPack:
     def test_dlpack_device(self):
         x = np.arange(5)
         assert x.__dlpack_device__() == (1, 0)
-        assert np._from_dlpack(x).__dlpack_device__() == (1, 0)
+        y = np._from_dlpack(x)
+        assert y.__dlpack_device__() == (1, 0)
+        z = y[::2]
+        assert z.__dlpack_device__() == (1, 0)
 
     def dlpack_deleter_exception(self):
         x = np.arange(5)


### PR DESCRIPTION
Backport of #21119.

fixes gh-20340

It is possible to export incorrect device information if a new view has been created from an imported array:

```python
import numpy as np
from torch

x = torch.arange(10).pin_memory()
y = np._from_dlpack(x)
y.base  # PyCapsule named 'numpy_dltensor' (contains device information)
z = y[::2]
z.base  # y (doesn't contain original device information)
z.__dlpack_device__()  # (1, 0) --> wrong (should be (3, 0) for pinned memory)
```

This PR fixes this behavior by walking the bases (if they are ndarray) as suggested in https://github.com/numpy/numpy/issues/20340#issuecomment-1000861064. The test just coves the new changes but doesn't really test against an array from a different device.

cc @seberg @mattip

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
