### PR TITLE
DOC: Improve documentation of ``as_array`` in ctypeslib.

### DIFF
--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -510,12 +510,31 @@ if ctypes is not None:
         Create a numpy array from a ctypes array or POINTER.
 
         The numpy array shares the memory with the ctypes object.
-
-        The shape parameter must be given if converting from a ctypes POINTER.
-        The shape parameter is ignored if converting from a ctypes array
         
-        The obj parameter must become ctypes Single Pointer
+        Parameters
+        ----------
+        obj : ctypes Pointer or ctypes array
+            data object with contiguous chunk of memory for numpy.ndarray data
+        shape : int or tuple of int, optional
+            return shape of numpy.ndarray
+            The shape parameter must be given if converting from a ctypes POINTER.
+            The shape parameter will be ignored if converting from a ctypes array
+            
+        Returns
+        -------
+        numpy.ndarray
+            numpy.ndarray sharing memory of input obj
+            
+        See Also
+        --------
+        Numpy Memory Management : https://numpy.org/devdocs/reference/c-api/data_memory.html
+        Numpy Ndarray : https://numpy.org/devdocs/reference/generated/numpy.ndarray.html
+        
+        Notes
+        -----                        
         Numpy array stores it's data as single Void pointer in C.        
+        If use Pointer as input, must use ctypes Single Pointer, Not a Double, Triple Pointer
+        
         """
         if isinstance(obj, ctypes._Pointer):
             # convert pointers to an array of the desired shape

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -527,10 +527,9 @@ if ctypes is not None:
             
         See Also
         --------
-        Numpy Ndarray : 
-            numpy ndarray core structure
+        'ndarray' : numpy ndarray core structure
             `<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_
-        Memory Managment Guide : 
+        Memory_Managment_Guide : 
             `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
         
         

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -509,16 +509,16 @@ if ctypes is not None:
         """
         Create a numpy array from a ctypes array or POINTER.
 
-        The numpy array shares the memory with the ctypes object.
+        The numpy array shares memory with the ctypes object.
         
         Parameters
         ----------
         obj : ctypes Pointer or ctypes array
-            data object with contiguous chunk of memory for numpy.ndarray data
+            Data object with contiguous chunk of memory for numpy.ndarray data
         shape : int or tuple of int, optional
-            return shape of numpy.ndarray.
-            shape must be given if converting from a ctypes POINTER.
-            shape will be ignored if converting from a ctypes array
+            The shape of the returned numpy.ndarray. `shape` must be given if
+            converting from a ctypes POINTER, but is ignored if converting from
+            a ctypes array.
             
         Returns
         -------
@@ -527,8 +527,8 @@ if ctypes is not None:
             
         Notes
         -----                        
-        Numpy array stores it's data as single Void pointer in C.        
-        If use Pointer, must use ctypes Single Pointer, Not a Double, Triple
+        Numpy array stores its data as a void pointer in C. If you use a Pointer,
+        you must use ctypes Single Pointer.
         
         PyArray_Data
             `<https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_DATA>`_

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -516,9 +516,9 @@ if ctypes is not None:
         obj : ctypes Pointer or ctypes array
             data object with contiguous chunk of memory for numpy.ndarray data
         shape : int or tuple of int, optional
-            return shape of numpy.ndarray
-            The shape parameter must be given if converting from a ctypes POINTER.
-            The shape parameter will be ignored if converting from a ctypes array
+            return shape of numpy.ndarray.
+            shape must be given if converting from a ctypes POINTER.
+            shape will be ignored if converting from a ctypes array
             
         Returns
         -------
@@ -527,8 +527,9 @@ if ctypes is not None:
             
         See Also
         --------
-        Numpy Memory docs : https://numpy.org/devdocs/reference/c-api/data_memory.html
-        Numpy Ndarray : https://numpy.org/devdocs/reference/generated/numpy.ndarray.html
+        `ndarray`
+        `Memory Managment <https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
+        
         
         Notes
         -----                        

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -527,13 +527,13 @@ if ctypes is not None:
             
         See Also
         --------
-        Numpy Memory Management : https://numpy.org/devdocs/reference/c-api/data_memory.html
+        Numpy Memory docs : https://numpy.org/devdocs/reference/c-api/data_memory.html
         Numpy Ndarray : https://numpy.org/devdocs/reference/generated/numpy.ndarray.html
         
         Notes
         -----                        
         Numpy array stores it's data as single Void pointer in C.        
-        If use Pointer as input, must use ctypes Single Pointer, Not a Double, Triple Pointer
+        If use Pointer, must use ctypes Single Pointer, Not a Double, Triple
         
         """
         if isinstance(obj, ctypes._Pointer):

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -527,10 +527,11 @@ if ctypes is not None:
             
         See Also
         --------
-        `ndarray`:
+        Numpy Ndarray : 
             numpy ndarray core structure
-        Memory Managment Guide
-        `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
+            `<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_
+        Memory Managment Guide : 
+            `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
         
         
         Notes

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -525,18 +525,15 @@ if ctypes is not None:
         numpy.ndarray
             numpy.ndarray sharing memory of input obj
             
-        See Also
-        --------
-        'ndarray' : numpy ndarray core structure
-            `<https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html>`_
-        Memory_Managment_Guide : 
-            `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
-        
-        
         Notes
         -----                        
         Numpy array stores it's data as single Void pointer in C.        
         If use Pointer, must use ctypes Single Pointer, Not a Double, Triple
+        
+        PyArray_Data
+            `<https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_DATA>`_
+        Memory_Managment_Guide
+            `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
         
         """
         if isinstance(obj, ctypes._Pointer):

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -513,6 +513,9 @@ if ctypes is not None:
 
         The shape parameter must be given if converting from a ctypes POINTER.
         The shape parameter is ignored if converting from a ctypes array
+        
+        The obj parameter must become ctypes Single Pointer
+        Numpy array stores it's data as single Void pointer in C.        
         """
         if isinstance(obj, ctypes._Pointer):
             # convert pointers to an array of the desired shape

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -527,8 +527,10 @@ if ctypes is not None:
             
         See Also
         --------
-        `ndarray`
-        `Memory Managment <https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
+        `ndarray`:
+            numpy ndarray core structure
+        Memory Managment Guide
+        `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
         
         
         Notes

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -532,8 +532,8 @@ if ctypes is not None:
         
         PyArray_Data
             `<https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_DATA>`_
-        Memory_Managment_Guide
-            `<https://numpy.org/devdocs/reference/c-api/data_memory.html>`_
+        Numpy_Array_Internal_Memory_layout
+            `<https://numpy.org/devdocs/reference/arrays.ndarray.html#internal-memory-layout-of-an-ndarray>`_
         
         """
         if isinstance(obj, ctypes._Pointer):

--- a/numpy/ctypeslib.py
+++ b/numpy/ctypeslib.py
@@ -527,8 +527,8 @@ if ctypes is not None:
             
         Notes
         -----                        
-        Numpy array stores its data as a void pointer in C. If you use a Pointer,
-        you must use ctypes Single Pointer.
+        Numpy array stores its data as a void pointer in C. If you use a
+        Pointer, you must use ctypes Single Pointer.
         
         PyArray_Data
             `<https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_DATA>`_


### PR DESCRIPTION
issue : [Issue No:#21335](https://github.com/numpy/numpy/issues/21335)

In ctypelib api doc, it will be helpful if object parameter have more rich explaination.

add some explain about obj parameter

please review it and apply it in API-Docs :)