### PR TITLE
ENH: reorder includes for testing on top of system installations of NumPy

### DIFF
--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -102,7 +102,7 @@ def compile_extension_module(
     dirname = builddir / name
     dirname.mkdir(exist_ok=True)
     cfile = _convert_str_to_file(source_string, dirname)
-    include_dirs = [sysconfig.get_config_var('INCLUDEPY')] + include_dirs
+    include_dirs = include_dirs + [sysconfig.get_config_var('INCLUDEPY')]
 
     return _c_compile(
         cfile, outputfilename=dirname / modname,


### PR DESCRIPTION
Backport of #22017.

I ran across this when using a ubuntu-system python with numpy installed. Since there are numpy include headers in `sysconfig.get_config_var('INCLUDEPY')`, putting it first means the tests use that set of headers and not the ones from the test environment.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
