### PR TITLE
ENH: Use `threadpoolctl` in `show_runtime` (a new function)

### DIFF
--- a/doc/release/upcoming_changes/21468.new_feature.rst
+++ b/doc/release/upcoming_changes/21468.new_feature.rst
@@ -1,0 +1,6 @@
+New function `np.show_runtime`
+------------------------------
+
+A new function `np.show_runtime` has been added to display the runtime
+information of the machine in addition to `np.show_config` which displays
+the build-related information.

--- a/doc/release/upcoming_changes/21468.new_feature.rst
+++ b/doc/release/upcoming_changes/21468.new_feature.rst
@@ -1,6 +1,6 @@
-New function `np.show_runtime`
-------------------------------
+New function ``np.show_runtime``
+--------------------------------
 
-A new function `np.show_runtime` has been added to display the runtime
-information of the machine in addition to `np.show_config` which displays
+A new function `numpy.show_runtime` has been added to display the runtime
+information of the machine in addition to `numpy.show_config` which displays
 the build-related information.

--- a/doc/source/reference/routines.other.rst
+++ b/doc/source/reference/routines.other.rst
@@ -45,6 +45,7 @@ Utility
 
    get_include
    show_config
+   show_runtime
    deprecate
    deprecate_with_doc
    broadcast_shapes

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -29,10 +29,10 @@ def show_runtime():
 
     Notes
     -----
-    1. Information is derived with the help of `threadpoolctl`
+    1. Information is derived with the help of `threadpoolctl <https://pypi.org/project/threadpoolctl/>`_
        library.
-    2. SIMD related information is derived from `__cpu_features__`,
-       `__cpu_baseline__` and `__cpu_dispatch__`
+    2. SIMD related information is derived from ``__cpu_features__``,
+       ``__cpu_baseline__`` and ``__cpu_dispatch__``
 
     Examples
     --------

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -13,8 +13,85 @@ import numpy as np
 __all__ = [
     'issubclass_', 'issubsctype', 'issubdtype', 'deprecate',
     'deprecate_with_doc', 'get_include', 'info', 'source', 'who',
-    'lookfor', 'byte_bounds', 'safe_eval'
+    'lookfor', 'byte_bounds', 'safe_eval', 'show_runtime'
     ]
+
+
+def show_runtime():
+    """
+    Print information about various resources in the system
+    including available intrinsic support and BLAS/LAPACK library
+    in use
+
+    See Also
+    --------
+    show_config : Show libraries in the system on which NumPy was built.
+
+    Notes
+    -----
+    1. Information is derived with the help of `threadpoolctl`
+       library.
+    2. SIMD related information is derived from `__cpu_features__`,
+       `__cpu_baseline__` and `__cpu_dispatch__`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> np.show_runtime()
+    [{'simd_extensions': {'baseline': ['SSE', 'SSE2', 'SSE3'],
+                          'found': ['SSSE3',
+                                    'SSE41',
+                                    'POPCNT',
+                                    'SSE42',
+                                    'AVX',
+                                    'F16C',
+                                    'FMA3',
+                                    'AVX2'],
+                          'not_found': ['AVX512F',
+                                        'AVX512CD',
+                                        'AVX512_KNL',
+                                        'AVX512_KNM',
+                                        'AVX512_SKX',
+                                        'AVX512_CLX',
+                                        'AVX512_CNL',
+                                        'AVX512_ICL']}},
+     {'architecture': 'Zen',
+      'filepath': '/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblasp-r0.3.20.so',
+      'internal_api': 'openblas',
+      'num_threads': 12,
+      'prefix': 'libopenblas',
+      'threading_layer': 'pthreads',
+      'user_api': 'blas',
+      'version': '0.3.20'}]
+    """
+    from numpy.core._multiarray_umath import (
+        __cpu_features__, __cpu_baseline__, __cpu_dispatch__
+    )
+    from pprint import pprint
+    config_found = []
+    features_found, features_not_found = [], []
+    for feature in __cpu_dispatch__:
+        if __cpu_features__[feature]:
+            features_found.append(feature)
+        else:
+            features_not_found.append(feature)
+    config_found.append({
+        "simd_extensions": {
+            "baseline": __cpu_baseline__,
+            "found": features_found,
+            "not_found": features_not_found
+        }
+    })
+    try:
+        from threadpoolctl import threadpool_info
+        config_found.extend(threadpool_info())
+    except ImportError:
+        print("WARNING: `threadpoolctl` not found in system!"
+              " Install it by `pip install threadpoolctl`."
+              " Once installed, try `np.show_runtime` again"
+              " for more detailed build information")
+    pprint(config_found)
+
 
 def get_include():
     """

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -51,6 +51,7 @@ def test_numpy_namespace():
         'safe_eval': 'numpy.lib.utils.safe_eval',
         'set_string_function': 'numpy.core.arrayprint.set_string_function',
         'show_config': 'numpy.__config__.show',
+        'show_runtime': 'numpy.lib.utils.show_runtime',
         'who': 'numpy.lib.utils.who',
     }
     # We override dir to not show these members


### PR DESCRIPTION
### ENH: Use `threadpoolctl`

* Use `threadpoolctl` at ~`np.show_config`~ `np.show_runtime`
* Refactor SIMD extensions display logic

### Sample output
```py
>>> np.show_runtime()
[{'simd_extensions': {'baseline': ['SSE', 'SSE2', 'SSE3'],
                      'found': ['SSSE3',
                                'SSE41',
                                'POPCNT',
                                'SSE42',
                                'AVX',
                                'F16C',
                                'FMA3',
                                'AVX2'],
                      'not_found': ['AVX512F',
                                    'AVX512CD',
                                    'AVX512_KNL',
                                    'AVX512_KNM',
                                    'AVX512_SKX',
                                    'AVX512_CLX',
                                    'AVX512_CNL',
                                    'AVX512_ICL']}},
 {'architecture': 'Zen',
  'filepath': '/usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblasp-r0.3.20.so',
  'internal_api': 'openblas',
  'num_threads': 12,
  'prefix': 'libopenblas',
  'threading_layer': 'pthreads',
  'user_api': 'blas',
  'version': '0.3.20'}]
```

or

```py
>>> np.show_runtime()
WARNING: `threadpoolctl` not found in system! Install it by `pip install threadpoolctl`. Once installed, try `np.show_runtime` again for more detailed build information
[{'simd_extensions': {'baseline': ['SSE', 'SSE2', 'SSE3'],
                      'found': ['SSSE3',
                                'SSE41',
                                'POPCNT',
                                'SSE42',
                                'AVX',
                                'F16C',
                                'FMA3',
                                'AVX2'],
                      'not_found': ['AVX512F',
                                    'AVX512CD',
                                    'AVX512_KNL',
                                    'AVX512_KNM',
                                    'AVX512_SKX',
                                    'AVX512_CLX',
                                    'AVX512_CNL',
                                    'AVX512_ICL']}}]
```

resolves: #21340
related: #20939