### PR TITLE
PERF: Improve intrinsics for tobits and pack on Apple silicon

### DIFF
--- a/numpy/core/src/common/simd/neon/conversion.h
+++ b/numpy/core/src/common/simd/neon/conversion.h
@@ -34,10 +34,10 @@ NPY_FINLINE npy_uint64 npyv_tobits_b8(npyv_b8 a)
 {
     const npyv_u8 scale = npyv_set_u8(1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128);
     npyv_u8 seq_scale = vandq_u8(a, scale);
-#if NPY_SIMD_F64
-    npy_uint8 sumlo = vaddv_u8(vget_low_u8(seq_scale));
-    npy_uint8 sumhi = vaddv_u8(vget_high_u8(seq_scale));
-    return sumlo + ((int)sumhi << 8);
+#if defined(__aarch64__)
+    const npyv_u8 byteOrder = {0,8,1,9,2,10,3,11,4,12,5,13,6,14,7,15};
+    npyv_u8 v0 = vqtbl1q_u8(seq_scale, byteOrder);
+    return vaddlvq_u16(vreinterpretq_u16_u8(v0));
 #else
     npyv_u64 sumh = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(seq_scale)));
     return vgetq_lane_u64(sumh, 0) + ((int)vgetq_lane_u64(sumh, 1) << 8);
@@ -67,8 +67,9 @@ NPY_FINLINE npy_uint64 npyv_tobits_b32(npyv_b32 a)
 }
 NPY_FINLINE npy_uint64 npyv_tobits_b64(npyv_b64 a)
 {
-    npyv_u64 bit = vshrq_n_u64(a, 63);
-    return vgetq_lane_u64(bit, 0) | ((int)vgetq_lane_u64(bit, 1) << 1);
+    uint64_t lo = vgetq_lane_u64(a, 0);
+    uint64_t hi = vgetq_lane_u64(a, 1);
+    return ((hi & 0x2) | (lo & 0x1));
 }
 
 //expand
@@ -88,14 +89,23 @@ NPY_FINLINE npyv_u32x2 npyv_expand_u32_u16(npyv_u16 data) {
 
 // pack two 16-bit boolean into one 8-bit boolean vector
 NPY_FINLINE npyv_b8 npyv_pack_b8_b16(npyv_b16 a, npyv_b16 b) {
+#if defined(__aarch64__)
+    return vuzp1q_u8(a, b);
+#else
     return vcombine_u8(vmovn_u16(a), vmovn_u16(b));
+#endif
 }
 
 // pack four 32-bit boolean vectors into one 8-bit boolean vector
 NPY_FINLINE npyv_b8
 npyv_pack_b8_b32(npyv_b32 a, npyv_b32 b, npyv_b32 c, npyv_b32 d) {
+#if defined(__aarch64__)
+    npyv_b16 ab = vuzp1q_u16(a, b);
+    npyv_b16 cd = vuzp1q_u16(c, d);
+#else
     npyv_b16 ab = vcombine_u16(vmovn_u32(a), vmovn_u32(b));
     npyv_b16 cd = vcombine_u16(vmovn_u32(c), vmovn_u32(d));
+#endif
     return npyv_pack_b8_b16(ab, cd);
 }
 
@@ -103,10 +113,17 @@ npyv_pack_b8_b32(npyv_b32 a, npyv_b32 b, npyv_b32 c, npyv_b32 d) {
 NPY_FINLINE npyv_b8
 npyv_pack_b8_b64(npyv_b64 a, npyv_b64 b, npyv_b64 c, npyv_b64 d,
                  npyv_b64 e, npyv_b64 f, npyv_b64 g, npyv_b64 h) {
+#if defined(__aarch64__)
+    npyv_b32 ab = vuzp1q_u32(a, b);
+    npyv_b32 cd = vuzp1q_u32(c, d);
+    npyv_b32 ef = vuzp1q_u32(e, f);
+    npyv_u32 gh = vuzp1q_u32(g, h);
+#else
     npyv_b32 ab = vcombine_u32(vmovn_u64(a), vmovn_u64(b));
     npyv_b32 cd = vcombine_u32(vmovn_u64(c), vmovn_u64(d));
     npyv_b32 ef = vcombine_u32(vmovn_u64(e), vmovn_u64(f));
     npyv_b32 gh = vcombine_u32(vmovn_u64(g), vmovn_u64(h));
+#endif
     return npyv_pack_b8_b32(ab, cd, ef, gh);
 }
 


### PR DESCRIPTION
**Improvements:**
- up to 1.25x faster on pack_bits()
- up to 1.63x faster for comparison loops

**Apple M1 native (arm64):**
```
       before           after         ratio
     [da6297b9]       [1d330fc2]
     <main>           <tobits-pack-intrinsics/upstream-pr>
+      67.2±0.6μs         74.9±6μs     1.11  bench_indexing.Indexing.time_op('indexes_', 'I', '')
+     38.6±0.06μs         42.8±1μs     1.11  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'invert'>, 4, 4, 'i')
+     7.68±0.02μs      8.47±0.01μs     1.10  bench_function_base.Sort.time_argsort('merge', 'uint32', ('uniform',))
-      42.5±0.3μs      38.6±0.03μs     0.91  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'invert'>, 2, 2, 'l')
-         147±1μs          133±1μs     0.91  bench_function_base.Histogram1D.time_small_coverage
-     4.62±0.04μs      4.17±0.04μs     0.90  bench_ufunc_strides.AVX_cmplx_funcs.time_ufunc('conjugate', 1, 'D')
-        1.11±0μs          992±2ns     0.90  bench_core.PackBits.time_packbits_little(<class 'bool'>)
-     2.60±0.01μs         2.33±0μs     0.90  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'float16')
-        2.89±0μs         2.59±0μs     0.90  bench_itemselection.Take.time_contiguous((1000, 2), 'raise', 'int32')
-        2.90±0μs         2.59±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'complex64')
-        2.90±0μs         2.59±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'float64')
-        2.90±0μs         2.58±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'int64')
-        2.59±0μs      2.31±0.02μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'int16')
-        2.90±0μs         2.58±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 2), 'raise', 'float32')
-        2.90±0μs         2.58±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'raise', 'longfloat')
-        4.78±0μs         4.25±0μs     0.89  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'int16')
-        4.78±0μs         4.25±0μs     0.89  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'float16')
-        5.41±0μs         4.79±0μs     0.89  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'float64')
-        5.41±0μs         4.78±0μs     0.88  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'complex64')
-        5.41±0μs         4.78±0μs     0.88  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'longfloat')
-        5.41±0μs         4.78±0μs     0.88  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'raise', 'int64')
-     10.8±0.02μs      9.42±0.03μs     0.87  bench_function_base.Sort.time_argsort('merge', 'uint32', ('reversed',))
-     90.0±0.08μs       78.4±0.4μs     0.87  bench_function_base.Sort.time_argsort('quick', 'int32', ('reversed',))
-     2.53±0.02μs      2.20±0.02μs     0.87  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.uint16'>)
-     2.53±0.01μs         2.18±0μs     0.86  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.uint16'>)
-     2.54±0.02μs      2.18±0.01μs     0.86  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.int16'>)
-     2.54±0.02μs      2.16±0.02μs     0.85  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.int16'>)
-      10.8±0.1μs      8.69±0.01μs     0.81  bench_core.PackBits.time_packbits_axis1(<class 'bool'>)
-       57.4±10μs      44.5±0.02μs     0.77  bench_core.CountNonzero.time_count_nonzero(1, 10000, <class 'str'>)
-     60.9±0.01μs      46.7±0.03μs     0.77  bench_function_base.Sort.time_argsort('quick', 'int32', ('ordered',))
-        5.41±1μs         4.15±0μs     0.77  bench_itemselection.Take.time_contiguous((1000, 2), 'wrap', 'complex128')
-     4.77±0.01μs      3.51±0.01μs     0.74  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.int32'>)
-     4.84±0.03μs      3.51±0.02μs     0.72  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.uint32'>)
-     4.87±0.01μs      3.50±0.03μs     0.72  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.float32'>)
-        4.86±0μs      3.50±0.01μs     0.72  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.uint32'>)
-     4.82±0.06μs      3.46±0.04μs     0.72  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.int32'>)
-     4.86±0.01μs      3.48±0.03μs     0.72  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.float32'>)
-     9.26±0.07μs      5.73±0.03μs     0.62  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.int64'>)
-        9.34±0μs      5.76±0.02μs     0.62  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.uint64'>)
-     9.34±0.07μs      5.75±0.02μs     0.62  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.float64'>)
-     9.31±0.04μs      5.73±0.04μs     0.61  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.float64'>)
-     9.28±0.09μs      5.67±0.04μs     0.61  bench_ufunc.CustomComparison.time_less_than_scalar1(<class 'numpy.int64'>)
-     9.18±0.02μs      5.60±0.02μs     0.61  bench_ufunc.CustomComparison.time_less_than_scalar2(<class 'numpy.uint64'>)
```
