### PR TITLE
BUG: Fix handling of skip-empty-wrappers

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -531,7 +531,7 @@ def run_compile():
         sysinfo_flags = [f[7:] for f in sysinfo_flags]
 
     _reg2 = re.compile(
-        r'--((no-|)(wrap-functions|lower)|debug-capi|quiet)|-include')
+        r'--((no-|)(wrap-functions|lower)|debug-capi|quiet|skip-empty-wrappers)|-include')
     f2py_flags = [_m for _m in sys.argv[1:] if _reg2.match(_m)]
     sys.argv = [_m for _m in sys.argv if _m not in f2py_flags]
     f2py_flags2 = []

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -1,5 +1,6 @@
 import platform
 import pytest
+import numpy as np
 
 from numpy import array
 from . import util
@@ -51,6 +52,10 @@ class TestReturnReal(util.F2PyTest):
     platform.system() == "Darwin",
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
     "but not when run in isolation",
+)
+@pytest.mark.skipif(
+    np.dtype(np.intp).itemsize < 8,
+    reason="32-bit builds are buggy"
 )
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -48,9 +48,9 @@ class TestReturnReal(util.F2PyTest):
 
 
 @pytest.mark.skipif(
-    platform.system() == "Darwin" or platform.system() == "Windows",
+    platform.system() == "Darwin",
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
-    "and windows, but not when run in isolation",
+    "but not when run in isolation",
 )
 class TestCReturnReal(TestReturnReal):
     suffix = ".pyf"

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -1,5 +1,6 @@
 import platform
 import pytest
+import numpy as np
 
 from . import util
 
@@ -8,6 +9,10 @@ from . import util
     platform.system() == "Darwin",
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
     "but not when run in isolation",
+)
+@pytest.mark.skipif(
+    np.dtype(np.intp).itemsize < 8,
+    reason="32-bit builds are buggy"
 )
 class TestMultiline(util.F2PyTest):
     suffix = ".pyf"
@@ -37,6 +42,10 @@ end python module {module_name}
     platform.system() == "Darwin",
     reason="Prone to error when run with numpy/f2py/tests on mac os, "
     "but not when run in isolation",
+)
+@pytest.mark.skipif(
+    np.dtype(np.intp).itemsize < 8,
+    reason="32-bit builds are buggy"
 )
 class TestCallstatement(util.F2PyTest):
     suffix = ".pyf"


### PR DESCRIPTION
Earlier, `-c` flags were not handled.