### PR TITLE
CI: skip azp and circleCI logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,17 @@ jobs:
 
     steps:
       - checkout:
+
+      - run:
+          name: Check-skip
+          command: |
+            export git_log=$(git log --max-count=1 --pretty=format:"%B" | tr "\n" " ")
+            echo "Got commit message:"
+            echo "${git_log}"
+            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$git_log" == *"[skip circle]"* ]] || [[ "$git_log" == *"[circle skip]"* ]]); then
+              echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
+              circleci-agent step halt;
+            fi
       - run:
           name: pull changes from merge
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,10 @@ jobs:
             export git_log=$(git log --max-count=1 --pretty=format:"%B" | tr "\n" " ")
             echo "Got commit message:"
             echo "${git_log}"
-            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$git_log" == *"[skip circle]"* ]] || [[ "$git_log" == *"[circle skip]"* ]]); then
+            if [[ -v CIRCLE_PULL_REQUEST ]] && \
+               ([[ "$git_log" == *"[skip circle]"* ]] || \
+                [[ "$git_log" == *"[circle skip]"* ]])
+            then
               echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
               circleci-agent step halt;
             fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,26 @@ pr:
 
 stages:
 
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-20.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+
 - stage: InitialTests
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
   jobs:
 
   # Native build is based on gcc flag `-march=native`
@@ -48,6 +67,8 @@ stages:
         testRunTitle: 'Publish test results for baseline/native'
 
 - stage: ComprehensiveTests
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
   jobs:
 
   - job: Lint

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -197,17 +197,14 @@ platforms to building the docs. In some cases you already know that CI isn't
 needed (or not all of it), for example if you work on CI config files, text in
 the README, or other files that aren't involved in regular build, test or docs
 sequences. In such cases you may explicitly skip CI by including one of these
-fragments in your commit message::
+fragments in your commit message:
 
-   ``[ci skip]``: skip as much CI as possible (not all jobs can be skipped)
-   ``[skip github]``: skip GitHub Actions "build numpy and run tests" jobs
-   ``[skip travis]``: skip TravisCI jobs
-   ``[skip azurepipelines]``: skip Azure jobs
-
-*Note*: unfortunately not all CI systems implement this feature well, or at all.
-CircleCI supports ``ci skip`` but has no command to skip only CircleCI.
-Azure chooses to still run jobs with skip commands on PRs, the jobs only get
-skipped on merging to master.
+* ``[skip ci]``: skip all CI
+* ``[skip github]``: skip GitHub Actions "build numpy and run tests" jobs
+* ``[skip actions]``: skip all GitHub Actions
+* ``[skip travis]``: skip TravisCI jobs
+* ``[skip azp]``: skip Azure jobs
+* ``[skip circle]``: skip CircleCI jobs
 
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I propose to add a `[skip azp]` and `[skip circle]` to respectively skip Azure and CircleCI.
Code taken from SciPy.

Other CIs can already be skipped with: `[skip actions] [skip travis]`

This would allow finer control on which part of the CI is being run.