### PR TITLE
PERF: Improve import time of numpy

### DIFF
--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -50,7 +50,6 @@ possible_aliases = numeric_type_aliases([
     ('complex256', 'Complex number type composed of 2 128-bit extended-precision floating-point numbers'),
     ])
 
-_possible_aliases_dict = {p[0]: p for idx, p in enumerate(possible_aliases)}
 
 def _get_platform_and_machine():
     try:
@@ -81,10 +80,8 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
                             for alias in fixed_aliases)
     else:
         alias_doc = ''
-    alias_entry = _possible_aliases_dict.get(o, None)
-    if alias_entry is not None:
-        alias_type, alias, doc = alias_entry
-        alias_doc += f"{_doc_alias_string} `numpy.{alias}`: {doc}.\n    "
+    alias_doc += ''.join("{_doc_alias_string} `numpy.{alias}`: {doc}.\n    "
+                         for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
     docstring = f"""
     {doc.strip()}

--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -80,7 +80,7 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
                             for alias in fixed_aliases)
     else:
         alias_doc = ''
-    alias_doc += ''.join("{_doc_alias_string} `numpy.{alias}`: {doc}.\n    "
+    alias_doc += ''.join(f"{_doc_alias_string} `numpy.{alias}`: {doc}.\n    "
                          for (alias_type, alias, doc) in possible_aliases if alias_type is o)
 
     docstring = f"""

--- a/numpy/core/_add_newdocs_scalars.py
+++ b/numpy/core/_add_newdocs_scalars.py
@@ -50,18 +50,23 @@ possible_aliases = numeric_type_aliases([
     ('complex256', 'Complex number type composed of 2 128-bit extended-precision floating-point numbers'),
     ])
 
-possible_aliases_dict = {p[0]: p for idx,p in enumerate(possible_aliases)}
+_possible_aliases_dict = {p[0]: p for idx, p in enumerate(possible_aliases)}
 
 def _get_platform_and_machine():
     try:
         system, _, _, _, machine = os.uname()
     except AttributeError:
         system = sys.platform
-        if system=='win32':
-            machine = os.environ.get('PROCESSOR_ARCHITEW6432', '') or os.environ.get('PROCESSOR_ARCHITECTURE', '')
+        if system == 'win32':
+            machine = os.environ.get('PROCESSOR_ARCHITEW6432', '') \
+                    or os.environ.get('PROCESSOR_ARCHITECTURE', '')
+        else:
+            machine = 'unknown'
     return system, machine
-        
-_doc_alias_platform_string = ":Alias on this platform ({} {}):".format(*_get_platform_and_machine())
+
+
+_system, _machine = _get_platform_and_machine()
+_doc_alias_string = f":Alias on this platform ({_system} {_machine}):"
 
 
 def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
@@ -69,15 +74,17 @@ def add_newdoc_for_scalar_type(obj, fixed_aliases, doc):
     o = getattr(_numerictypes, obj)
 
     character_code = dtype(o).char
-    canonical_name_doc = "" if obj == o.__name__ else f":Canonical name: `numpy.{obj}`\n    "
+    canonical_name_doc = "" if obj == o.__name__ else \
+                        f":Canonical name: `numpy.{obj}`\n    "
     if fixed_aliases:
-        alias_doc = ''.join(f":Alias: `numpy.{alias}`\n    " for alias in fixed_aliases)
+        alias_doc = ''.join(f":Alias: `numpy.{alias}`\n    "
+                            for alias in fixed_aliases)
     else:
         alias_doc = ''
-    p = possible_aliases_dict.get(o, None)
-    if p is not None:
-        alias_type, alias, doc= p
-        alias_doc += f"{_doc_alias_platform_string} `numpy.{alias}`: {doc}.\n    "
+    alias_entry = _possible_aliases_dict.get(o, None)
+    if alias_entry is not None:
+        alias_type, alias, doc = alias_entry
+        alias_doc += f"{_doc_alias_string} `numpy.{alias}`: {doc}.\n    "
 
     docstring = f"""
     {doc.strip()}


### PR DESCRIPTION
This PR improves the numpy import time (mainly for windows) by refactoring `add_newdoc_for_scalar_type` from `numpy.core._add_newdocs_scalars`

 * Replace format-style strings with f-strings
 * Reduce number of join statements
 * Take calculation of part of the docstring out the the function into a static variable
 * Eliminate call to `platform.system()`

The improvement is a few ms on linux, and 90-100 ms on windows. The main reason for the improvement on windows is that `platform.system()` takes about 90-100 ms when called for the first time (the `system()` call uses `platform.uname` which ends up calling `platform._syscmd_ver`)

The generated docstring is slightly different for windows: instead of `Windows` the string `win32` is generated.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
