### PR TITLE
PERF: Micro optimize find_common_type

### DIFF
--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -648,8 +648,10 @@ def find_common_type(array_types, scalar_types):
     dtype('complex128')
 
     """
-    maxa = _can_coerce_all([dtype(x) for x in array_types]) if array_types else None
-    maxsc = _can_coerce_all([dtype(x) for x in scalar_types]) if scalar_types else None
+    maxa = _can_coerce_all([dtype(x) for x in array_types]) if array_types \
+                                                            else None
+    maxsc = _can_coerce_all([dtype(x) for x in scalar_types]) \
+                                    if scalar_types else None
 
     if maxa is None:
         return maxsc

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -556,6 +556,7 @@ typeDict = sctypeDict
 _kind_list = ['b', 'u', 'i', 'f', 'c', 'S', 'U', 'V', 'O', 'M', 'm']
 
 __test_types = '?'+typecodes['AllInteger'][:-2]+typecodes['AllFloat']+'O'
+__test_types_dtype = [dtype(t) for t in __test_types]
 __len_test_types = len(__test_types)
 
 # Keep incrementing until a common type both can be coerced to
@@ -571,6 +572,7 @@ def _find_common_coerce(a, b):
 
 # Find a data-type that all data-types in a list can be coerced to
 def _can_coerce_all(dtypelist, start=0):
+    dtypelist = list(set(dtypelist))
     N = len(dtypelist)
     if N == 0:
         return None
@@ -578,7 +580,7 @@ def _can_coerce_all(dtypelist, start=0):
         return dtypelist[0]
     thisind = start
     while thisind < __len_test_types:
-        newdtype = dtype(__test_types[thisind])
+        newdtype = __test_types_dtype[thisind]
         numcoerce = len([x for x in dtypelist if newdtype >= x])
         if numcoerce == N:
             return newdtype

--- a/numpy/core/numerictypes.py
+++ b/numpy/core/numerictypes.py
@@ -648,11 +648,8 @@ def find_common_type(array_types, scalar_types):
     dtype('complex128')
 
     """
-    array_types = [dtype(x) for x in array_types]
-    scalar_types = [dtype(x) for x in scalar_types]
-
-    maxa = _can_coerce_all(array_types)
-    maxsc = _can_coerce_all(scalar_types)
+    maxa = _can_coerce_all([dtype(x) for x in array_types]) if array_types else None
+    maxsc = _can_coerce_all([dtype(x) for x in scalar_types]) if scalar_types else None
 
     if maxa is None:
         return maxsc


### PR DESCRIPTION
The `find_common_type` is a (small) performance bottleneck in one of the scipy algoritms. This PR optimizes the method:

A benchmark (extracted from  what is called from scipy):
```
import numpy as np
from numpy.core.numerictypes import find_common_type

array_types = [np.dtype('float64'), np.dtype('float64')]
scalar_types = []

find_common_type(array_types, scalar_types)
```
Results of `%timeit find_common_type(array_types, scalar_types)`.

* Main: `8.37 µs ± 500 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)`
* PR: `1.09 µs ± 57.6 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)` 
* PR (only first commit): `1.81 µs ± 313 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)`  

The optmizations are:
* Cache cast of  `__test_types` to `dtype`
* Make elements of  `dtypelist` unique. This could make other calls a bit slower, but the `list(set(dtypelist))` is fast and it makes cases with duplicate dtypes faster
* Fast path in `find_common_type` for empty arguments.





<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
