### PR TITLE
DOC: Note symmetry requirement in `multivariate_normal` error

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3736,10 +3736,10 @@ cdef class Generator:
                 psd = not np.any(s < -tol)
             if not psd:
                 if check_valid == 'warn':
-                    warnings.warn("covariance is not positive-semidefinite.",
+                    warnings.warn("covariance is not symmetric positive-semidefinite.",
                                   RuntimeWarning)
                 else:
-                    raise ValueError("covariance is not positive-semidefinite.")
+                    raise ValueError("covariance is not symmetric positive-semidefinite.")
 
         if method == 'cholesky':
             _factor = l

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4177,11 +4177,11 @@ cdef class RandomState:
             psd = np.allclose(np.dot(v.T * s, v), cov, rtol=tol, atol=tol)
             if not psd:
                 if check_valid == 'warn':
-                    warnings.warn("covariance is not positive-semidefinite.",
+                    warnings.warn("covariance is not symmetric positive-semidefinite.",
                         RuntimeWarning)
                 else:
                     raise ValueError(
-                        "covariance is not positive-semidefinite.")
+                        "covariance is not symmetric positive-semidefinite.")
 
         x = np.dot(x, np.sqrt(s)[:, None] * v)
         x += mean


### PR DESCRIPTION
…e_normal more descriptive (closes #22140)

Issue #22140 says that numpy.random.multivariate_normal incorrectly warns that a non-symmetric positive-semidefinite matrix isn't positive-semidefinite. In the replies, there was some ambiguity over whether it was possible for a positive-semidefinite matrix to be non-symmetric, with reliable sources saying that symmetry is a common condition to add but not actually necessary. To solve this problem, two different members of the Numpy organization decided that the warning and error message "covariance is not positive-semidefinite" should be changed to "covariance is not symmetric positive-semidefinite". However, this change was never actually made yet.

Since this change only required me to change a few strings instead of actually changing the code, I've decided to skip the CI jobs.

[skip ci]

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
