### PR TITLE
BUG: Reorder extern "C" to only apply to function declarations in npy_math.h

### DIFF
--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -1,10 +1,6 @@
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_MATH_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_MATH_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <numpy/npy_common.h>
 
 #include <math.h>
@@ -20,6 +16,10 @@ extern "C" {
 #define NPY_INPLACE
 #endif
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * NAN and INFINITY like macros (same behavior as glibc for NAN, same as C99


### PR DESCRIPTION
Backport of #21946.

That way incompatible included headers are not affected.

Fix #21802

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
