### PR TITLE
CI: Use OpenBLAS again on Cygwin

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -37,13 +37,7 @@ jobs:
       - name: Set Windows PATH
         uses: egor-tensin/cleanup-path@v1
         with:
-          dirs: 'C:\tools\cygwin\lib\lapack;C:\tools\cygwin\bin'
-      - name: Remove OpenBLAS
-        # Added to work around OpenBLAS bugs on AVX-512
-        # Add libopenblas to the Cygwin install step when removing this step
-        # Should be possible after next Cygwin OpenBLAS update.
-        run: |
-          dash -c "/bin/rm -f /usr/bin/cygblas-0.dll"
+          dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
       - name: Verify that bash is Cygwin bash
         run: |
           command bash


### PR DESCRIPTION
The OpenBLAS implementation was removed in CI jobs a few months ago to avoid failures with a previous version (#20654, #20660), necessitating the use of the Netlib reference BLAS instead (#20669).  The Cygwin OpenBLAS implementation [has updated to 0.3.20](https://cygwin.com/pipermail/cygwin-announce/2022-June/010616.html) since then, so using OpenBLAS again should be fine.

This may result in a small speed gain in the Cygwin CI runs, but probably not enough to be noticeable.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
