### PR TITLE
BUG: Ensure compile errors are raised correctly

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -357,7 +357,8 @@ def CCompiler_compile(self, sources, output_dir=None, macros=None,
         # build parallel
         from concurrent.futures import ThreadPoolExecutor
         with ThreadPoolExecutor(jobs) as pool:
-            pool.map(single_compile, build_items)
+            res = pool.map(single_compile, build_items)
+        list(res)  # access result to raise errors
     else:
         # build serial
         for o in build_items:


### PR DESCRIPTION
This has been bugging me for a bit.  The concurrent.futures Executor
requires checking the result for the error to be raised.  That makes
sense, but just means we need to consume the result explicitly here
to ensure we know about compile errors.

Otherwise, compile errors just pass silently (which is very confusing
if the old object files are still around and the tests run based on
the old version).
