### PR TITLE
BUG: Catch error if array-priority is not float compatible

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -129,12 +129,18 @@ PyArray_GetPriority(PyObject *obj, double default_)
     ret = PyArray_LookupSpecial_OnInstance(obj, "__array_priority__");
     if (ret == NULL) {
         if (PyErr_Occurred()) {
-            PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
+            /* TODO[gh-14801]: propagate crashes during attribute access? */
+            PyErr_Clear();
         }
         return default_;
     }
 
     priority = PyFloat_AsDouble(ret);
+    if (error_converting(priority)) {
+        /* TODO[gh-14801]: propagate crashes for bad priority? */
+        PyErr_Clear();
+        return default_;
+    }
     Py_DECREF(ret);
     return priority;
 }

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -3694,6 +3694,22 @@ class TestBinop:
         check(make_obj(np.ndarray, array_ufunc=None), True, False, False,
               check_scalar=False)
 
+    def test_ufunc_binop_bad_array_priority(self):
+        # Mainly checks that this does not crash.  The second array has a lower
+        # priority than -1 ("error value").  If the __radd__ actually exists,
+        # bad things can happen (I think via the scalar paths).
+        class BadPriority():
+            __array_priority__ = None
+
+            def __radd__(self, other):
+                return "result"
+
+        class LowPriority(np.ndarray):
+            __array_priority__ = -1000
+
+        with pytest.raises(TypeError):
+            np.arange(3).view(LowPriority) + BadPriority()
+
     def test_ufunc_override_normalize_signature(self):
         # gh-5674
         class SomeClass:


### PR DESCRIPTION
This is a bit cleaner than before.  This shouldn't lead to serious
issues, normally just a SystemError, because the error is not cleared.
But maybe it is a bit cleaner.

---

Just because I stumbled on it writing scalar-math tests... Happy to just not follow up as well ;).