### PR TITLE
BUG: Fix discovered MachAr (still used within valgrind)

### DIFF
--- a/numpy/core/_machar.py
+++ b/numpy/core/_machar.py
@@ -326,7 +326,9 @@ class MachAr:
         self.tiny = self.xmin
         self.huge = self.xmax
         self.smallest_normal = self.xmin
+        self._str_smallest_normal = float_to_str(self.xmin)
         self.smallest_subnormal = float_to_float(smallest_subnormal)
+        self._str_smallest_subnormal = float_to_str(smallest_subnormal)
 
         import math
         self.precision = int(-math.log10(float_to_float(self.eps)))

--- a/numpy/core/getlimits.py
+++ b/numpy/core/getlimits.py
@@ -343,8 +343,9 @@ def _get_machar(ftype):
         return ma_like
     # Fall back to parameter discovery
     warnings.warn(
-        'Signature {} for {} does not match any known type: '
-        'falling back to type probe function'.format(key, ftype),
+        f'Signature {key} for {ftype} does not match any known type: '
+        'falling back to type probe function.\n'
+        'This warnings indicates broken support for the dtype!',
         UserWarning, stacklevel=2)
     return _discovered_machar(ftype)
 


### PR DESCRIPTION
This fixes the missing attributes.  I tested the warning and fix
on valgrind itself.
These attributes were added in gh-18536 but the fallback path was
not checked there.

Replaces gh-21813, although something more like it may make sense
if it allows us to just delete MachAr completely.
