### PR TITLE
DOC: add explanation to makefile error 

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -88,6 +88,7 @@ ifeq "$(GITVER)" "Unknown"
 	# @echo sdist build with unlabeled sources
 else ifeq ("", "$(NUMPYVER)")
 	@echo numpy not found, cannot build documentation without successful \"import numpy\"
+	@echo Try overriding the makefile PYTHON variable with '"make PYTHON=python $(MAKECMDGOALS)"'
 	@exit 1
 else ifneq ($(NUMPYVER),$(GITVER))
 	@echo installed numpy $(NUMPYVER) != current repo git version \'$(GITVER)\'
@@ -263,4 +264,3 @@ info:
 
 show:
 	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"
-


### PR DESCRIPTION
This is the minimal fix #21563 

I would like it if the makefile would work out of the box, but changes to its logic may break more cases than it would fix, so I would be content with a one-liner such as this that gives a heads up to not to go into unrelated rabbit holes.

