### PR TITLE
BUG: Stop using PyBytesObject.ob_shash deprecated in Python 3.11.

### DIFF
--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -773,7 +773,9 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     if (PyTypeNum_ISFLEXIBLE(type_num)) {
         if (type_num == NPY_STRING) {
             destptr = PyBytes_AS_STRING(obj);
-            ((PyBytesObject *)obj)->ob_shash = -1;
+            #if PY_VERSION_HEX < 0x030b00b0
+                ((PyBytesObject *)obj)->ob_shash = -1;
+            #endif
             memcpy(destptr, data, itemsize);
             return obj;
         }


### PR DESCRIPTION
Backport of #21321.

This is unnecessary because a cached hash value should not be computed yet for `obj`. Moreover `PyBytesObject.ob_shash` was deprecated in Python 3.11, see https://github.com/python/cpython/issues/91020.

Fixes #21317.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
