### PR TITLE
BUILD: fix tag name for travis: it is v1.23.0rc1

### DIFF
--- a/tools/wheels/upload_wheels.sh
+++ b/tools/wheels/upload_wheels.sh
@@ -2,7 +2,7 @@ set_travis_vars() {
     # Set env vars
     echo "TRAVIS_EVENT_TYPE is $TRAVIS_EVENT_TYPE"
     echo "TRAVIS_TAG is $TRAVIS_TAG"
-    if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_TAG" == refs/tags/v* ]]; then
+    if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_TAG" == v* ]]; then
       IS_PUSH="true"
     else
       IS_PUSH="false"


### PR DESCRIPTION
Closes #21599 

The TRAVIS_TAG name is v1.23.0rc1, the old one was copied from github actions which is different.