### PR TITLE
DOC: Update linalg.qr docstring with numerically stable example

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -899,11 +899,11 @@ def qr(a, mode='reduced'):
            [1, 1],
            [1, 1],
            [2, 1]])
-    >>> b = np.array([1, 0, 2, 1])
+    >>> b = np.array([1, 2, 2, 3])
     >>> q, r = np.linalg.qr(A)
     >>> p = np.dot(q.T, b)
     >>> np.dot(np.linalg.inv(r), p)
-    array([  1.1e-16,   1.0e+00])
+    array([  1.,   1.])
 
     """
     if mode not in ('reduced', 'complete', 'r', 'raw'):


### PR DESCRIPTION
Updates linalg.qr docstring with a more numerically stable example written by @[melissawm](https://github.com/melissawm) in issue #20899. 

The previous example had a discrepancy with the consistency of it's first element:
`array([  1.1e-16,   1.0e+00])  vs array([6.66133815e-16, 1.00000000e+00])`

Testing it in my environment also yielded a different result: 
`array([4.4408921e-16, 1.0000000e+00])`