### PR TITLE
MAINT: [RFC] Improve representation methods of Polynomial

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -324,9 +324,15 @@ class ABCPolyBase(abc.ABC):
         return self._generate_string(self._str_term_unicode)
 
     def __str__(self):
+        scaled_series = not np.all(self.domain == self.window)
+
         if self._use_unicode:
-            return self._generate_string(self._str_term_unicode)
-        return self._generate_string(self._str_term_ascii)
+            s = self._generate_string(self._str_term_unicode)
+        else:
+            s =  self._generate_string(self._str_term_ascii)
+        if scaled_series:
+            s += ' (scaled)'
+        return s
 
     def _generate_string(self, term_method):
         """

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -329,7 +329,7 @@ class ABCPolyBase(abc.ABC):
         if self._use_unicode:
             s = self._generate_string(self._str_term_unicode)
         else:
-            s =  self._generate_string(self._str_term_ascii)
+            s = self._generate_string(self._str_term_ascii)
         if scaled_series:
             s += ' (scaled)'
         return s


### PR DESCRIPTION
The `Polynomial` is intended as a replacement for the deprecated `np.poly1d`. The `Polynomial` contains a `domain` and a `window` that can cause confusion if users are not aware of these elements and how they effect coefficients. (e.g. https://github.com/numpy/numpy/pull/15466#issuecomment-992632012)

This PR updates the `__str__` method of the `Polynomial` to be explicit when the `domain` and `window` are not standard.
```
In [189]: import numpy as np
     ...: p =np.polynomial.Polynomial([1, 1])
     ...: x=np.linspace(0, 3, 15)
     ...: y=p(x)
     ...: q=np.polynomial.Polynomial.fit(x, y, 1)
     ...: print(p)
     ...: print(q)
1.0 + 1.0 x**1
2.5000000000000004 + 1.500000000000001 x**1 (scaled)
```

The goal is to make people aware that something is going on. In addition, 

Some options to consider:

* Change `scaled` into some other text or a special symbol
* Include the domain and window in the representation.
* If we accept (a variation of this PR), we should also update the `_repr_latex_`

It would be good to update documentation (https://github.com/numpy/numpy/pull/15466)

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
