### PR TITLE
DOC: Fix documentation for percentile and quantile

### DIFF
--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -3979,7 +3979,7 @@ def percentile(a,
 
     Notes
     -----
-    Given a vector ``V`` of length ``N``, the q-th percentile of ``V`` is
+    Given a vector ``V`` of length ``n``, the q-th percentile of ``V`` is
     the value ``q/100`` of the way from the minimum to the maximum in a
     sorted copy of ``V``. The values and distances of the two nearest
     neighbors as well as the `method` parameter will determine the
@@ -3988,19 +3988,22 @@ def percentile(a,
     same as the minimum if ``q=0`` and the same as the maximum if
     ``q=100``.
 
-    This optional `method` parameter specifies the method to use when the
-    desired quantile lies between two data points ``i < j``.
-    If ``g`` is the fractional part of the index surrounded by ``i`` and
-    alpha and beta are correction constants modifying i and j.
+    The optional `method` parameter specifies the method to use when the
+    desired percentile lies between two indexes ``i`` and ``j = i + 1``.
+    In that case, we first determine ``i + g``, a virtual index that lies
+    between ``i`` and ``j``, where  ``i`` is the floor and ``g`` is the
+    fractional part of the index. The final result is, then, an interpolation
+    of ``a[i]`` and ``a[j]`` based on ``g``. During the computation of ``g``,
+    ``i`` and ``j`` are modified using correction constants ``alpha`` and
+    ``beta`` whose choices depend on the ``method`` used. Finally, note that
+    since Python uses 0-based indexing, the code subtracts another 1 from the
+    index internally.
 
-    Below, 'q' is the quantile value, 'n' is the sample size and
-    alpha and beta are constants.
-    The following formula gives an interpolation "i + g" of where the quantile
-    would be in the sorted sample.
-    With 'i' being the floor and 'g' the fractional part of the result.
+    The following formula determines the virtual index ``i + g``, the location 
+    of the percentile in the sorted sample:
 
     .. math::
-        i + g = q * ( n - alpha - beta + 1 ) + alpha
+        i + g = (q / 100) * ( n - alpha - beta + 1 ) + alpha
 
     The different methods then work as follows
 
@@ -4265,18 +4268,28 @@ def quantile(a,
 
     Notes
     -----
-    Given a vector ``V`` of length ``N``, the q-th quantile of ``V`` is the
-    value ``q`` of the way from the minimum to the maximum in a sorted copy of
-    ``V``. The values and distances of the two nearest neighbors as well as the
-    `method` parameter will determine the quantile if the normalized
-    ranking does not match the location of ``q`` exactly. This function is the
-    same as the median if ``q=0.5``, the same as the minimum if ``q=0.0`` and
-    the same as the maximum if ``q=1.0``.
+    Given a vector ``V`` of length ``n``, the q-th quantile of ``V`` is
+    the value ``q`` of the way from the minimum to the maximum in a
+    sorted copy of ``V``. The values and distances of the two nearest
+    neighbors as well as the `method` parameter will determine the
+    quantile if the normalized ranking does not match the location of
+    ``q`` exactly. This function is the same as the median if ``q=0.5``, the
+    same as the minimum if ``q=0.0`` and the same as the maximum if
+    ``q=1.0``.
 
     The optional `method` parameter specifies the method to use when the
-    desired quantile lies between two data points ``i < j``.
-    If ``g`` is the fractional part of the index surrounded by ``i`` and ``j``,
-    and alpha and beta are correction constants modifying i and j:
+    desired quantile lies between two indexes ``i`` and ``j = i + 1``.
+    In that case, we first determine ``i + g``, a virtual index that lies
+    between ``i`` and ``j``, where  ``i`` is the floor and ``g`` is the
+    fractional part of the index. The final result is, then, an interpolation
+    of ``a[i]`` and ``a[j]`` based on ``g``. During the computation of ``g``,
+    ``i`` and ``j`` are modified using correction constants ``alpha`` and
+    ``beta`` whose choices depend on the ``method`` used. Finally, note that
+    since Python uses 0-based indexing, the code subtracts another 1 from the
+    index internally.
+
+    The following formula determines the virtual index ``i + g``, the location 
+    of the quantile in the sorted sample:
 
     .. math::
         i + g = q * ( n - alpha - beta + 1 ) + alpha


### PR DESCRIPTION
From the original PR #21937 by @deego 

> Fix documentation for percentile and quantile:
> 
> This PR is a response to the promise I made to seberg in another bug report. Please find the following suggested changes to the doc
> 
> (a) Clarify that python internally uses 0-based indexing, like seberg mentioned.
> 
> (b) The documentation was very unclear, and not just to me. I spend a whole lot of time discussing with people on ##math, ##statistics, #python, etc, and to my knowledge, no one could figure anything out from the given documentation. Didn't help that the formula was wrong. In the end, I gave up on the documentation, "discovered" my own formula that makes sense, and worked backwards from that. Thus, a lot of clarity is needed. I hope we provide that in these changes.
> 
> (c) I clarified that i+g is a virtual index. That was never mentioned. It's mentioned in the comments in this file, but I think that never made it to the numpy documentation itself(?).
> 
> (d) Clarify that j = i + 1
> 
> (e) What is done with g once it is determined? Mention that we return an interpolation of the values between a[i] and a[j] based on g.
> 
> (f) The formula mentioned in percentile had yet another bug if taken literally. When it says q, it really means q/100. We fix that as well.
> 
> (g) The doc should say 'n', not 'N'.
