### PR TITLE
DOC: Change recommendation away from pinning numpy+3

### DIFF
--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -124,13 +124,20 @@ version bound: NumPy is careful to preserve backward-compatibility.
 That said, if you are (a) a project that is guaranteed to release
 frequently, (b) use a large part of NumPy's API surface, and (c) is
 worried that changes in NumPy may break your code, you can set an
-upper bound of `<MAJOR.MINOR + N` with N no less than 3, and
-`MAJOR.MINOR` being the current release of NumPy. If you use the NumPy
+upper bound of ``<MAJOR.MINOR + N`` with N no less than 3, and
+``MAJOR.MINOR`` being the current release of NumPy [*]_. If you use the NumPy
 C API (directly or via Cython), you can also pin the current major
 version to prevent ABI breakage. Note that setting an upper bound on
 NumPy may `affect the ability of your library to be installed
-alongside other, older packages
+alongside other, newer packages
 <https://iscinumpy.dev/post/bound-version-constraints/>`__.
+
+.. [*] The reason for setting ``N=3`` is that NumPy will, on the
+       rare occasion where it makes breaking changes, raise warnings
+       for at least two releases. (NumPy releases about once every six
+       months, so this translates to a window of at least a year;
+       hence the subsequent requirement that your project releases at
+       least on that cadence.)
 
 .. note::
 

--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -123,7 +123,7 @@ version bound: NumPy is careful to preserve backward-compatibility.
 
 That said, if you are (a) a project that is guaranteed to release
 frequently, (b) use a large part of NumPy's API surface, and (c) is
-worried that changes in NumPy may break your code, you may set an
+worried that changes in NumPy may break your code, you can set an
 upper bound of `<MAJOR.MINOR + N` with N no less than 3, and
 `MAJOR.MINOR` being the current release of NumPy. If you use the NumPy
 C API (directly or via Cython), you can also pin the current major

--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -114,25 +114,18 @@ for dropping support for old Python and NumPy versions: :ref:`NEP29`. We
 recommend all packages depending on NumPy to follow the recommendations in NEP
 29.
 
-For *run-time dependencies*, you specify the range of versions in
+For *run-time dependencies*, specify version bounds using
 ``install_requires`` in ``setup.py`` (assuming you use ``numpy.distutils`` or
-``setuptools`` to build). Getting the upper bound right for NumPy is slightly
-tricky. If we don't set any bound, a too-new version will be pulled in a few
-years down the line, and NumPy may have deprecated and removed some API that
-your package depended on by then. On the other hand if you set the upper bound
-to the newest already-released version, then as soon as a new NumPy version is
-released there will be no matching version of your package that works with it.
+``setuptools`` to build). The upper bound should be set to the next
+major release of NumPy, e.g. `numpy>=1.18,numpy<2`.
 
-What to do here depends on your release frequency. Given that NumPy releases
-come in a 6-monthly cadence and that features that get deprecated in NumPy
-should stay around for another two releases, a good upper bound is
-``<1.(xx+3).0`` - where ``xx`` is the minor version of the latest
-already-released NumPy. This is safe to do if you release at least once a year.
-If your own releases are much less frequent, you may set the upper bound a
-little further into the future - this is a trade-off between a future NumPy
-version _maybe_ removing something you rely on, and the upper bound being
-exceeded which _may_ lead to your package being hard to install in combination
-with other packages relying on the latest NumPy.
+Not specifying a tighter upper bound means there is a small
+possibility that new versions of NumPy will no longer work with your code,
+but that is unlikely since NumPy API changes are highly conservative.
+On the other hand, limiting the upper bound almost certainly will make
+it
+`difficult to install your package in combination with other ecosystem packages
+<https://iscinumpy.dev/post/bound-version-constraints/>`__.
 
 
 .. note::

--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -120,12 +120,15 @@ For *run-time dependencies*, specify version bounds using
 
 Most libraries that rely on NumPy will not need to set an upper
 version bound: NumPy is careful to preserve backward-compatibility.
-However, if you are (a) a project that is guaranteed to release
-frequently and (b) worried that changes in NumPy may break your code,
-you may set an upper bound of no less than `current_numpy + 3`.  It is
-also quite safe to set an upper bound on the next major release of
-NumPy, e.g. `numpy>=1.18,numpy<2`. Setting an upper bound on NumPy
-may, however, `affect the ability of your library to be installed
+
+That said, if you are (a) a project that is guaranteed to release
+frequently, (b) use a large part of NumPy's API surface, and (c) is
+worried that changes in NumPy may break your code, you may set an
+upper bound of `<MAJOR.MINOR + N` with N no less than 3, and
+`MAJOR.MINOR` being the current release of NumPy. If you use the NumPy
+C API (directly or via Cython), you can also pin the current major
+version to prevent ABI breakage. Note that setting an upper bound on
+NumPy may `affect the ability of your library to be installed
 alongside other, older packages
 <https://iscinumpy.dev/post/bound-version-constraints/>`__.
 

--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -116,17 +116,18 @@ recommend all packages depending on NumPy to follow the recommendations in NEP
 
 For *run-time dependencies*, specify version bounds using
 ``install_requires`` in ``setup.py`` (assuming you use ``numpy.distutils`` or
-``setuptools`` to build). The upper bound should be set to the next
-major release of NumPy, e.g. `numpy>=1.18,numpy<2`.
+``setuptools`` to build).
 
-Not specifying a tighter upper bound means there is a small
-possibility that new versions of NumPy will no longer work with your code,
-but that is unlikely since NumPy API changes are highly conservative.
-On the other hand, limiting the upper bound almost certainly will make
-it
-`difficult to install your package in combination with other ecosystem packages
+Most libraries that rely on NumPy will not need to set an upper
+version bound: NumPy is careful to preserve backward-compatibility.
+However, if you are (a) a project that is guaranteed to release
+frequently and (b) worried that changes in NumPy may break your code,
+you may set an upper bound of no less than `current_numpy + 3`.  It is
+also quite safe to set an upper bound on the next major release of
+NumPy, e.g. `numpy>=1.18,numpy<2`. Setting an upper bound on NumPy
+may, however, `affect the ability of your library to be installed
+alongside other, older packages
 <https://iscinumpy.dev/post/bound-version-constraints/>`__.
-
 
 .. note::
 


### PR DESCRIPTION
SciPy has a policy of pinning to `numpy<=current_ver + 3`.  While this may be fine for SciPy (or, put otherwise, for exactly *one* package in the ecosystem), I think a proliferation of this habit will certainly cause problems.

Imagine many projects started pinning to numpy+k. If any one of these projects is then unable to make a release in time, it can easily make it impossible to depend on a combination of them.

Pip isn't very strict about enforcing upper limits at the moment, but it complains if you try to build numpy in an environment with a not-very-old (<1.8) scipy installed—which happens commonly, since scipy is a dependency of the numpy docs.

A possible recommendation could be to warn if the package thinks that NumPy may be too old.  But with NumPy being so conservative in changing its API, forward-pinning causes more problems than it solves.

Also, if we urge users to pin to `<next_major_version`, we always have that mechanism of control (from the NumPy developer side) in case we want to change something that is likely to break multiple packages.  But some will even debate whether we want this pin in place (it will force all dependencies to "sign off" on a major NumPy release).

Also see https://iscinumpy.dev/post/bound-version-constraints/