### PR TITLE
ENH: Add equals_nan kwarg to np.unique

### DIFF
--- a/doc/release/upcoming_changes/21623.new_feature.rst
+++ b/doc/release/upcoming_changes/21623.new_feature.rst
@@ -1,0 +1,4 @@
+New parameter ``equal_nans`` added to `np.unique`
+-----------------------------------------------------------------------------------
+
+`np.unique` was previously changed to treat NaN values as equal. Now this functionality is decided by setting the ``equal_nans`` kwarg to True or False. True is the default behavior. 

--- a/doc/release/upcoming_changes/21623.new_feature.rst
+++ b/doc/release/upcoming_changes/21623.new_feature.rst
@@ -1,4 +1,6 @@
 New parameter ``equal_nans`` added to `np.unique`
 -----------------------------------------------------------------------------------
 
-`np.unique` was previously changed to treat NaN values as equal. Now this functionality is decided by setting the ``equal_nans`` kwarg to True or False. True is the default behavior. 
+`np.unique` was changed in 1.21 to treat all ``NaN`` values as equal and return
+a single ``NaN``. Setting ``equal_nans=False`` will restore pre-1.21 behavior
+to treat ``NaNs`` as unique. Defaults to ``True``.

--- a/doc/release/upcoming_changes/21623.new_feature.rst
+++ b/doc/release/upcoming_changes/21623.new_feature.rst
@@ -1,6 +1,6 @@
-New parameter ``equal_nans`` added to `np.unique`
------------------------------------------------------------------------------------
+New parameter ``equal_nan`` added to `np.unique`
+------------------------------------------------
 
 `np.unique` was changed in 1.21 to treat all ``NaN`` values as equal and return
-a single ``NaN``. Setting ``equal_nans=False`` will restore pre-1.21 behavior
+a single ``NaN``. Setting ``equal_nan=False`` will restore pre-1.21 behavior
 to treat ``NaNs`` as unique. Defaults to ``True``.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -338,7 +338,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
     if (equal_nans and aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and 
-    np.isnan(aux[-1])):
+            np.isnan(aux[-1])):
         if aux.dtype.kind == "c":  # for complex all NaNs are considered equivalent
             aux_firstnan = np.searchsorted(np.isnan(aux), True, side='left')
         else:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -165,7 +165,7 @@ def unique(ar, return_index=False, return_inverse=False,
     equal_nans : bool, optional
         If True, collapses multiple NaN values in return array into 1
 
-        .. versionchanged: NumPy 1.24
+        .. versionchanged: 1.24
 
     axis : int or None, optional
         The axis to operate on. If None, `ar` will be flattened. If an integer,

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -162,7 +162,7 @@ def unique(ar, return_index=False, return_inverse=False,
     return_counts : bool, optional
         If True, also return the number of times each unique item appears
         in `ar`.
-    equals_nan : bool, optional
+    equal_nans : bool, optional
         If True, collapses multiple NaN values in return array into 1
 
         .. versionchanged: NumPy 1.24
@@ -272,7 +272,7 @@ def unique(ar, return_index=False, return_inverse=False,
     ar = np.asanyarray(ar)
     if axis is None:
         ret = _unique1d(ar, return_index, return_inverse, return_counts, 
-        equal_nans)
+        equal_nans = equal_nans)
         return _unpack_tuple(ret)
 
     # axis was specified and not None
@@ -315,13 +315,13 @@ def unique(ar, return_index=False, return_inverse=False,
         return uniq
 
     output = _unique1d(consolidated, return_index,
-                       return_inverse, return_counts, equal_nans)
+                       return_inverse, return_counts, equal_nans = equal_nans)
     output = (reshape_uniq(output[0]),) + output[1:]
     return _unpack_tuple(output)
 
 
 def _unique1d(ar, return_index=False, return_inverse=False,
-              return_counts=False, equal_nans=True):
+              return_counts=False, *, equal_nans=True):
     """
     Find the unique elements of an array, ignoring shape.
     """

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -131,13 +131,13 @@ def _unpack_tuple(x):
 
 
 def _unique_dispatcher(ar, return_index=None, return_inverse=None,
-                       return_counts=None, axis=None, *, equal_nans=None):
+                       return_counts=None, axis=None, *, equal_nan=None):
     return (ar,)
 
 
 @array_function_dispatch(_unique_dispatcher)
 def unique(ar, return_index=False, return_inverse=False,
-           return_counts=False, axis=None, *, equal_nans=True):
+           return_counts=False, axis=None, *, equal_nan=True):
     """
     Find the unique elements of an array.
 
@@ -162,11 +162,6 @@ def unique(ar, return_index=False, return_inverse=False,
     return_counts : bool, optional
         If True, also return the number of times each unique item appears
         in `ar`.
-    equal_nans : bool, optional
-        If True, collapses multiple NaN values in return array into 1
-
-        .. versionchanged: 1.24
-
     axis : int or None, optional
         The axis to operate on. If None, `ar` will be flattened. If an integer,
         the subarrays indexed by the given axis will be flattened and treated
@@ -176,6 +171,11 @@ def unique(ar, return_index=False, return_inverse=False,
         default is None.
 
         .. versionadded:: 1.13.0
+
+    equal_nan : bool, optional
+        If True, collapses multiple NaN values in the return array into one.
+
+        .. versionadded:: 1.24
 
     Returns
     -------
@@ -272,7 +272,7 @@ def unique(ar, return_index=False, return_inverse=False,
     ar = np.asanyarray(ar)
     if axis is None:
         ret = _unique1d(ar, return_index, return_inverse, return_counts, 
-        equal_nans = equal_nans)
+                        equal_nan=equal_nan)
         return _unpack_tuple(ret)
 
     # axis was specified and not None
@@ -315,13 +315,13 @@ def unique(ar, return_index=False, return_inverse=False,
         return uniq
 
     output = _unique1d(consolidated, return_index,
-                       return_inverse, return_counts, equal_nans = equal_nans)
+                       return_inverse, return_counts, equal_nan=equal_nan)
     output = (reshape_uniq(output[0]),) + output[1:]
     return _unpack_tuple(output)
 
 
 def _unique1d(ar, return_index=False, return_inverse=False,
-              return_counts=False, *, equal_nans=True):
+              return_counts=False, *, equal_nan=True):
     """
     Find the unique elements of an array, ignoring shape.
     """
@@ -337,7 +337,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
         aux = ar
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
-    if (equal_nans and aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and 
+    if (equal_nan and aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and
             np.isnan(aux[-1])):
         if aux.dtype.kind == "c":  # for complex all NaNs are considered equivalent
             aux_firstnan = np.searchsorted(np.isnan(aux), True, side='left')

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -131,13 +131,13 @@ def _unpack_tuple(x):
 
 
 def _unique_dispatcher(ar, return_index=None, return_inverse=None,
-                       return_counts=None, axis=None):
+                       return_counts=None, axis=None, *, equal_nans=None):
     return (ar,)
 
 
 @array_function_dispatch(_unique_dispatcher)
 def unique(ar, return_index=False, return_inverse=False,
-           return_counts=False, axis=None):
+           return_counts=False, axis=None, *, equal_nans=True):
     """
     Find the unique elements of an array.
 
@@ -162,8 +162,10 @@ def unique(ar, return_index=False, return_inverse=False,
     return_counts : bool, optional
         If True, also return the number of times each unique item appears
         in `ar`.
+    equals_nan : bool, optional
+        If True, collapses multiple NaN values in return array into 1
 
-        .. versionadded:: 1.9.0
+        .. versionchanged: NumPy 1.24
 
     axis : int or None, optional
         The axis to operate on. If None, `ar` will be flattened. If an integer,
@@ -269,7 +271,8 @@ def unique(ar, return_index=False, return_inverse=False,
     """
     ar = np.asanyarray(ar)
     if axis is None:
-        ret = _unique1d(ar, return_index, return_inverse, return_counts)
+        ret = _unique1d(ar, return_index, return_inverse, return_counts, 
+        equal_nans)
         return _unpack_tuple(ret)
 
     # axis was specified and not None
@@ -312,13 +315,13 @@ def unique(ar, return_index=False, return_inverse=False,
         return uniq
 
     output = _unique1d(consolidated, return_index,
-                       return_inverse, return_counts)
+                       return_inverse, return_counts, equal_nans)
     output = (reshape_uniq(output[0]),) + output[1:]
     return _unpack_tuple(output)
 
 
 def _unique1d(ar, return_index=False, return_inverse=False,
-              return_counts=False):
+              return_counts=False, equal_nans=True):
     """
     Find the unique elements of an array, ignoring shape.
     """
@@ -334,7 +337,8 @@ def _unique1d(ar, return_index=False, return_inverse=False,
         aux = ar
     mask = np.empty(aux.shape, dtype=np.bool_)
     mask[:1] = True
-    if aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and np.isnan(aux[-1]):
+    if (equal_nans and aux.shape[0] > 0 and aux.dtype.kind in "cfmM" and 
+    np.isnan(aux[-1])):
         if aux.dtype.kind == "c":  # for complex all NaNs are considered equivalent
             aux_firstnan = np.searchsorted(np.isnan(aux), True, side='left')
         else:

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -770,6 +770,6 @@ class TestUnique:
         # issue 20326
         a = np.array([1, 1, np.nan, np.nan, np.nan])
         unq = np.unique(a)
-        not_unq = np.unique(a, equal_nans = False)
+        not_unq = np.unique(a, equal_nan=False)
         assert_array_equal(unq, np.array([1, np.nan]))
         assert_array_equal(not_unq, np.array([1, np.nan, np.nan, np.nan]))

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -765,3 +765,11 @@ class TestUnique:
         assert_array_equal(uniq[:, inv], data)
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
+
+    def test_unique_nanequals(self):
+        # issue 20326
+        a = np.array([1, 1, np.nan, np.nan, np.nan])
+        unq = np.unique(a)
+        not_unq = np.unique(a, equal_nans = False)
+        assert_array_equal(unq, np.array([1, np.nan]))
+        assert_array_equal(not_unq, np.array([1, np.nan, np.nan, np.nan]))


### PR DESCRIPTION
Backport of #21623. 

Addresses #20326

np.unique previously had it's functionality changed so NaN values would be treated as non-unique.
This PR puts the functionality into the kwarg equal_nans(default: True).

Backport of  #21644.

The other similar arguments in the testing functions and np.array_equal
use equal_nan and not equal_nans (with plural s). So it seems we
should use that here as well for consistency.

Does some very minor style fixes otherwise.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
