### PR TITLE
DEV: reverted misplaced install of "esbonio".

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,8 +19,6 @@ tasks:
       echo "📖 Building docs 📖 "
       cd doc
       make html
-      echo "Installing dependencies for documentation Live-Preview"
-      pip install esbonio
       echo "✨ Pre-build complete! You can close this terminal ✨ "
 
 # --------------------------------------------------------

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -40,7 +40,7 @@ RUN conda activate ${CONDA_ENV} && \
     ccache -s
 
 # Install dependencies for Live-Preview on Gipod
-RUN python -m pip Install esbonio   
+RUN python -m pip install esbonio   
 
 # Gitpod will load the repository into /workspace/numpy. We remove the
 # directory from the image to prevent conflicts

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -39,6 +39,9 @@ RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s
 
+# Install dependencies for Live-Preview on Gipod
+RUN python -m pip Install esbonio   
+
 # Gitpod will load the repository into /workspace/numpy. We remove the
 # directory from the image to prevent conflicts
 RUN rm -rf ${WORKSPACE}

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -39,7 +39,6 @@ RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s
 
-
 # Gitpod will load the repository into /workspace/numpy. We remove the
 # directory from the image to prevent conflicts
 RUN rm -rf ${WORKSPACE}

--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -39,8 +39,6 @@ RUN conda activate ${CONDA_ENV} && \
     python setup.py build_ext --inplace && \
     ccache -s
 
-# Install dependencies for Live-Preview on Gipod
-RUN python -m pip install esbonio   
 
 # Gitpod will load the repository into /workspace/numpy. We remove the
 # directory from the image to prevent conflicts


### PR DESCRIPTION
Added it to gitpod.Dockerfile

Why this change was made?
This is is response to the changes made via PR #21250 . A change of `pip install esbonio` was added to `gitpod.yml` file, but when the image was deployed the dependency was getting installed in User Context not in root context(where it was required) and hence not getting picked up by restructuredText VS Code extension.

What this PR changed?
1) removed the dependency installation from `gitpod.yml`
2) (Unsure and need some suggestions on If this was correct) during the Gitpod image Pre-build all the commands ran in `gitpod.dockerfile` are in root context. It is only in the last line where the root privileges are removed. I tried adding `pip install esbonio` to this file, thinking if the dependency is installed in root context then it might get picked up by the extension. 

(But I am un-sure about Point Number 2)
