### PR TITLE
BUG: Use `Popen` to silently invoke f77 -v

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -382,7 +382,13 @@ class Gnu95FCompiler(GnuFCompiler):
 
     def get_target(self):
         try:
-            output = subprocess.check_output(self.compiler_f77 + ['-v'])
+            p = subprocess.Popen(
+                self.compiler_f77 + ['-v'],
+                stdin=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = p.communicate()
+            output = (stdout or b"") + (stderr or b"")
         except (OSError, subprocess.CalledProcessError):
             pass
         else:


### PR DESCRIPTION
The line changed here fetches the output of `gfortran -v`, which on my machine looks like this:

```
Using built-in specs.
COLLECT_GCC=C:\\Users\\osthege\\AppData\\Local\\Continuum\\miniconda3\\envs\\numpydev\\Library\\mingw-w64\\bin\\gfortran.exe
COLLECT_LTO_WRAPPER=C:/Users/osthege/AppData/Local/Continuum/miniconda3/envs/numpydev/Library/mingw-w64/bin/../lib/gcc/x86_64-w64-mingw32/5.3.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../gcc-5.3.0/configure --prefix=/mingw64 --with-local-prefix=/mingw64/local --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/mingw64/x86_64-w64-mingw32/include --libexecdir=/mingw64/lib --with-gxx-include-dir=/mingw64/include/c++/5.3.0 --enable-bootstrap --with-arch=x86-64 --with-tune=generic --enable-languages=c,lto,c++,objc,obj-c++,fortran,ada --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-time=yes --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-version-specific-runtime-libs --disable-isl-version-check --enable-lto --enable-libgomp --disable-multilib --enable-checking=release --disable-rpath --disable-win32-registry --disable-nls --disable-werror 
--disable-symvers --with-libiconv --with-system-zlib --with-gmp=/mingw64 --with-mpfr=/mingw64 --with-mpc=/mingw64 --with-isl=/mingw64 --with-pkgversion='Rev5, Built by MSYS2 project' --with-bugurl=https://sourceforge.net/projects/msys2 --with-gnu-as --with-gnu-ld
Thread model: posix
gcc version 5.3.0 (Rev5, Built by MSYS2 project)
```

Prior to the change, the output was fetched from `stdout`, but it was actually coming through `stderr`. (Probably a regression.)

I changed it aggregate from both `stdout` and `stderr`, which restores the previously intended behavior of `Gnu95FCompiler.get_target` to identify the target architecture, which in my case is `x86_64-w64-mingw32`.

Closes #21942

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
