### PR TITLE
BENCH: Add benchmarks targeted at small arrays

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -207,7 +207,7 @@ class Indices(Benchmark):
         np.indices((1000, 500))
 
 class VarComplex(Benchmark):
-    params = [10**n for n in range(1, 9)]
+    params = [10**n for n in range(0, 9)]
     def setup(self, n):
         self.arr = np.random.randn(n) + 1j * np.random.randn(n)
 

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -43,6 +43,20 @@ class Bincount(Benchmark):
         np.bincount(self.d, weights=self.e)
 
 
+class Mean(Benchmark):
+    param_names = ['size']
+    params = [[1, 10, 100_000]]
+
+    def setup(self, size):
+        self.array = np.arange(2*size).reshape(2, size)
+
+    def time_mean(self):
+        np.mean(self.array)
+
+    def time_mean_axis(self):
+        np.mean(self.array, axis=1)
+
+
 class Median(Benchmark):
     def setup(self):
         self.e = np.arange(10000, dtype=np.float32)

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -50,10 +50,10 @@ class Mean(Benchmark):
     def setup(self, size):
         self.array = np.arange(2*size).reshape(2, size)
 
-    def time_mean(self):
+    def time_mean(self, size):
         np.mean(self.array)
 
-    def time_mean_axis(self):
+    def time_mean_axis(self, size):
         np.mean(self.array, axis=1)
 
 

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -92,13 +92,16 @@ class Median(Benchmark):
 class Percentile(Benchmark):
     def setup(self):
         self.e = np.arange(10000, dtype=np.float32)
-        self.o = np.arange(10001, dtype=np.float32)
+        self.o = np.arange(21, dtype=np.float32)
 
     def time_quartile(self):
         np.percentile(self.e, [25, 75])
 
     def time_percentile(self):
         np.percentile(self.e, [25, 35, 55, 65, 75])
+
+    def time_percentile_small(self):
+        np.percentile(self.o, [25, 75])
 
 
 class Select(Benchmark):

--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -98,6 +98,18 @@ class Linalg(Benchmark):
         self.func(self.a)
 
 
+class LinalgSmallArrays(Benchmark):
+    """ Test overhead of linalg methods for small arrays """
+    def setup(self):
+        self.array_5 = np.arange(5.)
+        self.array_5_5 = np.arange(5.)
+
+    def time_norm_small_array(self):
+        np.linalg.norm(self.array_5)
+
+    def time_det_small_array(self):
+        np.linalg.det(self.array_5_5)
+        
 class Lstsq(Benchmark):
     def setup(self):
         self.a = get_squares_()['float64']

--- a/benchmarks/benchmarks/bench_ufunc.py
+++ b/benchmarks/benchmarks/bench_ufunc.py
@@ -57,10 +57,47 @@ class UFunc(Benchmark):
     def time_ufunc_types(self, ufuncname):
         [self.f(*arg) for arg in self.args]
 
+class UFuncSmall(Benchmark):
+    """  Benchmark for a selection of ufuncs on a small arrays and scalars 
+
+    Since the arrays and scalars are small, we are benchmarking the overhead 
+    of the numpy ufunc functionality
+    """
+    params = ['abs', 'sqrt', 'cos']
+    param_names = ['ufunc']
+    timeout = 10
+
+    def setup(self, ufuncname):
+        np.seterr(all='ignore')
+        try:
+            self.f = getattr(np, ufuncname)
+        except AttributeError:
+            raise NotImplementedError()
+        self.array_5 = np.array([1., 2., 10., 3., 4.])
+        self.array_int_3 = np.array([1, 2, 3])
+        self.float64 = np.float64(1.1)
+        self.python_float = 1.1
+        
+    def time_ufunc_small_array(self, ufuncname):
+        self.f(self.array_5)
+
+    def time_ufunc_small_array_inplace(self, ufuncname):
+        self.f(self.array_5, out = self.array_5)
+
+    def time_ufunc_small_int_array(self, ufuncname):
+        self.f(self.array_int_3)
+
+    def time_ufunc_numpy_scalar(self, ufuncname):
+        self.f(self.float64)
+
+    def time_ufunc_python_float(self, ufuncname):
+        self.f(self.python_float)
+        
 
 class Custom(Benchmark):
     def setup(self):
         self.b = np.ones(20000, dtype=bool)
+        self.b_small = np.ones(3, dtype=bool)
 
     def time_nonzero(self):
         np.nonzero(self.b)
@@ -73,6 +110,9 @@ class Custom(Benchmark):
 
     def time_or_bool(self):
         (self.b | self.b)
+
+    def time_and_bool_small(self):
+        (self.b_small & self.b_small)
 
 
 class CustomInplace(Benchmark):


### PR DESCRIPTION
This PR adds a benchmark file specifically targeted at small arrays and scalars. 

The goal is to benchmark the overhead of the various numpy methods. For benchmarks with large arrays (e.g. size > 1e6) the overhead is small compared to the actual computation, but for small arrays it is not.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
