### PR TITLE
BUG: Fix GCC error during build configuration

### DIFF
--- a/numpy/core/feature_detection_locale.h
+++ b/numpy/core/feature_detection_locale.h
@@ -1,1 +1,2 @@
+#pragma GCC diagnostic ignored "-Wnonnull"
 long double strtold_l(const char*, char**, locale_t);


### PR DESCRIPTION
GCC 11 fails the configuration test for detecting `strtold_l` when the
`-Wall` flag is present because `-Werror=nonnull` is activated. The fix
is to add a pragma to `numpy/core/feature_detection_locale.h` to ignore
that error.

Closes #21529.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
