### PR TITLE
BUG: lib: A loadtxt error message had two values reversed.

### DIFF
--- a/numpy/core/src/multiarray/textreading/rows.c
+++ b/numpy/core/src/multiarray/textreading/rows.c
@@ -91,7 +91,7 @@ create_conv_funcs(
             if (column < -num_fields || column >= num_fields) {
                 PyErr_Format(PyExc_ValueError,
                         "converter specified for column %zd, which is invalid "
-                        "for the number of fields %d.", column, num_fields);
+                        "for the number of fields %zd.", column, num_fields);
                 goto error;
             }
             if (column < 0) {
@@ -319,7 +319,7 @@ read_rows(stream *s,
 
         if (!usecols && (actual_num_fields != current_num_fields)) {
             PyErr_Format(PyExc_ValueError,
-                    "the number of columns changed from %d to %d at row %zu; "
+                    "the number of columns changed from %zd to %zd at row %zd; "
                     "use `usecols` to select a subset and avoid this error",
                     actual_num_fields, current_num_fields, row_count+1);
             goto error;
@@ -382,9 +382,9 @@ read_rows(stream *s,
                 }
                 if (NPY_UNLIKELY((col < 0) || (col >= current_num_fields))) {
                     PyErr_Format(PyExc_ValueError,
-                            "invalid column index %d at row %zu with %d "
+                            "invalid column index %zd at row %zd with %zd "
                             "columns",
-                            usecols[i], current_num_fields, row_count+1);
+                            usecols[i], row_count+1, current_num_fields);
                     goto error;
                 }
             }
@@ -419,7 +419,7 @@ read_rows(stream *s,
                 }
                 PyErr_Format(PyExc_ValueError,
                         "could not convert string %.100R to %S at "
-                        "row %zu, column %d.",
+                        "row %zd, column %zd.",
                         string, field_types[f].descr, row_count, col+1);
                 Py_DECREF(string);
                 npy_PyErr_ChainExceptionsCause(exc, val, tb);

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -253,7 +253,7 @@ def test_ragged_usecols():
 
     txt = StringIO("0,0,XXX\n0\n0,XXX,XXX,0,XXX\n")
     with pytest.raises(ValueError,
-                match="invalid column index -2 at row 1 with 2 columns"):
+                match="invalid column index -2 at row 2 with 1 columns"):
         # There is no -2 column in the second row:
         np.loadtxt(txt, dtype=float, delimiter=",", usecols=[0, -2])
 


### PR DESCRIPTION
Fix the reversed arguments to the call of PyErr_Format() that generates
the exception for an invalid index in usecols.

Also fix the format characters in several other calls of PyErr_Format()
where the arguments are Py_ssize_t.
