### PR TITLE
DOC: cross-reference descriptions of frombuffer and ndarray.tobytes

### DIFF
--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1604,7 +1604,8 @@ add_newdoc('numpy.core.multiarray', 'frombuffer',
     See also
     --------
     ndarray.tobytes
-        Construct Python bytes from the raw data bytes in the array.
+        Inverse of this operation, construct Python bytes from the raw data
+        bytes in the array.
 
     Notes
     -----
@@ -4465,7 +4466,9 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
 
     See also
     --------
-    frombuffer : Construct a 1-dimensional array from Python bytes.
+    frombuffer
+        Inverse of this operation, construct a 1-dimensional array from Python
+        bytes.
 
     Examples
     --------

--- a/numpy/core/_add_newdocs.py
+++ b/numpy/core/_add_newdocs.py
@@ -1601,6 +1601,11 @@ add_newdoc('numpy.core.multiarray', 'frombuffer',
     -------
     out : ndarray
 
+    See also
+    --------
+    ndarray.tobytes
+        Construct Python bytes from the raw data bytes in the array.
+
     Notes
     -----
     If the buffer has data that is not in machine byte-order, this should
@@ -4457,6 +4462,10 @@ add_newdoc('numpy.core.multiarray', 'ndarray', ('tobytes', """
     -------
     s : bytes
         Python bytes exhibiting a copy of `a`'s raw data.
+
+    See also
+    --------
+    frombuffer : Construct a 1-dimensional array from Python bytes.
 
     Examples
     --------


### PR DESCRIPTION
This is a PR for adding "See also" sections to documentations of `frombuffer` and `ndarray.tobytes` so that they link each other.

Although `frombuffer` and `ndarray.tobytes` are functions that perform almost opposite operations, it is not easy to instantly find the other by name, so I thought it would be a good idea to cross-reference them.