### PR TITLE
MAINT: make MismatchCAPIWarnining into MismatchCAPIError

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -476,11 +476,8 @@ def configuration(parent_package='',top_path=None):
     local_dir = config.local_path
     codegen_dir = join(local_dir, 'code_generators')
 
-    if is_released:
-        warnings.simplefilter('error', MismatchCAPIWarning)
-
     # Check whether we have a mismatch between the set C API VERSION and the
-    # actual C API VERSION
+    # actual C API VERSION. Will raise a MismatchCAPIError if so.
     check_api_version(C_API_VERSION, codegen_dir)
 
     generate_umath_py = join(codegen_dir, 'generate_umath.py')

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -51,7 +51,7 @@ C_ABI_VERSION = 0x01000009
 # 0x00000010 - 1.24.x
 C_API_VERSION = 0x00000010
 
-class MismatchCAPIWarning(Warning):
+class MismatchCAPIError(ValueError):
     pass
 
 
@@ -87,14 +87,13 @@ def check_api_version(apiversion, codegen_dir):
     # To compute the checksum of the current API, use numpy/core/cversions.py
     if not curapi_hash == api_hash:
         msg = ("API mismatch detected, the C API version "
-               "numbers have to be updated. Current C api version is %d, "
-               "with checksum %s, but recorded checksum for C API version %d "
-               "in core/codegen_dir/cversions.txt is %s. If functions were "
-               "added in the C API, you have to update C_API_VERSION in %s."
+               "numbers have to be updated. Current C api version is "
+               f"{apiversion}, with checksum {curapi_hash}, but recorded "
+               f"checksum in core/codegen_dir/cversions.txt is {api_hash}. If "
+               "functions were added in the C API, you have to update "
+               f"C_API_VERSION in {__file__}."
                )
-        warnings.warn(msg % (apiversion, curapi_hash, apiversion, api_hash,
-                             __file__),
-                      MismatchCAPIWarning, stacklevel=2)
+        raise MismatchCAPIError(msg)
 
 
 FUNC_CALL_ARGS = {}


### PR DESCRIPTION
Follow on from #21609. This part of the code base is very old.

- Change the warning into an error
- Use f-string formatting to create the msg. When I try the function with the wrong value (15 instead of 16), `msg` becomes:
> setup_common.MismatchCAPIError: API mismatch detected, the C API version numbers have to be updated. Current C api version is 15, with checksum 04a7bf1e65350926a0e528798da263c0, but recorded checksum in core/codegen_dir/cversions.txt is b8783365b873681cd204be50cdfb448d. If functions were added in the C API, you have to update C_API_VERSION in /home/matti/oss/numpy/numpy/core/setup_common.py