### PR TITLE
ENH: reorder includes for testing on top of system installations of NumPy

### DIFF
--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -102,7 +102,7 @@ def compile_extension_module(
     dirname = builddir / name
     dirname.mkdir(exist_ok=True)
     cfile = _convert_str_to_file(source_string, dirname)
-    include_dirs = [sysconfig.get_config_var('INCLUDEPY')] + include_dirs
+    include_dirs = include_dirs + [sysconfig.get_config_var('INCLUDEPY')]
 
     return _c_compile(
         cfile, outputfilename=dirname / modname,


### PR DESCRIPTION
I ran across this when using a ubuntu-system python with numpy installed. Since there are numpy include headers in `sysconfig.get_config_var('INCLUDEPY')`, putting it first means the tests use that set of headers and not the ones from the test environment.