### PR TITLE
MAINT: Remove compatibility shims for old versions of PyPy

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -424,10 +424,7 @@ PyDataMem_Handler default_handler = {
 };
 /* singleton capsule of the default handler */
 PyObject *PyDataMem_DefaultHandler;
-
-#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
 PyObject *current_handler;
-#endif
 
 int uo_index=0;   /* user_override index */
 
@@ -539,7 +536,6 @@ NPY_NO_EXPORT PyObject *
 PyDataMem_SetHandler(PyObject *handler)
 {
     PyObject *old_handler;
-#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     PyObject *token;
     if (PyContextVar_Get(current_handler, NULL, &old_handler)) {
         return NULL;
@@ -554,27 +550,6 @@ PyDataMem_SetHandler(PyObject *handler)
     }
     Py_DECREF(token);
     return old_handler;
-#else
-    PyObject *p;
-    p = PyThreadState_GetDict();
-    if (p == NULL) {
-        return NULL;
-    }
-    old_handler = PyDict_GetItemString(p, "current_allocator");
-    if (old_handler == NULL) {
-        old_handler = PyDataMem_DefaultHandler
-    }
-    Py_INCREF(old_handler);
-    if (handler == NULL) {
-        handler = PyDataMem_DefaultHandler;
-    }
-    const int error = PyDict_SetItemString(p, "current_allocator", handler);
-    if (error) {
-        Py_DECREF(old_handler);
-        return NULL;
-    }
-    return old_handler;
-#endif
 }
 
 /*NUMPY_API
@@ -585,28 +560,10 @@ NPY_NO_EXPORT PyObject *
 PyDataMem_GetHandler()
 {
     PyObject *handler;
-#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     if (PyContextVar_Get(current_handler, NULL, &handler)) {
         return NULL;
     }
     return handler;
-#else
-    PyObject *p = PyThreadState_GetDict();
-    if (p == NULL) {
-        return NULL;
-    }
-    handler = PyDict_GetItem(p, npy_ma_str_current_allocator);
-    if (handler == NULL) {
-        handler = PyCapsule_New(&default_handler, "mem_handler", NULL);
-        if (handler == NULL) {
-            return NULL;
-        }
-    }
-    else {
-        Py_INCREF(handler);
-    }
-    return handler;
-#endif
 }
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -44,9 +44,7 @@ npy_free_cache_dim_array(PyArrayObject * arr)
 }
 
 extern PyDataMem_Handler default_handler;
-#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
 extern PyObject *current_handler; /* PyContextVar/PyCapsule */
-#endif
 
 NPY_NO_EXPORT PyObject *
 get_handler_name(PyObject *NPY_UNUSED(self), PyObject *obj);

--- a/numpy/core/src/multiarray/compiled_base.c
+++ b/numpy/core/src/multiarray/compiled_base.c
@@ -1393,11 +1393,7 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *args)
 {
     PyObject *obj;
     PyObject *str;
-    #if !defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM > 0x07030300
     const char *docstr;
-    #else
-    char *docstr;
-    #endif
     static char *msg = "already has a different docstring";
 
     /* Don't add docstrings */

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4997,16 +4997,15 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     if (PyDataMem_DefaultHandler == NULL) {
         goto err;
     }
-#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     /*
      * Initialize the context-local current handler
      * with the default PyDataMem_Handler capsule.
-    */
+     */
     current_handler = PyContextVar_New("current_allocator", PyDataMem_DefaultHandler);
     if (current_handler == NULL) {
         goto err;
     }
-#endif
+
     return m;
 
  err:

--- a/numpy/core/src/multiarray/typeinfo.c
+++ b/numpy/core/src/multiarray/typeinfo.c
@@ -9,12 +9,6 @@
 #include "npy_pycompat.h"
 #include "typeinfo.h"
 
-#if (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM <= 0x07030000))
-/* PyPy issue 3160 */
-#include <structseq.h>
-#endif
-
-
 
 static PyTypeObject PyArray_typeinfoType;
 static PyTypeObject PyArray_typeinforangedType;
@@ -99,17 +93,6 @@ PyArray_typeinforanged(
     return entry;
 }
 
-/* Python version needed for older PyPy */
-#if (defined(PYPY_VERSION_NUM) && (PYPY_VERSION_NUM < 0x07020000))
-    static int
-    PyStructSequence_InitType2(PyTypeObject *type, PyStructSequence_Desc *desc) {
-        PyStructSequence_InitType(type, desc);
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        return 0;
-    }
-#endif
 
 NPY_NO_EXPORT int
 typeinfo_init_structsequences(PyObject *multiarray_dict)


### PR DESCRIPTION
It seems that the newest of these targeted versions of 7.3.5 and
older.  But these versions (as far as I can tell) did not even
ship Python 3.8 and thus should not be compatible in any case.
