### PR TITLE
DEV: Make the numpy.distutils support os400 similar as aix.[ci skip]

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -686,7 +686,7 @@ def CCompiler_cxx_compiler(self):
     cxx.compiler_cxx = cxx.compiler_cxx
     cxx.compiler_so = [cxx.compiler_cxx[0]] + \
                       sanitize_cxx_flags(cxx.compiler_so[1:])
-    if sys.platform.startswith('aix') and 'ld_so_aix' in cxx.linker_so[0]:
+    if sys.platform.startswith(('aix','os400')) and 'ld_so_aix' in cxx.linker_so[0]:
         # AIX needs the ld_so_aix script included with Python
         cxx.linker_so = [cxx.linker_so[0], cxx.compiler_cxx[0]] \
                         + cxx.linker_so[2:]


### PR DESCRIPTION
This change is in ccompiler.py in numpy.distutils. "os400" is one similar system comparing with aix . So, the changes here is quite simple to check the sys.platform.startswith on "os400" as well. Please help to review. thanks. 