### PR TITLE
DOC: Add version switcher to the documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -172,11 +172,7 @@ html_logo = '_static/numpylogo.svg'
 html_favicon = '_static/favicon/favicon.ico'
 
 # Set up the version switcher.  The versions.json is stored in the devdocs.
-if os.environ.get('CIRCLE_JOB', False) and \
-        os.environ.get('CIRCLE_BRANCH', '') != 'main':
-    # For PR, name is set to its ref
-    switcher_version = os.environ['CIRCLE_BRANCH']
-elif ".dev" in version:
+if ".dev" in version:
     switcher_version = "devdocs"
 else:
     switcher_version = f"doc/{version}"


### PR DESCRIPTION
Backport of #21426.

This enables the version switcher in the devdocs.  It currently uses the full `devdocs` url (prointing to `_static/versions.json`) to store the versions.
This means that the preview does not work since it fetches the versions from the deployed documentation.  It also means that this URL must be stable.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
