### PR TITLE
DOC: Fixed minor typo in reference

### DIFF
--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -486,7 +486,7 @@ cdef class BitGenerator():
         A seed to initialize the `BitGenerator`. If None, then fresh,
         unpredictable entropy will be pulled from the OS. If an ``int`` or
         ``array_like[ints]`` is passed, then it will be passed to
-        ~`numpy.random.SeedSequence` to derive the initial `BitGenerator` state.
+        `~numpy.random.SeedSequence` to derive the initial `BitGenerator` state.
         One may also pass in a `SeedSequence` instance.
 
     Attributes


### PR DESCRIPTION
The link was malformed.

[skip ci]
[skip azp]