### PR TITLE
MAINT,TYP: Add object-overloads for the ``np.generic`` rich comparisons

### DIFF
--- a/numpy/_typing/_callable.pyi
+++ b/numpy/_typing/_callable.pyi
@@ -44,6 +44,7 @@ from ._scalars import (
 )
 from . import NBitBase
 from ._generic_alias import NDArray
+from ._nested_sequence import _NestedSequence
 
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -318,8 +319,20 @@ class _ComplexOp(Protocol[_NBit1]):
 class _NumberOp(Protocol):
     def __call__(self, other: _NumberLike_co, /) -> Any: ...
 
+class _SupportsLT(Protocol):
+    def __lt__(self, other: Any, /) -> object: ...
+
+class _SupportsGT(Protocol):
+    def __gt__(self, other: Any, /) -> object: ...
+
 class _ComparisonOp(Protocol[_T1_contra, _T2_contra]):
     @overload
     def __call__(self, other: _T1_contra, /) -> bool_: ...
     @overload
     def __call__(self, other: _T2_contra, /) -> NDArray[bool_]: ...
+    @overload
+    def __call__(
+        self,
+        other: _SupportsLT | _SupportsGT | _NestedSequence[_SupportsLT | _SupportsGT],
+        /,
+    ) -> Any: ...

--- a/numpy/typing/tests/data/reveal/comparisons.pyi
+++ b/numpy/typing/tests/data/reveal/comparisons.pyi
@@ -1,4 +1,6 @@
 import numpy as np
+import fractions
+import decimal
 
 c16 = np.complex128()
 f8 = np.float64()
@@ -24,6 +26,13 @@ AR = np.array([0], dtype=np.int64)
 AR.setflags(write=False)
 
 SEQ = (0, 1, 2, 3, 4)
+
+# object-like comparisons
+
+reveal_type(i8 > fractions.Fraction(1, 5))  # E: Any
+reveal_type(i8 > [fractions.Fraction(1, 5)])  # E: Any
+reveal_type(i8 > decimal.Decimal("1.5"))  # E: Any
+reveal_type(i8 > [decimal.Decimal("1.5")])  # E: Any
 
 # Time structures
 


### PR DESCRIPTION
Backport of #21984.

Closes https://github.com/numpy/numpy/issues/21939

An overload was previously missing for object-based rich comparisons of the `np.generic` subclasses.

As object array-likes are notoriously difficult to type, the new overload simply checks whether the right operand supports `__gt__` or `__lt__` even though this will, in practice, be a bit too broad (*e.g.* it allows `np.int64(1) > "test"` to pass).

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
