### PR TITLE
DOC: updated masked_print_option and added explanation

### DIFF
--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -43,8 +43,8 @@ defines several constants.
 
    
    Add ``set_display()`` to change the default string.
-   Usage: ``numpy.ma.masked_print_option.set_display('·')`` 
-   replaces missing data with an ``'.'``
+   Example usage: ``numpy.ma.masked_print_option.set_display('·')`` 
+   replaces missing data with ``'.'``
    
 
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -44,7 +44,7 @@ defines several constants.
    
    Add ``set_display()`` to change the default string.
    Example usage: ``numpy.ma.masked_print_option.set_display('·')`` 
-   replaces missing data with ``'.'``
+   replaces missing data with ``'.'``.
    
 
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -40,13 +40,9 @@ defines several constants.
    String used in lieu of missing data when a masked array is printed.
    By default, this string is ``'--'``.
 
-
-   
    Use ``set_display()`` to change the default string.
    Example usage: ``numpy.ma.masked_print_option.set_display('X')`` 
    replaces missing data with ``'X'``.
-   
-
 
 .. _maskedarray.baseclass:
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -35,10 +35,17 @@ defines several constants.
    is not needed. It is represented internally as ``np.False_``.
 
 
-.. data:: masked_print_options
+.. data:: masked_print_option
 
    String used in lieu of missing data when a masked array is printed.
    By default, this string is ``'--'``.
+
+
+   
+   Add ``set_display()`` to change the default string.
+   Usage: ``numpy.ma.masked_print_option.set_display('·')`` 
+   replaces missing data with an ``'.'``
+   
 
 
 

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -42,17 +42,10 @@ defines several constants.
 
 
    
-   Use ``set_display()`` to change the default string::
+   Use ``set_display()`` to change the default string.
+   Example usage: ``numpy.ma.masked_print_option.set_display('X')`` 
+   replaces missing data with ``'X'``.
    
-       >>> a = ma.array([1, 2, 3], mask=[0, 1, 0])
-       >>> ma.masked_print_option.set_display("X")
-       >>> a
-       masked_array(data=[1, X, 3],                                             
-                    mask=[False,  True, False],                                    
-              fill_value=999999)
-   
-
-
 
 
 .. _maskedarray.baseclass:

--- a/doc/source/reference/maskedarray.baseclass.rst
+++ b/doc/source/reference/maskedarray.baseclass.rst
@@ -42,9 +42,14 @@ defines several constants.
 
 
    
-   Add ``set_display()`` to change the default string.
-   Example usage: ``numpy.ma.masked_print_option.set_display('·')`` 
-   replaces missing data with ``'.'``.
+   Use ``set_display()`` to change the default string::
+   
+       >>> a = ma.array([1, 2, 3], mask=[0, 1, 0])
+       >>> ma.masked_print_option.set_display("X")
+       >>> a
+       masked_array(data=[1, X, 3],                                             
+                    mask=[False,  True, False],                                    
+              fill_value=999999)
    
 
 


### PR DESCRIPTION
#21985 
- numpy/doc/source/reference/maskedarray.baseclass.rst
  - Changed masked_print_options to masked_print_option on line 38
  - added description of how to use masked_print_option since it cannot be set with direct assignment