### PR TITLE
BUG: fix np.average for Fraction elements

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -516,7 +516,8 @@ def average(a, axis=None, weights=None, returned=False, *,
 
     if weights is None:
         avg = a.mean(axis, **keepdims_kw)
-        scl = avg.dtype.type(a.size/avg.size)
+        avg_as_array = np.asanyarray(avg)
+        scl = avg_as_array.dtype.type(a.size/avg_as_array.size)
     else:
         wgt = np.asanyarray(weights)
 
@@ -547,12 +548,12 @@ def average(a, axis=None, weights=None, returned=False, *,
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 
-        avg = np.multiply(a, wgt,
+        avg = avg_as_array = np.multiply(a, wgt,
                           dtype=result_dtype).sum(axis, **keepdims_kw) / scl
 
     if returned:
-        if scl.shape != avg.shape:
-            scl = np.broadcast_to(scl, avg.shape).copy()
+        if scl.shape != avg_as_array.shape:
+            scl = np.broadcast_to(scl, avg_as_array.shape).copy()
         return avg, scl
     else:
         return avg

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -421,6 +421,11 @@ class TestAverage:
         w /= w.sum()
         assert_almost_equal(a.mean(0), average(a, weights=w))
 
+    def test_average_class_without_dtype(self):
+        # see gh-21988
+        a = np.array([Fraction(1, 5), Fraction(3, 5)])
+        assert_equal(np.average(a), Fraction(2, 5))
+
 class TestSelect:
     choices = [np.array([1, 2, 3]),
                np.array([4, 5, 6]),


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR allows calculation of the average of a numpy array with elements of type `fractions.Fraction`.
```Python
from numpy import np
from fractions import Fraction

arr = np.array([Fraction(1, 5), Fraction(3, 5)]))
np.average(arr) # works with this PR
```

Fixes #21988