### PR TITLE
MAINT: Remove check for SETUPTOOLS_USE_DISTUTILS in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,17 +85,6 @@ if os.path.exists('MANIFEST'):
 # so that it is in sys.modules
 import numpy.distutils.command.sdist
 import setuptools
-if int(setuptools.__version__.split('.')[0]) >= 60:
-    # setuptools >= 60 switches to vendored distutils by default; this
-    # may break the numpy build, so make sure the stdlib version is used
-    try:
-        setuptools_use_distutils = os.environ['SETUPTOOLS_USE_DISTUTILS']
-    except KeyError:
-        os.environ['SETUPTOOLS_USE_DISTUTILS'] = "stdlib"
-    else:
-        if setuptools_use_distutils != "stdlib":
-            raise RuntimeError("setuptools versions >= '60.0.0' require "
-                    "SETUPTOOLS_USE_DISTUTILS=stdlib in the environment")
 
 # Initialize cmdclass from versioneer
 from numpy.distutils.core import numpy_cmdclass


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This check was added in #20963 in an attempt to make numpy "more tolerant of setuptools >= 60". However, when `pip -install --no-build-isolation` is in use, (compared to numpy 1.21.x) this added check actually made numpy **less** tolerant of setuptools >= 60. 

In Sage, we use `SETUPTOOLS_USE_DISTUTILS=local` because we need to work around broken python 3.8 and 3.9 on Homebrew, which install a custom and problematic `distutils.cfg`. 

Ref: https://trac.sagemath.org/ticket/32423#comment:53, https://trac.sagemath.org/ticket/31335, https://trac.sagemath.org/ticket/31348#comment:38, https://github.com/Homebrew/homebrew-core/pull/91043#issuecomment-1032079055
