### PR TITLE
MAINT: remove some names from main numpy namespace

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -363,7 +363,6 @@ else:
         except ValueError:
             pass
 
-    import sys
     if sys.platform == "darwin":
         with warnings.catch_warnings(record=True) as w:
             _mac_os_check()

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -424,4 +424,4 @@ else:
 from .version import __version__, git_revision as __git_version__
 
 # Remove symbols imported for internal use
-del sys, warnings
+del sys, warnings, os

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -314,7 +314,7 @@ else:
     def __dir__():
         public_symbols = globals().keys() | {'Tester', 'testing'}
         public_symbols -= {
-            "char", "core", "matrixlib", "os", "sys", "warnings"
+            "core", "matrixlib", "os", "sys", "warnings"
         }
         return list(public_symbols)
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -312,7 +312,11 @@ else:
                              "{!r}".format(__name__, attr))
 
     def __dir__():
-        return list(globals().keys() | {'Tester', 'testing'})
+        public_symbols = globals().keys() | {'Tester', 'testing'}
+        public_symbols -= {
+            "char", "core", "matrixlib", "os", "sys", "warnings"
+        }
+        return list(public_symbols)
 
     # Pytest testing
     from numpy._pytesttester import PytestTester

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -419,9 +419,12 @@ else:
         from pathlib import Path
         return [str(Path(__file__).with_name("_pyinstaller").resolve())]
 
+    # Remove symbols imported for internal use
+    del os
+
 
 # get the version using versioneer
 from .version import __version__, git_revision as __git_version__
 
 # Remove symbols imported for internal use
-del sys, warnings, os
+del sys, warnings

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -274,6 +274,7 @@ else:
     def __getattr__(attr):
         # Warn for expired attributes, and return a dummy function
         # that always raises an exception.
+        import warnings
         try:
             msg = __expired_functions__[attr]
         except KeyError:
@@ -314,7 +315,7 @@ else:
     def __dir__():
         public_symbols = globals().keys() | {'Tester', 'testing'}
         public_symbols -= {
-            "core", "matrixlib", "os", "sys", "warnings"
+            "core", "matrixlib",
         }
         return list(public_symbols)
 
@@ -421,3 +422,6 @@ else:
 
 # get the version using versioneer
 from .version import __version__, git_revision as __git_version__
+
+# Remove symbols imported for internal use
+del sys, warnings

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -203,7 +203,6 @@ from numpy import (
     lib as lib,
     linalg as linalg,
     ma as ma,
-    matrixlib as matrixlib,
     polynomial as polynomial,
     random as random,
     testing as testing,


### PR DESCRIPTION
This PR proposes to modify the `__dir__` method for the main numpy namespace to exclude names that either don't belong in the numpy namespace, or are not recommend to be directly accessed in user code.

This is inspired by the work in #18447 (especially the [last comment](https://github.com/numpy/numpy/pull/18447#issuecomment-1030234911)) and is intended to be a small, incremental step towards namespace cleanup. This should at the very least modify the discoverability of certain modules without actually changing or reorganizing how modules are imported.

I've limited the names to be excluded to a very small subset that should be uncontroversial:
 - `char`, `core`, and `matrixlib` are documented as not intended for direct use in user code
 - `os`, `sys`, and `warnings` are builtins that shouldn't be re-exported by `numpy`

I'm more interested in feedback on the approach than in worrying about which names should be included. We can always add to the set of names to be removed in subsequent PRs to keep discussions focused. 