### PR TITLE
TEST: on PyPy, skip hanging slow test [wheel build]

### DIFF
--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -285,6 +285,7 @@ from numpy.testing import (
     assert_, assert_array_equal, assert_raises, assert_raises_regex,
     assert_warns,
     )
+from numpy.testing._private.utils import requires_memory
 from numpy.lib import format
 
 
@@ -879,11 +880,13 @@ def test_large_file_support(tmpdir):
 @pytest.mark.skipif(np.dtype(np.intp).itemsize < 8,
                     reason="test requires 64-bit system")
 @pytest.mark.slow
+@requires_memory(free_bytes=2 * 2**30)
 def test_large_archive(tmpdir):
     # Regression test for product of saving arrays with dimensions of array
     # having a product that doesn't fit in int32.  See gh-7598 for details.
+    shape = (2**30, 2)
     try:
-        a = np.empty((2**30, 2), dtype=np.uint8)
+        a = np.empty(shape, dtype=np.uint8)
     except MemoryError:
         pytest.skip("Could not create large file")
 
@@ -892,10 +895,12 @@ def test_large_archive(tmpdir):
     with open(fname, "wb") as f:
         np.savez(f, arr=a)
 
+    del a
+
     with open(fname, "rb") as f:
         new_a = np.load(f)["arr"]
 
-    assert_(a.shape == new_a.shape)
+    assert new_a.shape == shape
 
 
 def test_empty_npz(tmpdir):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -203,6 +203,7 @@ class TestSavezLoad(RoundtripTest):
                 self.arr_reloaded.fid.close()
                 os.remove(self.arr_reloaded.fid.name)
 
+    @pytest.mark.skipif(IS_PYPY, reason="Hangs on PyPy")
     @pytest.mark.skipif(not IS_64BIT, reason="Needs 64bit platform")
     @pytest.mark.slow
     def test_big_arrays(self):


### PR DESCRIPTION
I noticed that [recent wheel builds](https://github.com/numpy/numpy/runs/6204153842?check_suite_focus=true) have failed for PyPy, this test, marked slow is hanging. Skip it unconditionally on PyPy.