### PR TITLE
MAINT: support IBM i system

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -686,10 +686,17 @@ def CCompiler_cxx_compiler(self):
     cxx.compiler_cxx = cxx.compiler_cxx
     cxx.compiler_so = [cxx.compiler_cxx[0]] + \
                       sanitize_cxx_flags(cxx.compiler_so[1:])
-    if sys.platform.startswith('aix') and 'ld_so_aix' in cxx.linker_so[0]:
+    if (sys.platform.startswith(('aix', 'os400')) and
+            'ld_so_aix' in cxx.linker_so[0]):
         # AIX needs the ld_so_aix script included with Python
         cxx.linker_so = [cxx.linker_so[0], cxx.compiler_cxx[0]] \
                         + cxx.linker_so[2:]
+    if sys.platform.startswith('os400'):
+        #This is required by i 7.4 and prievous for PRId64 in printf() call.
+        cxx.compiler_so.append('-D__STDC_FORMAT_MACROS')
+        #This a bug of gcc10.3, which failed to handle the TLS init.
+        cxx.compiler_so.append('-fno-extern-tls-init')
+        cxx.linker_so.append('-fno-extern-tls-init')
     else:
         cxx.linker_so = [cxx.compiler_cxx[0]] + cxx.linker_so[1:]
     return cxx

--- a/numpy/distutils/fcompiler/__init__.py
+++ b/numpy/distutils/fcompiler/__init__.py
@@ -527,6 +527,12 @@ class FCompiler(CCompiler):
                 ld_so_aix = os.path.join(python_lib, 'config', 'ld_so_aix')
                 python_exp = os.path.join(python_lib, 'config', 'python.exp')
                 linker_so = [ld_so_aix] + linker_so + ['-bI:'+python_exp]
+            if sys.platform.startswith('os400'):
+                from distutils.sysconfig import get_config_var
+                python_config = get_config_var('LIBPL')
+                ld_so_aix = os.path.join(python_config, 'ld_so_aix')
+                python_exp = os.path.join(python_config, 'python.exp')
+                linker_so = [ld_so_aix] + linker_so + ['-bI:'+python_exp]
             self.set_commands(linker_so=linker_so+linker_so_flags)
 
         linker_exe = self.linker_exe

--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -256,7 +256,7 @@ class GnuFCompiler(FCompiler):
 
         if sys.platform == 'darwin':
             return f'-Wl,-rpath,{dir}'
-        elif sys.platform[:3] == 'aix':
+        elif sys.platform.startswith(('aix', 'os400')):
             # AIX RPATH is called LIBPATH
             return f'-Wl,-blibpath:{dir}'
         else:
@@ -305,7 +305,7 @@ class Gnu95FCompiler(GnuFCompiler):
     module_dir_switch = '-J'
     module_include_switch = '-I'
 
-    if sys.platform[:3] == 'aix':
+    if sys.platform.startswith(('aix', 'os400')):
         executables['linker_so'].append('-lpthread')
         if platform.architecture()[0][:2] == '64':
             for key in ['compiler_f77', 'compiler_f90','compiler_fix','linker_so', 'linker_exe']:


### PR DESCRIPTION
This fix to make numpy.distutils works well on IBM i system. Please kindly help to review and merge it. thanks.