### PR TITLE
BUG: Do not skip value-based promotion path for large Python integers

### DIFF
--- a/numpy/core/src/multiarray/convert_datatype.c
+++ b/numpy/core/src/multiarray/convert_datatype.c
@@ -1691,8 +1691,12 @@ PyArray_ResultType(
             all_DTypes[i_all] = &PyArray_PyComplexAbstractDType;
         }
         else {
-            /* N.B.: Could even be an object dtype here for large ints */
+            /* This could even be an object dtype here for large ints */
             all_DTypes[i_all] = &PyArray_PyIntAbstractDType;
+            if (PyArray_TYPE(arrs[i]) != NPY_LONG) {
+                /* Not a "normal" scalar, so we cannot avoid the legacy path */
+                all_pyscalar = 0;
+            }
         }
         Py_INCREF(all_DTypes[i_all]);
         /*

--- a/numpy/core/tests/test_dtype.py
+++ b/numpy/core/tests/test_dtype.py
@@ -1346,6 +1346,16 @@ class TestPromotion:
                 match=r".* no common DType exists for the given inputs"):
             np.result_type(1j, rational(1, 2))
 
+    @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2*100])
+    def test_python_integer_promotion(self, val):
+        # If we only path scalars (mainly python ones!), the result must take
+        # into account that the integer may be considered int32, int64, uint64,
+        # or object depending on the input value.  So test those paths!
+        expected_dtype = np.result_type(np.array(val).dtype, np.array(0).dtype)
+        assert np.result_type(val, 0) == expected_dtype
+        # For completeness sake, also check with a NumPy scalar as second arg:
+        assert np.result_type(val, np.int8(0)) == expected_dtype
+
     @pytest.mark.parametrize(["other", "expected"],
             [(1, rational), (1., np.float64)])
     def test_float_int_pyscalar_promote_rational(self, other, expected):


### PR DESCRIPTION
When we have:
1. Only Python scalars (int, float, complex) as inputs
2. One of the integers is too large for the default integer dtype

The "new" promotion path (which existed for a long time internally!)
would not produce the same result as the legacy value-based path.
However, my logic failed to check for the second part, so it did not
run the legacy path in this odd little case.

This fixes the issue reported in:
https://github.com/numpy/numpy/issues/13754#issuecomment-1155126639