### PR TITLE
BUG: Avoid errors on NULL during deepcopy

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1620,11 +1620,11 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
                                   &title)) {
-                return 0;
+                return -1;
             }
             res = _deepcopy_call(iptr + offset, optr + offset, new,
                                  deepcopy, visit);
-            if (res == -1) {
+            if (res < 0) {
                 return -1;
             }
         }

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -1602,17 +1602,17 @@ array_searchsorted(PyArrayObject *self,
     return PyArray_Return((PyArrayObject *)PyArray_SearchSorted(self, keys, side, sorter));
 }
 
-static void
+static int
 _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
                PyObject *deepcopy, PyObject *visit)
 {
     if (!PyDataType_REFCHK(dtype)) {
-        return;
+        return 0;
     }
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        int offset, res;
         Py_ssize_t pos = 0;
         while (PyDict_Next(dtype->fields, &pos, &key, &value)) {
             if (NPY_TITLE_KEY(key, value)) {
@@ -1620,10 +1620,13 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
             }
             if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
                                   &title)) {
-                return;
+                return 0;
             }
-            _deepcopy_call(iptr + offset, optr + offset, new,
-                           deepcopy, visit);
+            res = _deepcopy_call(iptr + offset, optr + offset, new,
+                                 deepcopy, visit);
+            if (res == -1) {
+                return -1;
+            }
         }
     }
     else {
@@ -1631,13 +1634,20 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
         PyObject *res;
         memcpy(&itemp, iptr, sizeof(itemp));
         memcpy(&otemp, optr, sizeof(otemp));
-        Py_XINCREF(itemp);
+        if (itemp == NULL) {
+            itemp = Py_None;
+        }
+        Py_INCREF(itemp);
         /* call deepcopy on this argument */
         res = PyObject_CallFunctionObjArgs(deepcopy, itemp, visit, NULL);
-        Py_XDECREF(itemp);
+        Py_DECREF(itemp);
+        if (res == NULL) {
+            return -1;
+        }
         Py_XDECREF(otemp);
         memcpy(optr, &res, sizeof(res));
     }
+    return 0;
 
 }
 
@@ -1654,6 +1664,7 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
     npy_intp *strideptr, *innersizeptr;
     npy_intp stride, count;
     PyObject *copy, *deepcopy;
+    int deepcopy_res;
 
     if (!PyArg_ParseTuple(args, "O:__deepcopy__", &visit)) {
         return NULL;
@@ -1704,8 +1715,12 @@ array_deepcopy(PyArrayObject *self, PyObject *args)
                 stride = *strideptr;
                 count = *innersizeptr;
                 while (count--) {
-                    _deepcopy_call(data, data, PyArray_DESCR(copied_array),
-                                   deepcopy, visit);
+                    deepcopy_res = _deepcopy_call(data, data, PyArray_DESCR(copied_array),
+                                                  deepcopy, visit);
+                    if (deepcopy_res == -1) {
+                        return NULL;
+                    }
+
                     data += stride;
                 }
             } while (iternext(iter));

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2251,7 +2251,7 @@ class TestMethods:
     def test__deepcopy__catches_failure(self):
         class MyObj:
              def __deepcopy__(self, *args, **kwargs):
-                 return Exception
+                raise Exception
 
         arr = np.array([1, MyObj(), 3], dtype='O')
         arr.__deepcopy__({})

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2248,6 +2248,15 @@ class TestMethods:
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
 
+    def test__deepcopy__catches_failure(self):
+        class MyObj:
+             def __deepcopy__(self, *args, **kwargs):
+                 return Exception
+
+        arr = np.array([1, MyObj(), 3], dtype='O')
+        arr.__deepcopy__({})
+        # TODO: Is this getting raised in the right location?
+
 
     def test_sort_order(self):
         # Test sorting an array with fields

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2250,7 +2250,7 @@ class TestMethods:
 
     def test__deepcopy__catches_failure(self):
         class MyObj:
-             def __deepcopy__(self, *args, **kwargs):
+            def __deepcopy__(self, *args, **kwargs):
                 raise RuntimeError
 
         arr = np.array([1, MyObj(), 3], dtype='O')

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2234,6 +2234,19 @@ class TestMethods:
         assert_c(a.copy('C'))
         assert_fortran(a.copy('F'))
         assert_c(a.copy('A'))
+    
+    @pytest.mark.parametrize("dtype", ['O', np.int32, 'i,O'])
+    def test__deepcopy__(self, dtype):
+        # Force the entry of NULLs into array
+        a = np.empty(4, dtype=dtype)
+        ctypes.memset(a.ctypes.data, 0, a.nbytes)
+
+        # Ensure no error is raised, see gh-21833
+        b = a.__deepcopy__({})
+
+        a[0] = 42
+        assert_raises(AssertionError, assert_array_equal, a, b)
+
 
     def test_sort_order(self):
         # Test sorting an array with fields

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2251,12 +2251,11 @@ class TestMethods:
     def test__deepcopy__catches_failure(self):
         class MyObj:
              def __deepcopy__(self, *args, **kwargs):
-                raise Exception
+                raise RuntimeError
 
         arr = np.array([1, MyObj(), 3], dtype='O')
-        arr.__deepcopy__({})
-        # TODO: Is this getting raised in the right location?
-
+        with pytest.raises(RuntimeError):
+            arr.__deepcopy__({})
 
     def test_sort_order(self):
         # Test sorting an array with fields

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -2245,7 +2245,8 @@ class TestMethods:
         b = a.__deepcopy__({})
 
         a[0] = 42
-        assert_raises(AssertionError, assert_array_equal, a, b)
+        with pytest.raises(AssertionError):
+            assert_array_equal(a, b)
 
 
     def test_sort_order(self):


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Closes #8706, #21883

Addresses concerns raised in the two linked issues by:
* Casting `NULL` objects to `Py_None` within `_deepcopy_call` to avoid issues within CPython's `deepcopy`
* Setting `_deepcopy_call` to return an `int` code for error/success, which is then checked in `array_deepcopy`
