### PR TITLE
MAINT,ENH: Rename all dispatchers as well as possible

### DIFF
--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -15,8 +15,11 @@ __all__ = ["require"]
 
 
 
-def _require_dispatcher(a, dtype=None, requirements=None, *, like=None):
+def require(a, dtype=None, requirements=None, *, like=None):
     return (like,)
+
+# Need the dispatcher after defining the real function currently:
+_require_dispatcher = require
 
 
 @set_array_function_like_doc

--- a/numpy/core/arrayprint.py
+++ b/numpy/core/arrayprint.py
@@ -549,7 +549,7 @@ def _array2string(a, options, separator=' ', prefix=""):
     return lst
 
 
-def _array2string_dispatcher(
+def array2string(
         a, max_line_width=None, precision=None,
         suppress_small=None, separator=None, prefix=None,
         style=None, formatter=None, threshold=None,
@@ -558,7 +558,7 @@ def _array2string_dispatcher(
     return (a,)
 
 
-@array_function_dispatch(_array2string_dispatcher, module='numpy')
+@array_function_dispatch(array2string, module='numpy')
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
                  style=np._NoValue, formatter=None, threshold=None,
@@ -1511,12 +1511,12 @@ def _array_repr_implementation(
     return arr_str + spacer + dtype_str
 
 
-def _array_repr_dispatcher(
+def array_repr(
         arr, max_line_width=None, precision=None, suppress_small=None):
     return (arr,)
 
 
-@array_function_dispatch(_array_repr_dispatcher, module='numpy')
+@array_function_dispatch(array_repr, module='numpy')
 def array_repr(arr, max_line_width=None, precision=None, suppress_small=None):
     """
     Return the string representation of an array.
@@ -1592,12 +1592,12 @@ def _array_str_implementation(
     return array2string(a, max_line_width, precision, suppress_small, ' ', "")
 
 
-def _array_str_dispatcher(
+def array_str(
         a, max_line_width=None, precision=None, suppress_small=None):
     return (a,)
 
 
-@array_function_dispatch(_array_str_dispatcher, module='numpy')
+@array_function_dispatch(array_str, module='numpy')
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     """
     Return a string representation of the data in an array.

--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -93,8 +93,12 @@ def _get_num_chars(a):
     return a.itemsize
 
 
-def _binary_op_dispatcher(x1, x2):
+def binary_operation(x1, x2):
     return (x1, x2)
+
+# Rename the dispatcher to hide it (we want the nicer name for the error):
+_binary_op_dispatcher = binary_operation
+del binary_operation
 
 
 @array_function_dispatch(_binary_op_dispatcher)
@@ -254,8 +258,12 @@ def less(x1, x2):
     return compare_chararrays(x1, x2, '<', True)
 
 
-def _unary_op_dispatcher(a):
+def unary_operation(a):
     return (a,)
+
+
+_unary_op_dispatcher = unary_operation
+del unary_operation
 
 
 @array_function_dispatch(_unary_op_dispatcher)
@@ -310,11 +318,11 @@ def add(x1, x2):
     return _vec_string(arr1, (dtype, out_size), '__add__', (arr2,))
 
 
-def _multiply_dispatcher(a, i):
+def multiply(a, i):
     return (a,)
 
 
-@array_function_dispatch(_multiply_dispatcher)
+@array_function_dispatch(multiply)
 def multiply(a, i):
     """
     Return (a * i), that is string multiple concatenation,
@@ -344,11 +352,11 @@ def multiply(a, i):
         a_arr, (a_arr.dtype.type, out_size), '__mul__', (i_arr,))
 
 
-def _mod_dispatcher(a, values):
+def mod(a, values):
     return (a, values)
 
 
-@array_function_dispatch(_mod_dispatcher)
+@array_function_dispatch(mod)
 def mod(a, values):
     """
     Return (a % i), that is pre-Python 2.6 string formatting
@@ -415,11 +423,11 @@ def capitalize(a):
     return _vec_string(a_arr, a_arr.dtype, 'capitalize')
 
 
-def _center_dispatcher(a, width, fillchar=None):
+def center(a, width, fillchar=None):
     return (a,)
 
 
-@array_function_dispatch(_center_dispatcher)
+@array_function_dispatch(center)
 def center(a, width, fillchar=' '):
     """
     Return a copy of `a` with its elements centered in a string of
@@ -456,8 +464,12 @@ def center(a, width, fillchar=' '):
         a_arr, (a_arr.dtype.type, size), 'center', (width_arr, fillchar))
 
 
-def _count_dispatcher(a, sub, start=None, end=None):
+def find_or_count(a, sub, start=None, end=None):
     return (a,)
+
+
+_count_dispatcher = find_or_count
+del find_or_count
 
 
 @array_function_dispatch(_count_dispatcher)
@@ -506,11 +518,11 @@ def count(a, sub, start=0, end=None):
     return _vec_string(a, int_, 'count', [sub, start] + _clean_args(end))
 
 
-def _code_dispatcher(a, encoding=None, errors=None):
+def decode(a, encoding=None, errors=None):
     return (a,)
 
 
-@array_function_dispatch(_code_dispatcher)
+@array_function_dispatch(decode)
 def decode(a, encoding=None, errors=None):
     """
     Calls `str.decode` element-wise.
@@ -556,7 +568,11 @@ def decode(a, encoding=None, errors=None):
         _vec_string(a, object_, 'decode', _clean_args(encoding, errors)))
 
 
-@array_function_dispatch(_code_dispatcher)
+def encode(a, encoding=None, errors=None):
+    return (a,)
+
+
+@array_function_dispatch(encode)
 def encode(a, encoding=None, errors=None):
     """
     Calls `str.encode` element-wise.
@@ -592,11 +608,11 @@ def encode(a, encoding=None, errors=None):
         _vec_string(a, object_, 'encode', _clean_args(encoding, errors)))
 
 
-def _endswith_dispatcher(a, suffix, start=None, end=None):
+def endswith(a, suffix, start=None, end=None):
     return (a,)
 
 
-@array_function_dispatch(_endswith_dispatcher)
+@array_function_dispatch(endswith)
 def endswith(a, suffix, start=0, end=None):
     """
     Returns a boolean array which is `True` where the string element
@@ -640,11 +656,11 @@ def endswith(a, suffix, start=0, end=None):
         a, bool_, 'endswith', [suffix, start] + _clean_args(end))
 
 
-def _expandtabs_dispatcher(a, tabsize=None):
+def expandtabs(a, tabsize=None):
     return (a,)
 
 
-@array_function_dispatch(_expandtabs_dispatcher)
+@array_function_dispatch(expandtabs)
 def expandtabs(a, tabsize=8):
     """
     Return a copy of each string element where all tab characters are
@@ -930,11 +946,11 @@ def isupper(a):
     return _vec_string(a, bool_, 'isupper')
 
 
-def _join_dispatcher(sep, seq):
+def join(sep, seq):
     return (sep, seq)
 
 
-@array_function_dispatch(_join_dispatcher)
+@array_function_dispatch(join)
 def join(sep, seq):
     """
     Return a string which is the concatenation of the strings in the
@@ -961,11 +977,11 @@ def join(sep, seq):
 
 
 
-def _just_dispatcher(a, width, fillchar=None):
+def ljust(a, width, fillchar=None):
     return (a,)
 
 
-@array_function_dispatch(_just_dispatcher)
+@array_function_dispatch(ljust)
 def ljust(a, width, fillchar=' '):
     """
     Return an array with the elements of `a` left-justified in a
@@ -1036,11 +1052,11 @@ def lower(a):
     return _vec_string(a_arr, a_arr.dtype, 'lower')
 
 
-def _strip_dispatcher(a, chars=None):
+def lstrip(a, chars=None):
     return (a,)
 
 
-@array_function_dispatch(_strip_dispatcher)
+@array_function_dispatch(lstrip)
 def lstrip(a, chars=None):
     """
     For each element in `a`, return a copy with the leading characters
@@ -1095,11 +1111,13 @@ def lstrip(a, chars=None):
     return _vec_string(a_arr, a_arr.dtype, 'lstrip', (chars,))
 
 
-def _partition_dispatcher(a, sep):
+def partition(a, sep):
     return (a,)
 
+_partition_dispatcher = partition  # also used by rpartition
 
-@array_function_dispatch(_partition_dispatcher)
+
+@array_function_dispatch(partition)
 def partition(a, sep):
     """
     Partition each element in `a` around `sep`.
@@ -1135,11 +1153,11 @@ def partition(a, sep):
         _vec_string(a, object_, 'partition', (sep,)))
 
 
-def _replace_dispatcher(a, old, new, count=None):
+def replace(a, old, new, count=None):
     return (a,)
 
 
-@array_function_dispatch(_replace_dispatcher)
+@array_function_dispatch(replace)
 def replace(a, old, new, count=None):
     """
     For each element in `a`, return a copy of the string with all
@@ -1235,7 +1253,11 @@ def rindex(a, sub, start=0, end=None):
         a, int_, 'rindex', [sub, start] + _clean_args(end))
 
 
-@array_function_dispatch(_just_dispatcher)
+def rjust(a, width, fillchar=None):
+    return (a,)
+
+
+@array_function_dispatch(rjust)
 def rjust(a, width, fillchar=' '):
     """
     Return an array with the elements of `a` right-justified in a
@@ -1307,11 +1329,11 @@ def rpartition(a, sep):
         _vec_string(a, object_, 'rpartition', (sep,)))
 
 
-def _split_dispatcher(a, sep=None, maxsplit=None):
+def rsplit(a, sep=None, maxsplit=None):
     return (a,)
 
 
-@array_function_dispatch(_split_dispatcher)
+@array_function_dispatch(rsplit)
 def rsplit(a, sep=None, maxsplit=None):
     """
     For each element in `a`, return a list of the words in the
@@ -1349,11 +1371,11 @@ def rsplit(a, sep=None, maxsplit=None):
         a, object_, 'rsplit', [sep] + _clean_args(maxsplit))
 
 
-def _strip_dispatcher(a, chars=None):
+def rstrip(a, chars=None):
     return (a,)
 
 
-@array_function_dispatch(_strip_dispatcher)
+@array_function_dispatch(rstrip)
 def rstrip(a, chars=None):
     """
     For each element in `a`, return a copy with the trailing
@@ -1398,7 +1420,11 @@ def rstrip(a, chars=None):
     return _vec_string(a_arr, a_arr.dtype, 'rstrip', (chars,))
 
 
-@array_function_dispatch(_split_dispatcher)
+def split(a, sep=None, maxsplit=None):
+    return (a,)
+
+
+@array_function_dispatch(split)
 def split(a, sep=None, maxsplit=None):
     """
     For each element in `a`, return a list of the words in the
@@ -1433,11 +1459,11 @@ def split(a, sep=None, maxsplit=None):
         a, object_, 'split', [sep] + _clean_args(maxsplit))
 
 
-def _splitlines_dispatcher(a, keepends=None):
+def splitlines(a, keepends=None):
     return (a,)
 
 
-@array_function_dispatch(_splitlines_dispatcher)
+@array_function_dispatch(splitlines)
 def splitlines(a, keepends=None):
     """
     For each element in `a`, return a list of the lines in the
@@ -1467,11 +1493,11 @@ def splitlines(a, keepends=None):
         a, object_, 'splitlines', _clean_args(keepends))
 
 
-def _startswith_dispatcher(a, prefix, start=None, end=None):
+def startswith(a, prefix, start=None, end=None):
     return (a,)
 
 
-@array_function_dispatch(_startswith_dispatcher)
+@array_function_dispatch(startswith)
 def startswith(a, prefix, start=0, end=None):
     """
     Returns a boolean array which is `True` where the string element
@@ -1503,7 +1529,11 @@ def startswith(a, prefix, start=0, end=None):
         a, bool_, 'startswith', [prefix, start] + _clean_args(end))
 
 
-@array_function_dispatch(_strip_dispatcher)
+def strip(a, chars=None):
+    return (a,)
+
+
+@array_function_dispatch(strip)
 def strip(a, chars=None):
     """
     For each element in `a`, return a copy with the leading and
@@ -1626,11 +1656,11 @@ def title(a):
     return _vec_string(a_arr, a_arr.dtype, 'title')
 
 
-def _translate_dispatcher(a, table, deletechars=None):
+def translate(a, table, deletechars=None):
     return (a,)
 
 
-@array_function_dispatch(_translate_dispatcher)
+@array_function_dispatch(translate)
 def translate(a, table, deletechars=None):
     """
     For each element in `a`, return a copy of the string where all
@@ -1702,11 +1732,11 @@ def upper(a):
     return _vec_string(a_arr, a_arr.dtype, 'upper')
 
 
-def _zfill_dispatcher(a, width):
+def zfill(a, width):
     return (a,)
 
 
-@array_function_dispatch(_zfill_dispatcher)
+@array_function_dispatch(zfill)
 def zfill(a, width):
     """
     Return the numeric string left-filled with zeros

--- a/numpy/core/einsumfunc.py
+++ b/numpy/core/einsumfunc.py
@@ -693,7 +693,7 @@ def _parse_einsum_input(operands):
     return (input_subscripts, output_subscript, operands)
 
 
-def _einsum_path_dispatcher(*operands, optimize=None, einsum_call=None):
+def einsum_path(*operands, optimize=None, einsum_call=None):
     # NOTE: technically, we should only dispatch on array-like arguments, not
     # subscripts (given as strings). But separating operands into
     # arrays/subscripts is a little tricky/slow (given einsum's two supported
@@ -703,7 +703,7 @@ def _einsum_path_dispatcher(*operands, optimize=None, einsum_call=None):
     return operands
 
 
-@array_function_dispatch(_einsum_path_dispatcher, module='numpy')
+@array_function_dispatch(einsum_path, module='numpy')
 def einsum_path(*operands, optimize='greedy', einsum_call=False):
     """
     einsum_path(subscripts, *operands, optimize='greedy')
@@ -998,7 +998,7 @@ def einsum_path(*operands, optimize='greedy', einsum_call=False):
     return (path, path_print)
 
 
-def _einsum_dispatcher(*operands, out=None, optimize=None, **kwargs):
+def einsum(*operands, out=None, optimize=None, **kwargs):
     # Arguably we dispatch on more arguments than we really should; see note in
     # _einsum_path_dispatcher for why.
     yield from operands
@@ -1006,7 +1006,7 @@ def _einsum_dispatcher(*operands, out=None, optimize=None, **kwargs):
 
 
 # Rewrite einsum to handle different cases
-@array_function_dispatch(_einsum_dispatcher, module='numpy')
+@array_function_dispatch(einsum, module='numpy')
 def einsum(*operands, out=None, optimize=False, **kwargs):
     """
     einsum(subscripts, *operands, out=None, dtype=None, order='K',

--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -86,11 +86,11 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
 
 
-def _take_dispatcher(a, indices, axis=None, out=None, mode=None):
+def take(a, indices, axis=None, out=None, mode=None):
     return (a, out)
 
 
-@array_function_dispatch(_take_dispatcher)
+@array_function_dispatch(take)
 def take(a, indices, axis=None, out=None, mode='raise'):
     """
     Take elements from an array along an axis.
@@ -190,12 +190,12 @@ def take(a, indices, axis=None, out=None, mode='raise'):
     return _wrapfunc(a, 'take', indices, axis=axis, out=out, mode=mode)
 
 
-def _reshape_dispatcher(a, newshape, order=None):
+def reshape(a, newshape, order=None):
     return (a,)
 
 
 # not deprecated --- copy if necessary, view otherwise
-@array_function_dispatch(_reshape_dispatcher)
+@array_function_dispatch(reshape)
 def reshape(a, newshape, order='C'):
     """
     Gives a new shape to an array without changing its data.
@@ -298,13 +298,13 @@ def reshape(a, newshape, order='C'):
     return _wrapfunc(a, 'reshape', newshape, order=order)
 
 
-def _choose_dispatcher(a, choices, out=None, mode=None):
+def choose(a, choices, out=None, mode=None):
     yield a
     yield from choices
     yield out
 
 
-@array_function_dispatch(_choose_dispatcher)
+@array_function_dispatch(choose)
 def choose(a, choices, out=None, mode='raise'):
     """
     Construct an array from an index array and a list of arrays to choose from.
@@ -429,11 +429,11 @@ def choose(a, choices, out=None, mode='raise'):
     return _wrapfunc(a, 'choose', choices, out=out, mode=mode)
 
 
-def _repeat_dispatcher(a, repeats, axis=None):
+def repeat(a, repeats, axis=None):
     return (a,)
 
 
-@array_function_dispatch(_repeat_dispatcher)
+@array_function_dispatch(repeat)
 def repeat(a, repeats, axis=None):
     """
     Repeat elements of an array.
@@ -479,11 +479,11 @@ def repeat(a, repeats, axis=None):
     return _wrapfunc(a, 'repeat', repeats, axis=axis)
 
 
-def _put_dispatcher(a, ind, v, mode=None):
+def put(a, ind, v, mode=None):
     return (a, ind, v)
 
 
-@array_function_dispatch(_put_dispatcher)
+@array_function_dispatch(put)
 def put(a, ind, v, mode='raise'):
     """
     Replaces specified elements of an array with given values.
@@ -543,11 +543,11 @@ def put(a, ind, v, mode='raise'):
     return put(ind, v, mode=mode)
 
 
-def _swapaxes_dispatcher(a, axis1, axis2):
+def swapaxes(a, axis1, axis2):
     return (a,)
 
 
-@array_function_dispatch(_swapaxes_dispatcher)
+@array_function_dispatch(swapaxes)
 def swapaxes(a, axis1, axis2):
     """
     Interchange two axes of an array.
@@ -594,11 +594,11 @@ def swapaxes(a, axis1, axis2):
     return _wrapfunc(a, 'swapaxes', axis1, axis2)
 
 
-def _transpose_dispatcher(a, axes=None):
+def transpose(a, axes=None):
     return (a,)
 
 
-@array_function_dispatch(_transpose_dispatcher)
+@array_function_dispatch(transpose)
 def transpose(a, axes=None):
     """
     Reverse or permute the axes of an array; returns the modified array.
@@ -660,11 +660,11 @@ def transpose(a, axes=None):
     return _wrapfunc(a, 'transpose', axes)
 
 
-def _partition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def partition(a, kth, axis=None, kind=None, order=None):
     return (a,)
 
 
-@array_function_dispatch(_partition_dispatcher)
+@array_function_dispatch(partition)
 def partition(a, kth, axis=-1, kind='introselect', order=None):
     """
     Return a partitioned copy of an array.
@@ -759,11 +759,11 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
     return a
 
 
-def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def argpartition(a, kth, axis=None, kind=None, order=None):
     return (a,)
 
 
-@array_function_dispatch(_argpartition_dispatcher)
+@array_function_dispatch(argpartition)
 def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     """
     Perform an indirect partition along the given axis using the
@@ -845,11 +845,11 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
     return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
 
 
-def _sort_dispatcher(a, axis=None, kind=None, order=None):
+def sort(a, axis=None, kind=None, order=None):
     return (a,)
 
 
-@array_function_dispatch(_sort_dispatcher)
+@array_function_dispatch(sort)
 def sort(a, axis=-1, kind=None, order=None):
     """
     Return a sorted copy of an array.
@@ -1005,11 +1005,11 @@ def sort(a, axis=-1, kind=None, order=None):
     return a
 
 
-def _argsort_dispatcher(a, axis=None, kind=None, order=None):
+def argsort(a, axis=None, kind=None, order=None):
     return (a,)
 
 
-@array_function_dispatch(_argsort_dispatcher)
+@array_function_dispatch(argsort)
 def argsort(a, axis=-1, kind=None, order=None):
     """
     Returns the indices that would sort an array.
@@ -1120,11 +1120,11 @@ def argsort(a, axis=-1, kind=None, order=None):
     return _wrapfunc(a, 'argsort', axis=axis, kind=kind, order=order)
 
 
-def _argmax_dispatcher(a, axis=None, out=None, *, keepdims=np._NoValue):
+def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     return (a, out)
 
 
-@array_function_dispatch(_argmax_dispatcher)
+@array_function_dispatch(argmax)
 def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Returns the indices of the maximum values along an axis.
@@ -1216,11 +1216,11 @@ def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     return _wrapfunc(a, 'argmax', axis=axis, out=out, **kwds)
 
 
-def _argmin_dispatcher(a, axis=None, out=None, *, keepdims=np._NoValue):
+def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     return (a, out)
 
 
-@array_function_dispatch(_argmin_dispatcher)
+@array_function_dispatch(argmin)
 def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Returns the indices of the minimum values along an axis.
@@ -1312,11 +1312,11 @@ def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     return _wrapfunc(a, 'argmin', axis=axis, out=out, **kwds)
 
 
-def _searchsorted_dispatcher(a, v, side=None, sorter=None):
+def searchsorted(a, v, side=None, sorter=None):
     return (a, v, sorter)
 
 
-@array_function_dispatch(_searchsorted_dispatcher)
+@array_function_dispatch(searchsorted)
 def searchsorted(a, v, side='left', sorter=None):
     """
     Find indices where elements should be inserted to maintain order.
@@ -1387,11 +1387,11 @@ def searchsorted(a, v, side='left', sorter=None):
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)
 
 
-def _resize_dispatcher(a, new_shape):
+def resize(a, new_shape):
     return (a,)
 
 
-@array_function_dispatch(_resize_dispatcher)
+@array_function_dispatch(resize)
 def resize(a, new_shape):
     """
     Return a new array with the specified shape.
@@ -1471,11 +1471,11 @@ def resize(a, new_shape):
     return reshape(a, new_shape)
 
 
-def _squeeze_dispatcher(a, axis=None):
+def squeeze(a, axis=None):
     return (a,)
 
 
-@array_function_dispatch(_squeeze_dispatcher)
+@array_function_dispatch(squeeze)
 def squeeze(a, axis=None):
     """
     Remove axes of length one from `a`.
@@ -1545,11 +1545,11 @@ def squeeze(a, axis=None):
         return squeeze(axis=axis)
 
 
-def _diagonal_dispatcher(a, offset=None, axis1=None, axis2=None):
+def diagonal(a, offset=None, axis1=None, axis2=None):
     return (a,)
 
 
-@array_function_dispatch(_diagonal_dispatcher)
+@array_function_dispatch(diagonal)
 def diagonal(a, offset=0, axis1=0, axis2=1):
     """
     Return specified diagonals.
@@ -1679,12 +1679,11 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
         return asanyarray(a).diagonal(offset=offset, axis1=axis1, axis2=axis2)
 
 
-def _trace_dispatcher(
-        a, offset=None, axis1=None, axis2=None, dtype=None, out=None):
+def trace(a, offset=None, axis1=None, axis2=None, dtype=None, out=None):
     return (a, out)
 
 
-@array_function_dispatch(_trace_dispatcher)
+@array_function_dispatch(trace)
 def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     """
     Return the sum along diagonals of the array.
@@ -1748,11 +1747,11 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         return asanyarray(a).trace(offset=offset, axis1=axis1, axis2=axis2, dtype=dtype, out=out)
 
 
-def _ravel_dispatcher(a, order=None):
+def ravel(a, order=None):
     return (a,)
 
 
-@array_function_dispatch(_ravel_dispatcher)
+@array_function_dispatch(ravel)
 def ravel(a, order='C'):
     """Return a contiguous flattened array.
 
@@ -1859,11 +1858,11 @@ def ravel(a, order='C'):
         return asanyarray(a).ravel(order=order)
 
 
-def _nonzero_dispatcher(a):
+def nonzero(a):
     return (a,)
 
 
-@array_function_dispatch(_nonzero_dispatcher)
+@array_function_dispatch(nonzero)
 def nonzero(a):
     """
     Return the indices of the elements that are non-zero.
@@ -1958,11 +1957,11 @@ def nonzero(a):
     return _wrapfunc(a, 'nonzero')
 
 
-def _shape_dispatcher(a):
+def shape(a):
     return (a,)
 
 
-@array_function_dispatch(_shape_dispatcher)
+@array_function_dispatch(shape)
 def shape(a):
     """
     Return the shape of an array.
@@ -2010,11 +2009,11 @@ def shape(a):
     return result
 
 
-def _compress_dispatcher(condition, a, axis=None, out=None):
+def compress(condition, a, axis=None, out=None):
     return (condition, a, out)
 
 
-@array_function_dispatch(_compress_dispatcher)
+@array_function_dispatch(compress)
 def compress(condition, a, axis=None, out=None):
     """
     Return selected slices of an array along given axis.
@@ -2078,11 +2077,11 @@ def compress(condition, a, axis=None, out=None):
     return _wrapfunc(a, 'compress', condition, axis=axis, out=out)
 
 
-def _clip_dispatcher(a, a_min, a_max, out=None, **kwargs):
+def clip(a, a_min, a_max, out=None, **kwargs):
     return (a, a_min, a_max)
 
 
-@array_function_dispatch(_clip_dispatcher)
+@array_function_dispatch(clip)
 def clip(a, a_min, a_max, out=None, **kwargs):
     """
     Clip (limit) the values in an array.
@@ -2154,12 +2153,12 @@ def clip(a, a_min, a_max, out=None, **kwargs):
     return _wrapfunc(a, 'clip', a_min, a_max, out=out, **kwargs)
 
 
-def _sum_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                    initial=None, where=None):
+def sum(a, axis=None, dtype=None, out=None, keepdims=None,
+        initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_sum_dispatcher)
+@array_function_dispatch(sum)
 def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
         initial=np._NoValue, where=np._NoValue):
     """
@@ -2299,9 +2298,10 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                           initial=initial, where=where)
 
 
-def _any_dispatcher(a, axis=None, out=None, keepdims=None, *,
-                    where=np._NoValue):
+def any(a, axis=None, out=None, keepdims=None, *, where=np._NoValue):
     return (a, where, out)
+
+_any_dispatcher = any  # dispatcher reused for sometrue
 
 
 @array_function_dispatch(_any_dispatcher)
@@ -2398,12 +2398,13 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
                           keepdims=keepdims, where=where)
 
 
-def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
-                    where=None):
+def all(a, axis=None, out=None, keepdims=None, *, where=None):
     return (a, where, out)
 
+_all_dispatcher = all  # dispatcher reused for alltrue
 
-@array_function_dispatch(_all_dispatcher)
+
+@array_function_dispatch(all)
 def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     """
     Test whether all array elements along a given axis evaluate to True.
@@ -2490,11 +2491,11 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
                           keepdims=keepdims, where=where)
 
 
-def _cumsum_dispatcher(a, axis=None, dtype=None, out=None):
+def cumsum(a, axis=None, dtype=None, out=None):
     return (a, out)
 
 
-@array_function_dispatch(_cumsum_dispatcher)
+@array_function_dispatch(cumsum)
 def cumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of the elements along a given axis.
@@ -2571,11 +2572,11 @@ def cumsum(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumsum', axis=axis, dtype=dtype, out=out)
 
 
-def _ptp_dispatcher(a, axis=None, out=None, keepdims=None):
+def ptp(a, axis=None, out=None, keepdims=None):
     return (a, out)
 
 
-@array_function_dispatch(_ptp_dispatcher)
+@array_function_dispatch(ptp)
 def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     """
     Range of values (maximum - minimum) along an axis.
@@ -2669,12 +2670,11 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     return _methods._ptp(a, axis=axis, out=out, **kwargs)
 
 
-def _amax_dispatcher(a, axis=None, out=None, keepdims=None, initial=None,
-                     where=None):
+def amax(a, axis=None, out=None, keepdims=None, initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_amax_dispatcher)
+@array_function_dispatch(amax)
 def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
          where=np._NoValue):
     """
@@ -2794,12 +2794,11 @@ def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims=keepdims, initial=initial, where=where)
 
 
-def _amin_dispatcher(a, axis=None, out=None, keepdims=None, initial=None,
-                     where=None):
+def amin(a, axis=None, out=None, keepdims=None, initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_amin_dispatcher)
+@array_function_dispatch(amin)
 def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
          where=np._NoValue):
     """
@@ -2919,12 +2918,14 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims=keepdims, initial=initial, where=where)
 
 
-def _prod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                     initial=None, where=None):
+def prod(a, axis=None, dtype=None, out=None, keepdims=None,
+         initial=None, where=None):
     return (a, out)
 
+_prod_dispatcher = prod  # dispatcher reused for product
 
-@array_function_dispatch(_prod_dispatcher)
+
+@array_function_dispatch(prod)
 def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
          initial=np._NoValue, where=np._NoValue):
     """
@@ -3046,11 +3047,13 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                           keepdims=keepdims, initial=initial, where=where)
 
 
-def _cumprod_dispatcher(a, axis=None, dtype=None, out=None):
+def cumprod(a, axis=None, dtype=None, out=None):
     return (a, out)
 
+_cumprod_dispatcher = cumprod  # dispatcher reused for cumproduct
 
-@array_function_dispatch(_cumprod_dispatcher)
+
+@array_function_dispatch(cumprod)
 def cumprod(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative product of elements along a given axis.
@@ -3114,11 +3117,11 @@ def cumprod(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumprod', axis=axis, dtype=dtype, out=out)
 
 
-def _ndim_dispatcher(a):
+def ndim(a):
     return (a,)
 
 
-@array_function_dispatch(_ndim_dispatcher)
+@array_function_dispatch(ndim)
 def ndim(a):
     """
     Return the number of dimensions of an array.
@@ -3156,11 +3159,11 @@ def ndim(a):
         return asarray(a).ndim
 
 
-def _size_dispatcher(a, axis=None):
+def size(a, axis=None):
     return (a,)
 
 
-@array_function_dispatch(_size_dispatcher)
+@array_function_dispatch(size)
 def size(a, axis=None):
     """
     Return the number of elements along a given axis.
@@ -3207,11 +3210,13 @@ def size(a, axis=None):
             return asarray(a).shape[axis]
 
 
-def _around_dispatcher(a, decimals=None, out=None):
+def around(a, decimals=None, out=None):
     return (a, out)
 
+_around_dispatcher = around  # dispatcher reused for round_
 
-@array_function_dispatch(_around_dispatcher)
+
+@array_function_dispatch(around)
 def around(a, decimals=0, out=None):
     """
     Evenly round to the given number of decimals.
@@ -3305,12 +3310,11 @@ def around(a, decimals=0, out=None):
     return _wrapfunc(a, 'round', decimals=decimals, out=out)
 
 
-def _mean_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None, *,
-                     where=None):
+def mean(a, axis=None, dtype=None, out=None, keepdims=None, *, where=None):
     return (a, where, out)
 
 
-@array_function_dispatch(_mean_dispatcher)
+@array_function_dispatch(mean)
 def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
          where=np._NoValue):
     """
@@ -3433,12 +3437,12 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
                           out=out, **kwargs)
 
 
-def _std_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None):
+def std(a, axis=None, dtype=None, out=None, ddof=None,keepdims=None, *,
+        where=None):
     return (a, where, out)
 
 
-@array_function_dispatch(_std_dispatcher)
+@array_function_dispatch(std)
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue):
     """
@@ -3574,12 +3578,12 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
                          **kwargs)
 
 
-def _var_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None):
+def var(a, axis=None, dtype=None, out=None, ddof=None, keepdims=None, *,
+        where=None):
     return (a, where, out)
 
 
-@array_function_dispatch(_var_dispatcher)
+@array_function_dispatch(var)
 def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue):
     """
@@ -3719,7 +3723,7 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
 # Aliases of other functions. These have their own definitions only so that
 # they can have unique docstrings.
 
-@array_function_dispatch(_around_dispatcher)
+@array_function_dispatch(_around_dispatcher, verify=False)
 def round_(a, decimals=0, out=None):
     """
     Round an array to the given number of decimals.

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -15,12 +15,12 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-def _linspace_dispatcher(start, stop, num=None, endpoint=None, retstep=None,
-                         dtype=None, axis=None):
+def linspace(start, stop, num=None, endpoint=None, retstep=None,
+             dtype=None, axis=None):
     return (start, stop)
 
 
-@array_function_dispatch(_linspace_dispatcher)
+@array_function_dispatch(linspace)
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
              axis=0):
     """
@@ -175,12 +175,12 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         return y.astype(dtype, copy=False)
 
 
-def _logspace_dispatcher(start, stop, num=None, endpoint=None, base=None,
-                         dtype=None, axis=None):
+def logspace(start, stop, num=None, endpoint=None, base=None,
+             dtype=None, axis=None):
     return (start, stop)
 
 
-@array_function_dispatch(_logspace_dispatcher)
+@array_function_dispatch(logspace)
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
              axis=0):
     """
@@ -278,12 +278,11 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
     return _nx.power(base, y).astype(dtype, copy=False)
 
 
-def _geomspace_dispatcher(start, stop, num=None, endpoint=None, dtype=None,
-                          axis=None):
+def geomspace(start, stop, num=None, endpoint=None, dtype=None, axis=None):
     return (start, stop)
 
 
-@array_function_dispatch(_geomspace_dispatcher)
+@array_function_dispatch(geomspace)
 def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     """
     Return numbers spaced evenly on a log scale (a geometric progression).

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -69,11 +69,11 @@ class ComplexWarning(RuntimeWarning):
     pass
 
 
-def _zeros_like_dispatcher(a, dtype=None, order=None, subok=None, shape=None):
+def zeros_like(a, dtype=None, order=None, subok=None, shape=None):
     return (a,)
 
 
-@array_function_dispatch(_zeros_like_dispatcher)
+@array_function_dispatch(zeros_like)
 def zeros_like(a, dtype=None, order='K', subok=True, shape=None):
     """
     Return an array of zeros with the same shape and type as a given array.
@@ -142,9 +142,11 @@ def zeros_like(a, dtype=None, order='K', subok=True, shape=None):
     return res
 
 
-def _ones_dispatcher(shape, dtype=None, order=None, *, like=None):
+def ones(shape, dtype=None, order=None, *, like=None):
     return(like,)
 
+# Need the dispatcher after defining the real function currently:
+_ones_dispatcher = ones
 
 @set_array_function_like_doc
 @set_module('numpy')
@@ -211,11 +213,11 @@ _ones_with_like = array_function_dispatch(
 )(ones)
 
 
-def _ones_like_dispatcher(a, dtype=None, order=None, subok=None, shape=None):
+def ones_like(a, dtype=None, order=None, subok=None, shape=None):
     return (a,)
 
 
-@array_function_dispatch(_ones_like_dispatcher)
+@array_function_dispatch(ones_like)
 def ones_like(a, dtype=None, order='K', subok=True, shape=None):
     """
     Return an array of ones with the same shape and type as a given array.
@@ -282,9 +284,11 @@ def ones_like(a, dtype=None, order='K', subok=True, shape=None):
     return res
 
 
-def _full_dispatcher(shape, fill_value, dtype=None, order=None, *, like=None):
+def full(shape, fill_value, dtype=None, order=None, *, like=None):
     return(like,)
 
+# Need the dispatcher after defining the real function currently:
+_full_dispatcher = full
 
 @set_array_function_like_doc
 @set_module('numpy')
@@ -350,11 +354,11 @@ _full_with_like = array_function_dispatch(
 )(full)
 
 
-def _full_like_dispatcher(a, fill_value, dtype=None, order=None, subok=None, shape=None):
+def full_like(a, fill_value, dtype=None, order=None, subok=None, shape=None):
     return (a,)
 
 
-@array_function_dispatch(_full_like_dispatcher)
+@array_function_dispatch(full_like)
 def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None):
     """
     Return a full array with the same shape and type as a given array.
@@ -424,11 +428,11 @@ def full_like(a, fill_value, dtype=None, order='K', subok=True, shape=None):
     return res
 
 
-def _count_nonzero_dispatcher(a, axis=None, *, keepdims=None):
+def count_nonzero(a, axis=None, *, keepdims=None):
     return (a,)
 
 
-@array_function_dispatch(_count_nonzero_dispatcher)
+@array_function_dispatch(count_nonzero)
 def count_nonzero(a, axis=None, *, keepdims=False):
     """
     Counts the number of non-zero values in the array ``a``.
@@ -570,11 +574,11 @@ def isfortran(a):
     return a.flags.fnc
 
 
-def _argwhere_dispatcher(a):
+def argwhere(a):
     return (a,)
 
 
-@array_function_dispatch(_argwhere_dispatcher)
+@array_function_dispatch(argwhere)
 def argwhere(a):
     """
     Find the indices of array elements that are non-zero, grouped by element.
@@ -624,11 +628,11 @@ def argwhere(a):
     return transpose(nonzero(a))
 
 
-def _flatnonzero_dispatcher(a):
+def flatnonzero(a):
     return (a,)
 
 
-@array_function_dispatch(_flatnonzero_dispatcher)
+@array_function_dispatch(flatnonzero)
 def flatnonzero(a):
     """
     Return indices that are non-zero in the flattened version of a.
@@ -669,11 +673,11 @@ def flatnonzero(a):
     return np.nonzero(np.ravel(a))[0]
 
 
-def _correlate_dispatcher(a, v, mode=None):
+def correlate(a, v, mode=None):
     return (a, v)
 
 
-@array_function_dispatch(_correlate_dispatcher)
+@array_function_dispatch(correlate)
 def correlate(a, v, mode='valid'):
     r"""
     Cross-correlation of two 1-dimensional sequences.
@@ -747,11 +751,11 @@ def correlate(a, v, mode='valid'):
     return multiarray.correlate2(a, v, mode)
 
 
-def _convolve_dispatcher(a, v, mode=None):
+def convolve(a, v, mode=None):
     return (a, v)
 
 
-@array_function_dispatch(_convolve_dispatcher)
+@array_function_dispatch(convolve)
 def convolve(a, v, mode='full'):
     """
     Returns the discrete, linear convolution of two one-dimensional sequences.
@@ -850,11 +854,11 @@ def convolve(a, v, mode='full'):
     return multiarray.correlate(a, v[::-1], mode)
 
 
-def _outer_dispatcher(a, b, out=None):
+def outer(a, b, out=None):
     return (a, b, out)
 
 
-@array_function_dispatch(_outer_dispatcher)
+@array_function_dispatch(outer)
 def outer(a, b, out=None):
     """
     Compute the outer product of two vectors.
@@ -942,11 +946,11 @@ def outer(a, b, out=None):
     return multiply(a.ravel()[:, newaxis], b.ravel()[newaxis, :], out)
 
 
-def _tensordot_dispatcher(a, b, axes=None):
+def tensordot(a, b, axes=None):
     return (a, b)
 
 
-@array_function_dispatch(_tensordot_dispatcher)
+@array_function_dispatch(tensordot)
 def tensordot(a, b, axes=2):
     """
     Compute tensor dot product along specified axes.
@@ -1139,11 +1143,11 @@ def tensordot(a, b, axes=2):
     return res.reshape(olda + oldb)
 
 
-def _roll_dispatcher(a, shift, axis=None):
+def roll(a, shift, axis=None):
     return (a,)
 
 
-@array_function_dispatch(_roll_dispatcher)
+@array_function_dispatch(roll)
 def roll(a, shift, axis=None):
     """
     Roll array elements along a given axis.
@@ -1250,11 +1254,11 @@ def roll(a, shift, axis=None):
         return result
 
 
-def _rollaxis_dispatcher(a, axis, start=None):
+def rollaxis(a, axis, start=None):
     return (a,)
 
 
-@array_function_dispatch(_rollaxis_dispatcher)
+@array_function_dispatch(rollaxis)
 def rollaxis(a, axis, start=0):
     """
     Roll the specified axis backwards, until it lies in a given position.
@@ -1403,11 +1407,11 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     return axis
 
 
-def _moveaxis_dispatcher(a, source, destination):
+def moveaxis(a, source, destination):
     return (a,)
 
 
-@array_function_dispatch(_moveaxis_dispatcher)
+@array_function_dispatch(moveaxis)
 def moveaxis(a, source, destination):
     """
     Move axes of an array to new positions.
@@ -1478,11 +1482,11 @@ def moveaxis(a, source, destination):
     return result
 
 
-def _cross_dispatcher(a, b, axisa=None, axisb=None, axisc=None, axis=None):
+def cross(a, b, axisa=None, axisb=None, axisc=None, axis=None):
     return (a, b)
 
 
-@array_function_dispatch(_cross_dispatcher)
+@array_function_dispatch(cross)
 def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     """
     Return the cross product of two (arrays of) vectors.
@@ -1786,8 +1790,11 @@ def indices(dimensions, dtype=int, sparse=False):
     return res
 
 
-def _fromfunction_dispatcher(function, shape, *, dtype=None, like=None, **kwargs):
+def fromfunction(function, shape, *, dtype=None, like=None, **kwargs):
     return (like,)
+
+# Need the dispatcher after defining the real function currently:
+_fromfunction_dispatcher = fromfunction
 
 
 @set_array_function_like_doc
@@ -2138,9 +2145,11 @@ def _maketup(descr, val):
         return tuple(res)
 
 
-def _identity_dispatcher(n, dtype=None, *, like=None):
+def identity(n, dtype=None, *, like=None):
     return (like,)
 
+# Need the dispatcher after defining the real function currently:
+_identity_dispatcher = identity
 
 @set_array_function_like_doc
 @set_module('numpy')
@@ -2187,11 +2196,11 @@ _identity_with_like = array_function_dispatch(
 )(identity)
 
 
-def _allclose_dispatcher(a, b, rtol=None, atol=None, equal_nan=None):
+def allclose(a, b, rtol=None, atol=None, equal_nan=None):
     return (a, b)
 
 
-@array_function_dispatch(_allclose_dispatcher)
+@array_function_dispatch(allclose)
 def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     Returns True if two arrays are element-wise equal within a tolerance.
@@ -2266,11 +2275,11 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     return bool(res)
 
 
-def _isclose_dispatcher(a, b, rtol=None, atol=None, equal_nan=None):
+def isclose(a, b, rtol=None, atol=None, equal_nan=None):
     return (a, b)
 
 
-@array_function_dispatch(_isclose_dispatcher)
+@array_function_dispatch(isclose)
 def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     Returns a boolean array where two arrays are element-wise equal within a
@@ -2395,11 +2404,11 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
         return cond[()]  # Flatten 0d arrays to scalars
 
 
-def _array_equal_dispatcher(a1, a2, equal_nan=None):
+def array_equal(a1, a2, equal_nan=None):
     return (a1, a2)
 
 
-@array_function_dispatch(_array_equal_dispatcher)
+@array_function_dispatch(array_equal)
 def array_equal(a1, a2, equal_nan=False):
     """
     True if two arrays have the same shape and elements, False otherwise.
@@ -2470,11 +2479,11 @@ def array_equal(a1, a2, equal_nan=False):
     return bool(asarray(a1[~a1nan] == a2[~a1nan]).all())
 
 
-def _array_equiv_dispatcher(a1, a2):
+def array_equiv(a1, a2):
     return (a1, a2)
 
 
-@array_function_dispatch(_array_equiv_dispatcher)
+@array_function_dispatch(array_equiv)
 def array_equiv(a1, a2):
     """
     Returns True if input arrays are shape consistent and all elements equal.

--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -171,6 +171,16 @@ def array_function_dispatch(dispatcher, module=None, verify=True,
         if verify:
             verify_matching_signatures(implementation, dispatcher)
 
+        # Uncomment the following to find dispatchers that have a mismatching
+        # name.  When incorrect parameters are passed there, the error message
+        # reports the dispatchers name, so this is nicer to avoid.
+        #
+        # generic_names = ["unary_operation", "binary_operation"]
+        # if (dispatcher.__name__ != implementation.__name__
+        #         and dispatcher.__name__ not in generic_names):
+        #     print(dispatcher.__module__, implementation.__name__,
+        #           dispatcher.__name__)
+
         if docs_from_dispatcher:
             add_docstring(implementation, dispatcher.__doc__)
 

--- a/numpy/core/shape_base.py
+++ b/numpy/core/shape_base.py
@@ -16,11 +16,11 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-def _atleast_1d_dispatcher(*arys):
+def atleast_1d(*arys):
     return arys
 
 
-@array_function_dispatch(_atleast_1d_dispatcher)
+@array_function_dispatch(atleast_1d)
 def atleast_1d(*arys):
     """
     Convert inputs to arrays with at least one dimension.
@@ -74,11 +74,11 @@ def atleast_1d(*arys):
         return res
 
 
-def _atleast_2d_dispatcher(*arys):
+def atleast_2d(*arys):
     return arys
 
 
-@array_function_dispatch(_atleast_2d_dispatcher)
+@array_function_dispatch(atleast_2d)
 def atleast_2d(*arys):
     """
     View inputs as arrays with at least two dimensions.
@@ -132,11 +132,11 @@ def atleast_2d(*arys):
         return res
 
 
-def _atleast_3d_dispatcher(*arys):
+def atleast_3d(*arys):
     return arys
 
 
-@array_function_dispatch(_atleast_3d_dispatcher)
+@array_function_dispatch(atleast_3d)
 def atleast_3d(*arys):
     """
     View inputs as arrays with at least three dimensions.
@@ -215,12 +215,11 @@ def _arrays_for_stack_dispatcher(arrays, stacklevel=4):
     return arrays
 
 
-def _vhstack_dispatcher(tup, *, 
-                        dtype=None, casting=None):
+def vstack(tup, *,  dtype=None, casting=None):
     return _arrays_for_stack_dispatcher(tup)
 
 
-@array_function_dispatch(_vhstack_dispatcher)
+@array_function_dispatch(vstack)
 def vstack(tup, *, dtype=None, casting="same_kind"):
     """
     Stack arrays in sequence vertically (row wise).
@@ -294,7 +293,11 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
     return _nx.concatenate(arrs, 0, dtype=dtype, casting=casting)
 
 
-@array_function_dispatch(_vhstack_dispatcher)
+def hstack(tup, *, dtype=None, casting="same_kind"):
+    return _arrays_for_stack_dispatcher(tup)
+
+
+@array_function_dispatch(hstack)
 def hstack(tup, *, dtype=None, casting="same_kind"):
     """
     Stack arrays in sequence horizontally (column wise).
@@ -368,8 +371,7 @@ def hstack(tup, *, dtype=None, casting="same_kind"):
         return _nx.concatenate(arrs, 1, dtype=dtype, casting=casting)
 
 
-def _stack_dispatcher(arrays, axis=None, out=None, *,
-                      dtype=None, casting=None):
+def stack(arrays, axis=None, out=None, *, dtype=None, casting=None):
     arrays = _arrays_for_stack_dispatcher(arrays, stacklevel=6)
     if out is not None:
         # optimize for the typical case where only arrays is provided
@@ -378,7 +380,7 @@ def _stack_dispatcher(arrays, axis=None, out=None, *,
     return arrays
 
 
-@array_function_dispatch(_stack_dispatcher)
+@array_function_dispatch(stack)
 def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
     """
     Join a sequence of arrays along a new axis.
@@ -702,7 +704,7 @@ def _block(arrays, max_depth, result_ndim, depth=0):
         return _atleast_nd(arrays, result_ndim)
 
 
-def _block_dispatcher(arrays):
+def block(arrays):
     # Use type(...) is list to match the behavior of np.block(), which special
     # cases list specifically rather than allowing for generic iterables or
     # tuple. Also, we know that list.__array_function__ will never exist.
@@ -712,8 +714,11 @@ def _block_dispatcher(arrays):
     else:
         yield arrays
 
+# Needed for recursive call:
+_block_dispatcher = block
 
-@array_function_dispatch(_block_dispatcher)
+
+@array_function_dispatch(block)
 def block(arrays):
     """
     Assemble an nd-array from nested lists of blocks.

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -115,8 +115,11 @@ def _swap_direction(norm):
                          '"ortho" or "forward".') from None
 
 
-def _fft_dispatcher(a, n=None, axis=None, norm=None):
+def fft(a, n=None, axis=None, norm=None):
     return (a,)
+
+
+_fft_dispatcher = fft
 
 
 @array_function_dispatch(_fft_dispatcher)
@@ -708,8 +711,11 @@ def _raw_fftnd(a, s=None, axes=None, function=fft, norm=None):
     return a
 
 
-def _fftn_dispatcher(a, s=None, axes=None, norm=None):
+def fftn(a, s=None, axes=None, norm=None):
     return (a,)
+
+
+_fftn_dispatcher = fftn
 
 
 @array_function_dispatch(_fftn_dispatcher)

--- a/numpy/fft/helper.py
+++ b/numpy/fft/helper.py
@@ -12,8 +12,11 @@ __all__ = ['fftshift', 'ifftshift', 'fftfreq', 'rfftfreq']
 integer_types = (int, integer)
 
 
-def _fftshift_dispatcher(x, axes=None):
+def fftshift(x, axes=None):
     return (x,)
+
+
+_fftshift_dispatcher = fftshift
 
 
 @array_function_dispatch(_fftshift_dispatcher, module='numpy.fft')

--- a/numpy/lib/arraypad.py
+++ b/numpy/lib/arraypad.py
@@ -518,7 +518,7 @@ def _as_pairs(x, ndim, as_index=False):
     return np.broadcast_to(x, (ndim, 2)).tolist()
 
 
-def _pad_dispatcher(array, pad_width, mode=None, **kwargs):
+def pad(array, pad_width, mode=None, **kwargs):
     return (array,)
 
 
@@ -526,7 +526,7 @@ def _pad_dispatcher(array, pad_width, mode=None, **kwargs):
 # Public functions
 
 
-@array_function_dispatch(_pad_dispatcher, module='numpy')
+@array_function_dispatch(pad, module='numpy')
 def pad(array, pad_width, mode='constant', **kwargs):
     """
     Pad an array.

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -30,11 +30,11 @@ __all__ = [
     ]
 
 
-def _ediff1d_dispatcher(ary, to_end=None, to_begin=None):
+def ediff1d(ary, to_end=None, to_begin=None):
     return (ary, to_end, to_begin)
 
 
-@array_function_dispatch(_ediff1d_dispatcher)
+@array_function_dispatch(ediff1d)
 def ediff1d(ary, to_end=None, to_begin=None):
     """
     The differences between consecutive elements of an array.
@@ -130,12 +130,12 @@ def _unpack_tuple(x):
         return x
 
 
-def _unique_dispatcher(ar, return_index=None, return_inverse=None,
+def unique(ar, return_index=None, return_inverse=None,
                        return_counts=None, axis=None, *, equal_nan=None):
     return (ar,)
 
 
-@array_function_dispatch(_unique_dispatcher)
+@array_function_dispatch(unique)
 def unique(ar, return_index=False, return_inverse=False,
            return_counts=False, axis=None, *, equal_nan=True):
     """
@@ -365,12 +365,12 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     return ret
 
 
-def _intersect1d_dispatcher(
+def intersect1d(
         ar1, ar2, assume_unique=None, return_indices=None):
     return (ar1, ar2)
 
 
-@array_function_dispatch(_intersect1d_dispatcher)
+@array_function_dispatch(intersect1d)
 def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
     """
     Find the intersection of two arrays.
@@ -469,11 +469,11 @@ def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
         return int1d
 
 
-def _setxor1d_dispatcher(ar1, ar2, assume_unique=None):
+def setxor1d(ar1, ar2, assume_unique=None):
     return (ar1, ar2)
 
 
-@array_function_dispatch(_setxor1d_dispatcher)
+@array_function_dispatch(setxor1d)
 def setxor1d(ar1, ar2, assume_unique=False):
     """
     Find the set exclusive-or of two arrays.
@@ -516,11 +516,11 @@ def setxor1d(ar1, ar2, assume_unique=False):
     return aux[flag[1:] & flag[:-1]]
 
 
-def _in1d_dispatcher(ar1, ar2, assume_unique=None, invert=None):
+def in1d(ar1, ar2, assume_unique=None, invert=None):
     return (ar1, ar2)
 
 
-@array_function_dispatch(_in1d_dispatcher)
+@array_function_dispatch(in1d)
 def in1d(ar1, ar2, assume_unique=False, invert=False):
     """
     Test whether each element of a 1-D array is also present in a second array.
@@ -637,11 +637,11 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
         return ret[rev_idx]
 
 
-def _isin_dispatcher(element, test_elements, assume_unique=None, invert=None):
+def isin(element, test_elements, assume_unique=None, invert=None):
     return (element, test_elements)
 
 
-@array_function_dispatch(_isin_dispatcher)
+@array_function_dispatch(isin)
 def isin(element, test_elements, assume_unique=False, invert=False):
     """
     Calculates ``element in test_elements``, broadcasting over `element` only.
@@ -740,11 +740,11 @@ def isin(element, test_elements, assume_unique=False, invert=False):
                 invert=invert).reshape(element.shape)
 
 
-def _union1d_dispatcher(ar1, ar2):
+def union1d(ar1, ar2):
     return (ar1, ar2)
 
 
-@array_function_dispatch(_union1d_dispatcher)
+@array_function_dispatch(union1d)
 def union1d(ar1, ar2):
     """
     Find the union of two arrays.
@@ -781,11 +781,11 @@ def union1d(ar1, ar2):
     return unique(np.concatenate((ar1, ar2), axis=None))
 
 
-def _setdiff1d_dispatcher(ar1, ar2, assume_unique=None):
+def setdiff1d(ar1, ar2, assume_unique=None):
     return (ar1, ar2)
 
 
-@array_function_dispatch(_setdiff1d_dispatcher)
+@array_function_dispatch(setdiff1d)
 def setdiff1d(ar1, ar2, assume_unique=False):
     """
     Find the set difference of two arrays.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3836,8 +3836,10 @@ def _median(a, axis=None, out=None, overwrite_input=False):
         kth = [szh - 1, szh]
     else:
         kth = [(sz - 1) // 2]
-    # Check if the array contains any nan's
-    if np.issubdtype(a.dtype, np.inexact):
+
+    # Check if the array contains any nan's or NaT's (unordered values)
+    supports_nans = np.issubdtype(a.dtype, np.inexact) or a.dtype.kind == 'm'
+    if supports_nans:
         kth.append(-1)
 
     if overwrite_input:
@@ -3869,7 +3871,7 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     # using out array if needed.
     rout = mean(part[indexer], axis=axis, out=out)
     # Check if the array contains any nan's
-    if np.issubdtype(a.dtype, np.inexact) and sz > 0:
+    if supports_nans and sz > 0:
         # If nans are possible, warn and replace by nans like mean would.
         rout = np.lib.utils._median_nancheck(part, rout, axis)
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4657,11 +4657,17 @@ def _quantile(
     # --- Setup
     arr = np.asanyarray(arr)
     values_count = arr.shape[axis]
+
+    # Check if the array contains any nan's or NaT's (unordered values)
+    supports_nans = (
+            np.issubdtype(arr.dtype, np.inexact) or arr.dtype.kind in 'Mm')
+
     # The dimensions of `q` are prepended to the output shape, so we need the
     # axis being sampled from `arr` to be last.
-    DATA_AXIS = 0
-    if axis != DATA_AXIS:  # But moveaxis is slow, so only call it if axis!=0.
-        arr = np.moveaxis(arr, axis, destination=DATA_AXIS)
+
+
+    if axis != 0:  # But moveaxis is slow, so only call it if necessary.
+        arr = np.moveaxis(arr, axis, destination=0)
     # --- Computation of indexes
     # Index where to find the value in the sorted array.
     # Virtual because it is a floating point value, not an valid index.
@@ -4676,14 +4682,14 @@ def _quantile(
     virtual_indexes = np.asanyarray(virtual_indexes)
     if np.issubdtype(virtual_indexes.dtype, np.integer):
         # No interpolation needed, take the points along axis
-        if np.issubdtype(arr.dtype, np.inexact):
+        if supports_nans:
             # may contain nan, which would sort to the end
             arr.partition(concatenate((virtual_indexes.ravel(), [-1])), axis=0)
-            slices_having_nans = np.isnan(arr[-1])
+            slices_having_nans = np.isnan(arr[-1, ...])
         else:
             # cannot contain nan
             arr.partition(virtual_indexes.ravel(), axis=0)
-            slices_having_nans = np.array(False, dtype=bool)
+            slices_having_nans = False
         result = take(arr, virtual_indexes, axis=0, out=out)
     else:
         previous_indexes, next_indexes = _get_indexes(arr,
@@ -4695,16 +4701,14 @@ def _quantile(
                                       previous_indexes.ravel(),
                                       next_indexes.ravel(),
                                       ))),
-            axis=DATA_AXIS)
-        if np.issubdtype(arr.dtype, np.inexact):
-            slices_having_nans = np.isnan(
-                take(arr, indices=-1, axis=DATA_AXIS)
-            )
+            axis=0)
+        if supports_nans:
+            slices_having_nans = np.isnan(arr[-1, ...])
         else:
-            slices_having_nans = None
+            slices_having_nans = False
         # --- Get values from indexes
-        previous = np.take(arr, previous_indexes, axis=DATA_AXIS)
-        next = np.take(arr, next_indexes, axis=DATA_AXIS)
+        previous = arr[previous_indexes]
+        next = arr[next_indexes]
         # --- Linear interpolation
         gamma = _get_gamma(virtual_indexes, previous_indexes, method)
         result_shape = virtual_indexes.shape + (1,) * (arr.ndim - 1)
@@ -4713,10 +4717,13 @@ def _quantile(
                        next,
                        gamma,
                        out=out)
-    if np.any(slices_having_nans):
+
+    if slices_having_nans is not False and slices_having_nans.any():
         if result.ndim == 0 and out is None:
             # can't write to a scalar
-            result = arr.dtype.type(np.nan)
+            result = arr[-1]
+        elif result.dtype.kind in 'mM':
+            result[..., slices_having_nans] = "NaT"
         else:
             result[..., slices_having_nans] = np.nan
     return result

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -151,11 +151,11 @@ _QuantileMethods = dict(
     ))
 
 
-def _rot90_dispatcher(m, k=None, axes=None):
+def rot90(m, k=None, axes=None):
     return (m,)
 
 
-@array_function_dispatch(_rot90_dispatcher)
+@array_function_dispatch(rot90)
 def rot90(m, k=1, axes=(0, 1)):
     """
     Rotate an array by 90 degrees in the plane specified by axes.
@@ -245,11 +245,11 @@ def rot90(m, k=1, axes=(0, 1)):
         return flip(transpose(m, axes_list), axes[1])
 
 
-def _flip_dispatcher(m, axis=None):
+def flip(m, axis=None):
     return (m,)
 
 
-@array_function_dispatch(_flip_dispatcher)
+@array_function_dispatch(flip)
 def flip(m, axis=None):
     """
     Reverse the order of elements in an array along the given axis.
@@ -388,12 +388,12 @@ def iterable(y):
     return True
 
 
-def _average_dispatcher(a, axis=None, weights=None, returned=None, *,
+def average(a, axis=None, weights=None, returned=None, *,
                         keepdims=None):
     return (a, weights)
 
 
-@array_function_dispatch(_average_dispatcher)
+@array_function_dispatch(average)
 def average(a, axis=None, weights=None, returned=False, *,
             keepdims=np._NoValue):
     """
@@ -629,14 +629,14 @@ def asarray_chkfinite(a, dtype=None, order=None):
     return a
 
 
-def _piecewise_dispatcher(x, condlist, funclist, *args, **kw):
+def piecewise(x, condlist, funclist, *args, **kw):
     yield x
     # support the undocumented behavior of allowing scalars
     if np.iterable(condlist):
         yield from condlist
 
 
-@array_function_dispatch(_piecewise_dispatcher)
+@array_function_dispatch(piecewise)
 def piecewise(x, condlist, funclist, *args, **kw):
     """
     Evaluate a piecewise-defined function.
@@ -757,12 +757,12 @@ def piecewise(x, condlist, funclist, *args, **kw):
     return y
 
 
-def _select_dispatcher(condlist, choicelist, default=None):
+def select(condlist, choicelist, default=None):
     yield from condlist
     yield from choicelist
 
 
-@array_function_dispatch(_select_dispatcher)
+@array_function_dispatch(select)
 def select(condlist, choicelist, default=0):
     """
     Return an array drawn from elements in choicelist, depending on conditions.
@@ -863,11 +863,11 @@ def select(condlist, choicelist, default=0):
     return result
 
 
-def _copy_dispatcher(a, order=None, subok=None):
+def copy(a, order=None, subok=None):
     return (a,)
 
 
-@array_function_dispatch(_copy_dispatcher)
+@array_function_dispatch(copy)
 def copy(a, order='K', subok=False):
     """
     Return an array copy of the given object.
@@ -961,12 +961,12 @@ def copy(a, order='K', subok=False):
 # Basic operations
 
 
-def _gradient_dispatcher(f, *varargs, axis=None, edge_order=None):
+def gradient(f, *varargs, axis=None, edge_order=None):
     yield f
     yield from varargs
 
 
-@array_function_dispatch(_gradient_dispatcher)
+@array_function_dispatch(gradient)
 def gradient(f, *varargs, axis=None, edge_order=1):
     """
     Return the gradient of an N-dimensional array.
@@ -1312,11 +1312,11 @@ def gradient(f, *varargs, axis=None, edge_order=1):
         return outvals
 
 
-def _diff_dispatcher(a, n=None, axis=None, prepend=None, append=None):
+def diff(a, n=None, axis=None, prepend=None, append=None):
     return (a, prepend, append)
 
 
-@array_function_dispatch(_diff_dispatcher)
+@array_function_dispatch(diff)
 def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     """
     Calculate the n-th discrete difference along the given axis.
@@ -1449,11 +1449,11 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     return a
 
 
-def _interp_dispatcher(x, xp, fp, left=None, right=None, period=None):
+def interp(x, xp, fp, left=None, right=None, period=None):
     return (x, xp, fp)
 
 
-@array_function_dispatch(_interp_dispatcher)
+@array_function_dispatch(interp)
 def interp(x, xp, fp, left=None, right=None, period=None):
     """
     One-dimensional linear interpolation for monotonically increasing sample points.
@@ -1594,11 +1594,11 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     return interp_func(x, xp, fp, left, right)
 
 
-def _angle_dispatcher(z, deg=None):
+def angle(z, deg=None):
     return (z,)
 
 
-@array_function_dispatch(_angle_dispatcher)
+@array_function_dispatch(angle)
 def angle(z, deg=False):
     """
     Return the angle of the complex argument.
@@ -1651,11 +1651,11 @@ def angle(z, deg=False):
     return a
 
 
-def _unwrap_dispatcher(p, discont=None, axis=None, *, period=None):
+def unwrap(p, discont=None, axis=None, *, period=None):
     return (p,)
 
 
-@array_function_dispatch(_unwrap_dispatcher)
+@array_function_dispatch(unwrap)
 def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     r"""
     Unwrap by taking the complement of large deltas with respect to the period.
@@ -1751,11 +1751,11 @@ def unwrap(p, discont=None, axis=-1, *, period=2*pi):
     return up
 
 
-def _sort_complex(a):
+def sort_complex(a):
     return (a,)
 
 
-@array_function_dispatch(_sort_complex)
+@array_function_dispatch(sort_complex)
 def sort_complex(a):
     """
     Sort a complex array using the real part first, then the imaginary part.
@@ -1792,11 +1792,11 @@ def sort_complex(a):
         return b
 
 
-def _trim_zeros(filt, trim=None):
+def trim_zeros(filt, trim=None):
     return (filt,)
 
 
-@array_function_dispatch(_trim_zeros)
+@array_function_dispatch(trim_zeros)
 def trim_zeros(filt, trim='fb'):
     """
     Trim the leading and/or trailing zeros from a 1-D array or sequence.
@@ -1849,11 +1849,11 @@ def trim_zeros(filt, trim='fb'):
     return filt[first:last]
 
 
-def _extract_dispatcher(condition, arr):
+def extract(condition, arr):
     return (condition, arr)
 
 
-@array_function_dispatch(_extract_dispatcher)
+@array_function_dispatch(extract)
 def extract(condition, arr):
     """
     Return the elements of an array that satisfy some condition.
@@ -1905,11 +1905,11 @@ def extract(condition, arr):
     return _nx.take(ravel(arr), nonzero(ravel(condition))[0])
 
 
-def _place_dispatcher(arr, mask, vals):
+def place(arr, mask, vals):
     return (arr, mask, vals)
 
 
-@array_function_dispatch(_place_dispatcher)
+@array_function_dispatch(place)
 def place(arr, mask, vals):
     """
     Change elements of an array based on conditional and input values.
@@ -2478,12 +2478,12 @@ class vectorize:
         return outputs[0] if nout == 1 else outputs
 
 
-def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
+def cov(m, y=None, rowvar=None, bias=None, ddof=None,
                     fweights=None, aweights=None, *, dtype=None):
     return (m, y, fweights, aweights)
 
 
-@array_function_dispatch(_cov_dispatcher)
+@array_function_dispatch(cov)
 def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         aweights=None, *, dtype=None):
     """
@@ -2705,12 +2705,12 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
+def corrcoef(x, y=None, rowvar=None, bias=None, ddof=None, *,
                          dtype=None):
     return (x, y)
 
 
-@array_function_dispatch(_corrcoef_dispatcher)
+@array_function_dispatch(corrcoef)
 def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
              dtype=None):
     """
@@ -3359,11 +3359,11 @@ def _i0_2(x):
     return exp(x) * _chbevl(32.0/x - 2.0, _i0B) / sqrt(x)
 
 
-def _i0_dispatcher(x):
+def i0(x):
     return (x,)
 
 
-@array_function_dispatch(_i0_dispatcher)
+@array_function_dispatch(i0)
 def i0(x):
     """
     Modified Bessel function of the first kind, order 0.
@@ -3553,11 +3553,11 @@ def kaiser(M, beta):
     return i0(beta * sqrt(1-((n-alpha)/alpha)**2.0))/i0(float(beta))
 
 
-def _sinc_dispatcher(x):
+def sinc(x):
     return (x,)
 
 
-@array_function_dispatch(_sinc_dispatcher)
+@array_function_dispatch(sinc)
 def sinc(x):
     r"""
     Return the normalized sinc function.
@@ -3638,11 +3638,11 @@ def sinc(x):
     return sin(y)/y
 
 
-def _msort_dispatcher(a):
+def msort(a):
     return (a,)
 
 
-@array_function_dispatch(_msort_dispatcher)
+@array_function_dispatch(msort)
 def msort(a):
     """
     Return a copy of an array sorted along the first axis.
@@ -3726,12 +3726,12 @@ def _ureduce(a, func, **kwargs):
     return r, keepdim
 
 
-def _median_dispatcher(
+def median(
         a, axis=None, out=None, overwrite_input=None, keepdims=None):
     return (a, out)
 
 
-@array_function_dispatch(_median_dispatcher)
+@array_function_dispatch(median)
 def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     """
     Compute the median along the specified axis.
@@ -3878,12 +3878,12 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     return rout
 
 
-def _percentile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
+def percentile(a, q, axis=None, out=None, overwrite_input=None,
                            method=None, keepdims=None, *, interpolation=None):
     return (a, q, out)
 
 
-@array_function_dispatch(_percentile_dispatcher)
+@array_function_dispatch(percentile)
 def percentile(a,
                q,
                axis=None,
@@ -4169,12 +4169,12 @@ def percentile(a,
         a, q, axis, out, overwrite_input, method, keepdims)
 
 
-def _quantile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
+def quantile(a, q, axis=None, out=None, overwrite_input=None,
                          method=None, keepdims=None, *, interpolation=None):
     return (a, q, out)
 
 
-@array_function_dispatch(_quantile_dispatcher)
+@array_function_dispatch(quantile)
 def quantile(a,
              q,
              axis=None,
@@ -4729,11 +4729,11 @@ def _quantile(
     return result
 
 
-def _trapz_dispatcher(y, x=None, dx=None, axis=None):
+def trapz(y, x=None, dx=None, axis=None):
     return (y, x)
 
 
-@array_function_dispatch(_trapz_dispatcher)
+@array_function_dispatch(trapz)
 def trapz(y, x=None, dx=1.0, axis=-1):
     r"""
     Integrate along the given axis using the composite trapezoidal rule.
@@ -4847,12 +4847,12 @@ def trapz(y, x=None, dx=1.0, axis=-1):
     return ret
 
 
-def _meshgrid_dispatcher(*xi, copy=None, sparse=None, indexing=None):
+def meshgrid(*xi, copy=None, sparse=None, indexing=None):
     return xi
 
 
 # Based on scitools meshgrid
-@array_function_dispatch(_meshgrid_dispatcher)
+@array_function_dispatch(meshgrid)
 def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     """
     Return coordinate matrices from coordinate vectors.
@@ -5001,11 +5001,11 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     return output
 
 
-def _delete_dispatcher(arr, obj, axis=None):
+def delete(arr, obj, axis=None):
     return (arr, obj)
 
 
-@array_function_dispatch(_delete_dispatcher)
+@array_function_dispatch(delete)
 def delete(arr, obj, axis=None):
     """
     Return a new array with sub-arrays along an axis deleted. For a one
@@ -5193,11 +5193,11 @@ def delete(arr, obj, axis=None):
         return new
 
 
-def _insert_dispatcher(arr, obj, values, axis=None):
+def insert(arr, obj, values, axis=None):
     return (arr, obj, values)
 
 
-@array_function_dispatch(_insert_dispatcher)
+@array_function_dispatch(insert)
 def insert(arr, obj, values, axis=None):
     """
     Insert values along the given axis before the given indices.
@@ -5387,11 +5387,11 @@ def insert(arr, obj, values, axis=None):
     return new
 
 
-def _append_dispatcher(arr, values, axis=None):
+def append(arr, values, axis=None):
     return (arr, values)
 
 
-@array_function_dispatch(_append_dispatcher)
+@array_function_dispatch(append)
 def append(arr, values, axis=None):
     """
     Append values to the end of an array.
@@ -5449,11 +5449,11 @@ def append(arr, values, axis=None):
     return concatenate((arr, values), axis=axis)
 
 
-def _digitize_dispatcher(x, bins, right=None):
+def digitize(x, bins, right=None):
     return (x, bins)
 
 
-@array_function_dispatch(_digitize_dispatcher)
+@array_function_dispatch(digitize)
 def digitize(x, bins, right=False):
     """
     Return the indices of the bins to which each value in input array belongs.

--- a/numpy/lib/histograms.py
+++ b/numpy/lib/histograms.py
@@ -463,11 +463,11 @@ def _search_sorted_inclusive(a, v):
     ))
 
 
-def _histogram_bin_edges_dispatcher(a, bins=None, range=None, weights=None):
+def histogram_bin_edges(a, bins=None, range=None, weights=None):
     return (a, bins, weights)
 
 
-@array_function_dispatch(_histogram_bin_edges_dispatcher)
+@array_function_dispatch(histogram_bin_edges)
 def histogram_bin_edges(a, bins=10, range=None, weights=None):
     r"""
     Function to calculate only the edges of the bins used by the `histogram`
@@ -670,12 +670,11 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     return bin_edges
 
 
-def _histogram_dispatcher(
-        a, bins=None, range=None, density=None, weights=None):
+def histogram(a, bins=None, range=None, density=None, weights=None):
     return (a, bins, weights)
 
 
-@array_function_dispatch(_histogram_dispatcher)
+@array_function_dispatch(histogram)
 def histogram(a, bins=10, range=None, density=None, weights=None):
     r"""
     Compute the histogram of a dataset.
@@ -885,8 +884,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     return n, bin_edges
 
 
-def _histogramdd_dispatcher(sample, bins=None, range=None, density=None,
-                            weights=None):
+def histogramdd(sample, bins=None, range=None, density=None, weights=None):
     if hasattr(sample, 'shape'):  # same condition as used in histogramdd
         yield sample
     else:
@@ -896,7 +894,7 @@ def _histogramdd_dispatcher(sample, bins=None, range=None, density=None,
     yield weights
 
 
-@array_function_dispatch(_histogramdd_dispatcher)
+@array_function_dispatch(histogramdd)
 def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     """
     Compute the multidimensional histogram of some data.

--- a/numpy/lib/index_tricks.py
+++ b/numpy/lib/index_tricks.py
@@ -28,11 +28,11 @@ __all__ = [
 ]
 
 
-def _ix__dispatcher(*args):
+def ix_(*args):
     return args
 
 
-@array_function_dispatch(_ix__dispatcher)
+@array_function_dispatch(ix_)
 def ix_(*args):
     """
     Construct an open mesh from multiple sequences.
@@ -775,11 +775,11 @@ s_ = IndexExpression(maketuple=False)
 # applicable to N-dimensions.
 
 
-def _fill_diagonal_dispatcher(a, val, wrap=None):
+def fill_diagonal(a, val, wrap=None):
     return (a,)
 
 
-@array_function_dispatch(_fill_diagonal_dispatcher)
+@array_function_dispatch(fill_diagonal)
 def fill_diagonal(a, val, wrap=False):
     """Fill the main diagonal of the given array of any dimensionality.
 
@@ -982,11 +982,11 @@ def diag_indices(n, ndim=2):
     return (idx,) * ndim
 
 
-def _diag_indices_from(arr):
+def diag_indices_from(arr):
     return (arr,)
 
 
-@array_function_dispatch(_diag_indices_from)
+@array_function_dispatch(diag_indices_from)
 def diag_indices_from(arr):
     """
     Return the indices to access the main diagonal of an n-dimensional array.

--- a/numpy/lib/nanfunctions.py
+++ b/numpy/lib/nanfunctions.py
@@ -228,12 +228,12 @@ def _divide_by_count(a, b, out=None):
                 return np.divide(a, b, out=out, casting='unsafe')
 
 
-def _nanmin_dispatcher(a, axis=None, out=None, keepdims=None,
+def nanmin(a, axis=None, out=None, keepdims=None,
                        initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanmin_dispatcher)
+@array_function_dispatch(nanmin)
 def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
            where=np._NoValue):
     """
@@ -361,12 +361,12 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     return res
 
 
-def _nanmax_dispatcher(a, axis=None, out=None, keepdims=None,
+def nanmax(a, axis=None, out=None, keepdims=None,
                        initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanmax_dispatcher)
+@array_function_dispatch(nanmax)
 def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
            where=np._NoValue):
     """
@@ -494,11 +494,11 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     return res
 
 
-def _nanargmin_dispatcher(a, axis=None, out=None, *, keepdims=None):
+def nanargmin(a, axis=None, out=None, *, keepdims=None):
     return (a,)
 
 
-@array_function_dispatch(_nanargmin_dispatcher)
+@array_function_dispatch(nanargmin)
 def nanargmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Return the indices of the minimum values in the specified axis ignoring
@@ -554,11 +554,11 @@ def nanargmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     return res
 
 
-def _nanargmax_dispatcher(a, axis=None, out=None, *, keepdims=None):
+def nanargmax(a, axis=None, out=None, *, keepdims=None):
     return (a,)
 
 
-@array_function_dispatch(_nanargmax_dispatcher)
+@array_function_dispatch(nanargmax)
 def nanargmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Return the indices of the maximum values in the specified axis ignoring
@@ -615,12 +615,12 @@ def nanargmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     return res
 
 
-def _nansum_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
+def nansum(a, axis=None, dtype=None, out=None, keepdims=None,
                        initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nansum_dispatcher)
+@array_function_dispatch(nansum)
 def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
            initial=np._NoValue, where=np._NoValue):
     """
@@ -724,12 +724,12 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                   initial=initial, where=where)
 
 
-def _nanprod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
+def nanprod(a, axis=None, dtype=None, out=None, keepdims=None,
                         initial=None, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanprod_dispatcher)
+@array_function_dispatch(nanprod)
 def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
             initial=np._NoValue, where=np._NoValue):
     """
@@ -807,11 +807,11 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                    initial=initial, where=where)
 
 
-def _nancumsum_dispatcher(a, axis=None, dtype=None, out=None):
+def nancumsum(a, axis=None, dtype=None, out=None):
     return (a, out)
 
 
-@array_function_dispatch(_nancumsum_dispatcher)
+@array_function_dispatch(nancumsum)
 def nancumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of array elements over a given axis treating Not a
@@ -877,11 +877,11 @@ def nancumsum(a, axis=None, dtype=None, out=None):
     return np.cumsum(a, axis=axis, dtype=dtype, out=out)
 
 
-def _nancumprod_dispatcher(a, axis=None, dtype=None, out=None):
+def nancumprod(a, axis=None, dtype=None, out=None):
     return (a, out)
 
 
-@array_function_dispatch(_nancumprod_dispatcher)
+@array_function_dispatch(nancumprod)
 def nancumprod(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative product of array elements over a given axis treating Not a
@@ -944,12 +944,12 @@ def nancumprod(a, axis=None, dtype=None, out=None):
     return np.cumprod(a, axis=axis, dtype=dtype, out=out)
 
 
-def _nanmean_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
+def nanmean(a, axis=None, dtype=None, out=None, keepdims=None,
                         *, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanmean_dispatcher)
+@array_function_dispatch(nanmean)
 def nanmean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
             *, where=np._NoValue):
     """
@@ -1118,12 +1118,12 @@ def _nanmedian_small(a, axis=None, out=None, overwrite_input=False):
     return m.filled(fill_value)
 
 
-def _nanmedian_dispatcher(
+def nanmedian(
         a, axis=None, out=None, overwrite_input=None, keepdims=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanmedian_dispatcher)
+@array_function_dispatch(nanmedian)
 def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValue):
     """
     Compute the median along the specified axis, while ignoring NaNs.
@@ -1222,13 +1222,13 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
         return r
 
 
-def _nanpercentile_dispatcher(
+def nanpercentile(
         a, q, axis=None, out=None, overwrite_input=None,
         method=None, keepdims=None, *, interpolation=None):
     return (a, q, out)
 
 
-@array_function_dispatch(_nanpercentile_dispatcher)
+@array_function_dispatch(nanpercentile)
 def nanpercentile(
         a,
         q,
@@ -1385,12 +1385,12 @@ def nanpercentile(
         a, q, axis, out, overwrite_input, method, keepdims)
 
 
-def _nanquantile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
+def nanquantile(a, q, axis=None, out=None, overwrite_input=None,
                             method=None, keepdims=None, *, interpolation=None):
     return (a, q, out)
 
 
-@array_function_dispatch(_nanquantile_dispatcher)
+@array_function_dispatch(nanquantile)
 def nanquantile(
         a,
         q,
@@ -1608,12 +1608,12 @@ def _nanquantile_1d(arr1d, q, overwrite_input=False, method="linear"):
         arr1d, q, overwrite_input=overwrite_input, method=method)
 
 
-def _nanvar_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
+def nanvar(a, axis=None, dtype=None, out=None, ddof=None,
                        keepdims=None, *, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanvar_dispatcher)
+@array_function_dispatch(nanvar)
 def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
            *, where=np._NoValue):
     """
@@ -1769,12 +1769,12 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
     return var
 
 
-def _nanstd_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
+def nanstd(a, axis=None, dtype=None, out=None, ddof=None,
                        keepdims=None, *, where=None):
     return (a, out)
 
 
-@array_function_dispatch(_nanstd_dispatcher)
+@array_function_dispatch(nanstd)
 def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
            *, where=np._NoValue):
     """

--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -424,11 +424,11 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
                     f"Failed to interpret file {file!r} as a pickle") from e
 
 
-def _save_dispatcher(file, arr, allow_pickle=None, fix_imports=None):
+def save(file, arr, allow_pickle=None, fix_imports=None):
     return (arr,)
 
 
-@array_function_dispatch(_save_dispatcher)
+@array_function_dispatch(save)
 def save(file, arr, allow_pickle=True, fix_imports=True):
     """
     Save an array to a binary file in NumPy ``.npy`` format.
@@ -503,12 +503,12 @@ def save(file, arr, allow_pickle=True, fix_imports=True):
                            pickle_kwargs=dict(fix_imports=fix_imports))
 
 
-def _savez_dispatcher(file, *args, **kwds):
+def savez(file, *args, **kwds):
     yield from args
     yield from kwds.values()
 
 
-@array_function_dispatch(_savez_dispatcher)
+@array_function_dispatch(savez)
 def savez(file, *args, **kwds):
     """Save several arrays into a single file in uncompressed ``.npz`` format.
 
@@ -595,12 +595,12 @@ def savez(file, *args, **kwds):
     _savez(file, args, kwds, False)
 
 
-def _savez_compressed_dispatcher(file, *args, **kwds):
+def savez_compressed(file, *args, **kwds):
     yield from args
     yield from kwds.values()
 
 
-@array_function_dispatch(_savez_compressed_dispatcher)
+@array_function_dispatch(savez_compressed)
 def savez_compressed(file, *args, **kwds):
     """
     Save several arrays into a single file in compressed ``.npz`` format.
@@ -740,11 +740,15 @@ def _ensure_ndmin_ndarray(a, *, ndmin: int):
 _loadtxt_chunksize = 50000
 
 
-def _loadtxt_dispatcher(
+def loadtxt(
         fname, dtype=None, comments=None, delimiter=None,
         converters=None, skiprows=None, usecols=None, unpack=None,
         ndmin=None, encoding=None, max_rows=None, *, like=None):
     return (like,)
+
+
+# Need the dispatcher after defining the real function currently:
+_loadtxt_dispatcher = loadtxt
 
 
 def _check_nonneg_int(value, name="argument"):
@@ -1311,13 +1315,13 @@ _loadtxt_with_like = array_function_dispatch(
 )(loadtxt)
 
 
-def _savetxt_dispatcher(fname, X, fmt=None, delimiter=None, newline=None,
+def savetxt(fname, X, fmt=None, delimiter=None, newline=None,
                         header=None, footer=None, comments=None,
                         encoding=None):
     return (X,)
 
 
-@array_function_dispatch(_savetxt_dispatcher)
+@array_function_dispatch(savetxt)
 def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             footer='', comments='# ', encoding=None):
     """
@@ -1669,7 +1673,7 @@ def fromregex(file, regexp, dtype, encoding=None):
 #####--------------------------------------------------------------------------
 
 
-def _genfromtxt_dispatcher(fname, dtype=None, comments=None, delimiter=None,
+def genfromtxt(fname, dtype=None, comments=None, delimiter=None,
                            skip_header=None, skip_footer=None, converters=None,
                            missing_values=None, filling_values=None, usecols=None,
                            names=None, excludelist=None, deletechars=None,
@@ -1678,6 +1682,10 @@ def _genfromtxt_dispatcher(fname, dtype=None, comments=None, delimiter=None,
                            invalid_raise=None, max_rows=None, encoding=None,
                            *, ndmin=None, like=None):
     return (like,)
+
+
+# Need the dispatcher after defining the real function currently:
+_genfromtxt_dispatcher = genfromtxt
 
 
 @set_array_function_like_doc

--- a/numpy/lib/polynomial.py
+++ b/numpy/lib/polynomial.py
@@ -37,11 +37,11 @@ class RankWarning(UserWarning):
     pass
 
 
-def _poly_dispatcher(seq_of_zeros):
+def poly(seq_of_zeros):
     return seq_of_zeros
 
 
-@array_function_dispatch(_poly_dispatcher)
+@array_function_dispatch(poly)
 def poly(seq_of_zeros):
     """
     Find the coefficients of a polynomial with the given sequence of roots.
@@ -164,11 +164,11 @@ def poly(seq_of_zeros):
     return a
 
 
-def _roots_dispatcher(p):
+def roots(p):
     return p
 
 
-@array_function_dispatch(_roots_dispatcher)
+@array_function_dispatch(roots)
 def roots(p):
     """
     Return the roots of a polynomial with coefficients given in p.
@@ -260,11 +260,11 @@ def roots(p):
     return roots
 
 
-def _polyint_dispatcher(p, m=None, k=None):
+def polyint(p, m=None, k=None):
     return (p,)
 
 
-@array_function_dispatch(_polyint_dispatcher)
+@array_function_dispatch(polyint)
 def polyint(p, m=1, k=None):
     """
     Return an antiderivative (indefinite integral) of a polynomial.
@@ -365,11 +365,11 @@ def polyint(p, m=1, k=None):
         return val
 
 
-def _polyder_dispatcher(p, m=None):
+def polyder(p, m=None):
     return (p,)
 
 
-@array_function_dispatch(_polyder_dispatcher)
+@array_function_dispatch(polyder)
 def polyder(p, m=1):
     """
     Return the derivative of the specified order of a polynomial.
@@ -445,11 +445,11 @@ def polyder(p, m=1):
     return val
 
 
-def _polyfit_dispatcher(x, y, deg, rcond=None, full=None, w=None, cov=None):
+def polyfit(x, y, deg, rcond=None, full=None, w=None, cov=None):
     return (x, y, w)
 
 
-@array_function_dispatch(_polyfit_dispatcher)
+@array_function_dispatch(polyfit)
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares polynomial fit.
@@ -697,11 +697,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         return c
 
 
-def _polyval_dispatcher(p, x):
+def polyval(p, x):
     return (p, x)
 
 
-@array_function_dispatch(_polyval_dispatcher)
+@array_function_dispatch(polyval)
 def polyval(p, x):
     """
     Evaluate a polynomial at specific values.
@@ -780,11 +780,15 @@ def polyval(p, x):
     return y
 
 
-def _binary_op_dispatcher(a1, a2):
+def binary_operation(a1, a2):
     return (a1, a2)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+_binaryop_dipatcher = binary_operation
+del binary_operation
+
+
+@array_function_dispatch(_binaryop_dipatcher)
 def polyadd(a1, a2):
     """
     Find the sum of two polynomials.
@@ -852,7 +856,7 @@ def polyadd(a1, a2):
     return val
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(_binaryop_dipatcher)
 def polysub(a1, a2):
     """
     Difference (subtraction) of two polynomials.
@@ -906,7 +910,7 @@ def polysub(a1, a2):
     return val
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(_binaryop_dipatcher)
 def polymul(a1, a2):
     """
     Find the product of two polynomials.
@@ -969,11 +973,11 @@ def polymul(a1, a2):
     return val
 
 
-def _polydiv_dispatcher(u, v):
+def polydiv(u, v):
     return (u, v)
 
 
-@array_function_dispatch(_polydiv_dispatcher)
+@array_function_dispatch(polydiv)
 def polydiv(u, v):
     """
     Returns the quotient and remainder of polynomial division.

--- a/numpy/lib/scimath.py
+++ b/numpy/lib/scimath.py
@@ -191,8 +191,13 @@ def _fix_real_abs_gt_1(x):
     return x
 
 
-def _unary_dispatcher(x):
+def unary_operation(x):
     return (x,)
+
+
+# Rename the dispatcher to hide it (we want the nicer name for the error):
+_unary_dispatcher = unary_operation
+del unary_operation
 
 
 @array_function_dispatch(_unary_dispatcher)
@@ -346,11 +351,11 @@ def log10(x):
     return nx.log10(x)
 
 
-def _logn_dispatcher(n, x):
+def logn(n, x):
     return (n, x,)
 
 
-@array_function_dispatch(_logn_dispatcher)
+@array_function_dispatch(logn)
 def logn(n, x):
     """
     Take log base n of x.
@@ -434,11 +439,11 @@ def log2(x):
     return nx.log2(x)
 
 
-def _power_dispatcher(x, p):
+def power(x, p):
     return (x, p)
 
 
-@array_function_dispatch(_power_dispatcher)
+@array_function_dispatch(power)
 def power(x, p):
     """
     Return x to the power p, (x**p).

--- a/numpy/lib/shape_base.py
+++ b/numpy/lib/shape_base.py
@@ -49,11 +49,11 @@ def _make_along_axis_idx(arr_shape, indices, axis):
     return tuple(fancy_index)
 
 
-def _take_along_axis_dispatcher(arr, indices, axis):
+def take_along_axis(arr, indices, axis):
     return (arr, indices)
 
 
-@array_function_dispatch(_take_along_axis_dispatcher)
+@array_function_dispatch(take_along_axis)
 def take_along_axis(arr, indices, axis):
     """
     Take values from the input array by matching 1d index and data slices.
@@ -170,11 +170,11 @@ def take_along_axis(arr, indices, axis):
     return arr[_make_along_axis_idx(arr_shape, indices, axis)]
 
 
-def _put_along_axis_dispatcher(arr, indices, values, axis):
+def put_along_axis(arr, indices, values, axis):
     return (arr, indices, values)
 
 
-@array_function_dispatch(_put_along_axis_dispatcher)
+@array_function_dispatch(put_along_axis)
 def put_along_axis(arr, indices, values, axis):
     """
     Put values into the destination array by matching 1d index and data slices.
@@ -260,11 +260,11 @@ def put_along_axis(arr, indices, values, axis):
     arr[_make_along_axis_idx(arr_shape, indices, axis)] = values
 
 
-def _apply_along_axis_dispatcher(func1d, axis, arr, *args, **kwargs):
+def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     return (arr,)
 
 
-@array_function_dispatch(_apply_along_axis_dispatcher)
+@array_function_dispatch(apply_along_axis)
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     """
     Apply a function to 1-D slices along the given axis.
@@ -414,11 +414,11 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
         return res.__array_wrap__(out_arr)
 
 
-def _apply_over_axes_dispatcher(func, a, axes):
+def apply_over_axes(func, a, axes):
     return (a,)
 
 
-@array_function_dispatch(_apply_over_axes_dispatcher)
+@array_function_dispatch(apply_over_axes)
 def apply_over_axes(func, a, axes):
     """
     Apply a function repeatedly over multiple axes.
@@ -505,11 +505,11 @@ def apply_over_axes(func, a, axes):
     return val
 
 
-def _expand_dims_dispatcher(a, axis):
+def expand_dims(a, axis):
     return (a,)
 
 
-@array_function_dispatch(_expand_dims_dispatcher)
+@array_function_dispatch(expand_dims)
 def expand_dims(a, axis):
     """
     Expand the shape of an array.
@@ -605,11 +605,11 @@ def expand_dims(a, axis):
 row_stack = vstack
 
 
-def _column_stack_dispatcher(tup):
+def column_stack(tup):
     return _arrays_for_stack_dispatcher(tup)
 
 
-@array_function_dispatch(_column_stack_dispatcher)
+@array_function_dispatch(column_stack)
 def column_stack(tup):
     """
     Stack 1-D arrays as columns into a 2-D array.
@@ -656,11 +656,11 @@ def column_stack(tup):
     return _nx.concatenate(arrays, 1)
 
 
-def _dstack_dispatcher(tup):
+def dstack(tup):
     return _arrays_for_stack_dispatcher(tup)
 
 
-@array_function_dispatch(_dstack_dispatcher)
+@array_function_dispatch(dstack)
 def dstack(tup):
     """
     Stack arrays in sequence depth wise (along third axis).
@@ -732,11 +732,11 @@ def _replace_zero_by_x_arrays(sub_arys):
     return sub_arys
 
 
-def _array_split_dispatcher(ary, indices_or_sections, axis=None):
+def array_split(ary, indices_or_sections, axis=None):
     return (ary, indices_or_sections)
 
 
-@array_function_dispatch(_array_split_dispatcher)
+@array_function_dispatch(array_split)
 def array_split(ary, indices_or_sections, axis=0):
     """
     Split an array into multiple sub-arrays.
@@ -792,11 +792,11 @@ def array_split(ary, indices_or_sections, axis=0):
     return sub_arys
 
 
-def _split_dispatcher(ary, indices_or_sections, axis=None):
+def split(ary, indices_or_sections, axis=None):
     return (ary, indices_or_sections)
 
 
-@array_function_dispatch(_split_dispatcher)
+@array_function_dispatch(split)
 def split(ary, indices_or_sections, axis=0):
     """
     Split an array into multiple sub-arrays as views into `ary`.
@@ -874,8 +874,12 @@ def split(ary, indices_or_sections, axis=0):
     return array_split(ary, indices_or_sections, axis)
 
 
-def _hvdsplit_dispatcher(ary, indices_or_sections):
+def hvdsplit(ary, indices_or_sections):
     return (ary, indices_or_sections)
+
+
+_hvdsplit_dispatcher = hvdsplit
+del hvdsplit
 
 
 @array_function_dispatch(_hvdsplit_dispatcher)
@@ -1066,11 +1070,11 @@ def get_array_wrap(*args):
     return None
 
 
-def _kron_dispatcher(a, b):
+def kron(a, b):
     return (a, b)
 
 
-@array_function_dispatch(_kron_dispatcher)
+@array_function_dispatch(kron)
 def kron(a, b):
     """
     Kronecker product of two arrays.
@@ -1184,11 +1188,11 @@ def kron(a, b):
     return result if not is_any_mat else matrix(result, copy=False)
 
 
-def _tile_dispatcher(A, reps):
+def tile(A, reps):
     return (A, reps)
 
 
-@array_function_dispatch(_tile_dispatcher)
+@array_function_dispatch(tile)
 def tile(A, reps):
     """
     Construct an array by repeating A the number of times given by reps.

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -115,12 +115,12 @@ def as_strided(x, shape=None, strides=None, subok=False, writeable=True):
     return view
 
 
-def _sliding_window_view_dispatcher(x, window_shape, axis=None, *,
-                                    subok=None, writeable=None):
+def sliding_window_view(x, window_shape, axis=None, *,
+                        subok=None, writeable=None):
     return (x,)
 
 
-@array_function_dispatch(_sliding_window_view_dispatcher)
+@array_function_dispatch(sliding_window_view)
 def sliding_window_view(x, window_shape, axis=None, *,
                         subok=False, writeable=False):
     """
@@ -360,11 +360,11 @@ def _broadcast_to(array, shape, subok, readonly):
     return result
 
 
-def _broadcast_to_dispatcher(array, shape, subok=None):
+def broadcast_to(array, shape, subok=None):
     return (array,)
 
 
-@array_function_dispatch(_broadcast_to_dispatcher, module='numpy')
+@array_function_dispatch(broadcast_to, module='numpy')
 def broadcast_to(array, shape, subok=False):
     """Broadcast an array to a new shape.
 
@@ -473,11 +473,11 @@ def broadcast_shapes(*args):
     return _broadcast_shape(*arrays)
 
 
-def _broadcast_arrays_dispatcher(*args, subok=None):
+def broadcast_arrays(*args, subok=None):
     return args
 
 
-@array_function_dispatch(_broadcast_arrays_dispatcher, module='numpy')
+@array_function_dispatch(broadcast_arrays, module='numpy')
 def broadcast_arrays(*args, subok=False):
     """
     Broadcast any number of arrays against each other.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3710,6 +3710,25 @@ class TestMedian:
         b[2] = np.nan
         assert_equal(np.median(a, (0, 2)), b)
 
+    @pytest.mark.parametrize("dtype", ["m8[s]"])
+    @pytest.mark.parametrize("pos", [0, 23, 10])
+    def test_nat_behavior(self, dtype, pos):
+        # TODO: Median does not support Datetime, due to `mean`.
+        # NaT and NaN should behave the same, do basic tests for NaT.
+        a = np.arange(0, 24, dtype=dtype)
+        a[pos] = "NaT"
+        res = np.median(a)
+        assert res.dtype == dtype
+        assert np.isnat(res)
+        res = np.percentile(a, [30, 60])
+        assert res.dtype == dtype
+        assert np.isnat(res).all()
+
+        a = np.arange(0, 24*3, dtype=dtype).reshape(-1, 3)
+        a[pos, 1] = "NaT"
+        res = np.median(a, axis=0)
+        assert_array_equal(np.isnat(res), [False, True, False])
+
     def test_empty(self):
         # mean(empty array) emits two warnings: empty slice and divide by 0
         a = np.array([], dtype=float)

--- a/numpy/lib/twodim_base.py
+++ b/numpy/lib/twodim_base.py
@@ -41,11 +41,11 @@ def _min_int(low, high):
     return int64
 
 
-def _flip_dispatcher(m):
+def fliplr(m):
     return (m,)
 
 
-@array_function_dispatch(_flip_dispatcher)
+@array_function_dispatch(fliplr)
 def fliplr(m):
     """
     Reverse the order of elements along axis 1 (left/right).
@@ -99,7 +99,11 @@ def fliplr(m):
     return m[:, ::-1]
 
 
-@array_function_dispatch(_flip_dispatcher)
+def flipud(m):
+    return (m,)
+
+
+@array_function_dispatch(flipud)
 def flipud(m):
     """
     Reverse the order of elements along axis 0 (up/down).
@@ -155,9 +159,11 @@ def flipud(m):
     return m[::-1, ...]
 
 
-def _eye_dispatcher(N, M=None, k=None, dtype=None, order=None, *, like=None):
+def eye(N, M=None, k=None, dtype=None, order=None, *, like=None):
     return (like,)
 
+# Need the dispatcher after defining the real function currently:
+_eye_dispatcher = eye
 
 @set_array_function_like_doc
 @set_module('numpy')
@@ -233,11 +239,11 @@ _eye_with_like = array_function_dispatch(
 )(eye)
 
 
-def _diag_dispatcher(v, k=None):
+def diag(v, k=None):
     return (v,)
 
 
-@array_function_dispatch(_diag_dispatcher)
+@array_function_dispatch(diag)
 def diag(v, k=0):
     """
     Extract a diagonal or construct a diagonal array.
@@ -309,7 +315,11 @@ def diag(v, k=0):
         raise ValueError("Input must be 1- or 2-d.")
 
 
-@array_function_dispatch(_diag_dispatcher)
+def diagflat(v, k=None):
+    return (v,)
+
+
+@array_function_dispatch(diagflat)
 def diagflat(v, k=0):
     """
     Create a two-dimensional array with the flattened input as a diagonal.
@@ -369,8 +379,12 @@ def diagflat(v, k=0):
     return wrap(res)
 
 
-def _tri_dispatcher(N, M=None, k=None, dtype=None, *, like=None):
+def tri(N, M=None, k=None, dtype=None, *, like=None):
     return (like,)
+
+
+# Need the dispatcher after defining the real function currently:
+_tri_dispatcher = tri
 
 
 @set_array_function_like_doc
@@ -435,11 +449,11 @@ _tri_with_like = array_function_dispatch(
 )(tri)
 
 
-def _trilu_dispatcher(m, k=None):
+def tril(m, k=None):
     return (m,)
 
 
-@array_function_dispatch(_trilu_dispatcher)
+@array_function_dispatch(tril)
 def tril(m, k=0):
     """
     Lower triangle of an array.
@@ -494,7 +508,11 @@ def tril(m, k=0):
     return where(mask, m, zeros(1, m.dtype))
 
 
-@array_function_dispatch(_trilu_dispatcher)
+def triu(m, k=None):
+    return (m,)
+
+
+@array_function_dispatch(triu)
 def triu(m, k=0):
     """
     Upper triangle of an array.
@@ -538,12 +556,12 @@ def triu(m, k=0):
     return where(mask, zeros(1, m.dtype), m)
 
 
-def _vander_dispatcher(x, N=None, increasing=None):
+def vander(x, N=None, increasing=None):
     return (x,)
 
 
 # Originally borrowed from John Hunter and matplotlib
-@array_function_dispatch(_vander_dispatcher)
+@array_function_dispatch(vander)
 def vander(x, N=None, increasing=False):
     """
     Generate a Vandermonde matrix.
@@ -634,8 +652,7 @@ def vander(x, N=None, increasing=False):
     return v
 
 
-def _histogram2d_dispatcher(x, y, bins=None, range=None, density=None,
-                            weights=None):
+def histogram2d(x, y, bins=None, range=None, density=None, weights=None):
     yield x
     yield y
 
@@ -652,7 +669,7 @@ def _histogram2d_dispatcher(x, y, bins=None, range=None, density=None,
     yield weights
 
 
-@array_function_dispatch(_histogram2d_dispatcher)
+@array_function_dispatch(histogram2d)
 def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     """
     Compute the bi-dimensional histogram of two data samples.
@@ -976,11 +993,11 @@ def tril_indices(n, k=0, m=None):
                  for inds in indices(tri_.shape, sparse=True))
 
 
-def _trilu_indices_form_dispatcher(arr, k=None):
+def tril_indices_from(arr, k=None):
     return (arr,)
 
 
-@array_function_dispatch(_trilu_indices_form_dispatcher)
+@array_function_dispatch(tril_indices_from)
 def tril_indices_from(arr, k=0):
     """
     Return the indices for the lower-triangle of arr.
@@ -1095,7 +1112,11 @@ def triu_indices(n, k=0, m=None):
                  for inds in indices(tri_.shape, sparse=True))
 
 
-@array_function_dispatch(_trilu_indices_form_dispatcher)
+def triu_indices_from(arr, k=None):
+    return (arr,)
+
+
+@array_function_dispatch(triu_indices_from)
 def triu_indices_from(arr, k=0):
     """
     Return the indices for the upper-triangle of arr.

--- a/numpy/lib/type_check.py
+++ b/numpy/lib/type_check.py
@@ -77,11 +77,11 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
     return min(intersection, key=_typecodes_by_elsize.index)
 
 
-def _asfarray_dispatcher(a, dtype=None):
+def asfarray(a, dtype=None):
     return (a,)
 
 
-@array_function_dispatch(_asfarray_dispatcher)
+@array_function_dispatch(asfarray)
 def asfarray(a, dtype=_nx.float_):
     """
     Return an array converted to a float type.
@@ -114,11 +114,11 @@ def asfarray(a, dtype=_nx.float_):
     return asarray(a, dtype=dtype)
 
 
-def _real_dispatcher(val):
+def real(val):
     return (val,)
 
 
-@array_function_dispatch(_real_dispatcher)
+@array_function_dispatch(real)
 def real(val):
     """
     Return the real part of the complex argument.
@@ -160,11 +160,11 @@ def real(val):
         return asanyarray(val).real
 
 
-def _imag_dispatcher(val):
+def imag(val):
     return (val,)
 
 
-@array_function_dispatch(_imag_dispatcher)
+@array_function_dispatch(imag)
 def imag(val):
     """
     Return the imaginary part of the complex argument.
@@ -203,8 +203,13 @@ def imag(val):
         return asanyarray(val).imag
 
 
-def _is_type_dispatcher(x):
+def is_type(x):
     return (x,)
+
+
+# Rename the dispatcher to hide it (we want the nicer name for the error):
+_is_type_dispatcher = is_type
+del is_type
 
 
 @array_function_dispatch(_is_type_dispatcher)
@@ -397,11 +402,11 @@ def _getmaxmin(t):
     return f.max, f.min
 
 
-def _nan_to_num_dispatcher(x, copy=None, nan=None, posinf=None, neginf=None):
+def nan_to_num(x, copy=None, nan=None, posinf=None, neginf=None):
     return (x,)
 
 
-@array_function_dispatch(_nan_to_num_dispatcher)
+@array_function_dispatch(nan_to_num)
 def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     """
     Replace NaN with zero and infinity with large finite numbers (default
@@ -522,11 +527,11 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 
 #-----------------------------------------------------------------------------
 
-def _real_if_close_dispatcher(a, tol=None):
+def real_if_close(a, tol=None):
     return (a,)
 
 
-@array_function_dispatch(_real_if_close_dispatcher)
+@array_function_dispatch(real_if_close)
 def real_if_close(a, tol=100):
     """
     If input is complex with all imaginary parts close to zero, return
@@ -675,11 +680,11 @@ array_precision = {_nx.half: 0,
                    _nx.clongdouble: 3}
 
 
-def _common_type_dispatcher(*arrays):
+def common_type(*arrays):
     return arrays
 
 
-@array_function_dispatch(_common_type_dispatcher)
+@array_function_dispatch(common_type)
 def common_type(*arrays):
     """
     Return a scalar type which is common to the input arrays.

--- a/numpy/lib/ufunclike.py
+++ b/numpy/lib/ufunclike.py
@@ -66,11 +66,11 @@ def _fix_and_maybe_deprecate_out_named_y(f):
 
 
 @_deprecate_out_named_y
-def _dispatcher(x, out=None):
+def fix(x, out=None):
     return (x, out)
 
 
-@array_function_dispatch(_dispatcher, verify=False, module='numpy')
+@array_function_dispatch(fix, verify=False, module='numpy')
 @_fix_and_maybe_deprecate_out_named_y
 def fix(x, out=None):
     """
@@ -124,7 +124,12 @@ def fix(x, out=None):
     return res
 
 
-@array_function_dispatch(_dispatcher, verify=False, module='numpy')
+@_deprecate_out_named_y
+def isposinf(x, out=None):
+    return (x, out)
+
+
+@array_function_dispatch(isposinf, verify=False, module='numpy')
 @_fix_and_maybe_deprecate_out_named_y
 def isposinf(x, out=None):
     """
@@ -196,7 +201,12 @@ def isposinf(x, out=None):
         return nx.logical_and(is_inf, signbit, out)
 
 
-@array_function_dispatch(_dispatcher, verify=False, module='numpy')
+@_deprecate_out_named_y
+def isneginf(x, out=None):
+    return (x, out)
+
+
+@array_function_dispatch(isneginf, verify=False, module='numpy')
 @_fix_and_maybe_deprecate_out_named_y
 def isneginf(x, out=None):
     """

--- a/numpy/lib/utils.py
+++ b/numpy/lib/utils.py
@@ -1039,9 +1039,11 @@ def _median_nancheck(data, result, axis):
         # Without given output, it is possible that the current result is a
         # numpy scalar, which is not writeable.  If so, just return nan.
         if isinstance(result, np.generic):
-            return data.dtype.type(np.nan)
-
-        result[n] = np.nan
+            return data.take(-1, axis=axis)
+        elif result.dtype.kind in 'mM':
+            result[n] = "NaT"
+        else:
+            result[n] = np.nan
     return result
 
 def _opt_info():

--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -232,11 +232,11 @@ def transpose(a):
 
 # Linear equations
 
-def _tensorsolve_dispatcher(a, b, axes=None):
+def tensorsolve(a, b, axes=None):
     return (a, b)
 
 
-@array_function_dispatch(_tensorsolve_dispatcher)
+@array_function_dispatch(tensorsolve)
 def tensorsolve(a, b, axes=None):
     """
     Solve the tensor equation ``a x = b`` for x.
@@ -313,11 +313,11 @@ def tensorsolve(a, b, axes=None):
     return res
 
 
-def _solve_dispatcher(a, b):
+def solve(a, b):
     return (a, b)
 
 
-@array_function_dispatch(_solve_dispatcher)
+@array_function_dispatch(solve)
 def solve(a, b):
     """
     Solve a linear matrix equation, or system of linear scalar equations.
@@ -402,11 +402,11 @@ def solve(a, b):
     return wrap(r.astype(result_t, copy=False))
 
 
-def _tensorinv_dispatcher(a, ind=None):
+def tensorinv(a, ind=None):
     return (a,)
 
 
-@array_function_dispatch(_tensorinv_dispatcher)
+@array_function_dispatch(tensorinv)
 def tensorinv(a, ind=2):
     """
     Compute the 'inverse' of an N-dimensional array.
@@ -476,9 +476,11 @@ def tensorinv(a, ind=2):
 
 # Matrix inversion
 
-def _unary_dispatcher(a):
+def unary_operation(a):
     return (a,)
 
+_unary_dispatcher = unary_operation
+del unary_operation
 
 @array_function_dispatch(_unary_dispatcher)
 def inv(a):
@@ -553,11 +555,11 @@ def inv(a):
     return wrap(ainv.astype(result_t, copy=False))
 
 
-def _matrix_power_dispatcher(a, n):
+def matrix_power(a, n):
     return (a,)
 
 
-@array_function_dispatch(_matrix_power_dispatcher)
+@array_function_dispatch(matrix_power)
 def matrix_power(a, n):
     """
     Raise a square matrix to the (integer) power `n`.
@@ -773,11 +775,11 @@ def cholesky(a):
 
 # QR decomposition
 
-def _qr_dispatcher(a, mode=None):
+def qr(a, mode=None):
     return (a,)
 
 
-@array_function_dispatch(_qr_dispatcher)
+@array_function_dispatch(qr)
 def qr(a, mode='reduced'):
     """
     Compute the qr factorization of a matrix.
@@ -1072,11 +1074,11 @@ def eigvals(a):
     return w.astype(result_t, copy=False)
 
 
-def _eigvalsh_dispatcher(a, UPLO=None):
+def eigvalsh(a, UPLO=None):
     return (a,)
 
 
-@array_function_dispatch(_eigvalsh_dispatcher)
+@array_function_dispatch(eigvalsh)
 def eigvalsh(a, UPLO='L'):
     """
     Compute the eigenvalues of a complex Hermitian or real symmetric matrix.
@@ -1328,7 +1330,11 @@ def eig(a):
     return w.astype(result_t, copy=False), wrap(vt)
 
 
-@array_function_dispatch(_eigvalsh_dispatcher)
+def eigh(a, UPLO=None):
+    return (a,)
+
+
+@array_function_dispatch(eigh)
 def eigh(a, UPLO='L'):
     """
     Return the eigenvalues and eigenvectors of a complex Hermitian
@@ -1470,11 +1476,11 @@ def eigh(a, UPLO='L'):
 
 # Singular value decomposition
 
-def _svd_dispatcher(a, full_matrices=None, compute_uv=None, hermitian=None):
+def svd(a, full_matrices=None, compute_uv=None, hermitian=None):
     return (a,)
 
 
-@array_function_dispatch(_svd_dispatcher)
+@array_function_dispatch(svd)
 def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     """
     Singular Value Decomposition.
@@ -1671,11 +1677,11 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
         return s
 
 
-def _cond_dispatcher(x, p=None):
+def cond(x, p=None):
     return (x,)
 
 
-@array_function_dispatch(_cond_dispatcher)
+@array_function_dispatch(cond)
 def cond(x, p=None):
     """
     Compute the condition number of a matrix.
@@ -1794,11 +1800,11 @@ def cond(x, p=None):
     return r
 
 
-def _matrix_rank_dispatcher(A, tol=None, hermitian=None):
+def matrix_rank(A, tol=None, hermitian=None):
     return (A,)
 
 
-@array_function_dispatch(_matrix_rank_dispatcher)
+@array_function_dispatch(matrix_rank)
 def matrix_rank(A, tol=None, hermitian=False):
     """
     Return matrix rank of array using SVD method
@@ -1905,11 +1911,11 @@ def matrix_rank(A, tol=None, hermitian=False):
 
 # Generalized inverse
 
-def _pinv_dispatcher(a, rcond=None, hermitian=None):
+def pinv(a, rcond=None, hermitian=None):
     return (a,)
 
 
-@array_function_dispatch(_pinv_dispatcher)
+@array_function_dispatch(pinv)
 def pinv(a, rcond=1e-15, hermitian=False):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
@@ -2158,11 +2164,11 @@ def det(a):
 
 # Linear Least Squares
 
-def _lstsq_dispatcher(a, b, rcond=None):
+def lstsq(a, b, rcond=None):
     return (a, b)
 
 
-@array_function_dispatch(_lstsq_dispatcher)
+@array_function_dispatch(lstsq)
 def lstsq(a, b, rcond="warn"):
     r"""
     Return the least-squares solution to a linear matrix equation.
@@ -2350,11 +2356,11 @@ def _multi_svd_norm(x, row_axis, col_axis, op):
     return result
 
 
-def _norm_dispatcher(x, ord=None, axis=None, keepdims=None):
+def norm(x, ord=None, axis=None, keepdims=None):
     return (x,)
 
 
-@array_function_dispatch(_norm_dispatcher)
+@array_function_dispatch(norm)
 def norm(x, ord=None, axis=None, keepdims=False):
     """
     Matrix or vector norm.
@@ -2609,12 +2615,12 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
 # multi_dot
 
-def _multidot_dispatcher(arrays, *, out=None):
+def multi_dot(arrays, *, out=None):
     yield from arrays
     yield out
 
 
-@array_function_dispatch(_multidot_dispatcher)
+@array_function_dispatch(multi_dot)
 def multi_dot(arrays, *, out=None):
     """
     Compute the dot product of two or more arrays in a single function call,


### PR DESCRIPTION
This is a bit of a call and various decisions could be made.
In some cases, I simply duplicated dispatchers to get the rigth name
(there is no other way to rename the function).

In other cases, I attempted to find a somewhat decent name (without
underscore) that at least gives a better idea than having
`_dispatcher` in there.
I tried to standardize the two most common ones to `unary_operation`
and `binary_operation`.

It may be possible to auto-copy the function and replace the name
in the decorator.  In general (if there is a custom decorator), I think
using the same name is probably best.

I do not have a strong opinion about the cases where dispatchers are
used multiple times though.  E.g. when to duplicate and when not.

---

As a reminder, this fixes (mostly) the problem that:
```
np.histogram(asdf=3)
```
gives:
```
TypeError: _histogram_dispatcher() got an unexpected keyword argument 'asdf'
```
which I think is potentially confusing to users.  It thus mostly addreses gh-21647.

@shoyer since this was originally your work, could you have a look/review this?

(I am happy about other ideas, or at least reducing it to only fix places where the dispatcher is defined directly before the function.)

The following symbols have dispatcher names that do not match and are not either `unary_operation` or `binary_operation`:
```
numpy.core.fromnumeric round_ around
numpy.core.fromnumeric product prod
numpy.core.fromnumeric cumproduct cumprod
numpy.core.fromnumeric sometrue any
numpy.core.fromnumeric alltrue all
numpy.core.defchararray count find_or_count
numpy.core.defchararray find find_or_count
numpy.core.defchararray index find_or_count
numpy.core.defchararray rfind find_or_count
numpy.core.defchararray rindex find_or_count
numpy.core.defchararray rpartition partition
numpy.lib.type_check iscomplex is_type
numpy.lib.type_check isreal is_type
numpy.lib.type_check iscomplexobj is_type
numpy.lib.type_check isrealobj is_type
numpy.lib.shape_base hsplit hvdsplit
numpy.lib.shape_base vsplit hvdsplit
numpy.lib.shape_base dsplit hvdsplit
numpy.fft._pocketfft ifft fft
numpy.fft._pocketfft rfft fft
numpy.fft._pocketfft irfft fft
numpy.fft._pocketfft hfft fft
numpy.fft._pocketfft ihfft fft
numpy.fft._pocketfft ifftn fftn
numpy.fft._pocketfft fft2 fftn
numpy.fft._pocketfft ifft2 fftn
numpy.fft._pocketfft rfftn fftn
numpy.fft._pocketfft rfft2 fftn
numpy.fft._pocketfft irfftn fftn
numpy.fft._pocketfft irfft2 fftn
```