### PR TITLE
BUG: Fix numpy.isin for timedelta dtype

### DIFF
--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -626,9 +626,8 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         raise ValueError(
             f"Invalid kind: '{kind}'. Please use None, 'sort' or 'table'.")
 
-    # Check if we can use a fast integer algorithm:
-    int_typecodes = ["u", "i", "b"]
-    is_int_arrays = all(ar.dtype.kind in int_typecodes for ar in (ar1, ar2))
+    # Can use the table method if all arrays are integers or boolean:
+    is_int_arrays = all(ar.dtype.kind in ("u", "i", "b") for ar in (ar1, ar2))
     use_table_method = is_int_arrays and kind in {None, 'table'}
 
     if use_table_method:
@@ -640,9 +639,9 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
 
         # Convert booleans to uint8 so we can use the fast integer algorithm
         if ar1.dtype == bool:
-            ar1 = ar1 + np.uint8(0)
+            ar1 = ar1.astype(np.uint8)
         if ar2.dtype == bool:
-            ar2 = ar2 + np.uint8(0)
+            ar2 = ar2.astype(np.uint8)
 
         ar2_min = np.min(ar2)
         ar2_max = np.max(ar2)

--- a/numpy/lib/arraysetops.py
+++ b/numpy/lib/arraysetops.py
@@ -627,8 +627,9 @@ def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
             f"Invalid kind: '{kind}'. Please use None, 'sort' or 'table'.")
 
     # Check if we can use a fast integer algorithm:
-    is_integer_arrays = all(ar.dtype.kind in "uib?" for ar in (ar1, ar2))
-    use_table_method = is_integer_arrays and kind in {None, 'table'}
+    int_typecodes = ["u", "i", "b"]
+    is_int_arrays = all(ar.dtype.kind in int_typecodes for ar in (ar1, ar2))
+    use_table_method = is_int_arrays and kind in {None, 'table'}
 
     if use_table_method:
         if ar2.size == 0:

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -414,6 +414,19 @@ class TestSetOps:
         with pytest.raises(ValueError):
             in1d(a, b, kind="table")
 
+    @pytest.mark.parametrize("kind", [None, "sort", "table"])
+    def test_in1d_mixed_boolean(self, kind):
+        """Test that in1d works as expected for bool/int input."""
+        for dtype in np.typecodes["AllInteger"]:
+            a = np.array([True, False, False], dtype=bool)
+            b = np.array([1, 1, 1, 1], dtype=dtype)
+            expected = np.array([True, False, False], dtype=bool)
+            assert_array_equal(in1d(a, b, kind=kind), expected)
+
+            a, b = b, a
+            expected = np.array([True, True, True, True], dtype=bool)
+            assert_array_equal(in1d(a, b, kind=kind), expected)
+
     def test_in1d_first_array_is_object(self):
         ar1 = [None]
         ar2 = np.array([1]*10)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -396,6 +396,17 @@ class TestSetOps:
         assert_array_equal(np.invert(expected),
                            in1d(a, b, invert=True, kind=kind))
 
+    @pytest.mark.parametrize("kind", [None, "sort"])
+    def test_in1d_timedelta(self, kind):
+        """Test that in1d works for timedelta input"""
+        rstate = np.random.RandomState(0)
+        a = rstate.randint(0, 100, size=10)
+        b = rstate.randint(0, 100, size=10)
+        truth = in1d(a, b)
+        a_timedelta = a.astype("timedelta64[s]")
+        b_timedelta = b.astype("timedelta64[s]")
+        assert_array_equal(truth, in1d(a_timedelta, b_timedelta, kind=kind))
+
     def test_in1d_first_array_is_object(self):
         ar1 = [None]
         ar2 = np.array([1]*10)

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -407,6 +407,13 @@ class TestSetOps:
         b_timedelta = b.astype("timedelta64[s]")
         assert_array_equal(truth, in1d(a_timedelta, b_timedelta, kind=kind))
 
+    def test_in1d_table_timedelta_fails(self):
+        a = np.array([0, 1, 2], dtype="timedelta64[s]")
+        b = a
+        # Make sure it raises a value error:
+        with pytest.raises(ValueError):
+            in1d(a, b, kind="table")
+
     def test_in1d_first_array_is_object(self):
         ar1 = [None]
         ar2 = np.array([1]*10)


### PR DESCRIPTION
This PR fixes the issue discussed on #12065 and #21843 where `'timedelta64'` was noted to be a subtype of `numpy.integer`. This in principle should detect any cases where `int(np.min(ar2))` fails. This PR also adds unittests for these.

@seberg @adeak could one of you have a look at this?

Thanks,
Miles