### PR TITLE
BLD: Make can_link_svml return False for 32bit builds on x86_64

### DIFF
--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -81,7 +81,9 @@ def can_link_svml():
     if NPY_DISABLE_SVML:
         return False
     platform = sysconfig.get_platform()
-    return "x86_64" in platform and "linux" in platform
+    return ("x86_64" in platform
+            and "linux" in platform
+            and sys.maxsize > 2**31)
 
 def check_svml_submodule(svmlpath):
     if not os.path.exists(svmlpath + "/README.md"):


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This makes it unnecessary to set `NPY_DISABLE_SVML` when using a 32-bit Python on x86_64, see #20736.

The test for a 32 bit interpreter follows the approach of https://github.com/pypa/packaging/blob/main/packaging/tags.py#L40
