### PR TITLE
DOC: Fix docstring and examples for rfn.get_names*

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -105,7 +105,8 @@ def _get_fieldspec(dtype):
 
 def get_names(adtype):
     """
-    Returns the field names of the input datatype as a tuple.
+    Returns the field names of the input datatype as a tuple. Input datatype
+    has to have fields otherwise error is raised.
 
     Parameters
     ----------
@@ -115,15 +116,10 @@ def get_names(adtype):
     Examples
     --------
     >>> from numpy.lib import recfunctions as rfn
-    >>> rfn.get_names(np.empty((1,), dtype=int))
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'numpy.ndarray' object has no attribute 'names'
-
-    >>> rfn.get_names(np.empty((1,), dtype=[('A',int), ('B', float)]))
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'numpy.ndarray' object has no attribute 'names'
+    >>> rfn.get_names(np.empty((1,), dtype=[('A', int)]).dtype)
+    ('A',)
+    >>> rfn.get_names(np.empty((1,), dtype=[('A',int), ('B', float)]).dtype)
+    ('A', 'B')
     >>> adtype = np.dtype([('a', int), ('b', [('ba', int), ('bb', int)])])
     >>> rfn.get_names(adtype)
     ('a', ('b', ('ba', 'bb')))
@@ -141,8 +137,9 @@ def get_names(adtype):
 
 def get_names_flat(adtype):
     """
-    Returns the field names of the input datatype as a tuple. Nested structure
-    are flattened beforehand.
+    Returns the field names of the input datatype as a tuple. Input datatype
+    has to have fields otherwise error is raised.
+    Nested structure are flattened beforehand.
 
     Parameters
     ----------
@@ -152,14 +149,10 @@ def get_names_flat(adtype):
     Examples
     --------
     >>> from numpy.lib import recfunctions as rfn
-    >>> rfn.get_names_flat(np.empty((1,), dtype=int)) is None
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'numpy.ndarray' object has no attribute 'names'
-    >>> rfn.get_names_flat(np.empty((1,), dtype=[('A',int), ('B', float)]))
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'numpy.ndarray' object has no attribute 'names'
+    >>> rfn.get_names_flat(np.empty((1,), dtype=[('A', int)]).dtype) is None
+    False
+    >>> rfn.get_names_flat(np.empty((1,), dtype=[('A',int), ('B', str)]).dtype)
+    ('A', 'B')
     >>> adtype = np.dtype([('a', int), ('b', [('ba', int), ('bb', int)])])
     >>> rfn.get_names_flat(adtype)
     ('a', 'b', 'ba', 'bb')

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -106,7 +106,7 @@ def _get_fieldspec(dtype):
 def get_names(adtype):
     """
     Returns the field names of the input datatype as a tuple. Input datatype
-    has to have fields otherwise error is raised.
+    must have fields otherwise error is raised.
 
     Parameters
     ----------
@@ -138,7 +138,7 @@ def get_names(adtype):
 def get_names_flat(adtype):
     """
     Returns the field names of the input datatype as a tuple. Input datatype
-    has to have fields otherwise error is raised.
+    must have fields otherwise error is raised.
     Nested structure are flattened beforehand.
 
     Parameters


### PR DESCRIPTION
This is to close #12485 

No point in getting names when they are not available for e.g scalar dtypes, and based on the arg description passing arrays instead of dtype objects is not a valid input indeed. So the issue only needed updates to the examples.