### PR TITLE
ENH: raise TypeError when arange() is called with string dtype

### DIFF
--- a/doc/release/upcoming_changes/22055.improvement.rst
+++ b/doc/release/upcoming_changes/22055.improvement.rst
@@ -1,0 +1,15 @@
+arange() now explicitly fails with dtype=str
+---------------------------------------------
+Previously, the `np.arange(n, dtype=str)` function worked for n==1 and n==2,
+but would raise a non-specific exception message for other values of n. Now,
+it raises a TypeError with a specific error message saying dtype=str` is not
+supported for these types of calls:
+
+    In [2]: np.arange(1, dtype=str)
+    ---------------------------------------------------------------------------
+    TypeError                                 Traceback (most recent call last)
+    <ipython-input-2-863d487ace18> in <module>
+    ----> 1 np.arange(1, dtype=str)
+    
+    TypeError: string types for arange() not supported
+

--- a/doc/release/upcoming_changes/22055.improvement.rst
+++ b/doc/release/upcoming_changes/22055.improvement.rst
@@ -3,10 +3,10 @@ arange() now explicitly fails with dtype=str
 Previously, the ``np.arange(n, dtype=str)`` function worked for ``n=1`` and
 ``n=2``, but would raise a non-specific exception message for other values of
 n.
-Now, it raises a `TypeError` with a specific error message saying ``arange``
-does not support string dtypes::
+Now, it raises a `TypeError` informing that ``arange`` does not support
+string dtypes::
 
     >>> np.arange(2, dtype=str)
     Traceback (most recent call last)
        ...
-    TypeError: string types for arange() not supported
+    TypeError: arange() not supported for inputs with DType <class 'numpy.dtype[str_]'>.

--- a/doc/release/upcoming_changes/22055.improvement.rst
+++ b/doc/release/upcoming_changes/22055.improvement.rst
@@ -1,15 +1,12 @@
 arange() now explicitly fails with dtype=str
 ---------------------------------------------
-Previously, the `np.arange(n, dtype=str)` function worked for n==1 and n==2,
-but would raise a non-specific exception message for other values of n. Now,
-it raises a TypeError with a specific error message saying dtype=str` is not
-supported for these types of calls:
+Previously, the ``np.arange(n, dtype=str)`` function worked for ``n=1`` and
+``n=2``, but would raise a non-specific exception message for other values of
+n.
+Now, it raises a `TypeError` with a specific error message saying ``arange``
+does not support string dtypes::
 
-    In [2]: np.arange(1, dtype=str)
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-2-863d487ace18> in <module>
-    ----> 1 np.arange(1, dtype=str)
-    
+    >>> np.arange(2, dtype=str)
+    Traceback (most recent call last)
+       ...
     TypeError: string types for arange() not supported
-

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3926,9 +3926,12 @@ OBJECT_dot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp 
 static int
 BOOL_fill(PyObject **buffer, npy_intp length, void *NPY_UNUSED(ignored))
 {
+    NPY_ALLOW_C_API_DEF;
+    NPY_ALLOW_C_API;
     PyErr_SetString(PyExc_TypeError,
             "arange() is only supported for booleans when the result has at "
             "most length 2.");
+    NPY_DISABLE_C_API;
     return -1;
 }
 

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3922,7 +3922,15 @@ OBJECT_dot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp 
  */
 
 
-#define BOOL_fill NULL
+/* Boolean fill never works, but define it so that it works up to length 2 */
+static int
+BOOL_fill(PyObject **buffer, npy_intp length, void *NPY_UNUSED(ignored))
+{
+    PyErr_SetString(PyExc_TypeError,
+            "arange() is only supported for booleans when the result has at "
+            "most length 2.");
+    return -1;
+}
 
 /* this requires buffer to be filled with objects or NULL */
 static int

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3266,34 +3266,24 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     Py_XINCREF(dtype);
 
     if (!dtype) {
-        PyArray_Descr *deftype;
-        PyArray_Descr *newtype;
-
         /* intentionally made to be at least NPY_LONG */
-        deftype = PyArray_DescrFromType(NPY_LONG);
-        newtype = PyArray_DescrFromObject(start, deftype);
-        Py_DECREF(deftype);
-        if (newtype == NULL) {
+        dtype = PyArray_DescrFromType(NPY_LONG);
+        Py_SETREF(dtype, PyArray_DescrFromObject(start, dtype));
+        if (dtype == NULL) {
             goto fail;
         }
-        deftype = newtype;
         if (stop && stop != Py_None) {
-            newtype = PyArray_DescrFromObject(stop, deftype);
-            Py_DECREF(deftype);
-            if (newtype == NULL) {
+            Py_SETREF(dtype, PyArray_DescrFromObject(stop, dtype));
+            if (dtype == NULL) {
                 goto fail;
             }
-            deftype = newtype;
         }
         if (step && step != Py_None) {
-            newtype = PyArray_DescrFromObject(step, deftype);
-            Py_DECREF(deftype);
-            if (newtype == NULL) {
+            Py_SETREF(dtype, PyArray_DescrFromObject(step, dtype));
+            if (dtype == NULL) {
                 goto fail;
             }
-            deftype = newtype;
         }
-        dtype = deftype;
     }
 
     /*

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3321,13 +3321,19 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
 
     if (!step || step == Py_None) {
         step = PyLong_FromLong(1);
+        if (step == NULL) {
+            goto fail;
+        }
     }
     else {
-        Py_XINCREF(step);
+        Py_INCREF(step);
     }
     if (!stop || stop == Py_None) {
         stop = start;
         start = PyLong_FromLong(0);
+        if (start == NULL) {
+            goto fail;
+        }
     }
     else {
         Py_INCREF(start);
@@ -3398,7 +3404,7 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     Py_DECREF(native);
     Py_DECREF(start);
     Py_DECREF(step);
-    Py_DECREF(next);
+    Py_XDECREF(next);
     return (PyObject *)range;
 
  fail:

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3292,6 +3292,14 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
     else {
         Py_INCREF(dtype);
     }
+
+    /* Explicitly fail for string types */
+    if (dtype != NULL && PyDataType_ISSTRING(dtype)) {
+      PyErr_SetString(PyExc_TypeError,
+           "string types for arange() not supported");
+       return NULL;
+    }
+
     if (!step || step == Py_None) {
         step = PyLong_FromLong(1);
     }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -3305,7 +3305,7 @@ PyArray_ArangeObj(PyObject *start, PyObject *stop, PyObject *step, PyArray_Descr
 
     funcs = native->f;
     if (!funcs->fill) {
-        /* This effectively forbits subarray types as well... */
+        /* This effectively forbids subarray types as well... */
         PyErr_Format(PyExc_TypeError,
                 "arange() not supported for inputs with DType %S.",
                 Py_TYPE(dtype));

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3091,13 +3091,6 @@ array_arange(PyObject *NPY_UNUSED(ignored),
         }
     }
 
-    if (typecode != NULL && (typecode->kind == 'S' || typecode->kind == 'U')) {
-      PyErr_SetString(PyExc_TypeError,
-           "string types for arange() not supported");
-       Py_XDECREF(typecode);
-       return NULL;
-    }
-
     if (o_stop == NULL) {
         if (len_args == 0){
             PyErr_SetString(PyExc_TypeError,

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -3091,6 +3091,13 @@ array_arange(PyObject *NPY_UNUSED(ignored),
         }
     }
 
+    if (typecode != NULL && (typecode->kind == 'S' || typecode->kind == 'U')) {
+      PyErr_SetString(PyExc_TypeError,
+           "string types for arange() not supported");
+       Py_XDECREF(typecode);
+       return NULL;
+    }
+
     if (o_stop == NULL) {
         if (len_args == 0){
             PyErr_SetString(PyExc_TypeError,

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9325,8 +9325,8 @@ class TestArange:
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
     def test_rejects_string(self):
-        assert_raises(TypeError, np.arange, step=2, dtype=str)
-
+        with pytest.raises(TypeError, match="string types for arange"):
+            np.arange(2, dtype=str)
 
 class TestArrayFinalize:
     """ Tests __array_finalize__ """

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9324,6 +9324,9 @@ class TestArange:
         assert len(keyword_start_stop) == 6
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
+    def test_rejects_string(self):
+        assert_raises(TypeError, np.arange, step=2, dtype=str)
+
 
 class TestArrayFinalize:
     """ Tests __array_finalize__ """

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9327,6 +9327,9 @@ class TestArange:
     def test_rejects_string(self):
         with pytest.raises(TypeError, match="string types for arange"):
             np.arange(2, dtype=str)
+        with pytest.raises(TypeError, match="string types for arange"):
+            np.arange("a", "b")
+
 
 class TestArrayFinalize:
     """ Tests __array_finalize__ """

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9,6 +9,7 @@ import functools
 import ctypes
 import os
 import gc
+import re
 import weakref
 import pytest
 from contextlib import contextmanager
@@ -9324,11 +9325,47 @@ class TestArange:
         assert len(keyword_start_stop) == 6
         assert_array_equal(keyword_stop, keyword_zerotostop)
 
-    def test_rejects_string(self):
-        with pytest.raises(TypeError, match="string types for arange"):
-            np.arange(2, dtype=str)
-        with pytest.raises(TypeError, match="string types for arange"):
+    def test_arange_booleans(self):
+        # Arange makes some sense for booleans and works up to length 2.
+        # But it is weird since `arange(2, 4, dtype=bool)` works.
+        # Arguably, much or all of this could be deprecated/removed.
+        res = np.arange(False, dtype=bool)
+        assert_array_equal(res, np.array([], dtype="bool"))
+
+        res = np.arange(True, dtype="bool")
+        assert_array_equal(res, [False])
+
+        res = np.arange(2, dtype="bool")
+        assert_array_equal(res, [False, True])
+
+        # This case is especially weird, but drops out without special case:
+        res = np.arange(6, 8, dtype="bool")
+        assert_array_equal(res, [True, True])
+
+        with pytest.raises(TypeError):
+            np.arange(3, dtype="bool")
+
+    @pytest.mark.parametrize("dtype", ["S3", "U", "5i"])
+    def test_rejects_bad_dtypes(self, dtype):
+        dtype = np.dtype(dtype)
+        DType_name = re.escape(str(type(dtype)))
+        with pytest.raises(TypeError,
+                match=rf"arange\(\) not supported for inputs .* {DType_name}"):
+            np.arange(2, dtype=dtype)
+
+    def test_rejects_strings(self):
+        # Explicitly test error for strings which may call "b" - "a":
+        DType_name = re.escape(str(type(np.array("a").dtype)))
+        with pytest.raises(TypeError,
+                match=rf"arange\(\) not supported for inputs .* {DType_name}"):
             np.arange("a", "b")
+
+    def test_byteswapped(self):
+        res_be = np.arange(1, 1000, dtype=">i4")
+        res_le = np.arange(1, 1000, dtype="<i4")
+        assert res_be.dtype == ">i4"
+        assert res_le.dtype == "<i4"
+        assert_array_equal(res_le, res_be)
 
 
 class TestArrayFinalize:

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -9367,6 +9367,19 @@ class TestArange:
         assert res_le.dtype == "<i4"
         assert_array_equal(res_le, res_be)
 
+    @pytest.mark.parametrize("which", [0, 1, 2])
+    def test_error_paths_and_promotion(self, which):
+        args = [0, 1, 2]  # start, stop, and step
+        args[which] = np.float64(2.)  # should ensure float64 output
+
+        assert np.arange(*args).dtype == np.float64
+
+        # Cover stranger error path, test only to achieve code coverage!
+        args[which] = [None, []]
+        with pytest.raises(ValueError):
+            # Fails discovering start dtype
+            np.arange(*args)
+
 
 class TestArrayFinalize:
     """ Tests __array_finalize__ """


### PR DESCRIPTION
This merge request addresses #22055, which reported unusual the behavior in `arange()` when string is provided as the dtype.

Previously, the function would work when n==1 or n==2, and raise with a vague message when n>=3. This merge requests makes it so it raises all the time with a clear error message.

```
In [2]: np.arange(1, dtype=str)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-863d487ace18> in <module>
----> 1 np.arange(1, dtype=str)

TypeError: string types for arange() not supported
```