### PR TITLE
PERF: Use python integer on _count_reduce_items

### DIFF
--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -71,7 +71,7 @@ def _count_reduce_items(arr, axis, keepdims=False, where=True):
             axis = tuple(range(arr.ndim))
         elif not isinstance(axis, tuple):
             axis = (axis,)
-        items = nt.intp(1)
+        items = 1
         for ax in axis:
             items *= arr.shape[mu.normalize_axis_index(ax, arr.ndim)]
     else:

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -170,7 +170,6 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     is_float16_result = False
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
-    
     if rcount == 0 if where is True else umr_any(rcount == 0, axis=None):
         warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
 
@@ -194,6 +193,9 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
         else:
             ret = ret.dtype.type(ret / rcount)
     else:
+        # corner case gh-21465
+        if isinstance(rcount, int):
+            rcount = nt.intp(rcount)
         ret = ret / rcount
 
     return ret
@@ -230,6 +232,9 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
     elif hasattr(arrmean, "dtype"):
         arrmean = arrmean.dtype.type(arrmean / rcount)
     else:
+        # corner case gh-21465
+        if isinstance(rcount, int):
+            rcount = nt.intp(rcount)
         arrmean = arrmean / rcount
 
     # Compute sum of squared deviations from mean

--- a/numpy/core/_methods.py
+++ b/numpy/core/_methods.py
@@ -64,6 +64,11 @@ def _all(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     return umr_all(a, axis, dtype, out, keepdims, where=where)
 
 def _count_reduce_items(arr, axis, keepdims=False, where=True):
+    """ Count number of items in the reduction
+    
+    Returns:
+        Integer if where=True, otherwise a np.ndarray
+    """
     # fast-path for the default case
     if where is True:
         # no boolean mask given, calculate items according to axis
@@ -165,6 +170,7 @@ def _mean(a, axis=None, dtype=None, out=None, keepdims=False, *, where=True):
     is_float16_result = False
 
     rcount = _count_reduce_items(arr, axis, keepdims=keepdims, where=where)
+    
     if rcount == 0 if where is True else umr_any(rcount == 0, axis=None):
         warnings.warn("Mean of empty slice.", RuntimeWarning, stacklevel=2)
 
@@ -212,7 +218,7 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
     arrmean = umr_sum(arr, axis, dtype, keepdims=True, where=where)
     # The shape of rcount has to match arrmean to not change the shape of out
     # in broadcasting. Otherwise, it cannot be stored back to arrmean.
-    if rcount.ndim == 0:
+    if isinstance(rcount, int):
         # fast-path for default case when where is True
         div = rcount
     else:


### PR DESCRIPTION
* The calculation in `_count_reduce_items` is faster with a plain python in than a numpy scalar `np.inp`. The elements of `arr.shape` are plain integers.
* The usage of the result (division in `np.mean`) also might be faster with `int` instead of `np.intp`. (although in the long run in might be better to make the division with `np.intp` just as fast as with `int`)
* 
Microbenchmark
```
import numpy as np
import time

x=np.random.rand(10,20)   
niter=20_0000

t0=time.perf_counter()
for ii in range(niter):
    y=np.mean(x, axis=1)
dt=time.perf_counter()-t0
print(dt)
```
Results in:
```
main: 1.78
PR: 1.39
```

Addresses one of the items in #21455


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
