### PR TITLE
ENH: Handle the value attribute in F2Py wrappers

### DIFF
--- a/doc/release/upcoming_changes/21807.improvement.rst
+++ b/doc/release/upcoming_changes/21807.improvement.rst
@@ -1,0 +1,7 @@
+F2PY supports the value attribute
+=================================
+
+The Fortran standard requires that variables declared with the ``value``
+attribute must be passed by value instead of reference. F2PY now supports this
+use pattern correctly. So ``integer, intent(in), value :: x`` in Fortran codes
+will have correct wrappers generated.

--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -47,7 +47,7 @@ __all__ = [
     'isunsigned_chararray', 'isunsigned_long_long',
     'isunsigned_long_longarray', 'isunsigned_short',
     'isunsigned_shortarray', 'l_and', 'l_not', 'l_or', 'outmess',
-    'replace', 'show', 'stripcomma', 'throw_error',
+    'replace', 'show', 'stripcomma', 'throw_error', 'isattr_value'
 ]
 
 
@@ -297,6 +297,9 @@ def issubroutine_wrap(rout):
     if isintent_c(rout):
         return 0
     return issubroutine(rout) and hasassumedshape(rout)
+
+def isattr_value(var):
+    return 'value' in var.get('attrspec', [])
 
 
 def hasassumedshape(rout):
@@ -692,7 +695,8 @@ def getcallprotoargument(rout, cb_map={}):
             elif isstring(var):
                 pass
             else:
-                ctype = ctype + '*'
+                if not isattr_value(var):
+                    ctype = ctype + '*'
             if ((isstring(var)
                  or isarrayofstrings(var)  # obsolete?
                  or isstringarray(var))):

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -71,7 +71,7 @@ from .auxfuncs import (
     islong_double, islong_doublefunction, islong_long,
     islong_longfunction, ismoduleroutine, isoptional, isrequired,
     isscalar, issigned_long_longarray, isstring, isstringarray,
-    isstringfunction, issubroutine,
+    isstringfunction, issubroutine, isattr_value,
     issubroutine_wrap, isthreadsafe, isunsigned, isunsigned_char,
     isunsigned_chararray, isunsigned_long_long,
     isunsigned_long_longarray, isunsigned_short, isunsigned_shortarray,
@@ -874,7 +874,7 @@ if (#varname#_cb.capi==Py_None) {
     {  # Common
         'decl': '    #ctype# #varname# = 0;',
         'pyobjfrom': {debugcapi: '    fprintf(stderr,"#vardebugshowvalue#\\n",#varname#);'},
-        'callfortran': {isintent_c: '#varname#,', l_not(isintent_c): '&#varname#,'},
+        'callfortran': {l_or(isintent_c, isattr_value): '#varname#,', l_not(l_or(isintent_c, isattr_value)): '&#varname#,'},
         'return': {isintent_out: ',#varname#'},
         '_check': l_and(isscalar, l_not(iscomplex))
     }, {

--- a/numpy/f2py/tests/src/value_attrspec/gh21665.f90
+++ b/numpy/f2py/tests/src/value_attrspec/gh21665.f90
@@ -1,0 +1,9 @@
+module fortfuncs
+  implicit none
+contains
+  subroutine square(x,y)
+    integer, intent(in), value :: x
+    integer, intent(out) :: y
+    y = x*x
+  end subroutine square
+end module fortfuncs

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -1,0 +1,14 @@
+import os
+import pytest
+
+from . import util
+
+class TestValueAttr(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "value_attrspec", "gh21665.f90")]
+
+    # gh-21665
+    def test_long_long_map(self):
+        inp = 2
+        out = self.module.fortfuncs.square(inp)
+        exp_out = 4
+        assert out == exp_out


### PR DESCRIPTION
Closes #21665. The implementation essentially takes advantage of the existing machinery which is very similar to the handling of `intent(c)`.

This should cover everything which is allowed by the standard since:
> Character values, substrings, assumed-size arrays, and adjustable arrays cannot be passed by value. [[source](https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/language-reference/a-to-z-reference/a-to-b/attributes/attributes-reference-and-value.html)]

Might need a release note, but then again maybe not.