### PR TITLE
ENH: adding covariance param to corrcoef - see ticket #19852

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2681,13 +2681,13 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
+def _corrcoef_dispatcher(x=None, cov = None, y=None, rowvar=None, bias=None, ddof=None, *,
                          dtype=None):
     return (x, y)
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x=np._NoValue, cov=np._NoValue, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
+def corrcoef(x=None, cov=None, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
              dtype=None,):
     """
     Return Pearson product-moment correlation coefficients.
@@ -2821,9 +2821,9 @@ def corrcoef(x=np._NoValue, cov=np._NoValue, y=None, rowvar=True, bias=np._NoVal
         # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning, stacklevel=3)
-    if x is np._NoValue and cov is np._NoValue:
+    if x is None and cov is None:
         raise ValueError("'x' or 'cov' must be passed as a parameter")
-    if x is not np._NoValue:
+    if x is not None:
         c = cov(x, y, rowvar, dtype=dtype)
     else:
         c = cov

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2687,8 +2687,8 @@ def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
-             dtype=None):
+def corrcoef(x=np._NoValue, cov=np._NoValue, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
+             dtype=None,):
     """
     Return Pearson product-moment correlation coefficients.
 
@@ -2727,6 +2727,9 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
         at least `numpy.float64` precision.
 
         .. versionadded:: 1.20
+
+    cov : _NoValue, optional
+        A known covariance matrix
 
     Returns
     -------
@@ -2818,7 +2821,12 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
         # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning, stacklevel=3)
-    c = cov(x, y, rowvar, dtype=dtype)
+    if x is np._NoValue and cov is np._NoValue:
+        raise ValueError("'x' or 'cov' must be passed as a parameter")
+    if x is not np._NoValue:
+        c = cov(x, y, rowvar, dtype=dtype)
+    else:
+        c = cov
     try:
         d = diag(c)
     except ValueError:
@@ -2837,6 +2845,9 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
         np.clip(c.imag, -1, 1, out=c.imag)
 
     return c
+
+
+
 
 
 @set_module('numpy')

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -2681,14 +2681,14 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x=None, cov = None, y=None, rowvar=None, bias=None, ddof=None, *,
-                         dtype=None):
+def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
+                         dtype=None, covM=False):
     return (x, y)
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x=None, cov=None, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
-             dtype=None,):
+def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
+             dtype=None, covM=False):
     """
     Return Pearson product-moment correlation coefficients.
 
@@ -2728,8 +2728,11 @@ def corrcoef(x=None, cov=None, y=None, rowvar=True, bias=np._NoValue, ddof=np._N
 
         .. versionadded:: 1.20
 
-    cov : _NoValue, optional
-        A known covariance matrix
+    covM : boolean, optional
+        If covM is true then this function assumes that the parameter
+        matrix 'x' passed to this function is a pre-calculated covariance matrix
+        and the call to Numpy.cov will be ignored. The default for this parameter
+        is False.
 
     Returns
     -------
@@ -2821,12 +2824,10 @@ def corrcoef(x=None, cov=None, y=None, rowvar=True, bias=np._NoValue, ddof=np._N
         # 2015-03-15, 1.10
         warnings.warn('bias and ddof have no effect and are deprecated',
                       DeprecationWarning, stacklevel=3)
-    if x is None and cov is None:
-        raise ValueError("'x' or 'cov' must be passed as a parameter")
-    if x is not None:
+    if covM is False:
         c = cov(x, y, rowvar, dtype=dtype)
     else:
-        c = cov
+        c = x
     try:
         d = diag(c)
     except ValueError:
@@ -2845,9 +2846,6 @@ def corrcoef(x=None, cov=None, y=None, rowvar=True, bias=np._NoValue, ddof=np._N
         np.clip(c.imag, -1, 1, out=c.imag)
 
     return c
-
-
-
 
 
 @set_module('numpy')

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2181,6 +2181,20 @@ class TestCorrCoef:
         res = corrcoef(cast_A, dtype=test_type)
         assert test_type == res.dtype
 
+    def test_corrcoef_covm(self):
+        A1 = np.cov(self.A)
+        B1 = np.cov(self.B)
+        res1A = np.cov(self.res1)
+        res2A = np.cov(self.res2)
+        assert_array_almost_equal(np.corrcoef(self.A).all(),
+                                  np.corrcoef(A1, covM=True).all())
+        assert_array_almost_equal(np.corrcoef(self.B).all(),
+                                  np.corrcoef(B1, covM=True))
+        assert_array_almost_equal(np.corrcoef(self.res1).all(),
+                                  np.corrcoef(res1A, covM=True))
+        assert_array_almost_equal(np.corrcoef(self.res2).all(),
+                                  np.corrcoef(res2A, covM=True))
+
 
 class TestCov:
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2189,11 +2189,11 @@ class TestCorrCoef:
         assert_array_almost_equal(np.corrcoef(self.A).all(),
                                   np.corrcoef(A1, covM=True).all())
         assert_array_almost_equal(np.corrcoef(self.B).all(),
-                                  np.corrcoef(B1, covM=True))
+                                  np.corrcoef(B1, covM=True).all())
         assert_array_almost_equal(np.corrcoef(self.res1).all(),
-                                  np.corrcoef(res1A, covM=True))
+                                  np.corrcoef(res1A, covM=True).all())
         assert_array_almost_equal(np.corrcoef(self.res2).all(),
-                                  np.corrcoef(res2A, covM=True))
+                                  np.corrcoef(res2A, covM=True).all())
 
 
 class TestCov:


### PR DESCRIPTION
Param cov was added to corrcoef func in order to accept a pre-calculated covariance matrix