### PR TITLE
Move doctesting part of refguide-check into a separate cross-project tool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,6 +204,10 @@ stages:
       displayName: 'Install matplotlib before refguide run'
     - script: python runtests.py -g --refguide-check
       displayName: 'Run Refguide Check'
+    - script: python -m pip install git+https://github.com/ev-br/scpdt.git
+      displayName: 'install scpdt for doctesting'
+    - script: python runtests.py --doctests -v
+      displayName: 'Run doctests'
       condition: eq(variables['USE_OPENBLAS'], '1')
     - script: python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
       displayName: 'Run Full NumPy Test Suite'

--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -275,8 +275,10 @@ following example::
  >>> a = np.array([1, 2, 3, 4, 5, 6])
  >>> b = a[:2]
  >>> b += 1
- >>> print('a =', a, '; b =', b)
- a = [2 3 3 4 5 6] ; b = [2 3]
+ >>> print(a)
+ [2 3 3 4 5 6]
+ >>> print(b)
+ [2 3]
 
 In this example, you did not create a new array. You created a variable,
 ``b`` that viewed the first 2 elements of ``a``. When you added 1 to ``b`` you
@@ -286,8 +288,10 @@ would get the same result by adding 1 to ``a[:2]``. If you want to create a
  >>> a = np.array([1, 2, 3, 4])
  >>> b = a[:2].copy()
  >>> b += 1
- >>> print('a = ', a, 'b = ', b)
- a =  [1 2 3 4] b =  [2 3]
+ >>> print(a)
+ [1 2 3 4]
+ >>> print(b)
+ [2 3]
 
 For more information and examples look at :ref:`Copies and Views
 <quickstart.copies-and-views>`.

--- a/numpy/ma/__init__.py
+++ b/numpy/ma/__init__.py
@@ -22,8 +22,8 @@ masked arrays:
 
 >>> m = np.ma.masked_array(x, np.isnan(x))
 >>> m
-masked_array(data = [2.0 1.0 3.0 -- 5.0 2.0 3.0 --],
-      mask = [False False False  True False False False  True],
+masked_array(data=[2.0, 1.0, 3.0, --, 5.0, 2.0, 3.0, --],
+      mask=[False, False, False, True, False, False, False, True],
       fill_value=1e+20)
 
 Here, we construct a masked array that suppress all ``NaN`` values.  We

--- a/numpy/polynomial/__init__.py
+++ b/numpy/polynomial/__init__.py
@@ -41,6 +41,8 @@ by arrays ``xdata`` and ``ydata``, the
 `~chebyshev.Chebyshev.fit` class method::
 
     >>> from numpy.polynomial import Chebyshev
+    >>> xdata = [1, 2, 3, 4]
+    >>> ydata = [1, 4, 9, 16]
     >>> c = Chebyshev.fit(xdata, ydata, deg=1)
 
 is preferred over the `chebyshev.chebfit` function from the

--- a/runtests.py
+++ b/runtests.py
@@ -292,6 +292,17 @@ def main(argv):
         if args.submodule:
             cmd += [args.submodule]
         os.execv(sys.executable, [sys.executable] + cmd)
+
+    if args.doctests:
+        # XXX: copy-paste the reguide-checking
+        cmd = [os.path.join(ROOT_DIR, 'tools', 'doctest_public_modules.py'),
+               '--rst']
+        if args.verbose:
+            cmd += ['-' + 'v'*args.verbose]
+        if args.submodule:
+            cmd += ['-s' + args.submodule]
+
+        os.execv(sys.executable, [sys.executable] + cmd)
         sys.exit(0)
 
     if args.bench:

--- a/tools/doctest_public_modules.py
+++ b/tools/doctest_public_modules.py
@@ -80,9 +80,27 @@ config.rndm_markers.add('#uninitialized')
 config.rndm_markers.add('# uninitialized')
 config.optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 
+config.skiplist = [
+    # cases where NumPy docstrings import things from SciPy:
+    'numpy.lib.vectorize',
+    'numpy.random.standard_gamma',
+    'numpy.random.gamma',
+    'numpy.random.vonmises',
+    'numpy.random.power',
+    'numpy.random.zipf',
+    # cases where NumPy docstrings import things from other 3'rd party libs:
+    'numpy.core.from_dlpack',
+    # remote / local file IO with DataSource is problematic in doctest:
+    'numpy.lib.DataSource',
+    'numpy.lib.Repository',
+]
 
-# printing the Romberg extrap table is flaky, adds blanklines on some platforms
-##config.stopwords.add('integrate.romb(y, show=True)')
+if sys.version_info < (3, 9):
+    config.skiplist += [
+        "numpy.core.ndarray.__class_getitem__",
+        "numpy.core.dtype.__class_getitem__",
+        "numpy.core.number.__class_getitem__",
+    ]
 
 
 ############################################################################

--- a/tools/doctest_public_modules.py
+++ b/tools/doctest_public_modules.py
@@ -1,0 +1,204 @@
+import os
+import glob
+import sys
+import importlib
+import doctest
+
+from scpdt import testmod, testfile, DTConfig
+from scpdt._util import get_all_list
+
+
+BASE_MODULE = "numpy"
+
+PUBLIC_SUBMODULES = [
+    'core',
+    'f2py',
+    'linalg',
+    'lib',
+    'lib.recfunctions',
+    'fft',
+    'ma',
+    'polynomial',
+    'matrixlib',
+    'random',
+    'testing',
+]
+################### A user ctx mgr to turn warnings to errors ###################
+'''
+from contextlib import contextmanager
+import warnings
+
+@contextmanager
+def warnings_errors(test):
+    """Temporarily turn (almost) all warnings to errors.
+
+    Some functions are allowed to emit specific warnings though;
+    these are listed explicitly.
+    """
+    from scipy import integrate
+    known_warnings = {
+        'scipy.linalg.norm':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.ndimage.center_of_mass':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.signal.bohman':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.signal.windows.bohman':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.signal.cosine':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.signal.windows.cosine':
+            dict(category=RuntimeWarning, message='divide by zero'),
+        'scipy.stats.anderson_ksamp':
+            dict(category=UserWarning, message='p-value capped:'),
+        'scipy.special.ellip_normal':
+            dict(category=integrate.IntegrationWarning,
+                 message='The occurrence of roundoff'),
+        'scipy.special.ellip_harm_2':
+            dict(category=integrate.IntegrationWarning,
+                 message='The occurrence of roundoff'),
+        # tutorials
+        'linalg.rst':
+            dict(message='the matrix subclass is not',
+                 category=PendingDeprecationWarning),
+        'stats.rst':
+            dict(message='The maximum number of subdivisions',
+                 category=integrate.IntegrationWarning),
+    }
+
+    with warnings.catch_warnings(record=True) as w:
+        if test.name in known_warnings:
+            warnings.filterwarnings('ignore', **known_warnings[test.name])      
+            yield
+        else:
+            warnings.simplefilter('error', Warning)
+            yield
+'''
+
+config = DTConfig()
+config.rndm_markers.add('#uninitialized')
+config.rndm_markers.add('# uninitialized')
+config.optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
+
+
+# printing the Romberg extrap table is flaky, adds blanklines on some platforms
+##config.stopwords.add('integrate.romb(y, show=True)')
+
+
+############################################################################
+
+LOGFILE = open('doctest.log', 'a')
+
+
+def doctest_submodules(module_names, verbose, fail_fast):
+    all_success = True
+    for submodule_name in module_names:
+        prefix = BASE_MODULE + '.'
+        if not submodule_name.startswith(prefix):
+            module_name = prefix + submodule_name
+        else:
+            module_name = submodule_name
+
+        module = importlib.import_module(module_name)
+
+        full_name = module.__name__
+        line = '='*len(full_name)
+        sys.stderr.write(f"\n\n{line}\n")
+        sys.stderr.write(full_name)
+        sys.stderr.write(f"\n{line}\n")
+
+        result, history = testmod(module, strategy='api',
+                                  verbose=verbose,
+                                  raise_on_error=fail_fast, config=config)
+
+        LOGFILE.write(module_name + '\n')
+        LOGFILE.write("="*len(module_name)  + '\n')
+        for entry in history:
+            LOGFILE.write(str(entry) + '\n')
+
+        sys.stderr.write(str(result))
+        all_success = all_success and (result.failed == 0)
+    return all_success
+
+
+def doctest_single_file(fname, verbose, fail_fast):
+    result, history = testfile(fname, config=config, module_relative=False,
+                               verbose=verbose, raise_on_error=fail_fast)
+    return result.failed == 0
+
+
+def doctest_tutorial(verbose, fail_fast):
+    base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
+    tut_path = os.path.join(base_dir, 'doc', 'source', 'tutorial', '*.rst')
+    sys.stderr.write('\nChecking tutorial files at %s:\n'
+                     % os.path.relpath(tut_path, os.getcwd()))
+
+    tutorials = [f for f in sorted(glob.glob(tut_path))]
+
+    # set up scipy-specific config
+    config.pseudocode = set(['integrate.nquad(func,'])
+
+    io_matfiles = glob.glob(os.path.join(tut_path.replace('.rst', '.mat')))
+    config.local_resources = {'io.rst': io_matfiles}
+
+
+    all_success = True
+    for filename in tutorials:
+        sys.stderr.write('\n' + filename + '\n')
+        sys.stderr.write("="*len(filename) + '\n')
+
+        result, history = testfile(filename, module_relative=False,
+                                    verbose=verbose, raise_on_error=fail_fast,
+                                    report=True, config=config)
+        all_success = all_success and (result.failed == 0)
+    return all_success
+
+
+def main(args):
+    if args.submodule and args.filename:
+        raise ValueError("Specify either a submodule or a single file,"
+                         " not both.")
+
+    if args.filename:
+        all_success = doctest_single_file(args.filename,
+                                          verbose=args.verbose,
+                                          fail_fast=args.fail_fast)
+    else:
+        name = args.submodule   # XXX : dance w/ subsubmodules : cluster.vq etc
+        submodule_names = [name]  if name else list(PUBLIC_SUBMODULES)
+        all_success = doctest_submodules(submodule_names,
+                                         verbose=args.verbose,
+                                         fail_fast=args.fail_fast)
+
+        # if full run: also check the tutorial
+        if not args.submodule:
+            tut_success = doctest_tutorial(verbose=args.verbose,
+                                           fail_fast=args.fail_fast)
+            all_success = all_success and tut_success
+
+    # final report
+    if all_success:
+        sys.stderr.write('\n\n>>>> OK: doctests PASSED\n')
+        sys.exit(0)
+    else:
+        sys.stderr.write('\n\n>>>> ERROR: doctests FAILED\n')
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="doctest runner")
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help='print verbose (`-v`) or very verbose (`-vv`) '
+                              'output for all tests')
+    parser.add_argument('-x', '--fail-fast', action='store_true',
+                        help=('stop running tests after first failure'))
+    parser.add_argument( "-s", "--submodule", default=None,
+                        help="Submodule whose tests to run (cluster,"
+                             " constants, ...)")
+    parser.add_argument( "-t", "--filename", default=None,
+                        help="Specify a .py file to check")
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
Following up on https://github.com/numpy/numpy/issues/21070, here is a proof-of-concept implementation of the doctesting part of refguide-check, with the main implementation common to numpy and scipy (and whoever else wants to take it for a ride). 

The matching scipy PR, https://github.com/scipy/scipy/pull/16391, runs with warnings turned to errors, while this one is not. 

I'm not sure if I activated the CI correctly, but anyway, locally it's plumbed through runtests.py, so

     $ python runtests.py --doctests -v

does the trick (after `$ python -mpip install git+https://github.com/ev-br/scpdt.git`).

Several things here are still WIP:
- [ ] the name of the runtests.py task: should it be `doctests` or something else?
- [ ] the main implementation is still picked up from my GH, under an awful name (https://mail.python.org/archives/list/scipy-dev@python.org/thread/XH5RDJ5GZRRBP3UAQGWNWMH6P3KYZAUA/), pending a move and rename
- [ ] the work is duplicated in refguide-check and the new wrapper
- [ ] checking the *.rst files is hackish and may miss some files.

Modulo these, the main thing is there and ready for a spin :-).