### PR TITLE
MAINT: Update the cversion hash.

### DIFF
--- a/numpy/core/code_generators/cversions.txt
+++ b/numpy/core/code_generators/cversions.txt
@@ -60,6 +60,10 @@
 # Version 14 (NumPy 1.21) No change.
 0x0000000e = 17a0f366e55ec05e5c5c149123478452
 
-# Version 15 (NumPy 1.22) Configurable memory allocations
-# Version 14 (NumPy 1.23) No change.
+# Version 15 (NumPy 1.22)
+# Configurable memory allocations
 0x0000000f = b8783365b873681cd204be50cdfb448d
+
+# Version 16 (NumPy 1.23)
+# NonNull attributes removed from numpy_api.py
+0x00000010 = 04a7bf1e65350926a0e528798da263c0

--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -353,7 +353,7 @@ multiarray_funcs_api = {
     # End 1.14 API
     'PyDataMem_SetHandler':                 (304,),
     'PyDataMem_GetHandler':                 (305,),
-    # End 1.21 API
+    # End 1.22 API
 }
 
 ufunc_types_api = {


### PR DESCRIPTION
Needed because the NonNull attribute was removed from numpy_api.py The
change only affected compiler warnings, the ABI remains unchanged.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
