### PR TITLE
MAINT: Point documentation version switcher at the docs homepage

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -283,7 +283,7 @@ If the release series is a new one, you will need to add a new section to the
     $ gvim index.html +/'insert here'
 
 Further, update the version-switcher json file to add the new release and
-update the version marked `(stable)`:
+update the version marked `(stable)`::
 
     $ gvim _static/versions.json
 

--- a/doc/RELEASE_WALKTHROUGH.rst.txt
+++ b/doc/RELEASE_WALKTHROUGH.rst.txt
@@ -282,6 +282,11 @@ If the release series is a new one, you will need to add a new section to the
 
     $ gvim index.html +/'insert here'
 
+Further, update the version-switcher json file to add the new release and
+update the version marked `(stable)`:
+
+    $ gvim _static/versions.json
+
 Otherwise, only the ``zip`` and ``pdf`` links should be updated with the
 new tag name::
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -171,7 +171,7 @@ html_logo = '_static/numpylogo.svg'
 
 html_favicon = '_static/favicon/favicon.ico'
 
-# Set up the version switcher.  The versions.json is stored in the devdocs.
+# Set up the version switcher.  The versions.json is stored in the doc repo.
 if os.environ.get('CIRCLE_JOB', False) and \
         os.environ.get('CIRCLE_BRANCH', '') != 'main':
     # For PR, name is set to its ref
@@ -193,7 +193,7 @@ html_theme_options = {
   "navbar_end": ["version-switcher", "navbar-icon-links"],
   "switcher": {
       "version_match": switcher_version,
-      "json_url": "https://numpy.org/devdocs/_static/versions.json",
+      "json_url": "https://numpy.org/doc/_static/versions.json",
   },
 }
 


### PR DESCRIPTION
Backport of #21681.

This moves the version switcher json file (which holds all the version
information and links to them), to the documentation repository.
It also removes the current one included in the devdocs. Since we only
have the devdocs currently released with the version switcher, this is
safe, so long it gets backported before any new documentation upload.



<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
