### PR TITLE
BUG: Fix KeyError in crackfortran operator support

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2147,7 +2147,7 @@ def analyzebody(block, args, tab=''):
             as_ = args
         b = postcrack(b, as_, tab=tab + '\t')
         if b['block'] in ['interface', 'abstract interface'] and \
-           not b['body'] and not b['implementedby']:
+           not b['body'] and not b.get('implementedby'):
             if 'f2pyenhancements' not in b:
                 continue
         if b['block'].replace(' ', '') == 'pythonmodule':


### PR DESCRIPTION
Backport of #21890.

Closes #21889 by simply using the safer `.get()` variant which returns `None` instead of a `KeyError`. This in turn allows the rest of the check to pass due to `not None` evaluating to `True` and keeping the rest of the intended logic.

Note that there isn't actually any handling of `operator()` or even `implementedby` in the rest of F2PY yet (it was an enhancement done for `sphinx-fortran` I think).
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
