### PR TITLE
ENH: Use Unicode for polynomials in Jupyter notebooks on Windows

### DIFF
--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -106,7 +106,8 @@ class ABCPolyBase(abc.ABC):
     # the full set of superscripts and subscripts, including common/default
     # fonts in Windows shells/terminals. Therefore, default to ascii-only
     # printing on windows.
-    _use_unicode = os.name != 'nt' or get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
+    _use_unicode = os.name != 'nt' or \
+                   get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
 
     @property
     def symbol(self):

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -10,6 +10,7 @@ import os
 import abc
 import numbers
 
+from IPython.core.getipython import get_ipython
 import numpy as np
 from . import polyutils as pu
 
@@ -105,7 +106,7 @@ class ABCPolyBase(abc.ABC):
     # the full set of superscripts and subscripts, including common/default
     # fonts in Windows shells/terminals. Therefore, default to ascii-only
     # printing on windows.
-    _use_unicode = not os.name == 'nt'
+    _use_unicode = os.name != 'nt' or get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
 
     @property
     def symbol(self):

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -7,10 +7,10 @@ abc module from the stdlib, hence it is only available for Python >= 2.6.
 
 """
 import os
+import sys
 import abc
 import numbers
 
-from IPython.core.getipython import get_ipython
 import numpy as np
 from . import polyutils as pu
 
@@ -106,8 +106,7 @@ class ABCPolyBase(abc.ABC):
     # the full set of superscripts and subscripts, including common/default
     # fonts in Windows shells/terminals. Therefore, default to ascii-only
     # printing on windows.
-    _use_unicode = os.name != 'nt' or \
-                   get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
+    _use_unicode = os.name != 'nt' or 'ipykernel' in sys.modules
 
     @property
     def symbol(self):


### PR DESCRIPTION
Fixes #21780