### PR TITLE
DOC: improve description of the `data` entry in `__array_interface__`

### DIFF
--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -125,11 +125,15 @@ This approach to the interface consists of the object having an
        **Default**: ``[('', typestr)]``
 
    **data** (optional)
-       A 2-tuple whose first argument is a signed integer (capable of
-       holding a pointer to ``void`` such as the C/C++ type
-       `intptr_t <https://en.cppreference.com/w/cpp/types/integer>`__)
-       that points to the data-area storing the array
-       contents.  This pointer must point to the first element of
+       A 2-tuple whose first argument is a :doc:`Python integer <c-api/long>`
+       that points to the data-area storing the array contents.
+
+       .. note::
+          When converting from C/C++ via ``PyLong_From*`` or high-level
+          bindings such as Cython or pybind11, make sure to use an integer
+          of sufficiently large bitness.
+
+       This pointer must point to the first element of
        data (in other words any offset is always ignored in this
        case). The second entry in the tuple is a read-only flag (true
        means the data area is read-only).

--- a/doc/source/reference/arrays.interface.rst
+++ b/doc/source/reference/arrays.interface.rst
@@ -125,8 +125,10 @@ This approach to the interface consists of the object having an
        **Default**: ``[('', typestr)]``
 
    **data** (optional)
-       A 2-tuple whose first argument is an integer (a long integer
-       if necessary) that points to the data-area storing the array
+       A 2-tuple whose first argument is a signed integer (capable of
+       holding a pointer to ``void`` such as the C/C++ type
+       `intptr_t <https://en.cppreference.com/w/cpp/types/integer>`__)
+       that points to the data-area storing the array
        contents.  This pointer must point to the first element of
        data (in other words any offset is always ignored in this
        case). The second entry in the tuple is a read-only flag (true


### PR DESCRIPTION
The previous guidance on the integer type of `data` was a bit misleading in practice and has now been improved.

In practice, Unix is fine with `int` (32bit) and `long` (64bit), but Windows 64bit requires `long long` to hold a pointer.
  https://en.cppreference.com/w/cpp/language/types

In order not to complicate the guidance, recommend the `intptr_t` type explicitly.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
