### PR TITLE
ENH: Add 'ulong' to sctypeDict

### DIFF
--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -172,7 +172,7 @@ def _set_up_aliases():
         allTypes[alias] = allTypes[t]
         sctypeDict[alias] = sctypeDict[t]
     # Remove aliases overriding python types and modules
-    to_remove = ['ulong', 'object', 'int', 'float',
+    to_remove = ['object', 'int', 'float',
                  'complex', 'bool', 'string', 'datetime', 'timedelta',
                  'bytes', 'str']
 

--- a/numpy/core/_type_aliases.py
+++ b/numpy/core/_type_aliases.py
@@ -182,6 +182,15 @@ def _set_up_aliases():
             del sctypeDict[t]
         except KeyError:
             pass
+
+    # Additional aliases in sctypeDict that should not be exposed as attributes
+    attrs_to_remove = ['ulong']
+
+    for t in attrs_to_remove:
+        try:
+            del allTypes[t]
+        except KeyError:
+            pass
 _set_up_aliases()
 
 

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1381,6 +1381,11 @@ def test_keyword_argument():
     assert np.dtype(dtype=np.float64) == np.dtype(np.float64)
 
 
+def test_ulong_dtype():
+    # test for gh-21063
+    assert np.dtype("ulong") == np.dtype(np.uint)
+
+
 class TestFromDTypeAttribute:
     def test_simple(self):
         class dt:

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -437,8 +437,11 @@ class TestSctypeDict:
         assert_(np.sctypeDict['c16'] is not np.clongdouble)
 
     def test_ulong(self):
-        # gh-21063
+        # Test that 'ulong' behaves like 'long'. np.sctypeDict['long'] is an
+        # alias for np.int_, but np.long is not supported for historical
+        # reasons (gh-21063)
         assert_(np.sctypeDict['ulong'] is np.uint)
+        assert_(not hasattr(np, 'ulong'))
 
 
 class TestBitName:

--- a/numpy/core/tests/test_numerictypes.py
+++ b/numpy/core/tests/test_numerictypes.py
@@ -436,6 +436,10 @@ class TestSctypeDict:
         assert_(np.sctypeDict['f8'] is not np.longdouble)
         assert_(np.sctypeDict['c16'] is not np.clongdouble)
 
+    def test_ulong(self):
+        # gh-21063
+        assert_(np.sctypeDict['ulong'] is np.uint)
+
 
 class TestBitName:
     def test_abstract(self):

--- a/numpy/typing/_char_codes.py
+++ b/numpy/typing/_char_codes.py
@@ -30,7 +30,7 @@ _UByteCodes = Literal["ubyte", "B", "=B", "<B", ">B"]
 _UShortCodes = Literal["ushort", "H", "=H", "<H", ">H"]
 _UIntCCodes = Literal["uintc", "I", "=I", "<I", ">I"]
 _UIntPCodes = Literal["uintp", "uint0", "P", "=P", "<P", ">P"]
-_UIntCodes = Literal["uint", "L", "=L", "<L", ">L"]
+_UIntCodes = Literal["ulong", "uint", "L", "=L", "<L", ">L"]
 _ULongLongCodes = Literal["ulonglong", "Q", "=Q", "<Q", ">Q"]
 
 _HalfCodes = Literal["half", "e", "=e", "<e", ">e"]


### PR DESCRIPTION
Add 'ulong' to `np.sctypeDict` so that `np.dtype("ulong")` is supported. Closes #21063