### PR TITLE
BUG: Small fixupes found using valgrind

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -3403,6 +3403,9 @@ void_to_void_resolve_descriptors(
         /* From structured to structured, need to check fields */
         casting = can_cast_fields_safety(
                 given_descrs[0], given_descrs[1], view_offset);
+        if (casting < 0) {
+            return -1;
+        }
     }
     else if (given_descrs[0]->names != NULL) {
         return structured_to_nonstructured_resolve_descriptors(

--- a/numpy/core/src/multiarray/textreading/tokenize.cpp
+++ b/numpy/core/src/multiarray/textreading/tokenize.cpp
@@ -386,9 +386,10 @@ tokenize(stream *s, tokenizer_state *ts, parser_config *const config)
      *    empty.
      * 2. If we are splitting on whitespace we always ignore a last empty
      *    field to match Python's splitting: `" 1 ".split()`.
+     *    (Zero fields are possible when we are only skipping lines)
      */
-    if (ts->num_fields == 1
-            || ts->unquoted_state == TOKENIZE_UNQUOTED_WHITESPACE) {
+    if (ts->num_fields == 1 || (ts->num_fields > 0
+                && ts->unquoted_state == TOKENIZE_UNQUOTED_WHITESPACE)) {
         size_t offset_last = ts->fields[ts->num_fields-1].offset;
         size_t end_last = ts->fields[ts->num_fields].offset;
         if (!ts->fields->quoted && end_last - offset_last == 1) {


### PR DESCRIPTION
Backport of #21691.

This is part of my pre 1.23.x valgrind run. Besides these two fixes, there is one in f2py (gh-21682).
There is another leak in numpy/core/tests/test_deprecations.py::TestNoseDecoratorsDeprecated::test_skip_generators_hardcoded, but I assume the test is either weird or it is upstream (since this is nose!).

Besides these, all further issues seem to be related to either proper longdouble support missing, or the fact that ufunc strides appear not always filled for empty inputs. I may look into the last point, but it does not seem relevant in practice (for empty input, the stride really should not matter).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
