### PR TITLE
MAINT: Disable checks for Win workaround for GCC

### DIFF
--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -12,7 +12,6 @@ import gc
 import weakref
 import pytest
 from contextlib import contextmanager
-import re
 
 from numpy.compat import pickle
 

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -5503,7 +5503,7 @@ class TestIO:
         These normally would hang doing something like this.
         See : https://github.com/numpy/numpy/issues/2256
         """
-        if sys.platform != 'win32' or re.search(r'\[GCC ', sys.version):
+        if sys.platform != 'win32' or '[GCC ' in sys.version:
             return
         try:
             # before workarounds, only up to 2**32-1 worked

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -12,6 +12,7 @@ import gc
 import weakref
 import pytest
 from contextlib import contextmanager
+import re
 
 from numpy.compat import pickle
 
@@ -5497,10 +5498,12 @@ class TestIO:
 
     @pytest.mark.slow  # takes > 1 minute on mechanical hard drive
     def test_big_binary(self):
-        """Test workarounds for 32-bit limited fwrite, fseek, and ftell
-        calls in windows. These normally would hang doing something like this.
-        See http://projects.scipy.org/numpy/ticket/1660"""
-        if sys.platform != 'win32':
+        """Test workarounds for 32-bit limit for MSVC fwrite, fseek, and ftell
+
+        These normally would hang doing something like this.
+        See : https://github.com/numpy/numpy/issues/2256
+        """
+        if sys.platform != 'win32' or re.search(r'\[GCC ', sys.version):
             return
         try:
             # before workarounds, only up to 2**32-1 worked


### PR DESCRIPTION
Python compiled with GCC on Windows does not suffer the same
deficiencies as MSVC; disable check for that platform.

Here are a couple of `sys.version` strings from Windows / Mingw-w64
Python binaries:

* '3.10.5 (main, Jun 18 2022, 01:33:07)  [GCC 12.1.0 32 bit]'
* '3.10.5 (main, Jun 18 2022, 01:32:32)  [GCC UCRT 12.1.0 64 bit (AMD64)]'

For MSVC Python binaries:

* '3.9.13 (tags/v3.9.13:6de2ca5, May 17 2022, 16:24:45) [MSC v.1929 32 bit (Intel)]'
* '3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)]'

Patch is a version of https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python-numpy/0004-fix-testsuite.patch