### PR TITLE
Revert "ENH: Adding __array_ufunc__ capability to MaskedArrays"

### DIFF
--- a/doc/release/upcoming_changes/16022.improvement.rst
+++ b/doc/release/upcoming_changes/16022.improvement.rst
@@ -1,9 +1,0 @@
-MaskedArray gains a ``__array_ufunc__`` method to better handle ufuncs
-----------------------------------------------------------------------
-The MaskedArray class now has an implementation of `__array_ufunc__` that
-handles deferrals to the desired implementations of the ufunc. If a masked
-implementation of a ufunc exists, that implementation will take priority.
-This means that code called with MaskedArray ma as ``np.ufunc(ma)`` will
-behave the same as ``np.ma.ufunc(ma)``. Additionally, adding this helps with
-dispatching to subclasses and preserving the proper types when another
-implementation should take priority.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -780,7 +780,7 @@ class TestDiff:
                      mask=[[False, False], [True, False],
                            [False, True], [True, True], [False, False]])
         out = diff(x)
-        assert_array_equal(out.data, [[1], [4], [6], [8], [1]])
+        assert_array_equal(out.data, [[1], [1], [1], [1], [1]])
         assert_array_equal(out.mask, [[False], [True],
                                       [True], [True], [False]])
         assert_(type(out) is type(x))

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -588,8 +588,8 @@ def average(a, axis=None, weights=None, returned=False, *,
     >>> avg, sumweights = np.ma.average(x, axis=0, weights=[1, 2, 3],
     ...                                 returned=True)
     >>> avg
-    masked_array(data=[2.66666667, 3.66666667],
-                 mask=False,
+    masked_array(data=[2.6666666666666665, 3.6666666666666665],
+                 mask=[False, False],
            fill_value=1e+20)
 
     With ``keepdims=True``, the following result has shape (3, 1).
@@ -2016,15 +2016,8 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         not_m = ~m
         if w is not None:
             w = w[not_m]
-        x = x[not_m]
-        y = y[not_m]
-
-    # Only pass the ndarray data
-    if w is not None:
-        w = w.view(np.ndarray)
-    x = x.view(np.ndarray)
-    y = y.view(np.ndarray)
-
-    return np.polyfit(x, y, deg, rcond, full, w, cov)
+        return np.polyfit(x[not_m], y[not_m], deg, rcond, full, w, cov)
+    else:
+        return np.polyfit(x, y, deg, rcond, full, w, cov)
 
 polyfit.__doc__ = ma.doc_note(np.polyfit.__doc__, polyfit.__doc__)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3208,7 +3208,7 @@ class TestMaskedArrayMethods:
         assert_equal(b.fill_value, 9999)
         assert_equal(b, a[condition])
 
-        condition = (a.data < 4.)
+        condition = (a < 4.)
         b = a.compress(condition)
         assert_equal(b._data, [1., 2., 3.])
         assert_equal(b._mask, [0, 0, 1])
@@ -5367,7 +5367,7 @@ def test_ufunc_with_out_varied():
     a        = array([ 1,  2,  3], mask=[1, 0, 0])
     b        = array([10, 20, 30], mask=[1, 0, 0])
     out      = array([ 0,  0,  0], mask=[0, 0, 1])
-    expected = array([1, 22, 33], mask=[1, 0, 0])
+    expected = array([11, 22, 33], mask=[1, 0, 0])
 
     out_pos = out.copy()
     res_pos = np.add(a, b, out_pos)

--- a/numpy/ma/tests/test_subclassing.py
+++ b/numpy/ma/tests/test_subclassing.py
@@ -7,7 +7,6 @@
 
 """
 import numpy as np
-from numpy.lib.mixins import NDArrayOperatorsMixin
 from numpy.testing import assert_, assert_raises
 from numpy.ma.testutils import assert_equal
 from numpy.ma.core import (
@@ -146,33 +145,6 @@ class ComplicatedSubArray(SubArray):
             obj.info['multiplied'] = obj.info.get('multiplied', 0) + 1
 
         return obj
-
-
-class WrappedArray(NDArrayOperatorsMixin):
-    """
-    Wrapping a MaskedArray rather than subclassing to test that
-    ufunc deferrals are commutative.
-    See: https://github.com/numpy/numpy/issues/15200)
-    """
-    __array_priority__ = 20
-
-    def __init__(self, array, **attrs):
-        self._array = array
-        self.attrs = attrs
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}(\n{self._array}\n{self.attrs}\n)"
-
-    def __array__(self):
-        return np.asarray(self._array)
-
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        if method == '__call__':
-            inputs = [arg._array if isinstance(arg, self.__class__) else arg
-                      for arg in inputs]
-            return self.__class__(ufunc(*inputs, **kwargs), **self.attrs)
-        else:
-            return NotImplemented
 
 
 class TestSubclassing:
@@ -412,34 +384,3 @@ def test_array_no_inheritance():
     # Test that the mask is False and not shared when keep_mask=False
     assert_(not new_array.mask)
     assert_(not new_array.sharedmask)
-
-
-class TestClassWrapping:
-    # Test suite for classes that wrap MaskedArrays
-
-    def setup(self):
-        m = np.ma.masked_array([1, 3, 5], mask=[False, True, False])
-        wm = WrappedArray(m)
-        self.data = (m, wm)
-
-    def test_masked_unary_operations(self):
-        # Tests masked_unary_operation
-        (m, wm) = self.data
-        with np.errstate(divide='ignore'):
-            assert_(isinstance(np.log(wm), WrappedArray))
-
-    def test_masked_binary_operations(self):
-        # Tests masked_binary_operation
-        (m, wm) = self.data
-        # Result should be a WrappedArray
-        assert_(isinstance(np.add(wm, wm), WrappedArray))
-        assert_(isinstance(np.add(m, wm), WrappedArray))
-        assert_(isinstance(np.add(wm, m), WrappedArray))
-        # add and '+' should call the same ufunc
-        assert_equal(np.add(m, wm), m + wm)
-        assert_(isinstance(np.hypot(m, wm), WrappedArray))
-        assert_(isinstance(np.hypot(wm, m), WrappedArray))
-        # Test domained binary operations
-        assert_(isinstance(np.divide(wm, m), WrappedArray))
-        assert_(isinstance(np.divide(m, wm), WrappedArray))
-        assert_equal(np.divide(wm, m) * m, np.divide(m, m) * wm)


### PR DESCRIPTION
Reverts numpy/numpy#16022 since it fails refguide check. 