### PR TITLE
BUG: use explicit einsum_path whenever it is given

### DIFF
--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -902,7 +902,11 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
     # Compute the path
     if path is not None:
         pass
-    elif (path_type is False) or (len(input_list) in [1, 2]) or (indices == output_set):
+    elif (
+        (path_type is False)
+        or (len(input_list) in [1, 2])
+        or (indices == output_set)
+    ):
         # Nothing to be optimized, leave it to einsum
         path = [tuple(range(len(input_list)))]
     elif path_type == "greedy":

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -821,7 +821,7 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
     if path_type is None:
         path_type = False
 
-    path = None
+    explicit_einsum_path = False
     memory_limit = None
 
     # No optimization or a named path algorithm
@@ -830,8 +830,7 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
 
     # Given an explicit path
     elif len(path_type) and (path_type[0] == 'einsum_path'):
-        path = path_type[1:]
-        path_type = 'einsum_path'
+        explicit_einsum_path = True
 
     # Path tuple with memory limit
     elif ((len(path_type) == 2) and isinstance(path_type[0], str) and
@@ -900,8 +899,8 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
     naive_cost = _flop_count(indices, inner_product, len(input_list), dimension_dict)
 
     # Compute the path
-    if path is not None:
-        pass
+    if explicit_einsum_path:
+        path = path_type[1:]
     elif (
         (path_type is False)
         or (len(input_list) in [1, 2])

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -1106,12 +1106,14 @@ class TestEinsumPath:
         path_test = self.build_operands('ab,bc,cd,de->ae')
         exp_path = ['einsum_path', (2, 3), (0, 1)]
         assert_raises(RuntimeError, np.einsum, *path_test, optimize=exp_path)
-        assert_raises(RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
+        assert_raises(
+            RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
 
         path_test = self.build_operands('a,a,a->a')
         exp_path = ['einsum_path', (1,), (0, 1)]
         assert_raises(RuntimeError, np.einsum, *path_test, optimize=exp_path)
-        assert_raises(RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
+        assert_raises(
+            RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
 
     def test_spaces(self):
         #gh-10794

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -1089,6 +1089,30 @@ class TestEinsumPath:
         opt = np.einsum(*path_test, optimize=exp_path)
         assert_almost_equal(noopt, opt)
 
+    def test_path_type_input_internal_trace(self):
+        #gh-20962
+        path_test = self.build_operands('cab,cdd->ab')
+        exp_path = ['einsum_path', (1,), (0, 1)]
+
+        path, path_str = np.einsum_path(*path_test, optimize=exp_path)
+        self.assert_path_equal(path, exp_path)
+
+        # Double check einsum works on the input path
+        noopt = np.einsum(*path_test, optimize=False)
+        opt = np.einsum(*path_test, optimize=exp_path)
+        assert_almost_equal(noopt, opt)
+
+    def test_path_type_input_invalid(self):
+        path_test = self.build_operands('ab,bc,cd,de->ae')
+        exp_path = ['einsum_path', (2, 3), (0, 1)]
+        assert_raises(RuntimeError, np.einsum, *path_test, optimize=exp_path)
+        assert_raises(RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
+
+        path_test = self.build_operands('a,a,a->a')
+        exp_path = ['einsum_path', (1,), (0, 1)]
+        assert_raises(RuntimeError, np.einsum, *path_test, optimize=exp_path)
+        assert_raises(RuntimeError, np.einsum_path, *path_test, optimize=exp_path)
+
     def test_spaces(self):
         #gh-10794
         arr = np.array([[1]])


### PR DESCRIPTION
For example, allow user to specify unary contractions in binary einsum as described in #20962.
The commit also adds a sanity check on user-specified einsum_path.