### PR TITLE
BUG: .f2py_f2cmap doesn't map long_long and other options

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -170,6 +170,7 @@ f2cmap_all = {'real': {'': 'float', '4': 'float', '8': 'double',
 
 f2cmap_default = copy.deepcopy(f2cmap_all)
 
+f2cmap_mapped = []
 
 def load_f2cmap_file(f2cmap_file):
     global f2cmap_all
@@ -206,6 +207,7 @@ def load_f2cmap_file(f2cmap_file):
                     f2cmap_all[k][k1] = d[k][k1]
                     outmess('\tMapping "%s(kind=%s)" to "%s"\n' %
                             (k, k1, d[k][k1]))
+                    f2cmap_mapped.append(d[k][k1])
                 else:
                     errmess("\tIgnoring map {'%s':{'%s':'%s'}}: '%s' must be in %s\n" % (
                         k, k1, d[k][k1], d[k][k1], list(c2py_map.keys())))

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -1262,6 +1262,9 @@ def buildmodule(m, um):
         rd = dictappend(rd, ar)
 
     needs = cfuncs.get_needs()
+    # Add mapped definitions
+    needs['typedefs'] += [cvar for cvar in capi_maps.f2cmap_mapped #
+                          if cvar in typedef_need_dict.values()]
     code = {}
     for n in needs.keys():
         code[n] = []

--- a/numpy/f2py/tests/src/f2cmap/.f2py_f2cmap
+++ b/numpy/f2py/tests/src/f2cmap/.f2py_f2cmap
@@ -1,0 +1,1 @@
+dict(real=dict(real32='float', real64='double'), integer=dict(int64='long_long'))

--- a/numpy/f2py/tests/src/f2cmap/isoFortranEnvMap.f90
+++ b/numpy/f2py/tests/src/f2cmap/isoFortranEnvMap.f90
@@ -1,0 +1,9 @@
+      subroutine func1(n, x, res)
+        use, intrinsic :: iso_fortran_env, only: int64, real64
+        implicit none
+        integer(int64), intent(in) :: n
+        real(real64), intent(in) :: x(n)
+        real(real64), intent(out) :: res
+Cf2py   intent(hide) :: n
+        res = sum(x)
+      end

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -1,0 +1,15 @@
+from . import util
+import numpy as np
+
+class TestF2Cmap(util.F2PyTest):
+    sources = [
+        util.getpath("tests", "src", "f2cmap", "isoFortranEnvMap.f90"),
+        util.getpath("tests", "src", "f2cmap", ".f2py_f2cmap")
+    ]
+
+    # gh-15095
+    def test_long_long_map(self):
+        inp = np.ones(3)
+        out = self.module.func1(inp)
+        exp_out = 3
+        assert out == exp_out


### PR DESCRIPTION
Backport of #21712.

Closes #15095.

Essentially the previous behavior correctly overwrote the internal type, but didn't generate the required `typedef` helpers needed for the `C` wrapper. The fix is to track when the file includes a mapping value for which the `typedef` is needed and then to generate it.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
