### PR TITLE
MAINT: remove redundant reversal of eigenvalues order in svd path

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -1631,7 +1631,6 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
             return wrap(u), s, wrap(vt)
         else:
             s = eigvalsh(a)
-            s = s[..., ::-1]
             s = abs(s)
             return sort(s)[..., ::-1]
 


### PR DESCRIPTION
#15468 added a sort of the eigenvalues which nullifies the effect of any prior re-ordering. 