### PR TITLE
BUG: Make mmap handling safer in frombuffer

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1557,6 +1557,10 @@ add_newdoc('numpy.core.multiarray', 'frombuffer',
     The data of the resulting array will not be byteswapped, but will be
     interpreted correctly.
 
+    This function creates a view into the original object.  This should be safe
+    in general, but it may make sense to copy the result when the original
+    object is mutable or untrusted.
+
     Examples
     --------
     >>> s = b'hello world'

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -18,6 +18,7 @@ from numpy.compat import pickle
 import pathlib
 import builtins
 from decimal import Decimal
+import mmap
 
 import numpy as np
 import numpy.core._multiarray_tests as _multiarray_tests
@@ -5475,9 +5476,32 @@ class TestFromBuffer:
         buf = x.tobytes()
         assert_array_equal(np.frombuffer(buf, dtype=dt), x.flat)
 
+    def test_array_base(self):
+        arr = np.arange(10)
+        new = np.frombuffer(arr)
+        # We currently special case arrays to ensure they are used as a base.
+        # This could probably be changed (removing the test).
+        assert new.base is arr
+
     def test_empty(self):
         assert_array_equal(np.frombuffer(b''), np.array([]))
 
+    @pytest.mark.skipif(IS_PYPY,
+            reason="PyPy's memoryview currently does not track exports. See: "
+                   "https://foss.heptapod.net/pypy/pypy/-/issues/3724")
+    def test_mmap_close(self):
+        # The old buffer protocol was not safe for some things that the new
+        # one is.  But `frombuffer` always used the old one for a long time.
+        # Checks that it is safe with the new one (using memoryviews)
+        with tempfile.TemporaryFile(mode='wb') as tmp:
+            tmp.write(b"asdf")
+            tmp.flush()
+            mm = mmap.mmap(tmp.fileno(), 0)
+            arr = np.frombuffer(mm, dtype=np.uint8)
+            with pytest.raises(BufferError):
+                mm.close()  # cannot close while array uses the buffer
+            del arr
+            mm.close()
 
 class TestFlat:
     def setup(self):


### PR DESCRIPTION
`frombuffer` always used the old buffer protocol, but this is not
safe in some cases when combined with the "new" one.
The main/only use-case that was ever found for this is that enabling
the new buffer protocol (by going through a memoryview) protects
users from accidentally closing memorymaps while they are still used.

Closes gh-9537