### PR TITLE
DOC: improve the docstring of numpy.sinc to explain behavior at zero.

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3562,14 +3562,16 @@ def sinc(x):
     r"""
     Return the normalized sinc function.
 
-    The sinc function is :math:`\sin(\pi x)/(\pi x)`.
+    The sinc function is equal to :math:`\sin(\pi x)/(\pi x)` for any argument
+    :math:`x\ne 0`. ``sinc(0)`` takes the limit value 1, making ``sinc`` not
+    only everywhere continuous but also analytic.
 
     .. note::
 
         Note the normalization factor of ``pi`` used in the definition.
         This is the most commonly used definition in signal processing.
         Use ``sinc(x / np.pi)`` to obtain the unnormalized sinc function
-        :math:`\sin(x)/(x)` that is more common in mathematics.
+        :math:`\sin(x)/x` that is more common in mathematics.
 
     Parameters
     ----------
@@ -3584,8 +3586,6 @@ def sinc(x):
 
     Notes
     -----
-    ``sinc(0)`` is the limit value 1.
-
     The name sinc is short for "sine cardinal" or "sinus cardinalis".
 
     The sinc function is used in various signal processing applications,

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3564,7 +3564,7 @@ def sinc(x):
 
     The sinc function is equal to :math:`\sin(\pi x)/(\pi x)` for any argument
     :math:`x\ne 0`. ``sinc(0)`` takes the limit value 1, making ``sinc`` not
-    only everywhere continuous but also analytic.
+    only everywhere continuous but also infinitely differentiable.
 
     .. note::
 


### PR DESCRIPTION
The first lines of the sinc docstring did not mention the behavior
when the argument is zero, and gave the impression that the function is
defined as the quotient between a sine and its argument everywhere. That
information was instead relegated to the "Notes" section. I found this
issue while navigating the documentation for jax.numpy.sinc, which
inherits those few lines. I think it is important to document not only
the value of the function at zero, but also that it make sinc a smooth
function. This connects better with some of the other routes used to
introduce sinc (e.g. as a Taylor series). I have tried to implement
the conclusions of the discussion around Issue #21538, keeping the
description close to the actual implementation and avoiding my original
suggestion of introducing the function as a limit.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
