### PR TITLE
ENH: Remove squeeze() before return of covariance matrix .

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2678,7 +2678,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         X_T = (X*w).T
     c = dot(X, X_T.conj())
     c *= np.true_divide(1, fact)
-    return c.squeeze()
+    return c
 
 
 def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,


### PR DESCRIPTION
Removing squeeze() before return for covariance matrix calculation to resolve ndim similarity issue.

This is done to resolve the ndim dissimilarity issue for single dimensional array i.e. the `np.cov` would return the final output with `c.squeeze()`. This makes the output ndarray `[[num]]` of ndim=1 to 0.

Related to #20951 