### PR TITLE
MAINT: bump macOS 10.15 to 11 in wheel and testing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,7 +72,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, manylinux_x86_64]
-        - [macos-10.15, macosx_*]
+        - [macos-11, macosx_*]
         - [windows-2019, win_amd64]
         - [windows-2019, win32]
         # TODO: uncomment PyPy 3.9 builds once PyPy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,14 +104,7 @@ stages:
 
   - job: macOS
     pool:
-      # NOTE: at time of writing, there is a danger
-      # that using an invalid vmIMage string for macOS
-      # image silently redirects to a Windows build on Azure;
-      # for now, use the only image name officially present in
-      # the docs even though i.e., numba uses another in their
-      # azure config for mac os -- Microsoft has indicated
-      # they will patch this issue
-      vmImage: 'macOS-1015'
+      vmImage: 'macos-11'
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
macos-10.15 is deprecated on github actions (will be removed Aug 30) and on azure (will be removed Sept 30). The oldest supported version is macos-11.