### PR TITLE
PERF: Fast path for dtype lookup of float and long

### DIFF
--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -216,9 +216,9 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
         DType = Py_None;
     }
     else if (pytype == &PyFloat_Type) {
-        DType = &PyArray_PyFloatAbstractDType;
+        DType = (PyObject *)&PyArray_PyFloatAbstractDType;
     } else if (pytype == &PyLong_Type) {
-        DType = &PyArray_PyIntAbstractDType;
+        DType = (PyObject *)&PyArray_PyIntAbstractDType;
     }
     else {
         DType = PyDict_GetItem(_global_pytype_to_type_dict,

--- a/numpy/core/src/multiarray/array_coercion.c
+++ b/numpy/core/src/multiarray/array_coercion.c
@@ -205,7 +205,7 @@ _PyArray_MapPyTypeToDType(
  * Lookup the DType for a registered known python scalar type.
  *
  * @param pytype Python Type to look up
- * @return DType, None if it a known non-scalar, or NULL if an unknown object.
+ * @return DType, None if it is a known non-scalar, or NULL if an unknown object.
  */
 static NPY_INLINE PyArray_DTypeMeta *
 npy_discover_dtype_from_pytype(PyTypeObject *pytype)
@@ -217,7 +217,8 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
     }
     else if (pytype == &PyFloat_Type) {
         DType = (PyObject *)&PyArray_PyFloatAbstractDType;
-    } else if (pytype == &PyLong_Type) {
+    }
+    else if (pytype == &PyLong_Type) {
         DType = (PyObject *)&PyArray_PyIntAbstractDType;
     }
     else {


### PR DESCRIPTION
* Add fast path for lookup of the dtype of a Python float and long
* Remove check on `Py_None`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
