### PR TITLE
BUG: Fix experimental dtype slot numbers

### DIFF
--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -336,8 +336,9 @@ typedef int (PyArrayMethod_StridedLoop)(PyArrayMethod_Context *context,
 #define NPY_DT_default_descr 3
 #define NPY_DT_common_dtype 4
 #define NPY_DT_common_instance 5
-#define NPY_DT_setitem 6
-#define NPY_DT_getitem 7
+#define NPY_DT_ensure_canonical 6
+#define NPY_DT_setitem 7
+#define NPY_DT_getitem 8
 
 
 // TODO: These slots probably still need some thought, and/or a way to "grow"?
@@ -457,7 +458,7 @@ PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
  */
 #if !defined(NO_IMPORT) && !defined(NO_IMPORT_ARRAY)
 
-#define __EXPERIMENTAL_DTYPE_VERSION 4
+#define __EXPERIMENTAL_DTYPE_VERSION 5
 
 static int
 import_experimental_dtype_api(int version)

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -16,7 +16,7 @@
 #include "common_dtype.h"
 
 
-#define EXPERIMENTAL_DTYPE_API_VERSION 4
+#define EXPERIMENTAL_DTYPE_API_VERSION 5
 
 
 typedef struct{
@@ -117,7 +117,7 @@ PyArray_ArrFuncs default_funcs = {
 
 
 /* other slots are in order, so keep only last around: */
-#define NUM_DTYPE_SLOTS 7
+#define NUM_DTYPE_SLOTS 8
 
 
 int


### PR DESCRIPTION
Unfortunately, I forgot to move them around when introducing ensure_canonical,
but the code relies on the order for simplicitly currently...

Which doesn't matter, just means that the DType part of the experimental ufunc
API is completely unusable in 1.23 right now.

----

Pretty big ooops by me, since I really thought I could tell peple in my SciPy talk that the super minimal unitdtype example will work with NumPy 1.23... And now I need this (so it will work with `main` only).