### PR TITLE
DOC: Add versionchanged for converter callable behavior.

### DIFF
--- a/numpy/lib/npyio.py
+++ b/numpy/lib/npyio.py
@@ -1097,6 +1097,11 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
         data, e.g. ``converters = lambda s: float(s.strip() or 0)`` will
         convert empty fields to 0.
         Default: None.
+
+        .. versionchanged:: 1.23.0
+           The ability to pass a single callable to be applied to all columns
+           was added.
+
     skiprows : int, optional
         Skip the first `skiprows` lines, including comments; default: 0.
     usecols : int or sequence, optional


### PR DESCRIPTION
Backport of #22010.

Add missing `.. versionchanged` directive to the `converters` argument of loadtxt to indicate that the passing in of a single callable to be applied to all columns became possible in version 1.23

See also #22007

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
