### PR TITLE
PERF: Reduce overhead of np.linalg.norm for small arrays

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -2526,10 +2526,7 @@ def norm(x, ord=None, axis=None, keepdims=False):
                 sqnorm = x_real.dot(x_real) + x_imag.dot(x_imag)
             else:
                 sqnorm = x.dot(x)
-            if isinstance(sqnorm, float):
-                ret = float64(math.sqrt(sqnorm))
-            else:
-                ret = sqrt(sqnorm)
+            ret = sqrt(sqnorm)
             if keepdims:
                 ret = ret.reshape(ndim*[1])
             return ret

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -17,6 +17,7 @@ __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
 import functools
 import operator
 import warnings
+import math
 
 from numpy.core import (
     array, asarray, zeros, empty, empty_like, intc, single, double,
@@ -25,7 +26,7 @@ from numpy.core import (
     finfo, errstate, geterrobj, moveaxis, amin, amax, product, abs,
     atleast_2d, intp, asanyarray, object_, matmul,
     swapaxes, divide, count_nonzero, isnan, sign, argsort, sort,
-    reciprocal
+    reciprocal, inner, float64
 )
 from numpy.core.multiarray import normalize_axis_index
 from numpy.core.overrides import set_module
@@ -2520,10 +2521,15 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
             x = x.ravel(order='K')
             if isComplexType(x.dtype.type):
-                sqnorm = dot(x.real, x.real) + dot(x.imag, x.imag)
+                x_real = x.real
+                x_imag = x.imag
+                sqnorm = x_real.dot(x_real) + x_imag.dot(x_imag)
             else:
-                sqnorm = dot(x, x)
-            ret = sqrt(sqnorm)
+                sqnorm = x.dot(x)
+            if isinstance(sqnorm, float):
+                ret = float64(math.sqrt(sqnorm))
+            else:
+                ret = sqrt(sqnorm)
             if keepdims:
                 ret = ret.reshape(ndim*[1])
             return ret

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -17,7 +17,6 @@ __all__ = ['matrix_power', 'solve', 'tensorsolve', 'tensorinv', 'inv',
 import functools
 import operator
 import warnings
-import math
 
 from numpy.core import (
     array, asarray, zeros, empty, empty_like, intc, single, double,
@@ -26,7 +25,7 @@ from numpy.core import (
     finfo, errstate, geterrobj, moveaxis, amin, amax, product, abs,
     atleast_2d, intp, asanyarray, object_, matmul,
     swapaxes, divide, count_nonzero, isnan, sign, argsort, sort,
-    reciprocal, inner, float64
+    reciprocal
 )
 from numpy.core.multiarray import normalize_axis_index
 from numpy.core.overrides import set_module


### PR DESCRIPTION
The `numpy.linalg.norm` method has some overhead for small and medium sized arrays. This PR reduces the overhead by making two small adjustments to the implementation. Details are discussed below.

Benchmark:
```
import numpy as np
x=np.random.rand(100,)
%timeit np.linalg.norm(x) 
%timeit np.sqrt(x.dot(x)) # for comparison

x=x+1j*np.random.rand(100,)
%timeit np.linalg.norm(x)
```
Results for main
```
3.63 µs ± 16.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
1.91 µs ± 7.91 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
5.33 µs ± 13.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
This PR
```
2.27 µs ± 10.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
1.92 µs ± 4.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
3.35 µs ± 10.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)```
```

* The call `dot(x,x)` is replaced with `x.dot(x)`. Since `x` has been cast with `asarray` and `ravel`, we know that `x` is a 1D numpy array. An alternative would be `np.inner(x,x)`. The call with `inner` is faster than `dot(x,x)` but slower than `x.dot(x)`
 
* The call to `np.sqrt` is replaced with a specialized call for float numbers (the common case). Ideally, the call would be replaced with a call to a numpy version of `sqrt` that only handles the scalar case. I could not find such a method exposed in the numpy codebase. Would it be possible to use a create such a method?


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
