### PR TITLE
ENH: Add strict parameter to assert_array_equal. Fixes #9542

### DIFF
--- a/doc/release/upcoming_changes/21595.new_feature.rst
+++ b/doc/release/upcoming_changes/21595.new_feature.rst
@@ -1,5 +1,5 @@
 ``strict`` option for `testing.assert_array_equal`
-----------------------------------------------------
+--------------------------------------------------
 The ``strict`` option is now available for `testing.assert_array_equal`.
 Setting ``strict=True`` will disable the broadcasting behaviour for scalars and
 ensure that input arrays have the same data type.

--- a/doc/release/upcoming_changes/21595.new_feature.rst
+++ b/doc/release/upcoming_changes/21595.new_feature.rst
@@ -1,0 +1,5 @@
+``strict`` option for `testing.assert_array_equal`
+----------------------------------------------------
+The ``strict`` option is now available for `testing.assert_array_equal`.
+Setting ``strict=True`` will disable the broadcasting behaviour for scalars and
+ensure that input arrays have the same data type.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -700,7 +700,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                          precision=6, equal_nan=True, equal_inf=True,
-                         strict=False):
+                         *, strict=False):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate, all, max, object_
 
@@ -856,7 +856,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         raise ValueError(msg)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True, strict=False):
+def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     """
     Raises an AssertionError if two array_like objects are not equal.
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -941,7 +941,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     >>> x = np.full((2, 5), fill_value=3)
     >>> np.testing.assert_array_equal(x, 3)
 
-    Use `strict` to raise an AssertionError when comparing a scalar with an array:
+    Use `strict` to raise an AssertionError when comparing a scalar with an
+    array:
 
     >>> np.testing.assert_array_equal(x, 3, strict=True)
     Traceback (most recent call last):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -759,9 +759,13 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         else:
             cond = (x.shape == () or y.shape == ()) or x.shape == y.shape
         if not cond:
+            if x.shape != y.shape:
+                reason = f'\n(shapes {x.shape}, {y.shape} mismatch)'
+            else:
+                reason = f'\n(dtypes {x.dtype}, {y.dtype} mismatch)'
             msg = build_err_msg([x, y],
                                 err_msg
-                                + f'\n(shapes {x.shape}, {y.shape} mismatch)',
+                                + reason,
                                 verbose=verbose, header=header,
                                 names=('x', 'y'), precision=precision)
             raise AssertionError(msg)
@@ -881,7 +885,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     verbose : bool, optional
         If True, the conflicting values are appended to the error message.
     strict : bool, optional
-        If True, raise an assertion when either the shape or the data
+        If True, raise an AssertionError when either the shape or the data
         type of the array_like objects does not match. The special
         handling for scalars mentioned in the Notes section is disabled.
 
@@ -937,7 +941,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     >>> x = np.full((2, 5), fill_value=3)
     >>> np.testing.assert_array_equal(x, 3)
 
-    Use `strict` to raise an assertion when comparing a scalar with an array:
+    Use `strict` to raise an AssertionError when comparing a scalar with an array:
 
     >>> np.testing.assert_array_equal(x, 3, strict=True)
     Traceback (most recent call last):
@@ -960,7 +964,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     AssertionError:
     Arrays are not equal
     <BLANKLINE>
-    (shapes (3,), (3,) mismatch)
+    (dtypes int64, float32 mismatch)
      x: array([2, 2, 2])
      y: array([2., 2., 2.], dtype=float32)
     """

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -939,10 +939,15 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False):
     Use `strict` to raise an assertion when comparing a scalar with an array:
 
     >>> np.testing.assert_array_equal(x, 3, strict=True)
-
+    Traceback (most recent call last):
+        ...
     AssertionError:
     Arrays are not equal
+    <BLANKLINE>
     (shapes (2, 5), () mismatch)
+     x: array([[3, 3, 3, 3, 3],
+           [3, 3, 3, 3, 3]])
+     y: array(3)
 
     """
     __tracebackhide__ = True  # Hide traceback for py.test

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -699,7 +699,7 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
-                         precision=6, equal_nan=True, equal_inf=True):
+                         precision=6, equal_nan=True, equal_inf=True, strict=False):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate, all, max, object_
 
@@ -753,7 +753,10 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
             return y_id
 
     try:
-        cond = (x.shape == () or y.shape == ()) or x.shape == y.shape
+        if strict:
+            cond = x.shape == y.shape
+        else:
+            cond = (x.shape == () or y.shape == ()) or x.shape == y.shape
         if not cond:
             msg = build_err_msg([x, y],
                                 err_msg
@@ -852,7 +855,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         raise ValueError(msg)
 
 
-def assert_array_equal(x, y, err_msg='', verbose=True):
+def assert_array_equal(x, y, err_msg='', verbose=True, strict=False):
     """
     Raises an AssertionError if two array_like objects are not equal.
 
@@ -876,6 +879,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
         The error message to be printed in case of failure.
     verbose : bool, optional
         If True, the conflicting values are appended to the error message.
+    strict : bool, optional
+        If True, raise an assertion when one of the array_like objects is a scalar.
 
     Raises
     ------
@@ -892,7 +897,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     -----
     When one of `x` and `y` is a scalar and the other is array_like, the
     function checks that each element of the array_like object is equal to
-    the scalar.
+    the scalar. This behaviour can be disabled with the `strict` parameter.
 
     Examples
     --------
@@ -929,10 +934,18 @@ def assert_array_equal(x, y, err_msg='', verbose=True):
     >>> x = np.full((2, 5), fill_value=3)
     >>> np.testing.assert_array_equal(x, 3)
 
+    Use `strict` to raise an assertion when comparing a scalar with an array:
+
+    >>> np.testing.assert_array_equal(x, 3, strict=True)
+
+    AssertionError:
+    Arrays are not equal
+    (shapes (2, 5), () mismatch)
+
     """
     __tracebackhide__ = True  # Hide traceback for py.test
     assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
-                         verbose=verbose, header='Arrays are not equal')
+                         verbose=verbose, header='Arrays are not equal', strict=strict)
 
 
 def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -755,7 +755,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
 
     try:
         if strict:
-            cond = x.shape == y.shape
+            cond = x.shape == y.shape and x.dtype == y.dtype
         else:
             cond = (x.shape == () or y.shape == ()) or x.shape == y.shape
         if not cond:
@@ -882,7 +882,7 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
         If True, the conflicting values are appended to the error message.
     strict : bool, optional
         If True, raise an assertion when one of the array_like objects is a
-        scalar.
+        scalar or if `x` and `y` have a different data type.
 
     Raises
     ------
@@ -949,6 +949,19 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
            [3, 3, 3, 3, 3]])
      y: array(3)
 
+    The `strict` parameter also ensures that the array data types match:
+
+    >>> x = np.array([2, 2, 2])
+    >>> y = np.array([2., 2., 2.], dtype=np.float32)
+    >>> np.testing.assert_array_equal(x, y, strict=True)
+    Traceback (most recent call last):
+        ...
+    AssertionError:
+    Arrays are not equal
+    <BLANKLINE>
+    (shapes (3,), (3,) mismatch)
+     x: array([2, 2, 2])
+     y: array([2., 2., 2.], dtype=float32)
     """
     __tracebackhide__ = True  # Hide traceback for py.test
     assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -881,8 +881,9 @@ def assert_array_equal(x, y, err_msg='', verbose=True, *, strict=False):
     verbose : bool, optional
         If True, the conflicting values are appended to the error message.
     strict : bool, optional
-        If True, raise an assertion when one of the array_like objects is a
-        scalar or if `x` and `y` have a different data type.
+        If True, raise an assertion when either the shape or the data
+        type of the array_like objects does not match. The special
+        handling for scalars mentioned in the Notes section is disabled.
 
     Raises
     ------

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -699,7 +699,8 @@ def assert_approx_equal(actual,desired,significant=7,err_msg='',verbose=True):
 
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
-                         precision=6, equal_nan=True, equal_inf=True, strict=False):
+                         precision=6, equal_nan=True, equal_inf=True,
+                         strict=False):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy.core import array, array2string, isnan, inf, bool_, errstate, all, max, object_
 
@@ -880,7 +881,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False):
     verbose : bool, optional
         If True, the conflicting values are appended to the error message.
     strict : bool, optional
-        If True, raise an assertion when one of the array_like objects is a scalar.
+        If True, raise an assertion when one of the array_like objects is a
+        scalar.
 
     Raises
     ------
@@ -945,7 +947,8 @@ def assert_array_equal(x, y, err_msg='', verbose=True, strict=False):
     """
     __tracebackhide__ = True  # Hide traceback for py.test
     assert_array_compare(operator.__eq__, x, y, err_msg=err_msg,
-                         verbose=verbose, header='Arrays are not equal', strict=strict)
+                         verbose=verbose, header='Arrays are not equal',
+                         strict=strict)
 
 
 def assert_array_almost_equal(x, y, decimal=6, err_msg='', verbose=True):

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -207,6 +207,8 @@ def assert_array_equal(
     y: ArrayLike,
     err_msg: str = ...,
     verbose: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 
 def assert_array_almost_equal(

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -200,6 +200,8 @@ def assert_array_compare(
     precision: SupportsIndex = ...,
     equal_nan: bool = ...,
     equal_inf: bool = ...,
+    *,
+    strict: bool = ...
 ) -> None: ...
 
 def assert_array_equal(

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -214,6 +214,35 @@ class TestArrayEqual(_GenericTest):
                     np.array([1, 2, 3], np.float32),
                     np.array([1, 1e-40, 3], np.float32))
 
+    def test_array_vs_scalar_is_equal(self):
+        """Test comparing an array with a scalar when all values are equal."""
+        a = np.array([1., 1., 1.])
+        b = 1.
+
+        self._test_equal(a, b)
+
+    def test_array_vs_scalar_not_equal(self):
+        """Test comparing an array with a scalar when not all values are equal."""
+        a = np.array([1., 2., 3.])
+        b = 1.
+
+        self._test_not_equal(a, b)
+
+    def test_array_vs_scalar_strict(self):
+        """Test comparing an array with a scalar with strict option."""
+        a = np.array([1., 1., 1.])
+        b = 1.
+
+        with pytest.raises(AssertionError):
+            self._assert_func(a, b, strict=True)
+
+    def test_array_vs_array_strict(self):
+        """Test comparing two arrays with strict option."""
+        a = np.array([1., 1., 1.])
+        b = np.array([1., 1., 1.])
+
+        self._assert_func(a, b, strict=True)
+
 
 class TestBuildErrorMessage:
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -243,6 +243,14 @@ class TestArrayEqual(_GenericTest):
 
         assert_array_equal(a, b, strict=True)
 
+    def test_array_vs_float_array_strict(self):
+        """Test comparing two arrays with strict option."""
+        a = np.array([1, 1, 1])
+        b = np.array([1., 1., 1.])
+
+        with pytest.raises(AssertionError):
+            assert_array_equal(a, b, strict=True)
+
 
 class TestBuildErrorMessage:
 

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -234,14 +234,14 @@ class TestArrayEqual(_GenericTest):
         b = 1.
 
         with pytest.raises(AssertionError):
-            self._assert_func(a, b, strict=True)
+            assert_array_equal(a, b, strict=True)
 
     def test_array_vs_array_strict(self):
         """Test comparing two arrays with strict option."""
         a = np.array([1., 1., 1.])
         b = np.array([1., 1., 1.])
 
-        self._assert_func(a, b, strict=True)
+        assert_array_equal(a, b, strict=True)
 
 
 class TestBuildErrorMessage:

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -222,7 +222,7 @@ class TestArrayEqual(_GenericTest):
         self._test_equal(a, b)
 
     def test_array_vs_scalar_not_equal(self):
-        """Test comparing an array with a scalar when not all values are equal."""
+        """Test comparing an array with a scalar when not all values equal."""
         a = np.array([1., 2., 3.])
         b = 1.
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
It's useful to have `assert_array_equal` broadcast a scalar to match every value in an array, but it would be nice to be able to turn this behaviour off. Sometimes you need to have an exact match.