### PR TITLE
DOC: fix code sample for leg2poly

### DIFF
--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -185,7 +185,7 @@ def leg2poly(c):
     >>> p = c.convert(kind=P.Polynomial)
     >>> p
     Polynomial([-1. , -3.5,  3. ,  7.5], domain=[-1.,  1.], window=[-1.,  1.])
-    >>> P.leg2poly(range(4))
+    >>> P.legendre.leg2poly(range(4))
     array([-1. , -3.5,  3. ,  7.5])
 
 


### PR DESCRIPTION
The previous code sample throws an attribute error around `P.leg2poly()`.
Since commit [d41fc4d](https://github.com/numpy/numpy/commit/d41fc4d518cb516c254959ca8c096bc8db2c81e9) (2012), leg2poly is not exposed in
np.polynomial, and need to be explicitly called from `legendre`.

Fixes #20925
