### PR TITLE
ENH: Optimize `np.lib.arraysetops.in1d` for python strings (#21804)

### DIFF
--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -491,6 +491,17 @@ class TestSetOps:
         result = np.in1d(ar1, ar2, invert=True)
         assert_array_equal(result, np.invert(expected))
 
+    def test_in1d_with_string_objects(self):
+        """Test special case of `in1d` for strings"""
+
+        # Miss first condition (small array optimization) of `in1d`
+        # and also miss second condition because all objects are strings.
+        ar1 = np.array(list("ababde"), dtype=object)
+        ar2 = np.array(list("bcdd0123456789"), dtype=object)
+        expected = np.array([False, True, False, True, True, False])
+        result = np.in1d(ar1, ar2)
+        assert_array_equal(result, expected)
+
     def test_in1d_errors(self):
         """Test that in1d raises expected errors."""
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This pull request introduces a fast path for `in1d` if all array values are strings, in which case they can be sorted and compared in $O(n \log n)$ instead of $O(n^2)$.

References issue https://github.com/numpy/numpy/issues/21804 and probably stale pull request https://github.com/numpy/numpy/pull/21805

In theory, one could improve this function even further by extending the special case to all sortable objects, i.e. objects which implement `__lt__`, but that might cause backwards compatibility issues for bad `__lt__` implementations which are not in sync with `__eq__`.

For example, `(not (a < b)) and (not (b < a))` should usually be equivalent to `a == b`, but there are cases where that is not the case, e.g. for NaNs, which always compare as `False`. Thoughts?

(Side note: I have not been able to run the tests yet because of the following error, but I hope it works anyway.)

```bash
$ python runtests.py -v
Building, see build.log...
Traceback (most recent call last):
  File "setup.py", line 64, in <module>
    raise RuntimeError(f'Cannot parse version {FULLVERSION}')
RuntimeError: Cannot parse version 0+untagged.30272.g012777c

Build failed!
```

Co-authored-by: Prateek Garg <gargprateek35@gmail.com>