### PR TITLE
DOC: Fix documentation for percentile and quantile:

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3982,25 +3982,26 @@ def percentile(a,
     Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
     the value ``q/100`` of the way from the minimum to the maximum in a
     sorted copy of ``V``. The values and distances of the two nearest
-    neighbors (that lie at indexes ``i`` and ``j=i+1`` as well as the `method` 
-    parameter will determine the percentile if the normalized ranking does not 
-    match the location of ``q`` exactly.
-    
-    This function is the same as the median if ``q=50``, the same as the minimum 
-    if ``q=0`` and the same as the maximum if``q=100``.
+    neighbors as well as the `method` parameter will determine the
+    percentile if the normalized ranking does not match the location of
+    ``q`` exactly. This function is the same as the median if ``q=50``, the
+    same as the minimum if ``q=0`` and the same as the maximum if
+    ``q=100``.
 
+    The optional `method` parameter specifies the method to use when the
+    desired quantile lies between two indexes ``i``  and ``j = i + 1 ``. 
+    In that case, we first  determine ``i + g``, a virtual index that lies 
+    between ``i`` and ``j`, where  ``i`` is the floor and ``g`` is the 
+    fractional part of the index. The final result is, then, an interpolation
+    of `a[i]` and `a[j]` based on ``g``. During  the computation of ``g``, ``i`` 
+    and ``j`` are modified using correction constants ``alpha`` and ``beta`` 
+    whose choices depend on the ``method`` used. Finally, note that since python 
+    uses 0-based indexing, we subtract another 1 from the index internally.
 
-
-    This optional `method` parameter specifies the method to use when the
-    desired quantile lies between two indexes ``i < j``. In that case, we first 
-    determine ``i + g``, a virtual index, that lies between ``i`` and ``j`, where 
-    ``i`` is the floor and ``g`` is the fractional part of the index. The final 
-    result is, then, an interpolation  of `a[i]` and `a[j]` based ``g``. During 
-    the computation of ``g``, ``i`` and ``j`` are modified using correction
-    constants ``alpha`` and ``beta`` whose choices depend on the ``method`` used.
-    Finally, note that since python uses 0-based indexing, we subtract another 
-    1 from the index internally.
-  
+    The optional `method` parameter specifies the method to use when the
+    desired quantile lies between two data points ``i < j``.
+    If ``g`` is the fractional part of the index surrounded by ``i`` and ``j``,
+    and alpha and beta are correction constants modifying i and j:
 
     The virtual index is determined using the formula:
 

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3993,15 +3993,11 @@ def percentile(a,
     In that case, we first  determine ``i + g``, a virtual index that lies 
     between ``i`` and ``j`, where  ``i`` is the floor and ``g`` is the 
     fractional part of the index. The final result is, then, an interpolation
-    of `a[i]` and `a[j]` based on ``g``. During  the computation of ``g``, ``i`` 
+    of `a[i]` and `a[j]` based ``g``. During  the computation of ``g``, ``i`` 
     and ``j`` are modified using correction constants ``alpha`` and ``beta`` 
-    whose choices depend on the ``method`` used. Finally, note that since python 
-    uses 0-based indexing, we subtract another 1 from the index internally.
-
-    The optional `method` parameter specifies the method to use when the
-    desired quantile lies between two data points ``i < j``.
-    If ``g`` is the fractional part of the index surrounded by ``i`` and ``j``,
-    and alpha and beta are correction constants modifying i and j:
+    whose choices depend on the ``method`` used. Finally, note that since
+    python uses 0-based indexing, the code subtracts another 1 from the index 
+    internally.
 
     The virtual index is determined using the formula:
 
@@ -4271,37 +4267,27 @@ def quantile(a,
 
     Notes
     -----
-    Given a vector ``V`` of length ``N``, the q-th quantile of ``V`` is the
-    value ``q`` of the way from the minimum to the maximum in a sorted copy of
-    ``V``. The values and distances of the two nearest neighbors 
-    `method` parameter will determine the quantile if the normalized
-    ranking does not match the location of ``q`` exactly. This function is the
-    same as the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and
-    the same as the maximum if ``q=1.0``.
-
     Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
     the value ``q/100`` of the way from the minimum to the maximum in a
     sorted copy of ``V``. The values and distances of the two nearest
-    neighbors as well as the `method` parameter will determine the percentile 
-    if the normalized ranking does not match the location of ``q`` exactly.
-    
-    This function is the same as the median if ``q=50``, the same as the minimum 
-    if ``q=0`` and the same as the maximum if``q=100``.
+    neighbors as well as the `method` parameter will determine the
+    percentile if the normalized ranking does not match the location of
+    ``q`` exactly. This function is the same as the median if ``q=50``, the
+    same as the minimum if ``q=0`` and the same as the maximum if
+    ``q=100``.
 
-    This optional `method` parameter specifies the method to use when the
+    The optional `method` parameter specifies the method to use when the
     desired quantile lies between two indexes ``i``  and ``j = i + 1 ``. 
     In that case, we first  determine ``i + g``, a virtual index that lies 
     between ``i`` and ``j`, where  ``i`` is the floor and ``g`` is the 
     fractional part of the index. The final result is, then, an interpolation
     of `a[i]` and `a[j]` based ``g``. During  the computation of ``g``, ``i`` 
     and ``j`` are modified using correction constants ``alpha`` and ``beta`` 
-    whose choices depend on the ``method`` used. Finally, note that since python 
-    uses 0-based indexing, we subtract another 1 from the index internally.
-
-    The optional `method` parameter specifies the method to use when the
-    desired quantile lies between two data points ``i < j``.
-    If ``g`` is the fractional part of the index surrounded by ``i`` and ``j``,
-    and alpha and beta are correction constants modifying i and j:
+    whose choices depend on the ``method`` used. Finally, note that since
+    python uses 0-based indexing, the code subtracts another 1 from the index 
+    internally.
+    
+    The virtual index is determined using the formula:
 
     .. math::
         i + g = q * ( n - alpha - beta + 1 ) + alpha

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3992,13 +3992,15 @@ def percentile(a,
 
 
     This optional `method` parameter specifies the method to use when the
-    desired quantile lies between two indexes ``i < j``. In that case, we first determine
-    ``i + g``, a virtual index, that lies between ``i`` and ``j`, where ``i`` is the floor and ``g`` is the fractional part of the index. 
-    The final result is, then, an interpolation of `a[i]` and `a[j]` based ``g``.
-    During the computation of ``g``, ``i`` and ``j`` are modified using correction constants ``alpha`` and ``beta`` whose choices depend on the ``method`` used.
-    Finally, note that since python uses 0-based indexing, we subtract another 1 from the index internally.
+    desired quantile lies between two indexes ``i < j``. In that case, we first 
+    determine ``i + g``, a virtual index, that lies between ``i`` and ``j`, where 
+    ``i`` is the floor and ``g`` is the fractional part of the index. The final 
+    result is, then, an interpolation  of `a[i]` and `a[j]` based ``g``. During 
+    the computation of ``g``, ``i`` and ``j`` are modified using correction
+    constants ``alpha`` and ``beta`` whose choices depend on the ``method`` used.
+    Finally, note that since python uses 0-based indexing, we subtract another 
+    1 from the index internally.
   
-    alpha and beta are correction constants modifying i and j. 
 
     The virtual index is determined using the formula:
 
@@ -4270,10 +4272,30 @@ def quantile(a,
     -----
     Given a vector ``V`` of length ``N``, the q-th quantile of ``V`` is the
     value ``q`` of the way from the minimum to the maximum in a sorted copy of
-    ``V``. The values and distances of the two nearest neighbors as well as the `method` parameter will determine the quantile if the normalized
+    ``V``. The values and distances of the two nearest neighbors 
+    `method` parameter will determine the quantile if the normalized
     ranking does not match the location of ``q`` exactly. This function is the
     same as the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and
     the same as the maximum if ``q=1.0``.
+
+    Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
+    the value ``q/100`` of the way from the minimum to the maximum in a
+    sorted copy of ``V``. The values and distances of the two nearest
+    neighbors as well as the `method` parameter will determine the percentile 
+    if the normalized ranking does not match the location of ``q`` exactly.
+    
+    This function is the same as the median if ``q=50``, the same as the minimum 
+    if ``q=0`` and the same as the maximum if``q=100``.
+
+    This optional `method` parameter specifies the method to use when the
+    desired quantile lies between two indexes ``i``  and ``j = i + 1 ``. 
+    In that case, we first  determine ``i + g``, a virtual index that lies 
+    between ``i`` and ``j`, where  ``i`` is the floor and ``g`` is the 
+    fractional part of the index. The final result is, then, an interpolation
+    of `a[i]` and `a[j]` based ``g``. During  the computation of ``g``, ``i`` 
+    and ``j`` are modified using correction constants ``alpha`` and ``beta`` 
+    whose choices depend on the ``method`` used. Finally, note that since python 
+    uses 0-based indexing, we subtract another 1 from the index internally.
 
     The optional `method` parameter specifies the method to use when the
     desired quantile lies between two data points ``i < j``.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3982,22 +3982,25 @@ def percentile(a,
     Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
     the value ``q/100`` of the way from the minimum to the maximum in a
     sorted copy of ``V``. The values and distances of the two nearest
-    neighbors as well as the `method` parameter will determine the
-    percentile if the normalized ranking does not match the location of
-    ``q`` exactly. This function is the same as the median if ``q=50``, the
-    same as the minimum if ``q=0`` and the same as the maximum if
-    ``q=100``.
+    neighbors (that lie at indexes ``i`` and ``j=i+1`` as well as the `method` 
+    parameter will determine the percentile if the normalized ranking does not 
+    match the location of ``q`` exactly.
+    
+    This function is the same as the median if ``q=50``, the same as the minimum 
+    if ``q=0`` and the same as the maximum if``q=100``.
+
+
 
     This optional `method` parameter specifies the method to use when the
-    desired quantile lies between two data points ``i < j``.
-    If ``g`` is the fractional part of the index surrounded by ``i`` and
-    alpha and beta are correction constants modifying i and j.
+    desired quantile lies between two indexes ``i < j``. In that case, we first determine
+    ``i + g``, a virtual index, that lies between ``i`` and ``j`, where ``i`` is the floor and ``g`` is the fractional part of the index. 
+    The final result is, then, an interpolation of `a[i]` and `a[j]` based ``g``.
+    During the computation of ``g``, ``i`` and ``j`` are modified using correction constants ``alpha`` and ``beta`` whose choices depend on the ``method`` used.
+    Finally, note that since python uses 0-based indexing, we subtract another 1 from the index internally.
+  
+    alpha and beta are correction constants modifying i and j. 
 
-    Below, 'q' is the quantile value, 'n' is the sample size and
-    alpha and beta are constants.
-    The following formula gives an interpolation "i + g" of where the quantile
-    would be in the sorted sample.
-    With 'i' being the floor and 'g' the fractional part of the result.
+    The virtual index is determined using the formula:
 
     .. math::
         i + g = q * ( n - alpha - beta + 1 ) + alpha
@@ -4267,8 +4270,7 @@ def quantile(a,
     -----
     Given a vector ``V`` of length ``N``, the q-th quantile of ``V`` is the
     value ``q`` of the way from the minimum to the maximum in a sorted copy of
-    ``V``. The values and distances of the two nearest neighbors as well as the
-    `method` parameter will determine the quantile if the normalized
+    ``V``. The values and distances of the two nearest neighbors as well as the `method` parameter will determine the quantile if the normalized
     ranking does not match the location of ``q`` exactly. This function is the
     same as the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and
     the same as the maximum if ``q=1.0``.

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4267,14 +4267,13 @@ def quantile(a,
 
     Notes
     -----
-    Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
-    the value ``q/100`` of the way from the minimum to the maximum in a
-    sorted copy of ``V``. The values and distances of the two nearest
-    neighbors as well as the `method` parameter will determine the
-    percentile if the normalized ranking does not match the location of
-    ``q`` exactly. This function is the same as the median if ``q=50``, the
-    same as the minimum if ``q=0`` and the same as the maximum if
-    ``q=100``.
+    Given a vector ``V`` of length ``N``, the q-th quantile of ``V`` is the
+    value ``q`` of the way from the minimum to the maximum in a sorted copy of
+    ``V``. The values and distances of the two nearest neighbors as well as the
+    `method` parameter will determine the quantile if the normalized
+    ranking does not match the location of ``q`` exactly. This function is the
+    same as the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and
+    the same as the maximum if ``q=1.0``.
 
     The optional `method` parameter specifies the method to use when the
     desired quantile lies between two indexes ``i``  and ``j = i + 1 ``. 


### PR DESCRIPTION
Fix documentation for percentile and quantile:

Hi,

I am a complete newbie to github, python, everything, so please take this PR more as a suggestion.

I likely messed up(?) the formatting/line wrap in spite of my best efforts.
(I did it all online on the github web interface, because I could not get pycharm to work with a copy of the repository.)


This PR is a response to the promise I made to seberg in another bug report. Please find the following suggested changes to the doc 

(a) Clarify that python internally uses 0-based indexing.

(b) The documentation was very unclear, and not just to me. I spend a whole lot of time discussing with people on ##math, ##statistics, #python, etc, and to my knowledge, no one could figure this out from the given documentation. Didn't help that the formula was wrong. In the end, I gave up on the documentation, "discovered" my own formula that makes sense, and worked backwards from that. 

(c) I clarified that i+g is a virtual index. That was never mentioned. It's mentioned in the comments in this file, but I think that never made it to the numby documentation.

(d) j=i+1 for clarity.

(e) What is done with g once it is determined? Mention that we return an interpolation of the values between a[i] and a[j] based on g. 


Before committing:

(1) Please check if I messed up anything in my understanding above.

(2) Formatting needs review, like I mentioned above.

(3) Sorry, I couldn't figure out how to squash my 7 commits into one. Please fix this as appropriate. 

