### PR TITLE
MAINT: Wheel CI: Re-enable PyPy 3.9, update cibuildwheel and environments

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -75,10 +75,7 @@ jobs:
         - [macos-10.15, macosx_*]
         - [windows-2019, win_amd64]
         - [windows-2019, win32]
-        # TODO: uncomment PyPy 3.9 builds once PyPy
-        # re-releases a new minor version
-        # NOTE: This needs a bump of cibuildwheel version, also, once that happens.
-        python: ["cp38", "cp39", "cp310", "pp38"] #, "pp39"]
+        python: ["cp38", "cp39", "cp310", "pp38", "pp39"]
         exclude:
         # Don't build PyPy 32-bit windows
         - buildplat: [windows-2019, win32]
@@ -115,7 +112,7 @@ jobs:
         if: ${{ env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -112,7 +112,7 @@ jobs:
         if: ${{ env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,15 +72,15 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, manylinux_x86_64]
-        - [macos-10.15, macosx_*]
-        - [windows-2019, win_amd64]
-        - [windows-2019, win32]
+        - [macos-11, macosx_*]
+        - [windows-2022, win_amd64]
+        - [windows-2022, win32]
         python: ["cp38", "cp39", "cp310", "pp38", "pp39"]
         exclude:
         # Don't build PyPy 32-bit windows
-        - buildplat: [windows-2019, win32]
+        - buildplat: [windows-2022, win32]
           python: "pp38"
-        - buildplat: [windows-2019, win32]
+        - buildplat: [windows-2022, win32]
           python: "pp39"
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -112,7 +112,7 @@ jobs:
         if: ${{ env.IS_32_BIT == 'true' }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.4.0
+      install: python3 -m pip install cibuildwheel==2.5.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -64,7 +64,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.4.0
+      install: python3 -m pip install cibuildwheel==2.5.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -77,7 +77,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.4.0
+      install: python3 -m pip install cibuildwheel==2.5.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.5.0
+      install: python3 -m pip install cibuildwheel==2.6.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -64,7 +64,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.5.0
+      install: python3 -m pip install cibuildwheel==2.6.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -77,7 +77,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.5.0
+      install: python3 -m pip install cibuildwheel==2.6.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.6.0
+      install: python3 -m pip install cibuildwheel==2.7.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -64,7 +64,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp39-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.6.0
+      install: python3 -m pip install cibuildwheel==2.7.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh
@@ -77,7 +77,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp310-manylinux_aarch64
-      install: python3 -m pip install cibuildwheel==2.6.0
+      install: python3 -m pip install cibuildwheel==2.7.0
       script: |
         cibuildwheel --output-dir wheelhouse
         source ./tools/wheels/upload_wheels.sh


### PR DESCRIPTION
This PR includes a bit of maintenance on the wheel CI. It re-enables PyPy 3.9 builds, updates the [cibuildwheel](https://github.com/pypa/cibuildwheel) action to [2.5.0](https://github.com/pypa/cibuildwheel/releases/tag/2.5.0) and updates the used [environments](https://github.com/actions/virtual-environments) to macOS 11 and Windows Server 2022, which updates the used build tools and compilers in the following way:

- The Windows job uses Visual Studio 2022 (with MSVC 14.32) instead of VS 2019 (MSVC 14.29)
- The macOS 11 job uses Xcode 13.2.1 (with Clang 13) instead of 12.4 (Clang 12)

This PR consists of two commits:

- [Wheel CI: Enable PyPy 3.9 wheels, update cibuildwheel](https://github.com/numpy/numpy/commit/1a5a2fc2acaaf7cd214b0eaf342de84505d83a25)
- [Wheel CI: Update to macOS 11 and Windows 2022 environments](https://github.com/numpy/numpy/commit/7fa1ec330f380f1d2d2026c79af4117e2710d172)

I tested both commits in CI on my own branch: [first](https://github.com/EwoutH/numpy/actions/runs/2384311681), [second](https://github.com/EwoutH/numpy/actions/runs/2384325513).

This PR is in **draft** status, because I would like to bump the cibuildwheel to 2.6.0 (which should release tonight, see https://github.com/pypa/cibuildwheel/pull/1109#issuecomment-1136932227). That release will also allow building wheels with Python 3.11, however, those shouldn't be uploaded to PyPI, since ABI changes can be introduced up to Python 3.11 beta 4.

The first two commits can be reviewed.