### PR TITLE
TST: Remove workaround for gh-9968 from `test_scalar_methods.test_roundtrip`

### DIFF
--- a/numpy/core/tests/test_scalar_methods.py
+++ b/numpy/core/tests/test_scalar_methods.py
@@ -97,9 +97,8 @@ class TestAsIntegerRatio:
             n, d = f.as_integer_ratio()
 
             try:
-                # workaround for gh-9968
-                nf = np.longdouble(str(n))
-                df = np.longdouble(str(d))
+                nf = np.longdouble(n)
+                df = np.longdouble(d)
             except (OverflowError, RuntimeWarning):
                 # the values may not fit in any float type
                 pytest.skip("longdouble too small on this platform")


### PR DESCRIPTION
#9968 was fixed. The workaround is no longer appropriate.

This way the PyLong -> longdouble codepath is tested in the round trip
through `.as_integer_ratio()` instead of str -> longdouble which you've
presumably tested elsewhere. The str() calls were added in the first version
of the code in 79799b32a13a3dfb15eb48bdd8b4c6a433ce50df before
#9968 had been dealt with.

Using a str is also unnecessarily inefficient once #22098 is implemented.