### PR TITLE
DOC: Add versionchanged for converter callable behavior.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1095,6 +1095,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         data, e.g. ``converters = lambda s: float(s.strip() or 0)`` will
         convert empty fields to 0.
         Default: None.
+
+        .. versionchanged:: 1.23.0
+           The ability to pass a single callable to be applied to all columns
+           was added.
+
     skiprows : int, optional
         Skip the first `skiprows` lines, including comments; default: 0.
     usecols : int or sequence, optional


### PR DESCRIPTION
Add missing `.. versionchanged` directive to the `converters` argument of loadtxt to indicate that the passing in of a single callable to be applied to all columns became possible in version 1.23

See also #22007