### PR TITLE
DOC:linalg: Remove ref to scipy.linalg.pinv2

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1951,7 +1951,6 @@ def pinv(a, rcond=1e-15, hermitian=False):
     See Also
     --------
     scipy.linalg.pinv : Similar function in SciPy.
-    scipy.linalg.pinv2 : Similar function in SciPy (SVD-based).
     scipy.linalg.pinvh : Compute the (Moore-Penrose) pseudo-inverse of a
                          Hermitian matrix.
 


### PR DESCRIPTION
We are approaching to removal point of `scipy.linalg.pinv2` (https://github.com/scipy/scipy/pull/16245) hence removing the references to it from the docs.