### PR TITLE
MAINT: Reduce object construction in np.require

### DIFF
--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -36,7 +36,7 @@ def require(a, dtype=None, requirements=None, *, like=None):
        The required data-type. If None preserve the current dtype. If your
        application requires the data to be in native byteorder, include
        a byteorder specification as a part of the dtype specification.
-    requirements : str or list of str
+    requirements : str or sequence of str
        The requirements list can be any of the following
 
        * 'F_CONTIGUOUS' ('F') - ensure a Fortran-contiguous array

--- a/numpy/core/_asarray.py
+++ b/numpy/core/_asarray.py
@@ -14,6 +14,15 @@ from .multiarray import array, asanyarray
 __all__ = ["require"]
 
 
+POSSIBLE_FLAGS = {
+    'C': 'C', 'C_CONTIGUOUS': 'C', 'CONTIGUOUS': 'C',
+    'F': 'F', 'F_CONTIGUOUS': 'F', 'FORTRAN': 'F',
+    'A': 'A', 'ALIGNED': 'A',
+    'W': 'W', 'WRITEABLE': 'W',
+    'O': 'O', 'OWNDATA': 'O',
+    'E': 'E', 'ENSUREARRAY': 'E'
+}
+
 
 def _require_dispatcher(a, dtype=None, requirements=None, *, like=None):
     return (like,)
@@ -97,16 +106,10 @@ def require(a, dtype=None, requirements=None, *, like=None):
             like=like,
         )
 
-    possible_flags = {'C': 'C', 'C_CONTIGUOUS': 'C', 'CONTIGUOUS': 'C',
-                      'F': 'F', 'F_CONTIGUOUS': 'F', 'FORTRAN': 'F',
-                      'A': 'A', 'ALIGNED': 'A',
-                      'W': 'W', 'WRITEABLE': 'W',
-                      'O': 'O', 'OWNDATA': 'O',
-                      'E': 'E', 'ENSUREARRAY': 'E'}
     if not requirements:
         return asanyarray(a, dtype=dtype)
-    else:
-        requirements = {possible_flags[x.upper()] for x in requirements}
+
+    requirements = {POSSIBLE_FLAGS[x.upper()] for x in requirements}
 
     if 'E' in requirements:
         requirements.remove('E')
@@ -128,8 +131,7 @@ def require(a, dtype=None, requirements=None, *, like=None):
 
     for prop in requirements:
         if not arr.flags[prop]:
-            arr = arr.copy(order)
-            break
+            return arr.copy(order)
     return arr
 
 


### PR DESCRIPTION
This is a small tweak to the implementation of `np.require`. The current implementation re-constructs the `possible_flags` dictionary on each call which may be better to avoid.

The change here moves the dictionary out to a global so it's only initialized once on import. I also made a similar change to the superset check for both `"C"` and `"F"` flags, using a tuple instead of a set so the tuple can be loaded as a constant instead of rebuilt each call.

There's also a small doc update to permit other types of sequences, so the documentation would explicitly allow using a tuple for similar constant-loading reasons for downstream users.

The type annotations allow any iterable, but there didn't seem to be too many core NumPy routines that document accepting iterables vs. sequences. Wasn't sure whether that full flexibility should be documented, but happy to update if so.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
