### PR TITLE
BUG: fix `_selected_real_kind_func` return values for macOS on arm64

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -359,7 +359,7 @@ jobs:
       run: |
         # use x86_64 cross-compiler to speed up the build
         sudo apt update
-        sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+        sudo apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf gfortran-arm-linux-gnueabihf
 
         # Keep the `test_requirements.txt` dependency-subset synced
         docker run --name the_container --interactive -v /:/host arm32v7/ubuntu:22.04 /bin/bash -c "
@@ -372,6 +372,7 @@ jobs:
           rm -rf /usr/lib/gcc/arm-linux-gnueabihf && ln -s /host/usr/lib/gcc-cross/arm-linux-gnueabihf /usr/lib/gcc/arm-linux-gnueabihf &&
           rm -f /usr/bin/arm-linux-gnueabihf-gcc && ln -s /host/usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc &&
           rm -f /usr/bin/arm-linux-gnueabihf-g++ && ln -s /host/usr/bin/arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++ &&
+          rm -f /usr/bin/arm-linux-gnueabihf-gfortran && ln -s /host/usr/bin/arm-linux-gnueabihf-gfortran /usr/bin/arm-linux-gnueabihf-gfortran &&
           rm -f /usr/bin/arm-linux-gnueabihf-ar && ln -s /host/usr/bin/arm-linux-gnueabihf-ar /usr/bin/arm-linux-gnueabihf-ar &&
           rm -f /usr/bin/arm-linux-gnueabihf-as && ln -s /host/usr/bin/arm-linux-gnueabihf-as /usr/bin/arm-linux-gnueabihf-as &&
           rm -f /usr/bin/arm-linux-gnueabihf-ld && ln -s /host/usr/bin/arm-linux-gnueabihf-ld /usr/bin/arm-linux-gnueabihf-ld &&
@@ -384,6 +385,7 @@ jobs:
           uname -a &&
           gcc --version &&
           g++ --version &&
+          arm-linux-gnueabihf-gfortran --version &&
           python3 --version &&
           git config --global --add safe.directory /numpy
           cd /numpy &&
@@ -393,7 +395,7 @@ jobs:
     - name: Run SIMD Tests
       run: |
         docker run --rm --interactive -v $(pwd):/numpy the_build /bin/bash -c "
-          cd /numpy && python3 runtests.py -n -v -- -k test_simd
+          cd /numpy && F90=arm-linux-gnueabihf-gfortran python3 runtests.py -n -v -- -k 'test_simd or test_kind'
         "
 
   sde_simd_avx512_test:

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2387,19 +2387,19 @@ def _selected_int_kind_func(r):
 
 def _selected_real_kind_func(p, r=0, radix=0):
     # XXX: This should be processor dependent
-    # This is only good for 0 <= p <= 20
+    # This is only verified for 0 <= p <= 20, possibly good for p <= 33 and above
     if p < 7:
         return 4
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'power', 'ppc', 'riscv', 's390x', 'sparc', 'arm64')):
-        if p <= 20:
+    if machine.startswith(('aarch64', 'arm64', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
+        if p <= 33:
             return 16
     else:
         if p < 19:
             return 10
-        elif p <= 20:
+        elif p <= 33:
             return 16
     return -1
 

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import platform
 
 from numpy.f2py.crackfortran import (
     _selected_int_kind_func as selected_int_kind,
@@ -11,8 +12,8 @@ from . import util
 class TestKind(util.F2PyTest):
     sources = [util.getpath("tests", "src", "kind", "foo.f90")]
 
-    def test_all(self):
-        selectedrealkind = self.module.selectedrealkind
+    def test_int(self):
+        """Test `int` kind_func for integers up to 10**40."""
         selectedintkind = self.module.selectedintkind
 
         for i in range(40):
@@ -20,7 +21,27 @@ class TestKind(util.F2PyTest):
                 i
             ), f"selectedintkind({i}): expected {selected_int_kind(i)!r} but got {selectedintkind(i)!r}"
 
-        for i in range(40):
+    def test_real(self):
+        """
+        Test (processor-dependent) `real` kind_func for real numbers
+        of up to 31 digits precision (extended/quadruple).
+        """
+        selectedrealkind = self.module.selectedrealkind
+
+        for i in range(32):
+            assert selectedrealkind(i) == selected_real_kind(
+                i
+            ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"
+
+    @pytest.mark.xfail(platform.machine().lower().startswith("ppc"),
+                       reason="Some PowerPC may not support full IEEE 754 precision")
+    def test_quad_precision(self):
+        """
+        Test kind_func for quadruple precision [`real(16)`] of 32+ digits .
+        """
+        selectedrealkind = self.module.selectedrealkind
+
+        for i in range(32, 40):
             assert selectedrealkind(i) == selected_real_kind(
                 i
             ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -20,7 +20,7 @@ class TestKind(util.F2PyTest):
                 i
             ), f"selectedintkind({i}): expected {selected_int_kind(i)!r} but got {selectedintkind(i)!r}"
 
-        for i in range(20):
+        for i in range(40):
             assert selectedrealkind(i) == selected_real_kind(
                 i
             ), f"selectedrealkind({i}): expected {selected_real_kind(i)!r} but got {selectedrealkind(i)!r}"


### PR DESCRIPTION
`np.f2py.crackfortran._selected_real_kind_func` was only considering `aarch64` as a `machine` value for determining Fortran's `selected_real_kind` values on these CPUs, but on macOS M1 `platform.machine()` returns `arm64` (in system `/usr/bin/python3` (3.8.9) and any Python 3.9-3.11 build I have tested).
This PR adds the latter to the list of processors, fixing #21765. I have also extended the return range to 33, which matches the Fortran values on arm64 and x86_64 (and thus possibly works for all higher numbers, for which –1 is returned); giving this a try here by extending the test to `range(40)`.
Tested on macOS 12.4 with the new ports for gcc 11.3 and 12.1 documented in iains/gcc-darwin-arm64#91 and iains/gcc-darwin-arm64#92.