### PR TITLE
Fix lib flags for librandom

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -9,6 +9,7 @@ import glob
 from os.path import join
 
 from numpy.distutils import log
+from numpy.distutils.msvccompiler import lib_opts_if_msvc
 from distutils.dep_util import newer
 from sysconfig import get_config_var
 from numpy.compat import npy_load_module
@@ -771,29 +772,12 @@ def configuration(parent_package='',top_path=None):
                        join('src', 'npymath', 'halffloat.c')
                        ]
 
-    def opts_if_msvc(build_cmd):
-        """ Add flags if we are using MSVC compiler
-
-        We can't see `build_cmd` in our scope, because we have not initialized
-        the distutils build command, so use this deferred calculation to run
-        when we are building the library.
-        """
-        if build_cmd.compiler.compiler_type != 'msvc':
-            return []
-        # Explicitly disable whole-program optimization.
-        flags = ['/GL-']
-        # Disable voltbl section for vc142 to allow link using mingw-w64; see:
-        # https://github.com/matthew-brett/dll_investigation/issues/1#issuecomment-1100468171
-        if build_cmd.compiler_opt.cc_test_flags(['-d2VolatileMetadata-']):
-            flags.append('-d2VolatileMetadata-')
-        return flags
-
     config.add_installed_library('npymath',
             sources=npymath_sources + [get_mathlib_info],
             install_dir='lib',
             build_info={
                 'include_dirs' : [],  # empty list required for creating npy_math_internal.h
-                'extra_compiler_args': [opts_if_msvc],
+                'extra_compiler_args': [lib_opts_if_msvc],
             })
     config.add_npy_pkg_config("npymath.ini.in", "lib/npy-pkg-config",
             subst_dict)

--- a/numpy/distutils/msvccompiler.py
+++ b/numpy/distutils/msvccompiler.py
@@ -56,3 +56,21 @@ class MSVCCompiler(_MSVCCompiler):
         if platform_bits == 32:
             self.compile_options += ['/arch:SSE2']
             self.compile_options_debug += ['/arch:SSE2']
+
+
+def lib_opts_if_msvc(build_cmd):
+    """ Add flags if we are using MSVC compiler
+
+    We can't see `build_cmd` in our scope, because we have not initialized
+    the distutils build command, so use this deferred calculation to run
+    when we are building the library.
+    """
+    if build_cmd.compiler.compiler_type != 'msvc':
+        return []
+    # Explicitly disable whole-program optimization.
+    flags = ['/GL-']
+    # Disable voltbl section for vc142 to allow link using mingw-w64; see:
+    # https://github.com/matthew-brett/dll_investigation/issues/1#issuecomment-1100468171
+    if build_cmd.compiler_opt.cc_test_flags(['-d2VolatileMetadata-']):
+        flags.append('-d2VolatileMetadata-')
+    return flags


### PR DESCRIPTION
Add the voltbl fix to librandom.  Remove SSE flag for GCC on 32-bit
Windows, it's the default.  It also causes an error on e.g. mingw-w64.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
