### PR TITLE
MAINT: Change array API unique_*() functions to not compare nans as equal

### DIFF
--- a/numpy/array_api/_set_functions.py
+++ b/numpy/array_api/_set_functions.py
@@ -46,6 +46,7 @@ def unique_all(x: Array, /) -> UniqueAllResult:
         return_counts=True,
         return_index=True,
         return_inverse=True,
+        equal_nan=False,
     )
     # np.unique() flattens inverse indices, but they need to share x's shape
     # See https://github.com/numpy/numpy/issues/20638
@@ -64,6 +65,7 @@ def unique_counts(x: Array, /) -> UniqueCountsResult:
         return_counts=True,
         return_index=False,
         return_inverse=False,
+        equal_nan=False,
     )
 
     return UniqueCountsResult(*[Array._new(i) for i in res])
@@ -80,6 +82,7 @@ def unique_inverse(x: Array, /) -> UniqueInverseResult:
         return_counts=False,
         return_index=False,
         return_inverse=True,
+        equal_nan=False,
     )
     # np.unique() flattens inverse indices, but they need to share x's shape
     # See https://github.com/numpy/numpy/issues/20638
@@ -98,5 +101,6 @@ def unique_values(x: Array, /) -> Array:
         return_counts=False,
         return_index=False,
         return_inverse=False,
+        equal_nan=False,
     )
     return Array._new(res)


### PR DESCRIPTION
The spec requires this, but it is only now possible to implement with the new
equal_nan flag in np.unique().

CC @leofang 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
