### PR TITLE
BUG,ENH: Fix negative bounds for F2PY

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2689,7 +2689,7 @@ def analyzevars(block):
             n_checks = []
             n_is_input = l_or(isintent_in, isintent_inout,
                               isintent_inplace)(vars[n])
-            if 'dimension' in vars[n]:  # n is array
+            if isarray(vars[n]):  # n is array
                 for i, d in enumerate(vars[n]['dimension']):
                     coeffs_and_deps = dimension_exprs.get(d)
                     if coeffs_and_deps is None:
@@ -2707,6 +2707,11 @@ def analyzevars(block):
                                 # - n depends on
                                 # - has user-defined initialization expression
                                 # - has user-defined dependencies
+                                continue
+                            # BUG: no checks for dimensions depending on
+                            # more than one variable
+                            # TODO: Reduce the restrictions on the caller
+                            if len(coeffs_and_deps.keys()) > 1:
                                 continue
                             if solver is not None:
                                 # v can be solved from d, hence, we

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -146,7 +146,6 @@ import re
 import os
 import copy
 import platform
-import itertools
 
 from . import __version__
 

--- a/numpy/f2py/tests/src/negative_bounds/issue_20853.f90
+++ b/numpy/f2py/tests/src/negative_bounds/issue_20853.f90
@@ -1,0 +1,7 @@
+subroutine foo(is_, ie_, arr, tout)
+ implicit none
+ integer :: is_,ie_
+ real, intent(in) :: arr(is_:ie_)
+ real, intent(out) :: tout(is_:ie_)
+ tout = arr
+end

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -34,7 +34,7 @@ class TestNegativeBounds(util.F2PyTest):
         # Calculate the upper bound,
         # Keeping the 1 index in mind
         def ubound(xl, xh):
-            return abs(xl) + abs(xh) + 1
+            return xh - xl + 1
         rval = self.module.foo(is_=xlow, ie_=xhigh,
                         arr=xvec[:ubound(xlow, xhigh)])
         expval = np.arange(11, dtype = np.float32)

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -22,6 +22,25 @@ class TestIntentInOut(util.F2PyTest):
         assert np.allclose(x, [3, 1, 2])
 
 
+class TestNegativeBounds(util.F2PyTest):
+    # Check that negative bounds work correctly
+    sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")]
+
+    @pytest.mark.slow
+    def test_negbound(self):
+        xvec = np.arange(12)
+        xlow = -6
+        xhigh = 4
+        # Calculate the upper bound,
+        # Keeping the 1 index in mind
+        def ubound(xl, xh):
+            return abs(xl) + abs(xh) + 1
+        rval = self.module.foo(is_=xlow, ie_=xhigh,
+                        arr=xvec[:ubound(xlow, xhigh)])
+        expval = np.arange(11, dtype = np.float32)
+        assert np.allclose(rval, expval)
+
+
 class TestNumpyVersionAttribute(util.F2PyTest):
     # Check that th attribute __f2py_numpy_version__ is present
     # in the compiled module and that has the value np.__version__.


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #20853.

Some alternatives were suggested in the issue, namely disabling all checks, which is still an option but seems sub-optimal.

However, there are some implementation notes which are important.

This PR changes the behaviour of the **python caller**, which is now responsible for being the right size. That is:

```fortran
subroutine foo(is_, ie_, arr, tout)
 implicit none
 integer :: is_,ie_
 real, intent(in) :: arr(is_:ie_)
 real, intent(out) :: tout(is_:ie_)
 tout = arr
end
```

After compiling `f2py -m blah blah.f90`, this can be called with:

```python
import numpy as np
import blah
xlow = -6
xhigh = 4
xvec = np.arange(12)
def ubound(xl, xh):
  return abs(xl) + abs(xh) + 1
rval = blah.foo(is_ = xlow, ie_ xhigh,
         arr = xvec[:ubound(xlow, xhigh))
expval = np.arange(11, dtype = np.float32)
np.allclose(rval, expval) 
```

Essentially, the caller is now responsible in this scenario for ensuring that the **size** of the array passed in is correct, and this means for the most part that the slice should be calculated as above.