### PR TITLE
DOC: Replace the mathematical notation N(...) with text.

### DIFF
--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -300,9 +300,10 @@ def randn(*args):
 
     Notes
     -----
-    For random samples from :math:`N(\\mu, \\sigma^2)`, use:
+    For random samples from the normal distribution with mean ``mu`` and
+    standard deviation ``sigma``, use::
 
-    ``sigma * np.matlib.randn(...) + mu``
+        sigma * np.matlib.randn(...) + mu
 
     Examples
     --------
@@ -314,7 +315,8 @@ def randn(*args):
     matrix([[ 0.99734545,  0.2829785 , -1.50629471],
             [-0.57860025,  1.65143654, -2.42667924]])
 
-    Two-by-four matrix of samples from :math:`N(3, 6.25)`:
+    Two-by-four matrix of samples from the normal distribution with
+    mean 3 and standard deviation 2.5:
 
     >>> 2.5 * np.matlib.randn((2, 4)) + 3
     matrix([[1.92771843, 6.16484065, 0.83314899, 1.30278462],

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -1339,7 +1339,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None):
     >>> np.random.seed(123)
     >>> from numpy.polynomial import polynomial as P
     >>> x = np.linspace(-1,1,51) # x "data": [-1, -0.96, ..., 0.96, 1]
-    >>> y = x**3 - x + np.random.randn(len(x)) # x^3 - x + N(0,1) "noise"
+    >>> y = x**3 - x + np.random.randn(len(x))  # x^3 - x + Gaussian noise
     >>> c, stats = P.polyfit(x,y,3,full=True)
     >>> np.random.seed(123)
     >>> c # c[0], c[2] should be approx. 0, c[1] approx. -1, c[3] approx. 1

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -1001,7 +1001,8 @@ cdef class Generator:
 
         Notes
         -----
-        For random samples from :math:`N(\\mu, \\sigma^2)`, use one of::
+        For random samples from the normal distribution with mean ``mu`` and
+        standard deviation ``sigma``, use one of::
 
             mu + sigma * rng.standard_normal(size=...)
             rng.normal(mu, sigma, size=...)
@@ -1022,7 +1023,8 @@ cdef class Generator:
         >>> s.shape
         (3, 4, 2)
 
-        Two-by-four array of samples from :math:`N(3, 6.25)`:
+        Two-by-four array of samples from the normal distribution with
+        mean 3 and standard deviation 2.5:
 
         >>> 3 + 2.5 * rng.standard_normal(size=(2, 4))
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random
@@ -1126,7 +1128,8 @@ cdef class Generator:
         ...          linewidth=2, color='r')
         >>> plt.show()
 
-        Two-by-four array of samples from N(3, 6.25):
+        Two-by-four array of samples from the normal distribution with
+        mean 3 and standard deviation 2.5:
 
         >>> np.random.default_rng().normal(3, 2.5, size=(2, 4))
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1224,16 +1224,18 @@ cdef class RandomState:
 
         Notes
         -----
-        For random samples from :math:`N(\\mu, \\sigma^2)`, use:
+        For random samples from the normal distribution with mean ``mu`` and
+        standard deviation ``sigma``, use::
 
-        ``sigma * np.random.randn(...) + mu``
+            sigma * np.random.randn(...) + mu
 
         Examples
         --------
         >>> np.random.randn()
         2.1923875335537315  # random
 
-        Two-by-four array of samples from N(3, 6.25):
+        Two-by-four array of samples from the normal distribution with
+        mean 3 and standard deviation 2.5:
 
         >>> 3 + 2.5 * np.random.randn(2, 4)
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random
@@ -1373,7 +1375,8 @@ cdef class RandomState:
 
         Notes
         -----
-        For random samples from :math:`N(\\mu, \\sigma^2)`, use one of::
+        For random samples from the normal distribution with mean ``mu`` and
+        standard deviation ``sigma``, use one of::
 
             mu + sigma * np.random.standard_normal(size=...)
             np.random.normal(mu, sigma, size=...)
@@ -1393,7 +1396,8 @@ cdef class RandomState:
         >>> s.shape
         (3, 4, 2)
 
-        Two-by-four array of samples from :math:`N(3, 6.25)`:
+        Two-by-four array of samples from the normal distribution with
+        mean 3 and standard deviation 2.5:
 
         >>> 3 + 2.5 * np.random.standard_normal(size=(2, 4))
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random
@@ -1500,7 +1504,8 @@ cdef class RandomState:
         ...          linewidth=2, color='r')
         >>> plt.show()
 
-        Two-by-four array of samples from N(3, 6.25):
+        Two-by-four array of samples from the normal distribution with
+        mean 3 and standard deviation 2.5:
 
         >>> np.random.normal(3, 2.5, size=(2, 4))
         array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],   # random


### PR DESCRIPTION
The meaning of the second argument in the mathematical notation
N(mu, b) for the normal distribution is not consistent. In some
references it is the variance while in others it is the standard
deviation.  Let's avoid the ambiguity by not using the notation.

Fixes #21296
