### PR TITLE
BUG: use ThreadPoolExecutor instead of ThreadPool

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -355,10 +355,9 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
 
     if len(build) > 1 and jobs > 1:
         # build parallel
-        import multiprocessing.pool
-        pool = multiprocessing.pool.ThreadPool(jobs)
-        pool.map(single_compile, build_items)
-        pool.close()
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(jobs) as pool:
+            pool.map(single_compile, build_items)
     else:
         # build serial
         for o in build_items:


### PR DESCRIPTION
Backport of #21027.

Use concurrent.futures.ThreadPoolExecutor in distutils instead of multiprocessing.pool.ThreadPool.

Fix #21026