### PR TITLE
DEP: drop support for msvc<=1900 and Interix

### DIFF
--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -1,5 +1,5 @@
 * Support for Visual Studio 2015 has been removed. Please update to at least
-Visual Studio 2019.
+  Visual Studio 2019.
 
 * Support for the Windows Interix POSIX interop layer has been removed.
 

--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -2,3 +2,4 @@
 Visual Studio 2019.
 
 * Support for the Windows Interix POSIX interop layer has been removed.
+

--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -1,0 +1,4 @@
+* Support for Visual Studio 2015 has been removed. Please update to at least
+Visual Studio 2109.
+
+* Support for the Windows Interix POSIX interop layer has been removed.

--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -1,4 +1,4 @@
 * Support for Visual Studio 2015 has been removed. Please update to at least
-Visual Studio 2109.
+Visual Studio 2019.
 
 * Support for the Windows Interix POSIX interop layer has been removed.

--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -1,4 +1,4 @@
-* Support for Visual Studio 2015 has been removed.
+* Support for Visual Studio 2015 and earlier has been removed.
 
 * Support for the Windows Interix POSIX interop layer has been removed.
 

--- a/doc/release/upcoming_changes/22139.expired.rst
+++ b/doc/release/upcoming_changes/22139.expired.rst
@@ -1,5 +1,4 @@
-* Support for Visual Studio 2015 has been removed. Please update to at least
-  Visual Studio 2019.
+* Support for Visual Studio 2015 has been removed.
 
 * Support for the Windows Interix POSIX interop layer has been removed.
 

--- a/numpy/core/include/numpy/npy_math.h
+++ b/numpy/core/include/numpy/npy_math.h
@@ -219,11 +219,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISNAN
         #define npy_isnan(x) ((x) != (x))
     #else
-        #if defined(_MSC_VER) && (_MSC_VER < 1900)
-            #define npy_isnan(x) _isnan((x))
-        #else
-            #define npy_isnan(x) isnan(x)
-        #endif
+        #define npy_isnan(x) isnan(x)
     #endif
 #endif
 
@@ -250,11 +246,7 @@ double npy_spacing(double x);
     #ifndef NPY_HAVE_DECL_ISINF
         #define npy_isinf(x) (!npy_isfinite(x) && !npy_isnan(x))
     #else
-        #if defined(_MSC_VER) && (_MSC_VER < 1900)
-            #define npy_isinf(x) (!_finite((x)) && !_isnan((x)))
-        #else
-            #define npy_isinf(x) isinf((x))
-        #endif
+        #define npy_isinf(x) isinf((x))
     #endif
 #endif
 

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -257,14 +257,6 @@ def check_complex(config, mathlibs):
     priv = []
     pub = []
 
-    try:
-        if os.uname()[0] == "Interix":
-            warnings.warn("Disabling broken complex support. See #1365", stacklevel=2)
-            return priv, pub
-    except Exception:
-        # os.uname not available on all platforms. blanket except ugly but safe
-        pass
-
     # Check for complex support
     st = config.check_header('complex.h')
     if st:

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -71,7 +71,7 @@
 #endif
 
 /* MSVC _hypot messes with fp precision mode on 32-bit, see gh-9567 */
-#if defined(_MSC_VER) !defined(_WIN64)
+#if defined(_MSC_VER) && !defined(_WIN64)
 
 #undef HAVE_CABS
 #undef HAVE_CABSF

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -29,7 +29,7 @@
 #endif
 
 /* Disable broken MS math functions */
-#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__MINGW32_VERSION)
+#if defined(__MINGW32_VERSION)
 
 #undef HAVE_ATAN2
 #undef HAVE_ATAN2F
@@ -41,7 +41,7 @@
 
 #endif
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#if defined(_MSC_VER)
 
 #undef HAVE_CASIN
 #undef HAVE_CASINF
@@ -71,7 +71,7 @@
 #endif
 
 /* MSVC _hypot messes with fp precision mode on 32-bit, see gh-9567 */
-#if defined(_MSC_VER) && (_MSC_VER >= 1900) && !defined(_WIN64)
+#if defined(_MSC_VER) !defined(_WIN64)
 
 #undef HAVE_CABS
 #undef HAVE_CABSF

--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -128,7 +128,7 @@ static inline pcg128_t pcg128_add(pcg128_t a, pcg128_t b) {
 static inline void _pcg_mult64(uint64_t x, uint64_t y, uint64_t *z1,
                                uint64_t *z0) {
 
-#if defined _WIN32 && _MSC_VER >= 1900 && _M_AMD64
+#if defined _WIN32 && _M_AMD64
   z0[0] = _umul128(x, y, z1);
 #else
   uint64_t x0, x1, y0, y1;
@@ -182,7 +182,7 @@ static inline void pcg_setseq_128_srandom_r(pcg_state_setseq_128 *rng,
 
 static inline uint64_t
 pcg_setseq_128_xsl_rr_64_random_r(pcg_state_setseq_128 *rng) {
-#if defined _WIN32 && _MSC_VER >= 1900 && _M_AMD64
+#if defined _WIN32 && _M_AMD64
   uint64_t h1;
   pcg128_t product;
 
@@ -212,7 +212,7 @@ static inline pcg128_t pcg128_mult_64(pcg128_t a, uint64_t b) {
 }
 
 static inline void pcg_cm_step_r(pcg_state_setseq_128 *rng) {
-#if defined _WIN32 && _MSC_VER >= 1900 && _M_AMD64
+#if defined _WIN32 && _M_AMD64
   uint64_t h1;
   pcg128_t product;
 
@@ -255,7 +255,7 @@ static inline uint64_t pcg_cm_random_r(pcg_state_setseq_128* rng)
   hi *= lo;
 
   /* Run the CM step. */
-#if defined _WIN32 && _MSC_VER >= 1900 && _M_AMD64
+#if defined _WIN32 && _M_AMD64
   uint64_t h1;
   pcg128_t product;
 


### PR DESCRIPTION
Remove support for MSVC<=1900 (visual studio 2015 and older) and the Interix POSIX support package.

See [this comment thread](https://github.com/numpy/numpy/pull/22090#issuecomment-1215800761)

xref @h-vetinari, @matthew-brett

Release note needed, I will add it in another commit