### PR TITLE
MAINT: improved overflow check to avoid undefined behavior

### DIFF
--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -166,7 +166,7 @@ static NPY_INLINE int
         return NPY_FPE_DIVIDEBYZERO;
     }
 #if @neg@
-    else if (b == -1 && a < 0 && a == NPY_MIN_@NAME@) {
+    else if (b == -1 && a == NPY_MIN_@NAME@) {
         *out = a / b;
         return NPY_FPE_OVERFLOW;
     }

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -156,7 +156,7 @@ static NPY_INLINE int
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *         npy_long, npy_ulong, npy_longlong, npy_ulonglong#
  * #neg = (1,0)*5#
- * #name = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ * #NAME = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
  *         LONG, ULONG, LONGLONG, ULONGLONG#
  */
 static NPY_INLINE int

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -156,6 +156,8 @@ static NPY_INLINE int
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *         npy_long, npy_ulong, npy_longlong, npy_ulonglong#
  * #neg = (1,0)*5#
+ * #name = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG#
  */
 static NPY_INLINE int
 @name@_ctype_divide(@type@ a, @type@ b, @type@ *out) {
@@ -164,7 +166,7 @@ static NPY_INLINE int
         return NPY_FPE_DIVIDEBYZERO;
     }
 #if @neg@
-    else if (b == -1 && a < 0 && a == -a) {
+    else if (b == -1 && a < 0 && a == NPY_MIN_@NAME@) {
         *out = a / b;
         return NPY_FPE_OVERFLOW;
     }


### PR DESCRIPTION
## Related Issues/PRs
Related to #21648

## Changes
- Adds `NAME` template to `@name@_ctype_divide`
- Changes part of overflow check from `a == -a` to `a == NPY_MIN_@NAME@`

## Comments
The old behavior was pointed out to be undefined, see: https://github.com/numpy/numpy/pull/21648#discussion_r888449481)