### PR TITLE
DOC: Add usage example to np.char.center docstring

### DIFF
--- a/numpy/core/defchararray.py
+++ b/numpy/core/defchararray.py
@@ -445,6 +445,22 @@ def center(a, width, fillchar=' '):
     See Also
     --------
     str.center
+    
+    Notes
+    -----
+    This function is intended to work with arrays of strings.  The
+    fill character is not applied to numeric types.
+
+    Examples
+    --------
+    >>> c = np.array(['a1b2','1b2a','b2a1','2a1b']); c
+    array(['a1b2', '1b2a', 'b2a1', '2a1b'], dtype='<U4')
+    >>> np.char.center(c, width=9)
+    array(['   a1b2  ', '   1b2a  ', '   b2a1  ', '   2a1b  '], dtype='<U9')
+    >>> np.char.center(c, width=9, fillchar='*')
+    array(['***a1b2**', '***1b2a**', '***b2a1**', '***2a1b**'], dtype='<U9')
+    >>> np.char.center(c, width=1)
+    array(['a', '1', 'b', '2'], dtype='<U1')
 
     """
     a_arr = numpy.asarray(a)


### PR DESCRIPTION
This pull request adds an example to the documentation for the center function in the char module of the NumPy library `np.char.center`.
The documentation for this function was lacking an example, so this pull request adds one.
The example shows how to use the function to center a string in an array.
This Pull request closes #21873.