### PR TITLE
ENH: Implement correct scalar and integer overflow errors for NEP 50

### DIFF
--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -305,7 +305,7 @@ static int
         else {
             /* Live in the future, outright error: */
             PyErr_Format(PyExc_OverflowError,
-                    "Python int %R too large to convert to %S", obj, descr);
+                    "Python integer %R out of bounds for %S", obj, descr);
             Py_DECREF(descr);
             return -1;
             }

--- a/numpy/core/src/multiarray/dtypemeta.h
+++ b/numpy/core/src/multiarray/dtypemeta.h
@@ -51,7 +51,6 @@ typedef struct {
     ensure_canonical_function *ensure_canonical;
     /*
      * Currently only used for experimental user DTypes.
-     * Typing as `void *` until NumPy itself uses these (directly).
      */
     setitemfunction *setitem;
     getitemfunction *getitem;
@@ -104,6 +103,7 @@ typedef struct {
     NPY_DT_SLOTS(NPY_DTYPE(descr))->getitem(descr, data_ptr)
 #define NPY_DT_CALL_setitem(descr, value, data_ptr)  \
     NPY_DT_SLOTS(NPY_DTYPE(descr))->setitem(descr, value, data_ptr)
+
 
 /*
  * This function will hopefully be phased out or replaced, but was convenient

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -33,7 +33,6 @@
 #include "umathmodule.h"
 
 #include "convert_datatype.h"
-#include "dtypemeta.h"
 
 
 /* TODO: Used for some functions, should possibly move these to npy_math.h */

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -26,10 +26,14 @@
 #include "binop_override.h"
 #include "npy_longdouble.h"
 
+#include "arraytypes.h"
 #include "array_coercion.h"
 #include "common.h"
 #include "can_cast_table.h"
 #include "umathmodule.h"
+
+#include "convert_datatype.h"
+#include "dtypemeta.h"
 
 
 /* TODO: Used for some functions, should possibly move these to npy_math.h */
@@ -792,7 +796,12 @@ typedef enum {
      */
     CONVERSION_SUCCESS,
     /*
-     * Other object is an unknown scalar or array-like, we (typically) use
+     * We use the normal conversion (setitem) function when coercing from
+     * Python scalars.
+     */
+    CONVERT_PYSCALAR,
+    /*
+     * Other object is an unkown scalar or array-like, we (typically) use
      * the generic path, which normally ends up in the ufunc machinery.
      */
     OTHER_IS_UNKNOWN_OBJECT,
@@ -956,7 +965,15 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
             *may_need_deferring = NPY_TRUE;
         }
         if (!IS_SAFE(NPY_DOUBLE, NPY_@TYPE@)) {
-            return PROMOTION_REQUIRED;
+            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+                /* Legacy promotion and weak-and-warn not handled here */
+                return PROMOTION_REQUIRED;
+            }
+            /* Weak promotion is used when self is float or complex: */
+            if (!PyTypeNum_ISFLOAT(NPY_@TYPE@) && !PyTypeNum_ISCOMPLEX(NPY_@TYPE@)) {
+                return PROMOTION_REQUIRED;
+            }
+            return CONVERT_PYSCALAR;
         }
         CONVERT_TO_RESULT(PyFloat_AS_DOUBLE(value));
         return CONVERSION_SUCCESS;
@@ -968,15 +985,19 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
         }
         if (!IS_SAFE(NPY_LONG, NPY_@TYPE@)) {
             /*
-             * long -> (c)longdouble is safe, so `THER_IS_UNKNOWN_OBJECT` will
+             * long -> (c)longdouble is safe, so `OTHER_IS_UNKNOWN_OBJECT` will
              * be returned below for huge integers.
              */
-            return PROMOTION_REQUIRED;
+            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+                /* Legacy promotion and weak-and-warn not handled here */
+                return PROMOTION_REQUIRED;
+            }
+            return CONVERT_PYSCALAR;
         }
         int overflow;
         long val = PyLong_AsLongAndOverflow(value, &overflow);
         if (overflow) {
-            return OTHER_IS_UNKNOWN_OBJECT;  /* handle as if arbitrary object */
+            return CONVERT_PYSCALAR;  /* handle as if "unsafe" */
         }
         if (error_converting(val)) {
             return CONVERSION_ERROR;  /* should not be possible */
@@ -995,7 +1016,15 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
             *may_need_deferring = NPY_TRUE;
         }
         if (!IS_SAFE(NPY_CDOUBLE, NPY_@TYPE@)) {
-            return PROMOTION_REQUIRED;
+            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+                /* Legacy promotion and weak-and-warn not handled here */
+                return PROMOTION_REQUIRED;
+            }
+            /* Weak promotion is used when self is float or complex: */
+            if (!PyTypeNum_ISCOMPLEX(NPY_@TYPE@)) {
+                return PROMOTION_REQUIRED;
+            }
+            return CONVERT_PYSCALAR;
         }
 #if defined(IS_CFLOAT) || defined(IS_CDOUBLE) || defined(IS_CLONGDOUBLE)
         Py_complex val = PyComplex_AsCComplex(value);
@@ -1164,12 +1193,24 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
  *         (npy_half, npy_float, npy_double, npy_longdouble,
  *             npy_cfloat, npy_cdouble, npy_clongdouble)*4,
  *         (npy_half, npy_float, npy_double, npy_longdouble)*3#
+ * #oname = (byte, ubyte, short, ushort, int, uint,
+ *              long, ulong, longlong, ulonglong)*11,
+ *          double*10,
+ *          (half, float, double, longdouble,
+ *              cfloat, cdouble, clongdouble)*4,
+ *          (half, float, double, longdouble)*3#
  * #OName = (Byte, UByte, Short, UShort, Int, UInt,
  *              Long, ULong, LongLong, ULongLong)*11,
  *          Double*10,
  *          (Half, Float, Double, LongDouble,
  *              CFloat, CDouble, CLongDouble)*4,
  *          (Half, Float, Double, LongDouble)*3#
+ * #ONAME = (BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *              LONG, ULONG, LONGLONG, ULONGLONG)*11,
+ *          DOUBLE*10,
+ *          (HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *              CFLOAT, CDOUBLE, CLONGDOUBLE)*4,
+ *          (HALF, FLOAT, DOUBLE, LONGDOUBLE)*3#
  */
 #define IS_@name@
 /* drop the "true_" from "true_divide" for floating point warnings: */
@@ -1179,13 +1220,12 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
 #else
     #define OP_NAME "@oper@"
 #endif
-#undef IS_@oper@
 
 static PyObject *
 @name@_@oper@(PyObject *a, PyObject *b)
 {
     PyObject *ret;
-    @type@ arg1, arg2, other_val;
+    @otype@ arg1, arg2, other_val;
 
     /*
      * Check if this operation may be considered forward.  Note `is_forward`
@@ -1214,7 +1254,7 @@ static PyObject *
     PyObject *other = is_forward ? b : a;
 
     npy_bool may_need_deferring;
-    conversion_result res = convert_to_@name@(
+    conversion_result res = convert_to_@oname@(
             other, &other_val, &may_need_deferring);
     if (res == CONVERSION_ERROR) {
         return NULL;  /* an error occurred (should never happen) */
@@ -1255,6 +1295,11 @@ static PyObject *
              *       correctly.  (e.g. `uint8 * int8` cannot warn).
              */
             return PyGenericArrType_Type.tp_as_number->nb_@oper@(a,b);
+        case CONVERT_PYSCALAR:
+            if (@ONAME@_setitem(other, (char *)&other_val, NULL) < 0) {
+                return NULL;
+            }
+            break;
         default:
             assert(0);  /* error was checked already, impossible to reach */
             return NULL;
@@ -1291,7 +1336,7 @@ static PyObject *
 #if @twoout@
     int retstatus = @name@_ctype_@oper@(arg1, arg2, &out, &out2);
 #else
-    int retstatus = @name@_ctype_@oper@(arg1, arg2, &out);
+    int retstatus = @oname@_ctype_@oper@(arg1, arg2, &out);
 #endif
 
 #if @fperr@
@@ -1336,6 +1381,7 @@ static PyObject *
 
 
 #undef OP_NAME
+#undef IS_@oper@
 #undef IS_@name@
 
 /**end repeat**/
@@ -1358,6 +1404,10 @@ static PyObject *
  *         Long, ULong, LongLong, ULongLong,
  *         Half, Float, Double, LongDouble,
  *         CFloat, CDouble, CLongDouble#
+ * #NAME = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         CFLOAT, CDOUBLE, CLONGDOUBLE#
  *
  * #isint = 1*10,0*7#
  * #isuint = (0,1)*5,0*7#
@@ -1417,6 +1467,11 @@ static PyObject *
 #endif
         case PROMOTION_REQUIRED:
             return PyGenericArrType_Type.tp_as_number->nb_power(a, b, modulo);
+        case CONVERT_PYSCALAR:
+            if (@NAME@_setitem(other, (char *)&other_val, NULL) < 0) {
+                return NULL;
+            }
+            break;
         default:
             assert(0);  /* error was checked already, impossible to reach */
             return NULL;
@@ -1759,6 +1814,10 @@ static PyObject *
  *         Long, ULong, LongLong, ULongLong,
  *         Half, Float, Double, LongDouble,
  *         CFloat, CDouble, CLongDouble#
+ * #NAME = BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         CFLOAT, CDOUBLE, CLONGDOUBLE#
  * #simp = def*10, def_half, def*3, cmplx*3#
  */
 #define IS_@name@
@@ -1791,6 +1850,11 @@ static PyObject*
 #endif
         case PROMOTION_REQUIRED:
             return PyGenericArrType_Type.tp_richcompare(self, other, cmp_op);
+        case CONVERT_PYSCALAR:
+            if (@NAME@_setitem(other, (char *)&arg2, NULL) < 0) {
+                return NULL;
+            }
+            break;
         default:
             assert(0);  /* error was checked already, impossible to reach */
             return NULL;

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -997,7 +997,11 @@ convert_to_@name@(PyObject *value, @type@ *result, npy_bool *may_need_deferring)
         int overflow;
         long val = PyLong_AsLongAndOverflow(value, &overflow);
         if (overflow) {
-            return CONVERT_PYSCALAR;  /* handle as if "unsafe" */
+            /* handle as if "unsafe" */
+            if (npy_promotion_state != NPY_USE_WEAK_PROMOTION) {
+                return PROMOTION_REQUIRED;
+            }
+            return CONVERT_PYSCALAR;
         }
         if (error_converting(val)) {
             return CONVERSION_ERROR;  /* should not be possible */

--- a/numpy/core/tests/test_mem_overlap.py
+++ b/numpy/core/tests/test_mem_overlap.py
@@ -105,7 +105,7 @@ def test_diophantine_fuzz():
                       for j in range(ndim))
 
             b_ub = min(max_int-2, sum(a*ub for a, ub in zip(A, U)))
-            b = rng.randint(-1, b_ub+2, dtype=np.intp)
+            b = int(rng.randint(-1, b_ub+2, dtype=np.intp))
 
             if ndim == 0 and feasible_count < min_count:
                 b = 0

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -165,7 +165,8 @@ def test_nep50_integer_conversion_errors():
         np.uint8(1) + 300
 
     # Error message depends on platform (maybe unsigned int or unsigned long)
-    with pytest.raises(OverflowError, match=".*unsigned"):
+    with pytest.raises(OverflowError,
+            match="Python integer -1 out of bounds for uint8"):
         np.uint8(1) + -1
 
 

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -123,6 +123,15 @@ def test_nep50_weak_integers_with_inexact(dtype):
         assert res == np.inf
 
 
+def test_nep50_complex_promotion():
+    np._set_promotion_state("weak")
+
+    with pytest.warns(RuntimeWarning, match=".*overflow"):
+        res = np.complex64(3) + complex(2**300)
+
+    assert type(res) == np.complex64
+
+
 def test_nep50_integer_conversion_errors():
     # Do not worry about warnings here (auto-fixture will reset).
     np._set_promotion_state("weak")

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -30,7 +30,7 @@ def test_nep50_examples():
     assert res.dtype == np.int64
 
     with pytest.warns(UserWarning, match="result dtype changed"):
-        # Note: Should warn (error with the errstate), but does not:
+        # Note: Overflow would be nice, but does not warn with change warning
         with np.errstate(over="raise"):
             res = np.uint8(100) + 200
     assert res.dtype == np.uint8
@@ -59,6 +59,21 @@ def test_nep50_examples():
     with pytest.warns(UserWarning, match="result dtype changed"):
         res = np.array([1.], np.float32) + np.int64(3)
     assert res.dtype == np.float64
+
+
+def test_nep50_without_warnings():
+    # Test that avoid the "warn" method, since that may lead to different
+    # code paths in some cases.
+    # Set promotion to weak (no warning), the auto-fixture will reset it.
+    np._set_promotion_state("weak")
+    with np.errstate(over="warn"):
+        with pytest.warns(RuntimeWarning):
+            res = np.uint8(100) + 200
+    assert res.dtype == np.uint8
+
+    with pytest.warns(RuntimeWarning):
+        res = np.float32(1) + 3e100
+    assert res.dtype == np.float32
 
 
 @pytest.mark.xfail

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -76,12 +76,15 @@ def test_nep50_without_warnings():
     assert res.dtype == np.float32
 
 
-@pytest.mark.xfail
 def test_nep50_integer_conversion_errors():
+    # Do not worry about warnings here (auto-fixture will reset).
+    np._set_promotion_state("weak")
     # Implementation for error paths is mostly missing (as of writing)
-    with pytest.raises(ValueError):  # (or TypeError?)
+    with pytest.raises(OverflowError, match=".*uint8"):
         np.array([1], np.uint8) + 300
 
-    with pytest.raises(ValueError):  # (or TypeError?)
+    with pytest.raises(OverflowError, match=".*uint8"):
         np.uint8(1) + 300
 
+    with pytest.raises(OverflowError, match=".*unsigned int"):
+        np.uint8(1) + -1

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -4,7 +4,10 @@ mode.  Most of these test are likely to be simply deleted again once NEP 50
 is adopted in the main test suite.  A few may be moved elsewhere.
 """
 
+import operator
+
 import numpy as np
+
 import pytest
 
 
@@ -121,6 +124,25 @@ def test_nep50_weak_integers_with_inexact(dtype):
             res = np.add(np.array(1, dtype=dtype), too_big_int, dtype=dtype)
         assert res.dtype == dtype
         assert res == np.inf
+
+
+@pytest.mark.parametrize("op", [operator.add, operator.pow, operator.eq])
+def test_weak_promotion_scalar_path(op):
+    # Some additional paths excercising the weak scalars.
+    np._set_promotion_state("weak")
+
+    # Integer path:
+    res = op(np.uint8(3), 5)
+    assert res == op(3, 5)
+    assert res.dtype == np.uint8 or res.dtype == bool
+
+    with pytest.raises(OverflowError):
+        op(np.uint8(3), 1000)
+
+    # Float path:
+    res = op(np.float32(3), 5.)
+    assert res == op(3., 5.)
+    assert res.dtype == np.float32 or res.dtype == bool
 
 
 def test_nep50_complex_promotion():

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -89,3 +89,12 @@ def test_nep50_integer_conversion_errors():
     # Error message depends on platform (maybe unsigned int or unsigned long)
     with pytest.raises(OverflowError, match=".*unsigned"):
         np.uint8(1) + -1
+
+
+def test_nep50_integer_regression():
+    # Test the old integer promotion rules.  When the integer is too large,
+    # we need to keep using the old-style promotion.
+    np._set_promotion_state("legacy")
+    arr = np.array(1)
+    assert (arr + 2**63).dtype == np.float64
+    assert (arr[()] + 2**63).dtype == np.float64

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -86,5 +86,6 @@ def test_nep50_integer_conversion_errors():
     with pytest.raises(OverflowError, match=".*uint8"):
         np.uint8(1) + 300
 
-    with pytest.raises(OverflowError, match=".*unsigned int"):
+    # Error message depends on platform (maybe unsigned int or unsigned long)
+    with pytest.raises(OverflowError, match=".*unsigned"):
         np.uint8(1) + -1

--- a/numpy/core/tests/test_nep50_promotions.py
+++ b/numpy/core/tests/test_nep50_promotions.py
@@ -33,7 +33,8 @@ def test_nep50_examples():
     assert res.dtype == np.int64
 
     with pytest.warns(UserWarning, match="result dtype changed"):
-        # Note: Overflow would be nice, but does not warn with change warning
+        # Note: For "weak_and_warn" promotion state the overflow warning is
+        #       unfortunately not given (because we use the full array path).
         with np.errstate(over="raise"):
             res = np.uint8(100) + 200
     assert res.dtype == np.uint8

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -68,12 +68,12 @@ def _int_to_uint32_array(n):
         raise ValueError("expected non-negative integer")
     if n == 0:
         arr.append(np.uint32(n))
-    if isinstance(n, np.unsignedinteger):
-        # Cannot do n & MASK32, convert to python int
-        n = int(n)
+
+    # NumPy ints may not like `n & MASK32` or ``//= 2**32` so use Python int
+    n = int(n)
     while n > 0:
         arr.append(np.uint32(n & MASK32))
-        n //= (2**32)
+        n //= 2**32
     return np.array(arr, dtype=np.uint32)
 
 def _coerce_to_uint32_array(x):

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -21,7 +21,7 @@ B0 = np.empty((), dtype=np.int32).view(SubClass)
 B1 = np.empty((1,), dtype=np.int32).view(SubClass)
 B2 = np.empty((1, 1), dtype=np.int32).view(SubClass)
 C: np.ndarray[Any, np.dtype[np.int32]] = np.array([0, 1, 2], dtype=np.int32)
-D = np.empty(3).view(SubClass)
+D = np.ones(3).view(SubClass)
 
 i4.all()
 A.all()


### PR DESCRIPTION
This adds the main missing chunk of NEP 50 support.  Unfortunately, I feel this is still fairly complex, although I am not sure it can be helped...

For the ufuncs, it may be possible to move the special handling to later.  For the scalars, the special handling has a bit of additional complexity because of the "defer" check (if we did it always it would be easier logic flow).
Unfortunately, for the scalars it makes sense to keep the "faster" version for the safe cast around (for speed reasons).

The other question is whether we want to do this as a distinct method on the DType, although I don't think we have to settle that yet.  It should be easy to change.

A small oddity is that the user has to `resolve` from one of the "int" dtypes (int32, int64, uint64, object).  That seems OK to me, although it also seems like something that we may well know better later.

---

Marking as draft, I need to let this sink in a bit to see if I have a better idea.  Bug, this should be ready for a test ride and may complete NEP 50 logic (with the exception of possibly allowing Python scalars for example in `np.can_cast(123, np.int8))`