### PR TITLE
DOC: style main page card

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -22,7 +22,6 @@ h1 {
   color: #013243; /* warm black */
 }
 
-
 h2 {
   color: #4d77cf; /* han blue */
   letter-spacing: -.03em;
@@ -31,4 +30,25 @@ h2 {
 h3 {
   color: #013243; /* warm black */
   letter-spacing: -.03em;
+}
+
+.intro-card {
+  padding: 20px 10px 20px 10px;
+  margin: 10px;
+}
+
+.intro-card p.card-text {
+  margin: 0;
+}
+
+.intro-card .card-img-top {
+  height: 52px;
+  width: 52px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.intro-card .card-header {
+  margin-top: 20px;
+  font-size: var(--pst-font-size-h5);
 }


### PR DESCRIPTION
Update the CSS of the cards on the main page of the documentation. The current panel has very large images.

Left is current, right is this PR–same zoom level was used.

<img width="400" alt="curr" src="https://user-images.githubusercontent.com/23188539/167028723-f925b50e-4caa-4f6a-94f2-cc32e3393dad.png"><img width="400" alt="new" src="https://user-images.githubusercontent.com/23188539/167028733-17446d9d-b448-47e7-b9a1-eee30342a56a.png">
