### PR TITLE
DOC: Explain how to use sequences of integers as seeds.

### DIFF
--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -216,9 +216,10 @@ Parallel Generation
 ~~~~~~~~~~~~~~~~~~~
 
 The included generators can be used in parallel, distributed applications in
-one of three ways:
+a number of ways:
 
 * :ref:`seedsequence-spawn`
+* :ref:`sequence-of-seeds`
 * :ref:`independent-streams`
 * :ref:`parallel-jumped`
 


### PR DESCRIPTION
Fixes #22119

Further document the ability of `SeedSequence` et al. to accept sequences of integers as the seed entropy and how this may be used to effect parallel PRNG streams for certain use cases.

As usual, it's a subtle topic that I may be too in-the-weeds to have explained usefully (and I have a penchant for overcomplicated sentence structures), so I would be open to suggestions for improvement.