### PR TITLE
TYP: Let `ndarray` fancy indexing always return an `ndarray`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1546,11 +1546,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     ) -> ndarray[_ShapeType2, _DType]: ...
 
     @overload
-    def __getitem__(self, key: (
-        SupportsIndex
-        | _ArrayLikeInt_co
-        | tuple[SupportsIndex | _ArrayLikeInt_co, ...]
-    )) -> Any: ...
+    def __getitem__(self, key: SupportsIndex | tuple[SupportsIndex, ...]) -> Any: ...
     @overload
     def __getitem__(self, key: (
         None

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -204,6 +204,8 @@ reveal_type(AR_V[AR_i8])  # E: Any
 reveal_type(AR_V[AR_i8, AR_i8])  # E: Any
 reveal_type(AR_V[AR_i8, None])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V[0, ...])  # E: ndarray[Any, dtype[void]]
+reveal_type(AR_V[[0]])  # E: ndarray[Any, dtype[void]]
+reveal_type(AR_V[[0], [0]])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V[:])  # E: ndarray[Any, dtype[void]]
 reveal_type(AR_V["a"])  # E: ndarray[Any, dtype[Any]]
 reveal_type(AR_V[["a", "b"]])  # E: ndarray[Any, dtype[void]]


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/21334

The argument types of the first `ndarray.__getitem__` overload , which is designed for handling normal integer indexing, are currently too broad, causing it to handle operations involving the likes of integer lists (and most fancy indexing operations in general). This is too broad, as these operations are guaranteed to return an array, rather than an array-or-scalar (_i.e._ `Any`) as is the case for normal integer-based indexing.