### PR TITLE
ENH Change return type of f2py_set_data_func, f2py_void_func, f2py_init_func from void to int

### DIFF
--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -49,9 +49,9 @@ Author: Pearu Peterson <pearu@cens.ioc.ee>
 #define F2PY_MAX_DIMS 40
 #define F2PY_MESSAGE_BUFFER_SIZE 300  // Increase on "stack smashing detected"
 
-typedef void (*f2py_set_data_func)(char *, npy_intp *);
-typedef void (*f2py_void_func)(void);
-typedef void (*f2py_init_func)(int *, npy_intp *, f2py_set_data_func, int *);
+typedef int (*f2py_set_data_func)(char *, npy_intp *);
+typedef int (*f2py_void_func)(void);
+typedef int (*f2py_init_func)(int *, npy_intp *, f2py_set_data_func, int *);
 
 /*typedef void* (*f2py_c_func)(void*,...);*/
 


### PR DESCRIPTION
For wasm32 support. This is split off from #21772.
@rgommers @HaoZeke @charris 