### PR TITLE
MAINT: allow absolute module names in refguide-check

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -1168,7 +1168,12 @@ def main(argv):
         init_matplotlib()
 
     for submodule_name in module_names:
-        module_name = BASE_MODULE + '.' + submodule_name
+        prefix = BASE_MODULE + '.'
+        if not submodule_name.startswith(prefix):
+            module_name = prefix + submodule_name
+        else:
+            module_name = submodule_name
+            
         __import__(module_name)
         module = sys.modules[module_name]
 


### PR DESCRIPTION
Make refguide-check accept module names either relative to the BASE_MODULE, or absolute, so that these two are equivalent:

```
$ python runtests.py --refguide-check -s lib.recfunctions
```

and
```
$ python runtests.py --refguide-check -s numpy.lib.recfunctions
```
Previously, only the former was accepted.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
