### PR TITLE
DOC: Add note about broadcasting support for `random.Generator.multinomial`

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3788,6 +3788,12 @@ cdef class Generator:
             Each entry ``out[i,j,...,:]`` is a ``p``-dimensional value drawn
             from the distribution.
 
+        Notes
+        -----
+
+        .. versionchanged:: 1.22.0
+            Added support for broadcasting of arguments
+
         Examples
         --------
         Throw a dice 20 times:

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3788,11 +3788,8 @@ cdef class Generator:
             Each entry ``out[i,j,...,:]`` is a ``p``-dimensional value drawn
             from the distribution.
 
-        Notes
-        -----
-
-        .. versionchanged:: 1.22.0
-            Added support for broadcasting of arguments
+            .. versionchanged:: 1.22.0
+                Added support for broadcasting ``pvals`` against ``n``
 
         Examples
         --------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3789,7 +3789,7 @@ cdef class Generator:
             from the distribution.
 
             .. versionchanged:: 1.22.0
-                Added support for broadcasting ``pvals`` against ``n``
+                Added support for broadcasting `pvals` against `n`
 
         Examples
         --------


### PR DESCRIPTION
Adds docstring note for `random.Generator.multinomial` about broadcasting behavior change.

Closes #21555.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
