### PR TITLE
MAINT: Mark `npy_memchr` with `no_sanitize("alignment")` on clang

### DIFF
--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -248,6 +248,15 @@ npy_uint_alignment(int itemsize)
  * compared to memchr it returns one stride past end instead of NULL if needle
  * is not found.
  */
+#ifdef __clang__
+    /*
+     * The code below currently makes use of !NPY_ALIGNMENT_REQUIRED, which
+     * should be OK but causes the clang sanitizer to warn.  It may make
+     * sense to modify the code to avoid this "unaligned" access but
+     * it would be good to carefully check the performance changes.
+     */
+    __attribute__((no_sanitize("alignment")))
+#endif
 static NPY_INLINE char *
 npy_memchr(char * haystack, char needle,
            npy_intp stride, npy_intp size, npy_intp * psubloopsize, int invert)


### PR DESCRIPTION
Clangs sanitizer reports unaligned access here, which is correct
but intentional.  It may well be that the code would be better of
trying to avoid this unaligned access (and rather vectorizing harder).

But, this is a bit of a tricky choice, since we have to optimize for
different use-cases (in particular very short scans may be interesting).

So changing this would best be done together with some more careful
benchmarks.

See also gh-21117, which introduced manual loop unrolling to avoid the
unaligned access.

Closes gh-21116