### PR TITLE
CI: Guard compile-time CPU features tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -61,6 +61,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11-dev"]
+    env:
+      EXPECT_CPU_FEATURES: "SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2 AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL"
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ jobs:
        - DOWNLOAD_OPENBLAS=1
        - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
+       # VSX4 still not supported by ubuntu/gcc-11
+       - EXPECT_CPU_FEATURES="VSX VSX2 VSX3"
 
     - python: "3.8"
       os: linux
@@ -46,6 +48,7 @@ jobs:
        - DOWNLOAD_OPENBLAS=1
        - NPY_USE_BLAS_ILP64=1
        - ATLAS=None
+       - EXPECT_CPU_FEATURES="VX VXE VXE2"
 
     # Wheel builders
     - python: "3.8"
@@ -54,6 +57,7 @@ jobs:
       virt: vm
       env:
         - CIBW_BUILD: cp38-manylinux_aarch64
+        - EXPECT_CPU_FEATURES: "NEON NEON_FP16 NEON_VFPV4 ASIMD ASIMDHP ASIMDDP ASIMDFHM"
       install: python3 -m pip install cibuildwheel==2.4.0
       script: |
         cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
  This guard protects against any sudden unexpected changes that may adversely
  affect the compile-time SIMD features detection which could leave the SIMD code
  inactivated. Until now we have faced two cases:

  1. Hardening the compile-time test files of Neon/ASIMD features without checking
     the sanity of the modification leading to disabling all optimizations on aarch64.
     see gh-21747

  2. A sudden compiler upgrades by CI side on s390x that causes conflicts with the
     installed assembler leading to disabling the whole VX/E features, which made us
     merge SIMD code without testing it. Later, it was discovered that this code
     disrupted the NumPy build.
     see gh-21750, gh-21748

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
