### PR TITLE
MAINT: generate_umath.py: do not write full path into output files

### DIFF
--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1236,7 +1236,7 @@ def make_code(funcdict, filename):
 
         return 0;
     }
-    """) % (filename, code1, code2, code3)
+    """) % (os.path.basename(filename), code1, code2, code3)
     return code
 
 


### PR DESCRIPTION
This helps reproducibility as those paths vary in automated
build environments.
