### PR TITLE
DOC: Misc RST reformatting.

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -189,7 +189,7 @@ Standard acronyms to start the commit message with are::
    REL: related to releasing numpy
 
 Commands to skip continuous integration
-```````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default a lot of continuous integration (CI) jobs are run for every PR,
 from running the test suite on different operating systems and hardware
@@ -210,7 +210,7 @@ Azure chooses to still run jobs with skip commands on PRs, the jobs only get
 skipped on merging to master.
 
 Test building wheels
-```````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~
 
 Numpy currently uses `cibuildwheel <https://https://cibuildwheel.readthedocs.io/en/stable/>`_
 in order to build wheels through continuous integration services. To save resources, the

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -354,7 +354,7 @@ an object :class:`busdaycalendar` which stores the data necessary
 in an optimized form.
 
 np.is_busday():
-```````````````
+---------------
 To test a `datetime64` value to see if it is a valid day, use :func:`is_busday`.
 
 .. admonition:: Example
@@ -370,7 +370,7 @@ To test a `datetime64` value to see if it is a valid day, use :func:`is_busday`.
     array([ True,  True,  True,  True,  True, False, False])
 
 np.busday_count():
-``````````````````
+------------------
 To find how many valid days there are in a specified range of datetime64
 dates, use :func:`busday_count`:
 

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -170,8 +170,8 @@ base offset itself is a multiple of `self.itemsize`. Understanding
     ``NPY_RELAXED_STRIDES_DEBUG=1`` can be used to help find errors when
     incorrectly relying on the strides in C-extension code (see below warning).
 
-Data in new :class:`ndarrays <ndarray>` is in the :term:`row-major`
-(C) order, unless otherwise specified, but, for example, :ref:`basic
+Data in new :class:`ndarrays <ndarray>` is in the :term:`row-major` (C)
+order, unless otherwise specified, but, for example, :ref:`basic
 array slicing <arrays.indexing>` often produces :term:`views <view>`
 in a different scheme.
 

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -102,7 +102,7 @@ Python Boolean scalar.
    :exclude-members: __init__
 
 Integer types
-~~~~~~~~~~~~~
+-------------
 
 .. autoclass:: numpy.integer
    :members: __init__
@@ -114,7 +114,7 @@ Integer types
    be subject to :ref:`overflow-errors`.
 
 Signed integer types
-++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: numpy.signedinteger
    :members: __init__
@@ -141,7 +141,7 @@ Signed integer types
    :exclude-members: __init__
 
 Unsigned integer types
-++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: numpy.unsignedinteger
    :members: __init__
@@ -168,7 +168,7 @@ Unsigned integer types
    :exclude-members: __init__
 
 Inexact types
-~~~~~~~~~~~~~
+-------------
 
 .. autoclass:: numpy.inexact
    :members: __init__
@@ -209,7 +209,7 @@ Inexact types
        (0.1, 0.1, 0.1)
 
 Floating-point types
-++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: numpy.floating
    :members: __init__
@@ -232,7 +232,7 @@ Floating-point types
    :exclude-members: __init__
 
 Complex floating-point types
-++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: numpy.complexfloating
    :members: __init__
@@ -251,7 +251,7 @@ Complex floating-point types
    :exclude-members: __init__
 
 Other types
-~~~~~~~~~~~
+-----------
 
 .. autoclass:: numpy.bool_
    :members: __init__
@@ -321,7 +321,7 @@ elements the data type consists of.)
 .. _sized-aliases:
 
 Sized aliases
-~~~~~~~~~~~~~
+-------------
 
 Along with their (mostly)
 C-derived names, the integer, float, and complex data-types are also
@@ -402,7 +402,7 @@ are also provided.
    The existence of these aliases depends on the platform.
 
 Other aliases
-~~~~~~~~~~~~~
+-------------
 
 The first two of these are conveniences which resemble the names of the
 builtin types, in the same style as `bool_`, `int_`, `str_`, `bytes_`, and

--- a/doc/source/reference/distutils_status_migration.rst
+++ b/doc/source/reference/distutils_status_migration.rst
@@ -36,7 +36,7 @@ can also consider switching to ``setuptools``. Note that most functionality of
 
 
 Moving to Meson
-```````````````
+~~~~~~~~~~~~~~~
 
 SciPy is moving to Meson for its 1.9.0 release, planned for July 2022. During
 this process, any remaining issues with Meson's Python support and achieving
@@ -56,7 +56,7 @@ migration is done.
 
 
 Moving to CMake / scikit-build
-``````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See the `scikit-build documentation <https://scikit-build.readthedocs.io/en/latest/>`__
 for how to use scikit-build. Please note that as of Feb 2022, scikit-build
@@ -69,7 +69,7 @@ mid-2023.  For more details on this, see
 
 
 Moving to ``setuptools``
-````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 For projects that only use ``numpy.distutils`` for historical reasons, and do
 not actually use features beyond those that ``setuptools`` also supports,

--- a/doc/source/reference/swig.interface-file.rst
+++ b/doc/source/reference/swig.interface-file.rst
@@ -235,7 +235,7 @@ the buffer pointer.  Names with ``FARRAY`` are for Fortran-ordered
 arrays, and names with ``ARRAY`` are for C-ordered (or 1D arrays).
 
 Input Arrays
-````````````
+~~~~~~~~~~~~
 
 Input arrays are defined as arrays of data that are passed into a
 routine but are not altered in-place or returned to the user.  The
@@ -279,7 +279,7 @@ one-dimensional arrays with hard-coded dimensions.  Likewise,
 with hard-coded dimensions, and similarly for three-dimensional.
 
 In-Place Arrays
-```````````````
+~~~~~~~~~~~~~~~
 
 In-place arrays are defined as arrays that are modified in-place.  The
 input values may or may not be used, but the values at the time the
@@ -332,7 +332,7 @@ ND:
 
 
 Argout Arrays
-`````````````
+~~~~~~~~~~~~~
 
 Argout arrays are arrays that appear in the input arguments in C, but
 are in fact output arrays.  This pattern occurs often when there is
@@ -376,7 +376,7 @@ cannot be avoided.  Note that for these types of 1D typemaps, the
 Python function will take a single argument representing ``DIM1``.
 
 Argout View Arrays
-``````````````````
+~~~~~~~~~~~~~~~~~~
 
 Argoutview arrays are for when your C code provides you with a view of
 its internal data and does not require any memory to be allocated by
@@ -424,7 +424,7 @@ Note that arrays with hard-coded dimensions are not supported.  These
 cannot follow the double pointer signatures of these typemaps.
 
 Memory Managed Argout View Arrays
-`````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A recent addition to ``numpy.i`` are typemaps that permit argout
 arrays with views into memory that is managed.  See the discussion `here
@@ -458,7 +458,7 @@ arrays with views into memory that is managed.  See the discussion `here
 
 
 Output Arrays
-`````````````
+~~~~~~~~~~~~~
 
 The ``numpy.i`` interface file does not support typemaps for output
 arrays, for several reasons.  First, C/C++ return arguments are
@@ -479,7 +479,7 @@ function to be wrapped, either with ``%extend`` for the case of class
 methods or ``%ignore`` and ``%rename`` for the case of functions.
 
 Other Common Types: bool
-````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Note that C++ type ``bool`` is not supported in the list in the
 `Available Typemaps`_ section.  NumPy bools are a single byte, while
@@ -497,7 +497,7 @@ to fix the data length problem, and `Input Arrays`_ will work fine,
 but `In-Place Arrays`_ might fail type-checking.
 
 Other Common Types: complex
-```````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Typemap conversions for complex floating-point types is also not
 supported automatically.  This is because Python and NumPy are
@@ -566,7 +566,7 @@ be fixed.  It is suggested that you do this anyway, as it only
 increases the capabilities of your Python interface.
 
 Why is There a Second File?
-```````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `SWIG`_ type checking and conversion system is a complicated
 combination of C macros, `SWIG`_ macros, `SWIG`_ typemaps and `SWIG`_
@@ -604,7 +604,7 @@ in your code using::
 in your `SWIG`_ interface file.
 
 Macros
-``````
+~~~~~~
 
   **is_array(a)**
     Evaluates as true if ``a`` is non-``NULL`` and can be cast to a
@@ -667,7 +667,7 @@ Macros
     Evaluates as true if ``a`` is FORTRAN ordered.
 
 Routines
-````````
+~~~~~~~~
 
   **pytype_string()**
 
@@ -916,7 +916,7 @@ There are many C or C++ array/NumPy array situations not covered by
 a simple ``%include "numpy.i"`` and subsequent ``%apply`` directives.
 
 A Common Example
-````````````````
+~~~~~~~~~~~~~~~~
 
 Consider a reasonable prototype for a dot product function::
 
@@ -974,7 +974,7 @@ above for ``my_dot`` to get the behavior we want (note that
 macro to perform this task.
 
 Other Situations
-````````````````
+~~~~~~~~~~~~~~~~
 
 There are other wrapping situations in which ``numpy.i`` may be
 helpful when you encounter them.
@@ -1007,7 +1007,7 @@ helpful when you encounter them.
     `Swig-user <mailto:Swig-user@lists.sourceforge.net>`_ mail lists.
 
 A Final Note
-````````````
+~~~~~~~~~~~~
 
 When you use the ``%apply`` directive, as is usually necessary to use
 ``numpy.i``, it will remain in effect until you tell `SWIG`_ that it

--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -82,6 +82,7 @@ you create the array.
 
 2) Intrinsic NumPy array creation functions
 ===========================================
+
 ..
   40 functions seems like a small number, but the routies.array-creation
   has ~47. I'm sure there are more. 

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -710,7 +710,7 @@ Slicing can be combined with broadcasted boolean indices::
 .. _arrays.indexing.fields:
 
 Field access
--------------
+------------
 
 .. seealso:: :ref:`structured_arrays`
 

--- a/doc/source/user/basics.rec.rst
+++ b/doc/source/user/basics.rec.rst
@@ -300,7 +300,7 @@ There are a number of ways to assign values to a structured array: Using python
 tuples, using scalar values, or using other structured arrays.
 
 Assignment from Python Native Types (Tuples)
-````````````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The simplest way to assign values to a structured array is using python tuples.
 Each assigned value should be a tuple of length equal to the number of fields
@@ -315,7 +315,7 @@ of the array, from left to right::
       dtype=[('f0', '<i8'), ('f1', '<f4'), ('f2', '<f8')])
 
 Assignment from Scalars
-```````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~
 
 A scalar assigned to a structured element will be assigned to all fields. This
 happens when a scalar is assigned to a structured array, or when an
@@ -343,7 +343,7 @@ structured datatype has just a single field::
  TypeError: Cannot cast array data from dtype([('A', '<i4'), ('B', '<i4')]) to dtype('int32') according to the rule 'unsafe'
 
 Assignment from other Structured Arrays
-```````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assignment between two structured arrays occurs as if the source elements had
 been converted to tuples and then assigned to the destination elements. That
@@ -362,7 +362,7 @@ included in any of the fields are unaffected. ::
 
 
 Assignment involving subarrays
-``````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When assigning to fields which are subarrays, the assigned value will first be
 broadcast to the shape of the subarray.
@@ -371,7 +371,7 @@ Indexing Structured Arrays
 --------------------------
 
 Accessing Individual Fields
-```````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Individual fields of a structured array may be accessed and modified by indexing
 the array with the field name. ::
@@ -409,7 +409,7 @@ are appended to the shape of the result::
    (2, 2, 3, 3)
 
 Accessing Multiple Fields
-```````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 One can index and assign to a structured array with a multi-field index, where
 the index is a list of field names.
@@ -502,7 +502,7 @@ multi-field indexes::
  >>> a[['a', 'c']] = a[['c', 'a']]
 
 Indexing with an Integer to get a Structured Scalar
-```````````````````````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Indexing a single element of a structured array (with an integer index) returns
 a structured scalar::

--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -49,7 +49,7 @@ Adding a dependency on NumPy
 ----------------------------
 
 Build-time dependency
-`````````````````````
+~~~~~~~~~~~~~~~~~~~~~
 
 If a package either uses the NumPy C API directly or it uses some other tool
 that depends on it like Cython or Pythran, NumPy is a *build-time* dependency
@@ -107,7 +107,7 @@ releases from breaking your packages on PyPI.
 
 
 Runtime dependency & version ranges
-```````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 NumPy itself and many core scientific Python packages have agreed on a schedule
 for dropping support for old Python and NumPy versions: :ref:`NEP29`. We

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -287,7 +287,7 @@ def inner(a, b):
 
         np.inner(a, b) = sum(a[:]*b[:])
 
-    More generally, if `ndim(a) = r > 0` and `ndim(b) = s > 0`::
+    More generally, if ``ndim(a) = r > 0`` and ``ndim(b) = s > 0``::
 
         np.inner(a, b) = np.tensordot(a, b, axes=(-1,-1))
 


### PR DESCRIPTION
This contains various RST reformatting.
One, moving `(C)` one line up, is specific to a bug in tree-sitter-rst
that mis-parses this section. Another is adding one black line for a
similar reason where `..` is seen as section underline by
tree-sitter-rst.

There is some shuffling of section underline: try to be consistent,
`=`, then `-`, then `~`, with this refactor there is also no more
sections that use backticks as underline.

Note in particular that non-consitency of underline lead to a problem in
datetime64 section where "weekmasks" (underlined with `-`) were actually
a level-4 heading instead of a level 2 or 3 I guess, and thus were
nested under the `busday_count()` section.

You'll note also 2 formulas that are under double-quotes as they are not
references.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
