### PR TITLE
MAINT: Make npy_half a strong type

### DIFF
--- a/doc/release/upcoming_changes/21487.c_api.rst
+++ b/doc/release/upcoming_changes/21487.c_api.rst
@@ -1,0 +1,19 @@
+``halffloat.h`` has received several changes
+--------------------------------------------
+
+The ``npy_half`` type is no longer a type alias, but a strong type. This make
+typing safer as ``npy_half x = 1`` or ``x += 1`` now raise an error.
+
+The ``halffloat.h`` header has been updated so that any code interacting with
+``npy_half`` through ``npy_half_*`` functions should recompile without error.
+Code that directly manipulate the bit representation of ``npy_half`` should do
+it explicitly by accessing the ``bits`` field of ``npy_half``. A few functions
+like ``npy_half_neg`` or ``npy_half_abs`` have been added to avoid this
+situation.
+
+For ABI compatibility, the legacy symbols that interacted with ``npy_half`` are
+still compiled in, but they are not exposed through the ``halffloat.h`` header.
+
+Downstream user that still need the legacy ABI can define the
+``NPY_USE_LEGACY_HALF`` macro before including ``halffloat.h``. In that case the
+legacy API is exposed.

--- a/numpy/core/include/numpy/halffloat.h
+++ b/numpy/core/include/numpy/halffloat.h
@@ -8,51 +8,164 @@
 extern "C" {
 #endif
 
+/* since NumPy 1.24, 2022-05, npy_half are represented as a struct instead of a
+ * type alias.
+ * To keep ABI compatibility with older version of numpy, npy routines that
+ * manipulates are renamed using the convention defined in macro NPY_HALF_API.
+ * Each symbol is then redefined based on that naming scheme to keep client code
+ * mostly unchanged at API level.
+ *
+ * If for any reason, the legacy API must be used, define NPY_USE_LEGACY_HALF
+ * before including this file. This behavior is not expected for internal Numpy
+ * code.
+ */
+
+#define NPY_HALF_LEGACY_API(name) npy_##name
+
+#ifdef NPY_USE_LEGACY_HALF
+
+#define NPY_HALF_API(name) NPY_HALF_LEGACY_API(name)
+#define NPY_HALF_BITS(v) v
+#define NPY_HALF_BUILD(v) v
+#define NPY_HALF_INIT(v) v
+
+#else
+
+#define NPY_HALF_API(name) npy_strongly_typed_##name
+#define NPY_HALF_BITS(v) ((v).bits)
+#define NPY_HALF_BUILD(v) ((npy_half){v})
+#define NPY_HALF_INIT(v) {v}
+
+#endif
+
 /*
  * Half-precision routines
  */
 
 /* Conversions */
+#define npy_half_to_float NPY_HALF_API(half_to_float)
 float npy_half_to_float(npy_half h);
+
+#define npy_half_to_double NPY_HALF_API(half_to_double)
 double npy_half_to_double(npy_half h);
+
+#define npy_float_to_half NPY_HALF_API(float_to_half)
 npy_half npy_float_to_half(float f);
+
+#define npy_double_to_half NPY_HALF_API(double_to_half)
 npy_half npy_double_to_half(double d);
+
 /* Comparisons */
+#define npy_half_eq NPY_HALF_API(half_eq)
 int npy_half_eq(npy_half h1, npy_half h2);
+
+#define npy_half_ne NPY_HALF_API(half_ne)
 int npy_half_ne(npy_half h1, npy_half h2);
+
+#define npy_half_le NPY_HALF_API(half_le)
 int npy_half_le(npy_half h1, npy_half h2);
+
+#define npy_half_lt NPY_HALF_API(half_lt)
 int npy_half_lt(npy_half h1, npy_half h2);
+
+#define npy_half_ge NPY_HALF_API(half_ge)
 int npy_half_ge(npy_half h1, npy_half h2);
+
+#define npy_half_gt NPY_HALF_API(half_gt)
 int npy_half_gt(npy_half h1, npy_half h2);
+
 /* faster *_nonan variants for when you know h1 and h2 are not NaN */
+#define npy_half_eq_nonan NPY_HALF_API(half_eq_nonan)
 int npy_half_eq_nonan(npy_half h1, npy_half h2);
+
+#define npy_half_lt_nonan NPY_HALF_API(half_lt_nonan)
 int npy_half_lt_nonan(npy_half h1, npy_half h2);
+
+#define npy_half_le_nonan NPY_HALF_API(half_le_nonan)
 int npy_half_le_nonan(npy_half h1, npy_half h2);
+
 /* Miscellaneous functions */
-int npy_half_iszero(npy_half h);
-int npy_half_isnan(npy_half h);
-int npy_half_isinf(npy_half h);
-int npy_half_isfinite(npy_half h);
-int npy_half_signbit(npy_half h);
+#define npy_half_copysign NPY_HALF_API(half_copysign)
 npy_half npy_half_copysign(npy_half x, npy_half y);
+
+#define npy_half_spacing NPY_HALF_API(half_spacing)
 npy_half npy_half_spacing(npy_half h);
+
+#define npy_half_nextafter NPY_HALF_API(half_nextafter)
 npy_half npy_half_nextafter(npy_half x, npy_half y);
+
+#define npy_half_divmod NPY_HALF_API(half_divmod)
 npy_half npy_half_divmod(npy_half x, npy_half y, npy_half *modulus);
+
+#ifdef NPY_USE_LEGACY_HALF
+
+int NPY_HALF_API(half_iszero)(npy_half_bits_t h);
+int NPY_HALF_API(half_isnan)(npy_half_bits_t h);
+int NPY_HALF_API(half_isinf)(npy_half_bits_t h);
+int NPY_HALF_API(half_isfinite)(npy_half_bits_t h);
+int NPY_HALF_API(half_signbit)(npy_half_bits_t h);
+
+#else
+
+#define npy_half_iszero NPY_HALF_API(half_iszero)
+NPY_INLINE int npy_half_iszero(npy_half h) {
+  return (NPY_HALF_BITS(h)&0x7fff) == 0;
+}
+
+#define npy_half_isnan NPY_HALF_API(half_isnan)
+NPY_INLINE int npy_half_isnan(npy_half h) {
+    return ((NPY_HALF_BITS(h)&0x7c00u) == 0x7c00u) && ((NPY_HALF_BITS(h)&0x03ffu) != 0x0000u);
+}
+
+#define npy_half_isinf NPY_HALF_API(half_isinf)
+NPY_INLINE int npy_half_isinf(npy_half h) {
+  return ((NPY_HALF_BITS(h)&0x7fffu) == 0x7c00u);
+}
+
+#define npy_half_isfinite NPY_HALF_API(half_isfinite)
+NPY_INLINE int npy_half_isfinite(npy_half h) {
+  return (NPY_HALF_BITS(h)&0x7c00u) != 0x7c00u;
+}
+
+#define npy_half_signbit NPY_HALF_API(half_signbit)
+NPY_INLINE int npy_half_signbit(npy_half h) {
+  return (NPY_HALF_BITS(h)&0x8000u) != 0;
+}
+
+#define npy_half_neg NPY_HALF_API(half_neg)
+NPY_INLINE npy_half npy_half_neg(npy_half h) {
+  npy_half res = NPY_HALF_INIT((npy_uint16)(NPY_HALF_BITS(h)^0x8000u));
+  return res;
+}
+
+#define npy_half_abs NPY_HALF_API(half_abs)
+NPY_INLINE npy_half npy_half_abs(npy_half h) {
+  npy_half res = NPY_HALF_INIT((npy_uint16)(NPY_HALF_BITS(h)&0x7fffu));
+  return res;
+}
+
+#define npy_half_pos NPY_HALF_API(half_pos)
+NPY_INLINE npy_half npy_half_pos(npy_half h) {
+  npy_half res = NPY_HALF_INIT((npy_uint16)(+NPY_HALF_BITS(h)));
+  return res;
+}
+
+#endif
 
 /*
  * Half-precision constants
  */
 
-#define NPY_HALF_ZERO   (0x0000u)
-#define NPY_HALF_PZERO  (0x0000u)
-#define NPY_HALF_NZERO  (0x8000u)
-#define NPY_HALF_ONE    (0x3c00u)
-#define NPY_HALF_NEGONE (0xbc00u)
-#define NPY_HALF_PINF   (0x7c00u)
-#define NPY_HALF_NINF   (0xfc00u)
-#define NPY_HALF_NAN    (0x7e00u)
+#define NPY_HALF_ZERO   NPY_HALF_BUILD(0x0000u)
+#define NPY_HALF_PZERO  NPY_HALF_BUILD(0x0000u)
+#define NPY_HALF_NZERO  NPY_HALF_BUILD(0x8000u)
+#define NPY_HALF_ONE    NPY_HALF_BUILD(0x3c00u)
+#define NPY_HALF_NEGONE NPY_HALF_BUILD(0xbc00u)
+#define NPY_HALF_PINF   NPY_HALF_BUILD(0x7c00u)
+#define NPY_HALF_NINF   NPY_HALF_BUILD(0xfc00u)
+#define NPY_HALF_NAN    NPY_HALF_BUILD(0x7e00u)
 
-#define NPY_MAX_HALF    (0x7bffu)
+#define NPY_MAX_HALF    NPY_HALF_BUILD(0x7bffu)
 
 /*
  * Bit-level conversions
@@ -66,5 +179,6 @@ npy_uint64 npy_halfbits_to_doublebits(npy_uint16 h);
 #ifdef __cplusplus
 }
 #endif
+
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_HALFFLOAT_H_ */

--- a/numpy/core/include/numpy/npy_common.h
+++ b/numpy/core/include/numpy/npy_common.h
@@ -1030,7 +1030,12 @@ typedef struct { npy_longdouble real, imag; } npy_clongdouble;
 
 /* half/float16 isn't a floating-point type in C */
 #define NPY_FLOAT16 NPY_HALF
-typedef npy_uint16 npy_half;
+typedef npy_uint16 npy_half_bits_t;
+#ifdef NPY_USE_LEGACY_HALF
+typedef npy_half_bits_t npy_half;
+#else
+typedef struct npy_half { npy_half_bits_t bits;} npy_half;
+#endif
 typedef npy_half npy_float16;
 
 #if NPY_BITSOF_LONGDOUBLE == 32

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -1159,6 +1159,14 @@ def configuration(parent_package='',top_path=None):
     config.add_extension('_struct_ufunc_tests',
                     sources=[join('src', 'umath', '_struct_ufunc_tests.c')])
 
+    #######################################################################
+    #                        half_legacy_test module                      #
+    #######################################################################
+
+    config.add_extension('_half_legacy_tests',
+                    sources=[join('src', 'npymath', '_half_legacy_tests.c')],
+                    libraries=['npymath'])
+
 
     #######################################################################
     #                        operand_flag_tests module                    #

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -219,11 +219,11 @@ static PyObject *
 
     if ((ap == NULL) || PyArray_ISBEHAVED_RO(ap)) {
         t1 = *((@type@ *)ip);
-        return @func1@((@type1@)t1);
+        return @func1@(t1);
     }
     else {
         PyArray_DESCR(ap)->f->copyswap(&t1, ip, PyArray_ISBYTESWAPPED(ap), ap);
-        return @func1@((@type1@)t1);
+        return @func1@(t1);
     }
 }
 
@@ -237,7 +237,7 @@ static int
         temp = PyArrayScalar_VAL(op, @kind@);
     }
     else {
-        temp = (@type@)@func2@(op);
+        temp = @func2@(op);
     }
     if (PyErr_Occurred()) {
         PyObject *type, *value, *traceback;
@@ -1252,7 +1252,7 @@ static void
     npy_half *op = output;
 
     while (n--) {
-        *op++ = npy_@name@bits_to_halfbits(*ip);
+        *op++ = (npy_half){npy_@name@bits_to_halfbits(*ip)};
 #if @iscomplex@
         ip += 2;
 #else
@@ -1269,7 +1269,7 @@ HALF_to_@TYPE@(void *input, void *output, npy_intp n,
     @itype@ *op = output;
 
     while (n--) {
-        *op++ = npy_halfbits_to_@name@bits(*ip++);
+        *op++ = npy_halfbits_to_@name@bits(NPY_HALF_BITS(*ip++));
 #if @iscomplex@
         *op++ = 0;
 #endif
@@ -1383,7 +1383,7 @@ BOOL_to_@TOTYPE@(void *input, void *output, npy_intp n,
     @totype@ *op = output;
 
     while (n--) {
-        *op++ = (@totype@)((*ip++ != NPY_FALSE) ? @one@ : @zero@);
+        *op++ = (*ip++ != NPY_FALSE) ? @one@ : @zero@;
     }
 }
 /**end repeat**/

--- a/numpy/core/src/multiarray/dragon4.c
+++ b/numpy/core/src/multiarray/dragon4.c
@@ -2216,7 +2216,7 @@ Dragon4_PrintFloat_IEEE_binary16(
     const npy_uint32 bufferSize = sizeof(scratch->repr);
     BigInt *bigints = scratch->bigints;
 
-    npy_uint16 val = *value;
+    npy_uint16 bits = value->bits;
     npy_uint32 floatExponent, floatMantissa, floatSign;
 
     npy_uint32 mantissa;
@@ -2226,9 +2226,9 @@ Dragon4_PrintFloat_IEEE_binary16(
     char signbit = '\0';
 
     /* deconstruct the floating point value */
-    floatMantissa = val & bitmask_u32(10);
-    floatExponent = (val >> 10) & bitmask_u32(5);
-    floatSign = val >> 15;
+    floatMantissa = bits & bitmask_u32(10);
+    floatExponent = (bits >> 10) & bitmask_u32(5);
+    floatSign = bits >> 15;
 
     /* output the sign */
     if (floatSign != 0) {

--- a/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/core/src/multiarray/lowlevel_strided_loops.c.src
@@ -802,9 +802,9 @@ NPY_NO_EXPORT PyArrayMethod_StridedLoop *
 #if @is_half1@
 
 #  if @is_float2@
-#    define _CONVERT_FN(x) npy_halfbits_to_floatbits(x)
+#    define _CONVERT_FN(x) npy_halfbits_to_floatbits(NPY_HALF_BITS(x))
 #  elif @is_double2@
-#    define _CONVERT_FN(x) npy_halfbits_to_doublebits(x)
+#    define _CONVERT_FN(x) npy_halfbits_to_doublebits(NPY_HALF_BITS(x))
 #  elif @is_half2@
 #    define _CONVERT_FN(x) (x)
 #  elif @is_bool2@
@@ -816,9 +816,9 @@ NPY_NO_EXPORT PyArrayMethod_StridedLoop *
 #elif @is_half2@
 
 #  if @is_float1@
-#    define _CONVERT_FN(x) npy_floatbits_to_halfbits(x)
+#    define _CONVERT_FN(x) (npy_half){npy_floatbits_to_halfbits(x)}
 #  elif @is_double1@
-#    define _CONVERT_FN(x) npy_doublebits_to_halfbits(x)
+#    define _CONVERT_FN(x) (npy_half){npy_doublebits_to_halfbits(x)}
 #  elif @is_half1@
 #    define _CONVERT_FN(x) (x)
 #  elif @is_bool1@

--- a/numpy/core/src/npymath/_half_legacy_tests.c
+++ b/numpy/core/src/npymath/_half_legacy_tests.c
@@ -1,0 +1,82 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#define NPY_USE_LEGACY_HALF
+#include "numpy/halffloat.h"
+
+
+static PyMethodDef TestMethods[] = {
+        {NULL, NULL, 0, NULL}
+};
+
+
+static void
+check_legacy_symbols(void)
+{
+  void *funcs[] = {(void *)&npy_half_to_float,
+                   (void *)&npy_half_to_double,
+                   (void *)&npy_float_to_half,
+                   (void *)&npy_double_to_half,
+                   (void *)&npy_half_eq,
+                   (void *)&npy_half_ne,
+                   (void *)&npy_half_le,
+                   (void *)&npy_half_lt,
+                   (void *)&npy_half_ge,
+                   (void *)&npy_half_gt,
+                   (void *)&npy_half_eq_nonan,
+                   (void *)&npy_half_lt_nonan,
+                   (void *)&npy_half_le_nonan,
+                   (void *)&npy_half_iszero,
+                   (void *)&npy_half_isnan,
+                   (void *)&npy_half_isinf,
+                   (void *)&npy_half_isfinite,
+                   (void *)&npy_half_signbit,
+                   (void *)&npy_half_copysign,
+                   (void *)&npy_half_spacing,
+                   (void *)&npy_half_nextafter,
+                   (void *)&npy_half_divmod,
+                   NULL};
+  // Flagged as a volatile pointer to make sure the pointer is not dismissed,
+  // preventing the compiler to *not* link with the above symbols.
+  void **volatile checker = funcs;
+  while (*checker)
+    ++checker;
+}
+
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_half_legacy_tests",
+    NULL,
+    -1,
+    TestMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit__half_legacy_tests(void)
+{
+    PyObject *m = PyModule_Create(&moduledef);
+    if (!m) {
+        goto fail;
+    }
+
+    check_legacy_symbols();
+
+    return m;
+
+fail:
+    if (!PyErr_Occurred()) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "cannot load _half_legacy_tests module.");
+    }
+    if (m) {
+        Py_DECREF(m);
+        m = NULL;
+    }
+    return m;
+}

--- a/numpy/core/src/npysort/npysort_common.h
+++ b/numpy/core/src/npysort/npysort_common.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <numpy/ndarraytypes.h>
+#include <numpy/halffloat.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -141,47 +142,16 @@ LONGDOUBLE_LT(npy_longdouble a, npy_longdouble b)
     return a < b || (b != b && a == a);
 }
 
-
-NPY_INLINE static int
-_npy_half_isnan(npy_half h)
-{
-    return ((h&0x7c00u) == 0x7c00u) && ((h&0x03ffu) != 0x0000u);
-}
-
-
-NPY_INLINE static int
-_npy_half_lt_nonan(npy_half h1, npy_half h2)
-{
-    if (h1&0x8000u) {
-        if (h2&0x8000u) {
-            return (h1&0x7fffu) > (h2&0x7fffu);
-        }
-        else {
-            /* Signed zeros are equal, have to check for it */
-            return (h1 != 0x8000u) || (h2 != 0x0000u);
-        }
-    }
-    else {
-        if (h2&0x8000u) {
-            return 0;
-        }
-        else {
-            return (h1&0x7fffu) < (h2&0x7fffu);
-        }
-    }
-}
-
-
 NPY_INLINE static int
 HALF_LT(npy_half a, npy_half b)
 {
     int ret;
 
-    if (_npy_half_isnan(b)) {
-        ret = !_npy_half_isnan(a);
+    if (npy_half_isnan(b)) {
+        ret = !npy_half_isnan(a);
     }
     else {
-        ret = !_npy_half_isnan(a) && _npy_half_lt_nonan(a, b);
+        ret = !npy_half_isnan(a) && npy_half_lt_nonan(a, b);
     }
 
     return ret;

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -1939,7 +1939,7 @@ HALF_conjugate(char **args, npy_intp const *dimensions, npy_intp const *steps, v
 NPY_NO_EXPORT NPY_GCC_OPT_3 void
 HALF_absolute(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    UNARY_LOOP_FAST(npy_half, npy_half, *out = in&0x7fffu);
+    UNARY_LOOP_FAST(npy_half, npy_half, *out = npy_half_abs(in));
 }
 
 NPY_NO_EXPORT void
@@ -1947,7 +1947,7 @@ HALF_negative(char **args, npy_intp const *dimensions, npy_intp const *steps, vo
 {
     UNARY_LOOP {
         const npy_half in1 = *(npy_half *)ip1;
-        *((npy_half *)op1) = in1^0x8000u;
+        *((npy_half *)op1) = npy_half_neg(in1);
     }
 }
 
@@ -1956,7 +1956,7 @@ HALF_positive(char **args, npy_intp const *dimensions, npy_intp const *steps, vo
 {
     UNARY_LOOP {
         const npy_half in1 = *(npy_half *)ip1;
-        *((npy_half *)op1) = +in1;
+        *((npy_half *)op1) = npy_half_pos(in1);
     }
 }
 
@@ -1967,8 +1967,8 @@ HALF_sign(char **args, npy_intp const *dimensions, npy_intp const *steps, void *
     UNARY_LOOP {
         const npy_half in1 = *(npy_half *)ip1;
         *((npy_half *)op1) = npy_half_isnan(in1) ? in1 :
-                    (((in1&0x7fffu) == 0) ? 0 :
-                      (((in1&0x8000u) == 0) ? NPY_HALF_ONE : NPY_HALF_NEGONE));
+                    (npy_half_iszero(in1) ? NPY_HALF_ZERO :
+                     (npy_half_signbit(in1) ? NPY_HALF_NEGONE : NPY_HALF_ONE));
     }
 }
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -370,7 +370,7 @@ half_ctype_floor_divide(npy_half a, npy_half b, npy_half *out)
 {
     npy_half mod;
 
-    if (!b) {
+    if (!NPY_HALF_BITS(b)) {
         float res = npy_half_to_float(a) / npy_half_to_float(b);
         *out = npy_float_to_half(res);
     }
@@ -514,7 +514,7 @@ static NPY_INLINE int
 static NPY_INLINE int
 half_ctype_negative(npy_half a, npy_half *out)
 {
-    *out = a^0x8000u;
+    *out = npy_half_neg(a);
     return 0;
 }
 
@@ -607,7 +607,7 @@ static NPY_INLINE int
 static NPY_INLINE int
 half_ctype_absolute(npy_half a, npy_half *out)
 {
-    *out = a&0x7fffu;
+    *out = npy_half_abs(a);
     return 0;
 }
 

--- a/numpy/core/tests/test_api.py
+++ b/numpy/core/tests/test_api.py
@@ -2,6 +2,7 @@ import sys
 
 import numpy as np
 from numpy.core._rational_tests import rational
+import numpy.core._half_legacy_tests
 import pytest
 from numpy.testing import (
      assert_, assert_equal, assert_array_equal, assert_raises, assert_warns,


### PR DESCRIPTION
Instead of using a type alias, make npy_half a struct.
As a consequence, cleanup npy_half usage to always reference function declared in
numpy/halffloat.h. This avoids vodoo incantation in files that should now
nothing of npy_half internal.

Some of numpy_half manipulating functions are promoted to inline to avoid
performance regression.
