### PR TITLE
BUG: Fix small reference leaks found with pytest-leaks

### DIFF
--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -142,12 +142,12 @@ PyArray_GetPriority(PyObject *obj, double default_)
     }
 
     priority = PyFloat_AsDouble(ret);
+    Py_DECREF(ret);
     if (error_converting(priority)) {
         /* TODO[gh-14801]: propagate crashes for bad priority? */
         PyErr_Clear();
         return default_;
     }
-    Py_DECREF(ret);
     return priority;
 }
 

--- a/numpy/core/src/multiarray/textreading/rows.c
+++ b/numpy/core/src/multiarray/textreading/rows.c
@@ -432,7 +432,12 @@ read_rows(stream *s,
     }
 
     tokenizer_clear(&ts);
-    PyMem_FREE(conv_funcs);
+    if (conv_funcs != NULL) {
+        for (Py_ssize_t i = 0; i < actual_num_fields; i++) {
+            Py_XDECREF(conv_funcs[i]);
+        }
+        PyMem_FREE(conv_funcs);
+    }
 
     if (data_array == NULL) {
         assert(row_count == 0 && result_shape[0] == 0);
@@ -474,7 +479,12 @@ read_rows(stream *s,
     return data_array;
 
   error:
-    PyMem_FREE(conv_funcs);
+    if (conv_funcs != NULL) {
+        for (Py_ssize_t i = 0; i < actual_num_fields; i++) {
+            Py_XDECREF(conv_funcs[i]);
+        }
+        PyMem_FREE(conv_funcs);
+    }
     tokenizer_clear(&ts);
     Py_XDECREF(data_array);
     return NULL;

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -5,6 +5,7 @@ These tests complement those found in `test_io.py`.
 """
 
 import sys
+import os
 import pytest
 from tempfile import NamedTemporaryFile, mkstemp
 from io import StringIO
@@ -960,9 +961,11 @@ def test_parametric_unit_discovery(
 
     # file-obj path
     fd, fname = mkstemp()
+    os.close(fd)
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
     a = np.loadtxt(fname, dtype=unitless_dtype)
+    os.remove(fname)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
 
@@ -982,9 +985,11 @@ def test_str_dtype_unit_discovery_with_converter():
 
     # file-obj path
     fd, fname = mkstemp()
+    os.close(fd)
     with open(fname, "w") as fh:
         fh.write("\n".join(data))
     a = np.loadtxt(fname, dtype="U", converters=conv, encoding=None)
+    os.remove(fname)
     assert a.dtype == expected.dtype
     assert_equal(a, expected)
 


### PR DESCRIPTION
This fixes a few small issues found with pytest-leaks.  The remaining issues (many) seem either related to fixtures (pytest-leaks needs some fixes to clean up after pytest better), or related to dynamic compilation.
There are a lot of "leaks" reported in the f2py tests, but I expect they are also just similar problems, so ignoring them.  (Since valgrind did not report them, these are unlikely to be serious memory leaks anyway.)