### PR TITLE
Tests/Docs: Update tests to Cython 0.29.30, mention in docs

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -20,7 +20,7 @@ Building NumPy requires the following installed software:
    e.g., on Debian/Ubuntu one needs to install both `python3` and
    `python3-dev`. On Windows and macOS this is normally not an issue.
 
-2) Cython >= 0.29.28
+2) Cython >= 0.29.30
 
 3) pytest__ (optional) 1.15 or later
 

--- a/numpy/core/tests/test_cython.py
+++ b/numpy/core/tests/test_cython.py
@@ -15,11 +15,11 @@ except ImportError:
 else:
     from numpy.compat import _pep440
 
-    # Cython 0.29.24 is required for Python 3.10 and there are
+    # Cython 0.29.30 is required for Python 3.11 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    required_version = "0.29.24"
+    required_version = "0.29.30"
     if _pep440.parse(cython_version) < _pep440.Version(required_version):
         # too old or wrong cython, skip the test
         cython = None

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -32,11 +32,11 @@ except ImportError:
     cython = None
 else:
     from numpy.compat import _pep440
-    # Cython 0.29.24 is required for Python 3.10 and there are
+    # Cython 0.29.30 is required for Python 3.11 and there are
     # other fixes in the 0.29 series that are needed even for earlier
     # Python versions.
     # Note: keep in sync with the one in pyproject.toml
-    required_version = '0.29.24'
+    required_version = '0.29.30'
     if _pep440.parse(cython_version) < _pep440.Version(required_version):
         # too old or wrong cython, skip the test
         cython = None


### PR DESCRIPTION
Cython 0.29.30 is required for building Numpy with Python 3.11. This commit updates that in the core/tests/test_cython.py and random/tests/test_exending.py files.

It also mentions that Cython 0.29.30 is needed in the INSTALL documentation.

This PR is a small follow-up on #21514 and #21530. It might also be needed to be backported, to the 1.22.x maintenance branch, like #21525.