### PR TITLE
BUG: ma.mean, ma.var and ma.std are not consistent with numpy for float32 dtype

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5390,6 +5390,7 @@ class MaskedArray(ndarray):
         else:
             danom *= danom
         dvar = true_divide(danom.sum(axis, **kwargs), cnt).astype(danom.dtype)
+        dvar = dvar.view(type(self))
         # Apply the mask if it's not a scalar
         if dvar.ndim:
             dvar._mask = mask_or(self._mask.all(axis, **kwargs), (cnt <= 0))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5305,9 +5305,9 @@ class MaskedArray(ndarray):
             if cnt.shape == () and (cnt == 0):
                 result = masked
             elif is_float16_result:
-                result = self.dtype.type(dsum * 1. / cnt)
+                result = divide(dsum, cnt, dtype=self.dtype)
             else:
-                result = dsum * 1. / cnt
+                result = divide(dsum, cnt, dtype=dsum.dtype)
         if out is not None:
             out.flat = result
             if isinstance(out, MaskedArray):
@@ -5389,7 +5389,7 @@ class MaskedArray(ndarray):
             danom = umath.absolute(danom) ** 2
         else:
             danom *= danom
-        dvar = divide(danom.sum(axis, **kwargs), cnt).view(type(self))
+        dvar = divide(danom.sum(axis, **kwargs), cnt, dtype=danom.dtype)
         # Apply the mask if it's not a scalar
         if dvar.ndim:
             dvar._mask = mask_or(self._mask.all(axis, **kwargs), (cnt <= 0))

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5305,9 +5305,9 @@ class MaskedArray(ndarray):
             if cnt.shape == () and (cnt == 0):
                 result = masked
             elif is_float16_result:
-                result = divide(dsum, cnt, dtype=self.dtype)
+                result = true_divide(dsum, cnt).astype(self.dtype)
             else:
-                result = divide(dsum, cnt, dtype=dsum.dtype)
+                result = true_divide(dsum, cnt).astype(dsum.dtype)
         if out is not None:
             out.flat = result
             if isinstance(out, MaskedArray):
@@ -5389,7 +5389,7 @@ class MaskedArray(ndarray):
             danom = umath.absolute(danom) ** 2
         else:
             danom *= danom
-        dvar = divide(danom.sum(axis, **kwargs), cnt, dtype=danom.dtype)
+        dvar = true_divide(danom.sum(axis, **kwargs), cnt).astype(danom.dtype)
         # Apply the mask if it's not a scalar
         if dvar.ndim:
             dvar._mask = mask_or(self._mask.all(axis, **kwargs), (cnt <= 0))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4043,6 +4043,23 @@ class TestMaskedArrayMathMethods:
                          mask=np.zeros((10000, 10000)))
         assert_equal(a.mean(), 65535.0)
 
+    def test_mean_float32(self):
+        x = ma.masked_array([[1, 2],[2, 4]], dtype=np.float32,
+                            mask=[[True, False], [False, True]])
+        y = x.mean(axis=0)
+        z = x.mean(axis=0, dtype=np.float32)
+        assert_equal(y.dtype, np.float32)
+        assert_equal(z.dtype, np.float32)
+
+    def test_std_float32(self):
+        x = ma.masked_array([[1, 2],[2, 4]], dtype=np.float32,
+                            mask=[[True, False], [False, True]])
+        y = x.mean(axis=0)
+        z = x.mean(axis=0, dtype=np.float32)
+        assert_equal(y.dtype, np.float32)
+        assert_equal(z.dtype, np.float32)
+
+
 class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
     def setup(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4044,7 +4044,7 @@ class TestMaskedArrayMathMethods:
         assert_equal(a.mean(), 65535.0)
 
     def test_mean_float32(self):
-        x = masked_array([[1, 2],[2, 4]], dtype=np.float32,
+        x = masked_array([[1, 2], [2, 4]], dtype=np.float32,
                          mask=[[True, False], [False, True]])
         y = x.mean(axis=0)
         z = x.mean(axis=0, dtype=np.float32)
@@ -4052,7 +4052,7 @@ class TestMaskedArrayMathMethods:
         assert_equal(z.dtype, np.float32)
 
     def test_std_float32(self):
-        x = masked_array([[1, 2],[2, 4]], dtype=np.float32,
+        x = masked_array([[1, 2], [2, 4]], dtype=np.float32,
                          mask=[[True, False], [False, True]])
         y = x.mean(axis=0)
         z = x.mean(axis=0, dtype=np.float32)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4054,8 +4054,8 @@ class TestMaskedArrayMathMethods:
     def test_std_float32(self):
         x = masked_array([[1, 2], [2, 4]], dtype=np.float32,
                          mask=[[True, False], [False, True]])
-        y = x.mean(axis=0)
-        z = x.mean(axis=0, dtype=np.float32)
+        y = x.std(axis=0)
+        z = x.std(axis=0, dtype=np.float32)
         assert_equal(y.dtype, np.float32)
         assert_equal(z.dtype, np.float32)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4044,16 +4044,16 @@ class TestMaskedArrayMathMethods:
         assert_equal(a.mean(), 65535.0)
 
     def test_mean_float32(self):
-        x = ma.masked_array([[1, 2],[2, 4]], dtype=np.float32,
-                            mask=[[True, False], [False, True]])
+        x = masked_array([[1, 2],[2, 4]], dtype=np.float32,
+                         mask=[[True, False], [False, True]])
         y = x.mean(axis=0)
         z = x.mean(axis=0, dtype=np.float32)
         assert_equal(y.dtype, np.float32)
         assert_equal(z.dtype, np.float32)
 
     def test_std_float32(self):
-        x = ma.masked_array([[1, 2],[2, 4]], dtype=np.float32,
-                            mask=[[True, False], [False, True]])
+        x = masked_array([[1, 2],[2, 4]], dtype=np.float32,
+                         mask=[[True, False], [False, True]])
         y = x.mean(axis=0)
         z = x.mean(axis=0, dtype=np.float32)
         assert_equal(y.dtype, np.float32)


### PR DESCRIPTION
Issue #21023 was resolved by #20914, but I cannot see how the fix affects the problem. Since the tests from issue were not included in the codebase, I've decided to add them in a separate PR.