### PR TITLE
MAINT: random: Disallow complex inputs in multivariate_normal

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3661,8 +3661,9 @@ cdef class Generator:
         mean = np.array(mean)
         cov = np.array(cov)
 
-        if np.issubdtype(cov.dtype, np.complexfloating):
-            raise NotImplementedError("Complex gaussians are not supported.")
+        if (np.issubdtype(mean.dtype, np.complexfloating) or
+                np.issubdtype(cov.dtype, np.complexfloating)):
+            raise TypeError("mean and cov must not be complex")
 
         if size is None:
             shape = []

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3660,6 +3660,10 @@ cdef class Generator:
         # Check preconditions on arguments
         mean = np.array(mean)
         cov = np.array(cov)
+
+        if np.issubdtype(cov.dtype, np.complexfloating):
+            raise NotImplementedError("Complex gaussians are not supported.")
+
         if size is None:
             shape = []
         elif isinstance(size, (int, long, np.integer)):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1453,7 +1453,11 @@ class TestRandomDist:
         assert_raises(ValueError, random.multivariate_normal,
                       mu, np.eye(3))
         
-        assert_raises(NotImplementedError, np.random.multivariate_normal, [0], [[1+1j]])
+    @pytest.mark.parametrize('mean, cov', [([0], [[1+1j]]), ([0j], [[1]])])
+    def test_multivariate_normal_disallow_complex(self, mean, cov):
+        random = Generator(MT19937(self.seed))
+        with pytest.raises(TypeError, match="must not be complex"):
+            random.multivariate_normal(mean, cov)
 
     @pytest.mark.parametrize("method", ["svd", "eigh", "cholesky"])
     def test_multivariate_normal_basic_stats(self, method):

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -1452,6 +1452,8 @@ class TestRandomDist:
                       mu, np.empty((3, 2)))
         assert_raises(ValueError, random.multivariate_normal,
                       mu, np.eye(3))
+        
+        assert_raises(NotImplementedError, np.random.multivariate_normal, [0], [[1+1j]])
 
     @pytest.mark.parametrize("method", ["svd", "eigh", "cholesky"])
     def test_multivariate_normal_basic_stats(self, method):


### PR DESCRIPTION
This is a continuation of https://github.com/numpy/numpy/pull/14733.

Note that this changes the `Generator` method only.  The legacy version of `multivariate_normal` has not been updated.