### PR TITLE
DOC: fix data type of parameter shape

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -110,8 +110,8 @@ def masked_all(shape, dtype=float):
 
     Parameters
     ----------
-    shape : tuple
-        Shape of the required MaskedArray.
+    shape : int or tuple of ints
+        Shape of the required MaskedArray, e.g., ``(2, 3)`` or ``2``.
     dtype : dtype, optional
         Data type of the output.
 


### PR DESCRIPTION
`np.ma.masked_all` uses `np.empty` under the hood, so the parameter
description for shape in `masked_all` should be updated to match
that of `np.empty`.

Closes #21203
