### PR TITLE
DOC: fix linalg.tensorsolve docstring

### DIFF
--- a/numpy/linalg/linalg.py
+++ b/numpy/linalg/linalg.py
@@ -243,7 +243,7 @@ def tensorsolve(a, b, axes=None):
 
     It is assumed that all indices of `x` are summed over in the product,
     together with the rightmost indices of `a`, as is done in, for example,
-    ``tensordot(a, x, axes=b.ndim)``.
+    ``tensordot(a, x, axes=x.ndim)``.
 
     Parameters
     ----------


### PR DESCRIPTION
According to `tensordot` doc, it seems that the `axes` in the docstring should be `x.ndim`.