### PR TITLE
ENH: Fix pointer size determination for cross build

### DIFF
--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sysconfig
 
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -38,7 +39,7 @@ def configuration(parent_package='', top_path=None):
         class numpy_linalg_lapack_lite(system_info):
             def calc_info(self):
                 info = {'language': 'c'}
-                if sys.maxsize > 2**32:
+                if sysconfig.get_config_var("SIZEOF_VOID_P") > 4:
                     # Build lapack-lite in 64-bit integer mode.
                     # The suffix is arbitrary (lapack_lite symbols follow it),
                     # but use the "64_" convention here.

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -39,7 +39,12 @@ def configuration(parent_package='', top_path=None):
         class numpy_linalg_lapack_lite(system_info):
             def calc_info(self):
                 info = {'language': 'c'}
-                if sysconfig.get_config_var("SIZEOF_SIZE_T") >= 8:
+                size_t_size = sysconfig.get_config_var("SIZEOF_SIZE_T")
+                if size_t_size:
+                    maxsize = 2**(size_t_size - 1) - 1
+                else: # handle windows
+                    maxsize = sys.maxsize
+                if maxsize > 2**32:
                     # Build lapack-lite in 64-bit integer mode.
                     # The suffix is arbitrary (lapack_lite symbols follow it),
                     # but use the "64_" convention here.

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -39,7 +39,7 @@ def configuration(parent_package='', top_path=None):
         class numpy_linalg_lapack_lite(system_info):
             def calc_info(self):
                 info = {'language': 'c'}
-                if sysconfig.get_config_var("SIZEOF_VOID_P") > 4:
+                if sysconfig.get_config_var("SIZEOF_SIZE_T") >= 8:
                     # Build lapack-lite in 64-bit integer mode.
                     # The suffix is arbitrary (lapack_lite symbols follow it),
                     # but use the "64_" convention here.

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -42,7 +42,7 @@ def configuration(parent_package='', top_path=None):
                 size_t_size = sysconfig.get_config_var("SIZEOF_SIZE_T")
                 if size_t_size:
                     maxsize = 2**(size_t_size - 1) - 1
-                else: # handle windows
+                else:  # handle windows
                     maxsize = sys.maxsize
                 if maxsize > 2**32:
                     # Build lapack-lite in 64-bit integer mode.

--- a/numpy/linalg/setup.py
+++ b/numpy/linalg/setup.py
@@ -42,7 +42,9 @@ def configuration(parent_package='', top_path=None):
                 size_t_size = sysconfig.get_config_var("SIZEOF_SIZE_T")
                 if size_t_size:
                     maxsize = 2**(size_t_size - 1) - 1
-                else:  # handle windows
+                else:
+                    # We prefer using sysconfig as it allows cross-compilation
+                    # but the information may be missing (e.g. on windows).
                     maxsize = sys.maxsize
                 if maxsize > 2**32:
                     # Build lapack-lite in 64-bit integer mode.


### PR DESCRIPTION
Using `sys` to ask about the build Python is hostile to cross
building because it is very hard to replace the sys module with one
that gives info about the target system. On the other hand, the
sysconfig data can be replaced by setting _PYTHON_SYSCONFIGDATA_NAME.
So instead of using `sys.maxsize` to determine pointer size, use
`sysconfig.get_config_var("SIZEOF_VOID_P")`