### PR TITLE
DOC: Fix broadcasting documentation.

### DIFF
--- a/doc/source/user/basics.broadcasting.rst
+++ b/doc/source/user/basics.broadcasting.rst
@@ -280,7 +280,7 @@ Typically, a large number of ``observations``, perhaps read from a database,
 are compared to a set of ``codes``. Consider this scenario::
 
   Observation      (2d array):      10 x 3
-  Codes            (2d array):       5 x 3
+  Codes            (3d array):   5 x 1 x 3
   Diff             (3d array):  5 x 10 x 3
 
 The three-dimensional array, ``diff``, is a consequence of broadcasting, not a


### PR DESCRIPTION
DOC : The example in documentation says 2d array. however it should be 3d array.

Closes #21642.

Details : 

The example says the following shapes : 

Observation      (2d array):      10 x 3
Codes            (2d array):       5 x 3
Diff             (3d array):  5 x 10 x 3

however since diff is a result of broadcasting, the codes must be a 3d array of shape 5 x 1 x 3. 

Final should look like : 

Observation      (2d array):      10 x 3
Codes            (3d array):       5 x 1 x 3
Diff             (3d array):  5 x 10 x 3

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
