### PR TITLE
BUG: fix ma.minimum.reduce with axis keyword

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6875,6 +6875,8 @@ class _extrema_operation(_MaskedUFunc):
 
         if m is nomask:
             t = self.f.reduce(target.view(np.ndarray), **kwargs)
+            if isinstance(t, ndarray):
+                t = MaskedArray(t, mask=nomask)
         else:
             target = target.filled(
                 self.fill_value_func(target)).view(type(target))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1235,6 +1235,18 @@ class TestMaskedArrayArithmetic:
         b = np.maximum.reduce(a)
         assert_equal(b, 3)
 
+    def test_minmax_reduce_axis(self):
+        # Test np.min/maximum.reduce along an axis for 2D array
+        import numpy as np
+        data = [[0, 1, 2, 3, 4, 9], [5, 5, 0, 9, 3, 3]]
+        mask = [[0, 0, 0, 0, 0, 1], [0, 0, 1, 1, 0, 0]]
+        a = array(data, mask=mask)
+
+        expected = array([0, 3], mask=False)
+        result = np.minimum.reduce(a, axis=1)
+
+        assert_array_equal(result, expected)
+
     def test_minmax_funcs_with_output(self):
         # Tests the min/max functions with explicit outputs
         mask = np.random.rand(12).round()


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fixes the problem reported at https://github.com/numpy/numpy/pull/21977#issuecomment-1186082534.

The `reduce` method here effectively calls itself with an unmasked `MaskedArray` (mask=nomask) and then expects either a `MaskedArray` or a scalar.  This change ensures that an ordinary `ndarray` is converted to a `MaskedArray`, following the pattern already used in `mean` and `var` in this module.

When `t` was an `ndarray`, we called `elif m` on a boolean array, triggering the "ambiguous truth value" error.
https://github.com/numpy/numpy/blob/bdec32181605c8179fd79624d14c1cf019de75af/numpy/ma/core.py#L6883-L6886