### PR TITLE
BUG: refguide-check: respect the verbosity

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -287,6 +287,8 @@ def main(argv):
     if args.refguide_check:
         cmd = [os.path.join(ROOT_DIR, 'tools', 'refguide_check.py'),
                '--doctests']
+        if args.verbose:
+            cmd += ['-' + 'v'*args.verbose]
         if args.submodule:
             cmd += [args.submodule]
         os.execv(sys.executable, [sys.executable] + cmd)


### PR DESCRIPTION
Consider
```
$ python runtests.py -s numpy.lib.recfunctions --refguide-check -v
```
Previously, the `-v` switch was silently ignored.


With this PR, the output is 

```
$ python runtests.py -s numpy.lib.recfunctions --refguide-check -v

<snip>

numpy.lib.recfunctions.unstructured_to_structured
-------------------------------------------------

Trying:
    from numpy.lib import recfunctions as rfn
Expecting nothing

ok
Trying:
    dt = np.dtype([('a', 'i4'), ('b', 'f4,u2'), ('c', 'f4', 2)])
Expecting nothing
ok
Trying:
    a = np.arange(20).reshape((4,5))
Expecting nothing
ok
Trying:
    a
Expecting:
    array([[ 0,  1,  2,  3,  4],
           [ 5,  6,  7,  8,  9],
           [10, 11, 12, 13, 14],
           [15, 16, 17, 18, 19]])
ok
Trying:
    rfn.unstructured_to_structured(a, dt)
Expecting:
    array([( 0, ( 1.,  2), [ 3.,  4.]), ( 5, ( 6.,  7), [ 8.,  9.]),
           (10, (11., 12), [13., 14.]), (15, (16., 17), [18., 19.])],
          dtype=[('a', '<i4'), ('b', [('f0', '<f4'), ('f1', '<u2')]), ('c', '<f4', (2,))])
ok
```

which might be a tad too noisy for some tastes. I'd suggest to treat this as a bugfix and consider various levels of verbosity between above and the default  dots `.....` as a separate enhancement.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
