### PR TITLE
ENH enable `__imatmul__` for ArrayAPI compatability.

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -9,7 +9,6 @@ import enum
 from abc import abstractmethod
 from types import TracebackType, MappingProxyType
 from contextlib import ContextDecorator
-from contextlib import contextmanager
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -181,7 +180,6 @@ from collections.abc import (
 from typing import (
     Literal as L,
     Any,
-    Generator,
     Generic,
     IO,
     NoReturn,
@@ -1915,7 +1913,6 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     def __neg__(self: NDArray[object_]) -> Any: ...
 
     # Binary ops
-    # NOTE: `ndarray` does not implement `__imatmul__`
     @overload
     def __matmul__(self: NDArray[bool_], other: _ArrayLikeBool_co) -> NDArray[bool_]: ...  # type: ignore[misc]
     @overload
@@ -1932,6 +1929,22 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
     def __matmul__(self: NDArray[object_], other: Any) -> Any: ...
     @overload
     def __matmul__(self: NDArray[Any], other: _ArrayLikeObject_co) -> Any: ...
+
+    def __imatmul__(self: NDArray[bool_], other: _ArrayLikeBool_co) -> NDArray[bool_]: ...  # type: ignore[misc]
+    @overload
+    def __imatmul__(self: _ArrayUInt_co, other: _ArrayLikeUInt_co) -> NDArray[unsignedinteger[Any]]: ...  # type: ignore[misc]
+    @overload
+    def __imatmul__(self: _ArrayInt_co, other: _ArrayLikeInt_co) -> NDArray[signedinteger[Any]]: ...  # type: ignore[misc]
+    @overload
+    def __imatmul__(self: _ArrayFloat_co, other: _ArrayLikeFloat_co) -> NDArray[floating[Any]]: ...  # type: ignore[misc]
+    @overload
+    def __imatmul__(self: _ArrayComplex_co, other: _ArrayLikeComplex_co) -> NDArray[complexfloating[Any, Any]]: ...
+    @overload
+    def __imatmul__(self: NDArray[number[Any]], other: _ArrayLikeNumber_co) -> NDArray[number[Any]]: ...
+    @overload
+    def __imatmul__(self: NDArray[object_], other: Any) -> Any: ...
+    @overload
+    def __imatmul__(self: NDArray[Any], other: _ArrayLikeObject_co) -> Any: ...
 
     @overload
     def __rmatmul__(self: NDArray[bool_], other: _ArrayLikeBool_co) -> NDArray[bool_]: ...  # type: ignore[misc]
@@ -3351,11 +3364,6 @@ class errstate(Generic[_CallType], ContextDecorator):
         traceback: None | TracebackType,
         /,
     ) -> None: ...
-
-@contextmanager
-def _no_nep50_warning() -> Generator[None, None, None]: ...
-def _get_promotion_state() -> str: ...
-def _set_promotion_state(state: str, /) -> None: ...
 
 class ndenumerate(Generic[_ScalarType]):
     iter: flatiter[NDArray[_ScalarType]]

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -9,6 +9,7 @@ import enum
 from abc import abstractmethod
 from types import TracebackType, MappingProxyType
 from contextlib import ContextDecorator
+from contextlib import contextmanager
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias
@@ -180,6 +181,7 @@ from collections.abc import (
 from typing import (
     Literal as L,
     Any,
+    Generator,
     Generic,
     IO,
     NoReturn,
@@ -3364,6 +3366,11 @@ class errstate(Generic[_CallType], ContextDecorator):
         traceback: None | TracebackType,
         /,
     ) -> None: ...
+
+@contextmanager
+def _no_nep50_warning() -> Generator[None, None, None]: ...
+def _get_promotion_state() -> str: ...
+def _set_promotion_state(state: str, /) -> None: ...
 
 class ndenumerate(Generic[_ScalarType]):
     iter: flatiter[NDArray[_ScalarType]]

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -116,7 +116,6 @@ _PyArray_SetNumericOps(PyObject *dict)
     SET(conjugate);
     SET(matmul);
     SET(clip);
-    SET(imatmul);
     return 0;
 }
 
@@ -184,7 +183,6 @@ _PyArray_GetNumericOps(void)
     GET(conjugate);
     GET(matmul);
     GET(clip);
-    GET(imatmul);
     return dict;
 
  fail:
@@ -353,8 +351,8 @@ static PyObject *
 array_inplace_matrix_multiply(PyArrayObject *m1, PyObject *m2)
 {
     INPLACE_GIVE_UP_IF_NEEDED(
-            m1, m2, nb_inplace_matrix_multiply, array_inplace_multiply);
-    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.imatmul);
+            m1, m2, nb_inplace_matrix_multiply, array_matrix_multiply);
+    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.matmul);
 }
 
 /*
@@ -690,7 +688,7 @@ array_inplace_multiply(PyArrayObject *m1, PyObject *m2)
 {
     INPLACE_GIVE_UP_IF_NEEDED(
             m1, m2, nb_inplace_multiply, array_inplace_multiply);
-    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.matmul);
+    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.multiply);
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -116,6 +116,7 @@ _PyArray_SetNumericOps(PyObject *dict)
     SET(conjugate);
     SET(matmul);
     SET(clip);
+    SET(imatmul);
     return 0;
 }
 
@@ -183,6 +184,7 @@ _PyArray_GetNumericOps(void)
     GET(conjugate);
     GET(matmul);
     GET(clip);
+    GET(imatmul);
     return dict;
 
  fail:
@@ -348,13 +350,11 @@ array_matrix_multiply(PyObject *m1, PyObject *m2)
 }
 
 static PyObject *
-array_inplace_matrix_multiply(
-        PyArrayObject *NPY_UNUSED(m1), PyObject *NPY_UNUSED(m2))
+array_inplace_matrix_multiply(PyArrayObject *m1, PyObject *m2)
 {
-    PyErr_SetString(PyExc_TypeError,
-                    "In-place matrix multiplication is not (yet) supported. "
-                    "Use 'a = a @ b' instead of 'a @= b'.");
-    return NULL;
+    INPLACE_GIVE_UP_IF_NEEDED(
+            m1, m2, nb_inplace_matrix_multiply, array_inplace_multiply);
+    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.imatmul);
 }
 
 /*
@@ -690,7 +690,7 @@ array_inplace_multiply(PyArrayObject *m1, PyObject *m2)
 {
     INPLACE_GIVE_UP_IF_NEEDED(
             m1, m2, nb_inplace_multiply, array_inplace_multiply);
-    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.multiply);
+    return PyArray_GenericInplaceBinaryFunction(m1, m2, n_ops.matmul);
 }
 
 static PyObject *

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -41,7 +41,6 @@ typedef struct {
     PyObject *conjugate;
     PyObject *matmul;
     PyObject *clip;
-    PyObject *imatmul;
 } NumericOps;
 
 extern NPY_NO_EXPORT NumericOps n_ops;

--- a/numpy/core/src/multiarray/number.h
+++ b/numpy/core/src/multiarray/number.h
@@ -41,6 +41,7 @@ typedef struct {
     PyObject *conjugate;
     PyObject *matmul;
     PyObject *clip;
+    PyObject *imatmul;
 } NumericOps;
 
 extern NPY_NO_EXPORT NumericOps n_ops;

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7127,12 +7127,6 @@ def test_matmul_inplace():
     a @= a
     assert_array_equal(a, 4*np.eye(3))
 
-    assert_raises(ValueError, a.__imatmul__, c)
-
-    import operator
-    assert_raises(ValueError, operator.imatmul, a, c)
-    assert_raises(ValueError, exec, "a @= c", globals(), locals())
-
 def test_matmul_axes():
     a = np.arange(3*4*5).reshape(3, 4, 5)
     c = np.matmul(a, a, axes=[(-2, -1), (-1, -2), (1, 2)])

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -7111,15 +7111,27 @@ class TestMatmulOperator(MatmulCommon):
         assert_raises(TypeError, self.matmul, np.arange(10), np.void(b'abc'))
 
 def test_matmul_inplace():
-    # It would be nice to support in-place matmul eventually, but for now
-    # we don't have a working implementation, so better just to error out
-    # and nudge people to writing "a = a @ b".
     a = np.eye(3)
-    b = np.eye(3)
-    assert_raises(TypeError, a.__imatmul__, b)
+    b = 2*np.eye(3)
+    c = np.eye(4)
+
+    a @= a
+    assert_array_equal(a, np.eye(3))
+
+    b @= a
+    assert_array_equal(b, 2*np.eye(3))
+
+    a @= b
+    assert_array_equal(a, 2*np.eye(3))
+
+    a @= a
+    assert_array_equal(a, 4*np.eye(3))
+
+    assert_raises(ValueError, a.__imatmul__, c)
+
     import operator
-    assert_raises(TypeError, operator.imatmul, a, b)
-    assert_raises(TypeError, exec, "a @= b", globals(), locals())
+    assert_raises(ValueError, operator.imatmul, a, c)
+    assert_raises(ValueError, exec, "a @= c", globals(), locals())
 
 def test_matmul_axes():
     a = np.arange(3*4*5).reshape(3, 4, 5)


### PR DESCRIPTION
Enables `__imatmul__`, albeit just inefficiently performing the out-of-place operation and copying, to bring `ndarray` closer to ArrayAPI compatability.