### PR TITLE
ENH: add overflow handling for scalar `negative` operation

### DIFF
--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -499,17 +499,26 @@ half_ctype_power(npy_half a, npy_half b, npy_half *out)
  * #type = npy_byte, npy_ubyte, npy_short, npy_ushort, npy_int, npy_uint,
  *         npy_long, npy_ulong, npy_longlong, npy_ulonglong,
  *         npy_float, npy_double, npy_longdouble#
+ * #NAME = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         FLOAT, DOUBLE, LONGDOUBLE#
  * #uns = (0,1)*5,0*3#
+ * #int = 1*10,0*3#
  */
 static NPY_INLINE int
 @name@_ctype_negative(@type@ a, @type@ *out)
 {
-    *out = -a;
 #if @uns@
+    *out = -a;
     return NPY_FPE_OVERFLOW;
-#else
-    return 0;
+#elif ~@uns@ && @int@
+    if(a == NPY_MIN_@NAME@){
+        *out = a;
+        return NPY_FPE_OVERFLOW;
+    }
 #endif
+    *out = -a;
+    return 0;
 }
 /**end repeat**/
 

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -511,7 +511,7 @@ static NPY_INLINE int
 #if @uns@
     *out = -a;
     return NPY_FPE_OVERFLOW;
-#elif ~@uns@ && @int@
+#elif @int@
     if(a == NPY_MIN_@NAME@){
         *out = a;
         return NPY_FPE_OVERFLOW;

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -683,12 +683,12 @@ class TestNegative:
             sup.filter(RuntimeWarning)
             for dt in types:
                 a = np.ones((), dtype=dt)[()]
-            if dt in np.typecodes['UnsignedInteger']:
-                st = np.dtype(dt).type
-                min = st(np.iinfo(dt).min)
-                assert_equal(operator.neg(a), min)
-            else:
-                assert_equal(operator.neg(a) + a, 0)
+                if dt in np.typecodes['UnsignedInteger']:
+                    st = np.dtype(dt).type
+                    max = st(np.iinfo(dt).max)
+                    assert_equal(operator.neg(a), max)
+                else:
+                    assert_equal(operator.neg(a) + a, 0)
 
 class TestSubtract:
     def test_exceptions(self):

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -906,7 +906,7 @@ def test_scalar_integer_operation_overflow(dtype, operation):
             marks=pytest.mark.xfail(reason="broken on some platforms")),
         pytest.param(lambda min, neg_1: min // neg_1,
             marks=pytest.mark.skip(reason="broken on some platforms"))],
-        ids=["neg","abs", "*", "//"])
+        ids=["neg", "abs", "*", "//"])
 def test_scalar_signed_integer_overflow(dtype, operation):
     # The minimum signed integer can "overflow" for some additional operations
     st = np.dtype(dtype).type

--- a/numpy/core/tests/test_scalarmath.py
+++ b/numpy/core/tests/test_scalarmath.py
@@ -683,8 +683,12 @@ class TestNegative:
             sup.filter(RuntimeWarning)
             for dt in types:
                 a = np.ones((), dtype=dt)[()]
+            if dt in np.typecodes['UnsignedInteger']:
+                st = np.dtype(dt).type
+                min = st(np.iinfo(dt).min)
+                assert_equal(operator.neg(a), min)
+            else:
                 assert_equal(operator.neg(a) + a, 0)
-
 
 class TestSubtract:
     def test_exceptions(self):
@@ -896,12 +900,13 @@ def test_scalar_integer_operation_overflow(dtype, operation):
 
 @pytest.mark.parametrize("dtype", np.typecodes["Integer"])
 @pytest.mark.parametrize("operation", [
+        lambda min, neg_1: -min,
         lambda min, neg_1: abs(min),
         pytest.param(lambda min, neg_1: min * neg_1,
             marks=pytest.mark.xfail(reason="broken on some platforms")),
         pytest.param(lambda min, neg_1: min // neg_1,
             marks=pytest.mark.skip(reason="broken on some platforms"))],
-        ids=["abs", "*", "//"])
+        ids=["neg","abs", "*", "//"])
 def test_scalar_signed_integer_overflow(dtype, operation):
     # The minimum signed integer can "overflow" for some additional operations
     st = np.dtype(dtype).type


### PR DESCRIPTION
Related Issues/PRs
Follow-up to #21648

Changes
Adds check to scalar `negative` for determining whether an overflow warning should be raised for signed integers. Improves testing for `negative` operator on unsigned integers.

Comments
N/A