### PR TITLE
ENH: allow importlib.LazyLoader to work with numpy and add test of this

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -75,8 +75,10 @@ from .numeric import *
 from . import fromnumeric
 from .fromnumeric import *
 from . import defchararray as char
+from . import records
 from . import records as rec
 from .records import record, recarray, format_parser
+from . import memmap
 from .memmap import *
 from .defchararray import chararray
 from . import function_base

--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -78,7 +78,7 @@ from . import defchararray as char
 from . import records
 from . import records as rec
 from .records import record, recarray, format_parser
-from . import memmap
+# Note: module name memmap is overwritten by a class with same name
 from .memmap import *
 from .defchararray import chararray
 from . import function_base

--- a/numpy/lib/__init__.py
+++ b/numpy/lib/__init__.py
@@ -21,6 +21,24 @@ from . import mixins
 from . import scimath as emath
 
 # Private submodules
+# load module names. See https://github.com/networkx/networkx/issues/5838
+from . import type_check
+from . import index_tricks
+from . import function_base
+from . import nanfunctions
+from . import shape_base
+from . import stride_tricks
+from . import twodim_base
+from . import ufunclike
+from . import histograms
+from . import polynomial
+from . import utils
+from . import arraysetops
+from . import npyio
+from . import arrayterator
+from . import arraypad
+from . import _version
+
 from .type_check import *
 from .index_tricks import *
 from .function_base import *

--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -1,6 +1,7 @@
 """Sub-package containing the matrix class and related functions.
 
 """
+from . import defmatrix
 from .defmatrix import *
 
 __all__ = defmatrix.__all__

--- a/numpy/testing/__init__.py
+++ b/numpy/testing/__init__.py
@@ -7,6 +7,7 @@ away.
 """
 from unittest import TestCase
 
+from . import _private
 from ._private.utils import *
 from ._private.utils import (_assert_valid_refcount, _gen_alignment_data)
 from ._private import extbuild, decorators as dec

--- a/numpy/tests/test_lazyloading.py
+++ b/numpy/tests/test_lazyloading.py
@@ -4,9 +4,10 @@ from importlib.util import LazyLoader, find_spec, module_from_spec
 import pytest
 
 
-@pytest.mark.filterwarnings("ignore:The NumPy")
+# Warning raised by _reload_guard() in numpy/__init__.py
+@pytest.mark.filterwarnings("ignore:The NumPy module was reloaded")
 def test_lazy_load():
-    # gh-XXXX. lazyload doesn't import submodule names into the namespace
+    # gh-22045. lazyload doesn't import submodule names into the namespace
     # muck with sys.modules to test the importing system
     old_numpy = sys.modules.pop("numpy")
 

--- a/numpy/tests/test_lazyloading.py
+++ b/numpy/tests/test_lazyloading.py
@@ -1,0 +1,36 @@
+import sys
+import importlib
+from importlib.util import LazyLoader, find_spec, module_from_spec
+import pytest
+
+
+@pytest.mark.filterwarnings("ignore:The NumPy")
+def test_lazy_load():
+    # gh-XXXX. lazyload doesn't import submodule names into the namespace
+    # muck with sys.modules to test the importing system
+    old_numpy = sys.modules.pop("numpy")
+
+    numpy_modules = {}
+    for mod_name, mod in list(sys.modules.items()):
+        if mod_name[:6] == "numpy.":
+            numpy_modules[mod_name] = mod
+            sys.modules.pop(mod_name)
+
+    try:
+        # create lazy load of numpy as np
+        spec  = find_spec("numpy")
+        module = module_from_spec(spec)
+        sys.modules["numpy"] = module
+        loader = LazyLoader(spec.loader)
+        loader.exec_module(module)
+        np = module
+
+        # test a subpackage import
+        from numpy.lib import recfunctions
+        # test triggering the import of the package
+        np.ndarray
+
+    finally:
+        if old_numpy:
+            sys.modules["numpy"] = old_numpy
+            sys.modules.update(numpy_modules)

--- a/numpy/tests/test_lazyloading.py
+++ b/numpy/tests/test_lazyloading.py
@@ -18,7 +18,7 @@ def test_lazy_load():
 
     try:
         # create lazy load of numpy as np
-        spec  = find_spec("numpy")
+        spec = find_spec("numpy")
         module = module_from_spec(spec)
         sys.modules["numpy"] = module
         loader = LazyLoader(spec.loader)
@@ -27,6 +27,7 @@ def test_lazy_load():
 
         # test a subpackage import
         from numpy.lib import recfunctions
+
         # test triggering the import of the package
         np.ndarray
 


### PR DESCRIPTION
Python's LazyLoader tool from importlib, does not load a submodule name to the local namespace. This differs from a standard import. It is mentioned in PEP 650 as a difference. Indeed, it makes sense that `from .type_check import *` would load the names within the `type_check` module and not load the name `type_check`. But the standard import does that and is unlikely to change soon. 

The difference in treatment of submodule names between standard and lazy imports is not a concern unless the package being imported depends on its submodule names being available without explicitly importing them. Even then it is only a problem if the user tries to import from a subpackage without first importing the package. 

Currently when a user LazyLoads numpy (or any package the user imports LazyLoads numpy) and imports a subpackage as the first access to numpy that triggers a load, a NameError is raised. E.g. `from numpy.lib import recfunctions` works for standard imports, but not if the NumPy package has been lazyloaded and the lazyload has not been triggered. Adding `import numpy` before the `from ...` subpackage import solves the trouble.

See networkx/networkx#5838 for more discussion.

This PR allows numpy to be loaded with the `importlib.LazyLoader` tools by explicitly importing submodule names where needed. There are only a few places where numpy does this, most notably in `numpy.lib.__init__.py`. 

A test is also added to check that this works. The test does not check every submodule, so in the future, if some code is added that expects a submodule name to exist in the local namespace without explicitly importing it, that will potentially break the lazyloading/subpackage-access-as-1st-access capability for that submodule.  I'm not sure it is worth testing every submodule, but we could attempt to do that. 

The test manually changes `sys.modules` (and restores it in a `Finally` clause) because we must mimic conditions where `numpy` has not been previously imported. Changing `sys.modules` always makes me nervous, but I don't see another way to test this. We could leave it untested too -- especially since this test is not checking every subpackage anyway.

I'd love for this issue to be fixed by Python's builtin `importlib`. But the PEP indicates it is a known difference between the import systems. We are likely going to need to point out the difficulty that this difference creates. But in the meantime, it seems reasonable to make sure our code explicitly imports the submodule names when it uses them.
