### PR TITLE
CI: fix Gitpod image build

### DIFF
--- a/tools/gitpod/gitpod.Dockerfile
+++ b/tools/gitpod/gitpod.Dockerfile
@@ -34,6 +34,7 @@ COPY --from=clone --chown=gitpod /tmp/numpy ${WORKSPACE}
 WORKDIR ${WORKSPACE}
 
 # Build numpy to populate the cache used by ccache
+RUN git config --global --add safe.directory /workspace/numpy
 RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml
 RUN conda activate ${CONDA_ENV} && \ 
     python setup.py build_ext --inplace && \


### PR DESCRIPTION
Fixes gh-21551

EDIT the error in CI was:
```
#15 [build 4/6] RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml
#15 0.655 fatal: unsafe repository ('/workspace/numpy' is owned by someone else)
#15 0.655 To add an exception for this directory, call:
#15 0.655 
#15 0.655 	git config --global --add safe.directory /workspace/numpy
#15 ERROR: process "/bin/bash --login -o pipefail -c git submodule update --init --depth=1 -- numpy/core/src/umath/svml" did not complete successfully: exit code: 128
------
 > [build 4/6] RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml:
#15 0.655 fatal: unsafe repository ('/workspace/numpy' is owned by someone else)
#15 0.655 To add an exception for this directory, call:
#15 0.655 
#15 0.655 	git config --global --add safe.directory /workspace/numpy
------
gitpod.Dockerfile:37
--------------------
  35 |     
  36 |     # Build numpy to populate the cache used by ccache
  37 | >>> RUN git submodule update --init --depth=1 -- numpy/core/src/umath/svml
  38 |     RUN conda activate ${CONDA_ENV} && \ 
  39 |         python setup.py build_ext --inplace && \
--------------------
error: failed to solve: process "/bin/bash --login -o pipefail -c git submodule update --init --depth=1 -- numpy/core/src/umath/svml" did not complete successfully: exit code: 128
Error: buildx failed with: error: failed to solve: process "/bin/bash --login -o pipefail -c git submodule update --init --depth=1 -- numpy/core/src/umath/svml" did not complete successfully: exit code: 128
0s
```