### PR TITLE
DOC: Typesetting of math for np.correlate and np.convolve

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -681,10 +681,10 @@ def correlate(a, v, mode='valid'):
     This function computes the correlation as generally defined in signal
     processing texts::
 
-        c_{av}[k] = sum_n a[n+k] * conj(v[n])
+    .. math:: c_k = \sum_n a_{n+k} * \overline{v_n}
 
-    with a and v sequences being zero-padded where necessary and conj being
-    the conjugate.
+    with a and v sequences being zero-padded where necessary and
+    :math:`\overline x` denoting complex conjugation.
 
     Parameters
     ----------
@@ -713,9 +713,9 @@ def correlate(a, v, mode='valid'):
     The definition of correlation above is not unique and sometimes correlation
     may be defined differently. Another common definition is::
 
-        c'_{av}[k] = sum_n a[n] conj(v[n+k])
+    .. math:: c'_k = \sum_n a_{n} * \overline{v_{n+k}
 
-    which is related to ``c_{av}[k]`` by ``c'_{av}[k] = c_{av}[-k]``.
+    which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
 
     `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5) because it does
     not use the FFT to compute the convolution; in that case, `scipy.signal.correlate` might

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -675,7 +675,7 @@ def _correlate_dispatcher(a, v, mode=None):
 
 @array_function_dispatch(_correlate_dispatcher)
 def correlate(a, v, mode='valid'):
-    """
+    r"""
     Cross-correlation of two 1-dimensional sequences.
 
     This function computes the correlation as generally defined in signal

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -679,9 +679,9 @@ def correlate(a, v, mode='valid'):
     Cross-correlation of two 1-dimensional sequences.
 
     This function computes the correlation as generally defined in signal
-    processing texts::
+    processing texts:
 
-    .. math:: c_k = \sum_n a_{n+k} * \overline{v_n}
+    .. math:: c_k = \sum_n a_{n+k} \cdot \overline{v_n}
 
     with a and v sequences being zero-padded where necessary and
     :math:`\overline x` denoting complex conjugation.
@@ -711,9 +711,9 @@ def correlate(a, v, mode='valid'):
     Notes
     -----
     The definition of correlation above is not unique and sometimes correlation
-    may be defined differently. Another common definition is::
+    may be defined differently. Another common definition is:
 
-    .. math:: c'_k = \sum_n a_{n} * \overline{v_{n+k}
+    .. math:: c'_k = \sum_n a_{n} \cdot \overline{v_{n+k}}
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
 
@@ -804,7 +804,7 @@ def convolve(a, v, mode='full'):
     -----
     The discrete convolution operation is defined as
 
-    .. math:: (a * v)[n] = \\sum_{m = -\\infty}^{\\infty} a[m] v[n - m]
+    .. math:: (a * v)_n = \\sum_{m = -\\infty}^{\\infty} a_m v_{n - m}
 
     It can be shown that a convolution :math:`x(t) * y(t)` in time/space
     is equivalent to the multiplication :math:`X(f) Y(f)` in the Fourier

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -737,8 +737,8 @@ def correlate(a, v, mode='valid'):
     array([ 0.5-0.5j,  1.0+0.j ,  1.5-1.5j,  3.0-1.j ,  0.0+0.j ])
 
     Note that you get the time reversed, complex conjugated result
-    when the two input sequences change places, i.e.,
-    ``c_{va}[k] = c^{*}_{av}[-k]``:
+    (:math:`\overline{c_{-k}}`) when the two input sequences a and v change 
+    places:
 
     >>> np.correlate([0, 1, 0.5j], [1+1j, 2, 3-1j], 'full')
     array([ 0.0+0.j ,  3.0+1.j ,  1.5+1.5j,  1.0+0.j ,  0.5+0.5j])


### PR DESCRIPTION
This PR improves the documentation for

* `np.correlate`: Use math environment instead of formula shown as code
* `np.convolve`: Use more natural subscripts instead of brackets to denote item in sequence

I've checked that it displays correctly in the html.