### PR TITLE
TST: Skip F2PY tests without Fortran compilers

### DIFF
--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -344,10 +344,6 @@ class F2PyTest:
         # Check compiler availability first
         if not has_c_compiler():
             pytest.skip("No C compiler available")
-        if not has_f77_compiler():
-            pytest.skip("No Fortran 77 compiler available")
-        if not has_f90_compiler():
-            pytest.skip("No Fortran 90 compiler available")
 
         codes = []
         if self.sources:
@@ -357,11 +353,20 @@ class F2PyTest:
 
         needs_f77 = False
         needs_f90 = False
+        needs_pyf = False
         for fn in codes:
             if str(fn).endswith(".f"):
                 needs_f77 = True
             elif str(fn).endswith(".f90"):
                 needs_f90 = True
+            elif str(fn).endswith(".pyf"):
+                needs_pyf = True
+        if needs_f77 and not has_f77_compiler():
+            pytest.skip("No Fortran 77 compiler available")
+        if needs_f90 and not has_f90_compiler():
+            pytest.skip("No Fortran 90 compiler available")
+        if needs_pyf and not (has_f90_compiler() or has_f77_compiler()):
+            pytest.skip("No Fortran compiler available")
 
         # Build the module
         if self.code is not None:

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -344,6 +344,10 @@ class F2PyTest:
         # Check compiler availability first
         if not has_c_compiler():
             pytest.skip("No C compiler available")
+        if not has_f77_compiler():
+            pytest.skip("No Fortran 77 compiler available")
+        if not has_f90_compiler():
+            pytest.skip("No Fortran 90 compiler available")
 
         codes = []
         if self.sources:
@@ -358,10 +362,6 @@ class F2PyTest:
                 needs_f77 = True
             elif str(fn).endswith(".f90"):
                 needs_f90 = True
-        if needs_f77 and not has_f77_compiler():
-            pytest.skip("No Fortran 77 compiler available")
-        if needs_f90 and not has_f90_compiler():
-            pytest.skip("No Fortran 90 compiler available")
 
         # Build the module
         if self.code is not None:


### PR DESCRIPTION
Backport of #21622.

Closes #21621 by bailing out for `pyf` files.

Note that the class used is for testing runtime behavior of F2PY components. In general, the only reason to keep this structure is to allow for tests written for the `C` code generation aspect of F2PY without the `Fortran` wrappers. As we have no such tests currently (nor are any planned) we might not even want to bother with separately checking for F77 or F90 compilers conditionally; i.e. we could simply check for a Fortran compiler and bail early where the C compiler check is done...

In fact, a `pyf` file is valid with only a `C` codebase, but again, since we don't have any such examples..

FWIW though, I like (and prefer still) that `conda-forge` runs these tests as currently done here: https://github.com/conda-forge/numpy-feedstock/pull/272
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
