### PR TITLE
MAINT: Remove the reference to the “good first issue” label

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Call for Contributions
 
 The NumPy project welcomes your expertise and enthusiasm!
 
-Small improvements or fixes are always appreciated; issues labeled as ["good
-first issue"](https://github.com/numpy/numpy/labels/good%20first%20issue)
-may be a good starting point. If you are considering larger contributions
+Small improvements or fixes are always appreciated. If you are considering larger contributions
 to the source code, please contact us through the [mailing
 list](https://mail.python.org/mailman/listinfo/numpy-discussion) first.
 


### PR DESCRIPTION
The “good first issue” label has been deprecated. We had discussions about its possibly misleading nature at several NumPy community meetings. It was decided not to assign levels of difficulty to any issues within the NumPy project.




