### PR TITLE
BLD: Allow GCC compile on mingw-w64-based systems

### DIFF
--- a/numpy/random/src/mt19937/mt19937.h
+++ b/numpy/random/src/mt19937/mt19937.h
@@ -2,7 +2,7 @@
 #include <math.h>
 #include <stdint.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined (__MINGW32__)
 #define inline __forceinline
 #endif
 

--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -52,7 +52,7 @@
 
 #include <inttypes.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined (__MINGW32__)
 #include <stdlib.h>
 #define inline __forceinline
 #endif

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -33,7 +33,7 @@ static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
   return (uint64_t)product;
 }
 #else
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include <intrin.h>
 #if defined(_WIN64) && defined(_M_AMD64)
 #pragma intrinsic(_umul128)


### PR DESCRIPTION
Macro `__MINGW32__` always defined for Mingw-w64 compilers (32- or
64-bit):

https://sourceforge.net/p/predef/wiki/Compilers/

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
