### PR TITLE
TST,TYP: Fix a python 3.11 failure for the `GenericAlias` tests

### DIFF
--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -17,6 +17,10 @@ T2 = TypeVar("T2")
 DType = _GenericAlias(np.dtype, (ScalarType,))
 NDArray = _GenericAlias(np.ndarray, (Any, DType))
 
+# NOTE: The `npt._GenericAlias` *class* isn't quite stable on python >=3.11.
+# This is not a problem during runtime (as it's 3.8-exclusive), but we still
+# need it for the >=3.9 in order to verify its semantics match
+# `types.GenericAlias` replacement. xref numpy/numpy#21526
 if sys.version_info >= (3, 9):
     DType_ref = types.GenericAlias(np.dtype, (ScalarType,))
     NDArray_ref = types.GenericAlias(np.ndarray, (Any, DType_ref))

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -20,11 +20,11 @@ NDArray = _GenericAlias(np.ndarray, (Any, DType))
 if sys.version_info >= (3, 9):
     DType_ref = types.GenericAlias(np.dtype, (ScalarType,))
     NDArray_ref = types.GenericAlias(np.ndarray, (Any, DType_ref))
-    FuncType = Callable[[Union[_GenericAlias, types.GenericAlias]], Any]
+    FuncType = Callable[["_GenericAlias | types.GenericAlias"], Any]
 else:
     DType_ref = Any
     NDArray_ref = Any
-    FuncType = Callable[[_GenericAlias], Any]
+    FuncType = Callable[["_GenericAlias"], Any]
 
 GETATTR_NAMES = sorted(set(dir(np.ndarray)) - _GenericAlias._ATTR_EXCEPTIONS)
 


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/21526

Fixes (sort of...) a python 3.11 issue wherein the `npt._GenericAlias` class (not instance) can now raise when used as a type parameter, as typing expects an iterable for the `__parameter__` attribute but instead gets a `property` descriptor object.

The fix consists of simply not using `npt._GenericAlias` as a type parameter, and instead just stringify the expression. As the relevant class is never exposed in Python >=3.9 in the first place (and never will), I don't feel it's worth to implement a more rigorous fix.