### PR TITLE
DEP: drop older cygwin compatibility shims

### DIFF
--- a/doc/release/upcoming_changes/22159.expired.rst
+++ b/doc/release/upcoming_changes/22159.expired.rst
@@ -1,1 +1,1 @@
-* Support for cygwin < 3003 has been removed.
+* Support for cygwin < 3.3 has been removed.

--- a/doc/release/upcoming_changes/22159.expired.rst
+++ b/doc/release/upcoming_changes/22159.expired.rst
@@ -1,0 +1,1 @@
+* Support for cygwin < 3003 has been removed.

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -138,18 +138,8 @@
 
 #include <cygwin/version.h>
 #if CYGWIN_VERSION_DLL_MAJOR < 3003
-/* https://cygwin.com/pipermail/cygwin-announce/2021-October/010268.html */
-/* Builtin abs reports overflow */
-#undef HAVE_CABSL
-#undef HAVE_HYPOTL
-#endif
-
-#if CYGWIN_VERSION_DLL_MAJOR < 3002
-/* https://cygwin.com/pipermail/cygwin-announce/2021-March/009987.html */
-/* Segfault */
-#undef HAVE_MODFL
-/* sqrt(-inf) returns -inf instead of -nan */
-#undef HAVE_SQRTL
+// rather than blocklist cabsl, hypotl, modfl, sqrtl, error out
+#error cygwin < 3003 not supported, please update
 #endif
 #endif
 

--- a/numpy/core/src/common/npy_config.h
+++ b/numpy/core/src/common/npy_config.h
@@ -139,7 +139,7 @@
 #include <cygwin/version.h>
 #if CYGWIN_VERSION_DLL_MAJOR < 3003
 // rather than blocklist cabsl, hypotl, modfl, sqrtl, error out
-#error cygwin < 3003 not supported, please update
+#error cygwin < 3.3 not supported, please update
 #endif
 #endif
 


### PR DESCRIPTION
Continuation of #22139, see [this comment](https://github.com/numpy/numpy/pull/22139#issuecomment-1221094635)

xref @dwesl