### PR TITLE
TST: Fixup loadtxt int-via-float tests when in release mode

### DIFF
--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -1216,6 +1216,12 @@ class TestAxisNotMAXDIMS(_DeprecationTestCase):
 
 
 class TestLoadtxtParseIntsViaFloat(_DeprecationTestCase):
+    # Deprecated 2022-07-03, NumPy 1.23
+    # This test can be removed without replacement after the deprecation.
+    # The tests:
+    #   * numpy/lib/tests/test_loadtxt.py::test_integer_signs
+    #   * lib/tests/test_loadtxt.py::test_implicit_cast_float_to_int_fails
+    # Have a warning filter that needs to be removed.
     message = r"loadtxt\(\): Parsing an integer via a float is deprecated.*"
 
     @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -390,6 +390,7 @@ def test_bool():
 @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
                     reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
+@pytest.mark.filterwarnings("error:.*integer via a float.*:DeprecationWarning")
 def test_integer_signs(dtype):
     dtype = np.dtype(dtype)
     assert np.loadtxt(["+2"], dtype=dtype) == 2
@@ -407,6 +408,7 @@ def test_integer_signs(dtype):
 @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
                     reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
+@pytest.mark.filterwarnings("error:.*integer via a float.*:DeprecationWarning")
 def test_implicit_cast_float_to_int_fails(dtype):
     txt = StringIO("1.0, 2.1, 3.7\n4, 5, 6")
     with pytest.raises(ValueError):


### PR DESCRIPTION
In release mode, the DeprecationWarning is not automatically raised,
so we need to ensure this using a warning filter.

(Also add missing metadata/info to the deprecation tests)

Closes gh-21706

---

Tested locally, by removing everything interesting from `pytest.ini` (simulating a release for testing purposes).  Should be good, unless there are slow tests (which would be surprising).