### PR TITLE
DOC, MAINT: Document the C-API incompatibility error and point the error message to this doc.

### DIFF
--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -146,3 +146,21 @@ following in python::
 
 This may mainly help you if you are not running the python and/or NumPy
 version you are expecting to run.
+
+
+C-API incompatibility
+---------------------------
+
+If you see this error you may have:
+
+* A bad extension "wheel" (binary install) that should use `oldest-support-numpy <https://pypi.org/project/oldest-supported-numpy/>`_ (with manual constraints if necessary) to build their binary packages.
+* An environment issue messing with package versions, or incompatible package versions somehow enforced manually.
+* An extension module compiled locally against a very recent version followed by a NumPy downgrade or a compiled extension copied to a different computer with an older NumPy version.
+
+The best thing to do if you see this error is to contact the maintainers of the package that is causing problem so that they can solve the problem properly.
+
+However, while you wait for a solution, a work around that usually works is to upgrade the NumPy version:
+
+
+    pip install numpy --upgrade
+

--- a/doc/source/user/troubleshooting-importerror.rst
+++ b/doc/source/user/troubleshooting-importerror.rst
@@ -151,15 +151,34 @@ version you are expecting to run.
 C-API incompatibility
 ---------------------------
 
-If you see this error you may have:
+If you see an error like:
 
-* A bad extension "wheel" (binary install) that should use `oldest-support-numpy <https://pypi.org/project/oldest-supported-numpy/>`_ (with manual constraints if necessary) to build their binary packages.
-* An environment issue messing with package versions, or incompatible package versions somehow enforced manually.
-* An extension module compiled locally against a very recent version followed by a NumPy downgrade or a compiled extension copied to a different computer with an older NumPy version.
 
-The best thing to do if you see this error is to contact the maintainers of the package that is causing problem so that they can solve the problem properly.
+    RuntimeError: module compiled against API version v1 but this version of numpy is v2
 
-However, while you wait for a solution, a work around that usually works is to upgrade the NumPy version:
+
+You may have:
+
+* A bad extension "wheel" (binary install) that should use
+  `oldest-support-numpy <https://pypi.org/project/oldest-supported-numpy/>`_ (
+  with manual constraints if necessary) to build their binary packages.
+
+* An environment issue messing with package versions.
+
+* Incompatible package versions somehow enforced manually.
+
+* An extension module compiled locally against a very recent version
+  followed by a NumPy downgrade.
+
+* A compiled extension copied to a different computer with an
+  older NumPy version.
+
+The best thing to do if you see this error is to contact
+the maintainers of the package that is causing problem
+so that they can solve the problem properly.
+
+However, while you wait for a solution, a work around
+that usually works is to upgrade the NumPy version:
 
 
     pip install numpy --upgrade

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -78,9 +78,9 @@ _import_array(void)
   }
   if (NPY_FEATURE_VERSION > PyArray_GetNDArrayCFeatureVersion()) {
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
-             "API version 0x%%x but this version of numpy is 0x%%x ."\
-             "Check the section C-API incompatibility at the "\ 
-             "Troubleshooting ImportError section at "\ 
+             "API version 0x%%x but this version of numpy is 0x%%x . "\
+             "Check the section C-API incompatibility at the "\
+             "Troubleshooting ImportError section at "\
              "https://numpy.org/devdocs/user/troubleshooting-importerror.html"\
              "#c-api-incompatibility "\
               "for indications on how to solve this problem .", \

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -78,7 +78,10 @@ _import_array(void)
   }
   if (NPY_FEATURE_VERSION > PyArray_GetNDArrayCFeatureVersion()) {
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
-             "API version 0x%%x but this version of numpy is 0x%%x", \
+             "API version 0x%%x but this version of numpy is 0x%%x ."\
+             "Check the section C-API incompatibility at the Troubleshooting ImportError section at "\ 
+             "https://numpy.org/devdocs/user/troubleshooting-importerror.html#troubleshooting-importerror "\
+              "for indications on how to solve this problem .", \
              (int) NPY_FEATURE_VERSION, (int) PyArray_GetNDArrayCFeatureVersion());
       return -1;
   }

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -80,7 +80,7 @@ _import_array(void)
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
              "API version 0x%%x but this version of numpy is 0x%%x ."\
              "Check the section C-API incompatibility at the Troubleshooting ImportError section at "\ 
-             "https://numpy.org/devdocs/user/troubleshooting-importerror.html#troubleshooting-importerror "\
+             "https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility "\
               "for indications on how to solve this problem .", \
              (int) NPY_FEATURE_VERSION, (int) PyArray_GetNDArrayCFeatureVersion());
       return -1;

--- a/numpy/core/code_generators/generate_numpy_api.py
+++ b/numpy/core/code_generators/generate_numpy_api.py
@@ -79,8 +79,10 @@ _import_array(void)
   if (NPY_FEATURE_VERSION > PyArray_GetNDArrayCFeatureVersion()) {
       PyErr_Format(PyExc_RuntimeError, "module compiled against "\
              "API version 0x%%x but this version of numpy is 0x%%x ."\
-             "Check the section C-API incompatibility at the Troubleshooting ImportError section at "\ 
-             "https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility "\
+             "Check the section C-API incompatibility at the "\ 
+             "Troubleshooting ImportError section at "\ 
+             "https://numpy.org/devdocs/user/troubleshooting-importerror.html"\
+             "#c-api-incompatibility "\
               "for indications on how to solve this problem .", \
              (int) NPY_FEATURE_VERSION, (int) PyArray_GetNDArrayCFeatureVersion());
       return -1;


### PR DESCRIPTION
Add docs about the C-API incompatibility error in the file `troubleshooting-importerror.rst `and pointing to this docs in the error message generated at the submodule `core.code_generators.generate_numpy_api `.

[Related issue](https://github.com/numpy/numpy/issues/21901)