### PR TITLE
MAINT: fix typo in test_array_object.py

### DIFF
--- a/numpy/array_api/tests/test_array_object.py
+++ b/numpy/array_api/tests/test_array_object.py
@@ -364,7 +364,7 @@ def test_array_keys_use_private_array():
     in __getitem__(). This is achieved by passing array_api arrays with 0-sized
     dimensions, which NumPy-proper treats erroneously - not sure why!
 
-    TODO: Find and use appropiate __setitem__() case.
+    TODO: Find and use appropriate __setitem__() case.
     """
     a = ones((0, 0), dtype=bool_)
     assert a[a].shape == (0,)


### PR DESCRIPTION
appropiate -> appropriate
