### PR TITLE
BLD: remove outdated pin for `packaging` on macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "packaging==20.5; platform_machine=='arm64'",  # macos M1
     "setuptools==59.2.0",
     "wheel==0.37.0",
     "Cython>=0.29.30,<3.0",


### PR DESCRIPTION
Why we don't need this anymore:

- This pin for `packaging` 20.5 was added in gh-18538.
- `setuptools` then upgraded its vendored `packaging` version to 21.2 in its 59.1.0 release (see
  https://setuptools.pypa.io/en/latest/history.html#v59-1-0)
- And we then upgraded to `setuptools` 59.2.0 in commit 1adb70d99

We do not depend on `packaging` at all, it was a pin of a transitive build dependency. So let's clean it up.

Tested locally as well with `python -m build --wheel` (which uses `pyproject.toml` to build a wheel in an isolated venv), and then checking the wheel tags and ensuring the wheel can be installed with Pip.

`[ci skip]`