### PR TITLE
MAINT: Adapt  npt._GenericAlias to Python 3.11 types.GenericAlias changes

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -276,12 +276,13 @@ jobs:
           git config --global --add safe.directory /numpy
           cd /numpy &&
           python3 setup.py install
+          python3 pip3 install -r ./test_requirements.txt
         "
         docker commit the_build the_build
     - name: Run SIMD Tests
       run: |
         docker run --rm --interactive -v $(pwd):/numpy the_build /bin/bash -c "
-          cd /numpy && python3 pip3 install -r ./test_requirements.txt && python3 runtests.py -n -v -- -k test_simd
+          cd /numpy && python3 runtests.py -n -v -- -k test_simd
         "
 
   sde_simd_avx512_test:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -250,6 +250,8 @@ jobs:
         # use x86_64 cross-compiler to speed up the build
         sudo apt update
         sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+
+        # Keep the `test_requirements.txt` dependency-subset synced
         docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:focal /bin/bash -c "
           apt update &&
           apt install -y git python3 python3-dev python3-pip &&

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -276,7 +276,7 @@ jobs:
           git config --global --add safe.directory /numpy
           cd /numpy &&
           python3 setup.py install
-          python3 pip3 install -r ./test_requirements.txt
+          python3 pip install -r ./test_requirements.txt
         "
         docker commit the_build the_build
     - name: Run SIMD Tests

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -281,7 +281,7 @@ jobs:
     - name: Run SIMD Tests
       run: |
         docker run --rm --interactive -v $(pwd):/numpy the_build /bin/bash -c "
-          cd /numpy && python3 runtests.py -n -v -- -k test_simd
+          cd /numpy && python3 pip3 install -r ./test_requirements.txt && python3 runtests.py -n -v -- -k test_simd
         "
 
   sde_simd_avx512_test:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -253,7 +253,7 @@ jobs:
         docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:focal /bin/bash -c "
           apt update &&
           apt install -y git python3 python3-dev python3-pip &&
-          pip3 install cython==0.29.30 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 &&
+          pip3 install cython==0.29.30 setuptools\<49.2.0 hypothesis==6.23.3 pytest==6.2.5 'typing_extensions>=4.2.0' &&
           ln -s /host/lib64 /lib64 &&
           ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&
           ln -s /host/usr/arm-linux-gnueabihf /usr/arm-linux-gnueabihf &&
@@ -276,7 +276,6 @@ jobs:
           git config --global --add safe.directory /numpy
           cd /numpy &&
           python3 setup.py install
-          python3 pip install -r ./test_requirements.txt
         "
         docker commit the_build the_build
     - name: Run SIMD Tests

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - hypothesis
   # For type annotations
   - mypy=0.950
+  - typing_extensions>=4.2.0
   # For building docs
   - sphinx=4.5.0
   - sphinx-panels

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -10,6 +10,7 @@ from typing import TypeVar, Any, Union, Callable
 import pytest
 import numpy as np
 from numpy._typing._generic_alias import _GenericAlias
+from typing_extensions import Unpack
 
 ScalarType = TypeVar("ScalarType", bound=np.generic, covariant=True)
 T1 = TypeVar("T1")
@@ -55,8 +56,8 @@ class TestGenericAlias:
         ("__origin__", lambda n: n.__origin__),
         ("__args__", lambda n: n.__args__),
         ("__parameters__", lambda n: n.__parameters__),
-        ("__reduce__", lambda n: n.__reduce__()[1:]),
-        ("__reduce_ex__", lambda n: n.__reduce_ex__(1)[1:]),
+        ("__reduce__", lambda n: n.__reduce__()[1][:3]),
+        ("__reduce_ex__", lambda n: n.__reduce_ex__(1)[1][:3]),
         ("__mro_entries__", lambda n: n.__mro_entries__([object])),
         ("__hash__", lambda n: hash(n)),
         ("__repr__", lambda n: repr(n)),
@@ -66,7 +67,6 @@ class TestGenericAlias:
         ("__getitem__", lambda n: n[Union[T1, T2]][np.float32, np.float64]),
         ("__eq__", lambda n: n == n),
         ("__ne__", lambda n: n != np.ndarray),
-        ("__dir__", lambda n: dir(n)),
         ("__call__", lambda n: n((1,), np.int64, BUFFER)),
         ("__call__", lambda n: n(shape=(1,), dtype=np.int64, buffer=BUFFER)),
         ("subclassing", lambda n: _get_subclass_mro(n)),
@@ -97,6 +97,45 @@ class TestGenericAlias:
             sys.version_info[:2] == (3, 9) and sys.version_info >= (3, 9, 8)
         )
         if GE_398 or sys.version_info >= (3, 10, 1):
+            value_ref = func(NDArray_ref)
+            assert value == value_ref
+
+    def test_dir(self) -> None:
+        value = dir(NDArray)
+        if sys.version_info < (3, 9):
+            return
+
+        # A number attributes only exist in `types.GenericAlias` in >= 3.11
+        if sys.version_info < (3, 11, 0, "beta", 3):
+            value.remove("__typing_unpacked_tuple_args__")
+        if sys.version_info < (3, 11, 0, "beta", 1):
+            value.remove("__unpacked__")
+        assert value == dir(NDArray_ref)
+
+    @pytest.mark.parametrize("name,func,dev_version", [
+        ("__iter__", lambda n: len(list(n)), ("beta", 1)),
+        ("__iter__", lambda n: next(iter(n)), ("beta", 1)),
+        ("__unpacked__", lambda n: n.__unpacked__, ("beta", 1)),
+        ("Unpack", lambda n: Unpack[n], ("beta", 1)),
+
+        # The right operand should now have `__unpacked__ = True`,
+        # and they are thus now longer equivalent
+        ("__ne__", lambda n: n != next(iter(n)), ("beta", 1)),
+
+        # >= beta3 stuff
+        ("__typing_unpacked_tuple_args__",
+         lambda n: n.__typing_unpacked_tuple_args__, ("beta", 3)),
+    ])
+    def test_py311_features(
+        self,
+        name: str,
+        func: FuncType,
+        dev_version: tuple[str, int],
+    ) -> None:
+        """Test Python 3.11 features."""
+        value = func(NDArray)
+
+        if sys.version_info >= (3, 11, 0, *dev_version):
             value_ref = func(NDArray_ref)
             assert value == value_ref
 

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -56,8 +56,6 @@ class TestGenericAlias:
         ("__origin__", lambda n: n.__origin__),
         ("__args__", lambda n: n.__args__),
         ("__parameters__", lambda n: n.__parameters__),
-        ("__reduce__", lambda n: n.__reduce__()[1][:3]),
-        ("__reduce_ex__", lambda n: n.__reduce_ex__(1)[1][:3]),
         ("__mro_entries__", lambda n: n.__mro_entries__([object])),
         ("__hash__", lambda n: hash(n)),
         ("__repr__", lambda n: repr(n)),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,3 +11,4 @@ cffi; python_version < '3.10'
 # - Mypy relies on C API features not present in PyPy
 # NOTE: Keep mypy in sync with environment.yml
 mypy==0.950; platform_python_implementation != "PyPy"
+typing_extensions>=4.2.0


### PR DESCRIPTION
Backport of #21605.

Follow up on https://github.com/numpy/numpy/pull/21543, xref https://github.com/numpy/numpy/pull/21308

Adapt `npt._GenericAlias` to the various PEP 646-related changes introduced in `types.GenericAlias`, notably the introduction of three new attributes and/or methods:
* `__iter__`
* `__unpacked__`
* `__typing_unpacked_tuple_args__`

Note that `types.GenericAlias` still seems to updated on a regular basis in the current 3.11 dev cycle (so more changes may or may not be necessary in the future), but this should be enough to get things running again for https://github.com/numpy/numpy/pull/21308.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
