### PR TITLE
MAINT: Clean-up includes of auto-generated umath code

### DIFF
--- a/numpy/core/src/common/umathmodule.h
+++ b/numpy/core/src/common/umathmodule.h
@@ -1,8 +1,8 @@
 #ifndef NUMPY_CORE_SRC_COMMON_UMATHMODULE_H_
 #define NUMPY_CORE_SRC_COMMON_UMATHMODULE_H_
 
-#include "__umath_generated.c"
-#include "__ufunc_api.c"
+#include "ufunc_object.h"
+#include "ufunc_type_resolution.h"
 
 NPY_NO_EXPORT PyObject *
 get_sfloat_dtype(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args));

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -73,13 +73,15 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 
 #include "npy_dlpack.h"
 
+#include "umathmodule.h"
+
 /*
  *****************************************************************************
  **                    INCLUDE GENERATED CODE                               **
  *****************************************************************************
  */
-#include "funcs.inc"
-#include "umathmodule.h"
+/* __ufunc_api.c define is the PyUFunc_API table: */
+#include "__ufunc_api.c"
 
 NPY_NO_EXPORT int initscalarmath(PyObject *);
 NPY_NO_EXPORT int set_matmul_flags(PyObject *d); /* in ufunc_object.c */
@@ -4948,8 +4950,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
-    /* Load the ufunc operators into the array module's namespace */
-    if (InitOperators(d) < 0) {
+    if (initumath(m) != 0) {
         goto err;
     }
 
@@ -4957,9 +4958,6 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
         goto err;
     }
 
-    if (initumath(m) != 0) {
-        goto err;
-    }
     /*
      * Initialize the default PyDataMem_Handler capsule singleton.
      */

--- a/numpy/core/src/umath/umathmodule.c
+++ b/numpy/core/src/umath/umathmodule.c
@@ -24,6 +24,10 @@
 #include "number.h"
 #include "dispatching.h"
 
+/* Automatically generated code to define all ufuncs: */
+#include "funcs.inc"
+#include "__umath_generated.c"
+
 static PyUFuncGenericFunction pyfunc_functions[] = {PyUFunc_On_Om};
 
 static int
@@ -245,6 +249,10 @@ int initumath(PyObject *m)
 
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
+
+    if (InitOperators(d) < 0) {
+        return -1;
+    }
 
     PyDict_SetItemString(d, "pi", s = PyFloat_FromDouble(NPY_PI));
     Py_DECREF(s);


### PR DESCRIPTION
This moves the include of the autogenerated c code (not headers!)
for the ufunc handling to where it belongs (or at least closer to it).

The `InitOperators` is now part of `initumath`.  The ufunc API table
which is exported is exported through `multiarray.c`, so it is
included there.

This allows including of umath code elsewhere in NumPy without losing
sanity.  It is probably not quite as clean as it could be, but
definitely a step in the right direction.

---

I need this (somewhat), because I want floating point error handling for casts.  But the FPE handlers are all defined in the umath code.  Moving this around, makes them reachable in a sane manner without moving it fully out of the umath code.
(But part of the API is also exported via the umath API table, so this seemed reasonable)

It is also just much cleaner IMO.  This is C code that is not meant to be in-lined or anything.  This should not be included into a header?
Maybe, `"__ufunc_api.c"` should maybe be defined in `umathmodule.h` and filled in `umathmodule.c`.  But it is really only useful in that one place anyway...