### PR TITLE
TYP: Bump mypy to 0.950

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,6 +224,7 @@ numpy/core/src/umath/loops_trigonometric.dispatch.c
 numpy/core/src/umath/loops_exponent_log.dispatch.c
 numpy/core/src/umath/loops_umath_fp.dispatch.c
 numpy/core/src/umath/loops_hyperbolic.dispatch.c
+numpy/core/src/umath/loops_modulo.dispatch.c
 # npysort module
 numpy/core/src/npysort/x86-qsort.dispatch.c
 numpy/core/src/npysort/x86-qsort.dispatch.*.cpp

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=0.942
+  - mypy=0.950
   # For building docs
   - sphinx=4.5.0
   - sphinx-panels

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,4 +10,4 @@ cffi; python_version < '3.10'
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
-mypy==0.942; platform_python_implementation != "PyPy"
+mypy==0.950; platform_python_implementation != "PyPy"


### PR DESCRIPTION
Bump mypy from 0.942 to 0.950.

No need for a backport as both versions seem to be fully compatible.