### PR TITLE
TYP, BUG: Fix ``np.lib.stride_tricks`` re-exported under wrong name

### DIFF
--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -14,7 +14,7 @@ from numpy.lib import (
     format as format,
     mixins as mixins,
     scimath as scimath,
-    stride_tricks as stride_stricks,
+    stride_tricks as stride_tricks,
 )
 
 from numpy.lib._version import (


### PR DESCRIPTION
Closes #21183.

In practice this is a typo fix: `stride_stricks` -> `stride_tricks`.