### PR TITLE
DEP: Finalize ragged array creation deprecation

### DIFF
--- a/doc/neps/nep-0034-infer-dtype-is-object.rst
+++ b/doc/neps/nep-0034-infer-dtype-is-object.rst
@@ -5,7 +5,7 @@ NEP 34 — Disallow inferring ``dtype=object`` from sequences
 ===========================================================
 
 :Author: Matti Picus
-:Status: Accepted
+:Status: Final
 :Type: Standards Track
 :Created: 2019-10-10
 :Resolution: https://mail.python.org/pipermail/numpy-discussion/2019-October/080200.html

--- a/doc/release/upcoming_changes/22004.expired.rst
+++ b/doc/release/upcoming_changes/22004.expired.rst
@@ -1,0 +1,2 @@
+* Ragged array creation will now always raise a ``ValueError`` unless
+  ``dtype=object`` is passed.  This includes very deeply nested sequences.

--- a/numpy/core/tests/test_array_coercion.py
+++ b/numpy/core/tests/test_array_coercion.py
@@ -490,9 +490,10 @@ class TestNested:
         with pytest.raises(ValueError):
             np.array([nested], dtype="float64")
 
-        # We discover object automatically at this time:
-        with assert_warns(np.VisibleDeprecationWarning):
-            arr = np.array([nested])
+        with pytest.raises(ValueError, match=".*would exceed the maximum"):
+            np.array([nested])  # user must ask for `object` explicitly
+
+        arr = np.array([nested], dtype=object)
         assert arr.dtype == np.dtype("O")
         assert arr.shape == (1,) * np.MAXDIMS
         assert arr.item() is initial
@@ -523,7 +524,7 @@ class TestNested:
         for i in range(np.MAXDIMS - 1):
             nested = [nested]
 
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match=".*would exceed the maximum"):
             # It will refuse to assign the array into
             np.array(nested, dtype="float64")
 

--- a/numpy/core/tests/test_deprecations.py
+++ b/numpy/core/tests/test_deprecations.py
@@ -475,34 +475,6 @@ class TestNonZero(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.nonzero(np.array(1)))
 
 
-def test_deprecate_ragged_arrays():
-    # 2019-11-29 1.19.0
-    #
-    # NEP 34 deprecated automatic object dtype when creating ragged
-    # arrays. Also see the "ragged" tests in `test_multiarray`
-    #
-    # emits a VisibleDeprecationWarning
-    arg = [1, [2, 3]]
-    with assert_warns(np.VisibleDeprecationWarning):
-        np.array(arg)
-
-
-class TestTooDeepDeprecation(_VisibleDeprecationTestCase):
-    # NumPy 1.20, 2020-05-08
-    # This is a bit similar to the above ragged array deprecation case.
-    message = re.escape("Creating an ndarray from nested sequences exceeding")
-
-    def test_deprecation(self):
-        nested = [1]
-        for i in range(np.MAXDIMS - 1):
-            nested = [nested]
-        self.assert_not_deprecated(np.array, args=(nested,))
-        self.assert_not_deprecated(np.array,
-                args=(nested,), kwargs=dict(dtype=object))
-
-        self.assert_deprecated(np.array, args=([nested],))
-
-
 class TestToString(_DeprecationTestCase):
     # 2020-03-06 1.19.0
     message = re.escape("tostring() is deprecated. Use tobytes() instead.")
@@ -642,20 +614,6 @@ class TestMatrixInOuter(_DeprecationTestCase):
         self.assert_deprecated(np.add.outer, args=(arr, m))
         self.assert_deprecated(np.add.outer, args=(m, arr))
         self.assert_not_deprecated(np.add.outer, args=(arr, arr))
-
-
-class TestRaggedArray(_DeprecationTestCase):
-    # 2020-07-24, NumPy 1.20.0
-    message = "setting an array element with a sequence"
-
-    def test_deprecated(self):
-        arr = np.ones((1, 1))
-        # Deprecated if the array is a leave node:
-        self.assert_deprecated(lambda: np.array([arr, 0], dtype=np.float64))
-        self.assert_deprecated(lambda: np.array([0, arr], dtype=np.float64))
-        # And when it is an assignment into a lower dimensional subarray:
-        self.assert_deprecated(lambda: np.array([arr, [0]], dtype=np.float64))
-        self.assert_deprecated(lambda: np.array([[0], arr], dtype=np.float64))
 
 
 class FlatteningConcatenateUnsafeCast(_DeprecationTestCase):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -1118,12 +1118,11 @@ class TestCreation:
                           shape=(max_bytes//itemsize + 1,), dtype=dtype)
 
     def _ragged_creation(self, seq):
-        # without dtype=object, the ragged object should raise
-        with assert_warns(np.VisibleDeprecationWarning):
+        # without dtype=object, the ragged object raises
+        with pytest.raises(ValueError, match=".*detected shape was"):
             a = np.array(seq)
-        b = np.array(seq, dtype=object)
-        assert_equal(a, b)
-        return b
+
+        return np.array(seq, dtype=object)
 
     def test_ragged_ndim_object(self):
         # Lists of mismatching depths are treated as object arrays


### PR DESCRIPTION
This finalizes all DeprcationWarnings related to the creation of object
arrays from nested lists enforcing that users use `dtype=object` if this
is intentional.