### PR TITLE
ENH,MAINT: Improve and simplify scalar floating point warnings

### DIFF
--- a/numpy/core/_ufunc_config.py
+++ b/numpy/core/_ufunc_config.py
@@ -97,7 +97,7 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     >>> np.int16(32000) * np.int16(3)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    FloatingPointError: overflow encountered in short_scalars
+    FloatingPointError: overflow encountered in scalar multiply
 
     >>> old_settings = np.seterr(all='print')
     >>> np.geterr()

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -394,19 +394,9 @@ static int
         /* Overflow could have occured converting double to float */
         if (NPY_UNLIKELY((npy_isinf(temp.real) && !npy_isinf(oop.real)) ||
                          (npy_isinf(temp.imag) && !npy_isinf(oop.imag)))) {
-            int bufsize, errmask;
-            PyObject *errobj;
-
-            if (PyUFunc_GetPyValues("assignment", &bufsize, &errmask,
-                    &errobj) < 0) {
+            if (PyUFunc_GiveFloatingpointErrors("cast", NPY_FPE_OVERFLOW) < 0) {
                 return -1;
             }
-            int first = 1;
-            if (PyUFunc_handlefperr(errmask, errobj, NPY_FPE_OVERFLOW, &first)) {
-                Py_XDECREF(errobj);
-                return -1;
-            }
-            Py_XDECREF(errobj);
         }
 #endif
     }

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -29,6 +29,8 @@
 #include "array_coercion.h"
 #include "common.h"
 #include "can_cast_table.h"
+#include "umathmodule.h"
+
 
 /* TODO: Used for some functions, should possibly move these to npy_math.h */
 #include "loops.h"
@@ -1162,6 +1164,14 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
  *          (Half, Float, Double, LongDouble)*3#
  */
 #define IS_@name@
+/* drop the "true_" from "true_divide" for floating point warnings: */
+#define IS_@oper@
+#ifdef IS_true_divide
+    #define OP_NAME "divide"
+#else
+    #define OP_NAME "@oper@"
+#endif
+#undef IS_@oper@
 
 static PyObject *
 @name@_@oper@(PyObject *a, PyObject *b)
@@ -1281,19 +1291,9 @@ static PyObject *
     retstatus |= npy_get_floatstatus_barrier((char*)&out);
 #endif
     if (retstatus) {
-        int bufsize, errmask;
-        PyObject *errobj;
-
-        if (PyUFunc_GetPyValues("@name@_scalars", &bufsize, &errmask,
-                                &errobj) < 0) {
+        if (PyUFunc_GiveFloatingpointErrors("scalar " OP_NAME, retstatus) < 0) {
             return NULL;
         }
-        int first = 1;
-        if (PyUFunc_handlefperr(errmask, errobj, retstatus, &first)) {
-            Py_XDECREF(errobj);
-            return NULL;
-        }
-        Py_XDECREF(errobj);
     }
 
 
@@ -1327,6 +1327,7 @@ static PyObject *
 }
 
 
+#undef OP_NAME
 #undef IS_@name@
 
 /**end repeat**/
@@ -1449,19 +1450,9 @@ static PyObject *
     retstatus |= npy_get_floatstatus_barrier((char*)&out);
 #endif
     if (retstatus) {
-        int bufsize, errmask;
-        PyObject *errobj;
-
-        if (PyUFunc_GetPyValues("@name@_scalars", &bufsize, &errmask,
-                                &errobj) < 0) {
+        if (PyUFunc_GiveFloatingpointErrors("scalar power", retstatus) < 0) {
             return NULL;
         }
-        int first = 1;
-        if (PyUFunc_handlefperr(errmask, errobj, retstatus, &first)) {
-            Py_XDECREF(errobj);
-            return NULL;
-        }
-        Py_XDECREF(errobj);
     }
 
     ret = PyArrayScalar_New(@Name@);
@@ -1581,19 +1572,9 @@ static PyObject *
     int retstatus = @name@_ctype_@oper@(val, &out);
 
     if (retstatus) {
-        int bufsize, errmask;
-        PyObject *errobj;
-
-        if (PyUFunc_GetPyValues("@name@_scalars", &bufsize, &errmask,
-                                &errobj) < 0) {
+        if (PyUFunc_GiveFloatingpointErrors("scalar @oper@", retstatus) < 0) {
             return NULL;
         }
-        int first = 1;
-        if (PyUFunc_handlefperr(errmask, errobj, retstatus, &first)) {
-            Py_XDECREF(errobj);
-            return NULL;
-        }
-        Py_XDECREF(errobj);
     }
 
     /*

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -474,8 +474,7 @@ class TestStatistic:
 
     @pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
     @pytest.mark.filterwarnings(
-        "ignore:invalid value encountered in (divide|double_scalars):"
-        "RuntimeWarning"
+        "ignore:invalid value encountered in( scalar)? divide:RuntimeWarning"
     )
     @pytest.mark.parametrize("mode", ["mean", "median"])
     def test_zero_stat_length_valid(self, mode):


### PR DESCRIPTION
This makes the scalar operations warnings read e.g.:
```
   overflow encountered in scalar multiply
```
rather than:
```
   overflow encountered in float_scalars
```
It also fixes one case where "assignment" rather than "cast" was
used when I added the FPEs for casts.

Otherwise, uses the helper that I intrudced for for the floating
point casts in all places to simplify the code, the only
"complicated" thing is that I try to give "scalar divide" rather
than "scalar true_divide" as warnings, since "true_divide" should
not really be something that end-users need be aware of.

---

I had thought that I changed some of the warnings already previously in the scalar paths, not that it matters so long that wasn't reverted and I forgot ;).