### PR TITLE
DOC: add links to `linalg` in docs of `dot` and `matmul`

### DIFF
--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2800,6 +2800,8 @@ add_newdoc('numpy.core.umath', 'matmul',
     The matmul function implements the semantics of the ``@`` operator introduced
     in Python 3.5 following :pep:`465`.
 
+    It uses an optimized BLAS library when possible (see `numpy.linalg`).
+
     Examples
     --------
     For 2-D arrays it is the matrix product:

--- a/numpy/core/code_generators/ufunc_docstrings.py
+++ b/numpy/core/code_generators/ufunc_docstrings.py
@@ -2797,8 +2797,8 @@ add_newdoc('numpy.core.umath', 'matmul',
       (9, 5, 7, 3)
       >>> # n is 7, k is 4, m is 3
 
-    The matmul function implements the semantics of the ``@`` operator introduced
-    in Python 3.5 following :pep:`465`.
+    The matmul function implements the semantics of the ``@`` operator
+    introduced in Python 3.5 following :pep:`465`.
 
     It uses an optimized BLAS library when possible (see `numpy.linalg`).
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -750,14 +750,16 @@ def dot(a, b, out=None):
     - If both `a` and `b` are 2-D arrays, it is matrix multiplication,
       but using :func:`matmul` or ``a @ b`` is preferred.
 
-    - If either `a` or `b` is 0-D (scalar), it is equivalent to :func:`multiply`
-      and using ``numpy.multiply(a, b)`` or ``a * b`` is preferred.
+    - If either `a` or `b` is 0-D (scalar), it is equivalent to
+      :func:`multiply` and using ``numpy.multiply(a, b)`` or ``a * b`` is
+      preferred.
 
     - If `a` is an N-D array and `b` is a 1-D array, it is a sum product over
       the last axis of `a` and `b`.
 
     - If `a` is an N-D array and `b` is an M-D array (where ``M>=2``), it is a
-      sum product over the last axis of `a` and the second-to-last axis of `b`::
+      sum product over the last axis of `a` and the second-to-last axis of
+      `b`::
 
         dot(a, b)[i,j,k,m] = sum(a[i,j,:] * b[k,:,m])
 

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -761,6 +761,8 @@ def dot(a, b, out=None):
 
         dot(a, b)[i,j,k,m] = sum(a[i,j,:] * b[k,:,m])
 
+    It uses an optimized BLAS library when possible (see `numpy.linalg`).
+
     Parameters
     ----------
     a : array_like


### PR DESCRIPTION
Closes #19530.