### PR TITLE
Revert "DEV: Fixed Un-responsive live-preview in gitpod."

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,8 +19,6 @@ tasks:
       echo "📖 Building docs 📖 "
       cd doc
       make html
-      echo "Installing dependencies for documentation Live-Preview"
-      pip install esbonio
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -29,8 +29,7 @@ dependencies:
   - pandas
   - matplotlib
   - pydata-sphinx-theme=0.7.2
-  # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
-  - breathe!=4.33.0
+  - breathe
   # For linting
   - pycodestyle=2.7.0
   - gitpython

--- a/tools/gitpod/settings.json
+++ b/tools/gitpod/settings.json
@@ -1,8 +1,9 @@
 {
+    "restructuredtext.languageServer.disabled": true,
+    "restructuredtext.builtDocumentationPath": "${workspaceRoot}/doc/build/html",
+    "restructuredtext.confPath": "",
     "restructuredtext.updateOnTextChanged": "true",
     "restructuredtext.updateDelay": 300,
-    "restructuredtext.linter.disabledLinters": ["doc8","rst-lint", "rstcheck"],
-    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python",
-    "esbonio.sphinx.buildDir": "${workspaceRoot}/doc/build/html",
-    "esbonio.sphinx.confDir": ""
+    "restructuredtext.linter.disabled": true,
+    "python.defaultInterpreterPath": "/home/gitpod/mambaforge3/envs/numpy-dev/bin/python"
 }


### PR DESCRIPTION
Reverts numpy/numpy#21250.

`# NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz`

@rossbar [Commit](https://github.com/numpy/numpy/commit/41cf10dcb6ab46064d73f2c054e618c76c3cfabc) Ran with Skip-CI seems to have broken the builds.

This is a Revert PR.
