### PR TITLE
TYP, BUG: Fix ``np.lib.stride_tricks`` re-exported under the wrong name

### DIFF
--- a/numpy/lib/__init__.pyi
+++ b/numpy/lib/__init__.pyi
@@ -14,7 +14,7 @@ from numpy.lib import (
     format as format,
     mixins as mixins,
     scimath as scimath,
-    stride_tricks as stride_stricks,
+    stride_tricks as stride_tricks,
 )
 
 from numpy.lib._version import (


### PR DESCRIPTION
Backport of #21185.

Closes #21183.

In practice this is a typo fix: `stride_stricks` -> `stride_tricks`.




<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
