### PR TITLE
BUG: Fix `array_api` arrays not inplace adding neg zeros correctly

### DIFF
--- a/numpy/array_api/_array_object.py
+++ b/numpy/array_api/_array_object.py
@@ -752,6 +752,10 @@ class Array:
         # The Array API spec mandates that the result should be -0, so we
         # fallback to the ndarray's __add__() method, which is compliant.
         # See https://github.com/numpy/numpy/issues/21211
+        if np.result_type(self.dtype, other.dtype) != self.dtype:
+            raise TypeError(f"{other.dtype=!s} would modify {self.dtype=!s}")
+        if np.broadcast_shapes(self.shape, other.shape) != self.shape:
+            raise ValueError(f"{other.shape=} would modify {self.shape=}")
         self._array = self._array.__add__(other._array)
         return self
 

--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -1,7 +1,10 @@
 import operator
+from warnings import catch_warnings
 
+import pytest
 from numpy.testing import assert_raises
 import numpy as np
+from numpy import array_api as xp
 
 from .. import ones, asarray, result_type, all, equal
 from .._array_object import Array
@@ -322,3 +325,12 @@ def test___array__():
     b = np.asarray(a, dtype=np.float64)
     assert np.all(np.equal(b, np.ones((2, 3), dtype=np.float64)))
     assert b.dtype == np.float64
+
+@pytest.mark.filterwarnings("ignore:divide by zero:RuntimeWarning")
+def test_iadd_neg_zeros_case():
+    # See https://github.com/numpy/numpy/issues/21211
+    x1 = xp.asarray(-0.)
+    x2 = xp.asarray(-0.)
+    x1 += x2
+    # This is a round-about way to test x1 is a negative 0
+    assert (xp.asarray(1.) / x1) == -float('inf')

--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -334,3 +334,10 @@ def test_iadd_neg_zeros_case():
     x1 += x2
     # This is a round-about way to test x1 is a negative 0
     assert (xp.asarray(1.) / x1) == -float('inf')
+
+def test_iadd_raise_on_modification():
+    x1 = xp.ones((2,), dtype=xp.float32)
+    with pytest.raises(TypeError):
+        x1 += xp.ones((2,), dtype=xp.float64)
+    with pytest.raises(ValueError):
+        x1 += xp.ones((4,), dtype=xp.float32)


### PR DESCRIPTION
Fixes #21211 and includes a regression test. Testing for neg zeros is a bit annoying—let me know if I missed an existing utility for this.

Note I opted to just fallback on `ndarray.__add__()`. This is not ideal as we lose the checks against an inplace array having their dtype/shape modified, so I hard-coded those checks in (an introduced an additional test).
