### PR TITLE
MAINT: use f-string format in test_abc.py

### DIFF
--- a/numpy/core/tests/test_abc.py
+++ b/numpy/core/tests/test_abc.py
@@ -20,35 +20,35 @@ class TestABC:
     def test_floats(self):
         for t in sctypes['float']:
             assert_(isinstance(t(), numbers.Real),
-                    "{0} is not instance of Real".format(t.__name__))
+                    f"{t.__name__} is not instance of Real"))
             assert_(issubclass(t, numbers.Real),
-                    "{0} is not subclass of Real".format(t.__name__))
+                    f"{t.__name__} is not subclass of Real")
             assert_(not isinstance(t(), numbers.Rational),
-                    "{0} is instance of Rational".format(t.__name__))
+                    f"{t.__name__} is instance of Rational")
             assert_(not issubclass(t, numbers.Rational),
-                    "{0} is subclass of Rational".format(t.__name__))
+                    f"{t.__name__} is subclass of Rational")
 
     def test_complex(self):
         for t in sctypes['complex']:
             assert_(isinstance(t(), numbers.Complex),
-                    "{0} is not instance of Complex".format(t.__name__))
+                    f"{t.__name__} is not instance of Complex")
             assert_(issubclass(t, numbers.Complex),
-                    "{0} is not subclass of Complex".format(t.__name__))
+                    f"{t.__name__} is not subclass of Complex")
             assert_(not isinstance(t(), numbers.Real),
-                    "{0} is instance of Real".format(t.__name__))
+                    f"{t.__name__} is instance of Real")
             assert_(not issubclass(t, numbers.Real),
-                    "{0} is subclass of Real".format(t.__name__))
+                    f"{t.__name__} is subclass of Real")
 
     def test_int(self):
         for t in sctypes['int']:
             assert_(isinstance(t(), numbers.Integral),
-                    "{0} is not instance of Integral".format(t.__name__))
+                    f"{t.__name__} is not instance of Integral")
             assert_(issubclass(t, numbers.Integral),
-                    "{0} is not subclass of Integral".format(t.__name__))
+                    f"{t.__name__} is not subclass of Integral")
 
     def test_uint(self):
         for t in sctypes['uint']:
             assert_(isinstance(t(), numbers.Integral),
-                    "{0} is not instance of Integral".format(t.__name__))
+                    f"{t.__name__} is not instance of Integral")
             assert_(issubclass(t, numbers.Integral),
-                    "{0} is not subclass of Integral".format(t.__name__))
+                    f"{t.__name__} is not subclass of Integral")

--- a/numpy/core/tests/test_abc.py
+++ b/numpy/core/tests/test_abc.py
@@ -20,7 +20,7 @@ class TestABC:
     def test_floats(self):
         for t in sctypes['float']:
             assert_(isinstance(t(), numbers.Real),
-                    f"{t.__name__} is not instance of Real"))
+                    f"{t.__name__} is not instance of Real")
             assert_(issubclass(t, numbers.Real),
                     f"{t.__name__} is not subclass of Real")
             assert_(not isinstance(t(), numbers.Rational),


### PR DESCRIPTION
Changed f-string format for a clear and clean understanding of code.
