### PR TITLE
BUG: Large distances between start and stop in np.linspace() result in non-finite values

### DIFF
--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -184,7 +184,10 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
             else:
                 step *= 2
         else:
-            step = step + _nx.where(_nx.absolute(step) > may_overflow_threshold, _nx.where(step > 0, _nx.inf, -_nx.inf), step)
+            step = step + _nx.where(
+                _nx.absolute(step) > may_overflow_threshold,
+                _nx.where(step > 0, _nx.inf, -_nx.inf),
+                step)
 
     if axis != 0:
         y = _nx.moveaxis(y, 0, axis)

--- a/numpy/core/function_base.py
+++ b/numpy/core/function_base.py
@@ -4,7 +4,7 @@ import operator
 import types
 
 from . import numeric as _nx
-from .numeric import result_type, NaN, asanyarray, ndim
+from .numeric import isscalar, result_type, NaN, asanyarray, ndim
 from numpy.core.multiarray import add_docstring
 from numpy.core import overrides
 
@@ -133,6 +133,14 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         integer_dtype = False
     else:
         integer_dtype = _nx.issubdtype(dtype, _nx.integer)
+    
+    import numpy as np  # import here for no circular import
+    may_overflow_threshold = np.finfo(np.float64).max / 2
+    may_overflow = _nx.any(_nx.absolute(start) > may_overflow_threshold)\
+                or _nx.any(_nx.absolute(stop) > may_overflow_threshold)
+    if may_overflow:
+        stop = stop / 2
+        start = start / 2
 
     delta = stop - start
     y = _nx.arange(0, num, dtype=dt).reshape((-1,) + (1,) * ndim(delta))
@@ -167,6 +175,16 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
 
     if endpoint and num > 1:
         y[-1] = stop
+
+    if may_overflow:
+        y = y * 2
+        if _nx.isscalar(step):
+            if _nx.absolute(step) > may_overflow_threshold:
+                step = _nx.sign(step) * _nx.inf
+            else:
+                step *= 2
+        else:
+            step = step + _nx.where(_nx.absolute(step) > may_overflow_threshold, _nx.where(step > 0, _nx.inf, -_nx.inf), step)
 
     if axis != 0:
         y = _nx.moveaxis(y, 0, axis)

--- a/numpy/core/tests/test_function_base.py
+++ b/numpy/core/tests/test_function_base.py
@@ -407,3 +407,13 @@ class TestLinspace:
         y = linspace(-1, 3, num=8, dtype=int)
         t = array([-1, -1, 0, 0, 1, 1, 2, 3], dtype=int)
         assert_array_equal(y, t)
+
+    def test_bignumber(self):
+        import numpy as np
+        max_number = np.finfo(np.float64).max
+        y, step = linspace(-max_number, max_number, 2, retstep=True)
+        assert_(not isnan(y[0]))
+        assert_equal(step, np.inf)
+        
+        y, step = linspace(-max_number/2, max_number/2, 2, retstep=True)
+        assert_equal(step, max_number)


### PR DESCRIPTION
if abs(stop - start) may greater then max(float64) then
result = 2 * linspace(start / 2, stop / 2, ...)

bug fix. see #21585 