### PR TITLE
BUG: Support using libunwind for backtrack

### DIFF
--- a/numpy/core/setup_common.py
+++ b/numpy/core/setup_common.py
@@ -142,7 +142,9 @@ OPTIONAL_HEADERS = [
                 "immintrin.h",  # AVX
                 "features.h",  # for glibc version linux
                 "xlocale.h",  # see GH#8367
-                "dlfcn.h", # dladdr
+                "dlfcn.h",  # dladdr
+                "execinfo.h",  # backtrace
+                "libunwind.h",  # backtrace for LLVM/Clang using libunwind
                 "sys/mman.h", #madvise
 ]
 

--- a/numpy/core/src/multiarray/temp_elide.c
+++ b/numpy/core/src/multiarray/temp_elide.c
@@ -82,7 +82,12 @@
 #define NPY_MIN_ELIDE_BYTES (32)
 #endif
 #include <dlfcn.h>
+
+#if defined HAVE_EXECINFO_H
 #include <execinfo.h>
+#elif defined HAVE_LIBUNWIND_H
+#include <libunwind.h>
+#endif
 
 /*
  * linear search pointer in table

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -50,7 +50,11 @@ using dispatch_scalar = typename std::conditional<std::is_scalar<typ>::value, sc
     } while (0)
 
 #if 0
+#if defined HAVE_EXECINFO_H
 #include <execinfo.h>
+#elif defined HAVE_LIBUNWIND_H
+#include <libunwind.h>
+#endif
 void
 dbg_stack_trace()
 {


### PR DESCRIPTION
Some system (e.g. musl) do not have "execinfo.h", and the backtracking
is provided by libunwind.

Fix: #22084

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
