### PR TITLE
PERF: Skip probing `__array_ufunc__` for NumPy builtin scalars

### DIFF
--- a/numpy/core/src/common/get_attr_string.h
+++ b/numpy/core/src/common/get_attr_string.h
@@ -42,7 +42,7 @@ _is_basic_python_type(PyTypeObject *tp)
  * on the type object, rather than on the instance itself.
  *
  * Assumes that the special method is a numpy-specific one, so does not look
- * at builtin types, nor does it look at a base ndarray.
+ * at builtin types. It does check base ndarray and numpy scalar types.
  *
  * In future, could be made more like _Py_LookupSpecial
  */

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -6,6 +6,8 @@
 #include "npy_import.h"
 #include "ufunc_override.h"
 
+#define PyObject_CheckExact_Type(op, checktype) (((PyObject*)(op))->ob_type == &checktype)
+
 /*
  * Check whether an object has __array_ufunc__ defined on its class and it
  * is not the default, i.e., the object is not an ndarray, and its
@@ -30,6 +32,11 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
     if (PyArray_CheckExact(obj)) {
         return NULL;
     }
+    /* Fast return for most common numpy scalar types */
+    if (PyObject_CheckExact_Type(obj, PyDoubleArrType_Type) || PyObject_CheckExact_Type(obj, PyIntArrType_Type)) {
+        return NULL;
+    }
+
     /*
      * Does the class define __array_ufunc__? (Note that LookupSpecial has fast
      * return for basic python types, so no need to worry about those here)

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -7,8 +7,6 @@
 #include "ufunc_override.h"
 #include "scalartypes.h"
 
-#define PyObject_CheckExact_Type(op, checktype) (((PyObject*)(op))->ob_type == &checktype)
-
 /*
  * Check whether an object has __array_ufunc__ defined on its class and it
  * is not the default, i.e., the object is not an ndarray, and its

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -34,8 +34,7 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
         return NULL;
     }
    /* Fast return for numpy scalar types */
-    if (is_anyscalar_exact(obj) )
-    {
+    if (is_anyscalar_exact(obj)) {
         return NULL;
     }
 

--- a/numpy/core/src/common/ufunc_override.c
+++ b/numpy/core/src/common/ufunc_override.c
@@ -5,6 +5,7 @@
 #include "get_attr_string.h"
 #include "npy_import.h"
 #include "ufunc_override.h"
+#include "scalartypes.h"
 
 #define PyObject_CheckExact_Type(op, checktype) (((PyObject*)(op))->ob_type == &checktype)
 
@@ -32,8 +33,9 @@ PyUFuncOverride_GetNonDefaultArrayUfunc(PyObject *obj)
     if (PyArray_CheckExact(obj)) {
         return NULL;
     }
-    /* Fast return for most common numpy scalar types */
-    if (PyObject_CheckExact_Type(obj, PyDoubleArrType_Type) || PyObject_CheckExact_Type(obj, PyIntArrType_Type)) {
+   /* Fast return for numpy scalar types */
+    if (is_anyscalar_exact(obj) )
+    {
         return NULL;
     }
 


### PR DESCRIPTION

The method `PyUFuncOverride_GetNonDefaultArrayUfunc` is expensive on numpy scalars because these objects do not have a `__array_ufunc__` set and for a missing attribute lookup cpython generates an exception that is later cleared by numpy. This is a performance bottleneck, see #21455.

An issue has been submitted to cpython (https://github.com/python/cpython/issues/92216). But even if this is addressed in cpython, it will take untill python 3.12+ before this will be useable by numpy.

As an alternative solution, this PR adds a fast path to `PyUFuncOverride_GetNonDefaultArrayUfunc` to determine whether an object is a numpy scalar. Some remarks:

- Currently the check is only on `PyDoubleArrType_Type` and `PyIntArrType_Type`. Perhaps we can check all types easily? Or select a different subset of all numpy scalar types.
- Subclasses of the numpy scalars are not handled
- An alternative would be to add `__array_ufunc__` to the numpy scalars, but this is not backwards compatible (https://github.com/numpy/numpy/pull/21423#issuecomment-1115803712)

Microbenchmark on `np.sqrt(np.float64(1.1))`:
```
main: 0.54
PR: 0.40
```
<details>
<summary>Full benchmark</summary>

```
import numpy as np
import math
import time
print(np.__version__)

w=np.float64(1.1)
#w=1.1

niter=600_000
for kk in range(3):
    t0=time.perf_counter()
    for ii in range(niter):
        _=np.sqrt(w)
    dt=time.perf_counter()-t0
    print(f'loop {kk}: {dt}')
```
</details>

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
