### PR TITLE
PERF: Fast check on equivalent arrays in PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK

### DIFF
--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -688,6 +688,11 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     npy_intp size1, size2, stride1, stride2;
     int arr1_ahead = 0, arr2_ahead = 0;
 
+    if (arr1 == arr2) {
+        // case common for inplace operations
+        return 1;
+    }
+    
     if (arr1_read && arr2_read) {
         return 1;
     }

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -685,9 +685,6 @@ static NPY_INLINE int
 PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr2,
                                          int arr1_read, int arr2_read)
 {
-    assert(arr1);
-    assert(arr2);
-
     npy_intp size1, size2, stride1, stride2;
     int arr1_ahead = 0, arr2_ahead = 0;
 

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -685,15 +685,22 @@ static NPY_INLINE int
 PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr2,
                                          int arr1_read, int arr2_read)
 {
+    assert(arr1);
+    assert(arr2);
+
     npy_intp size1, size2, stride1, stride2;
     int arr1_ahead = 0, arr2_ahead = 0;
 
-    if (arr1 == arr2) {
-        // case common for inplace operations
-        return 1;
-    }
     
     if (arr1_read && arr2_read) {
+        return 1;
+    }
+
+    size1 = PyArray_SIZE(arr1);
+    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
+
+    if (arr1 == arr2 && stride1 !=0) {
+        // case common for inplace operations
         return 1;
     }
 
@@ -706,10 +713,7 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
      * arrays stride ahead faster than output arrays.
      */
 
-    size1 = PyArray_SIZE(arr1);
     size2 = PyArray_SIZE(arr2);
-
-    stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2);
 
     /*

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -695,8 +695,13 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     size1 = PyArray_SIZE(arr1);
     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
 
+    /*
+     * arr1 == arr2 is common for in-place operations, so we fast-path it here.
+     * TODO: The stride1 != 0 check rejects broadcast arrays.  This may affect
+     *       self-overlapping arrays, but seems only necessary due to
+     *       `try_trivial_single_output_loop` not rejecting broadcast outputs.
+     */
     if (arr1 == arr2 && stride1 != 0) {
-        // case common for inplace operations
         return 1;
     }
 

--- a/numpy/core/src/common/lowlevel_strided_loops.h
+++ b/numpy/core/src/common/lowlevel_strided_loops.h
@@ -688,7 +688,6 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     npy_intp size1, size2, stride1, stride2;
     int arr1_ahead = 0, arr2_ahead = 0;
 
-    
     if (arr1_read && arr2_read) {
         return 1;
     }
@@ -696,7 +695,7 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
     size1 = PyArray_SIZE(arr1);
     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1);
 
-    if (arr1 == arr2 && stride1 !=0) {
+    if (arr1 == arr2 && stride1 != 0) {
         // case common for inplace operations
         return 1;
     }

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -1206,6 +1206,7 @@ prepare_ufunc_output(PyUFuncObject *ufunc,
  * cannot broadcast any other array (as it requires a single stride).
  * The function accepts all 1-D arrays, and N-D arrays that are either all
  * C- or all F-contiguous.
+ * NOTE: Broadcast outputs are implicitly rejected in the overlap detection.
  *
  * Returns -2 if a trivial loop is not possible, 0 on success and -1 on error.
  */


### PR DESCRIPTION
The `PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK` has to go through all the checks for identical arrays (a common case for inplace operations). This PR adds a fast check to see whether the two arrays to be compared are identical.

Benchmark
```
import numpy as np
import time

x=np.random.rand(10,20)   
niter=20_0000

t0=time.perf_counter()
for ii in range(niter):
    x=np.cos(x, out=x)
dt=time.perf_counter()-t0
print(dt)
```
Results in:
```
main: 0.51
PR: 0.39
```

Addresses one of the items in #21455

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
