### PR TITLE
DOC: allow jax to correctly reference numpy documentation

### DIFF
--- a/doc/source/reference/routines.math.rst
+++ b/doc/source/reference/routines.math.rst
@@ -1,3 +1,5 @@
+.. module:: numpy
+
 Mathematical functions
 ======================
 


### PR DESCRIPTION
@jakevdp pointed out this might be necessary in order to get jax documentation links pointing to numpy's to correctly parse the numpy hyper-links.

The discussion that triggered this comment [started here](https://github.com/google/jax/pull/11578)

@rgommers WDYT?