### PR TITLE
BUG: Enable fortran preprocessing for ifort on Windows

### DIFF
--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -154,7 +154,8 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore', 
+               '/fpp']
         return opt
 
     def get_flags_free(self):

--- a/numpy/distutils/fcompiler/intel.py
+++ b/numpy/distutils/fcompiler/intel.py
@@ -154,8 +154,8 @@ class IntelVisualFCompiler(BaseIntelFCompiler):
     module_include_switch = '/I'
 
     def get_flags(self):
-        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', '/assume:underscore', 
-               '/fpp']
+        opt = ['/nologo', '/MD', '/nbs', '/names:lowercase', 
+               '/assume:underscore', '/fpp']
         return opt
 
     def get_flags_free(self):


### PR DESCRIPTION
Backport of #21701.

Needed especially when compiling the latest scipy on Windows. This flag is already
set on Linux and Mac.