### PR TITLE
DEV: Fix Warnings/Errors on Gitpod

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - pandas
   - matplotlib
   - pydata-sphinx-theme=0.8.1
+  - doxygen
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe!=4.33.0
   # For linting


### PR DESCRIPTION
There has been this persistent issue on Gitpod.
When Docs are build using `make html` it creates warnings which are treated as errors

With the collaboration of other contributors @rossbar @melissawm @Mukulikaa we were able to track its root cause which was
`doxygen`, Which has been addressed in this PR.

**After this PR gets merged**
It will push the latest changes to dockerhub and It may take some time to get reflected on Gitpod.

**Build Steps that were taken to resolve this Issue**
These steps were taken documented in this PDF, To rectify this Issue

[Link to the Successful Build Steps Doc](https://docs.google.com/document/d/17KTUal0EfhhRsZdg5snPyTPu5ifC4b3aoQDk24fvFqA/edit?usp=sharing)

**Further Steps**
Remove or adjust the references for doxygen in building from source docs for numpy. Which currently points to system wide installation of doxygen. `sudo apt-get install doxygen`