### PR TITLE
DOC: Link to PEP-484 in the typing docs

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -5,7 +5,7 @@ Typing (:mod:`numpy.typing`)
 
 .. versionadded:: 1.20
 
-Large parts of the NumPy API have PEP-484-style[https://peps.python.org/pep-0484/] type annotations. In
+Large parts of the NumPy API have :pep:`484`-style type annotations. In
 addition a number of type aliases are available to users, most prominently
 the two below:
 

--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -5,7 +5,7 @@ Typing (:mod:`numpy.typing`)
 
 .. versionadded:: 1.20
 
-Large parts of the NumPy API have PEP-484-style type annotations. In
+Large parts of the NumPy API have PEP-484-style[https://peps.python.org/pep-0484/] type annotations. In
 addition a number of type aliases are available to users, most prominently
 the two below:
 


### PR DESCRIPTION
DOC: documentation
Linking PEP-484 to the documentation for better understanding