### PR TITLE
MAINT: Fix non-void function does not return a value warning

### DIFF
--- a/numpy/linalg/lapack_lite/f2c.c
+++ b/numpy/linalg/lapack_lite/f2c.c
@@ -377,10 +377,11 @@ p->i = p1.i;
 
 #endif /* NO_OVERWRITE */
 
- int
 #ifdef KR_headers
+int
 s_cat(lp, rpp, rnp, np, ll) char *lp, *rpp[]; ftnlen rnp[], *np, ll;
 #else
+int
 s_cat(char *lp, char *rpp[], ftnlen rnp[], ftnlen *np, ftnlen ll)
 #endif
 {
@@ -429,7 +430,8 @@ s_cat(char *lp, char *rpp[], ftnlen rnp[], ftnlen *np, ftnlen ll)
 		free(lp1);
 		}
 #endif
-	}
+	return 0;
+}
 
 
 /* compare two strings */


### PR DESCRIPTION
This is the only error that comes up when compiling with `-Werror=return-type`.
