### PR TITLE
BUG: Allow legacy dtypes to cast to datetime again

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -106,9 +106,6 @@ PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to)
         return NULL;
     }
     else {
-        if (NPY_DT_is_parametric(from) || NPY_DT_is_parametric(to)) {
-            Py_RETURN_NONE;
-        }
         /* Reject non-legacy dtypes (they need to use the new API) */
         if (!NPY_DT_is_legacy(from) || !NPY_DT_is_legacy(to)) {
             Py_RETURN_NONE;


### PR DESCRIPTION
Backport of #21372.

This constraint was added out of a caution with the thought that nobody
uses it. Turns out ora does use it.
In practice, this only affects cast to and from datetimes (or possibly
strings but that seems even less likely).

Tested via ora (see https://github.com/numpy/numpy/issues/21365) the paths are not particularly special,
but the parametric dtype resolution is in principle missing.
This is not particularly problematic, since NumPy barely exposes that
though, and it never worked.

Closes https://github.com/numpy/numpy/issues/21365

---

Test is missing, it could be added a rational to string cast probably, but overall it seems `ora` is working fine with it (see issue) and I always only added the check because I thought that without a proper dtype resolution, this is probably useless in any case.  (proper dtype resolution was not possible previously)

If there is a small chance of another 1.21.x release, this should also be backported to there.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
