### PR TITLE
MAINT: use doc_requirements.txt in azure build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,8 +173,8 @@ stages:
       displayName: 'Install tools'
     - script: |
         python -m pip install -r test_requirements.txt
-        python -m pip install vulture
-        python -m pip install -r doc_requirements.txt
+        # Don't use doc_requirements.txt since that messes up tests
+        python -m pip install vulture sphinx==4.2.0 numpydoc==1.2.0
       displayName: 'Install dependencies; some are optional to avoid test skips'
     - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
       displayName: 'Check for unreachable code paths in Python modules'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,8 @@ stages:
       displayName: 'Install tools'
     - script: |
         python -m pip install -r test_requirements.txt
-        python -m pip install vulture docutils sphinx==2.2.0 numpydoc
+        python -m pip install vulture
+        python -m pip install -r doc_requirements.txt
       displayName: 'Install dependencies; some are optional to avoid test skips'
     - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
       displayName: 'Check for unreachable code paths in Python modules'


### PR DESCRIPTION
~Azure refguidecheck builds are failing. The configuration has sphinx 2.2. Use the `doc_requirements.txt` instead.~

Azure refguidecheck builds are failing. Pin the sphinx and numpydoc versions.