### PR TITLE
BUG: Enable fortran preprocessing for ifort on Windows

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -154,7 +154,8 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore', 
+               '/fpp']
         return opt
 
     def get_flags_free(self):

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -154,8 +154,8 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore', 
-               '/fpp']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', 
+               '/assume:underscore', '/fpp']
         return opt
 
     def get_flags_free(self):


### PR DESCRIPTION
Needed especially when compiling the latest scipy on Windows. This flag is already
set on Linux and Mac.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
