### PR TITLE
ENH: F2PY build output determinism

### DIFF
--- a/doc/release/upcoming_changes/21187.new_feature.rst
+++ b/doc/release/upcoming_changes/21187.new_feature.rst
@@ -5,4 +5,4 @@ unconditionally, though these may be empty.  For free-form inputs,
 ``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90`` will both be generated
 unconditionally, and may be empty. This allows writing generic output rules in
 ``cmake`` or ``meson`` and other build systems. Older behavior can be restored
-by passing ``--no-empty-gen`` to ``f2py``. :ref:`f2py-meson` details usage.
+by passing ``--skip-empty-wrappers`` to ``f2py``. :ref:`f2py-meson` details usage.

--- a/doc/release/upcoming_changes/21187.new_feature.rst
+++ b/doc/release/upcoming_changes/21187.new_feature.rst
@@ -1,6 +1,7 @@
 optionally deterministic output files for F2PY
 ----------------------------------------------
 ``f2py`` now accepts the ``--empty-gen`` flag for producing all possible output
-files, namely: ``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90``. This
-allows writing generic output rules in ``cmake`` or ``meson`` and other build
-systems. :ref:`f2py-meson` details usage.
+files, namely: ``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90`` for F90
+inputs and ``modname-f2pywrappers.f`` for F77 inputs. This allows writing
+generic output rules in ``cmake`` or ``meson`` and other build systems.
+:ref:`f2py-meson` details usage.

--- a/doc/release/upcoming_changes/21187.new_feature.rst
+++ b/doc/release/upcoming_changes/21187.new_feature.rst
@@ -1,7 +1,8 @@
-optionally deterministic output files for F2PY
-----------------------------------------------
-``f2py`` now accepts the ``--empty-gen`` flag for producing all possible output
-files, namely: ``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90`` for F90
-inputs and ``modname-f2pywrappers.f`` for F77 inputs. This allows writing
-generic output rules in ``cmake`` or ``meson`` and other build systems.
-:ref:`f2py-meson` details usage.
+deterministic output files for F2PY
+-----------------------------------
+For F77 inputs, ``f2py`` will generate ``modname-f2pywrappers.f``
+unconditionally, though these may be empty.  For free-form inputs,
+``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90`` will both be generated
+unconditionally, and may be empty. This allows writing generic output rules in
+``cmake`` or ``meson`` and other build systems. Older behavior can be restored
+by passing ``--no-empty-gen`` to ``f2py``. :ref:`f2py-meson` details usage.

--- a/doc/release/upcoming_changes/21187.new_feature.rst
+++ b/doc/release/upcoming_changes/21187.new_feature.rst
@@ -1,0 +1,6 @@
+optionally deterministic output files for F2PY
+----------------------------------------------
+``f2py`` now accepts the ``--empty-gen`` flag for producing all possible output
+files, namely: ``modname-f2pywrappers.f``, ``modname-f2pywrappers2.f90``. This
+allows writing generic output rules in ``cmake`` or ``meson`` and other build
+systems. :ref:`f2py-meson` details usage.

--- a/doc/source/f2py/buildtools/index.rst
+++ b/doc/source/f2py/buildtools/index.rst
@@ -82,7 +82,7 @@ Signature files
 
    From NumPy ``1.22.4`` onwards, ``f2py`` will deterministically generate
    wrapper files based on the input file Fortran standard (F77 or greater).
-   ``--no-empty-gen`` can be passed to ``f2py`` to restore the previous
+   ``--skip-empty-wrappers`` can be passed to ``f2py`` to restore the previous
    behaviour of only generating wrappers when needed by the input .
 
 

--- a/doc/source/f2py/buildtools/index.rst
+++ b/doc/source/f2py/buildtools/index.rst
@@ -80,8 +80,10 @@ Signature files
 
 .. note::
 
-   To generate every possible input for a given standard (F77 or F90)
-   ``--empty-gen`` can be passed to ``f2py`` from NumPy version ``1.22.4``.
+   From NumPy ``1.22.4`` onwards, ``f2py`` will deterministically generate
+   wrapper files based on the input file Fortran standard (F77 or greater).
+   ``--no-empty-gen`` can be passed to ``f2py`` to restore the previous
+   behaviour of only generating wrappers when needed by the input .
 
 
 In theory keeping the above requirements in hand, any build system can be

--- a/doc/source/f2py/buildtools/index.rst
+++ b/doc/source/f2py/buildtools/index.rst
@@ -80,8 +80,8 @@ Signature files
 
 .. note::
 
-   To generate every possible input ``--empty-gen`` can be passed to ``f2py``
-   from NumPy version ``1.22.4``.
+   To generate every possible input for a given standard (F77 or F90)
+   ``--empty-gen`` can be passed to ``f2py`` from NumPy version ``1.22.4``.
 
 
 In theory keeping the above requirements in hand, any build system can be

--- a/doc/source/f2py/buildtools/index.rst
+++ b/doc/source/f2py/buildtools/index.rst
@@ -80,7 +80,8 @@ Signature files
 
 .. note::
 
-   The signature file output situation is being reconsidered in `issue 20385`_ .
+   To generate every possible input ``--empty-gen`` can be passed to ``f2py``
+   from NumPy version ``1.22.4``.
 
 
 In theory keeping the above requirements in hand, any build system can be

--- a/doc/source/f2py/buildtools/meson.rst
+++ b/doc/source/f2py/buildtools/meson.rst
@@ -85,8 +85,10 @@ for reasons discussed in :ref:`f2py-bldsys`.
 
 .. note::
 
-   To generate every possible input for a given standard (F77 or F90)
-   ``--empty-gen`` can be passed to ``f2py`` from NumPy version ``1.22.4``.
+   From NumPy ``1.22.4`` onwards, ``f2py`` will deterministically generate
+   wrapper files based on the input file Fortran standard (F77 or greater).
+   ``--no-empty-gen`` can be passed to ``f2py`` to restore the previous
+   behaviour of only generating wrappers when needed by the input .
 
 However, we can augment our workflow in a straightforward to take into account
 files for which the outputs are known when the build system is set up.

--- a/doc/source/f2py/buildtools/meson.rst
+++ b/doc/source/f2py/buildtools/meson.rst
@@ -83,6 +83,11 @@ A major pain point in the workflow defined above, is the manual tracking of
 inputs. Although it would require more effort to figure out the actual outputs
 for reasons discussed in :ref:`f2py-bldsys`.
 
+.. note::
+
+   To generate every possible input ``--empty-gen`` can be passed to ``f2py``
+   from NumPy version ``1.22.4``.
+
 However, we can augment our workflow in a straightforward to take into account
 files for which the outputs are known when the build system is set up.
 

--- a/doc/source/f2py/buildtools/meson.rst
+++ b/doc/source/f2py/buildtools/meson.rst
@@ -87,7 +87,7 @@ for reasons discussed in :ref:`f2py-bldsys`.
 
    From NumPy ``1.22.4`` onwards, ``f2py`` will deterministically generate
    wrapper files based on the input file Fortran standard (F77 or greater).
-   ``--no-empty-gen`` can be passed to ``f2py`` to restore the previous
+   ``--skip-empty-wrappers`` can be passed to ``f2py`` to restore the previous
    behaviour of only generating wrappers when needed by the input .
 
 However, we can augment our workflow in a straightforward to take into account

--- a/doc/source/f2py/buildtools/meson.rst
+++ b/doc/source/f2py/buildtools/meson.rst
@@ -85,8 +85,8 @@ for reasons discussed in :ref:`f2py-bldsys`.
 
 .. note::
 
-   To generate every possible input ``--empty-gen`` can be passed to ``f2py``
-   from NumPy version ``1.22.4``.
+   To generate every possible input for a given standard (F77 or F90)
+   ``--empty-gen`` can be passed to ``f2py`` from NumPy version ``1.22.4``.
 
 However, we can augment our workflow in a straightforward to take into account
 files for which the outputs are known when the build system is set up.

--- a/doc/source/f2py/code/meson.build
+++ b/doc/source/f2py/code/meson.build
@@ -22,9 +22,9 @@ incdir_f2py = run_command(py3,
 
 fibby_source = custom_target('fibbymodule.c',
                             input : ['fib1.f'],
-                            output : ['fibbymodule.c'],
+                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f', 'fibby-f2pywrappers2.f90'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
-                            '-m', 'fibby', '--lower' ]
+                            '-m', 'fibby', '--lower', '--empty-gen' ]
                             )
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)

--- a/doc/source/f2py/code/meson.build
+++ b/doc/source/f2py/code/meson.build
@@ -24,7 +24,7 @@ fibby_source = custom_target('fibbymodule.c',
                             input : ['fib1.f'], # .f so no F90 wrappers
                             output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
-                            '-m', 'fibby', '--lower', '--empty-gen' ]
+                            '-m', 'fibby', '--lower']
                             )
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)

--- a/doc/source/f2py/code/meson.build
+++ b/doc/source/f2py/code/meson.build
@@ -21,8 +21,8 @@ incdir_f2py = run_command(py3,
 ).stdout().strip()
 
 fibby_source = custom_target('fibbymodule.c',
-                            input : ['fib1.f'],
-                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f', 'fibby-f2pywrappers2.f90'],
+                            input : ['fib1.f'], # .f so no F90 wrappers
+                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
                             '-m', 'fibby', '--lower', '--empty-gen' ]
                             )

--- a/doc/source/f2py/code/meson_upd.build
+++ b/doc/source/f2py/code/meson_upd.build
@@ -24,7 +24,7 @@ fibby_source = custom_target('fibbymodule.c',
                             input : ['fib1.f'], # .f so no F90 wrappers
                             output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
-                            '-m', 'fibby', '--lower', '--empty-gen' ])
+                            '-m', 'fibby', '--lower'])
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)
 

--- a/doc/source/f2py/code/meson_upd.build
+++ b/doc/source/f2py/code/meson_upd.build
@@ -21,8 +21,8 @@ incdir_f2py = run_command(py3,
 ).stdout().strip()
 
 fibby_source = custom_target('fibbymodule.c',
-                            input : ['fib1.f'],
-                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f', 'fibby-f2pywrappers2.f90'],
+                            input : ['fib1.f'], # .f so no F90 wrappers
+                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
                             '-m', 'fibby', '--lower', '--empty-gen' ])
 

--- a/doc/source/f2py/code/meson_upd.build
+++ b/doc/source/f2py/code/meson_upd.build
@@ -22,9 +22,9 @@ incdir_f2py = run_command(py3,
 
 fibby_source = custom_target('fibbymodule.c',
                             input : ['fib1.f'],
-                            output : ['fibbymodule.c'],
+                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f', 'fibby-f2pywrappers2.f90'],
                             command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
-                            '-m', 'fibby', '--lower' ])
+                            '-m', 'fibby', '--lower', '--empty-gen' ])
 
 inc_np = include_directories(incdir_numpy, incdir_f2py)
 

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -224,7 +224,7 @@ Other options
     Run quietly.
   ``--verbose``
     Run with extra verbosity.
-  ``--no-empty-gen``
+  ``--skip-empty-wrappers``
     Do not generate wrapper files unless required by the inputs.
     This is a backwards compatibility flag to restore pre 1.22.4 behavior.
   ``-v``

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -224,8 +224,9 @@ Other options
     Run quietly.
   ``--verbose``
     Run with extra verbosity.
-  ``--empty-gen``
-    Generate all possible (empty) wrapper files.
+  ``--no-empty-gen``
+    Do not generate wrapper files unless required by the inputs.
+    This is a backwards compatibility flag to restore pre 1.22.4 behavior.
   ``-v``
     Print the F2PY version and exit.
 

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -224,6 +224,8 @@ Other options
     Run quietly.
   ``--verbose``
     Run with extra verbosity.
+  ``--empty-gen``
+    Generate all possible (empty) wrapper files.
   ``-v``
     Print the F2PY version and exit.
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -122,7 +122,8 @@ Options:
 
   --quiet          Run quietly.
   --verbose        Run with extra verbosity.
-  --empty-gen      Ensure all possible output files are created
+  --empty-gen      Ensure all possible output files are created for a language
+                   standard.
   -v               Print f2py version ID and exit.
 
 
@@ -360,15 +361,6 @@ def callcrackfortran(files, options):
     else:
         for mod in postlist:
             mod["f2py_wrapper_output"] = options["f2py_wrapper_output"]
-    if options["emptygen"]:
-        # Generate all possible outputs
-        for mod in postlist:
-            m_name = mod["name"]
-            b_path = options["buildpath"]
-            Path(f'{b_path}/{m_name}module.c').touch()
-            Path(f'{b_path}/{m_name}-f2pywrappers.f').touch()
-            Path(f'{b_path}/{m_name}-f2pywrappers2.f90').touch()
-            outmess(f'    Generating possibly empty wrappers "{m_name}-f2pywrappers.f" and "{m_name}-f2pywrappers2.f90"\n')
     return postlist
 
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -122,8 +122,7 @@ Options:
 
   --quiet          Run quietly.
   --verbose        Run with extra verbosity.
-  --empty-gen      Ensure all possible output files are created for a language
-                   standard.
+  --no-empty-gen   Only generate wrapper files when needed.
   -v               Print f2py version ID and exit.
 
 
@@ -181,7 +180,7 @@ def scaninputline(inputline):
     files, skipfuncs, onlyfuncs, debug = [], [], [], []
     f, f2, f3, f5, f6, f7, f8, f9, f10 = 1, 0, 0, 0, 0, 0, 0, 0, 0
     verbose = 1
-    emptygen = 0
+    emptygen = True
     dolc = -1
     dolatexdoc = 0
     dorestdoc = 0
@@ -253,8 +252,8 @@ def scaninputline(inputline):
             f7 = 1
         elif l[:15] in '--include-paths':
             f7 = 1
-        elif l == '--empty-gen':
-            emptygen = 1
+        elif l == '--no-empty-gen':
+            emptygen = False
         elif l[0] == '-':
             errmess('Unknown option %s\n' % repr(l))
             sys.exit()
@@ -304,9 +303,9 @@ def scaninputline(inputline):
             'Signature file "%s" exists!!! Use --overwrite-signature to overwrite.\n' % (signsfile))
         sys.exit()
 
+    options['emptygen'] = emptygen
     options['debug'] = debug
     options['verbose'] = verbose
-    options['emptygen'] = emptygen
     if dolc == -1 and not signsfile:
         options['do-lower'] = 0
     else:
@@ -325,16 +324,6 @@ def scaninputline(inputline):
     options['buildpath'] = buildpath
     options['include_paths'] = include_paths
     options.setdefault('f2cmap_file', None)
-    if not emptygen:
-        import warnings
-        warnings.warn("\n --empty-gen is false"
-                      " this will default to true"
-                      " in subsequent releases"
-                      " for build uniformity\n"
-                      " see: "
-                      "https://numpy.org/devdocs/f2py/buildtools/index.html"
-                      "\n Pass --empty-gen to silence this warning\n",
-                      FutureWarning, stacklevel=2)
     return files, options
 
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -122,7 +122,7 @@ Options:
 
   --quiet          Run quietly.
   --verbose        Run with extra verbosity.
-  --no-empty-gen   Only generate wrapper files when needed.
+  --skip-empty-wrappers   Only generate wrapper files when needed.
   -v               Print f2py version ID and exit.
 
 
@@ -252,7 +252,7 @@ def scaninputline(inputline):
             f7 = 1
         elif l[:15] in '--include-paths':
             f7 = 1
-        elif l == '--no-empty-gen':
+        elif l == '--skip-empty-wrappers':
             emptygen = False
         elif l[0] == '-':
             errmess('Unknown option %s\n' % repr(l))

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -18,6 +18,7 @@ import sys
 import os
 import pprint
 import re
+from pathlib import Path
 
 from . import crackfortran
 from . import rules
@@ -121,6 +122,7 @@ Options:
 
   --quiet          Run quietly.
   --verbose        Run with extra verbosity.
+  --empty-gen      Ensure all possible output files are created
   -v               Print f2py version ID and exit.
 
 
@@ -178,6 +180,7 @@ def scaninputline(inputline):
     files, skipfuncs, onlyfuncs, debug = [], [], [], []
     f, f2, f3, f5, f6, f7, f8, f9, f10 = 1, 0, 0, 0, 0, 0, 0, 0, 0
     verbose = 1
+    emptygen = 0
     dolc = -1
     dolatexdoc = 0
     dorestdoc = 0
@@ -249,6 +252,8 @@ def scaninputline(inputline):
             f7 = 1
         elif l[:15] in '--include-paths':
             f7 = 1
+        elif l == '--empty-gen':
+            emptygen = 1
         elif l[0] == '-':
             errmess('Unknown option %s\n' % repr(l))
             sys.exit()
@@ -300,6 +305,7 @@ def scaninputline(inputline):
 
     options['debug'] = debug
     options['verbose'] = verbose
+    options['emptygen'] = emptygen
     if dolc == -1 and not signsfile:
         options['do-lower'] = 0
     else:
@@ -354,6 +360,15 @@ def callcrackfortran(files, options):
     else:
         for mod in postlist:
             mod["f2py_wrapper_output"] = options["f2py_wrapper_output"]
+    if options["emptygen"]:
+        # Generate all possible outputs
+        for mod in postlist:
+            m_name = mod["name"]
+            b_path = options["buildpath"]
+            Path(f'{b_path}/{m_name}module.c').touch()
+            Path(f'{b_path}/{m_name}-f2pywrappers.f').touch()
+            Path(f'{b_path}/{m_name}-f2pywrappers2.f90').touch()
+            outmess(f'    Generating possibly empty wrappers "{m_name}-f2pywrappers.f" and "{m_name}-f2pywrappers2.f90"\n')
     return postlist
 
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -325,6 +325,16 @@ def scaninputline(inputline):
     options['buildpath'] = buildpath
     options['include_paths'] = include_paths
     options.setdefault('f2cmap_file', None)
+    if not emptygen:
+        import warnings
+        warnings.warn("\n --empty-gen is false"
+                      " this will default to true"
+                      " in subsequent releases"
+                      " for build uniformity\n"
+                      " see: "
+                      "https://numpy.org/devdocs/f2py/buildtools/index.html"
+                      "\n Pass --empty-gen to silence this warning\n",
+                      FutureWarning, stacklevel=2)
     return files, options
 
 

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -53,6 +53,7 @@ Pearu Peterson
 import os
 import time
 import copy
+from pathlib import Path
 
 # __version__.version is now the same as the NumPy version
 from . import __version__
@@ -1213,6 +1214,22 @@ def buildmodule(m, um):
             # requiresf90wrapper must be called before buildapi as it
             # rewrites assumed shape arrays as automatic arrays.
             isf90 = requiresf90wrapper(nb)
+            # options is in scope here
+            if options['emptygen']:
+                b_path = options['buildpath']
+                m_name = vrd['modulename']
+                outmess('    Generating possibly empty wrappers"\n')
+                Path(f"{b_path}/{vrd['coutput']}").touch()
+                if isf90:
+                    # f77 + f90 wrappers
+                    outmess(f'    Maybe empty "{m_name}-f2pywrappers2.f90"\n')
+                    Path(f'{b_path}/{m_name}-f2pywrappers2.f90').touch()
+                    outmess(f'    Maybe empty "{m_name}-f2pywrappers.f"\n')
+                    Path(f'{b_path}/{m_name}-f2pywrappers.f').touch()
+                else:
+                    # only f77 wrappers
+                    outmess(f'    Maybe empty "{m_name}-f2pywrappers.f"\n')
+                    Path(f'{b_path}/{m_name}-f2pywrappers.f').touch()
             api, wrap = buildapi(nb)
             if wrap:
                 if isf90:


### PR DESCRIPTION
Closes #20385 and adds documentation for usage to fix https://github.com/rgommers/scipy/issues/22#issuecomment-920968853.

Essentially:
- [x] Changes the default behavior of F2PY to ensure possibly empty files are generated for build determinism
- [x] Adds an optional `--no-empty-gen` flag to restore earlier behavior
- [x] Documents its usage 

A few things which are out of scope for this PR:
- Testing, since that is part of the wider CLI testing PR #20668 
- Better / other CLI design concerns, these will be part of a separate refactor


Might need a release note? (as a new CLI arugment) **done**


See also https://github.com/numpy/numpy/pull/21187#issuecomment-1073438567
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
