### PR TITLE
TST: Fix uninitialized value in masked ndenumerate test

### DIFF
--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1674,7 +1674,7 @@ class TestShapeBase:
 class TestNDEnumerate:
 
     def test_ndenumerate_nomasked(self):
-        ordinary = np.ndarray(6).reshape((1, 3, 2))
+        ordinary = np.arange(6.).reshape((1, 3, 2))
         empty_mask = np.zeros_like(ordinary, dtype=bool)
         with_mask = masked_array(ordinary, mask=empty_mask)
         assert_equal(list(np.ndenumerate(ordinary)),


### PR DESCRIPTION
The test used unintialized values, if NaN happened to be there
the test would fail (and generally, uninitialized values being used
in tests is bad, since it shows up in valgrind).