### PR TITLE
DOC: Update sphinx, numpydoc, and pydata-sphinx-theme

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
     - script: |
         python -m pip install -r test_requirements.txt
         # Don't use doc_requirements.txt since that messes up tests
-        python -m pip install vulture sphinx==5.0.1 numpydoc==1.4.0
+        python -m pip install vulture sphinx==4.3.0 numpydoc==1.4.0
       displayName: 'Install dependencies; some are optional to avoid test skips'
     - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
       displayName: 'Check for unreachable code paths in Python modules'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ stages:
     - script: |
         python -m pip install -r test_requirements.txt
         # Don't use doc_requirements.txt since that messes up tests
-        python -m pip install vulture sphinx==4.2.0 numpydoc==1.2.0
+        python -m pip install vulture sphinx==5.0.1 numpydoc==1.4.0
       displayName: 'Install dependencies; some are optional to avoid test skips'
     - script: /bin/bash -c "! vulture . --min-confidence 100 --exclude doc/,numpy/distutils/ | grep 'unreachable'"
       displayName: 'Check for unreachable code paths in Python modules'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -179,7 +179,6 @@ else:
     switcher_version = f"doc/{version}"
 
 html_theme_options = {
-  "logo_link": "index",
   "github_url": "https://github.com/numpy/numpy",
   "twitter_url": "https://twitter.com/numpy_team",
   "collapse_navigation": True,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,7 +4,7 @@ import sys
 import importlib
 
 # Minimum version, enforced by sphinx
-needs_sphinx = '3.2.0'
+needs_sphinx = '5.0.1'
 
 
 # This is a nasty hack to use platform-agnostic names for types in the
@@ -103,9 +103,6 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# Will change to `root_doc` in Sphinx 4
-master_doc = 'index'
-
 # General substitutions.
 project = 'NumPy'
 copyright = '2008-2022, NumPy Developers'
@@ -190,7 +187,7 @@ html_theme_options = {
       {"name": "Learn", "url": "https://numpy.org/numpy-tutorials/"}
       ],
   # Add light/dark mode and documentation version switcher:
-  "navbar_end": ["version-switcher", "navbar-icon-links"],
+  "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
   "switcher": {
       "version_match": switcher_version,
       "json_url": "https://numpy.org/doc/_static/versions.json",
@@ -201,6 +198,7 @@ html_title = "%s v%s Manual" % (project, version)
 html_static_path = ['_static']
 html_last_updated_fmt = '%b %d, %Y'
 html_css_files = ["numpy.css"]
+html_context = {"default_mode": "light"}
 
 # Prevent sphinx-panels from loading bootstrap css, the pydata-sphinx-theme
 # already loads it

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,7 +4,7 @@ import sys
 import importlib
 
 # Minimum version, enforced by sphinx
-needs_sphinx = '5.0.1'
+needs_sphinx = '4.3'
 
 
 # This is a nasty hack to use platform-agnostic names for types in the

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,7 +1,7 @@
 # doxygen required, use apt-get or dnf
-sphinx==4.5.0
-numpydoc==1.3.1
-pydata-sphinx-theme==0.8.1
+sphinx==5.0.1
+numpydoc==1.4
+pydata-sphinx-theme==0.9.0
 sphinx-panels
 ipython!=8.1.0
 scipy

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx==5.0.1
+sphinx>=4.5.0
 numpydoc==1.4
 pydata-sphinx-theme==0.9.0
 sphinx-panels

--- a/environment.yml
+++ b/environment.yml
@@ -22,14 +22,14 @@ dependencies:
   - mypy=0.950
   - typing_extensions>=4.2.0
   # For building docs
-  - sphinx=4.5.0
+  - sphinx=5.0.1
   - sphinx-panels
-  - numpydoc=1.3.1
+  - numpydoc=1.4.0
   - ipython
   - scipy
   - pandas
   - matplotlib
-  - pydata-sphinx-theme=0.8.1
+  - pydata-sphinx-theme=0.9.0
   - doxygen
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
   - breathe!=4.33.0

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - mypy=0.950
   - typing_extensions>=4.2.0
   # For building docs
-  - sphinx=5.0.1
+  - sphinx>=4.5.0
   - sphinx-panels
   - numpydoc=1.4.0
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - pydata-sphinx-theme=0.9.0
   - doxygen
   # NOTE: breathe 4.33.0 collides with sphinx.ext.graphviz
-  - breathe!=4.33.0
+  - breathe>4.33.0
   # For linting
   - pycodestyle=2.7.0
   - gitpython

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -42,7 +42,6 @@ from contextlib import contextmanager, redirect_stderr
 from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 
 from docutils.parsers.rst import directives
-from pkg_resources import parse_version
 
 import sphinx
 import numpy as np
@@ -52,20 +51,10 @@ from numpydoc.docscrape_sphinx import get_doc_object
 
 SKIPBLOCK = doctest.register_optionflag('SKIPBLOCK')
 
-if parse_version(sphinx.__version__) >= parse_version('1.5'):
-    # Enable specific Sphinx directives
-    from sphinx.directives.other import SeeAlso, Only
-    directives.register_directive('seealso', SeeAlso)
-    directives.register_directive('only', Only)
-else:
-    # Remove sphinx directives that don't run without Sphinx environment.
-    # Sphinx < 1.5 installs all directives on import...
-    directives._directives.pop('versionadded', None)
-    directives._directives.pop('versionchanged', None)
-    directives._directives.pop('moduleauthor', None)
-    directives._directives.pop('sectionauthor', None)
-    directives._directives.pop('codeauthor', None)
-    directives._directives.pop('toctree', None)
+# Enable specific Sphinx directives
+from sphinx.directives.other import SeeAlso, Only
+directives.register_directive('seealso', SeeAlso)
+directives.register_directive('only', Only)
 
 
 BASE_MODULE = "numpy"


### PR DESCRIPTION
Updates for sphinx, numpydoc, and pydata-sphinx-theme.

The new version of the pydata-sphinx-theme adds a theme switcher (light, dark, auto mode) among other improvements. I've set it to default to light mode for now. Once we have more feedback on the dark theme, we can set it to auto mode.