### PR TITLE
DEV: Remove deprecated "python.pythonPath"

### DIFF
--- a/tools/gitpod/settings.json
+++ b/tools/gitpod/settings.json
@@ -5,5 +5,5 @@
     "restructuredtext.updateOnTextChanged": "true",
     "restructuredtext.updateDelay": 300,
     "restructuredtext.linter.disabled": true,
-    "python.pythonPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python"
+    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python"
 }


### PR DESCRIPTION
Replaced with stable property "python.defaultInterpreterPath"

This PR is in response to the comment made at
[Solution to the issue 
DEV: Un-responsive reStructuredText preview via Gitpod ](https://github.com/numpy/numpy/issues/21176#issuecomment-1064827858)

This closes issue #21176 