### PR TITLE
CI: add workflow for non-optimized builds

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -45,6 +45,8 @@ jobs:
   smoke_test:
     if: "github.repository == 'numpy/numpy' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     runs-on: ubuntu-latest
+    env:
+      WITHOUT_SIMD: 1
     steps:
     - uses: actions/checkout@v3
       with:
@@ -71,6 +73,21 @@ jobs:
     - uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: ./.github/actions
+
+  without_opt:
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    env:
+      WITHOUT_OPT: 1
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v3
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
     - uses: ./.github/actions
 
   debug:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -75,7 +75,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: ./.github/actions
 
-  without_opt:
+  without_optimizations:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -79,7 +79,7 @@ jobs:
     needs: [smoke_test]
     runs-on: ubuntu-latest
     env:
-      WITHOUT_OPT: 1
+      WITHOUT_OPTIMIZATIONS: 1
     steps:
     - uses: actions/checkout@v3
       with:

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -39,7 +39,7 @@ setup_base()
 
   build_args=()
   # Strictly disable all kinds of optimizations
-  if [ -n "$WITHOUT_OPT" ]; then
+  if [ -n "$WITHOUT_OPTIMIZATIONS" ]; then
       build_args+=("--disable-optimization")
   # only disable SIMD optimizations
   elif [ -n "$WITHOUT_SIMD" ]; then

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -36,11 +36,21 @@ setup_base()
   sysflags="$($PYTHON -c "from distutils import sysconfig; \
     print (sysconfig.get_config_var('CFLAGS'))")"
   export CFLAGS="$sysflags $werrors -Wlogical-op -Wno-sign-compare"
-  # SIMD extensions that need to be tested on both runtime and compile-time via (test_simd.py)
-  # any specified features will be ignored if they're not supported by compiler or platform
-  # note: it almost the same default value of --simd-test execpt adding policy `$werror` to treat all
-  # warnings as errors
-  simd_test="\$werror BASELINE SSE2 SSE42 XOP FMA4 (FMA3 AVX2) AVX512F AVX512_SKX VSX VSX2 VSX3 NEON ASIMD VX VXE VXE2"
+
+  build_args=()
+  # Strictly disable all kinds of optimizations
+  if [ -n "$WITHOUT_OPT" ]; then
+      build_args+=("--disable-optimization")
+  # only disable SIMD optimizations
+  elif [ -n "$WITHOUT_SIMD" ]; then
+      build_args+=("--cpu-baseline=none" "--cpu-dispatch=none")
+  else
+    # SIMD extensions that need to be tested on both runtime and compile-time via (test_simd.py)
+    # any specified features will be ignored if they're not supported by compiler or platform
+    # note: it almost the same default value of --simd-test execpt adding policy `$werror` to treat all
+    # warnings as errors
+    build_args+=("--simd-test=\$werror BASELINE SSE2 SSE42 XOP FMA4 (FMA3 AVX2) AVX512F AVX512_SKX VSX VSX2 VSX3 NEON ASIMD VX VXE VXE2")
+  fi
   # We used to use 'setup.py install' here, but that has the terrible
   # behaviour that if a copy of the package is already installed in the
   # install location, then the new copy just gets dropped on top of it.
@@ -58,11 +68,11 @@ setup_base()
     # #if !HAVE_FFI_PREP_CIF_VAR && defined(__arm64__) && defined(__APPLE__)
     #
     export CFLAGS="$CFLAGS -Werror=undef"
-    $PYTHON setup.py build --simd-test "$simd_test" install 2>&1 | tee log
+    $PYTHON setup.py build "${build_args[@]}" install 2>&1 | tee log
   else
     # The job run with USE_DEBUG=1 on travis needs this.
     export CFLAGS=$CFLAGS" -Wno-maybe-uninitialized"
-    $PYTHON setup.py build --simd-test "$simd_test" build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
+    $PYTHON setup.py build "${build_args[@]}" build_src --verbose-cfg build_ext --inplace 2>&1 | tee log
   fi
   grep -v "_configtest" log \
     | grep -vE "ld returned 1|no files found matching" \


### PR DESCRIPTION
  since the support of zsystem, all current overflows have SIMD
  support which leaves no room for testing pure C code that runs
  on non-supported architectures.
  note: smoke test no longer build with SIMD support


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
