### PR TITLE
MAINT: fix up use of `NPY_NO_DEPRECATED_API` usage in f2py

### DIFF
--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -6,7 +6,9 @@ extern "C" {
 
 #include <Python.h>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#endif
 #ifdef FORTRANOBJECT_C
 #define NO_IMPORT_ARRAY
 #endif


### PR DESCRIPTION
This was giving a lot of warnings like:

    numpy/f2py/src/fortranobject.h:9: warning: "NPY_NO_DEPRECATED_API" redefined

when building SciPy. In general, this is generated code which is included in the build of other projects which may have already set this macro - so only set it if it is not yet set.

The other change is to set it to the current numpy version, like is done everywhere else in numpy, rather than to a fixed 1.7 version. This will ensure that if new deprecations happen, f2py gets updated for them.

This came in with gh-19388 recently (not present in the 1.23.x branch).