### PR TITLE
DOC: Mention positional-only arguments in the array API compatibility doc

### DIFF
--- a/doc/source/reference/array_api.rst
+++ b/doc/source/reference/array_api.rst
@@ -801,3 +801,8 @@ Other Differences
      - **Strictness**
      - The spec allows duck typing, so ``finfo`` returning dtype
        scalars is considered type compatible with ``float``.
+   * - Positional arguments in every function are positional-only.
+     - **Breaking**
+     - See the spec for the exact signature of each function. Note that NumPy
+       ufuncs already use positional-only arguments, but non-ufuncs like
+       ``asarray`` generally do not.


### PR DESCRIPTION
I forgot to mention them, but they are important because this would be a
breaking change.

This applies to basically every function except for ufuncs, so I just mentioned it in one bullet point. It's a breaking change because it would break the ability for code to use the current positional argument names as keywords. 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
