### PR TITLE
WIP, BUG: preserve endianness of concat

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -382,6 +382,9 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
                           NPY_CASTING casting)
 {
     int iarrays, idim, ndim;
+    char initial_byteorder;
+    char iterative_byteorder;
+    int single_byteorder = 1;
     npy_intp shape[NPY_MAXDIMS];
     PyArrayObject_fields *sliding_view = NULL;
 
@@ -466,6 +469,18 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
                 narrays, arrays,  (PyObject *)dtype);
         if (descr == NULL) {
             return NULL;
+        }
+
+        initial_byteorder = PyArray_DESCR(arrays[0])->byteorder;
+        for (iarrays = 0; iarrays < narrays; ++iarrays) {
+            iterative_byteorder = PyArray_DESCR(arrays[iarrays])->byteorder;
+            if (iterative_byteorder != initial_byteorder) {
+                single_byteorder = 0;
+            }
+        }
+
+        if (single_byteorder == 1 && dtype == NULL) {
+            descr->byteorder = initial_byteorder;
         }
 
         /*

--- a/numpy/core/tests/test_shape_base.py
+++ b/numpy/core/tests/test_shape_base.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 import numpy as np
 from numpy.core import (
@@ -196,6 +197,21 @@ class TestVstack:
     def test_generator(self):
         with assert_warns(FutureWarning):
             vstack((np.arange(3) for _ in range(2)))
+
+    @pytest.mark.parametrize("func", [np.vstack, np.concatenate])
+    def test_issue_7289(self, func):
+        # preserve endianness with vstack/concatenate
+        a = np.zeros((3, 3), dtype='>i2')
+        expected_bytes = a.tobytes() + a.tobytes()
+        actual = func((a, a))
+
+        if sys.byteorder == "little":
+            expected = ">"
+        else:
+            expected = "="
+
+        assert actual.dtype.byteorder == expected
+        assert actual.tobytes() == expected_bytes
 
 
 class TestConcatenate:


### PR DESCRIPTION
Fixes #7829

* add a regression test for the described issue,
and C code changes to make it pass

* one curious problem, likely at the C level:
this causes a few test failures in the full test suite,
but none of them are reproducible if you tell `pytest`
to run them in isolation; also, which tests fail is
somewhat stochastic--reference counting issue maybe?

* other things it may be useful to consider:
  * most sensible behavior when combining arrays with different
endianness when `out` and/or `dtype` are not specified (I've assumed
this is covered by the tests already in place, though quite possible it is not)
  * if we want to do this, need for `versionchanged` directive? maybe
just in `concatenate` but not the functions that leverage `concatenate`?
  * run the tests on a big endian machine on the gcc compile farm to be
safe

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
