### PR TITLE
BUG: fix ediff1d for np.datetime64 types

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -85,7 +85,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
     # The difference of np.datetime64 will yield an np.timedelta64 as the
     # required dtype for to_begin and to_end
     if np.issubdtype(ary.dtype, np.datetime64):
-        dtype_req = np.timedelta64
+        dtype_req = ary.astype(np.timedelta64).dtype
     else:
         dtype_req = ary.dtype
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -81,13 +81,12 @@ def ediff1d(ary, to_end=None, to_begin=None):
     # force a 1d array
     ary = np.asanyarray(ary).ravel()
 
-    # enforce that the dtype of `ary` is used for the output
-    # The difference of np.datetime64 will yield an np.timedelta64 as the
-    # required dtype for to_begin and to_end
-    if np.issubdtype(ary.dtype, np.datetime64):
-        dtype_req = ary.astype(np.timedelta64).dtype
-    else:
-        dtype_req = ary.dtype
+    # Perform a partial calculation to obtain the return dtype. Handles the
+    # edge case whereby the difference of np.datetime64 will yield an
+    # np.timedelta64 as the required dtype for to_begin and to_end.
+    # TODO: Once exposed, may use `np.subtract.resolve_descriptors()`
+    #       (or similar) to find the result dtype and generalize this.
+    dtype_req = (ary[:1] - ary[:1]).dtype
 
     # fast track default case
     if to_begin is None and to_end is None:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -81,12 +81,15 @@ def ediff1d(ary, to_end=None, to_begin=None):
     # force a 1d array
     ary = np.asanyarray(ary).ravel()
 
-    # Perform a partial calculation to obtain the return dtype. Handles the
+    # Check if input ary has datetime64 dtype. Handles the
     # edge case whereby the difference of np.datetime64 will yield an
     # np.timedelta64 as the required dtype for to_begin and to_end.
     # TODO: Once exposed, may use `np.subtract.resolve_descriptors()`
     #       (or similar) to find the result dtype and generalize this.
-    dtype_req = (ary[:1] - ary[:1]).dtype
+    if ary.dtype.kind == "M":
+        dtype_req = np.dtype(ary.dtype.str.replace("M", "m"))
+    else:
+        dtype_req = ary.dtype
 
     # fast track default case
     if to_begin is None and to_end is None:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -82,7 +82,12 @@ def ediff1d(ary, to_end=None, to_begin=None):
     ary = np.asanyarray(ary).ravel()
 
     # enforce that the dtype of `ary` is used for the output
-    dtype_req = ary.dtype
+    # The difference of np.datetime64 will yield an np.timedelta64 as the
+    # required dtype for to_begin and to_end
+    if np.issubdtype(ary.dtype, np.datetime64):
+        dtype_req = np.timedelta64
+    else:
+        dtype_req = ary.dtype
 
     # fast track default case
     if to_begin is None and to_end is None:

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -87,7 +87,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
     # TODO: Once exposed, may use `np.subtract.resolve_descriptors()`
     #       (or similar) to find the result dtype and generalize this.
     if ary.dtype.kind == "M":
-        dtype_req = np.dtype(ary.dtype.str.replace("M", "m"))
+        dtype_req = (ary[:1] - ary[:1]).dtype
     else:
         dtype_req = ary.dtype
 

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -117,7 +117,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
 
     # do the calculation in place and copy to_begin and to_end
     l_diff = max(len(ary) - 1, 0)
-    result = np.empty(l_diff + l_begin + l_end, dtype=ary.dtype)
+    result = np.empty(l_diff + l_begin + l_end, dtype=dtype_req)
     result = ary.__array_wrap__(result)
     if l_begin > 0:
         result[:l_begin] = to_begin

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -110,6 +110,7 @@ class TestSetOps:
         zero_elem = np.array([])
         one_elem = np.array([1])
         two_elem = np.array([1, 2])
+        datetime64_elem = np.arange(np.datetime64('2000-01-01'), 2)
 
         assert_array_equal([], ediff1d(zero_elem))
         assert_array_equal([0], ediff1d(zero_elem, to_begin=0))
@@ -124,6 +125,30 @@ class TestSetOps:
         assert_array_equal([1, 7, 8], ediff1d(two_elem, to_end=[7, 8]))
         assert_array_equal([7, 1], ediff1d(two_elem, to_begin=7))
         assert_array_equal([5, 6, 1], ediff1d(two_elem, to_begin=[5, 6]))
+
+        assert_array_equal(
+                [np.timedelta64(1, 'D')], ediff1d(datetime64_elem)
+        )
+        assert_array_equal(
+                [np.timedelta64(5, 'D'), np.timedelta64(1, 'D')],
+                ediff1d(datetime64_elem, to_begin=np.timedelta64(5, 'D'))
+        )
+        assert_array_equal(
+                [np.timedelta64(1, 'D'), np.timedelta64(5, 'D')],
+                ediff1d(datetime64_elem, to_end=np.timedelta64(5, 'D'))
+        )
+        assert_array_equal(
+                [
+                    np.timedelta64(2, 'D'),
+                    np.timedelta64(1, 'D'),
+                    np.timedelta64(5, 'D')
+                ],
+                ediff1d(
+                    datetime64_elem,
+                    to_begin=np.timedelta64(2, 'D'),
+                    to_end=np.timedelta64(5, 'D')
+                )
+        )
 
     @pytest.mark.parametrize("ary, prepend, append, expected", [
         # should fail because trying to cast

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -110,7 +110,6 @@ class TestSetOps:
         zero_elem = np.array([])
         one_elem = np.array([1])
         two_elem = np.array([1, 2])
-        datetime64_elem = np.arange(np.datetime64('2000-01-01'), 2)
 
         assert_array_equal([], ediff1d(zero_elem))
         assert_array_equal([0], ediff1d(zero_elem, to_begin=0))
@@ -126,6 +125,8 @@ class TestSetOps:
         assert_array_equal([7, 1], ediff1d(two_elem, to_begin=7))
         assert_array_equal([5, 6, 1], ediff1d(two_elem, to_begin=[5, 6]))
 
+    def test_ediff1d_datetime64(self):
+        datetime64_elem = np.arange(np.datetime64('2000-01-01'), 2)
         assert_array_equal(
                 [np.timedelta64(1, 'D')], ediff1d(datetime64_elem)
         )
@@ -174,6 +175,37 @@ class TestSetOps:
          'to_begin'),
          ])
     def test_ediff1d_forbidden_type_casts(self, ary, prepend, append, expected):
+        # verify resolution of gh-11490
+
+        # specifically, raise an appropriate
+        # Exception when attempting to append or
+        # prepend with an incompatible type
+        msg = 'dtype of `{}` must be compatible'.format(expected)
+        with assert_raises_regex(TypeError, msg):
+            ediff1d(ary=ary,
+                    to_end=append,
+                    to_begin=prepend)
+
+    @pytest.mark.parametrize("ary, prepend, append, expected", [
+        # should fail because dates will give a timedelta64(1, 'D') diff
+        (np.array(['2000-01-01', '2000-01-02'], dtype=np.datetime64),
+         None,
+         np.timedelta64(1, 'Y'),
+         'to_end'),
+        # should fail because attempting
+        # to cast to floats to timedelta64
+        (np.array(['2000-01-01', '2000-01-02'], dtype=np.datetime64),
+         np.array([5, 7, 2], dtype=np.float32),
+         None,
+         'to_begin'),
+         ])
+    def test_ediff1d_forbidden_datetime64_type_casts(
+            self,
+            ary,
+            prepend,
+            append,
+            expected
+    ):
         # verify resolution of gh-11490
 
         # specifically, raise an appropriate


### PR DESCRIPTION
Type check for np.datetime64 arrays would not acknowledge that the
return dtype will be np.timedelta64 as opposed to np.datetime64.

The following fails as a result:

```
dts = np.arange(np.datetime64('2000-01-01'), 2)
np.ediff1d(dts, to_begin=np.timedelta64(1, 'D'))
```