### PR TITLE
MAINT: be sure to match base and docker images

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -235,7 +235,8 @@ jobs:
 
   armv7_simd_test:
     needs: [smoke_test]
-    runs-on: ubuntu-latest
+    # make sure this (20.04) matches the base docker image (focal) below
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -249,7 +250,7 @@ jobs:
         # use x86_64 cross-compiler to speed up the build
         sudo apt update
         sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-        docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:latest /bin/bash -c "
+        docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:focal /bin/bash -c "
           apt update &&
           apt install -y git python3 python3-dev python3-pip &&
           pip3 install cython==0.29.28 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 &&


### PR DESCRIPTION
Fixes the armv7_simd_test CI run by matching the compiler versions.

The latest ubuntu release made the base CI image (with gcc9) different from the docker image (with gcc11) used in the test