### PR TITLE
BUG: Fix comparison for empty structured arrays

### DIFF
--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -768,9 +768,9 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
                     }
 
                     /*
-                    * Compute the new dimension size manually, as reshaping
-                    * with -1 does not work on empty arrays.
-                    */
+                     * Compute the new dimension size manually, as reshaping
+                     * with -1 does not work on empty arrays.
+                     */
                     dimensions[result_ndim] = PyArray_MultiplyList(
                         PyArray_DIMS((PyArrayObject *)temp) + result_ndim,
                         PyArray_NDIM((PyArrayObject *)temp) - result_ndim);

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -768,8 +768,8 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
                     }
 
                     /*
-                    * Compute the new dimension size manually 
-                    * (instead of reshaping with -1) to avoid division by zero.
+                    * Compute the new dimension size manually, as reshaping
+                    * with -1 does not work on empty arrays.
                     */
                     dimensions[result_ndim] = PyArray_MultiplyList(
                         PyArray_DIMS((PyArrayObject *)temp) + result_ndim,

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -766,7 +766,15 @@ _void_compare(PyArrayObject *self, PyArrayObject *other, int cmp_op)
                         memcpy(dimensions, PyArray_DIMS((PyArrayObject *)temp),
                                sizeof(npy_intp)*result_ndim);
                     }
-                    dimensions[result_ndim] = -1;
+
+                    /*
+                    * Compute the new dimension size manually 
+                    * (instead of reshaping with -1) to avoid division by zero.
+                    */
+                    dimensions[result_ndim] = PyArray_MultiplyList(
+                        PyArray_DIMS((PyArrayObject *)temp) + result_ndim,
+                        PyArray_NDIM((PyArrayObject *)temp) - result_ndim);
+
                     temp2 = PyArray_Newshape((PyArrayObject *)temp,
                                              &newdims, NPY_ANYORDER);
                     if (temp2 == NULL) {

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1247,13 +1247,13 @@ class TestStructured:
         
         # Check that comparison works on empty arrays with nontrivially 
         # shaped fields
-        a = np.zeros(0, [('a', '<f8', (1,1))])
+        a = np.zeros(0, [('a', '<f8', (1, 1))])
         assert_equal(a, a)
         a = np.zeros(0, [('a', '<f8', (1,))])
         assert_equal(a, a)
-        a = np.zeros((0,0), [('a', '<f8', (1,1))])
+        a = np.zeros((0, 0), [('a', '<f8', (1, 1))])
         assert_equal(a, a)
-        a = np.zeros((1,0,1), [('a', '<f8', (1,1))])
+        a = np.zeros((1, 0, 1), [('a', '<f8', (1, 1))])
         assert_equal(a, a)
 
     def test_structured_comparisons_with_promotion(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1244,6 +1244,17 @@ class TestStructured:
         # The main importance is that it does not return True:
         with pytest.raises(TypeError):
             x == y
+        
+        # Check that comparison works on empty arrays with nontrivially 
+        # shaped fields
+        a = np.zeros(0, [('a', '<f8', (1,1))])
+        assert_equal(a, a)
+        a = np.zeros(0, [('a', '<f8', (1,))])
+        assert_equal(a, a)
+        a = np.zeros((0,0), [('a', '<f8', (1,1))])
+        assert_equal(a, a)
+        a = np.zeros((1,0,1), [('a', '<f8', (1,1))])
+        assert_equal(a, a)
 
     def test_structured_comparisons_with_promotion(self):
         # Check that structured arrays can be compared so long as their

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1244,7 +1244,7 @@ class TestStructured:
         # The main importance is that it does not return True:
         with pytest.raises(TypeError):
             x == y
-        
+ 
     def test_empty_structured_array_comparison(self):
         # Check that comparison works on empty arrays with nontrivially 
         # shaped fields

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1245,6 +1245,7 @@ class TestStructured:
         with pytest.raises(TypeError):
             x == y
         
+    def test_empty_structured_array_comparison(self):
         # Check that comparison works on empty arrays with nontrivially 
         # shaped fields
         a = np.zeros(0, [('a', '<f8', (1, 1))])


### PR DESCRIPTION
Fixes #21739

When empty structured arrays with nontrivially shaped fields are
compared, the reshape operation invoked fails. Instead of reshaping
using -1, computing the new dimension manually solves the problem. 