### PR TITLE
BUG: Adding the default pytest doctest instead of the ValueError

### DIFF
--- a/numpy/_pytesttester.py
+++ b/numpy/_pytesttester.py
@@ -33,7 +33,6 @@ import os
 __all__ = ['PytestTester']
 
 
-
 def _show_numpy_info():
     import numpy as np
 
@@ -42,7 +41,6 @@ def _show_numpy_info():
     print("NumPy relaxed strides checking option:", relaxed_strides)
     info = np.lib.utils._opt_info()
     print("NumPy CPU features: ", (info if info else 'nothing enabled'))
-
 
 
 class PytestTester:
@@ -167,7 +165,7 @@ class PytestTester:
             ]
 
         if doctests:
-            raise ValueError("Doctests not supported")
+            pytest_args += ["--doctest-modules"]
 
         if extra_argv:
             pytest_args += list(extra_argv)


### PR DESCRIPTION
This PR does the bare minimum of bringing the code in sync with the docs, and addresses the issue https://github.com/numpy/numpy/issues/21070 partially.


Naturally, a lot of the doctests are failing, but those can be tracked in an issue and fix them gradually (excellent source for spring and first timer events), there is no reason to keep the infrastructure artificially broken with a ValueError, especially when it's documented all over in the docs that doctests can be run with:

```
>>> np.test(doctests=True)
# OR
>>> np.lib.test(doctests=True)
```

In addition it's also possible to individually run files with `rundocs`, but I find that approach more clumsy and would rather suggest to retire that test function in favour of the more standard pytest approach.

```
>>> from numpy.testing import rundocs
>>> rundocs('numpy/lib/recfunctions.py')
```

