### PR TITLE
DEV: Fixed Un-responsive live-preview in gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,6 +19,8 @@ tasks:
       echo "📖 Building docs 📖 "
       cd doc
       make html
+      echo "Installing dependencies for documentation Live-Preview"
+      pip install esbonio
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - matplotlib
   - pydata-sphinx-theme=0.7.2
-  - breathe
+  - breathe!=4.33.0
   # For linting
   - pycodestyle=2.7.0
   - gitpython

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - pandas
   - matplotlib
   - pydata-sphinx-theme=0.7.2
+  # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe!=4.33.0
   # For linting
   - pycodestyle=2.7.0

--- a/tools/gitpod/settings.json
+++ b/tools/gitpod/settings.json
@@ -1,9 +1,8 @@
 {
-    "restructuredtext.languageServer.disabled": true,
-    "restructuredtext.builtDocumentationPath": "${workspaceRoot}/doc/build/html",
-    "restructuredtext.confPath": "",
     "restructuredtext.updateOnTextChanged": "true",
     "restructuredtext.updateDelay": 300,
-    "restructuredtext.linter.disabled": true,
-    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python"
+    "restructuredtext.linter.disabledLinters": ["doc8","rst-lint", "rstcheck"],
+    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python",
+    "esbonio.sphinx.buildDir": "${workspaceRoot}/doc/build/html",
+    "esbonio.sphinx.confDir": ""
 }


### PR DESCRIPTION
I wanted to keep the gitpod working environment Up To date as it is a Gem for Documentation workers and who wants a quick on the go setup.

Replaced existing Obselete dependencies. Added Install "esbonio".

This PR is in response of closing issue #21246

What this PR Introduces.
1) Use New Properties for restructuredtext VSCode Extension defined in newest Release [178.0.0](https://github.com/vscode-restructuredtext/vscode-restructuredtext/releases/tag/178.0.0)
2) Add a Dependency installation step in gitpod container build namely `esbonio` as they have completely moved from `docutils` based preview. Now the extension also gives a prompt to install `esbonio` for the Live-Preview to work.

Image of Working Live-Preview

![working-live-preview](https://user-images.githubusercontent.com/41142068/160245401-953fb702-7012-41e9-8288-c0bb44e2ef25.PNG)

