### PR TITLE
BUG: Fix KeyError in crackfortran operator support

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2191,7 +2191,7 @@ def analyzebody(block, args, tab=''):
             as_ = args
         b = postcrack(b, as_, tab=tab + '\t')
         if b['block'] in ['interface', 'abstract interface'] and \
-           not b['body'] and not b['implementedby']:
+           not b['body'] and not b.get('implementedby'):
             if 'f2pyenhancements' not in b:
                 continue
         if b['block'].replace(' ', '') == 'pythonmodule':


### PR DESCRIPTION
Closes #21889 by simply using the safer `.get()` variant which returns `None` instead of a `KeyError`. This in turn allows the rest of the check to pass due to `not None` evaluating to `True` and keeping the rest of the intended logic.

Note that there isn't actually any handling of `operator()` or even `implementedby` in the rest of F2PY yet (it was an enhancement done for `sphinx-fortran` I think).