### PR TITLE
MAINT: Do not let ``_GenericAlias`` wrap the underlying classes' ``__class__`` attribute.

### DIFF
--- a/numpy/_typing/_generic_alias.py
+++ b/numpy/_typing/_generic_alias.py
@@ -216,6 +216,7 @@ class _GenericAlias:
         "__deepcopy__",
         "__unpacked__",
         "__typing_unpacked_tuple_args__",
+        "__class__",
     })
 
     def __getattribute__(self, name: str) -> Any:

--- a/numpy/typing/tests/test_generic_alias.py
+++ b/numpy/typing/tests/test_generic_alias.py
@@ -120,9 +120,12 @@ class TestGenericAlias:
         # and they are thus now longer equivalent
         ("__ne__", lambda n: n != next(iter(n)), ("beta", 1)),
 
-        # >= beta3 stuff
+        # >= beta3
         ("__typing_unpacked_tuple_args__",
          lambda n: n.__typing_unpacked_tuple_args__, ("beta", 3)),
+
+        # >= beta4
+        ("__class__", lambda n: n.__class__ == type(n), ("beta", 4)),
     ])
     def test_py311_features(
         self,


### PR DESCRIPTION
Backport of #21982.

Adapt to the 3.11b4 changes introduced in https://github.com/python/cpython/pull/93754

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
