### PR TITLE
DOC: F2PY documentation improvements

### DIFF
--- a/doc/source/f2py/code/f2cmap_demo.f
+++ b/doc/source/f2py/code/f2cmap_demo.f
@@ -1,0 +1,9 @@
+      subroutine func1(n, x, res)
+        use, intrinsic :: iso_fortran_env, only: int64, real64
+        implicit none
+        integer(int64), intent(in) :: n
+        real(real64), intent(in) :: x(n)
+        real(real64), intent(out) :: res
+Cf2py   intent(hide) :: n
+        res = sum(x)
+      end

--- a/doc/source/f2py/code/meson.build
+++ b/doc/source/f2py/code/meson.build
@@ -20,18 +20,11 @@ incdir_f2py = run_command(py3,
     check : true
 ).stdout().strip()
 
-fibby_source = custom_target('fibbymodule.c',
-                            input : ['fib1.f'], # .f so no F90 wrappers
-                            output : ['fibbymodule.c', 'fibby-f2pywrappers.f'],
-                            command : [ py3, '-m', 'numpy.f2py', '@INPUT@',
-                            '-m', 'fibby', '--lower']
-                            )
-
 inc_np = include_directories(incdir_numpy, incdir_f2py)
 
-py3.extension_module('fibby',
+py3.extension_module('fib2',
            'fib1.f',
-           fibby_source,
+           'fib2module.c',
            incdir_f2py+'/fortranobject.c',
            include_directories: inc_np,
            dependencies : py3_dep,

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -220,6 +220,26 @@ Other options
   ``--build-dir <dirname>``
     All F2PY generated files are created in ``<dirname>``. Default is
     ``tempfile.mkdtemp()``.
+  ``--f2cmap <filename>``
+    Load Fortran-to-Python KIND specification from the given file.
+    For example, if you have a fortran file ``func1.f`` with the following:
+
+    .. literalinclude:: ./code/f2cmap_demo.f
+       :language: fortran
+
+    In order to convert ``int64`` and ``real64`` to vaild C data types,
+    you can create a ``.f2py_f2cmap`` file in the current directory:
+
+    .. code-block:: text
+
+      dict(real=dict(real32='float', real64='double'), integer=dict(int64='long long'))
+
+    and pass it to ``f2py`` using ``--f2cmap`` flag.
+
+    .. code-block:: sh
+
+      f2py -c func1.f -m func1 --f2cmap .f2py_f2cmap
+
   ``--quiet``
     Run quietly.
   ``--verbose``


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Made some corrections to existing F2PY docs-
1. Added [missing documentation](https://numpy.org/doc/stable/f2py/usage.html) for `--f2cmap` flag usage.
2. The first `meson.build` [example in f2py build documentation](https://numpy.org/doc/stable/f2py/buildtools/meson.html#fibonacci-walkthrough-f77) is out of place (it will work correctly and not show exceptions as mentioned in docs). Fixed the doc with an exception generating build file.