### PR TITLE
ENH: Improve `np.kron` performance

### DIFF
--- a/doc/release/upcoming_changes/21354.performance.rst
+++ b/doc/release/upcoming_changes/21354.performance.rst
@@ -1,0 +1,4 @@
+Faster ``np.kron``
+------------------
+`numpy.kron` is about 80% faster as the product is now computed
+using broadcasting.

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -1141,6 +1141,7 @@ def kron(a, b):
     """
     b = asanyarray(b)
     a = array(a, copy=False, subok=True, ndmin=b.ndim)
+    is_any_mat = isinstance(a, matrix) or isinstance(b, matrix)
     ndb, nda = b.ndim, a.ndim
     nd = max(ndb, nda)
 
@@ -1158,17 +1159,17 @@ def kron(a, b):
     as_ = (1,)*max(0, ndb-nda) + as_
     bs = (1,)*max(0, nda-ndb) + bs
 
+    # Insert empty dimensions
+    a_arr = expand_dims(a, axis=tuple(range(ndb-nda)))
+    b_arr = expand_dims(b, axis=tuple(range(nda-ndb)))
+
     # Compute the product
-    a_arr = a.reshape(a.size, 1)
-    b_arr = b.reshape(1, b.size)
-    is_any_mat = isinstance(a_arr, matrix) or isinstance(b_arr, matrix)
+    a_arr = expand_dims(a_arr, axis=tuple(range(1, nd*2, 2)))
+    b_arr = expand_dims(b_arr, axis=tuple(range(0, nd*2, 2)))
     # In case of `mat`, convert result to `array`
     result = _nx.multiply(a_arr, b_arr, subok=(not is_any_mat))
 
     # Reshape back
-    result = result.reshape(as_+bs)
-    transposer = _nx.arange(nd*2).reshape([2, nd]).ravel(order='f')
-    result = result.transpose(transposer)
     result = result.reshape(_nx.multiply(as_, bs))
 
     return result if not is_any_mat else matrix(result, copy=False)

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -1139,6 +1139,15 @@ def kron(a, b):
     True
 
     """
+    # Working:
+    # 1. Equalise the shapes by prepending smaller array with 1s
+    # 2. Expand shapes of both the arrays by adding new axes at
+    #    odd positions for 1st array and even positions for 2nd
+    # 3. Compute the product of the modified array
+    # 4. The inner most array elements now contain the rows of
+    #    the Kronecker product
+    # 5. Reshape the result to kron's shape, which is same as
+    #    product of shapes of the two arrays.
     b = asanyarray(b)
     a = array(a, copy=False, subok=True, ndmin=b.ndim)
     is_any_mat = isinstance(a, matrix) or isinstance(b, matrix)


### PR DESCRIPTION
### Improve `np.kron` performance

* Use broadcasting during multiply to speed up the performance
* Also removed transpose logic to reduce total operations.

### Boost amount

<details>

<summary> Compare with bb811f45 (main) </summary>

```
~/os/numpy (perf_kron_21257) » python3 runtests.py --bench-compare main bench_shape_base.Kron                                                                         129 ↵ ganesh@ganesh-MS-7B86
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.9-Cython
·· Installing 06d34945 <perf_kron_21257> into virtualenv-py3.9-Cython.
· Running 6 total benchmarks (2 commits * 1 environments * 3 benchmarks)
[  0.00%] · For numpy commit bb811f45 <main> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.9-Cython.
[  0.00%] ·· Benchmarking virtualenv-py3.9-Cython
[  0.00%] ··· Importing benchmark suite produced output:
[  0.00%] ···· NumPy CPU features: SSE SSE2 SSE3 SSSE3* SSE41* POPCNT* SSE42* AVX* F16C* FMA3* AVX2* AVX512F? AVX512CD? AVX512_KNL? AVX512_KNM? AVX512_SKX? AVX512_CLX? AVX512_CNL? AVX512_ICL?
[  8.33%] ··· Running (bench_shape_base.Kron.time_arr_kron--)...
[ 25.00%] · For numpy commit 06d34945 <perf_kron_21257> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.9-Cython.
[ 25.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 33.33%] ··· Running (bench_shape_base.Kron.time_arr_kron--)...
[ 50.00%] · For numpy commit 06d34945 <perf_kron_21257> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 58.33%] ··· bench_shape_base.Kron.time_arr_kron                                                                                                                                          274±2ms
[ 66.67%] ··· bench_shape_base.Kron.time_mat_kron                                                                                                                                          215±2ms
[ 75.00%] ··· bench_shape_base.Kron.time_scalar_kron                                                                                                                                   3.96±0.05μs
[ 75.00%] · For numpy commit bb811f45 <main> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.9-Cython.
[ 75.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 83.33%] ··· bench_shape_base.Kron.time_arr_kron                                                                                                                                          438±2ms
[ 91.67%] ··· bench_shape_base.Kron.time_mat_kron                                                                                                                                          413±7ms
[100.00%] ··· bench_shape_base.Kron.time_scalar_kron                                                                                                                                   3.87±0.07μs
       before           after         ratio
     [bb811f45]       [06d34945]
     <main>           <perf_kron_21257>
-         438±2ms          274±2ms     0.63  bench_shape_base.Kron.time_arr_kron
-         413±7ms          215±2ms     0.52  bench_shape_base.Kron.time_mat_kron

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

</details>

<details>

<summary> Compare with latest release (v1.22.3) </summary>

```
~/os/numpy (perf_kron_21257) » python3 runtests.py --bench-compare v1.22.3 bench_shape_base.Kron                                                                            ganesh@ganesh-MS-7B86
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.9-Cython
·· Installing 06d34945 <perf_kron_21257> into virtualenv-py3.9-Cython.
· Running 6 total benchmarks (2 commits * 1 environments * 3 benchmarks)
[  0.00%] · For numpy commit 7d4349e3 <v1.22.3^0> (round 1/2):
[  0.00%] ·· Building for virtualenv-py3.9-Cython.......................................
[  0.00%] ·· Benchmarking virtualenv-py3.9-Cython
[  0.00%] ··· Importing benchmark suite produced output:
[  0.00%] ···· NumPy CPU features: SSE SSE2 SSE3 SSSE3* SSE41* POPCNT* SSE42* AVX* F16C* FMA3* AVX2* AVX512F? AVX512CD? AVX512_KNL? AVX512_KNM? AVX512_SKX? AVX512_CLX? AVX512_CNL? AVX512_ICL?
[  8.33%] ··· Running (bench_shape_base.Kron.time_arr_kron--)...
[ 25.00%] · For numpy commit 06d34945 <perf_kron_21257> (round 1/2):
[ 25.00%] ·· Building for virtualenv-py3.9-Cython.
[ 25.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 33.33%] ··· Running (bench_shape_base.Kron.time_arr_kron--)...
[ 50.00%] · For numpy commit 06d34945 <perf_kron_21257> (round 2/2):
[ 50.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 58.33%] ··· bench_shape_base.Kron.time_arr_kron                                                                                                                                          276±3ms
[ 66.67%] ··· bench_shape_base.Kron.time_mat_kron                                                                                                                                          220±4ms
[ 75.00%] ··· bench_shape_base.Kron.time_scalar_kron                                                                                                                                   3.94±0.05μs
[ 75.00%] · For numpy commit 7d4349e3 <v1.22.3^0> (round 2/2):
[ 75.00%] ·· Building for virtualenv-py3.9-Cython..
[ 75.00%] ·· Benchmarking virtualenv-py3.9-Cython
[ 83.33%] ··· bench_shape_base.Kron.time_arr_kron                                                                                                                                       1.32±0.02s
[ 91.67%] ··· bench_shape_base.Kron.time_mat_kron                                                                                                                                         733±20ms
[100.00%] ··· bench_shape_base.Kron.time_scalar_kron                                                                                                                                    3.78±0.1μs
       before           after         ratio
     [7d4349e3]       [06d34945]
     <v1.22.3^0>       <perf_kron_21257>
-        733±20ms          220±4ms     0.30  bench_shape_base.Kron.time_mat_kron
-      1.32±0.02s          276±3ms     0.21  bench_shape_base.Kron.time_arr_kron

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

</details>

Total speedup of about 70-80% compared to the current release

### Explanation
Ok let me try my best to explain the current flow:
1. Let's take two arrays `a` and `b` such that
```
a = np.ones((2,0,2))
b = np.ones((2,2))
```
2. Transform the ~shape~ ndims of smaller array (`b` in this case) to make them equal, hence `a`'s shape stays `(2,0,2)` while `b` becomes `(1,2,2)`. We prepend in case you were wondering. This is arbitrary from my searching, as few people prefer to append as well.
3. Now insert dimensions to both, such that we add them at odd axes for `a` and even for `b`. This is to compute the product for the required sub parts. Using broadcasting for the product of course which is helping in the performance.
4. The shape of `a` is now `(2, 1, 0, 1, 2, 1)` and `b` will be `(1, 1, 1, 2, 1, 2)`
5. After computing the product we reshape the result to the krons shape, `2, 0, 4`. We get this shape by multiplying shapes of `a` and `b`.

### TODO
- [x] One release note for performance [e18e312](https://github.com/numpy/numpy/pull/21354/commits/e18e3123d2483497d6c006d2ab251e01fb66be60)
- [x] Add inline comments [8e447c8](https://github.com/numpy/numpy/pull/21354/commits/8e447c8d64fc88390a5dcc4f205fad40fe470f4e)

Part of #21257 