### PR TITLE
PERF: Remove numpy.compat._pep440 from default imports

### DIFF
--- a/numpy/compat/__init__.py
+++ b/numpy/compat/__init__.py
@@ -9,7 +9,6 @@ extensions, which may be included for the following reasons:
 
 """
 from . import _inspect
-from . import _pep440
 from . import py3k
 from ._inspect import getargspec, formatargspec
 from .py3k import *


### PR DESCRIPTION
The submodule `numpy.compat._pep440` is removed from the default import of
numpy to reduce the import time. This saves about 3-4 ms on the import time. See #22061 and #22080.

Users who want to make use of the functionality can use `import numpy.compat._pep440`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
