### PR TITLE
DOC: directive fix (single instead of double backticks).

### DIFF
--- a/doc/source/release/1.19.0-notes.rst
+++ b/doc/source/release/1.19.0-notes.rst
@@ -317,9 +317,9 @@ New Features
 
 ``numpy.frompyfunc`` now accepts an identity argument
 -----------------------------------------------------
-This allows the :attr:``numpy.ufunc.identity`` attribute to be set on the
+This allows the :attr:`numpy.ufunc.identity` attribute to be set on the
 resulting ufunc, meaning it can be used for empty and multi-dimensional
-calls to :meth:``numpy.ufunc.reduce``.
+calls to :meth:`numpy.ufunc.reduce`.
 
 (`gh-8255 <https://github.com/numpy/numpy/pull/8255>`__)
 


### PR DESCRIPTION
This is invalid syntax (well technically valid, it's literally rendering
:role: followed by what's inside the double backticks as verbatim text
instead of a link...

[ci skip]
[skip azp]
[skip circle]
