### PR TITLE
MAINT: Make output of Polynomial representations consistent

### DIFF
--- a/doc/release/upcoming_changes/21760.compatibility.rst
+++ b/doc/release/upcoming_changes/21760.compatibility.rst
@@ -1,0 +1,6 @@
+Modified representation for ``Polynomial``
+------------------------------------------
+The representation method for `numpy.polynomial.Polynomial` was updated to include the domain in the representation.
+The plain text and latex representations are now consistent.
+For example the output of ``str(np.polynomial.Polynomial([1, 1], domain=[.1, .2]))`` used to be ``1.0 + 1.0 x``, but 
+now is ``1.0 + 1.0 (-3.0000000000000004 + 20.0 x)``.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -9,6 +9,7 @@ abc module from the stdlib, hence it is only available for Python >= 2.6.
 import os
 import abc
 import numbers
+from typing import Callable
 
 import numpy as np
 from . import polyutils as pu
@@ -367,6 +368,14 @@ class ABCPolyBase(abc.ABC):
         if linewidth < 1:
             linewidth = 1
         out = pu.format_float(self.coef[0])
+
+        off, scale = self.mapparms()
+
+        scaled_symbol, needs_parens = self._format_term(pu.format_float,
+                                                        off, scale)
+        if needs_parens:
+            scaled_symbol = '(' + scaled_symbol + ')'
+
         for i, coef in enumerate(self.coef[1:]):
             out += " "
             power = str(i + 1)
@@ -376,13 +385,13 @@ class ABCPolyBase(abc.ABC):
             # complex). In this case, represent the coefficient as-is.
             try:
                 if coef >= 0:
-                    next_term = f"+ " + pu.format_float(coef, parens=True)
+                    next_term = "+ " + pu.format_float(coef, parens=True)
                 else:
-                    next_term = f"- " + pu.format_float(-coef, parens=True)
+                    next_term = "- " + pu.format_float(-coef, parens=True)
             except TypeError:
                 next_term = f"+ {coef}"
             # Polynomial term
-            next_term += term_method(power, self.symbol)
+            next_term += term_method(power, scaled_symbol)
             # Length of the current line with next term added
             line_len = len(out.split('\n')[-1]) + len(next_term)
             # If not the last term in the polynomial, it will be two
@@ -437,24 +446,30 @@ class ABCPolyBase(abc.ABC):
         # exponents in this function
         return r'\text{{{}}}'.format(pu.format_float(x, parens=parens))
 
-    def _repr_latex_(self):
-        # get the scaled argument string to the basis functions
-        off, scale = self.mapparms()
+    def _format_term(self, scalar_format: Callable, off: float, scale: float):
+        """ Format a single term in the expansion """
         if off == 0 and scale == 1:
             term = self.symbol
             needs_parens = False
         elif scale == 1:
-            term = f"{self._repr_latex_scalar(off)} + {self.symbol}"
+            term = f"{scalar_format(off)} + {self.symbol}"
             needs_parens = True
         elif off == 0:
-            term = f"{self._repr_latex_scalar(scale)}{self.symbol}"
+            term = f"{scalar_format(scale)}{self.symbol}"
             needs_parens = True
         else:
             term = (
-                f"{self._repr_latex_scalar(off)} + "
-                f"{self._repr_latex_scalar(scale)}{self.symbol}"
+                f"{scalar_format(off)} + "
+                f"{scalar_format(scale)}{self.symbol}"
             )
             needs_parens = True
+        return term, needs_parens
+    
+    def _repr_latex_(self):
+        # get the scaled argument string to the basis functions
+        off, scale = self.mapparms()
+        term, needs_parens = self._format_term(self._repr_latex_scalar,
+                                               off, scale)
 
         mute = r"\color{{LightGray}}{{{}}}".format
 

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -480,7 +480,7 @@ class ABCPolyBase(abc.ABC):
                 coef_str = f"{self._repr_latex_scalar(c)}"
             elif not isinstance(c, numbers.Real):
                 coef_str = f" + ({self._repr_latex_scalar(c)})"
-            elif not np.signbit(c):
+            elif c >= 0:
                 coef_str = f" + {self._repr_latex_scalar(c, parens=True)}"
             else:
                 coef_str = f" - {self._repr_latex_scalar(-c, parens=True)}"

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -472,7 +472,7 @@ class TestLatexRepr:
     def test_numeric_object_coefficients(self):
         coefs = array([Fraction(1, 2), Fraction(1)])
         p = poly.Polynomial(coefs)
-        assert_equal(self.as_latex(p), '$x \\mapsto 1/2$')
+        assert_equal(self.as_latex(p), '$x \\mapsto 1/2 + 1\\,x$')
 
 SWITCH_TO_EXP = (
     '1.0 + (1.0e-01) x + (1.0e-02) x**2',

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -323,8 +323,19 @@ def test_symbol(poly, tgt):
     assert_equal(f"{p:unicode}", tgt)
 
 
-class TestRepr:
+class TestStr:
     def test_polynomial_str(self):
+        res = str(poly.Polynomial([0, 1]))
+        tgt = '0.0 + 1.0 x'
+        assert_equal(res, tgt)
+
+        res = str(poly.Polynomial([0, 1], domain=[0, 2]))
+        tgt = '0.0 + 1.0 (-1.0 + x)'
+        assert_equal(res, tgt)
+
+
+class TestRepr:
+    def test_polynomial_repr(self):
         res = repr(poly.Polynomial([0, 1]))
         tgt = (
             "Polynomial([0., 1.], domain=[-1,  1], window=[-1,  1], "
@@ -332,7 +343,7 @@ class TestRepr:
         )
         assert_equal(res, tgt)
 
-    def test_chebyshev_str(self):
+    def test_chebyshev_repr(self):
         res = repr(poly.Chebyshev([0, 1]))
         tgt = (
             "Chebyshev([0., 1.], domain=[-1,  1], window=[-1,  1], "

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -387,7 +387,8 @@ class TestRepr:
 class TestLatexRepr:
     """Test the latex repr used by Jupyter"""
 
-    def as_latex(self, obj):
+    @staticmethod
+    def as_latex(obj):
         # right now we ignore the formatting of scalars in our tests, since
         # it makes them too verbose. Ideally, the formatting of scalars will
         # be fixed such that tests below continue to pass
@@ -468,6 +469,10 @@ class TestLatexRepr:
             ),
         )
 
+    def test_numeric_object_coefficients(self):
+        coefs = array([Fraction(1, 2), Fraction(1)])
+        p = poly.Polynomial(coefs)
+        assert_equal(self.as_latex(p), '$x \\mapsto 1/2$')
 
 SWITCH_TO_EXP = (
     '1.0 + (1.0e-01) x + (1.0e-02) x**2',


### PR DESCRIPTION
This is a followup from #21653 and #21654. In this PR we make the output of `Polynomial.__str__` and `Polynomial._repr_latex_` consistent. The representation for `str` now includes the domain-window mapping, which was hidden before.

Input
```
import numpy as np
x = np.arange(10)
y = 5 * x + 1 + .1*x*x-.1*x*x*x
f = np.polynomial.Polynomial.fit(x, y, 1)

print(str(f))
print(f._repr_latex_())

np.set_printoptions(precision=2)
print(str(f))
print(f._repr_latex_())

```
Output before:
```
6.1 - 7.38 x
$x \mapsto \text{6.1} - \text{7.38}\,\left(\text{-1.0} + \text{0.22222222}x\right)$
6.1 - 7.38 x
$x \mapsto \text{6.1} - \text{7.38}\,\left(\text{-1.0} + \text{0.22}x\right)$
```
After:
```
6.1 - 7.38 (-1.0 + 0.22222222x)
$x \mapsto \text{6.1} - \text{7.38}\,\left(\text{-1.0} + \text{0.22222222}x\right)$
6.1 - 7.38 (-1.0 + 0.22x)
$x \mapsto \text{6.1} - \text{7.38}\,\left(\text{-1.0} + \text{0.22}x\right)$
```

* When hiding the domain and window in the representation confusion can occur. See for example #24497 or [numpy-discussion: Suggestions for changes to the polynomial module](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/H5ROUE5GG5WEULCQPWXTQZEDZ4M2DIJ4/)
* Fixes issue #24576


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
