### PR TITLE
DOC: Fix typo on Byte-swapping page

### DIFF
--- a/doc/source/user/basics.byteswapping.rst
+++ b/doc/source/user/basics.byteswapping.rst
@@ -5,7 +5,7 @@ Byte-swapping
 Introduction to byte ordering and ndarrays
 ==========================================
 
-The ``ndarray`` is an object that provide a python array interface to data
+The ``ndarray`` is an object that provides a python array interface to data
 in memory.
 
 It often happens that the memory that you want to view with an array is


### PR DESCRIPTION
Sorry, I didn't see the instructions to prefix the commit with `DOC` before creating the PR. Hope that's OK.
