### PR TITLE
DOC: Fix the interpolation formulae for quantile and percentile

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4000,7 +4000,7 @@ def percentile(a,
     With 'i' being the floor and 'g' the fractional part of the result.
 
     .. math::
-        i + g = (q - alpha) / ( n - alpha - beta + 1 )
+        i + g = q * ( n - alpha - beta + 1 ) + alpha
 
     The different methods then work as follows
 
@@ -4279,7 +4279,7 @@ def quantile(a,
     and alpha and beta are correction constants modifying i and j:
 
     .. math::
-        i + g = (q - alpha) / ( n - alpha - beta + 1 )
+        i + g = q * ( n - alpha - beta + 1 ) + alpha
 
     The different methods then work as follows
 


### PR DESCRIPTION
…tile() and percentile().

Fix the interpolation formulae in the docs which led to absurd results.  For quantile() and percentile().

Example, for median of a = [1,2,10,11], you expect to obtain i+g=2.5 for method = linear (or weibull, or hazen, or median_unbiased or normal_unbiased).

Instead, you obtain a /negative/ index.

The correted formula is:

i + g = q * (n - alpha - beta + 1 ) + alpha

Notice among other things that n belongs in the numerator, not the denominator! 

As a check, the corrected formula does lead to the correct index 2.5 for each of the cases above.

MYSTERY: Surely the original formula was the result of a small typo/thinko?  Then, why does the correction look so completely different?

RESOLUTION OF MYSTERY: 
Take our formula, massage it, and swap q with (i+g), and you end up with the original formula.
In other words, the original author of the doc. simply confused their percentile with their index halfway through the creation of the doc. Then, they massaged it to isolate (i+g) on the left.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
