### PR TITLE
MAINT: Specify sphinx, numpydoc versions for CI doc builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,8 @@ stages:
       displayName: 'Install tools'
     - script: |
         python -m pip install -r test_requirements.txt
-        python -m pip install vulture docutils sphinx==2.2.0 numpydoc
+        # Don't use doc_requirements.txt since that messes up tests
+        python -m pip install vulture sphinx==4.2.0 numpydoc==1.2.0
       displayName: 'Install dependencies; some are optional to avoid test skips'
     - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
       displayName: 'Check for unreachable code paths in Python modules'


### PR DESCRIPTION
Backport of #21241.

Azure refguidecheck builds are failing. Pin the sphinx and numpydoc versions.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
