### PR TITLE
DOC: Add missing entries in `numpy.testing` documentation

### DIFF
--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -27,6 +27,8 @@ Asserts
    assert_raises
    assert_raises_regex
    assert_warns
+   assert_no_warnings
+   assert_no_gc_cycles
    assert_string_equal
 
 Asserts (not recommended)
@@ -38,9 +40,11 @@ functions for more consistent floating point comparisons.
 .. autosummary::
    :toctree: generated/
 
+   assert_
    assert_almost_equal
    assert_approx_equal
    assert_array_almost_equal
+   print_assert_equal
 
 Decorators
 ----------
@@ -53,6 +57,7 @@ Decorators
    dec.skipif
    dec.slow
    decorate_methods
+   raises
 
 Test Running
 ------------
@@ -60,6 +65,8 @@ Test Running
    :toctree: generated/
 
    Tester
+   clear_and_catch_warnings
+   measure
    run_module_suite
    rundocs
    suppress_warnings

--- a/doc/source/reference/routines.testing.rst
+++ b/doc/source/reference/routines.testing.rst
@@ -57,7 +57,6 @@ Decorators
    dec.skipif
    dec.slow
    decorate_methods
-   raises
 
 Test Running
 ------------


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      http://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      http://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #21397

It appears that some `numpy.testing` functions are not included in the corresponding documentation page. In this PR, I have added the missing functions in `routines.testing.rst`. Which missing functions to add, in which documentation category to add them and the order within each category are by no means definitive choices.