### PR TITLE
TST: Remove most prints from the test suit run

### DIFF
--- a/numpy/core/tests/examples/cython/checks.pyx
+++ b/numpy/core/tests/examples/cython/checks.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 """
 Functions in this module give python-space wrappers for cython functions
 exposed in numpy/__init__.pxd, so they can be tested in test_cython.py

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -40,7 +40,7 @@ def install_temp(request, tmp_path):
     # build the examples and "install" them into a temporary directory
 
     install_log = str(tmp_path / "tmp_install_log.txt")
-    subprocess.check_call(
+    subprocess.check_output(
         [
             sys.executable,
             "setup.py",

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -1019,12 +1019,10 @@ class TestEinsumPath:
         # Long test 2
         long_test2 = self.build_operands('chd,bde,agbc,hiad,bdi,cgh,agdb')
         path, path_str = np.einsum_path(*long_test2, optimize='greedy')
-        print(path)
         self.assert_path_equal(path, ['einsum_path',
                                       (3, 4), (0, 3), (3, 4), (1, 3), (1, 2), (0, 1)])
 
         path, path_str = np.einsum_path(*long_test2, optimize='optimal')
-        print(path)
         self.assert_path_equal(path, ['einsum_path',
                                       (0, 5), (1, 4), (3, 4), (1, 3), (1, 2), (0, 1)])
 

--- a/numpy/core/tests/test_limited_api.py
+++ b/numpy/core/tests/test_limited_api.py
@@ -26,7 +26,7 @@ def test_limited_api(tmp_path):
     # build the examples and "install" them into a temporary directory
 
     install_log = str(tmp_path / "tmp_install_log.txt")
-    subprocess.check_call(
+    subprocess.check_output(
         [
             sys.executable,
             "setup.py",

--- a/numpy/core/tests/test_scalarbuffer.py
+++ b/numpy/core/tests/test_scalarbuffer.py
@@ -59,7 +59,6 @@ class TestScalarPEP3118:
                         shape=(), format=code, readonly=True)
 
         mv_x = memoryview(x)
-        print(mv_x.readonly, self._as_dict(mv_x))
         assert self._as_dict(mv_x) == expected
 
     @pytest.mark.parametrize('scalar', scalars_only, ids=codes_only)

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -6,7 +6,7 @@ import operator
 import platform
 from numpy.compat import _pep440
 import pytest
-from hypothesis import given, settings, Verbosity
+from hypothesis import given, settings
 from hypothesis.strategies import sampled_from
 
 import numpy as np
@@ -753,7 +753,6 @@ class TestHash:
             else:
                 val = float(numpy_val)
             assert val == numpy_val
-            print(repr(numpy_val), repr(val))
             assert hash(val) == hash(numpy_val)
 
         if hash(float(np.nan)) != hash(float(np.nan)):
@@ -791,7 +790,6 @@ reasonable_operators_for_scalars = [
 @given(sampled_from(objecty_things),
        sampled_from(reasonable_operators_for_scalars),
        sampled_from(types))
-@settings(verbosity=Verbosity.verbose)
 def test_operator_object_left(o, op, type_):
     try:
         with recursionlimit(200):

--- a/numpy/distutils/tests/test_log.py
+++ b/numpy/distutils/tests/test_log.py
@@ -8,7 +8,9 @@ from numpy.distutils import log
 
 
 def setup_module():
-    log.set_verbosity(2, force=True)  # i.e. DEBUG
+    f = io.StringIO()  # changing verbosity also logs here, capture that
+    with redirect_stdout(f):
+        log.set_verbosity(2, force=True)  # i.e. DEBUG
 
 
 def teardown_module():


### PR DESCRIPTION
Pytest silence these normally anyway (capturing it to print it only on failure),
but occasionally I run with `-s` and I don't think this output adds anything.
If nobody else cares about it nvm, just close it :).  Otherwise this cleans up everything
in the fast tests, except the f2py compilation right now.