### PR TITLE
BLD: use OpenBLAS HEAD with '-fvisibility=protected'

### DIFF
--- a/doc/release/upcoming_changes/21717.improvement.rst
+++ b/doc/release/upcoming_changes/21717.improvement.rst
@@ -1,0 +1,5 @@
+OpenBLAS v0.3.20
+----------------
+
+Update the OpenBLAS used in testing and in wheels to v0.3.20, and use
+``-fvisibility=protected`` to prevent overriding exported symbols.

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -13,8 +13,8 @@ from tempfile import mkstemp, gettempdir
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError
 
-OPENBLAS_V = '0.3.20'
-OPENBLAS_LONG = 'v0.3.20'
+OPENBLAS_V = "0.3.20"
+OPENBLAS_LONG = "v0.3.20-140-gbfd9c1b5"
 BASE_LOC = 'https://anaconda.org/multibuild-wheels-staging/openblas-libs'
 BASEURL = f'{BASE_LOC}/{OPENBLAS_LONG}/download'
 SUPPORTED_PLATFORMS = [


### PR DESCRIPTION
Fixes #21643 by using an OpenBLAS built with `-fvisibility=protected`.

If this passes and @charris approves, we can consider rebuilding the `v0.3.20` OpenBLAS builds used in the `1.23.0rc1` release, see PR MacPython/openblas-libs#81