### PR TITLE
BUG: Fix segmentation fault

### DIFF
--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5890,8 +5890,8 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     if (ufunc->core_enabled) {
         PyErr_Format(PyExc_TypeError,
-            "numpy.ufunc.at does not support ufunc with non-trivial "\
-            "signature: this ufunc has signature %s.", ufunc->core_signature);
+            "numpy.%s.at does not support ufunc with non-trivial signature: %s has signature %s.",
+            ufunc->name, ufunc->name, ufunc->core_signature);
         return NULL;
     }
 

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5890,7 +5890,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     if (ufunc->core_enabled) {
         PyErr_Format(PyExc_TypeError,
-            "numpy.%s.at does not support ufunc with non-trivial signature: %s has signature %s.",
+            "%s.at does not support ufunc with non-trivial signature: %s has signature %s.",
             ufunc->name, ufunc->name, ufunc->core_signature);
         return NULL;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5888,6 +5888,13 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
     NPY_BEGIN_THREADS_DEF;
 
+    if (ufunc->core_enabled) {
+        PyErr_Format(PyExc_TypeError,
+            "numpy.ufunc.at does not support ufunc with non-trivial "\
+            "signature: this ufunc has signature %s.", ufunc->core_signature);
+        return NULL;
+    }
+
     if (ufunc->nin > 2) {
         PyErr_SetString(PyExc_ValueError,
             "Only unary and binary ufuncs supported at this time");

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -389,7 +389,7 @@ class TestUfunc:
         assert_equal(ixs, (0, 0, 0, 1, 2))
         assert_equal(flags, (self.can_ignore, self.size_inferred, 0))
         assert_equal(sizes, (3, -1, 9))
-    
+
     def test_signature9(self):
         enabled, num_dims, ixs, flags, sizes = umt.test_signature(
             1, 1, "(  3)  -> ( )")
@@ -2001,6 +2001,23 @@ class TestUfunc:
 
         # Test multiple output ufuncs raise error, gh-5665
         assert_raises(ValueError, np.modf.at, np.arange(10), [1])
+
+        # Test ufuncs with non-trivial signature raise a TypeError
+        a = np.ones((2, 2, 2))
+        b = np.ones((1, 2, 2))
+        assert_raises(TypeError, np.matmul.at, a, [0], b)
+
+        a = np.array([[[1, 2], [3, 4]]])
+        assert_raises(TypeError, np.linalg._umath_linalg.det.at, a, [0])
+
+        # Ufunc with None signature should work as intended
+        a = np.array([1, 2, 3])
+        np.add.at(a, [0], 4)
+        assert_equal(np.array([5, 2, 3]), a)
+
+        a = np.array([1, 2, 3])
+        np.maximum.at(a, [0], 0)
+        assert_equal(np.array([1, 2, 3]), a)
 
     def test_reduce_arguments(self):
         f = np.add.reduce

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -2002,6 +2002,12 @@ class TestUfunc:
         # Test multiple output ufuncs raise error, gh-5665
         assert_raises(ValueError, np.modf.at, np.arange(10), [1])
 
+        # Test maximum
+        a = np.array([1, 2, 3])
+        np.maximum.at(a, [0], 0)
+        assert_equal(np.array([1, 2, 3]), a)
+
+    def test_at_not_none_signature(self):
         # Test ufuncs with non-trivial signature raise a TypeError
         a = np.ones((2, 2, 2))
         b = np.ones((1, 2, 2))
@@ -2009,15 +2015,6 @@ class TestUfunc:
 
         a = np.array([[[1, 2], [3, 4]]])
         assert_raises(TypeError, np.linalg._umath_linalg.det.at, a, [0])
-
-        # Ufunc with None signature should work as intended
-        a = np.array([1, 2, 3])
-        np.add.at(a, [0], 4)
-        assert_equal(np.array([5, 2, 3]), a)
-
-        a = np.array([1, 2, 3])
-        np.maximum.at(a, [0], 0)
-        assert_equal(np.array([1, 2, 3]), a)
 
     def test_reduce_arguments(self):
         f = np.add.reduce


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

BUG: Fixed segmentation fault with numpy.ufunc.at when ufunc has
nontrivial signature, issue #21301.

Test cases were added in numpy/core/tests/test_ufunc.py to show that
when numpy.ufunc.at uses ufunc with nontrivial signature, then
TypeError should be raised, instead of a potential segmentation fault.
Test cases were also added to show that ufunc with trivial signature is
still valid and works as intended. See [issue #21301](https://github.com/numpy/numpy/issues/21301). 