### PR TITLE
MAINT: Remove two unused imports

### DIFF
--- a/numpy/core/overrides.py
+++ b/numpy/core/overrides.py
@@ -2,7 +2,6 @@
 import collections
 import functools
 import os
-import sys
 
 from numpy.core._multiarray_umath import (
     add_docstring, implement_array_function, _get_implementing_args)

--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -3,7 +3,6 @@ import copy
 import pathlib
 import sys
 import textwrap
-import warnings
 
 from numpy.distutils.misc_util import mingw32
 


### PR DESCRIPTION
STY: Removed two unused imports identified by LGTM, one was importing the sys module in numpy/core/overrides.py and the other is importing warnings in numpy/core/setup_common.py
