### PR TITLE
DOC: Fix a typo in docstring of MT19937

### DIFF
--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -214,7 +214,7 @@ cdef class MT19937(BitGenerator):
 
         Returns a new bit generator with the state jumped
 
-        The state of the returned big generator is jumped as-if
+        The state of the returned bit generator is jumped as-if
         2**(128 * jumps) random numbers have been generated.
 
         Parameters


### PR DESCRIPTION
Corrected misspelled phrase "big generator" to "bit generator".