### PR TITLE
MAINT: Reduce f2py verbiage for valid parameters

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2428,18 +2428,19 @@ def get_parameters(vars, global_params={}):
             elif iscomplex(vars[n]):
                 outmess(f'get_parameters[TODO]: '
                         f'implement evaluation of complex expression {v}\n')
+
+            # Handle _dp for gh-6624
+            # Also fixes gh-20460
+            if real16pattern.search(v):
+                v = 8
+            elif real8pattern.search(v):
+                v = 4
             try:
                 params[n] = eval(v, g_params, params)
+
             except Exception as msg:
-                # Handle _dp for gh-6624
-                if real16pattern.search(v):
-                    v = 8
-                elif real8pattern.search(v):
-                    v = 4
                 params[n] = v
-                # Don't report if the parameter is numeric gh-20460
-                if not real16pattern.search(v) and not real8pattern.search(v):
-                    outmess('get_parameters: got "%s" on %s\n' % (msg, repr(v)))
+                outmess('get_parameters: got "%s" on %s\n' % (msg, repr(v)))
             if isstring(vars[n]) and isinstance(params[n], int):
                 params[n] = chr(params[n])
             nl = n.lower()

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2433,7 +2433,9 @@ def get_parameters(vars, global_params={}):
                 params[n] = eval(v, g_params, params)
             except Exception as msg:
                 params[n] = v
-                outmess('get_parameters: got "%s" on %s\n' % (msg, repr(v)))
+                # Don't report if the parameter is numeric gh-20460
+                if not real16pattern.match(v):
+                    outmess('get_parameters: got "%s" on %s\n' % (msg, repr(v)))
             if isstring(vars[n]) and isinstance(params[n], int):
                 params[n] = chr(params[n])
             nl = n.lower()

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2428,13 +2428,17 @@ def get_parameters(vars, global_params={}):
             elif iscomplex(vars[n]):
                 outmess(f'get_parameters[TODO]: '
                         f'implement evaluation of complex expression {v}\n')
-
             try:
                 params[n] = eval(v, g_params, params)
             except Exception as msg:
+                # Handle _dp for gh-6624
+                if real16pattern.search(v):
+                    v = 8
+                elif real8pattern.search(v):
+                    v = 4
                 params[n] = v
                 # Don't report if the parameter is numeric gh-20460
-                if not real16pattern.match(v):
+                if not real16pattern.search(v) and not real8pattern.search(v):
                     outmess('get_parameters: got "%s" on %s\n' % (msg, repr(v)))
             if isstring(vars[n]) and isinstance(params[n], int):
                 params[n] = chr(params[n])

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -48,9 +48,9 @@ class TestReturnReal(util.F2PyTest):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Darwin",
+    platform.system() == "Darwin" or platform.system() == "Windows",
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
-    "but not when run in isolation",
+    "and windows, but not when run in isolation",
 )
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/20460. Essentially, valid parameter values with numeric literals (e.g. `1d0`) were throwing syntax errors due to an `eval` statement.

The "fix" in this case is to simply not report this for numeric values.

Also closes https://github.com/numpy/numpy/issues/6624 by explicitly checking for literals in `selected_real_kind`.