### PR TITLE
MAINT: fix defines for universal2 python builds of NumPy

### DIFF
--- a/numpy/core/include/numpy/numpyconfig.h
+++ b/numpy/core/include/numpy/numpyconfig.h
@@ -22,13 +22,21 @@
 
     #undef NPY_SIZEOF_LONGDOUBLE
     #undef NPY_SIZEOF_COMPLEX_LONGDOUBLE
+    #ifdef HAVE_LDOUBLE_IEEE_DOUBLE_LE
+      #undef HAVE_LDOUBLE_IEEE_DOUBLE_LE
+    #endif
+    #ifdef HAVE_LDOUBLE_INTEL_EXTENDED_16_BYTES_LE
+      #undef HAVE_LDOUBLE_INTEL_EXTENDED_16_BYTES_LE
+    #endif
 
     #if defined(__arm64__)
         #define NPY_SIZEOF_LONGDOUBLE         8
         #define NPY_SIZEOF_COMPLEX_LONGDOUBLE 16
+        #define HAVE_LDOUBLE_IEEE_DOUBLE_LE 1
     #elif defined(__x86_64)
         #define NPY_SIZEOF_LONGDOUBLE         16
         #define NPY_SIZEOF_COMPLEX_LONGDOUBLE 32
+        #define HAVE_LDOUBLE_INTEL_EXTENDED_16_BYTES_LE 1
     #elif defined (__i386)
         #define NPY_SIZEOF_LONGDOUBLE         12
         #define NPY_SIZEOF_COMPLEX_LONGDOUBLE 24

--- a/numpy/core/setup.py
+++ b/numpy/core/setup.py
@@ -530,6 +530,10 @@ def configuration(parent_package='',top_path=None):
 
             # Generate the config.h file from moredefs
             with open(target, 'w') as target_f:
+                if sys.platform == 'darwin':
+                    target_f.write(
+                        "/* may be overridden by numpyconfig.h on darwin */\n"
+                    )
                 for d in moredefs:
                     if isinstance(d, str):
                         target_f.write('#define %s\n' % (d))


### PR DESCRIPTION
When using a universal2 python (one that supports both x86-64 and arm64), there is confusion around the size of `long double`. On x86-64 it is 16 bytes, on arm64 it is 8 bytes. This confuses the automatic detection done in `setup.py` which uses heuristics to determine the size in creating the build-only `configure.h` header file. PR #20270 already overrides some of the affected macros, this PR adds in a few more used in the `dragon4.c` routines. It also adds a hint to `configure.h` for the next time I need to debug this.

I tried this out on the xcode-provided universal2 python3.8. See also the [comments](https://github.com/numpy/numpy/pull/22090#issuecomment-1223727596) where I slowly figured this out.