### PR TITLE
PERF: Statically allocate unicode strings of memhandler

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -576,7 +576,7 @@ PyDataMem_GetHandler()
     if (p == NULL) {
         return NULL;
     }
-    handler = PyDict_GetItemString(p, "current_allocator");
+    handler = PyDict_GetItem(p, npy_ma_str_current_allocator);
     if (handler == NULL) {
         handler = PyCapsule_New(&default_handler, "mem_handler", NULL);
         if (handler == NULL) {

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4682,7 +4682,7 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_numpy = NULL;
 static int
 intern_strings(void)
 {
-    npy_ma_str_current_allocator = PyUnicode_InternFromString("npy_ma_str_current_allocator");
+    npy_ma_str_current_allocator = PyUnicode_InternFromString("current_allocator");
     if (npy_ma_str_current_allocator == NULL) {
         return -1;
     }

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4665,6 +4665,7 @@ set_flaginfo(PyObject *d)
     return;
 }
 
+NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_current_allocator = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_function = NULL;
 NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_array_struct = NULL;
@@ -4681,6 +4682,10 @@ NPY_VISIBILITY_HIDDEN PyObject * npy_ma_str_numpy = NULL;
 static int
 intern_strings(void)
 {
+    npy_ma_str_current_allocator = PyUnicode_InternFromString("npy_ma_str_current_allocator");
+    if (npy_ma_str_current_allocator == NULL) {
+        return -1;
+    }
     npy_ma_str_array = PyUnicode_InternFromString("__array__");
     if (npy_ma_str_array == NULL) {
         return -1;

--- a/numpy/core/src/multiarray/multiarraymodule.h
+++ b/numpy/core/src/multiarray/multiarraymodule.h
@@ -1,6 +1,7 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 
+NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_current_allocator;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_function;
 NPY_VISIBILITY_HIDDEN extern PyObject * npy_ma_str_array_struct;


### PR DESCRIPTION
The `current_allocator` string was converted to unicode in the loop with a numpy scalar. This PR statically converts it to unicode (similar to #21423)

@seberg Are you aware of any more conversions to be statically handled?

There are more unicode conversions  in `npy_parse_arguments`, but they are harder to replace since there is some preprocessing before the conversion to unicode.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
