### PR TITLE
DEP: Remove `normed=` keyword argument from histograms

### DIFF
--- a/doc/release/upcoming_changes/21645.expired.rst
+++ b/doc/release/upcoming_changes/21645.expired.rst
@@ -1,0 +1,4 @@
+* The ``normed`` keyword argument has been removed from
+  `np.histogram`, `np.histogram2d`, and `np.histogramdd`.
+  Use ``density`` instead.  If ``normed`` was passed by
+  position, ``density`` is now used.

--- a/numpy/lib/histograms.pyi
+++ b/numpy/lib/histograms.pyi
@@ -34,16 +34,14 @@ def histogram(
     a: ArrayLike,
     bins: _BinKind | SupportsIndex | ArrayLike = ...,
     range: None | tuple[float, float] = ...,
-    normed: None = ...,
-    weights: None | ArrayLike = ...,
     density: bool = ...,
+    weights: None | ArrayLike = ...,
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 
 def histogramdd(
     sample: ArrayLike,
     bins: SupportsIndex | ArrayLike = ...,
     range: Sequence[tuple[float, float]] = ...,
-    normed: None | bool = ...,
-    weights: None | ArrayLike = ...,
     density: None | bool = ...,
+    weights: None | ArrayLike = ...,
 ) -> tuple[NDArray[Any], list[NDArray[Any]]]: ...

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -38,30 +38,6 @@ class TestHistogram:
         assert_equal(h, np.array([2]))
         assert_allclose(e, np.array([1., 2.]))
 
-    def test_normed(self):
-        sup = suppress_warnings()
-        with sup:
-            rec = sup.record(np.VisibleDeprecationWarning, '.*normed.*')
-            # Check that the integral of the density equals 1.
-            n = 100
-            v = np.random.rand(n)
-            a, b = histogram(v, normed=True)
-            area = np.sum(a * np.diff(b))
-            assert_almost_equal(area, 1)
-            assert_equal(len(rec), 1)
-
-        sup = suppress_warnings()
-        with sup:
-            rec = sup.record(np.VisibleDeprecationWarning, '.*normed.*')
-            # Check with non-constant bin widths (buggy but backwards
-            # compatible)
-            v = np.arange(10)
-            bins = [0, 1, 5, 9, 10]
-            a, b = histogram(v, bins, normed=True)
-            area = np.sum(a * np.diff(b))
-            assert_almost_equal(area, 1)
-            assert_equal(len(rec), 1)
-
     def test_density(self):
         # Check that the integral of the density equals 1.
         n = 100
@@ -819,20 +795,3 @@ class TestHistogramdd:
         hist_dd, edges_dd = histogramdd((v,), (bins,), density=True)
         assert_equal(hist, hist_dd)
         assert_equal(edges, edges_dd[0])
-
-    def test_density_via_normed(self):
-        # normed should simply alias to density argument
-        v = np.arange(10)
-        bins = np.array([0, 1, 3, 6, 10])
-        hist, edges = histogram(v, bins, density=True)
-        hist_dd, edges_dd = histogramdd((v,), (bins,), normed=True)
-        assert_equal(hist, hist_dd)
-        assert_equal(edges, edges_dd[0])
-
-    def test_density_normed_redundancy(self):
-        v = np.arange(10)
-        bins = np.array([0, 1, 3, 6, 10])
-        with assert_raises_regex(TypeError, "Cannot specify both"):
-            hist_dd, edges_dd = histogramdd((v,), (bins,),
-                                            density=True,
-                                            normed=True)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -634,8 +634,8 @@ def vander(x, N=None, increasing=False):
     return v
 
 
-def _histogram2d_dispatcher(x, y, bins=None, range=None, normed=None,
-                            weights=None, density=None):
+def _histogram2d_dispatcher(x, y, bins=None, range=None, density=None,
+                            weights=None):
     yield x
     yield y
 
@@ -653,8 +653,7 @@ def _histogram2d_dispatcher(x, y, bins=None, range=None, normed=None,
 
 
 @array_function_dispatch(_histogram2d_dispatcher)
-def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
-                density=None):
+def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     """
     Compute the bi-dimensional histogram of two data samples.
 
@@ -688,13 +687,9 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
         If False, the default, returns the number of samples in each bin.
         If True, returns the probability *density* function at the bin,
         ``bin_count / sample_count / bin_area``.
-    normed : bool, optional
-        An alias for the density argument that behaves identically. To avoid
-        confusion with the broken normed argument to `histogram`, `density`
-        should be preferred.
     weights : array_like, shape(N,), optional
         An array of values ``w_i`` weighing each sample ``(x_i, y_i)``.
-        Weights are normalized to 1 if `normed` is True. If `normed` is
+        Weights are normalized to 1 if `density` is True. If `density` is
         False, the values of the returned histogram are equal to the sum of
         the weights belonging to the samples falling into each bin.
 
@@ -716,7 +711,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     Notes
     -----
-    When `normed` is True, then the returned histogram is the sample
+    When `density` is True, then the returned histogram is the sample
     density, defined such that the sum over bins of the product
     ``bin_value * bin_area`` is 1.
 
@@ -822,7 +817,7 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     if N != 1 and N != 2:
         xedges = yedges = asarray(bins)
         bins = [xedges, yedges]
-    hist, edges = histogramdd([x, y], bins, range, normed, weights, density)
+    hist, edges = histogramdd([x, y], bins, range, density, weights)
     return hist, edges[0], edges[1]
 
 

--- a/numpy/lib/twodim_base.pyi
+++ b/numpy/lib/twodim_base.pyi
@@ -166,9 +166,8 @@ def histogram2d(  # type: ignore[misc]
     y: _ArrayLikeFloat_co,
     bins: int | Sequence[int] = ...,
     range: None | _ArrayLikeFloat_co = ...,
-    normed: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
     density: None | bool = ...,
+    weights: None | _ArrayLikeFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
     NDArray[floating[Any]],
@@ -180,9 +179,8 @@ def histogram2d(
     y: _ArrayLikeComplex_co,
     bins: int | Sequence[int] = ...,
     range: None | _ArrayLikeFloat_co = ...,
-    normed: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
     density: None | bool = ...,
+    weights: None | _ArrayLikeFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
     NDArray[complexfloating[Any, Any]],
@@ -194,9 +192,8 @@ def histogram2d(
     y: _ArrayLikeComplex_co,
     bins: Sequence[_ArrayLikeInt_co],
     range: None | _ArrayLikeFloat_co = ...,
-    normed: None | bool = ...,
-    weights: None | _ArrayLikeFloat_co = ...,
     density: None | bool = ...,
+    weights: None | _ArrayLikeFloat_co = ...,
 ) -> tuple[
     NDArray[float64],
     NDArray[Any],

--- a/numpy/typing/tests/data/fail/histograms.pyi
+++ b/numpy/typing/tests/data/fail/histograms.pyi
@@ -7,7 +7,6 @@ AR_f8: npt.NDArray[np.float64]
 np.histogram_bin_edges(AR_i8, range=(0, 1, 2))  # E: incompatible type
 
 np.histogram(AR_i8, range=(0, 1, 2))  # E: incompatible type
-np.histogram(AR_i8, normed=True)  # E: incompatible type
 
 np.histogramdd(AR_i8, range=(0, 1))  # E: incompatible type
 np.histogramdd(AR_i8, range=[(0, 1, 2)])  # E: incompatible type


### PR DESCRIPTION
The normed keyword argument has been deprecated for a long time.
This removes it, replacing its position with the new density
argument.