### PR TITLE
ENH: Introduce numpy.core.setup_common.NPY_CXX_FLAGS

### DIFF
--- a/doc/source/user/building.rst
+++ b/doc/source/user/building.rst
@@ -48,6 +48,9 @@ Building NumPy requires the following software installed:
    Much of NumPy is written in C.  You will need a C compiler that complies
    with the C99 standard.
 
+   Part of Numpy is now written in C++. You will also need a C++ compiler that
+   complies with the C++11 standard.
+
    While a FORTRAN 77 compiler is not necessary for building NumPy, it is
    needed to run the ``numpy.f2py`` tests. These tests are skipped if the
    compiler is not auto-detected.

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -469,6 +469,7 @@ def configuration(parent_package='',top_path=None):
                                            exec_mod_from_location)
     from numpy.distutils.system_info import (get_info, blas_opt_info,
                                              lapack_opt_info)
+    from numpy.distutils.ccompiler_opt import NPY_CXX_FLAGS
     from numpy.version import release as is_released
 
     config = Configuration('core', parent_package, top_path)
@@ -737,11 +738,17 @@ def configuration(parent_package='',top_path=None):
         ):
             is_cpp = lang == 'c++'
             if is_cpp:
-                # this a workround to get rid of invalid c++ flags
+                # this a workaround to get rid of invalid c++ flags
                 # without doing big changes to config.
                 # c tested first, compiler should be here
                 bk_c = config_cmd.compiler
                 config_cmd.compiler = bk_c.cxx_compiler()
+
+                # Check that Linux compiler actually support the default flags
+                if hasattr(config_cmd.compiler, 'compiler'):
+                    config_cmd.compiler.compiler.extend(NPY_CXX_FLAGS)
+                    config_cmd.compiler.compiler_so.extend(NPY_CXX_FLAGS)
+
             st = config_cmd.try_link(test_code, lang=lang)
             if not st:
                 # rerun the failing command in verbose mode
@@ -1120,10 +1127,7 @@ def configuration(parent_package='',top_path=None):
                          libraries=['npymath'],
                          extra_objects=svml_objs,
                          extra_info=extra_info,
-                         extra_cxx_compile_args=['-std=c++11',
-                                                 '-D__STDC_VERSION__=0',
-                                                 '-fno-exceptions',
-                                                 '-fno-rtti'])
+                         extra_cxx_compile_args=NPY_CXX_FLAGS)
 
     #######################################################################
     #                        umath_tests module                           #

--- a/numpy/distutils/ccompiler_opt.py
+++ b/numpy/distutils/ccompiler_opt.py
@@ -16,6 +16,14 @@ import re
 import subprocess
 import textwrap
 
+# These flags are used to compile any C++ source within Numpy.
+# They are chosen to have very few runtime dependencies.
+NPY_CXX_FLAGS = [
+    '-std=c++11',  # Minimal standard version
+    '-D__STDC_VERSION__=0',  # for compatibility with C headers
+    '-fno-exceptions',  # no exception support
+    '-fno-rtti']  # no runtime type information
+
 
 class _Config:
     """An abstract class holds all configurable attributes of `CCompilerOpt`,

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -3,6 +3,7 @@ import sys
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
+    from numpy.distutils.ccompiler_opt import NPY_CXX_FLAGS
     from numpy.distutils.system_info import get_info, system_info
     config = Configuration('linalg', parent_package, top_path)
 
@@ -72,10 +73,7 @@ def configuration(parent_package='', top_path=None):
         sources=['umath_linalg.cpp', get_lapack_lite_sources],
         depends=['lapack_lite/f2c.h'],
         extra_info=lapack_info,
-        extra_cxx_compile_args=['-std=c++11',
-                                '-D__STDC_VERSION__=0',
-                                '-fno-exceptions',
-                                '-fno-rtti'],
+        extra_cxx_compile_args=NPY_CXX_FLAGS,
         libraries=['npymath'],
     )
     config.add_data_files('*.pyi')


### PR DESCRIPTION
Group all C++ flags in one location.

This avoids redundancy and makes sure we test the flags we use, and use the
flags we test.

Fix #21302

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
