### PR TITLE
API: Retain `arr.base` more strictly in `np.frombuffer`

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5608,12 +5608,13 @@ class TestFromBuffer:
         buf = x.tobytes()
         assert_array_equal(np.frombuffer(buf, dtype=dt), x.flat)
 
-    def test_array_base(self):
-        arr = np.arange(10)
-        new = np.frombuffer(arr)
-        # We currently special case arrays to ensure they are used as a base.
-        # This could probably be changed (removing the test).
-        assert new.base is arr
+    @pytest.mark.parametrize("obj", [np.arange(10), b"12345678"])
+    def test_array_base(self, obj):
+        # Objects (including NumPy arrays), which do not use the
+        # `release_buffer` slot should be directly used as a base object.
+        # See also gh-21612
+        new = np.frombuffer(obj)
+        assert new.base is obj
 
     def test_empty(self):
         assert_array_equal(np.frombuffer(b''), np.array([]))


### PR DESCRIPTION
Checking the implementation of `releasebuffer` is the most strict
version for when we can safely assume that wrapping into a
`memoryview` is not necessary.
In theory, `view.obj` could also be set to a new object even with
the old buffer-protocol, in practice I don't think that should
happen (the docs read like it should not be used).

So this is the minimal fix to retain old behavior as much as
(safely) possible.

Closes gh-21612
