### PR TITLE
DOC: correct docstring for numpy.correlate()

### DIFF
--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -682,7 +682,7 @@ def correlate(a, v, mode='valid'):
     This function computes the correlation as generally defined in signal
     processing texts:
 
-    .. math:: c_k = \sum_n a_{n+k} \cdot \overline{v_n}
+    .. math:: c_k = \sum_n a_{n+k} \cdot \overline{v}_n
 
     with a and v sequences being zero-padded where necessary and
     :math:`\overline x` denoting complex conjugation.


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This is a very minor documentation change. At the moment the mathematical definition of correlation mistakenly places the subscript n within the overbar denoting the complex conjugate. This commit simply moves the subscript n outside the overbar, where it should be.

Old:
$$c_k = \sum_n a_{n+k} \cdot \overline{v_n}$$

New:
$$c_k = \sum_n a_{n+k} \cdot \overline{v}_n$$