### PR TITLE
CI: Fix CI SIMD build on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ jobs:
     - python: "3.8"
       os: linux
       arch: s390x
+      # fixes VX assembler ambiguous errors
+      # due to compiler incompatibility
+      install: sudo apt update && sudo apt -y --only-upgrade install binutils
       env:
        # use OpenBLAS build, not system ATLAS
        - DOWNLOAD_OPENBLAS=1


### PR DESCRIPTION
On s390x, Travis CI runner fails to build SIMD VX features. The assembler errors seems to be caused due to invalid repo packages or incompatible assembler. the following error looks new, I didn't detect it before so maybe a new update has been made by Travis causes this issue.

```Bash
extra options: '-march=arch11 -mzvector -Werror'

WARN: CCompilerOpt.dist_test[630] : CCompilerOpt._dist_test_spawn[764] : Command (gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Werror=vla -Werror=nonnull -Werror=pointer-arith -Werror=implicit-function-declaration -Wlogical-op -Wno-sign-compare -Werror=undef -fPIC -Inumpy/core/src/common -Inumpy/core/src -Inumpy/core -Inumpy/core/src/npymath -Inumpy/core/src/multiarray -Inumpy/core/src/umath -Inumpy/core/src/npysort -Inumpy/core/src/_simd -I/home/travis/build/numpy/numpy/builds/venv/include -I/opt/python/3.8.13/include/python3.8 -Ibuild/src.linux-s390x-3.8/numpy/core/src/common -Ibuild/src.linux-s390x-3.8/numpy/core/src/npymath -c /home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vx.c -o /tmp/tmp7602jpef/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vx.o -MMD -MF /tmp/tmp7602jpef/home/travis/build/numpy/numpy/numpy/distutils/checks/cpu_vx.o.d -march=arch11 -mzvector -Werror) failed with exit status 1 output -> 

/tmp/ccucTcH0.s: Assembler messages:

/tmp/ccucTcH0.s:19: Error: junk at end of line: `,3'

```