### PR TITLE
DOC: Add a note about security and NumPy to the documentation

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -29,6 +29,7 @@ For learning how to use NumPy, see the :ref:`complete documentation <numpy_docs_
    distutils_status_migration
    c-api/index
    simd/index
+   security
    swig
 
 

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -1,0 +1,62 @@
+NumPy security considertions and reporting
+==========================================
+
+Security issues can be reported privately as described on the issue tracker.
+The [Python security reporting guidlines](https://www.python.org/dev/security/)
+are a good resource and its notes apply also to NumPy.
+
+NumPy's maintainers are not security experts.  However, we are conscientious
+about security and experts of both the code NumPy and its typical use.
+Please do notify us before creating security advisories against NumPy as
+we are happy to prioritize issues or help with assessing the severity of a bug.
+A security advisory we are not aware of beforehand can lead to a lot of work
+for all involved parties.
+
+
+Advise for using NumPy on untrusted data
+----------------------------------------
+
+A user who can freely execute NumPy (or Python) functions must be considered
+to have the same privilege as the process/Python interpreter.
+If an untrusted user has direct access to parts of the NumPy API,
+a the whole process must generally be isolated.
+
+That said, NumPy should be generally safe to use on *data* provided by
+unprivileged users and read through safe API functions (e.g. loaded from a
+text file or ``.npy`` file without pickle support).
+Malicious *values* or *data sizes* should never lead to privilege escalation. 
+
+The following points may be useful or should be noted when working with
+untrusted data:
+
+* Exhausting memory can result in an out-of-memory kill, which is a possible
+  denial of service attack.  Possible causes could be:
+
+  * Functions reading text files, which may require much more memory than
+    the original input file size.
+  * If users can create arbitrarily shaped arrays, NumPy's broadcasting means
+    that intermediate or result arrays can be much larger than the inputs.
+
+* NumPy structured dtypes allow for a large amount of complexity.  Fortunately,
+  most code fails gracefully when a structured dtype is provided unexpectedly.
+  However, code should either not allow untrusted users to provide these
+  (e.g. via ``.npy`` files) or carefully check the fields including for
+  nested structured/subarray dtypes.
+
+* Passing should generally be considered unsafe (except for data being read).
+  An example would be ``np.dtype(user_string)`` or ``dtype=user_string``.
+
+* The speed of operations can depend on values and memory order can lead to
+  larger temporary memory use and slower execution.
+  This means that operations may be significantly slower or use more memory
+  compared to simple test cases.
+
+* When reading data consider enforcing a specific shape (e.g. one dimensional)
+  or dtype such as ``float64``, ``float32``, or ``int64`` to reduce complexity.
+
+When working with non-trivial untrusted data, it is advisable to sandbox the
+analysis to guard against memory exhaustion and potential other privilege
+escalation.
+This is especially advisable if further libraries based on NumPy are used since
+these add additional complexity and potential security issues.
+

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -7,7 +7,7 @@ The `Python security reporting guidlines <https://www.python.org/dev/security/>`
 are a good resource and its notes apply also to NumPy.
 
 NumPy's maintainers are not security experts.  However, we are conscientious
-about security and experts of both the code NumPy and its typical use.
+about security and experts of both the NumPy codebase and how it's used.
 Please do notify us before creating security advisories against NumPy as
 we are happy to prioritize issues or help with assessing the severity of a bug.
 A security advisory we are not aware of beforehand can lead to a lot of work

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -1,8 +1,9 @@
-NumPy security considertions and reporting
-==========================================
+NumPy security
+==============
 
-Security issues can be reported privately as described on the issue tracker.
-The [Python security reporting guidlines](https://www.python.org/dev/security/)
+Security issues can be reported privately as described in the project README
+and when opening a `new issue on the issue tracker <https://github.com/numpy/numpy/issues/new/choose>`_.
+The `Python security reporting guidlines <https://www.python.org/dev/security/>`_
 are a good resource and its notes apply also to NumPy.
 
 NumPy's maintainers are not security experts.  However, we are conscientious
@@ -13,7 +14,7 @@ A security advisory we are not aware of beforehand can lead to a lot of work
 for all involved parties.
 
 
-Advise for using NumPy on untrusted data
+Advice for using NumPy on untrusted data
 ----------------------------------------
 
 A user who can freely execute NumPy (or Python) functions must be considered

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -18,8 +18,6 @@ Advise for using NumPy on untrusted data
 
 A user who can freely execute NumPy (or Python) functions must be considered
 to have the same privilege as the process/Python interpreter.
-If an untrusted user has direct access to parts of the NumPy API,
-a the whole process must generally be isolated.
 
 That said, NumPy should be generally safe to use on *data* provided by
 unprivileged users and read through safe API functions (e.g. loaded from a
@@ -39,11 +37,12 @@ untrusted data:
 
 * NumPy structured dtypes allow for a large amount of complexity.  Fortunately,
   most code fails gracefully when a structured dtype is provided unexpectedly.
-  However, code should either not allow untrusted users to provide these
-  (e.g. via ``.npy`` files) or carefully check the fields including for
+  However, code should either disallow untrusted users to provide these
+  (e.g. via ``.npy`` files) or carefully check the fields included for
   nested structured/subarray dtypes.
 
-* Passing should generally be considered unsafe (except for data being read).
+* Passing on user input should generally be considered unsafe
+  (except for the data being read).
   An example would be ``np.dtype(user_string)`` or ``dtype=user_string``.
 
 * The speed of operations can depend on values and memory order can lead to
@@ -55,8 +54,7 @@ untrusted data:
   or dtype such as ``float64``, ``float32``, or ``int64`` to reduce complexity.
 
 When working with non-trivial untrusted data, it is advisable to sandbox the
-analysis to guard against memory exhaustion and potential other privilege
-escalation.
+analysis to guard against potential privilege escalation.
 This is especially advisable if further libraries based on NumPy are used since
 these add additional complexity and potential security issues.
 

--- a/doc/source/reference/security.rst
+++ b/doc/source/reference/security.rst
@@ -51,7 +51,7 @@ untrusted data:
   This means that operations may be significantly slower or use more memory
   compared to simple test cases.
 
-* When reading data consider enforcing a specific shape (e.g. one dimensional)
+* When reading data, consider enforcing a specific shape (e.g. one dimensional)
   or dtype such as ``float64``, ``float32``, or ``int64`` to reduce complexity.
 
 When working with non-trivial untrusted data, it is advisable to sandbox the


### PR DESCRIPTION
The main plan is to have something to point to when we get "security
adviseries" for issues where it is necessary to trigger very exact
bugs in impossible places, or just require direct API access to begin
with.

Neither of this is a serious security issue.  I thought it might be
good to make a note that e.g. structured dtypes are a big complexity
source that one should maybe be careful about.

---

There could  be a list of known CVEs, but I am hesitant... It is practically bound to be outdated and I am not currently convinced that there is any advisory that should be considered critical. 