### PR TITLE
DOC: Explain spawn_key a little more.

### DIFF
--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -261,8 +261,10 @@ cdef class SeedSequence():
     entropy : {None, int, sequence[int]}, optional
         The entropy for creating a `SeedSequence`.
     spawn_key : {(), sequence[int]}, optional
-        A third source of entropy, used internally when calling
-        `SeedSequence.spawn`
+        An additional source of entropy based on the position of this
+        `SeedSequence` in the tree of such objects created with the
+        `SeedSequence.spawn` method. Typically, only `SeedSequence.spawn` will
+        set this, and users will not.
     pool_size : {int}, optional
         Size of the pooled entropy to store. Default is 4 to give a 128-bit
         entropy pool. 8 (for 256 bits) is another reasonable choice if working


### PR DESCRIPTION
As found in #22119, we have a remnant of a previous iteration where we describe `spawn_key` as the "third" source of entropy while it is currently only the second. We removed another argument that was the second source of entropy some time earlier but did not adjust the wording here. I have extended the description a little more to make it clearer that one will typically not set this directly, but is intended to be controlled by the `spawn()` method.