### PR TITLE
DOC: Tell people to use only-binary option

### DIFF
--- a/doc/source/user/depending_on_numpy.rst
+++ b/doc/source/user/depending_on_numpy.rst
@@ -37,7 +37,10 @@ Testing against the NumPy main branch or pre-releases
 For large, actively maintained packages that depend on NumPy, we recommend
 testing against the development version of NumPy in CI. To make this easy,
 nightly builds are provided as wheels at
-https://anaconda.org/scipy-wheels-nightly/.
+https://anaconda.org/scipy-wheels-nightly/. Example install command::
+
+    pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+
 This helps detect regressions in NumPy that need fixing before the next NumPy
 release.  Furthermore, we recommend to raise errors on warnings in CI for this
 job, either all warnings or otherwise at least ``DeprecationWarning`` and


### PR DESCRIPTION
Tell people to use only-binary option when installing nightly wheel for downstream testing.

Close #21711

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
