### PR TITLE
TYP,ENH: Mark all unhashable classes as such

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -933,6 +933,7 @@ _FlatIterSelf = TypeVar("_FlatIterSelf", bound=flatiter)
 
 @final
 class flatiter(Generic[_NdArraySubClass]):
+    __hash__: ClassVar[None]
     @property
     def base(self) -> _NdArraySubClass: ...
     @property
@@ -1474,6 +1475,7 @@ class _SupportsImag(Protocol[_T_co]):
     def imag(self) -> _T_co: ...
 
 class ndarray(_ArrayOrScalarCommon, Generic[_ShapeType, _DType_co]):
+    __hash__: ClassVar[None]
     @property
     def base(self) -> None | ndarray: ...
     @property
@@ -3786,7 +3788,7 @@ class poly1d:
     @coefficients.setter
     def coefficients(self, value: NDArray[Any]) -> None: ...
 
-    __hash__: None  # type: ignore
+    __hash__: ClassVar[None]  # type: ignore
 
     @overload
     def __array__(self, t: None = ...) -> NDArray[Any]: ...

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -12,6 +12,7 @@ from typing import (
     final,
     Final,
     Protocol,
+    ClassVar,
 )
 
 from numpy import (
@@ -977,7 +978,7 @@ _SetItemKeys = L[
 
 @final
 class flagsobj:
-    __hash__: None  # type: ignore[assignment]
+    __hash__: ClassVar[None]  # type: ignore[assignment]
     aligned: bool
     # NOTE: deprecated
     # updateifcopy: bool


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/21930

Ensure that all unhashable classes are marked with `__hash__: ClassVar[None]`.