### PR TITLE
PERF: Move regular expression compilation in numpy.compat._pep440 out of numpy import

### DIFF
--- a/numpy/compat/_pep440.py
+++ b/numpy/compat/_pep440.py
@@ -284,12 +284,12 @@ VERSION_PATTERN = r"""
 
 class Version(_BaseVersion):
 
-    _regex = re.compile(
-        r"^\s*" + VERSION_PATTERN + r"\s*$",
-        re.VERBOSE | re.IGNORECASE,
-    )
+    _regex = None
 
     def __init__(self, version):
+        if Version._regex is None:
+            Version._regex = re.compile(r"^\s*" + VERSION_PATTERN + r"\s*$",
+                                        re.VERBOSE | re.IGNORECASE)
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:


### PR DESCRIPTION
This PR changes the compiled regular expression in `numpy.compact._pep440.Version` into a lazy compiled version.
This improves the python startup time by about 3 ms (system dependent). The performance improvement is not large, but it makes a difference each time numpy is used (e.g. imported).

Also see issue #22061 

**Notes**

An alternative to this PR would be to not import `numpy.compat._pep440` by default. This is not backwards compatible, but would be easy to fix for users. (e.g. run `import numpy.compat._pep440`)

The `numpy.compat._pep440.Version` class itself is not used during the numpy import. It also does not seem to be used inside the normal numpy classes.

There are other possible implementations of making the regular expression lazy (e.g. functools.lru_cache, module wide variable, caching inside the `Version.__init__` ), there is no particular reason for choosing this one over the others.

Performance improvement was estimated in two ways: [importtime-waterfall](https://github.com/asottile/importtime-waterfall) and the [`test_import`](https://github.com/sympy/sympy/blob/master/bin/test_import) script adapted from sympy 

<details><summary>importtime-waterfall</summary>

On main:
```
$ importtime-waterfall numpy | grep 440
            numpy.compat._pep440 (4631)
```
This PR:
```
$ importtime-waterfall numpy | grep 440
            numpy.compat._pep440 (1262)

```
</details>

<details><summary>test_import</summary>

On main:
```
eendebakpt@woelmuis:~/numpy$ bin/test_import 
Note: the first run (warm up) was not included in the average + std dev
All runs (including warm up):
[0.26469611100003476, 0.260050662000026, 0.26272287500000857, 0.2656999149999706, 0.25757114099997125, 0.26262436500002195, 0.2556352480000328, 0.2609982680000371, 0.26683778300002814, 0.25308944200003225, 0.25502330099999426, 0.2589412350000089, 0.25961472900002036, 0.2561210719999849, 0.25554810300002373, 0.26087276999999176, 0.2589599519999979, 0.258963657000038, 0.25495190200001616, 0.2540302200000042, 0.26496679399997447, 0.26354998300001853, 0.2572918559999948, 0.26132359500002167, 0.26384254200002033, 0.2580267390000017, 0.25624088199998596, 0.25461950499999375, 0.25977765699997235, 0.2595665670000358, 0.2590771049999603, 0.2546979530000044, 0.2548699470000315, 0.2612612310000486, 0.2563717600000359, 0.259570167999982, 0.2594617469999889, 0.26241046699999515, 0.2561560899999904, 0.25166940599996224, 0.2552150750000237, 0.2550046860000066, 0.26149713500001326, 0.25688707599999816, 0.25824711399997113, 0.2607429069999512, 0.2550081379999938, 0.2567217479999613, 0.2631998560000284, 0.26072032999996964, 0.25819627300001]
Number of tests: 50
The speed of "import numpy" is: 0.258689 +- 0.003430
```
This PR:
```
eendebakpt@woelmuis:/mnt/data/numpy$ bin/test_import 
Note: the first run (warm up) was not included in the average + std dev
All runs (including warm up):
[0.2544178319999446, 0.25732622100008484, 0.26032008399999995, 0.2615479989999585, 0.25329577299999073, 0.2520542409999962, 0.2591800019999937, 0.2532924060000141, 0.2559488089999604, 0.25678147500002524, 0.25735870100004377, 0.25896810999995523, 0.2582105980000051, 0.2550174209999341, 0.2544107740000072, 0.2545991099999583, 0.25092308899991167, 0.25356768400001783, 0.269587447000049, 0.2554895470000247, 0.2535604280000143, 0.2525148579999268, 0.25777236499993705, 0.2609519469999668, 0.2591578749999144, 0.25472244200000205, 0.2564024350000409, 0.2531698170000709, 0.2507985510000026, 0.25478009699997983, 0.25141224399999373, 0.25741288199992596, 0.2546432179999556, 0.25361933299996053, 0.25243826600001285, 0.2520117220000202, 0.2506717450000906, 0.25451402299995607, 0.25719834400001673, 0.24846615100000236, 0.25440153399995324, 0.2553193920000467, 0.2531646609999143, 0.2514427620000106, 0.26248820000000705, 0.26297768099993846, 0.25503504100004193, 0.2553540090000297, 0.25294507000000976, 0.25576463099992, 0.28048981699998876]
Number of tests: 50
The speed of "import numpy" is: 0.256070 +- 0.005108
```


</details>


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
