### PR TITLE
DOC: Mention uniform in the np.random.Generator.random function.

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -269,7 +269,7 @@ cdef class Generator:
 
         See Also
         --------
-        ~.Generator.uniform : Drawn samples from the parameterized uniform distribution.
+        `~.Generator.uniform` : Drawn samples from the parameterized uniform distribution.
 
         Examples
         --------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -242,10 +242,10 @@ cdef class Generator:
         Return random floats in the half-open interval [0.0, 1.0).
 
         Results are from the "continuous uniform" distribution over the
-        stated interval.  To sample :math:`Unif[a, b), b > a` use `uniform` or multiply
-        the output of `random` by `(b-a)` and add `a`::
+        stated interval.  To sample :math:`Unif[a, b), b > a` use `uniform`
+        or multiply the output of `random` by ``(b - a)`` and add ``a``::
 
-          (b - a) * random() + a
+            (b - a) * random() + a
 
         Parameters
         ----------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -242,7 +242,7 @@ cdef class Generator:
         Return random floats in the half-open interval [0.0, 1.0).
 
         Results are from the "continuous uniform" distribution over the
-        stated interval.  To sample :math:`Unif[a, b), b > a` use `uniform` or multiply
+        stated interval.  To sample :math:`Unif[a, b), b > a` use `~.Generator.uniform` or multiply
         the output of `random` by `(b-a)` and add `a`::
 
           (b - a) * random() + a
@@ -269,7 +269,7 @@ cdef class Generator:
 
         See Also
         --------
-        uniform : Drawn samples from the parameterized uniform distribution.
+        ~.Generator.uniform : Drawn samples from the parameterized uniform distribution.
 
         Examples
         --------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -242,7 +242,7 @@ cdef class Generator:
         Return random floats in the half-open interval [0.0, 1.0).
 
         Results are from the "continuous uniform" distribution over the
-        stated interval.  To sample :math:`Unif[a, b), b > a` multiply
+        stated interval.  To sample :math:`Unif[a, b), b > a` use `uniform` or multiply
         the output of `random` by `(b-a)` and add `a`::
 
           (b - a) * random() + a
@@ -266,6 +266,10 @@ cdef class Generator:
         out : float or ndarray of floats
             Array of random floats of shape `size` (unless ``size=None``, in which
             case a single float is returned).
+
+        See Also
+        --------
+        uniform : Drawn samples from the parameterized uniform distribution.
 
         Examples
         --------

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -242,7 +242,7 @@ cdef class Generator:
         Return random floats in the half-open interval [0.0, 1.0).
 
         Results are from the "continuous uniform" distribution over the
-        stated interval.  To sample :math:`Unif[a, b), b > a` use `~.Generator.uniform` or multiply
+        stated interval.  To sample :math:`Unif[a, b), b > a` use `uniform` or multiply
         the output of `random` by `(b-a)` and add `a`::
 
           (b - a) * random() + a
@@ -269,7 +269,7 @@ cdef class Generator:
 
         See Also
         --------
-        `~.Generator.uniform` : Drawn samples from the parameterized uniform distribution.
+        uniform : Draw samples from the parameterized uniform distribution.
 
         Examples
         --------


### PR DESCRIPTION
Added a _See also_ section to mention np.random.Generator.uniform.
``[ci skip]``