### PR TITLE
TYP,MAINT: Allow `einsum` subscripts to be passed via integer array-likes

### DIFF
--- a/numpy/core/einsumfunc.pyi
+++ b/numpy/core/einsumfunc.pyi
@@ -45,7 +45,7 @@ __all__: list[str]
 # Something like `is_scalar = bool(__subscripts.partition("->")[-1])`
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeBool_co,
     out: None = ...,
@@ -56,7 +56,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeUInt_co,
     out: None = ...,
@@ -67,7 +67,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeInt_co,
     out: None = ...,
@@ -78,7 +78,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeFloat_co,
     out: None = ...,
@@ -89,7 +89,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeComplex_co,
     out: None = ...,
@@ -100,7 +100,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: Any,
     casting: _CastingUnsafe,
@@ -111,7 +111,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeComplex_co,
     out: _ArrayType,
@@ -122,7 +122,7 @@ def einsum(
 ) -> _ArrayType: ...
 @overload
 def einsum(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: Any,
     out: _ArrayType,
@@ -137,7 +137,7 @@ def einsum(
 # NOTE: In practice the list consists of a `str` (first element)
 # and a variable number of integer tuples.
 def einsum_path(
-    subscripts: str,
+    subscripts: str | _ArrayLikeInt_co,
     /,
     *operands: _ArrayLikeComplex_co,
     optimize: _OptimizeKind = ...,

--- a/numpy/typing/tests/data/reveal/einsumfunc.pyi
+++ b/numpy/typing/tests/data/reveal/einsumfunc.pyi
@@ -30,3 +30,6 @@ reveal_type(np.einsum_path("i,i->i", AR_LIKE_f, AR_LIKE_f))  # E: Tuple[builtins
 reveal_type(np.einsum_path("i,i->i", AR_LIKE_c, AR_LIKE_c))  # E: Tuple[builtins.list[Any], builtins.str]
 reveal_type(np.einsum_path("i,i->i", AR_LIKE_b, AR_LIKE_i))  # E: Tuple[builtins.list[Any], builtins.str]
 reveal_type(np.einsum_path("i,i,i,i->i", AR_LIKE_b, AR_LIKE_u, AR_LIKE_i, AR_LIKE_c))  # E: Tuple[builtins.list[Any], builtins.str]
+
+reveal_type(np.einsum([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i))  # E: Any
+reveal_type(np.einsum_path([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i))  # E: Tuple[builtins.list[Any], builtins.str]


### PR DESCRIPTION
Backport of #21983.

closes https://github.com/numpy/numpy/issues/21978

In addition to strings, einsum's subscripts can be passed either via a nested integer list. This is now reflected in the annotations.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
