### PR TITLE
BUG: Make `mask_invalid` consistent with `mask_where` if `copy` is set to `False`

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2356,20 +2356,11 @@ def masked_invalid(a, copy=True):
            fill_value=1e+20)
 
     """
-    a = np.array(a, copy=copy, subok=True)
-    mask = getattr(a, '_mask', None)
-    if mask is not None:
-        condition = ~(np.isfinite(getdata(a)))
-        if mask is not nomask:
-            condition |= mask
-        cls = type(a)
-    else:
-        condition = ~(np.isfinite(a))
-        cls = MaskedArray
-    result = a.view(cls)
-    result._mask = condition
-    return result
 
+    try:
+        return masked_where(~(np.isfinite(getdata(a))), a, copy=copy)
+    except TypeError:
+        raise
 
 ###############################################################################
 #                            Printing options                                 #

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2357,10 +2357,7 @@ def masked_invalid(a, copy=True):
 
     """
 
-    try:
-        return masked_where(~(np.isfinite(getdata(a))), a, copy=copy)
-    except TypeError:
-        raise
+    return masked_where(~(np.isfinite(getdata(a))), a, copy=copy)
 
 ###############################################################################
 #                            Printing options                                 #

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4500,7 +4500,8 @@ class TestMaskedArrayFunctions:
         a = np.arange(5, dtype=object)
         a[3] = np.PINF
         a[2] = np.NaN
-        with pytest.raises(TypeError, match="not supported for the input types"):
+        with pytest.raises(TypeError,
+                           match="not supported for the input types"):
             np.ma.masked_invalid(a)
 
     def test_choose(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4496,6 +4496,13 @@ class TestMaskedArrayFunctions:
         assert_equal(ma, expected)
         assert_equal(ma.mask, expected.mask)
 
+    def test_masked_invalid_error(self):
+        a = np.arange(5, dtype=object)
+        a[3] = np.PINF
+        a[2] = np.NaN
+        with pytest.raises(TypeError, match="not supported for the input types"):
+            np.ma.masked_invalid(a)
+
     def test_choose(self):
         # Test choose
         choices = [[0, 1, 2, 3], [10, 11, 12, 13],

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5317,6 +5317,10 @@ def test_masked_array_no_copy():
     a = np.ma.array([1, 2, 3, 4], mask=[1, 0, 0, 0])
     _ = np.ma.masked_where(a == 3, a, copy=False)
     assert_array_equal(a.mask, [True, False, True, False])
+    # check masked array with masked_invalid is updated in place
+    a = np.ma.array([np.inf, 1, 2, 3, 4])
+    _ = np.ma.masked_invalid(a, copy=False)
+    assert_array_equal(a.mask, [True, False, False, False, False])
 
 def test_append_masked_array():
     a = np.ma.masked_equal([1,2,3], value=2)


### PR DESCRIPTION
This pull requests makes `mask_invalid` consistent with `mask_where` when `copy` is set to `False`.
Fixes #19332.

I'd rather make the two functions consistent than change the documentation.
Also from the documentation

> Only applies to arrays with a dtype where NaNs or infs make sense

I added a test checking that an error is thrown when `isinfinite` is not applicable.

Thanks for considering it.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
