### PR TITLE
DOC: update logarithm docs as per theory.

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2007,19 +2007,15 @@ add_newdoc('numpy.core.umath', 'log',
     --------
     log10, log2, log1p, emath.log
 
-    Principal Logarithm
-    -------------------
+    Notes
+    -----
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `exp(z) = x`. The convention is to return the
     `z` whose imaginary part lies in `(-pi, pi]`.
 
-    Additional Info
-    ---------------
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
 
-    Notes
-    -----
     For real-valued input data types, `log` always returns real output. For
     each value that cannot be expressed as a real number or infinity, it
     yields ``nan`` and sets the `invalid` floating point error flag.
@@ -2064,19 +2060,15 @@ add_newdoc('numpy.core.umath', 'log10',
     --------
     emath.log10
 
-    Principal Logarithm
-    -------------------
+    Notes
+    -----
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `exp(z) = x`. The convention is to return the
     `z` whose imaginary part lies in `(-pi, pi]`.
 
-    Additional Info
-    ---------------
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
 
-    Notes
-    -----
     For real-valued input data types, `log10` always returns real output.
     For each value that cannot be expressed as a real number or infinity,
     it yields ``nan`` and sets the `invalid` floating point error flag.
@@ -2120,20 +2112,16 @@ add_newdoc('numpy.core.umath', 'log2',
     --------
     log, log10, log1p, emath.log2
 
-    Principal Logarithm
-    --------------------
+    Notes
+    -----
+    .. versionadded:: 1.3.0
+    
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `exp(z) = x`. The convention is to return the
     `z` whose imaginary part lies in `(-pi, pi]`.
 
-    Additional Info
-    ---------------
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
-
-    Notes
-    -----
-    .. versionadded:: 1.3.0
 
     For real-valued input data types, `log2` always returns real output.
     For each value that cannot be expressed as a real number or infinity,

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2023,7 +2023,7 @@ add_newdoc('numpy.core.umath', 'log',
     number, conforming to the C99 standard.
     
     In the cases where the input has a negative real part and a very small
-    negative complex part (approaching 0), The result is so close to `-pi`
+    negative complex part (approaching 0), the result is so close to `-pi`
     that it evaluates to exactly `-pi`.
 
     References
@@ -2077,7 +2077,7 @@ add_newdoc('numpy.core.umath', 'log10',
     negative number, conforming to the C99 standard.
 
     In the cases where the input has a negative real part and a very small
-    negative complex part (approaching 0), The result is so close to `-pi`
+    negative complex part (approaching 0), the result is so close to `-pi`
     that it evaluates to exactly `-pi`.
 
     References
@@ -2132,7 +2132,7 @@ add_newdoc('numpy.core.umath', 'log2',
     number, conforming to the C99 standard.
 
     In the cases where the input has a negative real part and a very small
-    negative complex part (approaching 0), The result is so close to `-pi`
+    negative complex part (approaching 0), the result is so close to `-pi`
     that it evaluates to exactly `-pi`.
 
     Examples

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2007,12 +2007,19 @@ add_newdoc('numpy.core.umath', 'log',
     --------
     log10, log2, log1p, emath.log
 
-    Notes
-    -----
+    Principal Logarithm
+    -------------------
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `exp(z) = x`. The convention is to return the
-    `z` whose imaginary part lies in `[-pi, pi]`.
+    `z` whose imaginary part lies in `(-pi, pi]`.
 
+    Additional Info
+    ---------------
+    In the cases where x array element input value tends to -1. 
+    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
+
+    Notes
+    -----
     For real-valued input data types, `log` always returns real output. For
     each value that cannot be expressed as a real number or infinity, it
     yields ``nan`` and sets the `invalid` floating point error flag.
@@ -2057,12 +2064,19 @@ add_newdoc('numpy.core.umath', 'log10',
     --------
     emath.log10
 
+    Principal Logarithm
+    -------------------
+    Logarithm is a multivalued function: for each `x` there is an infinite
+    number of `z` such that `exp(z) = x`. The convention is to return the
+    `z` whose imaginary part lies in `(-pi, pi]`.
+
+    Additional Info
+    ---------------
+    In the cases where x array element input value tends to -1. 
+    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
+
     Notes
     -----
-    Logarithm is a multivalued function: for each `x` there is an infinite
-    number of `z` such that `10**z = x`. The convention is to return the
-    `z` whose imaginary part lies in `[-pi, pi]`.
-
     For real-valued input data types, `log10` always returns real output.
     For each value that cannot be expressed as a real number or infinity,
     it yields ``nan`` and sets the `invalid` floating point error flag.
@@ -2106,13 +2120,20 @@ add_newdoc('numpy.core.umath', 'log2',
     --------
     log, log10, log1p, emath.log2
 
+    Principal Logarithm
+    --------------------
+    Logarithm is a multivalued function: for each `x` there is an infinite
+    number of `z` such that `exp(z) = x`. The convention is to return the
+    `z` whose imaginary part lies in `(-pi, pi]`.
+
+    Additional Info
+    ---------------
+    In the cases where x array element input value tends to -1. 
+    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
+
     Notes
     -----
     .. versionadded:: 1.3.0
-
-    Logarithm is a multivalued function: for each `x` there is an infinite
-    number of `z` such that `2**z = x`. The convention is to return the `z`
-    whose imaginary part lies in `[-pi, pi]`.
 
     For real-valued input data types, `log2` always returns real output.
     For each value that cannot be expressed as a real number or infinity,

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2122,9 +2122,6 @@ add_newdoc('numpy.core.umath', 'log2',
     number of `z` such that `2**z = x`. The convention is to return the `z`
     whose imaginary part lies in `(-pi, pi]`.
 
-    In the cases where x array element input value tends to -1. 
-    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
-
     For real-valued input data types, `log2` always returns real output.
     For each value that cannot be expressed as a real number or infinity,
     it yields ``nan`` and sets the `invalid` floating point error flag.

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2020,7 +2020,7 @@ add_newdoc('numpy.core.umath', 'log',
     For complex-valued input, `log` is a complex analytical function that
     has a branch cut `[-inf, 0]` and is continuous from above on it. `log`
     handles the floating-point negative zero as an infinitesimal negative
-    number, conforming to the C99 standard. 
+    number, conforming to the C99 standard.
     
     In the cases where the input has a negative real part and a very small
     negative complex part (approaching 0), The result is so close to `-pi`
@@ -2066,9 +2066,6 @@ add_newdoc('numpy.core.umath', 'log10',
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `10**z = x`. The convention is to return the
     `z` whose imaginary part lies in `(-pi, pi]`.
-
-    In the cases where x array element input value tends to -1. 
-    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
 
     For real-valued input data types, `log10` always returns real output.
     For each value that cannot be expressed as a real number or infinity,

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2064,7 +2064,7 @@ add_newdoc('numpy.core.umath', 'log10',
     -----
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `10**z = x`. The convention is to return the
-    `z` whose imaginary part lies in `[-pi, pi]`.
+    `z` whose imaginary part lies in `(-pi, pi]`.
 
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
@@ -2118,7 +2118,7 @@ add_newdoc('numpy.core.umath', 'log2',
 
     Logarithm is a multivalued function: for each `x` there is an infinite
     number of `z` such that `2**z = x`. The convention is to return the `z`
-    whose imaginary part lies in `[-pi, pi]`.
+    whose imaginary part lies in `(-pi, pi]`.
 
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2063,8 +2063,8 @@ add_newdoc('numpy.core.umath', 'log10',
     Notes
     -----
     Logarithm is a multivalued function: for each `x` there is an infinite
-    number of `z` such that `exp(z) = x`. The convention is to return the
-    `z` whose imaginary part lies in `(-pi, pi]`.
+    number of `z` such that `10**z = x`. The convention is to return the
+    `z` whose imaginary part lies in `[-pi, pi]`.
 
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
@@ -2115,10 +2115,10 @@ add_newdoc('numpy.core.umath', 'log2',
     Notes
     -----
     .. versionadded:: 1.3.0
-    
+
     Logarithm is a multivalued function: for each `x` there is an infinite
-    number of `z` such that `exp(z) = x`. The convention is to return the
-    `z` whose imaginary part lies in `(-pi, pi]`.
+    number of `z` such that `2**z = x`. The convention is to return the `z`
+    whose imaginary part lies in `[-pi, pi]`.
 
     In the cases where x array element input value tends to -1. 
     The result is in the vicinity of `-pi`, that it evaluates to `-pi`.

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2013,9 +2013,6 @@ add_newdoc('numpy.core.umath', 'log',
     number of `z` such that `exp(z) = x`. The convention is to return the
     `z` whose imaginary part lies in `(-pi, pi]`.
 
-    In the cases where x array element input value tends to -1. 
-    The result is in the vicinity of `-pi`, that it evaluates to `-pi`.
-
     For real-valued input data types, `log` always returns real output. For
     each value that cannot be expressed as a real number or infinity, it
     yields ``nan`` and sets the `invalid` floating point error flag.
@@ -2023,7 +2020,11 @@ add_newdoc('numpy.core.umath', 'log',
     For complex-valued input, `log` is a complex analytical function that
     has a branch cut `[-inf, 0]` and is continuous from above on it. `log`
     handles the floating-point negative zero as an infinitesimal negative
-    number, conforming to the C99 standard.
+    number, conforming to the C99 standard. 
+    
+    In the cases where the input has a negative real part and a very small
+    negative complex part (approaching 0), The result is so close to `-pi`
+    that it evaluates to exactly `-pi`.
 
     References
     ----------
@@ -2078,6 +2079,10 @@ add_newdoc('numpy.core.umath', 'log10',
     `log10` handles the floating-point negative zero as an infinitesimal
     negative number, conforming to the C99 standard.
 
+    In the cases where the input has a negative real part and a very small
+    negative complex part (approaching 0), The result is so close to `-pi`
+    that it evaluates to exactly `-pi`.
+
     References
     ----------
     .. [1] M. Abramowitz and I.A. Stegun, "Handbook of Mathematical Functions",
@@ -2131,6 +2136,10 @@ add_newdoc('numpy.core.umath', 'log2',
     has a branch cut `[-inf, 0]` and is continuous from above on it. `log2`
     handles the floating-point negative zero as an infinitesimal negative
     number, conforming to the C99 standard.
+
+    In the cases where the input has a negative real part and a very small
+    negative complex part (approaching 0), The result is so close to `-pi`
+    that it evaluates to exactly `-pi`.
 
     Examples
     --------


### PR DESCRIPTION
Made some changes addressing the discussions in Issue #21235 . 

What this PR updates
- Range of `log` functions in the Docs
- Adds Additional Notes on the theoretical range outcomes. `-pi` 

Tagging @rossbar @seberg who contributed to the discussion. 

DRAFT

Future - Add more examples(covering various edge cases) to logarithm function. The current one example on each page might not give the complete context.
[numpy.log page](https://numpy.org/doc/stable/reference/generated/numpy.log.html)