### PR TITLE
BLD: Add LoongArch support

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -18,6 +18,7 @@
  *              NPY_CPU_ARCEL
  *              NPY_CPU_ARCEB
  *              NPY_CPU_RISCV64
+ *              NPY_CPU_LOONGARCH
  *              NPY_CPU_WASM
  */
 #ifndef _NPY_CPUARCH_H_
@@ -102,6 +103,8 @@
     #define NPY_CPU_ARCEB
 #elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
     #define NPY_CPU_RISCV64
+#elif defined(__loongarch__)
+    #define NPY_CPU_LOONGARCH
 #elif defined(__EMSCRIPTEN__)
     /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */
     #define NPY_CPU_WASM

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -49,6 +49,7 @@
             || defined(NPY_CPU_PPC64LE)       \
             || defined(NPY_CPU_ARCEL)         \
             || defined(NPY_CPU_RISCV64)       \
+            || defined(NPY_CPU_LOONGARCH)     \
             || defined(NPY_CPU_WASM)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)                \


### PR DESCRIPTION
Numpy is already supported in 1.22.x and we hope to support 1.21.x.
https://github.com/numpy/numpy/pull/19527#issue-948343276

There are many developers using python 3.7 on LoongArch, and `pip install numpy` gives an `#error Unknown CPU, please report this to numpy maintainers with` error, so we hope numpy 1.21.x will support LA. Thanks! @charris 