### PR TITLE
DEV: Pin setuptools in the asv config

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -43,6 +43,7 @@
     // version.
     "matrix": {
         "Cython": [],
+        "setuptools": ["59.2.0"]
     },
 
     // The directory (relative to the current directory) that benchmarks are

--- a/benchmarks/asv_compare.conf.json.tpl
+++ b/benchmarks/asv_compare.conf.json.tpl
@@ -47,6 +47,7 @@
     // version.
     "matrix": {
         "Cython": [],
+        "setuptools": ["59.2.0"]
     },
 
     // The directory (relative to the current directory) that benchmarks are


### PR DESCRIPTION
Adding the setuptools version to the matrix makes sure that asv
(run through `runtests`) locally works again.  I am not quite sure
what changed that I now run into this issue and previously do not
(and neither does the CI runner yet).

There may be a better solution, but this seems fine for now?

Closes gh-21428