### PR TITLE
Added priority in bug-report issue-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -53,7 +53,7 @@ body:
 - type: textarea
   attributes:
     label: "Context for the issue:"
-    description: >
+    description: |
       Please explain how this issue affects your work or why it should be prioritized.
     placeholder: |
       << your explanation here >>

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,7 +72,7 @@ body:
   attributes:
     label: "Significance of the issue:"
     description: >
-      Please explain how this issue negatively affects your work or why it should be prioritized.
+      Please explain how this issue affects your work or why it should be prioritized.
     placeholder: |
       << your explanation here >>
   validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -49,3 +49,31 @@ body:
     description: Output from `import sys, numpy; print(numpy.__version__, sys.version)`.
   validations:
     required: true
+
+- type: dropdown
+  attributes:
+    label: "Please select priority:"
+    description: |
+      Critical - The issue prevents users from running NumPy or causes crashes.
+      High - Issues that negatively affect someone’s work or that are critical for the project.
+      Medium -Issues that are important for the project, but not critical.
+      Low - Issues that are not critical for the project.
+      Trivial - The issue is a cosmetic issue or a very low-priority bug.
+    options:
+    - P1 (Critical)
+    - P2 (High)
+    - P3 (Medium)
+    - P4 (Low)
+    - P5 (Trivial)
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Significance of the issue:"
+    description: >
+      Please explain how this issue negatively affects your work or why it should be prioritized.
+    placeholder: |
+      << your explanation here >>
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -50,24 +50,6 @@ body:
   validations:
     required: true
 
-- type: dropdown
-  attributes:
-    label: "Please select priority:"
-    description: |
-      Critical - The issue prevents users from running NumPy or causes crashes.
-      High - Issues that negatively affect someone’s work or that are critical for the project.
-      Medium -Issues that are important for the project, but not critical.
-      Low - Issues that are not critical for the project.
-      Trivial - The issue is a cosmetic issue or a very low-priority bug.
-    options:
-    - P1 (Critical)
-    - P2 (High)
-    - P3 (Medium)
-    - P4 (Low)
-    - P5 (Trivial)
-  validations:
-    required: true
-
 - type: textarea
   attributes:
     label: "Context for the issue:"

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,7 +70,7 @@ body:
 
 - type: textarea
   attributes:
-    label: "Significance of the issue:"
+    label: "Context for the issue:"
     description: >
       Please explain how this issue affects your work or why it should be prioritized.
     placeholder: |

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -58,4 +58,4 @@ body:
     placeholder: |
       << your explanation here >>
   validations:
-    required: true
+    required: false


### PR DESCRIPTION
Added the following to the “Bug report” issue template:
- Dropdown to select the priority
- Textarea for Mentioning the Significance of the issue.

**Priority**:
- P1 (Critical)
- P2 (High)
- P3 (Medium)
- P4 (Low)
- P5 (Trivial)

**Significance of the issue**:
- textarea to mention the significance of the issue.

Justification:
Mentioning the priority of an issue will help the core developers and triage team to better understand and manage open issues.
We can also set up GitHub Bot to automatically assign a label to the issue based on the priority.

This Pull request closes #21919.