### PR TITLE
MAINT: loosen Cython pin in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9 #need to pin to avoid issues with builds
-  - cython=0.29.30
+  - cython>=0.29.30
   - compilers
   - openblas
   - nomkl


### PR DESCRIPTION
0.29.30 is the minimum version, but there's no need to pin to that
exact version.

This is a follow up to gh-21530

[skip azurepipelines]