### PR TITLE
DOC: Clarify wording on Copies and Views page

### DIFF
--- a/doc/source/user/basics.copies.rst
+++ b/doc/source/user/basics.copies.rst
@@ -130,7 +130,7 @@ How to tell if the array is a view or a copy
 
 The :attr:`base <.ndarray.base>` attribute of the ndarray makes it easy
 to tell if an array is a view or a copy. The base attribute of a view returns
-the original array while it returns ``None`` for a copy.
+an array while it returns ``None`` for a copy.
 
     >>> x = np.arange(9)
     >>> x


### PR DESCRIPTION
The page: https://numpy.org/doc/stable/user/basics.copies.html#other-operations

I read this and assumed that if `b` is a view of `a`, then `b.base is a` would be `True`.
```py
>>> a = np.arange(4).reshape(2, 2)
>>> b = a[:]
>>> b.base
array([0, 1, 2, 3])
```

So the wording "returns **the originary array**" is a bit misleading IMO.